### PR TITLE
Add MereRun Studio app with live streaming output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,23 @@
 
 All notable changes to this public repository will be documented in this file.
 
-The format is based on Keep a Changelog and uses a simple `Unreleased` section
-until tagged public releases begin.
+The format is based on Keep a Changelog.
 
 ## Unreleased
+
+No notable changes yet.
+
+## 0.4.0 - 2026-05-07
 
 ### Added
 
 - third-party notices for vendored runtime artifacts
 - GitHub issue templates, pull request template, Dependabot, and a lightweight security workflow
+- MereRun Studio, a user-facing SwiftUI macOS app shell with a unified output canvas, mode-aware prompt bar, local Library, guided model readiness, and the technical command surface preserved behind Advanced
+- Studio mode mapping for image, text chat/code, speech, vision, music, and video workflows backed by the public `mere.run` CLI
+- persistent Studio library metadata under Application Support with local output previews for images, media, text, JSON, and generic files
+- repeatable `MereRun.app` bundle creation through `scripts/build_mere_run_app.sh`
+- streaming output support for `mere.run text chat --stream`, including live Studio canvas rendering for chat and code runs
 
 ### Changed
 
@@ -21,7 +29,10 @@ until tagged public releases begin.
 - made signed model-source endpoint failures fail closed unless fallback is explicitly allowed
 - added SHA-256 verification support for managed archive downloads from catalog pins or `MERERUN_MODEL_SOURCE_SHA256S`
 - hardened recoverable runtime construction and conditioning failures to throw typed errors instead of terminating the process
+- default GUI launch instructions now use the app bundle path while keeping `swift run mere.run.app` as a contributor smoke path
+- Studio CLI resolution now prefers local build products before installed binaries during development
 
 ### Fixed
 
 - fixed DMG installs when the optional packaged model-source URL sidecar is absent
+- fixed nested ASR managed-model root normalization so qwen3/parakeet alternates do not recurse indefinitely

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
     .library(name: "AudioCodecs", targets: ["AudioCodecs"]),
     .library(name: "AudioSTT", targets: ["AudioSTT"]),
     .library(name: "AudioTTS", targets: ["AudioTTS"]),
-    .executable(name: "mere.run", targets: ["MereRunCLI"])
+    .executable(name: "mere.run", targets: ["MereRunCLI"]),
+    .executable(name: "mere.run.app", targets: ["MereRunApp"])
   ],
   dependencies: [
     .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.0"),
@@ -108,6 +109,11 @@ let package = Package(
       ]
     ),
     .executableTarget(
+      name: "MereRunApp",
+      dependencies: [],
+      path: "Sources/MereRunApp"
+    ),
+    .executableTarget(
       name: "MereRunCLI",
       dependencies: [
         "MereRunCore",
@@ -147,6 +153,11 @@ let package = Package(
       swiftSettings: [
         .interoperabilityMode(.Cxx)
       ]
+    ),
+    .testTarget(
+      name: "MereRunAppTests",
+      dependencies: ["MereRunApp"],
+      path: "Tests/MereRunAppTests"
     ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # mere.run
 
-mere.run is a Swift package and CLI for local-first inference on Apple Silicon. This OSS repo contains the core inference libraries plus the public `mere.run` executable for image, text, speech, vision, music, video, model management, and local API serving.
+mere.run is a Swift package, CLI, and optional macOS studio for local-first inference on Apple Silicon. This OSS repo contains the core inference libraries, the public `mere.run` executable, and a SwiftUI app that keeps the user-facing experience prompt-first while still running the public CLI underneath.
 
 ## What works today
 
@@ -23,12 +23,14 @@ The public OSS repo currently supports:
 - native music and video generation
 - managed model installs into a shared local model store
 - a local API surface for supported engines
+- an optional macOS studio that wraps the public CLI instead of reimplementing runtime logic
 
 ## What’s included in this repo
 
 - `Sources/MereRunCore`: shared model resolution, manifests, generation primitives, and MLX-backed inference code
 - `Sources/AudioCore`, `Sources/AudioCodecs`, `Sources/AudioSTT`, `Sources/AudioTTS`: audio generation and transcription support
-- `Sources`: core libraries plus the CLI target that builds the public `mere.run` executable
+- `Sources/MereRunCLI`: the target that builds the public `mere.run` executable
+- `Sources/MereRunApp`: a SwiftUI `mere.run.app` target with a user-facing studio and advanced CLI details
 - `Tests`: SwiftPM test coverage for the core and CLI surfaces
 - `vendor/llama.xcframework`: vendored `llama.cpp` runtime used by `mere.run text code` and `mere.run api serve`
 - `vendor/mlx-swift_Cmlx.bundle`: vendored Metal shader resources needed by MLX-backed runtime paths
@@ -60,6 +62,8 @@ brew install node pnpm gitleaks
 swift build
 swift test
 swift run mere.run --help
+app_path="$(./scripts/build_mere_run_app.sh debug)"
+open "$app_path"
 ```
 
 ## Quick start
@@ -67,6 +71,10 @@ swift run mere.run --help
 ```bash
 # See the public command tree
 swift run mere.run --help
+
+# Launch the optional macOS studio
+app_path="$(./scripts/build_mere_run_app.sh debug)"
+open "$app_path"
 
 # List managed models
 swift run mere.run model list
@@ -162,6 +170,10 @@ The public CLI is modality-first:
 - `mere.run api serve`
 - `mere.run setup`
 - `mere.run agent { onboard, install-pi, start }`
+
+The optional `mere.run.app` product opens to a user-facing studio for the same
+command families and keeps raw command previews, logs, runtime paths, model
+management, API serving, and arbitrary arguments in Advanced details.
 
 ## Vision notes
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ swift run mere.run image generate \
 
 # Run local chat
 swift run mere.run text chat \
+  --stream \
   --prompt "Summarize diffusion models in one paragraph."
 
 # Serve the OpenAI-compatible local API on loopback

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -1,0 +1,875 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum CommandCategory: String, CaseIterable, Identifiable {
+    case setup = "Setup"
+    case models = "Models"
+    case image = "Image"
+    case text = "Text"
+    case speech = "Speech"
+    case vision = "Vision"
+    case media = "Music & Video"
+    case server = "Server"
+    case custom = "Custom"
+
+    var id: String { rawValue }
+}
+
+enum CommandTemplateID: String, CaseIterable {
+    case setup
+    case agentOnboard
+    case agentInstallPi
+    case agentStart
+    case modelList
+    case modelCapabilities
+    case modelPull
+    case modelInfo
+    case modelRemove
+    case modelRepairManifests
+    case imageGenerate
+    case imageValidate
+    case textChat
+    case textCode
+    case textEmbed
+    case textAnonymize
+    case speechSynthesize
+    case speechTranscribe
+    case speechProfileList
+    case speechProfileCreate
+    case speechProfileDelete
+    case visionInspect
+    case visionCaption
+    case visionOCR
+    case visionGround
+    case visionSegment
+    case visionTrack
+    case visionTrackLive
+    case musicGenerate
+    case videoGenerate
+    case videoExportLatents
+    case apiServe
+    case custom
+}
+
+enum CommandInputKind: Equatable {
+    case none
+    case file([UTType])
+    case image
+    case audio
+    case video
+
+    var title: String {
+        switch self {
+        case .none: return "Input"
+        case .file: return "File"
+        case .image: return "Image"
+        case .audio: return "Audio"
+        case .video: return "Video"
+        }
+    }
+
+    var allowedTypes: [UTType] {
+        switch self {
+        case .none: return []
+        case .file(let types): return types
+        case .image: return [.image]
+        case .audio: return [.audio]
+        case .video: return [.movie, .video, .audiovisualContent]
+        }
+    }
+}
+
+enum CommandOutputKind: Equatable {
+    case none
+    case file(String)
+    case directory
+
+    var isFile: Bool {
+        if case .file = self { return true }
+        return false
+    }
+}
+
+struct CommandDraft: Equatable {
+    var prompt = ""
+    var secondaryText = ""
+    var model = ""
+    var inputPath = ""
+    var outputPath = ""
+    var width = 1024
+    var height = 1024
+    var steps = 4
+    var seed = ""
+    var cfgScale = 1.0
+    var strength = 0.75
+    var maxTokens = 2048
+    var temperature = 0.7
+    var topP = 0.9
+    var durationSeconds = 10.0
+    var fps = 24
+    var numFrames = 65
+    var host = "127.0.0.1"
+    var port = 8080
+    var apiKey = ""
+    var engine = "text-chat-gemma4"
+    var variant = "distilled"
+    var backend = "auto"
+    var task = "transcribe"
+    var language = "auto"
+    var timestamps = true
+    var setupMode = "agent"
+    var agentModel = "tier"
+    var quiet = false
+    var force = false
+    var all = false
+    var stream = false
+    var extraArguments = ""
+}
+
+struct CommandTemplate: Identifiable, Equatable {
+    let id: CommandTemplateID
+    let category: CommandCategory
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let promptLabel: String?
+    let secondaryLabel: String?
+    let inputKind: CommandInputKind
+    let outputKind: CommandOutputKind
+    let defaultPrompt: String
+    let defaultSecondaryText: String
+    let defaultModel: String
+    let defaultExtraArguments: String
+
+    init(
+        id: CommandTemplateID,
+        category: CommandCategory,
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        promptLabel: String? = nil,
+        secondaryLabel: String? = nil,
+        inputKind: CommandInputKind = .none,
+        outputKind: CommandOutputKind = .none,
+        defaultPrompt: String = "",
+        defaultSecondaryText: String = "",
+        defaultModel: String = "",
+        defaultExtraArguments: String = ""
+    ) {
+        self.id = id
+        self.category = category
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.promptLabel = promptLabel
+        self.secondaryLabel = secondaryLabel
+        self.inputKind = inputKind
+        self.outputKind = outputKind
+        self.defaultPrompt = defaultPrompt
+        self.defaultSecondaryText = defaultSecondaryText
+        self.defaultModel = defaultModel
+        self.defaultExtraArguments = defaultExtraArguments
+    }
+
+    func defaultDraft() -> CommandDraft {
+        var draft = CommandDraft()
+        draft.prompt = defaultPrompt
+        draft.secondaryText = defaultSecondaryText
+        draft.model = defaultModel
+        draft.extraArguments = defaultExtraArguments
+
+        switch id {
+        case .textCode:
+            draft.temperature = 1.0
+            draft.topP = 0.95
+        case .visionCaption, .visionOCR:
+            draft.maxTokens = id == .visionCaption ? 96 : 4096
+            draft.temperature = id == .visionCaption ? 0.2 : 0.2
+        case .apiServe:
+            draft.engine = "text-chat-gemma4"
+            draft.port = 8080
+        case .setup:
+            draft.setupMode = "agent"
+            draft.agentModel = "tier"
+        case .agentStart:
+            draft.prompt = defaultPrompt
+            draft.port = 8080
+        case .imageValidate:
+            draft.backend = "all"
+            draft.variant = "zimage"
+        case .videoGenerate:
+            draft.width = 768
+            draft.height = 512
+            draft.steps = 0
+        case .videoExportLatents:
+            draft.width = 768
+            draft.height = 512
+            draft.numFrames = 65
+            draft.seed = "42"
+        case .musicGenerate:
+            draft.steps = 8
+            draft.durationSeconds = 10
+        case .speechTranscribe:
+            draft.backend = "auto"
+            draft.maxTokens = 448
+            draft.task = "transcribe"
+            draft.language = "auto"
+            draft.timestamps = true
+        default:
+            break
+        }
+
+        switch outputKind {
+        case .file(let ext):
+            draft.outputPath = Self.defaultOutputURL(stem: id.rawValue, extension: ext).path
+        case .directory:
+            draft.outputPath = Self.defaultOutputDirectory(stem: id.rawValue).path
+        case .none:
+            break
+        }
+
+        return draft
+    }
+
+    func validationMessage(for draft: CommandDraft) -> String? {
+        if promptLabel != nil && id != .custom && draft.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "\(promptLabel ?? "Prompt") is required."
+        }
+
+        let optionalInputs: Set<CommandTemplateID> = [.imageGenerate, .videoGenerate]
+        if inputKind != .none
+            && !optionalInputs.contains(id)
+            && draft.inputPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "\(inputKind.title) path is required."
+        }
+
+        switch id {
+        case .modelPull:
+            if !draft.all && draft.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "Choose a model id, or enable All."
+            }
+        case .modelRemove:
+            if draft.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "Model id is required."
+            }
+        case .modelInfo:
+            if draft.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "Model id or local model path is required."
+            }
+        case .custom:
+            if ShellWords.split(draft.extraArguments).isEmpty {
+                return "Enter mere.run arguments."
+            }
+        default:
+            break
+        }
+
+        return nil
+    }
+
+    func arguments(from draft: CommandDraft) -> [String] {
+        var args: [String]
+
+        switch id {
+        case .setup:
+            args = ["setup", "--mode", draft.setupMode, "--agent-model", draft.agentModel]
+            if draft.force { args.append("--install") }
+            if draft.stream { args.append("--start") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .agentOnboard:
+            args = ["agent", "onboard"]
+            if draft.force { args.append("--pull-recommended") }
+            if draft.all { args.append("--install-pi") }
+            if draft.stream { args.append("--configure-pi") }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            args += ["--host", draft.host, "--port", String(draft.port)]
+            if draft.quiet { args.append("--quiet") }
+
+        case .agentInstallPi:
+            args = ["agent", "install-pi"]
+            if draft.force { args.append("--force") }
+
+        case .agentStart:
+            args = ["agent", "start", "--host", draft.host, "--port", String(draft.port)]
+            if !draft.prompt.isBlank { args += ["--prompt", draft.prompt] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.stream { args.append("--skip-server") }
+            if draft.force { args.append("--allow-unsupported") }
+
+        case .modelList:
+            args = ["model", "list"]
+
+        case .modelCapabilities:
+            args = ["model", "capabilities"]
+            if draft.all { args.append("--all") }
+            if draft.force { args.append("--recommended") }
+
+        case .modelPull:
+            args = ["model", "pull"]
+            if draft.all {
+                args.append("--all")
+            } else {
+                args.append(draft.model)
+            }
+            if draft.force { args.append("--force") }
+            if draft.stream { args.append("--allow-unsupported") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .modelInfo:
+            args = ["model", "info", draft.model]
+            if draft.all { args.append("--json") }
+            if draft.force { args.append("--components") }
+
+        case .modelRemove:
+            args = ["model", "remove", draft.model]
+            if draft.force { args.append("--force") }
+
+        case .modelRepairManifests:
+            args = ["model", "repair-manifests"]
+            if draft.force { args.append("--dry-run") }
+
+        case .imageGenerate:
+            args = ["image", "generate", "--prompt", draft.prompt, "--output", draft.outputPath]
+            args += ["--width", String(draft.width), "--height", String(draft.height)]
+            args += ["--steps", String(draft.steps)]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.secondaryText.isBlank { args += ["--negative-prompt", draft.secondaryText] }
+            if draft.cfgScale != 1.0 { args += ["--cfg", format(draft.cfgScale)] }
+            if !draft.seed.isBlank { args += ["--seed", draft.seed] }
+            if !draft.inputPath.isBlank {
+                args += ["--input", draft.inputPath, "--strength", format(draft.strength)]
+            }
+            if draft.quiet { args.append("--quiet") }
+
+        case .imageValidate:
+            args = ["image", "validate", "--test", draft.backend, "--family", draft.variant]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if draft.force { args.append("--save-reference") }
+            if draft.all { args.append("--compare") }
+
+        case .textChat:
+            args = ["text", "chat", "--prompt", draft.prompt]
+            if !draft.secondaryText.isBlank { args += ["--system", draft.secondaryText] }
+            args += ["--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature), "--top-p", format(draft.topP)]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.all { args.append("--thinking") }
+            if draft.force { args.append("--stats") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .textCode:
+            args = ["text", "code", "--prompt", draft.prompt]
+            if !draft.secondaryText.isBlank { args += ["--system", draft.secondaryText] }
+            args += ["--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature), "--top-p", format(draft.topP)]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.stream { args.append("--stream") }
+            if draft.force { args.append("--stats") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .textEmbed:
+            args = ["text", "embed", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.maxTokens > 0 { args += ["--max-tokens", String(draft.maxTokens)] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if draft.force { args.append("--pretty") }
+
+        case .textAnonymize:
+            args = ["text", "anonymize", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.maxTokens > 0 { args += ["--max-tokens", String(draft.maxTokens)] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if draft.all { args.append("--json") }
+            if draft.force { args.append("--pretty") }
+
+        case .speechSynthesize:
+            args = ["speech", "synthesize", draft.prompt, "--output", draft.outputPath]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.secondaryText.isBlank { args += ["--voice", draft.secondaryText] }
+            args += ["--temperature", format(draft.temperature)]
+            if draft.stream { args.append("--stream") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .speechTranscribe:
+            args = ["speech", "transcribe", draft.inputPath]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            args += ["--backend", draft.backend, "--task", draft.task, "--max-tokens", String(draft.maxTokens)]
+            if !draft.language.isBlank, draft.language != "auto" { args += ["--language", draft.language] }
+            if draft.stream { args.append("--stream") }
+            if !draft.timestamps { args.append("--no-timestamps") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .speechProfileList:
+            args = ["speech", "profile", "list"]
+
+        case .speechProfileCreate:
+            args = ["speech", "profile", "create", "--name", draft.prompt, "--audio", draft.inputPath]
+            if !draft.secondaryText.isBlank { args += ["--text", draft.secondaryText] }
+            if !draft.language.isBlank { args += ["--language", draft.language] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .speechProfileDelete:
+            args = ["speech", "profile", "delete", "--id", draft.prompt]
+
+        case .visionInspect:
+            args = ["vision", "inspect", draft.inputPath, draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            args += ["--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature), "--top-p", format(draft.topP)]
+
+        case .visionCaption:
+            args = ["vision", "caption", draft.inputPath]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.outputPath.isBlank { args += ["--output-dir", draft.outputPath] }
+            args += ["--prompt", draft.prompt, "--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature)]
+
+        case .visionOCR:
+            args = ["vision", "ocr", draft.inputPath, "--backend", draft.backend]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            args += ["--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature)]
+            if draft.all { args.append("--compare") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .visionGround:
+            args = ["vision", "ground", draft.inputPath, "--query", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+
+        case .visionSegment:
+            args = ["vision", "segment", draft.inputPath, "--prompt", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if draft.force { args.append("--show-boxes") }
+
+        case .visionTrack:
+            args = ["vision", "track", draft.inputPath, "--prompt", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if draft.force { args.append("--show-boxes") }
+
+        case .visionTrackLive:
+            args = ["vision", "track-live", "--prompt", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            args += ["--duration-seconds", format(draft.durationSeconds)]
+            if draft.force { args.append("--show-boxes") }
+
+        case .musicGenerate:
+            args = ["music", "generate", draft.prompt]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.secondaryText.isBlank { args += ["--lyrics", draft.secondaryText] }
+            args += ["--duration", format(draft.durationSeconds), "--steps", String(draft.steps)]
+            if !draft.seed.isBlank { args += ["--seed", draft.seed] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .videoGenerate:
+            args = ["video", "generate", draft.prompt]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            args += ["--variant", draft.variant, "--width", String(draft.width), "--height", String(draft.height)]
+            args += ["--num-frames", String(draft.numFrames), "--fps", String(draft.fps)]
+            if !draft.seed.isBlank { args += ["--seed", draft.seed] }
+            if !draft.inputPath.isBlank { args += ["--image", draft.inputPath, "--image-strength", format(draft.strength)] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .videoExportLatents:
+            args = ["video", "export-latents", draft.prompt]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            args += ["--width", String(draft.width), "--height", String(draft.height)]
+            args += ["--num-frames", String(draft.numFrames)]
+            if !draft.seed.isBlank { args += ["--seed", draft.seed] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .apiServe:
+            args = ["api", "serve", "--host", draft.host, "--port", String(draft.port), "--engine", draft.engine]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.apiKey.isBlank { args += ["--api-key", draft.apiKey] }
+
+        case .custom:
+            return ShellWords.split(draft.extraArguments)
+        }
+
+        let extra = ShellWords.split(draft.extraArguments)
+        if !extra.isEmpty {
+            args.append(contentsOf: extra)
+        }
+        return args
+    }
+
+    private static func defaultOutputDirectory(stem: String) -> URL {
+        outputRoot().appendingPathComponent(stem, isDirectory: true)
+    }
+
+    private static func defaultOutputURL(stem: String, extension ext: String) -> URL {
+        let stamp = DateFormatter.mereRunTimestamp.string(from: Date())
+        return outputRoot()
+            .appendingPathComponent("\(stem)-\(stamp)")
+            .appendingPathExtension(ext)
+    }
+
+    private static func outputRoot() -> URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MereRun", isDirectory: true)
+            .appendingPathComponent("App Outputs", isDirectory: true)
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.4g", value)
+    }
+}
+
+enum CommandCatalog {
+    static let templates: [CommandTemplate] = [
+        CommandTemplate(
+            id: .setup,
+            category: .setup,
+            title: "Setup path",
+            subtitle: "Plan or run guided, BYOA, or manual setup",
+            systemImage: "wand.and.stars"
+        ),
+        CommandTemplate(
+            id: .agentOnboard,
+            category: .setup,
+            title: "Agent onboarding",
+            subtitle: "Check local readiness and prepare Pi integration",
+            systemImage: "person.crop.circle.badge.gearshape",
+            defaultModel: "text-code-qwen3-coder"
+        ),
+        CommandTemplate(
+            id: .agentInstallPi,
+            category: .setup,
+            title: "Install Pi",
+            subtitle: "Install or replace the optional setup agent",
+            systemImage: "square.and.arrow.down"
+        ),
+        CommandTemplate(
+            id: .agentStart,
+            category: .setup,
+            title: "Start agent",
+            subtitle: "Launch a guided setup session",
+            systemImage: "terminal.fill",
+            promptLabel: "Prompt",
+            defaultPrompt: "Guide me through setting up mere.run on this machine. Start by summarizing what this Mac can run, then help me install only supported models."
+        ),
+        CommandTemplate(id: .modelList, category: .models, title: "List models", subtitle: "Installed and missing managed models", systemImage: "list.bullet.rectangle"),
+        CommandTemplate(id: .modelCapabilities, category: .models, title: "Capabilities", subtitle: "Hardware support and recommended pulls", systemImage: "memorychip"),
+        CommandTemplate(id: .modelPull, category: .models, title: "Pull model", subtitle: "Download a managed model", systemImage: "arrow.down.circle", defaultModel: "image-zimage-nano"),
+        CommandTemplate(id: .modelInfo, category: .models, title: "Model info", subtitle: "Manifest and validation report", systemImage: "info.circle", defaultModel: "image-zimage-max"),
+        CommandTemplate(id: .modelRemove, category: .models, title: "Remove model", subtitle: "Delete a local model install", systemImage: "trash", defaultModel: "image-zimage-nano"),
+        CommandTemplate(id: .modelRepairManifests, category: .models, title: "Repair manifests", subtitle: "Write missing known model manifests", systemImage: "wrench.and.screwdriver"),
+        CommandTemplate(
+            id: .imageGenerate,
+            category: .image,
+            title: "Generate image",
+            subtitle: "Text-to-image and image-to-image",
+            systemImage: "photo",
+            promptLabel: "Prompt",
+            secondaryLabel: "Negative prompt",
+            inputKind: .image,
+            outputKind: .file("png"),
+            defaultPrompt: "a ceramic coffee mug in soft morning light",
+            defaultModel: "image-zimage-max"
+        ),
+        CommandTemplate(
+            id: .imageValidate,
+            category: .image,
+            title: "Validate image stack",
+            subtitle: "Run deterministic image runtime checks",
+            systemImage: "checkmark.seal",
+            outputKind: .directory
+        ),
+        CommandTemplate(
+            id: .textChat,
+            category: .text,
+            title: "Chat",
+            subtitle: "Local chat models",
+            systemImage: "bubble.left.and.bubble.right",
+            promptLabel: "Prompt",
+            secondaryLabel: "System",
+            defaultPrompt: "Summarize diffusion models in one paragraph.",
+            defaultModel: "text-chat-gemma4"
+        ),
+        CommandTemplate(
+            id: .textCode,
+            category: .text,
+            title: "Code",
+            subtitle: "Local code generation",
+            systemImage: "chevron.left.forwardslash.chevron.right",
+            promptLabel: "Prompt",
+            secondaryLabel: "System",
+            defaultPrompt: "Write a tiny Swift function that formats byte counts.",
+            defaultModel: "text-code-qwen3-coder"
+        ),
+        CommandTemplate(
+            id: .textEmbed,
+            category: .text,
+            title: "Embeddings",
+            subtitle: "Generate JSON embedding vectors",
+            systemImage: "point.3.connected.trianglepath.dotted",
+            promptLabel: "Text",
+            outputKind: .file("json"),
+            defaultPrompt: "semantic search query",
+            defaultModel: "text-embed-qwen3-0.6b"
+        ),
+        CommandTemplate(
+            id: .textAnonymize,
+            category: .text,
+            title: "Anonymize",
+            subtitle: "Detect and redact PII",
+            systemImage: "eye.slash",
+            promptLabel: "Text",
+            outputKind: .file("txt"),
+            defaultPrompt: "My name is Alice Smith and my email is alice@example.com",
+            defaultModel: "text-anonymize-privacy-filter"
+        ),
+        CommandTemplate(
+            id: .speechSynthesize,
+            category: .speech,
+            title: "Synthesize",
+            subtitle: "Text to speech",
+            systemImage: "waveform",
+            promptLabel: "Text",
+            secondaryLabel: "Voice",
+            outputKind: .file("wav"),
+            defaultPrompt: "Hello from mere.run.",
+            defaultSecondaryText: "A calm female voice with clear pronunciation",
+            defaultModel: "speech-tts-qwen3-nano"
+        ),
+        CommandTemplate(
+            id: .speechTranscribe,
+            category: .speech,
+            title: "Transcribe",
+            subtitle: "Speech to text",
+            systemImage: "captions.bubble",
+            inputKind: .audio,
+            outputKind: .file("txt")
+        ),
+        CommandTemplate(id: .speechProfileList, category: .speech, title: "Voice profiles", subtitle: "List saved clone profiles", systemImage: "person.wave.2"),
+        CommandTemplate(
+            id: .speechProfileCreate,
+            category: .speech,
+            title: "Create voice profile",
+            subtitle: "Save reference audio for clone mode",
+            systemImage: "person.badge.plus",
+            promptLabel: "Profile name",
+            secondaryLabel: "Transcript override",
+            inputKind: .audio,
+            defaultPrompt: "Narration profile"
+        ),
+        CommandTemplate(
+            id: .speechProfileDelete,
+            category: .speech,
+            title: "Delete voice profile",
+            subtitle: "Remove a saved clone profile",
+            systemImage: "person.badge.minus",
+            promptLabel: "Profile UUID"
+        ),
+        CommandTemplate(
+            id: .visionInspect,
+            category: .vision,
+            title: "Inspect image",
+            subtitle: "Ask a VLM about an image",
+            systemImage: "eye",
+            promptLabel: "Question",
+            inputKind: .image,
+            defaultPrompt: "Describe this image."
+        ),
+        CommandTemplate(
+            id: .visionCaption,
+            category: .vision,
+            title: "Caption",
+            subtitle: "Write LoRA-friendly captions",
+            systemImage: "text.bubble",
+            promptLabel: "Instruction",
+            inputKind: .image,
+            outputKind: .directory,
+            defaultPrompt: "Write a short, concrete caption describing the image for LoRA training. Avoid fluff."
+        ),
+        CommandTemplate(
+            id: .visionOCR,
+            category: .vision,
+            title: "OCR",
+            subtitle: "Extract text from images",
+            systemImage: "doc.text.viewfinder",
+            inputKind: .image,
+            outputKind: .directory,
+            defaultModel: "vision-ocr-lighton"
+        ),
+        CommandTemplate(
+            id: .visionGround,
+            category: .vision,
+            title: "Ground objects",
+            subtitle: "Find prompted objects in an image",
+            systemImage: "scope",
+            promptLabel: "Query",
+            inputKind: .image,
+            outputKind: .file("png"),
+            defaultPrompt: "a person",
+            defaultModel: "vision-ground-falcon-perception"
+        ),
+        CommandTemplate(
+            id: .visionSegment,
+            category: .vision,
+            title: "Segment",
+            subtitle: "Segment prompted objects",
+            systemImage: "square.dashed",
+            promptLabel: "Prompt",
+            inputKind: .image,
+            outputKind: .file("png"),
+            defaultPrompt: "a person",
+            defaultModel: "vision-segment-sam31"
+        ),
+        CommandTemplate(
+            id: .visionTrack,
+            category: .vision,
+            title: "Track video",
+            subtitle: "Track prompted objects through a clip",
+            systemImage: "point.topleft.down.curvedto.point.bottomright.up",
+            promptLabel: "Prompt",
+            inputKind: .video,
+            outputKind: .file("mp4"),
+            defaultPrompt: "a person",
+            defaultModel: "vision-segment-sam31"
+        ),
+        CommandTemplate(
+            id: .visionTrackLive,
+            category: .vision,
+            title: "Track camera",
+            subtitle: "Capture then track from a camera",
+            systemImage: "video.badge.waveform",
+            promptLabel: "Prompt",
+            outputKind: .file("mp4"),
+            defaultPrompt: "a person",
+            defaultModel: "vision-segment-sam31"
+        ),
+        CommandTemplate(
+            id: .musicGenerate,
+            category: .media,
+            title: "Generate music",
+            subtitle: "ACE-Step music generation",
+            systemImage: "music.note",
+            promptLabel: "Caption",
+            secondaryLabel: "Lyrics",
+            outputKind: .file("wav"),
+            defaultPrompt: "upbeat electronic groove",
+            defaultModel: "music-acestep"
+        ),
+        CommandTemplate(
+            id: .videoGenerate,
+            category: .media,
+            title: "Generate video",
+            subtitle: "Native LTX video generation",
+            systemImage: "film",
+            promptLabel: "Prompt",
+            inputKind: .image,
+            outputKind: .file("mp4"),
+            defaultPrompt: "a cinematic drone flythrough over snowy mountains",
+            defaultModel: "video-ltx-av"
+        ),
+        CommandTemplate(
+            id: .videoExportLatents,
+            category: .media,
+            title: "Export video latents",
+            subtitle: "Write native LTX final latents",
+            systemImage: "shippingbox",
+            promptLabel: "Prompt",
+            outputKind: .file("safetensors"),
+            defaultPrompt: "a cinematic drone flythrough over snowy mountains",
+            defaultModel: "video-ltx-av"
+        ),
+        CommandTemplate(
+            id: .apiServe,
+            category: .server,
+            title: "API server",
+            subtitle: "OpenAI-compatible local server",
+            systemImage: "network",
+            defaultModel: "text-chat-gemma4"
+        ),
+        CommandTemplate(
+            id: .custom,
+            category: .custom,
+            title: "Raw arguments",
+            subtitle: "Run any mere.run command",
+            systemImage: "terminal",
+            defaultExtraArguments: "--help"
+        ),
+    ]
+
+    static func templates(in category: CommandCategory) -> [CommandTemplate] {
+        templates.filter { $0.category == category }
+    }
+
+    static func template(id: CommandTemplateID) -> CommandTemplate? {
+        templates.first { $0.id == id }
+    }
+}
+
+enum ShellWords {
+    static func split(_ raw: String) -> [String] {
+        var words: [String] = []
+        var current = ""
+        var quote: Character?
+        var escaping = false
+
+        for char in raw {
+            if escaping {
+                current.append(char)
+                escaping = false
+                continue
+            }
+
+            if char == "\\" {
+                escaping = true
+                continue
+            }
+
+            if let activeQuote = quote {
+                if char == activeQuote {
+                    quote = nil
+                } else {
+                    current.append(char)
+                }
+                continue
+            }
+
+            if char == "\"" || char == "'" {
+                quote = char
+                continue
+            }
+
+            if char.isWhitespace {
+                if !current.isEmpty {
+                    words.append(current)
+                    current.removeAll(keepingCapacity: true)
+                }
+                continue
+            }
+
+            current.append(char)
+        }
+
+        if escaping {
+            current.append("\\")
+        }
+        if !current.isEmpty {
+            words.append(current)
+        }
+        return words
+    }
+}
+
+extension String {
+    var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+extension DateFormatter {
+    static let mereRunTimestamp: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter
+    }()
+}

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -179,9 +179,12 @@ struct CommandTemplate: Identifiable, Equatable {
         draft.extraArguments = defaultExtraArguments
 
         switch id {
+        case .textChat:
+            draft.stream = true
         case .textCode:
             draft.temperature = 1.0
             draft.topP = 0.95
+            draft.stream = true
         case .visionCaption, .visionOCR:
             draft.maxTokens = id == .visionCaption ? 96 : 4096
             draft.temperature = id == .visionCaption ? 0.2 : 0.2
@@ -353,6 +356,7 @@ struct CommandTemplate: Identifiable, Equatable {
             if !draft.secondaryText.isBlank { args += ["--system", draft.secondaryText] }
             args += ["--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature), "--top-p", format(draft.topP)]
             if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.stream { args.append("--stream") }
             if draft.all { args.append("--thinking") }
             if draft.force { args.append("--stats") }
             if draft.quiet { args.append("--quiet") }
@@ -535,7 +539,7 @@ enum CommandCatalog {
             title: "Agent onboarding",
             subtitle: "Check local readiness and prepare Pi integration",
             systemImage: "person.crop.circle.badge.gearshape",
-            defaultModel: "text-code-qwen3-coder"
+            defaultModel: "text-code-qwen3"
         ),
         CommandTemplate(
             id: .agentInstallPi,
@@ -600,7 +604,7 @@ enum CommandCatalog {
             promptLabel: "Prompt",
             secondaryLabel: "System",
             defaultPrompt: "Write a tiny Swift function that formats byte counts.",
-            defaultModel: "text-code-qwen3-coder"
+            defaultModel: "text-code-qwen3"
         ),
         CommandTemplate(
             id: .textEmbed,

--- a/Sources/MereRunApp/MereRunApp.swift
+++ b/Sources/MereRunApp/MereRunApp.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+@main
+struct MereRunApp: App {
+    @StateObject private var controller = MereRunController()
+
+    var body: some Scene {
+        WindowGroup {
+            MereRunRootView()
+                .environmentObject(controller)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowToolbarStyle(.unified(showsTitle: false))
+        .defaultSize(width: 1280, height: 820)
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("Stop") {
+                    controller.cancel()
+                }
+                .keyboardShortcut(".", modifiers: .command)
+                .disabled(!controller.isRunning)
+            }
+        }
+
+        Settings {
+            MereRunSettingsView()
+                .environmentObject(controller)
+                .frame(width: 560)
+        }
+    }
+}

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -80,8 +80,8 @@ enum CLIResolver {
         let roots = packageRootCandidates(fileManager: fm)
         let candidates = bundledCandidates()
             + siblingCandidates()
-            + installedCandidates()
             + buildProductCandidates(packageRoots: roots)
+            + installedCandidates()
 
         for candidate in candidates {
             if fm.isExecutableFile(atPath: candidate.path) {
@@ -123,10 +123,10 @@ enum CLIResolver {
     private static func buildProductCandidates(packageRoots: [URL]) -> [URL] {
         packageRoots.flatMap { root in
             [
-                ".build/arm64-apple-macosx/release/mere.run",
                 ".build/arm64-apple-macosx/debug/mere.run",
-                ".build/release/mere.run",
+                ".build/arm64-apple-macosx/release/mere.run",
                 ".build/debug/mere.run",
+                ".build/release/mere.run",
             ].map { root.appendingPathComponent($0) }
         }
     }
@@ -283,6 +283,7 @@ struct MereRunRunResult: Identifiable, Equatable {
     let commandPreview: String
     let exitCode: Int32
     let outputURL: URL?
+    let outputText: String?
     let completedAt = Date()
 }
 
@@ -310,6 +311,7 @@ final class MereRunController: ObservableObject {
     @Published var workingDirectory: String {
         didSet { UserDefaults.standard.set(workingDirectory, forKey: Keys.workingDirectory) }
     }
+    @Published private(set) var liveOutputText = ""
 
     private enum Keys {
         static let cliPath = "mererun.app.cliPath"
@@ -436,6 +438,7 @@ final class MereRunController: ObservableObject {
 
         logs.removeAll()
         stdoutBuffer.removeAll(keepingCapacity: true)
+        liveOutputText = ""
         lastOutputURL = nil
         lastExitCode = nil
 
@@ -476,7 +479,8 @@ final class MereRunController: ObservableObject {
                     templateID: activeRunTemplateID,
                     commandPreview: activeRunPreview,
                     exitCode: -1,
-                    outputURL: nil
+                    outputURL: nil,
+                    outputText: capturedStdoutText()
                 )
             }
             activeRunTemplateID = nil
@@ -507,6 +511,7 @@ final class MereRunController: ObservableObject {
         lastExitCode = exitCode
 
         let detectedOutput = detectOutputURL(expected: expectedOutput, stdout: stdoutBuffer)
+        let outputText = capturedStdoutText()
         lastOutputURL = detectedOutput
 
         if exitCode == 0 {
@@ -522,7 +527,8 @@ final class MereRunController: ObservableObject {
                 templateID: activeRunTemplateID,
                 commandPreview: activeRunPreview,
                 exitCode: exitCode,
-                outputURL: detectedOutput
+                outputURL: detectedOutput,
+                outputText: outputText
             )
         }
         activeRunTemplateID = nil
@@ -533,6 +539,7 @@ final class MereRunController: ObservableObject {
         if stream == .stdout {
             stdoutBuffer += text
             trimStdoutBuffer()
+            liveOutputText = stdoutBuffer.replacingOccurrences(of: "\0", with: "")
         }
 
         let normalized = text
@@ -553,6 +560,13 @@ final class MereRunController: ObservableObject {
     private func trimStdoutBuffer() {
         guard stdoutBuffer.utf8.count > Self.stdoutBufferByteLimit else { return }
         stdoutBuffer = String(decoding: stdoutBuffer.utf8.suffix(Self.stdoutBufferByteLimit), as: UTF8.self)
+    }
+
+    private func capturedStdoutText() -> String? {
+        let trimmed = stdoutBuffer
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func expectedOutputURL() -> URL? {

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -1,0 +1,689 @@
+import AppKit
+import Foundation
+
+enum LogStream {
+    case system
+    case stdout
+    case stderr
+
+    var label: String {
+        switch self {
+        case .system: return "mere"
+        case .stdout: return "out"
+        case .stderr: return "err"
+        }
+    }
+}
+
+struct LogLine: Identifiable, Equatable {
+    let id = UUID()
+    let date = Date()
+    let stream: LogStream
+    let text: String
+}
+
+enum MereRunLaunch: Equatable {
+    case executable(URL)
+    case swiftRun(packagePath: URL)
+
+    var executableURL: URL {
+        switch self {
+        case .executable(let url):
+            return url
+        case .swiftRun:
+            return URL(fileURLWithPath: "/usr/bin/swift")
+        }
+    }
+
+    var sourceDescription: String {
+        switch self {
+        case .executable(let url):
+            if Bundle.main.resourceURL.map({ url.path.hasPrefix($0.path) }) == true {
+                return "Bundled CLI"
+            }
+            return url.path
+        case .swiftRun(let packagePath):
+            return "swift run --package-path \(packagePath.path)"
+        }
+    }
+
+    func processArguments(for cliArguments: [String]) -> [String] {
+        switch self {
+        case .executable:
+            return cliArguments
+        case .swiftRun(let packagePath):
+            return ["run", "--package-path", packagePath.path, "mere.run"] + cliArguments
+        }
+    }
+
+    func displayCommand(for cliArguments: [String]) -> String {
+        switch self {
+        case .executable(let url):
+            if url.path == "/usr/bin/env" {
+                return (["/usr/bin/env", "mere.run"] + cliArguments).shellQuoted()
+            }
+            return ([url.path] + cliArguments).shellQuoted()
+        case .swiftRun(let packagePath):
+            return (["swift", "run", "--package-path", packagePath.path, "mere.run"] + cliArguments).shellQuoted()
+        }
+    }
+}
+
+enum CLIResolver {
+    static func resolve(customPath: String) -> MereRunLaunch {
+        let fm = FileManager.default
+        let expandedCustomPath = NSString(string: customPath).expandingTildeInPath
+        if !expandedCustomPath.isBlank, fm.isExecutableFile(atPath: expandedCustomPath) {
+            return .executable(URL(fileURLWithPath: expandedCustomPath))
+        }
+
+        let roots = packageRootCandidates(fileManager: fm)
+        let candidates = bundledCandidates()
+            + siblingCandidates()
+            + installedCandidates()
+            + buildProductCandidates(packageRoots: roots)
+
+        for candidate in candidates {
+            if fm.isExecutableFile(atPath: candidate.path) {
+                return .executable(candidate)
+            }
+        }
+
+        if let packageRoot = roots.first {
+            return .swiftRun(packagePath: packageRoot)
+        }
+
+        return .executable(URL(fileURLWithPath: "/usr/bin/env"))
+    }
+
+    private static func bundledCandidates() -> [URL] {
+        let resourceURL = Bundle.main.resourceURL
+        return [
+            resourceURL?.appendingPathComponent("mere.run/mere.run"),
+            resourceURL?.appendingPathComponent("mere.run"),
+        ].compactMap { $0 }
+    }
+
+    private static func siblingCandidates() -> [URL] {
+        guard let executableURL = Bundle.main.executableURL else {
+            return []
+        }
+        return [
+            executableURL.deletingLastPathComponent().appendingPathComponent("mere.run")
+        ]
+    }
+
+    private static func installedCandidates() -> [URL] {
+        [
+            "/usr/local/bin/mere.run",
+            "/opt/homebrew/bin/mere.run",
+        ].map(URL.init(fileURLWithPath:))
+    }
+
+    private static func buildProductCandidates(packageRoots: [URL]) -> [URL] {
+        packageRoots.flatMap { root in
+            [
+                ".build/arm64-apple-macosx/release/mere.run",
+                ".build/arm64-apple-macosx/debug/mere.run",
+                ".build/release/mere.run",
+                ".build/debug/mere.run",
+            ].map { root.appendingPathComponent($0) }
+        }
+    }
+
+    private static func packageRootCandidates(fileManager fm: FileManager) -> [URL] {
+        let anchors: [URL] = [
+            URL(fileURLWithPath: fm.currentDirectoryPath, isDirectory: true),
+            Bundle.main.executableURL?.deletingLastPathComponent(),
+            Bundle.main.resourceURL,
+        ].compactMap { $0 }
+
+        var roots: [URL] = []
+        var seen: Set<String> = []
+        for anchor in anchors {
+            guard let root = nearestPackageRoot(from: anchor, fileManager: fm) else {
+                continue
+            }
+            let path = root.standardizedFileURL.path
+            if seen.insert(path).inserted {
+                roots.append(root)
+            }
+        }
+        return roots
+    }
+
+    private static func nearestPackageRoot(from anchor: URL, fileManager fm: FileManager) -> URL? {
+        var cursor = anchor.standardizedFileURL
+        while true {
+            if fm.fileExists(atPath: cursor.appendingPathComponent("Package.swift").path) {
+                return cursor
+            }
+            let parent = cursor.deletingLastPathComponent()
+            if parent.path == cursor.path {
+                return nil
+            }
+            cursor = parent
+        }
+    }
+}
+
+struct MereRunProcessConfiguration: Equatable {
+    let executableURL: URL
+    let arguments: [String]
+    let currentDirectoryURL: URL
+    let environment: [String: String]
+}
+
+protocol MereRunRunningProcess: AnyObject {
+    func terminate()
+}
+
+protocol MereRunProcessRunning: AnyObject {
+    func start(
+        configuration: MereRunProcessConfiguration,
+        stdout: @escaping @Sendable (String) -> Void,
+        stderr: @escaping @Sendable (String) -> Void,
+        termination: @escaping @Sendable (Int32) -> Void
+    ) throws -> MereRunRunningProcess
+}
+
+private final class FoundationRunningProcess: MereRunRunningProcess, @unchecked Sendable {
+    private let process: Process
+    private let stdoutPipe: Pipe
+    private let stderrPipe: Pipe
+
+    init(process: Process, stdoutPipe: Pipe, stderrPipe: Pipe) {
+        self.process = process
+        self.stdoutPipe = stdoutPipe
+        self.stderrPipe = stderrPipe
+    }
+
+    func terminate() {
+        process.terminate()
+    }
+
+    func cleanup() {
+        stdoutPipe.fileHandleForReading.readabilityHandler = nil
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+    }
+
+    func waitUntilExit() -> Int32 {
+        process.waitUntilExit()
+        cleanup()
+        return process.terminationStatus
+    }
+}
+
+private final class FoundationMereRunProcessRunner: MereRunProcessRunning {
+    func start(
+        configuration: MereRunProcessConfiguration,
+        stdout: @escaping @Sendable (String) -> Void,
+        stderr: @escaping @Sendable (String) -> Void,
+        termination: @escaping @Sendable (Int32) -> Void
+    ) throws -> MereRunRunningProcess {
+        let process = Process()
+        process.executableURL = configuration.executableURL
+        process.arguments = configuration.arguments
+        process.currentDirectoryURL = configuration.currentDirectoryURL
+        process.environment = configuration.environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let runningProcess = FoundationRunningProcess(
+            process: process,
+            stdoutPipe: stdoutPipe,
+            stderrPipe: stderrPipe
+        )
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            stdout(text)
+        }
+
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            stderr(text)
+        }
+
+        try process.run()
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            termination(runningProcess.waitUntilExit())
+        }
+
+        return runningProcess
+    }
+}
+
+private final class ReadinessOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = ""
+
+    func append(_ text: String) {
+        lock.lock()
+        value += text
+        lock.unlock()
+    }
+
+    func text() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+struct MereRunRunResult: Identifiable, Equatable {
+    let id = UUID()
+    let templateID: CommandTemplateID
+    let commandPreview: String
+    let exitCode: Int32
+    let outputURL: URL?
+    let completedAt = Date()
+}
+
+@MainActor
+final class MereRunController: ObservableObject {
+    @Published var selectedTemplate: CommandTemplate
+    @Published var draft: CommandDraft
+    @Published var logs: [LogLine] = []
+    @Published var isRunning = false
+    @Published var status = "Idle"
+    @Published var lastExitCode: Int32?
+    @Published var resolvedCLI = ""
+    @Published var lastOutputURL: URL?
+    @Published var lastRunResult: MereRunRunResult?
+    @Published var readinessByMode: [StudioMode: ModelReadinessState] = [:]
+    @Published var cliPath: String {
+        didSet { UserDefaults.standard.set(cliPath, forKey: Keys.cliPath) }
+    }
+    @Published var modelsRoot: String {
+        didSet { UserDefaults.standard.set(modelsRoot, forKey: Keys.modelsRoot) }
+    }
+    @Published var hubCache: String {
+        didSet { UserDefaults.standard.set(hubCache, forKey: Keys.hubCache) }
+    }
+    @Published var workingDirectory: String {
+        didSet { UserDefaults.standard.set(workingDirectory, forKey: Keys.workingDirectory) }
+    }
+
+    private enum Keys {
+        static let cliPath = "mererun.app.cliPath"
+        static let modelsRoot = "mererun.app.modelsRoot"
+        static let hubCache = "mererun.app.hubCache"
+        static let workingDirectory = "mererun.app.workingDirectory"
+    }
+
+    private let processRunner: MereRunProcessRunning
+    private var currentProcess: MereRunRunningProcess?
+    private var stdoutBuffer = ""
+    private var activeRunTemplateID: CommandTemplateID?
+    private var activeRunPreview = ""
+
+    private static let stdoutBufferByteLimit = 32 * 1024
+    private static let outputDetectionLineLimit = 40
+
+    var commandArguments: [String] {
+        commandArguments(template: selectedTemplate, draft: draft)
+    }
+
+    var commandPreview: String {
+        commandPreview(template: selectedTemplate, draft: draft, masksSecrets: true)
+    }
+
+    var advancedCommandPreview: String {
+        commandPreview(template: selectedTemplate, draft: draft, masksSecrets: false)
+    }
+
+    init(processRunner: MereRunProcessRunning = FoundationMereRunProcessRunner()) {
+        self.processRunner = processRunner
+        let initial = CommandCatalog.templates.first!
+        selectedTemplate = initial
+        draft = initial.defaultDraft()
+        cliPath = UserDefaults.standard.string(forKey: Keys.cliPath) ?? ""
+        modelsRoot = UserDefaults.standard.string(forKey: Keys.modelsRoot) ?? ""
+        hubCache = UserDefaults.standard.string(forKey: Keys.hubCache) ?? ""
+        workingDirectory = UserDefaults.standard.string(forKey: Keys.workingDirectory) ?? FileManager.default.homeDirectoryForCurrentUser.path
+        refreshResolvedCLI()
+    }
+
+    func select(_ template: CommandTemplate) {
+        selectedTemplate = template
+        draft = template.defaultDraft()
+        lastOutputURL = nil
+        lastExitCode = nil
+        status = "Idle"
+    }
+
+    func refreshResolvedCLI() {
+        resolvedCLI = CLIResolver.resolve(customPath: cliPath).sourceDescription
+    }
+
+    func commandArguments(template: CommandTemplate, draft: CommandDraft) -> [String] {
+        var args: [String] = []
+        if !modelsRoot.isBlank {
+            args += ["--models-root", NSString(string: modelsRoot).expandingTildeInPath]
+        }
+        args += template.arguments(from: draft)
+        return args
+    }
+
+    func commandPreview(template: CommandTemplate, draft: CommandDraft, masksSecrets: Bool) -> String {
+        let launch = CLIResolver.resolve(customPath: cliPath)
+        let args = commandArguments(template: template, draft: draft)
+        return launch.displayCommand(for: masksSecrets ? args.maskingSecrets() : args)
+    }
+
+    func run(studio request: StudioRunRequest) {
+        selectedTemplate = request.template
+        draft = request.draft
+        run()
+    }
+
+    func checkReadiness(for mode: StudioMode, draft studioDraft: StudioDraft) {
+        let modelID = StudioCommandAdapter.requiredModel(for: mode, draft: studioDraft)
+        guard !modelID.isBlank else {
+            readinessByMode[mode] = .ready
+            return
+        }
+
+        readinessByMode[mode] = .checking
+        let launch = CLIResolver.resolve(customPath: cliPath)
+        let args = commandArguments(
+            template: CommandCatalog.template(id: .modelList) ?? selectedTemplate,
+            draft: CommandCatalog.template(id: .modelList)?.defaultDraft() ?? CommandDraft()
+        )
+        let output = ReadinessOutputBuffer()
+
+        do {
+            _ = try processRunner.start(
+                configuration: processConfiguration(launch: launch, args: args),
+                stdout: { text in output.append(text) },
+                stderr: { _ in },
+                termination: { [weak self] _ in
+                    Task { @MainActor in
+                        self?.readinessByMode[mode] = ModelReadinessParser.state(
+                            for: modelID,
+                            modelListOutput: output.text()
+                        )
+                    }
+                }
+            )
+        } catch {
+            readinessByMode[mode] = .unknown(error.localizedDescription)
+        }
+    }
+
+    func run() {
+        guard !isRunning else { return }
+        refreshResolvedCLI()
+
+        if let message = selectedTemplate.validationMessage(for: draft) {
+            append(message, stream: .system)
+            status = message
+            lastExitCode = nil
+            return
+        }
+
+        let launch = CLIResolver.resolve(customPath: cliPath)
+        let args = commandArguments
+        let display = launch.displayCommand(for: args)
+        let expectedOutput = expectedOutputURL()
+
+        logs.removeAll()
+        stdoutBuffer.removeAll(keepingCapacity: true)
+        lastOutputURL = nil
+        lastExitCode = nil
+
+        guard prepareOutputLocation() else { return }
+
+        status = "Running"
+        isRunning = true
+        activeRunTemplateID = selectedTemplate.id
+        activeRunPreview = display
+
+        append(display, stream: .system)
+
+        do {
+            currentProcess = try processRunner.start(
+                configuration: processConfiguration(launch: launch, args: args),
+                stdout: { [weak self] text in
+                    Task { @MainActor in
+                        self?.append(text, stream: .stdout)
+                    }
+                },
+                stderr: { [weak self] text in
+                    Task { @MainActor in
+                        self?.append(text, stream: .stderr)
+                    }
+                },
+                termination: { [weak self] code in
+                    Task { @MainActor in
+                        self?.finishRun(exitCode: code, expectedOutput: expectedOutput)
+                    }
+                }
+            )
+        } catch {
+            isRunning = false
+            status = "Failed to start"
+            append(error.localizedDescription, stream: .stderr)
+            if let activeRunTemplateID {
+                lastRunResult = MereRunRunResult(
+                    templateID: activeRunTemplateID,
+                    commandPreview: activeRunPreview,
+                    exitCode: -1,
+                    outputURL: nil
+                )
+            }
+            activeRunTemplateID = nil
+            activeRunPreview = ""
+            return
+        }
+    }
+
+    func cancel() {
+        guard isRunning else { return }
+        currentProcess?.terminate()
+        append("Termination requested.", stream: .system)
+    }
+
+    func openLastOutput() {
+        guard let lastOutputURL else { return }
+        NSWorkspace.shared.open(lastOutputURL)
+    }
+
+    func revealLastOutput() {
+        guard let lastOutputURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([lastOutputURL])
+    }
+
+    private func finishRun(exitCode: Int32, expectedOutput: URL?) {
+        currentProcess = nil
+        isRunning = false
+        lastExitCode = exitCode
+
+        let detectedOutput = detectOutputURL(expected: expectedOutput, stdout: stdoutBuffer)
+        lastOutputURL = detectedOutput
+
+        if exitCode == 0 {
+            status = detectedOutput == nil ? "Completed" : "Completed: \(detectedOutput!.lastPathComponent)"
+            append("Completed with exit code 0.", stream: .system)
+        } else {
+            status = "Exited \(exitCode)"
+            append("Exited with code \(exitCode).", stream: .system)
+        }
+
+        if let activeRunTemplateID {
+            lastRunResult = MereRunRunResult(
+                templateID: activeRunTemplateID,
+                commandPreview: activeRunPreview,
+                exitCode: exitCode,
+                outputURL: detectedOutput
+            )
+        }
+        activeRunTemplateID = nil
+        activeRunPreview = ""
+    }
+
+    private func append(_ text: String, stream: LogStream) {
+        if stream == .stdout {
+            stdoutBuffer += text
+            trimStdoutBuffer()
+        }
+
+        let normalized = text
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: .newlines)
+
+        for line in normalized {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            logs.append(LogLine(stream: stream, text: trimmed))
+        }
+
+        if logs.count > 1200 {
+            logs.removeFirst(logs.count - 1200)
+        }
+    }
+
+    private func trimStdoutBuffer() {
+        guard stdoutBuffer.utf8.count > Self.stdoutBufferByteLimit else { return }
+        stdoutBuffer = String(decoding: stdoutBuffer.utf8.suffix(Self.stdoutBufferByteLimit), as: UTF8.self)
+    }
+
+    private func expectedOutputURL() -> URL? {
+        guard selectedTemplate.outputKind.isFile, !draft.outputPath.isBlank else {
+            return nil
+        }
+        return URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
+    }
+
+    private func prepareOutputLocation() -> Bool {
+        guard !draft.outputPath.isBlank else {
+            return true
+        }
+
+        let outputURL = URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
+        let directoryURL: URL
+        switch selectedTemplate.outputKind {
+        case .file:
+            directoryURL = outputURL.deletingLastPathComponent()
+        case .directory:
+            directoryURL = outputURL
+        case .none:
+            return true
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            return true
+        } catch {
+            status = "Output path unavailable"
+            append("Could not create output directory \(directoryURL.path): \(error.localizedDescription)", stream: .stderr)
+            return false
+        }
+    }
+
+    private func detectOutputURL(expected: URL?, stdout: String) -> URL? {
+        let fm = FileManager.default
+        if let expected, fm.fileExists(atPath: expected.path) {
+            return expected
+        }
+
+        let candidates = stdout
+            .components(separatedBy: .newlines)
+            .compactMap { line -> String? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            .suffix(Self.outputDetectionLineLimit)
+            .reversed()
+
+        for candidate in candidates {
+            let expanded = NSString(string: candidate).expandingTildeInPath
+            if fm.fileExists(atPath: expanded) {
+                return URL(fileURLWithPath: expanded)
+            }
+        }
+
+        return nil
+    }
+
+    private func processEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+            env["PATH"] ?? "",
+        ].joined(separator: ":")
+        if !modelsRoot.isBlank {
+            env["MERERUN_MODELS_DIR"] = NSString(string: modelsRoot).expandingTildeInPath
+        }
+        if !hubCache.isBlank {
+            env["MERERUN_HUB_CACHE"] = NSString(string: hubCache).expandingTildeInPath
+        }
+        return env
+    }
+
+    private func processConfiguration(launch: MereRunLaunch, args: [String]) -> MereRunProcessConfiguration {
+        let processArgs: [String]
+        if case .executable(let url) = launch, url.path == "/usr/bin/env" {
+            processArgs = ["mere.run"] + args
+        } else {
+            processArgs = launch.processArguments(for: args)
+        }
+
+        return MereRunProcessConfiguration(
+            executableURL: launch.executableURL,
+            arguments: processArgs,
+            currentDirectoryURL: workingDirectoryURL(),
+            environment: processEnvironment()
+        )
+    }
+
+    private func workingDirectoryURL() -> URL {
+        let expanded = NSString(string: workingDirectory).expandingTildeInPath
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: expanded, isDirectory: &isDirectory), isDirectory.boolValue {
+            return URL(fileURLWithPath: expanded, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+    }
+}
+
+extension Array where Element == String {
+    func maskingSecrets() -> [String] {
+        var masked = self
+        var index = masked.startIndex
+        while index < masked.endIndex {
+            if masked[index] == "--api-key" {
+                let valueIndex = masked.index(after: index)
+                if valueIndex < masked.endIndex {
+                    masked[valueIndex] = "••••••••"
+                }
+            }
+            index = masked.index(after: index)
+        }
+        return masked
+    }
+
+    func shellQuoted() -> String {
+        map { arg in
+            if arg.isEmpty { return "''" }
+            let safe = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_+-=.,/:@%")
+            if arg.unicodeScalars.allSatisfy({ safe.contains($0) }) {
+                return arg
+            }
+            return "'" + arg.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+        .joined(separator: " ")
+    }
+}

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -1,0 +1,1077 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct MereRunRootView: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        StudioRootView()
+            .background(MereRunTheme.background.ignoresSafeArea())
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .onAppear {
+                controller.refreshResolvedCLI()
+            }
+    }
+}
+
+struct AdvancedControlSurface: View {
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 0) {
+                CommandSidebar()
+                    .frame(width: 268)
+
+                Divider()
+                    .overlay(MereRunTheme.border.opacity(0.6))
+
+                CommandEditor()
+                    .frame(width: 500)
+
+                Divider()
+                    .overlay(MereRunTheme.border.opacity(0.6))
+
+                RunConsole()
+                    .frame(width: 440)
+            }
+            .frame(width: 1_210)
+        }
+        .background(MereRunTheme.background.ignoresSafeArea())
+        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+}
+
+private struct CommandSidebar: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("mere.run")
+                    .font(.system(size: 24, weight: .semibold))
+                Text("local control surface")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .padding(.horizontal, 18)
+            .padding(.top, 22)
+            .padding(.bottom, 18)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    ForEach(CommandCategory.allCases) { category in
+                        let templates = CommandCatalog.templates(in: category)
+                        if !templates.isEmpty {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(category.rawValue.uppercased())
+                                    .font(MereRunTheme.sectionFont)
+                                    .foregroundStyle(MereRunTheme.textMuted)
+                                    .padding(.horizontal, 18)
+
+                                ForEach(templates) { template in
+                                    CommandRow(
+                                        template: template,
+                                        isSelected: template.id == controller.selectedTemplate.id
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 18)
+            }
+
+            Divider()
+                .overlay(MereRunTheme.border.opacity(0.6))
+
+            VStack(alignment: .leading, spacing: 8) {
+                Label(controller.resolvedCLI, systemImage: "terminal")
+                    .lineLimit(2)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textSecondary)
+
+                HStack {
+                    Circle()
+                        .fill(controller.isRunning ? MereRunTheme.yellow : statusColor)
+                        .frame(width: 8, height: 8)
+                    Text(controller.status)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    Spacer()
+                }
+            }
+            .padding(18)
+        }
+        .background(MereRunTheme.background)
+    }
+
+    private var statusColor: Color {
+        guard let exitCode = controller.lastExitCode else { return MereRunTheme.green }
+        return exitCode == 0 ? MereRunTheme.green : MereRunTheme.red
+    }
+}
+
+private struct CommandRow: View {
+    @EnvironmentObject private var controller: MereRunController
+    let template: CommandTemplate
+    let isSelected: Bool
+
+    var body: some View {
+        Button {
+            controller.select(template)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: template.systemImage)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(isSelected ? MereRunTheme.background : MereRunTheme.accent)
+                    .frame(width: 22)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(template.title)
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(template.subtitle)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(isSelected ? MereRunTheme.background.opacity(0.72) : MereRunTheme.textMuted)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(isSelected ? MereRunTheme.background : MereRunTheme.textPrimary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .background {
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(isSelected ? MereRunTheme.accent : Color.clear)
+            }
+            .padding(.horizontal, 10)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct CommandEditor: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                header
+                commandPreview
+                templateFields
+                runtimeFields
+                actionRow
+            }
+            .padding(22)
+        }
+        .background(MereRunTheme.background)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: controller.selectedTemplate.systemImage)
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+                .frame(width: 38, height: 38)
+                .background {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(MereRunTheme.surfaceRaised)
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(controller.selectedTemplate.title)
+                    .font(MereRunTheme.titleFont)
+                Text(controller.selectedTemplate.subtitle)
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textSecondary)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var commandPreview: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("COMMAND")
+                .font(MereRunTheme.sectionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+            Text(controller.advancedCommandPreview)
+                .font(MereRunTheme.monoFont)
+                .textSelection(.enabled)
+                .lineLimit(5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .merePanel()
+        }
+    }
+
+    @ViewBuilder
+    private var templateFields: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if let promptLabel = controller.selectedTemplate.promptLabel {
+                EditorSection(promptLabel) {
+                    TextEditor(text: $controller.draft.prompt)
+                        .font(MereRunTheme.bodyFont)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 88)
+                        .padding(8)
+                        .merePanel()
+                }
+            }
+
+            if let secondaryLabel = controller.selectedTemplate.secondaryLabel {
+                EditorSection(secondaryLabel) {
+                    TextEditor(text: $controller.draft.secondaryText)
+                        .font(MereRunTheme.bodyFont)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: secondaryLabel == "Lyrics" ? 88 : 58)
+                        .padding(8)
+                        .merePanel()
+                }
+            }
+
+            if controller.selectedTemplate.inputKind != .none {
+                EditorSection(controller.selectedTemplate.inputKind.title) {
+                    PathField(
+                        path: $controller.draft.inputPath,
+                        placeholder: "Choose \(controller.selectedTemplate.inputKind.title.lowercased())",
+                        mode: .openFile(controller.selectedTemplate.inputKind.allowedTypes)
+                    )
+                }
+            }
+
+            if controller.selectedTemplate.outputKind != .none {
+                EditorSection(outputLabel) {
+                    PathField(
+                        path: $controller.draft.outputPath,
+                        placeholder: outputLabel,
+                        mode: controller.selectedTemplate.outputKind == .directory ? .openDirectory : .saveFile
+                    )
+                }
+            }
+
+            if showsModelField {
+                EditorSection("Model") {
+                    TextField("Managed model id or local path", text: $controller.draft.model)
+                        .textFieldStyle(.plain)
+                        .font(MereRunTheme.bodyFont)
+                        .padding(10)
+                        .merePanel()
+                }
+            }
+
+            parameterFields
+        }
+    }
+
+    @ViewBuilder
+    private var parameterFields: some View {
+        switch controller.selectedTemplate.id {
+        case .imageGenerate:
+            DimensionsGrid()
+            GenerationOptions()
+        case .imageValidate:
+            ImageValidationOptions()
+        case .textChat, .textCode, .textEmbed, .textAnonymize, .visionInspect, .visionCaption, .visionOCR:
+            TextGenerationOptions()
+        case .speechSynthesize:
+            SpeechOptions()
+        case .speechTranscribe:
+            SpeechTranscribeOptions()
+        case .speechProfileCreate:
+            SpeechProfileCreateOptions()
+        case .visionSegment, .visionTrack, .visionTrackLive:
+            VisionTrackingOptions()
+        case .musicGenerate:
+            MusicOptions()
+        case .videoGenerate:
+            DimensionsGrid()
+            VideoOptions()
+        case .videoExportLatents:
+            DimensionsGrid()
+            VideoLatentsOptions()
+        case .apiServe:
+            APIOptions()
+        case .setup:
+            SetupOptions()
+        case .agentOnboard:
+            AgentOptions()
+        case .agentInstallPi:
+            AgentInstallOptions()
+        case .agentStart:
+            AgentStartOptions()
+        case .modelPull:
+            ModelPullOptions()
+        case .modelRemove, .modelRepairManifests:
+            ModelMaintenanceOptions()
+        case .modelCapabilities, .modelInfo:
+            ModelInspectionOptions()
+        default:
+            EmptyView()
+        }
+
+        if controller.selectedTemplate.id != .custom {
+            EditorSection("Extra arguments") {
+                TextField("--flag value", text: $controller.draft.extraArguments)
+                    .textFieldStyle(.plain)
+                    .font(MereRunTheme.monoFont)
+                    .padding(10)
+                    .merePanel()
+            }
+        } else {
+            EditorSection("Arguments") {
+                TextEditor(text: $controller.draft.extraArguments)
+                    .font(MereRunTheme.monoFont)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 150)
+                    .padding(8)
+                    .merePanel()
+            }
+        }
+    }
+
+    private var runtimeFields: some View {
+        EditorSection("Runtime") {
+            VStack(spacing: 10) {
+                PathField(path: $controller.cliPath, placeholder: "Auto-detect mere.run", mode: .openFile([.unixExecutable, .item]))
+                PathField(path: $controller.modelsRoot, placeholder: "Optional models root", mode: .openDirectory)
+                PathField(path: $controller.workingDirectory, placeholder: "Working directory", mode: .openDirectory)
+            }
+        }
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 10) {
+            Button {
+                controller.run()
+            } label: {
+                Label("Run", systemImage: "play.fill")
+                    .frame(minWidth: 86)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(MereRunTheme.accent)
+            .keyboardShortcut(.return, modifiers: .command)
+            .disabled(controller.isRunning)
+
+            Button {
+                controller.cancel()
+            } label: {
+                Label("Stop", systemImage: "stop.fill")
+                    .frame(minWidth: 76)
+            }
+            .buttonStyle(.bordered)
+            .disabled(!controller.isRunning)
+
+            Spacer()
+
+            if controller.lastOutputURL != nil {
+                Button {
+                    controller.openLastOutput()
+                } label: {
+                    Label("Open", systemImage: "arrow.up.right.square")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    controller.revealLastOutput()
+                } label: {
+                    Image(systemName: "finder")
+                }
+                .buttonStyle(.bordered)
+                .help("Reveal in Finder")
+            }
+        }
+    }
+
+    private var showsModelField: Bool {
+        ![
+            .agentInstallPi,
+            .imageValidate,
+            .modelList,
+            .modelCapabilities,
+            .modelRepairManifests,
+            .setup,
+            .custom,
+            .speechProfileList,
+            .speechProfileCreate,
+            .speechProfileDelete,
+        ].contains(controller.selectedTemplate.id)
+    }
+
+    private var outputLabel: String {
+        controller.selectedTemplate.outputKind == .directory ? "Output directory" : "Output file"
+    }
+}
+
+private struct RunConsole: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Run")
+                        .font(.system(size: 17, weight: .semibold))
+                    Text(controller.status)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                Spacer()
+                if controller.isRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+            .padding(18)
+
+            Divider()
+                .overlay(MereRunTheme.border.opacity(0.6))
+
+            if controller.logs.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 28, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    Text("Run output will appear here.")
+                        .font(MereRunTheme.bodyFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 6) {
+                            ForEach(controller.logs) { line in
+                                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                    Text(line.stream.label)
+                                        .font(MereRunTheme.monoFont)
+                                        .foregroundStyle(color(for: line.stream))
+                                        .frame(width: 34, alignment: .leading)
+                                    Text(line.text)
+                                        .font(MereRunTheme.monoFont)
+                                        .foregroundStyle(line.stream == .stderr ? MereRunTheme.textSecondary : MereRunTheme.textPrimary)
+                                        .textSelection(.enabled)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .id(line.id)
+                            }
+                        }
+                        .padding(14)
+                    }
+                    .onChange(of: controller.logs.count) {
+                        if let last = controller.logs.last {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            if let output = controller.lastOutputURL {
+                Divider()
+                    .overlay(MereRunTheme.border.opacity(0.6))
+                OutputPreview(url: output)
+                    .padding(14)
+            }
+        }
+        .background(MereRunTheme.surface.opacity(0.55))
+    }
+
+    private func color(for stream: LogStream) -> Color {
+        switch stream {
+        case .system: return MereRunTheme.accent
+        case .stdout: return MereRunTheme.green
+        case .stderr: return MereRunTheme.yellow
+        }
+    }
+}
+
+private struct OutputPreview: View {
+    let url: URL
+
+    var body: some View {
+        HStack(spacing: 12) {
+            preview
+                .frame(width: 76, height: 58)
+                .background(MereRunTheme.background)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(url.lastPathComponent)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(1)
+                Text(url.deletingLastPathComponent().path)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .padding(10)
+        .merePanel()
+    }
+
+    @ViewBuilder
+    private var preview: some View {
+        if let image = NSImage(contentsOf: url) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+        } else {
+            Image(systemName: iconName)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(MereRunTheme.accent)
+        }
+    }
+
+    private var iconName: String {
+        switch url.pathExtension.lowercased() {
+        case "wav", "mp3", "m4a": return "waveform"
+        case "mp4", "mov": return "film"
+        case "json": return "curlybraces"
+        default: return "doc"
+        }
+    }
+}
+
+private struct EditorSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    init(_ title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title.uppercased())
+                .font(MereRunTheme.sectionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+            content
+        }
+    }
+}
+
+private enum PathFieldMode: Equatable {
+    case openFile([UTType])
+    case openDirectory
+    case saveFile
+}
+
+private struct PathField: View {
+    @Binding var path: String
+    let placeholder: String
+    let mode: PathFieldMode
+
+    var body: some View {
+        HStack(spacing: 8) {
+            TextField(placeholder, text: $path)
+                .textFieldStyle(.plain)
+                .font(MereRunTheme.bodyFont)
+            Button {
+                choosePath()
+            } label: {
+                Image(systemName: mode == .saveFile ? "square.and.arrow.down" : "folder")
+            }
+            .buttonStyle(.borderless)
+            .help(mode == .saveFile ? "Choose output path" : "Choose path")
+        }
+        .padding(10)
+        .merePanel()
+    }
+
+    private func choosePath() {
+        switch mode {
+        case .openFile(let types):
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = false
+            panel.allowsMultipleSelection = false
+            panel.allowedContentTypes = types
+            if panel.runModal() == .OK, let url = panel.url {
+                path = url.path
+            }
+        case .openDirectory:
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.allowsMultipleSelection = false
+            if panel.runModal() == .OK, let url = panel.url {
+                path = url.path
+            }
+        case .saveFile:
+            let panel = NSSavePanel()
+            panel.nameFieldStringValue = URL(fileURLWithPath: path).lastPathComponent
+            if panel.runModal() == .OK, let url = panel.url {
+                path = url.path
+            }
+        }
+    }
+}
+
+private struct DimensionsGrid: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Size") {
+            HStack(spacing: 10) {
+                NumberStepper(title: "Width", value: $controller.draft.width, range: 64...4096, step: 64)
+                NumberStepper(title: "Height", value: $controller.draft.height, range: 64...4096, step: 64)
+            }
+        }
+    }
+}
+
+private struct GenerationOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Generation") {
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    NumberStepper(title: "Steps", value: $controller.draft.steps, range: 1...80, step: 1)
+                    NumberField(title: "CFG", value: $controller.draft.cfgScale)
+                    NumberField(title: "Strength", value: $controller.draft.strength)
+                }
+                TextField("Seed", text: $controller.draft.seed)
+                    .textFieldStyle(.plain)
+                    .font(MereRunTheme.bodyFont)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct ImageValidationOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Validation") {
+            VStack(spacing: 10) {
+                Picker("Suite", selection: $controller.draft.backend) {
+                    Text("All").tag("all")
+                    Text("VAE").tag("vae")
+                    Text("Encoder").tag("encoder")
+                    Text("Transformer").tag("transformer")
+                    Text("Pipeline").tag("pipeline")
+                }
+                .pickerStyle(.segmented)
+                Picker("Family", selection: $controller.draft.variant) {
+                    Text("ZImage").tag("zimage")
+                    Text("Klein").tag("klein")
+                }
+                .pickerStyle(.segmented)
+                HStack {
+                    Toggle("Save reference", isOn: $controller.draft.force)
+                    Toggle("Compare", isOn: $controller.draft.all)
+                    Spacer()
+                }
+            }
+        }
+    }
+}
+
+private struct TextGenerationOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Parameters") {
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    NumberStepper(title: "Max tokens", value: $controller.draft.maxTokens, range: 1...32768, step: 64)
+                    NumberField(title: "Temp", value: $controller.draft.temperature)
+                    NumberField(title: "Top-p", value: $controller.draft.topP)
+                }
+                HStack {
+                    if [.textChat].contains(controller.selectedTemplate.id) {
+                        Toggle("Thinking", isOn: $controller.draft.all)
+                    }
+                    if [.textChat, .textCode].contains(controller.selectedTemplate.id) {
+                        Toggle("Stats", isOn: $controller.draft.force)
+                    }
+                    if controller.selectedTemplate.id == .textCode {
+                        Toggle("Stream", isOn: $controller.draft.stream)
+                    }
+                    if [.textEmbed, .textAnonymize].contains(controller.selectedTemplate.id) {
+                        Toggle("Pretty", isOn: $controller.draft.force)
+                    }
+                    if controller.selectedTemplate.id == .textAnonymize {
+                        Toggle("JSON", isOn: $controller.draft.all)
+                    }
+                    Spacer()
+                    Toggle("Quiet", isOn: $controller.draft.quiet)
+                }
+            }
+        }
+    }
+}
+
+private struct SpeechOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Speech") {
+            HStack(spacing: 10) {
+                NumberField(title: "Temperature", value: $controller.draft.temperature)
+                Toggle("Stream", isOn: $controller.draft.stream)
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct SpeechTranscribeOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Transcription") {
+            VStack(spacing: 10) {
+                Picker("Backend", selection: $controller.draft.backend) {
+                    Text("Auto").tag("auto")
+                    Text("Parakeet").tag("parakeet")
+                    Text("Qwen").tag("qwen")
+                }
+                .pickerStyle(.segmented)
+                Picker("Task", selection: $controller.draft.task) {
+                    Text("Transcribe").tag("transcribe")
+                    Text("Translate").tag("translate")
+                }
+                .pickerStyle(.segmented)
+                HStack {
+                    NumberStepper(title: "Max tokens", value: $controller.draft.maxTokens, range: 1...4096, step: 64)
+                    TextField("Language", text: $controller.draft.language)
+                        .textFieldStyle(.plain)
+                        .padding(10)
+                        .merePanel()
+                    Toggle("Stream", isOn: $controller.draft.stream)
+                    Toggle("Timestamps", isOn: $controller.draft.timestamps)
+                    Toggle("Quiet", isOn: $controller.draft.quiet)
+                }
+            }
+        }
+    }
+}
+
+private struct SpeechProfileCreateOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Profile") {
+            HStack(spacing: 10) {
+                TextField("Language", text: $controller.draft.language)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct VisionTrackingOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Vision") {
+            HStack {
+                if controller.selectedTemplate.id == .visionTrackLive {
+                    NumberField(title: "Seconds", value: $controller.draft.durationSeconds)
+                }
+                Toggle("Show boxes", isOn: $controller.draft.force)
+                Spacer()
+            }
+        }
+    }
+}
+
+private struct MusicOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Music") {
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    NumberField(title: "Seconds", value: $controller.draft.durationSeconds)
+                    NumberStepper(title: "Steps", value: $controller.draft.steps, range: 1...80, step: 1)
+                }
+                TextField("Seed", text: $controller.draft.seed)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct VideoOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Video") {
+            VStack(spacing: 10) {
+                Picker("Variant", selection: $controller.draft.variant) {
+                    Text("Distilled").tag("distilled")
+                    Text("Unified AV").tag("unified-av")
+                }
+                .pickerStyle(.segmented)
+                HStack(spacing: 10) {
+                    NumberStepper(title: "Frames", value: $controller.draft.numFrames, range: 9...257, step: 8)
+                    NumberStepper(title: "FPS", value: $controller.draft.fps, range: 1...60, step: 1)
+                    NumberField(title: "Image strength", value: $controller.draft.strength)
+                }
+                TextField("Seed", text: $controller.draft.seed)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct VideoLatentsOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Latents") {
+            VStack(spacing: 10) {
+                NumberStepper(title: "Frames", value: $controller.draft.numFrames, range: 9...257, step: 8)
+                TextField("Seed", text: $controller.draft.seed)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct APIOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Server") {
+            VStack(spacing: 10) {
+                Picker("Engine", selection: $controller.draft.engine) {
+                    Text("Chat Gemma4").tag("text-chat-gemma4")
+                    Text("Chat Q35").tag("text-chat-q35")
+                    Text("Chat Klein").tag("text-chat-klein")
+                    Text("Code").tag("text-code")
+                }
+                .pickerStyle(.segmented)
+                HStack(spacing: 10) {
+                    TextField("Host", text: $controller.draft.host)
+                        .textFieldStyle(.plain)
+                        .padding(10)
+                        .merePanel()
+                    NumberStepper(title: "Port", value: $controller.draft.port, range: 1...65535, step: 1)
+                }
+                SecureField("API key", text: $controller.draft.apiKey)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+            }
+        }
+    }
+}
+
+private struct AgentInstallOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Install") {
+            Toggle("Force reinstall", isOn: $controller.draft.force)
+        }
+    }
+}
+
+private struct AgentStartOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Agent") {
+            VStack(spacing: 10) {
+                HStack(spacing: 10) {
+                    TextField("Host", text: $controller.draft.host)
+                        .textFieldStyle(.plain)
+                        .padding(10)
+                        .merePanel()
+                    NumberStepper(title: "Port", value: $controller.draft.port, range: 1...65535, step: 1)
+                }
+                HStack {
+                    Toggle("Skip server", isOn: $controller.draft.stream)
+                    Toggle("Allow unsupported", isOn: $controller.draft.force)
+                    Spacer()
+                }
+            }
+        }
+    }
+}
+
+private struct SetupOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Setup") {
+            VStack(spacing: 10) {
+                Picker("Mode", selection: $controller.draft.setupMode) {
+                    Text("Agent").tag("agent")
+                    Text("BYOA").tag("byoa")
+                    Text("Manual").tag("manual")
+                }
+                .pickerStyle(.segmented)
+                Picker("Agent", selection: $controller.draft.agentModel) {
+                    Text("Small").tag("small")
+                    Text("Tier").tag("tier")
+                    Text("Premier").tag("premier")
+                }
+                .pickerStyle(.segmented)
+                HStack {
+                    Toggle("Install", isOn: $controller.draft.force)
+                    Toggle("Start", isOn: $controller.draft.stream)
+                    Toggle("Quiet", isOn: $controller.draft.quiet)
+                }
+            }
+        }
+    }
+}
+
+private struct AgentOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Agent") {
+            VStack(spacing: 10) {
+                HStack {
+                    Toggle("Pull recommended", isOn: $controller.draft.force)
+                    Toggle("Install Pi", isOn: $controller.draft.all)
+                    Toggle("Configure Pi", isOn: $controller.draft.stream)
+                }
+                HStack(spacing: 10) {
+                    TextField("Host", text: $controller.draft.host)
+                        .textFieldStyle(.plain)
+                        .padding(10)
+                        .merePanel()
+                    NumberStepper(title: "Port", value: $controller.draft.port, range: 1...65535, step: 1)
+                }
+            }
+        }
+    }
+}
+
+private struct ModelPullOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Download") {
+            HStack {
+                Toggle("All", isOn: $controller.draft.all)
+                Toggle("Force", isOn: $controller.draft.force)
+                Toggle("Allow unsupported", isOn: $controller.draft.stream)
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct ModelMaintenanceOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Maintenance") {
+            if controller.selectedTemplate.id == .modelRemove {
+                Toggle("Force", isOn: $controller.draft.force)
+            } else {
+                Toggle("Dry run", isOn: $controller.draft.force)
+            }
+        }
+    }
+}
+
+private struct ModelInspectionOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Output") {
+            HStack {
+                if controller.selectedTemplate.id == .modelCapabilities {
+                    Toggle("All", isOn: $controller.draft.all)
+                    Toggle("Recommended", isOn: $controller.draft.force)
+                } else {
+                    Toggle("JSON", isOn: $controller.draft.all)
+                    Toggle("Components", isOn: $controller.draft.force)
+                }
+                Spacer()
+            }
+        }
+    }
+}
+
+private struct NumberStepper: View {
+    let title: String
+    @Binding var value: Int
+    let range: ClosedRange<Int>
+    let step: Int
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+            Spacer()
+            Stepper(value: $value, in: range, step: step) {
+                Text("\(value)")
+                    .font(MereRunTheme.monoFont)
+            }
+        }
+        .padding(10)
+        .merePanel()
+    }
+}
+
+private struct NumberField: View {
+    let title: String
+    @Binding var value: Double
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+            Spacer()
+            TextField(title, value: $value, format: .number)
+                .multilineTextAlignment(.trailing)
+                .textFieldStyle(.plain)
+                .font(MereRunTheme.monoFont)
+                .frame(width: 76)
+        }
+        .padding(10)
+        .merePanel()
+    }
+}
+
+struct MereRunSettingsView: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("mere.run")
+                .font(MereRunTheme.titleFont)
+            VStack(spacing: 12) {
+                PathField(path: $controller.cliPath, placeholder: "Auto-detect executable", mode: .openFile([.unixExecutable, .item]))
+                PathField(path: $controller.modelsRoot, placeholder: "Optional models root", mode: .openDirectory)
+                PathField(path: $controller.hubCache, placeholder: "Optional Hugging Face hub cache", mode: .openDirectory)
+                PathField(path: $controller.workingDirectory, placeholder: "Working directory", mode: .openDirectory)
+            }
+            Text("The app uses a bundled `mere.run` first, then nearby SwiftPM build products, common install locations, and the current package checkout.")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+            Spacer()
+        }
+        .padding(22)
+        .background(MereRunTheme.background)
+        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+}

--- a/Sources/MereRunApp/MereRunTheme.swift
+++ b/Sources/MereRunApp/MereRunTheme.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+enum MereRunTheme {
+    static let background = Color(hex: "171614")
+    static let surface = Color(hex: "23211D")
+    static let surfaceRaised = Color(hex: "302D27")
+    static let border = Color(hex: "4E493F")
+    static let textPrimary = Color(hex: "F1EDE3")
+    static let textSecondary = Color(hex: "C9C1B3")
+    static let textMuted = Color(hex: "918A7C")
+    static let accent = Color(hex: "C9A65D")
+    static let green = Color(hex: "8EAA74")
+    static let yellow = Color(hex: "D2A24E")
+    static let red = Color(hex: "D98072")
+
+    static let titleFont = Font.system(size: 22, weight: .semibold)
+    static let sectionFont = Font.system(size: 12, weight: .semibold)
+    static let bodyFont = Font.system(size: 13, weight: .regular)
+    static let captionFont = Font.system(size: 11, weight: .medium)
+    static let monoFont = Font.system(size: 12, weight: .regular, design: .monospaced)
+
+    static let cornerRadius: CGFloat = 8
+}
+
+extension Color {
+    init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var value: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&value)
+
+        let red: UInt64
+        let green: UInt64
+        let blue: UInt64
+        let alpha: UInt64
+
+        switch cleaned.count {
+        case 8:
+            alpha = value >> 24
+            red = value >> 16 & 0xff
+            green = value >> 8 & 0xff
+            blue = value & 0xff
+        case 6:
+            alpha = 255
+            red = value >> 16 & 0xff
+            green = value >> 8 & 0xff
+            blue = value & 0xff
+        default:
+            alpha = 255
+            red = 21
+            green = 25
+            blue = 26
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(red) / 255,
+            green: Double(green) / 255,
+            blue: Double(blue) / 255,
+            opacity: Double(alpha) / 255
+        )
+    }
+}
+
+extension View {
+    func merePanel(cornerRadius: CGFloat = MereRunTheme.cornerRadius) -> some View {
+        background {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                }
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioLibraryStore.swift
+++ b/Sources/MereRunApp/StudioLibraryStore.swift
@@ -1,0 +1,139 @@
+import Combine
+import Foundation
+
+@MainActor
+final class StudioLibraryStore: ObservableObject {
+    @Published private(set) var items: [StudioLibraryItem] = []
+
+    let libraryURL: URL
+    private let fileManager: FileManager
+
+    init(
+        libraryURL: URL = StudioLibraryStore.defaultLibraryURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.libraryURL = libraryURL
+        self.fileManager = fileManager
+        load()
+    }
+
+    static func defaultLibraryURL() -> URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MereRun", isDirectory: true)
+            .appendingPathComponent("App Library", isDirectory: true)
+            .appendingPathComponent("library.json", isDirectory: false)
+    }
+
+    func load() {
+        do {
+            guard fileManager.fileExists(atPath: libraryURL.path) else {
+                items = []
+                return
+            }
+
+            let data = try Data(contentsOf: libraryURL)
+            items = try JSONDecoder.mereRunApp.decode([StudioLibraryItem].self, from: data)
+                .sorted { $0.createdAt > $1.createdAt }
+        } catch {
+            items = []
+            recoverCorruptLibrary()
+        }
+    }
+
+    @discardableResult
+    func start(request: StudioRunRequest, commandPreview: String) -> StudioLibraryItem {
+        let item = StudioLibraryItem(
+            id: request.id,
+            mode: request.mode,
+            prompt: request.draft.prompt,
+            inputURL: request.draft.inputPath.isBlank ? nil : URL(fileURLWithPath: request.draft.inputPath),
+            outputURL: request.expectedOutputURL,
+            createdAt: request.createdAt,
+            updatedAt: Date(),
+            status: .running,
+            exitCode: nil,
+            commandPreview: commandPreview
+        )
+        upsert(item)
+        return item
+    }
+
+    func complete(
+        id: UUID,
+        exitCode: Int32,
+        outputURL: URL?,
+        commandPreview: String
+    ) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        var item = items[index]
+        item.status = exitCode == 0 ? .completed : .failed
+        item.exitCode = exitCode
+        item.updatedAt = Date()
+        item.commandPreview = commandPreview
+        if let outputURL {
+            item.outputURL = outputURL
+        }
+
+        if shouldKeep(item) {
+            items[index] = item
+        } else {
+            items.remove(at: index)
+        }
+        save()
+    }
+
+    func upsert(_ item: StudioLibraryItem) {
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index] = item
+        } else {
+            items.insert(item, at: 0)
+        }
+        save()
+    }
+
+    private func shouldKeep(_ item: StudioLibraryItem) -> Bool {
+        item.status == .completed
+            || item.outputURL != nil
+            || !item.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || item.inputURL != nil
+    }
+
+    private func save() {
+        do {
+            try fileManager.createDirectory(
+                at: libraryURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let data = try JSONEncoder.mereRunApp.encode(items)
+            try data.write(to: libraryURL, options: [.atomic])
+        } catch {
+            // Library persistence should never block local generation.
+        }
+    }
+
+    private func recoverCorruptLibrary() {
+        guard fileManager.fileExists(atPath: libraryURL.path) else { return }
+        let recoveryURL = libraryURL
+            .deletingPathExtension()
+            .appendingPathExtension("corrupt-\(DateFormatter.mereRunTimestamp.string(from: Date()))")
+            .appendingPathExtension("json")
+        try? fileManager.moveItem(at: libraryURL, to: recoveryURL)
+    }
+}
+
+extension JSONEncoder {
+    static var mereRunApp: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+extension JSONDecoder {
+    static var mereRunApp: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Sources/MereRunApp/StudioLibraryStore.swift
+++ b/Sources/MereRunApp/StudioLibraryStore.swift
@@ -52,7 +52,8 @@ final class StudioLibraryStore: ObservableObject {
             updatedAt: Date(),
             status: .running,
             exitCode: nil,
-            commandPreview: commandPreview
+            commandPreview: commandPreview,
+            outputText: nil
         )
         upsert(item)
         return item
@@ -62,6 +63,7 @@ final class StudioLibraryStore: ObservableObject {
         id: UUID,
         exitCode: Int32,
         outputURL: URL?,
+        outputText: String?,
         commandPreview: String
     ) {
         guard let index = items.firstIndex(where: { $0.id == id }) else { return }
@@ -73,6 +75,7 @@ final class StudioLibraryStore: ObservableObject {
         if let outputURL {
             item.outputURL = outputURL
         }
+        item.outputText = outputText
 
         if shouldKeep(item) {
             items[index] = item
@@ -94,6 +97,7 @@ final class StudioLibraryStore: ObservableObject {
     private func shouldKeep(_ item: StudioLibraryItem) -> Bool {
         item.status == .completed
             || item.outputURL != nil
+            || item.outputText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
             || !item.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || item.inputURL != nil
     }

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -57,6 +57,7 @@ struct StudioRootView: View {
                     readiness: readiness,
                     error: studioError,
                     logs: controller.logs,
+                    liveOutputText: controller.liveOutputText,
                     onOpen: openSelectedOutput,
                     onReveal: revealSelectedOutput,
                     onPullModel: pullModel,
@@ -124,6 +125,7 @@ struct StudioRootView: View {
                 id: activeLibraryID,
                 exitCode: result.exitCode,
                 outputURL: result.outputURL,
+                outputText: result.outputText,
                 commandPreview: result.commandPreview.maskingAPIKeyValue()
             )
             selectedLibraryID = activeLibraryID
@@ -330,15 +332,24 @@ private struct StudioCanvas: View {
     let readiness: ModelReadinessState
     let error: String?
     let logs: [LogLine]
+    let liveOutputText: String
     let onOpen: () -> Void
     let onReveal: () -> Void
     let onPullModel: () -> Void
     let onShowDetails: () -> Void
 
+    private var visibleLiveOutputText: String? {
+        guard isRunning, mode == .chat || mode == .code else { return nil }
+        let text = liveOutputText
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+
     var body: some View {
         ZStack {
             if let item {
-                StudioOutputView(item: item, onOpen: onOpen, onReveal: onReveal)
+                StudioOutputView(item: item, liveOutputText: visibleLiveOutputText, onOpen: onOpen, onReveal: onReveal)
                     .padding(32)
                     .transition(.opacity.combined(with: .scale(scale: 0.98)))
             } else {
@@ -346,7 +357,7 @@ private struct StudioCanvas: View {
                     .padding(32)
             }
 
-            if isRunning {
+            if isRunning && visibleLiveOutputText == nil {
                 StudioRunningOverlay(status: status, latestLog: logs.last?.text)
                     .transition(.opacity)
             }
@@ -467,6 +478,7 @@ private struct StudioReadinessOverlay: View {
 
 private struct StudioOutputView: View {
     let item: StudioLibraryItem
+    let liveOutputText: String?
     let onOpen: () -> Void
     let onReveal: () -> Void
 
@@ -536,6 +548,14 @@ private struct StudioOutputView: View {
                     .lineLimit(1)
             }
             .padding(22)
+        } else if let text = liveOutputText ?? item.outputText, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            ScrollView {
+                Text(text)
+                    .font(item.mode == .chat ? MereRunTheme.bodyFont : MereRunTheme.monoFont)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(22)
+            }
         } else {
             VStack(spacing: 12) {
                 Image(systemName: "doc")

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -1,0 +1,867 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct StudioRootView: View {
+    @EnvironmentObject private var controller: MereRunController
+    @StateObject private var library = StudioLibraryStore()
+    @State private var mode: StudioMode = .createImage
+    @State private var draft = StudioDraft()
+    @State private var showLibrary = true
+    @State private var showAdvanced = false
+    @State private var showOptions = false
+    @State private var activeLibraryID: UUID?
+    @State private var selectedLibraryID: UUID?
+    @State private var studioError: String?
+
+    private var selectedItem: StudioLibraryItem? {
+        guard let selectedLibraryID else { return library.items.first }
+        return library.items.first { $0.id == selectedLibraryID }
+    }
+
+    private var readiness: ModelReadinessState {
+        controller.readinessByMode[mode] ?? .unknown("Readiness has not been checked yet.")
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if showLibrary {
+                StudioLibraryPanel(
+                    items: library.items,
+                    selectedID: $selectedLibraryID,
+                    isVisible: $showLibrary
+                )
+                .frame(width: 292)
+
+                Divider()
+                    .overlay(MereRunTheme.border.opacity(0.55))
+            }
+
+            VStack(spacing: 0) {
+                StudioTopBar(
+                    mode: $mode,
+                    showLibrary: $showLibrary,
+                    showAdvanced: $showAdvanced,
+                    readiness: readiness,
+                    resolvedCLI: controller.resolvedCLI
+                )
+
+                Divider()
+                    .overlay(MereRunTheme.border.opacity(0.45))
+
+                StudioCanvas(
+                    mode: mode,
+                    item: selectedItem,
+                    isRunning: controller.isRunning,
+                    status: controller.status,
+                    readiness: readiness,
+                    error: studioError,
+                    logs: controller.logs,
+                    onOpen: openSelectedOutput,
+                    onReveal: revealSelectedOutput,
+                    onPullModel: pullModel,
+                    onShowDetails: { showAdvanced = true }
+                )
+
+                StudioPromptBar(
+                    mode: mode,
+                    draft: $draft,
+                    showOptions: $showOptions,
+                    isRunning: controller.isRunning,
+                    readiness: readiness,
+                    onRun: runStudioCommand,
+                    onStop: controller.cancel,
+                    onAttach: chooseAttachment
+                )
+                .padding(.horizontal, 24)
+                .padding(.bottom, 22)
+            }
+            .frame(minWidth: 680)
+
+            if showAdvanced {
+                Divider()
+                    .overlay(MereRunTheme.border.opacity(0.55))
+                AdvancedControlSurface()
+                    .frame(width: 560)
+            }
+        }
+        .background {
+            ZStack {
+                MereRunTheme.background
+                LinearGradient(
+                    colors: [
+                        MereRunTheme.surfaceRaised.opacity(0.28),
+                        MereRunTheme.background,
+                        MereRunTheme.surface.opacity(0.2)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            }
+            .ignoresSafeArea()
+        }
+        .sheet(isPresented: $showOptions) {
+            StudioOptionsSheet(mode: mode, draft: $draft)
+                .frame(width: 500)
+        }
+        .onAppear {
+            draft.reset(for: mode)
+            controller.checkReadiness(for: mode, draft: draft)
+        }
+        .onChange(of: mode) { _, newMode in
+            var nextDraft = StudioDraft()
+            nextDraft.reset(for: newMode)
+            draft = nextDraft
+            studioError = nil
+            controller.checkReadiness(for: newMode, draft: nextDraft)
+        }
+        .onChange(of: draft.model) { _, _ in
+            controller.checkReadiness(for: mode, draft: draft)
+        }
+        .onChange(of: controller.lastRunResult) { _, result in
+            guard let result, let activeLibraryID else { return }
+            library.complete(
+                id: activeLibraryID,
+                exitCode: result.exitCode,
+                outputURL: result.outputURL,
+                commandPreview: result.commandPreview.maskingAPIKeyValue()
+            )
+            selectedLibraryID = activeLibraryID
+            self.activeLibraryID = nil
+            controller.checkReadiness(for: mode, draft: draft)
+        }
+    }
+
+    private func runStudioCommand() {
+        studioError = nil
+
+        if readiness.blocksRun {
+            studioError = readiness.message
+            return
+        }
+
+        do {
+            let request = try StudioCommandAdapter.makeRequest(mode: mode, draft: draft)
+            let preview = controller
+                .commandPreview(template: request.template, draft: request.draft, masksSecrets: true)
+            library.start(request: request, commandPreview: preview)
+            activeLibraryID = request.id
+            selectedLibraryID = request.id
+            controller.run(studio: request)
+        } catch {
+            studioError = error.localizedDescription
+        }
+    }
+
+    private func pullModel() {
+        do {
+            guard let request = try StudioCommandAdapter.pullRequest(for: mode, draft: draft) else {
+                studioError = "This mode does not need a managed model."
+                return
+            }
+            showAdvanced = true
+            controller.run(studio: request)
+        } catch {
+            studioError = error.localizedDescription
+        }
+    }
+
+    private func chooseAttachment() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = mode.acceptedTypes.isEmpty ? [.item] : mode.acceptedTypes
+        if panel.runModal() == .OK, let url = panel.url {
+            draft.inputPath = url.path
+            studioError = nil
+        }
+    }
+
+    private func openSelectedOutput() {
+        guard let url = selectedItem?.outputURL else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func revealSelectedOutput() {
+        guard let url = selectedItem?.outputURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+}
+
+private struct StudioTopBar: View {
+    @Binding var mode: StudioMode
+    @Binding var showLibrary: Bool
+    @Binding var showAdvanced: Bool
+    let readiness: ModelReadinessState
+    let resolvedCLI: String
+
+    var body: some View {
+        VStack(spacing: 14) {
+            HStack(spacing: 12) {
+                Button {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        showLibrary.toggle()
+                    }
+                } label: {
+                    Image(systemName: "sidebar.left")
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.plain)
+                .help("Show library")
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("mere.run")
+                        .font(.system(size: 20, weight: .semibold))
+                    Text("Create anything. Locally.")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+
+                Spacer()
+
+                StudioStatusPill(
+                    title: readiness.title,
+                    detail: readiness.message,
+                    systemImage: readiness.blocksRun ? "arrow.down.circle" : "checkmark.circle",
+                    color: readiness.blocksRun ? MereRunTheme.yellow : MereRunTheme.green
+                )
+
+                StudioStatusPill(
+                    title: "CLI",
+                    detail: resolvedCLI,
+                    systemImage: "terminal",
+                    color: MereRunTheme.accent
+                )
+
+                Button {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        showAdvanced.toggle()
+                    }
+                } label: {
+                    Label("Advanced", systemImage: "slider.horizontal.3")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(StudioMode.allCases) { candidate in
+                        StudioModeChip(
+                            mode: candidate,
+                            isSelected: candidate == mode
+                        ) {
+                            withAnimation(.easeOut(duration: 0.18)) {
+                                mode = candidate
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 2)
+            }
+        }
+        .padding(.horizontal, 22)
+        .padding(.top, 16)
+        .padding(.bottom, 14)
+    }
+}
+
+private struct StudioModeChip: View {
+    let mode: StudioMode
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: mode.systemImage)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(mode.title)
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(isSelected ? MereRunTheme.background : MereRunTheme.textSecondary)
+            .padding(.horizontal, 12)
+            .frame(height: 32)
+            .background {
+                Capsule()
+                    .fill(isSelected ? MereRunTheme.accent : MereRunTheme.surface)
+                    .overlay {
+                        Capsule()
+                            .strokeBorder(MereRunTheme.border.opacity(isSelected ? 0 : 0.8), lineWidth: 1)
+                    }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct StudioStatusPill: View {
+    let title: String
+    let detail: String
+    let systemImage: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(color)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(detail)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 38)
+        .frame(maxWidth: 210)
+        .merePanel(cornerRadius: 18)
+    }
+}
+
+private struct StudioCanvas: View {
+    let mode: StudioMode
+    let item: StudioLibraryItem?
+    let isRunning: Bool
+    let status: String
+    let readiness: ModelReadinessState
+    let error: String?
+    let logs: [LogLine]
+    let onOpen: () -> Void
+    let onReveal: () -> Void
+    let onPullModel: () -> Void
+    let onShowDetails: () -> Void
+
+    var body: some View {
+        ZStack {
+            if let item {
+                StudioOutputView(item: item, onOpen: onOpen, onReveal: onReveal)
+                    .padding(32)
+                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
+            } else {
+                StudioEmptyState(mode: mode)
+                    .padding(32)
+            }
+
+            if isRunning {
+                StudioRunningOverlay(status: status, latestLog: logs.last?.text)
+                    .transition(.opacity)
+            }
+
+            if readiness.blocksRun || error != nil {
+                StudioReadinessOverlay(
+                    title: error == nil ? readiness.title : "Needs attention",
+                    message: error ?? readiness.message,
+                    canPull: readiness.blocksRun,
+                    onPullModel: onPullModel,
+                    onShowDetails: onShowDetails
+                )
+                .padding(32)
+                .transition(.opacity.combined(with: .scale(scale: 0.98)))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.easeOut(duration: 0.18), value: isRunning)
+        .animation(.easeOut(duration: 0.18), value: readiness.blocksRun)
+    }
+}
+
+private struct StudioEmptyState: View {
+    let mode: StudioMode
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: mode.systemImage)
+                .font(.system(size: 48, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+                .frame(width: 92, height: 92)
+                .background {
+                    Circle()
+                        .fill(MereRunTheme.surfaceRaised)
+                }
+
+            VStack(spacing: 8) {
+                Text(mode.emptyTitle)
+                    .font(.system(size: 30, weight: .semibold))
+                Text(mode.emptyMessage)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 460)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct StudioRunningOverlay: View {
+    let status: String
+    let latestLog: String?
+
+    var body: some View {
+        VStack(spacing: 14) {
+            ProgressView()
+                .controlSize(.large)
+            Text(status)
+                .font(.system(size: 18, weight: .semibold))
+            if let latestLog {
+                Text(latestLog)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(3)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 420)
+            }
+        }
+        .padding(28)
+        .merePanel(cornerRadius: 18)
+        .shadow(color: .black.opacity(0.28), radius: 28, y: 12)
+    }
+}
+
+private struct StudioReadinessOverlay: View {
+    let title: String
+    let message: String
+    let canPull: Bool
+    let onPullModel: () -> Void
+    let onShowDetails: () -> Void
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: canPull ? "arrow.down.circle" : "exclamationmark.triangle")
+                .font(.system(size: 32, weight: .semibold))
+                .foregroundStyle(canPull ? MereRunTheme.yellow : MereRunTheme.red)
+            Text(title)
+                .font(.system(size: 22, weight: .semibold))
+            Text(message)
+                .font(MereRunTheme.bodyFont)
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 280)
+            HStack(spacing: 10) {
+                if canPull {
+                    Button {
+                        onPullModel()
+                    } label: {
+                        Label("Pull Model", systemImage: "arrow.down.circle.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(MereRunTheme.accent)
+                }
+                Button {
+                    onShowDetails()
+                } label: {
+                    Label("Details", systemImage: "terminal")
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(28)
+        .merePanel(cornerRadius: 18)
+        .shadow(color: .black.opacity(0.3), radius: 30, y: 12)
+    }
+}
+
+private struct StudioOutputView: View {
+    let item: StudioLibraryItem
+    let onOpen: () -> Void
+    let onReveal: () -> Void
+
+    var body: some View {
+        VStack(spacing: 18) {
+            outputPreview
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(MereRunTheme.surface.opacity(0.45))
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 18)
+                        .strokeBorder(MereRunTheme.border.opacity(0.65), lineWidth: 1)
+                }
+
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.mode.title)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    Text(item.displayTitle)
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                }
+                Spacer()
+                statusBadge
+                if item.outputURL != nil {
+                    Button("Open", action: onOpen)
+                        .buttonStyle(.bordered)
+                    Button {
+                        onReveal()
+                    } label: {
+                        Image(systemName: "finder")
+                    }
+                    .buttonStyle(.bordered)
+                    .help("Reveal in Finder")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var outputPreview: some View {
+        if let url = item.outputURL, let image = NSImage(contentsOf: url) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .padding(22)
+        } else if let url = item.outputURL, let text = try? String(contentsOf: url, encoding: .utf8) {
+            ScrollView {
+                Text(String(text.prefix(6_000)))
+                    .font(MereRunTheme.monoFont)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(22)
+            }
+        } else if let url = item.outputURL {
+            VStack(spacing: 12) {
+                Image(systemName: iconName(for: url))
+                    .font(.system(size: 54, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+                Text(url.lastPathComponent)
+                    .font(.system(size: 16, weight: .semibold))
+                    .lineLimit(1)
+                Text(url.deletingLastPathComponent().path)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+            .padding(22)
+        } else {
+            VStack(spacing: 12) {
+                Image(systemName: "doc")
+                    .font(.system(size: 46, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                Text(item.status == .failed ? "Run did not produce a file." : "Output will appear here.")
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+        }
+    }
+
+    private var statusBadge: some View {
+        Text(item.status.rawValue.capitalized)
+            .font(MereRunTheme.captionFont)
+            .foregroundStyle(statusColor)
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .background {
+                Capsule()
+                    .fill(statusColor.opacity(0.14))
+            }
+    }
+
+    private var statusColor: Color {
+        switch item.status {
+        case .running: return MereRunTheme.yellow
+        case .completed: return MereRunTheme.green
+        case .failed: return MereRunTheme.red
+        }
+    }
+
+    private func iconName(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "wav", "mp3", "m4a": return "waveform"
+        case "mp4", "mov": return "film"
+        case "json": return "curlybraces"
+        case "safetensors": return "shippingbox"
+        default: return "doc"
+        }
+    }
+}
+
+private struct StudioPromptBar: View {
+    let mode: StudioMode
+    @Binding var draft: StudioDraft
+    @Binding var showOptions: Bool
+    let isRunning: Bool
+    let readiness: ModelReadinessState
+    let onRun: () -> Void
+    let onStop: () -> Void
+    let onAttach: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            if !draft.inputPath.isBlank {
+                HStack {
+                    Label(URL(fileURLWithPath: draft.inputPath).lastPathComponent, systemImage: "paperclip")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textSecondary)
+                    Spacer()
+                    Button {
+                        draft.inputPath = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 14)
+            }
+
+            HStack(spacing: 12) {
+                Button(action: onAttach) {
+                    Image(systemName: mode.requiresAttachment ? "paperclip.circle.fill" : "paperclip")
+                        .font(.system(size: 18, weight: .semibold))
+                        .frame(width: 34, height: 34)
+                }
+                .buttonStyle(.plain)
+                .disabled(mode.acceptedTypes.isEmpty)
+                .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
+
+                if mode == .listen {
+                    Text(mode.promptPlaceholder)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    TextField(mode.promptPlaceholder, text: $draft.prompt, axis: .vertical)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 15, weight: .medium))
+                        .lineLimit(1...4)
+                        .onSubmit(onRun)
+                }
+
+                Button {
+                    showOptions = true
+                } label: {
+                    Image(systemName: "slider.horizontal.3")
+                        .frame(width: 34, height: 34)
+                }
+                .buttonStyle(.plain)
+                .help("Options")
+
+                Button {
+                    isRunning ? onStop() : onRun()
+                } label: {
+                    Image(systemName: isRunning ? "stop.fill" : "arrow.up")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(MereRunTheme.background)
+                        .frame(width: 38, height: 38)
+                        .background {
+                            Circle()
+                                .fill(isRunning ? MereRunTheme.red : (readiness.blocksRun ? MereRunTheme.yellow : MereRunTheme.accent))
+                        }
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(MereRunTheme.surfaceRaised)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 20)
+                            .strokeBorder(MereRunTheme.border.opacity(0.75), lineWidth: 1)
+                    }
+                    .shadow(color: .black.opacity(0.22), radius: 20, y: 10)
+            }
+        }
+    }
+}
+
+private struct StudioOptionsSheet: View {
+    let mode: StudioMode
+    @Binding var draft: StudioDraft
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack {
+                Text("\(mode.title) Options")
+                    .font(MereRunTheme.titleFont)
+                Spacer()
+                Button("Done") {
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+
+            if mode == .readImage {
+                Picker("Task", selection: $draft.readImageAction) {
+                    ForEach(StudioReadImageAction.allCases) { action in
+                        Text(action.title).tag(action)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            if secondaryLabel != nil {
+                TextField(secondaryLabel!, text: $draft.secondaryText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+            }
+
+            TextField("Model", text: $draft.model)
+                .textFieldStyle(.plain)
+                .padding(10)
+                .merePanel()
+
+            if [.createImage, .video].contains(mode) {
+                HStack(spacing: 10) {
+                    Stepper("Width \(draft.width)", value: $draft.width, in: 64...4096, step: 64)
+                    Stepper("Height \(draft.height)", value: $draft.height, in: 64...4096, step: 64)
+                }
+            }
+
+            if [.createImage, .music].contains(mode) {
+                Stepper("Steps \(draft.steps)", value: $draft.steps, in: 1...80, step: 1)
+            }
+
+            if mode == .music {
+                TextField("Duration seconds", value: $draft.durationSeconds, format: .number)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+            }
+
+            if [.createImage, .music, .video].contains(mode) {
+                TextField("Seed", text: $draft.seed)
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+            }
+
+            Spacer()
+        }
+        .padding(22)
+        .background(MereRunTheme.background)
+        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+
+    private var secondaryLabel: String? {
+        switch mode {
+        case .createImage: return "Negative prompt"
+        case .chat, .code: return "System"
+        case .speak: return "Voice"
+        case .music: return "Lyrics"
+        default: return nil
+        }
+    }
+}
+
+private struct StudioLibraryPanel: View {
+    let items: [StudioLibraryItem]
+    @Binding var selectedID: UUID?
+    @Binding var isVisible: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Library")
+                        .font(.system(size: 20, weight: .semibold))
+                    Text("\(items.count) local runs")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                Spacer()
+                Button {
+                    withAnimation(.easeOut(duration: 0.18)) {
+                        isVisible = false
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(18)
+
+            Divider()
+                .overlay(MereRunTheme.border.opacity(0.55))
+
+            if items.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "rectangle.stack")
+                        .font(.system(size: 30, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    Text("Runs you create will land here.")
+                        .font(MereRunTheme.bodyFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(22)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(items) { item in
+                            StudioLibraryRow(
+                                item: item,
+                                isSelected: selectedID == item.id
+                            ) {
+                                selectedID = item.id
+                            }
+                        }
+                    }
+                    .padding(12)
+                }
+            }
+        }
+        .background(MereRunTheme.background)
+    }
+}
+
+private struct StudioLibraryRow: View {
+    let item: StudioLibraryItem
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                thumbnail
+                    .frame(width: 46, height: 38)
+                    .background(MereRunTheme.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 7))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.displayTitle)
+                        .font(.system(size: 12, weight: .semibold))
+                        .lineLimit(1)
+                    Text("\(item.mode.title) · \(item.status.rawValue)")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                Spacer()
+            }
+            .padding(9)
+            .background {
+                RoundedRectangle(cornerRadius: 9)
+                    .fill(isSelected ? MereRunTheme.surfaceRaised : Color.clear)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let url = item.outputURL, let image = NSImage(contentsOf: url) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+        } else {
+            Image(systemName: item.mode.systemImage)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+        }
+    }
+}
+
+private extension String {
+    func maskingAPIKeyValue() -> String {
+        var words = ShellWords.split(self)
+        words = words.maskingSecrets()
+        return words.shellQuoted()
+    }
+}

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -401,6 +401,7 @@ struct StudioLibraryItem: Codable, Identifiable, Equatable {
     var status: StudioLibraryStatus
     var exitCode: Int32?
     var commandPreview: String
+    var outputText: String?
 
     var displayTitle: String {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -1,0 +1,481 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum StudioMode: String, CaseIterable, Codable, Identifiable {
+    case createImage
+    case chat
+    case code
+    case speak
+    case listen
+    case readImage
+    case findObjects
+    case segment
+    case track
+    case music
+    case video
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .createImage: return "Create Image"
+        case .chat: return "Chat"
+        case .code: return "Code"
+        case .speak: return "Speak"
+        case .listen: return "Listen"
+        case .readImage: return "Read Image"
+        case .findObjects: return "Find"
+        case .segment: return "Segment"
+        case .track: return "Track"
+        case .music: return "Music"
+        case .video: return "Video"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .createImage: return "Text or reference image to PNG"
+        case .chat: return "Ask a local model"
+        case .code: return "Draft code locally"
+        case .speak: return "Text to natural speech"
+        case .listen: return "Audio to text"
+        case .readImage: return "Inspect, OCR, or caption"
+        case .findObjects: return "Ground prompted objects"
+        case .segment: return "Cut out prompted objects"
+        case .track: return "Follow objects through video"
+        case .music: return "Prompt to song"
+        case .video: return "Prompt to clip"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .createImage: return "photo"
+        case .chat: return "bubble.left.and.bubble.right"
+        case .code: return "chevron.left.forwardslash.chevron.right"
+        case .speak: return "waveform"
+        case .listen: return "captions.bubble"
+        case .readImage: return "doc.viewfinder"
+        case .findObjects: return "scope"
+        case .segment: return "square.dashed"
+        case .track: return "point.topleft.down.curvedto.point.bottomright.up"
+        case .music: return "music.note"
+        case .video: return "film"
+        }
+    }
+
+    var defaultTemplateID: CommandTemplateID {
+        switch self {
+        case .createImage: return .imageGenerate
+        case .chat: return .textChat
+        case .code: return .textCode
+        case .speak: return .speechSynthesize
+        case .listen: return .speechTranscribe
+        case .readImage: return .visionInspect
+        case .findObjects: return .visionGround
+        case .segment: return .visionSegment
+        case .track: return .visionTrack
+        case .music: return .musicGenerate
+        case .video: return .videoGenerate
+        }
+    }
+
+    var acceptedTypes: [UTType] {
+        switch self {
+        case .createImage, .readImage, .findObjects, .segment:
+            return [.image]
+        case .listen:
+            return [.audio]
+        case .track:
+            return [.movie, .video, .audiovisualContent]
+        case .video:
+            return [.image]
+        default:
+            return []
+        }
+    }
+
+    var requiresAttachment: Bool {
+        switch self {
+        case .listen, .readImage, .findObjects, .segment, .track:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var promptPlaceholder: String {
+        switch self {
+        case .createImage: return "Describe the image..."
+        case .chat: return "Ask anything..."
+        case .code: return "Describe the code you want..."
+        case .speak: return "Type what to say..."
+        case .listen: return "Attach audio to transcribe..."
+        case .readImage: return "Ask about the image..."
+        case .findObjects: return "What should mere.run find?"
+        case .segment: return "What should mere.run segment?"
+        case .track: return "What should mere.run track?"
+        case .music: return "Describe the song..."
+        case .video: return "Describe the video..."
+        }
+    }
+
+    var emptyTitle: String {
+        switch self {
+        case .createImage: return "Make something visible."
+        case .chat: return "Ask locally, keep it local."
+        case .code: return "Turn intent into code."
+        case .speak: return "Give text a voice."
+        case .listen: return "Drop in audio."
+        case .readImage: return "Let the image answer."
+        case .findObjects: return "Find what matters."
+        case .segment: return "Separate subject from scene."
+        case .track: return "Follow motion through time."
+        case .music: return "Score the moment."
+        case .video: return "Make the frame move."
+        }
+    }
+
+    var emptyMessage: String {
+        switch self {
+        case .createImage: return "Write a prompt, attach a reference if you have one, then create."
+        case .chat: return "Ask a question and mere.run will answer with a local model."
+        case .code: return "Describe a function, script, or refactor and run it on-device."
+        case .speak: return "Enter the line, pick a voice style, and render a WAV."
+        case .listen: return "Attach an audio file to create a transcript."
+        case .readImage: return "Attach an image and ask for an inspection, OCR pass, or caption."
+        case .findObjects: return "Attach an image and name the thing to locate."
+        case .segment: return "Attach an image and name the object to isolate."
+        case .track: return "Attach a video and name the subject to follow."
+        case .music: return "Describe the sound, add lyrics if needed, and create audio."
+        case .video: return "Describe a shot, optionally attach a starting image, and create a clip."
+        }
+    }
+}
+
+enum StudioReadImageAction: String, CaseIterable, Codable, Identifiable {
+    case inspect
+    case ocr
+    case caption
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .inspect: return "Inspect"
+        case .ocr: return "OCR"
+        case .caption: return "Caption"
+        }
+    }
+
+    var templateID: CommandTemplateID {
+        switch self {
+        case .inspect: return .visionInspect
+        case .ocr: return .visionOCR
+        case .caption: return .visionCaption
+        }
+    }
+}
+
+struct StudioDraft: Codable, Equatable {
+    var prompt = ""
+    var secondaryText = ""
+    var inputPath = ""
+    var model = ""
+    var width = 1024
+    var height = 1024
+    var steps = 4
+    var seed = ""
+    var durationSeconds = 10.0
+    var readImageAction: StudioReadImageAction = .inspect
+
+    mutating func reset(for mode: StudioMode) {
+        prompt = modeDefaultPrompt(mode)
+        secondaryText = modeDefaultSecondaryText(mode)
+        inputPath = ""
+        model = CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
+        width = mode == .video ? 768 : 1024
+        height = mode == .video ? 512 : 1024
+        steps = mode == .music ? 8 : 4
+        seed = ""
+        durationSeconds = 10
+        readImageAction = .inspect
+    }
+
+    private func modeDefaultPrompt(_ mode: StudioMode) -> String {
+        switch mode {
+        case .listen:
+            return ""
+        default:
+            return CommandCatalog.template(id: mode.defaultTemplateID)?.defaultPrompt ?? ""
+        }
+    }
+
+    private func modeDefaultSecondaryText(_ mode: StudioMode) -> String {
+        CommandCatalog.template(id: mode.defaultTemplateID)?.defaultSecondaryText ?? ""
+    }
+}
+
+struct StudioRunRequest: Identifiable, Equatable {
+    let id: UUID
+    let mode: StudioMode
+    let templateID: CommandTemplateID
+    let template: CommandTemplate
+    let draft: CommandDraft
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        mode: StudioMode,
+        templateID: CommandTemplateID,
+        template: CommandTemplate,
+        draft: CommandDraft,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.mode = mode
+        self.templateID = templateID
+        self.template = template
+        self.draft = draft
+        self.createdAt = createdAt
+    }
+
+    var expectedOutputURL: URL? {
+        guard !draft.outputPath.isBlank else { return nil }
+        return URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
+    }
+}
+
+enum StudioCommandError: LocalizedError, Equatable {
+    case missingPrompt(String)
+    case missingInput(String)
+    case missingTemplate(CommandTemplateID)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingPrompt(let label):
+            return "\(label) is required."
+        case .missingInput(let label):
+            return "Attach \(label.lowercased()) first."
+        case .missingTemplate(let id):
+            return "No command template found for \(id.rawValue)."
+        }
+    }
+}
+
+enum StudioCommandAdapter {
+    static func makeRequest(mode: StudioMode, draft studioDraft: StudioDraft) throws -> StudioRunRequest {
+        let templateID = templateID(for: mode, draft: studioDraft)
+        guard let template = CommandCatalog.template(id: templateID) else {
+            throw StudioCommandError.missingTemplate(templateID)
+        }
+
+        try validate(mode: mode, templateID: templateID, draft: studioDraft)
+
+        var draft = template.defaultDraft()
+        let prompt = studioDraft.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secondary = studioDraft.secondaryText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch mode {
+        case .createImage:
+            draft.prompt = prompt
+            draft.secondaryText = secondary
+            draft.inputPath = studioDraft.inputPath
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.width = studioDraft.width
+            draft.height = studioDraft.height
+            draft.steps = studioDraft.steps
+            draft.seed = studioDraft.seed
+
+        case .chat, .code:
+            draft.prompt = prompt
+            draft.secondaryText = secondary
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+
+        case .speak:
+            draft.prompt = prompt
+            draft.secondaryText = secondary.isEmpty ? draft.secondaryText : secondary
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+
+        case .listen:
+            draft.inputPath = studioDraft.inputPath
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+
+        case .readImage:
+            draft.inputPath = studioDraft.inputPath
+            draft.prompt = prompt.isEmpty ? draft.prompt : prompt
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+
+        case .findObjects, .segment, .track:
+            draft.prompt = prompt
+            draft.inputPath = studioDraft.inputPath
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+
+        case .music:
+            draft.prompt = prompt
+            draft.secondaryText = secondary
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.durationSeconds = studioDraft.durationSeconds
+            draft.steps = studioDraft.steps
+            draft.seed = studioDraft.seed
+
+        case .video:
+            draft.prompt = prompt
+            draft.inputPath = studioDraft.inputPath
+            draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.width = studioDraft.width
+            draft.height = studioDraft.height
+            draft.seed = studioDraft.seed
+        }
+
+        return StudioRunRequest(mode: mode, templateID: templateID, template: template, draft: draft)
+    }
+
+    static func pullRequest(for mode: StudioMode, draft: StudioDraft) throws -> StudioRunRequest? {
+        let model = requiredModel(for: mode, draft: draft)
+        guard !model.isBlank else { return nil }
+        guard let template = CommandCatalog.template(id: .modelPull) else {
+            throw StudioCommandError.missingTemplate(.modelPull)
+        }
+
+        var commandDraft = template.defaultDraft()
+        commandDraft.model = model
+        return StudioRunRequest(mode: mode, templateID: .modelPull, template: template, draft: commandDraft)
+    }
+
+    static func requiredModel(for mode: StudioMode, draft: StudioDraft) -> String {
+        if !draft.model.isBlank { return draft.model }
+        let templateID = templateID(for: mode, draft: draft)
+        return CommandCatalog.template(id: templateID)?.defaultModel ?? ""
+    }
+
+    private static func templateID(for mode: StudioMode, draft: StudioDraft) -> CommandTemplateID {
+        if mode == .readImage {
+            return draft.readImageAction.templateID
+        }
+        return mode.defaultTemplateID
+    }
+
+    private static func validate(
+        mode: StudioMode,
+        templateID: CommandTemplateID,
+        draft: StudioDraft
+    ) throws {
+        let prompt = draft.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let input = draft.inputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if mode.requiresAttachment && input.isEmpty {
+            throw StudioCommandError.missingInput(mode.acceptedTypes.first == .audio ? "audio" : mode.acceptedTypes.first == .movie ? "video" : "image")
+        }
+
+        let promptRequired: Bool
+        switch mode {
+        case .listen:
+            promptRequired = false
+        case .readImage:
+            promptRequired = templateID != .visionOCR
+        default:
+            promptRequired = true
+        }
+
+        if promptRequired && prompt.isEmpty {
+            throw StudioCommandError.missingPrompt("Prompt")
+        }
+    }
+}
+
+enum StudioLibraryStatus: String, Codable, Equatable {
+    case running
+    case completed
+    case failed
+}
+
+struct StudioLibraryItem: Codable, Identifiable, Equatable {
+    let id: UUID
+    var mode: StudioMode
+    var prompt: String
+    var inputURL: URL?
+    var outputURL: URL?
+    var createdAt: Date
+    var updatedAt: Date
+    var status: StudioLibraryStatus
+    var exitCode: Int32?
+    var commandPreview: String
+
+    var displayTitle: String {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return mode.title
+    }
+}
+
+enum ModelReadinessState: Equatable {
+    case checking
+    case ready
+    case missingModel(String)
+    case unsupported(String)
+    case unknown(String)
+
+    var blocksRun: Bool {
+        switch self {
+        case .missingModel, .unsupported:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .checking: return "Checking"
+        case .ready: return "Ready"
+        case .missingModel: return "Model needed"
+        case .unsupported: return "Unsupported"
+        case .unknown: return "Not checked"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .checking:
+            return "Checking local model availability."
+        case .ready:
+            return "This mode is ready to run locally."
+        case .missingModel(let model):
+            return "Download \(model) before running this mode."
+        case .unsupported(let reason):
+            return reason
+        case .unknown(let reason):
+            return reason
+        }
+    }
+}
+
+enum ModelReadinessParser {
+    static func state(for modelID: String, modelListOutput: String) -> ModelReadinessState {
+        guard !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .ready
+        }
+
+        let rows = modelListOutput
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        for row in rows {
+            let fields = row.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+            guard fields.first == modelID else { continue }
+
+            let normalized = row.lowercased()
+            if normalized.contains("unsupported") {
+                return .unsupported("\(modelID) is listed as unsupported on this Mac.")
+            }
+            if normalized.contains("installed") || normalized.contains("ready") || normalized.contains("present") {
+                return .ready
+            }
+            return .missingModel(modelID)
+        }
+
+        return .unknown("Run model capabilities or configure model sources to check \(modelID).")
+    }
+}

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -67,6 +67,9 @@ struct TextChat: AsyncParsableCommand {
     @Flag(name: [.customLong("stats")], help: "Print generation timing and tokens/sec.")
     var stats: Bool = false
 
+    @Flag(name: [.customLong("stream")], help: "Stream generated text to stdout as tokens arrive.")
+    var stream: Bool = false
+
     @Option(name: [.customLong("tools")], help: "Comma-separated built-in tool names: write_file, shell_exec.")
     var tools: String?
 
@@ -114,11 +117,15 @@ struct TextChat: AsyncParsableCommand {
             tools: toolDefs
         )
 
+        let streamingOutput = StreamingChatOutput(enabled: stream)
         let progressHandler: (@Sendable (ChatProgress) -> Void)?
         if quiet {
             progressHandler = nil
         } else {
             progressHandler = { progress in
+                if streamingOutput.write(progress: progress) {
+                    return
+                }
                 fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
             }
         }
@@ -176,7 +183,11 @@ struct TextChat: AsyncParsableCommand {
                 let result = try await chatOnce(req)
 
                 guard let calls = result.toolCalls, !calls.isEmpty else {
-                    print(cleanResponse(result.response, showThinking: thinking))
+                    if stream && streamingOutput.hasWritten {
+                        streamingOutput.finishLine()
+                    } else {
+                        print(cleanResponse(result.response, showThinking: thinking))
+                    }
                     return
                 }
 
@@ -243,7 +254,11 @@ struct TextChat: AsyncParsableCommand {
                 }
             }
 
-            print(cleanResponse(result.response, showThinking: thinking))
+            if stream && streamingOutput.hasWritten {
+                streamingOutput.finishLine()
+            } else {
+                print(cleanResponse(result.response, showThinking: thinking))
+            }
         }
     }
 
@@ -299,5 +314,47 @@ struct TextChat: AsyncParsableCommand {
 
     private static func stdinIsInteractive() -> Bool {
         isatty(fileno(stdin)) != 0
+    }
+}
+
+private final class StreamingChatOutput: @unchecked Sendable {
+    let enabled: Bool
+
+    private let lock = NSLock()
+    private var wroteOutput = false
+
+    init(enabled: Bool) {
+        self.enabled = enabled
+    }
+
+    var hasWritten: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return wroteOutput
+    }
+
+    func write(progress: ChatProgress) -> Bool {
+        guard enabled, progress.stage == .generating else {
+            return false
+        }
+
+        let text = progress.message ?? ""
+        guard !text.isEmpty, text != "Generating..." else {
+            return true
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+        fputs(text, stdout)
+        fflush(stdout)
+        wroteOutput = true
+        return true
+    }
+
+    func finishLine() {
+        lock.lock()
+        defer { lock.unlock() }
+        fputs("\n", stdout)
+        fflush(stdout)
     }
 }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -735,56 +735,63 @@ public extension ManagedModelSpec {
         case .none, .musicACEStep:
             return base
         case .qwen3ASRNested:
-            let direct = missingPaths(in: base, fileManager: fileManager)
+            let direct = missingPathsWithoutNormalization(in: base, fileManager: fileManager)
             if direct.isEmpty {
                 return base
             }
             let nested = base.appendingPathComponent(id, isDirectory: true)
-            return missingPaths(in: nested, fileManager: fileManager).isEmpty ? nested : base
+            return missingPathsWithoutNormalization(in: nested, fileManager: fileManager).isEmpty ? nested : base
         case .parakeetNested:
-            let direct = missingPaths(in: base, fileManager: fileManager)
+            let direct = missingPathsWithoutNormalization(in: base, fileManager: fileManager)
             if direct.isEmpty {
                 return base
             }
             let nested = base.appendingPathComponent(id, isDirectory: true)
-            return missingPaths(in: nested, fileManager: fileManager).isEmpty ? nested : base
+            return missingPathsWithoutNormalization(in: nested, fileManager: fileManager).isEmpty ? nested : base
         }
     }
 
     func missingPaths(in rootURL: URL, fileManager: FileManager = .default) -> [URL] {
+        missingPathsWithoutNormalization(
+            in: normalizedRootURL(rootURL, fileManager: fileManager),
+            fileManager: fileManager
+        )
+    }
+
+    private func missingPathsWithoutNormalization(in rootURL: URL, fileManager: FileManager = .default) -> [URL] {
         switch validationKind {
         case .flux2Klein:
-            return Self.missingDiffusersImagePaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingDiffusersImagePaths(in: rootURL, fileManager: fileManager)
         case .zimageTurbo:
-            return ZImageTurboResources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager)).validate(fileManager: fileManager)
+            return ZImageTurboResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .gemma4:
-            return Gemma4Resources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager)).validate(fileManager: fileManager)
+            return Gemma4Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .q35:
-            return Q35Resources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager)).validate(fileManager: fileManager)
+            return Q35Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .sam31:
-            return SAM31Resources(modelRootURL: normalizedRootURL(rootURL, fileManager: fileManager)).missingRequiredPaths(fileManager: fileManager)
+            return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:
-            return FalconPerceptionResources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager)).validate(fileManager: fileManager)
+            return FalconPerceptionResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .qwen3TTS:
-            return Self.missingQwen3TTSPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingQwen3TTSPaths(in: rootURL, fileManager: fileManager)
         case .qwen3ASR:
-            return Self.missingQwen3ASRPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingQwen3ASRPaths(in: rootURL, fileManager: fileManager)
         case .parakeet:
-            return Self.missingParakeetPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingParakeetPaths(in: rootURL, fileManager: fileManager)
         case .qwen3Embedding:
-            return Qwen3EmbeddingResources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager)).validate(fileManager: fileManager)
+            return Qwen3EmbeddingResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .privacyFilter:
-            return OpenAIPrivacyFilterResources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager)).validate(fileManager: fileManager)
+            return OpenAIPrivacyFilterResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .codegenGGUF:
-            return Self.missingCodeGenPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingCodeGenPaths(in: rootURL, fileManager: fileManager)
         case .lightOnOCR:
-            return Self.missingLightOnOCRPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingLightOnOCRPaths(in: rootURL, fileManager: fileManager)
         case .aceStep:
-            return Self.missingACEStepPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingACEStepPaths(in: rootURL, fileManager: fileManager)
         case .ltxVideo:
-            return Self.missingLTXVideoPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingLTXVideoPaths(in: rootURL, fileManager: fileManager)
         case .hfTextChat:
-            return Self.missingHFTextRootPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
+            return Self.missingHFTextRootPaths(in: rootURL, fileManager: fileManager)
         }
     }
 

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -65,19 +65,11 @@ public enum MereRunModelValidator {
         }
 
         let supportsImagePipeline: Bool
-        let supportsVisionModel: Bool
         if let unwrappedManifest = manifest {
             let supports = Set(unwrappedManifest.supports ?? [])
             supportsImagePipeline = supports.contains(.txt2img) || supports.contains(.img2img) || supports.contains(.referenceEdit)
-            supportsVisionModel = supports.contains(.visionGrounding)
-                || supports.contains(.visionDetection)
-                || supports.contains(.visionSegmentation)
-                || supports.contains(.visionTracking)
-                || unwrappedManifest.family == .sam
-                || unwrappedManifest.family == .falcon
         } else {
             supportsImagePipeline = true
-            supportsVisionModel = false
         }
 
         if let manifest = manifest {

--- a/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
+++ b/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
@@ -1,0 +1,81 @@
+@testable import MereRunApp
+import XCTest
+
+@MainActor
+final class StudioLibraryStoreTests: XCTestCase {
+    func testLibraryPersistsAndReloadsItems() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let item = StudioLibraryItem(
+            id: UUID(),
+            mode: .createImage,
+            prompt: "a small brass lamp",
+            inputURL: nil,
+            outputURL: URL(fileURLWithPath: "/tmp/lamp.png"),
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run image generate"
+        )
+
+        store.upsert(item)
+
+        let reloaded = StudioLibraryStore(libraryURL: url)
+        XCTAssertEqual(reloaded.items.count, 1)
+        XCTAssertEqual(reloaded.items.first?.id, item.id)
+        XCTAssertEqual(reloaded.items.first?.mode, .createImage)
+        XCTAssertEqual(reloaded.items.first?.prompt, "a small brass lamp")
+        XCTAssertEqual(reloaded.items.first?.outputURL?.path, "/tmp/lamp.png")
+        XCTAssertEqual(reloaded.items.first?.status, .completed)
+        XCTAssertEqual(reloaded.items.first?.exitCode, 0)
+        XCTAssertEqual(reloaded.items.first?.commandPreview, "mere.run image generate")
+    }
+
+    func testLibraryCompletionUpdatesRunningItem() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let request = try StudioCommandAdapter.makeRequest(
+            mode: .createImage,
+            draft: {
+                var draft = StudioDraft()
+                draft.reset(for: .createImage)
+                draft.prompt = "a blue plate"
+                return draft
+            }()
+        )
+
+        store.start(request: request, commandPreview: "preview")
+        store.complete(
+            id: request.id,
+            exitCode: 0,
+            outputURL: URL(fileURLWithPath: "/tmp/plate.png"),
+            commandPreview: "preview"
+        )
+
+        XCTAssertEqual(store.items.first?.status, .completed)
+        XCTAssertEqual(store.items.first?.exitCode, 0)
+        XCTAssertEqual(store.items.first?.outputURL?.path, "/tmp/plate.png")
+    }
+
+    func testCorruptLibraryRecoversToEmptyList() throws {
+        let url = try temporaryLibraryURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("not json".utf8).write(to: url)
+
+        let store = StudioLibraryStore(libraryURL: url)
+
+        XCTAssertTrue(store.items.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    private func temporaryLibraryURL() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-app-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root.appendingPathComponent("library.json")
+    }
+}

--- a/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
+++ b/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
@@ -16,7 +16,8 @@ final class StudioLibraryStoreTests: XCTestCase {
             updatedAt: Date(),
             status: .completed,
             exitCode: 0,
-            commandPreview: "mere.run image generate"
+            commandPreview: "mere.run image generate",
+            outputText: nil
         )
 
         store.upsert(item)
@@ -50,12 +51,44 @@ final class StudioLibraryStoreTests: XCTestCase {
             id: request.id,
             exitCode: 0,
             outputURL: URL(fileURLWithPath: "/tmp/plate.png"),
+            outputText: nil,
             commandPreview: "preview"
         )
 
         XCTAssertEqual(store.items.first?.status, .completed)
         XCTAssertEqual(store.items.first?.exitCode, 0)
         XCTAssertEqual(store.items.first?.outputURL?.path, "/tmp/plate.png")
+    }
+
+    func testLibraryCompletionPersistsStdoutOnlyRuns() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let request = try StudioCommandAdapter.makeRequest(
+            mode: .chat,
+            draft: {
+                var draft = StudioDraft()
+                draft.reset(for: .chat)
+                draft.prompt = "Hello"
+                return draft
+            }()
+        )
+
+        store.start(request: request, commandPreview: "preview")
+        store.complete(
+            id: request.id,
+            exitCode: 0,
+            outputURL: nil,
+            outputText: "Hi from local chat.",
+            commandPreview: "preview"
+        )
+
+        let item = try XCTUnwrap(store.items.first)
+        XCTAssertEqual(item.status, .completed)
+        XCTAssertNil(item.outputURL)
+        XCTAssertEqual(item.outputText, "Hi from local chat.")
+
+        let reloaded = StudioLibraryStore(libraryURL: url)
+        XCTAssertEqual(reloaded.items.first?.outputText, "Hi from local chat.")
     }
 
     func testCorruptLibraryRecoversToEmptyList() throws {

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -1,0 +1,99 @@
+@testable import MereRunApp
+import XCTest
+
+final class StudioTypesTests: XCTestCase {
+    func testStudioModesMapToPublicTemplates() {
+        XCTAssertEqual(StudioMode.createImage.defaultTemplateID, .imageGenerate)
+        XCTAssertEqual(StudioMode.chat.defaultTemplateID, .textChat)
+        XCTAssertEqual(StudioMode.code.defaultTemplateID, .textCode)
+        XCTAssertEqual(StudioMode.speak.defaultTemplateID, .speechSynthesize)
+        XCTAssertEqual(StudioMode.listen.defaultTemplateID, .speechTranscribe)
+        XCTAssertEqual(StudioMode.readImage.defaultTemplateID, .visionInspect)
+        XCTAssertEqual(StudioMode.findObjects.defaultTemplateID, .visionGround)
+        XCTAssertEqual(StudioMode.segment.defaultTemplateID, .visionSegment)
+        XCTAssertEqual(StudioMode.track.defaultTemplateID, .visionTrack)
+        XCTAssertEqual(StudioMode.music.defaultTemplateID, .musicGenerate)
+        XCTAssertEqual(StudioMode.video.defaultTemplateID, .videoGenerate)
+    }
+
+    func testStudioRunRequestBuildsImageCommandWithDefaultOutput() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        draft.prompt = "a porcelain teapot on linen"
+        draft.secondaryText = "blurry"
+        draft.width = 768
+        draft.height = 512
+        draft.steps = 8
+
+        let request = try StudioCommandAdapter.makeRequest(mode: .createImage, draft: draft)
+
+        XCTAssertEqual(request.templateID, .imageGenerate)
+        XCTAssertEqual(request.draft.prompt, "a porcelain teapot on linen")
+        XCTAssertEqual(request.draft.secondaryText, "blurry")
+        XCTAssertEqual(request.draft.width, 768)
+        XCTAssertEqual(request.draft.height, 512)
+        XCTAssertEqual(request.draft.steps, 8)
+        XCTAssertEqual(request.expectedOutputURL?.pathExtension, "png")
+    }
+
+    func testReadImageVariantsResolveToDistinctTemplates() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .readImage)
+        draft.inputPath = "/tmp/image.png"
+        draft.prompt = "What text is visible?"
+
+        draft.readImageAction = .inspect
+        XCTAssertEqual(try StudioCommandAdapter.makeRequest(mode: .readImage, draft: draft).templateID, .visionInspect)
+
+        draft.readImageAction = .ocr
+        XCTAssertEqual(try StudioCommandAdapter.makeRequest(mode: .readImage, draft: draft).templateID, .visionOCR)
+
+        draft.readImageAction = .caption
+        XCTAssertEqual(try StudioCommandAdapter.makeRequest(mode: .readImage, draft: draft).templateID, .visionCaption)
+    }
+
+    func testMissingInputValidationIsFriendly() {
+        var draft = StudioDraft()
+        draft.reset(for: .listen)
+
+        XCTAssertThrowsError(try StudioCommandAdapter.makeRequest(mode: .listen, draft: draft)) { error in
+            XCTAssertEqual(error as? StudioCommandError, .missingInput("audio"))
+        }
+    }
+
+    func testModelReadinessParserFindsInstalledMissingAndUnknown() {
+        let output = """
+        ID Category Status Size
+        image-zimage-nano image installed 4 GB
+        video-ltx-av media missing 12 GB
+        vision-segment-sam31 vision unsupported 7 GB
+        """
+
+        XCTAssertEqual(
+            ModelReadinessParser.state(for: "image-zimage-nano", modelListOutput: output),
+            .ready
+        )
+        XCTAssertEqual(
+            ModelReadinessParser.state(for: "video-ltx-av", modelListOutput: output),
+            .missingModel("video-ltx-av")
+        )
+        XCTAssertEqual(
+            ModelReadinessParser.state(for: "vision-segment-sam31", modelListOutput: output),
+            .unsupported("vision-segment-sam31 is listed as unsupported on this Mac.")
+        )
+
+        if case .unknown = ModelReadinessParser.state(for: "missing", modelListOutput: output) {
+            // expected
+        } else {
+            XCTFail("Expected unknown readiness for a model absent from the list.")
+        }
+    }
+
+    func testAPIKeyPreviewMasking() {
+        let args = ["api", "serve", "--api-key", "secret-token", "--port", "8080"]
+        XCTAssertEqual(
+            args.maskingSecrets(),
+            ["api", "serve", "--api-key", "••••••••", "--port", "8080"]
+        )
+    }
+}

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -16,6 +16,24 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertEqual(StudioMode.video.defaultTemplateID, .videoGenerate)
     }
 
+    func testCodeStudioDefaultsUsePublicModelID() throws {
+        let codeTemplate = try XCTUnwrap(CommandCatalog.template(id: .textCode))
+        XCTAssertEqual(codeTemplate.defaultModel, "text-code-qwen3")
+
+        var draft = StudioDraft()
+        draft.reset(for: .code)
+        XCTAssertEqual(draft.model, "text-code-qwen3")
+        XCTAssertEqual(StudioCommandAdapter.requiredModel(for: .code, draft: draft), "text-code-qwen3")
+    }
+
+    func testChatStudioDefaultsToStreamingOutput() throws {
+        let chatTemplate = try XCTUnwrap(CommandCatalog.template(id: .textChat))
+        let draft = chatTemplate.defaultDraft()
+
+        XCTAssertTrue(draft.stream)
+        XCTAssertTrue(chatTemplate.arguments(from: draft).contains("--stream"))
+    }
+
     func testStudioRunRequestBuildsImageCommandWithDefaultOutput() throws {
         var draft = StudioDraft()
         draft.reset(for: .createImage)

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -29,4 +29,49 @@ final class ManagedModelCatalogTests: XCTestCase {
             )
         }
     }
+
+    func testNestedASRNormalizationDoesNotRecurseThroughValidation() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for id in ["speech-asr-qwen3", "speech-asr-parakeet"] {
+            let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
+
+            XCTAssertFalse(
+                spec.isManagedRootComplete(root, fileManager: .default),
+                "Missing nested ASR roots should validate as incomplete without recursing forever."
+            )
+            XCTAssertEqual(spec.normalizedRootURL(root, fileManager: .default), root.resolvingSymlinksInPath())
+        }
+    }
+
+    func testNestedASRNormalizationPrefersCompleteNestedRoot() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let qwenSpec = try XCTUnwrap(ManagedModelCatalog.spec(for: "speech-asr-qwen3"))
+        let qwenRoot = root.appendingPathComponent(qwenSpec.id, isDirectory: true)
+        try FileManager.default.createDirectory(at: qwenRoot, withIntermediateDirectories: true)
+        for file in ["config.json", "model.safetensors", "tokenizer.json", "tokenizer_config.json"] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: qwenRoot.appendingPathComponent(file).path, contents: Data()))
+        }
+
+        XCTAssertEqual(qwenSpec.normalizedRootURL(root, fileManager: .default), qwenRoot)
+
+        let parakeetSpec = try XCTUnwrap(ManagedModelCatalog.spec(for: "speech-asr-parakeet"))
+        let parakeetRoot = root.appendingPathComponent(parakeetSpec.id, isDirectory: true)
+        try FileManager.default.createDirectory(at: parakeetRoot, withIntermediateDirectories: true)
+        for file in ["config.json", "model.safetensors", "tokenizer.model"] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: parakeetRoot.appendingPathComponent(file).path, contents: Data()))
+        }
+
+        XCTAssertEqual(parakeetSpec.normalizedRootURL(root, fileManager: .default), parakeetRoot)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-managed-model-catalog-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # mere.run Documentation
 
 This documentation set is organized like a practical manual for the public
-`mere.run` package and CLI. The goal is to make it easy to learn the tool,
+`mere.run` package, CLI, and optional macOS studio. The goal is to make it easy to learn the tool,
 understand the repository, and navigate the runtime code without guessing where
 things live.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -213,6 +213,7 @@ Key options:
 - `--max-tokens`
 - `--temperature`
 - `--top-p`
+- `--stream`
 - `--thinking`
 - `--stats`
 - `--quiet`
@@ -222,6 +223,7 @@ Examples:
 ```bash
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
 swift run mere.run text chat --model text-chat-q35-nano --prompt "Explain speculative decoding."
+swift run mere.run text chat --stream --prompt "Write a short welcome message."
 swift run mere.run text chat --thinking --stats --prompt "How would you design a tokenizer?"
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,6 +141,7 @@ swift run mere.run image generate \
 
 ```bash
 swift run mere.run text chat \
+  --stream \
   --prompt "Explain classifier-free guidance in one paragraph."
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,8 @@ workflow.
 - reusable inference libraries in `Sources/MereRunCore`, `Sources/AudioCore`,
   `Sources/AudioCodecs`, `Sources/AudioSTT`, and `Sources/AudioTTS`
 - a public executable product named `mere.run`
+- an optional macOS SwiftUI studio named `mere.run.app` that wraps the public
+  CLI
 - tests and smoke harnesses for the package and CLI surfaces
 
 It does not include hosted-service, billing, or private-deployment surfaces.
@@ -33,10 +35,30 @@ From the repo root:
 swift build
 swift test
 swift run mere.run --help
+app_path="$(./scripts/build_mere_run_app.sh debug)"
+open "$app_path"
 ```
 
-That confirms the package graph, CLI product, and basic command parsing are all
-working.
+That confirms the package graph, CLI product, optional app product, app bundle,
+and basic command parsing are all working.
+
+## Launch the macOS studio
+
+The app is a user-facing local studio backed by the public CLI. It opens to a
+unified canvas and prompt bar, keeps generated outputs in a local library, and
+keeps command previews and logs in Advanced details. Launch it from a checkout
+with:
+
+```bash
+app_path="$(./scripts/build_mere_run_app.sh debug)"
+open "$app_path"
+```
+
+For contributor smoke tests, `swift run mere.run.app` still builds the executable
+product, but the bundle script is the recommended local launch path for normal
+macOS window behavior. The app auto-detects a bundled CLI first, then nearby
+SwiftPM build products, common install locations, and finally the current
+package checkout.
 
 ## Understand the command tree
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: mere.run
   text: Local-first inference on Apple Silicon
-  tagline: A public Swift package and CLI for image, text, speech, vision, music, video, model management, and local API serving.
+  tagline: A public Swift package, CLI, and optional macOS studio for image, text, speech, vision, music, video, model management, and local API serving.
   actions:
     - theme: brand
       text: Get Started
@@ -19,6 +19,8 @@ hero:
 features:
   - title: One CLI, clear modalities
     details: The public surface is organized around image, text, speech, vision, music, video, model management, and local API serving.
+  - title: Native macOS studio
+    details: The optional SwiftUI app opens to a prompt-first canvas, local output library, guided readiness, and advanced CLI details.
   - title: Canonical model system
     details: Public model IDs, shared model-store rules, and explicit source configuration make installs predictable and scriptable.
   - title: Readable runtime families

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -17,7 +17,7 @@ mere-run/
 
 ## SwiftPM products
 
-`Package.swift` defines six public products:
+`Package.swift` defines seven public products:
 
 - `MereRunCore`
 - `AudioCore`
@@ -25,8 +25,10 @@ mere-run/
 - `AudioSTT`
 - `AudioTTS`
 - `mere.run` (the executable product backed by the `MereRunCLI` target)
+- `mere.run.app` (the optional SwiftUI studio backed by the `MereRunApp` target)
 
-Those map cleanly to the main runtime families exposed by the CLI.
+Those map cleanly to the main runtime families exposed by the CLI and the
+optional macOS studio.
 
 ## Source tree
 
@@ -40,6 +42,13 @@ The public command-line surface.
   API support
 
 If you want to understand the CLI end to end, start here.
+
+### `Sources/MereRunApp`
+
+The optional macOS studio. It does not own runtime behavior; it turns
+user-facing studio requests into `mere.run` arguments, launches the CLI as a
+child process, streams stdout and stderr, saves local library metadata, and keeps
+the raw command surface available in Advanced details.
 
 ### `Sources/MereRunCore`
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -38,6 +38,7 @@ embeddings, and PII anonymization.
 
 ```bash
 swift run mere.run text chat \
+  --stream \
   --model text-chat-gemma4 \
   --prompt "Summarize diffusion models in one paragraph."
 ```
@@ -98,7 +99,8 @@ swift run mere.run text anonymize \
 ### `mere.run text chat`
 
 Use this for local assistant-style generation. It supports prompt/system
-control, token limits, and the chat-oriented model families.
+control, token limits, token streaming with `--stream`, and the chat-oriented
+model families.
 
 ### `mere.run text code`
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+configuration="${1:-debug}"
+case "$configuration" in
+  debug|release) ;;
+  *)
+    echo "Usage: $0 [debug|release]" >&2
+    exit 64
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+swift_args=(build --product mere.run.app)
+if [[ "$configuration" == "release" ]]; then
+  swift_args+=(--configuration release)
+fi
+
+swift "${swift_args[@]}"
+
+triple="$(swift -print-target-info | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["target"]["triple"])')"
+build_dir=".build/${triple}/${configuration}"
+executable="${build_dir}/mere.run.app"
+
+if [[ ! -x "$executable" ]]; then
+  build_dir=".build/${configuration}"
+  executable="${build_dir}/mere.run.app"
+fi
+
+if [[ ! -x "$executable" ]]; then
+  echo "Built executable not found: ${executable}" >&2
+  exit 66
+fi
+
+bundle="${build_dir}/MereRun.app"
+contents="${bundle}/Contents"
+macos="${contents}/MacOS"
+resources="${contents}/Resources"
+
+rm -rf "$bundle"
+mkdir -p "$macos" "$resources"
+cp "$executable" "${macos}/mere.run.app"
+
+plutil -create xml1 "${contents}/Info.plist"
+plutil -insert CFBundleExecutable -string "mere.run.app" "${contents}/Info.plist"
+plutil -insert CFBundleIdentifier -string "run.mere.MereRunApp" "${contents}/Info.plist"
+plutil -insert CFBundleName -string "MereRun" "${contents}/Info.plist"
+plutil -insert CFBundleDisplayName -string "MereRun" "${contents}/Info.plist"
+plutil -insert CFBundlePackageType -string "APPL" "${contents}/Info.plist"
+plutil -insert CFBundleVersion -string "1" "${contents}/Info.plist"
+plutil -insert CFBundleShortVersionString -string "0.1" "${contents}/Info.plist"
+plutil -insert LSMinimumSystemVersion -string "15.0" "${contents}/Info.plist"
+plutil -insert NSPrincipalClass -string "NSApplication" "${contents}/Info.plist"
+
+codesign --force --sign - "$bundle" >/dev/null
+echo "$repo_root/$bundle"

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 configuration="${1:-debug}"
+app_version="${MERERUN_APP_VERSION:-0.4.0}"
+app_build="${MERERUN_APP_BUILD:-1}"
 case "$configuration" in
   debug|release) ;;
   *)
@@ -49,8 +51,8 @@ plutil -insert CFBundleIdentifier -string "run.mere.MereRunApp" "${contents}/Inf
 plutil -insert CFBundleName -string "MereRun" "${contents}/Info.plist"
 plutil -insert CFBundleDisplayName -string "MereRun" "${contents}/Info.plist"
 plutil -insert CFBundlePackageType -string "APPL" "${contents}/Info.plist"
-plutil -insert CFBundleVersion -string "1" "${contents}/Info.plist"
-plutil -insert CFBundleShortVersionString -string "0.1" "${contents}/Info.plist"
+plutil -insert CFBundleVersion -string "$app_build" "${contents}/Info.plist"
+plutil -insert CFBundleShortVersionString -string "$app_version" "${contents}/Info.plist"
 plutil -insert LSMinimumSystemVersion -string "15.0" "${contents}/Info.plist"
 plutil -insert NSPrincipalClass -string "NSApplication" "${contents}/Info.plist"
 


### PR DESCRIPTION
## Summary
- Introduce **MereRun Studio**, a SwiftUI app target wrapping the `mere.run` CLI with mode-driven canvases (chat, code, image, vision, speech, music, video) and a persistent run library
- Add `--stream` to `mere.run text chat`; Studio defaults chat/code to streaming and renders live tokens on the canvas, persisting stdout-only runs alongside file outputs
- Fix infinite recursion when normalizing nested ASR (qwen3 / parakeet) managed-model roots, prefer local build products over installed binaries when the app resolves the bundled CLI, and switch the public code template default to `text-code-qwen3`

## Test plan
- [ ] `swift test` (App + Core + CLI test targets)
- [ ] `swift run mere.run text chat --stream --prompt "hello"` streams tokens to stdout
- [ ] Launch Studio, run a chat prompt, confirm live tokens appear on the canvas and the completed run is restored from the library after relaunch
- [ ] Confirm an incomplete managed model root for `speech-asr-qwen3` / `speech-asr-parakeet` reports as incomplete without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)