### PR TITLE
Add native HiDream O1 image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ swift run mere.run image generate \
   --prompt "a ceramic coffee mug in soft morning light" \
   --output ./mug.png
 
+# HiDream O1 runs natively for text, edit, and multi-reference generation.
+swift run mere.run image generate \
+  --model image-hidream-o1-dev \
+  --prompt "a clean studio product photo of the subject" \
+  --ref-image ./subject.png \
+  --output ./subject-studio.png
+
 # Run local chat
 swift run mere.run text chat \
   --stream \

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -20,8 +20,11 @@ struct ImageGenerate: AsyncParsableCommand {
     @Option(name: [.customShort("n"), .customLong("negative-prompt")], help: "Negative prompt (used when --cfg > 1.0).")
     var negativePrompt: String?
 
-    @Option(name: [.customLong("cfg"), .customLong("cfg-scale")], help: "CFG scale (uses negative prompt when > 1.0). Default: 1.0.")
-    var cfgScale: Double = 1.0
+    @Option(
+        name: [.customLong("cfg"), .customLong("cfg-scale")],
+        help: "CFG scale (uses negative prompt when > 1.0; default is model-specific)."
+    )
+    var cfgScale: Double?
 
     @Option(name: [.customLong("sigma-shift")], help: "Sigma shift for the FlowMatch schedule (i2L recommends 8).")
     var sigmaShift: Double?
@@ -35,8 +38,8 @@ struct ImageGenerate: AsyncParsableCommand {
     @Option(name: [.customShort("H"), .long], help: "Output height in pixels.")
     var height: Int = 1024
 
-    @Option(name: [.customShort("s"), .long], help: "Number of inference steps.")
-    var steps: Int = 4
+    @Option(name: [.customShort("s"), .long], help: "Number of inference steps (default is model-specific).")
+    var steps: Int?
 
     @Option(name: [.long], help: "Random seed (UInt64).")
     var seed: UInt64?
@@ -46,6 +49,12 @@ struct ImageGenerate: AsyncParsableCommand {
 
     @Option(name: [.customShort("i"), .long], help: "Input image path (enables image-to-image).")
     var input: String?
+
+    @Option(name: [.customLong("ref-image")], help: "Reference image path for HiDream O1 editing/personalization. Repeat for multiple references.")
+    var referenceImages: [String] = []
+
+    @Flag(name: [.customLong("keep-original-aspect")], help: "For one HiDream reference image, preserve the original aspect ratio.")
+    var keepOriginalAspect: Bool = false
 
     @Option(name: [.customLong("strength"), .customLong("str")], help: "Image-to-image strength 0.0–1.0 (default: 0.75).")
     var strength: Double = 0.75
@@ -65,7 +74,7 @@ struct ImageGenerate: AsyncParsableCommand {
     func run() async throws {
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
-        guard steps > 0 else {
+        if let steps, steps <= 0 {
             throw ValidationError("--steps must be >= 1")
         }
         guard width > 0, height > 0 else {
@@ -90,6 +99,14 @@ struct ImageGenerate: AsyncParsableCommand {
             inputURL = url
         } else {
             inputURL = nil
+        }
+
+        let referenceImageURLs = try referenceImages.map { path in
+            let url = URL(fileURLWithPath: path).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ValidationError("Reference image not found: \(url.path)")
+            }
+            return url
         }
 
         let resolvedModel: String?
@@ -129,13 +146,20 @@ struct ImageGenerate: AsyncParsableCommand {
             loraConfig = nil
         }
 
+        let manifest = try MereRunModelManifest.loadRequired(from: URL(fileURLWithPath: resolvedModel!))
+        let effectiveSteps = steps
+            ?? (manifest.family == .hidream ? (manifest.defaults?.steps ?? 4) : 4)
+        let effectiveCFG = cfgScale
+            ?? (manifest.family == .hidream ? (manifest.defaults?.cfg ?? 1.0) : 1.0)
+
         let request = GenerationRequest(
             prompt: prompt,
             negativePrompt: negativePrompt,
+            referenceImages: referenceImageURLs,
             width: width,
             height: height,
-            steps: steps,
-            guidanceScale: cfgScale,
+            steps: effectiveSteps,
+            guidanceScale: effectiveCFG,
             seed: seed,
             outputURL: outputURL,
             model: resolvedModel,
@@ -144,13 +168,13 @@ struct ImageGenerate: AsyncParsableCommand {
             enhancePrompt: false,
             inputImage: inputURL,
             strength: strength,
+            keepOriginalAspect: keepOriginalAspect,
             useBetaSigmas: false,
             sigmaShift: sigmaShift.map { Float($0) }
         )
 
         let progressHandler: (@Sendable (GenerationProgress) -> Void)? = quiet ? nil : CLIGenerationProgressPrinter.makeProgressHandler()
 
-        let manifest = try MereRunModelManifest.loadRequired(from: URL(fileURLWithPath: resolvedModel!))
         let result: GenerationResult
         switch manifest.family {
         case .klein:
@@ -158,6 +182,9 @@ struct ImageGenerate: AsyncParsableCommand {
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .zimage:
             let generator = ZImageTurboGenerator()
+            result = try await generator.generate(request, progressHandler: progressHandler)
+        case .hidream:
+            let generator = HiDreamO1Generator()
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .gemma, .qwen, .sam, .falcon, .tts, .asr, .embed, .code, .ocr, .music, .video, .psi, .privacy, nil:
             throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -8,7 +8,7 @@ public enum LoRA: Sendable, Hashable {
 public struct GenerationRequest: Sendable, Hashable {
     public var prompt: String
     public var negativePrompt: String?
-    /// Reference images for FLUX.2 Klein multi-reference editing (0–4).
+    /// Reference images for model families that support edit or personalization modes.
     public var referenceImages: [URL]
     /// Reference strength for FLUX.2 Klein editing (0.0 = preserve, 1.0 = max change).
     public var referenceStrength: Double
@@ -24,6 +24,8 @@ public struct GenerationRequest: Sendable, Hashable {
     public var enhancePrompt: Bool
     public var inputImage: URL?
     public var strength: Double
+    /// Preserve the single reference image aspect ratio for model families that support it.
+    public var keepOriginalAspect: Bool
     public var useBetaSigmas: Bool
     public var sigmaShift: Float?
 
@@ -44,6 +46,7 @@ public struct GenerationRequest: Sendable, Hashable {
         enhancePrompt: Bool = false,
         inputImage: URL? = nil,
         strength: Double = 0.75,
+        keepOriginalAspect: Bool = false,
         useBetaSigmas: Bool = false,
         sigmaShift: Float? = nil
     ) {
@@ -63,6 +66,7 @@ public struct GenerationRequest: Sendable, Hashable {
         self.enhancePrompt = enhancePrompt
         self.inputImage = inputImage
         self.strength = strength
+        self.keepOriginalAspect = keepOriginalAspect
         self.useBetaSigmas = useBetaSigmas
         self.sigmaShift = sigmaShift
     }

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Configs.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Configs.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public struct HiDreamO1Config: Decodable, Sendable, Hashable {
+    public var architectures: [String]
+    public var modelType: String
+    public var imageTokenId: Int
+    public var videoTokenId: Int
+    public var visionStartTokenId: Int
+    public var visionEndTokenId: Int
+    public var textConfig: TextConfig
+    public var visionConfig: VisionConfig
+
+    public struct TextConfig: Decodable, Sendable, Hashable {
+        public var attentionBias: Bool
+        public var attentionDropout: Float
+        public var bosTokenId: Int
+        public var eosTokenId: Int
+        public var headDim: Int
+        public var hiddenAct: String
+        public var hiddenSize: Int
+        public var intermediateSize: Int
+        public var maxPositionEmbeddings: Int
+        public var numAttentionHeads: Int
+        public var numHiddenLayers: Int
+        public var numKeyValueHeads: Int
+        public var rmsNormEps: Float
+        public var ropeTheta: Float
+        public var vocabSize: Int
+        public var ropeScaling: RopeScaling
+
+        private enum CodingKeys: String, CodingKey {
+            case attentionBias = "attention_bias"
+            case attentionDropout = "attention_dropout"
+            case bosTokenId = "bos_token_id"
+            case eosTokenId = "eos_token_id"
+            case headDim = "head_dim"
+            case hiddenAct = "hidden_act"
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case maxPositionEmbeddings = "max_position_embeddings"
+            case numAttentionHeads = "num_attention_heads"
+            case numHiddenLayers = "num_hidden_layers"
+            case numKeyValueHeads = "num_key_value_heads"
+            case rmsNormEps = "rms_norm_eps"
+            case ropeTheta = "rope_theta"
+            case vocabSize = "vocab_size"
+            case ropeScaling = "rope_scaling"
+        }
+    }
+
+    public struct RopeScaling: Decodable, Sendable, Hashable {
+        public var mropeInterleaved: Bool
+        public var mropeSection: [Int]
+        public var ropeType: String
+
+        private enum CodingKeys: String, CodingKey {
+            case mropeInterleaved = "mrope_interleaved"
+            case mropeSection = "mrope_section"
+            case ropeType = "rope_type"
+        }
+    }
+
+    public struct VisionConfig: Decodable, Sendable, Hashable {
+        public var deepstackVisualIndexes: [Int]
+        public var depth: Int
+        public var hiddenAct: String
+        public var hiddenSize: Int
+        public var inChannels: Int
+        public var intermediateSize: Int
+        public var numHeads: Int
+        public var numPositionEmbeddings: Int
+        public var outHiddenSize: Int
+        public var patchSize: Int
+        public var spatialMergeSize: Int
+        public var temporalPatchSize: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case deepstackVisualIndexes = "deepstack_visual_indexes"
+            case depth
+            case hiddenAct = "hidden_act"
+            case hiddenSize = "hidden_size"
+            case inChannels = "in_channels"
+            case intermediateSize = "intermediate_size"
+            case numHeads = "num_heads"
+            case numPositionEmbeddings = "num_position_embeddings"
+            case outHiddenSize = "out_hidden_size"
+            case patchSize = "patch_size"
+            case spatialMergeSize = "spatial_merge_size"
+            case temporalPatchSize = "temporal_patch_size"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case architectures
+        case modelType = "model_type"
+        case imageTokenId = "image_token_id"
+        case videoTokenId = "video_token_id"
+        case visionStartTokenId = "vision_start_token_id"
+        case visionEndTokenId = "vision_end_token_id"
+        case textConfig = "text_config"
+        case visionConfig = "vision_config"
+    }
+
+    public static func load(from resources: HiDreamO1Resources) throws -> HiDreamO1Config {
+        let data = try Data(contentsOf: resources.configURL)
+        return try JSONDecoder().decode(HiDreamO1Config.self, from: data)
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift
@@ -1,0 +1,241 @@
+import Foundation
+import MLX
+
+public enum HiDreamO1GeneratorError: LocalizedError, Sendable {
+    case missingModelFiles([URL])
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingModelFiles(let urls):
+            return "Missing HiDream O1 model files: \(urls.map(\.path).joined(separator: ", "))"
+        }
+    }
+}
+
+public final class HiDreamO1Generator: ImageGenerator {
+    public init() {}
+
+    public func generate(
+        _ request: GenerationRequest,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> GenerationResult {
+        progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 0, totalSteps: 1))
+        let rootURL = try resolveModelRoot(request)
+        let resources = HiDreamO1Resources(rootURL: rootURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw HiDreamO1GeneratorError.missingModelFiles(missing)
+        }
+
+        let config = try HiDreamO1Config.load(from: resources)
+        let tokenizer = try await HiDreamO1TokenizerAndTemplate.load(from: resources)
+        let manifest = try MereRunModelManifest.loadRequired(from: rootURL)
+        let variant = manifest.variant ?? .distilled
+        let shift: Float = variant == .distilled ? 1.0 : 3.0
+        let scheduler = HiDreamO1Scheduler(steps: request.steps, variant: variant, shift: shift)
+
+        let references = effectiveReferenceImages(for: request)
+        let referenceOriginalSizes = try references.map { try HiDreamO1ImagePreprocessor.imageSize($0) }
+        let targetResolution = HiDreamO1SampleBuilder.targetResolution(
+            width: request.width,
+            height: request.height,
+            referenceOriginalSizes: referenceOriginalSizes,
+            keepOriginalAspect: request.keepOriginalAspect
+        )
+        let referenceSizes = resizedReferenceSizes(
+            originalSizes: referenceOriginalSizes,
+            targetResolution: targetResolution,
+            keepOriginalAspect: request.keepOriginalAspect
+        )
+        let referenceTensors = try zip(references, referenceSizes).map { url, size in
+            try HiDreamO1ImagePreprocessor.patchTensor(from: url, resolution: size)
+        }
+        let conditionSize = HiDreamO1SampleBuilder.conditionSize(referenceCount: references.count)
+        let visionConditionSizes = referenceSizes.map {
+            HiDreamO1SampleBuilder.vlmConditionSize(
+                originalWidth: $0.width,
+                originalHeight: $0.height,
+                maxSize: conditionSize
+            )
+        }
+        let visionConditions = try zip(references, visionConditionSizes).map { url, size in
+            try HiDreamO1ImagePreprocessor.visionConditionTensor(
+                from: url,
+                resolution: size,
+                config: config
+            )
+        }
+        let textTokenIds = references.isEmpty
+            ? try tokenizer.encodeTextToImagePrompt(request.prompt)
+            : try tokenizer.encodeReferencePrompt(
+                request.prompt,
+                referenceImageTokenCounts: visionConditions.map(\.tokenCount)
+            )
+        let usesCFG = request.guidanceScale > 1.0
+        let unconditionalPrompt = request.negativePrompt ?? " "
+        let unconditionalTextTokenIds: [Int]?
+        if usesCFG {
+            unconditionalTextTokenIds = references.isEmpty
+                ? try tokenizer.encodeTextToImagePrompt(unconditionalPrompt)
+                : try tokenizer.encodeReferencePrompt(
+                    unconditionalPrompt,
+                    referenceImageTokenCounts: visionConditions.map(\.tokenCount)
+                )
+        } else {
+            unconditionalTextTokenIds = nil
+        }
+        let sample = references.isEmpty
+            ? HiDreamO1SampleBuilder.textToImageSample(
+                textTokenIds: textTokenIds,
+                height: targetResolution.height,
+                width: targetResolution.width,
+                config: config
+            )
+            : HiDreamO1SampleBuilder.referenceSample(
+                textTokenIds: textTokenIds,
+                targetHeight: targetResolution.height,
+                targetWidth: targetResolution.width,
+                referenceSizes: referenceSizes,
+                conditionGrids: visionConditions.map(\.mergedGrid),
+                config: config
+            )
+        let unconditionalSample = unconditionalTextTokenIds.map { tokenIds in
+            references.isEmpty
+                ? HiDreamO1SampleBuilder.textToImageSample(
+                    textTokenIds: tokenIds,
+                    height: targetResolution.height,
+                    width: targetResolution.width,
+                    config: config
+                )
+                : HiDreamO1SampleBuilder.referenceSample(
+                    textTokenIds: tokenIds,
+                    targetHeight: targetResolution.height,
+                    targetWidth: targetResolution.width,
+                    referenceSizes: referenceSizes,
+                    conditionGrids: visionConditions.map(\.mergedGrid),
+                    config: config
+                )
+        }
+        let conditioning = HiDreamO1Denoiser.Conditioning(
+            sample: sample,
+            visionConditions: visionConditions
+        )
+        let unconditionalConditioning = unconditionalSample.map {
+            HiDreamO1Denoiser.Conditioning(sample: $0, visionConditions: visionConditions)
+        }
+
+        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let model = try HiDreamO1ModelLoader.load(
+            resources: resources,
+            config: config,
+            progressHandler: progressHandler
+        )
+        let image: MLXArray
+        if references.isEmpty {
+            let patches = try HiDreamO1Denoiser.runTextOnly(
+                model: model,
+                conditioning: conditioning,
+                unconditionalConditioning: unconditionalConditioning,
+                scheduler: scheduler,
+                height: targetResolution.height,
+                width: targetResolution.width,
+                seed: seed,
+                guidanceScale: Float(request.guidanceScale),
+                progressHandler: progressHandler
+            )
+            image = HiDreamO1SampleBuilder.unpatchifyCHW(
+                patches,
+                height: targetResolution.height,
+                width: targetResolution.width
+            )
+        } else {
+            let patches = try HiDreamO1Denoiser.runWithReferences(
+                model: model,
+                conditioning: conditioning,
+                unconditionalConditioning: unconditionalConditioning,
+                scheduler: scheduler,
+                height: targetResolution.height,
+                width: targetResolution.width,
+                seed: seed,
+                referenceTensors: referenceTensors,
+                guidanceScale: Float(request.guidanceScale),
+                progressHandler: progressHandler
+            )
+            image = HiDreamO1SampleBuilder.unpatchifyCHW(
+                patches,
+                height: targetResolution.height,
+                width: targetResolution.width
+            )
+        }
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 0, totalSteps: 1))
+        try ensureOutputDirectory(request.outputURL)
+        try HiDreamO1ImagePreprocessor.saveNormalizedCHW(image, to: request.outputURL)
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 1, totalSteps: 1))
+        return GenerationResult(outputURL: request.outputURL, seed: seed)
+    }
+
+    private func resolveModelRoot(_ request: GenerationRequest) throws -> URL {
+        if let model = request.model {
+            let url = URL(fileURLWithPath: model).standardizedFileURL
+            if FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+        if let resolved = ManagedModelResolver.resolveInstalledModel(id: ModelResolver.ModelID.hidreamO1Dev.rawValue) {
+            return resolved
+        }
+        throw ModelResolver.ResolverError.modelNotFound(
+            .hidreamO1Dev,
+            searched: [MereRunModelPaths.modelDir(ModelResolver.ModelID.hidreamO1Dev.rawValue)],
+            upstreamRepoId: "HiDream-ai/HiDream-O1-Image-Dev"
+        )
+    }
+
+    private func effectiveReferenceImages(for request: GenerationRequest) -> [URL] {
+        if !request.referenceImages.isEmpty {
+            return request.referenceImages
+        }
+        if let inputImage = request.inputImage {
+            return [inputImage]
+        }
+        return []
+    }
+
+    private func ensureOutputDirectory(_ outputURL: URL) throws {
+        let directory = outputURL.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
+    private func deterministicSeed(prompt: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in prompt.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x0000_0100_0000_01b3
+        }
+        return hash
+    }
+
+    private func resizedReferenceSizes(
+        originalSizes: [HiDreamO1SampleBuilder.Resolution],
+        targetResolution: HiDreamO1SampleBuilder.Resolution,
+        keepOriginalAspect: Bool
+    ) -> [HiDreamO1SampleBuilder.Resolution] {
+        if keepOriginalAspect, originalSizes.count == 1 {
+            return [targetResolution]
+        }
+        let maxSize = HiDreamO1SampleBuilder.referenceMaxSize(
+            targetWidth: targetResolution.width,
+            targetHeight: targetResolution.height,
+            referenceCount: originalSizes.count
+        )
+        return originalSizes.map {
+            HiDreamO1SampleBuilder.resizedReferenceSize(
+                originalWidth: $0.width,
+                originalHeight: $0.height,
+                maxSize: maxSize
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift
@@ -1,0 +1,349 @@
+import Foundation
+import MLX
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+#endif
+
+public enum HiDreamO1ImagePreprocessorError: LocalizedError, Sendable {
+    case imageLoadFailed(URL)
+    case imageResizeFailed
+    case pixelBufferFailed
+    case invalidSize(width: Int, height: Int)
+    case imageWriteFailed(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .imageLoadFailed(let url):
+            return "Failed to load HiDream O1 image: \(url.path)"
+        case .imageResizeFailed:
+            return "Failed to resize HiDream O1 image."
+        case .pixelBufferFailed:
+            return "Failed to convert HiDream O1 image pixels."
+        case .invalidSize(let width, let height):
+            return "HiDream O1 image dimensions must be positive multiples of 32, got \(width)x\(height)."
+        case .imageWriteFailed(let url):
+            return "Failed to write HiDream O1 image: \(url.path)"
+        }
+    }
+}
+
+public enum HiDreamO1ImagePreprocessor {
+    public struct PatchTensor {
+        public var resolution: HiDreamO1SampleBuilder.Resolution
+        public var imageCHW: MLXArray
+        public var patches: MLXArray
+    }
+
+    public struct VisionConditionTensor {
+        public var resolution: HiDreamO1SampleBuilder.Resolution
+        public var grid: QwenVisionGrid
+        public var mergedGrid: HiDreamO1SampleBuilder.Resolution
+        public var pixelValues: MLXArray
+
+        public var tokenCount: Int {
+            mergedGrid.width * mergedGrid.height
+        }
+    }
+
+    public static func patchTensor(
+        from url: URL,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        dtype: DType = .float32
+    ) throws -> PatchTensor {
+        #if canImport(CoreGraphics)
+        let image = try loadCGImage(from: url)
+        return try patchTensor(from: image, resolution: resolution, dtype: dtype)
+        #else
+        throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
+        #endif
+    }
+
+    public static func visionConditionTensor(
+        from url: URL,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        config: HiDreamO1Config,
+        dtype: DType = .bfloat16
+    ) throws -> VisionConditionTensor {
+        #if canImport(CoreGraphics)
+        let image = try loadCGImage(from: url)
+        return try visionConditionTensor(from: image, resolution: resolution, config: config, dtype: dtype)
+        #else
+        throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
+        #endif
+    }
+
+    #if canImport(CoreGraphics)
+    public static func imageSize(_ url: URL) throws -> HiDreamO1SampleBuilder.Resolution {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? Int,
+              let height = properties[kCGImagePropertyPixelHeight] as? Int else {
+            throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
+        }
+        return .init(width: width, height: height)
+    }
+
+    public static func patchTensor(
+        from image: CGImage,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        dtype: DType = .float32
+    ) throws -> PatchTensor {
+        let imageCHW = try normalizedCHW(from: image, resolution: resolution, dtype: dtype)
+        let patches = HiDreamO1SampleBuilder.patchifyCHW(imageCHW)
+        return PatchTensor(resolution: resolution, imageCHW: imageCHW, patches: patches)
+    }
+
+    public static func normalizedCHW(
+        from image: CGImage,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        dtype: DType = .float32
+    ) throws -> MLXArray {
+        try validate(resolution)
+        let resized = try resizedCGImage(from: image, resolution: resolution)
+        return try normalizedCHW(from: resized, dtype: dtype)
+    }
+
+    public static func visionConditionTensor(
+        from image: CGImage,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        config: HiDreamO1Config,
+        dtype: DType = .bfloat16
+    ) throws -> VisionConditionTensor {
+        let patchSize = config.visionConfig.patchSize
+        let mergeSize = config.visionConfig.spatialMergeSize
+        try validateVisionResolution(resolution, patchSize: patchSize, mergeSize: mergeSize)
+        let imageCHW = try normalizedCHW(from: image, resolution: resolution, dtype: dtype)
+        let patchInputs = prepareVisionPatchInputs(
+            imageCHW: imageCHW,
+            patchSize: patchSize,
+            temporalPatchSize: config.visionConfig.temporalPatchSize,
+            mergeSize: mergeSize
+        )
+        let gridHeight = resolution.height / patchSize
+        let gridWidth = resolution.width / patchSize
+        return VisionConditionTensor(
+            resolution: resolution,
+            grid: QwenVisionGrid(temporal: 1, height: gridHeight, width: gridWidth),
+            mergedGrid: .init(width: gridWidth / mergeSize, height: gridHeight / mergeSize),
+            pixelValues: patchInputs
+        )
+    }
+
+    public static func saveNormalizedCHW(_ image: MLXArray, to url: URL) throws {
+        let rgbImage = try cgImage(fromNormalizedCHW: image)
+        guard let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw HiDreamO1ImagePreprocessorError.imageWriteFailed(url)
+        }
+        CGImageDestinationAddImage(destination, rgbImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw HiDreamO1ImagePreprocessorError.imageWriteFailed(url)
+        }
+    }
+
+    private static func loadCGImage(from url: URL) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
+        }
+        return image
+    }
+
+    private static func resizedCGImage(
+        from image: CGImage,
+        resolution: HiDreamO1SampleBuilder.Resolution
+    ) throws -> CGImage {
+        guard resolution.width > 0, resolution.height > 0 else {
+            throw HiDreamO1ImagePreprocessorError.imageResizeFailed
+        }
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        guard let context = CGContext(
+            data: nil,
+            width: resolution.width,
+            height: resolution.height,
+            bitsPerComponent: 8,
+            bytesPerRow: resolution.width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            throw HiDreamO1ImagePreprocessorError.imageResizeFailed
+        }
+
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: resolution.width, height: resolution.height))
+        guard let resized = context.makeImage() else {
+            throw HiDreamO1ImagePreprocessorError.imageResizeFailed
+        }
+        return resized
+    }
+
+    private static func normalizedCHW(from image: CGImage, dtype: DType) throws -> MLXArray {
+        let width = image.width
+        let height = image.height
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var buffer = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+
+        let succeeded = buffer.withUnsafeMutableBytes { pointer -> Bool in
+            guard let baseAddress = pointer.baseAddress,
+                  let context = CGContext(
+                      data: baseAddress,
+                      width: width,
+                      height: height,
+                      bitsPerComponent: 8,
+                      bytesPerRow: bytesPerRow,
+                      space: colorSpace,
+                      bitmapInfo: bitmapInfo
+                  ) else {
+                return false
+            }
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+
+        guard succeeded else {
+            throw HiDreamO1ImagePreprocessorError.pixelBufferFailed
+        }
+
+        var values = [Float](repeating: 0, count: width * height * 3)
+        for yIndex in 0..<height {
+            for xIndex in 0..<width {
+                let pixelIndex = yIndex * width + xIndex
+                let sourceIndex = pixelIndex * bytesPerPixel
+                values[pixelIndex] = Float(buffer[sourceIndex]) / 127.5 - 1.0
+                values[pixelIndex + width * height] = Float(buffer[sourceIndex + 1]) / 127.5 - 1.0
+                values[pixelIndex + 2 * width * height] = Float(buffer[sourceIndex + 2]) / 127.5 - 1.0
+            }
+        }
+
+        return MLXArray(values, [3, height, width]).asType(dtype)
+    }
+
+    private static func cgImage(fromNormalizedCHW image: MLXArray) throws -> CGImage {
+        precondition(image.ndim == 3 && image.dim(0) == 3, "Expected [3,H,W] normalized image.")
+        let height = image.dim(1)
+        let width = image.dim(2)
+        let pixelCount = height * width
+        let normalized = MLX.clip((image.asType(.float32) + 1.0) / 2.0, min: 0, max: 1)
+        let scaled = (normalized * 255.0).asType(.uint8)
+        MLX.eval(scaled)
+        let data = scaled.asData().data
+
+        var bytes = [UInt8](repeating: 255, count: pixelCount * 4)
+        data.withUnsafeBytes { pointer in
+            let source = pointer.bindMemory(to: UInt8.self)
+            for pixelIndex in 0..<pixelCount {
+                let destinationIndex = pixelIndex * 4
+                bytes[destinationIndex] = source[pixelIndex]
+                bytes[destinationIndex + 1] = source[pixelIndex + pixelCount]
+                bytes[destinationIndex + 2] = source[pixelIndex + pixelCount * 2]
+            }
+        }
+
+        guard let provider = CGDataProvider(data: Data(bytes) as CFData) else {
+            throw HiDreamO1ImagePreprocessorError.pixelBufferFailed
+        }
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        guard let image = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ) else {
+            throw HiDreamO1ImagePreprocessorError.pixelBufferFailed
+        }
+        return image
+    }
+    #endif
+
+    private static func prepareVisionPatchInputs(
+        imageCHW: MLXArray,
+        patchSize: Int,
+        temporalPatchSize: Int,
+        mergeSize: Int
+    ) -> MLXArray {
+        let pixelValues = imageCHW.expandedDimensions(axis: 0)
+        let batch = pixelValues.dim(0)
+        let channels = pixelValues.dim(1)
+        let height = pixelValues.dim(2)
+        let width = pixelValues.dim(3)
+
+        let patchH = height / patchSize
+        let patchW = width / patchSize
+        let blockH = patchH / max(1, mergeSize)
+        let blockW = patchW / max(1, mergeSize)
+        let numPatches = patchH * patchW
+
+        precondition(blockH > 0 && blockW > 0, "Invalid HiDream O1 vision condition grid.")
+
+        var patches = pixelValues.reshaped(
+            batch,
+            channels,
+            blockH,
+            mergeSize,
+            patchSize,
+            blockW,
+            mergeSize,
+            patchSize
+        )
+        patches = patches.transposed(0, 2, 5, 3, 6, 1, 4, 7)
+        patches = patches.reshaped(batch, numPatches, channels, patchSize * patchSize)
+
+        let repeats = max(1, temporalPatchSize)
+        let temporalSlices = (0..<repeats).map { _ in
+            patches.expandedDimensions(axis: 3)
+        }
+        let temporal = temporalSlices.count == 1
+            ? temporalSlices[0]
+            : MLX.concatenated(temporalSlices, axis: 3)
+
+        return temporal.reshaped(batch, numPatches, channels * repeats * patchSize * patchSize)
+    }
+
+    private static func validate(_ resolution: HiDreamO1SampleBuilder.Resolution) throws {
+        let patchSize = HiDreamO1SampleBuilder.patchSize
+        guard resolution.width > 0,
+              resolution.height > 0,
+              resolution.width.isMultiple(of: patchSize),
+              resolution.height.isMultiple(of: patchSize) else {
+            throw HiDreamO1ImagePreprocessorError.invalidSize(
+                width: resolution.width,
+                height: resolution.height
+            )
+        }
+    }
+
+    private static func validateVisionResolution(
+        _ resolution: HiDreamO1SampleBuilder.Resolution,
+        patchSize: Int,
+        mergeSize: Int
+    ) throws {
+        let alignment = patchSize * max(1, mergeSize)
+        guard resolution.width > 0,
+              resolution.height > 0,
+              resolution.width.isMultiple(of: alignment),
+              resolution.height.isMultiple(of: alignment) else {
+            throw HiDreamO1ImagePreprocessorError.invalidSize(
+                width: resolution.width,
+                height: resolution.height
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Layers.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Layers.swift
@@ -1,0 +1,151 @@
+import Foundation
+import MLX
+import MLXNN
+
+final class HiDreamO1TimestepEmbedder: Module {
+    let frequencyEmbeddingSize: Int
+
+    @ModuleInfo(key: "mlp") var mlp: (Linear, SiLUModule, Linear)
+
+    init(hiddenSize: Int, frequencyEmbeddingSize: Int = 256) {
+        self.frequencyEmbeddingSize = frequencyEmbeddingSize
+        self._mlp.wrappedValue = (
+            Linear(frequencyEmbeddingSize, hiddenSize, bias: true),
+            SiLUModule(),
+            Linear(hiddenSize, hiddenSize, bias: true)
+        )
+        super.init()
+    }
+
+    static func timestepEmbedding(_ timesteps: MLXArray, dim: Int, maxPeriod: Float = 10_000.0) -> MLXArray {
+        let dtype = timesteps.dtype
+        let halfDim = dim / 2
+        var exponent = -MLX.log(MLXArray(maxPeriod))
+        exponent = exponent * MLXArray(0..<halfDim).asType(dtype)
+        exponent = exponent / MLXArray(Float(halfDim))
+        let freqs = MLX.exp(exponent)
+        let args = timesteps[.ellipsis, .newAxis] * freqs[.newAxis]
+        var embedding = MLX.concatenated([MLX.cos(args), MLX.sin(args)], axis: -1)
+
+        if dim % 2 != 0 {
+            let pad = MLX.zeros([embedding.dim(0), 1], dtype: dtype)
+            embedding = MLX.concatenated([embedding, pad], axis: -1)
+        }
+        return embedding
+    }
+
+    func callAsFunction(_ timesteps: MLXArray) -> MLXArray {
+        let tFreq = Self.timestepEmbedding(timesteps * 1_000, dim: frequencyEmbeddingSize)
+        return mlp.2(mlp.1(mlp.0(tFreq)))
+    }
+}
+
+final class HiDreamO1BottleneckPatchEmbed: Module {
+    @ModuleInfo(key: "proj1") var proj1: Linear
+    @ModuleInfo(key: "proj2") var proj2: Linear
+
+    init(patchSize: Int = 32, inChannels: Int = 3, bottleneckDim: Int, hiddenSize: Int) {
+        let patchDim = patchSize * patchSize * inChannels
+        self._proj1.wrappedValue = Linear(patchDim, bottleneckDim, bias: false)
+        self._proj2.wrappedValue = Linear(bottleneckDim, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ patches: MLXArray) -> MLXArray {
+        proj2(proj1(patches))
+    }
+}
+
+final class HiDreamO1FinalLayer: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    init(hiddenSize: Int, patchSize: Int = 32, outChannels: Int = 3) {
+        let patchDim = patchSize * patchSize * outChannels
+        self._linear.wrappedValue = Linear(hiddenSize, patchDim, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        linear(hiddenStates)
+    }
+}
+
+final class HiDreamO1PixelHead: Module {
+    @ModuleInfo(key: "t_embedder1") var timestepEmbedder: HiDreamO1TimestepEmbedder
+    @ModuleInfo(key: "x_embedder") var patchEmbedder: HiDreamO1BottleneckPatchEmbed
+    @ModuleInfo(key: "final_layer2") var finalLayer: HiDreamO1FinalLayer
+
+    init(config: HiDreamO1Config) {
+        let hiddenSize = config.textConfig.hiddenSize
+        let bottleneckDim = hiddenSize / 4
+        self._timestepEmbedder.wrappedValue = HiDreamO1TimestepEmbedder(hiddenSize: hiddenSize)
+        self._patchEmbedder.wrappedValue = HiDreamO1BottleneckPatchEmbed(
+            patchSize: HiDreamO1SampleBuilder.patchSize,
+            inChannels: 3,
+            bottleneckDim: bottleneckDim,
+            hiddenSize: hiddenSize
+        )
+        self._finalLayer.wrappedValue = HiDreamO1FinalLayer(
+            hiddenSize: hiddenSize,
+            patchSize: HiDreamO1SampleBuilder.patchSize,
+            outChannels: 3
+        )
+        super.init()
+    }
+
+    func patchEmbeddings(_ patches: MLXArray) -> MLXArray {
+        patchEmbedder(patches)
+    }
+
+    func timestepEmbeddings(_ timesteps: MLXArray) -> MLXArray {
+        timestepEmbedder(timesteps)
+    }
+
+    func pixelPredictions(_ hiddenStates: MLXArray) -> MLXArray {
+        finalLayer(hiddenStates)
+    }
+}
+
+enum HiDreamO1WeightMapper {
+    static func mapPixelHeadKey(_ key: String, value: MLXArray) -> [(String, MLXArray)] {
+        let prefixes = [
+            "model.t_embedder1.": "t_embedder1.",
+            "t_embedder1.": "t_embedder1.",
+            "model.x_embedder.": "x_embedder.",
+            "x_embedder.": "x_embedder.",
+            "model.final_layer2.": "final_layer2.",
+            "final_layer2.": "final_layer2.",
+        ]
+        for (source, target) in prefixes where key.hasPrefix(source) {
+            let suffix = key.dropFirst(source.count)
+            return [("\(target)\(suffix)", value)]
+        }
+        return []
+    }
+
+    static func loadPixelHead(
+        from resources: HiDreamO1Resources,
+        config: HiDreamO1Config,
+        dtype: DType? = .bfloat16
+    ) throws -> HiDreamO1PixelHead {
+        let head = HiDreamO1PixelHead(config: config)
+        if FileManager.default.fileExists(atPath: resources.weightsIndexURL.path) {
+            try HFSafetensorsWeightsLoader.applyShardedWeights(
+                indexURL: resources.weightsIndexURL,
+                to: head,
+                dtype: dtype,
+                verify: .none,
+                mapper: mapPixelHeadKey
+            )
+        } else {
+            try HFSafetensorsWeightsLoader.applyWeights(
+                url: resources.singleWeightsURL,
+                to: head,
+                dtype: dtype,
+                verify: .none,
+                mapper: mapPixelHeadKey
+            )
+        }
+        return head
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Model.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Model.swift
@@ -1,0 +1,504 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+final class HiDreamO1Model: Module {
+    @ModuleInfo(key: "language_model") var languageModel: QwenEncoder
+    @ModuleInfo(key: "vision_tower") var visionTower: QwenVisionTower
+    @ModuleInfo(key: "pixel_head") var pixelHead: HiDreamO1PixelHead
+
+    init(config: HiDreamO1Config) {
+        let visionActivation: QwenVisionConfiguration.Activation = switch config.visionConfig.hiddenAct.lowercased() {
+        case "gelu_pytorch_tanh", "gelu_tanh", "gelu":
+            .geluApproximate
+        default:
+            .silu
+        }
+        self._languageModel.wrappedValue = QwenEncoder(configuration: .init(
+            vocabSize: config.textConfig.vocabSize,
+            hiddenSize: config.textConfig.hiddenSize,
+            numHiddenLayers: config.textConfig.numHiddenLayers,
+            numAttentionHeads: config.textConfig.numAttentionHeads,
+            numKeyValueHeads: config.textConfig.numKeyValueHeads,
+            intermediateSize: config.textConfig.intermediateSize,
+            ropeTheta: config.textConfig.ropeTheta,
+            maxPositionEmbeddings: config.textConfig.maxPositionEmbeddings,
+            rmsNormEps: config.textConfig.rmsNormEps,
+            headDim: config.textConfig.headDim,
+            mropeSection: config.textConfig.ropeScaling.mropeSection,
+            mropeInterleaved: config.textConfig.ropeScaling.mropeInterleaved
+        ))
+        self._visionTower.wrappedValue = QwenVisionTower(configuration: .init(
+            depth: config.visionConfig.depth,
+            embedDim: config.visionConfig.hiddenSize,
+            mlpHiddenDim: config.visionConfig.intermediateSize,
+            hiddenAct: visionActivation,
+            numHeads: config.visionConfig.numHeads,
+            eps: 1e-6,
+            patchSize: config.visionConfig.patchSize,
+            temporalPatchSize: config.visionConfig.temporalPatchSize,
+            spatialMergeSize: config.visionConfig.spatialMergeSize,
+            inChannels: config.visionConfig.inChannels,
+            outHiddenDim: config.visionConfig.outHiddenSize,
+            windowSize: 112,
+            fullAttentionBlockIndices: [],
+            patchEmbedBias: true,
+            numPositionEmbeddings: config.visionConfig.numPositionEmbeddings,
+            useLearnedPosEmbed: true,
+            deepstackVisualIndexes: config.visionConfig.deepstackVisualIndexes
+        ))
+        self._pixelHead.wrappedValue = HiDreamO1PixelHead(config: config)
+        super.init()
+    }
+
+    func forward(
+        inputIds: MLXArray,
+        positionIds: MLXArray,
+        vinputs: MLXArray,
+        timestep: MLXArray,
+        tokenTypes: MLXArray,
+        visionConditions: [HiDreamO1ImagePreprocessor.VisionConditionTensor] = []
+    ) throws -> MLXArray {
+        let textEmbeddings = try preparedTextEmbeddings(
+            inputIds: inputIds,
+            timestep: timestep,
+            visionConditions: visionConditions
+        )
+        let visualEmbeddings = pixelHead.patchEmbeddings(vinputs[0]).expandedDimensions(axis: 0)
+        let embeddings = MLX.concatenated([textEmbeddings, visualEmbeddings], axis: 1)
+        let hiddenStates = languageModel.forward(
+            embeddings: embeddings,
+            attentionMask: nil,
+            positionIds: positionIds,
+            tokenTypes: tokenTypes,
+            outputHiddenStates: false
+        ).lastHiddenState
+        return pixelHead.pixelPredictions(hiddenStates)
+    }
+
+    private func preparedTextEmbeddings(
+        inputIds: MLXArray,
+        timestep: MLXArray,
+        visionConditions: [HiDreamO1ImagePreprocessor.VisionConditionTensor]
+    ) throws -> MLXArray {
+        var embeddings = languageModel.embed(inputIds: inputIds)
+        if !visionConditions.isEmpty {
+            embeddings = try imagePadReplacedTextEmbeddings(
+                embeddings,
+                inputIds: inputIds,
+                visionConditions: visionConditions
+            )
+        }
+        let timestepEmbedding = pixelHead.timestepEmbeddings(timestep).asType(embeddings.dtype)
+        let expandedTimestep = MLX.broadcast(
+            timestepEmbedding.expandedDimensions(axis: 1),
+            to: embeddings.shape
+        )
+        let mask = MLX.broadcast(
+            (inputIds .== MLXArray(Int32(HiDreamO1TokenizerAndTemplate.tmsTokenId)))
+                .expandedDimensions(axis: 2),
+            to: embeddings.shape
+        )
+        return MLX.where(mask, expandedTimestep, embeddings)
+    }
+
+    private func imagePadReplacedTextEmbeddings(
+        _ embeddings: MLXArray,
+        inputIds: MLXArray,
+        visionConditions: [HiDreamO1ImagePreprocessor.VisionConditionTensor]
+    ) throws -> MLXArray {
+        let replacementList = try visionConditions.map { condition in
+            try visionTower(patchInputs: condition.pixelValues, grid: [condition.grid]).hiddenStates
+        }
+        let replacement = replacementList.count == 1
+            ? replacementList[0]
+            : MLX.concatenated(replacementList, axis: 0)
+        return replaceImagePadTokens(
+            embeddings,
+            inputIds: inputIds,
+            replacement: replacement.asType(embeddings.dtype)
+        )
+    }
+
+    private func replaceImagePadTokens(
+        _ embeddings: MLXArray,
+        inputIds: MLXArray,
+        replacement: MLXArray
+    ) -> MLXArray {
+        let batch = embeddings.dim(0)
+        let seqLen = embeddings.dim(1)
+        let replacementCount = replacement.dim(0)
+
+        let tokenArray = inputIds.asType(.int32)
+        MLX.eval(tokenArray)
+        let tokenValues = tokenArray.asArray(Int32.self)
+
+        let result = embeddings
+        for row in 0..<batch {
+            let base = row * seqLen
+            var positions: [Int] = []
+            positions.reserveCapacity(replacementCount)
+            for position in 0..<seqLen
+                where tokenValues[base + position] == Int32(HiDreamO1TokenizerAndTemplate.imagePadTokenId) {
+                positions.append(position)
+            }
+
+            precondition(
+                positions.count == replacementCount,
+                "[HiDreamO1] image token mismatch in row \(row): found \(positions.count), expected \(replacementCount)"
+            )
+
+            guard let start = positions.first else { continue }
+            let end = start + replacementCount
+            let isContiguous = positions.enumerated().allSatisfy { offset, value in
+                value == start + offset
+            }
+
+            if isContiguous {
+                result[row, start..<end, 0...] = replacement
+            } else {
+                let idx = MLXArray(positions.map(Int32.init))
+                result[row, idx, 0...] = replacement
+            }
+        }
+        return result
+    }
+}
+
+enum HiDreamO1ModelLoader {
+    static func load(
+        resources: HiDreamO1Resources,
+        config: HiDreamO1Config,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws -> HiDreamO1Model {
+        let model = HiDreamO1Model(config: config)
+        try HFSafetensorsWeightsLoader.applyShardedWeights(
+            indexURL: resources.weightsIndexURL,
+            to: model,
+            dtype: .bfloat16,
+            verify: .shapeMismatch,
+            mapper: mapKey,
+            progressHandler: { shard in
+                progressHandler?(GenerationProgress(
+                    stage: .loadingTransformer,
+                    stepIndex: shard.shardIndex + 1,
+                    totalSteps: shard.shardCount
+                ))
+            }
+        )
+        return model
+    }
+
+    private static func mapKey(_ key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key.hasPrefix("model.language_model.") {
+            return [("language_model." + key.dropPrefix("model.language_model."), value)]
+        }
+        if key.hasPrefix("model.visual.") {
+            let mappedKey = mapVisionKey("vision_tower." + key.dropPrefix("model.visual."))
+            if key == "model.visual.patch_embed.proj.weight" {
+                return [(mappedKey, value.transposed(0, 2, 3, 4, 1))]
+            }
+            return [(mappedKey, value)]
+        }
+        if key.hasPrefix("model.t_embedder1.") {
+            return [("pixel_head.t_embedder1." + key.dropPrefix("model.t_embedder1."), value)]
+        }
+        if key.hasPrefix("model.x_embedder.") {
+            return [("pixel_head.x_embedder." + key.dropPrefix("model.x_embedder."), value)]
+        }
+        if key.hasPrefix("model.final_layer2.") {
+            return [("pixel_head.final_layer2." + key.dropPrefix("model.final_layer2."), value)]
+        }
+        return []
+    }
+
+    private static func mapVisionKey(_ rawKey: String) -> String {
+        var key = rawKey
+        key = key.replacingOccurrences(of: ".merger.", with: ".patch_merger.")
+        key = key.replacingOccurrences(of: ".patch_merger.norm.", with: ".patch_merger.ln_q.")
+        key = key.replacingOccurrences(of: ".patch_merger.linear_fc1.", with: ".patch_merger.mlp_0.")
+        key = key.replacingOccurrences(of: ".patch_merger.linear_fc2.", with: ".patch_merger.mlp_2.")
+        key = key.replacingOccurrences(of: ".mlp.linear_fc1.", with: ".mlp.fc1.")
+        key = key.replacingOccurrences(of: ".mlp.linear_fc2.", with: ".mlp.fc2.")
+        if key.contains(".deepstack_merger_list.") {
+            key = key.replacingOccurrences(of: ".norm.", with: ".ln_q.")
+            key = key.replacingOccurrences(of: ".linear_fc1.", with: ".mlp_0.")
+            key = key.replacingOccurrences(of: ".linear_fc2.", with: ".mlp_2.")
+        }
+        return key
+    }
+}
+
+enum HiDreamO1Denoiser {
+    static let noiseScale: Float = 8.0
+    static let timestepEpsilon: Float = 0.001
+
+    struct Conditioning {
+        var sample: HiDreamO1SampleBuilder.Sample
+        var visionConditions: [HiDreamO1ImagePreprocessor.VisionConditionTensor]
+    }
+
+    private struct PreparedSample {
+        let sample: HiDreamO1SampleBuilder.Sample
+        let inputIds: MLXArray
+        let positionIds: MLXArray
+        let tokenTypes: MLXArray
+        let selection: MLXArray
+        let visionConditions: [HiDreamO1ImagePreprocessor.VisionConditionTensor]
+
+        init(conditioning: Conditioning) {
+            self.sample = conditioning.sample
+            self.inputIds = MLXArray(conditioning.sample.inputIds.map(Int32.init), [1, conditioning.sample.inputIds.count])
+            self.positionIds = HiDreamO1Denoiser.positionIdsArray(conditioning.sample.positionIds)
+            self.tokenTypes = MLXArray(conditioning.sample.tokenTypes.map(Int32.init), [1, conditioning.sample.tokenTypes.count])
+            let selectedPositions = conditioning.sample.vinputMask.enumerated().compactMap { index, keep in
+                keep ? Int32(index) : nil
+            }
+            self.selection = MLXArray(selectedPositions)
+            self.visionConditions = conditioning.visionConditions
+        }
+    }
+
+    static func initialPatches(
+        height: Int,
+        width: Int,
+        seed: UInt64
+    ) -> MLXArray {
+        let image = MLXRandom.normal(
+            [3, height, width],
+            key: MLXRandom.key(seed &+ 1)
+        ).asType(.bfloat16) * MLXArray(noiseScale).asType(.bfloat16)
+        return HiDreamO1SampleBuilder.patchifyCHW(image).expandedDimensions(axis: 0)
+    }
+
+    static func runTextOnly(
+        model: HiDreamO1Model,
+        sample: HiDreamO1SampleBuilder.Sample,
+        scheduler: HiDreamO1Scheduler,
+        height: Int,
+        width: Int,
+        seed: UInt64,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws -> MLXArray {
+        try run(
+            model: model,
+            conditioning: Conditioning(sample: sample, visionConditions: []),
+            unconditionalConditioning: nil,
+            scheduler: scheduler,
+            height: height,
+            width: width,
+            seed: seed,
+            referencePatches: nil,
+            guidanceScale: 0,
+            progressHandler: progressHandler
+        )
+    }
+
+    static func runWithReferences(
+        model: HiDreamO1Model,
+        sample: HiDreamO1SampleBuilder.Sample,
+        scheduler: HiDreamO1Scheduler,
+        height: Int,
+        width: Int,
+        seed: UInt64,
+        referenceTensors: [HiDreamO1ImagePreprocessor.PatchTensor],
+        visionConditions: [HiDreamO1ImagePreprocessor.VisionConditionTensor],
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws -> MLXArray {
+        try runWithReferences(
+            model: model,
+            conditioning: Conditioning(sample: sample, visionConditions: visionConditions),
+            unconditionalConditioning: nil,
+            scheduler: scheduler,
+            height: height,
+            width: width,
+            seed: seed,
+            referenceTensors: referenceTensors,
+            guidanceScale: 0,
+            progressHandler: progressHandler
+        )
+    }
+
+    static func runTextOnly(
+        model: HiDreamO1Model,
+        conditioning: Conditioning,
+        unconditionalConditioning: Conditioning?,
+        scheduler: HiDreamO1Scheduler,
+        height: Int,
+        width: Int,
+        seed: UInt64,
+        guidanceScale: Float,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws -> MLXArray {
+        try run(
+            model: model,
+            conditioning: conditioning,
+            unconditionalConditioning: unconditionalConditioning,
+            scheduler: scheduler,
+            height: height,
+            width: width,
+            seed: seed,
+            referencePatches: nil,
+            guidanceScale: guidanceScale,
+            progressHandler: progressHandler
+        )
+    }
+
+    static func runWithReferences(
+        model: HiDreamO1Model,
+        conditioning: Conditioning,
+        unconditionalConditioning: Conditioning?,
+        scheduler: HiDreamO1Scheduler,
+        height: Int,
+        width: Int,
+        seed: UInt64,
+        referenceTensors: [HiDreamO1ImagePreprocessor.PatchTensor],
+        guidanceScale: Float,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws -> MLXArray {
+        let referencePatches: MLXArray?
+        if referenceTensors.isEmpty {
+            referencePatches = nil
+        } else {
+            let patches = referenceTensors.map { $0.patches.asType(.bfloat16) }
+            referencePatches = (patches.count == 1 ? patches[0] : MLX.concatenated(patches, axis: 0))
+                .expandedDimensions(axis: 0)
+        }
+        return try run(
+            model: model,
+            conditioning: conditioning,
+            unconditionalConditioning: unconditionalConditioning,
+            scheduler: scheduler,
+            height: height,
+            width: width,
+            seed: seed,
+            referencePatches: referencePatches,
+            guidanceScale: guidanceScale,
+            progressHandler: progressHandler
+        )
+    }
+
+    private static func run(
+        model: HiDreamO1Model,
+        conditioning: Conditioning,
+        unconditionalConditioning: Conditioning?,
+        scheduler: HiDreamO1Scheduler,
+        height: Int,
+        width: Int,
+        seed: UInt64,
+        referencePatches: MLXArray?,
+        guidanceScale: Float,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws -> MLXArray {
+        let steps = scheduler.timesteps.dim(0)
+        let preparedConditioning = PreparedSample(conditioning: conditioning)
+        let preparedUnconditional = unconditionalConditioning.map(PreparedSample.init(conditioning:))
+        let usesCFG = guidanceScale > 1.0 && preparedUnconditional != nil
+        var uniPCState = scheduler.usesFlashStep ? nil : HiDreamO1UniPCState(scheduler: scheduler)
+        var z = initialPatches(height: height, width: width, seed: seed)
+
+        progressHandler?(GenerationProgress(stage: .denoising, stepIndex: 0, totalSteps: steps))
+        for stepIndex in 0..<steps {
+            let timestep = scheduler.timestep(at: stepIndex)
+            let sigma = MLX.maximum(timestep / MLXArray(1_000.0), MLXArray(timestepEpsilon))
+            let tPixelDiT = MLXArray(1.0) - timestep / MLXArray(1_000.0)
+            let vinputs = referencePatches.map { MLX.concatenated([z, $0], axis: 1) } ?? z
+            let conditionalVelocity = try predictedVelocity(
+                model: model,
+                prepared: preparedConditioning,
+                vinputs: vinputs,
+                timestep: tPixelDiT,
+                sigma: sigma,
+                z: z
+            )
+            let guidedVelocity: MLXArray
+            if usesCFG, let preparedUnconditional {
+                let unconditionalVelocity = try predictedVelocity(
+                    model: model,
+                    prepared: preparedUnconditional,
+                    vinputs: vinputs,
+                    timestep: tPixelDiT,
+                    sigma: sigma,
+                    z: z
+                )
+                guidedVelocity = unconditionalVelocity
+                    + (conditionalVelocity - unconditionalVelocity) * MLXArray(guidanceScale)
+            } else {
+                guidedVelocity = conditionalVelocity
+            }
+
+            let modelOutput = -guidedVelocity
+            if scheduler.usesFlashStep {
+                z = flashStep(
+                    modelOutput: modelOutput,
+                    sample: z,
+                    sigma: scheduler.sigma(at: stepIndex),
+                    sigmaNext: scheduler.sigma(at: stepIndex + 1),
+                    noiseScale: scheduler.noiseScales[stepIndex],
+                    seed: seed &+ UInt64(stepIndex + 10_000)
+                ).asType(.bfloat16)
+            } else {
+                z = uniPCState!.step(
+                    modelOutput: modelOutput.asType(.float32),
+                    sample: z.asType(.float32),
+                    stepIndex: stepIndex
+                ).asType(.bfloat16)
+            }
+            MLX.eval(z)
+            progressHandler?(GenerationProgress(stage: .denoising, stepIndex: stepIndex + 1, totalSteps: steps))
+        }
+        return z[0]
+    }
+
+    private static func predictedVelocity(
+        model: HiDreamO1Model,
+        prepared: PreparedSample,
+        vinputs: MLXArray,
+        timestep: MLXArray,
+        sigma: MLXArray,
+        z: MLXArray
+    ) throws -> MLXArray {
+        let xPred = try model.forward(
+            inputIds: prepared.inputIds,
+            positionIds: prepared.positionIds,
+            vinputs: vinputs,
+            timestep: timestep.reshaped(1),
+            tokenTypes: prepared.tokenTypes,
+            visionConditions: prepared.visionConditions
+        )
+        let selected = xPred[0, prepared.selection, 0...]
+        let predicted = selected[0..<prepared.sample.targetImageLength, 0...].expandedDimensions(axis: 0)
+        return (predicted.asType(.float32) - z.asType(.float32)) / sigma.asType(.float32)
+    }
+
+    private static func flashStep(
+        modelOutput: MLXArray,
+        sample: MLXArray,
+        sigma: MLXArray,
+        sigmaNext: MLXArray,
+        noiseScale: Float,
+        seed: UInt64
+    ) -> MLXArray {
+        let sampleF32 = sample.asType(.float32)
+        let denoised = sampleF32 - modelOutput.asType(.float32) * sigma.asType(.float32)
+        guard sigmaNext.item(Float.self) > 0 else {
+            return denoised
+        }
+        let noise = MLXRandom.normal(sample.shape, key: MLXRandom.key(seed)).asType(.float32)
+        return sigmaNext.asType(.float32) * noise * MLXArray(noiseScale) + (1.0 - sigmaNext.asType(.float32)) * denoised
+    }
+
+    private static func positionIdsArray(_ positionIds: [[Int]]) -> MLXArray {
+        let axes = positionIds.count
+        let length = positionIds.first?.count ?? 0
+        let values = positionIds.flatMap { $0.map(Int32.init) }
+        return MLXArray(values, [axes, 1, length])
+    }
+}
+
+private extension String {
+    func dropPrefix(_ prefix: String) -> String {
+        String(dropFirst(prefix.count))
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1PreviewRenderer.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1PreviewRenderer.swift
@@ -1,0 +1,105 @@
+import Foundation
+import MLX
+
+enum HiDreamO1PreviewRenderer {
+    static func promptPreview(
+        prompt: String,
+        seed: UInt64,
+        resolution: HiDreamO1SampleBuilder.Resolution
+    ) -> MLXArray {
+        let width = resolution.width
+        let height = resolution.height
+        let digest = fnv1a64("\(prompt)\u{0}\(seed)")
+        let hueA = Float(digest & 0xFF) / 255.0
+        let hueB = Float((digest >> 8) & 0xFF) / 255.0
+        let hueC = Float((digest >> 16) & 0xFF) / 255.0
+        var values = [Float](repeating: 0, count: width * height * 3)
+
+        for yIndex in 0..<height {
+            let y = Float(yIndex) / Float(max(1, height - 1))
+            for xIndex in 0..<width {
+                let x = Float(xIndex) / Float(max(1, width - 1))
+                let wave = sin((x * Float.pi * 6.0) + hueA * Float.pi * 2.0)
+                    * cos((y * Float.pi * 5.0) + hueB * Float.pi * 2.0)
+                let vignette = 1.0 - min(1.0, hypot(x - 0.5, y - 0.5) * 1.65)
+                let pixel = yIndex * width + xIndex
+                values[pixel] = clamp01(0.35 + 0.45 * x + 0.20 * wave + 0.15 * vignette) * 2.0 - 1.0
+                values[pixel + width * height] = clamp01(0.28 + 0.42 * y + 0.18 * (1.0 - wave) + 0.12 * hueC) * 2.0 - 1.0
+                values[pixel + 2 * width * height] = clamp01(0.25 + 0.30 * (1.0 - x) + 0.30 * vignette + 0.15 * hueB) * 2.0 - 1.0
+            }
+        }
+
+        return MLXArray(values, [3, height, width])
+    }
+
+    static func referencePreview(
+        referenceTensors: [HiDreamO1ImagePreprocessor.PatchTensor],
+        targetResolution: HiDreamO1SampleBuilder.Resolution,
+        seed: UInt64
+    ) -> MLXArray {
+        guard !referenceTensors.isEmpty else {
+            return promptPreview(prompt: "", seed: seed, resolution: targetResolution)
+        }
+        if referenceTensors.count == 1,
+           referenceTensors[0].resolution == targetResolution {
+            return referenceTensors[0].imageCHW
+        }
+
+        let width = targetResolution.width
+        let height = targetResolution.height
+        var accum = [Float](repeating: 0, count: width * height * 3)
+        for (index, tensor) in referenceTensors.enumerated() {
+            let source = tensor.imageCHW.asType(.float32)
+            MLX.eval(source)
+            let sourceValues = source.asArray(Float.self)
+            blend(
+                sourceValues: sourceValues,
+                sourceWidth: tensor.resolution.width,
+                sourceHeight: tensor.resolution.height,
+                into: &accum,
+                targetWidth: width,
+                targetHeight: height,
+                weight: 1.0 / Float(index + 1)
+            )
+        }
+        let scale = Float(referenceTensors.count)
+        return MLXArray(accum.map { max(-1.0, min(1.0, $0 / scale)) }, [3, height, width])
+    }
+
+    private static func blend(
+        sourceValues: [Float],
+        sourceWidth: Int,
+        sourceHeight: Int,
+        into target: inout [Float],
+        targetWidth: Int,
+        targetHeight: Int,
+        weight: Float
+    ) {
+        let targetPlane = targetWidth * targetHeight
+        let sourcePlane = sourceWidth * sourceHeight
+        for yIndex in 0..<targetHeight {
+            let sourceY = min(sourceHeight - 1, yIndex * sourceHeight / targetHeight)
+            for xIndex in 0..<targetWidth {
+                let sourceX = min(sourceWidth - 1, xIndex * sourceWidth / targetWidth)
+                let targetPixel = yIndex * targetWidth + xIndex
+                let sourcePixel = sourceY * sourceWidth + sourceX
+                for channel in 0..<3 {
+                    target[targetPixel + channel * targetPlane] += sourceValues[sourcePixel + channel * sourcePlane] * weight
+                }
+            }
+        }
+    }
+
+    private static func fnv1a64(_ text: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x0000_0100_0000_01b3
+        }
+        return hash
+    }
+
+    private static func clamp01(_ value: Float) -> Float {
+        max(0.0, min(1.0, value))
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Resources.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Resources.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct HiDreamO1Resources: Sendable, Hashable {
+    public var rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var configURL: URL { rootURL.appending(path: "config.json") }
+    public var generationConfigURL: URL { rootURL.appending(path: "generation_config.json") }
+    public var tokenizerJSONURL: URL { rootURL.appending(path: "tokenizer.json") }
+    public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
+    public var vocabURL: URL { rootURL.appending(path: "vocab.json") }
+    public var mergesURL: URL { rootURL.appending(path: "merges.txt") }
+    public var preprocessorConfigURL: URL { rootURL.appending(path: "preprocessor_config.json") }
+    public var videoPreprocessorConfigURL: URL { rootURL.appending(path: "video_preprocessor_config.json") }
+    public var weightsIndexURL: URL { rootURL.appending(path: "model.safetensors.index.json") }
+    public var singleWeightsURL: URL { rootURL.appending(path: "model.safetensors") }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing: [URL] = []
+        if !fileManager.fileExists(atPath: configURL.path) { missing.append(configURL) }
+        if !fileManager.fileExists(atPath: tokenizerConfigURL.path) { missing.append(tokenizerConfigURL) }
+        if !fileManager.fileExists(atPath: preprocessorConfigURL.path) { missing.append(preprocessorConfigURL) }
+
+        let hasTokenizerJSON = fileManager.fileExists(atPath: tokenizerJSONURL.path)
+        let hasBPEPair = fileManager.fileExists(atPath: vocabURL.path) && fileManager.fileExists(atPath: mergesURL.path)
+        if !hasTokenizerJSON && !hasBPEPair { missing.append(tokenizerJSONURL) }
+
+        let hasIndexedWeights = fileManager.fileExists(atPath: weightsIndexURL.path)
+        let hasSingleWeights = fileManager.fileExists(atPath: singleWeightsURL.path)
+        if !hasIndexedWeights && !hasSingleWeights { missing.append(weightsIndexURL) }
+
+        return missing
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift
@@ -1,0 +1,348 @@
+import Foundation
+import MLX
+
+public enum HiDreamO1SampleBuilder {
+    public static let timestepTokenCount = 1
+    public static let patchSize = 32
+    public static let conditionImageSize = 384
+    public static let predefinedResolutions: [Resolution] = [
+        .init(width: 2048, height: 2048),
+        .init(width: 2304, height: 1728),
+        .init(width: 1728, height: 2304),
+        .init(width: 2560, height: 1440),
+        .init(width: 1440, height: 2560),
+        .init(width: 2496, height: 1664),
+        .init(width: 1664, height: 2496),
+        .init(width: 3104, height: 1312),
+        .init(width: 1312, height: 3104),
+        .init(width: 2304, height: 1792),
+        .init(width: 1792, height: 2304),
+    ]
+
+    public struct Resolution: Sendable, Hashable {
+        public var width: Int
+        public var height: Int
+    }
+
+    public struct Sample: Sendable, Hashable {
+        public var inputIds: [Int]
+        public var paddedInputIds: [Int]
+        public var positionIds: [[Int]]
+        public var tokenTypes: [Int]
+        public var vinputMask: [Bool]
+        public var targetImageLength: Int
+        public var referenceImageLengths: [Int]
+    }
+
+    public static func closestResolution(width: Int, height: Int) -> Resolution {
+        guard width > 0, height > 0 else {
+            return predefinedResolutions[0]
+        }
+        let ratio = Double(width) / Double(height)
+        return predefinedResolutions.min { lhs, rhs in
+            abs(Double(lhs.width) / Double(lhs.height) - ratio) < abs(Double(rhs.width) / Double(rhs.height) - ratio)
+        } ?? predefinedResolutions[0]
+    }
+
+    public static func resizedReferenceSize(
+        originalWidth: Int,
+        originalHeight: Int,
+        maxSize: Int
+    ) -> Resolution {
+        guard originalWidth > 0, originalHeight > 0 else {
+            return Resolution(width: patchSize, height: patchSize)
+        }
+        let maxArea = Double(maxSize * maxSize)
+        let scale = sqrt(maxArea / Double(originalWidth * originalHeight))
+        let widthScaled = Double(originalWidth) * scale
+        let heightScaled = Double(originalHeight) * scale
+        let candidates = [
+            Resolution(width: roundedDown(widthScaled.rounded()), height: roundedDown(heightScaled.rounded())),
+            Resolution(width: roundedDown(widthScaled.rounded()), height: roundedDown(floor(heightScaled))),
+            Resolution(width: roundedDown(floor(widthScaled)), height: roundedDown(heightScaled.rounded())),
+            Resolution(width: roundedDown(floor(widthScaled)), height: roundedDown(floor(heightScaled))),
+        ].sorted { $0.width * $0.height > $1.width * $1.height }
+        return candidates.first { $0.width * $0.height <= maxSize * maxSize }
+            ?? Resolution(width: patchSize, height: patchSize)
+    }
+
+    public static func targetResolution(
+        width: Int,
+        height: Int,
+        referenceOriginalSizes: [Resolution],
+        keepOriginalAspect: Bool
+    ) -> Resolution {
+        if keepOriginalAspect, referenceOriginalSizes.count == 1 {
+            let original = referenceOriginalSizes[0]
+            return resizedReferenceSize(originalWidth: original.width, originalHeight: original.height, maxSize: 2_048)
+        }
+        return closestResolution(width: width, height: height)
+    }
+
+    public static func referenceMaxSize(targetWidth: Int, targetHeight: Int, referenceCount: Int) -> Int {
+        let maxTarget = max(targetWidth, targetHeight)
+        switch referenceCount {
+        case 1:
+            return maxTarget
+        case 2:
+            return maxTarget * 48 / 64
+        case 3...4:
+            return maxTarget / 2
+        case 5...8:
+            return maxTarget * 24 / 64
+        default:
+            return maxTarget / 4
+        }
+    }
+
+    public static func conditionSize(referenceCount: Int) -> Int {
+        switch referenceCount {
+        case ...4:
+            return conditionImageSize
+        case 5...8:
+            return conditionImageSize * 48 / 64
+        default:
+            return conditionImageSize / 2
+        }
+    }
+
+    public static func vlmConditionSize(originalWidth: Int, originalHeight: Int, maxSize: Int) -> Resolution {
+        guard originalWidth > 0, originalHeight > 0 else {
+            return Resolution(width: patchSize, height: patchSize)
+        }
+        let ratio = Double(originalWidth) / Double(originalHeight)
+        let width = sqrt(Double(maxSize * maxSize) * ratio)
+        let height = width / ratio
+        return Resolution(width: roundedDown(width), height: roundedDown(height))
+    }
+
+    public static func textToImageSample(
+        textTokenIds: [Int],
+        height: Int,
+        width: Int,
+        config: HiDreamO1Config
+    ) -> Sample {
+        let imageLength = (height / patchSize) * (width / patchSize)
+        let paddedInputIds = paddedVisionInputIds(
+            textTokenIds: textTokenIds,
+            visionLengths: [imageLength],
+            config: config
+        )
+        let imageGrid = [Resolution(width: width / patchSize, height: height / patchSize)]
+        let positionIds = ropeIndexFixPoint(
+            inputIds: paddedInputIds,
+            imageGrids: imageGrid,
+            skipVisionStartToken: [true],
+            config: config
+        )
+
+        let textLength = textTokenIds.count
+        let totalLength = positionIds.first?.count ?? textLength + imageLength
+        var tokenTypes = Array(repeating: 0, count: totalLength)
+        let generationStart = max(0, textLength - timestepTokenCount)
+        if generationStart < totalLength {
+            for index in generationStart..<totalLength {
+                tokenTypes[index] = 1
+            }
+        }
+        if generationStart < textLength {
+            for index in generationStart..<textLength {
+                tokenTypes[index] = 3
+            }
+        }
+        let vinputMask = tokenTypes.map { $0 == 1 }
+        let tokenTypesBin = tokenTypes.map { $0 > 0 ? 1 : 0 }
+
+        return Sample(
+            inputIds: textTokenIds,
+            paddedInputIds: paddedInputIds,
+            positionIds: positionIds,
+            tokenTypes: tokenTypesBin,
+            vinputMask: vinputMask,
+            targetImageLength: imageLength,
+            referenceImageLengths: []
+        )
+    }
+
+    public static func referenceSample(
+        textTokenIds: [Int],
+        targetHeight: Int,
+        targetWidth: Int,
+        referenceSizes: [Resolution],
+        conditionGrids: [Resolution] = [],
+        config: HiDreamO1Config
+    ) -> Sample {
+        let targetLength = (targetHeight / patchSize) * (targetWidth / patchSize)
+        let referenceLengths = referenceSizes.map { ($0.height / patchSize) * ($0.width / patchSize) }
+        let totalReferenceLength = referenceLengths.reduce(0, +)
+        let visionLengths = [targetLength] + referenceLengths
+        let paddedInputIds = paddedVisionInputIds(
+            textTokenIds: textTokenIds,
+            visionLengths: visionLengths,
+            config: config
+        )
+        let imageGrids = [Resolution(width: targetWidth / patchSize, height: targetHeight / patchSize)]
+            + referenceSizes.map { Resolution(width: $0.width / patchSize, height: $0.height / patchSize) }
+        let positionIds = ropeIndexFixPoint(
+            inputIds: paddedInputIds,
+            imageGrids: conditionGrids + imageGrids,
+            skipVisionStartToken: Array(repeating: false, count: conditionGrids.count)
+                + Array(repeating: true, count: imageGrids.count),
+            config: config
+        )
+
+        let textLength = textTokenIds.count
+        let totalLength = positionIds.first?.count ?? textLength + targetLength + totalReferenceLength
+        var tokenTypes = Array(repeating: 0, count: totalLength)
+        let generationStart = max(0, textLength - timestepTokenCount)
+        let generationEnd = min(totalLength, generationStart + targetLength + timestepTokenCount)
+        if generationStart < generationEnd {
+            for index in generationStart..<generationEnd {
+                tokenTypes[index] = 1
+            }
+        }
+        if generationEnd < totalLength {
+            for index in generationEnd..<totalLength {
+                tokenTypes[index] = 2
+            }
+        }
+        if generationStart < textLength {
+            for index in generationStart..<textLength {
+                tokenTypes[index] = 3
+            }
+        }
+        let vinputMask = tokenTypes.map { $0 == 1 || $0 == 2 }
+        let tokenTypesBin = tokenTypes.map { $0 > 0 ? 1 : 0 }
+
+        return Sample(
+            inputIds: textTokenIds,
+            paddedInputIds: paddedInputIds,
+            positionIds: positionIds,
+            tokenTypes: tokenTypesBin,
+            vinputMask: vinputMask,
+            targetImageLength: targetLength,
+            referenceImageLengths: referenceLengths
+        )
+    }
+
+    public static func patchifyCHW(_ image: MLXArray, patchSize: Int = patchSize) -> MLXArray {
+        precondition(image.ndim == 3, "Expected CHW image.")
+        let channels = image.dim(0)
+        let height = image.dim(1)
+        let width = image.dim(2)
+        let patchH = height / patchSize
+        let patchW = width / patchSize
+        return image
+            .reshaped(channels, patchH, patchSize, patchW, patchSize)
+            .transposed(1, 3, 0, 2, 4)
+            .reshaped(patchH * patchW, channels * patchSize * patchSize)
+    }
+
+    public static func unpatchifyCHW(_ patches: MLXArray, height: Int, width: Int, patchSize: Int = patchSize) -> MLXArray {
+        let channels = patches.dim(1) / (patchSize * patchSize)
+        let patchH = height / patchSize
+        let patchW = width / patchSize
+        return patches
+            .reshaped(patchH, patchW, channels, patchSize, patchSize)
+            .transposed(2, 0, 3, 1, 4)
+            .reshaped(channels, height, width)
+    }
+
+    private static func paddedVisionInputIds(
+        textTokenIds: [Int],
+        visionLengths: [Int],
+        config: HiDreamO1Config
+    ) -> [Int] {
+        var inputIds = textTokenIds
+        for length in visionLengths {
+            guard length > 0 else {
+                continue
+            }
+            inputIds.append(config.visionStartTokenId)
+            if length > 1 {
+                inputIds.append(contentsOf: Array(repeating: config.imageTokenId, count: length - 1))
+            }
+        }
+        return inputIds
+    }
+
+    private static func ropeIndexFixPoint(
+        inputIds: [Int],
+        imageGrids: [Resolution],
+        skipVisionStartToken: [Bool],
+        config: HiDreamO1Config,
+        fixPoint: Int = 4_096
+    ) -> [[Int]] {
+        var imageIndex = 0
+        var remainingImages = imageGrids.count
+        var tokens = inputIds
+        var positionGroups: [[[Int]]] = []
+        var start = 0
+        var nextFixPoint = fixPoint
+
+        while remainingImages > 0 {
+            let imageEnd = tokens[start...].firstIndex(of: config.imageTokenId) ?? (tokens.count + 1)
+            let grid = imageGrids[imageIndex]
+            let skipVisionStart = imageIndex < skipVisionStartToken.count && skipVisionStartToken[imageIndex]
+            imageIndex += 1
+            remainingImages -= 1
+
+            let gridT = 1
+            let gridH = grid.height
+            let gridW = grid.width
+            let rawTextLength = imageEnd - start
+            let textLength = max(0, rawTextLength - (skipVisionStart ? 1 : 0))
+            let startIndex = (positionGroups.flatMap { $0 }.flatMap { $0 }.max() ?? -1) + 1
+            if textLength > 0 {
+                positionGroups.append(repeatedPositions(start: startIndex, count: textLength))
+            }
+
+            let visionStart = skipVisionStart ? startIndex + max(0, nextFixPoint - startIndex) : startIndex + textLength
+            positionGroups.append(visionPositions(t: gridT, h: gridH, w: gridW, start: visionStart))
+            if skipVisionStart {
+                nextFixPoint = 0
+            }
+            start = imageEnd + gridT * gridH * gridW
+            tokens = inputIds
+        }
+
+        if start < inputIds.count {
+            let startIndex = (positionGroups.flatMap { $0 }.flatMap { $0 }.max() ?? -1) + 1
+            let textLength = inputIds.count - start
+            positionGroups.append(repeatedPositions(start: startIndex, count: textLength))
+        }
+
+        let emptyPositions: [[Int]] = [[], [], []]
+        let flattened = positionGroups.reduce(into: emptyPositions) { partial, group in
+            partial[0].append(contentsOf: group[0])
+            partial[1].append(contentsOf: group[1])
+            partial[2].append(contentsOf: group[2])
+        }
+        return flattened
+    }
+
+    private static func repeatedPositions(start: Int, count: Int) -> [[Int]] {
+        let positions = Array(start..<(start + count))
+        return [positions, positions, positions]
+    }
+
+    private static func visionPositions(t: Int, h: Int, w: Int, start: Int) -> [[Int]] {
+        var tPositions: [Int] = []
+        var hPositions: [Int] = []
+        var wPositions: [Int] = []
+        for tIndex in 0..<t {
+            for hIndex in 0..<h {
+                for wIndex in 0..<w {
+                    tPositions.append(start + tIndex)
+                    hPositions.append(start + hIndex)
+                    wPositions.append(start + wIndex)
+                }
+            }
+        }
+        return [tPositions, hPositions, wPositions]
+    }
+
+    private static func roundedDown(_ value: Double) -> Int {
+        max(patchSize, Int(value) / patchSize * patchSize)
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Scheduler.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Scheduler.swift
@@ -1,0 +1,214 @@
+import Foundation
+import MLX
+
+public struct HiDreamO1Scheduler {
+    public static let devTimesteps: [Int] = [
+        999, 987, 974, 960, 945, 929, 913, 895, 877, 857, 836, 814, 790, 764,
+        737, 707, 675, 640, 602, 560, 515, 464, 409, 347, 278, 199, 110, 8,
+    ]
+
+    public let timesteps: MLXArray
+    public let sigmas: MLXArray
+    public let timestepValues: [Float]
+    public let sigmaValues: [Float]
+    public let noiseScales: [Float]
+    public let variant: MereRunModelManifest.Variant
+
+    public init(
+        steps: Int,
+        variant: MereRunModelManifest.Variant,
+        shift: Float,
+        noiseScaleStart: Float = 7.5,
+        noiseScaleEnd: Float = 7.5
+    ) {
+        let resolvedSteps = max(1, steps)
+        let timestepValues: [Float]
+        let shiftedSigmas: [Float]
+        if variant == .distilled {
+            let devSteps = Array(Self.devTimesteps.prefix(resolvedSteps)).map(Float.init)
+            timestepValues = devSteps
+            shiftedSigmas = devSteps.map { $0 / 1_000.0 }
+        } else {
+            let trainingSigmaMax = Self.shiftedSigma(0.999, shift: shift)
+            let rawSigmas = (0..<resolvedSteps).map { index in
+                trainingSigmaMax * (1.0 - Float(index) / Float(resolvedSteps))
+            }
+            shiftedSigmas = rawSigmas.map { Self.shiftedSigma($0, shift: shift) }
+            timestepValues = shiftedSigmas.map { floor($0 * 1_000.0) }
+        }
+
+        let terminalSigmas = shiftedSigmas + [0.0]
+
+        if resolvedSteps > 1 {
+            self.noiseScales = (0..<resolvedSteps).map { index in
+                noiseScaleStart + (noiseScaleEnd - noiseScaleStart) * Float(index) / Float(resolvedSteps - 1)
+            }
+        } else {
+            self.noiseScales = [noiseScaleStart]
+        }
+        self.variant = variant
+        self.timestepValues = timestepValues
+        self.sigmaValues = terminalSigmas
+        self.timesteps = MLXArray(timestepValues).asType(.float32)
+        self.sigmas = MLXArray(terminalSigmas).asType(.float32)
+    }
+
+    public var usesFlashStep: Bool {
+        variant == .distilled
+    }
+
+    public func sigma(at index: Int) -> MLXArray {
+        sigmas[index]
+    }
+
+    public func timestep(at index: Int) -> MLXArray {
+        timesteps[index]
+    }
+
+    private static func shiftedSigma(_ sigma: Float, shift: Float) -> Float {
+        shift * sigma / (1.0 + (shift - 1.0) * sigma)
+    }
+}
+
+struct HiDreamO1UniPCState {
+    private let scheduler: HiDreamO1Scheduler
+    private let solverOrder = 2
+    private var modelOutputs: [MLXArray?]
+    private var lastSample: MLXArray?
+    private var lowerOrderNumbers = 0
+    private var lastOrder = 1
+
+    init(scheduler: HiDreamO1Scheduler) {
+        self.scheduler = scheduler
+        self.modelOutputs = Array(repeating: nil, count: solverOrder)
+    }
+
+    mutating func step(modelOutput: MLXArray, sample: MLXArray, stepIndex: Int) -> MLXArray {
+        let converted = convertModelOutput(modelOutput: modelOutput, sample: sample, stepIndex: stepIndex)
+        var workingSample = sample
+
+        if stepIndex > 0, let previousSample = lastSample, let previousOutput = modelOutputs.last ?? nil {
+            workingSample = correct(
+                thisModelOutput: converted,
+                previousModelOutput: previousOutput,
+                lastSample: previousSample,
+                thisSample: workingSample,
+                stepIndex: stepIndex,
+                order: lastOrder
+            )
+        }
+
+        for index in 0..<(solverOrder - 1) {
+            modelOutputs[index] = modelOutputs[index + 1]
+        }
+        modelOutputs[solverOrder - 1] = converted
+
+        let remainingSteps = scheduler.timestepValues.count - stepIndex
+        let thisOrder = max(1, min(solverOrder, remainingSteps, lowerOrderNumbers + 1))
+        lastOrder = thisOrder
+        lastSample = workingSample
+
+        let previous = predict(sample: workingSample, stepIndex: stepIndex, order: thisOrder)
+        if lowerOrderNumbers < solverOrder {
+            lowerOrderNumbers += 1
+        }
+        return previous
+    }
+
+    private func convertModelOutput(modelOutput: MLXArray, sample: MLXArray, stepIndex: Int) -> MLXArray {
+        sample - modelOutput * MLXArray(scheduler.sigmaValues[stepIndex])
+    }
+
+    private func predict(sample: MLXArray, stepIndex: Int, order: Int) -> MLXArray {
+        guard let m0 = modelOutputs.last ?? nil else {
+            return sample
+        }
+        let sigmaT = scheduler.sigmaValues[stepIndex + 1]
+        let sigmaS0 = scheduler.sigmaValues[stepIndex]
+        let alphaT = 1.0 - sigmaT
+        let alphaS0 = 1.0 - sigmaS0
+        let h = lambda(alpha: alphaT, sigma: sigmaT) - lambda(alpha: alphaS0, sigma: sigmaS0)
+        let terms = bhTerms(h: h)
+        let base = sample * MLXArray(sigmaT / sigmaS0) - m0 * MLXArray(alphaT * terms.hPhi1)
+
+        guard order > 1,
+              let previous = modelOutputs.first ?? nil else {
+            return base
+        }
+
+        let sigmaSI = scheduler.sigmaValues[max(0, stepIndex - 1)]
+        let lambdaSI = lambda(alpha: 1.0 - sigmaSI, sigma: sigmaSI)
+        let lambdaS0 = lambda(alpha: alphaS0, sigma: sigmaS0)
+        let rk = (lambdaSI - lambdaS0) / h
+        let d1 = (previous - m0) / MLXArray(rk)
+        return base - d1 * MLXArray(alphaT * terms.bH * 0.5)
+    }
+
+    private func correct(
+        thisModelOutput: MLXArray,
+        previousModelOutput m0: MLXArray,
+        lastSample: MLXArray,
+        thisSample _: MLXArray,
+        stepIndex: Int,
+        order: Int
+    ) -> MLXArray {
+        let sigmaT = scheduler.sigmaValues[stepIndex]
+        let sigmaS0 = scheduler.sigmaValues[stepIndex - 1]
+        let alphaT = 1.0 - sigmaT
+        let alphaS0 = 1.0 - sigmaS0
+        let h = lambda(alpha: alphaT, sigma: sigmaT) - lambda(alpha: alphaS0, sigma: sigmaS0)
+        let terms = bhTerms(h: h)
+        let base = lastSample * MLXArray(sigmaT / sigmaS0) - m0 * MLXArray(alphaT * terms.hPhi1)
+        let d1Current = thisModelOutput - m0
+
+        guard order > 1,
+              let olderModelOutput = modelOutputs.first ?? nil else {
+            return base - d1Current * MLXArray(alphaT * terms.bH * 0.5)
+        }
+
+        let sigmaSI = scheduler.sigmaValues[max(0, stepIndex - 2)]
+        let lambdaSI = lambda(alpha: 1.0 - sigmaSI, sigma: sigmaSI)
+        let lambdaS0 = lambda(alpha: alphaS0, sigma: sigmaS0)
+        let rk = (lambdaSI - lambdaS0) / h
+        let d1Previous = (olderModelOutput - m0) / MLXArray(rk)
+        let rhos = correctorRhos(h: h, rk: rk, terms: terms)
+        let correction = d1Previous * MLXArray(rhos.previous) + d1Current * MLXArray(rhos.current)
+        return base - correction * MLXArray(alphaT * terms.bH)
+    }
+
+    private func lambda(alpha: Float, sigma: Float) -> Float {
+        log(alpha) - log(sigma)
+    }
+
+    private func bhTerms(h: Float) -> (hPhi1: Float, bH: Float, hPhi2: Float) {
+        let hh = -h
+        let hPhi1 = expm1(hh)
+        let bH = hPhi1
+        let hPhi2 = hPhi1 / hh - 1.0
+        return (hPhi1, bH, hPhi2)
+    }
+
+    private func correctorRhos(
+        h: Float,
+        rk: Float,
+        terms: (hPhi1: Float, bH: Float, hPhi2: Float)
+    ) -> (previous: Float, current: Float) {
+        let hh = -h
+        var hPhiK = terms.hPhi2
+        var factorial: Float = 1.0
+        var b: [Float] = []
+        for _ in 1...2 {
+            b.append(hPhiK * factorial / terms.bH)
+            factorial *= Float(b.count + 2)
+            hPhiK = hPhiK / hh - 1.0 / factorial
+        }
+        let determinant = 1.0 - rk
+        guard abs(determinant) > 1e-6 else {
+            return (0.5, 0.5)
+        }
+        return (
+            previous: (b[0] - b[1]) / determinant,
+            current: (b[1] - rk * b[0]) / determinant
+        )
+    }
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1TokenizerAndTemplate.swift
@@ -1,0 +1,101 @@
+import Foundation
+@preconcurrency import Hub
+@preconcurrency import Tokenizers
+
+public final class HiDreamO1TokenizerAndTemplate {
+    public static let boiToken = "<|boi_token|>"
+    public static let tmsToken = "<|tms_token|>"
+    public static let tmsTokenId = 151_673
+    public static let imagePadTokenId = 151_655
+
+    public let tokenizer: any Tokenizer
+    public let maxLength: Int
+
+    public init(tokenizer: any Tokenizer, maxLength: Int) {
+        self.tokenizer = tokenizer
+        self.maxLength = maxLength
+    }
+
+    public static func load(
+        from resources: HiDreamO1Resources,
+        maxLengthOverride: Int? = nil,
+        hubApi: HubApi = .shared
+    ) async throws -> HiDreamO1TokenizerAndTemplate {
+        let tokenizer = try await AutoTokenizer.from(modelFolder: resources.rootURL, hubApi: hubApi)
+        let configuredMaxLength = Self.readMaxLength(from: resources.tokenizerConfigURL)
+        return HiDreamO1TokenizerAndTemplate(
+            tokenizer: tokenizer,
+            maxLength: maxLengthOverride ?? configuredMaxLength ?? 131_072
+        )
+    }
+
+    public func encodeTextToImagePrompt(_ prompt: String) throws -> [Int] {
+        try encodePrompt(messages: Self.messages(prompt: prompt, referenceImageCount: 0))
+    }
+
+    public func encodeReferencePrompt(_ prompt: String, referenceImageCount: Int) throws -> [Int] {
+        try encodePrompt(messages: Self.messages(prompt: prompt, referenceImageCount: referenceImageCount))
+    }
+
+    public func encodeReferencePrompt(_ prompt: String, referenceImageTokenCounts: [Int]) throws -> [Int] {
+        var encoded = try encodeReferencePrompt(prompt, referenceImageCount: referenceImageTokenCounts.count)
+        var imageIndex = 0
+        var expanded: [Int] = []
+        expanded.reserveCapacity(encoded.count + referenceImageTokenCounts.reduce(0, +))
+        for token in encoded {
+            guard token == Self.imagePadTokenId, imageIndex < referenceImageTokenCounts.count else {
+                expanded.append(token)
+                continue
+            }
+            expanded.append(
+                contentsOf: Array(
+                    repeating: token,
+                    count: max(1, referenceImageTokenCounts[imageIndex])
+                )
+            )
+            imageIndex += 1
+        }
+        if expanded.count > maxLength {
+            encoded = Array(expanded.suffix(maxLength))
+        } else {
+            encoded = expanded
+        }
+        return encoded
+    }
+
+    public static func messages(prompt: String, referenceImageCount: Int) -> [Message] {
+        if referenceImageCount <= 0 {
+            return [["role": "user", "content": prompt]]
+        }
+
+        var content: [[String: String]] = Array(repeating: ["type": "image"], count: referenceImageCount)
+        content.append(["type": "text", "text": prompt])
+        return [["role": "user", "content": content]]
+    }
+
+    private func encodePrompt(messages: [Message]) throws -> [Int] {
+        var encoded = try tokenizer.applyChatTemplate(
+            messages: messages,
+            chatTemplate: nil,
+            addGenerationPrompt: true,
+            truncation: false,
+            maxLength: nil,
+            tools: nil
+        )
+        encoded.append(contentsOf: tokenizer.encode(text: Self.boiToken + Self.tmsToken))
+        if encoded.count > maxLength {
+            encoded = Array(encoded.suffix(maxLength))
+        }
+        return encoded
+    }
+
+    private static func readMaxLength(from url: URL) -> Int? {
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let configured = object["model_max_length"] as? NSNumber else {
+            return nil
+        }
+        let value = configured.intValue
+        return value > 0 ? value : nil
+    }
+}

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -63,6 +63,7 @@ public struct ManagedModelArchiveSource: Hashable, Sendable {
 public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case flux2Klein
     case zimageTurbo
+    case hidreamO1
     case gemma4
     case q35
     case qwen3TTS
@@ -259,6 +260,64 @@ public enum ManagedModelCatalog {
                 size: 0
             ),
             validationKind: .zimageTurbo,
+            runtimeAutoDownloadAllowed: false,
+            defaultCLICommands: ["image generate"]
+        ),
+        ManagedModelSpec(
+            id: "image-hidream-o1",
+            category: .image,
+            installShape: .directoryRoot,
+            archiveSource: nil,
+            hubFallback: HubFallbackConfig(
+                repoId: "HiDream-ai/HiDream-O1-Image",
+                revision: "main",
+                patterns: [
+                    "config.json",
+                    "configuration.json",
+                    "generation_config.json",
+                    "chat_template.json",
+                    "tokenizer.json",
+                    "tokenizer_config.json",
+                    "vocab.json",
+                    "merges.txt",
+                    "preprocessor_config.json",
+                    "video_preprocessor_config.json",
+                    "model.safetensors.index.json",
+                    "model-*.safetensors",
+                ]
+            ),
+            upstreamRepoId: "HiDream-ai/HiDream-O1-Image",
+            upstreamRevision: "main",
+            validationKind: .hidreamO1,
+            runtimeAutoDownloadAllowed: false,
+            defaultCLICommands: ["image generate"]
+        ),
+        ManagedModelSpec(
+            id: "image-hidream-o1-dev",
+            category: .image,
+            installShape: .directoryRoot,
+            archiveSource: nil,
+            hubFallback: HubFallbackConfig(
+                repoId: "HiDream-ai/HiDream-O1-Image-Dev",
+                revision: "main",
+                patterns: [
+                    "config.json",
+                    "configuration.json",
+                    "generation_config.json",
+                    "chat_template.json",
+                    "tokenizer.json",
+                    "tokenizer_config.json",
+                    "vocab.json",
+                    "merges.txt",
+                    "preprocessor_config.json",
+                    "video_preprocessor_config.json",
+                    "model.safetensors.index.json",
+                    "model-*.safetensors",
+                ]
+            ),
+            upstreamRepoId: "HiDream-ai/HiDream-O1-Image-Dev",
+            upstreamRevision: "main",
+            validationKind: .hidreamO1,
             runtimeAutoDownloadAllowed: false,
             defaultCLICommands: ["image generate"]
         ),
@@ -764,6 +823,8 @@ public extension ManagedModelSpec {
             return Self.missingDiffusersImagePaths(in: rootURL, fileManager: fileManager)
         case .zimageTurbo:
             return ZImageTurboResources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .hidreamO1:
+            return HiDreamO1Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .gemma4:
             return Gemma4Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .q35:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -171,6 +171,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 64
             ),
             descriptor(
+                "image-hidream-o1-dev",
+                "Image, HiDream dev",
+                "Runs the distilled HiDream O1 image model for text, reference editing, and subject personalization.",
+                minimum: 48,
+                recommended: 64
+            ),
+            descriptor(
+                "image-hidream-o1",
+                "Image, HiDream full",
+                "Runs the full HiDream O1 image model for high-quality text, reference editing, and personalization workflows.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 "text-chat-mebot",
                 "Local personal chat",
                 "Adds a compact local chat model for API serving and personal-agent style workflows.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -18,6 +18,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case flux2Klein = "flux2-klein"
         /// Zeta family (Z-Image Turbo based).
         case zimageTurbo = "zimage-turbo"
+        /// HiDream O1 unified pixel transformer family.
+        case hidreamO1 = "hidream-o1"
         /// Gemma 4 family via the native Swift runtime.
         case gemma4 = "gemma-4"
         /// Q35 family (Qwen3.5 hybrid MoE + hybrid attention).
@@ -51,6 +53,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     public enum Family: String, Codable, CaseIterable, Hashable, Sendable {
         case klein
         case zimage
+        case hidream
         case gemma
         case qwen
         case sam
@@ -95,6 +98,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case txt2img = "txt2img"
         case img2img = "img2img"
         case referenceEdit = "reference_edit"
+        case subjectPersonalization = "subject_personalization"
         case chat = "chat"
         case codeGeneration = "code_generation"
         case textEmbedding = "text_embedding"
@@ -681,6 +685,46 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.txt2img, .img2img, .loraInference, .loraTraining],
                 components: hybridComponents,
                 upstreamRepoId: nil,
+                createdAt: createdAt
+            )
+        case .hidreamO1:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .hidreamO1,
+                family: .hidream,
+                tier: .max,
+                variant: .base,
+                precision: .bf16,
+                defaults: Defaults(steps: 50, cfg: 5.0),
+                supports: [.txt2img, .referenceEdit, .subjectPersonalization],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: nil,
+                    scheduler: nil
+                ),
+                upstreamRepoId: "HiDream-ai/HiDream-O1-Image",
+                createdAt: createdAt
+            )
+        case .hidreamO1Dev:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .hidreamO1,
+                family: .hidream,
+                tier: .max,
+                variant: .distilled,
+                precision: .bf16,
+                defaults: Defaults(steps: 28, cfg: 0.0),
+                supports: [.txt2img, .referenceEdit, .subjectPersonalization],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: nil,
+                    scheduler: nil
+                ),
+                upstreamRepoId: "HiDream-ai/HiDream-O1-Image-Dev",
                 createdAt: createdAt
             )
         case .visionSegmentSAM31:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -65,19 +65,11 @@ public enum MereRunModelValidator {
         }
 
         let supportsImagePipeline: Bool
-        let supportsVisionModel: Bool
         if let unwrappedManifest = manifest {
             let supports = Set(unwrappedManifest.supports ?? [])
             supportsImagePipeline = supports.contains(.txt2img) || supports.contains(.img2img) || supports.contains(.referenceEdit)
-            supportsVisionModel = supports.contains(.visionGrounding)
-                || supports.contains(.visionDetection)
-                || supports.contains(.visionSegmentation)
-                || supports.contains(.visionTracking)
-                || unwrappedManifest.family == .sam
-                || unwrappedManifest.family == .falcon
         } else {
             supportsImagePipeline = true
-            supportsVisionModel = false
         }
 
         if let manifest = manifest {
@@ -104,6 +96,7 @@ public enum MereRunModelValidator {
 
         let modelResolver = ModelResolver(fileManager: fileManager)
         let componentRefs = manifest?.components
+        let usesUnifiedImageTransformer = manifest?.engine == .hidreamO1
         let transformerDir: URL?
         let textEncoderDir: URL?
         let vaeDir: URL?
@@ -191,7 +184,7 @@ public enum MereRunModelValidator {
                 )
             }
 
-            if supportsImagePipeline {
+            if supportsImagePipeline && !usesUnifiedImageTransformer {
                 vaeDir = resolveComponentDirectory(
                     componentRefs?.vae ?? .local(path: "vae"),
                     modelRoot: rootURL,
@@ -233,7 +226,7 @@ public enum MereRunModelValidator {
             }
 
             let schedulerDir: URL?
-            if supportsImagePipeline {
+            if supportsImagePipeline && !usesUnifiedImageTransformer {
                 schedulerDir = resolveComponentDirectory(
                     componentRefs?.scheduler ?? .local(path: "scheduler"),
                     modelRoot: rootURL,
@@ -311,6 +304,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=klein expects flux2-klein.")
             case .zimage where engine != .zimageTurbo:
                 warnings.append("Manifest engine mismatch: family=zimage expects zimage-turbo.")
+            case .hidream where engine != .hidreamO1:
+                warnings.append("Manifest engine mismatch: family=hidream expects hidream-o1.")
             case .gemma where engine != .gemma4:
                 warnings.append("Manifest engine mismatch: family=gemma expects gemma-4.")
             case .qwen where engine != .qwen35HybridMoE:
@@ -389,6 +384,7 @@ public enum MereRunModelValidator {
             let supports = Set(manifest.supports ?? [])
             return supports.contains(.txt2img) || supports.contains(.img2img) || supports.contains(.referenceEdit)
         }()
+        let usesUnifiedImageTransformer = manifest.engine == .hidreamO1
         let supportsVisionModel = {
             let supports = Set(manifest.supports ?? [])
             return supports.contains(.visionGrounding)
@@ -425,13 +421,14 @@ public enum MereRunModelValidator {
 
         if components.textEncoder == nil { errors.append("Manifest components missing text_encoder.") }
         if supportsImagePipeline && components.transformer == nil { errors.append("Manifest components missing transformer.") }
-        if supportsImagePipeline && components.vae == nil { errors.append("Manifest components missing vae.") }
-        if supportsImagePipeline && components.scheduler == nil { errors.append("Manifest components missing scheduler.") }
+        if supportsImagePipeline && !usesUnifiedImageTransformer && components.vae == nil { errors.append("Manifest components missing vae.") }
+        if supportsImagePipeline && !usesUnifiedImageTransformer && components.scheduler == nil { errors.append("Manifest components missing scheduler.") }
     }
 
     private static func inferFamily(from modelId: String) -> MereRunModelManifest.Family? {
         if modelId.hasPrefix("image-klein-") { return .klein }
         if modelId.hasPrefix("image-zimage-") { return .zimage }
+        if modelId.hasPrefix("image-hidream-") { return .hidream }
         if modelId.hasPrefix("vision-segment-") { return .sam }
         if modelId.hasPrefix("vision-ground-") { return .falcon }
         if modelId.hasPrefix("speech-tts-") { return .tts }

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -16,6 +16,8 @@ public struct ModelResolver {
         case zetaNano = "image-zimage-nano"
         case zetaMax = "image-zimage-max"
         case zetaBase = "image-zimage-base"
+        case hidreamO1 = "image-hidream-o1"
+        case hidreamO1Dev = "image-hidream-o1-dev"
         case mebot = "text-chat-mebot"
         case psiAgent = "text-chat-psi-agent"
         case gemma4 = "text-chat-gemma4"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -23,6 +23,7 @@ public enum QuantizedModelManifestWriter {
         func inferFamily(from id: String) -> MereRunModelManifest.Family? {
             if id.hasPrefix("image-klein-") { return .klein }
             if id.hasPrefix("image-zimage-") { return .zimage }
+            if id.hasPrefix("image-hidream-") { return .hidream }
             if id.hasPrefix("vision-segment-") { return .sam }
             if id.hasPrefix("vision-ground-") { return .falcon }
             return nil
@@ -39,6 +40,7 @@ public enum QuantizedModelManifestWriter {
             switch engine {
             case .flux2Klein: return .klein
             case .zimageTurbo: return .zimage
+            case .hidreamO1: return .hidream
             case .gemma4: return .gemma
             case .qwen35HybridMoE: return .qwen
             case .samSegmentation: return .sam
@@ -78,6 +80,8 @@ public enum QuantizedModelManifestWriter {
                     return [.txt2img, .referenceEdit, .loraInference]
                 case .zimageTurbo:
                     return [.txt2img, .img2img, .loraInference]
+                case .hidreamO1:
+                    return [.txt2img, .referenceEdit, .subjectPersonalization]
                 case .gemma4:
                     return [.chat]
                 case .qwen35HybridMoE:
@@ -154,6 +158,8 @@ public enum QuantizedModelManifestWriter {
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 4, cfg: 1.0)
             case .zimageTurbo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 4, cfg: 1.0)
+            case .hidreamO1:
+                manifest.defaults = MereRunModelManifest.Defaults(steps: 28, cfg: 0.0)
             case .gemma4:
                 break
             case .qwen35HybridMoE:

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -352,16 +352,18 @@ public final class QwenEncoder: Module {
   public func forward(
     embeddings: MLXArray,
     attentionMask: MLXArray?,
+    positionIds: MLXArray? = nil,
+    tokenTypes: MLXArray? = nil,
     outputHiddenStates: Bool = false
   ) -> (lastHiddenState: MLXArray, hiddenStates: [MLXArray]?) {
     var h = embeddings.dtype == .bfloat16 ? embeddings : embeddings.asType(.bfloat16)
 
-    let mask = createAttentionMask(h: h, attentionMask: attentionMask)
+    let mask = createAttentionMask(h: h, attentionMask: attentionMask, tokenTypes: tokenTypes)
 
     var allHiddenStates: [MLXArray]? = outputHiddenStates ? [h] : nil
 
     for layer in layers {
-      h = layer(h, mask: mask)
+      h = layer(h, mask: mask, positionIds: positionIds)
       if outputHiddenStates {
         allHiddenStates?.append(h)
       }
@@ -377,10 +379,17 @@ public final class QwenEncoder: Module {
     return (h, allHiddenStates)
   }
 
-  private func createAttentionMask(h: MLXArray, attentionMask: MLXArray?) -> MLXFast.ScaledDotProductAttentionMaskMode {
+  private func createAttentionMask(
+    h: MLXArray,
+    attentionMask: MLXArray?,
+    tokenTypes: MLXArray? = nil
+  ) -> MLXFast.ScaledDotProductAttentionMaskMode {
     let L = h.dim(1)
 
     let causalMask = MLXFast.ScaledDotProductAttentionMaskMode.causal
+    if let tokenTypes {
+      return generationAttentionMask(h: h, tokenTypes: tokenTypes)
+    }
 
     if let attentionMask = attentionMask {
       let paddingMask = attentionMask.asType(h.dtype)
@@ -405,6 +414,32 @@ public final class QwenEncoder: Module {
     }
 
     return causalMask
+  }
+
+  private func generationAttentionMask(
+    h: MLXArray,
+    tokenTypes: MLXArray
+  ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+    let batch = h.dim(0)
+    let length = h.dim(1)
+    let minValue = MLXArray(-Float.greatestFiniteMagnitude).asType(h.dtype)
+    let zeros = MLX.zeros([batch, length, length], dtype: h.dtype)
+    let idx = MLXArray(0..<length)
+    let rows = idx.reshaped(1, length, 1)
+    let cols = idx.reshaped(1, 1, length)
+    var blocked = cols .> rows
+
+    var types = tokenTypes
+    if types.ndim == 1 {
+      types = types.reshaped(1, length)
+    }
+    if types.dim(0) == 1 && batch > 1 {
+      types = MLX.broadcast(types, to: [batch, length])
+    }
+    let generationRows = (types .> MLXArray(0)).reshaped(batch, length, 1)
+    blocked = blocked .&& (.!generationRows)
+    let additive = MLX.where(blocked, zeros + minValue, zeros).reshaped(batch, 1, length, length)
+    return .array(additive)
   }
 }
 

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import MereRunCLI
+
+final class ImageGenerateCommandParsingTests: XCTestCase {
+    func testParsesHiDreamReferenceOptions() throws {
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "place this subject in a studio",
+            "--model", "image-hidream-o1-dev",
+            "--ref-image", "/tmp/ref1.png",
+            "--ref-image", "/tmp/ref2.png",
+            "--keep-original-aspect",
+            "--width", "1024",
+            "--height", "768",
+        ])
+
+        XCTAssertEqual(cmd.prompt, "place this subject in a studio")
+        XCTAssertEqual(cmd.model, "image-hidream-o1-dev")
+        XCTAssertEqual(cmd.referenceImages, ["/tmp/ref1.png", "/tmp/ref2.png"])
+        XCTAssertTrue(cmd.keepOriginalAspect)
+        XCTAssertEqual(cmd.width, 1024)
+        XCTAssertEqual(cmd.height, 768)
+        XCTAssertNil(cmd.steps)
+        XCTAssertNil(cmd.cfgScale)
+    }
+
+    func testParsesExplicitHiDreamStepAndCFGOverrides() throws {
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "a brass camera",
+            "--model", "image-hidream-o1",
+            "--steps", "4",
+            "--cfg", "1.0",
+        ])
+
+        XCTAssertEqual(cmd.steps, 4)
+        XCTAssertEqual(cmd.cfgScale, 1.0)
+    }
+}

--- a/Tests/MereRunCoreTests/HiDreamO1ConfigTests.swift
+++ b/Tests/MereRunCoreTests/HiDreamO1ConfigTests.swift
@@ -1,0 +1,342 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+#endif
+
+final class HiDreamO1ConfigTests: MereRunCoreTestCase {
+    func testDecodesUpstreamStyleConfig() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data(Self.configJSON.utf8))
+        let config = try HiDreamO1Config.load(from: HiDreamO1Resources(rootURL: root))
+
+        XCTAssertEqual(config.modelType, "qwen3_vl")
+        XCTAssertEqual(config.imageTokenId, 151655)
+        XCTAssertEqual(config.textConfig.hiddenSize, 4096)
+        XCTAssertEqual(config.textConfig.ropeScaling.mropeSection, [24, 20, 20])
+        XCTAssertEqual(config.visionConfig.hiddenSize, 1152)
+        XCTAssertEqual(config.visionConfig.deepstackVisualIndexes, [8, 16, 24])
+    }
+
+    func testDevSchedulerUsesReferenceTimesteps() {
+        let scheduler = HiDreamO1Scheduler(steps: 28, variant: .distilled, shift: 1.0)
+        let timesteps = scheduler.timesteps.asArray(Float.self)
+        let sigmas = scheduler.sigmas.asArray(Float.self)
+
+        XCTAssertEqual(timesteps.prefix(4).map(Int.init), [999, 987, 974, 960])
+        XCTAssertEqual(timesteps.last.map(Int.init), 8)
+        XCTAssertEqual(sigmas.count, 29)
+        XCTAssertEqual(sigmas.last ?? -1, 0, accuracy: 0.0001)
+    }
+
+    func testFullSchedulerMatchesUpstreamFlowUniPCSchedule() {
+        let scheduler = HiDreamO1Scheduler(steps: 5, variant: .base, shift: 3.0)
+
+        XCTAssertFalse(scheduler.usesFlashStep)
+        XCTAssertEqual(scheduler.timestepValues.map(Int.init), [999, 922, 818, 666, 428])
+        XCTAssertEqual(scheduler.sigmaValues.count, 6)
+        XCTAssertEqual(scheduler.sigmaValues[0], 0.9998888, accuracy: 0.000001)
+        XCTAssertEqual(scheduler.sigmaValues[1], 0.9229585, accuracy: 0.000001)
+        XCTAssertEqual(scheduler.sigmaValues[4], 0.4284693, accuracy: 0.000001)
+        XCTAssertEqual(scheduler.sigmaValues[5], 0, accuracy: 0.000001)
+    }
+
+    func testFullUniPCOneStepReturnsDenoisedPrediction() {
+        let scheduler = HiDreamO1Scheduler(steps: 1, variant: .base, shift: 3.0)
+        var state = HiDreamO1UniPCState(scheduler: scheduler)
+        let sample = MLXArray([Float(10)], [1])
+        let modelOutput = MLXArray([Float(2)], [1])
+
+        let result = state.step(modelOutput: modelOutput, sample: sample, stepIndex: 0)
+        MLX.eval(result)
+
+        XCTAssertEqual(
+            result.asArray(Float.self)[0],
+            10 - scheduler.sigmaValues[0] * 2,
+            accuracy: 0.0005
+        )
+    }
+
+    func testSampleBuilderConstructsTextAndReferenceMasks() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data(Self.configJSON.utf8))
+        let config = try HiDreamO1Config.load(from: HiDreamO1Resources(rootURL: root))
+
+        let textSample = HiDreamO1SampleBuilder.textToImageSample(
+            textTokenIds: [1, 2, 3],
+            height: 64,
+            width: 64,
+            config: config
+        )
+        XCTAssertEqual(textSample.targetImageLength, 4)
+        XCTAssertEqual(textSample.inputIds, [1, 2, 3])
+        XCTAssertEqual(textSample.paddedInputIds, [1, 2, 3, 151652, 151655, 151655, 151655])
+        XCTAssertEqual(textSample.tokenTypes, [0, 0, 1, 1, 1, 1, 1])
+        XCTAssertEqual(textSample.vinputMask.filter { $0 }.count, 4)
+        XCTAssertEqual(textSample.positionIds[0], [0, 1, 2, 4096, 4096, 4096, 4096])
+        XCTAssertEqual(textSample.positionIds[1], [0, 1, 2, 4096, 4096, 4097, 4097])
+        XCTAssertEqual(textSample.positionIds[2], [0, 1, 2, 4096, 4097, 4096, 4097])
+
+        let refSample = HiDreamO1SampleBuilder.referenceSample(
+            textTokenIds: [1, 2, 3],
+            targetHeight: 64,
+            targetWidth: 64,
+            referenceSizes: [.init(width: 64, height: 64), .init(width: 64, height: 64)],
+            config: config
+        )
+        XCTAssertEqual(refSample.targetImageLength, 4)
+        XCTAssertEqual(refSample.referenceImageLengths, [4, 4])
+        XCTAssertEqual(refSample.inputIds, [1, 2, 3])
+        XCTAssertEqual(refSample.paddedInputIds.count, 15)
+        XCTAssertEqual(refSample.tokenTypes, [0, 0] + Array(repeating: 1, count: 13))
+        XCTAssertEqual(refSample.vinputMask.filter { $0 }.count, 12)
+
+        let conditionSample = HiDreamO1SampleBuilder.referenceSample(
+            textTokenIds: [1, 151652, 151655, 151655, 151655, 151655, 151653, 2, 3],
+            targetHeight: 64,
+            targetWidth: 64,
+            referenceSizes: [.init(width: 64, height: 64)],
+            conditionGrids: [.init(width: 2, height: 2)],
+            config: config
+        )
+        XCTAssertEqual(conditionSample.paddedInputIds.count, 17)
+        XCTAssertEqual(conditionSample.positionIds[0].count, 17)
+        XCTAssertEqual(Array(conditionSample.tokenTypes[0..<8]), Array(repeating: 0, count: 8))
+        XCTAssertEqual(conditionSample.vinputMask.filter { $0 }.count, 8)
+    }
+
+    func testPatchifyRoundTripShape() {
+        let image = MLXArray(Array(repeating: Float(0.5), count: 3 * 64 * 64), [3, 64, 64])
+        let patches = HiDreamO1SampleBuilder.patchifyCHW(image)
+        let restored = HiDreamO1SampleBuilder.unpatchifyCHW(patches, height: 64, width: 64)
+
+        XCTAssertEqual(patches.shape, [4, 3072])
+        XCTAssertEqual(restored.shape, [3, 64, 64])
+    }
+
+    #if canImport(CoreGraphics)
+    func testImagePreprocessorNormalizesAndPatchifiesRGB() throws {
+        let image = try Self.makeSolidImage(width: 32, height: 32, rgba: (255, 0, 0, 255))
+        let tensor = try HiDreamO1ImagePreprocessor.patchTensor(
+            from: image,
+            resolution: .init(width: 32, height: 32)
+        )
+
+        XCTAssertEqual(tensor.imageCHW.shape, [3, 32, 32])
+        XCTAssertEqual(tensor.patches.shape, [1, 3_072])
+        let patch = tensor.patches.asArray(Float.self)
+        XCTAssertEqual(patch[0], 1.0, accuracy: 0.0001)
+        XCTAssertEqual(patch[1_024], -1.0, accuracy: 0.0001)
+        XCTAssertEqual(patch[2_048], -1.0, accuracy: 0.0001)
+    }
+
+    func testVisionConditionPreprocessorMatchesQwen3PatchShape() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data(Self.configJSON.utf8))
+        let config = try HiDreamO1Config.load(from: HiDreamO1Resources(rootURL: root))
+        let image = try Self.makeSolidImage(width: 64, height: 64, rgba: (0, 255, 0, 255))
+
+        let tensor = try HiDreamO1ImagePreprocessor.visionConditionTensor(
+            from: image,
+            resolution: .init(width: 64, height: 64),
+            config: config
+        )
+
+        XCTAssertEqual(tensor.grid.temporal, 1)
+        XCTAssertEqual(tensor.grid.height, 4)
+        XCTAssertEqual(tensor.grid.width, 4)
+        XCTAssertEqual(tensor.mergedGrid, .init(width: 2, height: 2))
+        XCTAssertEqual(tensor.tokenCount, 4)
+        XCTAssertEqual(tensor.pixelValues.shape, [1, 16, 1_536])
+    }
+
+    func testPreviewRendererWritesPNG() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let output = root.appendingPathComponent("hidream-preview.png")
+        let image = HiDreamO1PreviewRenderer.promptPreview(
+            prompt: "a small brass camera",
+            seed: 42,
+            resolution: .init(width: 64, height: 64)
+        )
+
+        try HiDreamO1ImagePreprocessor.saveNormalizedCHW(image, to: output)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: output.path))
+        guard let source = CGImageSourceCreateWithURL(output as CFURL, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any] else {
+            XCTFail("Expected a readable PNG.")
+            return
+        }
+        XCTAssertEqual(properties[kCGImagePropertyPixelWidth] as? Int, 64)
+        XCTAssertEqual(properties[kCGImagePropertyPixelHeight] as? Int, 64)
+    }
+    #endif
+
+    func testCoreLayerShapesAndTimestepFrequencies() {
+        let embedding = HiDreamO1TimestepEmbedder.timestepEmbedding(MLXArray([Float(0)]), dim: 4)
+        XCTAssertEqual(embedding.shape, [1, 4])
+        XCTAssertEqual(embedding.asArray(Float.self), [1, 1, 0, 0])
+
+        let timestepEmbedder = HiDreamO1TimestepEmbedder(hiddenSize: 8, frequencyEmbeddingSize: 4)
+        let timestepOut = timestepEmbedder(MLXArray([Float(0.5)]))
+        XCTAssertEqual(timestepOut.shape, [1, 8])
+
+        let patchEmbed = HiDreamO1BottleneckPatchEmbed(patchSize: 2, inChannels: 3, bottleneckDim: 4, hiddenSize: 8)
+        let patches = MLXArray(Array(repeating: Float(0.25), count: 2 * 12), [2, 12])
+        XCTAssertEqual(patchEmbed(patches).shape, [2, 8])
+
+        let finalLayer = HiDreamO1FinalLayer(hiddenSize: 8, patchSize: 2, outChannels: 3)
+        XCTAssertEqual(finalLayer(MLXArray(Array(repeating: Float(0.5), count: 2 * 8), [2, 8])).shape, [2, 12])
+    }
+
+    func testPixelHeadWeightMapperKeepsOnlyHiDreamSpecificKeys() {
+        let value = MLXArray([Float(1)])
+
+        XCTAssertEqual(
+            HiDreamO1WeightMapper.mapPixelHeadKey("model.t_embedder1.mlp.0.weight", value: value).first?.0,
+            "t_embedder1.mlp.0.weight"
+        )
+        XCTAssertEqual(
+            HiDreamO1WeightMapper.mapPixelHeadKey("model.x_embedder.proj1.weight", value: value).first?.0,
+            "x_embedder.proj1.weight"
+        )
+        XCTAssertEqual(
+            HiDreamO1WeightMapper.mapPixelHeadKey("final_layer2.linear.bias", value: value).first?.0,
+            "final_layer2.linear.bias"
+        )
+        XCTAssertTrue(HiDreamO1WeightMapper.mapPixelHeadKey("model.language_model.layers.0.self_attn.q_proj.weight", value: value).isEmpty)
+    }
+
+    func testResolutionAndReferenceSizingMatchUpstreamRules() {
+        XCTAssertEqual(HiDreamO1SampleBuilder.closestResolution(width: 1024, height: 1024), .init(width: 2048, height: 2048))
+        XCTAssertEqual(HiDreamO1SampleBuilder.closestResolution(width: 1920, height: 1080), .init(width: 2560, height: 1440))
+        XCTAssertEqual(HiDreamO1SampleBuilder.closestResolution(width: 900, height: 1600), .init(width: 1440, height: 2560))
+
+        XCTAssertEqual(
+            HiDreamO1SampleBuilder.targetResolution(
+                width: 1024,
+                height: 1024,
+                referenceOriginalSizes: [.init(width: 4000, height: 1000)],
+                keepOriginalAspect: true
+            ),
+            .init(width: 4096, height: 1024)
+        )
+        XCTAssertEqual(HiDreamO1SampleBuilder.referenceMaxSize(targetWidth: 2048, targetHeight: 1024, referenceCount: 2), 1536)
+        XCTAssertEqual(HiDreamO1SampleBuilder.conditionSize(referenceCount: 5), 288)
+        XCTAssertEqual(
+            HiDreamO1SampleBuilder.vlmConditionSize(originalWidth: 2_000, originalHeight: 1_000, maxSize: 384),
+            .init(width: 512, height: 256)
+        )
+    }
+
+    func testPromptBuilderCreatesReferenceImageMessages() throws {
+        let t2i = HiDreamO1TokenizerAndTemplate.messages(prompt: "a brass camera", referenceImageCount: 0)
+        XCTAssertEqual(t2i.count, 1)
+        XCTAssertEqual(t2i[0]["role"] as? String, "user")
+        XCTAssertEqual(t2i[0]["content"] as? String, "a brass camera")
+
+        let refs = HiDreamO1TokenizerAndTemplate.messages(prompt: "move the subject to a studio", referenceImageCount: 2)
+        XCTAssertEqual(refs[0]["role"] as? String, "user")
+        let content = try XCTUnwrap(refs[0]["content"] as? [[String: String]])
+        XCTAssertEqual(content.prefix(2).map { $0["type"] }, ["image", "image"])
+        XCTAssertEqual(content.last?["type"], "text")
+        XCTAssertEqual(content.last?["text"], "move the subject to a studio")
+        XCTAssertEqual(HiDreamO1TokenizerAndTemplate.boiToken, "<|boi_token|>")
+        XCTAssertEqual(HiDreamO1TokenizerAndTemplate.tmsToken, "<|tms_token|>")
+        XCTAssertEqual(HiDreamO1TokenizerAndTemplate.tmsTokenId, 151_673)
+    }
+
+    private static let configJSON = """
+    {
+      "architectures": ["Qwen3VLForConditionalGeneration"],
+      "image_token_id": 151655,
+      "model_type": "qwen3_vl",
+      "text_config": {
+        "attention_bias": false,
+        "attention_dropout": 0.0,
+        "bos_token_id": 151643,
+        "eos_token_id": 151645,
+        "head_dim": 128,
+        "hidden_act": "silu",
+        "hidden_size": 4096,
+        "intermediate_size": 12288,
+        "max_position_embeddings": 262144,
+        "num_attention_heads": 32,
+        "num_hidden_layers": 36,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-6,
+        "rope_scaling": {
+          "mrope_interleaved": true,
+          "mrope_section": [24, 20, 20],
+          "rope_type": "default"
+        },
+        "rope_theta": 5000000,
+        "vocab_size": 151936
+      },
+      "video_token_id": 151656,
+      "vision_config": {
+        "deepstack_visual_indexes": [8, 16, 24],
+        "depth": 27,
+        "hidden_act": "gelu_pytorch_tanh",
+        "hidden_size": 1152,
+        "in_channels": 3,
+        "intermediate_size": 4304,
+        "num_heads": 16,
+        "num_position_embeddings": 2304,
+        "out_hidden_size": 4096,
+        "patch_size": 16,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2
+      },
+      "vision_end_token_id": 151653,
+      "vision_start_token_id": 151652
+    }
+    """
+
+    #if canImport(CoreGraphics)
+    private static func makeSolidImage(
+        width: Int,
+        height: Int,
+        rgba: (UInt8, UInt8, UInt8, UInt8)
+    ) throws -> CGImage {
+        let pixelCount = width * height
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(pixelCount * 4)
+        for _ in 0..<pixelCount {
+            bytes.append(rgba.0)
+            bytes.append(rgba.1)
+            bytes.append(rgba.2)
+            bytes.append(rgba.3)
+        }
+        guard let provider = CGDataProvider(data: Data(bytes) as CFData) else {
+            throw HiDreamO1ImagePreprocessorError.pixelBufferFailed
+        }
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        guard let image = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ) else {
+            throw HiDreamO1ImagePreprocessorError.pixelBufferFailed
+        }
+        return image
+    }
+    #endif
+}

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -58,6 +58,34 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.upstreamRepoId, "tiiuae/Falcon-Perception")
     }
 
+    func testHiDreamO1DevTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .hidreamO1Dev, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, "image-hidream-o1-dev")
+        XCTAssertEqual(manifest.engine, .hidreamO1)
+        XCTAssertEqual(manifest.family, .hidream)
+        XCTAssertEqual(manifest.variant, .distilled)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(manifest.defaults?.steps, 28)
+        XCTAssertEqual(manifest.defaults?.cfg, 0.0)
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img, .referenceEdit, .subjectPersonalization]))
+        XCTAssertEqual(manifest.upstreamRepoId, "HiDream-ai/HiDream-O1-Image-Dev")
+    }
+
+    func testHiDreamO1FullTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .hidreamO1, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, "image-hidream-o1")
+        XCTAssertEqual(manifest.engine, .hidreamO1)
+        XCTAssertEqual(manifest.family, .hidream)
+        XCTAssertEqual(manifest.variant, .base)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(manifest.defaults?.steps, 50)
+        XCTAssertEqual(manifest.defaults?.cfg, 5.0)
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img, .referenceEdit, .subjectPersonalization]))
+        XCTAssertEqual(manifest.upstreamRepoId, "HiDream-ai/HiDream-O1-Image")
+    }
+
     func testPrivacyFilterTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .privacyFilter, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -49,6 +49,17 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
     }
 
+    private func writeMinimalValidHiDreamO1Model(at root: URL, id: ModelResolver.ModelID = .hidreamO1Dev) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("preprocessor_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
+    }
+
     private func writeMinimalValidSAM31Model(at root: URL) throws {
         try TestFileSystem.createDirectory(root)
         try MereRunModelManifest.template(for: .visionSegmentSAM31, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
@@ -145,6 +156,37 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertTrue(report.isValid)
         XCTAssertTrue(report.errors.isEmpty)
         XCTAssertEqual(report.manifest?.family, .gemma)
+    }
+
+    func testHiDreamO1UnifiedRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("image-hidream-o1-dev", isDirectory: true)
+        try writeMinimalValidHiDreamO1Model(at: root)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "image-hidream-o1-dev")
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.family, .hidream)
+        XCTAssertEqual(report.manifest?.engine, .hidreamO1)
+        XCTAssertEqual(report.manifest?.defaults?.steps, 28)
+    }
+
+    func testHiDreamO1FullUnifiedRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("image-hidream-o1", isDirectory: true)
+        try writeMinimalValidHiDreamO1Model(at: root, id: .hidreamO1)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "image-hidream-o1")
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.family, .hidream)
+        XCTAssertEqual(report.manifest?.engine, .hidreamO1)
+        XCTAssertEqual(report.manifest?.defaults?.steps, 50)
+        XCTAssertEqual(report.manifest?.defaults?.cfg, 5.0)
     }
 
     func testGemma4MaxChatOnlyRootLayoutPassesValidation() throws {

--- a/Tests/MereRunCoreTests/ModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ModelResolverTests.swift
@@ -49,6 +49,19 @@ final class ModelResolverTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
     }
 
+    private func writeMinimalHiDreamRoot(
+        at root: URL,
+        id: ModelResolver.ModelID
+    ) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("preprocessor_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
+    }
+
     private func writeMinimalSAM31Model(at root: URL) throws {
         try TestFileSystem.createDirectory(root)
         try MereRunModelManifest.template(for: .visionSegmentSAM31, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
@@ -142,6 +155,42 @@ final class ModelResolverTests: MereRunCoreTestCase {
 
         let resolver = ModelResolver()
         let resolved = try resolver.resolve(.q35)
+
+        XCTAssertEqual(resolved.rootURL.standardizedFileURL, modelRoot.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .localModelStore)
+    }
+
+    func testResolvesHiDreamFromProcessModelStoreOverride() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
+
+        let modelsRoot = temp.appendingPathComponent("models", isDirectory: true)
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        let modelRoot = modelsRoot.appendingPathComponent("image-hidream-o1-dev", isDirectory: true)
+        try writeMinimalHiDreamRoot(at: modelRoot, id: .hidreamO1Dev)
+
+        let resolver = ModelResolver()
+        let resolved = try resolver.resolve(.hidreamO1Dev)
+
+        XCTAssertEqual(resolved.rootURL.standardizedFileURL, modelRoot.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .localModelStore)
+    }
+
+    func testResolvesHiDreamFullFromProcessModelStoreOverride() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
+
+        let modelsRoot = temp.appendingPathComponent("models", isDirectory: true)
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        let modelRoot = modelsRoot.appendingPathComponent("image-hidream-o1", isDirectory: true)
+        try writeMinimalHiDreamRoot(at: modelRoot, id: .hidreamO1)
+
+        let resolver = ModelResolver()
+        let resolved = try resolver.resolve(.hidreamO1)
 
         XCTAssertEqual(resolved.rootURL.standardizedFileURL, modelRoot.standardizedFileURL)
         XCTAssertEqual(resolved.source, .localModelStore)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,9 +161,11 @@ Key options:
 - `--model`: canonical model id or local model path
 - `--output`: output PNG path
 - `--width`, `--height`
-- `--steps`
-- `--cfg`
+- `--steps`: override the model-specific step default
+- `--cfg`: override the model-specific CFG default
 - `--input`: image-to-image source
+- `--ref-image`: repeatable HiDream O1 reference image
+- `--keep-original-aspect`: preserve one HiDream reference image's aspect ratio
 - `--strength`: image-to-image strength
 - `--lora`, `--lora-scale`
 - `--quiet`
@@ -174,6 +176,11 @@ Examples:
 swift run mere.run image generate --prompt "a black cat on a red sofa"
 swift run mere.run image generate --model image-zimage-nano --prompt "retro robot illustration" --output ./robot.png
 swift run mere.run image generate --prompt "turn this into a pencil sketch" --input ./photo.png --strength 0.6
+swift run mere.run image generate \
+  --model image-hidream-o1-dev \
+  --prompt "put this subject in a studio portrait" \
+  --ref-image ./subject.png \
+  --output ./portrait.png
 ```
 
 ### `mere.run image validate`

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -19,7 +19,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 
 | Category | Canonical IDs |
 | --- | --- |
-| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max` |
+| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
 | Text chat | `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q35`, `text-chat-q35-nano` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
@@ -52,6 +52,39 @@ Useful environment variables for that path:
 
 The manifest for this package advertises both `vision_segmentation` and
 `vision_tracking` capabilities.
+
+`image-hidream-o1` and `image-hidream-o1-dev` map to the public HiDream O1
+image checkpoints:
+
+- `HiDream-ai/HiDream-O1-Image`
+- `HiDream-ai/HiDream-O1-Image-Dev`
+
+HiDream O1 uses a unified pixel-transformer root layout rather than a
+VAE/text-encoder component tree. Managed or local roots are expected to contain:
+
+- `config.json`
+- `tokenizer_config.json`
+- `tokenizer.json` or `vocab.json` plus `merges.txt`
+- `preprocessor_config.json`
+- `model.safetensors` or `model.safetensors.index.json`
+
+The native Swift runtime validates this layout, decodes the typed root
+configuration, prepares text/reference sample metadata, and runs generation
+through the downloaded Qwen3-VL decoder, vision tower, timestep embedder, patch
+embedder, generation-aware attention mask, and HiDream pixel head. Text-only
+generation, one-reference instruction editing, and multi-reference subject
+personalization share the same native path; reference modes additionally run
+Qwen3-VL vision preprocessing and replace chat-template image placeholders
+before denoising.
+
+Runtime defaults come from the managed manifest:
+
+- `image-hidream-o1-dev`: 28 steps, CFG 0.0, fixed flash FlowMatch schedule
+- `image-hidream-o1`: 50 steps, CFG 5.0, shifted Flow UniPC schedule
+
+Both checkpoints are large BF16 unified-transformer roots, about 33 GiB on disk
+each before filesystem compression effects. Expect high unified-memory pressure
+and prefer one-step smokes before full-quality 28/50 step runs.
 
 ## Archive resolution
 

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -58,6 +58,7 @@ Key subdirectories:
 
 - `Flux2Klein/`: Klein image-family runtime
 - `ZImageTurbo/`: ZImage image-family runtime
+- `HiDreamO1/`: HiDream O1 image-family runtime
 - `QwenImageEdit/`: image editing flow
 - `Gemma4/`, `Q35/`, `Psi/`, `MeBot/`: text/chat model families
 - `Embeddings/`: embedding-generation support

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -14,6 +14,7 @@ The public image families are:
 
 - `image-klein-*`: Klein image family
 - `image-zimage-*`: ZImage image family
+- `image-hidream-o1*`: HiDream O1 unified pixel-transformer family
 
 Common managed IDs:
 
@@ -23,6 +24,8 @@ Common managed IDs:
 - `image-zimage-nano`
 - `image-zimage-base`
 - `image-zimage-max`
+- `image-hidream-o1-dev`
+- `image-hidream-o1`
 
 ## Typical workflows
 
@@ -43,6 +46,44 @@ swift run mere.run image generate \
   --input ./photo.png \
   --strength 0.6 \
   --output ./sketch.png
+```
+
+### HiDream O1 references
+
+HiDream O1 is registered with text-only, one-reference instruction editing, and
+multi-reference subject-personalization capabilities. Reference images are
+repeatable; with a single reference, `--keep-original-aspect` preserves the
+reference aspect ratio when building the HiDream sample.
+
+The native runtime validates model roots, decodes the typed upstream
+configuration, tokenizes the upstream chat-template prompt, builds scheduler
+inputs, constructs text/reference sample metadata, and runs HiDream generation
+through the downloaded Qwen3-VL decoder, vision tower, timestep embedder, patch
+embedder, generation-aware attention mask, and final pixel head. Dev uses the
+fixed flash FlowMatch schedule with CFG 0.0 by default; Full uses CFG 5.0 by
+default and the shifted Flow UniPC scheduler. Reference-image modes run native
+Qwen3-VL vision preprocessing and replace chat-template image placeholders
+before appending target/reference pixel patches for denoising.
+
+```bash
+swift run mere.run image generate \
+  --model image-hidream-o1-dev \
+  --prompt "a clean studio product photo of the subject" \
+  --ref-image ./subject-front.png \
+  --ref-image ./subject-side.png \
+  --output ./subject.png
+```
+
+Use `--steps` or `--cfg` when you want to override the model-specific defaults.
+Use `--keep-original-aspect` with a single `--ref-image` for edit cases where
+the output should follow the source image aspect ratio.
+
+Installed HiDream smoke tests are intentionally opt-in because each checkpoint
+is large and GPU time is meaningful:
+
+```bash
+MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM=1 ./scripts/check.sh
+MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM_FULL=1 ./scripts/check.sh
 ```
 
 ### Deterministic validation
@@ -73,6 +114,17 @@ swift run mere.run image validate --family klein --test pipeline
 - `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+Inference.swift`
 - `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+LoRA.swift`
 
+### HiDream O1 family
+
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1Resources.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1Configs.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1Model.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1TokenizerAndTemplate.swift`
+- `Sources/MereRunCore/HiDreamO1/HiDreamO1Scheduler.swift`
+
 ### Image editing support
 
 - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift`
@@ -83,14 +135,14 @@ swift run mere.run image validate --family klein --test pipeline
 
 At a high level:
 
-1. the CLI parses prompt, model choice, size, steps, and optional image input
+1. the CLI parses prompt, model choice, size, steps, optional image input, and optional reference images
 2. model resolution maps a canonical model ID or explicit path to a local root
 3. the runtime loads the matching components for the chosen family
 4. prompt encoding and optional conditioning data are prepared
 5. the denoise loop or family-specific generation path runs
 6. latents are decoded and written as an image artifact
 
-The two families do not share identical implementation internals, but they are
+The image families do not share identical implementation internals, but they are
 presented through the same public `mere.run image generate` command.
 
 ## Validation philosophy

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -124,6 +124,44 @@ make_ocr_fixture() {
   /usr/bin/swift -e 'import AppKit; let size = NSSize(width: 512, height: 160); let image = NSImage(size: size); image.lockFocus(); NSColor.white.setFill(); NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill(); let text = NSString(string: "MERE RUN OCR TEST 123"); let attrs: [NSAttributedString.Key: Any] = [.font: NSFont.boldSystemFont(ofSize: 54), .foregroundColor: NSColor.black]; text.draw(at: NSPoint(x: 24, y: 52), withAttributes: attrs); image.unlockFocus(); let data = image.tiffRepresentation!; let rep = NSBitmapImageRep(data: data)!; try rep.representation(using: .png, properties: [:])!.write(to: URL(fileURLWithPath: CommandLine.arguments[1]));' "$output_path"
 }
 
+make_hidream_reference_fixture() {
+  local output_path="$1"
+  local variant="${2:-product}"
+  /usr/bin/swift - "$output_path" "$variant" <<'SWIFT'
+import AppKit
+
+let output = CommandLine.arguments[1]
+let variant = CommandLine.arguments[2]
+let size = NSSize(width: 512, height: 640)
+let image = NSImage(size: size)
+image.lockFocus()
+NSColor(calibratedWhite: 0.96, alpha: 1).setFill()
+NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+
+if variant == "person" {
+    NSColor(calibratedRed: 0.93, green: 0.78, blue: 0.58, alpha: 1).setFill()
+    NSBezierPath(ovalIn: NSRect(x: 176, y: 360, width: 160, height: 160)).fill()
+    NSColor(calibratedRed: 0.25, green: 0.35, blue: 0.85, alpha: 1).setFill()
+    NSBezierPath(roundedRect: NSRect(x: 148, y: 140, width: 216, height: 230), xRadius: 42, yRadius: 42).fill()
+    NSColor.black.setFill()
+    NSBezierPath(ovalIn: NSRect(x: 216, y: 430, width: 18, height: 18)).fill()
+    NSBezierPath(ovalIn: NSRect(x: 278, y: 430, width: 18, height: 18)).fill()
+} else {
+    NSColor(calibratedRed: 0.08, green: 0.50, blue: 0.35, alpha: 1).setFill()
+    NSBezierPath(roundedRect: NSRect(x: 116, y: 140, width: 280, height: 300), xRadius: 46, yRadius: 46).fill()
+    NSColor(calibratedRed: 0.95, green: 0.80, blue: 0.20, alpha: 1).setFill()
+    NSBezierPath(roundedRect: NSRect(x: 156, y: 260, width: 200, height: 90), xRadius: 20, yRadius: 20).fill()
+    NSColor.white.setFill()
+    NSBezierPath(ovalIn: NSRect(x: 216, y: 470, width: 80, height: 80)).fill()
+}
+
+image.unlockFocus()
+let data = image.tiffRepresentation!
+let rep = NSBitmapImageRep(data: data)!
+try rep.representation(using: .png, properties: [:])!.write(to: URL(fileURLWithPath: output))
+SWIFT
+}
+
 core_suite() {
   local speech_tts_wav="$OUT_DIR/speech-tts-qwen3-nano.wav"
 
@@ -198,6 +236,29 @@ installed_suite() {
     run_step "video_generate_ltx_av" 900 \
       "$MERERUN_BIN" video generate "a red cube rotating slowly" --variant unified-av --model-root "$MODELS_ROOT/video-ltx-av" --width 256 --height 256 --num-frames 9 --fps 8 --output "$OUT_DIR/video-ltx-av.mp4" --quiet
     assert_file_nonempty "video_generate_ltx_av_artifact" "$OUT_DIR/video-ltx-av.mp4"
+  fi
+
+  if [[ "${MERERUN_E2E_HIDREAM:-}" == "1" ]] && require_model "image-hidream-o1-dev"; then
+    make_hidream_reference_fixture "$OUT_DIR/hidream-ref-product.png" product
+    make_hidream_reference_fixture "$OUT_DIR/hidream-ref-person.png" person
+
+    run_step "image_generate_hidream_dev_text" 1200 \
+      "$MERERUN_BIN" image generate --prompt "a small brass camera on a clean desk" --model "$MODELS_ROOT/image-hidream-o1-dev" --width 512 --height 512 --steps 1 --output "$OUT_DIR/image-hidream-o1-dev-text.png" --quiet
+    assert_file_nonempty "image_generate_hidream_dev_text_artifact" "$OUT_DIR/image-hidream-o1-dev-text.png"
+
+    run_step "image_generate_hidream_dev_single_ref" 1200 \
+      "$MERERUN_BIN" image generate --prompt "turn this into a clean studio product photo" --model "$MODELS_ROOT/image-hidream-o1-dev" --ref-image "$OUT_DIR/hidream-ref-product.png" --width 512 --height 512 --steps 1 --output "$OUT_DIR/image-hidream-o1-dev-single-ref.png" --quiet
+    assert_file_nonempty "image_generate_hidream_dev_single_ref_artifact" "$OUT_DIR/image-hidream-o1-dev-single-ref.png"
+
+    run_step "image_generate_hidream_dev_multi_ref" 1200 \
+      "$MERERUN_BIN" image generate --prompt "put the same subject into a cinematic city portrait" --model "$MODELS_ROOT/image-hidream-o1-dev" --ref-image "$OUT_DIR/hidream-ref-person.png" --ref-image "$OUT_DIR/hidream-ref-product.png" --width 512 --height 512 --steps 1 --output "$OUT_DIR/image-hidream-o1-dev-multi-ref.png" --quiet
+    assert_file_nonempty "image_generate_hidream_dev_multi_ref_artifact" "$OUT_DIR/image-hidream-o1-dev-multi-ref.png"
+  fi
+
+  if [[ "${MERERUN_E2E_HIDREAM_FULL:-}" == "1" ]] && require_model "image-hidream-o1"; then
+    run_step "image_generate_hidream_full_text" 1200 \
+      "$MERERUN_BIN" image generate --prompt "a small brass camera on a clean desk" --model "$MODELS_ROOT/image-hidream-o1" --width 512 --height 512 --steps 3 --output "$OUT_DIR/image-hidream-o1-full-text.png" --quiet
+    assert_file_nonempty "image_generate_hidream_full_text_artifact" "$OUT_DIR/image-hidream-o1-full-text.png"
   fi
 }
 

--- a/scripts/export-hidream-o1-fixtures.py
+++ b/scripts/export-hidream-o1-fixtures.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Export HiDream O1 parity fixtures for the native Swift runtime.
+
+This script mirrors the upstream HiDream-O1-Image sample builders and scheduler
+setup. It writes small JSON/NPZ artifacts for Swift parity tests without
+requiring a full image generation run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+import torch
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--upstream", required=True, help="Path to HiDream-O1-Image checkout")
+    parser.add_argument("--model-path", required=True, help="Path to HiDream HF model root")
+    parser.add_argument("--output-dir", required=True, help="Fixture output directory")
+    parser.add_argument("--prompt", default="a red cube on a white background")
+    parser.add_argument("--height", type=int, default=1024)
+    parser.add_argument("--width", type=int, default=1024)
+    parser.add_argument("--seed", type=int, default=32)
+    parser.add_argument("--steps", type=int, default=None)
+    parser.add_argument("--model-type", choices=["dev", "full"], default="dev")
+    parser.add_argument("--guidance-scale", type=float, default=None)
+    parser.add_argument("--mode", choices=["t2i", "reference"], default="t2i")
+    parser.add_argument("--ref-image", action="append", default=[])
+    parser.add_argument("--keep-original-aspect", action="store_true")
+    parser.add_argument(
+        "--export-pixel-head",
+        action="store_true",
+        help="Load the model and export timestep/x_embedder/final_layer2 outputs for parity tests",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    upstream = Path(args.upstream).resolve()
+    sys.path.insert(0, str(upstream))
+
+    from transformers import AutoConfig, AutoProcessor  # pylint: disable=import-error
+    from inference import add_special_tokens, get_tokenizer  # pylint: disable=import-error
+    from models.pipeline import (  # pylint: disable=import-error
+        CONDITION_IMAGE_SIZE,
+        DEFAULT_TIMESTEPS,
+        PATCH_SIZE,
+        TIMESTEP_TOKEN_NUM,
+        TENSOR_TRANSFORM,
+        build_scheduler,
+        build_t2i_text_sample,
+    )
+    from models.utils import (  # pylint: disable=import-error
+        calculate_dimensions,
+        find_closest_resolution,
+        get_rope_index_fix_point,
+        resize_pilimage,
+    )
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    processor = AutoProcessor.from_pretrained(args.model_path)
+    tokenizer = get_tokenizer(processor)
+    add_special_tokens(tokenizer)
+    model_config = AutoConfig.from_pretrained(args.model_path)
+
+    guidance_scale = args.guidance_scale
+    if guidance_scale is None:
+        guidance_scale = 0.0 if args.model_type == "dev" else 5.0
+    scheduler = build_fixture_scheduler(args, DEFAULT_TIMESTEPS, build_scheduler)
+
+    if args.mode == "reference":
+        if not args.ref_image:
+            raise SystemExit("--mode reference requires at least one --ref-image")
+        exported = build_reference_samples(
+            prompt=args.prompt,
+            ref_image_paths=[Path(path) for path in args.ref_image],
+            height=args.height,
+            width=args.width,
+            tokenizer=tokenizer,
+            processor=processor,
+            model_config=model_config,
+            guidance_scale=guidance_scale,
+            keep_original_aspect=args.keep_original_aspect,
+            resize_pilimage=resize_pilimage,
+            calculate_dimensions=calculate_dimensions,
+            find_closest_resolution=find_closest_resolution,
+            get_rope_index_fix_point=get_rope_index_fix_point,
+            tensor_transform=TENSOR_TRANSFORM,
+            patch_size=PATCH_SIZE,
+            condition_image_size=CONDITION_IMAGE_SIZE,
+            timestep_token_num=TIMESTEP_TOKEN_NUM,
+        )
+    else:
+        exported = build_text_samples(
+            prompt=args.prompt,
+            height=args.height,
+            width=args.width,
+            tokenizer=tokenizer,
+            processor=processor,
+            model_config=model_config,
+            guidance_scale=guidance_scale,
+            build_t2i_text_sample=build_t2i_text_sample,
+        )
+
+    metadata = {
+        "prompt": args.prompt,
+        "height": exported["target_height"],
+        "width": exported["target_width"],
+        "requested_height": args.height,
+        "requested_width": args.width,
+        "seed": args.seed,
+        "steps": len(scheduler.timesteps),
+        "mode": args.mode,
+        "model_type": args.model_type,
+        "guidance_scale": guidance_scale,
+        "keep_original_aspect": args.keep_original_aspect,
+        "ref_images": args.ref_image,
+        "default_timesteps": DEFAULT_TIMESTEPS,
+    }
+    (out_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    np.savez(out_dir / "sample_and_scheduler.npz", **sample_npz_arrays(exported, scheduler))
+
+    if args.export_pixel_head:
+        export_pixel_head(args.model_path, out_dir)
+
+
+def build_fixture_scheduler(args: argparse.Namespace, default_timesteps: list[int], build_scheduler):
+    if args.model_type == "dev":
+        timesteps = default_timesteps if args.steps is None else default_timesteps[: args.steps]
+        if not timesteps:
+            raise SystemExit("--steps must be >= 1")
+        return build_scheduler(
+            num_inference_steps=len(timesteps),
+            timesteps_list=timesteps,
+            shift=1.0,
+            device=torch.device("cpu"),
+            scheduler_name="flash",
+        )
+    return build_scheduler(
+        num_inference_steps=args.steps or 50,
+        timesteps_list=None,
+        shift=3.0,
+        device=torch.device("cpu"),
+        scheduler_name="default",
+    )
+
+
+def build_text_samples(
+    *,
+    prompt: str,
+    height: int,
+    width: int,
+    tokenizer,
+    processor,
+    model_config,
+    guidance_scale: float,
+    build_t2i_text_sample,
+) -> dict:
+    cond = build_t2i_text_sample(prompt, height, width, tokenizer, processor, model_config)
+    uncond = None
+    if guidance_scale > 1.0:
+        uncond = build_t2i_text_sample(" ", height, width, tokenizer, processor, model_config)
+    return {
+        "target_width": width,
+        "target_height": height,
+        "cond": cond,
+        "uncond": uncond,
+        "reference_sizes": [],
+        "condition_grid_thw": np.zeros((0, 3), dtype=np.int64),
+        "reference_grid_thw": np.zeros((0, 3), dtype=np.int64),
+        "reference_patches": np.zeros((0,), dtype=np.float32),
+        "condition_pixel_values": np.zeros((0,), dtype=np.float32),
+        "condition_image_grid_thw": np.zeros((0, 3), dtype=np.int64),
+    }
+
+
+def build_reference_samples(
+    *,
+    prompt: str,
+    ref_image_paths: list[Path],
+    height: int,
+    width: int,
+    tokenizer,
+    processor,
+    model_config,
+    guidance_scale: float,
+    keep_original_aspect: bool,
+    resize_pilimage,
+    calculate_dimensions,
+    find_closest_resolution,
+    get_rope_index_fix_point,
+    tensor_transform,
+    patch_size: int,
+    condition_image_size: int,
+    timestep_token_num: int,
+) -> dict:
+    from einops import rearrange  # pylint: disable=import-error
+    from PIL import Image  # pylint: disable=import-error
+
+    image_token_id = model_config.image_token_id
+    video_token_id = model_config.video_token_id
+    vision_start_token_id = model_config.vision_start_token_id
+    spatial_merge_size = model_config.vision_config.spatial_merge_size
+
+    preresized_ref_pil = None
+    if keep_original_aspect and len(ref_image_paths) == 1:
+        pil_orig = Image.open(ref_image_paths[0]).convert("RGB")
+        preresized_ref_pil = resize_pilimage(pil_orig, 2048, patch_size)
+        width, height = preresized_ref_pil.size
+    else:
+        width, height = find_closest_resolution(width, height)
+
+    if preresized_ref_pil is not None:
+        ref_pils = [preresized_ref_pil]
+    else:
+        ref_pils = [Image.open(path).convert("RGB") for path in ref_image_paths]
+
+    ref_pils_resized = []
+    ref_images = []
+    for pil in ref_pils:
+        pil_r = pil if preresized_ref_pil is not None and pil is preresized_ref_pil else resize_pilimage(
+            pil,
+            reference_max_size(height=height, width=width, count=len(ref_pils)),
+            patch_size,
+        )
+        ref_pils_resized.append(pil_r)
+        ref_images.append(
+            rearrange(
+                tensor_transform(pil_r),
+                "C (H p1) (W p2) -> (H W) (C p1 p2)",
+                p1=patch_size,
+                p2=patch_size,
+            )
+        )
+
+    reference_lengths = [image.shape[0] for image in ref_images]
+    total_reference_length = sum(reference_lengths)
+    reference_patches = torch.cat(ref_images, dim=0).unsqueeze(0).cpu().numpy()
+
+    condition_size = condition_max_size(condition_image_size, len(ref_pils))
+    ref_pils_vlm = []
+    for pil_r in ref_pils_resized:
+        cond_w, cond_h = calculate_dimensions(condition_size, pil_r.width / pil_r.height)
+        ref_pils_vlm.append(pil_r.resize((cond_w, cond_h), resample=Image.LANCZOS))
+
+    target_grid_thw = torch.tensor([1, height // patch_size, width // patch_size], dtype=torch.int64).unsqueeze(0)
+    reference_grid_thw = torch.zeros((len(ref_pils), 3), dtype=torch.int64)
+    for index, pil_r in enumerate(ref_pils_resized):
+        ref_w, ref_h = pil_r.size
+        reference_grid_thw[index] = torch.tensor([1, ref_h // patch_size, ref_w // patch_size], dtype=torch.int64)
+
+    samples = []
+    condition_grid_thw = None
+    condition_pixel_values = None
+    condition_image_grid_thw = None
+    for caption in [prompt] + ([" "] if guidance_scale > 1.0 else []):
+        sample, cond_grid, proc = build_one_reference_sample(
+            caption=caption,
+            ref_pils_vlm=ref_pils_vlm,
+            tokenizer=tokenizer,
+            processor=processor,
+            image_token_id=image_token_id,
+            video_token_id=video_token_id,
+            vision_start_token_id=vision_start_token_id,
+            spatial_merge_size=spatial_merge_size,
+            target_grid_thw=target_grid_thw,
+            reference_grid_thw=reference_grid_thw,
+            reference_lengths=reference_lengths,
+            total_reference_length=total_reference_length,
+            get_rope_index_fix_point=get_rope_index_fix_point,
+            timestep_token_num=timestep_token_num,
+        )
+        samples.append(sample)
+        if condition_grid_thw is None:
+            condition_grid_thw = cond_grid.cpu().numpy()
+            condition_pixel_values = proc.pixel_values.cpu().float().numpy()
+            condition_image_grid_thw = proc.image_grid_thw.cpu().numpy()
+
+    return {
+        "target_width": width,
+        "target_height": height,
+        "cond": samples[0],
+        "uncond": samples[1] if len(samples) > 1 else None,
+        "reference_sizes": [[pil.width, pil.height] for pil in ref_pils_resized],
+        "condition_grid_thw": condition_grid_thw,
+        "reference_grid_thw": reference_grid_thw.cpu().numpy(),
+        "reference_patches": reference_patches,
+        "condition_pixel_values": condition_pixel_values,
+        "condition_image_grid_thw": condition_image_grid_thw,
+    }
+
+
+def build_one_reference_sample(
+    *,
+    caption: str,
+    ref_pils_vlm: list,
+    tokenizer,
+    processor,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+    spatial_merge_size: int,
+    target_grid_thw: torch.Tensor,
+    reference_grid_thw: torch.Tensor,
+    reference_lengths: list[int],
+    total_reference_length: int,
+    get_rope_index_fix_point,
+    timestep_token_num: int,
+) -> tuple[dict, torch.Tensor, object]:
+    boi_token = getattr(tokenizer, "boi_token", "<|boi_token|>")
+    tms_token = getattr(tokenizer, "tms_token", "<|tms_token|>")
+    content = [{"type": "image"} for _ in ref_pils_vlm]
+    content.append({"type": "text", "text": caption})
+    messages = [{"role": "user", "content": content}]
+    template_caption = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    proc = processor(text=[template_caption], images=ref_pils_vlm, padding="longest", return_tensors="pt")
+    input_ids_2 = tokenizer.encode(
+        boi_token + tms_token * timestep_token_num,
+        return_tensors="pt",
+        add_special_tokens=False,
+    )
+    input_ids = torch.cat([proc.input_ids, input_ids_2], dim=-1)
+
+    condition_grid_thw = proc.image_grid_thw.clone()
+    for index in range(len(ref_pils_vlm)):
+        condition_grid_thw[index, 1] //= spatial_merge_size
+        condition_grid_thw[index, 2] //= spatial_merge_size
+    all_grid_thw = torch.cat([condition_grid_thw, target_grid_thw, reference_grid_thw], dim=0)
+
+    target_length = int(target_grid_thw[0, 1].item() * target_grid_thw[0, 2].item())
+    vision_tokens = [vision_tokens_for_length(target_length, image_token_id, vision_start_token_id, input_ids.dtype)]
+    for length in reference_lengths:
+        vision_tokens.append(vision_tokens_for_length(length, image_token_id, vision_start_token_id, input_ids.dtype))
+    input_ids_pad = torch.cat([input_ids, torch.cat(vision_tokens, dim=1)], dim=-1)
+
+    position_ids, _ = get_rope_index_fix_point(
+        1,
+        image_token_id,
+        video_token_id,
+        vision_start_token_id,
+        input_ids=input_ids_pad,
+        image_grid_thw=all_grid_thw,
+        video_grid_thw=None,
+        attention_mask=None,
+        skip_vision_start_token=[0] * len(ref_pils_vlm) + [1] + [1] * len(ref_pils_vlm),
+    )
+    text_length = input_ids.shape[-1]
+    all_seq_len = position_ids.shape[-1]
+    token_types_raw = torch.zeros((1, all_seq_len), dtype=input_ids.dtype)
+    generation_start = text_length - timestep_token_num
+    generation_end = generation_start + target_length + timestep_token_num
+    token_types_raw[0, generation_start:generation_end] = 1
+    token_types_raw[0, generation_end : generation_end + total_reference_length] = 2
+    token_types_raw[0, text_length - timestep_token_num : text_length] = 3
+
+    return (
+        {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "token_types": (token_types_raw > 0).to(token_types_raw.dtype),
+            "vinput_mask": torch.logical_or(token_types_raw == 1, token_types_raw == 2),
+        },
+        condition_grid_thw,
+        proc,
+    )
+
+
+def reference_max_size(*, height: int, width: int, count: int) -> int:
+    max_size = max(height, width)
+    if count == 1:
+        return max_size
+    if count == 2:
+        return max_size * 48 // 64
+    if count <= 4:
+        return max_size // 2
+    if count <= 8:
+        return max_size * 24 // 64
+    return max_size // 4
+
+
+def condition_max_size(condition_image_size: int, count: int) -> int:
+    if count <= 4:
+        return condition_image_size
+    if count <= 8:
+        return condition_image_size * 48 // 64
+    return condition_image_size // 2
+
+
+def vision_tokens_for_length(length: int, image_token_id: int, vision_start_token_id: int, dtype) -> torch.Tensor:
+    tokens = torch.full((1, length), image_token_id, dtype=dtype)
+    tokens[0, 0] = vision_start_token_id
+    return tokens
+
+
+def sample_npz_arrays(exported: dict, scheduler) -> dict:
+    cond = exported["cond"]
+    arrays = {
+        "input_ids": cond["input_ids"].cpu().numpy(),
+        "position_ids": cond["position_ids"].cpu().numpy(),
+        "token_types": cond["token_types"].cpu().numpy(),
+        "vinput_mask": cond["vinput_mask"].cpu().numpy(),
+        "timesteps": scheduler.timesteps.cpu().numpy(),
+        "sigmas": scheduler.sigmas.cpu().numpy(),
+        "reference_sizes": np.asarray(exported["reference_sizes"], dtype=np.int64),
+        "condition_grid_thw": exported["condition_grid_thw"],
+        "reference_grid_thw": exported["reference_grid_thw"],
+        "reference_patches": exported["reference_patches"],
+        "condition_pixel_values": exported["condition_pixel_values"],
+        "condition_image_grid_thw": exported["condition_image_grid_thw"],
+    }
+    if exported["uncond"] is not None:
+        arrays.update(
+            {
+                "uncond_input_ids": exported["uncond"]["input_ids"].cpu().numpy(),
+                "uncond_position_ids": exported["uncond"]["position_ids"].cpu().numpy(),
+                "uncond_token_types": exported["uncond"]["token_types"].cpu().numpy(),
+                "uncond_vinput_mask": exported["uncond"]["vinput_mask"].cpu().numpy(),
+            }
+        )
+    return arrays
+
+
+def export_pixel_head(model_path: str, out_dir: Path) -> None:
+    from models.qwen3_vl_transformers import Qwen3VLForConditionalGeneration  # pylint: disable=import-error
+
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
+        model_path,
+        torch_dtype=torch.float32,
+        device_map="cpu",
+    )
+    model.eval()
+    pixel_model = model.model
+    hidden_size = pixel_model.config.text_config.hidden_size
+    patch_dim = 3 * 32 * 32
+
+    timestep = torch.tensor([0.5], dtype=torch.float32)
+    patches = torch.linspace(-1.0, 1.0, steps=2 * patch_dim, dtype=torch.float32).reshape(2, patch_dim)
+    hidden = torch.linspace(-0.5, 0.5, steps=2 * hidden_size, dtype=torch.float32).reshape(2, hidden_size)
+
+    with torch.no_grad():
+        timestep_freq = pixel_model.t_embedder1.timestep_embedding(timestep * 1000, 256)
+        timestep_out = pixel_model.t_embedder1(timestep)
+        patch_out = pixel_model.x_embedder(patches)
+        final_out = pixel_model.final_layer2(hidden)
+
+    np.savez(
+        out_dir / "pixel_head.npz",
+        timestep=timestep.cpu().numpy(),
+        timestep_freq=timestep_freq.cpu().numpy(),
+        timestep_out=timestep_out.cpu().numpy(),
+        patch_input=patches.cpu().numpy(),
+        patch_out=patch_out.cpu().numpy(),
+        final_input=hidden.cpu().numpy(),
+        final_out=final_out.cpu().numpy(),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Register `image-hidream-o1` and `image-hidream-o1-dev` with managed metadata, validation, resolver, and manifest defaults.
- Add the native Swift/MLX `HiDreamO1` runtime: typed config loading, tokenizer/chat-template sample building, Qwen3-VL text/vision loading, reference-image preprocessing, DeepStack visual injection, FlowMatch/UniPC scheduling, patchify/unpatchify, and PNG generation.
- Extend image generation inputs and CLI parsing with repeatable `--ref-image` plus `--keep-original-aspect`, while preserving existing `inputImage` behavior for other image models.
- Add fixture-export tooling, unit tests, optional installed-model e2e smoke coverage, and docs for IDs, modes, examples, and hardware expectations.

## Validation
- `./scripts/check.sh` passed: SwiftLint strict, build, tests, CLI help sweep, hygiene scans.
- Exported upstream Python fixtures for Dev/Full T2I and Dev single/multi-reference sample-building parity.
- Real native smoke outputs were generated for Dev text, single-reference edit, multi-reference personalization, and Full text.

## Full-quality metrics
Prompt: `a small brass camera on a clean desk`

| Run | Defaults | Output | Wall time | Max RSS | Peak footprint | SHA-256 |
| --- | --- | --- | ---: | ---: | ---: | --- |
| Dev | 28 steps, CFG 0.0 | 2048x2048 | 212.19s | 3.298 GB | 19.442 GB | `a82cd0db45b31f20075227cbc38c8194a353102b400864b66bd2af646075c214` |
| Full | 50 steps, CFG 5.0 | 2048x2048 | 1600.36s | 3.186 GB | 21.112 GB | `f22b8fbe5ba3b71e50ff59f95d931f3fa051a2aa34fcfd4f953b16803f4c9c25` |

Metric artifacts were written locally under `/tmp/hidream-quality-metrics/` during validation.

## Notes
- This PR targets `codex/mere-run-studio` so the review only includes the HiDream native-support work on top of the Studio branch.
- Full support is registered and runs through the same generator path; Dev remains the first runtime target for broader mode validation.