### PR TITLE
Fix mflux Z-Image VAE loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog.
 
 No notable changes yet.
 
+## 0.4.13 - 2026-05-12
+
+### Fixed
+
+- fixed Image Nano (`image-zimage-nano`) generation from the public mflux Z-Image checkpoint by mapping mflux VAE wrapper keys onto the Swift VAE loader and aligning sigma shift values with mflux.
+
 ## 0.4.12 - 2026-05-12
 
 ### Added

--- a/Sources/MereRunCore/HFSafetensorsWeightsLoader.swift
+++ b/Sources/MereRunCore/HFSafetensorsWeightsLoader.swift
@@ -251,6 +251,7 @@ public enum HFSafetensorsWeightsLoader {
         bits: Int = 4,
         applySVDResiduals: Bool? = nil,
         keyMapper: ((String) -> String)? = nil,
+        mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in [(key, value)] },
         progressHandler: (@Sendable (ShardProgress) -> Void)? = nil
     ) throws {
         let useResiduals = applySVDResiduals ?? Self.residualEnabled
@@ -419,7 +420,7 @@ public enum HFSafetensorsWeightsLoader {
         // 5. Apply remaining parameters (non-quantized weights like norms, embeddings, etc.)
         var remainingUpdates: [(String, MLXArray)] = []
         for (key, value) in weights where !usedKeys.contains(key) {
-            remainingUpdates.append((key, value))
+            remainingUpdates.append(contentsOf: mapper(key, value))
         }
 
         if !remainingUpdates.isEmpty {
@@ -441,7 +442,8 @@ public enum HFSafetensorsWeightsLoader {
         groupSize: Int = 64,
         bits: Int = 4,
         applySVDResiduals: Bool? = nil,
-        keyMapper: ((String) -> String)? = nil
+        keyMapper: ((String) -> String)? = nil,
+        mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in [(key, value)] }
     ) throws {
         let useResiduals = applySVDResiduals ?? Self.residualEnabled
 
@@ -594,7 +596,7 @@ public enum HFSafetensorsWeightsLoader {
         // Apply remaining parameters
         var remainingUpdates: [(String, MLXArray)] = []
         for (key, value) in mappedWeights where !usedKeys.contains(key) {
-            remainingUpdates.append((key, value))
+            remainingUpdates.append(contentsOf: mapper(key, value))
         }
 
         if !remainingUpdates.isEmpty {

--- a/Sources/MereRunCore/ModelWeightsLoader.swift
+++ b/Sources/MereRunCore/ModelWeightsLoader.swift
@@ -110,6 +110,7 @@ public enum ModelWeightsLoader {
                     bits: q.bits,
                     applySVDResiduals: q.applySVDResiduals,
                     keyMapper: keyMapper,
+                    mapper: mapper,
                     progressHandler: progressHandler
                 )
             } else {
@@ -140,7 +141,8 @@ public enum ModelWeightsLoader {
                     groupSize: q.groupSize,
                     bits: q.bits,
                     applySVDResiduals: q.applySVDResiduals,
-                    keyMapper: keyMapper
+                    keyMapper: keyMapper,
+                    mapper: mapper
                 )
             } else {
                 try applyNonQuantizedWeightsFromArrays(
@@ -238,7 +240,8 @@ public enum ModelWeightsLoader {
                 groupSize: q.groupSize,
                 bits: q.bits,
                 applySVDResiduals: q.applySVDResiduals,
-                keyMapper: keyMapper
+                keyMapper: keyMapper,
+                mapper: mapper
             )
         } else {
             // Apply each shard sequentially.

--- a/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
@@ -321,7 +321,7 @@ public final class QwenTokenizer {
     return QwenTokenBatch(inputIds: inputIds, attentionMask: attentionMask)
   }
 
-  /// Direct tokenization without chat template - used by Z-Image pipeline
+  /// Direct tokenization without a chat template.
   public func encodePlain(
     prompts: [String],
     maxLength: Int? = nil

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+ModelLoading.swift
@@ -264,6 +264,7 @@ extension ZImageTurboGenerator {
                 to: model,
                 dtype: .bfloat16,
                 verify: [.noUnusedKeys, .shapeMismatch],
+                mapper: ZImageTurboMFluxVAEWeights.map,
                 quantization: quantization
             )
             return
@@ -275,6 +276,7 @@ extension ZImageTurboGenerator {
             to: model,
             dtype: .bfloat16,
             verify: [.noUnusedKeys, .shapeMismatch],
+            mapper: ZImageTurboMFluxVAEWeights.map,
             quantization: quantization
         )
     }

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboLinearScheduler.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboLinearScheduler.swift
@@ -53,7 +53,7 @@ public struct ZImageTurboLinearScheduler {
         // Ported from mflux `LinearScheduler._get_sigmas` for Z-Image Turbo.
         let y1: Float = 0.5
         let x1: Float = 256
-        let m = (Float(1.16) - y1) / (Float(4096) - x1)
+        let m = (Float(1.15) - y1) / (Float(4096) - x1)
         let b = y1 - m * x1
 
         let mu = m * Float(width * height) / Float(256) + b

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer+ModelLoading.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer+ModelLoading.swift
@@ -128,6 +128,7 @@ extension ZImageTurboLoRATrainer {
                 to: model,
                 dtype: .bfloat16,
                 verify: [.noUnusedKeys, .shapeMismatch],
+                mapper: ZImageTurboMFluxVAEWeights.map,
                 quantization: quantization
             )
             return
@@ -139,6 +140,7 @@ extension ZImageTurboLoRATrainer {
             to: model,
             dtype: .bfloat16,
             verify: [.noUnusedKeys, .shapeMismatch],
+            mapper: ZImageTurboMFluxVAEWeights.map,
             quantization: quantization
         )
     }

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer+TimestepSampling.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer+TimestepSampling.swift
@@ -150,7 +150,7 @@ extension ZImageTurboLoRATrainer {
             // Matches ZImageTurboLinearScheduler.applySigmaShift
             let y1: Float = 0.5
             let x1: Float = 256
-            let m = (1.16 - y1) / (4096 - x1)
+            let m = (1.15 - y1) / (4096 - x1)
             let b = y1 - m * x1
             let mu = m * Float(w * h) / 256.0 + b
             let expMu = exp(mu)

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboMFluxVAEWeights.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboMFluxVAEWeights.swift
@@ -1,0 +1,16 @@
+import MLX
+
+enum ZImageTurboMFluxVAEWeights {
+  static func mapKey(_ key: String) -> String {
+    key
+      .replacingOccurrences(of: ".conv_in.conv.", with: ".conv_in.")
+      .replacingOccurrences(of: ".conv_in.conv2d.", with: ".conv_in.")
+      .replacingOccurrences(of: ".conv_out.conv.", with: ".conv_out.")
+      .replacingOccurrences(of: ".conv_out.conv2d.", with: ".conv_out.")
+      .replacingOccurrences(of: ".conv_norm_out.norm.", with: ".conv_norm_out.")
+  }
+
+  static func map(_ key: String, _ value: MLXArray) -> [(String, MLXArray)] {
+    [(mapKey(key), value)]
+  }
+}

--- a/Tests/MereRunCoreTests/ZImageTurboLinearSchedulerTests.swift
+++ b/Tests/MereRunCoreTests/ZImageTurboLinearSchedulerTests.swift
@@ -50,4 +50,16 @@ final class ZImageTurboLinearSchedulerTests: MereRunCoreTestCase {
         let terminal = scheduler.sigmas[4].item(Float.self)
         XCTAssertEqual(terminal, 0)
     }
+
+    func testShiftedSigmasMatchMFluxAt1024ForFourSteps() {
+        let config = ZImageTurboInferenceConfig(width: 1024, height: 1024, numInferenceSteps: 4)
+        let scheduler = ZImageTurboLinearScheduler(config: config, requiresSigmaShift: true, sigmaShift: nil)
+        let sigmas = scheduler.sigmas.asArray(Float.self)
+
+        XCTAssertEqual(sigmas[0], 1.0, accuracy: 0.000001)
+        XCTAssertEqual(sigmas[1], 0.9045307, accuracy: 0.000001)
+        XCTAssertEqual(sigmas[2], 0.75951093, accuracy: 0.000001)
+        XCTAssertEqual(sigmas[3], 0.51284415, accuracy: 0.000001)
+        XCTAssertEqual(sigmas[4], 0.0, accuracy: 0.000001)
+    }
 }

--- a/Tests/MereRunCoreTests/ZImageTurboMFluxVAEWeightsTests.swift
+++ b/Tests/MereRunCoreTests/ZImageTurboMFluxVAEWeightsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import MereRunCore
+
+final class ZImageTurboMFluxVAEWeightsTests: XCTestCase {
+    func testMapsMFluxDecoderWrapperKeysToSwiftVAEKeys() {
+        XCTAssertEqual(
+            ZImageTurboMFluxVAEWeights.mapKey("decoder.conv_in.conv.weight"),
+            "decoder.conv_in.weight"
+        )
+        XCTAssertEqual(
+            ZImageTurboMFluxVAEWeights.mapKey("decoder.conv_out.conv.bias"),
+            "decoder.conv_out.bias"
+        )
+        XCTAssertEqual(
+            ZImageTurboMFluxVAEWeights.mapKey("decoder.conv_norm_out.norm.weight"),
+            "decoder.conv_norm_out.weight"
+        )
+    }
+
+    func testMapsMFluxEncoderWrapperKeysToSwiftVAEKeys() {
+        XCTAssertEqual(
+            ZImageTurboMFluxVAEWeights.mapKey("encoder.conv_in.conv2d.weight"),
+            "encoder.conv_in.weight"
+        )
+        XCTAssertEqual(
+            ZImageTurboMFluxVAEWeights.mapKey("encoder.conv_out.conv2d.bias"),
+            "encoder.conv_out.bias"
+        )
+        XCTAssertEqual(
+            ZImageTurboMFluxVAEWeights.mapKey("encoder.conv_norm_out.norm.bias"),
+            "encoder.conv_norm_out.bias"
+        )
+    }
+
+    func testLeavesNestedVAEBlockKeysUnchanged() {
+        let key = "decoder.up_blocks.0.resnets.0.conv1.weight"
+        XCTAssertEqual(ZImageTurboMFluxVAEWeights.mapKey(key), key)
+    }
+}

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 configuration="${1:-debug}"
-app_version="${MERERUN_APP_VERSION:-0.4.12}"
-app_build="${MERERUN_APP_BUILD:-12}"
+app_version="${MERERUN_APP_VERSION:-0.4.13}"
+app_build="${MERERUN_APP_BUILD:-13}"
 case "$configuration" in
   debug|release) ;;
   *)


### PR DESCRIPTION
## Summary
- map mflux Z-Image VAE wrapper keys onto Swift AutoencoderKL module keys
- pass weight mappers through quantized safetensor loading for remaining non-quantized params
- align Z-Image sigma shift with mflux reference values and add coverage
- prepare v0.4.13 with changelog and app bundle version/build bump

## Release
- tag: v0.4.13
- release ref: 7eb4d5f
- uploaded DMG: https://mere.run/releases/mere-run.dmg

## Verification
- swift test --filter ZImageTurboLinearSchedulerTests
- swift test --filter ZImageTurboMFluxVAEWeightsTests
- swift build -c release --product mere.run
- ./scripts/check.sh
- PUBLIC_REF=v0.4.13 ./scripts/release_public.sh check (from /Users/nerd/mere/mere-run-release-tools)
- PUBLIC_REF=v0.4.13 ./scripts/release_public.sh release (notarized + stapled DMG)
- PUBLIC_REF=v0.4.13 ./scripts/release_public.sh upload
- curl -I -L https://mere.run/releases/mere-run.dmg returned 200
- generated a clean Z-Image mug with image-zimage-nano after the fix: /tmp/mere-zimage-fixed.png