### PR TITLE
Refresh public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ mere.run is a Swift package, CLI, and optional macOS studio for local-first infe
 
 The public OSS repo currently supports:
 
-- local image generation and deterministic image validation
+- local image generation across Klein, ZImage, and HiDream O1 families,
+  including image-to-image, HiDream reference images, LoRA input, and
+  deterministic image validation
 - local text chat, code generation, embeddings, and PII anonymization
 - local speech synthesis, transcription, and voice-profile management
-- local vision captioning, inspection, segmentation, tracking, and OCR
-- native music and video generation
+- local vision captioning, inspection, grounding, segmentation, tracking, live camera tracking, and OCR
+- native ACEStep music generation and LTX video generation
 - managed model installs into a shared local model store
-- a local API surface for supported engines
+- offline command cookbooks through `mere.run guide`
+- a local OpenAI-compatible API surface for supported text engines
 - an optional macOS studio that wraps the public CLI instead of reimplementing runtime logic
 
 ## What’s included in this repo
@@ -39,11 +42,33 @@ The public OSS repo currently supports:
 
 ## Platform expectations
 
-- the public CLI and local runtime are developed and validated on Apple Silicon macOS
+- the public CLI and local runtime are developed and validated on Apple Silicon macOS 15 or newer
+- `Package.swift` uses Swift tools 6.0 and declares macOS 15 / iOS 18 package platforms
 - `swift build` and `swift test` are the supported first-run validation path for contributors
 - some vendored binaries include additional Apple platform slices for package consumers, but the public quickstart is macOS-first
 
-## Build
+## Install the latest release
+
+The signed and notarized macOS DMG is published at:
+
+```bash
+curl -L https://mere.run/releases/mere-run.dmg -o mere-run.dmg
+open mere-run.dmg
+```
+
+The DMG contains `MereRun.app`, a bundled CLI payload, runtime assets, notices,
+and a terminal installer. Drag `MereRun.app` to Applications for the studio. For
+terminal-only installs, open the mounted DMG and run:
+
+```bash
+cd /Volumes/mere.run/.mere-run
+./install.sh
+```
+
+The installer copies `mere.run` and its colocated runtime assets to
+`/usr/local/bin/mere.run`, using `sudo` only when the destination requires it.
+
+## Build from source
 
 Install SwiftLint and ripgrep once if you plan to run the contributor
 validation script:
@@ -73,6 +98,9 @@ open "$app_path"
 # See the public command tree
 swift run mere.run --help
 
+# Read packaged command cookbooks
+swift run mere.run guide --list
+
 # Launch the optional macOS studio
 app_path="$(./scripts/build_mere_run_app.sh debug)"
 open "$app_path"
@@ -82,6 +110,7 @@ swift run mere.run model list
 
 # See what this Mac can run before pulling large models
 swift run mere.run model capabilities
+swift run mere.run model capabilities --recommended
 
 # Choose guided, bring-your-own-agent, or manual setup
 swift run mere.run setup
@@ -94,7 +123,7 @@ swift run mere.run image generate \
   --prompt "a ceramic coffee mug in soft morning light" \
   --output ./mug.png
 
-# HiDream O1 runs natively for text, edit, and multi-reference generation.
+# HiDream O1 runs natively for text-only, edit, and multi-reference generation.
 swift run mere.run image generate \
   --model image-hidream-o1-dev \
   --prompt "a clean studio product photo of the subject" \
@@ -105,6 +134,10 @@ swift run mere.run image generate \
 swift run mere.run text chat \
   --stream \
   --prompt "Summarize diffusion models in one paragraph."
+
+# Redact PII locally
+swift run mere.run text anonymize \
+  "My name is Alice Smith and my email is alice@example.com"
 
 # Serve the OpenAI-compatible local API on loopback
 swift run mere.run api serve --engine text-chat-gemma4
@@ -148,7 +181,7 @@ swift run mere.run music generate \
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
   --variant unified-av \
-  --model-root ~/Library/Application\\ Support/MereRun/models/video-ltx-av \
+  --model-root "$HOME/Library/Application Support/MereRun/models/video-ltx-av" \
   --output ./clip.mp4
 ```
 
@@ -156,6 +189,7 @@ swift run mere.run video generate \
 
 The public CLI is modality-first:
 
+- `mere.run guide`
 - `mere.run image generate`
 - `mere.run image validate`
 - `mere.run text chat`
@@ -208,14 +242,18 @@ swift run mere.run --models-root /path/to/models model list
 
 ### Hugging Face snapshot cache
 
-A second store holds models that resolve through the native Hugging Face snapshot path (e.g. `text-chat-gemma4`). It is a mere.run-local cache, not the default `~/.cache/huggingface/hub` — the resolution chain is:
+`mere.run model pull` and runtime auto-download paths use the native Hugging
+Face snapshot cache before linking or resolving prepared models into the local
+model store. It is a mere.run-local cache, not the default
+`~/.cache/huggingface/hub` — the resolution chain is:
 
 1. `MERERUN_HUB_CACHE` (explicit override)
 2. `MERERUN_MODEL_CACHE_HOME/hub` (shared cache root)
 3. `~/Library/Application Support/MereRun/hub` (default)
 4. `~/Library/Caches/MereRun/hub`, then a temp dir as last-resort fallbacks
 
-If you already pull from Hugging Face elsewhere and want to share cached weights, point `MERERUN_HUB_CACHE` at your existing `huggingface/hub` directory.
+If you already pull from Hugging Face elsewhere and want to share cached weights,
+point `MERERUN_HUB_CACHE` at your existing `huggingface/hub` directory.
 
 ## Security defaults
 
@@ -303,6 +341,9 @@ mere.run exists because the Python MLX community proved that local-first inferen
 - [`ml-explore/mlx-lm`](https://github.com/ml-explore/mlx-lm) — language model inference on MLX; the reference for `mere.run text` engine surfaces and chat / code paths.
 - [`Blaizzy/mlx-vlm`](https://github.com/Blaizzy/mlx-vlm) — vision-language models on MLX; informed `mere.run vision` captioning, OCR, and inspection commands.
 - [`Blaizzy/mlx-audio`](https://github.com/Blaizzy/mlx-audio) — TTS / STT / audio codecs on MLX; shaped `mere.run speech` (synthesis, transcription, voice profiles).
-- [`filipstrand/mflux`](https://github.com/filipstrand/mflux) — FLUX image generation on MLX; shaped how `mere.run image` exposes engines and validates output.
+- [`filipstrand/mflux`](https://github.com/filipstrand/mflux) — MLX
+  image-generation reference work for Z-Image and FLUX-family behavior; shaped
+  how `mere.run image` loads components, schedules denoising, decodes VAE
+  output, exposes engines, and validates generated images.
 
 Where these projects ship runtime artifacts that mere.run actually links against, attribution and license terms live in [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md). The credits above are for the architectural debt: the design conversations, reference implementations, and hard-won model bring-up work these repos held in public before mere.run wrote its first line of Swift.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,16 +12,19 @@ swift run mere.run --help
 
 Public tree:
 
+- `mere.run guide`
 - `mere.run image generate`
 - `mere.run image validate`
 - `mere.run text chat`
 - `mere.run text code`
 - `mere.run text embed`
+- `mere.run text anonymize`
 - `mere.run speech synthesize`
 - `mere.run speech transcribe`
 - `mere.run speech profile { list, create, delete }`
 - `mere.run vision caption`
 - `mere.run vision inspect`
+- `mere.run vision ground`
 - `mere.run vision segment`
 - `mere.run vision track`
 - `mere.run vision track-live`
@@ -54,14 +57,18 @@ See [`model-sources.md`](./model-sources.md) for the full source story,
 including which IDs are pullable from Hugging Face. The most common managed IDs
 are:
 
-- Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`
+- Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`,
+  `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
+  `image-hidream-o1`, `image-hidream-o1-dev`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q35`, `text-chat-q35-nano`
 - Text code / agents: `text-agent-qwen35-9b`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
+- Text anonymize: `text-anonymize-privacy-filter`
 - Speech TTS: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`
 - Speech ASR: `speech-asr-qwen3`, `speech-asr-parakeet`
 - Vision OCR: `vision-ocr-lighton`
 - Vision segmentation / tracking: `vision-segment-sam31`
+- Vision grounding: `vision-ground-falcon-perception`
 - Music: `music-acestep`
 - Video: `video-ltx-av`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,6 +64,7 @@ package checkout.
 
 The public CLI is modality-first:
 
+- `mere.run guide ...`
 - `mere.run image ...`
 - `mere.run text ...`
 - `mere.run speech ...`
@@ -72,6 +73,8 @@ The public CLI is modality-first:
 - `mere.run video ...`
 - `mere.run model ...`
 - `mere.run api ...`
+- `mere.run setup ...`
+- `mere.run agent ...`
 
 For the full reference, see [CLI Reference](./cli.md).
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -50,9 +50,10 @@ Face sources.
 Hugging Face source `unsloth/Qwen3.5-9B-GGUF` and selects
 `Qwen3.5-9B-Q4_K_M.gguf`.
 
-`text-chat-gemma4` is also a canonical chat model in the CLI, but it does not use
-`mere.run model pull`. It resolves through the native Hugging Face snapshot path
-on first use unless you point it at a local model root.
+`text-chat-gemma4` is also the default chat model in the CLI. You can install it
+explicitly with `mere.run model pull text-chat-gemma4`, or let supported runtime
+paths resolve a Hugging Face snapshot on first use unless you point them at a
+local model root.
 
 Useful environment variables for that path:
 


### PR DESCRIPTION
## Summary
- add the signed/notarized DMG install path and terminal installer notes to the README
- refresh README feature coverage for HiDream O1, ZImage, vision grounding/tracking, guide cookbooks, API serving, and current model-store behavior
- sync linked CLI/model-source docs for missing commands, managed IDs, and Gemma4 pull/runtime behavior
- fix the README video example path quoting for `Application Support`

## Verification
- ./scripts/check.sh
- pnpm docs:build
- git diff --check origin/main..HEAD