### PR TITLE
Queue Studio jobs and publish live outputs

### DIFF
--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -304,13 +304,34 @@ private final class ReadinessOutputBuffer: @unchecked Sendable {
 }
 
 struct MereRunRunResult: Identifiable, Equatable {
-    let id = UUID()
+    let id: UUID
+    let requestID: UUID?
     let templateID: CommandTemplateID
     let commandPreview: String
     let exitCode: Int32
     let outputURL: URL?
     let outputText: String?
-    let completedAt = Date()
+    let completedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        requestID: UUID? = nil,
+        templateID: CommandTemplateID,
+        commandPreview: String,
+        exitCode: Int32,
+        outputURL: URL?,
+        outputText: String?,
+        completedAt: Date = Date()
+    ) {
+        self.id = id
+        self.requestID = requestID
+        self.templateID = templateID
+        self.commandPreview = commandPreview
+        self.exitCode = exitCode
+        self.outputURL = outputURL
+        self.outputText = outputText
+        self.completedAt = completedAt
+    }
 }
 
 struct MereRunUtilityCommandResult: Equatable {
@@ -339,6 +360,8 @@ final class MereRunController: ObservableObject {
     @Published var resolvedCLI = ""
     @Published var lastOutputURL: URL?
     @Published var lastRunResult: MereRunRunResult?
+    @Published private(set) var activeRunRequestID: UUID?
+    @Published private(set) var queuedRunCount = 0
     @Published var readinessByMode: [StudioMode: ModelReadinessState] = [:]
     @Published var modelCapabilitiesByID: [String: StudioModelCapability] = [:]
     @Published var cliPath: String {
@@ -371,6 +394,8 @@ final class MereRunController: ObservableObject {
     private var stderrBuffer = ""
     private var activeRunTemplateID: CommandTemplateID?
     private var activeRunPreview = ""
+    private var outputWatchTask: Task<Void, Never>?
+    private var queuedRuns: [StudioRunRequest] = []
     private var didAttemptAutomaticCLIInstall = false
 
     private static let stdoutBufferByteLimit = 32 * 1024
@@ -500,9 +525,14 @@ final class MereRunController: ObservableObject {
 
     @discardableResult
     func run(studio request: StudioRunRequest) -> Bool {
+        if isRunning || !queuedRuns.isEmpty {
+            enqueue(request)
+            return true
+        }
+
         selectedTemplate = request.template
         draft = request.draft
-        return run()
+        return startRun(requestID: request.id)
     }
 
     func checkReadiness(for mode: StudioMode, draft studioDraft: StudioDraft) {
@@ -661,6 +691,11 @@ final class MereRunController: ObservableObject {
 
     @discardableResult
     func run() -> Bool {
+        startRun(requestID: nil)
+    }
+
+    @discardableResult
+    private func startRun(requestID: UUID?) -> Bool {
         guard !isRunning else { return false }
         refreshResolvedCLI()
 
@@ -670,6 +705,7 @@ final class MereRunController: ObservableObject {
         let expectedOutput = expectedOutputURL()
         activeRunTemplateID = selectedTemplate.id
         activeRunPreview = display
+        activeRunRequestID = requestID
 
         if let message = selectedTemplate.validationMessage(for: draft) {
             append(message, stream: .system)
@@ -696,6 +732,7 @@ final class MereRunController: ObservableObject {
         isRunning = true
 
         append(display, stream: .system)
+        startOutputWatch(expectedOutput: expectedOutput)
 
         do {
             currentProcess = try processRunner.start(
@@ -722,6 +759,7 @@ final class MereRunController: ObservableObject {
             append(error.localizedDescription, stream: .stderr)
             if let activeRunTemplateID {
                 lastRunResult = MereRunRunResult(
+                    requestID: activeRunRequestID,
                     templateID: activeRunTemplateID,
                     commandPreview: activeRunPreview,
                     exitCode: -1,
@@ -731,6 +769,9 @@ final class MereRunController: ObservableObject {
             }
             activeRunTemplateID = nil
             activeRunPreview = ""
+            activeRunRequestID = nil
+            stopOutputWatch()
+            startNextQueuedRun()
             return false
         }
         return true
@@ -755,6 +796,7 @@ final class MereRunController: ObservableObject {
     private func finishRun(exitCode: Int32, expectedOutput: URL?) {
         currentProcess = nil
         isRunning = false
+        stopOutputWatch()
         lastExitCode = exitCode
 
         let detectedOutput = detectOutputURL(expected: expectedOutput, stdout: stdoutBuffer)
@@ -771,6 +813,7 @@ final class MereRunController: ObservableObject {
 
         if let activeRunTemplateID {
             lastRunResult = MereRunRunResult(
+                requestID: activeRunRequestID,
                 templateID: activeRunTemplateID,
                 commandPreview: activeRunPreview,
                 exitCode: exitCode,
@@ -780,11 +823,14 @@ final class MereRunController: ObservableObject {
         }
         activeRunTemplateID = nil
         activeRunPreview = ""
+        activeRunRequestID = nil
+        startNextQueuedRun()
     }
 
     private func finishPreflightFailure(exitCode: Int32, outputText: String?) {
         guard let templateID = activeRunTemplateID else { return }
         lastRunResult = MereRunRunResult(
+            requestID: activeRunRequestID,
             templateID: templateID,
             commandPreview: activeRunPreview,
             exitCode: exitCode,
@@ -793,6 +839,49 @@ final class MereRunController: ObservableObject {
         )
         activeRunTemplateID = nil
         activeRunPreview = ""
+        activeRunRequestID = nil
+        stopOutputWatch()
+        startNextQueuedRun()
+    }
+
+    private func enqueue(_ request: StudioRunRequest) {
+        queuedRuns.append(request)
+        queuedRunCount = queuedRuns.count
+        append("Queued \(request.mode.title.lowercased()) job.", stream: .system)
+    }
+
+    private func startNextQueuedRun() {
+        guard !isRunning, currentProcess == nil, !queuedRuns.isEmpty else { return }
+        let next = queuedRuns.removeFirst()
+        queuedRunCount = queuedRuns.count
+        selectedTemplate = next.template
+        draft = next.draft
+        _ = startRun(requestID: next.id)
+    }
+
+    private func startOutputWatch(expectedOutput: URL?) {
+        stopOutputWatch()
+        outputWatchTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await MainActor.run {
+                    self?.publishDetectedOutputIfNeeded(expectedOutput: expectedOutput)
+                }
+                try? await Task.sleep(for: .milliseconds(350))
+            }
+        }
+    }
+
+    private func stopOutputWatch() {
+        outputWatchTask?.cancel()
+        outputWatchTask = nil
+    }
+
+    private func publishDetectedOutputIfNeeded(expectedOutput: URL?) {
+        guard isRunning else { return }
+        let detectedOutput = detectOutputURL(expected: expectedOutput, stdout: stdoutBuffer)
+        guard let detectedOutput, detectedOutput != lastOutputURL else { return }
+        lastOutputURL = detectedOutput
+        status = "Generated: \(detectedOutput.lastPathComponent)"
     }
 
     private func handleAutomaticCLIInstall(_ outcome: CLIBootstrapInstallOutcome) {
@@ -828,6 +917,7 @@ final class MereRunController: ObservableObject {
             stdoutBuffer += text
             trimStdoutBuffer()
             liveOutputText = stdoutBuffer.replacingOccurrences(of: "\0", with: "")
+            publishDetectedOutputIfNeeded(expectedOutput: expectedOutputURL())
         } else if stream == .stderr {
             stderrBuffer += text
             trimStderrBuffer()
@@ -885,7 +975,7 @@ final class MereRunController: ObservableObject {
     }
 
     private func expectedOutputURL() -> URL? {
-        guard selectedTemplate.outputKind.isFile, !draft.outputPath.isBlank else {
+        guard selectedTemplate.outputKind != .none, !draft.outputPath.isBlank else {
             return nil
         }
         return URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)

--- a/Sources/MereRunApp/StudioLibraryStore.swift
+++ b/Sources/MereRunApp/StudioLibraryStore.swift
@@ -41,22 +41,44 @@ final class StudioLibraryStore: ObservableObject {
     }
 
     @discardableResult
-    func start(request: StudioRunRequest, commandPreview: String) -> StudioLibraryItem {
+    func start(
+        request: StudioRunRequest,
+        commandPreview: String,
+        status: StudioLibraryStatus = .running
+    ) -> StudioLibraryItem {
         let item = StudioLibraryItem(
             id: request.id,
             mode: request.mode,
             prompt: request.draft.prompt,
             inputURL: request.draft.inputPath.isBlank ? nil : URL(fileURLWithPath: request.draft.inputPath),
-            outputURL: request.expectedOutputURL,
+            outputURL: nil,
             createdAt: request.createdAt,
             updatedAt: Date(),
-            status: .running,
+            status: status,
             exitCode: nil,
             commandPreview: commandPreview,
             outputText: nil
         )
         upsert(item)
         return item
+    }
+
+    func markRunning(id: UUID) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        var item = items[index]
+        item.status = .running
+        item.updatedAt = Date()
+        items[index] = item
+        save()
+    }
+
+    func updateOutput(id: UUID, outputURL: URL) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        var item = items[index]
+        item.outputURL = outputURL
+        item.updatedAt = Date()
+        items[index] = item
+        save()
     }
 
     func complete(

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -11,7 +11,6 @@ struct StudioRootView: View {
     @State private var showAdvanced = false
     @State private var showOptions = false
     @State private var showModels = false
-    @State private var activeLibraryID: UUID?
     @State private var selectedLibraryID: UUID?
     @State private var pendingPullRefresh: StudioReadinessRefresh?
     @State private var studioError: String?
@@ -43,6 +42,12 @@ struct StudioRootView: View {
             return nil
         }
         return message
+    }
+
+    private var displayStatus: String {
+        guard controller.queuedRunCount > 0 else { return controller.status }
+        let suffix = controller.queuedRunCount == 1 ? "1 queued" : "\(controller.queuedRunCount) queued"
+        return "\(controller.status) · \(suffix)"
     }
 
     private var modeCapabilities: [StudioMode: StudioModelCapability] {
@@ -96,7 +101,7 @@ struct StudioRootView: View {
                     mode: mode,
                     item: selectedItem,
                     isRunning: controller.isRunning,
-                    status: controller.status,
+                    status: displayStatus,
                     readiness: readiness,
                     error: studioError,
                     logs: controller.logs,
@@ -112,6 +117,7 @@ struct StudioRootView: View {
                     draft: $draft,
                     showOptions: $showOptions,
                     isRunning: controller.isRunning,
+                    queuedCount: controller.queuedRunCount,
                     readiness: readiness,
                     onRun: runStudioCommand,
                     onStop: controller.cancel,
@@ -195,17 +201,16 @@ struct StudioRootView: View {
         .onChange(of: controller.lastRunResult) { _, result in
             guard let result else { return }
 
-            let completedLibraryItem = activeLibraryID != nil
-            if let activeLibraryID {
+            let completedLibraryItem = result.requestID != nil
+            if let requestID = result.requestID {
                 library.complete(
-                    id: activeLibraryID,
+                    id: requestID,
                     exitCode: result.exitCode,
                     outputURL: result.outputURL,
                     outputText: result.outputText,
                     commandPreview: result.commandPreview.maskingAPIKeyValue()
                 )
-                selectedLibraryID = activeLibraryID
-                self.activeLibraryID = nil
+                selectedLibraryID = requestID
             }
 
             let mutatedModels = result.templateID == .modelPull
@@ -218,6 +223,16 @@ struct StudioRootView: View {
             } else if mutatedModels || completedLibraryItem {
                 refreshReadiness()
             }
+        }
+        .onChange(of: controller.activeRunRequestID) { _, requestID in
+            guard let requestID else { return }
+            library.markRunning(id: requestID)
+            selectedLibraryID = requestID
+        }
+        .onChange(of: controller.lastOutputURL) { _, outputURL in
+            guard let requestID = controller.activeRunRequestID, let outputURL else { return }
+            library.updateOutput(id: requestID, outputURL: outputURL)
+            selectedLibraryID = requestID
         }
     }
 
@@ -243,8 +258,8 @@ struct StudioRootView: View {
             let request = try StudioCommandAdapter.makeRequest(mode: mode, draft: draft)
             let preview = controller
                 .commandPreview(template: request.template, draft: request.draft, masksSecrets: true)
-            library.start(request: request, commandPreview: preview)
-            activeLibraryID = request.id
+            let status: StudioLibraryStatus = controller.isRunning || controller.queuedRunCount > 0 ? .queued : .running
+            library.start(request: request, commandPreview: preview, status: status)
             selectedLibraryID = request.id
             controller.run(studio: request)
         } catch {
@@ -516,7 +531,7 @@ private struct StudioCanvas: View {
     let onShowDetails: () -> Void
 
     private var visibleLiveOutputText: String? {
-        guard isRunning, mode == .chat || mode == .code else { return nil }
+        guard isRunning else { return nil }
         let text = liveOutputText
             .replacingOccurrences(of: "\0", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -791,6 +806,7 @@ private struct StudioOutputView: View {
 
     private var statusColor: Color {
         switch item.status {
+        case .queued: return MereRunTheme.textMuted
         case .running: return MereRunTheme.yellow
         case .completed: return MereRunTheme.green
         case .failed: return MereRunTheme.red
@@ -911,6 +927,7 @@ private struct StudioPromptBar: View {
     @Binding var draft: StudioDraft
     @Binding var showOptions: Bool
     let isRunning: Bool
+    let queuedCount: Int
     let readiness: ModelReadinessState
     let onRun: () -> Void
     let onStop: () -> Void
@@ -966,21 +983,32 @@ private struct StudioPromptBar: View {
                 .buttonStyle(.plain)
                 .help("Options")
 
+                if isRunning {
+                    Button(action: onStop) {
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(MereRunTheme.red)
+                            .frame(width: 34, height: 34)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Stop current run")
+                }
+
                 Button {
-                    isRunning ? onStop() : onRun()
+                    onRun()
                 } label: {
-                    Image(systemName: isRunning ? "stop.fill" : "arrow.up")
+                    Image(systemName: "arrow.up")
                         .font(.system(size: 14, weight: .bold))
                         .foregroundStyle(MereRunTheme.background)
                         .frame(width: 38, height: 38)
                         .background {
                             Circle()
                                 .fill(runButtonColor)
-                        }
+                    }
                 }
                 .buttonStyle(.plain)
-                .disabled(!isRunning && readiness.blocksRun)
-                .help(isRunning ? "Stop" : readiness.blocksRun ? readiness.message : "Run")
+                .disabled(readiness.blocksRun)
+                .help(runButtonHelp)
                 .keyboardShortcut(.return, modifiers: .command)
             }
             .padding(.horizontal, 14)
@@ -998,9 +1026,17 @@ private struct StudioPromptBar: View {
     }
 
     private var runButtonColor: Color {
-        if isRunning { return MereRunTheme.red }
         if readiness.blocksRun { return MereRunTheme.yellow }
         return MereRunTheme.accent
+    }
+
+    private var runButtonHelp: String {
+        if readiness.blocksRun { return readiness.message }
+        if isRunning {
+            let queueLabel = queuedCount == 0 ? "Queue run" : "Queue run (\(queuedCount) waiting)"
+            return queueLabel
+        }
+        return "Run"
     }
 }
 

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -428,6 +428,7 @@ enum StudioCommandAdapter {
 }
 
 enum StudioLibraryStatus: String, Codable, Equatable {
+    case queued
     case running
     case completed
     case failed

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -208,6 +208,73 @@ final class MereRunControllerTests: XCTestCase {
             ["model", "pull", "image-zimage-nano"]
         )
     }
+
+    func testStudioRunsQueueBehindActiveProcess() async throws {
+        let runner = RecordingProcessRunner()
+        let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
+        controller.cliPath = "/usr/bin/true"
+        let template = try XCTUnwrap(CommandCatalog.template(id: .custom))
+        var firstDraft = template.defaultDraft()
+        firstDraft.extraArguments = "first"
+        var secondDraft = template.defaultDraft()
+        secondDraft.extraArguments = "second"
+        let first = StudioRunRequest(mode: .chat, templateID: .custom, template: template, draft: firstDraft)
+        let second = StudioRunRequest(mode: .code, templateID: .custom, template: template, draft: secondDraft)
+
+        XCTAssertTrue(controller.run(studio: first))
+        XCTAssertTrue(controller.isRunning)
+        XCTAssertEqual(controller.activeRunRequestID, first.id)
+        XCTAssertEqual(runner.starts.count, 1)
+
+        XCTAssertTrue(controller.run(studio: second))
+        XCTAssertEqual(controller.queuedRunCount, 1)
+        XCTAssertEqual(runner.starts.count, 1)
+
+        runner.starts[0].termination(0)
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(controller.lastRunResult?.requestID, first.id)
+        XCTAssertEqual(controller.activeRunRequestID, second.id)
+        XCTAssertEqual(controller.queuedRunCount, 0)
+        XCTAssertEqual(runner.starts.count, 2)
+        XCTAssertEqual(runner.starts[1].configuration.arguments, ["second"])
+
+        runner.starts[1].termination(0)
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(controller.isRunning)
+        XCTAssertNil(controller.activeRunRequestID)
+        XCTAssertEqual(controller.lastRunResult?.requestID, second.id)
+    }
+
+    func testRunningStudioRunPublishesOutputBeforeProcessExits() async throws {
+        let runner = RecordingProcessRunner()
+        let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
+        controller.cliPath = "/usr/bin/true"
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MereRunControllerTests-\(UUID().uuidString)", isDirectory: true)
+        let output = temp.appendingPathComponent("image.png", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: temp) }
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        var draft = template.defaultDraft()
+        draft.prompt = "a blue plate"
+        draft.outputPath = output.path
+        let request = StudioRunRequest(mode: .createImage, templateID: .imageGenerate, template: template, draft: draft)
+
+        XCTAssertTrue(controller.run(studio: request))
+        XCTAssertTrue(controller.isRunning)
+        XCTAssertNil(controller.lastOutputURL)
+
+        try Data("png".utf8).write(to: output)
+        runner.starts[0].stdout("wrote \(output.path)\n")
+        await Task.yield()
+
+        XCTAssertTrue(controller.isRunning)
+        XCTAssertEqual(controller.lastOutputURL?.path, output.path)
+    }
 }
 
 private func supportedCapabilitiesOutput(for modelID: String, minimum: Int) -> String {

--- a/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
+++ b/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
@@ -60,6 +60,28 @@ final class StudioLibraryStoreTests: XCTestCase {
         XCTAssertEqual(store.items.first?.outputURL?.path, "/tmp/plate.png")
     }
 
+    func testRunningLibraryItemStartsWithoutOutputAndCanPublishOutput() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let request = try StudioCommandAdapter.makeRequest(
+            mode: .createImage,
+            draft: {
+                var draft = StudioDraft()
+                draft.reset(for: .createImage)
+                draft.prompt = "a blue plate"
+                return draft
+            }()
+        )
+
+        store.start(request: request, commandPreview: "preview")
+        XCTAssertNil(store.items.first?.outputURL)
+
+        store.updateOutput(id: request.id, outputURL: URL(fileURLWithPath: "/tmp/plate.png"))
+
+        XCTAssertEqual(store.items.first?.status, .running)
+        XCTAssertEqual(store.items.first?.outputURL?.path, "/tmp/plate.png")
+    }
+
     func testLibraryCompletionPersistsStdoutOnlyRuns() throws {
         let url = try temporaryLibraryURL()
         let store = StudioLibraryStore(libraryURL: url)


### PR DESCRIPTION
## Summary
- add FIFO queueing for Studio runs so only one CLI job starts at a time
- mark queued/running library rows by request id and publish generated outputs as soon as files appear
- keep live stdout visible for all Studio modes and add tests for queued jobs plus pre-exit output publishing

## Tests
- swift test --filter MereRunAppTests
- ./scripts/check.sh

Release notes intentionally not updated per request.