### PR TITLE
Add scripts/install-local.sh for source → /usr/local/bin in one command

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build mere.run from this checkout and install it globally so the `mere.run`
+# command on your $PATH points at the local source tree's latest code.
+#
+# Typical use:
+#   scripts/install-local.sh                       # release build, /usr/local/bin
+#   scripts/install-local.sh --debug               # faster build, for hacking
+#   MERERUN_INSTALL_BIN_DEST=~/bin/mere.run \
+#     scripts/install-local.sh                     # no-sudo prefix
+#
+# The script:
+# 1. Runs `swift build` for the `mere.run` CLI product.
+# 2. Stages the built binary + colocated runtime assets (vendor/ds4, llama
+#    xcframework, MLX bundle, Resources/) into a temp directory in the layout
+#    scripts/install.sh expects.
+# 3. Delegates to scripts/install.sh to ditto everything into place. That keeps
+#    the actual install logic (sudo handling, MLX shader copy, etc.) in one
+#    well-tested place.
+#
+# After this script returns, `which mere.run` should point at the installed
+# binary and `mere.run --help` should reflect the code in your working tree.
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/install-local.sh [--debug] [--no-build] [--help]
+
+Build mere.run from the current source checkout and install it globally.
+
+Options:
+  --debug       Build with `swift build` (default: --configuration release).
+  --no-build    Skip the swift build step and reuse whatever's already at
+                `.build/release/mere.run` (or .build/debug if --debug).
+  -h, --help    Show this help.
+
+Environment:
+  MERERUN_INSTALL_BIN_DEST     Override install path. Default: /usr/local/bin/mere.run
+                               Use ~/bin/mere.run or similar to skip sudo.
+USAGE
+}
+
+configuration="release"
+do_build=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --debug)
+      configuration="debug"
+      shift
+      ;;
+    --no-build)
+      do_build=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[install-local] error: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v swift >/dev/null 2>&1; then
+  echo "[install-local] error: swift not found in PATH. Install Xcode or the Swift toolchain." >&2
+  exit 127
+fi
+
+swift_build_args=(build --product mere.run)
+swift_bin_path_args=(build --show-bin-path)
+if [[ "$configuration" == "release" ]]; then
+  swift_build_args+=(--configuration release)
+  swift_bin_path_args+=(--configuration release)
+fi
+
+if (( do_build )); then
+  echo "[install-local] swift build (--configuration $configuration)"
+  swift "${swift_build_args[@]}"
+fi
+
+build_dir="$(swift "${swift_bin_path_args[@]}")"
+cli_executable="${build_dir}/mere.run"
+
+if [[ ! -x "$cli_executable" ]]; then
+  echo "[install-local] error: built CLI not found at $cli_executable" >&2
+  echo "[install-local] run without --no-build, or build first with: swift build --configuration $configuration --product mere.run" >&2
+  exit 66
+fi
+
+staging="$(mktemp -d "${TMPDIR:-/tmp}/mere-run-install.XXXXXX")"
+cleanup() {
+  rm -rf "$staging"
+}
+trap cleanup EXIT
+
+cp "$cli_executable" "$staging/mere.run"
+chmod +x "$staging/mere.run"
+
+# Colocated runtime assets that mere.run looks for next to its binary.
+# Each is optional: skipped silently if not built or not present in vendor/.
+for asset in \
+  "${build_dir}/llama.framework" \
+  "${build_dir}/mlx-swift_Cmlx.bundle" \
+  "${build_dir}/Resources"
+do
+  if [[ -e "$asset" ]]; then
+    cp -R "$asset" "$staging/"
+  fi
+done
+
+# vendor/ds4 is the bundled DeepSeek V4 Flash inference engine spawned by the
+# premier agent tier. install.sh expects it at vendor/ds4 under SOURCE_DIR.
+if [[ -d "${repo_root}/vendor/ds4" ]]; then
+  mkdir -p "$staging/vendor"
+  cp -R "${repo_root}/vendor/ds4" "$staging/vendor/ds4"
+fi
+
+echo "[install-local] staged $(du -sh "$staging" | cut -f1) of payload at $staging"
+
+# Hand off to the existing installer for the actual copy + sudo handling.
+MERERUN_INSTALL_SOURCE_DIR="$staging" bash "${repo_root}/scripts/install.sh"


### PR DESCRIPTION
## Summary

Adds a single script that builds `mere.run` from the local checkout and installs it as the global command — so `which mere.run` and `mere.run --help` reflect the code in your working tree.

```sh
scripts/install-local.sh                     # release build → /usr/local/bin/mere.run
scripts/install-local.sh --debug             # faster build, for hacking
MERERUN_INSTALL_BIN_DEST=~/bin/mere.run scripts/install-local.sh   # no-sudo prefix
```

## Why

Before this, the dev loop to make the global `mere.run` reflect your current code was:

1. `swift build -c release --product mere.run`
2. Copy the binary by hand
3. Copy `llama.framework`, `mlx-swift_Cmlx.bundle`, `Resources/`, and (now) `vendor/ds4/` by hand to sit next to it
4. Notice you forgot one and hit a runtime error

`build_mere_run_app.sh` makes the `.app` bundle and `install.sh` expects a pre-packaged DMG layout, so neither was the right tool for a "build my tree and put it on `$PATH`" loop.

## What it does

1. `swift build` for the `mere.run` product (release by default, `--debug` available).
2. Stages the binary + colocated runtime assets (`llama.framework`, `mlx-swift_Cmlx.bundle`, `Resources/`, `vendor/ds4/` when present) into a temp directory in the layout `install.sh` expects.
3. Hands off to `scripts/install.sh` via `MERERUN_INSTALL_SOURCE_DIR=...` so all the actual copy / sudo / ditto / MLX shader plumbing stays in one well-tested place.

Each runtime asset is optional — `vendor/ds4` only gets installed on branches that have it (so this script works on `main` today and picks up DS4 once #17 lands).

## Test plan

- [x] `swiftlint --strict` clean
- [x] `--help` text reads cleanly
- [ ] `scripts/install-local.sh` end-to-end on the DS4 branch produces a working `/usr/local/bin/mere.run` with the latest features (verifying now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)