### PR TITLE
Report CLI release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog.
 - routed DS4 chat completions through a shared client adapter that repairs
   non-stream JSON responses containing literal control characters before they
   reach OpenAI-compatible clients.
+- fixed the root CLI so `mere.run --version` reports the public release version.
 
 ## 0.5.2 - 2026-05-15
 

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -15,6 +15,7 @@ struct MereRunCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "mere.run",
         abstract: "Run local inference workflows with MereRunCore.",
+        version: MereRunCLIVersion.current,
         subcommands: [
             GuideCommand.self,
             Image.self,

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,0 +1,3 @@
+enum MereRunCLIVersion {
+    static let current = "0.5.2"
+}

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -69,6 +69,11 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
         XCTAssertTrue(help.contains("--models-root <models-root>"))
     }
 
+    func testMereRunCLIExposesReleaseVersion() {
+        XCTAssertEqual(MereRunCLIVersion.current, "0.5.2")
+        XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
+    }
+
     private func makeDefaults() -> UserDefaults {
         let suite = "CLIModelStoreBootstrapTests.\(UUID().uuidString)"
         defaultsSuites.append(suite)


### PR DESCRIPTION
## Summary
- wire the root mere.run command into Swift ArgumentParser's version support
- add a release-version helper so mere.run --version prints the current public version
- cover the version metadata in CLI tests and note the public CLI fix in the changelog

## Tests
- swift test --filter CLIModelStoreBootstrapTests
- .build/debug/mere.run --version
- ./scripts/check.sh