### PR TITLE
Add mere.run status docs and guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added `mere.run status` for a quick local snapshot of API health, the served
+  model, the active model store, and installed managed models.
+
 ### Fixed
 
 - fixed DeepSeek V4 Flash model resolution so existing imatrix GGUF symlinks

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The public OSS repo currently supports:
 - Hugging Face-backed model pulls that resolve into a shared local model store
 - offline command cookbooks through `mere.run guide`
 - a local OpenAI-compatible API surface for supported text engines
+- a quick status snapshot for the local server, loaded API model, and installed model store
 - an optional macOS studio that wraps the public CLI instead of reimplementing runtime logic
 
 ## What’s included in this repo
@@ -110,6 +111,9 @@ open "$app_path"
 # List known model IDs and local install status
 swift run mere.run model list
 
+# See the local server, served model, model-store path, and installed models
+swift run mere.run status
+
 # See what this Mac can run before pulling large models
 swift run mere.run model capabilities
 swift run mere.run model capabilities --recommended
@@ -143,6 +147,9 @@ swift run mere.run text anonymize \
 
 # Serve the OpenAI-compatible local API on loopback
 swift run mere.run api serve --engine text-chat-gemma4
+
+# In another terminal, confirm the server and served model
+swift run mere.run status
 
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
@@ -212,6 +219,7 @@ The public CLI is modality-first:
 - `mere.run video generate`
 - `mere.run video export-latents`
 - `mere.run model { list, capabilities, info, pull, remove, repair-manifests }`
+- `mere.run status`
 - `mere.run api serve`
 - `mere.run setup`
 - `mere.run agent { onboard, install-pi, start }`

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -39,6 +39,9 @@ struct APIServe: AsyncParsableCommand {
           export MERERUN_API_KEY=change-me
           mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY"
 
+          # Check server health and the served model from another terminal
+          mere.run status --port 11434
+
           # Test with curl (request.json contains an OpenAI chat payload)
           curl http://localhost:8080/v1/chat/completions \\
             -H "Content-Type: application/json" \\

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -323,6 +323,13 @@ enum GuideRegistry {
             resourceName: "api-serve.md"
         ),
         GuideTopic(
+            topic: "status",
+            title: "Status",
+            commandPaths: [["status"]],
+            models: [],
+            resourceName: "status.md"
+        ),
+        GuideTopic(
             topic: "model-list",
             title: "Model List",
             commandPaths: [["model", "list"]],

--- a/Sources/MereRunCLI/Commands/ModelListCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelListCommand.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Foundation
-import MereRunCore
 
 struct ModelList: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -9,52 +8,7 @@ struct ModelList: ParsableCommand {
     )
 
     func run() throws {
-        let resolver = ModelResolver()
-        let specs = ManagedModelCatalog.allSpecs
-        let knownSpecs = Dictionary(uniqueKeysWithValues: specs.map { ($0.id, $0) })
-        let idsInOrder = specs.map(\.id)
-        var rows: [ModelListRow] = []
-        rows.reserveCapacity(idsInOrder.count)
-
-        for id in idsInOrder {
-            let spec = knownSpecs[id]
-            let status: String
-            let size: String
-
-            // For image gen models that have a ModelResolver.ModelID, check via resolver too
-            let modelID = ModelResolver.ModelID(rawValue: id)
-            let resolvedViaResolver = modelID.flatMap { resolver.resolveIfPresent($0) }
-
-            let flatDir = MereRunModelPaths.modelDir(id)
-            let flatInstalled = isNonEmptyDirectory(flatDir)
-            let gemmaAliasInstall = gemmaAliasInstallURL(for: id)
-
-            if let resolution = resolvedViaResolver {
-                status = "installed"
-                let bytes = FileSystemHelper.directorySize(at: resolution.rootURL)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-            } else if let gemmaAliasInstall {
-                status = "installed"
-                let bytes = FileSystemHelper.directorySize(at: gemmaAliasInstall)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-            } else if flatInstalled || spec?.managedRuntimeURL() != nil {
-                status = "installed"
-                let bytes = FileSystemHelper.directorySize(at: flatDir)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-            } else {
-                status = "missing"
-                size = "—"
-            }
-
-            rows.append(
-                ModelListRow(
-                    id: id,
-                    category: spec?.category.rawValue ?? inferCategory(for: id),
-                    status: status,
-                    size: size
-                )
-            )
-        }
+        let rows = ModelInventory.rows()
 
         let widths = ModelListColumnWidths(rows: rows)
         printRow("ID", "Category", "Status", "Size", widths: widths)
@@ -62,33 +16,6 @@ struct ModelList: ParsableCommand {
         for row in rows {
             printRow(row.id, row.category, row.status, row.size, widths: widths)
         }
-    }
-
-    private func isNonEmptyDirectory(_ url: URL) -> Bool {
-        let fm = FileManager.default
-        var isDir: ObjCBool = false
-        guard fm.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
-            return false
-        }
-        return (try? fm.contentsOfDirectory(atPath: url.path))?.isEmpty == false
-    }
-
-    private func gemmaAliasInstallURL(for id: String) -> URL? {
-        guard id == Gemma4Resources.defaultModelId else {
-            return nil
-        }
-
-        let maxURL = MereRunModelPaths.modelDir(Gemma4Resources.maxModelId)
-        if isNonEmptyDirectory(maxURL) {
-            return maxURL
-        }
-
-        let nanoURL = MereRunModelPaths.modelDir(Gemma4Resources.nanoModelId)
-        if isNonEmptyDirectory(nanoURL) {
-            return nanoURL
-        }
-
-        return nil
     }
 
     private func printRow(_ id: String, _ category: String, _ status: String, _ size: String, widths: ModelListColumnWidths) {
@@ -101,27 +28,6 @@ struct ModelList: ParsableCommand {
         print(row)
     }
 
-    private func inferCategory(for id: String) -> String {
-        if id.hasPrefix("text-chat-") { return "text-chat" }
-        if id.hasPrefix("text-code-") { return "text-code" }
-        if id.hasPrefix("text-embed-") { return "text-embed" }
-        if id.hasPrefix("image-") { return "image" }
-        if id.hasPrefix("speech-tts-") { return "speech-tts" }
-        if id.hasPrefix("speech-asr-") { return "speech-asr" }
-        if id.hasPrefix("vision-ocr-") { return "vision-ocr" }
-        if id.hasPrefix("vision-segment-") { return "vision-segment" }
-        if id.hasPrefix("vision-ground-") { return "vision-ground" }
-        if id.hasPrefix("music-") { return "music" }
-        if id.hasPrefix("video-") { return "video" }
-        return "other"
-    }
-}
-
-private struct ModelListRow {
-    let id: String
-    let category: String
-    let status: String
-    let size: String
 }
 
 private struct ModelListColumnWidths {
@@ -129,7 +35,7 @@ private struct ModelListColumnWidths {
     let category: Int
     let status: Int
 
-    init(rows: [ModelListRow]) {
+    init(rows: [ModelInventoryRow]) {
         self.id = max("ID".count, rows.map(\.id.count).max() ?? 0)
         self.category = max("Category".count, rows.map(\.category.count).max() ?? 0)
         self.status = max("Status".count, rows.map(\.status.count).max() ?? 0)

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -1,0 +1,284 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct Status: AsyncParsableCommand {
+    private static let apiKeyEnvironmentKey = "MERERUN_API_KEY"
+
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show local server, loaded model, and installed model status.",
+        discussion: """
+        Prints a quick snapshot of the active local setup.
+
+        It probes the configured API server's /health endpoint, reads /v1/models
+        when available, and summarizes the active model store plus installed
+        managed models.
+
+        Examples:
+          mere.run status
+          mere.run status --host 127.0.0.1 --port 11434
+          mere.run status --json
+        """
+    )
+
+    @Option(name: [.long], help: "Local API host to check.")
+    var host: String = "127.0.0.1"
+
+    @Option(name: [.long], help: "Local API port to check.")
+    var port: Int = 8080
+
+    @Option(name: [.long], help: "Bearer token for /v1/models. Also read from MERERUN_API_KEY.")
+    var apiKey: String?
+
+    @Option(name: [.long], help: "Network probe timeout in seconds.")
+    var timeoutSeconds: Double = 1.0
+
+    @Flag(name: [.long], help: "Emit the snapshot as JSON.")
+    var json: Bool = false
+
+    func run() async throws {
+        let snapshot = await StatusSnapshotBuilder(
+            host: host,
+            port: port,
+            apiKey: resolvedAPIKey(),
+            timeoutSeconds: timeoutSeconds
+        ).snapshot()
+
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(snapshot)
+            guard let output = String(data: data, encoding: .utf8) else {
+                throw ValidationError("Could not encode status snapshot as UTF-8.")
+            }
+            print(output)
+        } else {
+            print(StatusFormatter.text(snapshot))
+        }
+    }
+
+    private func resolvedAPIKey() -> String? {
+        if let apiKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines), !apiKey.isEmpty {
+            return apiKey
+        }
+        if let apiKey = ProcessInfo.processInfo.environment[Self.apiKeyEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !apiKey.isEmpty {
+            return apiKey
+        }
+        return nil
+    }
+}
+
+struct StatusSnapshot: Codable, Equatable {
+    let server: StatusServerSnapshot
+    let modelStore: StatusModelStoreSnapshot
+    let knownModelCount: Int
+    let installedModels: [StatusInstalledModelSnapshot]
+}
+
+struct StatusServerSnapshot: Codable, Equatable {
+    let url: String
+    let health: String
+    let detail: String?
+    let loadedModels: [String]
+    let modelsDetail: String?
+}
+
+struct StatusModelStoreSnapshot: Codable, Equatable {
+    let path: String
+    let source: String
+    let configuredPath: String?
+    let isFallbackToDefault: Bool
+}
+
+struct StatusInstalledModelSnapshot: Codable, Equatable {
+    let id: String
+    let category: String
+    let size: String
+}
+
+struct StatusSnapshotBuilder {
+    let host: String
+    let port: Int
+    let apiKey: String?
+    let timeoutSeconds: Double
+
+    func snapshot() async -> StatusSnapshot {
+        let inventoryRows = ModelInventory.rows()
+        let installedModels = inventoryRows
+            .filter(\.isInstalled)
+            .map {
+                StatusInstalledModelSnapshot(
+                    id: $0.id,
+                    category: $0.category,
+                    size: $0.size
+                )
+            }
+        let modelStore = MereRunModelPaths.modelStoreResolution()
+        let server = await serverSnapshot()
+
+        return StatusSnapshot(
+            server: server,
+            modelStore: StatusModelStoreSnapshot(
+                path: modelStore.activeModelsDir.path,
+                source: modelStore.source.rawValue,
+                configuredPath: modelStore.configuredModelsDir?.path,
+                isFallbackToDefault: modelStore.isFallbackToDefault
+            ),
+            knownModelCount: inventoryRows.count,
+            installedModels: installedModels
+        )
+    }
+
+    private func serverSnapshot() async -> StatusServerSnapshot {
+        let baseURL = serverBaseURLString(host: host, port: port)
+        let health = await probeHealth(baseURL: baseURL)
+        guard health.isUp else {
+            return StatusServerSnapshot(
+                url: baseURL,
+                health: "down",
+                detail: health.detail,
+                loadedModels: [],
+                modelsDetail: nil
+            )
+        }
+
+        let models = await probeModels(baseURL: baseURL)
+        return StatusServerSnapshot(
+            url: baseURL,
+            health: "up",
+            detail: health.detail,
+            loadedModels: models.loadedModels,
+            modelsDetail: models.detail
+        )
+    }
+
+    private func probeHealth(baseURL: String) async -> (isUp: Bool, detail: String?) {
+        guard let url = URL(string: "\(baseURL)/health") else {
+            return (false, "invalid server URL")
+        }
+
+        do {
+            let (data, response) = try await data(from: url, authorize: false)
+            guard let http = response as? HTTPURLResponse else {
+                return (false, "health returned a non-HTTP response")
+            }
+            guard http.statusCode == 200 else {
+                return (false, "health returned HTTP \(http.statusCode)")
+            }
+            guard let health = try? JSONDecoder().decode(APIHealthStatus.self, from: data),
+                  health.status == "ok" else {
+                return (true, "health responded with an unexpected payload")
+            }
+            return (true, nil)
+        } catch {
+            return (false, StatusSnapshotBuilder.shortNetworkError(error))
+        }
+    }
+
+    private func probeModels(baseURL: String) async -> (loadedModels: [String], detail: String?) {
+        guard let url = URL(string: "\(baseURL)/v1/models") else {
+            return ([], "invalid models URL")
+        }
+
+        do {
+            let (data, response) = try await data(from: url, authorize: true)
+            guard let http = response as? HTTPURLResponse else {
+                return ([], "models returned a non-HTTP response")
+            }
+            switch http.statusCode {
+            case 200:
+                let models = try JSONDecoder().decode(OpenAIModelsResponse.self, from: data)
+                return (models.data.map(\.id), nil)
+            case 401, 403:
+                return ([], "requires API key")
+            default:
+                return ([], "models returned HTTP \(http.statusCode)")
+            }
+        } catch {
+            return ([], StatusSnapshotBuilder.shortNetworkError(error))
+        }
+    }
+
+    private func data(from url: URL, authorize: Bool) async throws -> (Data, URLResponse) {
+        var request = URLRequest(url: url, timeoutInterval: max(0.1, timeoutSeconds))
+        if authorize, let apiKey {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        return try await URLSession.shared.data(for: request)
+    }
+
+    private func serverBaseURLString(host: String, port: Int) -> String {
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlHost: String
+        if trimmedHost.contains(":") && !trimmedHost.hasPrefix("[") {
+            urlHost = "[\(trimmedHost)]"
+        } else {
+            urlHost = trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
+        }
+        return "http://\(urlHost):\(port)"
+    }
+
+    private static func shortNetworkError(_ error: Error) -> String {
+        guard let urlError = error as? URLError else {
+            return error.localizedDescription
+        }
+
+        switch urlError.code {
+        case .cannotConnectToHost, .networkConnectionLost, .notConnectedToInternet:
+            return "not reachable"
+        case .timedOut:
+            return "timed out"
+        default:
+            return urlError.localizedDescription
+        }
+    }
+}
+
+enum StatusFormatter {
+    static func text(_ snapshot: StatusSnapshot) -> String {
+        var lines: [String] = []
+        lines.append("mere.run status")
+
+        var serverLine = "  server: \(snapshot.server.health) (\(snapshot.server.url))"
+        if let detail = snapshot.server.detail {
+            serverLine += " - \(detail)"
+        }
+        lines.append(serverLine)
+
+        if snapshot.server.health == "up" {
+            if !snapshot.server.loadedModels.isEmpty {
+                lines.append("  loaded models: \(snapshot.server.loadedModels.joined(separator: ", "))")
+            } else if let modelsDetail = snapshot.server.modelsDetail {
+                lines.append("  loaded models: unavailable (\(modelsDetail))")
+            } else {
+                lines.append("  loaded models: none reported")
+            }
+        } else {
+            lines.append("  loaded models: unavailable")
+        }
+
+        lines.append("  model store: \(modelStoreText(snapshot.modelStore))")
+        lines.append("  installed models: \(snapshot.installedModels.count)/\(snapshot.knownModelCount)")
+
+        if snapshot.installedModels.isEmpty {
+            lines.append("    none")
+        } else {
+            for model in snapshot.installedModels {
+                lines.append("    - \(model.id) (\(model.category), \(model.size))")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func modelStoreText(_ modelStore: StatusModelStoreSnapshot) -> String {
+        let source = modelStore.source
+        guard modelStore.isFallbackToDefault, let configuredPath = modelStore.configuredPath else {
+            return "\(modelStore.path) (source: \(source))"
+        }
+        return "\(modelStore.path) (source: \(source), fallback from unreadable \(configuredPath))"
+    }
+}

--- a/Sources/MereRunCLI/Guides/agent-onboard.md
+++ b/Sources/MereRunCLI/Guides/agent-onboard.md
@@ -45,6 +45,7 @@ mere.run agent onboard --install-pi --configure-pi --model text-agent-deepseek-v
 
 - Copy the printed recommended setup-agent id into later `model pull` or `agent start` commands.
 - Keep host and port aligned with `api serve`.
+- Use `mere.run status --host <host> --port <port>` after starting a server.
 - Re-run after changing hardware, model store, or setup model choice.
 
 ## Troubleshooting

--- a/Sources/MereRunCLI/Guides/agent-start.md
+++ b/Sources/MereRunCLI/Guides/agent-start.md
@@ -15,6 +15,7 @@ mere.run agent onboard
 mere.run model pull text-agent-deepseek-v4-flash
 mere.run agent install-pi
 mere.run agent start --model text-agent-deepseek-v4-flash
+mere.run status
 ```
 
 ## Parameters
@@ -32,6 +33,7 @@ mere.run agent start --model text-agent-deepseek-v4-flash
 - Run `model capabilities --recommended` or `agent onboard` first and use the recommended setup-agent id.
 - Pull the selected model before `agent start`.
 - Use `--skip-server` only when you already started a compatible local API server.
+- Run `status` when you need to confirm the local server and served model.
 - Keep the default prompt unless the user has a specific setup goal.
 
 ## Examples
@@ -58,6 +60,7 @@ mere.run agent start \
 - Model missing: run `mere.run model pull <id>`.
 - Pi missing: run `mere.run agent install-pi` or pass `--pi-path`.
 - Health check times out: verify host/port and local API logs.
+- Unsure what is already running: run `mere.run status --host <host> --port <port>`.
 
 ## Sources
 

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -20,6 +20,7 @@ Supported engines:
 mere.run model capabilities
 mere.run model pull text-agent-deepseek-v4-flash
 mere.run api serve --help
+mere.run status
 ```
 
 ## Parameters
@@ -39,7 +40,8 @@ mere.run api serve --help
 - Keep loopback binds for local-only tools.
 - For non-loopback hosts, always set `MERERUN_API_KEY` or pass `--api-key`.
 - Choose the engine first, then the model path/id.
-- Test `/health`, then `/v1/models`, then `/v1/chat/completions`.
+- Use `mere.run status` as the quick `/health` plus `/v1/models` check.
+- Test `/v1/chat/completions` after status shows the expected served model.
 - DS4 raw-proxies the complete OpenAI chat request to `ds4-server`.
 - Native engines reject unsupported OpenAI fields explicitly instead of silently dropping them.
 - Use `stream_options.include_usage` when a client expects the OpenAI streaming usage chunk.
@@ -62,14 +64,14 @@ mere.run api serve --host 0.0.0.0 --api-key "$MERERUN_API_KEY"
 
 ## Iteration Tips
 
-- Use `curl http://127.0.0.1:8080/health` before connecting an editor.
+- Use `mere.run status` before connecting an editor.
 - Start with one client and default rate limit.
 - For Gemma memory pressure, test KV quantization on a local prompt before long sessions.
 
 ## Troubleshooting
 
 - Non-loopback bind rejected: set `--api-key` or `MERERUN_API_KEY`.
-- Client cannot connect: confirm host, port, and firewall settings.
+- Client cannot connect: run `mere.run status --host <host> --port <port>`, then confirm firewall settings.
 - Wrong model family: match `--engine` to the model path.
 - Unsupported OpenAI field: choose a compatible engine or remove the field named in the `invalid_request_error`.
 

--- a/Sources/MereRunCLI/Guides/model-info.md
+++ b/Sources/MereRunCLI/Guides/model-info.md
@@ -11,6 +11,7 @@ The target must be either an installed managed id or an existing local model pat
 ## Install And Check
 
 ```bash
+mere.run status
 mere.run model list
 mere.run model info image-zimage-nano
 mere.run model info image-zimage-nano --components
@@ -25,6 +26,7 @@ mere.run model info image-zimage-nano --components
 ## Usage Patterns
 
 - Use before debugging a failed generation command.
+- Start with `status` when you are unsure which model store is active.
 - Use `--components` for structured roots with tokenizer, transformer, VAE, scheduler, or text encoder folders.
 - Use `--json` when scripts need the manifest.
 

--- a/Sources/MereRunCLI/Guides/model-list.md
+++ b/Sources/MereRunCLI/Guides/model-list.md
@@ -3,6 +3,8 @@
 ## Purpose
 
 Show all known managed model ids, categories, install status, and local size. Use this before pulling or running models.
+Use `mere.run status` when you also need the active API server and currently
+served model.
 
 ## Required Models
 
@@ -12,6 +14,7 @@ No model is required.
 
 ```bash
 mere.run model list
+mere.run status
 mere.run guide model list
 ```
 
@@ -22,6 +25,8 @@ This command has no flags. It reads the configured model store.
 ## Usage Patterns
 
 - Run before telling a user to pull something; it shows what is already installed.
+- Prefer `status` for a first support snapshot because it includes the model
+  store and server state.
 - Pair with `model capabilities` when choosing a first model.
 - Use `MERERUN_MODELS_DIR` or `--models-root` before the command when inspecting a non-default store.
 

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -13,6 +13,7 @@ No model is required before running pull, but the target id must exist in the ma
 ```bash
 mere.run model capabilities
 mere.run model pull image-zimage-nano
+mere.run status
 mere.run model list
 ```
 
@@ -45,6 +46,7 @@ MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
 ## Iteration Tips
 
 - Pull the runtime model before opening a creative loop.
+- Use `status` to confirm the model landed in the active store.
 - Verify with `model info <id>` after a forced re-download.
 - Keep hub cache and model store on the same large disk when possible.
 - If disk is tight, set both `MERERUN_HUB_CACHE` and `MERERUN_MODELS_DIR`.

--- a/Sources/MereRunCLI/Guides/model-remove.md
+++ b/Sources/MereRunCLI/Guides/model-remove.md
@@ -13,6 +13,7 @@ The target model must be installed.
 ```bash
 mere.run model list
 mere.run model remove image-zimage-nano
+mere.run status
 ```
 
 ## Parameters
@@ -39,7 +40,7 @@ mere.run model remove text-chat-gemma4-nano --force
 ## Iteration Tips
 
 - Remove large creative models before pulling a different family.
-- Re-run `model list` after deletion to confirm status.
+- Re-run `status` or `model list` after deletion to confirm status.
 - Remember that hub caches may still consume disk outside the model store.
 
 ## Troubleshooting

--- a/Sources/MereRunCLI/Guides/status.md
+++ b/Sources/MereRunCLI/Guides/status.md
@@ -1,0 +1,74 @@
+# Status
+
+## Purpose
+
+Show one local snapshot of the mere.run runtime: API server reachability, the
+model currently reported by `/v1/models`, the active model-store path, and the
+managed models installed there.
+
+## Required Models
+
+No model is required.
+
+## Install And Check
+
+```bash
+mere.run status
+mere.run status --json
+mere.run guide status
+```
+
+## Parameters
+
+- `--host`: local API host to check, default `127.0.0.1`.
+- `--port`: local API port to check, default `8080`.
+- `--api-key`: bearer token for `/v1/models`, also read from `MERERUN_API_KEY`.
+- `--timeout-seconds`: network probe timeout, default `1.0`.
+- `--json`: emit a structured snapshot.
+
+## Usage Patterns
+
+- Run before connecting an editor, agent, or local integration to the API server.
+- Run after `api serve` starts to confirm the health endpoint and served model.
+- Use it instead of separate `curl /health`, `curl /v1/models`, and `model list`
+  checks when you only need the current local state.
+- Use `--json` in scripts, setup agents, or support tooling.
+
+## Examples
+
+```bash
+mere.run status
+```
+
+```bash
+mere.run status --host 127.0.0.1 --port 11434
+```
+
+```bash
+MERERUN_API_KEY=change-me mere.run status --json
+```
+
+## Iteration Tips
+
+- `server: down` means nothing answered the configured `/health` URL.
+- `loaded models: unavailable (requires API key)` means the server is up, but
+  `/v1/models` needs `--api-key` or `MERERUN_API_KEY`.
+- The loaded model list is what the API server reports; it is not a system-wide
+  RAM/process scan for every runtime family.
+- The installed model list follows the same shared inventory path as
+  `mere.run model list`.
+
+## Troubleshooting
+
+- Wrong port: rerun with the same `--host` and `--port` passed to `api serve`.
+- Server is up but loaded model is unavailable: provide the API key used to
+  start the server.
+- Installed model missing: run `mere.run model list` or
+  `mere.run model info <id>` for deeper model-store diagnostics.
+- Non-default model store: pass global `--models-root` before `status` or set
+  `MERERUN_MODELS_DIR`.
+
+## Sources
+
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/StatusCommand.swift
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Support/ModelInventory.swift

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -24,6 +24,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Music.self,
             Video.self,
             Model.self,
+            Status.self,
             API.self,
             Setup.self,
             Agent.self,

--- a/Sources/MereRunCLI/Support/ModelInventory.swift
+++ b/Sources/MereRunCLI/Support/ModelInventory.swift
@@ -1,0 +1,100 @@
+import Foundation
+import MereRunCore
+
+struct ModelInventoryRow: Equatable {
+    let id: String
+    let category: String
+    let status: String
+    let size: String
+
+    var isInstalled: Bool {
+        status == "installed"
+    }
+}
+
+enum ModelInventory {
+    static func rows(fileManager: FileManager = .default) -> [ModelInventoryRow] {
+        let resolver = ModelResolver(fileManager: fileManager)
+        let specs = ManagedModelCatalog.allSpecs
+        let knownSpecs = Dictionary(uniqueKeysWithValues: specs.map { ($0.id, $0) })
+        let idsInOrder = specs.map(\.id)
+
+        return idsInOrder.map { id in
+            let spec = knownSpecs[id]
+            let status: String
+            let size: String
+
+            let modelID = ModelResolver.ModelID(rawValue: id)
+            let resolvedViaResolver = modelID.flatMap { resolver.resolveIfPresent($0) }
+
+            let flatDir = MereRunModelPaths.modelDir(id)
+            let flatInstalled = isNonEmptyDirectory(flatDir, fileManager: fileManager)
+            let gemmaAliasInstall = gemmaAliasInstallURL(for: id, fileManager: fileManager)
+
+            if let resolution = resolvedViaResolver {
+                status = "installed"
+                let bytes = FileSystemHelper.directorySize(at: resolution.rootURL)
+                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            } else if let gemmaAliasInstall {
+                status = "installed"
+                let bytes = FileSystemHelper.directorySize(at: gemmaAliasInstall)
+                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            } else if flatInstalled || spec?.managedRuntimeURL(fileManager: fileManager) != nil {
+                status = "installed"
+                let bytes = FileSystemHelper.directorySize(at: flatDir)
+                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            } else {
+                status = "missing"
+                size = "—"
+            }
+
+            return ModelInventoryRow(
+                id: id,
+                category: spec?.category.rawValue ?? inferCategory(for: id),
+                status: status,
+                size: size
+            )
+        }
+    }
+
+    private static func isNonEmptyDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+            return false
+        }
+        return (try? fileManager.contentsOfDirectory(atPath: url.path))?.isEmpty == false
+    }
+
+    private static func gemmaAliasInstallURL(for id: String, fileManager: FileManager) -> URL? {
+        guard id == Gemma4Resources.defaultModelId else {
+            return nil
+        }
+
+        let maxURL = MereRunModelPaths.modelDir(Gemma4Resources.maxModelId)
+        if isNonEmptyDirectory(maxURL, fileManager: fileManager) {
+            return maxURL
+        }
+
+        let nanoURL = MereRunModelPaths.modelDir(Gemma4Resources.nanoModelId)
+        if isNonEmptyDirectory(nanoURL, fileManager: fileManager) {
+            return nanoURL
+        }
+
+        return nil
+    }
+
+    private static func inferCategory(for id: String) -> String {
+        if id.hasPrefix("text-chat-") { return "text-chat" }
+        if id.hasPrefix("text-code-") { return "text-code" }
+        if id.hasPrefix("text-embed-") { return "text-embed" }
+        if id.hasPrefix("image-") { return "image" }
+        if id.hasPrefix("speech-tts-") { return "speech-tts" }
+        if id.hasPrefix("speech-asr-") { return "speech-asr" }
+        if id.hasPrefix("vision-ocr-") { return "vision-ocr" }
+        if id.hasPrefix("vision-segment-") { return "vision-segment" }
+        if id.hasPrefix("vision-ground-") { return "vision-ground" }
+        if id.hasPrefix("music-") { return "music" }
+        if id.hasPrefix("video-") { return "video" }
+        return "other"
+    }
+}

--- a/Sources/MereRunCLI/Support/SetupAgentPrompt.swift
+++ b/Sources/MereRunCLI/Support/SetupAgentPrompt.swift
@@ -49,6 +49,7 @@ enum SetupAgentPrompt {
         - Treat the recommended setup-agent line as authoritative for agent/chat setup recommendations; the broader supported managed-model list is cross-modality coverage, not a ranked upgrade list.
         - Do not explore the repository to discover setup facts unless a listed command fails.
         - Do not run demo scripts, sample scripts, `demo.sh`, `scripts/check.sh`, `swift build`, or `swift test` for onboarding.
+        - Use `mere.run status` for a quick server, served-model, and installed-model snapshot.
         - First use `mere.run model capabilities --recommended` for the concise supported setup list.
         - Use `mere.run model list` to check what is already installed before suggesting downloads.
         - Use `mere.run model capabilities --all` only when explaining why a model is hidden or unsupported.

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -70,6 +70,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "music",
             "video",
             "model",
+            "status",
             "api",
             "setup",
             "agent",

--- a/Tests/MereRunCLITests/StatusCommandTests.swift
+++ b/Tests/MereRunCLITests/StatusCommandTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import MereRunCLI
+
+final class StatusCommandTests: XCTestCase {
+    func testMereRunCLIExposesStatusCommand() {
+        let commandNames = Set(MereRunCLI.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("status"))
+    }
+
+    func testStatusParsesDefaults() throws {
+        let cmd = try Status.parse([])
+
+        XCTAssertEqual(cmd.host, "127.0.0.1")
+        XCTAssertEqual(cmd.port, 8080)
+        XCTAssertNil(cmd.apiKey)
+        XCTAssertEqual(cmd.timeoutSeconds, 1.0)
+        XCTAssertFalse(cmd.json)
+    }
+
+    func testStatusParsesOverrides() throws {
+        let cmd = try Status.parse([
+            "--host", "localhost",
+            "--port", "11434",
+            "--api-key", "secret",
+            "--timeout-seconds", "2.5",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.host, "localhost")
+        XCTAssertEqual(cmd.port, 11_434)
+        XCTAssertEqual(cmd.apiKey, "secret")
+        XCTAssertEqual(cmd.timeoutSeconds, 2.5)
+        XCTAssertTrue(cmd.json)
+    }
+
+    func testFormatterShowsLoadedAndInstalledModels() {
+        let snapshot = StatusSnapshot(
+            server: StatusServerSnapshot(
+                url: "http://127.0.0.1:8080",
+                health: "up",
+                detail: nil,
+                loadedModels: ["text-chat-gemma4"],
+                modelsDetail: nil
+            ),
+            modelStore: StatusModelStoreSnapshot(
+                path: "/Users/test/Library/Application Support/MereRun/models",
+                source: "default",
+                configuredPath: nil,
+                isFallbackToDefault: false
+            ),
+            knownModelCount: 2,
+            installedModels: [
+                StatusInstalledModelSnapshot(
+                    id: "text-chat-gemma4",
+                    category: "text-chat",
+                    size: "12 GB"
+                ),
+            ]
+        )
+
+        let output = StatusFormatter.text(snapshot)
+
+        XCTAssertTrue(output.contains("server: up (http://127.0.0.1:8080)"))
+        XCTAssertTrue(output.contains("loaded models: text-chat-gemma4"))
+        XCTAssertTrue(output.contains("installed models: 1/2"))
+        XCTAssertTrue(output.contains("text-chat-gemma4 (text-chat, 12 GB)"))
+    }
+
+    func testFormatterShowsUnavailableLoadedModels() {
+        let snapshot = StatusSnapshot(
+            server: StatusServerSnapshot(
+                url: "http://127.0.0.1:8080",
+                health: "up",
+                detail: nil,
+                loadedModels: [],
+                modelsDetail: "requires API key"
+            ),
+            modelStore: StatusModelStoreSnapshot(
+                path: "/Users/test/Library/Application Support/MereRun/models",
+                source: "default",
+                configuredPath: nil,
+                isFallbackToDefault: false
+            ),
+            knownModelCount: 0,
+            installedModels: []
+        )
+
+        let output = StatusFormatter.text(snapshot)
+
+        XCTAssertTrue(output.contains("loaded models: unavailable (requires API key)"))
+        XCTAssertTrue(output.contains("installed models: 0/0"))
+        XCTAssertTrue(output.contains("    none"))
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ If you are new to the repo, read these in order:
 ### Fundamentals
 
 - [Getting Started](./getting-started.md): clone, build, first commands, first
-  model pulls, and local setup
+  status checks, model pulls, and local setup
 - [Cookbooks](./cookbooks.md): `mere.run guide` command topics for practical
   prompting, parameters, examples, and troubleshooting
 - [Configuration](./configuration.md): supported environment variables and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,9 @@
 # mere.run CLI
 
-`mere.run` is the public command-line interface for the OSS `mere.run` package. It exposes a modality-first command tree for image, text, speech, vision, music, video, model management, and local API serving.
+`mere.run` is the public command-line interface for the OSS `mere.run`
+package. It exposes a modality-first command tree for image, text, speech,
+vision, music, video, model management, local status snapshots, and local API
+serving.
 
 If you are looking for the broader docs set, start at [mere.run Documentation](/).
 
@@ -33,6 +36,7 @@ Public tree:
 - `mere.run video generate`
 - `mere.run video export-latents`
 - `mere.run model { list, capabilities, info, pull, remove, repair-manifests }`
+- `mere.run status`
 - `mere.run api serve`
 - `mere.run setup`
 - `mere.run agent { onboard, install-pi, start }`
@@ -87,6 +91,7 @@ For subsystem-specific implementation guides, see:
 
 ```bash
 swift run mere.run model list
+swift run mere.run status
 swift run mere.run model capabilities
 swift run mere.run model pull image-zimage-nano
 swift run mere.run model info image-zimage-nano
@@ -638,6 +643,26 @@ List all managed model IDs and whether they are installed.
 swift run mere.run model list
 ```
 
+### `mere.run status`
+
+Show a quick local snapshot: whether the API server answers, which model it
+reports as loaded through `/v1/models`, the active model-store path/source, and
+which managed models are installed in that store.
+
+```bash
+swift run mere.run status
+swift run mere.run status --host 127.0.0.1 --port 11434
+swift run mere.run status --json
+```
+
+Useful options:
+
+- `--host`: local API host to check, default `127.0.0.1`
+- `--port`: local API port to check, default `8080`
+- `--api-key`: bearer token for `/v1/models`, also read from `MERERUN_API_KEY`
+- `--timeout-seconds`: network probe timeout
+- `--json`: emit a structured snapshot for scripts and agents
+
 ### `mere.run model pull`
 
 Download a managed Hugging Face snapshot into the local model store. The command checks
@@ -737,6 +762,9 @@ swift run mere.run api serve --engine text-chat-gemma4
 swift run mere.run api serve --engine text-code --model ./Qwen3-Coder-Next-Q4_K_M.gguf
 swift run mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY" --rate-limit-per-minute 120
 ```
+
+After starting a server, run `swift run mere.run status` from another terminal
+to confirm `/health`, `/v1/models`, and the served model.
 
 ### `mere.run setup`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ Overrides the shared local model store.
 
 ```bash
 export MERERUN_MODELS_DIR=/Volumes/Models/mere.run
-swift run mere.run model list
+swift run mere.run status
 ```
 
 Default:
@@ -51,6 +51,7 @@ Provides the bearer token accepted by `mere.run api serve` for `/v1/models` and
 `/v1/chat/completions`.
 
 This is optional for loopback-only usage and required for non-loopback binds.
+`mere.run status` also reads it when probing `/v1/models`.
 
 ## Debug toggles
 

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -39,6 +39,7 @@ Creative and runtime workflows:
 - `video generate`
 - `video export-latents`
 - `api serve`
+- `status`
 
 Operational workflows:
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -63,12 +63,14 @@ The public runtime is hard-cut to the canonical OSS model IDs. That means:
 
 - runtime code should use canonical public IDs only
 - examples should use canonical public IDs only
-- model-store troubleshooting should point readers at `mere.run model list`,
-  `mere.run model info`, and `mere.run model repair-manifests`
+- model-store and server troubleshooting should point readers at
+  `mere.run status`, `mere.run model list`, `mere.run model info`, and
+  `mere.run model repair-manifests`
 
 When testing locally, inspect your current state with:
 
 ```bash
+swift run mere.run status
 swift run mere.run model list
 swift run mere.run model info image-klein-max
 ```
@@ -80,6 +82,8 @@ swift run mere.run model info image-klein-max
 - keep the modality-first structure intact
 - preserve stdout and stderr discipline
 - update `docs/cli.md` if the user-facing behavior changes
+- update quickstarts, cookbooks, and runtime docs when the command becomes part
+  of setup or troubleshooting
 - add or update `Tests/MereRunCLITests`
 
 ### If you touch runtime code

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,7 @@ The public CLI is modality-first:
 - `mere.run music ...`
 - `mere.run video ...`
 - `mere.run model ...`
+- `mere.run status`
 - `mere.run api ...`
 - `mere.run setup ...`
 - `mere.run agent ...`
@@ -99,6 +100,23 @@ or:
 
 ```bash
 swift run mere.run --models-root /path/to/models model list
+```
+
+## Check local status
+
+Use `status` whenever you want a quick snapshot of this machine's mere.run
+state:
+
+```bash
+swift run mere.run status
+```
+
+It reports whether the local API server is reachable, which model the server
+currently exposes through `/v1/models`, the active model store, and the managed
+models installed there. Use JSON output when scripting:
+
+```bash
+swift run mere.run status --json
 ```
 
 ## Pull a model

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: mere.run
   text: Local-first inference on Apple Silicon
-  tagline: A public Swift package, CLI, and optional macOS studio for image, text, speech, vision, music, video, model management, and local API serving.
+  tagline: A public Swift package, CLI, and optional macOS studio for image, text, speech, vision, music, video, model management, status snapshots, and local API serving.
   actions:
     - theme: brand
       text: Get Started
@@ -18,11 +18,11 @@ hero:
 
 features:
   - title: One CLI, clear modalities
-    details: The public surface is organized around image, text, speech, vision, music, video, model management, and local API serving.
+    details: The public surface is organized around image, text, speech, vision, music, video, model management, status snapshots, and local API serving.
   - title: Native macOS studio
     details: The optional SwiftUI app opens to a prompt-first canvas, local output library, guided readiness, and advanced CLI details.
   - title: Canonical model system
-    details: Public model IDs, shared model-store rules, and Hugging Face-backed pulls make installs predictable and scriptable.
+    details: Public model IDs, shared model-store rules, Hugging Face-backed pulls, and `mere.run status` make installs predictable and scriptable.
   - title: Readable runtime families
     details: The repo is documented and decomposed so contributors can follow command -> runtime -> model loading -> generation without guesswork.
 ---

--- a/docs/internals/cli-and-runtime.md
+++ b/docs/internals/cli-and-runtime.md
@@ -41,6 +41,7 @@ Commands are grouped by user intent:
 - music
 - video
 - model
+- status
 - api
 
 ### 2. Canonical public model IDs

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -154,6 +154,7 @@ swift run mere.run model pull image-zimage-nano
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-q35
 
 # Inspect what is currently installed
+swift run mere.run status
 swift run mere.run model list
 swift run mere.run model info image-klein-max
 ```

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -38,7 +38,7 @@ The public command-line surface.
 
 - `MereRunCLI.swift`: top-level command tree
 - `Commands/`: modality-scoped subcommands
-- `Support/`: shared CLI bootstrap, model registry, output helpers, and local
+- `Support/`: shared CLI bootstrap, model inventory, output helpers, and local
   API support
 
 If you want to understand the CLI end to end, start here.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -5,6 +5,7 @@ This page covers `mere.run api serve`, the local API surface exposed by the pack
 ## Public surface
 
 - `mere.run api serve`
+- `mere.run status`
 
 ## What it is for
 
@@ -36,6 +37,13 @@ package-scoped.
 swift run mere.run api serve --engine text-chat-gemma4
 ```
 
+In another terminal, confirm that the server is reachable and which model it
+reports:
+
+```bash
+swift run mere.run status
+```
+
 Network-exposed example:
 
 ```bash
@@ -52,6 +60,8 @@ swift run mere.run api serve \
 
 - the API server follows the same model-resolution and model-store rules as the
   rest of the CLI
+- `mere.run status` is the preferred quick check before wiring an editor or
+  agent to a local server
 - it is intentionally local-first
 - it should not reintroduce relay, billing, or hosted-infrastructure concerns
 - non-loopback binds require an API key, and the OpenAI-compatible chat route
@@ -106,3 +116,17 @@ stay in logs/stderr, and `stream_options.include_usage` adds the final usage
 chunk before `[DONE]`.
 
 If you are working on this area, read [CLI and Runtime Internals](../internals/cli-and-runtime.md) after the command source.
+
+## Troubleshooting
+
+Start with:
+
+```bash
+swift run mere.run status
+```
+
+- `server: down` means nothing answered the configured `/health` URL.
+- `loaded models: unavailable (requires API key)` means `/health` worked but
+  `/v1/models` needs `--api-key` or `MERERUN_API_KEY`.
+- A wrong loaded model usually means another server is already bound to that
+  host and port.

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -11,6 +11,7 @@ the model-management commands.
 - `mere.run model pull`
 - `mere.run model remove`
 - `mere.run model repair-manifests`
+- `mere.run status`
 - `mere.run setup`
 
 ## Default model store
@@ -58,6 +59,12 @@ the canonical names shown by `mere.run model list`.
 ### `mere.run model list`
 
 Shows the canonical managed model table and installed status.
+
+### `mere.run status`
+
+Combines the model inventory with a local API probe. It reports the active
+model-store path/source, installed managed models, whether the configured API
+server answers `/health`, and the model IDs returned by `/v1/models`.
 
 ### `mere.run model capabilities`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,7 @@ This script is the main gate for contributors. It runs:
 - `swift test`
 - help smoke for the public command tree
 - `mere.run model list` output sanity checks
+- `mere.run status` output sanity checks
 - docs and source hygiene sweeps
 
 Use this for almost every change before you stop.
@@ -124,9 +125,13 @@ swift test
 Check:
 
 ```bash
+swift run mere.run status
 swift run mere.run model list
 swift run mere.run model info image-klein-max
 ```
+
+`status` shows the active model store first; `model info` is better when you
+need manifest and component details for one model.
 
 ### `mere.run model pull` fails immediately
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -53,11 +53,18 @@ fi
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null
 "$mere_run_bin" model --help >/dev/null
+"$mere_run_bin" status --help >/dev/null
 "$mere_run_bin" api serve --help >/dev/null
 
 model_list_output="$("$mere_run_bin" model list)"
 rg -q '^ID +Category +Status +Size$' <<<"$model_list_output"
 rg -q '^image-klein-max +image +' <<<"$model_list_output"
+
+status_output="$("$mere_run_bin" status --timeout-seconds 0.1)"
+rg -q '^mere\.run status$' <<<"$status_output"
+rg -q '^  server: ' <<<"$status_output"
+rg -q '^  model store: ' <<<"$status_output"
+rg -q '^  installed models: ' <<<"$status_output"
 
 if rg -n \
   -e 'print\("\[(Flux2KleinGenerator|ZImageTurboGenerator|QwenTextLoRAApplicator)\]' \


### PR DESCRIPTION
## Summary
- add top-level `mere.run status` for API health, served model, model-store, and installed-model snapshots
- share model inventory logic with `model list` and include status in `scripts/check.sh`
- promote status through README, quickstart docs, CLI/runtime docs, changelog, and offline `mere.run guide status`

## Validation
- `swift test --filter StatusCommandTests`
- `swift test --filter GuideCommandTests`
- `swift run mere.run guide status`
- `swift run mere.run status --timeout-seconds 0.1`
- `./scripts/check.sh`
- `pnpm docs:build`