### PR TITLE
Add Gemma4 turbo backend defaults

### DIFF
--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -77,13 +77,13 @@ struct APIServe: AsyncParsableCommand {
     var kvBits: Double?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform or turboquant.")
-    var kvQuantScheme: String = Gemma4Resources.defaultKVQuantizationScheme.rawValue
+    var kvQuantScheme: String?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization group size.")
-    var kvGroupSize: Int = Gemma4Resources.defaultKVGroupSize
+    var kvGroupSize: Int?
 
     @Option(name: [.long], help: "Gemma4 token offset at which KV cache quantization begins.")
-    var quantizedKVStart: Int = Gemma4Resources.defaultQuantizedKVStart
+    var quantizedKVStart: Int?
 
     func run() async throws {
         let resolvedAPIKey = resolveAPIKey()
@@ -147,15 +147,11 @@ struct APIServe: AsyncParsableCommand {
     }
 
     func resolveGemma4KVCacheQuantization() throws -> Gemma4KVCacheQuantization {
-        guard let scheme = Gemma4KVQuantizationScheme(
-            rawValue: kvQuantScheme.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        ) else {
-            throw ValidationError("Unsupported --kv-quant-scheme '\(kvQuantScheme)'. Expected 'uniform' or 'turboquant'.")
-        }
+        let scheme = try resolveGemma4KVQuantizationScheme()
         return Gemma4KVCacheQuantization(
             bits: resolvedGemma4KVBits,
-            scheme: resolvedGemma4KVQuantizationScheme(fallback: scheme),
-            groupSize: kvGroupSize,
+            scheme: scheme,
+            groupSize: kvGroupSize ?? Gemma4Resources.defaultKVGroupSize,
             quantizedStart: resolvedGemma4QuantizedKVStart
         )
     }
@@ -165,21 +161,30 @@ struct APIServe: AsyncParsableCommand {
     }
 
     private var usesGemma4TurboKVDefaults: Bool {
-        kvBits == nil && Gemma4Resources.usesTurboDefaults(modelSpec: requestedGemma4ModelSpec)
+        Gemma4Resources.usesTurboDefaults(modelSpec: requestedGemma4ModelSpec)
     }
 
     private var resolvedGemma4KVBits: Double? {
-        usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboKVBits : kvBits
+        kvBits ?? (usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboKVBits : nil)
     }
 
-    private func resolvedGemma4KVQuantizationScheme(
-        fallback: Gemma4KVQuantizationScheme
-    ) -> Gemma4KVQuantizationScheme {
-        usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboKVQuantizationScheme : fallback
+    private func resolveGemma4KVQuantizationScheme() throws -> Gemma4KVQuantizationScheme {
+        let raw = kvQuantScheme
+            ?? (usesGemma4TurboKVDefaults
+                ? Gemma4Resources.defaultTurboKVQuantizationScheme.rawValue
+                : Gemma4Resources.defaultKVQuantizationScheme.rawValue)
+        guard let scheme = Gemma4KVQuantizationScheme(
+            rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        ) else {
+            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform' or 'turboquant'.")
+        }
+        return scheme
     }
 
     private var resolvedGemma4QuantizedKVStart: Int {
-        usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboQuantizedKVStart : quantizedKVStart
+        quantizedKVStart ?? (usesGemma4TurboKVDefaults
+            ? Gemma4Resources.defaultTurboQuantizedKVStart
+            : Gemma4Resources.defaultQuantizedKVStart)
     }
 
     private func resolveAPIKey() -> String? {

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -146,18 +146,40 @@ struct APIServe: AsyncParsableCommand {
         }
     }
 
-    private func resolveGemma4KVCacheQuantization() throws -> Gemma4KVCacheQuantization {
+    func resolveGemma4KVCacheQuantization() throws -> Gemma4KVCacheQuantization {
         guard let scheme = Gemma4KVQuantizationScheme(
             rawValue: kvQuantScheme.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ) else {
             throw ValidationError("Unsupported --kv-quant-scheme '\(kvQuantScheme)'. Expected 'uniform' or 'turboquant'.")
         }
         return Gemma4KVCacheQuantization(
-            bits: kvBits,
-            scheme: scheme,
+            bits: resolvedGemma4KVBits,
+            scheme: resolvedGemma4KVQuantizationScheme(fallback: scheme),
             groupSize: kvGroupSize,
-            quantizedStart: quantizedKVStart
+            quantizedStart: resolvedGemma4QuantizedKVStart
         )
+    }
+
+    private var requestedGemma4ModelSpec: String {
+        model?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? Gemma4Resources.defaultModelId
+    }
+
+    private var usesGemma4TurboKVDefaults: Bool {
+        kvBits == nil && Gemma4Resources.usesTurboDefaults(modelSpec: requestedGemma4ModelSpec)
+    }
+
+    private var resolvedGemma4KVBits: Double? {
+        usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboKVBits : kvBits
+    }
+
+    private func resolvedGemma4KVQuantizationScheme(
+        fallback: Gemma4KVQuantizationScheme
+    ) -> Gemma4KVQuantizationScheme {
+        usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboKVQuantizationScheme : fallback
+    }
+
+    private var resolvedGemma4QuantizedKVStart: Int {
+        usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboQuantizedKVStart : quantizedKVStart
     }
 
     private func resolveAPIKey() -> String? {

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -48,13 +48,13 @@ struct TextChat: AsyncParsableCommand {
     var kvBits: Double?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform or turboquant.")
-    var kvQuantScheme: String = Gemma4Resources.defaultKVQuantizationScheme.rawValue
+    var kvQuantScheme: String?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization group size.")
-    var kvGroupSize: Int = Gemma4Resources.defaultKVGroupSize
+    var kvGroupSize: Int?
 
     @Option(name: [.long], help: "Gemma4 token offset at which KV cache quantization begins.")
-    var quantizedKVStart: Int = Gemma4Resources.defaultQuantizedKVStart
+    var quantizedKVStart: Int?
 
     @Option(name: [.customShort("m"), .long], help: "Override model root directory (skips auto-download).")
     var modelRoot: String?
@@ -271,22 +271,19 @@ struct TextChat: AsyncParsableCommand {
     }
 
     func resolveGemma4KVCacheQuantization(for modelId: String) throws -> Gemma4KVCacheQuantization {
-        let scheme = try parseGemma4KVQuantizationScheme(kvQuantScheme)
-
-        if kvBits == nil, Gemma4Resources.usesTurboDefaults(modelSpec: modelId) {
-            return Gemma4KVCacheQuantization(
-                bits: Gemma4Resources.defaultTurboKVBits,
-                scheme: Gemma4Resources.defaultTurboKVQuantizationScheme,
-                groupSize: kvGroupSize,
-                quantizedStart: Gemma4Resources.defaultTurboQuantizedKVStart
-            )
-        }
+        let usesTurboDefaults = Gemma4Resources.usesTurboDefaults(modelSpec: modelId)
+        let defaultScheme = usesTurboDefaults
+            ? Gemma4Resources.defaultTurboKVQuantizationScheme.rawValue
+            : Gemma4Resources.defaultKVQuantizationScheme.rawValue
+        let scheme = try parseGemma4KVQuantizationScheme(kvQuantScheme ?? defaultScheme)
 
         return Gemma4KVCacheQuantization(
-            bits: kvBits,
+            bits: kvBits ?? (usesTurboDefaults ? Gemma4Resources.defaultTurboKVBits : nil),
             scheme: scheme,
-            groupSize: kvGroupSize,
-            quantizedStart: quantizedKVStart
+            groupSize: kvGroupSize ?? Gemma4Resources.defaultKVGroupSize,
+            quantizedStart: quantizedKVStart ?? (usesTurboDefaults
+                ? Gemma4Resources.defaultTurboQuantizedKVStart
+                : Gemma4Resources.defaultQuantizedKVStart)
         )
     }
 

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -17,6 +17,7 @@ struct TextChat: AsyncParsableCommand {
         Auto-downloads the selected model on first use.
         Known model IDs:
           - text-chat-gemma4 (Gemma 4 default alias, currently 31B)
+          - text-chat-gemma4-turbo (Gemma 4 26B-A4B NVFP4 native Swift runtime)
           - text-chat-gemma4-max (Gemma 4 31B native Swift runtime)
           - text-chat-gemma4-nano (Gemma 4 4B native Swift runtime)
           - text-chat-q35-nano (Qwen3.5-35B-A3B 4-bit)
@@ -58,7 +59,7 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.customShort("m"), .long], help: "Override model root directory (skips auto-download).")
     var modelRoot: String?
 
-    @Option(name: [.long], help: "Canonical model id: text-chat-gemma4 (default alias), text-chat-gemma4-max, text-chat-gemma4-nano, text-chat-q35, text-chat-q35-nano, or text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id: text-chat-gemma4 (default alias), text-chat-gemma4-turbo, text-chat-gemma4-max, text-chat-gemma4-nano, text-chat-q35, text-chat-q35-nano, or text-chat-psi-agent.")
     var model: String = Gemma4Resources.defaultModelId
 
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")
@@ -139,15 +140,10 @@ struct TextChat: AsyncParsableCommand {
                 return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
             } else if Gemma4Resources.handles(modelSpec: normalizedModelId) {
                 let effectiveModelId = normalizedModelId.isEmpty ? Gemma4Resources.defaultModelId : normalizedModelId
-                let scheme = try self.parseGemma4KVQuantizationScheme(self.kvQuantScheme)
+                let kvQuantization = try self.resolveGemma4KVCacheQuantization(for: effectiveModelId)
                 let generator = Gemma4Generator(
                     modelId: effectiveModelId,
-                    kvCacheQuantization: Gemma4KVCacheQuantization(
-                        bits: self.kvBits,
-                        scheme: scheme,
-                        groupSize: self.kvGroupSize,
-                        quantizedStart: self.quantizedKVStart
-                    )
+                    kvCacheQuantization: kvQuantization
                 )
                 return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
             } else {
@@ -272,6 +268,26 @@ struct TextChat: AsyncParsableCommand {
         cleaned = cleaned.replacingOccurrences(of: "<think>", with: "")
         cleaned = cleaned.replacingOccurrences(of: "</think>", with: "")
         return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func resolveGemma4KVCacheQuantization(for modelId: String) throws -> Gemma4KVCacheQuantization {
+        let scheme = try parseGemma4KVQuantizationScheme(kvQuantScheme)
+
+        if kvBits == nil, Gemma4Resources.usesTurboDefaults(modelSpec: modelId) {
+            return Gemma4KVCacheQuantization(
+                bits: Gemma4Resources.defaultTurboKVBits,
+                scheme: Gemma4Resources.defaultTurboKVQuantizationScheme,
+                groupSize: kvGroupSize,
+                quantizedStart: Gemma4Resources.defaultTurboQuantizedKVStart
+            )
+        }
+
+        return Gemma4KVCacheQuantization(
+            bits: kvBits,
+            scheme: scheme,
+            groupSize: kvGroupSize,
+            quantizedStart: quantizedKVStart
+        )
     }
 
     private func parseGemma4KVQuantizationScheme(_ raw: String) throws -> Gemma4KVQuantizationScheme {

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -33,7 +33,7 @@ mere.run status
 - `--api-key`: bearer token, also read from `MERERUN_API_KEY`.
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--context-size`: context limit.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,13 +6,14 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported managed ids include `text-chat-gemma4`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, and `text-chat-psi-agent`.
+`text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
 
 ## Install And Check
 
 ```bash
 mere.run model capabilities
-mere.run model pull text-chat-gemma4
+mere.run model pull text-chat-gemma4-nano
 mere.run text chat --help
 ```
 
@@ -23,7 +24,7 @@ mere.run text chat --help
 - `--max-tokens`: maximum generated tokens.
 - `--temperature`: randomness. Lower for factual work, higher for brainstorming.
 - `--top-p`: nucleus sampling cutoff.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
 - `--model-root`, `-m`: explicit local model root.
 - `--model`: canonical model id.
 - `--thinking`, `--show-thinking`: include hidden reasoning output when supported.

--- a/Sources/MereRunCore/ACEStep/ACEStep5HzLMTokenizer.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStep5HzLMTokenizer.swift
@@ -36,7 +36,8 @@ public final class ACEStep5HzLMTokenizer {
 
     public static func load(
         from directory: URL,
-        hubApi: HubApi = .shared
+        hubApi: HubApi = .shared,
+        requireAudioCodeTokens: Bool = true
     ) throws -> ACEStep5HzLMTokenizer {
         guard FileManager.default.fileExists(atPath: directory.path) else {
             throw ACEStep5HzLMTokenizerError.directoryNotFound(directory)
@@ -78,7 +79,15 @@ public final class ACEStep5HzLMTokenizer {
         }
 
         let addedTokensURL = directory.appending(path: "added_tokens.json")
-        let (audioCodeIds, audioCodeMap) = try loadAudioCodeTokens(from: addedTokensURL)
+        let (audioCodeIds, audioCodeMap): (Set<Int>, [Int: Int])
+        if FileManager.default.fileExists(atPath: addedTokensURL.path) {
+            (audioCodeIds, audioCodeMap) = try loadAudioCodeTokens(from: addedTokensURL)
+        } else if requireAudioCodeTokens {
+            throw ACEStep5HzLMTokenizerError.fileNotFound(addedTokensURL)
+        } else {
+            audioCodeIds = []
+            audioCodeMap = [:]
+        }
 
         return ACEStep5HzLMTokenizer(
             tokenizer: tokenizer,

--- a/Sources/MereRunCore/Embeddings/Qwen3EmbeddingModel.swift
+++ b/Sources/MereRunCore/Embeddings/Qwen3EmbeddingModel.swift
@@ -68,7 +68,10 @@ public final class Qwen3EmbeddingModel {
             fileManager: fileManager
         )
 
-        self.tokenizer = try ACEStep5HzLMTokenizer.load(from: resources.rootURL)
+        self.tokenizer = try ACEStep5HzLMTokenizer.load(
+            from: resources.rootURL,
+            requireAudioCodeTokens: false
+        )
         self.encoder = qwen
     }
 
@@ -155,4 +158,3 @@ public final class Qwen3EmbeddingModel {
         return vector / norm
     }
 }
-

--- a/Sources/MereRunCore/Gemma4/Gemma4Config.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Config.swift
@@ -37,6 +37,9 @@ public struct Gemma4TextConfig: Decodable, Sendable, Hashable {
     public let finalLogitSoftcapping: Float?
     public let useDoubleWideMLP: Bool
     public let enableMoEBlock: Bool
+    public let numExperts: Int
+    public let topKExperts: Int
+    public let moeIntermediateSize: Int
     public let numKVSharedLayers: Int
     public let tieWordEmbeddings: Bool
 
@@ -65,6 +68,9 @@ public struct Gemma4TextConfig: Decodable, Sendable, Hashable {
         case finalLogitSoftcapping = "final_logit_softcapping"
         case useDoubleWideMLP = "use_double_wide_mlp"
         case enableMoEBlock = "enable_moe_block"
+        case numExperts = "num_experts"
+        case topKExperts = "top_k_experts"
+        case moeIntermediateSize = "moe_intermediate_size"
         case numKVSharedLayers = "num_kv_shared_layers"
         case tieWordEmbeddings = "tie_word_embeddings"
     }
@@ -99,6 +105,9 @@ public struct Gemma4TextConfig: Decodable, Sendable, Hashable {
         self.finalLogitSoftcapping = try container.decodeIfPresent(Float.self, forKey: .finalLogitSoftcapping)
         self.useDoubleWideMLP = try container.decodeIfPresent(Bool.self, forKey: .useDoubleWideMLP) ?? false
         self.enableMoEBlock = try container.decodeIfPresent(Bool.self, forKey: .enableMoEBlock) ?? false
+        self.numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts) ?? 0
+        self.topKExperts = try container.decodeIfPresent(Int.self, forKey: .topKExperts) ?? 0
+        self.moeIntermediateSize = try container.decodeIfPresent(Int.self, forKey: .moeIntermediateSize) ?? 0
         self.numKVSharedLayers = try container.decodeIfPresent(Int.self, forKey: .numKVSharedLayers) ?? 0
         self.tieWordEmbeddings = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
     }

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -83,9 +83,6 @@ public actor Gemma4Generator: ChatGenerator {
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 config"))
         let configData = try Data(contentsOf: resources.configURL)
         let config = try JSONDecoder().decode(Gemma4Config.self, from: configData)
-        guard !config.textConfig.enableMoEBlock else {
-            throw Gemma4Error.unsupportedConfiguration("Gemma4 native runtime currently supports dense text checkpoints only.")
-        }
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 tokenizer"))
         let tokenizer = try await Gemma4TokenizerAndTemplate.load(
@@ -95,7 +92,7 @@ public actor Gemma4Generator: ChatGenerator {
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 weights"))
         let textModel = Gemma4TextCausalLM(config: config.textConfig)
-        try loadWeights(into: textModel, from: resources)
+        try loadWeights(into: textModel, from: resources, config: config)
 
         model = textModel
         tokenizerAndTemplate = tokenizer
@@ -251,6 +248,30 @@ public actor Gemma4Generator: ChatGenerator {
         _ location: String,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> URL {
+        if let modelID = ModelResolver.ModelID(rawValue: location),
+           Gemma4Resources.handles(modelSpec: modelID.rawValue) {
+            if let resolved = ModelResolver().resolveIfPresent(modelID) {
+                return resolved.rootURL
+            }
+            do {
+                let resolution = try await ManagedModelResolver.resolveForRuntime(
+                    requestedModel: modelID.rawValue,
+                    defaultModelID: modelID.rawValue,
+                    progress: { event in
+                        switch event {
+                        case .downloading(let percent):
+                            progressHandler?(ChatProgress(stage: .loadingModel, message: "Downloading Gemma4... \(percent)%"))
+                        case .extracting:
+                            progressHandler?(ChatProgress(stage: .loadingModel, message: "Extracting Gemma4..."))
+                        }
+                    }
+                )
+                return Gemma4Resources.normalizedRootURL(resolution.url)
+            } catch {
+                throw Gemma4Error.downloadFailed(error.localizedDescription)
+            }
+        }
+
         let fileURL = URL(fileURLWithPath: location).standardizedFileURL
         if FileManager.default.fileExists(atPath: fileURL.path) {
             return Gemma4Resources.normalizedRootURL(fileURL)
@@ -281,7 +302,8 @@ public actor Gemma4Generator: ChatGenerator {
 
     private func loadWeights(
         into model: Gemma4TextCausalLM,
-        from resources: Gemma4Resources
+        from resources: Gemma4Resources,
+        config: Gemma4Config
     ) throws {
         let include: (String) -> Bool = { key in
             key.hasPrefix("model.language_model.") || key.hasPrefix("language_model.")
@@ -290,20 +312,56 @@ public actor Gemma4Generator: ChatGenerator {
             if key.hasPrefix("model.language_model.") {
                 return [(String(key.dropFirst("model.".count)), value)]
             }
+            if key.hasPrefix("language_model.model.") {
+                return [("language_model.\(key.dropFirst("language_model.model.".count))", value)]
+            }
             if key.hasPrefix("language_model.") {
                 return [(key, value)]
             }
             return []
         }
+        let keyMapper: (String) -> String = { key in
+            if key.hasPrefix("model.language_model.") {
+                return String(key.dropFirst("model.".count))
+            }
+            if key.hasPrefix("language_model.model.") {
+                return "language_model.\(key.dropFirst("language_model.model.".count))"
+            }
+            if key.hasPrefix("language_model.") {
+                return key
+            }
+            return "__unused__.\(key)"
+        }
+        let quantizedMapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            key.hasPrefix("__unused__.") ? [] : [(key, value)]
+        }
+        let quantizedModuleResolver: HFSafetensorsWeightsLoader.QuantizedModuleResolver = { _, _, _, _, biases, fallbackGroupSize, fallbackBits in
+            if biases != nil || fallbackBits > 4 {
+                return (groupSize: fallbackGroupSize, bits: fallbackBits, mode: QuantizationMode.affine)
+            }
+            return (groupSize: fallbackGroupSize, bits: fallbackBits, mode: QuantizationMode.nvfp4)
+        }
 
         if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
-            try HFSafetensorsWeightsLoader.applyShardedWeights(
-                indexURL: resources.modelIndexURL,
-                to: model,
-                dtype: .bfloat16,
-                verify: .none,
-                mapper: mapper
-            )
+            if config.textConfig.enableMoEBlock {
+                try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                    indexURL: resources.modelIndexURL,
+                    to: model,
+                    groupSize: 16,
+                    bits: 4,
+                    quantizedModuleResolver: quantizedModuleResolver,
+                    keyMapper: keyMapper,
+                    mapper: quantizedMapper
+                )
+            } else {
+                try HFSafetensorsWeightsLoader.applyShardedWeights(
+                    indexURL: resources.modelIndexURL,
+                    to: model,
+                    dtype: .bfloat16,
+                    verify: .none,
+                    mapper: mapper
+                )
+            }
         } else if FileManager.default.fileExists(atPath: resources.modelWeightsURL.path) {
             try SafetensorsStreamingLoader.applyWeightsStreaming(
                 url: resources.modelWeightsURL,

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -549,6 +549,19 @@ private enum Gemma4AffineFastKernels {
     }
 }
 
+private func concatenatedOptional(_ lhs: MLXArray?, _ rhs: MLXArray?, axis: Int) -> MLXArray? {
+    switch (lhs, rhs) {
+    case (.some(let lhs), .some(let rhs)):
+        return concatenated([lhs, rhs], axis: axis)
+    case (.some(let lhs), .none):
+        return lhs
+    case (.none, .some(let rhs)):
+        return rhs
+    case (.none, .none):
+        return nil
+    }
+}
+
 final class Gemma4QuantizedTensorState {
     let weight: MLXArray
     let scales: MLXArray
@@ -582,6 +595,27 @@ final class Gemma4QuantizedTensorState {
         self.groupSize = groupSize
         self.bits = bits
         self.dtype = source.dtype
+    }
+
+    init(weight: MLXArray, scales: MLXArray, biases: MLXArray?, groupSize: Int, bits: Int, dtype: DType) {
+        self.weight = weight
+        self.scales = scales
+        self.biases = biases
+        self.groupSize = groupSize
+        self.bits = bits
+        self.dtype = dtype
+    }
+
+    func appending(_ source: MLXArray) -> Gemma4QuantizedTensorState {
+        let next = Gemma4QuantizedTensorState(source: source, groupSize: groupSize, bits: bits)
+        return Gemma4QuantizedTensorState(
+            weight: concatenated([weight, next.weight], axis: 2),
+            scales: concatenated([scales, next.scales], axis: 2),
+            biases: concatenatedOptional(biases, next.biases, axis: 2),
+            groupSize: groupSize,
+            bits: bits,
+            dtype: dtype
+        )
     }
 
     func dequantized() -> MLXArray {
@@ -635,6 +669,11 @@ final class Gemma4QuantizedKVCache: Gemma4AttentionCache {
     }
 
     func append(keys: MLXArray, values: MLXArray) {
+        guard maxSize != nil else {
+            appendUnbounded(keys: keys, values: values)
+            return
+        }
+
         let existing = reconstructState()
 
         let combinedKeys: MLXArray
@@ -660,6 +699,69 @@ final class Gemma4QuantizedKVCache: Gemma4AttentionCache {
         }
 
         repartition(keys: keptKeys, values: keptValues, newOffset: newOffset)
+    }
+
+    private func appendUnbounded(keys: MLXArray, values: MLXArray) {
+        let tokenCount = keys.dim(2)
+        let newOffset = offset + tokenCount
+        defer { offset = newOffset }
+
+        guard let keyBits = configuration.keyBits,
+              let valueBits = configuration.valueBits else {
+            appendLeading(keys: keys, values: values)
+            return
+        }
+
+        let plainCount = max(0, min(tokenCount, configuration.quantizedStart - offset))
+        if plainCount > 0 {
+            appendLeading(
+                keys: keys[0..., 0..., ..<plainCount, 0...],
+                values: values[0..., 0..., ..<plainCount, 0...]
+            )
+        }
+
+        guard plainCount < tokenCount else {
+            return
+        }
+
+        appendQuantized(
+            keys: keys[0..., 0..., plainCount..., 0...],
+            values: values[0..., 0..., plainCount..., 0...],
+            keyBits: keyBits,
+            valueBits: valueBits
+        )
+    }
+
+    private func appendLeading(keys: MLXArray, values: MLXArray) {
+        if let existingKeys = leadingKeys, let existingValues = leadingValues {
+            leadingKeys = concatenated([existingKeys, keys], axis: 2)
+            leadingValues = concatenated([existingValues, values], axis: 2)
+        } else {
+            leadingKeys = keys
+            leadingValues = values
+        }
+    }
+
+    private func appendQuantized(keys: MLXArray, values: MLXArray, keyBits: Int, valueBits: Int) {
+        if let quantizedKeys {
+            self.quantizedKeys = quantizedKeys.appending(keys)
+        } else {
+            quantizedKeys = Gemma4QuantizedTensorState(
+                source: keys,
+                groupSize: configuration.groupSize,
+                bits: keyBits
+            )
+        }
+
+        if let quantizedValues {
+            self.quantizedValues = quantizedValues.appending(values)
+        } else {
+            quantizedValues = Gemma4QuantizedTensorState(
+                source: values,
+                groupSize: configuration.groupSize,
+                bits: valueBits
+            )
+        }
     }
 
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -2,6 +2,7 @@ import Foundation
 import MLX
 import MLXFast
 import MLXNN
+import MLXRandom
 
 @inline(__always)
 private func gemma4RepeatAlongHeads(_ x: MLXArray, heads: Int) -> MLXArray {
@@ -181,6 +182,174 @@ final class Gemma4MLP: Module {
     }
 }
 
+final class Gemma4SwitchLinear: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "scales") var scales: MLXArray?
+    @ModuleInfo(key: "biases") var biases: MLXArray?
+    @ModuleInfo(key: "bias") var bias: MLXArray?
+
+    private let groupSize: Int
+    private let bits: Int
+    private let mode: QuantizationMode
+
+    init(
+        inputDims: Int,
+        outputDims: Int,
+        numExperts: Int,
+        groupSize: Int = 16,
+        bits: Int = 4,
+        mode: QuantizationMode = .nvfp4,
+        bias: Bool = false
+    ) {
+        self.groupSize = groupSize
+        self.bits = bits
+        self.mode = mode
+        let scale = sqrt(1.0 / Float(max(1, inputDims)))
+        self._weight.wrappedValue = MLXRandom.uniform(
+            low: -scale,
+            high: scale,
+            [numExperts, outputDims, inputDims]
+        )
+        let groups = max(1, (inputDims + groupSize - 1) / groupSize)
+        self._scales.wrappedValue = MLXArray.zeros([numExperts, outputDims, groups])
+        self._biases.wrappedValue = nil
+        if bias {
+            self._bias.wrappedValue = MLXArray.zeros([numExperts, outputDims])
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let sequenceLength = x.dim(1)
+        let topK = indices.dim(2)
+        let inputDim = x.dim(x.ndim - 1)
+        let batchTokens = batch * sequenceLength
+
+        let flatX: MLXArray
+        if x.ndim == 4 && x.dim(2) == topK {
+            flatX = x.reshaped([batchTokens * topK, 1, inputDim])
+        } else {
+            var expanded = x.reshaped([batchTokens, 1, inputDim])
+            expanded = MLX.expandedDimensions(expanded, axis: 1)
+            expanded = MLX.repeated(expanded, count: topK, axis: 1)
+            flatX = expanded.reshaped([batchTokens * topK, 1, inputDim])
+        }
+
+        let flatIndices = indices.reshaped([batchTokens * topK])
+        let output: MLXArray
+        if let scales {
+            output = gatherQuantizedMM(
+                flatX,
+                weight,
+                scales: scales,
+                biases: biases,
+                rhsIndices: flatIndices,
+                transpose: true,
+                groupSize: groupSize,
+                bits: bits,
+                mode: mode,
+                sortedIndices: false
+            )
+        } else {
+            output = gatherMM(
+                flatX,
+                weight.swappedAxes(-1, -2),
+                rhsIndices: flatIndices,
+                sortedIndices: false
+            )
+        }
+
+        let outputDim = output.dim(2)
+        var reshaped = output.reshaped([batchTokens, topK, outputDim])
+        reshaped = reshaped.reshaped([batch, sequenceLength, topK, outputDim])
+
+        if let bias {
+            let selectedBias = take(bias, flatIndices, axis: 0)
+                .reshaped([batch, sequenceLength, topK, outputDim])
+            return reshaped + selectedBias
+        }
+        return reshaped
+    }
+}
+
+final class Gemma4SwitchGLU: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Gemma4SwitchLinear
+    @ModuleInfo(key: "up_proj") var upProj: Gemma4SwitchLinear
+    @ModuleInfo(key: "down_proj") var downProj: Gemma4SwitchLinear
+
+    init(config: Gemma4TextConfig) {
+        self._gateProj.wrappedValue = Gemma4SwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: max(1, config.moeIntermediateSize),
+            numExperts: max(1, config.numExperts)
+        )
+        self._upProj.wrappedValue = Gemma4SwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: max(1, config.moeIntermediateSize),
+            numExperts: max(1, config.numExperts)
+        )
+        self._downProj.wrappedValue = Gemma4SwitchLinear(
+            inputDims: max(1, config.moeIntermediateSize),
+            outputDims: config.hiddenSize,
+            numExperts: max(1, config.numExperts)
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let up = upProj(x, indices: indices)
+        let gate = gateProj(x, indices: indices)
+        return downProj(geluApproximate(gate) * up, indices: indices)
+    }
+}
+
+final class Gemma4Router: Module {
+    @ModuleInfo(key: "proj") var proj: Linear
+    @ParameterInfo(key: "scale") var scale: MLXArray
+    @ParameterInfo(key: "per_expert_scale") var perExpertScale: MLXArray
+
+    private let topK: Int
+    private let eps: Float
+    private let rootSize: Float
+
+    init(config: Gemma4TextConfig) {
+        self.topK = max(1, config.topKExperts)
+        self.eps = config.rmsNormEps
+        self.rootSize = pow(Float(max(1, config.hiddenSize)), -0.5)
+        self._proj.wrappedValue = Linear(config.hiddenSize, max(1, config.numExperts), bias: false)
+        self._scale.wrappedValue = MLXArray.ones([config.hiddenSize])
+        self._perExpertScale.wrappedValue = MLXArray.ones([max(1, config.numExperts)])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (indices: MLXArray, weights: MLXArray) {
+        let normWeight = scale * MLXArray(rootSize).asType(scale.dtype)
+        let routedInput = MLXFast.rmsNorm(x, weight: normWeight, eps: eps)
+        let expertScores = proj(routedInput)
+        let k = min(topK, expertScores.dim(-1))
+        let indices = argPartition(-expertScores, kth: k - 1, axis: -1)[.ellipsis, 0..<k]
+        var weights = takeAlong(expertScores, indices, axis: -1)
+        weights = softmax(weights, axis: -1)
+        weights = weights * take(perExpertScale, indices, axis: 0)
+        return (indices, weights)
+    }
+}
+
+final class Gemma4Experts: Module {
+    @ModuleInfo(key: "switch_glu") var switchGLU: Gemma4SwitchGLU
+
+    init(config: Gemma4TextConfig) {
+        self._switchGLU.wrappedValue = Gemma4SwitchGLU(config: config)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray, weights: MLXArray) -> MLXArray {
+        let routed = switchGLU(x, indices: indices)
+        return (routed * MLX.expandedDimensions(weights, axis: weights.ndim)).sum(axis: -2)
+    }
+}
+
 final class Gemma4Attention: Module {
     @ModuleInfo(key: "q_proj") var qProj: Linear
     @ModuleInfo(key: "k_proj") var kProj: Linear
@@ -260,15 +429,33 @@ final class Gemma4Attention: Module {
 
         let keys: MLXArray
         let values: MLXArray
-        if isKVSharedLayer, let shared = cache?.currentState() {
+        if isKVSharedLayer, let cache {
             if sequenceLength == 1,
-               let cache,
                let attended = cache.specializedAttention(queries: queries, repeats: repeats, scale: scale) {
                 let reshaped = attended.transposed(0, 2, 1, 3).reshaped(batchSize, sequenceLength, numHeads * headDim)
                 return oProj(reshaped)
             }
-            keys = shared.0
-            values = shared.1
+            if let shared = cache.currentState() {
+                keys = shared.0
+                values = shared.1
+            } else {
+                var rawKeys = kProj(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
+                var rawValues = useKeyEqualsValue
+                    ? rawKeys
+                    : vProj!(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
+
+                rawKeys = kNorm(rawKeys)
+                rawValues = gemma4RMSNormNoScale(rawValues, eps: rmsNormEps)
+
+                var computedKeys = rawKeys.transposed(0, 2, 1, 3)
+                let computedValues = rawValues.transposed(0, 2, 1, 3)
+                computedKeys = rope(computedKeys, offset: offset)
+
+                cache.append(keys: computedKeys, values: computedValues)
+                let updated = cache.currentState()!
+                keys = updated.0
+                values = updated.1
+            }
         } else {
             var rawKeys = kProj(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
             var rawValues = useKeyEqualsValue
@@ -354,10 +541,15 @@ final class Gemma4Attention: Module {
 final class Gemma4DecoderLayer: Module {
     @ModuleInfo(key: "self_attn") var selfAttention: Gemma4Attention
     @ModuleInfo(key: "mlp") var mlp: Gemma4MLP
+    @ModuleInfo(key: "router") var router: Gemma4Router?
+    @ModuleInfo(key: "experts") var experts: Gemma4Experts?
     @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
     @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayerNorm: RMSNorm
     @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayerNorm: RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm_2") var preFeedforwardLayerNorm2: RMSNorm?
+    @ModuleInfo(key: "post_feedforward_layernorm_1") var postFeedforwardLayerNorm1: RMSNorm?
+    @ModuleInfo(key: "post_feedforward_layernorm_2") var postFeedforwardLayerNorm2: RMSNorm?
     @ModuleInfo(key: "per_layer_input_gate") var perLayerInputGate: Linear
     @ModuleInfo(key: "per_layer_projection") var perLayerProjection: Linear
     @ModuleInfo(key: "post_per_layer_input_norm") var postPerLayerInputNorm: RMSNorm
@@ -368,6 +560,19 @@ final class Gemma4DecoderLayer: Module {
     init(config: Gemma4TextConfig, layerIndex: Int) {
         self._selfAttention.wrappedValue = Gemma4Attention(config: config, layerIndex: layerIndex)
         self._mlp.wrappedValue = Gemma4MLP(config: config, layerIndex: layerIndex)
+        if config.enableMoEBlock {
+            self._router.wrappedValue = Gemma4Router(config: config)
+            self._experts.wrappedValue = Gemma4Experts(config: config)
+            self._preFeedforwardLayerNorm2.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+            self._postFeedforwardLayerNorm1.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+            self._postFeedforwardLayerNorm2.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        } else {
+            self._router.wrappedValue = nil
+            self._experts.wrappedValue = nil
+            self._preFeedforwardLayerNorm2.wrappedValue = nil
+            self._postFeedforwardLayerNorm1.wrappedValue = nil
+            self._postFeedforwardLayerNorm2.wrappedValue = nil
+        }
         self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._preFeedforwardLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
@@ -392,8 +597,21 @@ final class Gemma4DecoderLayer: Module {
         hidden = attentionResidual + hidden
 
         let mlpResidual = hidden
-        hidden = preFeedforwardLayerNorm(hidden)
-        hidden = mlp(hidden)
+        if let router, let experts, let preFeedforwardLayerNorm2, let postFeedforwardLayerNorm1, let postFeedforwardLayerNorm2 {
+            var dense = preFeedforwardLayerNorm(hidden)
+            dense = mlp(dense)
+            dense = postFeedforwardLayerNorm1(dense)
+
+            let route = router(hidden)
+            var sparse = preFeedforwardLayerNorm2(hidden)
+            sparse = experts(sparse, indices: route.indices, weights: route.weights)
+            sparse = postFeedforwardLayerNorm2(sparse)
+
+            hidden = dense + sparse
+        } else {
+            hidden = preFeedforwardLayerNorm(hidden)
+            hidden = mlp(hidden)
+        }
         hidden = postFeedforwardLayerNorm(hidden)
         hidden = mlpResidual + hidden
 

--- a/Sources/MereRunCore/Gemma4/Gemma4Resources.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Resources.swift
@@ -4,13 +4,18 @@ public struct Gemma4Resources: Sendable, Hashable {
     public static let defaultModelId = "text-chat-gemma4"
     public static let nanoModelId = "text-chat-gemma4-nano"
     public static let maxModelId = "text-chat-gemma4-max"
+    public static let turboModelId = "text-chat-gemma4-turbo"
     public static let nanoUpstreamModelId = "google/gemma-4-E4B-it"
     public static let maxUpstreamModelId = "google/gemma-4-31B-it"
+    public static let turboUpstreamModelId = "mlx-community/gemma-4-26b-a4b-it-nvfp4"
     public static let defaultUpstreamModelId = maxUpstreamModelId
     public static let defaultContextLength = 32_768
     public static let defaultKVGroupSize = 64
     public static let defaultQuantizedKVStart = 5_000
     public static let defaultKVQuantizationScheme: Gemma4KVQuantizationScheme = .uniform
+    public static let defaultTurboKVBits = 4.0
+    public static let defaultTurboQuantizedKVStart = 0
+    public static let defaultTurboKVQuantizationScheme: Gemma4KVQuantizationScheme = .turboquant
     public static let snapshotPatterns = [
         "config.json",
         "generation_config.json",
@@ -81,6 +86,13 @@ public struct Gemma4Resources: Sendable, Hashable {
             return false
         }
         return trimmed.split(separator: "/").count == 2
+    }
+
+    public static func usesTurboDefaults(modelSpec raw: String) -> Bool {
+        let normalized = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized == turboModelId || normalized == turboUpstreamModelId.lowercased()
     }
 }
 

--- a/Sources/MereRunCore/HFSafetensorsWeightsLoader.swift
+++ b/Sources/MereRunCore/HFSafetensorsWeightsLoader.swift
@@ -56,6 +56,16 @@ public enum HFSafetensorsWeightsLoader {
         }
     }
 
+    public typealias QuantizedModuleResolver = (
+        _ path: String,
+        _ module: Module,
+        _ quantizedWeight: MLXArray,
+        _ scales: MLXArray,
+        _ biases: MLXArray?,
+        _ fallbackGroupSize: Int,
+        _ fallbackBits: Int
+    ) -> (groupSize: Int, bits: Int, mode: QuantizationMode)
+
     /// Applies weights from a Hugging Face sharded safetensors index (`*.safetensors.index.json`).
     ///
     /// This streams shards one-at-a-time to keep peak memory low.
@@ -250,6 +260,7 @@ public enum HFSafetensorsWeightsLoader {
         groupSize: Int = 64,
         bits: Int = 4,
         applySVDResiduals: Bool? = nil,
+        quantizedModuleResolver: QuantizedModuleResolver? = nil,
         keyMapper: ((String) -> String)? = nil,
         mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in [(key, value)] },
         progressHandler: (@Sendable (ShardProgress) -> Void)? = nil
@@ -312,6 +323,15 @@ public enum HFSafetensorsWeightsLoader {
                     fallbackGroupSize: groupSize,
                     fallbackBits: bits
                 )
+                let resolved = quantizedModuleResolver?(
+                    path,
+                    module,
+                    qWeight,
+                    scales,
+                    qBiases,
+                    qp.groupSize,
+                    qp.bits
+                ) ?? (groupSize: qp.groupSize, bits: qp.bits, mode: QuantizationMode.affine)
 
                 let quantized: Module
                 if useResiduals, let svdUp, let svdDown {
@@ -320,8 +340,9 @@ public enum HFSafetensorsWeightsLoader {
                         bias: linearBias,
                         scales: scales,
                         biases: qBiases,
-                        groupSize: qp.groupSize,
-                        bits: qp.bits,
+                        groupSize: resolved.groupSize,
+                        bits: resolved.bits,
+                        mode: resolved.mode,
                         residualDown: svdDown,
                         residualUp: svdUp
                     )
@@ -332,8 +353,9 @@ public enum HFSafetensorsWeightsLoader {
                         bias: linearBias,
                         scales: scales,
                         biases: qBiases,
-                        groupSize: qp.groupSize,
-                        bits: qp.bits
+                        groupSize: resolved.groupSize,
+                        bits: resolved.bits,
+                        mode: resolved.mode
                     )
                 }
                 quantizedReplacements[path] = quantized
@@ -348,12 +370,22 @@ public enum HFSafetensorsWeightsLoader {
                     fallbackGroupSize: groupSize,
                     fallbackBits: bits
                 )
+                let resolved = quantizedModuleResolver?(
+                    path,
+                    module,
+                    qWeight,
+                    scales,
+                    qBiases,
+                    qp.groupSize,
+                    qp.bits
+                ) ?? (groupSize: qp.groupSize, bits: qp.bits, mode: QuantizationMode.affine)
                 let quantized = PreQuantizedEmbedding(
                     weight: qWeight,
                     scales: scales,
                     biases: qBiases,
-                    groupSize: qp.groupSize,
-                    bits: qp.bits
+                    groupSize: resolved.groupSize,
+                    bits: resolved.bits,
+                    mode: resolved.mode
                 )
                 quantizedReplacements[path] = quantized
             } else {
@@ -442,6 +474,7 @@ public enum HFSafetensorsWeightsLoader {
         groupSize: Int = 64,
         bits: Int = 4,
         applySVDResiduals: Bool? = nil,
+        quantizedModuleResolver: QuantizedModuleResolver? = nil,
         keyMapper: ((String) -> String)? = nil,
         mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in [(key, value)] }
     ) throws {
@@ -500,6 +533,15 @@ public enum HFSafetensorsWeightsLoader {
                     fallbackGroupSize: groupSize,
                     fallbackBits: bits
                 )
+                let resolved = quantizedModuleResolver?(
+                    path,
+                    module,
+                    qWeight,
+                    scales,
+                    qBiases,
+                    qp.groupSize,
+                    qp.bits
+                ) ?? (groupSize: qp.groupSize, bits: qp.bits, mode: QuantizationMode.affine)
 
                 let quantized: Module
                 if useResiduals, let svdUp, let svdDown {
@@ -508,8 +550,9 @@ public enum HFSafetensorsWeightsLoader {
                         bias: linearBias,
                         scales: scales,
                         biases: qBiases,
-                        groupSize: qp.groupSize,
-                        bits: qp.bits,
+                        groupSize: resolved.groupSize,
+                        bits: resolved.bits,
+                        mode: resolved.mode,
                         residualDown: svdDown,
                         residualUp: svdUp
                     )
@@ -520,8 +563,9 @@ public enum HFSafetensorsWeightsLoader {
                         bias: linearBias,
                         scales: scales,
                         biases: qBiases,
-                        groupSize: qp.groupSize,
-                        bits: qp.bits
+                        groupSize: resolved.groupSize,
+                        bits: resolved.bits,
+                        mode: resolved.mode
                     )
                 }
                 quantizedReplacements[path] = quantized
@@ -535,12 +579,22 @@ public enum HFSafetensorsWeightsLoader {
                     fallbackGroupSize: groupSize,
                     fallbackBits: bits
                 )
+                let resolved = quantizedModuleResolver?(
+                    path,
+                    module,
+                    qWeight,
+                    scales,
+                    qBiases,
+                    qp.groupSize,
+                    qp.bits
+                ) ?? (groupSize: qp.groupSize, bits: qp.bits, mode: QuantizationMode.affine)
                 let quantized = PreQuantizedEmbedding(
                     weight: qWeight,
                     scales: scales,
                     biases: qBiases,
-                    groupSize: qp.groupSize,
-                    bits: qp.bits
+                    groupSize: resolved.groupSize,
+                    bits: resolved.bits,
+                    mode: resolved.mode
                 )
                 quantizedReplacements[path] = quantized
             } else {

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift
@@ -40,7 +40,11 @@ public enum HiDreamO1SampleBuilder {
         }
         let ratio = Double(width) / Double(height)
         return predefinedResolutions.min { lhs, rhs in
-            abs(Double(lhs.width) / Double(lhs.height) - ratio) < abs(Double(rhs.width) / Double(rhs.height) - ratio)
+            let lhsRatio = Double(lhs.width) / Double(lhs.height)
+            let rhsRatio = Double(rhs.width) / Double(rhs.height)
+            let lhsDistance = Darwin.fabs(lhsRatio - ratio)
+            let rhsDistance = Darwin.fabs(rhsRatio - ratio)
+            return lhsDistance < rhsDistance
         } ?? predefinedResolutions[0]
     }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -291,6 +291,20 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["api serve"]
         ),
         ManagedModelSpec(
+            id: Gemma4Resources.turboModelId,
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Gemma4Resources.turboUpstreamModelId,
+                patterns: Gemma4Resources.snapshotPatterns
+            ),
+            upstreamRepoId: Gemma4Resources.turboUpstreamModelId,
+            validationKind: .gemma4,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 31 * 1_073_741_824,
+            defaultCLICommands: ["text chat", "api serve"]
+        ),
+        ManagedModelSpec(
             id: "text-chat-gemma4-nano",
             category: .textChat,
             installShape: .directoryRoot,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -200,10 +200,18 @@ public enum ManagedModelCapabilityCatalog {
             ),
             descriptor(
                 "text-chat-gemma4",
-                "Gemma 4 chat alias",
-                "Resolves to the best installed Gemma 4 chat model for native Swift text chat.",
-                minimum: 16,
-                recommended: 32
+                "Gemma 4 dense bf16 alias",
+                "Resolves to dense bf16 Gemma 4 chat models for native Swift text chat; use the TurboQuant tier on 32 GB Macs.",
+                minimum: 48,
+                recommended: 64
+            ),
+            descriptor(
+                Gemma4Resources.turboModelId,
+                "Gemma 4 NVFP4 MoE",
+                "Installs the MLX NVFP4 Gemma 4 26B-A4B-it MoE snapshot for the native Swift 32 GB tier.",
+                minimum: 24,
+                recommended: 32,
+                setup: true
             ),
             descriptor(
                 "text-chat-gemma4-nano",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -77,6 +77,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case base
         case max
         case latest
+        case turbo
     }
 
     public enum Variant: String, Codable, CaseIterable, Hashable, Sendable {
@@ -564,6 +565,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.chat],
                 components: gemma4TextComponents,
                 upstreamRepoId: Gemma4Resources.maxUpstreamModelId,
+                createdAt: createdAt
+            )
+        case .gemma4Turbo:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .gemma4,
+                family: .gemma,
+                tier: .turbo,
+                variant: .standard,
+                precision: .int4,
+                defaults: nil,
+                supports: [.chat],
+                components: gemma4TextComponents,
+                upstreamRepoId: Gemma4Resources.turboUpstreamModelId,
                 createdAt: createdAt
             )
         case .q35:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -92,7 +92,17 @@ public enum MereRunModelValidator {
         let rootConfig = rootURL.appendingPathComponent("config.json")
 
         let hasRootMarker = fileManager.fileExists(atPath: modelIndex.path) || fileManager.fileExists(atPath: rootConfig.path)
-        if !hasRootMarker && !usesMFluxZImage {
+        let requiresRootMarker: Bool = {
+            guard let spec else { return true }
+            switch spec.installShape {
+            case .singleFile:
+                return false
+            case .directoryRoot, .structuredRoot:
+                return spec.validationKind != .codegenGGUF
+                    && spec.validationKind != .deepseekV4FlashIMatrixGGUF
+            }
+        }()
+        if !hasRootMarker && !usesMFluxZImage && requiresRootMarker {
             warnings.append("Missing model root marker (expected model_index.json).")
         }
 
@@ -343,7 +353,9 @@ public enum MereRunModelValidator {
             switch precision {
             case .int4, .int8:
                 guard let q = manifest.quantization else {
-                    errors.append("Quantized precision (\(precision.rawValue)) requires quantization metadata.")
+                    if manifestRequiresInlineQuantization(manifest) {
+                        errors.append("Quantized precision (\(precision.rawValue)) requires quantization metadata.")
+                    }
                     break
                 }
                 if let bits = q.bits, !(2...8).contains(bits) {
@@ -427,6 +439,15 @@ public enum MereRunModelValidator {
         if supportsImagePipeline && !usesUnifiedImageTransformer && components.scheduler == nil { errors.append("Manifest components missing scheduler.") }
     }
 
+    private static func manifestRequiresInlineQuantization(_ manifest: MereRunModelManifest) -> Bool {
+        switch manifest.engine {
+        case .flux2Klein?, .zimageTurbo?, .qwen35HybridMoE?:
+            return true
+        default:
+            return false
+        }
+    }
+
     private static func inferFamily(from modelId: String) -> MereRunModelManifest.Family? {
         if modelId.hasPrefix("image-klein-") { return .klein }
         if modelId.hasPrefix("image-zimage-") { return .zimage }
@@ -444,7 +465,8 @@ public enum MereRunModelValidator {
         if modelId.hasPrefix("text-chat-psi-") { return .psi }
         if modelId == ModelResolver.ModelID.gemma4.rawValue
             || modelId == ModelResolver.ModelID.gemma4Nano.rawValue
-            || modelId == ModelResolver.ModelID.gemma4Max.rawValue {
+            || modelId == ModelResolver.ModelID.gemma4Max.rawValue
+            || modelId == ModelResolver.ModelID.gemma4Turbo.rawValue {
             return .gemma
         }
         if modelId == ModelResolver.ModelID.q35.rawValue || modelId == ModelResolver.ModelID.q35Nano.rawValue {

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -23,6 +23,7 @@ public struct ModelResolver {
         case gemma4 = "text-chat-gemma4"
         case gemma4Nano = "text-chat-gemma4-nano"
         case gemma4Max = "text-chat-gemma4-max"
+        case gemma4Turbo = "text-chat-gemma4-turbo"
         case q35 = "text-chat-q35"
         case q35Nano = "text-chat-q35-nano"
         case qwen35Agent9B = "text-agent-qwen35-9b"

--- a/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
+++ b/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
@@ -153,7 +153,7 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
 
     private struct LoadedState {
         let config: SAM31ModelConfig
-        let tokenizer: SAM31Tokenizer
+        let tokenizer: SAM31Tokenizer?
         let model: SAM31Model
     }
 
@@ -280,7 +280,12 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             switch promptObject.promptKind {
             case .text:
                 guard let textPrompt = promptObject.textPrompt else { continue }
-                let tokens = state.tokenizer.encode(
+                guard let tokenizer = state.tokenizer else {
+                    throw SegmenterError.failedToEncodeMetadata(
+                        "Text prompts require tokenizer.json and tokenizer_config.json in the SAM 3.1 model root."
+                    )
+                }
+                let tokens = tokenizer.encode(
                     prompts: [textPrompt],
                     maxLength: state.config.detectorConfig.textConfig.maxPositionEmbeddings
                 )
@@ -401,7 +406,15 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
 
         let resources = SAM31Resources(modelRootURL: modelRootURL)
         let config = try SAM31ModelConfig.load(from: resources.configURL)
-        let tokenizer = try SAM31Tokenizer.load(from: resources.tokenizerRootURL)
+        let tokenizer: SAM31Tokenizer?
+        let tokenizerConfigURL = resources.tokenizerRootURL.appendingPathComponent("tokenizer_config.json")
+        let tokenizerDataURL = resources.tokenizerRootURL.appendingPathComponent("tokenizer.json")
+        if fileManager.fileExists(atPath: tokenizerConfigURL.path),
+           fileManager.fileExists(atPath: tokenizerDataURL.path) {
+            tokenizer = try SAM31Tokenizer.load(from: resources.tokenizerRootURL)
+        } else {
+            tokenizer = nil
+        }
         let model = SAM31Model(config: config)
         try Self.loadWeights(resources: resources, into: model)
 

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -21,9 +21,9 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.rateLimitPerMinute, 60)
         XCTAssertEqual(cmd.contextSize, 32_768)
         XCTAssertNil(cmd.kvBits)
-        XCTAssertEqual(cmd.kvQuantScheme, "uniform")
-        XCTAssertEqual(cmd.kvGroupSize, 64)
-        XCTAssertEqual(cmd.quantizedKVStart, 5_000)
+        XCTAssertNil(cmd.kvQuantScheme)
+        XCTAssertNil(cmd.kvGroupSize)
+        XCTAssertNil(cmd.quantizedKVStart)
     }
 
     func testAPIServeParsesOverrides() throws {
@@ -68,6 +68,23 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(quantization.scheme, .turboquant)
         XCTAssertEqual(quantization.groupSize, Gemma4Resources.defaultKVGroupSize)
         XCTAssertEqual(quantization.quantizedStart, Gemma4Resources.defaultTurboQuantizedKVStart)
+    }
+
+    func testAPIServeGemma4TurboKVFlagsOverrideIndependently() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-gemma4",
+            "--model-path", Gemma4Resources.turboModelId,
+            "--kv-quant-scheme", "uniform",
+            "--kv-group-size", "32",
+            "--quantized-kv-start", "128",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization()
+
+        XCTAssertEqual(quantization.bits, Gemma4Resources.defaultTurboKVBits)
+        XCTAssertEqual(quantization.scheme, .uniform)
+        XCTAssertEqual(quantization.groupSize, 32)
+        XCTAssertEqual(quantization.quantizedStart, 128)
     }
 
     func testHealthContractUsesStablePayload() {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -56,6 +56,20 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.quantizedKVStart, 2048)
     }
 
+    func testAPIServeGemma4TurboModelDefaultsToTurboQuantKVCache() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-gemma4",
+            "--model-path", Gemma4Resources.turboModelId,
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization()
+
+        XCTAssertEqual(quantization.bits, Gemma4Resources.defaultTurboKVBits)
+        XCTAssertEqual(quantization.scheme, .turboquant)
+        XCTAssertEqual(quantization.groupSize, Gemma4Resources.defaultKVGroupSize)
+        XCTAssertEqual(quantization.quantizedStart, Gemma4Resources.defaultTurboQuantizedKVStart)
+    }
+
     func testHealthContractUsesStablePayload() {
         XCTAssertEqual(APIServerContract.healthStatus(), APIHealthStatus(status: "ok"))
     }

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MereRunCLI
+@testable import MereRunCore
 
 final class TextChatCommandParsingTests: XCTestCase {
     func testTextChatDefaultsToNonStreamingCLIOutput() throws {
@@ -18,5 +19,37 @@ final class TextChatCommandParsingTests: XCTestCase {
         ])
 
         XCTAssertTrue(cmd.stream)
+    }
+
+    func testGemma4TurboDefaultsToTurboQuantKVCache() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+            "--model", Gemma4Resources.turboModelId,
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization(for: Gemma4Resources.turboModelId)
+
+        XCTAssertEqual(quantization.bits, Gemma4Resources.defaultTurboKVBits)
+        XCTAssertEqual(quantization.scheme, .turboquant)
+        XCTAssertEqual(quantization.groupSize, Gemma4Resources.defaultKVGroupSize)
+        XCTAssertEqual(quantization.quantizedStart, Gemma4Resources.defaultTurboQuantizedKVStart)
+    }
+
+    func testExplicitGemma4KVCacheOptionsOverrideTurboDefaults() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+            "--model", Gemma4Resources.turboModelId,
+            "--kv-bits", "3.5",
+            "--kv-quant-scheme", "turboquant",
+            "--kv-group-size", "32",
+            "--quantized-kv-start", "128",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization(for: Gemma4Resources.turboModelId)
+
+        XCTAssertEqual(quantization.bits, 3.5)
+        XCTAssertEqual(quantization.scheme, .turboquant)
+        XCTAssertEqual(quantization.groupSize, 32)
+        XCTAssertEqual(quantization.quantizedStart, 128)
     }
 }

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -52,4 +52,21 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertEqual(quantization.groupSize, 32)
         XCTAssertEqual(quantization.quantizedStart, 128)
     }
+
+    func testGemma4TurboKVFlagsOverrideIndependently() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+            "--model", Gemma4Resources.turboModelId,
+            "--kv-quant-scheme", "uniform",
+            "--kv-group-size", "32",
+            "--quantized-kv-start", "128",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization(for: Gemma4Resources.turboModelId)
+
+        XCTAssertEqual(quantization.bits, Gemma4Resources.defaultTurboKVBits)
+        XCTAssertEqual(quantization.scheme, .uniform)
+        XCTAssertEqual(quantization.groupSize, 32)
+        XCTAssertEqual(quantization.quantizedStart, 128)
+    }
 }

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -112,4 +112,17 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         XCTAssertNil(attention.vProj)
         XCTAssertEqual(output.shape, [1, 2, config.hiddenSize])
     }
+
+    func testMoEDecoderLayerInstallsRouterAndExperts() throws {
+        var configObject = makeBaseConfig()
+        configObject["enable_moe_block"] = true
+        configObject["num_experts"] = 4
+        configObject["top_k_experts"] = 2
+        configObject["moe_intermediate_size"] = 4
+        let config = try decodeTextConfig(configObject)
+        let layer = Gemma4DecoderLayer(config: config, layerIndex: 0)
+
+        XCTAssertNotNil(layer.router)
+        XCTAssertNotNil(layer.experts)
+    }
 }

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -71,6 +71,14 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.upstreamRevision, "main")
     }
 
+    func testGemma4TurboUsesNVFP4HubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Gemma4Resources.turboModelId))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "mlx-community/gemma-4-26b-a4b-it-nvfp4")
+        XCTAssertEqual(spec.upstreamRepoId, "mlx-community/gemma-4-26b-a4b-it-nvfp4")
+        XCTAssertEqual(spec.validationKind, .gemma4)
+    }
+
     func testZImageNanoAcceptsMFluxLayoutWithoutDiffusersConfigs() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -39,6 +39,34 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(report.reasons, [])
     }
 
+    func testDenseGemma4IsRejectedOnThirtyTwoGB() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Gemma4Resources.defaultModelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M1 Max",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+
+        XCTAssertFalse(report.isSupported)
+        XCTAssertTrue(report.reasons.joined(separator: " ").contains("Requires at least 48 GB"))
+    }
+
+    func testGemma4TurboIsSupportedOnThirtyTwoGB() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Gemma4Resources.turboModelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M1 Max",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertEqual(report.reasons, [])
+    }
+
     func testNonAppleSiliconMacIsRejected() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -94,6 +94,25 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors"), contents: Data())
     }
 
+    private func writeMinimalValidQwen3ASRModel(at root: URL) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: .qwen3ASR, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent("config.json"),
+            contents: Data(#"{"quantization":{"bits":8,"group_size":64}}"#.utf8)
+        )
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
+    }
+
+    private func writeMinimalValidQwen35AgentGGUFModel(at root: URL) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: .qwen35Agent9B, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try TestFileSystem.writeFile(root.appendingPathComponent("Qwen3.5-9B-Q4_K_M.gguf"), contents: Data())
+    }
+
     func testValidModelPasses() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
@@ -295,5 +314,30 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertTrue(report.errors.isEmpty)
         XCTAssertEqual(report.manifest?.family, .privacy)
         XCTAssertEqual(Set(report.manifest?.supports ?? []), Set([.textAnonymization]))
+    }
+
+    func testQwen3ASRUsesHFQuantizationConfigWithoutManifestQuantization() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("speech-asr-qwen3", isDirectory: true)
+        try writeMinimalValidQwen3ASRModel(at: root)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "speech-asr-qwen3")
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+    }
+
+    func testGGUFCodeModelDoesNotRequireManifestQuantization() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("text-agent-qwen35-9b", isDirectory: true)
+        try writeMinimalValidQwen35AgentGGUFModel(at: root)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "text-agent-qwen35-9b")
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertFalse(report.warnings.contains("Missing model root marker (expected model_index.json)."))
     }
 }

--- a/Tests/MereRunCoreTests/ModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ModelResolverTests.swift
@@ -250,6 +250,24 @@ final class ModelResolverTests: MereRunCoreTestCase {
         XCTAssertEqual(resolved.source, .localModelStore)
     }
 
+    func testResolvesGemma4TurboFromProcessModelStoreOverride() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
+
+        let modelsRoot = temp.appendingPathComponent("models", isDirectory: true)
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        let modelRoot = modelsRoot.appendingPathComponent("text-chat-gemma4-turbo", isDirectory: true)
+        try writeMinimalTextRoot(at: modelRoot, id: .gemma4Turbo)
+
+        let resolver = ModelResolver()
+        let resolved = try resolver.resolve(.gemma4Turbo)
+
+        XCTAssertEqual(resolved.rootURL.standardizedFileURL, modelRoot.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .localModelStore)
+    }
+
     func testResolvesVisionSegmentSAM31FromProcessModelStoreOverride() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/demo-all-models.sh
+++ b/demo-all-models.sh
@@ -1,0 +1,471 @@
+#!/bin/bash
+# Smoke-test every installed mere.run managed model on this machine.
+#
+# This is intentionally minimal, not a quality showcase. It runs the shortest
+# practical command per model/category and writes logs/artifacts under:
+#   ~/Desktop/mererun-model-smoke/<timestamp>/
+set -uo pipefail
+
+MERE_RUN="${MERE_RUN:-mere.run}"
+OUT="${OUT:-$HOME/Desktop/mererun-model-smoke/$(date +%Y%m%d-%H%M%S)}"
+ONLY_MODEL=""
+LIST_ONLY=0
+METADATA_ONLY=0
+INCLUDE_API=1
+INCLUDE_UNSUPPORTED=0
+
+IMAGE_SIZE="${IMAGE_SIZE:-512}"
+IMAGE_STEPS="${IMAGE_STEPS:-1}"
+TEXT_MAX_TOKENS="${TEXT_MAX_TOKENS:-16}"
+MUSIC_DURATION="${MUSIC_DURATION:-2}"
+MUSIC_STEPS="${MUSIC_STEPS:-1}"
+API_PORT_BASE="${API_PORT_BASE:-18080}"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./demo-all-models.sh [options]
+
+Options:
+  --list                 List installed models that would be tested.
+  --only <model-id>      Test one installed model.
+  --metadata-only        Only run `mere.run model info --components`.
+  --no-api               Do not boot localhost API smoke tests for API-only models.
+  --include-unsupported  Also test installed models unsupported on this machine.
+  --out <dir>            Output directory.
+  -h, --help             Show this help.
+
+Environment knobs:
+  MERE_RUN=/path/to/mere.run
+  IMAGE_SIZE=512
+  IMAGE_STEPS=1
+  TEXT_MAX_TOKENS=16
+  MUSIC_DURATION=2
+  MUSIC_STEPS=1
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --list) LIST_ONLY=1; shift ;;
+    --only)
+      ONLY_MODEL="${2:-}"
+      if [[ -z "$ONLY_MODEL" ]]; then
+        echo "--only requires a model id" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --metadata-only) METADATA_ONLY=1; shift ;;
+    --no-api) INCLUDE_API=0; shift ;;
+    --include-unsupported) INCLUDE_UNSUPPORTED=1; shift ;;
+    --out)
+      OUT="${2:-}"
+      if [[ -z "$OUT" ]]; then
+        echo "--out requires a directory" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$OUT/logs" "$OUT/artifacts"
+SUMMARY="$OUT/summary.tsv"
+: > "$SUMMARY"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+ts() { date "+%H:%M:%S"; }
+log() { echo "[$(ts)] $*"; }
+slug() { printf "%s" "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+
+record() {
+  status="$1"
+  model="$2"
+  category="$3"
+  detail="$4"
+  printf "%s\t%s\t%s\t%s\n" "$status" "$model" "$category" "$detail" >> "$SUMMARY"
+  case "$status" in
+    PASS) PASS=$((PASS + 1)) ;;
+    FAIL) FAIL=$((FAIL + 1)) ;;
+    SKIP) SKIP=$((SKIP + 1)) ;;
+  esac
+  log "$status  $model  $detail"
+}
+
+run_logged() {
+  model="$1"
+  category="$2"
+  name="$3"
+  shift 3
+  logfile="$OUT/logs/$(slug "$model")--$(slug "$name").log"
+
+  log "RUN   $model  $name"
+  if "$@" >"$logfile" 2>&1; then
+    record PASS "$model" "$category" "$name"
+    return 0
+  fi
+
+  record FAIL "$model" "$category" "$name failed; see $logfile"
+  return 1
+}
+
+model_root() {
+  "$MERE_RUN" model info "$1" 2>/dev/null | awk -F': ' '/^Model Root:/ {print $2; exit}'
+}
+
+first_gguf() {
+  root="$1"
+  find -L "$root" -type f -name '*.gguf' -print 2>/dev/null | head -n 1
+}
+
+create_fixture_image() {
+  image="$OUT/artifacts/fixture.png"
+  [[ -f "$image" ]] && { printf "%s\n" "$image"; return 0; }
+
+  swift - "$image" <<'SWIFT' >/dev/null 2>&1
+import AppKit
+
+let url = URL(fileURLWithPath: CommandLine.arguments[1])
+let size = NSSize(width: 512, height: 512)
+let image = NSImage(size: size)
+image.lockFocus()
+NSColor.white.setFill()
+NSRect(origin: .zero, size: size).fill()
+NSColor.systemRed.setFill()
+NSBezierPath(rect: NSRect(x: 72, y: 170, width: 368, height: 190)).fill()
+NSColor.black.setStroke()
+let border = NSBezierPath(rect: NSRect(x: 72, y: 170, width: 368, height: 190))
+border.lineWidth = 8
+border.stroke()
+let paragraph = NSMutableParagraphStyle()
+paragraph.alignment = .center
+let attrs: [NSAttributedString.Key: Any] = [
+    .font: NSFont.boldSystemFont(ofSize: 58),
+    .foregroundColor: NSColor.black,
+    .paragraphStyle: paragraph
+]
+"MERE RUN\n123".draw(in: NSRect(x: 80, y: 210, width: 352, height: 120), withAttributes: attrs)
+image.unlockFocus()
+guard
+    let tiff = image.tiffRepresentation,
+    let rep = NSBitmapImageRep(data: tiff),
+    let png = rep.representation(using: .png, properties: [:])
+else { exit(1) }
+try png.write(to: url)
+SWIFT
+
+  if [[ ! -f "$image" ]]; then
+    echo "Unable to create fixture image at $image" >&2
+    return 1
+  fi
+  printf "%s\n" "$image"
+}
+
+ensure_audio_fixture() {
+  audio="$OUT/artifacts/fixture.wav"
+  [[ -f "$audio" ]] && { printf "%s\n" "$audio"; return 0; }
+
+  "$MERE_RUN" speech synthesize \
+    "Mere run smoke test. The quick check is working." \
+    --model speech-tts-qwen3-nano \
+    --voice "A calm clear voice" \
+    --temperature 0.2 \
+    --quiet \
+    -o "$audio" >/dev/null 2>&1
+
+  if [[ ! -f "$audio" ]]; then
+    echo "Unable to create fixture audio at $audio" >&2
+    return 1
+  fi
+  printf "%s\n" "$audio"
+}
+
+api_smoke() {
+  model="$1"
+  category="$2"
+  engine="$3"
+  model_arg="$4"
+  port="$5"
+  logfile="$OUT/logs/$(slug "$model")--api-serve.log"
+  request="$OUT/artifacts/$(slug "$model")-api-request.json"
+  response="$OUT/artifacts/$(slug "$model")-api-response.json"
+
+  cat > "$request" <<'JSON'
+{
+  "model": "local",
+  "messages": [
+    { "role": "user", "content": "Reply with exactly OK." }
+  ],
+  "max_tokens": 8,
+  "temperature": 0.1
+}
+JSON
+
+  log "RUN   $model  api serve smoke"
+  "$MERE_RUN" api serve --engine "$engine" -m "$model_arg" --port "$port" >"$logfile" 2>&1 &
+  pid=$!
+
+  ready=0
+  for _ in $(seq 1 120); do
+    if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    if ! kill -0 "$pid" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "$ready" -eq 1 ]] && curl -fsS \
+      -H "Content-Type: application/json" \
+      --data @"$request" \
+      "http://127.0.0.1:$port/v1/chat/completions" >"$response" 2>>"$logfile"; then
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+    record PASS "$model" "$category" "api serve smoke"
+    return 0
+  fi
+
+  kill "$pid" >/dev/null 2>&1 || true
+  wait "$pid" >/dev/null 2>&1 || true
+  record FAIL "$model" "$category" "api serve smoke failed; see $logfile"
+  return 1
+}
+
+smoke_model() {
+  model="$1"
+  category="$2"
+  root="$(model_root "$model")"
+
+  if [[ -z "$root" ]]; then
+    record FAIL "$model" "$category" "could not resolve model root"
+    return
+  fi
+
+  run_logged "$model" "$category" "model info" \
+    "$MERE_RUN" model info "$model" --components || return
+
+  if [[ "$METADATA_ONLY" -eq 1 ]]; then
+    return
+  fi
+
+  case "$category" in
+    image)
+      run_logged "$model" "$category" "image generate" \
+        "$MERE_RUN" image generate \
+          --model "$model" \
+          --prompt "a simple studio product photo of a red cube on a white table" \
+          --width "$IMAGE_SIZE" \
+          --height "$IMAGE_SIZE" \
+          --steps "$IMAGE_STEPS" \
+          --seed 42 \
+          --quiet \
+          --output "$OUT/artifacts/$(slug "$model").png"
+      ;;
+    text-chat)
+      case "$model" in
+        text-chat-mebot)
+          if [[ "$INCLUDE_API" -eq 1 ]]; then
+            api_smoke "$model" "$category" "text-chat-klein" "$root" "$API_PORT_BASE"
+          else
+            record SKIP "$model" "$category" "API-only smoke disabled by --no-api"
+          fi
+          ;;
+        text-chat-q35|text-chat-q35-nano)
+          run_logged "$model" "$category" "text chat" \
+            "$MERE_RUN" text chat \
+              --model "$model" \
+              --prompt "Reply with exactly OK." \
+              --max-tokens "$TEXT_MAX_TOKENS" \
+              --temperature 0.1 \
+              --quiet
+          ;;
+        *)
+          run_logged "$model" "$category" "text chat" \
+            "$MERE_RUN" text chat \
+              --model "$model" \
+              --prompt "Reply with exactly OK." \
+              --max-tokens "$TEXT_MAX_TOKENS" \
+              --temperature 0.1 \
+              --quiet
+          ;;
+      esac
+      ;;
+    text-code)
+      gguf="$(first_gguf "$root")"
+      if [[ -z "$gguf" ]]; then
+        record FAIL "$model" "$category" "no GGUF file found under $root"
+      else
+        run_logged "$model" "$category" "text code" \
+          "$MERE_RUN" text code \
+            --model "$gguf" \
+            --prompt "Write one Swift print statement that prints OK." \
+            --max-tokens "$TEXT_MAX_TOKENS" \
+            --temperature 0.1 \
+            --quiet
+      fi
+      ;;
+    speech-tts)
+      run_logged "$model" "$category" "speech synthesize" \
+        "$MERE_RUN" speech synthesize \
+          "Mere run smoke test." \
+          --model "$model" \
+          --voice "A calm clear voice" \
+          --temperature 0.2 \
+          --quiet \
+          --output "$OUT/artifacts/$(slug "$model").wav"
+      ;;
+    speech-asr)
+      audio="$(ensure_audio_fixture)" || {
+        record FAIL "$model" "$category" "could not create audio fixture"
+        return
+      }
+      backend="parakeet"
+      [[ "$model" == "speech-asr-qwen3" ]] && backend="qwen"
+      run_logged "$model" "$category" "speech transcribe" \
+        "$MERE_RUN" speech transcribe "$audio" \
+          --backend "$backend" \
+          --model "$model" \
+          --max-tokens 96 \
+          --quiet
+      ;;
+    text-embed)
+      run_logged "$model" "$category" "text embed" \
+        "$MERE_RUN" text embed \
+          --model "$model" \
+          --output "$OUT/artifacts/$(slug "$model").json" \
+          --pretty \
+          "red cube" "white table"
+      ;;
+    text-anonymize)
+      run_logged "$model" "$category" "text anonymize" \
+        "$MERE_RUN" text anonymize \
+          --model "$model" \
+          --json \
+          --pretty \
+          --output "$OUT/artifacts/$(slug "$model").json" \
+          "Alice Smith can be reached at alice@example.com."
+      ;;
+    vision-ocr)
+      image="$(create_fixture_image)" || {
+        record FAIL "$model" "$category" "could not create image fixture"
+        return
+      }
+      run_logged "$model" "$category" "vision ocr" \
+        "$MERE_RUN" vision ocr "$image" \
+          --model "$model" \
+          --backend lighton \
+          --output-dir "$OUT/artifacts/ocr-$(slug "$model")" \
+          --quiet
+      ;;
+    vision-segment)
+      image="$(create_fixture_image)" || {
+        record FAIL "$model" "$category" "could not create image fixture"
+        return
+      }
+      run_logged "$model" "$category" "vision segment" \
+        "$MERE_RUN" vision segment "$image" \
+          --model "$model" \
+          --box "72,152,440,342,red square" \
+          --output "$OUT/artifacts/$(slug "$model")-segmented.png" \
+          --json-output "$OUT/artifacts/$(slug "$model")-segmented.json" \
+          --mask-output-dir "$OUT/artifacts/$(slug "$model")-masks"
+      ;;
+    vision-ground)
+      image="$(create_fixture_image)" || {
+        record FAIL "$model" "$category" "could not create image fixture"
+        return
+      }
+      run_logged "$model" "$category" "vision ground" \
+        "$MERE_RUN" vision ground "$image" \
+          --model "$model" \
+          --query "red square" \
+          --output "$OUT/artifacts/$(slug "$model")-grounded.png" \
+          --json-output "$OUT/artifacts/$(slug "$model")-grounded.json" \
+          --mask-output-dir "$OUT/artifacts/$(slug "$model")-masks"
+      ;;
+    music)
+      run_logged "$model" "$category" "music generate" \
+        "$MERE_RUN" music generate \
+          "short warm synth tone, simple pulse" \
+          --model "$model" \
+          --duration "$MUSIC_DURATION" \
+          --steps "$MUSIC_STEPS" \
+          --seed 42 \
+          --quiet \
+          --output "$OUT/artifacts/$(slug "$model").wav"
+      ;;
+    video)
+      run_logged "$model" "$category" "video generate" \
+        "$MERE_RUN" video generate \
+          "a red cube rotating on a white table" \
+          --model "$model" \
+          --width 256 \
+          --height 256 \
+          --num-frames 9 \
+          --fps 8 \
+          --seed 42 \
+          --quiet \
+          --output "$OUT/artifacts/$(slug "$model").mp4"
+      ;;
+    *)
+      record SKIP "$model" "$category" "no smoke command registered for category"
+      ;;
+  esac
+}
+
+installed_file="$OUT/installed-models.tsv"
+if [[ "$INCLUDE_UNSUPPORTED" -eq 1 ]]; then
+  "$MERE_RUN" model list | awk 'NR > 2 && $3 == "installed" { print $1 "\t" $2 }' > "$installed_file"
+else
+  supported_file="$OUT/supported-models.txt"
+  "$MERE_RUN" model capabilities \
+    | awk '/^- / && $3 == "[supported]" { print $2 }' \
+    > "$supported_file"
+  "$MERE_RUN" model list \
+    | awk 'NR == FNR { supported[$1] = 1; next } NR > 2 && $3 == "installed" && supported[$1] { print $1 "\t" $2 }' \
+      "$supported_file" - \
+    > "$installed_file"
+fi
+
+if [[ "$LIST_ONLY" -eq 1 ]]; then
+  cat "$installed_file"
+  exit 0
+fi
+
+if [[ ! -s "$installed_file" ]]; then
+  echo "No installed models found via: $MERE_RUN model list" >&2
+  exit 1
+fi
+
+log "Output: $OUT"
+log "mere.run: $($MERE_RUN --version 2>/dev/null || echo unknown)"
+
+while IFS="$(printf '\t')" read -r model category; do
+  [[ -z "$model" ]] && continue
+  if [[ -n "$ONLY_MODEL" && "$model" != "$ONLY_MODEL" ]]; then
+    continue
+  fi
+  smoke_model "$model" "$category"
+done < "$installed_file"
+
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "Smoke complete: PASS=$PASS FAIL=$FAIL SKIP=$SKIP"
+log "Summary: $SUMMARY"
+log "Logs:    $OUT/logs"
+log "Files:   $OUT/artifacts"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -23,7 +23,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Category | Hugging Face pull IDs |
 | --- | --- |
 | Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
-| Text chat | `text-chat-gemma4`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, `text-agent-deepseek-v4-flash` |
+| Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, `text-agent-deepseek-v4-flash` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
 | Text anonymize | `text-anonymize-privacy-filter` |
@@ -54,10 +54,10 @@ Hugging Face source `unsloth/Qwen3.5-9B-GGUF` and selects
 96 GB+ Apple Silicon Macs. Q35/Qwen setup agents are lower-memory or comparison
 alternatives, not upgrades from DeepSeek V4 Flash.
 
-`text-chat-gemma4` is also the default chat model in the CLI. You can install it
-explicitly with `mere.run model pull text-chat-gemma4`, or let supported runtime
-paths resolve a Hugging Face snapshot on first use unless you point them at a
-local model root.
+`text-chat-gemma4` is the dense bf16 Gemma 4 31B alias and is gated for larger
+machines. On 32 GB Apple Silicon Macs, use `text-chat-gemma4-turbo`, which
+installs the MLX NVFP4 Gemma 4 26B-A4B-it MoE snapshot and runs through the native
+Swift Gemma runtime.
 
 Useful environment variables for that path:
 
@@ -66,8 +66,11 @@ Useful environment variables for that path:
 `vision-segment-sam31` packages the native SAM 3.1 segmentation and tracking runtime used by `mere.run vision segment`, `mere.run vision track`, and `mere.run vision track-live`. Managed or local SAM roots are expected to contain:
 
 - `config.json`
-- `tokenizer/`
 - `model.safetensors` or `model.safetensors.index.json`
+
+Tokenizer files are optional for geometry prompts. Text prompts require
+`tokenizer.json` and `tokenizer_config.json` in the SAM root or tokenizer
+subdirectory.
 
 The manifest for this package advertises both `vision_segmentation` and
 `vision_tracking` capabilities.

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -15,6 +15,7 @@ embeddings, and PII anonymization.
 ### Chat
 
 - `text-chat-gemma4`
+- `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
 - `text-chat-q35`
 - `text-chat-q35-nano`
 - `text-agent-deepseek-v4-flash` (API/agent serving)
@@ -43,6 +44,10 @@ swift run mere.run text chat \
   --model text-chat-gemma4 \
   --prompt "Summarize diffusion models in one paragraph."
 ```
+
+On 32 GB Apple Silicon Macs, avoid pulling the dense bf16
+`text-chat-gemma4`/31B path. Use `text-chat-gemma4-turbo` for the managed
+Gemma 4 26B-A4B-it NVFP4 snapshot, which uses the native Swift Gemma MoE runtime.
 
 ### Local code generation
 


### PR DESCRIPTION
## Summary
- add native Gemma4 turbo/NVFP4 support, manifest metadata, validation, and model catalog wiring
- default Gemma4 turbo CLI/API runs to turboquant KV cache while preserving explicit override flags
- add demo-all-models.sh coverage helper and docs for Gemma4 turbo defaults

## Verification
- swift build
- swift test --filter Gemma4ModelTests --filter ManagedModelSupportTests --filter ManagedModelCatalogTests --filter TextChatCommandParsingTests --filter APIServeCommandTests --filter MereRunModelValidatorTests --filter ModelResolverTests