### PR TITLE
Fail MeBot when standalone model is missing

### DIFF
--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -110,15 +110,10 @@ struct APIServe: AsyncParsableCommand {
             if let explicit = model {
                 return explicit
             }
-            // Prefer standalone MeBot Instruct model
             if let mebotPath = MeBotModelCatalog.resolveModelPath() {
                 return mebotPath
             }
-            // Fall back to Klein model
-            if let resolved = ModelResolver().resolveIfPresent(.mebot) {
-                return resolved.rootURL.path
-            }
-            throw ValidationError("Model 'text-chat-mebot' is not installed. Download image-klein-nano or image-klein-max first.")
+            throw ValidationError("Model 'text-chat-mebot' is not installed.")
         case .textChatGemma4:
             if let explicit = model {
                 return explicit

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -267,7 +267,6 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             validationKind: .hfTextChat,
             runtimeAutoDownloadAllowed: false,
-            resolutionFallbackIDs: ["image-klein-nano", "image-klein-max"],
             defaultCLICommands: ["api serve"]
         ),
         ManagedModelSpec(

--- a/Tests/MereRunCoreTests/ModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ModelResolverTests.swift
@@ -103,7 +103,7 @@ final class ModelResolverTests: MereRunCoreTestCase {
         XCTAssertEqual(resolved.source, .localModelStore)
     }
 
-    func testMebotFallsBackToZeroNano() throws {
+    func testMebotDoesNotFallBackToKleinImageModel() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
         defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
@@ -116,9 +116,25 @@ final class ModelResolverTests: MereRunCoreTestCase {
         try writeMinimalImageModel(at: nanoRoot, id: .kleinNano)
 
         let resolver = ModelResolver()
+        XCTAssertThrowsError(try resolver.resolve(.mebot))
+    }
+
+    func testResolvesStandaloneMebotModel() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
+
+        let modelsRoot = temp.appendingPathComponent("models", isDirectory: true)
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        let mebotRoot = modelsRoot
+            .appendingPathComponent("text-chat-mebot", isDirectory: true)
+        try writeMinimalTextRoot(at: mebotRoot, id: .mebot)
+
+        let resolver = ModelResolver()
         let resolved = try resolver.resolve(.mebot)
 
-        XCTAssertEqual(resolved.rootURL.standardizedFileURL, nanoRoot.standardizedFileURL)
+        XCTAssertEqual(resolved.rootURL.standardizedFileURL, mebotRoot.standardizedFileURL)
         XCTAssertEqual(resolved.source, .localModelStore)
     }
 

--- a/demo-all-models.sh
+++ b/demo-all-models.sh
@@ -448,6 +448,11 @@ if [[ ! -s "$installed_file" ]]; then
   exit 1
 fi
 
+if [[ -n "$ONLY_MODEL" ]] && ! awk -v model="$ONLY_MODEL" '$1 == model { found = 1 } END { exit(found ? 0 : 1) }' "$installed_file"; then
+  echo "Model is not installed or not supported on this machine: $ONLY_MODEL" >&2
+  exit 1
+fi
+
 log "Output: $OUT"
 log "mere.run: $($MERE_RUN --version 2>/dev/null || echo unknown)"
 


### PR DESCRIPTION
## Summary
- remove MeBot resolution fallback to Klein image models
- make API serve fail when text-chat-mebot is missing instead of silently using image models
- add resolver coverage for missing vs standalone MeBot installs
- make demo filtering fail early for unsupported or uninstalled ONLY_MODEL values

## Tests
- swift test --filter ModelResolverTests