### PR TITLE
Align ACE-Step music defaults with upstream

### DIFF
--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -39,7 +39,7 @@ struct MusicGenerate: AsyncParsableCommand {
     var checkpointsRoot: String?
 
     @Option(name: [.customLong("turbo-subdirectory")], help: "Turbo decoder subdirectory under checkpoints root.")
-    var turboSubdirectory: String = "music-acestep-v15-turbo"
+    var turboSubdirectory: String = "acestep-v15-turbo"
 
     @Option(name: [.customLong("vae-subdirectory")], help: "VAE subdirectory under checkpoints root.")
     var vaeSubdirectory: String = "vae"
@@ -60,7 +60,7 @@ struct MusicGenerate: AsyncParsableCommand {
     var steps: Int = 8
 
     @Option(name: [.customLong("shift")], help: "Turbo scheduler shift.")
-    var shift: Float = 3.0
+    var shift: Float = 1.0
 
     @Option(name: [.long], help: "Seed for deterministic generation.")
     var seed: UInt64?
@@ -148,6 +148,10 @@ struct MusicGenerate: AsyncParsableCommand {
         }
 
         let checkpointsRootURL = try await resolveACEStepCheckpointsRoot()
+        let resolvedTurboSubdirectory = try resolveACEStepTurboSubdirectory(
+            at: checkpointsRootURL,
+            explicit: turboSubdirectory
+        )
         let resolvedLMSubdirectory = try resolveACEStepLMSubdirectory(
             at: checkpointsRootURL,
             explicit: lmSubdirectory
@@ -190,7 +194,7 @@ struct MusicGenerate: AsyncParsableCommand {
 
         let container = ACEStepModelContainer(
             checkpointsRootURL: checkpointsRootURL,
-            turboSubdirectory: turboSubdirectory,
+            turboSubdirectory: resolvedTurboSubdirectory,
             vaeSubdirectory: vaeSubdirectory,
             lmSubdirectory: useLM ? resolvedLMSubdirectory : nil,
             textEncoderSubdirectory: resolvedTextSubdirectory
@@ -500,6 +504,26 @@ struct MusicGenerate: AsyncParsableCommand {
         return candidates
     }
 
+    private func resolveACEStepTurboSubdirectory(at root: URL, explicit: String) throws -> String {
+        let fm = FileManager.default
+        func isDirectory(_ url: URL) -> Bool {
+            var isDir: ObjCBool = false
+            return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+        }
+
+        let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+        let upstreamDefault = "acestep-v15-turbo"
+        let compatibilityDefault = "music-acestep-v15-turbo"
+        let candidates = trimmed == upstreamDefault
+            ? [upstreamDefault, compatibilityDefault]
+            : [trimmed]
+
+        for candidate in candidates where isDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
+            return candidate
+        }
+        throw ValidationError("--turbo-subdirectory not found: \(trimmed)")
+    }
+
     private func isUsableCheckpointsRoot(_ root: URL) -> Bool {
         let fm = FileManager.default
 
@@ -511,7 +535,10 @@ struct MusicGenerate: AsyncParsableCommand {
         guard isDirectory(root) else {
             return false
         }
-        guard isDirectory(root.appendingPathComponent(turboSubdirectory)) else {
+        let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
+            ? ["acestep-v15-turbo", "music-acestep-v15-turbo"]
+            : [turboSubdirectory]
+        guard turboCandidates.contains(where: { isDirectory(root.appendingPathComponent($0, isDirectory: true)) }) else {
             return false
         }
         guard isDirectory(root.appendingPathComponent(vaeSubdirectory)) else {

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -44,7 +44,7 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("vae-subdirectory")], help: "VAE subdirectory under checkpoints root.")
     var vaeSubdirectory: String = "vae"
 
-    @Option(name: [.customLong("lm-subdirectory")], help: "Optional 5Hz LM subdirectory under checkpoints root. Auto-detected as 'music-acestep-5hz-lm-1.7b' when omitted.")
+    @Option(name: [.customLong("lm-subdirectory")], help: "Optional 5Hz LM subdirectory under checkpoints root. Auto-detected as 'acestep-5Hz-lm-1.7B' when omitted.")
     var lmSubdirectory: String?
 
     @Option(name: [.customLong("text-subdirectory")], help: "Text encoder subdirectory under checkpoints root. Auto-detected as 'Qwen3-Embedding-0.6B' when omitted.")
@@ -161,7 +161,7 @@ struct MusicGenerate: AsyncParsableCommand {
             explicit: textSubdirectory
         )
         if useLM && resolvedLMSubdirectory == nil {
-            throw ValidationError("--use-lm requires --lm-subdirectory. Set --lm-subdirectory or keep a default layout like 'music-acestep-5hz-lm-1.7b'.")
+            throw ValidationError("--use-lm requires --lm-subdirectory. Set --lm-subdirectory or keep a default layout like 'acestep-5Hz-lm-1.7B'.")
         }
         if resolvedTextSubdirectory == nil {
             throw ValidationError("ACE-Step text encoder not found. Set --text-subdirectory or keep a default layout like 'Qwen3-Embedding-0.6B'.")
@@ -396,6 +396,10 @@ struct MusicGenerate: AsyncParsableCommand {
         }
 
         let preferredCandidates = [
+            "acestep-5Hz-lm-1.7B",
+            "acestep-5hz-lm-1.7b",
+            "acestep-5Hz-lm",
+            "acestep-5hz-lm",
             "music-acestep-5hz-lm-1.7b",
             "music-acestep-5Hz-lm-1.7B",
             "music-acestep-5hz-lm",

--- a/Sources/MereRunCore/ACEStep/ACEStepInferenceConfig.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepInferenceConfig.swift
@@ -12,7 +12,7 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
     /// Turbo "fix_nfe" (default 8).
     public var fixNFE: Int
 
-    /// Turbo shift factor (rounded to {1,2,3} by the scheduler; default 3).
+    /// Turbo shift factor. Upstream ACE-Step defaults to 1.0.
     public var shift: Float
 
     /// Optional custom timesteps in `[0, 1]` (terminal zeros are ignored).
@@ -30,7 +30,7 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
     public init(
         durationSeconds: Float = 10.0,
         fixNFE: Int = 8,
-        shift: Float = 3.0,
+        shift: Float = 1.0,
         timesteps: [Float]? = nil,
         inferMethod: ACEStepInferenceMethod = .ode,
         useTiledVaeDecode: Bool = true,

--- a/Sources/MereRunCore/ACEStep/ACEStepModelContainer.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepModelContainer.swift
@@ -91,7 +91,7 @@ public actor ACEStepModelContainer {
 
     public init(
         checkpointsRootURL: URL,
-        turboSubdirectory: String = "music-acestep-v15-turbo",
+        turboSubdirectory: String = "acestep-v15-turbo",
         vaeSubdirectory: String = "vae",
         lmSubdirectory: String? = nil,
         textEncoderSubdirectory: String? = nil,

--- a/Sources/MereRunCore/ACEStep/ACEStepTurboScheduler.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepTurboScheduler.swift
@@ -10,11 +10,17 @@ import Foundation
 /// are mapped to the nearest valid timestep.
 public struct ACEStepTurboScheduler: Sendable, Hashable {
     public static let validShifts: [Float] = [1.0, 2.0, 3.0]
+    public static let validReferenceTimesteps: [Float] = [
+        1.0, 0.95454545, 0.93333334, 0.9, 0.875,
+        0.85714287, 0.8333333, 0.7692308, 0.75,
+        0.6666667, 0.64285713, 0.625, 0.54545456,
+        0.5, 0.4, 0.375, 0.3, 0.25, 0.22222222, 0.125,
+    ]
 
     /// Descending timesteps in `[0, 1]` (does not include the terminal `0`).
     public let timesteps: [Float]
 
-    public init(fixNFE: Int = 8, shift: Float = 3.0, timesteps: [Float]? = nil) {
+    public init(fixNFE: Int = 8, shift: Float = 1.0, timesteps: [Float]? = nil) {
         self.timesteps = Self.makeTimesteps(fixNFE: fixNFE, shift: shift, custom: timesteps)
     }
 
@@ -34,7 +40,7 @@ public struct ACEStepTurboScheduler: Sendable, Hashable {
         }
         guard !custom.isEmpty else { return defaultSchedule }
 
-        let candidates = validTimesteps(fixNFE: fixNFE)
+        let candidates = validReferenceTimesteps
         let maxCount = candidates.count
         if custom.count > maxCount {
             custom = Array(custom.prefix(maxCount))
@@ -81,4 +87,3 @@ public struct ACEStepTurboScheduler: Sendable, Hashable {
         candidates.min { abs($0 - t) < abs($1 - t) } ?? t
     }
 }
-

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -972,10 +972,13 @@ public extension ManagedModelSpec {
 
     private static func missingACEStepPaths(in rootURL: URL, fileManager: FileManager) -> [URL] {
         var missing: [URL] = []
-        let turboDir = rootURL.appendingPathComponent("music-acestep-v15-turbo", isDirectory: true)
+        let upstreamTurboDir = rootURL.appendingPathComponent("acestep-v15-turbo", isDirectory: true)
+        let compatibilityTurboDir = rootURL.appendingPathComponent("music-acestep-v15-turbo", isDirectory: true)
         let vaeDir = rootURL.appendingPathComponent("vae", isDirectory: true)
         let textDir = rootURL.appendingPathComponent("Qwen3-Embedding-0.6B", isDirectory: true)
-        if !fileManager.fileExists(atPath: turboDir.path) { missing.append(turboDir) }
+        if !fileManager.fileExists(atPath: upstreamTurboDir.path) && !fileManager.fileExists(atPath: compatibilityTurboDir.path) {
+            missing.append(upstreamTurboDir)
+        }
         if !fileManager.fileExists(atPath: vaeDir.path) { missing.append(vaeDir) }
         if !fileManager.fileExists(atPath: textDir.path) { missing.append(textDir) }
         return missing

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -303,28 +303,8 @@ public enum ManagedModelResolver {
         fileManager: FileManager
     ) throws {
         switch spec.normalizationKind {
-        case .none, .qwen3ASRNested, .parakeetNested:
+        case .none, .qwen3ASRNested, .parakeetNested, .musicACEStep:
             return
-        case .musicACEStep:
-            try renameDirectoryIfPresent(
-                from: rootURL.appendingPathComponent("acestep-v15-turbo", isDirectory: true),
-                to: rootURL.appendingPathComponent("music-acestep-v15-turbo", isDirectory: true),
-                fileManager: fileManager
-            )
-            let renamePairs: [(String, String)] = [
-                ("acestep-5Hz-lm-1.7B", "music-acestep-5hz-lm-1.7b"),
-                ("acestep-5hz-lm-1.7b", "music-acestep-5hz-lm-1.7b"),
-                ("acestep-5Hz-lm", "music-acestep-5hz-lm"),
-                ("acestep-5hz-lm", "music-acestep-5hz-lm"),
-                ("acestep-lm", "music-acestep-lm"),
-            ]
-            for (fromName, toName) in renamePairs {
-                try renameDirectoryIfPresent(
-                    from: rootURL.appendingPathComponent(fromName, isDirectory: true),
-                    to: rootURL.appendingPathComponent(toName, isDirectory: true),
-                    fileManager: fileManager
-                )
-            }
         }
     }
 
@@ -357,18 +337,4 @@ public enum ManagedModelResolver {
         }
     }
 
-    private static func renameDirectoryIfPresent(
-        from source: URL,
-        to destination: URL,
-        fileManager: FileManager
-    ) throws {
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: source.path, isDirectory: &isDirectory), isDirectory.boolValue else {
-            return
-        }
-        guard !fileManager.fileExists(atPath: destination.path) else {
-            throw ResolverError.invalidInstalledModel("Destination already exists at \(destination.path)")
-        }
-        try fileManager.moveItem(at: source, to: destination)
-    }
 }

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -15,6 +15,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.vaeSubdirectory, "vae")
         XCTAssertFalse(cmd.useLM)
         XCTAssertEqual(cmd.durationSeconds, 10.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.shift, 1.0, accuracy: 0.0001)
     }
 
     func testMusicGenerateParsesModelAndAdvancedOverrides() throws {

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -11,7 +11,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.caption, "warm synthwave groove")
         XCTAssertEqual(cmd.model, ModelResolver.ModelID.aceStep.rawValue)
         XCTAssertNil(cmd.checkpointsRoot)
-        XCTAssertEqual(cmd.turboSubdirectory, "music-acestep-v15-turbo")
+        XCTAssertEqual(cmd.turboSubdirectory, "acestep-v15-turbo")
         XCTAssertEqual(cmd.vaeSubdirectory, "vae")
         XCTAssertFalse(cmd.useLM)
         XCTAssertEqual(cmd.durationSeconds, 10.0, accuracy: 0.0001)

--- a/Tests/MereRunCoreTests/ACEStepModelContainerTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepModelContainerTests.swift
@@ -61,7 +61,7 @@ final class ACEStepModelContainerTests: MereRunCoreTestCase {
         let checkpointsRoot = try TestFileSystem.makeTempDir(prefix: "acestep-checkpoints")
         let turboSubdir = "acestep-v15-turbo"
         let vaeSubdir = "vae"
-        let lmSubdir = "music-acestep-5hz-lm-1.7b"
+        let lmSubdir = "acestep-5Hz-lm-1.7B"
         let textSubdir = "Qwen3-Embedding-0.6B"
 
         try writeDecoderStub(at: checkpointsRoot.appending(path: turboSubdir))

--- a/Tests/MereRunCoreTests/ACEStepModelContainerTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepModelContainerTests.swift
@@ -59,7 +59,7 @@ final class ACEStepModelContainerTests: MereRunCoreTestCase {
 
     func testCheckpointsRootInitializerResolvesSubdirectories() async throws {
         let checkpointsRoot = try TestFileSystem.makeTempDir(prefix: "acestep-checkpoints")
-        let turboSubdir = "music-acestep-v15-turbo"
+        let turboSubdir = "acestep-v15-turbo"
         let vaeSubdir = "vae"
         let lmSubdir = "music-acestep-5hz-lm-1.7b"
         let textSubdir = "Qwen3-Embedding-0.6B"

--- a/Tests/MereRunCoreTests/ACEStepTurboSchedulerTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepTurboSchedulerTests.swift
@@ -52,6 +52,11 @@ final class ACEStepTurboSchedulerTests: XCTestCase {
         XCTAssertEqual(sched.timesteps[1], 0.9545454545454546, accuracy: 1e-6)
     }
 
+    func testCustomTimestepsUseReferenceCandidateSetIndependentOfFixNFE() {
+        let sched = ACEStepTurboScheduler(fixNFE: 12, shift: 1.0, timesteps: [0.95])
+        XCTAssertEqual(sched.timesteps, [0.95454545])
+    }
+
     private func assertClose(_ got: [Float], _ expected: [Float], accuracy: Float = 1e-6) {
         XCTAssertEqual(got.count, expected.count)
         for (g, e) in zip(got, expected) {
@@ -59,4 +64,3 @@ final class ACEStepTurboSchedulerTests: XCTestCase {
         }
     }
 }
-

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -149,11 +149,34 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(parakeetSpec.normalizedRootURL(root, fileManager: .default), parakeetRoot)
     }
 
+    func testACEStepAcceptsUpstreamAndLegacyTurboLayouts() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "music-acestep"))
+
+        let upstreamRoot = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: upstreamRoot) }
+        try writeMinimalACEStepRoot(at: upstreamRoot, turboSubdirectory: "acestep-v15-turbo")
+        XCTAssertTrue(spec.isManagedRootComplete(upstreamRoot, fileManager: .default))
+
+        let legacyRoot = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: legacyRoot) }
+        try writeMinimalACEStepRoot(at: legacyRoot, turboSubdirectory: "music-acestep-v15-turbo")
+        XCTAssertTrue(spec.isManagedRootComplete(legacyRoot, fileManager: .default))
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-managed-model-catalog-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private func writeMinimalACEStepRoot(at root: URL, turboSubdirectory: String) throws {
+        for subdirectory in [turboSubdirectory, "vae", "Qwen3-Embedding-0.6B"] {
+            try FileManager.default.createDirectory(
+                at: root.appendingPathComponent(subdirectory, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
     }
 
     private func writeMinimalMFluxZImageNano(at root: URL, upstreamRepoId: String) throws {

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -176,10 +176,13 @@ The top-level model root is:
 
 That root may contain:
 
-- `music-acestep-v15-turbo/`
-- `music-acestep-5hz-lm-1.7b/` or another supported LM subdirectory
+- `acestep-v15-turbo/`
+- `acestep-5Hz-lm-1.7B/` or another supported LM subdirectory
 - `Qwen3-Embedding-0.6B/`
 - `vae/`
+
+Older local installs that still use `music-acestep-v15-turbo/` remain
+supported.
 
 `mere.run music generate` auto-discovers that layout unless you override the root
 with `--checkpoints-root` or `MERERUN_MUSIC_ACESTEP_ROOT`.


### PR DESCRIPTION
## Summary
- Align ACE-Step music generation defaults with upstream checkpoint layout (`acestep-v15-turbo`, `vae`, `Qwen3-Embedding-0.6B`) while preserving compatibility with the previous `music-acestep-v15-turbo` directory.
- Match upstream turbo scheduler behavior by defaulting `shift` to `1.0` and mapping custom timesteps against the full reference timestep set instead of the current `fixNFE` slice.
- Update CLI/model-container defaults and focused tests for the upstream layout.

## Verification
- `swift test --filter ACEStepTurboSchedulerTests`
- `swift test --filter ACEStepModelContainerTests`
- `swift test --filter MusicGenerateCommandParsingTests`

## Note
A broader exploratory filter also ran unrelated CLI tests and hit `SetupCommandParsingTests.testConfiguredAgentModelMustBeInstalledToBeStartable`, which appears environment-sensitive and outside this change's touched surface.