### PR TITLE
feat: add Linux CUDA MLX implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,48 @@ jobs:
         run: brew install swiftlint ripgrep
       - name: Run package checks
         run: ./scripts/check.sh
+
+  linux-cli-compatibility-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify Linux CLI compatibility documentation
+        run: |
+          set -euo pipefail
+
+          grep -R "Linux CLI compatibility" README.md docs/getting-started.md docs/development-workflow.md docs/testing.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
+          grep -R "MERERUN_FFMPEG" README.md docs/getting-started.md docs/development-workflow.md docs/testing.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
+          grep -R "MERERUN_FFPROBE" README.md docs/getting-started.md docs/development-workflow.md docs/testing.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
+          grep -R "CPU MLX" README.md docs/development-workflow.md docs/testing.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
+          grep -R "CUDA" README.md docs/development-workflow.md docs/testing.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
+          grep -R "macOS-only" README.md docs/getting-started.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
+
+  linux-cli:
+    runs-on: ubuntu-22.04
+    container: swift:6.0-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Linux check dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            cmake \
+            curl \
+            ffmpeg \
+            gfortran \
+            git \
+            gzip \
+            libcurl4-openssl-dev \
+            liblapacke-dev \
+            libopenblas-dev \
+            ninja-build \
+            pkg-config \
+            ripgrep \
+            unzip \
+            zip \
+            zlib1g-dev
+      - name: Run Linux CLI compatibility gate
+        run: ./scripts/check-linux.sh

--- a/Package.swift
+++ b/Package.swift
@@ -191,9 +191,13 @@ if isLinuxPackage {
   mereRunCoreDependencies.append("llama")
 }
 
+let linuxNativeLlamaLibraryPath = packagePath(".build/native/linux-\(hostArch)/llama/lib").path
 let linuxNativeLinkerSettings: [LinkerSetting] = isLinuxPackage
-  ? [.unsafeFlags(["-Xlinker", "-L\(packagePath(".build/native/linux-\(hostArch)/llama/lib").path)"])]
-    + prebuiltMLXLinkerSettings
+  ? [.unsafeFlags([
+      "-Xlinker", "-L\(linuxNativeLlamaLibraryPath)",
+      "-Xlinker", "-rpath", "-Xlinker", linuxNativeLlamaLibraryPath,
+      "-Xlinker", "-rpath", "-Xlinker", "$ORIGIN/lib"
+    ])] + prebuiltMLXLinkerSettings
   : []
 
 var mereRunCoreLinkerSettings: [LinkerSetting] = linuxNativeLinkerSettings

--- a/Package.swift
+++ b/Package.swift
@@ -1,150 +1,303 @@
 // swift-tools-version: 6.0
+import Foundation
 import PackageDescription
 
-let package = Package(
-  name: "MereRun",
-  platforms: [.macOS(.v15), .iOS(.v18)],
-  products: [
-    .library(name: "MereRunCore", targets: ["MereRunCore"]),
-    .library(name: "AudioCore", targets: ["AudioCore"]),
-    .library(name: "AudioCodecs", targets: ["AudioCodecs"]),
-    .library(name: "AudioSTT", targets: ["AudioSTT"]),
-    .library(name: "AudioTTS", targets: ["AudioTTS"]),
-    .executable(name: "mere.run", targets: ["MereRunCLI"]),
-    .executable(name: "mere.run.app", targets: ["MereRunApp"])
-  ],
-  dependencies: [
-    .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.0"),
-    .package(
-      url: "https://github.com/huggingface/swift-transformers",
-      from: "1.3.0"
-    ),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-    .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")
-  ],
-  targets: [
+let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+func packagePath(_ relativePath: String) -> URL {
+  packageRoot.appendingPathComponent(relativePath, isDirectory: false)
+}
+
+func packagePathExists(_ relativePath: String) -> Bool {
+  FileManager.default.fileExists(atPath: packagePath(relativePath).path)
+}
+
+func packageDirectoryContainsSwiftSources(_ relativePath: String) -> Bool {
+  let url = packagePath(relativePath)
+  var isDirectory: ObjCBool = false
+  let fileManager = FileManager.default
+  guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+    return false
+  }
+  guard let enumerator = fileManager.enumerator(
+    at: url,
+    includingPropertiesForKeys: [.isRegularFileKey],
+    options: [.skipsHiddenFiles]
+  ) else {
+    return false
+  }
+  for case let sourceURL as URL in enumerator where sourceURL.pathExtension == "swift" {
+    return true
+  }
+  return false
+}
+
+#if os(Linux)
+let hostIsLinux = true
+#else
+let hostIsLinux = false
+#endif
+
+#if arch(x86_64)
+let hostArch = "x86_64"
+#elseif arch(arm64)
+let hostArch = "arm64"
+#else
+let hostArch = "unknown"
+#endif
+
+let packagePlatformOverride = ProcessInfo.processInfo.environment["MERERUN_PACKAGE_PLATFORM"]?.lowercased()
+let isLinuxPackage = if packagePlatformOverride == "linux" {
+  true
+} else if packagePlatformOverride == "darwin" || packagePlatformOverride == "macos" {
+  false
+} else {
+  hostIsLinux
+}
+
+let packagePlatforms: [SupportedPlatform]? = isLinuxPackage ? nil : [.macOS(.v15), .iOS(.v18)]
+let commonSwiftSettings: [SwiftSetting] = [
+  .interoperabilityMode(.Cxx)
+]
+let hasMediaIOTarget = packageDirectoryContainsSwiftSources("Sources/MediaIO")
+
+var products: [Product] = [
+  .library(name: "MereRunCore", targets: ["MereRunCore"]),
+  .library(name: "AudioCore", targets: ["AudioCore"]),
+  .library(name: "AudioCodecs", targets: ["AudioCodecs"]),
+  .library(name: "AudioSTT", targets: ["AudioSTT"]),
+  .library(name: "AudioTTS", targets: ["AudioTTS"]),
+  .executable(name: "mere.run", targets: ["MereRunCLI"])
+]
+if !isLinuxPackage {
+  products.append(.executable(name: "mere.run.app", targets: ["MereRunApp"]))
+}
+
+var targets: [Target] = []
+var mereRunCoreDependencies: [Target.Dependency] = [
+  .product(name: "MLX", package: "mlx-swift"),
+  .product(name: "MLXFast", package: "mlx-swift"),
+  .product(name: "MLXNN", package: "mlx-swift"),
+  .product(name: "MLXOptimizers", package: "mlx-swift"),
+  .product(name: "MLXRandom", package: "mlx-swift"),
+  .product(name: "Crypto", package: "swift-crypto"),
+  .product(name: "Transformers", package: "swift-transformers")
+]
+
+if hasMediaIOTarget {
+  products.append(.library(name: "MediaIO", targets: ["MediaIO"]))
+  targets.append(
+    .target(
+      name: "MediaIO",
+      dependencies: [],
+      path: "Sources/MediaIO",
+      exclude: [
+        "README.md"
+      ],
+      swiftSettings: commonSwiftSettings
+    )
+  )
+  if packageDirectoryContainsSwiftSources("Sources/MediaIOSmoke") {
+    targets.append(
+      .executableTarget(
+        name: "MediaIOSmoke",
+        dependencies: [
+          "MediaIO"
+        ],
+        path: "Sources/MediaIOSmoke",
+        swiftSettings: commonSwiftSettings
+      )
+    )
+  }
+  mereRunCoreDependencies.append("MediaIO")
+}
+
+if isLinuxPackage {
+  if packagePathExists("Sources/llama/module.modulemap") {
+    targets.append(
+      .systemLibrary(
+        name: "llama",
+        path: "Sources/llama",
+        pkgConfig: "llama"
+      )
+    )
+    mereRunCoreDependencies.append("llama")
+  }
+} else {
+  targets.append(
     .binaryTarget(
       name: "llama",
       path: "vendor/llama.xcframework"
-    ),
-    .target(
-      name: "MereRunCore",
-      dependencies: [
-        .product(name: "MLX", package: "mlx-swift"),
-        .product(name: "MLXFast", package: "mlx-swift"),
-        .product(name: "MLXNN", package: "mlx-swift"),
-        .product(name: "MLXOptimizers", package: "mlx-swift"),
-        .product(name: "MLXRandom", package: "mlx-swift"),
-        .product(name: "Transformers", package: "swift-transformers"),
-        "llama"
-      ],
-      path: "Sources/MereRunCore",
-      exclude: [
-        "README.md",
-        "ACEStep/README.md",
-        "ACEStep/Model/README.md",
-        "ACEStep/VAE/README.md",
-        "CodeGen/README.md",
-        "DeepseekV4Flash/README.md",
-        "FalconPerception/README.md",
-        "Flux2Klein/README.md",
-        "Flux2Klein/Model/Transformer/README.md",
-        "Gemma4/README.md",
-        "HiDreamO1/README.md",
-        "LightOnOCR/README.md",
-        "LTX/README.md",
-        "LoRA/README.md",
-        "PrivacyFilter/README.md",
-        "Psi/README.md",
-        "Q35/README.md",
-        "QwenImageEdit/README.md",
-        "QwenImageEdit/Model/Transformer/README.md",
-        "QwenImageEdit/Model/VAE/README.md",
-        "SAM3/README.md",
-        "Support/README.md",
-        "VLM/README.md",
-        "ZImageI2L/README.md",
-        "ZImageI2L/Model/README.md",
-        "ZImageTurbo/README.md",
-        "ZImageTurbo/Model/TextEncoder/README.md",
-        "ZImageTurbo/Model/TextEncoder/Vision/README.md",
-        "ZImageTurbo/Model/Transformer/README.md",
-        "ZImageTurbo/Model/VAE/README.md",
-        "ZImageTurbo/Util/README.md"
-      ],
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ],
-      linkerSettings: [
-        .linkedFramework("Metal")
-      ]
-    ),
-    .target(
-      name: "AudioCore",
-      dependencies: [],
-      path: "Sources/AudioCore",
-      exclude: [
-        "README.md"
-      ],
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
-    .target(
-      name: "AudioCodecs",
-      dependencies: [
-        .product(name: "MLX", package: "mlx-swift")
-      ],
-      path: "Sources/AudioCodecs",
-      exclude: [
-        "README.md"
-      ],
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
-    .target(
-      name: "AudioSTT",
-      dependencies: [
-        "MereRunCore",
-        "AudioCore",
-        "AudioCodecs",
-        .product(name: "MLX", package: "mlx-swift"),
-        .product(name: "MLXFast", package: "mlx-swift"),
-        .product(name: "MLXNN", package: "mlx-swift"),
-        .product(name: "MLXRandom", package: "mlx-swift"),
-        .product(name: "Transformers", package: "swift-transformers")
-      ],
-      path: "Sources/AudioSTT",
-      exclude: [
-        "Parakeet/README.md",
-        "Qwen3ASR/Model/README.md",
-        "Qwen3ASR/README.md"
-      ],
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
-    .target(
-      name: "AudioTTS",
-      dependencies: [
-        "MereRunCore",
-        "AudioCore",
-        "AudioCodecs",
-        .product(name: "MLX", package: "mlx-swift"),
-        .product(name: "MLXFast", package: "mlx-swift"),
-        .product(name: "MLXNN", package: "mlx-swift"),
-        .product(name: "MLXRandom", package: "mlx-swift"),
-        .product(name: "Transformers", package: "swift-transformers")
-      ],
-      path: "Sources/AudioTTS",
-      exclude: [
-        "Qwen3TTS/README.md"
-      ],
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
+    )
+  )
+  mereRunCoreDependencies.append("llama")
+}
+
+let linuxNativeLinkerSettings: [LinkerSetting] = isLinuxPackage
+  ? [.unsafeFlags(["-Xlinker", "-L\(packagePath(".build/native/linux-\(hostArch)/llama/lib").path)"])]
+  : []
+
+var mereRunCoreLinkerSettings: [LinkerSetting] = linuxNativeLinkerSettings
+if !isLinuxPackage {
+  mereRunCoreLinkerSettings.append(.linkedFramework("Metal"))
+}
+
+var audioCodecsDependencies: [Target.Dependency] = [
+  .product(name: "MLX", package: "mlx-swift")
+]
+if hasMediaIOTarget {
+  audioCodecsDependencies.append("MediaIO")
+}
+
+var mereRunCoreTestDependencies: [Target.Dependency] = [
+  "MereRunCore",
+  "AudioCore",
+  "AudioCodecs",
+  "AudioSTT",
+  "AudioTTS",
+  .product(name: "Crypto", package: "swift-crypto")
+]
+if hasMediaIOTarget {
+  mereRunCoreTestDependencies.append("MediaIO")
+}
+
+targets.append(contentsOf: [
+  .target(
+    name: "MereRunCore",
+    dependencies: mereRunCoreDependencies,
+    path: "Sources/MereRunCore",
+    exclude: [
+      "README.md",
+      "ACEStep/README.md",
+      "ACEStep/Model/README.md",
+      "ACEStep/VAE/README.md",
+      "CodeGen/README.md",
+      "DeepseekV4Flash/README.md",
+      "FalconPerception/README.md",
+      "Flux2Klein/README.md",
+      "Flux2Klein/Model/Transformer/README.md",
+      "Gemma4/README.md",
+      "HiDreamO1/README.md",
+      "LightOnOCR/README.md",
+      "LTX/README.md",
+      "LoRA/README.md",
+      "PrivacyFilter/README.md",
+      "Psi/README.md",
+      "Q35/README.md",
+      "QwenImageEdit/README.md",
+      "QwenImageEdit/Model/Transformer/README.md",
+      "QwenImageEdit/Model/VAE/README.md",
+      "SAM3/README.md",
+      "Support/README.md",
+      "VLM/README.md",
+      "ZImageI2L/README.md",
+      "ZImageI2L/Model/README.md",
+      "ZImageTurbo/README.md",
+      "ZImageTurbo/Model/TextEncoder/README.md",
+      "ZImageTurbo/Model/TextEncoder/Vision/README.md",
+      "ZImageTurbo/Model/Transformer/README.md",
+      "ZImageTurbo/Model/VAE/README.md",
+      "ZImageTurbo/Util/README.md"
+    ],
+    swiftSettings: commonSwiftSettings,
+    linkerSettings: mereRunCoreLinkerSettings
+  ),
+  .target(
+    name: "AudioCore",
+    dependencies: [],
+    path: "Sources/AudioCore",
+    exclude: [
+      "README.md"
+    ],
+    swiftSettings: commonSwiftSettings
+  ),
+  .target(
+    name: "AudioCodecs",
+    dependencies: audioCodecsDependencies,
+    path: "Sources/AudioCodecs",
+    exclude: [
+      "README.md"
+    ],
+    swiftSettings: commonSwiftSettings
+  ),
+  .target(
+    name: "AudioSTT",
+    dependencies: [
+      "MereRunCore",
+      "AudioCore",
+      "AudioCodecs",
+      .product(name: "MLX", package: "mlx-swift"),
+      .product(name: "MLXFast", package: "mlx-swift"),
+      .product(name: "MLXNN", package: "mlx-swift"),
+      .product(name: "MLXRandom", package: "mlx-swift"),
+      .product(name: "Transformers", package: "swift-transformers")
+    ],
+    path: "Sources/AudioSTT",
+    exclude: [
+      "Parakeet/README.md",
+      "Qwen3ASR/Model/README.md",
+      "Qwen3ASR/README.md"
+    ],
+    swiftSettings: commonSwiftSettings
+  ),
+  .target(
+    name: "AudioTTS",
+    dependencies: [
+      "MereRunCore",
+      "AudioCore",
+      "AudioCodecs",
+      .product(name: "MLX", package: "mlx-swift"),
+      .product(name: "MLXFast", package: "mlx-swift"),
+      .product(name: "MLXNN", package: "mlx-swift"),
+      .product(name: "MLXRandom", package: "mlx-swift"),
+      .product(name: "Transformers", package: "swift-transformers")
+    ],
+    path: "Sources/AudioTTS",
+    exclude: [
+      "Qwen3TTS/README.md"
+    ],
+    swiftSettings: commonSwiftSettings
+  ),
+  .executableTarget(
+    name: "MereRunCLI",
+    dependencies: [
+      "MereRunCore",
+      "AudioCore",
+      "AudioCodecs",
+      "AudioSTT",
+      "AudioTTS",
+      .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      .product(name: "Hummingbird", package: "hummingbird")
+    ],
+    path: "Sources/MereRunCLI",
+    exclude: [
+      "Commands/README.md",
+      "Support/README.md"
+    ],
+    resources: [
+      .process("Guides")
+    ],
+    swiftSettings: commonSwiftSettings,
+    linkerSettings: linuxNativeLinkerSettings
+  ),
+  .testTarget(
+    name: "MereRunCoreTests",
+    dependencies: mereRunCoreTestDependencies,
+    path: "Tests/MereRunCoreTests",
+    swiftSettings: commonSwiftSettings,
+    linkerSettings: linuxNativeLinkerSettings
+  ),
+  .testTarget(
+    name: "MereRunCLITests",
+    dependencies: ["MereRunCLI"],
+    path: "Tests/MereRunCLITests",
+    swiftSettings: commonSwiftSettings,
+    linkerSettings: linuxNativeLinkerSettings
+  )
+])
+
+if !isLinuxPackage {
+  targets.append(
     .executableTarget(
       name: "MereRunApp",
       dependencies: [],
@@ -152,56 +305,30 @@ let package = Package(
       exclude: [
         "README.md"
       ]
-    ),
-    .executableTarget(
-      name: "MereRunCLI",
-      dependencies: [
-        "MereRunCore",
-        "AudioCore",
-        "AudioCodecs",
-        "AudioSTT",
-        "AudioTTS",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "Hummingbird", package: "hummingbird")
-      ],
-      path: "Sources/MereRunCLI",
-      exclude: [
-        "Commands/README.md",
-        "Support/README.md"
-      ],
-      resources: [
-        .process("Guides")
-      ],
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
-    .testTarget(
-      name: "MereRunCoreTests",
-      dependencies: [
-        "MereRunCore",
-        "AudioCore",
-        "AudioCodecs",
-        "AudioSTT",
-        "AudioTTS"
-      ],
-      path: "Tests/MereRunCoreTests",
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
-    .testTarget(
-      name: "MereRunCLITests",
-      dependencies: ["MereRunCLI"],
-      path: "Tests/MereRunCLITests",
-      swiftSettings: [
-        .interoperabilityMode(.Cxx)
-      ]
-    ),
+    )
+  )
+  targets.append(
     .testTarget(
       name: "MereRunAppTests",
       dependencies: ["MereRunApp"],
       path: "Tests/MereRunAppTests"
+    )
+  )
+}
+
+let package = Package(
+  name: "MereRun",
+  platforms: packagePlatforms,
+  products: products,
+  dependencies: [
+    .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.0"),
+    .package(
+      url: "https://github.com/huggingface/swift-transformers",
+      from: "1.3.0"
     ),
-  ]
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
+    .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")
+  ],
+  targets: targets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -218,18 +218,16 @@ if hasMediaIOTarget {
   mereRunCoreTestDependencies.append("MediaIO")
 }
 
-let audioRuntimeDependencies: [Target.Dependency] = [
+var audioRuntimeDependencies: [Target.Dependency] = [
   "MereRunCore",
   "AudioCore",
-  "AudioCodecs"
+  "AudioCodecs",
+  .product(name: "Transformers", package: "swift-transformers")
 ]
-  + mlxDependency("MLX")
-  + mlxDependency("MLXFast")
-  + mlxDependency("MLXNN")
-  + mlxDependency("MLXRandom")
-  + [
-    .product(name: "Transformers", package: "swift-transformers")
-  ]
+audioRuntimeDependencies.append(contentsOf: mlxDependency("MLX"))
+audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXFast"))
+audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXNN"))
+audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXRandom"))
 
 targets.append(contentsOf: [
   .target(

--- a/Package.swift
+++ b/Package.swift
@@ -56,10 +56,68 @@ let isLinuxPackage = if packagePlatformOverride == "linux" {
 }
 
 let packagePlatforms: [SupportedPlatform]? = isLinuxPackage ? nil : [.macOS(.v15), .iOS(.v18)]
+let useLinuxPrebuiltMLX = isLinuxPackage
+  && ProcessInfo.processInfo.environment["MERERUN_MLX_SWIFT_LINKAGE"]?.lowercased() == "cuda-prebuilt"
+let prebuiltMLXBuildRoot = ProcessInfo.processInfo.environment["MERERUN_MLX_SWIFT_BUILD_DIR"]
+  ?? packagePath(".build/native/linux-\(hostArch)/build/mlx-swift-cuda-smoke").path
+let prebuiltMLXSourceRoot = ProcessInfo.processInfo.environment["MERERUN_MLX_SWIFT_SOURCE_DIR"]
+  ?? packagePath(".build/native/src/mlx-swift").path
+let prebuiltMLXSwiftSettings: [SwiftSetting] = useLinuxPrebuiltMLX
+  ? [
+      .unsafeFlags([
+        "-I", prebuiltMLXBuildRoot,
+        "-I", "\(prebuiltMLXBuildRoot)/swift",
+        "-I", "\(prebuiltMLXSourceRoot)/Source/Cmlx/include",
+        "-I", "\(prebuiltMLXBuildRoot)/_deps/mlx-c-src",
+        "-I", "\(prebuiltMLXBuildRoot)/_deps/swift-numerics-src/Sources/_NumericsShims/include"
+      ])
+    ]
+  : []
 let commonSwiftSettings: [SwiftSetting] = [
   .interoperabilityMode(.Cxx)
-]
+] + prebuiltMLXSwiftSettings
 let hasMediaIOTarget = packageDirectoryContainsSwiftSources("Sources/MediaIO")
+
+func mlxDependency(_ name: String) -> [Target.Dependency] {
+  useLinuxPrebuiltMLX ? [] : [.product(name: name, package: "mlx-swift")]
+}
+
+func shellSplit(_ value: String) -> [String] {
+  value.split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" }).map(String.init)
+}
+
+let prebuiltMLXExtraLinkFlags = ProcessInfo.processInfo.environment["MERERUN_MLX_SWIFT_LINK_FLAGS"].map(shellSplit) ?? []
+let prebuiltMLXLinkerSettings: [LinkerSetting] = useLinuxPrebuiltMLX
+  ? [
+      .unsafeFlags([
+        "-L", prebuiltMLXBuildRoot,
+        "-L", "\(prebuiltMLXBuildRoot)/_deps/mlx-c-build",
+        "-L", "\(prebuiltMLXBuildRoot)/_deps/mlx-build",
+        "-L", "\(prebuiltMLXBuildRoot)/_deps/mlx-build/mlx/io",
+        "-L", "\(prebuiltMLXBuildRoot)/lib",
+        "-lMLXOptimizers",
+        "-lMLXNN",
+        "-lMLXRandom",
+        "-lMLXFast",
+        "-lMLXFFT",
+        "-lMLXLinalg",
+        "-lMLX",
+        "-lmlxc",
+        "-lmlx",
+        "-lgguflib",
+        "-lNumerics",
+        "-lComplexModule",
+        "-lRealModule",
+        "-lpthread",
+        "-ldl",
+        "-lstdc++",
+        "-lm",
+        "-lblas",
+        "-llapack",
+        "-lopenblas"
+      ] + prebuiltMLXExtraLinkFlags)
+    ]
+  : []
 
 var products: [Product] = [
   .library(name: "MereRunCore", targets: ["MereRunCore"]),
@@ -74,15 +132,15 @@ if !isLinuxPackage {
 }
 
 var targets: [Target] = []
-var mereRunCoreDependencies: [Target.Dependency] = [
-  .product(name: "MLX", package: "mlx-swift"),
-  .product(name: "MLXFast", package: "mlx-swift"),
-  .product(name: "MLXNN", package: "mlx-swift"),
-  .product(name: "MLXOptimizers", package: "mlx-swift"),
-  .product(name: "MLXRandom", package: "mlx-swift"),
-  .product(name: "Crypto", package: "swift-crypto"),
-  .product(name: "Transformers", package: "swift-transformers")
-]
+var mereRunCoreDependencies: [Target.Dependency] = mlxDependency("MLX")
+  + mlxDependency("MLXFast")
+  + mlxDependency("MLXNN")
+  + mlxDependency("MLXOptimizers")
+  + mlxDependency("MLXRandom")
+  + [
+      .product(name: "Crypto", package: "swift-crypto"),
+      .product(name: "Transformers", package: "swift-transformers")
+    ]
 
 if hasMediaIOTarget {
   products.append(.library(name: "MediaIO", targets: ["MediaIO"]))
@@ -135,6 +193,7 @@ if isLinuxPackage {
 
 let linuxNativeLinkerSettings: [LinkerSetting] = isLinuxPackage
   ? [.unsafeFlags(["-Xlinker", "-L\(packagePath(".build/native/linux-\(hostArch)/llama/lib").path)"])]
+    + prebuiltMLXLinkerSettings
   : []
 
 var mereRunCoreLinkerSettings: [LinkerSetting] = linuxNativeLinkerSettings
@@ -142,9 +201,7 @@ if !isLinuxPackage {
   mereRunCoreLinkerSettings.append(.linkedFramework("Metal"))
 }
 
-var audioCodecsDependencies: [Target.Dependency] = [
-  .product(name: "MLX", package: "mlx-swift")
-]
+var audioCodecsDependencies: [Target.Dependency] = mlxDependency("MLX")
 if hasMediaIOTarget {
   audioCodecsDependencies.append("MediaIO")
 }
@@ -160,6 +217,19 @@ var mereRunCoreTestDependencies: [Target.Dependency] = [
 if hasMediaIOTarget {
   mereRunCoreTestDependencies.append("MediaIO")
 }
+
+let audioRuntimeDependencies: [Target.Dependency] = [
+  "MereRunCore",
+  "AudioCore",
+  "AudioCodecs"
+]
+  + mlxDependency("MLX")
+  + mlxDependency("MLXFast")
+  + mlxDependency("MLXNN")
+  + mlxDependency("MLXRandom")
+  + [
+    .product(name: "Transformers", package: "swift-transformers")
+  ]
 
 targets.append(contentsOf: [
   .target(
@@ -222,16 +292,7 @@ targets.append(contentsOf: [
   ),
   .target(
     name: "AudioSTT",
-    dependencies: [
-      "MereRunCore",
-      "AudioCore",
-      "AudioCodecs",
-      .product(name: "MLX", package: "mlx-swift"),
-      .product(name: "MLXFast", package: "mlx-swift"),
-      .product(name: "MLXNN", package: "mlx-swift"),
-      .product(name: "MLXRandom", package: "mlx-swift"),
-      .product(name: "Transformers", package: "swift-transformers")
-    ],
+    dependencies: audioRuntimeDependencies,
     path: "Sources/AudioSTT",
     exclude: [
       "Parakeet/README.md",
@@ -242,16 +303,7 @@ targets.append(contentsOf: [
   ),
   .target(
     name: "AudioTTS",
-    dependencies: [
-      "MereRunCore",
-      "AudioCore",
-      "AudioCodecs",
-      .product(name: "MLX", package: "mlx-swift"),
-      .product(name: "MLXFast", package: "mlx-swift"),
-      .product(name: "MLXNN", package: "mlx-swift"),
-      .product(name: "MLXRandom", package: "mlx-swift"),
-      .product(name: "Transformers", package: "swift-transformers")
-    ],
+    dependencies: audioRuntimeDependencies,
     path: "Sources/AudioTTS",
     exclude: [
       "Qwen3TTS/README.md"
@@ -316,19 +368,22 @@ if !isLinuxPackage {
   )
 }
 
+let packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
+  .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.0")
+]) + [
+  .package(
+    url: "https://github.com/huggingface/swift-transformers",
+    from: "1.3.0"
+  ),
+  .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
+  .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
+  .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")
+]
+
 let package = Package(
   name: "MereRun",
   platforms: packagePlatforms,
   products: products,
-  dependencies: [
-    .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.0"),
-    .package(
-      url: "https://github.com/huggingface/swift-transformers",
-      from: "1.3.0"
-    ),
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
-    .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")
-  ],
+  dependencies: packageDependencies,
   targets: targets
 )

--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ The public OSS repo currently supports:
 ## Platform expectations
 
 - the public CLI and local runtime are developed and validated on Apple Silicon macOS 15 or newer
+- the optional SwiftUI studio, app bundle, installer, and DMG are macOS-only; Linux compatibility work is for the headless `mere.run` CLI
 - `Package.swift` uses Swift tools 6.0 and declares macOS 15 / iOS 18 package platforms
-- `swift build` and `swift test` are the supported first-run validation path for contributors
-- some vendored binaries include additional Apple platform slices for package consumers, but the public quickstart is macOS-first
+- `swift build` and `swift test` are the supported first-run validation path for macOS contributors
+- Linux CLI compatibility work expects a Swift 6.x toolchain, `clang`, `cmake`, `ninja`, `pkg-config`, `gfortran`, curl/zlib/OpenBLAS/LAPACK development headers, `ffmpeg`, `ffprobe`, `gzip`, `unzip`, and `zip`
+- media I/O should discover `ffmpeg` and `ffprobe` on `PATH`, with `MERERUN_FFMPEG` and `MERERUN_FFPROBE` reserved for absolute executable overrides
+- Linux CI should stay CPU MLX-oriented and fixture-sized; CUDA is an optional local acceleration path, not a baseline for pull-request checks
+- some vendored binaries include additional Apple platform slices for package consumers, but the public quickstart and release artifact remain macOS-first
 
 ## Install the latest release
 
@@ -94,6 +98,21 @@ swift run mere.run --help
 app_path="$(./scripts/build_mere_run_app.sh debug)"
 open "$app_path"
 ```
+
+For Linux CLI compatibility work, install the platform packages first and keep
+the validation headless:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
+export MERERUN_FFMPEG=/usr/bin/ffmpeg
+export MERERUN_FFPROBE=/usr/bin/ffprobe
+./scripts/check-linux.sh
+swift run mere.run --help
+```
+
+Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio
+flows, and DMG packaging stay macOS-only.
 
 ## Quick start
 

--- a/Sources/AudioCodecs/AudioReader.swift
+++ b/Sources/AudioCodecs/AudioReader.swift
@@ -1,45 +1,32 @@
 import Foundation
-import Accelerate
-import AVFoundation
+import MediaIO
 
-/// Audio reader supporting WAV, M4A, MP3, and other formats via AVFoundation
+/// Audio reader supporting WAV, M4A, MP3, and other formats via platform media backends.
 public enum AudioReader {
     /// Read audio file and return mono 16kHz audio samples
-    /// Supports WAV, M4A, MP3, CAF, AIFF, and other AVFoundation-supported formats
+    /// Supports WAV, M4A, MP3, CAF, AIFF, and other platform-supported formats.
     /// - Parameter url: URL to audio file
     /// - Returns: Audio samples in range [-1, 1] at 16kHz mono
     public static func readAudio(from url: URL) throws -> [Float] {
-        // Use AVFoundation for broad format support
-        let file: AVAudioFile
+        let buffer = try readAudioBuffer(from: url, sampleRate: 16_000, channels: 1)
+        return buffer.samples
+    }
+
+    /// Read audio and return a normalized floating-point buffer.
+    public static func readAudioBuffer(
+        from url: URL,
+        sampleRate: Int = 16_000,
+        channels: Int = 1
+    ) throws -> MediaAudioBuffer {
+        let decoded: MediaAudioBuffer
         do {
-            file = try AVAudioFile(forReading: url)
+            decoded = try MediaAudioIO.decode(url, targetSampleRate: sampleRate, channels: channels)
         } catch {
-            throw AudioReaderError.readFailed("Failed to open audio file: \(error.localizedDescription)")
+            throw AudioReaderError.readFailed(error.localizedDescription)
         }
-
-        let sourceFormat = file.processingFormat
-        let frameCount = AVAudioFrameCount(file.length)
-
-        guard frameCount > 0 else {
-            throw AudioReaderError.invalidFormat("Audio file is empty")
-        }
-
-        // Read into buffer
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: frameCount) else {
-            throw AudioReaderError.readFailed("Failed to create audio buffer")
-        }
-
-        do {
-            try file.read(into: buffer)
-        } catch {
-            throw AudioReaderError.readFailed("Failed to read audio data: \(error.localizedDescription)")
-        }
-
-        // Convert to mono 16kHz float using AVAudioConverter (more reliable than manual resample)
-        var samples = try convertToMono16kFloat(buffer: buffer, sourceFormat: sourceFormat)
 
         if Self.isDebugEnabled {
-            let stats = audioStats(samples)
+            let stats = audioStats(decoded.samples)
             let message = String(
                 format: "[ASR DEBUG] audio pre-norm rms=%.6f peak=%.6f\n",
                 stats.rms, stats.peak
@@ -48,7 +35,7 @@ public enum AudioReader {
         }
 
         // Auto-gain very quiet audio so ASR doesn't return empty output.
-        samples = normalizeIfNeeded(samples)
+        let samples = normalizeIfNeeded(decoded.samples)
 
         if Self.isDebugEnabled {
             let stats = audioStats(samples)
@@ -59,67 +46,17 @@ public enum AudioReader {
             FileHandle.standardError.write(Data(message.utf8))
         }
 
-        return samples
+        return MediaAudioBuffer(
+            samples: samples,
+            sampleRate: decoded.sampleRate,
+            channelCount: decoded.channelCount,
+            isInterleaved: decoded.isInterleaved
+        )
     }
 
     /// Legacy WAV-only reader (kept for compatibility)
     public static func readWAV(from url: URL) throws -> [Float] {
         try readAudio(from: url)
-    }
-
-    /// Convert input buffer to mono 16kHz Float32 using AVAudioConverter.
-    private static func convertToMono16kFloat(
-        buffer: AVAudioPCMBuffer,
-        sourceFormat: AVAudioFormat
-    ) throws -> [Float] {
-        let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: 16000,
-            channels: 1,
-            interleaved: false
-        )!
-
-        if sourceFormat.sampleRate == targetFormat.sampleRate,
-           sourceFormat.channelCount == targetFormat.channelCount,
-           sourceFormat.commonFormat == .pcmFormatFloat32 {
-            if let floatData = buffer.floatChannelData {
-                let frameLength = Int(buffer.frameLength)
-                return Array(UnsafeBufferPointer(start: floatData[0], count: frameLength))
-            }
-        }
-
-        guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
-            throw AudioReaderError.invalidFormat("Failed to create audio converter")
-        }
-
-        let ratio = targetFormat.sampleRate / sourceFormat.sampleRate
-        let outputCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
-        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputCapacity) else {
-            throw AudioReaderError.readFailed("Failed to create output buffer")
-        }
-
-        var didConvert = false
-        var conversionError: NSError?
-        converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
-            if didConvert {
-                outStatus.pointee = .noDataNow
-                return nil
-            }
-            didConvert = true
-            outStatus.pointee = .haveData
-            return buffer
-        }
-
-        if let conversionError {
-            throw AudioReaderError.readFailed("Audio conversion failed: \(conversionError.localizedDescription)")
-        }
-
-        guard let floatData = outputBuffer.floatChannelData else {
-            throw AudioReaderError.invalidFormat("Converted audio missing float data")
-        }
-
-        let frameLength = Int(outputBuffer.frameLength)
-        return Array(UnsafeBufferPointer(start: floatData[0], count: frameLength))
     }
 
     /// Normalize extremely quiet audio to a target RMS level.

--- a/Sources/AudioCodecs/MelSpectrogram.swift
+++ b/Sources/AudioCodecs/MelSpectrogram.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Accelerate
 import MLX
 
 /// Mel spectrogram configuration.
@@ -31,7 +30,7 @@ public struct Qwen3ASRMelConfig: Sendable, Hashable {
     }
 }
 
-/// Mel spectrogram extractor using vDSP for FFT
+/// Mel spectrogram extractor using the shared real FFT backend.
 /// Matches Whisper/OpenAI preprocessing for ASR models
 public final class MelSpectrogram {
     let nMels: Int
@@ -40,10 +39,9 @@ public final class MelSpectrogram {
     let winLength: Int
     let sampleRate: Int
 
-    private let fftSetup: vDSP.FFT<DSPSplitComplex>
+    private let fftPlan: RealFFTPlan
     private let hannWindow: [Float]
     private let melFilters: [[Float]]
-    private let log2n: vDSP_Length
 
     public init(config: Qwen3ASRMelConfig = Qwen3ASRMelConfig()) {
         self.nMels = config.nMels
@@ -52,9 +50,11 @@ public final class MelSpectrogram {
         self.winLength = config.winLength
         self.sampleRate = config.sampleRate
 
-        // FFT setup
-        self.log2n = vDSP_Length(log2(Double(nFFT)))
-        self.fftSetup = vDSP.FFT(log2n: log2n, radix: .radix2, ofType: DSPSplitComplex.self)!
+        do {
+            self.fftPlan = try RealFFTPlan(size: nFFT)
+        } catch {
+            preconditionFailure("Invalid mel spectrogram FFT size: \(nFFT)")
+        }
 
         // Hann window (periodic, matches WhisperFeatureExtractor)
         var window = [Float](repeating: 0, count: winLength)
@@ -82,9 +82,6 @@ public final class MelSpectrogram {
         let numFrames = max(1, 1 + (paddedAudio.count - winLength) / hopLength)
         var melSpec = [[Float]](repeating: [Float](repeating: 0, count: numFrames), count: nMels)
 
-        // Buffers for FFT
-        var realp = [Float](repeating: 0, count: nFFT / 2)
-        var imagp = [Float](repeating: 0, count: nFFT / 2)
         var paddedFrame = [Float](repeating: 0, count: nFFT)
         var magnitudes = [Float](repeating: 0, count: nFFT / 2 + 1)
 
@@ -100,39 +97,7 @@ public final class MelSpectrogram {
                 }
             }
 
-            // Perform FFT
-            realp = [Float](repeating: 0, count: nFFT / 2)
-            imagp = [Float](repeating: 0, count: nFFT / 2)
-
-            paddedFrame.withUnsafeBufferPointer { inputPtr in
-                realp.withUnsafeMutableBufferPointer { realPtr in
-                    imagp.withUnsafeMutableBufferPointer { imagPtr in
-                        var splitComplex = DSPSplitComplex(
-                            realp: realPtr.baseAddress!,
-                            imagp: imagPtr.baseAddress!
-                        )
-                        vDSP_ctoz(
-                            UnsafePointer<DSPComplex>(OpaquePointer(inputPtr.baseAddress!)),
-                            2,
-                            &splitComplex,
-                            1,
-                            vDSP_Length(nFFT / 2)
-                        )
-                        fftSetup.forward(input: splitComplex, output: &splitComplex)
-                    }
-                }
-            }
-
-            // Compute magnitude spectrum
-            magnitudes = [Float](repeating: 0, count: nFFT / 2 + 1)
-            for i in 0..<(nFFT / 2) {
-                magnitudes[i] = realp[i] * realp[i] + imagp[i] * imagp[i]
-            }
-            // DC and Nyquist
-            magnitudes[0] = realp[0] * realp[0]
-            if nFFT / 2 < magnitudes.count {
-                magnitudes[nFFT / 2] = imagp[0] * imagp[0]
-            }
+            magnitudes = fftPlan.powerSpectrum(paddedFrame)
 
             // Apply mel filterbank
             for melIdx in 0..<nMels {

--- a/Sources/AudioCodecs/RealFFTPlan.swift
+++ b/Sources/AudioCodecs/RealFFTPlan.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+#if canImport(Accelerate)
+import Accelerate
+#endif
+
+public struct RealFFTPlan {
+    public let size: Int
+
+    #if canImport(Accelerate)
+    private let acceleratePlan: vDSP.FFT<DSPSplitComplex>?
+    #endif
+
+    public init(size: Int) throws {
+        guard size > 1 else {
+            throw RealFFTError.invalidSize(size)
+        }
+        self.size = size
+        #if canImport(Accelerate)
+        if size.nonzeroBitCount == 1 {
+            let log2n = vDSP_Length(log2(Double(size)))
+            self.acceleratePlan = vDSP.FFT(log2n: log2n, radix: .radix2, ofType: DSPSplitComplex.self)
+        } else {
+            self.acceleratePlan = nil
+        }
+        #endif
+    }
+
+    public func powerSpectrum(_ samples: [Float]) -> [Float] {
+        var frame = samples
+        if frame.count < size {
+            frame += [Float](repeating: 0, count: size - frame.count)
+        } else if frame.count > size {
+            frame = Array(frame.prefix(size))
+        }
+
+        #if canImport(Accelerate)
+        if let acceleratePlan {
+            return acceleratePowerSpectrum(frame, plan: acceleratePlan)
+        }
+        #endif
+
+        return discretePowerSpectrum(frame)
+    }
+
+    #if canImport(Accelerate)
+    private func acceleratePowerSpectrum(
+        _ frame: [Float],
+        plan: vDSP.FFT<DSPSplitComplex>
+    ) -> [Float] {
+        var real = [Float](repeating: 0, count: size / 2)
+        var imag = [Float](repeating: 0, count: size / 2)
+        frame.withUnsafeBufferPointer { inputPtr in
+            real.withUnsafeMutableBufferPointer { realPtr in
+                imag.withUnsafeMutableBufferPointer { imagPtr in
+                    var split = DSPSplitComplex(
+                        realp: realPtr.baseAddress!,
+                        imagp: imagPtr.baseAddress!
+                    )
+                    vDSP_ctoz(
+                        UnsafePointer<DSPComplex>(OpaquePointer(inputPtr.baseAddress!)),
+                        2,
+                        &split,
+                        1,
+                        vDSP_Length(size / 2)
+                    )
+                    plan.forward(input: split, output: &split)
+                }
+            }
+        }
+
+        var magnitudes = [Float](repeating: 0, count: (size / 2) + 1)
+        magnitudes[0] = real[0] * real[0]
+        for index in 1..<(size / 2) {
+            magnitudes[index] = (real[index] * real[index]) + (imag[index] * imag[index])
+        }
+        magnitudes[size / 2] = imag[0] * imag[0]
+        return magnitudes
+    }
+    #endif
+
+    private func discretePowerSpectrum(_ frame: [Float]) -> [Float] {
+        var magnitudes = [Float](repeating: 0, count: (size / 2) + 1)
+        let denominator = Double(size)
+        for frequency in 0...(size / 2) {
+            var real = 0.0
+            var imaginary = 0.0
+            for sampleIndex in 0..<size {
+                let angle = -2.0 * Double.pi * Double(frequency * sampleIndex) / denominator
+                let value = Double(frame[sampleIndex])
+                real += value * cos(angle)
+                imaginary += value * sin(angle)
+            }
+            magnitudes[frequency] = Float((real * real) + (imaginary * imaginary))
+        }
+        return magnitudes
+    }
+}
+
+public enum RealFFTError: LocalizedError {
+    case invalidSize(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSize(let size):
+            return "FFT size must be greater than 1; got \(size)."
+        }
+    }
+}

--- a/Sources/AudioCodecs/StreamingWAVWriter.swift
+++ b/Sources/AudioCodecs/StreamingWAVWriter.swift
@@ -1,63 +1,104 @@
-import AVFoundation
 import Foundation
 
 public final class StreamingWAVWriter {
     public enum Error: LocalizedError {
         case invalidFormat
-        case bufferAllocationFailed
-        case missingChannelData
+        case appendAfterClose
 
         public var errorDescription: String? {
             switch self {
             case .invalidFormat:
                 return "Failed to create audio format for streaming WAV output."
-            case .bufferAllocationFailed:
-                return "Failed to allocate audio buffer for streaming WAV output."
-            case .missingChannelData:
-                return "Streaming audio buffer is missing channel data."
+            case .appendAfterClose:
+                return "Cannot append samples after the WAV stream has been closed."
             }
         }
     }
 
-    private let file: AVAudioFile
-    private let format: AVAudioFormat
+    private let fileHandle: FileHandle
+    private let sampleRate: Int
+    private let channels: Int
+    private var sampleCount = 0
+    private var didClose = false
 
-    public init(outputURL: URL, sampleRate: Int, channels: AVAudioChannelCount = 1) throws {
-        guard let format = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Double(max(1, sampleRate)),
-            channels: max(1, channels),
-            interleaved: false
-        ) else {
+    public init(outputURL: URL, sampleRate: Int, channels: Int = 1) throws {
+        guard sampleRate > 0, channels > 0 else {
             throw Error.invalidFormat
         }
 
-        self.format = format
-        self.file = try AVAudioFile(
-            forWriting: outputURL,
-            settings: format.settings,
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
+        FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        self.fileHandle = try FileHandle(forWritingTo: outputURL)
+        self.sampleRate = sampleRate
+        self.channels = channels
+        try writeHeader(dataByteCount: 0)
+    }
+
+    deinit {
+        try? close()
     }
 
     public func append(samples: [Float]) throws {
         guard !samples.isEmpty else { return }
-        let frameCount = AVAudioFrameCount(samples.count)
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
-            throw Error.bufferAllocationFailed
+        guard !didClose else {
+            throw Error.appendAfterClose
         }
 
-        buffer.frameLength = frameCount
-        guard let channelData = buffer.floatChannelData?[0] else {
-            throw Error.missingChannelData
+        var data = Data()
+        data.reserveCapacity(samples.count * MemoryLayout<Float>.size)
+        for sample in samples {
+            data.append(contentsOf: sample.littleEndianBytes)
         }
+        try fileHandle.write(contentsOf: data)
+        sampleCount += samples.count
+    }
 
-        samples.withUnsafeBufferPointer { ptr in
-            guard let baseAddress = ptr.baseAddress else { return }
-            channelData.update(from: baseAddress, count: samples.count)
-        }
+    public func close() throws {
+        guard !didClose else { return }
+        didClose = true
+        let dataByteCount = sampleCount * MemoryLayout<Float>.size
+        try fileHandle.seek(toOffset: 0)
+        try writeHeader(dataByteCount: dataByteCount)
+        try fileHandle.close()
+    }
 
-        try file.write(from: buffer)
+    private func writeHeader(dataByteCount: Int) throws {
+        let byteRate = sampleRate * channels * MemoryLayout<Float>.size
+        let blockAlign = channels * MemoryLayout<Float>.size
+        let chunkSize = 36 + dataByteCount
+
+        var header = Data()
+        header.append(contentsOf: Array("RIFF".utf8))
+        header.appendLE(UInt32(chunkSize))
+        header.append(contentsOf: Array("WAVE".utf8))
+        header.append(contentsOf: Array("fmt ".utf8))
+        header.appendLE(UInt32(16))
+        header.appendLE(UInt16(3))
+        header.appendLE(UInt16(channels))
+        header.appendLE(UInt32(sampleRate))
+        header.appendLE(UInt32(byteRate))
+        header.appendLE(UInt16(blockAlign))
+        header.appendLE(UInt16(MemoryLayout<Float>.size * 8))
+        header.append(contentsOf: Array("data".utf8))
+        header.appendLE(UInt32(dataByteCount))
+        try fileHandle.write(contentsOf: header)
+    }
+}
+
+private extension Float {
+    var littleEndianBytes: [UInt8] {
+        var bitPattern = self.bitPattern.littleEndian
+        return withUnsafeBytes(of: &bitPattern) { Array($0) }
+    }
+}
+
+private extension Data {
+    mutating func appendLE(_ value: UInt16) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
+    }
+
+    mutating func appendLE(_ value: UInt32) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
     }
 }

--- a/Sources/AudioSTT/Parakeet/ParakeetAudio.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetAudio.swift
@@ -1,4 +1,4 @@
-import Accelerate
+import AudioCodecs
 import Foundation
 import MLX
 
@@ -19,22 +19,22 @@ public final class ParakeetAudioPreprocessor {
 
     public let config: ParakeetPreprocessorConfig
 
-    private let fftSetup: vDSP.FFT<DSPSplitComplex>
+    private let fftPlan: RealFFTPlan
     private let window: [Float]
     private let melFilters: [[Float]]
 
     public init(config: ParakeetPreprocessorConfig) throws {
         self.config = config
 
-        guard config.nFFT > 0, config.nFFT.nonzeroBitCount == 1 else {
+        guard config.nFFT > 0 else {
             throw PreprocessorError.invalidFFTSize(config.nFFT)
         }
 
-        let log2n = vDSP_Length(log2(Double(config.nFFT)))
-        guard let fftSetup = vDSP.FFT(log2n: log2n, radix: .radix2, ofType: DSPSplitComplex.self) else {
+        do {
+            self.fftPlan = try RealFFTPlan(size: config.nFFT)
+        } catch {
             throw PreprocessorError.fftSetupFailed(nFFT: config.nFFT)
         }
-        self.fftSetup = fftSetup
 
         self.window = Self.makeWindow(name: config.window, count: config.winLength)
         self.melFilters = Self.createMelFilterbank(
@@ -55,8 +55,6 @@ public final class ParakeetAudioPreprocessor {
             count: config.features
         )
 
-        var real = [Float](repeating: 0, count: config.nFFT / 2)
-        var imag = [Float](repeating: 0, count: config.nFFT / 2)
         var frameBuffer = [Float](repeating: 0, count: config.nFFT)
         var fftWindow = [Float](repeating: 0, count: config.nFFT)
         let copyCount = min(config.winLength, config.nFFT)
@@ -79,36 +77,7 @@ public final class ParakeetAudioPreprocessor {
                 }
             }
 
-            real = [Float](repeating: 0, count: config.nFFT / 2)
-            imag = [Float](repeating: 0, count: config.nFFT / 2)
-
-            frameBuffer.withUnsafeBufferPointer { inputPtr in
-                real.withUnsafeMutableBufferPointer { realPtr in
-                    imag.withUnsafeMutableBufferPointer { imagPtr in
-                        var split = DSPSplitComplex(
-                            realp: realPtr.baseAddress!,
-                            imagp: imagPtr.baseAddress!
-                        )
-
-                        vDSP_ctoz(
-                            UnsafePointer<DSPComplex>(OpaquePointer(inputPtr.baseAddress!)),
-                            2,
-                            &split,
-                            1,
-                            vDSP_Length(config.nFFT / 2)
-                        )
-
-                        fftSetup.forward(input: split, output: &split)
-                    }
-                }
-            }
-
-            magnitudes = [Float](repeating: 0, count: config.nFFT / 2 + 1)
-            magnitudes[0] = real[0] * real[0]
-            for i in 1..<(config.nFFT / 2) {
-                magnitudes[i] = real[i] * real[i] + imag[i] * imag[i]
-            }
-            magnitudes[config.nFFT / 2] = imag[0] * imag[0]
+            magnitudes = fftPlan.powerSpectrum(frameBuffer)
 
             for melIndex in 0..<config.features {
                 var energy: Float = 0

--- a/Sources/AudioTTS/Qwen3TTS/Qwen3TTSAudioPreprocessor.swift
+++ b/Sources/AudioTTS/Qwen3TTS/Qwen3TTSAudioPreprocessor.swift
@@ -1,16 +1,6 @@
 import Foundation
-@preconcurrency import AVFoundation
-import Accelerate
+import AudioCodecs
 import MLX
-
-private final class AudioConverterInputState: @unchecked Sendable {
-    var didProvideInput = false
-    let buffer: AVAudioPCMBuffer
-
-    init(buffer: AVAudioPCMBuffer) {
-        self.buffer = buffer
-    }
-}
 
 public enum Qwen3TTSAudioPreprocessor {
     public struct ProcessedReference: Sendable, Hashable {
@@ -52,37 +42,20 @@ public enum Qwen3TTSAudioPreprocessor {
         minDuration: Double = 2.0,
         maxDuration: Double = 12.0
     ) throws -> ProcessedReference {
-        let file: AVAudioFile
+        let samples: [Float]
         do {
-            file = try AVAudioFile(forReading: url)
+            samples = try AudioReader
+                .readAudioBuffer(from: url, sampleRate: targetSampleRate, channels: 1)
+                .samples
         } catch {
             throw Error.readFailed(error.localizedDescription)
         }
 
-        let sourceFormat = file.processingFormat
-        let frameCount = AVAudioFrameCount(file.length)
-        guard frameCount > 0 else { throw Error.emptyAudio }
-
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: frameCount) else {
-            throw Error.readFailed("Failed to allocate audio buffer")
-        }
-
-        do {
-            try file.read(into: buffer)
-        } catch {
-            throw Error.readFailed(error.localizedDescription)
-        }
-
-        let converted = try convertToMonoFloat(
-            buffer: buffer,
-            sourceFormat: sourceFormat,
-            sampleRate: Double(targetSampleRate)
-        )
-        if converted.isEmpty {
+        if samples.isEmpty {
             throw Error.emptyAudio
         }
 
-        let trimmed = trimSilence(normalize(converted), threshold: 0.01)
+        let trimmed = trimSilence(normalize(samples), threshold: 0.01)
         if trimmed.isEmpty {
             throw Error.emptyAudio
         }
@@ -149,15 +122,12 @@ public enum Qwen3TTSAudioPreprocessor {
             fMax: Double(sampleRate) / 2.0
         ) // [nMels, fftBins]
 
-        let log2n = vDSP_Length(log2(Double(nFFT)))
-        guard let fftSetup = vDSP.FFT(log2n: log2n, radix: .radix2, ofType: DSPSplitComplex.self) else {
+        guard let fftPlan = try? RealFFTPlan(size: nFFT) else {
             return MLXArray.zeros([1, frameCount, nMels], dtype: .float32)
         }
 
         var melOutput = [Float](repeating: 0, count: frameCount * nMels)
         var frameBuffer = [Float](repeating: 0, count: nFFT)
-        var realp = [Float](repeating: 0, count: nFFT / 2)
-        var imagp = [Float](repeating: 0, count: nFFT / 2)
         var magnitudes = [Float](repeating: 0, count: fftBins)
 
         for frameIdx in 0..<frameCount {
@@ -166,34 +136,7 @@ public enum Qwen3TTSAudioPreprocessor {
                 frameBuffer[i] = paddedSamples[start + i] * hann[i]
             }
 
-            realp = [Float](repeating: 0, count: nFFT / 2)
-            imagp = [Float](repeating: 0, count: nFFT / 2)
-
-            frameBuffer.withUnsafeBufferPointer { inputPtr in
-                realp.withUnsafeMutableBufferPointer { realPtr in
-                    imagp.withUnsafeMutableBufferPointer { imagPtr in
-                        var splitComplex = DSPSplitComplex(
-                            realp: realPtr.baseAddress!,
-                            imagp: imagPtr.baseAddress!
-                        )
-                        vDSP_ctoz(
-                            UnsafePointer<DSPComplex>(OpaquePointer(inputPtr.baseAddress!)),
-                            2,
-                            &splitComplex,
-                            1,
-                            vDSP_Length(nFFT / 2)
-                        )
-                        fftSetup.forward(input: splitComplex, output: &splitComplex)
-                    }
-                }
-            }
-
-            magnitudes = [Float](repeating: 0, count: fftBins)
-            magnitudes[0] = realp[0] * realp[0]
-            for i in 1..<(nFFT / 2) {
-                magnitudes[i] = realp[i] * realp[i] + imagp[i] * imagp[i]
-            }
-            magnitudes[nFFT / 2] = imagp[0] * imagp[0]
+            magnitudes = fftPlan.powerSpectrum(frameBuffer)
 
             for melIdx in 0..<nMels {
                 let rowOffset = melIdx * fftBins
@@ -207,58 +150,6 @@ public enum Qwen3TTSAudioPreprocessor {
         }
 
         return MLXArray(melOutput).reshaped(1, frameCount, nMels).asType(.float32)
-    }
-
-    private static func convertToMonoFloat(
-        buffer: AVAudioPCMBuffer,
-        sourceFormat: AVAudioFormat,
-        sampleRate: Double
-    ) throws -> [Float] {
-        let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: sampleRate,
-            channels: 1,
-            interleaved: false
-        )!
-
-        if sourceFormat.sampleRate == targetFormat.sampleRate,
-           sourceFormat.channelCount == targetFormat.channelCount,
-           sourceFormat.commonFormat == .pcmFormatFloat32,
-           let floatData = buffer.floatChannelData {
-            return Array(UnsafeBufferPointer(start: floatData[0], count: Int(buffer.frameLength)))
-        }
-
-        guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
-            throw Error.readFailed("Failed to create converter")
-        }
-
-        let ratio = targetFormat.sampleRate / sourceFormat.sampleRate
-        let outputCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
-        guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputCapacity) else {
-            throw Error.readFailed("Failed to create output buffer")
-        }
-
-        let inputState = AudioConverterInputState(buffer: buffer)
-        var conversionError: NSError?
-        converter.convert(to: output, error: &conversionError) { _, outStatus in
-            if inputState.didProvideInput {
-                outStatus.pointee = .noDataNow
-                return nil
-            }
-            inputState.didProvideInput = true
-            outStatus.pointee = .haveData
-            return inputState.buffer
-        }
-
-        if let conversionError {
-            throw Error.readFailed(conversionError.localizedDescription)
-        }
-
-        guard let floatData = output.floatChannelData else {
-            throw Error.readFailed("Converted audio has no float channel data")
-        }
-
-        return Array(UnsafeBufferPointer(start: floatData[0], count: Int(output.frameLength)))
     }
 
     private static func normalize(_ samples: [Float]) -> [Float] {

--- a/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift
+++ b/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift
@@ -96,7 +96,7 @@ public actor Qwen3TTSGenerator: TTSGenerator {
 
     nonisolated public func generateStream(
         _ request: TTSRequest,
-        options: TTSStreamingOptions,
+        options: TTSStreamingOptions
     ) -> AsyncThrowingStream<TTSStreamingEvent, Error> {
         generateStream(request, options: options, modelPath: nil)
     }

--- a/Sources/MediaIO/AppleMediaAudioIO.swift
+++ b/Sources/MediaIO/AppleMediaAudioIO.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+#if canImport(AVFoundation)
+@preconcurrency import AVFoundation
+
+enum AppleMediaAudioIO {
+    static func decode(
+        _ url: URL,
+        targetSampleRate: Int,
+        channels: Int
+    ) throws -> MediaAudioBuffer {
+        let file: AVAudioFile
+        do {
+            file = try AVAudioFile(forReading: url)
+        } catch {
+            throw MediaIOError.audioDecodeFailed(url, error.localizedDescription)
+        }
+
+        let sourceFormat = file.processingFormat
+        let frameCount = AVAudioFrameCount(file.length)
+        guard frameCount > 0 else {
+            throw MediaIOError.audioDecodeFailed(url, "Audio file is empty.")
+        }
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: frameCount) else {
+            throw MediaIOError.audioDecodeFailed(url, "Failed to allocate audio buffer.")
+        }
+        do {
+            try file.read(into: buffer)
+        } catch {
+            throw MediaIOError.audioDecodeFailed(url, error.localizedDescription)
+        }
+
+        let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(max(1, targetSampleRate)),
+            channels: AVAudioChannelCount(max(1, channels)),
+            interleaved: false
+        )!
+
+        let outputBuffer: AVAudioPCMBuffer
+        if sourceFormat.sampleRate == targetFormat.sampleRate,
+           sourceFormat.channelCount == targetFormat.channelCount,
+           sourceFormat.commonFormat == .pcmFormatFloat32 {
+            outputBuffer = buffer
+        } else {
+            guard let converter = AVAudioConverter(from: sourceFormat, to: targetFormat) else {
+                throw MediaIOError.audioDecodeFailed(url, "Failed to create audio converter.")
+            }
+            let ratio = targetFormat.sampleRate / sourceFormat.sampleRate
+            let outputCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
+            guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outputCapacity) else {
+                throw MediaIOError.audioDecodeFailed(url, "Failed to allocate converted audio buffer.")
+            }
+            var didConvert = false
+            var conversionError: NSError?
+            converter.convert(to: converted, error: &conversionError) { _, outStatus in
+                if didConvert {
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+                didConvert = true
+                outStatus.pointee = .haveData
+                return buffer
+            }
+            if let conversionError {
+                throw MediaIOError.audioDecodeFailed(url, conversionError.localizedDescription)
+            }
+            outputBuffer = converted
+        }
+
+        guard let floatData = outputBuffer.floatChannelData else {
+            throw MediaIOError.audioDecodeFailed(url, "Decoded audio has no float channel data.")
+        }
+
+        let frames = Int(outputBuffer.frameLength)
+        let channelCount = Int(outputBuffer.format.channelCount)
+        var interleaved = [Float](repeating: 0, count: frames * channelCount)
+        for frame in 0..<frames {
+            for channel in 0..<channelCount {
+                interleaved[(frame * channelCount) + channel] = floatData[channel][frame]
+            }
+        }
+
+        return MediaAudioBuffer(
+            samples: interleaved,
+            sampleRate: Int(outputBuffer.format.sampleRate.rounded()),
+            channelCount: channelCount,
+            isInterleaved: true
+        )
+    }
+}
+#endif

--- a/Sources/MediaIO/AppleMediaImageIO.swift
+++ b/Sources/MediaIO/AppleMediaImageIO.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
+
+enum AppleMediaImageIO {
+    static func size(of url: URL) throws -> (width: Int, height: Int) {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? Int,
+              let height = properties[kCGImagePropertyPixelHeight] as? Int else {
+            throw MediaIOError.imageMetadataFailed(url)
+        }
+        return (width, height)
+    }
+
+    static func decode(_ url: URL) throws -> MediaImage {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw MediaIOError.imageDecodeFailed(url)
+        }
+        return try mediaImage(from: image)
+    }
+
+    static func decode(data: Data) throws -> MediaImage {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw MediaIOError.unsupportedPlatform("Failed to decode in-memory image data.")
+        }
+        return try mediaImage(from: image)
+    }
+
+    static func writePNG(_ image: MediaImage, to url: URL) throws {
+        let cgImage = try cgImage(from: image)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        guard let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            throw MediaIOError.imageEncodeFailed(url)
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw MediaIOError.imageEncodeFailed(url)
+        }
+    }
+
+    static func mediaImage(from image: CGImage) throws -> MediaImage {
+        let width = image.width
+        let height = image.height
+        let bytesPerRow = width * 4
+        var rgba = [UInt8](repeating: 0, count: width * height * 4)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+
+        let succeeded = rgba.withUnsafeMutableBytes { ptr -> Bool in
+            guard let base = ptr.baseAddress,
+                  let context = CGContext(
+                      data: base,
+                      width: width,
+                      height: height,
+                      bitsPerComponent: 8,
+                      bytesPerRow: bytesPerRow,
+                      space: colorSpace,
+                      bitmapInfo: bitmapInfo
+                  ) else {
+                return false
+            }
+            context.interpolationQuality = .high
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard succeeded else {
+            throw MediaIOError.imageDecodeFailed(URL(fileURLWithPath: "<memory>"))
+        }
+        return try MediaImage(width: width, height: height, rgba8: rgba)
+    }
+
+    static func cgImage(from image: MediaImage) throws -> CGImage {
+        guard let provider = CGDataProvider(data: Data(image.rgba8) as CFData) else {
+            throw MediaIOError.invalidBufferSize(expected: image.width * image.height * 4, actual: image.rgba8.count)
+        }
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        guard let cgImage = CGImage(
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: image.width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ) else {
+            throw MediaIOError.invalidBufferSize(expected: image.width * image.height * 4, actual: image.rgba8.count)
+        }
+        return cgImage
+    }
+}
+#endif

--- a/Sources/MediaIO/AppleMediaVideoIO.swift
+++ b/Sources/MediaIO/AppleMediaVideoIO.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+#if canImport(AVFoundation) && canImport(CoreGraphics)
+import AVFoundation
+import CoreGraphics
+import CoreVideo
+import ImageIO
+import UniformTypeIdentifiers
+
+private typealias AppleVideoSettings = Dictionary<String, Any>
+
+enum AppleMediaVideoIO {
+    static func writeMP4(
+        rgb24: [UInt8],
+        width: Int,
+        height: Int,
+        frameCount: Int,
+        fps: Int,
+        to outputURL: URL
+    ) throws {
+        guard fps >= 1, width > 0, height > 0, frameCount > 0 else {
+            throw MediaIOError.videoOperationFailed("Invalid MP4 dimensions or frame rate.")
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: outputURL)
+
+        guard let writer = try? AVAssetWriter(outputURL: outputURL, fileType: .mp4) else {
+            throw MediaIOError.videoOperationFailed("Could not create MP4 writer for \(outputURL.path).")
+        }
+        let settings: AppleVideoSettings = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+            AVVideoCompressionPropertiesKey: [
+                AVVideoAverageBitRateKey: max(1_000_000, width * height * fps * 4),
+                AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
+            ],
+        ]
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        input.expectsMediaDataInRealTime = false
+        guard writer.canAdd(input) else {
+            throw MediaIOError.videoOperationFailed("AVAssetWriter rejected video input settings.")
+        }
+        writer.add(input)
+
+        let attributes: AppleVideoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
+            kCVPixelBufferWidthKey as String: width,
+            kCVPixelBufferHeightKey as String: height,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: attributes
+        )
+        guard writer.startWriting() else {
+            throw MediaIOError.videoOperationFailed(writer.error?.localizedDescription ?? "writer failed")
+        }
+        writer.startSession(atSourceTime: .zero)
+        guard let pool = adaptor.pixelBufferPool else {
+            throw MediaIOError.videoOperationFailed("AVAssetWriter did not provide a pixel buffer pool.")
+        }
+
+        let frameStride = width * height * 3
+        guard rgb24.count == frameStride * frameCount else {
+            throw MediaIOError.invalidBufferSize(expected: frameStride * frameCount, actual: rgb24.count)
+        }
+
+        for frameIndex in 0..<frameCount {
+            while !input.isReadyForMoreMediaData {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer)
+            guard status == kCVReturnSuccess, let pixelBuffer else {
+                throw MediaIOError.videoOperationFailed("Failed to allocate pixel buffer.")
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+                CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+                throw MediaIOError.videoOperationFailed("Pixel buffer base address unavailable.")
+            }
+            let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+            let dst = base.bindMemory(to: UInt8.self, capacity: bytesPerRow * height)
+            let srcOffset = frameIndex * frameStride
+            for y in 0..<height {
+                let dstRow = dst.advanced(by: y * bytesPerRow)
+                let srcRow = srcOffset + (y * width * 3)
+                for x in 0..<width {
+                    let src = srcRow + (x * 3)
+                    let out = x * 4
+                    dstRow[out] = rgb24[src + 2]
+                    dstRow[out + 1] = rgb24[src + 1]
+                    dstRow[out + 2] = rgb24[src]
+                    dstRow[out + 3] = 255
+                }
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+            let time = CMTime(value: Int64(frameIndex), timescale: CMTimeScale(fps))
+            guard adaptor.append(pixelBuffer, withPresentationTime: time) else {
+                throw MediaIOError.videoOperationFailed("Failed to append frame \(frameIndex).")
+            }
+        }
+
+        input.markAsFinished()
+        let semaphore = DispatchSemaphore(value: 0)
+        writer.finishWriting { semaphore.signal() }
+        semaphore.wait()
+        guard writer.status == .completed else {
+            throw MediaIOError.videoOperationFailed(writer.error?.localizedDescription ?? "writer did not complete")
+        }
+    }
+
+    static func mux(videoURL: URL, audioURL: URL, outputURL: URL) throws {
+        let videoAsset = AVURLAsset(url: videoURL)
+        let audioAsset = AVURLAsset(url: audioURL)
+        guard let videoTrack = videoAsset.tracks(withMediaType: .video).first else {
+            throw MediaIOError.videoOperationFailed("Video track is missing from source asset.")
+        }
+        guard let audioTrack = audioAsset.tracks(withMediaType: .audio).first else {
+            throw MediaIOError.videoOperationFailed("Audio track is missing from source asset.")
+        }
+        let composition = AVMutableComposition()
+        guard let compositionVideoTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid),
+              let compositionAudioTrack = composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid) else {
+            throw MediaIOError.videoOperationFailed("Could not create composition tracks.")
+        }
+        let duration = CMTimeMinimum(videoAsset.duration, audioAsset.duration)
+        try compositionVideoTrack.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: videoTrack, at: .zero)
+        try compositionAudioTrack.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: audioTrack, at: .zero)
+        compositionVideoTrack.preferredTransform = videoTrack.preferredTransform
+        try exportComposition(composition, outputURL: outputURL, videoComposition: nil, audioMix: nil)
+    }
+
+    static func extractFrames(
+        from videoURL: URL,
+        into outputDirectoryURL: URL,
+        endFrame: Int?
+    ) throws -> VideoFrameSequence {
+        try FileManager.default.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
+        let asset = AVURLAsset(url: videoURL)
+        guard let track = asset.tracks(withMediaType: .video).first else {
+            throw MediaIOError.videoOperationFailed("Video track missing in asset: \(videoURL.path)")
+        }
+        let fps = max(1.0, Double(track.nominalFrameRate > 0 ? track.nominalFrameRate : 30.0))
+        let durationSeconds = CMTimeGetSeconds(asset.duration)
+        let estimatedFrameCount = max(1, Int((durationSeconds * fps).rounded(.toNearestOrEven)))
+        let frameCount = min(endFrame.map { $0 + 1 } ?? estimatedFrameCount, estimatedFrameCount)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+
+        var frameURLs: [URL] = []
+        var frameWidth = 0
+        var frameHeight = 0
+        for frameIndex in 0..<frameCount {
+            let time = CMTime(value: CMTimeValue(frameIndex), timescale: CMTimeScale(max(1, Int32(fps.rounded()))))
+            let image = try generator.copyCGImage(at: time, actualTime: nil)
+            if frameWidth == 0 || frameHeight == 0 {
+                frameWidth = image.width
+                frameHeight = image.height
+            }
+            let frameURL = outputDirectoryURL
+                .appendingPathComponent(String(format: "frame_%05d", frameIndex))
+                .appendingPathExtension("png")
+            try writeImage(image, to: frameURL)
+            frameURLs.append(frameURL)
+        }
+        return VideoFrameSequence(frameURLs: frameURLs, fps: fps, frameWidth: frameWidth, frameHeight: frameHeight)
+    }
+
+    static func writeVideo(frameURLs: [URL], fps: Double, to outputURL: URL) throws {
+        guard let firstURL = frameURLs.first,
+              let firstImage = loadCGImage(firstURL) else {
+            throw MediaIOError.videoOperationFailed("No frames supplied for video writing.")
+        }
+        var rgb = [UInt8]()
+        rgb.reserveCapacity(frameURLs.count * firstImage.width * firstImage.height * 3)
+        for url in frameURLs {
+            let media = try MediaImageIO.decode(url)
+            guard media.width == firstImage.width, media.height == firstImage.height else {
+                throw MediaIOError.videoOperationFailed("Frame dimensions do not match.")
+            }
+            for pixel in 0..<(media.width * media.height) {
+                let src = pixel * 4
+                rgb.append(media.rgba8[src])
+                rgb.append(media.rgba8[src + 1])
+                rgb.append(media.rgba8[src + 2])
+            }
+        }
+        try writeMP4(
+            rgb24: rgb,
+            width: firstImage.width,
+            height: firstImage.height,
+            frameCount: frameURLs.count,
+            fps: max(1, Int(fps.rounded())),
+            to: outputURL
+        )
+    }
+
+    static func hasAudioTrack(_ url: URL) -> Bool {
+        let asset = AVURLAsset(url: url)
+        return !asset.tracks(withMediaType: .audio).isEmpty
+    }
+
+    private static func loadCGImage(_ url: URL) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private static func writeImage(_ image: CGImage, to url: URL) throws {
+        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+            throw MediaIOError.imageEncodeFailed(url)
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw MediaIOError.imageEncodeFailed(url)
+        }
+    }
+
+    private static func exportComposition(
+        _ composition: AVComposition,
+        outputURL: URL,
+        videoComposition: AVVideoComposition?,
+        audioMix: AVAudioMix?
+    ) throws {
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: outputURL)
+        guard let export = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetHighestQuality) else {
+            throw MediaIOError.videoOperationFailed("Could not create AVAssetExportSession.")
+        }
+        export.outputURL = outputURL
+        export.outputFileType = outputURL.pathExtension.lowercased() == "mov" ? .mov : .mp4
+        export.shouldOptimizeForNetworkUse = true
+        export.videoComposition = videoComposition
+        export.audioMix = audioMix
+        let semaphore = DispatchSemaphore(value: 0)
+        export.exportAsynchronously { semaphore.signal() }
+        semaphore.wait()
+        guard export.status == .completed else {
+            throw MediaIOError.videoOperationFailed(export.error?.localizedDescription ?? "export failed")
+        }
+    }
+}
+#endif

--- a/Sources/MediaIO/FFmpegMediaIO.swift
+++ b/Sources/MediaIO/FFmpegMediaIO.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+enum FFmpegMediaIO {
+    static func imageSize(of url: URL) throws -> (width: Int, height: Int) {
+        let result = try FFmpegProcess.run(
+            tool: MediaTool.ffprobePath,
+            arguments: [
+                "-v", "error",
+                "-select_streams", "v:0",
+                "-show_entries", "stream=width,height",
+                "-of", "csv=p=0:s=x",
+                url.path
+            ]
+        )
+        let text = String(decoding: result.stdout, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pieces = text.split(separator: "x").compactMap { Int($0) }
+        guard pieces.count == 2, pieces[0] > 0, pieces[1] > 0 else {
+            throw MediaIOError.imageMetadataFailed(url)
+        }
+        return (pieces[0], pieces[1])
+    }
+
+    static func decodeImage(_ url: URL) throws -> MediaImage {
+        let size = try imageSize(of: url)
+        let result = try FFmpegProcess.run(
+            tool: MediaTool.ffmpegPath,
+            arguments: [
+                "-v", "error",
+                "-i", url.path,
+                "-f", "rawvideo",
+                "-pix_fmt", "rgba",
+                "pipe:1"
+            ]
+        )
+        let bytes = [UInt8](result.stdout)
+        return try MediaImage(width: size.width, height: size.height, rgba8: bytes)
+    }
+
+    static func writePNG(_ image: MediaImage, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try FFmpegProcess.run(
+            tool: MediaTool.ffmpegPath,
+            arguments: [
+                "-v", "error",
+                "-y",
+                "-f", "rawvideo",
+                "-pix_fmt", "rgba",
+                "-s", "\(image.width)x\(image.height)",
+                "-i", "pipe:0",
+                "-frames:v", "1",
+                url.path
+            ],
+            stdin: Data(image.rgba8)
+        )
+    }
+
+    static func decodeAudio(
+        _ url: URL,
+        targetSampleRate: Int,
+        channels: Int
+    ) throws -> MediaAudioBuffer {
+        let sampleRate = max(1, targetSampleRate)
+        let channelCount = max(1, channels)
+        do {
+            let result = try FFmpegProcess.run(
+                tool: MediaTool.ffmpegPath,
+                arguments: [
+                    "-v", "error",
+                    "-i", url.path,
+                    "-ac", "\(channelCount)",
+                    "-ar", "\(sampleRate)",
+                    "-f", "f32le",
+                    "pipe:1"
+                ]
+            )
+            let samples = result.stdout.withUnsafeBytes { raw -> [Float] in
+                let floats = raw.bindMemory(to: Float.self)
+                return Array(floats)
+            }
+            return MediaAudioBuffer(
+                samples: samples,
+                sampleRate: sampleRate,
+                channelCount: channelCount,
+                isInterleaved: true
+            )
+        } catch let error as MediaIOError {
+            throw MediaIOError.audioDecodeFailed(url, error.localizedDescription)
+        } catch {
+            throw MediaIOError.audioDecodeFailed(url, error.localizedDescription)
+        }
+    }
+
+    static func writeMP4(
+        rgb24: [UInt8],
+        width: Int,
+        height: Int,
+        frameCount: Int,
+        fps: Int,
+        to outputURL: URL
+    ) throws {
+        guard width > 0, height > 0, frameCount > 0, fps > 0 else {
+            throw MediaIOError.videoOperationFailed("Invalid MP4 dimensions or frame rate.")
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try FFmpegProcess.run(
+            tool: MediaTool.ffmpegPath,
+            arguments: [
+                "-v", "error",
+                "-y",
+                "-f", "rawvideo",
+                "-pix_fmt", "rgb24",
+                "-s", "\(width)x\(height)",
+                "-r", "\(fps)",
+                "-i", "pipe:0",
+                "-an",
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                outputURL.path
+            ],
+            stdin: Data(rgb24)
+        )
+    }
+
+    static func mux(videoURL: URL, audioURL: URL, outputURL: URL) throws {
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try FFmpegProcess.run(
+            tool: MediaTool.ffmpegPath,
+            arguments: [
+                "-v", "error",
+                "-y",
+                "-i", videoURL.path,
+                "-i", audioURL.path,
+                "-c:v", "copy",
+                "-c:a", "aac",
+                "-shortest",
+                outputURL.path
+            ]
+        )
+    }
+
+    static func extractFrames(
+        from videoURL: URL,
+        into directoryURL: URL,
+        endFrame: Int?
+    ) throws -> VideoFrameSequence {
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let pattern = directoryURL.appendingPathComponent("frame_%05d.png")
+        var arguments = [
+            "-v", "error",
+            "-y",
+            "-i", videoURL.path
+        ]
+        if let endFrame {
+            arguments += ["-frames:v", "\(max(0, endFrame) + 1)"]
+        }
+        arguments.append(pattern.path)
+        _ = try FFmpegProcess.run(tool: MediaTool.ffmpegPath, arguments: arguments)
+
+        let frameURLs = (try? FileManager.default.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: nil
+        ))?.filter { $0.pathExtension.lowercased() == "png" }.sorted { $0.path < $1.path } ?? []
+
+        guard let first = frameURLs.first else {
+            throw MediaIOError.videoOperationFailed("No frames extracted from \(videoURL.path).")
+        }
+        let size = try imageSize(of: first)
+        return VideoFrameSequence(
+            frameURLs: frameURLs,
+            fps: videoFPS(videoURL) ?? 30.0,
+            frameWidth: size.width,
+            frameHeight: size.height
+        )
+    }
+
+    static func writeVideo(frameURLs: [URL], fps: Double, to outputURL: URL) throws {
+        guard let first = frameURLs.first else {
+            throw MediaIOError.videoOperationFailed("No frames supplied for video writing.")
+        }
+        let tempDir = first.deletingLastPathComponent()
+        let listURL = tempDir.appendingPathComponent("mererun-frames-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: listURL) }
+        let duration = 1.0 / max(fps, 1.0)
+        let list = frameURLs.map { "file '\($0.path.replacingOccurrences(of: "'", with: "'\\''"))'\nduration \(duration)" }
+            .joined(separator: "\n")
+        try list.write(to: listURL, atomically: true, encoding: .utf8)
+        _ = try FFmpegProcess.run(
+            tool: MediaTool.ffmpegPath,
+            arguments: [
+                "-v", "error",
+                "-y",
+                "-f", "concat",
+                "-safe", "0",
+                "-i", listURL.path,
+                "-r", "\(max(1, Int(fps.rounded())))",
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                outputURL.path
+            ]
+        )
+    }
+
+    static func hasAudioTrack(_ url: URL) -> Bool {
+        guard let result = try? FFmpegProcess.run(
+            tool: MediaTool.ffprobePath,
+            arguments: [
+                "-v", "error",
+                "-select_streams", "a",
+                "-show_entries", "stream=index",
+                "-of", "csv=p=0",
+                url.path
+            ]
+        ) else {
+            return false
+        }
+        let text = String(decoding: result.stdout, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return !text.isEmpty
+    }
+
+    private static func videoFPS(_ url: URL) -> Double? {
+        guard let result = try? FFmpegProcess.run(
+            tool: MediaTool.ffprobePath,
+            arguments: [
+                "-v", "error",
+                "-select_streams", "v:0",
+                "-show_entries", "stream=r_frame_rate",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                url.path
+            ]
+        ) else {
+            return nil
+        }
+        let text = String(decoding: result.stdout, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = text.split(separator: "/").compactMap { Double($0) }
+        if parts.count == 2, parts[1] != 0 {
+            return parts[0] / parts[1]
+        }
+        return Double(text)
+    }
+}

--- a/Sources/MediaIO/FFmpegProcess.swift
+++ b/Sources/MediaIO/FFmpegProcess.swift
@@ -1,0 +1,96 @@
+import Foundation
+#if os(Linux)
+import Glibc
+#endif
+
+enum FFmpegProcess {
+    struct Result {
+        let stdout: Data
+        let stderr: String
+    }
+
+    static func run(
+        tool: String,
+        arguments: [String],
+        stdin: Data? = nil
+    ) throws -> Result {
+        let executable = try resolveTool(tool)
+        let scratchID = UUID().uuidString
+        let tempRoot = FileManager.default.temporaryDirectory
+        let stdoutURL = tempRoot.appendingPathComponent("mererun-ffmpeg-\(scratchID).stdout")
+        let stderrURL = tempRoot.appendingPathComponent("mererun-ffmpeg-\(scratchID).stderr")
+        let stdinURL = tempRoot.appendingPathComponent("mererun-ffmpeg-\(scratchID).stdin")
+        _ = FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+        _ = FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+        defer {
+            try? FileManager.default.removeItem(at: stdoutURL)
+            try? FileManager.default.removeItem(at: stderrURL)
+            try? FileManager.default.removeItem(at: stdinURL)
+        }
+
+        if let stdin {
+            try stdin.write(to: stdinURL)
+        }
+
+        var command = ([executable.path] + arguments).map(shellQuote).joined(separator: " ")
+        if stdin != nil {
+            command += " < \(shellQuote(stdinURL.path))"
+        }
+        command += " > \(shellQuote(stdoutURL.path)) 2> \(shellQuote(stderrURL.path))"
+
+        #if os(Linux)
+        let status = system(command)
+        #elseif os(macOS)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        do {
+            try process.run()
+        } catch {
+            throw MediaIOError.missingTool(tool)
+        }
+        process.waitUntilExit()
+        let status = process.terminationStatus
+        #else
+        throw MediaIOError.unsupportedPlatform("The FFmpeg MediaIO backend is only available on Linux and macOS.")
+        #endif
+
+        let stdout = try Data(contentsOf: stdoutURL)
+        let stderrData = try Data(contentsOf: stderrURL)
+        let stderr = String(decoding: stderrData, as: UTF8.self)
+        guard status == 0 else {
+            throw MediaIOError.processFailed(
+                tool: tool,
+                status: status,
+                stderr: stderr
+            )
+        }
+
+        return Result(stdout: stdout, stderr: stderr)
+    }
+
+    private static func resolveTool(_ tool: String) throws -> URL {
+        let raw = tool
+        if raw.contains("/") {
+            let url = URL(fileURLWithPath: raw)
+            guard FileManager.default.isExecutableFile(atPath: url.path) else {
+                throw MediaIOError.missingTool(tool)
+            }
+            return url
+        }
+
+        let pathEntries = ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":") ?? []
+        for entry in pathEntries {
+            let candidate = URL(fileURLWithPath: String(entry), isDirectory: true)
+                .appendingPathComponent(raw)
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        throw MediaIOError.missingTool(tool)
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/Sources/MediaIO/MediaAudioIO.swift
+++ b/Sources/MediaIO/MediaAudioIO.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public enum MediaAudioIO {
+    public static func decode(
+        _ url: URL,
+        targetSampleRate: Int,
+        channels: Int
+    ) throws -> MediaAudioBuffer {
+        #if canImport(AVFoundation)
+        try AppleMediaAudioIO.decode(url, targetSampleRate: targetSampleRate, channels: channels)
+        #else
+        try FFmpegMediaIO.decodeAudio(url, targetSampleRate: targetSampleRate, channels: channels)
+        #endif
+    }
+
+    public static func writeFloatWAV(
+        samples: [Float],
+        sampleRate: Int,
+        channels: Int,
+        to url: URL
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        var data = Data()
+        let channelCount = max(1, channels)
+        let bitsPerSample = 32
+        let byteRate = max(1, sampleRate) * channelCount * bitsPerSample / 8
+        let blockAlign = channelCount * bitsPerSample / 8
+        let dataSize = samples.count * MemoryLayout<Float>.size
+        let riffSize = 36 + dataSize
+
+        data.append(contentsOf: Array("RIFF".utf8))
+        data.appendLE(UInt32(riffSize))
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        data.appendLE(UInt32(16))
+        data.appendLE(UInt16(3))
+        data.appendLE(UInt16(channelCount))
+        data.appendLE(UInt32(max(1, sampleRate)))
+        data.appendLE(UInt32(byteRate))
+        data.appendLE(UInt16(blockAlign))
+        data.appendLE(UInt16(bitsPerSample))
+        data.append(contentsOf: Array("data".utf8))
+        data.appendLE(UInt32(dataSize))
+        samples.withUnsafeBufferPointer { ptr in
+            data.append(contentsOf: UnsafeRawBufferPointer(ptr))
+        }
+        try data.write(to: url)
+    }
+}
+
+extension Data {
+    mutating func appendLE(_ value: UInt16) {
+        var little = value.littleEndian
+        Swift.withUnsafeBytes(of: &little) { append(contentsOf: $0) }
+    }
+
+    mutating func appendLE(_ value: UInt32) {
+        var little = value.littleEndian
+        Swift.withUnsafeBytes(of: &little) { append(contentsOf: $0) }
+    }
+}

--- a/Sources/MediaIO/MediaIO.swift
+++ b/Sources/MediaIO/MediaIO.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+public struct MediaImage: Sendable, Hashable {
+    public let width: Int
+    public let height: Int
+    public var rgba8: [UInt8]
+
+    public init(width: Int, height: Int, rgba8: [UInt8]) throws {
+        guard width > 0, height > 0 else {
+            throw MediaIOError.invalidImageDimensions(width: width, height: height)
+        }
+        guard rgba8.count == width * height * 4 else {
+            throw MediaIOError.invalidBufferSize(expected: width * height * 4, actual: rgba8.count)
+        }
+        self.width = width
+        self.height = height
+        self.rgba8 = rgba8
+    }
+}
+
+public struct MediaAudioBuffer: Sendable, Hashable {
+    public let samples: [Float]
+    public let sampleRate: Int
+    public let channelCount: Int
+    public let isInterleaved: Bool
+
+    public init(
+        samples: [Float],
+        sampleRate: Int,
+        channelCount: Int = 1,
+        isInterleaved: Bool = true
+    ) {
+        self.samples = samples
+        self.sampleRate = max(1, sampleRate)
+        self.channelCount = max(1, channelCount)
+        self.isInterleaved = isInterleaved
+    }
+}
+
+public struct VideoFrameSequence: Sendable, Hashable {
+    public let frameURLs: [URL]
+    public let fps: Double
+    public let frameWidth: Int
+    public let frameHeight: Int
+
+    public init(frameURLs: [URL], fps: Double, frameWidth: Int, frameHeight: Int) {
+        self.frameURLs = frameURLs
+        self.fps = max(1, fps)
+        self.frameWidth = max(0, frameWidth)
+        self.frameHeight = max(0, frameHeight)
+    }
+}
+
+public enum ImageResizeMode: Sendable, Hashable {
+    case exact(width: Int, height: Int)
+    case aspectFill(width: Int, height: Int)
+}
+
+public enum MediaIOError: LocalizedError, Sendable, Equatable {
+    case invalidImageDimensions(width: Int, height: Int)
+    case invalidBufferSize(expected: Int, actual: Int)
+    case imageDecodeFailed(URL)
+    case imageEncodeFailed(URL)
+    case imageMetadataFailed(URL)
+    case audioDecodeFailed(URL, String)
+    case audioEncodeFailed(URL, String)
+    case videoOperationFailed(String)
+    case missingTool(String)
+    case processFailed(tool: String, status: Int32, stderr: String)
+    case unsupportedPlatform(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidImageDimensions(let width, let height):
+            return "Invalid media image dimensions \(width)x\(height)."
+        case .invalidBufferSize(let expected, let actual):
+            return "Invalid media buffer size: expected \(expected) bytes, got \(actual)."
+        case .imageDecodeFailed(let url):
+            return "Failed to decode image: \(url.path)"
+        case .imageEncodeFailed(let url):
+            return "Failed to encode image: \(url.path)"
+        case .imageMetadataFailed(let url):
+            return "Failed to read image metadata: \(url.path)"
+        case .audioDecodeFailed(let url, let details):
+            return "Failed to decode audio \(url.path): \(details)"
+        case .audioEncodeFailed(let url, let details):
+            return "Failed to encode audio \(url.path): \(details)"
+        case .videoOperationFailed(let details):
+            return "Video operation failed: \(details)"
+        case .missingTool(let tool):
+            return "\(tool) was not found. Install ffmpeg or set MERERUN_\(tool.uppercased()) to the executable path."
+        case .processFailed(let tool, let status, let stderr):
+            let details = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return "\(tool) exited with status \(status).\(details.isEmpty ? "" : " \(details)")"
+        case .unsupportedPlatform(let message):
+            return message
+        }
+    }
+}
+
+public enum MediaTool {
+    public static var ffmpegPath: String {
+        ProcessInfo.processInfo.environment["MERERUN_FFMPEG"] ?? "ffmpeg"
+    }
+
+    public static var ffprobePath: String {
+        ProcessInfo.processInfo.environment["MERERUN_FFPROBE"] ?? "ffprobe"
+    }
+}

--- a/Sources/MediaIO/MediaImageIO.swift
+++ b/Sources/MediaIO/MediaImageIO.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+public enum MediaImageIO {
+    public static func size(of url: URL) throws -> (width: Int, height: Int) {
+        #if canImport(CoreGraphics)
+        try AppleMediaImageIO.size(of: url)
+        #else
+        try FFmpegMediaIO.imageSize(of: url)
+        #endif
+    }
+
+    public static func decode(_ url: URL) throws -> MediaImage {
+        #if canImport(CoreGraphics)
+        try AppleMediaImageIO.decode(url)
+        #else
+        try FFmpegMediaIO.decodeImage(url)
+        #endif
+    }
+
+    public static func decode(data: Data) throws -> MediaImage {
+        #if canImport(CoreGraphics)
+        try AppleMediaImageIO.decode(data: data)
+        #else
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-image-\(UUID().uuidString)")
+            .appendingPathExtension("img")
+        try data.write(to: temp)
+        defer { try? FileManager.default.removeItem(at: temp) }
+        return try FFmpegMediaIO.decodeImage(temp)
+        #endif
+    }
+
+    public static func writePNG(_ image: MediaImage, to url: URL) throws {
+        #if canImport(CoreGraphics)
+        try AppleMediaImageIO.writePNG(image, to: url)
+        #else
+        try FFmpegMediaIO.writePNG(image, to: url)
+        #endif
+    }
+
+    public static func pngData(from image: MediaImage) throws -> Data {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-image-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        try writePNG(image, to: temp)
+        return try Data(contentsOf: temp)
+    }
+
+    public static func resized(_ image: MediaImage, width: Int, height: Int) throws -> MediaImage {
+        guard width > 0, height > 0 else {
+            throw MediaIOError.invalidImageDimensions(width: width, height: height)
+        }
+        if image.width == width, image.height == height {
+            return image
+        }
+
+        var output = [UInt8](repeating: 255, count: width * height * 4)
+        let xScale = Double(image.width) / Double(width)
+        let yScale = Double(image.height) / Double(height)
+
+        for y in 0..<height {
+            let srcY = min(image.height - 1, Int((Double(y) + 0.5) * yScale))
+            for x in 0..<width {
+                let srcX = min(image.width - 1, Int((Double(x) + 0.5) * xScale))
+                let src = ((srcY * image.width) + srcX) * 4
+                let dst = ((y * width) + x) * 4
+                output[dst] = image.rgba8[src]
+                output[dst + 1] = image.rgba8[src + 1]
+                output[dst + 2] = image.rgba8[src + 2]
+                output[dst + 3] = image.rgba8[src + 3]
+            }
+        }
+        return try MediaImage(width: width, height: height, rgba8: output)
+    }
+
+    public static func centerCropped(_ image: MediaImage, width: Int, height: Int) throws -> MediaImage {
+        guard width > 0, height > 0 else {
+            throw MediaIOError.invalidImageDimensions(width: width, height: height)
+        }
+        let scale = max(Double(width) / Double(image.width), Double(height) / Double(image.height))
+        let scaledWidth = max(width, Int((Double(image.width) * scale).rounded()))
+        let scaledHeight = max(height, Int((Double(image.height) * scale).rounded()))
+        let resized = try resized(image, width: scaledWidth, height: scaledHeight)
+        let originX = max(0, (scaledWidth - width) / 2)
+        let originY = max(0, (scaledHeight - height) / 2)
+
+        var output = [UInt8](repeating: 255, count: width * height * 4)
+        for y in 0..<height {
+            let srcY = y + originY
+            for x in 0..<width {
+                let srcX = x + originX
+                let src = ((srcY * scaledWidth) + srcX) * 4
+                let dst = ((y * width) + x) * 4
+                output[dst] = resized.rgba8[src]
+                output[dst + 1] = resized.rgba8[src + 1]
+                output[dst + 2] = resized.rgba8[src + 2]
+                output[dst + 3] = resized.rgba8[src + 3]
+            }
+        }
+        return try MediaImage(width: width, height: height, rgba8: output)
+    }
+
+    public static func rgbCHWFloat(_ image: MediaImage, normalizedToMinusOneToOne: Bool) -> [Float] {
+        let pixelCount = image.width * image.height
+        var values = [Float](repeating: 0, count: pixelCount * 3)
+        for pixel in 0..<pixelCount {
+            let src = pixel * 4
+            let r = Float(image.rgba8[src]) / 255.0
+            let g = Float(image.rgba8[src + 1]) / 255.0
+            let b = Float(image.rgba8[src + 2]) / 255.0
+            if normalizedToMinusOneToOne {
+                values[pixel] = (r * 2.0) - 1.0
+                values[pixel + pixelCount] = (g * 2.0) - 1.0
+                values[pixel + (pixelCount * 2)] = (b * 2.0) - 1.0
+            } else {
+                values[pixel] = r
+                values[pixel + pixelCount] = g
+                values[pixel + (pixelCount * 2)] = b
+            }
+        }
+        return values
+    }
+
+    public static func imageFromRGBCHW(
+        _ bytes: [UInt8],
+        width: Int,
+        height: Int
+    ) throws -> MediaImage {
+        let pixelCount = width * height
+        guard bytes.count == pixelCount * 3 else {
+            throw MediaIOError.invalidBufferSize(expected: pixelCount * 3, actual: bytes.count)
+        }
+        var rgba = [UInt8](repeating: 255, count: pixelCount * 4)
+        for pixel in 0..<pixelCount {
+            let dst = pixel * 4
+            rgba[dst] = bytes[pixel]
+            rgba[dst + 1] = bytes[pixel + pixelCount]
+            rgba[dst + 2] = bytes[pixel + (pixelCount * 2)]
+        }
+        return try MediaImage(width: width, height: height, rgba8: rgba)
+    }
+
+    public static func imageFromRGBHWC(
+        _ bytes: [UInt8],
+        width: Int,
+        height: Int
+    ) throws -> MediaImage {
+        let pixelCount = width * height
+        guard bytes.count == pixelCount * 3 else {
+            throw MediaIOError.invalidBufferSize(expected: pixelCount * 3, actual: bytes.count)
+        }
+        var rgba = [UInt8](repeating: 255, count: pixelCount * 4)
+        for pixel in 0..<pixelCount {
+            let src = pixel * 3
+            let dst = pixel * 4
+            rgba[dst] = bytes[src]
+            rgba[dst + 1] = bytes[src + 1]
+            rgba[dst + 2] = bytes[src + 2]
+        }
+        return try MediaImage(width: width, height: height, rgba8: rgba)
+    }
+}

--- a/Sources/MediaIO/MediaVideoIO.swift
+++ b/Sources/MediaIO/MediaVideoIO.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum MediaVideoIO {
+    public static func writeMP4(
+        rgb24: [UInt8],
+        width: Int,
+        height: Int,
+        frameCount: Int,
+        fps: Int,
+        to outputURL: URL
+    ) throws {
+        #if canImport(AVFoundation)
+        try AppleMediaVideoIO.writeMP4(
+            rgb24: rgb24,
+            width: width,
+            height: height,
+            frameCount: frameCount,
+            fps: fps,
+            to: outputURL
+        )
+        #else
+        try FFmpegMediaIO.writeMP4(
+            rgb24: rgb24,
+            width: width,
+            height: height,
+            frameCount: frameCount,
+            fps: fps,
+            to: outputURL
+        )
+        #endif
+    }
+
+    public static func mux(videoURL: URL, audioURL: URL, outputURL: URL) throws {
+        #if canImport(AVFoundation)
+        try AppleMediaVideoIO.mux(videoURL: videoURL, audioURL: audioURL, outputURL: outputURL)
+        #else
+        try FFmpegMediaIO.mux(videoURL: videoURL, audioURL: audioURL, outputURL: outputURL)
+        #endif
+    }
+
+    public static func extractFrames(
+        from videoURL: URL,
+        into outputDirectoryURL: URL,
+        endFrame: Int? = nil
+    ) throws -> VideoFrameSequence {
+        #if canImport(AVFoundation) && canImport(CoreGraphics)
+        try AppleMediaVideoIO.extractFrames(from: videoURL, into: outputDirectoryURL, endFrame: endFrame)
+        #else
+        try FFmpegMediaIO.extractFrames(from: videoURL, into: outputDirectoryURL, endFrame: endFrame)
+        #endif
+    }
+
+    public static func writeVideo(frameURLs: [URL], fps: Double, to outputURL: URL) throws {
+        #if canImport(AVFoundation) && canImport(CoreGraphics)
+        try AppleMediaVideoIO.writeVideo(frameURLs: frameURLs, fps: fps, to: outputURL)
+        #else
+        try FFmpegMediaIO.writeVideo(frameURLs: frameURLs, fps: fps, to: outputURL)
+        #endif
+    }
+
+    public static func hasAudioTrack(_ url: URL) -> Bool {
+        #if canImport(AVFoundation)
+        AppleMediaVideoIO.hasAudioTrack(url)
+        #else
+        FFmpegMediaIO.hasAudioTrack(url)
+        #endif
+    }
+}

--- a/Sources/MediaIO/README.md
+++ b/Sources/MediaIO/README.md
@@ -1,0 +1,13 @@
+# MediaIO
+
+`MediaIO` is the cross-platform media boundary for the CLI runtime. It keeps
+Apple framework use in Apple-specific backend files and routes Linux image,
+audio, and video work through `ffmpeg`/`ffprobe` subprocesses.
+
+The target exposes small value types (`MediaImage`, `MediaAudioBuffer`, and
+`VideoFrameSequence`) plus facades for image, audio, and video operations. Core
+model code should depend on these facades instead of importing AVFoundation,
+CoreGraphics, ImageIO, or CoreVideo directly.
+
+Linux users can override executable discovery with `MERERUN_FFMPEG` and
+`MERERUN_FFPROBE`.

--- a/Sources/MediaIOSmoke/main.swift
+++ b/Sources/MediaIOSmoke/main.swift
@@ -1,0 +1,119 @@
+import Foundation
+import MediaIO
+
+@main
+struct MediaIOSmoke {
+    static func main() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-mediaio-smoke-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try smokeImages(in: tempRoot)
+        try smokeAudio(in: tempRoot)
+        try smokeVideo(in: tempRoot)
+
+        print("MediaIO smoke passed")
+    }
+
+    private static func smokeImages(in tempRoot: URL) throws {
+        let image = try MediaImage(
+            width: 2,
+            height: 2,
+            rgba8: [
+                255, 0, 0, 255,
+                0, 255, 0, 255,
+                0, 0, 255, 255,
+                255, 255, 255, 255,
+            ]
+        )
+
+        let pngURL = tempRoot.appendingPathComponent("image.png")
+        try MediaImageIO.writePNG(image, to: pngURL)
+        let size = try MediaImageIO.size(of: pngURL)
+        try require(size.width == 2 && size.height == 2, "PNG size mismatch: \(size)")
+
+        let decoded = try MediaImageIO.decode(pngURL)
+        try require(decoded.width == 2 && decoded.height == 2, "PNG decode dimensions mismatch")
+        try require(decoded.rgba8.count == 16, "PNG decode buffer size mismatch")
+
+        let resized = try MediaImageIO.resized(decoded, width: 4, height: 4)
+        try require(resized.rgba8.count == 4 * 4 * 4, "resize buffer size mismatch")
+
+        let cropped = try MediaImageIO.centerCropped(decoded, width: 1, height: 1)
+        try require(cropped.rgba8.count == 4, "crop buffer size mismatch")
+
+        let tensor = MediaImageIO.rgbCHWFloat(decoded, normalizedToMinusOneToOne: true)
+        try require(tensor.count == 12, "RGB CHW tensor size mismatch")
+        try require(tensor.allSatisfy { $0.isFinite && $0 >= -1.0 && $0 <= 1.0 }, "RGB tensor range mismatch")
+    }
+
+    private static func smokeAudio(in tempRoot: URL) throws {
+        let wavURL = tempRoot.appendingPathComponent("tone.wav")
+        let sampleRate = 16_000
+        let samples = (0..<sampleRate / 10).map { index -> Float in
+            sin(Float(index) * 0.025)
+        }
+        try MediaAudioIO.writeFloatWAV(samples: samples, sampleRate: sampleRate, channels: 1, to: wavURL)
+
+        let decoded = try MediaAudioIO.decode(wavURL, targetSampleRate: 8_000, channels: 1)
+        try require(decoded.sampleRate == 8_000, "audio sample rate mismatch")
+        try require(decoded.channelCount == 1, "audio channel count mismatch")
+        try require(!decoded.samples.isEmpty, "audio decode produced no samples")
+        try require(decoded.samples.allSatisfy(\.isFinite), "audio decode produced non-finite samples")
+    }
+
+    private static func smokeVideo(in tempRoot: URL) throws {
+        let width = 4
+        let height = 4
+        let frameCount = 2
+        let frameBytes = width * height * 3
+        var rgb24 = [UInt8](repeating: 0, count: frameBytes * frameCount)
+        for frame in 0..<frameCount {
+            for pixel in 0..<(width * height) {
+                let offset = (frame * frameBytes) + (pixel * 3)
+                rgb24[offset] = frame == 0 ? 255 : 0
+                rgb24[offset + 1] = frame == 0 ? 0 : 255
+                rgb24[offset + 2] = UInt8((pixel * 11) % 255)
+            }
+        }
+
+        let videoURL = tempRoot.appendingPathComponent("video.mp4")
+        try MediaVideoIO.writeMP4(
+            rgb24: rgb24,
+            width: width,
+            height: height,
+            frameCount: frameCount,
+            fps: 2,
+            to: videoURL
+        )
+        try require(FileManager.default.fileExists(atPath: videoURL.path), "video was not written")
+        try require(!MediaVideoIO.hasAudioTrack(videoURL), "video-only MP4 unexpectedly has audio")
+
+        let frameDirectory = tempRoot.appendingPathComponent("frames", isDirectory: true)
+        let sequence = try MediaVideoIO.extractFrames(from: videoURL, into: frameDirectory, endFrame: 1)
+        try require(!sequence.frameURLs.isEmpty, "frame extraction produced no frames")
+        try require(sequence.frameWidth == width && sequence.frameHeight == height, "frame size mismatch")
+
+        let rebuiltURL = tempRoot.appendingPathComponent("rebuilt.mp4")
+        try MediaVideoIO.writeVideo(frameURLs: sequence.frameURLs, fps: sequence.fps, to: rebuiltURL)
+        try require(FileManager.default.fileExists(atPath: rebuiltURL.path), "rebuilt video was not written")
+
+        let audioURL = tempRoot.appendingPathComponent("mux-audio.wav")
+        try MediaAudioIO.writeFloatWAV(
+            samples: (0..<4_000).map { sin(Float($0) * 0.03) },
+            sampleRate: 8_000,
+            channels: 1,
+            to: audioURL
+        )
+        let muxedURL = tempRoot.appendingPathComponent("muxed.mp4")
+        try MediaVideoIO.mux(videoURL: rebuiltURL, audioURL: audioURL, outputURL: muxedURL)
+        try require(MediaVideoIO.hasAudioTrack(muxedURL), "muxed MP4 has no audio track")
+    }
+
+    private static func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+        if !condition() {
+            throw MediaIOError.videoOperationFailed("MediaIO smoke failed: \(message)")
+        }
+    }
+}

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -1,5 +1,8 @@
 import ArgumentParser
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Hummingbird
 import NIOCore
 import MereRunCore
@@ -744,7 +747,7 @@ actor CodeGenServer {
 
             // Pre-load model
             try await generator.prepare(modelPath: modelPath) { progress in
-                fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
             }
         case .textChatKlein:
             self.llamaGenerator = nil
@@ -768,7 +771,7 @@ actor CodeGenServer {
             self.useStandaloneModel = false
 
             try await generator.prepare(modelPath: modelPath) { progress in
-                fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
             }
         case .textChatQ35:
             let generator = Q35Generator(modelId: Q35Resources.defaultModelId)
@@ -780,7 +783,7 @@ actor CodeGenServer {
             self.useStandaloneModel = false
 
             try await generator.prepare(modelPath: modelPath) { progress in
-                fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
             }
         case .textChatDeepseekV4Flash:
             let generator = DeepseekV4FlashGenerator()
@@ -792,7 +795,7 @@ actor CodeGenServer {
             self.useStandaloneModel = false
 
             try await generator.prepare(modelPath: modelPath) { progress in
-                fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
             }
         }
     }
@@ -820,7 +823,7 @@ actor CodeGenServer {
             return Response(
                 status: .ok,
                 headers: [.contentType: "application/json"],
-                body: .init(byteBuffer: ByteBuffer(data: data))
+                body: .init(byteBuffer: ByteBuffer(bytes: data))
             )
         }
 
@@ -847,7 +850,7 @@ actor CodeGenServer {
         return Response(
             status: .ok,
             headers: [.contentType: "application/json"],
-            body: .init(byteBuffer: ByteBuffer(data: data))
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
     }
 
@@ -888,7 +891,7 @@ actor CodeGenServer {
 
         let openaiRequest: OpenAIChatRequest
         do {
-            openaiRequest = try JSONDecoder().decode(OpenAIChatRequest.self, from: body)
+            openaiRequest = try JSONDecoder().decode(OpenAIChatRequest.self, from: Data(body.readableBytesView))
         } catch {
             return makeErrorResponse(status: .badRequest, message: "Invalid request payload.", type: "invalid_request_error")
         }
@@ -960,7 +963,7 @@ actor CodeGenServer {
         return Response(
             status: .ok,
             headers: [.contentType: "application/json"],
-            body: .init(byteBuffer: ByteBuffer(data: data))
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
     }
 
@@ -969,8 +972,7 @@ actor CodeGenServer {
             throw DeepseekV4FlashError.serverFailedToStart("generator not initialized")
         }
         let upstreamURL = try await generator.chatCompletionsURL(modelPath: modelPath, progressHandler: nil)
-        var requestBody = body
-        let data = requestBody.readData(length: requestBody.readableBytes) ?? Data()
+        let data = Data(body.readableBytesView)
 
         if !DeepseekV4FlashClient.requestWantsStreamingResponse(data) {
             let upstreamResponse = try await DeepseekV4FlashClient.normalizedChatCompletionData(
@@ -983,7 +985,7 @@ actor CodeGenServer {
             return Response(
                 status: .init(code: upstreamResponse.statusCode),
                 headers: headers,
-                body: .init(byteBuffer: ByteBuffer(data: upstreamResponse.body))
+                body: .init(byteBuffer: ByteBuffer(bytes: upstreamResponse.body))
             )
         }
 
@@ -992,6 +994,36 @@ actor CodeGenServer {
             requestBody: data,
             contentType: contentType
         )
+#if os(Linux)
+        let (upstreamData, response) = try await URLSession.shared.data(for: upstreamRequest)
+        let http = response as? HTTPURLResponse
+        var headers: HTTPFields = [:]
+        headers[.contentType] = http?.value(forHTTPHeaderField: "Content-Type") ?? "application/json"
+        if DeepseekV4FlashClient.isEventStreamContentType(headers[.contentType]) {
+            headers[.init("Cache-Control")!] = "no-cache"
+            headers[.connection] = "keep-alive"
+            let stream = AsyncStream<ByteBuffer> { continuation in
+                if !upstreamData.isEmpty {
+                    continuation.yield(ByteBuffer(bytes: upstreamData))
+                }
+                continuation.finish()
+            }
+            return Response(
+                status: .init(code: http?.statusCode ?? 502),
+                headers: headers,
+                body: .init(asyncSequence: stream)
+            )
+        }
+        let repairedData = DeepseekV4FlashClient.normalizedChatCompletionBody(
+            upstreamData,
+            contentType: headers[.contentType]
+        )
+        return Response(
+            status: .init(code: http?.statusCode ?? 502),
+            headers: headers,
+            body: .init(byteBuffer: ByteBuffer(bytes: repairedData))
+        )
+#else
         let (upstreamBytes, response) = try await URLSession.shared.bytes(for: upstreamRequest)
         let http = response as? HTTPURLResponse
         var headers: HTTPFields = [:]
@@ -1007,12 +1039,12 @@ actor CodeGenServer {
                         for try await byte in upstreamBytes {
                             buffer.append(byte)
                             if byte == 10 || buffer.count >= 4_096 {
-                                continuation.yield(ByteBuffer(data: buffer))
+                                continuation.yield(ByteBuffer(bytes: buffer))
                                 buffer.removeAll(keepingCapacity: true)
                             }
                         }
                         if !buffer.isEmpty {
-                            continuation.yield(ByteBuffer(data: buffer))
+                            continuation.yield(ByteBuffer(bytes: buffer))
                         }
                         continuation.finish()
                     } catch {
@@ -1038,8 +1070,9 @@ actor CodeGenServer {
         return Response(
             status: .init(code: http?.statusCode ?? 502),
             headers: headers,
-            body: .init(byteBuffer: ByteBuffer(data: repairedData))
+            body: .init(byteBuffer: ByteBuffer(bytes: repairedData))
         )
+#endif
     }
 
     private func handleStreamingChat(_ request: ChatRequest, includeUsage: Bool) async throws -> Response {
@@ -1271,7 +1304,7 @@ actor CodeGenServer {
         return Response(
             status: status,
             headers: headers,
-            body: .init(byteBuffer: ByteBuffer(data: data))
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
     }
 }

--- a/Sources/MereRunCLI/Commands/AgentCommand.swift
+++ b/Sources/MereRunCLI/Commands/AgentCommand.swift
@@ -52,6 +52,7 @@ struct AgentOnboard: AsyncParsableCommand {
         print("mere.run onboarding")
         print("  machine: \(machine.processorName), \(machine.unifiedMemoryGB) GB unified memory")
         print("  appleSiliconMac: \(machine.isAppleSiliconMac)")
+        print("  linux: \(machine.isLinux)")
         print("  supportedModels: \(supported.count)")
         print("  unsupportedModels: \(unsupported.count)")
 
@@ -278,7 +279,7 @@ struct AgentStart: AsyncParsableCommand {
             serverProcess = startedServer.process
             CLIStderr.write("[agent] Loading \(runtime.providerModel.id). Server log: \(startedServer.logURL.path)\n")
             try await PiAgentIntegration.waitForHealth(host: host, port: port, timeoutSeconds: runtime.healthTimeoutSeconds)
-            CLIStderr.write("[agent] Local API is ready. Opening Pi in Terminal.app.\n")
+            CLIStderr.write("[agent] Local API is ready. \(PiTerminalLauncher.launchProgressMessage)\n")
         }
         defer {
             if let serverProcess, serverProcess.isRunning {
@@ -293,8 +294,10 @@ struct AgentStart: AsyncParsableCommand {
             modelURL: modelURL
         )
         if serverProcess != nil {
-            CLIStderr.write("[agent] Pi is running in Terminal.app. Keep this command running; press Ctrl+C here to stop the API server.\n")
-            waitForServerProcess()
+            CLIStderr.write("[agent] \(PiTerminalLauncher.runningProgressMessage)\n")
+            if PiTerminalLauncher.launchesDetached {
+                waitForServerProcess()
+            }
         }
     }
 
@@ -351,6 +354,9 @@ struct AgentStart: AsyncParsableCommand {
     }
 
     private func autoInstallPi() async throws -> URL {
+        guard PiAgentIntegration.canInstallLatestRelease else {
+            throw PiAgentIntegration.IntegrationError.unsupportedPlatform
+        }
         if !quiet {
             CLIStderr.write("[agent] Pi is not installed. Installing the latest release.\n")
         }

--- a/Sources/MereRunCLI/Commands/SetupCommand.swift
+++ b/Sources/MereRunCLI/Commands/SetupCommand.swift
@@ -91,8 +91,8 @@ struct Setup: AsyncParsableCommand {
 
     private func runAgentSetup() async throws {
         let machine = MereRunMachineProfile.current
-        guard machine.isAppleSiliconMac else {
-            throw ValidationError("The local Mere agent requires Apple Silicon macOS. Use `mere.run setup --mode byoa` or `--mode manual`.")
+        guard machine.isSupportedRuntime else {
+            throw ValidationError("The local Mere agent requires Apple Silicon macOS or Linux. Use `mere.run setup --mode byoa` or `--mode manual`.")
         }
         guard let recommendation = MereRunAgentModelCatalog.recommendation(
             for: agentModel.coreChoice,
@@ -131,7 +131,7 @@ struct Setup: AsyncParsableCommand {
     ) {
         printSetupTitle("Mere agent")
         print("")
-        print("This Mac")
+        print("This machine")
         print("  \(machine.processorName)")
         print("  \(machine.unifiedMemoryGB) GB unified memory")
         print("")
@@ -185,7 +185,7 @@ struct Setup: AsyncParsableCommand {
     private func printUnsupportedAgentPlan(machine: MereRunMachineProfile) {
         printSetupTitle("Mere agent")
         print("")
-        print("This Mac")
+        print("This machine")
         print("  \(machine.processorName)")
         print("  \(machine.unifiedMemoryGB) GB unified memory")
         print("")
@@ -202,7 +202,7 @@ struct Setup: AsyncParsableCommand {
             print("  No local agent tier is supported on this machine.")
         case .premier:
             print("  Unavailable on this machine.")
-            print("  DeepSeek V4 Flash requires at least 96 GB unified memory and Apple Silicon.")
+            print("  DeepSeek V4 Flash requires at least 96 GB unified memory and a supported runtime.")
             print("  It is the preferred managed setup-agent tier when available.")
         }
         print("")
@@ -236,15 +236,24 @@ struct Setup: AsyncParsableCommand {
                 }
             }
         )
-        if !quiet {
-            CLIStderr.write("\n[setup] installing Pi\n")
-        }
-        let piResult = try await PiAgentIntegration.installLatest(force: false) { message in
-            guard !quiet else { return }
-            CLIStderr.write("[pi] \(message)\n")
-        }
-        if !quiet {
-            CLIStderr.write("[setup] Pi installed at \(piResult.binaryURL.path)\n")
+        if PiAgentIntegration.canInstallLatestRelease {
+            if !quiet {
+                CLIStderr.write("\n[setup] installing Pi\n")
+            }
+            let piResult = try await PiAgentIntegration.installLatest(force: false) { message in
+                guard !quiet else { return }
+                CLIStderr.write("[pi] \(message)\n")
+            }
+            if !quiet {
+                CLIStderr.write("[setup] Pi installed at \(piResult.binaryURL.path)\n")
+            }
+        } else if let piURL = PiAgentIntegration.findPiExecutable(explicitPath: piPath) {
+            if !quiet {
+                CLIStderr.write("\n[setup] using Pi at \(piURL.path)\n")
+            }
+        } else if !quiet {
+            CLIStderr.write("\n[setup] Pi auto-install unavailable\n")
+            CLIStderr.write("[setup] Pi auto-install is not available on this platform. Install Pi separately and pass --pi-path or put pi on PATH.\n")
         }
         let extensionURL = try PiAgentIntegration.writeLocalProviderExtension(
             host: host,
@@ -271,15 +280,17 @@ struct Setup: AsyncParsableCommand {
         }
         CLIStderr.write("[setup] Loading \(runtime.providerModel.id). Server log: \(startedServer.logURL.path)\n")
         try await PiAgentIntegration.waitForHealth(host: host, port: port, timeoutSeconds: runtime.healthTimeoutSeconds)
-        CLIStderr.write("[setup] Local API is ready. Opening Pi in Terminal.app.\n")
+        CLIStderr.write("[setup] Local API is ready. \(PiTerminalLauncher.launchProgressMessage)\n")
         try runPi(
             piURL: piURL,
             modelID: runtime.providerModel.id,
             engine: runtime.engine,
             modelURL: modelURL
         )
-        CLIStderr.write("[setup] Pi is running in Terminal.app. Keep this command running; press Ctrl+C here to stop the API server.\n")
-        waitForServerProcess()
+        CLIStderr.write("[setup] \(PiTerminalLauncher.runningProgressMessage)\n")
+        if PiTerminalLauncher.launchesDetached {
+            waitForServerProcess()
+        }
     }
 
     private func startAPIServer(modelURL: URL, engine: APIEngine) throws -> (process: Process, logURL: URL) {
@@ -339,8 +350,8 @@ struct Setup: AsyncParsableCommand {
         print("Copy this prompt into Claude, Codex, or another local/remote agent:")
         print("")
         print("""
-        You are helping me set up mere.run on this Mac.
-        Machine: \(machine.processorName), \(machine.unifiedMemoryGB) GB unified memory, Apple Silicon: \(machine.isAppleSiliconMac).
+        You are helping me set up mere.run on this machine.
+        Machine: \(machine.processorName), \(machine.unifiedMemoryGB) GB memory, Apple Silicon: \(machine.isAppleSiliconMac), Linux: \(machine.isLinux).
         Supported managed models: \(supported.isEmpty ? "none detected" : supported).
         First run `\(CLICommandDisplay.command("model capabilities --all"))`.
         Only pull models that mere.run reports as supported on this machine.
@@ -357,7 +368,7 @@ struct Setup: AsyncParsableCommand {
         print("Commands")
         printNumberedCommand(
             index: 1,
-            title: "Inspect this Mac",
+            title: "Inspect this machine",
             command: CLICommandDisplay.command("model capabilities --all"),
             trailingBlankLine: true
         )

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -1,5 +1,8 @@
 import ArgumentParser
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import MereRunCore
 
 struct Status: AsyncParsableCommand {

--- a/Sources/MereRunCLI/Commands/TextAnonymizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextAnonymizeCommand.swift
@@ -82,7 +82,7 @@ struct TextAnonymize: AsyncParsableCommand {
             return texts
         }
 
-        guard isatty(fileno(stdin)) == 0 else {
+        guard !CLIStdin.isInteractive() else {
             throw ValidationError("Provide text arguments or pipe UTF-8 text on stdin.")
         }
 

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -127,7 +127,7 @@ struct TextChat: AsyncParsableCommand {
                 if streamingOutput.write(progress: progress) {
                     return
                 }
-                fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
             }
         }
 
@@ -162,7 +162,7 @@ struct TextChat: AsyncParsableCommand {
                     .appendingPathComponent("mererun-tools-\(ProcessInfo.processInfo.processIdentifier)")
             }
             try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
-            if !quiet { fputs("[tool-loop] Sandbox: \(sandbox.path)\n", stderr) }
+            if !quiet { CLIStderr.write("[tool-loop] Sandbox: \(sandbox.path)\n") }
             let toolPolicy = BuiltinTools.ToolExecutionPolicy(
                 sandboxDir: sandbox,
                 allowShellExec: allowShellExec,
@@ -192,13 +192,13 @@ struct TextChat: AsyncParsableCommand {
                     .replacingOccurrences(of: "<\\|tool_call>.*?<tool_call\\|>", with: "", options: .regularExpression)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if !textBeforeTools.isEmpty {
-                    fputs(cleanResponse(textBeforeTools, showThinking: thinking) + "\n", stderr)
+                    CLIStderr.write(cleanResponse(textBeforeTools, showThinking: thinking) + "\n")
                 }
 
                 loopMessages.append(ChatMessage(role: .assistant, content: result.response))
 
                 for call in calls {
-                    if !quiet { fputs("[tool] \(call.name)(\(call.arguments.map { "\($0.key)=\($0.value.prefix(80))" }.joined(separator: ", ")))\n", stderr) }
+                    if !quiet { CLIStderr.write("[tool] \(call.name)(\(call.arguments.map { "\($0.key)=\($0.value.prefix(80))" }.joined(separator: ", ")))\n") }
                     let approved = BuiltinTools.canAutoApprove(call, autoApproveTools: autoApproveTools)
                         || confirmToolCall(
                             call,
@@ -215,14 +215,14 @@ struct TextChat: AsyncParsableCommand {
                     } else {
                         output = "Denied: tool execution was not approved."
                     }
-                    if !quiet { fputs("[tool] → \(output.prefix(200))\n", stderr) }
+                    if !quiet { CLIStderr.write("[tool] → \(output.prefix(200))\n") }
                     loopMessages.append(ChatMessage(role: .tool, content: output))
                 }
 
-                if !quiet { fputs("[tool-loop] Iteration \(iteration + 1)/\(maxIterations)\n", stderr) }
+                if !quiet { CLIStderr.write("[tool-loop] Iteration \(iteration + 1)/\(maxIterations)\n") }
             }
 
-            fputs("[tool-loop] Hit iteration limit (\(maxIterations))\n", stderr)
+            CLIStderr.write("[tool-loop] Hit iteration limit (\(maxIterations))\n")
         } else {
             let result = try await chatOnce(request)
 
@@ -243,10 +243,10 @@ struct TextChat: AsyncParsableCommand {
                         decodeTps,
                         e2eTps
                     )
-                    fputs("\(line)\n", stderr)
+                    CLIStderr.write("\(line)\n")
                 } else {
                     let line = String(format: "time=%.2fs tokens=%d tps=%.2f", elapsed, result.tokensGenerated, e2eTps)
-                    fputs("\(line)\n", stderr)
+                    CLIStderr.write("\(line)\n")
                 }
             }
 
@@ -303,9 +303,9 @@ struct TextChat: AsyncParsableCommand {
     ) -> Bool {
         guard Self.stdinIsInteractive() else {
             if autoApproveToolsRequested && call.name == "shell_exec" {
-                fputs("[tool] Denied shell_exec: this tool always requires interactive approval, even when --auto-approve-tools is set.\n", stderr)
+                CLIStderr.write("[tool] Denied shell_exec: this tool always requires interactive approval, even when --auto-approve-tools is set.\n")
             } else {
-                fputs("[tool] Denied \(call.name): stdin is not interactive. Re-run with --auto-approve-tools to allow non-interactive execution.\n", stderr)
+                CLIStderr.write("[tool] Denied \(call.name): stdin is not interactive. Re-run with --auto-approve-tools to allow non-interactive execution.\n")
             }
             return false
         }
@@ -314,8 +314,7 @@ struct TextChat: AsyncParsableCommand {
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: ", ")
-        fputs("[tool] Approve \(call.name)(\(args)) in \(sandbox.path)? [y/N] ", stderr)
-        fflush(stderr)
+        CLIStderr.write("[tool] Approve \(call.name)(\(args)) in \(sandbox.path)? [y/N] ")
 
         guard let line = readLine(strippingNewline: true)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -326,7 +325,7 @@ struct TextChat: AsyncParsableCommand {
     }
 
     private static func stdinIsInteractive() -> Bool {
-        isatty(fileno(stdin)) != 0
+        CLIStdin.isInteractive()
     }
 }
 
@@ -358,8 +357,7 @@ private final class StreamingChatOutput: @unchecked Sendable {
 
         lock.lock()
         defer { lock.unlock() }
-        fputs(text, stdout)
-        fflush(stdout)
+        CLIStdout.write(text)
         wroteOutput = true
         return true
     }
@@ -367,7 +365,6 @@ private final class StreamingChatOutput: @unchecked Sendable {
     func finishLine() {
         lock.lock()
         defer { lock.unlock() }
-        fputs("\n", stdout)
-        fflush(stdout)
+        CLIStdout.write("\n")
     }
 }

--- a/Sources/MereRunCLI/Commands/TextCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextCodeCommand.swift
@@ -69,15 +69,14 @@ struct TextCode: AsyncParsableCommand {
         } else if stream {
             progressHandler = { progress in
                 if progress.stage == .generating, let token = progress.message {
-                    print(token, terminator: "")
-                    fflush(stdout)
+                    CLIStdout.write(token)
                 } else if progress.stage == .loadingModel {
-                    fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                    CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
                 }
             }
         } else {
             progressHandler = { progress in
-                fputs("[\(progress.stage.rawValue)] \(progress.message ?? "")\n", stderr)
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
             }
         }
 
@@ -92,7 +91,7 @@ struct TextCode: AsyncParsableCommand {
         if stats {
             let tps = elapsed > 0 ? Double(result.tokensGenerated) / elapsed : 0
             let timing = String(format: "time=%.2fs tokens=%d tps=%.2f", elapsed, result.tokensGenerated, tps)
-            fputs("\(timing)\n", stderr)
+            CLIStderr.write("\(timing)\n")
         }
 
         if !stream {

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
-import AVFoundation
 import Foundation
+import MediaIO
 import MLX
 import MereRunCore
 
@@ -15,8 +15,8 @@ struct Video: AsyncParsableCommand {
         abstract: "Generate videos with native Swift/MLX LTX pipelines.",
         subcommands: [
             VideoExportLatents.self,
-            VideoGenerate.self,
-        ],
+            VideoGenerate.self
+        ]
     )
 }
 
@@ -359,12 +359,7 @@ struct VideoGenerate: AsyncParsableCommand {
     }
 
     private func mediaHasAudioTrack(at url: URL) async -> Bool {
-        let asset = AVURLAsset(url: url)
-        do {
-            return !(try await asset.loadTracks(withMediaType: .audio)).isEmpty
-        } catch {
-            return false
-        }
+        MediaVideoIO.hasAudioTrack(url)
     }
 }
 

--- a/Sources/MereRunCLI/Commands/VisionCaptionCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionCaptionCommand.swift
@@ -59,8 +59,7 @@ struct VisionCaption: AsyncParsableCommand {
             print("No model specified, downloading \(Qwen3VLAutoCaptioner.modelId)...")
             let autoCaptioner = Qwen3VLAutoCaptioner()
             modelURL = try await autoCaptioner.ensureReady { progress in
-                print("\r\(progress.status) (\(Int(progress.fraction * 100))%)", terminator: "")
-                fflush(stdout)
+                CLIStdout.write("\r\(progress.status) (\(Int(progress.fraction * 100))%)")
             }
             print()  // newline after progress
         }

--- a/Sources/MereRunCLI/Guides/agent-install-pi.md
+++ b/Sources/MereRunCLI/Guides/agent-install-pi.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Install the latest Pi coding-agent release so mere.run can launch a guided local setup agent.
+Install the latest Pi coding-agent release so mere.run can launch a guided local setup agent. Auto-install uses the published macOS release assets; on Linux, install Pi separately and pass `--pi-path` or put `pi` on PATH.
 
 ## Required Models
 
@@ -21,7 +21,7 @@ mere.run agent install-pi --help
 
 ## Usage Patterns
 
-- Run before `agent start` when Pi is not on PATH or not managed by mere.run.
+- Run before `agent start` on macOS when Pi is not on PATH or not managed by mere.run.
 - Use `--force` when the installed Pi binary is corrupt or outdated.
 - Pair with `agent onboard --configure-pi` to register the local provider.
 
@@ -45,6 +45,7 @@ mere.run agent install-pi --force
 
 - Network failure: retry when GitHub release downloads are reachable.
 - Still not found: pass `--pi-path` to `agent start`.
+- Linux: provide an existing Pi binary with `--pi-path` or PATH.
 - Wrong version: use `--force`.
 
 ## Sources

--- a/Sources/MereRunCLI/Guides/agent-start.md
+++ b/Sources/MereRunCLI/Guides/agent-start.md
@@ -6,7 +6,7 @@ Start Pi against a local mere.run setup-agent API server. This is the guided "he
 
 ## Required Models
 
-Use this Mac's supported setup-agent tier. On 96 GB+ Apple Silicon Macs, `text-agent-deepseek-v4-flash` is the preferred managed setup agent. Qwen/Q35 agent models are lower-memory or comparison alternatives, not upgrades from DeepSeek V4 Flash.
+Use this machine's supported setup-agent tier. On 96 GB+ Apple Silicon Macs, `text-agent-deepseek-v4-flash` is the preferred managed setup agent. Qwen/Q35 agent models are lower-memory or comparison alternatives, not upgrades from DeepSeek V4 Flash. On Linux, provide Pi with `--pi-path` or PATH; auto-install uses macOS release assets.
 
 ## Install And Check
 
@@ -33,6 +33,7 @@ mere.run status
 - Run `model capabilities --recommended` or `agent onboard` first and use the recommended setup-agent id.
 - Pull the selected model before `agent start`.
 - Use `--skip-server` only when you already started a compatible local API server.
+- On Linux, provide an existing Pi binary with `--pi-path` or PATH before starting.
 - Run `status` when you need to confirm the local server and served model.
 - Keep the default prompt unless the user has a specific setup goal.
 
@@ -58,7 +59,7 @@ mere.run agent start \
 
 - Model unsupported: choose a supported model from `agent onboard`.
 - Model missing: run `mere.run model pull <id>`.
-- Pi missing: run `mere.run agent install-pi` or pass `--pi-path`.
+- Pi missing: run `mere.run agent install-pi` on macOS, or pass `--pi-path` / put `pi` on PATH on Linux.
 - Health check times out: verify host/port and local API logs.
 - Unsure what is already running: run `mere.run status --host <host> --port <port>`.
 

--- a/Sources/MereRunCLI/Guides/model-capabilities.md
+++ b/Sources/MereRunCLI/Guides/model-capabilities.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Report which managed models this Mac can run, including memory fit, recommendations, categories, and reasons unsupported models are hidden or rejected.
+Report which managed models this machine can run, including memory fit, recommendations, categories, and reasons unsupported models are hidden or rejected.
 
 ## Required Models
 

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -23,7 +23,7 @@ mere.run model list
 - `--all`: pull every model that has a Hugging Face source and passes support checks.
 - `--force`: re-download even if already installed.
 - `--quiet`, `-q`: suppress progress.
-- `--allow-unsupported`: bypass Apple Silicon/unified-memory support checks.
+- `--allow-unsupported`: bypass platform and memory support checks.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/setup.md
+++ b/Sources/MereRunCLI/Guides/setup.md
@@ -6,7 +6,7 @@ Choose a guided, bring-your-own-agent, or manual setup path for a new mere.run i
 
 ## Required Models
 
-No model is required to view the plan. Agent setup selects this Mac's supported tier; on 96 GB+ Apple Silicon Macs that is `text-agent-deepseek-v4-flash`. Qwen/Q35 agent models are lower-memory or comparison alternatives, not upgrades from DeepSeek V4 Flash.
+No model is required to view the plan. Agent setup selects this machine's supported tier; on 96 GB+ machines that is `text-agent-deepseek-v4-flash`. Qwen/Q35 agent models are lower-memory or comparison alternatives, not upgrades from DeepSeek V4 Flash.
 
 ## Install And Check
 
@@ -32,7 +32,8 @@ mere.run model capabilities --recommended
 
 - Use interactive `mere.run setup` for humans.
 - Use `--mode manual --dry-run` for docs or scripts.
-- Use agent mode only on Apple Silicon macOS with a supported model. Prefer `--agent-model tier` unless the user asks for a smaller comparison model.
+- Use agent mode only with a supported local runtime and model. Prefer `--agent-model tier` unless the user asks for a smaller comparison model.
+- On Linux, provide Pi with `--pi-path` or put `pi` on PATH; auto-install uses macOS release assets.
 
 ## Examples
 
@@ -46,14 +47,14 @@ mere.run setup --mode agent --agent-model small --install --start
 
 ## Iteration Tips
 
-- Run capabilities first when the user is unsure what their Mac can run.
-- Start with the small agent model on lower-memory machines; keep DeepSeek V4 Flash as the preferred tier/premier agent on 96 GB+ Macs.
+- Run capabilities first when the user is unsure what their machine can run.
+- Start with the small agent model on lower-memory machines; keep DeepSeek V4 Flash as the preferred tier/premier agent on 96 GB+ machines.
 - Use BYOA when the user already prefers Claude, Codex, or another local tool.
 
 ## Troubleshooting
 
 - No supported agent model: use `--mode byoa` or `--mode manual`.
-- Pi not found: run `mere.run agent install-pi`.
+- Pi not found: run `mere.run agent install-pi` on macOS, or pass `--pi-path` / put `pi` on PATH on Linux.
 - Start fails because model is missing: pull the selected model or rerun with `--install`.
 
 ## Sources

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -29,6 +29,6 @@ struct MereRunCLI: AsyncParsableCommand {
             API.self,
             Setup.self,
             Agent.self,
-        ],
+        ]
     )
 }

--- a/Sources/MereRunCLI/Support/CLIStderr.swift
+++ b/Sources/MereRunCLI/Support/CLIStderr.swift
@@ -1,7 +1,24 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 enum CLIStderr {
     static func write(_ text: String) {
         FileHandle.standardError.write(Data(text.utf8))
+    }
+}
+
+enum CLIStdout {
+    static func write(_ text: String) {
+        FileHandle.standardOutput.write(Data(text.utf8))
+    }
+}
+
+enum CLIStdin {
+    static func isInteractive() -> Bool {
+        isatty(STDIN_FILENO) != 0
     }
 }

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -5,6 +5,9 @@ import Darwin
 import Foundation
 
 enum MLXBundleSupport {
+#if os(Linux)
+    static func ensureAvailable(quiet _: Bool) throws {}
+#else
     static func ensureAvailable(quiet: Bool) throws {
         let bundleName = "mlx-swift_Cmlx.bundle"
         let fm = FileManager.default
@@ -287,4 +290,5 @@ enum MLXBundleSupport {
 
         return nil
     }
+#endif
 }

--- a/Sources/MereRunCLI/Support/PiAgentIntegration.swift
+++ b/Sources/MereRunCLI/Support/PiAgentIntegration.swift
@@ -130,7 +130,7 @@ enum PiAgentIntegration {
             case .applicationSupportUnavailable:
                 return "Could not locate Application Support directory."
             case .unsupportedPlatform:
-                return "Pi agent install is currently supported for macOS arm64 and x64 release assets."
+                return "Pi auto-install is currently supported for macOS arm64 and x64 release assets. On Linux, install Pi separately and pass --pi-path or put pi on PATH."
             case .releaseAssetMissing(let name):
                 return "Latest Pi release does not include expected asset: \(name)"
             case .digestMismatch(let expected, let actual):
@@ -142,13 +142,21 @@ enum PiAgentIntegration {
             case .piBinaryMissing(let url):
                 return "No executable named pi was found under \(url.path)."
             case .piBinaryNotFound:
-                return "Pi is not installed. Run `mere.run agent install-pi` or pass --pi-path."
+                return "Pi is not installed. Run `mere.run agent install-pi` on macOS, or pass --pi-path / put pi on PATH on Linux."
             case .serverDidNotBecomeReady(let url):
                 return "mere.run API server did not become ready at \(url.absoluteString)."
             case .terminalLaunchFailed:
                 return "Could not open Pi in Terminal.app."
             }
         }
+    }
+
+    static var canInstallLatestRelease: Bool {
+        #if os(macOS) && (arch(arm64) || arch(x86_64))
+        return true
+        #else
+        return false
+        #endif
     }
 
     static func installLatest(force: Bool = false, progress: (String) -> Void) async throws -> PiAgentInstallResult {
@@ -400,7 +408,7 @@ enum PiAgentIntegration {
         #elseif os(macOS) && arch(x86_64)
         return "pi-darwin-x64.tar.gz"
         #else
-        throw IntegrationError.unsupportedPlatform
+            throw IntegrationError.unsupportedPlatform
         #endif
     }
 

--- a/Sources/MereRunCLI/Support/PiTerminalLauncher.swift
+++ b/Sources/MereRunCLI/Support/PiTerminalLauncher.swift
@@ -1,6 +1,30 @@
 import Foundation
 
 enum PiTerminalLauncher {
+    static var launchesDetached: Bool {
+        #if os(macOS)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static var launchProgressMessage: String {
+        #if os(macOS)
+        return "Opening Pi in Terminal.app."
+        #else
+        return "Starting Pi in this terminal."
+        #endif
+    }
+
+    static var runningProgressMessage: String {
+        #if os(macOS)
+        return "Pi is running in Terminal.app. Keep this command running; press Ctrl+C here to stop the API server."
+        #else
+        return "Pi exited. Stopping the API server."
+        #endif
+    }
+
     static func launch(
         piURL: URL,
         modelID: String,
@@ -10,6 +34,7 @@ enum PiTerminalLauncher {
     ) throws {
         try FileManager.default.createDirectory(at: homeDirectory, withIntermediateDirectories: true)
 
+        #if os(macOS)
         let command = [
             "mkdir -p \(shellQuote(homeDirectory.path))",
             "export HOME=\(shellQuote(homeDirectory.path))",
@@ -44,6 +69,35 @@ enum PiTerminalLauncher {
         guard process.terminationStatus == 0 else {
             throw PiAgentIntegration.IntegrationError.terminalLaunchFailed
         }
+        #else
+        let process = Process()
+        process.executableURL = piURL
+        process.arguments = [
+            "--provider",
+            "mere-run",
+            "--model",
+            modelID,
+            prompt,
+        ]
+        process.currentDirectoryURL = workingDirectory
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = homeDirectory.path
+        environment["XDG_CONFIG_HOME"] = homeDirectory
+            .appendingPathComponent(".config", isDirectory: true)
+            .path
+        environment["XDG_DATA_HOME"] = homeDirectory
+            .appendingPathComponent(".local/share", isDirectory: true)
+            .path
+        process.environment = environment
+        process.standardInput = FileHandle.standardInput
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw PiAgentIntegration.IntegrationError.terminalLaunchFailed
+        }
+        #endif
     }
 
     private static func shellQuote(_ value: String) -> String {

--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -71,7 +71,7 @@ public enum MereRunAgentModelCatalog {
         for choice: MereRunAgentModelChoice,
         on machine: MereRunMachineProfile = .current
     ) -> MereRunAgentModelRecommendation? {
-        guard machine.isAppleSiliconMac else {
+        guard machine.isSupportedRuntime else {
             return nil
         }
         switch choice {
@@ -94,7 +94,7 @@ public enum MereRunAgentModelCatalog {
     public static func tierRecommendation(
         on machine: MereRunMachineProfile = .current
     ) -> MereRunAgentModelRecommendation? {
-        guard machine.isAppleSiliconMac else { return nil }
+        guard machine.isSupportedRuntime else { return nil }
         if machine.unifiedMemoryGB >= 96 {
             return deepseekV4Flash()
         }
@@ -110,7 +110,7 @@ public enum MereRunAgentModelCatalog {
     public static func premierRecommendation(
         on machine: MereRunMachineProfile = .current
     ) -> MereRunAgentModelRecommendation? {
-        guard machine.isAppleSiliconMac, machine.unifiedMemoryGB >= 96 else {
+        guard machine.isSupportedRuntime, machine.unifiedMemoryGB >= 96 else {
             return nil
         }
         return deepseekV4Flash()
@@ -119,7 +119,7 @@ public enum MereRunAgentModelCatalog {
     public static func fallbackStartableRecommendation(
         on machine: MereRunMachineProfile = .current
     ) -> MereRunAgentModelRecommendation? {
-        guard machine.isAppleSiliconMac else { return nil }
+        guard machine.isSupportedRuntime else { return nil }
         if machine.unifiedMemoryGB >= 96 {
             return deepseekV4Flash()
         }
@@ -141,7 +141,7 @@ public enum MereRunAgentModelCatalog {
             qwen3CoderNext(),
             qwen35122B4Bit(),
             deepseekV4Flash(),
-        ].filter { machine.isAppleSiliconMac && machine.unifiedMemoryGB >= $0.minimumUnifiedMemoryGB }
+        ].filter { machine.isSupportedRuntime && machine.unifiedMemoryGB >= $0.minimumUnifiedMemoryGB }
     }
 
     private static func qwen35NineB() -> MereRunAgentModelRecommendation {

--- a/Sources/MereRunCore/CodeGen/CodeGenGenerator.swift
+++ b/Sources/MereRunCore/CodeGen/CodeGenGenerator.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if canImport(llama)
 import Foundation
 
 /// Actor-based code generation using GGUF models via llama.cpp.

--- a/Sources/MereRunCore/CodeGen/LlamaContext.swift
+++ b/Sources/MereRunCore/CodeGen/LlamaContext.swift
@@ -41,6 +41,25 @@ public final class LlamaContext: @unchecked Sendable {
         self.vocab = llama_model_get_vocab(model)
     }
 
+    #if os(Linux)
+    private static func linuxGPULayerCount(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int32 {
+        if let rawValue = environment["MERERUN_LLAMA_GPU_LAYERS"] {
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let parsed = Int32(trimmed) {
+                return max(0, parsed)
+            }
+        }
+
+        if environment["MERERUN_LINUX_ACCEL"]?.lowercased() == "cuda" {
+            return 999
+        }
+
+        return 0
+    }
+    #endif
+
     deinit {
         if let s = sampling { llama_sampler_free(s) }
         if let m = model { llama_model_free(m) }
@@ -62,6 +81,8 @@ public final class LlamaContext: @unchecked Sendable {
         var modelParams = llama_model_default_params()
         #if targetEnvironment(simulator)
         modelParams.n_gpu_layers = 0
+        #elseif os(Linux)
+        modelParams.n_gpu_layers = linuxGPULayerCount()
         #endif
 
         guard let model = llama_model_load_from_file(path, modelParams) else {

--- a/Sources/MereRunCore/CodeGen/LlamaContext.swift
+++ b/Sources/MereRunCore/CodeGen/LlamaContext.swift
@@ -1,4 +1,4 @@
-#if os(macOS)
+#if canImport(llama)
 import Foundation
 @preconcurrency import llama
 

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashBinary.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashBinary.swift
@@ -4,11 +4,14 @@ import Foundation
 ///
 /// Search order:
 /// 1. `$MERERUN_DS4_BIN_DIR/ds4-server` (explicit override, useful for tests).
-/// 2. `vendor/ds4/ds4-server` alongside the running executable
+/// 2. `$MERERUN_DS4_BIN_DIR/<platform>/ds4-server` when an override points at
+///    a platform-rooted DS4 directory.
+/// 3. `vendor/ds4/ds4-server` alongside the running executable on macOS, or
+///    `vendor/ds4/<platform>/ds4-server` first on Linux.
 ///    (installed layout produced by `scripts/install.sh`).
-/// 3. `vendor/ds4/ds4-server` under the SwiftPM build, walking upward from
+/// 4. `vendor/ds4/ds4-server` under the SwiftPM build, walking upward from
 ///    the executable path until we find a directory containing `Package.swift`.
-/// 4. `ds4-server` on `$PATH`.
+/// 5. `ds4-server` on `$PATH`.
 public enum DeepseekV4FlashBinary {
     public enum Kind: String, Sendable {
         case server = "ds4-server"
@@ -22,12 +25,21 @@ public enum DeepseekV4FlashBinary {
         fileManager: FileManager = .default
     ) throws -> URL {
         var searched: [URL] = []
+        let platformDirectory = Self.platformDirectoryName(environment: environment)
+        let preferPlatformDirectory = Self.prefersPlatformDirectory()
 
         if let override = environment["MERERUN_DS4_BIN_DIR"], !override.isEmpty {
-            let candidate = URL(fileURLWithPath: override).appendingPathComponent(kind.rawValue)
-            searched.append(candidate)
-            if fileManager.isExecutableFile(atPath: candidate.path) {
-                return candidate
+            let overrideRoot = URL(fileURLWithPath: override)
+            for candidate in ds4CandidateURLs(
+                root: overrideRoot,
+                kind: kind,
+                platformDirectory: platformDirectory,
+                preferPlatformDirectory: false
+            ) {
+                searched.append(candidate)
+                if fileManager.isExecutableFile(atPath: candidate.path) {
+                    return candidate
+                }
             }
         }
 
@@ -36,13 +48,19 @@ public enum DeepseekV4FlashBinary {
         let executableDir = executableURL.deletingLastPathComponent()
 
         // Installed layout: vendor/ds4/<kind> next to mere.run.
-        let installedCandidate = executableDir
+        let installedRoot = executableDir
             .appendingPathComponent("vendor")
             .appendingPathComponent("ds4")
-            .appendingPathComponent(kind.rawValue)
-        searched.append(installedCandidate)
-        if fileManager.isExecutableFile(atPath: installedCandidate.path) {
-            return installedCandidate
+        for candidate in ds4CandidateURLs(
+            root: installedRoot,
+            kind: kind,
+            platformDirectory: platformDirectory,
+            preferPlatformDirectory: preferPlatformDirectory
+        ) {
+            searched.append(candidate)
+            if fileManager.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
         }
 
         // Also try a flat layout (DMG / install.sh style): <kind> next to mere.run.
@@ -58,13 +76,19 @@ public enum DeepseekV4FlashBinary {
         for _ in 0..<8 {
             let packageURL = dir.appendingPathComponent("Package.swift")
             if fileManager.fileExists(atPath: packageURL.path) {
-                let devCandidate = dir
+                let devRoot = dir
                     .appendingPathComponent("vendor")
                     .appendingPathComponent("ds4")
-                    .appendingPathComponent(kind.rawValue)
-                searched.append(devCandidate)
-                if fileManager.isExecutableFile(atPath: devCandidate.path) {
-                    return devCandidate
+                for candidate in ds4CandidateURLs(
+                    root: devRoot,
+                    kind: kind,
+                    platformDirectory: platformDirectory,
+                    preferPlatformDirectory: preferPlatformDirectory
+                ) {
+                    searched.append(candidate)
+                    if fileManager.isExecutableFile(atPath: candidate.path) {
+                        return candidate
+                    }
                 }
                 break
             }
@@ -86,5 +110,61 @@ public enum DeepseekV4FlashBinary {
         }
 
         throw DeepseekV4FlashError.binaryNotFound(searched: searched)
+    }
+
+    private static func ds4CandidateURLs(
+        root: URL,
+        kind: Kind,
+        platformDirectory: String?,
+        preferPlatformDirectory: Bool
+    ) -> [URL] {
+        let rootCandidate = root.appendingPathComponent(kind.rawValue)
+        guard let platformDirectory, !platformDirectory.isEmpty else {
+            return [rootCandidate]
+        }
+
+        let platformCandidate = root
+            .appendingPathComponent(platformDirectory, isDirectory: true)
+            .appendingPathComponent(kind.rawValue)
+
+        if preferPlatformDirectory {
+            return [platformCandidate, rootCandidate]
+        } else {
+            return [rootCandidate, platformCandidate]
+        }
+    }
+
+    private static func platformDirectoryName(environment: [String: String]) -> String? {
+        if let override = environment["MERERUN_DS4_PLATFORM_DIR"], !override.isEmpty {
+            return override
+        }
+
+        let osName: String
+        #if os(macOS)
+        osName = "macos"
+        #elseif os(Linux)
+        osName = "linux"
+        #else
+        return nil
+        #endif
+
+        let archName: String
+        #if arch(arm64)
+        archName = "arm64"
+        #elseif arch(x86_64)
+        archName = "x86_64"
+        #else
+        return nil
+        #endif
+
+        return "\(osName)-\(archName)"
+    }
+
+    private static func prefersPlatformDirectory() -> Bool {
+        #if os(Linux)
+        return true
+        #else
+        return false
+        #endif
     }
 }

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashClient.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct DeepseekV4FlashClientResponse: Sendable {
     public let statusCode: Int

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
@@ -1,4 +1,12 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 /// Premier-tier agent runtime backed by the vendored DeepSeek V4 Flash engine.
 ///
@@ -416,7 +424,11 @@ public actor DeepseekV4FlashGenerator: ChatGenerator {
     }
 
     private func pickFreeLoopbackPort() throws -> Int {
+        #if os(Linux)
+        let sock = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        #else
         let sock = socket(AF_INET, SOCK_STREAM, 0)
+        #endif
         guard sock >= 0 else {
             throw DeepseekV4FlashError.serverFailedToStart("socket() failed")
         }

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 @preconcurrency import MLX
 import MLXNN
 
@@ -189,18 +190,31 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
         maxNewTokens: Int = 512,
         segmentationThreshold: Float = 0.5
     ) throws -> FalconPerceptionGroundingRun {
-        #if !canImport(CoreGraphics)
-        throw GrounderError.unsupportedPlatform
-        #else
         let normalizedQueries = queries.map {
             $0.trimmingCharacters(in: .whitespacesAndNewlines)
         }.filter { !$0.isEmpty }
         guard !normalizedQueries.isEmpty else {
             throw GrounderError.failedToEncodeMetadata("At least one non-empty query is required.")
         }
+
+        let imageWidth: Int
+        let imageHeight: Int
+        #if canImport(CoreGraphics)
         guard let baseImage = QwenVLImageLoader.loadCGImage(url: imageURL) else {
             throw GrounderError.invalidImage(imageURL)
         }
+        imageWidth = baseImage.width
+        imageHeight = baseImage.height
+        #else
+        let baseImage: MediaImage
+        do {
+            baseImage = try MediaImageIO.decode(imageURL)
+            imageWidth = baseImage.width
+            imageHeight = baseImage.height
+        } catch {
+            throw GrounderError.invalidImage(imageURL)
+        }
+        #endif
 
         let state = try ensureLoaded()
         var preparedDetections: [PreparedDetection] = []
@@ -211,7 +225,8 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
                 contentsOf: try groundSingleQuery(
                     query: query,
                     imageURL: imageURL,
-                    baseImage: baseImage,
+                    imageWidth: imageWidth,
+                    imageHeight: imageHeight,
                     state: state,
                     maxNewTokens: maxNewTokens,
                     segmentationThreshold: segmentationThreshold
@@ -231,12 +246,21 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
 
         let exportedDetections = try Self.writeMaskArtifacts(
             preparedDetections,
-            width: baseImage.width,
-            height: baseImage.height,
+            width: imageWidth,
+            height: imageHeight,
             outputDirectoryURL: maskOutputDirectoryURL
         )
+        #if canImport(CoreGraphics)
         let annotatedImage = try Self.renderAnnotatedImage(baseImage: baseImage, detections: exportedDetections)
         try Self.writeImage(annotatedImage, to: annotatedImageURL)
+        #else
+        let annotatedImage = try Self.renderAnnotatedImage(baseImage: baseImage, detections: exportedDetections)
+        do {
+            try MediaImageIO.writePNG(annotatedImage, to: annotatedImageURL)
+        } catch {
+            throw GrounderError.failedToWriteImage(annotatedImageURL)
+        }
+        #endif
 
         let detections = exportedDetections.map {
             FalconPerceptionDetection(
@@ -266,7 +290,6 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
             detections: detections,
             metadata: metadata
         )
-        #endif
     }
 
     private func createParentDirectoryIfNeeded(for url: URL) throws {
@@ -303,7 +326,8 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
     private func groundSingleQuery(
         query: String,
         imageURL: URL,
-        baseImage: CGImage,
+        imageWidth: Int,
+        imageHeight: Int,
         state: LoadedState,
         maxNewTokens: Int,
         segmentationThreshold: Float
@@ -488,8 +512,8 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
                         let mask = model.decodeSegmentationMask(
                             segHidden: hiddenLast,
                             segmentationFeatures: segmentationFeatures,
-                            outputHeight: baseImage.height,
-                            outputWidth: baseImage.width,
+                            outputHeight: imageHeight,
+                            outputWidth: imageWidth,
                             threshold: segmentationThreshold
                         )
                         if let mask {
@@ -1101,6 +1125,138 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
         CGImageDestinationAddImage(destination, image, nil)
         guard CGImageDestinationFinalize(destination) else {
             throw GrounderError.failedToWriteImage(url)
+        }
+    }
+    #else
+    private static func renderAnnotatedImage(
+        baseImage: MediaImage,
+        detections: [PreparedDetection]
+    ) throws -> MediaImage {
+        let width = baseImage.width
+        let height = baseImage.height
+        var bytes = baseImage.rgba8
+
+        for (index, detection) in detections.enumerated() {
+            let color = overlayColor(for: detection, index: index)
+            if let mask = detection.binaryMask {
+                for pixelIndex in 0..<(width * height) where mask[pixelIndex] != 0 {
+                    let base = pixelIndex * 4
+                    bytes[base] = UInt8(Float(bytes[base]) * 0.55 + Float(color.0) * 0.45)
+                    bytes[base + 1] = UInt8(Float(bytes[base + 1]) * 0.55 + Float(color.1) * 0.45)
+                    bytes[base + 2] = UInt8(Float(bytes[base + 2]) * 0.55 + Float(color.2) * 0.45)
+                    bytes[base + 3] = 255
+                }
+            }
+
+            drawBox(
+                into: &bytes,
+                width: width,
+                height: height,
+                box: detection.box,
+                color: color,
+                lineWidth: 2
+            )
+        }
+
+        return try MediaImage(width: width, height: height, rgba8: bytes)
+    }
+
+    private static func overlayColor(for detection: PreparedDetection, index: Int) -> (UInt8, UInt8, UInt8) {
+        let seed = detection.label
+        let hash = seed.isEmpty ? index : abs(seed.hashValue)
+        return overlayColors[hash % overlayColors.count]
+    }
+
+    private static func drawBox(
+        into bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        box: FalconPerceptionBoundingBox,
+        color: (UInt8, UInt8, UInt8),
+        lineWidth: Int
+    ) {
+        let x1 = max(0, min(width - 1, Int((box.x1 * Float(width)).rounded(.down))))
+        let y1 = max(0, min(height - 1, Int((box.y1 * Float(height)).rounded(.down))))
+        let x2 = max(0, min(width - 1, Int((box.x2 * Float(width)).rounded(.down))))
+        let y2 = max(0, min(height - 1, Int((box.y2 * Float(height)).rounded(.down))))
+        guard x2 > x1, y2 > y1 else { return }
+
+        for thickness in 0..<lineWidth {
+            let top = min(height - 1, y1 + thickness)
+            let bottom = max(0, y2 - thickness)
+            for x in x1...x2 {
+                writePixel(&bytes, width: width, height: height, x: x, y: top, color: color)
+                writePixel(&bytes, width: width, height: height, x: x, y: bottom, color: color)
+            }
+
+            let left = min(width - 1, x1 + thickness)
+            let right = max(0, x2 - thickness)
+            for y in y1...y2 {
+                writePixel(&bytes, width: width, height: height, x: left, y: y, color: color)
+                writePixel(&bytes, width: width, height: height, x: right, y: y, color: color)
+            }
+        }
+    }
+
+    private static func writePixel(
+        _ bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        x: Int,
+        y: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        guard (0..<width).contains(x), (0..<height).contains(y) else { return }
+        let offset = (y * width + x) * 4
+        bytes[offset] = color.0
+        bytes[offset + 1] = color.1
+        bytes[offset + 2] = color.2
+        bytes[offset + 3] = 255
+    }
+
+    private static func writeMaskArtifacts(
+        _ detections: [PreparedDetection],
+        width: Int,
+        height: Int,
+        outputDirectoryURL: URL?
+    ) throws -> [PreparedDetection] {
+        guard let outputDirectoryURL else { return detections }
+        return try detections.enumerated().map { index, detection in
+            guard let binaryMask = detection.binaryMask else { return detection }
+            let base = slugify(detection.label)
+            let url = outputDirectoryURL.appendingPathComponent("\(base)_mask_\(index)").appendingPathExtension("png")
+            try writeMaskImage(binaryMask: binaryMask, width: width, height: height, to: url)
+            return PreparedDetection(
+                label: detection.label,
+                xy: detection.xy,
+                hw: detection.hw,
+                box: detection.box,
+                score: detection.score,
+                binaryMask: binaryMask,
+                maskPath: url.path
+            )
+        }
+    }
+
+    private static func writeMaskImage(
+        binaryMask: [UInt8],
+        width: Int,
+        height: Int,
+        to url: URL
+    ) throws {
+        var rgba = [UInt8](repeating: 0, count: width * height * 4)
+        for pixelIndex in 0..<(width * height) where binaryMask[pixelIndex] != 0 {
+            let offset = pixelIndex * 4
+            rgba[offset] = 255
+            rgba[offset + 1] = 255
+            rgba[offset + 2] = 255
+            rgba[offset + 3] = 255
+        }
+
+        do {
+            try MediaImageIO.writePNG(MediaImage(width: width, height: height, rgba8: rgba), to: url)
+        } catch {
+            throw GrounderError.failedToWriteMask(url)
         }
     }
     #endif

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
@@ -2,6 +2,19 @@ import Foundation
 @preconcurrency import MLX
 import MLXFast
 import MLXNN
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+#if os(Linux)
+private func mererunCos(_ value: Double) -> Double { Glibc.cos(value) }
+private func mererunSin(_ value: Double) -> Double { Glibc.sin(value) }
+#else
+private func mererunCos(_ value: Double) -> Double { Darwin.cos(value) }
+private func mererunSin(_ value: Double) -> Double { Darwin.sin(value) }
+#endif
 
 private func falconPerceptionRMSNorm(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
     let dtype = x.dtype
@@ -433,8 +446,8 @@ final class FalconPerceptionTransformerModel: Module {
         for position in 0..<text.maxPositionEmbeddings {
             for frequency in invFreqs {
                 let value = Double(position) * frequency
-                cos.append(Float(Darwin.cos(value)))
-                sin.append(Float(Darwin.sin(value)))
+                cos.append(Float(mererunCos(value)))
+                sin.append(Float(mererunSin(value)))
             }
         }
         self.cos1DTable = cos
@@ -1037,8 +1050,8 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
                     let base = ((head * freqCount) + frequencyIndex) * 2
                     let theta = (px * freqValues[base]) + (py * freqValues[base + 1])
                     let outIndex = ((tokenIndex * heads) + head) * freqCount + frequencyIndex
-                    cosValues[outIndex] = Float(Darwin.cos(Double(theta)))
-                    sinValues[outIndex] = Float(Darwin.sin(Double(theta)))
+                    cosValues[outIndex] = Float(mererunCos(Double(theta)))
+                    sinValues[outIndex] = Float(mererunSin(Double(theta)))
                 }
             }
         }

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionProcessor.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionProcessor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 @preconcurrency import MLX
 
 #if canImport(CoreGraphics)
@@ -27,7 +28,7 @@ public enum FalconPerceptionProcessorError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .unsupportedPlatform:
-            return "Falcon Perception preprocessing requires CoreGraphics/ImageIO."
+            return "Falcon Perception preprocessing requires a supported MediaIO image backend."
         case .invalidImage(let url):
             return "Failed to load image: \(url.path)"
         }
@@ -51,17 +52,16 @@ public struct FalconPerceptionProcessor: @unchecked Sendable {
     }
 
     public func process(imageURL: URL, query: String) throws -> FalconPerceptionProcessedInput {
-        #if canImport(CoreGraphics)
-        guard let image = Self.loadImageRGBA(url: imageURL) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(imageURL)
+        } catch {
             throw FalconPerceptionProcessorError.invalidImage(imageURL)
         }
         return process(imageRGBA: image, query: query)
-        #else
-        throw FalconPerceptionProcessorError.unsupportedPlatform
-        #endif
     }
 
-    public func process(imageRGBA: CGImage, query: String) -> FalconPerceptionProcessedInput {
+    public func process(imageRGBA: MediaImage, query: String) -> FalconPerceptionProcessedInput {
         let resized = Self.resizeIfNecessary(imageRGBA, shortest: 256, longest: 1024)
         let smartResized = Self.smartResize(resized, factor: config.visionConfig.spatialPatchSize)
         let pixels = Self.normalizedPixels(from: smartResized)
@@ -86,6 +86,33 @@ public struct FalconPerceptionProcessor: @unchecked Sendable {
         )
     }
 
+    #if canImport(CoreGraphics)
+    public func process(imageRGBA: CGImage, query: String) -> FalconPerceptionProcessedInput {
+        let resized = Self.resizeIfNecessary(imageRGBA, shortest: 256, longest: 1024)
+        let smartResized = Self.smartResize(resized, factor: config.visionConfig.spatialPatchSize)
+        let pixels = Self.normalizedPixels(from: smartResized)
+        let height = smartResized.height
+        let width = smartResized.width
+        let gridH = height / config.visionConfig.spatialPatchSize
+        let gridW = width / config.visionConfig.spatialPatchSize
+
+        let prompt = makePrompt(for: query)
+        let tokenIDs = tokenizer.encode(prompt, addSpecialTokens: false)
+        let expanded = expandImageTokens(tokenIDs, gridH: gridH, gridW: gridW)
+
+        let inputIDs = MLXArray(expanded.map(Int32.init), [1, expanded.count])
+        let pixelValues = MLXArray(pixels, [1, height, width, 3])
+        let imageGridHW = MLXArray([Int32(gridH), Int32(gridW)], [1, 2])
+
+        return FalconPerceptionProcessedInput(
+            inputIDs: inputIDs,
+            pixelValues: pixelValues,
+            imageGridHW: imageGridHW,
+            processedSize: (width, height)
+        )
+    }
+    #endif
+
     public func expandImageTokens(_ tokenIDs: [Int], gridH: Int, gridW: Int) -> [Int] {
         let imagePrefixIDs = [
             config.imageCLSTokenID,
@@ -109,6 +136,85 @@ public struct FalconPerceptionProcessor: @unchecked Sendable {
         return expanded
     }
 
+    public static func resizeIfNecessary(_ image: MediaImage, shortest: Int, longest: Int) -> MediaImage {
+        let width = image.width
+        let height = image.height
+        if shortest <= width && width <= longest && shortest <= height && height <= longest {
+            return image
+        }
+
+        let aspectRatio = Double(width) / Double(height)
+        let isVertical = width < height
+
+        var newWidth: Int
+        var newHeight: Int
+        if width < shortest || height < shortest {
+            if isVertical {
+                newWidth = shortest
+                newHeight = Int(Double(shortest) / aspectRatio)
+            } else {
+                newHeight = shortest
+                newWidth = Int(Double(shortest) * aspectRatio)
+            }
+        } else if isVertical {
+            newWidth = longest
+            newHeight = Int(Double(newWidth) / aspectRatio)
+        } else {
+            newHeight = longest
+            newWidth = Int(Double(newHeight) * aspectRatio)
+        }
+
+        if newWidth > longest {
+            newWidth = longest
+            newHeight = Int(Double(newWidth) / aspectRatio)
+        }
+        if newHeight > longest {
+            newHeight = longest
+            newWidth = Int(Double(newHeight) * aspectRatio)
+        }
+
+        return (try? MediaImageIO.resized(image, width: newWidth, height: newHeight)) ?? image
+    }
+
+    public static func smartResize(_ image: MediaImage, factor: Int, minPixels: Int = 56 * 56, maxPixels: Int = 28 * 28 * 1280) -> MediaImage {
+        let width = image.width
+        let height = image.height
+
+        var roundedHeight = max(factor, Int((Double(height) / Double(factor)).rounded()) * factor)
+        var roundedWidth = max(factor, Int((Double(width) / Double(factor)).rounded()) * factor)
+
+        if roundedHeight * roundedWidth > maxPixels {
+            let beta = sqrt(Double(height * width) / Double(maxPixels))
+            roundedHeight = max(factor, Int(floor(Double(height) / beta / Double(factor))) * factor)
+            roundedWidth = max(factor, Int(floor(Double(width) / beta / Double(factor))) * factor)
+        } else if roundedHeight * roundedWidth < minPixels {
+            let beta = sqrt(Double(minPixels) / Double(height * width))
+            roundedHeight = Int(ceil(Double(height) * beta / Double(factor))) * factor
+            roundedWidth = Int(ceil(Double(width) * beta / Double(factor))) * factor
+        }
+
+        if roundedWidth == width && roundedHeight == height {
+            return image
+        }
+        return (try? MediaImageIO.resized(image, width: roundedWidth, height: roundedHeight)) ?? image
+    }
+
+    private static func normalizedPixels(from image: MediaImage) -> [Float] {
+        let width = image.width
+        let height = image.height
+        var normalized: [Float] = []
+        normalized.reserveCapacity(width * height * 3)
+        for pixel in 0..<(width * height) {
+            let offset = pixel * 4
+            for channel in 0..<3 {
+                let value = Float(image.rgba8[offset + channel]) / 255.0
+                normalized.append((value - imageMean[channel]) / imageStd[channel])
+            }
+        }
+        return normalized
+    }
+
+    #if canImport(CoreGraphics)
     public static func resizeIfNecessary(_ image: CGImage, shortest: Int, longest: Int) -> CGImage {
         let width = image.width
         let height = image.height
@@ -172,7 +278,6 @@ public struct FalconPerceptionProcessor: @unchecked Sendable {
         return resize(image, width: roundedWidth, height: roundedHeight)
     }
 
-    #if canImport(CoreGraphics)
     private static func loadImageRGBA(url: URL) -> CGImage? {
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
         return CGImageSourceCreateImageAtIndex(source, 0, nil)

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
@@ -1,8 +1,8 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGenerator {
 
@@ -460,14 +460,16 @@ extension Flux2KleinGenerator {
             throw Flux2Error.referenceImageNotFound(url)
         }
 
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(url)
+        } catch {
             throw Flux2Error.referenceImageDecodeFailed(url)
         }
 
         // 1. Load and resize image to target dimensions
         let resizedArray = try QwenImageIO.resizedPixelArray(
-            from: cgImage,
+            from: image,
             width: width,
             height: height,
             addBatchDimension: true,

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGenerator {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 // MARK: - Flux2 Klein Generator
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Decode.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Decode.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Denoising.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Denoising.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ModelLoading.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+PersistentState.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+PersistentState.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+PromptEncoding.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+PromptEncoding.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ReferenceEncoding.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ReferenceEncoding.swift
@@ -1,8 +1,8 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 
@@ -99,14 +99,16 @@ extension Flux2KleinGeneratoriOS {
             throw Flux2Error.referenceImageNotFound(url)
         }
 
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(url)
+        } catch {
             throw Flux2Error.referenceImageDecodeFailed(url)
         }
 
         // Load and resize image
         let resizedArray = try QwenImageIO.resizedPixelArray(
-            from: cgImage,
+            from: image,
             width: width,
             height: height,
             addBatchDimension: true,

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Support.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Support.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 extension Flux2KleinGeneratoriOS {
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXRandom
 import MLXNN
-import ImageIO
 
 // MARK: - Flux2 Klein Generator (iOS Memory-Optimized)
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer+DatasetEncoding.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer+DatasetEncoding.swift
@@ -3,11 +3,6 @@ import MLX
 import MLXNN
 import MLXRandom
 
-#if canImport(CoreGraphics)
-import CoreGraphics
-import ImageIO
-#endif
-
 extension Flux2KleinLoRATrainer {
     // MARK: - Dataset Encoding
 
@@ -49,15 +44,9 @@ extension Flux2KleinLoRATrainer {
             throw Flux2KleinLoRATrainerError.imageNotFound(url)
         }
 
-    #if canImport(CoreGraphics)
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
-            throw Flux2KleinLoRATrainerError.imageDecodeFailed(url)
-        }
-
         // Use center crop (ai-toolkit style) to preserve aspect ratio
         let resizedArray = try QwenImageIO.resizedCenterCropPixelArray(
-            from: cgImage,
+            from: url,
             width: width,
             height: height,
             addBatchDimension: true,
@@ -82,9 +71,6 @@ extension Flux2KleinLoRATrainer {
             .transposed(0, 2, 3, 1)
             .reshaped([1, patchedHeight * patchedWidth, 128])
             .asType(.bfloat16)
-    #else
-        throw Flux2KleinLoRATrainerError.imageDecodeFailed(url)
-    #endif
     }
 
     private static func patchifyLatents(_ latents: MLXArray, height: Int, width: Int) -> MLXArray {
@@ -96,4 +82,3 @@ extension Flux2KleinLoRATrainer {
         return x.reshaped([batch, channels * 4, height / 2, width / 2])
     }
 }
-

--- a/Sources/MereRunCore/Gemma4/Gemma4TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TokenizerAndTemplate.swift
@@ -2,7 +2,7 @@ import Foundation
 @preconcurrency import Hub
 @preconcurrency import Tokenizers
 
-public final class Gemma4TokenizerAndTemplate {
+public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
     public let tokenizer: any Tokenizer
     public let maxLength: Int
     public let eosTokenId: Int?

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 import MLX
 
 #if canImport(CoreGraphics)
@@ -53,12 +54,8 @@ public enum HiDreamO1ImagePreprocessor {
         resolution: HiDreamO1SampleBuilder.Resolution,
         dtype: DType = .float32
     ) throws -> PatchTensor {
-        #if canImport(CoreGraphics)
-        let image = try loadCGImage(from: url)
+        let image = try loadImage(from: url)
         return try patchTensor(from: image, resolution: resolution, dtype: dtype)
-        #else
-        throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
-        #endif
     }
 
     public static func visionConditionTensor(
@@ -67,24 +64,83 @@ public enum HiDreamO1ImagePreprocessor {
         config: HiDreamO1Config,
         dtype: DType = .bfloat16
     ) throws -> VisionConditionTensor {
-        #if canImport(CoreGraphics)
-        let image = try loadCGImage(from: url)
+        let image = try loadImage(from: url)
         return try visionConditionTensor(from: image, resolution: resolution, config: config, dtype: dtype)
-        #else
-        throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
-        #endif
+    }
+
+    public static func imageSize(_ url: URL) throws -> HiDreamO1SampleBuilder.Resolution {
+        do {
+            let size = try MediaImageIO.size(of: url)
+            return .init(width: size.width, height: size.height)
+        } catch {
+            throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
+        }
+    }
+
+    public static func patchTensor(
+        from image: MediaImage,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        dtype: DType = .float32
+    ) throws -> PatchTensor {
+        let imageCHW = try normalizedCHW(from: image, resolution: resolution, dtype: dtype)
+        let patches = HiDreamO1SampleBuilder.patchifyCHW(imageCHW)
+        return PatchTensor(resolution: resolution, imageCHW: imageCHW, patches: patches)
+    }
+
+    public static func normalizedCHW(
+        from image: MediaImage,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        dtype: DType = .float32
+    ) throws -> MLXArray {
+        try validate(resolution)
+        let resized = try MediaImageIO.resized(image, width: resolution.width, height: resolution.height)
+        let values = MediaImageIO.rgbCHWFloat(resized, normalizedToMinusOneToOne: true)
+        return MLXArray(values, [3, resized.height, resized.width]).asType(dtype)
+    }
+
+    public static func visionConditionTensor(
+        from image: MediaImage,
+        resolution: HiDreamO1SampleBuilder.Resolution,
+        config: HiDreamO1Config,
+        dtype: DType = .bfloat16
+    ) throws -> VisionConditionTensor {
+        let patchSize = config.visionConfig.patchSize
+        let mergeSize = config.visionConfig.spatialMergeSize
+        try validateVisionResolution(resolution, patchSize: patchSize, mergeSize: mergeSize)
+        let imageCHW = try normalizedCHW(from: image, resolution: resolution, dtype: dtype)
+        let patchInputs = prepareVisionPatchInputs(
+            imageCHW: imageCHW,
+            patchSize: patchSize,
+            temporalPatchSize: config.visionConfig.temporalPatchSize,
+            mergeSize: mergeSize
+        )
+        let gridHeight = resolution.height / patchSize
+        let gridWidth = resolution.width / patchSize
+        return VisionConditionTensor(
+            resolution: resolution,
+            grid: QwenVisionGrid(temporal: 1, height: gridHeight, width: gridWidth),
+            mergedGrid: .init(width: gridWidth / mergeSize, height: gridHeight / mergeSize),
+            pixelValues: patchInputs
+        )
+    }
+
+    public static func saveNormalizedCHW(_ image: MLXArray, to url: URL) throws {
+        do {
+            try QwenImageIO.saveImage(array: (image.asType(.float32) + 1.0) / 2.0, to: url)
+        } catch {
+            throw HiDreamO1ImagePreprocessorError.imageWriteFailed(url)
+        }
+    }
+
+    private static func loadImage(from url: URL) throws -> MediaImage {
+        do {
+            return try MediaImageIO.decode(url)
+        } catch {
+            throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
+        }
     }
 
     #if canImport(CoreGraphics)
-    public static func imageSize(_ url: URL) throws -> HiDreamO1SampleBuilder.Resolution {
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
-              let width = properties[kCGImagePropertyPixelWidth] as? Int,
-              let height = properties[kCGImagePropertyPixelHeight] as? Int else {
-            throw HiDreamO1ImagePreprocessorError.imageLoadFailed(url)
-        }
-        return .init(width: width, height: height)
-    }
 
     public static func patchTensor(
         from image: CGImage,
@@ -130,22 +186,6 @@ public enum HiDreamO1ImagePreprocessor {
             mergedGrid: .init(width: gridWidth / mergeSize, height: gridHeight / mergeSize),
             pixelValues: patchInputs
         )
-    }
-
-    public static func saveNormalizedCHW(_ image: MLXArray, to url: URL) throws {
-        let rgbImage = try cgImage(fromNormalizedCHW: image)
-        guard let destination = CGImageDestinationCreateWithURL(
-            url as CFURL,
-            UTType.png.identifier as CFString,
-            1,
-            nil
-        ) else {
-            throw HiDreamO1ImagePreprocessorError.imageWriteFailed(url)
-        }
-        CGImageDestinationAddImage(destination, rgbImage, nil)
-        guard CGImageDestinationFinalize(destination) else {
-            throw HiDreamO1ImagePreprocessorError.imageWriteFailed(url)
-        }
     }
 
     private static func loadCGImage(from url: URL) throws -> CGImage {

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1SampleBuilder.swift
@@ -42,8 +42,8 @@ public enum HiDreamO1SampleBuilder {
         return predefinedResolutions.min { lhs, rhs in
             let lhsRatio = Double(lhs.width) / Double(lhs.height)
             let rhsRatio = Double(rhs.width) / Double(rhs.height)
-            let lhsDistance = Darwin.fabs(lhsRatio - ratio)
-            let rhsDistance = Darwin.fabs(rhsRatio - ratio)
+            let lhsDistance = abs(lhsRatio - ratio)
+            let rhsDistance = abs(rhsRatio - ratio)
             return lhsDistance < rhsDistance
         } ?? predefinedResolutions[0]
     }

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreGraphics
-import ImageIO
+import MediaIO
 import MLX
 import MLXFast
 import MLXNN
@@ -1028,99 +1027,17 @@ private func loadImageForEncoding(
     height: Int,
     dtype: DType
 ) throws -> MLXArray {
-    guard let src = CGImageSourceCreateWithURL(url as CFURL, nil),
-          let cgImage = CGImageSourceCreateImageAtIndex(src, 0, nil) else {
+    let image: MediaImage
+    do {
+        image = try MediaImageIO.resized(try MediaImageIO.decode(url), width: width, height: height)
+    } catch {
         throw LTXDistilledLatentGeneratorError.imageDecodeFailed(url)
     }
 
-    let resized = resizeImageExact(cgImage, width: width, height: height)
-    guard let rgb = readRGB8(resized) else {
-        throw LTXDistilledLatentGeneratorError.imageDecodeFailed(url)
-    }
-    var channels = [Float](repeating: 0, count: 3 * width * height)
-
-    channels.withUnsafeMutableBufferPointer { dst in
-        rgb.withUnsafeBytes { src in
-            let bytes = src.bindMemory(to: UInt8.self)
-            for y in 0..<height {
-                for x in 0..<width {
-                    let pixel = y * width + x
-                    let r = Float(bytes[pixel * 3 + 0]) / 127.5 - 1.0
-                    let g = Float(bytes[pixel * 3 + 1]) / 127.5 - 1.0
-                    let b = Float(bytes[pixel * 3 + 2]) / 127.5 - 1.0
-                    dst[0 * width * height + pixel] = r
-                    dst[1 * width * height + pixel] = g
-                    dst[2 * width * height + pixel] = b
-                }
-            }
-        }
-    }
+    let channels = MediaImageIO.rgbCHWFloat(image, normalizedToMinusOneToOne: true)
 
     let chw = MLXArray(channels).reshaped(1, 3, height, width).asType(dtype)
     return chw.reshaped(1, 3, 1, height, width)
-}
-
-private func resizeImageExact(_ image: CGImage, width: Int, height: Int) -> CGImage {
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let bytesPerRow = width * 4
-    let bitmapInfo = CGImageAlphaInfo.noneSkipLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-
-    guard let context = CGContext(
-        data: nil,
-        width: width,
-        height: height,
-        bitsPerComponent: 8,
-        bytesPerRow: bytesPerRow,
-        space: colorSpace,
-        bitmapInfo: bitmapInfo
-    ) else {
-        return image
-    }
-
-    context.interpolationQuality = .high
-    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-    return context.makeImage() ?? image
-}
-
-private func readRGB8(_ image: CGImage) -> Data? {
-    let width = image.width
-    let height = image.height
-    let bytesPerRow = width * 4
-    var rgba = Data(count: bytesPerRow * height)
-
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let bitmapInfo = CGImageAlphaInfo.noneSkipLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-    let rendered = rgba.withUnsafeMutableBytes { ptr -> Bool in
-        guard let context = CGContext(
-            data: ptr.baseAddress,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo
-        ) else {
-            return false
-        }
-        context.interpolationQuality = .high
-        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-        return true
-    }
-    guard rendered else { return nil }
-
-    var rgb = Data(count: width * height * 3)
-    rgb.withUnsafeMutableBytes { dstPtr in
-        rgba.withUnsafeBytes { srcPtr in
-            let dst = dstPtr.bindMemory(to: UInt8.self)
-            let src = srcPtr.bindMemory(to: UInt8.self)
-            for i in 0..<(width * height) {
-                dst[i * 3 + 0] = src[i * 4 + 0]
-                dst[i * 3 + 1] = src[i * 4 + 1]
-                dst[i * 3 + 2] = src[i * 4 + 2]
-            }
-        }
-    }
-    return rgb
 }
 
 private func toDenoised(

--- a/Sources/MereRunCore/LTX/LTXVideoMP4Writer.swift
+++ b/Sources/MereRunCore/LTX/LTXVideoMP4Writer.swift
@@ -1,6 +1,5 @@
-import AVFoundation
-import CoreVideo
 import Foundation
+import MediaIO
 import MLX
 
 public enum LTXVideoMP4Writer {
@@ -109,103 +108,17 @@ public enum LTXVideoMP4Writer {
         }
         try fm.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-        guard let writer = try? AVAssetWriter(outputURL: outputURL, fileType: .mp4) else {
+        do {
+            try MediaVideoIO.writeMP4(
+                rgb24: rgbBytes,
+                width: width,
+                height: height,
+                frameCount: frameCount,
+                fps: fps,
+                to: outputURL
+            )
+        } catch {
             throw WriterError.writerCreationFailed(outputURL)
-        }
-
-        let settings: [String: Any] = [
-            AVVideoCodecKey: AVVideoCodecType.h264,
-            AVVideoWidthKey: width,
-            AVVideoHeightKey: height,
-            AVVideoCompressionPropertiesKey: [
-                AVVideoAverageBitRateKey: max(1_000_000, width * height * fps * 4),
-                AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
-            ],
-        ]
-
-        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
-        input.expectsMediaDataInRealTime = false
-        guard writer.canAdd(input) else {
-            throw WriterError.inputRejected
-        }
-        writer.add(input)
-
-        let attributes: [String: Any] = [
-            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
-            kCVPixelBufferWidthKey as String: width,
-            kCVPixelBufferHeightKey as String: height,
-            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
-        ]
-
-        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
-            assetWriterInput: input,
-            sourcePixelBufferAttributes: attributes
-        )
-
-        guard writer.startWriting() else {
-            let details = writer.error?.localizedDescription ?? "unknown error"
-            throw WriterError.finishFailed(details)
-        }
-        writer.startSession(atSourceTime: .zero)
-
-        guard let pool = adaptor.pixelBufferPool else {
-            throw WriterError.pixelBufferPoolUnavailable
-        }
-
-        let frameStride = height * width * 3
-        for frameIndex in 0..<frameCount {
-            while !input.isReadyForMoreMediaData {
-                Thread.sleep(forTimeInterval: 0.001)
-            }
-
-            var pixelBuffer: CVPixelBuffer?
-            let status = CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer)
-            guard status == kCVReturnSuccess, let pixelBuffer else {
-                throw WriterError.pixelBufferCreationFailed
-            }
-
-            CVPixelBufferLockBaseAddress(pixelBuffer, [])
-            guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
-                CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
-                throw WriterError.pixelBufferBaseAddressUnavailable
-            }
-
-            let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-            let dst = baseAddress.bindMemory(to: UInt8.self, capacity: bytesPerRow * height)
-            let srcOffset = frameIndex * frameStride
-
-            for y in 0..<height {
-                let dstRow = dst.advanced(by: y * bytesPerRow)
-                let srcRow = srcOffset + (y * width * 3)
-                for x in 0..<width {
-                    let s = srcRow + x * 3
-                    let d = x * 4
-                    dstRow[d] = rgbBytes[s + 2]     // B
-                    dstRow[d + 1] = rgbBytes[s + 1] // G
-                    dstRow[d + 2] = rgbBytes[s]     // R
-                    dstRow[d + 3] = 255             // A
-                }
-            }
-
-            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
-
-            let time = CMTime(value: Int64(frameIndex), timescale: CMTimeScale(fps))
-            if !adaptor.append(pixelBuffer, withPresentationTime: time) {
-                throw WriterError.appendFailed(frameIndex)
-            }
-        }
-
-        input.markAsFinished()
-
-        let semaphore = DispatchSemaphore(value: 0)
-        writer.finishWriting {
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        guard writer.status == .completed else {
-            let details = writer.error?.localizedDescription ?? "unknown error"
-            throw WriterError.finishFailed(details)
         }
     }
 
@@ -287,104 +200,19 @@ public enum LTXVideoMP4Writer {
         }
         try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-        let frameCount = interleaved.count / max(1, channels)
-        var pcm = [Int16](repeating: 0, count: interleaved.count)
-        for i in 0..<interleaved.count {
-            let clipped = max(-1.0, min(1.0, interleaved[i]))
-            pcm[i] = Int16((clipped * 32767.0).rounded())
-        }
-
-        var data = Data()
-        data.reserveCapacity(44 + pcm.count * MemoryLayout<Int16>.size)
-
-        let bitsPerSample = 16
-        let blockAlign = channels * bitsPerSample / 8
-        let byteRate = sampleRate * blockAlign
-        let dataSize = pcm.count * MemoryLayout<Int16>.size
-        let riffSize = 36 + dataSize
-
-        data.append(contentsOf: Array("RIFF".utf8))
-        data.appendLE(UInt32(riffSize))
-        data.append(contentsOf: Array("WAVE".utf8))
-        data.append(contentsOf: Array("fmt ".utf8))
-        data.appendLE(UInt32(16)) // PCM fmt chunk size
-        data.appendLE(UInt16(1)) // PCM
-        data.appendLE(UInt16(channels))
-        data.appendLE(UInt32(sampleRate))
-        data.appendLE(UInt32(byteRate))
-        data.appendLE(UInt16(blockAlign))
-        data.appendLE(UInt16(bitsPerSample))
-        data.append(contentsOf: Array("data".utf8))
-        data.appendLE(UInt32(dataSize))
-        pcm.withUnsafeBufferPointer { buffer in
-            data.append(contentsOf: UnsafeRawBufferPointer(buffer))
-        }
-
-        try data.write(to: url)
-        _ = frameCount
+        try MediaAudioIO.writeFloatWAV(
+            samples: interleaved,
+            sampleRate: sampleRate,
+            channels: channels,
+            to: url
+        )
     }
 
     private static func mux(videoURL: URL, audioURL: URL, outputURL: URL) throws {
-        let fm = FileManager.default
-        if fm.fileExists(atPath: outputURL.path) {
-            try fm.removeItem(at: outputURL)
-        }
-        try fm.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-
-        let videoAsset = AVURLAsset(url: videoURL)
-        let audioAsset = AVURLAsset(url: audioURL)
-
-        guard let videoTrack = videoAsset.tracks(withMediaType: .video).first else {
-            throw WriterError.videoTrackMissing
-        }
-        guard let audioTrack = audioAsset.tracks(withMediaType: .audio).first else {
-            throw WriterError.audioTrackMissing
-        }
-
-        let composition = AVMutableComposition()
-        guard let compositionVideoTrack = composition.addMutableTrack(withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid) else {
-            throw WriterError.videoTrackMissing
-        }
-        guard let compositionAudioTrack = composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid) else {
-            throw WriterError.audioTrackMissing
-        }
-
-        let videoDuration = videoAsset.duration
-        let audioDuration = audioAsset.duration
-        let duration = CMTimeMinimum(videoDuration, audioDuration)
-
-        try compositionVideoTrack.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: videoTrack, at: .zero)
-        try compositionAudioTrack.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: audioTrack, at: .zero)
-        compositionVideoTrack.preferredTransform = videoTrack.preferredTransform
-
-        guard let export = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetHighestQuality) else {
+        do {
+            try MediaVideoIO.mux(videoURL: videoURL, audioURL: audioURL, outputURL: outputURL)
+        } catch {
             throw WriterError.exportSessionCreationFailed
         }
-        export.outputURL = outputURL
-        export.outputFileType = .mp4
-        export.shouldOptimizeForNetworkUse = true
-
-        let semaphore = DispatchSemaphore(value: 0)
-        export.exportAsynchronously {
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        guard export.status == .completed else {
-            let details = export.error?.localizedDescription ?? "unknown error"
-            throw WriterError.finishFailed(details)
-        }
-    }
-}
-
-private extension Data {
-    mutating func appendLE(_ value: UInt16) {
-        var little = value.littleEndian
-        Swift.withUnsafeBytes(of: &little) { append(contentsOf: $0) }
-    }
-
-    mutating func appendLE(_ value: UInt32) {
-        var little = value.littleEndian
-        Swift.withUnsafeBytes(of: &little) { append(contentsOf: $0) }
     }
 }

--- a/Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator+Inference.swift
+++ b/Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator+Inference.swift
@@ -1,8 +1,8 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXNN
 import MLXFast
-import ImageIO
 
 /// Owns OCR image preprocessing and autoregressive decoding.
 /// Keeping these helpers together makes the vision -> prompt -> text path
@@ -13,13 +13,15 @@ extension LightOnOCRGenerator {
         patchSize: Int,
         spatialMergeSize: Int
     ) throws -> MLXArray {
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(url)
+        } catch {
             throw LightOnOCRError.imageLoadFailed(url)
         }
 
-        let originalWidth = cgImage.width
-        let originalHeight = cgImage.height
+        let originalWidth = image.width
+        let originalHeight = image.height
         let maxEdge = 1540
         let mergeUnit = max(1, patchSize * spatialMergeSize)
         let longestEdge = max(originalWidth, originalHeight)
@@ -36,7 +38,7 @@ extension LightOnOCRGenerator {
         targetHeight = min(maxEdge, max(mergeUnit, targetHeight))
 
         let pixelArray = try QwenImageIO.resizedPixelArray(
-            from: cgImage,
+            from: image,
             width: targetWidth,
             height: targetHeight,
             addBatchDimension: true,

--- a/Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator.swift
+++ b/Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator.swift
@@ -2,7 +2,6 @@ import Foundation
 import MLX
 import MLXNN
 import MLXFast
-import ImageIO
 
 /// Owns the public OCR entrypoint and runtime state for the LightOn stack.
 /// Model loading and generation helpers live in companion files so readers can

--- a/Sources/MereRunCore/LoRA/LoRACheckpointArchive.swift
+++ b/Sources/MereRunCore/LoRA/LoRACheckpointArchive.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#endif
 
 public enum LoRACheckpointArchive {
     public static func archiveURL(for checkpointURL: URL) -> URL {
@@ -10,7 +13,6 @@ public enum LoRACheckpointArchive {
         primaryFile: URL,
         additionalFiles: [URL] = []
     ) throws -> URL? {
-        #if os(macOS)
         let archiveURL = archiveURL(for: primaryFile)
         let fm = FileManager.default
         let tempRoot = fm.temporaryDirectory.appendingPathComponent(
@@ -40,6 +42,7 @@ public enum LoRACheckpointArchive {
             try fm.removeItem(at: archiveURL)
         }
 
+        #if os(macOS)
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
         process.arguments = ["-c", "-k", "--sequesterRsrc", "--keepParent", bundleDir.path, archiveURL.path]
@@ -52,10 +55,26 @@ public enum LoRACheckpointArchive {
                 userInfo: [NSLocalizedDescriptionKey: "Failed to create checkpoint archive with ditto (status \(process.terminationStatus))."]
             )
         }
-
-        return archiveURL
+        #elseif os(Linux)
+        let command = [
+            "cd \(shellQuote(tempRoot.path))",
+            "zip -qry \(shellQuote(archiveURL.path)) \(shellQuote(bundleDir.lastPathComponent))"
+        ].joined(separator: " && ")
+        guard system(command) == 0 else {
+            throw NSError(
+                domain: "LoRACheckpointArchive",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create checkpoint archive with zip."]
+            )
+        }
         #else
         return nil
         #endif
+
+        return archiveURL
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }

--- a/Sources/MereRunCore/LoRA/LoRACheckpointResolver.swift
+++ b/Sources/MereRunCore/LoRA/LoRACheckpointResolver.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#endif
 
 public struct LoRAResolvedCheckpoint: Sendable {
     public let checkpointURL: URL
@@ -51,7 +54,6 @@ public enum LoRACheckpointResolver {
     }
 
     private static func resolveZip(_ zipURL: URL) throws -> LoRAResolvedCheckpoint {
-        #if os(macOS)
         let fm = FileManager.default
         let extractRoot = fm.temporaryDirectory.appendingPathComponent(
             "mererun-lora-resume-\(UUID().uuidString)",
@@ -59,6 +61,7 @@ public enum LoRACheckpointResolver {
         )
         try fm.createDirectory(at: extractRoot, withIntermediateDirectories: true)
         do {
+            #if os(macOS)
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
             process.arguments = ["-x", "-k", zipURL.path, extractRoot.path]
@@ -71,6 +74,22 @@ public enum LoRACheckpointResolver {
                     userInfo: [NSLocalizedDescriptionKey: "Failed to extract checkpoint archive \(zipURL.lastPathComponent)."]
                 )
             }
+            #elseif os(Linux)
+            let command = "unzip -q \(shellQuote(zipURL.path)) -d \(shellQuote(extractRoot.path))"
+            guard system(command) == 0 else {
+                throw NSError(
+                    domain: "LoRACheckpointResolver",
+                    code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to extract checkpoint archive \(zipURL.lastPathComponent)."]
+                )
+            }
+            #else
+            throw NSError(
+                domain: "LoRACheckpointResolver",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Zip checkpoint resume is unsupported on this platform."]
+            )
+            #endif
 
             guard let checkpointURL = findCheckpoint(
                 in: extractRoot,
@@ -102,13 +121,6 @@ public enum LoRACheckpointResolver {
             try? fm.removeItem(at: extractRoot)
             throw error
         }
-        #else
-        throw NSError(
-            domain: "LoRACheckpointResolver",
-            code: 3,
-            userInfo: [NSLocalizedDescriptionKey: "Zip checkpoint resume is supported only on macOS."]
-        )
-        #endif
     }
 
     private static func findCheckpoint(in root: URL, preferredName: String) -> URL? {
@@ -274,5 +286,9 @@ public enum LoRACheckpointResolver {
         }
 
         return nil
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }

--- a/Sources/MereRunCore/LoRA/LoRATrainingMetrics.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingMetrics.swift
@@ -1,4 +1,8 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 
 public enum LoRATrainingFingerprint {

--- a/Sources/MereRunCore/LoRA/LoRATrainingResolution.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingResolution.swift
@@ -1,9 +1,5 @@
 import Foundation
-
-#if canImport(CoreGraphics)
-import CoreGraphics
-import ImageIO
-#endif
+import MediaIO
 
 public struct LoRAResolvedResolution: Sendable, Hashable {
     public let width: Int
@@ -85,25 +81,15 @@ public enum LoRATrainingResolution {
     }
 
     public static func imageSize(at imageURL: URL) throws -> (width: Int, height: Int) {
-        #if canImport(CoreGraphics)
-        guard let imageSource = CGImageSourceCreateWithURL(imageURL as CFURL, nil),
-              let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any],
-              let width = properties[kCGImagePropertyPixelWidth] as? NSNumber,
-              let height = properties[kCGImagePropertyPixelHeight] as? NSNumber else {
+        do {
+            return try MediaImageIO.size(of: imageURL)
+        } catch {
             throw NSError(
                 domain: "LoRATrainingResolution",
                 code: 5,
                 userInfo: [NSLocalizedDescriptionKey: "Failed to read image dimensions: \(imageURL.path)"]
             )
         }
-        return (width: width.intValue, height: height.intValue)
-        #else
-        throw NSError(
-            domain: "LoRATrainingResolution",
-            code: 6,
-            userInfo: [NSLocalizedDescriptionKey: "Image size inference requires CoreGraphics support."]
-        )
-        #endif
     }
 
     public static func allocateSteps(totalSteps: Int, bucketSizes: [Int]) -> [Int] {

--- a/Sources/MereRunCore/LoRA/LoRAWeightLoader.swift
+++ b/Sources/MereRunCore/LoRA/LoRAWeightLoader.swift
@@ -1,4 +1,10 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if os(Linux)
+import Glibc
+#endif
 import MLX
 
 public enum LoRAWeightLoader {
@@ -297,7 +303,7 @@ public enum LoRAWeightLoader {
         }
 
         #if os(macOS)
-        fileManager.createFile(atPath: outURL.path, contents: nil)
+        _ = fileManager.createFile(atPath: outURL.path, contents: nil)
         let outputHandle = try FileHandle(forWritingTo: outURL)
         defer { try? outputHandle.close() }
 
@@ -312,8 +318,18 @@ public enum LoRAWeightLoader {
             throw LoRAError.invalidFormat("Failed to decompress gzip LoRA archive: \(url.lastPathComponent)")
         }
         return outURL
+        #elseif os(Linux)
+        let command = "gzip -dc \(shellQuote(url.path)) > \(shellQuote(outURL.path))"
+        guard system(command) == 0 else {
+            throw LoRAError.invalidFormat("Failed to decompress gzip LoRA archive: \(url.lastPathComponent)")
+        }
+        return outURL
         #else
         throw LoRAError.invalidFormat("Gzip LoRA archives are unsupported on this platform.")
         #endif
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -7,31 +7,47 @@ public struct MereRunMachineProfile: Hashable, Sendable {
     public let physicalMemoryBytes: UInt64
     public let processorName: String
     public let isAppleSiliconMac: Bool
+    public let isLinux: Bool
 
     public init(
         physicalMemoryBytes: UInt64,
         processorName: String,
-        isAppleSiliconMac: Bool
+        isAppleSiliconMac: Bool,
+        isLinux: Bool = false
     ) {
         self.physicalMemoryBytes = physicalMemoryBytes
         self.processorName = processorName
         self.isAppleSiliconMac = isAppleSiliconMac
+        self.isLinux = isLinux
     }
 
     public var unifiedMemoryGB: Int {
         max(1, Int(physicalMemoryBytes / 1_073_741_824))
     }
 
+    public var isSupportedRuntime: Bool {
+        isAppleSiliconMac || isLinux
+    }
+
     public static var current: MereRunMachineProfile {
         MereRunMachineProfile(
             physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
             processorName: currentProcessorName(),
-            isAppleSiliconMac: currentIsAppleSiliconMac()
+            isAppleSiliconMac: currentIsAppleSiliconMac(),
+            isLinux: currentIsLinux()
         )
     }
 
     private static func currentIsAppleSiliconMac() -> Bool {
         #if os(macOS) && arch(arm64)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    private static func currentIsLinux() -> Bool {
+        #if os(Linux)
         return true
         #else
         return false
@@ -47,7 +63,11 @@ public struct MereRunMachineProfile: Hashable, Sendable {
             return brand
         }
         #endif
+        #if os(Linux)
+        return "Linux"
+        #else
         return currentIsAppleSiliconMac() ? "Apple Silicon" : "Unknown processor"
+        #endif
     }
 
     #if canImport(Darwin)
@@ -376,8 +396,8 @@ public enum ManagedModelCapabilityCatalog {
         let descriptor = descriptor(for: spec)
         var reasons: [String] = []
 
-        if !machine.isAppleSiliconMac {
-            reasons.append("Apple Silicon macOS is required.")
+        if !machine.isSupportedRuntime {
+            reasons.append("Apple Silicon macOS or Linux is required.")
         }
 
         if machine.unifiedMemoryGB < descriptor.minimumUnifiedMemoryGB {

--- a/Sources/MereRunCore/NativeMediaAssembler.swift
+++ b/Sources/MereRunCore/NativeMediaAssembler.swift
@@ -1,9 +1,17 @@
+import Foundation
+import MediaIO
+#if canImport(AVFoundation) && canImport(CoreGraphics)
 import AVFoundation
 import CoreGraphics
 import CoreText
-import Foundation
 import ImageIO
 import QuartzCore
+#elseif os(Linux)
+import Glibc
+public typealias CGFloat = Double
+#else
+public typealias CGFloat = Double
+#endif
 
 public struct NativeMediaSegment: Sendable {
     public enum Source: Sendable {
@@ -200,6 +208,7 @@ public enum NativeMediaAssemblerError: LocalizedError {
 public struct NativeMediaAssembler {
     public init() {}
 
+#if canImport(AVFoundation) && canImport(CoreGraphics)
     public func assemble(
         request: NativeMediaAssemblyRequest,
         onLog: @escaping (String) -> Void
@@ -822,4 +831,502 @@ public struct NativeMediaAssembler {
             throw NativeMediaAssemblerError.exportFailed(details)
         }
     }
+#else
+    public func assemble(
+        request: NativeMediaAssemblyRequest,
+        onLog: @escaping (String) -> Void
+    ) throws -> URL {
+        guard request.fps >= 1 else {
+            throw NativeMediaAssemblerError.invalidFPS(request.fps)
+        }
+
+        let orderedSegments = request.segments
+            .filter { $0.endSeconds > $0.startSeconds }
+            .sorted { $0.startSeconds < $1.startSeconds }
+
+        guard !orderedSegments.isEmpty else {
+            throw NativeMediaAssemblerError.emptySegments
+        }
+
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: request.outputURL.path) {
+            try fileManager.removeItem(at: request.outputURL)
+        }
+        try fileManager.createDirectory(
+            at: request.outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let segmentsDir = request.workDirectory.appendingPathComponent("segments", isDirectory: true)
+        if fileManager.fileExists(atPath: segmentsDir.path) {
+            try fileManager.removeItem(at: segmentsDir)
+        }
+        try fileManager.createDirectory(at: segmentsDir, withIntermediateDirectories: true)
+
+        onLog("  Native assembly: rendering \(orderedSegments.count) segment(s)")
+
+        var renderedSegmentURLs: [URL] = []
+        var totalDuration = 0.0
+        renderedSegmentURLs.reserveCapacity(orderedSegments.count)
+
+        for (index, segment) in orderedSegments.enumerated() {
+            let segmentDuration = max(0.1, segment.endSeconds - segment.startSeconds)
+            totalDuration += segmentDuration
+            let segmentURL = segmentsDir.appendingPathComponent(String(format: "segment-%03d.mp4", index))
+
+            switch segment.source {
+            case .image(let url, let motion):
+                onLog("  Native assembly: beat \(index + 1)/\(orderedSegments.count) image motion")
+                try renderImageSegmentPortable(
+                    imageURL: url,
+                    outputURL: segmentURL,
+                    durationSeconds: segmentDuration,
+                    motion: motion,
+                    renderWidth: request.renderWidth,
+                    renderHeight: request.renderHeight,
+                    fps: request.fps
+                )
+            case .video(let url):
+                onLog("  Native assembly: beat \(index + 1)/\(orderedSegments.count) video normalize")
+                try renderVideoSegmentPortable(
+                    videoURL: url,
+                    outputURL: segmentURL,
+                    durationSeconds: segmentDuration,
+                    renderWidth: request.renderWidth,
+                    renderHeight: request.renderHeight,
+                    fps: request.fps
+                )
+            }
+
+            renderedSegmentURLs.append(segmentURL)
+        }
+
+        onLog("  Native assembly: stitching timeline")
+        let timelineURL = request.workDirectory.appendingPathComponent("native-timeline.mp4")
+        try concatenateSegments(renderedSegmentURLs, outputURL: timelineURL)
+
+        let captionedURL: URL
+        if request.captions.contains(where: { $0.endSeconds > $0.startSeconds && !$0.text.isEmpty }) {
+            onLog("  Native assembly: burning captions")
+            captionedURL = request.workDirectory.appendingPathComponent("native-captioned.mp4")
+            try burnCaptions(
+                captions: request.captions,
+                style: request.captionStyle,
+                renderHeight: request.renderHeight,
+                inputURL: timelineURL,
+                outputURL: captionedURL,
+                workDirectory: request.workDirectory
+            )
+        } else {
+            captionedURL = timelineURL
+        }
+
+        let narrationLayers = request.narrationLayers.filter {
+            fileManager.fileExists(atPath: $0.url.path) && MediaVideoIO.hasAudioTrack($0.url)
+        }
+        let backgroundLayer = request.backgroundLayer.flatMap { layer -> NativeMediaAudioLayer? in
+            guard fileManager.fileExists(atPath: layer.url.path), MediaVideoIO.hasAudioTrack(layer.url) else {
+                return nil
+            }
+            return layer
+        }
+
+        if !narrationLayers.isEmpty || backgroundLayer != nil {
+            onLog("  Native assembly: mixing audio")
+            try mixAudio(
+                videoURL: captionedURL,
+                narrationLayers: narrationLayers,
+                backgroundLayer: backgroundLayer,
+                totalDuration: totalDuration,
+                outputURL: request.outputURL
+            )
+        } else {
+            try copyMedia(from: captionedURL, to: request.outputURL)
+        }
+
+        return request.outputURL
+    }
+
+    private func renderImageSegmentPortable(
+        imageURL: URL,
+        outputURL: URL,
+        durationSeconds: Double,
+        motion: NativeKenBurnsMotion,
+        renderWidth: Int,
+        renderHeight: Int,
+        fps: Int
+    ) throws {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(imageURL)
+        } catch {
+            throw NativeMediaAssemblerError.imageDecodeFailed(imageURL)
+        }
+
+        let frameCount = max(1, Int((durationSeconds * Double(fps)).rounded(.up)))
+        var rgb24: [UInt8] = []
+        rgb24.reserveCapacity(renderWidth * renderHeight * 3 * frameCount)
+
+        for frameIndex in 0..<frameCount {
+            rgb24.append(contentsOf: renderKenBurnsFrame(
+                image: image,
+                frameIndex: frameIndex,
+                frameCount: frameCount,
+                motion: motion,
+                renderWidth: renderWidth,
+                renderHeight: renderHeight
+            ))
+        }
+
+        try MediaVideoIO.writeMP4(
+            rgb24: rgb24,
+            width: renderWidth,
+            height: renderHeight,
+            frameCount: frameCount,
+            fps: fps,
+            to: outputURL
+        )
+    }
+
+    private func renderKenBurnsFrame(
+        image: MediaImage,
+        frameIndex: Int,
+        frameCount: Int,
+        motion: NativeKenBurnsMotion,
+        renderWidth: Int,
+        renderHeight: Int
+    ) -> [UInt8] {
+        let canvasWidth = Double(renderWidth)
+        let canvasHeight = Double(renderHeight)
+        let imageWidth = Double(image.width)
+        let imageHeight = Double(image.height)
+        let progress = frameCount > 1 ? Double(frameIndex) / Double(frameCount - 1) : 0
+        let zoom = motion.startZoom + (motion.endZoom - motion.startZoom) * progress
+        let baseScale = max(canvasWidth / imageWidth, canvasHeight / imageHeight)
+        let drawWidth = imageWidth * baseScale * zoom
+        let drawHeight = imageHeight * baseScale * zoom
+
+        let overflowX = max(0, drawWidth - canvasWidth)
+        let overflowY = max(0, drawHeight - canvasHeight)
+        let angleX = 2.0 * Double.pi * motion.driftXFrequency * progress
+        let angleY = 2.0 * Double.pi * motion.driftYFrequency * progress
+        let driftX = overflowX * motion.driftXFraction * sin(angleX)
+        let driftY = overflowY * motion.driftYFraction * cos(angleY)
+        let originX = -(overflowX / 2.0) + driftX
+        let originY = -(overflowY / 2.0) + driftY
+        let scaleX = drawWidth / imageWidth
+        let scaleY = drawHeight / imageHeight
+
+        var output = [UInt8](repeating: 0, count: renderWidth * renderHeight * 3)
+        for y in 0..<renderHeight {
+            for x in 0..<renderWidth {
+                let sourceX = Int(((Double(x) - originX) / scaleX).rounded(.down))
+                let sourceY = Int(((Double(y) - originY) / scaleY).rounded(.down))
+                guard sourceX >= 0, sourceX < image.width, sourceY >= 0, sourceY < image.height else {
+                    continue
+                }
+
+                let sourceOffset = ((sourceY * image.width) + sourceX) * 4
+                let outputOffset = ((y * renderWidth) + x) * 3
+                output[outputOffset] = image.rgba8[sourceOffset]
+                output[outputOffset + 1] = image.rgba8[sourceOffset + 1]
+                output[outputOffset + 2] = image.rgba8[sourceOffset + 2]
+            }
+        }
+        return output
+    }
+
+    private func renderVideoSegmentPortable(
+        videoURL: URL,
+        outputURL: URL,
+        durationSeconds: Double,
+        renderWidth: Int,
+        renderHeight: Int,
+        fps: Int
+    ) throws {
+        let duration = formatSeconds(max(0.1, durationSeconds))
+        let filter = [
+            "scale=\(renderWidth):\(renderHeight):force_original_aspect_ratio=increase",
+            "crop=\(renderWidth):\(renderHeight)",
+            "fps=\(fps)",
+            "tpad=stop_mode=clone:stop_duration=\(duration)",
+            "trim=duration=\(duration)",
+            "setpts=PTS-STARTPTS",
+            "format=yuv420p",
+        ].joined(separator: ",")
+
+        try runFFmpeg([
+            "-v", "error",
+            "-y",
+            "-i", videoURL.path,
+            "-an",
+            "-vf", filter,
+            "-c:v", "libx264",
+            "-pix_fmt", "yuv420p",
+            outputURL.path,
+        ])
+    }
+
+    private func concatenateSegments(_ segmentURLs: [URL], outputURL: URL) throws {
+        guard let first = segmentURLs.first else {
+            throw NativeMediaAssemblerError.emptySegments
+        }
+        let listURL = first.deletingLastPathComponent()
+            .appendingPathComponent("native-segments-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: listURL) }
+
+        let list = segmentURLs
+            .map { "file '\(escapeFFConcatPath($0.path))'" }
+            .joined(separator: "\n")
+        try list.write(to: listURL, atomically: true, encoding: .utf8)
+
+        try runFFmpeg([
+            "-v", "error",
+            "-y",
+            "-f", "concat",
+            "-safe", "0",
+            "-i", listURL.path,
+            "-an",
+            "-c:v", "libx264",
+            "-pix_fmt", "yuv420p",
+            outputURL.path,
+        ])
+    }
+
+    private func burnCaptions(
+        captions: [NativeMediaCaptionCue],
+        style: NativeMediaCaptionStyle,
+        renderHeight: Int,
+        inputURL: URL,
+        outputURL: URL,
+        workDirectory: URL
+    ) throws {
+        let assURL = workDirectory.appendingPathComponent("native-captions-\(UUID().uuidString).ass")
+        defer { try? FileManager.default.removeItem(at: assURL) }
+        try makeASS(captions: captions, style: style, renderHeight: renderHeight)
+            .write(to: assURL, atomically: true, encoding: .utf8)
+
+        try runFFmpeg([
+            "-v", "error",
+            "-y",
+            "-i", inputURL.path,
+            "-vf", "ass=\(escapeFFmpegFilterPath(assURL.path))",
+            "-c:v", "libx264",
+            "-pix_fmt", "yuv420p",
+            "-an",
+            outputURL.path,
+        ])
+    }
+
+    private func mixAudio(
+        videoURL: URL,
+        narrationLayers: [NativeMediaAudioLayer],
+        backgroundLayer: NativeMediaAudioLayer?,
+        totalDuration: Double,
+        outputURL: URL
+    ) throws {
+        var layers = narrationLayers
+        if let backgroundLayer {
+            layers.append(backgroundLayer)
+        }
+        guard !layers.isEmpty else {
+            try copyMedia(from: videoURL, to: outputURL)
+            return
+        }
+
+        var arguments = [
+            "-v", "error",
+            "-y",
+            "-i", videoURL.path,
+        ]
+        for layer in layers {
+            arguments += ["-i", layer.url.path]
+        }
+
+        var filters: [String] = []
+        var labels: [String] = []
+        for (index, layer) in layers.enumerated() {
+            let inputIndex = index + 1
+            let label = "a\(index)"
+            let delayMilliseconds = max(0, Int((layer.startSeconds * 1000.0).rounded()))
+            let remainingDuration = max(0.1, totalDuration - max(0, layer.startSeconds))
+            filters.append(
+                "[\(inputIndex):a]" +
+                    "adelay=\(delayMilliseconds):all=1," +
+                    "volume=\(formatSeconds(Double(layer.volume)))," +
+                    "atrim=duration=\(formatSeconds(remainingDuration))," +
+                    "asetpts=N/SR/TB[\(label)]"
+            )
+            labels.append("[\(label)]")
+        }
+
+        if labels.count == 1 {
+            filters.append("\(labels[0])atrim=duration=\(formatSeconds(totalDuration))[mix]")
+        } else {
+            filters.append(
+                labels.joined() +
+                    "amix=inputs=\(labels.count):duration=longest:dropout_transition=0," +
+                    "atrim=duration=\(formatSeconds(totalDuration))[mix]"
+            )
+        }
+
+        arguments += [
+            "-filter_complex", filters.joined(separator: ";"),
+            "-map", "0:v",
+            "-map", "[mix]",
+            "-c:v", "copy",
+            "-c:a", "aac",
+            "-shortest",
+            outputURL.path,
+        ]
+
+        try runFFmpeg(arguments)
+    }
+
+    private func makeASS(
+        captions: [NativeMediaCaptionCue],
+        style: NativeMediaCaptionStyle,
+        renderHeight: Int
+    ) -> String {
+        let cleanedCues = captions
+            .filter { $0.endSeconds > $0.startSeconds && !$0.text.isEmpty }
+            .sorted { $0.startSeconds < $1.startSeconds }
+        let fontSize = Int(max(1, style.fontSize.rounded()))
+        let outline = Int(max(0, abs(style.outlineWidth).rounded()))
+        let marginH = Int(max(0, style.horizontalInset.rounded()))
+        let marginV = Int(max(0, style.bottomInset.rounded()))
+        let primary = assColor(style.textColor)
+        let outlineColor = assColor(style.outlineColor)
+
+        var lines = [
+            "[Script Info]",
+            "ScriptType: v4.00+",
+            "PlayResX: 1080",
+            "PlayResY: \(max(1, renderHeight))",
+            "",
+            "[V4+ Styles]",
+            "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding",
+            "Style: Default,\(escapeASSStyle(style.fontName)),\(fontSize),\(primary),\(primary),\(outlineColor),&H00000000,-1,0,0,0,100,100,0,0,1,\(outline),0,2,\(marginH),\(marginH),\(marginV),1",
+            "",
+            "[Events]",
+            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+        ]
+
+        for cue in cleanedCues {
+            lines.append(
+                "Dialogue: 0,\(formatASSTime(cue.startSeconds)),\(formatASSTime(cue.endSeconds)),Default,,0,0,0,,\(escapeASSText(cue.text))"
+            )
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func copyMedia(from sourceURL: URL, to outputURL: URL) throws {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: outputURL.path) {
+            try fileManager.removeItem(at: outputURL)
+        }
+        try fileManager.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.copyItem(at: sourceURL, to: outputURL)
+    }
+
+    private func runFFmpeg(_ arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = try resolveExecutable(MediaTool.ffmpegPath)
+        process.arguments = arguments
+
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        process.standardOutput = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            throw NativeMediaAssemblerError.exportFailed(
+                "ffmpeg was not found. Install ffmpeg or set MERERUN_FFMPEG to the executable path."
+            )
+        }
+
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let details = String(decoding: stderrData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw NativeMediaAssemblerError.exportFailed(
+                details.isEmpty ? "ffmpeg exited with status \(process.terminationStatus)." : details
+            )
+        }
+    }
+
+    private func resolveExecutable(_ raw: String) throws -> URL {
+        if raw.contains("/") {
+            let url = URL(fileURLWithPath: raw)
+            if FileManager.default.isExecutableFile(atPath: url.path) {
+                return url
+            }
+            throw NativeMediaAssemblerError.exportFailed("Executable not found: \(raw)")
+        }
+
+        let pathEntries = ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":") ?? []
+        for entry in pathEntries {
+            let candidate = URL(fileURLWithPath: String(entry), isDirectory: true)
+                .appendingPathComponent(raw)
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        throw NativeMediaAssemblerError.exportFailed("Executable not found: \(raw)")
+    }
+
+    private func escapeFFConcatPath(_ path: String) -> String {
+        path.replacingOccurrences(of: "'", with: "'\\''")
+    }
+
+    private func escapeFFmpegFilterPath(_ path: String) -> String {
+        var value = path
+        for character in ["\\", ":", "'", ",", "[", "]", " "] {
+            value = value.replacingOccurrences(of: character, with: "\\\(character)")
+        }
+        return value
+    }
+
+    private func escapeASSText(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "{", with: "\\{")
+            .replacingOccurrences(of: "}", with: "\\}")
+            .replacingOccurrences(of: "\n", with: "\\N")
+    }
+
+    private func escapeASSStyle(_ text: String) -> String {
+        text.replacingOccurrences(of: ",", with: "")
+    }
+
+    private func assColor(_ rgba: (Double, Double, Double, Double)) -> String {
+        let red = colorByte(rgba.0)
+        let green = colorByte(rgba.1)
+        let blue = colorByte(rgba.2)
+        let alpha = UInt8(255 - Int(colorByte(rgba.3)))
+        return String(format: "&H%02X%02X%02X%02X", alpha, blue, green, red)
+    }
+
+    private func colorByte(_ value: Double) -> UInt8 {
+        UInt8(max(0, min(255, Int((value * 255.0).rounded()))))
+    }
+
+    private func formatASSTime(_ seconds: Double) -> String {
+        let centiseconds = max(0, Int((seconds * 100.0).rounded()))
+        let hours = centiseconds / 360_000
+        let minutes = (centiseconds / 6_000) % 60
+        let wholeSeconds = (centiseconds / 100) % 60
+        let fraction = centiseconds % 100
+        return String(format: "%d:%02d:%02d.%02d", hours, minutes, wholeSeconds, fraction)
+    }
+
+    private func formatSeconds(_ seconds: Double) -> String {
+        String(format: "%.3f", seconds)
+    }
+#endif
 }

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -1,9 +1,6 @@
 import Foundation
+import MediaIO
 import MLX
-#if canImport(CoreGraphics)
-import CoreGraphics
-import ImageIO
-#endif
 
 public actor Q35Generator: ChatGenerator {
     private var model: Q35Model?
@@ -428,13 +425,12 @@ public actor Q35Generator: ChatGenerator {
         return MLX.concatenated(parts, axis: 1)
     }
 
-    #if canImport(CoreGraphics)
     private func loadImageTensor(
         from imageRef: String,
         patchSize: Int,
         spatialMergeSize: Int
     ) throws -> (tensor: MLXArray, gridTHW: (Int, Int, Int)) {
-        let image = try loadCGImage(from: imageRef)
+        let image = try loadImage(from: imageRef)
         let divisor = max(1, patchSize * max(1, spatialMergeSize))
 
         let targetWidth = max(divisor, (image.width / divisor) * divisor)
@@ -452,20 +448,20 @@ public actor Q35Generator: ChatGenerator {
         return (normalized, gridTHW)
     }
 
-    private func loadCGImage(from imageRef: String) throws -> CGImage {
+    private func loadImage(from imageRef: String) throws -> MediaImage {
         if let remoteURL = URL(string: imageRef),
            let scheme = remoteURL.scheme?.lowercased(),
            scheme == "http" || scheme == "https" {
             let data = try Data(contentsOf: remoteURL)
-            guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-                  let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            do {
+                return try MediaImageIO.decode(data: data)
+            } catch {
                 throw NSError(
                     domain: "Q35Generator",
                     code: 1002,
                     userInfo: [NSLocalizedDescriptionKey: "Failed to decode image URL: \(imageRef)"]
                 )
             }
-            return image
         }
 
         let localURL: URL
@@ -481,27 +477,14 @@ public actor Q35Generator: ChatGenerator {
                 userInfo: [NSLocalizedDescriptionKey: "Image file not found: \(imageRef)"]
             )
         }
-        guard let source = CGImageSourceCreateWithURL(localURL as CFURL, nil),
-              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+        do {
+            return try MediaImageIO.decode(localURL)
+        } catch {
             throw NSError(
                 domain: "Q35Generator",
                 code: 1004,
                 userInfo: [NSLocalizedDescriptionKey: "Failed to decode image file: \(imageRef)"]
             )
         }
-        return image
     }
-    #else
-    private func loadImageTensor(
-        from _: String,
-        patchSize _: Int,
-        spatialMergeSize _: Int
-    ) throws -> (tensor: MLXArray, gridTHW: (Int, Int, Int)) {
-        throw NSError(
-            domain: "Q35Generator",
-            code: 1001,
-            userInfo: [NSLocalizedDescriptionKey: "Image input requires CoreGraphics support."]
-        )
-    }
-    #endif
 }

--- a/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift
+++ b/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift
@@ -1,11 +1,7 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXNN
-
-#if canImport(CoreGraphics)
-import CoreGraphics
-import ImageIO
-#endif
 
 /// Owns image preprocessing, semantic conditioning, and latent decoding.
 /// These helpers form the middle of the edit pipeline between model loading and
@@ -17,14 +13,13 @@ extension QwenImageEditGenerator {
         targetWidth: Int,
         targetHeight: Int
     ) async throws -> (latents: MLXArray, tensor: MLXArray) {
-        #if !canImport(CoreGraphics)
-        throw GeneratorError.unsupportedPlatform
-        #else
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw GeneratorError.inputImageNotFound(url)
         }
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(url)
+        } catch {
             throw GeneratorError.inputImageDecodeFailed(url)
         }
 
@@ -34,7 +29,7 @@ extension QwenImageEditGenerator {
         let vlHeight = (targetHeight / 14) * 14
 
         let vaeArray = try QwenImageIO.resizedPixelArray(
-            from: cgImage,
+            from: image,
             width: vaeWidth,
             height: vaeHeight,
             addBatchDimension: true,
@@ -44,14 +39,13 @@ extension QwenImageEditGenerator {
         let latents = vae.encode(normalized).asType(.bfloat16)
 
         let vlArray = try QwenImageIO.resizedPixelArray(
-            from: cgImage,
+            from: image,
             width: vlWidth,
             height: vlHeight,
             addBatchDimension: true,
             dtype: .float16
         )
         return (latents, vlArray)
-        #endif
     }
 
     func encodeSemanticEmbeddingsForRequest(

--- a/Sources/MereRunCore/SAM3/SAM31CameraCapture.swift
+++ b/Sources/MereRunCore/SAM3/SAM31CameraCapture.swift
@@ -95,4 +95,76 @@ private final class CameraRecordingDelegate: NSObject, AVCaptureFileOutputRecord
         semaphore.wait()
     }
 }
+#else
+import MediaIO
+
+public enum SAM31CameraCapture {
+    public enum CaptureError: LocalizedError, Sendable {
+        case cameraUnavailable(Int)
+        case failedToCreateInput
+        case failedToCreateOutputDirectory(URL)
+        case failedToRecord(URL, reason: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .cameraUnavailable(let index):
+                return "No video camera available at index \(index)."
+            case .failedToCreateInput:
+                return "Failed to create a camera capture input for this platform."
+            case .failedToCreateOutputDirectory(let url):
+                return "Failed to create capture output directory: \(url.path)"
+            case .failedToRecord(let url, let reason):
+                return "Failed to record camera capture to \(url.path): \(reason)"
+            }
+        }
+    }
+
+    public static func record(
+        cameraIndex: Int,
+        durationSeconds: TimeInterval,
+        outputURL: URL
+    ) throws {
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        } catch {
+            throw CaptureError.failedToCreateOutputDirectory(outputURL.deletingLastPathComponent())
+        }
+        try? fileManager.removeItem(at: outputURL)
+
+        let devicePath = "/dev/video\(cameraIndex)"
+        guard fileManager.fileExists(atPath: devicePath) else {
+            throw CaptureError.cameraUnavailable(cameraIndex)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: MediaTool.ffmpegPath)
+        process.arguments = [
+            "-hide_banner",
+            "-loglevel", "error",
+            "-y",
+            "-f", "v4l2",
+            "-t", String(max(durationSeconds, 0.1)),
+            "-i", devicePath,
+            "-c:v", "libx264",
+            "-pix_fmt", "yuv420p",
+            outputURL.path,
+        ]
+
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw CaptureError.failedToRecord(outputURL, reason: error.localizedDescription)
+        }
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let details = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "ffmpeg failed"
+            throw CaptureError.failedToRecord(outputURL, reason: details)
+        }
+    }
+}
 #endif

--- a/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
+++ b/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXNN
 
@@ -255,12 +256,24 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             throw SegmenterError.failedToEncodeMetadata("At least one prompt is required.")
         }
 
-        #if !canImport(CoreGraphics)
-        throw SegmenterError.unsupportedPlatform
-        #else
+        #if canImport(CoreGraphics)
         guard let cgImage = QwenVLImageLoader.loadCGImage(url: imageURL) else {
             throw SegmenterError.invalidImage(imageURL)
         }
+        let imageWidth = cgImage.width
+        let imageHeight = cgImage.height
+        let pixelValues = try Self.preprocessImage(cgImage: cgImage, resolution: resolution)
+        #else
+        let mediaImage: MediaImage
+        do {
+            mediaImage = try MediaImageIO.decode(imageURL)
+        } catch {
+            throw SegmenterError.invalidImage(imageURL)
+        }
+        let imageWidth = mediaImage.width
+        let imageHeight = mediaImage.height
+        let pixelValues = try Self.preprocessImage(image: mediaImage, resolution: resolution)
+        #endif
 
         let state = try ensureLoaded()
         let maxObjects = min(state.config.trackerConfig?.multiplexCount ?? 16, state.config.maxNumObjects)
@@ -269,7 +282,6 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             throw SegmenterError.failedToEncodeMetadata("At least one non-empty prompt is required.")
         }
 
-        let pixelValues = try Self.preprocessImage(cgImage: cgImage, resolution: resolution)
         let visionContext = state.model.detectorModel.prepareVision(pixelValues)
         MLX.eval(visionContext.src, visionContext.posFlat)
 
@@ -303,8 +315,8 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
                     contentsOf: Self.postprocess(
                         output: output,
                         prompt: textPrompt,
-                        imageWidth: cgImage.width,
-                        imageHeight: cgImage.height,
+                        imageWidth: imageWidth,
+                        imageHeight: imageHeight,
                         threshold: threshold,
                         nmsThreshold: state.config.detNMSThresh,
                         objectID: promptObject.objectID,
@@ -319,8 +331,8 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
                     trackerModel: trackerModel,
                     featurePyramid: visionContext.featurePyramid,
                     promptObject: promptObject,
-                    imageWidth: cgImage.width,
-                    imageHeight: cgImage.height,
+                    imageWidth: imageWidth,
+                    imageHeight: imageHeight,
                     threshold: threshold,
                     multimask: multimask
                 )
@@ -343,11 +355,12 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
 
         let exportedDetections = try Self.writeMaskArtifacts(
             preparedDetections,
-            width: cgImage.width,
-            height: cgImage.height,
+            width: imageWidth,
+            height: imageHeight,
             outputDirectoryURL: maskOutputDirectoryURL
         )
 
+        #if canImport(CoreGraphics)
         let annotatedImage = try Self.renderAnnotatedImage(
             baseImage: cgImage,
             detections: exportedDetections,
@@ -355,6 +368,15 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             showLabels: showLabels
         )
         try Self.writeImage(annotatedImage, to: annotatedImageURL)
+        #else
+        let annotatedImage = try Self.renderAnnotatedImage(
+            baseImage: mediaImage,
+            detections: exportedDetections,
+            showBoxes: showBoxes,
+            showLabels: showLabels
+        )
+        try MediaImageIO.writePNG(annotatedImage, to: annotatedImageURL)
+        #endif
 
         let detections = exportedDetections.map {
             SAM31SegmentationDetection(
@@ -387,7 +409,6 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             detections: detections,
             metadata: metadata
         )
-        #endif
     }
 
     private func createParentDirectoryIfNeeded(for url: URL) throws {
@@ -752,6 +773,8 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             let url = outputDirectoryURL.appendingPathComponent("\(base)\(suffix)_\(index)").appendingPathExtension("png")
             #if canImport(CoreGraphics)
             try writeMaskImage(binaryMask: detection.binaryMask, width: width, height: height, to: url)
+            #else
+            try writeMaskImagePortable(binaryMask: detection.binaryMask, width: width, height: height, to: url)
             #endif
             return PreparedDetection(
                 objectID: detection.objectID,
@@ -950,7 +973,6 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         }
     }
 
-    #if canImport(CoreGraphics)
     private static let overlayColors: [(UInt8, UInt8, UInt8)] = [
         (31, 120, 181),
         (255, 128, 13),
@@ -960,6 +982,214 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         (140, 87, 74),
     ]
 
+    private static func preprocessImage(image: MediaImage, resolution: Int) throws -> MLXArray {
+        let resized = try MediaImageIO.resized(image, width: resolution, height: resolution)
+        var floats = [Float](repeating: 0, count: resolution * resolution * 3)
+        for index in 0..<(resolution * resolution) {
+            let src = index * 4
+            let dst = index * 3
+            floats[dst] = Float(resized.rgba8[src]) / 127.5 - 1.0
+            floats[dst + 1] = Float(resized.rgba8[src + 1]) / 127.5 - 1.0
+            floats[dst + 2] = Float(resized.rgba8[src + 2]) / 127.5 - 1.0
+        }
+        return MLXArray(floats, [1, resolution, resolution, 3]).asType(.float32)
+    }
+
+    private static func renderAnnotatedImage(
+        baseImage: MediaImage,
+        detections: [PreparedDetection],
+        showBoxes: Bool,
+        showLabels: Bool
+    ) throws -> MediaImage {
+        var bytes = baseImage.rgba8
+        for (index, detection) in detections.enumerated() {
+            let color = overlayColors[index % overlayColors.count]
+            blendMask(
+                detection.binaryMask,
+                into: &bytes,
+                width: baseImage.width,
+                height: baseImage.height,
+                color: color
+            )
+            if showBoxes {
+                drawBox(
+                    detection.box,
+                    into: &bytes,
+                    width: baseImage.width,
+                    height: baseImage.height,
+                    color: color
+                )
+            }
+            if showLabels {
+                drawLabelMarker(
+                    detection.box,
+                    into: &bytes,
+                    width: baseImage.width,
+                    height: baseImage.height,
+                    color: color
+                )
+            }
+        }
+        return try MediaImage(width: baseImage.width, height: baseImage.height, rgba8: bytes)
+    }
+
+    private static func blendMask(
+        _ binaryMask: [UInt8],
+        into bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        let count = min(binaryMask.count, width * height)
+        for index in 0..<count where binaryMask[index] != 0 {
+            let offset = index * 4
+            bytes[offset] = UInt8((UInt16(bytes[offset]) + UInt16(color.0)) / 2)
+            bytes[offset + 1] = UInt8((UInt16(bytes[offset + 1]) + UInt16(color.1)) / 2)
+            bytes[offset + 2] = UInt8((UInt16(bytes[offset + 2]) + UInt16(color.2)) / 2)
+            bytes[offset + 3] = 255
+        }
+    }
+
+    private static func drawBox(
+        _ box: SAM31SegmentationBox,
+        into bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        let minX = max(0, min(width - 1, Int(box.x1.rounded(.down))))
+        let minY = max(0, min(height - 1, Int(box.y1.rounded(.down))))
+        let maxX = max(0, min(width - 1, Int(box.x2.rounded(.up))))
+        let maxY = max(0, min(height - 1, Int(box.y2.rounded(.up))))
+        for inset in 0..<2 {
+            drawHorizontalLine(
+                y: minY + inset,
+                x1: minX,
+                x2: maxX,
+                into: &bytes,
+                width: width,
+                height: height,
+                color: color
+            )
+            drawHorizontalLine(
+                y: maxY - inset,
+                x1: minX,
+                x2: maxX,
+                into: &bytes,
+                width: width,
+                height: height,
+                color: color
+            )
+            drawVerticalLine(
+                x: minX + inset,
+                y1: minY,
+                y2: maxY,
+                into: &bytes,
+                width: width,
+                height: height,
+                color: color
+            )
+            drawVerticalLine(
+                x: maxX - inset,
+                y1: minY,
+                y2: maxY,
+                into: &bytes,
+                width: width,
+                height: height,
+                color: color
+            )
+        }
+    }
+
+    private static func drawLabelMarker(
+        _ box: SAM31SegmentationBox,
+        into bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        let minX = max(0, min(width - 1, Int(box.x1.rounded(.down))))
+        let minY = max(0, min(height - 1, Int(box.y1.rounded(.down))))
+        let markerWidth = max(8, min(48, width - minX))
+        let markerHeight = max(4, min(12, height - minY))
+        for y in minY..<min(height, minY + markerHeight) {
+            for x in minX..<min(width, minX + markerWidth) {
+                setPixel(x: x, y: y, in: &bytes, width: width, height: height, color: color)
+            }
+        }
+    }
+
+    private static func drawHorizontalLine(
+        y: Int,
+        x1: Int,
+        x2: Int,
+        into bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        guard y >= 0, y < height else { return }
+        let lower = max(0, x1)
+        let upper = min(width - 1, x2)
+        guard lower <= upper else { return }
+        for x in lower...upper {
+            setPixel(x: x, y: y, in: &bytes, width: width, height: height, color: color)
+        }
+    }
+
+    private static func drawVerticalLine(
+        x: Int,
+        y1: Int,
+        y2: Int,
+        into bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        guard x >= 0, x < width else { return }
+        let lower = max(0, y1)
+        let upper = min(height - 1, y2)
+        guard lower <= upper else { return }
+        for y in lower...upper {
+            setPixel(x: x, y: y, in: &bytes, width: width, height: height, color: color)
+        }
+    }
+
+    private static func setPixel(
+        x: Int,
+        y: Int,
+        in bytes: inout [UInt8],
+        width: Int,
+        height: Int,
+        color: (UInt8, UInt8, UInt8)
+    ) {
+        guard x >= 0, y >= 0, x < width, y < height else { return }
+        let offset = ((y * width) + x) * 4
+        bytes[offset] = color.0
+        bytes[offset + 1] = color.1
+        bytes[offset + 2] = color.2
+        bytes[offset + 3] = 255
+    }
+
+    private static func writeMaskImagePortable(binaryMask: [UInt8], width: Int, height: Int, to url: URL) throws {
+        var rgba = [UInt8](repeating: 0, count: width * height * 4)
+        let count = min(binaryMask.count, width * height)
+        for index in 0..<count {
+            let value: UInt8 = binaryMask[index] == 0 ? 0 : 255
+            let offset = index * 4
+            rgba[offset] = value
+            rgba[offset + 1] = value
+            rgba[offset + 2] = value
+            rgba[offset + 3] = 255
+        }
+        do {
+            try MediaImageIO.writePNG(try MediaImage(width: width, height: height, rgba8: rgba), to: url)
+        } catch {
+            throw SegmenterError.failedToWriteMask(url)
+        }
+    }
+
+    #if canImport(CoreGraphics)
     private static func preprocessImage(cgImage: CGImage, resolution: Int) throws -> MLXArray {
         let resized = try QwenImageIO.resizedCGImage(from: cgImage, width: resolution, height: resolution)
         let width = resized.width

--- a/Sources/MereRunCore/SAM3/SAM31VideoIO.swift
+++ b/Sources/MereRunCore/SAM3/SAM31VideoIO.swift
@@ -1,11 +1,5 @@
 import Foundation
-
-#if canImport(AVFoundation) && canImport(CoreGraphics)
-import AVFoundation
-import CoreGraphics
-import CoreVideo
-import ImageIO
-import UniformTypeIdentifiers
+import MediaIO
 
 struct SAM31VideoAsset: Sendable {
     let frameURLs: [URL]
@@ -16,30 +10,18 @@ struct SAM31VideoAsset: Sendable {
 
 enum SAM31VideoIO {
     enum VideoIOError: LocalizedError, Sendable {
-        case missingVideoTrack(URL)
         case failedToExtractFrame(URL, Int)
         case failedToLoadFrame(URL)
-        case failedToWriteFrame(URL)
         case failedToCreateWriter(URL)
-        case failedToCreatePixelBuffer
-        case failedToAppendFrame(Int)
 
         var errorDescription: String? {
             switch self {
-            case .missingVideoTrack(let url):
-                return "Video track missing in asset: \(url.path)"
             case .failedToExtractFrame(let url, let index):
                 return "Failed to extract frame \(index) from \(url.path)."
             case .failedToLoadFrame(let url):
                 return "Failed to load frame image: \(url.path)"
-            case .failedToWriteFrame(let url):
-                return "Failed to write frame image: \(url.path)"
             case .failedToCreateWriter(let url):
                 return "Failed to create MP4 writer for \(url.path)."
-            case .failedToCreatePixelBuffer:
-                return "Failed to create a video pixel buffer."
-            case .failedToAppendFrame(let index):
-                return "Failed to append frame \(index) to the output video."
             }
         }
     }
@@ -49,57 +31,21 @@ enum SAM31VideoIO {
         into outputDirectoryURL: URL,
         endFrame: Int? = nil
     ) throws -> SAM31VideoAsset {
-        let fileManager = FileManager.default
-        try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
-
-        let asset = AVURLAsset(url: videoURL)
-        guard let track = asset.tracks(withMediaType: .video).first else {
-            throw VideoIOError.missingVideoTrack(videoURL)
+        do {
+            let sequence = try MediaVideoIO.extractFrames(
+                from: videoURL,
+                into: outputDirectoryURL,
+                endFrame: endFrame
+            )
+            return SAM31VideoAsset(
+                frameURLs: sequence.frameURLs,
+                fps: sequence.fps,
+                frameWidth: sequence.frameWidth,
+                frameHeight: sequence.frameHeight
+            )
+        } catch {
+            throw VideoIOError.failedToExtractFrame(videoURL, endFrame ?? 0)
         }
-
-        let nominalFPS = track.nominalFrameRate > 0 ? Double(track.nominalFrameRate) : 30.0
-        let fps = max(1.0, nominalFPS)
-        let durationSeconds = CMTimeGetSeconds(asset.duration)
-        let estimatedFrameCount = max(1, Int((durationSeconds * fps).rounded(.toNearestOrEven)))
-        let frameCount = min(endFrame.map { $0 + 1 } ?? estimatedFrameCount, estimatedFrameCount)
-
-        let generator = AVAssetImageGenerator(asset: asset)
-        generator.appliesPreferredTrackTransform = true
-        generator.requestedTimeToleranceBefore = .zero
-        generator.requestedTimeToleranceAfter = .zero
-
-        var frameURLs: [URL] = []
-        frameURLs.reserveCapacity(frameCount)
-        var frameWidth = 0
-        var frameHeight = 0
-
-        for frameIndex in 0..<frameCount {
-            let time = CMTime(value: CMTimeValue(frameIndex), timescale: CMTimeScale(max(1, Int32(fps.rounded()))))
-            let image: CGImage
-            do {
-                image = try generator.copyCGImage(at: time, actualTime: nil)
-            } catch {
-                throw VideoIOError.failedToExtractFrame(videoURL, frameIndex)
-            }
-
-            if frameWidth == 0 || frameHeight == 0 {
-                frameWidth = image.width
-                frameHeight = image.height
-            }
-
-            let frameURL = outputDirectoryURL
-                .appendingPathComponent(String(format: "frame_%05d", frameIndex))
-                .appendingPathExtension("png")
-            try writeImage(image, to: frameURL)
-            frameURLs.append(frameURL)
-        }
-
-        return SAM31VideoAsset(
-            frameURLs: frameURLs,
-            fps: fps,
-            frameWidth: frameWidth,
-            frameHeight: frameHeight
-        )
     }
 
     static func writeVideo(
@@ -107,129 +53,13 @@ enum SAM31VideoIO {
         fps: Double,
         to outputURL: URL
     ) throws {
-        guard let firstURL = frameURLs.first,
-              let firstImage = QwenVLImageLoader.loadCGImage(url: firstURL)
-        else {
-            throw VideoIOError.failedToLoadFrame(frameURLs.first ?? outputURL)
+        guard !frameURLs.isEmpty else {
+            throw VideoIOError.failedToLoadFrame(outputURL)
         }
-
-        let width = firstImage.width
-        let height = firstImage.height
-        let frameDuration = CMTime(seconds: 1.0 / max(fps, 1.0), preferredTimescale: 600)
-
-        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? FileManager.default.removeItem(at: outputURL)
-
-        guard let writer = try? AVAssetWriter(outputURL: outputURL, fileType: .mp4) else {
+        do {
+            try MediaVideoIO.writeVideo(frameURLs: frameURLs, fps: fps, to: outputURL)
+        } catch {
             throw VideoIOError.failedToCreateWriter(outputURL)
-        }
-
-        let outputSettings: [String: Any] = [
-            AVVideoCodecKey: AVVideoCodecType.h264,
-            AVVideoWidthKey: width,
-            AVVideoHeightKey: height,
-            AVVideoCompressionPropertiesKey: [
-                AVVideoAverageBitRateKey: max(1_000_000, width * height * Int(fps) * 4),
-                AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
-            ],
-        ]
-        let input = AVAssetWriterInput(mediaType: .video, outputSettings: outputSettings)
-        input.expectsMediaDataInRealTime = false
-
-        let pixelBufferAttributes: [String: Any] = [
-            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA),
-            kCVPixelBufferWidthKey as String: width,
-            kCVPixelBufferHeightKey as String: height,
-            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
-        ]
-        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
-            assetWriterInput: input,
-            sourcePixelBufferAttributes: pixelBufferAttributes
-        )
-
-        guard writer.canAdd(input) else {
-            throw VideoIOError.failedToCreateWriter(outputURL)
-        }
-        writer.add(input)
-
-        guard writer.startWriting() else {
-            throw VideoIOError.failedToCreateWriter(outputURL)
-        }
-        writer.startSession(atSourceTime: .zero)
-
-        guard let pool = adaptor.pixelBufferPool else {
-            throw VideoIOError.failedToCreatePixelBuffer
-        }
-
-        for (frameIndex, frameURL) in frameURLs.enumerated() {
-            guard let image = QwenVLImageLoader.loadCGImage(url: frameURL) else {
-                throw VideoIOError.failedToLoadFrame(frameURL)
-            }
-
-            while !input.isReadyForMoreMediaData {
-                Thread.sleep(forTimeInterval: 0.002)
-            }
-
-            var pixelBuffer: CVPixelBuffer?
-            let status = CVPixelBufferPoolCreatePixelBuffer(nil, pool, &pixelBuffer)
-            guard status == kCVReturnSuccess, let pixelBuffer else {
-                throw VideoIOError.failedToCreatePixelBuffer
-            }
-
-            try render(image, into: pixelBuffer)
-            let presentationTime = CMTimeMultiply(frameDuration, multiplier: Int32(frameIndex))
-            guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
-                throw VideoIOError.failedToAppendFrame(frameIndex)
-            }
-        }
-
-        input.markAsFinished()
-        let semaphore = DispatchSemaphore(value: 0)
-        writer.finishWriting {
-            semaphore.signal()
-        }
-        semaphore.wait()
-    }
-
-    private static func render(_ image: CGImage, into pixelBuffer: CVPixelBuffer) throws {
-        CVPixelBufferLockBaseAddress(pixelBuffer, [])
-        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
-
-        guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
-            throw VideoIOError.failedToCreatePixelBuffer
-        }
-
-        let width = CVPixelBufferGetWidth(pixelBuffer)
-        let height = CVPixelBufferGetHeight(pixelBuffer)
-        let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
-
-        guard let context = CGContext(
-            data: baseAddress,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo
-        ) else {
-            throw VideoIOError.failedToCreatePixelBuffer
-        }
-
-        context.interpolationQuality = .high
-        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-    }
-
-    private static func writeImage(_ image: CGImage, to url: URL) throws {
-        let utType = UTType(filenameExtension: url.pathExtension.lowercased()) ?? .png
-        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, utType.identifier as CFString, 1, nil) else {
-            throw VideoIOError.failedToWriteFrame(url)
-        }
-        CGImageDestinationAddImage(destination, image, nil)
-        guard CGImageDestinationFinalize(destination) else {
-            throw VideoIOError.failedToWriteFrame(url)
         }
     }
 }
-#endif

--- a/Sources/MereRunCore/SAM3/SAM31VideoTracker.swift
+++ b/Sources/MereRunCore/SAM3/SAM31VideoTracker.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-#if canImport(AVFoundation) && canImport(CoreGraphics)
 public final class SAM31VideoTracker: @unchecked Sendable {
     public enum TrackingError: LocalizedError, Sendable {
         case unsupportedPlatform
@@ -9,7 +8,7 @@ public final class SAM31VideoTracker: @unchecked Sendable {
         public var errorDescription: String? {
             switch self {
             case .unsupportedPlatform:
-                return "Native video tracking requires AVFoundation and CoreGraphics."
+                return "Video tracking requires a supported MediaIO video backend."
             case .initFrameOutOfRange(let frame):
                 return "Initial tracking frame \(frame) is outside the extracted video frame range."
             }
@@ -545,4 +544,3 @@ public final class SAM31VideoTracker: @unchecked Sendable {
         return false
     }
 }
-#endif

--- a/Sources/MereRunCore/Support/CoreFoundationCompat.swift
+++ b/Sources/MereRunCore/Support/CoreFoundationCompat.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+#if os(Linux)
+typealias CFTimeInterval = TimeInterval
+
+func CFAbsoluteTimeGetCurrent() -> CFTimeInterval {
+    Date().timeIntervalSinceReferenceDate
+}
+#endif

--- a/Sources/MereRunCore/VLM/QwenVLCaptioner.swift
+++ b/Sources/MereRunCore/VLM/QwenVLCaptioner.swift
@@ -1,5 +1,4 @@
 import Foundation
-import ImageIO
 import MLX
 import MLXNN
 
@@ -174,10 +173,6 @@ public final class QwenVLCaptioner: @unchecked Sendable {
         prompt: String,
         config: ModelConfig = .init()
     ) throws -> String {
-        guard let image = QwenVLImageLoader.loadCGImage(url: imageURL) else {
-            throw Error.imageLoadFailed(imageURL)
-        }
-
         guard let imageTokenId = tokenizer.imageTokenId,
               let visionStartTokenId = tokenizer.visionStartTokenId
         else {
@@ -185,11 +180,16 @@ public final class QwenVLCaptioner: @unchecked Sendable {
         }
 
         // Load and resize image using Qwen3-VL's max_pixels constraint
-        let pixelValues = try QwenVLImageLoader.pixelValues(
-            cgImage: image,
-            patchSize: encoder.visionPatchSize,
-            spatialMergeSize: encoder.visionSpatialMergeSize
-        )
+        let pixelValues: MLXArray
+        do {
+            pixelValues = try QwenVLImageLoader.pixelValues(
+                imageURL: imageURL,
+                patchSize: encoder.visionPatchSize,
+                spatialMergeSize: encoder.visionSpatialMergeSize
+            )
+        } catch {
+            throw Error.imageLoadFailed(imageURL)
+        }
         let grid = [(1, pixelValues.dim(2) / encoder.visionPatchSize, pixelValues.dim(3) / encoder.visionPatchSize)]
         let imageTokenCount = max(
             1,

--- a/Sources/MereRunCore/VLM/QwenVLImageLoader.swift
+++ b/Sources/MereRunCore/VLM/QwenVLImageLoader.swift
@@ -1,18 +1,62 @@
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
 import ImageIO
+#endif
+import MediaIO
 import MLX
 
 enum QwenVLImageLoader {
+#if canImport(CoreGraphics)
     static func loadCGImage(url: URL) -> CGImage? {
         guard let src = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
         return CGImageSourceCreateImageAtIndex(src, 0, nil)
     }
+#endif
 
     /// Default pixel constraints - nil means no constraint (matches mlx-community model configs)
     static let defaultMinPixels: Int? = nil
     static let defaultMaxPixels: Int? = nil
 
+    static func pixelValues(
+        imageURL: URL,
+        minPixels: Int? = defaultMinPixels,
+        maxPixels: Int? = defaultMaxPixels,
+        patchSize: Int,
+        spatialMergeSize: Int = 2
+    ) throws -> MLXArray {
+        let image = try MediaImageIO.decode(imageURL)
+        return try pixelValues(
+            image: image,
+            minPixels: minPixels,
+            maxPixels: maxPixels,
+            patchSize: patchSize,
+            spatialMergeSize: spatialMergeSize
+        )
+    }
+
+    static func pixelValues(
+        image: MediaImage,
+        minPixels: Int? = defaultMinPixels,
+        maxPixels: Int? = defaultMaxPixels,
+        patchSize: Int,
+        spatialMergeSize: Int = 2
+    ) throws -> MLXArray {
+        let (targetW, targetH) = Self.computeTargetSize(
+            originalWidth: image.width,
+            originalHeight: image.height,
+            minPixels: minPixels,
+            maxPixels: maxPixels,
+            patchSize: patchSize,
+            mergeSize: spatialMergeSize
+        )
+
+        let resized = try MediaImageIO.resized(image, width: targetW, height: targetH)
+        let floats = MediaImageIO.rgbCHWFloat(resized, normalizedToMinusOneToOne: true)
+        return MLXArray(floats, [1, 3, resized.height, resized.width])
+    }
+
+#if canImport(CoreGraphics)
     static func pixelValues(
         cgImage: CGImage,
         minPixels: Int? = defaultMinPixels,
@@ -61,6 +105,7 @@ enum QwenVLImageLoader {
 
         return MLXArray(floats, [1, 3, h, w])
     }
+#endif
 
     private static func saveDebugImage(floats: [Float32], width: Int, height: Int, to url: URL) {
         // Denormalize and save as PNG for visual inspection
@@ -79,6 +124,7 @@ enum QwenVLImageLoader {
             }
         }
 
+        #if canImport(CoreGraphics)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         pixels.withUnsafeBytes { ptr in
             guard let ctx = CGContext(
@@ -94,8 +140,17 @@ enum QwenVLImageLoader {
             CGImageDestinationFinalize(dest)
             print("[QwenVLImageLoader] Debug image saved to: \(url.path)")
         }
+        #else
+        do {
+            try MediaImageIO.writePNG(MediaImage(width: width, height: height, rgba8: pixels), to: url)
+            print("[QwenVLImageLoader] Debug image saved to: \(url.path)")
+        } catch {
+            // Debug image persistence should never affect inference.
+        }
+        #endif
     }
 
+#if canImport(CoreGraphics)
     private static func rgb8Pixels(cgImage: CGImage) -> Data? {
         let w = cgImage.width
         let h = cgImage.height
@@ -134,6 +189,7 @@ enum QwenVLImageLoader {
         }
         return rgb
     }
+#endif
 
     /// Computes target dimensions matching Qwen2VLImageProcessor's smart_resize
     /// Grid dimensions must be divisible by merge_size, visual dimensions divisible by patch_size
@@ -170,6 +226,7 @@ enum QwenVLImageLoader {
         return (targetW, targetH)
     }
 
+#if canImport(CoreGraphics)
     private static func resizeExact(cgImage: CGImage, width: Int, height: Int) -> CGImage {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bytesPerRow = width * 4
@@ -192,4 +249,5 @@ enum QwenVLImageLoader {
         ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
         return ctx.makeImage() ?? cgImage
     }
+#endif
 }

--- a/Sources/MereRunCore/ZImageI2L/ZImageI2LGenerator.swift
+++ b/Sources/MereRunCore/ZImageI2L/ZImageI2LGenerator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXNN
 import MLXRandom
@@ -379,162 +380,53 @@ public actor ZImageI2LGenerator {
     // MARK: - Image Processing
 
     private func loadImageForEncoders(from url: URL) throws -> (siglip: MLXArray, dino: MLXArray) {
-        #if os(macOS)
-        guard let nsImage = NSImage(contentsOf: url),
-              let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(url)
+        } catch {
             throw ZImageI2LError.imageLoadFailed(url.path)
         }
 
         // 1) Crop+resize to 1024x1024 using DiffSynth's `ImageCropAndResize` logic.
-        let highRes = try cropAndResizeAspectFill(cgImage, targetSize: 1024)
+        let highRes = try MediaImageIO.centerCropped(image, width: 1024, height: 1024)
 
         // 2) Resize for each encoder.
-        let siglipImage = try resizeImage(highRes, targetSize: 384)
-        let dinoImage = try resizeImage(highRes, targetSize: 224)
+        let siglipImage = try MediaImageIO.resized(highRes, width: 384, height: 384)
+        let dinoImage = try MediaImageIO.resized(highRes, width: 224, height: 224)
 
         // 3) Convert to NCHW tensors with the correct per-encoder normalization.
-        let siglip = try cgImageToMLXArray(
+        let siglip = try imageToMLXArray(
             siglipImage,
             mean: [0.5, 0.5, 0.5],
             std: [0.5, 0.5, 0.5]
         )
-        let dino = try cgImageToMLXArray(
+        let dino = try imageToMLXArray(
             dinoImage,
             mean: [0.485, 0.456, 0.406],
             std: [0.229, 0.224, 0.225]
         )
         return (siglip: siglip, dino: dino)
-        #else
-        throw ZImageI2LError.unsupportedPlatform
-        #endif
     }
 
-    #if os(macOS)
-    private func cgImageToMLXArray(_ cgImage: CGImage, mean: [Float], std: [Float]) throws -> MLXArray {
-        let width = cgImage.width
-        let height = cgImage.height
-
+    private func imageToMLXArray(_ image: MediaImage, mean: [Float], std: [Float]) throws -> MLXArray {
         guard mean.count == 3, std.count == 3 else {
             throw ZImageI2LError.imageProcessingFailed
         }
 
-        guard let context = CGContext(
-            data: nil,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: width * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-
-        // Make y=0 correspond to the top row (PIL-style).
-        context.translateBy(x: 0, y: CGFloat(height))
-        context.scaleBy(x: 1, y: -1)
-
-        context.interpolationQuality = .high
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-
-        guard let data = context.data else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-
-        let ptr = data.bindMemory(to: UInt8.self, capacity: width * height * 4)
-
+        let width = image.width
+        let height = image.height
         var rgbData: [Float] = []
         rgbData.reserveCapacity(width * height * 3)
 
-        for c in 0..<3 {  // R, G, B channels
-            for y in 0..<height {
-                for x in 0..<width {
-                    let idx = (y * width + x) * 4
-                    let value = Float(ptr[idx + c]) / 255.0
-                    let normalized = (value - mean[c]) / std[c]
-                    rgbData.append(normalized)
-                }
+        for channel in 0..<3 {
+            for pixel in 0..<(width * height) {
+                let value = Float(image.rgba8[pixel * 4 + channel]) / 255.0
+                rgbData.append((value - mean[channel]) / std[channel])
             }
         }
 
         return MLXArray(rgbData).reshaped(1, 3, height, width).asType(dtype)
     }
-
-    private func resizeImage(_ cgImage: CGImage, targetSize: Int) throws -> CGImage {
-        guard let context = CGContext(
-            data: nil,
-            width: targetSize,
-            height: targetSize,
-            bitsPerComponent: 8,
-            bytesPerRow: targetSize * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-
-        context.translateBy(x: 0, y: CGFloat(targetSize))
-        context.scaleBy(x: 1, y: -1)
-
-        context.interpolationQuality = .high
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: targetSize, height: targetSize))
-
-        guard let out = context.makeImage() else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-        return out
-    }
-
-    private func cropAndResizeAspectFill(_ cgImage: CGImage, targetSize: Int) throws -> CGImage {
-        let srcW = cgImage.width
-        let srcH = cgImage.height
-
-        guard srcW > 0, srcH > 0 else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-
-        // Matches DiffSynth `ImageCropAndResize.crop_and_resize`:
-        //   scale = max(targetW/srcW, targetH/srcH)
-        //   resize to (round(srcH*scale), round(srcW*scale))
-        //   center crop (targetH, targetW)
-        let scale = max(Double(targetSize) / Double(srcW), Double(targetSize) / Double(srcH))
-        let scaledW = Int((Double(srcW) * scale).rounded())
-        let scaledH = Int((Double(srcH) * scale).rounded())
-
-        // torchvision center_crop uses integer top/left = floor((scaled - target)/2)
-        let left = max(0, (scaledW - targetSize) / 2)
-        let top = max(0, (scaledH - targetSize) / 2)
-
-        guard let context = CGContext(
-            data: nil,
-            width: targetSize,
-            height: targetSize,
-            bitsPerComponent: 8,
-            bytesPerRow: targetSize * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-
-        context.translateBy(x: 0, y: CGFloat(targetSize))
-        context.scaleBy(x: 1, y: -1)
-
-        context.interpolationQuality = .high
-        let drawRect = CGRect(
-            x: -CGFloat(left),
-            y: -CGFloat(top),
-            width: CGFloat(scaledW),
-            height: CGFloat(scaledH)
-        )
-        context.draw(cgImage, in: drawRect)
-
-        guard let out = context.makeImage() else {
-            throw ZImageI2LError.imageProcessingFailed
-        }
-        return out
-    }
-    #endif
 
     // MARK: - LoRA Saving
 
@@ -567,7 +459,3 @@ public enum ZImageI2LError: Error, LocalizedError {
         }
     }
 }
-
-#if os(macOS)
-import AppKit
-#endif

--- a/Sources/MereRunCore/ZImageTurbo/Util/ImageIO.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Util/ImageIO.swift
@@ -1,10 +1,12 @@
 import Foundation
+import MediaIO
 import MLX
 
 #if canImport(CoreGraphics)
 import CoreGraphics
 import ImageIO
 import UniformTypeIdentifiers
+#endif
 
 public enum QwenImageIOError: Error {
   case unsupportedPixelFormat
@@ -14,6 +16,7 @@ public enum QwenImageIOError: Error {
 }
 
 public enum QwenImageIO {
+#if canImport(CoreGraphics)
   static func resizedCGImage(
     from image: CGImage,
     width: Int,
@@ -113,7 +116,7 @@ public enum QwenImageIO {
     return try array(from: cropped, addBatchDimension: addBatchDimension, dtype: dtype)
   }
 
-  static func array(
+  public static func array(
     from image: CGImage,
     addBatchDimension: Bool = true,
     dtype: DType = .float32
@@ -174,7 +177,93 @@ public enum QwenImageIO {
     return MLXArray(floats, shape).asType(dtype)
   }
 
-  static func image(from array: MLXArray) throws -> CGImage {
+  public static func image(from array: MLXArray) throws -> CGImage {
+    let media = try mediaImage(from: array)
+    let providerData = Data(media.rgba8)
+    guard let provider = CGDataProvider(data: providerData as CFData) else {
+      throw QwenImageIOError.unsupportedPixelFormat
+    }
+
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+    guard let image = CGImage(
+      width: media.width,
+      height: media.height,
+      bitsPerComponent: 8,
+      bitsPerPixel: 32,
+      bytesPerRow: media.width * 4,
+      space: colorSpace,
+      bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+      provider: provider,
+      decode: nil,
+      shouldInterpolate: false,
+      intent: .defaultIntent
+    ) else {
+      throw QwenImageIOError.unsupportedPixelFormat
+    }
+
+    return image
+  }
+
+  public static func resizedPixelArray(
+    from image: CGImage,
+    width: Int,
+    height: Int,
+    addBatchDimension: Bool = true,
+    dtype: DType = .float32,
+    interpolation: CGInterpolationQuality = .high
+  ) throws -> MLXArray {
+    guard width > 0, height > 0 else {
+      throw QwenImageIOError.resizeFailed
+    }
+
+    let resizedImage = try resizedCGImage(from: image, width: width, height: height, interpolation: interpolation)
+    return try array(from: resizedImage, addBatchDimension: addBatchDimension, dtype: dtype)
+  }
+#endif
+
+  public static func resizedCenterCropPixelArray(
+    from url: URL,
+    width: Int,
+    height: Int,
+    addBatchDimension: Bool = true,
+    dtype: DType = .float32
+  ) throws -> MLXArray {
+    let image = try MediaImageIO.decode(url)
+    return try resizedCenterCropPixelArray(
+      from: image,
+      width: width,
+      height: height,
+      addBatchDimension: addBatchDimension,
+      dtype: dtype
+    )
+  }
+
+  public static func resizedCenterCropPixelArray(
+    from image: MediaImage,
+    width: Int,
+    height: Int,
+    addBatchDimension: Bool = true,
+    dtype: DType = .float32
+  ) throws -> MLXArray {
+    let cropped = try MediaImageIO.centerCropped(image, width: width, height: height)
+    return try array(from: cropped, addBatchDimension: addBatchDimension, dtype: dtype)
+  }
+
+  public static func array(
+    from image: MediaImage,
+    addBatchDimension: Bool = true,
+    dtype: DType = .float32
+  ) throws -> MLXArray {
+    let floats = MediaImageIO.rgbCHWFloat(image, normalizedToMinusOneToOne: false)
+    var shape = [3, image.height, image.width]
+    if addBatchDimension {
+      shape.insert(1, at: 0)
+    }
+    return MLXArray(floats, shape).asType(dtype)
+  }
+
+  public static func mediaImage(from array: MLXArray) throws -> MediaImage {
     var tensor = array
     precondition(tensor.ndim == 3 || (tensor.ndim == 4 && tensor.dim(0) == 1))
     if tensor.ndim == 4 {
@@ -194,7 +283,6 @@ public enum QwenImageIO {
     let data = uint8Tensor.asData().data
 
     var bytes = [UInt8](repeating: 255, count: pixelCount * 4)
-
     data.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
       let srcPointer = pointer.bindMemory(to: UInt8.self)
       for pixel in 0..<pixelCount {
@@ -205,30 +293,7 @@ public enum QwenImageIO {
       }
     }
 
-    let providerData = Data(bytes)
-    guard let provider = CGDataProvider(data: providerData as CFData) else {
-      throw QwenImageIOError.unsupportedPixelFormat
-    }
-
-    let colorSpace = CGColorSpaceCreateDeviceRGB()
-    let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-    guard let image = CGImage(
-      width: width,
-      height: height,
-      bitsPerComponent: 8,
-      bitsPerPixel: 32,
-      bytesPerRow: width * 4,
-      space: colorSpace,
-      bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
-      provider: provider,
-      decode: nil,
-      shouldInterpolate: false,
-      intent: .defaultIntent
-    ) else {
-      throw QwenImageIOError.unsupportedPixelFormat
-    }
-
-    return image
+    return try MediaImage(width: width, height: height, rgba8: bytes)
   }
 
   public static func normalizeForEncoder(_ image: MLXArray) -> MLXArray {
@@ -240,48 +305,51 @@ public enum QwenImageIO {
   }
 
   static func saveImage(array: MLXArray, to url: URL) throws {
-    let cg = try image(from: array)
-    guard let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
-      throw QwenImageIOError.writeFailed
-    }
-    CGImageDestinationAddImage(destination, cg, nil)
-    guard CGImageDestinationFinalize(destination) else {
+    do {
+      try MediaImageIO.writePNG(try mediaImage(from: array), to: url)
+    } catch {
       throw QwenImageIOError.writeFailed
     }
   }
+
   public static func imageData(from array: MLXArray) throws -> Data {
-    let cg = try image(from: array)
-    let mutableData = NSMutableData()
-    guard let destination = CGImageDestinationCreateWithData(
-      mutableData as CFMutableData,
-      UTType.png.identifier as CFString,
-      1,
-      nil
-    ) else {
+    do {
+      return try MediaImageIO.pngData(from: try mediaImage(from: array))
+    } catch {
       throw QwenImageIOError.writeFailed
     }
-    CGImageDestinationAddImage(destination, cg, nil)
-    guard CGImageDestinationFinalize(destination) else {
-      throw QwenImageIOError.writeFailed
-    }
-    return mutableData as Data
   }
 
   public static func resizedPixelArray(
-    from image: CGImage,
+    from url: URL,
     width: Int,
     height: Int,
     addBatchDimension: Bool = true,
-    dtype: DType = .float32,
-    interpolation: CGInterpolationQuality = .high
+    dtype: DType = .float32
+  ) throws -> MLXArray {
+    let image = try MediaImageIO.decode(url)
+    return try resizedPixelArray(
+      from: image,
+      width: width,
+      height: height,
+      addBatchDimension: addBatchDimension,
+      dtype: dtype
+    )
+  }
+
+  public static func resizedPixelArray(
+    from image: MediaImage,
+    width: Int,
+    height: Int,
+    addBatchDimension: Bool = true,
+    dtype: DType = .float32
   ) throws -> MLXArray {
     guard width > 0, height > 0 else {
       throw QwenImageIOError.resizeFailed
     }
 
-    let resizedImage = try resizedCGImage(from: image, width: width, height: height, interpolation: interpolation)
-    let arr = try array(from: resizedImage, addBatchDimension: addBatchDimension, dtype: dtype)
-    return arr
+    let resizedImage = try MediaImageIO.resized(image, width: width, height: height)
+    return try array(from: resizedImage, addBatchDimension: addBatchDimension, dtype: dtype)
   }
 
   static func resize(
@@ -581,4 +649,3 @@ public enum QwenImageIO {
     return contributions
   }
 }
-#endif

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+Inference.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+Inference.swift
@@ -1,11 +1,7 @@
 import Foundation
+import MediaIO
 import MLX
 import MLXNN
-
-#if canImport(CoreGraphics)
-import CoreGraphics
-import ImageIO
-#endif
 
 /// Owns prompt encoding, latent decoding, and image-to-image preparation.
 /// These helpers stay separate from model loading so the inference data flow is
@@ -68,20 +64,19 @@ extension ZImageTurboGenerator {
         height: Int,
         width: Int
     ) async throws -> MLXArray {
-        #if !canImport(CoreGraphics)
-        throw GeneratorError.inputImageUnsupportedPlatform
-        #else
         guard FileManager.default.fileExists(atPath: inputImageURL.path) else {
             throw GeneratorError.inputImageNotFound(inputImageURL)
         }
 
-        guard let imageSource = CGImageSourceCreateWithURL(inputImageURL as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+        let image: MediaImage
+        do {
+            image = try MediaImageIO.decode(inputImageURL)
+        } catch {
             throw GeneratorError.inputImageDecodeFailed(inputImageURL)
         }
 
         let resizedArray = try QwenImageIO.resizedPixelArray(
-            from: cgImage,
+            from: image,
             width: width,
             height: height,
             addBatchDimension: true,
@@ -100,6 +95,5 @@ extension ZImageTurboGenerator {
         let blended = (one - sigmaCast) * clean + sigmaCast * noise
         MLX.eval(blended)
         return blended
-        #endif
     }
 }

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer+DatasetEncoding.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer+DatasetEncoding.swift
@@ -3,11 +3,6 @@ import MLX
 import MLXNN
 import MLXRandom
 
-#if canImport(CoreGraphics)
-import CoreGraphics
-import ImageIO
-#endif
-
 extension ZImageTurboLoRATrainer {
     // MARK: - Dataset Encoding
 
@@ -44,15 +39,9 @@ extension ZImageTurboLoRATrainer {
             throw ZImageTurboLoRATrainerError.imageNotFound(url)
         }
 
-    #if canImport(CoreGraphics)
-        guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
-            throw ZImageTurboLoRATrainerError.imageDecodeFailed(url)
-        }
-
         // Use center crop (ai-toolkit style) to preserve aspect ratio
         let resizedArray = try QwenImageIO.resizedCenterCropPixelArray(
-            from: cgImage,
+            from: url,
             width: width,
             height: height,
             addBatchDimension: true,
@@ -67,9 +56,5 @@ extension ZImageTurboLoRATrainer {
         let cleanLatent = (mean - MLXArray(vae.configuration.shiftFactor)) * MLXArray(vae.configuration.scalingFactor)
 
         return cleanLatent.asType(.bfloat16)
-    #else
-        throw ZImageTurboLoRATrainerError.imageDecodeFailed(url)
-    #endif
     }
 }
-

--- a/Sources/llama/module.modulemap
+++ b/Sources/llama/module.modulemap
@@ -1,0 +1,5 @@
+module llama [system] {
+  header "shim.h"
+  link "llama"
+  export *
+}

--- a/Sources/llama/shim.h
+++ b/Sources/llama/shim.h
@@ -1,0 +1,1 @@
+#include <llama.h>

--- a/Tests/MereRunCLITests/InstallScriptTests.swift
+++ b/Tests/MereRunCLITests/InstallScriptTests.swift
@@ -1,5 +1,8 @@
 import Foundation
 import XCTest
+#if os(Linux)
+import Glibc
+#endif
 
 final class InstallScriptTests: XCTestCase {
     private let modelSourceConfigFilename = "mererun-model-source-base-url.txt"
@@ -100,6 +103,9 @@ final class InstallScriptTests: XCTestCase {
     }
 
     func testInstallerCopiesMlxBundleAndCompatibilityMetallibsWhenPresent() throws {
+        #if os(Linux)
+        throw XCTSkip("MLX Metal bundle staging is macOS-only.")
+        #else
         let fixture = try makeInstallerFixture()
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
 
@@ -142,6 +148,28 @@ final class InstallScriptTests: XCTestCase {
                 atPath: fixture.destDirURL.appendingPathComponent("mlx.metallib").path
             )
         )
+        #endif
+    }
+
+    func testInstallerCopiesLinuxSharedLibrariesWhenPresent() throws {
+        let fixture = try makeInstallerFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let sharedLibraryURL = fixture.sourceDirURL.appendingPathComponent("libmere_native.so", isDirectory: false)
+        try "fake shared library".write(to: sharedLibraryURL, atomically: true, encoding: .utf8)
+
+        let result = try runInstaller(
+            scriptURL: fixture.installScriptURL,
+            binDestURL: fixture.destDirURL.appendingPathComponent("mere.run", isDirectory: false),
+            extraEnvironment: ["MERERUN_INSTALL_PLATFORM": "Linux"]
+        )
+
+        XCTAssertEqual(result.status, 0, result.combinedOutput)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: fixture.destDirURL.appendingPathComponent("libmere_native.so").path
+            )
+        )
     }
 
     func testInstallerCopiesDS4RuntimeWhenPresent() throws {
@@ -164,7 +192,8 @@ final class InstallScriptTests: XCTestCase {
 
         let result = try runInstaller(
             scriptURL: fixture.installScriptURL,
-            binDestURL: fixture.destDirURL.appendingPathComponent("mere.run", isDirectory: false)
+            binDestURL: fixture.destDirURL.appendingPathComponent("mere.run", isDirectory: false),
+            extraEnvironment: ["MERERUN_INSTALL_DISABLE_DITTO": "1"]
         )
 
         XCTAssertEqual(result.status, 0, result.combinedOutput)
@@ -219,30 +248,113 @@ final class InstallScriptTests: XCTestCase {
     private func runInstaller(
         scriptURL: URL,
         binDestURL: URL,
-        arguments: [String] = []
+        arguments: [String] = [],
+        extraEnvironment: [String: String] = [:]
     ) throws -> InstallerRunResult {
+        #if os(Linux)
+        return try runInstallerWithSystem(
+            scriptURL: scriptURL,
+            binDestURL: binDestURL,
+            arguments: arguments,
+            extraEnvironment: extraEnvironment
+        )
+        #else
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/bash")
         process.arguments = [scriptURL.path] + arguments
         var environment = ProcessInfo.processInfo.environment
         environment["MERERUN_INSTALL_BIN_DEST"] = binDestURL.path
         environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+        for (key, value) in extraEnvironment {
+            environment[key] = value
+        }
         process.environment = environment
 
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
+        let captureRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InstallScriptTests-output-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: captureRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: captureRoot) }
+        let stdoutURL = captureRoot.appendingPathComponent("stdout.txt", isDirectory: false)
+        let stderrURL = captureRoot.appendingPathComponent("stderr.txt", isDirectory: false)
+        try Data().write(to: stdoutURL)
+        try Data().write(to: stderrURL)
+        let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+        let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+        process.standardOutput = stdoutHandle
+        process.standardError = stderrHandle
 
         try process.run()
         process.waitUntilExit()
+        try stdoutHandle.close()
+        try stderrHandle.close()
 
         return InstallerRunResult(
             status: process.terminationStatus,
-            stdout: String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-            stderr: String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            stdout: String(data: try Data(contentsOf: stdoutURL), encoding: .utf8) ?? "",
+            stderr: String(data: try Data(contentsOf: stderrURL), encoding: .utf8) ?? ""
+        )
+        #endif
+    }
+
+    #if os(Linux)
+    private func runInstallerWithSystem(
+        scriptURL: URL,
+        binDestURL: URL,
+        arguments: [String],
+        extraEnvironment: [String: String]
+    ) throws -> InstallerRunResult {
+        let captureRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InstallScriptTests-output-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: captureRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: captureRoot) }
+
+        let stdoutURL = captureRoot.appendingPathComponent("stdout.txt", isDirectory: false)
+        let stderrURL = captureRoot.appendingPathComponent("stderr.txt", isDirectory: false)
+        let runnerURL = captureRoot.appendingPathComponent("run-installer.sh", isDirectory: false)
+
+        var lines = [
+            "set -e",
+            "export MERERUN_INSTALL_BIN_DEST=\(shellQuote(binDestURL.path))",
+            "export PATH='/usr/bin:/bin:/usr/sbin:/sbin'",
+        ]
+        for (key, value) in extraEnvironment.sorted(by: { $0.key < $1.key }) {
+            lines.append("export \(key)=\(shellQuote(value))")
+        }
+
+        let renderedArguments = ([scriptURL.path] + arguments)
+            .map(shellQuote)
+            .joined(separator: " ")
+        lines.append("exec /bin/bash \(renderedArguments)")
+        try (lines.joined(separator: "\n") + "\n").write(to: runnerURL, atomically: true, encoding: .utf8)
+
+        let command = [
+            "/bin/bash",
+            shellQuote(runnerURL.path),
+            ">",
+            shellQuote(stdoutURL.path),
+            "2>",
+            shellQuote(stderrURL.path),
+        ].joined(separator: " ")
+
+        let rawStatus = system(command)
+        let status: Int32
+        if rawStatus == -1 {
+            status = -1
+        } else {
+            status = Int32((rawStatus >> 8) & 0xff)
+        }
+
+        return InstallerRunResult(
+            status: status,
+            stdout: String(data: try Data(contentsOf: stdoutURL), encoding: .utf8) ?? "",
+            stderr: String(data: try Data(contentsOf: stderrURL), encoding: .utf8) ?? ""
         )
     }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+    #endif
 }
 
 private struct InstallerFixture {

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+final class LinuxNativeBridgeTests: XCTestCase {
+    func testPackageManifestCanConsumePrebuiltMlxSwiftCudaArtifacts() throws {
+        let package = try readRepositoryFile("Package.swift")
+
+        XCTAssertTrue(package.contains("MERERUN_MLX_SWIFT_LINKAGE"))
+        XCTAssertTrue(package.contains("cuda-prebuilt"))
+        XCTAssertTrue(package.contains("MERERUN_MLX_SWIFT_BUILD_DIR"))
+        XCTAssertTrue(package.contains("MERERUN_MLX_SWIFT_SOURCE_DIR"))
+        XCTAssertTrue(package.contains("MERERUN_MLX_SWIFT_LINK_FLAGS"))
+        XCTAssertTrue(package.contains("func mlxDependency(_ name: String) -> [Target.Dependency]"))
+        XCTAssertTrue(package.contains("useLinuxPrebuiltMLX ? [] : [.product(name: name, package: \"mlx-swift\")]"))
+        XCTAssertTrue(package.contains("prebuiltMLXLinkerSettings"))
+        XCTAssertTrue(package.contains("-lMLXFast"))
+        XCTAssertFalse(
+            package.contains(".product(name: \"MLXFast\", package: \"mlx-swift\")"),
+            "Direct MLX product dependencies must go through mlxDependency so cuda-prebuilt mode can import CMake-built modules."
+        )
+    }
+
+    func testLinuxNativePreparationExportsSwiftPMCudaBridgeEnvironment() throws {
+        let script = try readRepositoryFile("scripts/prepare-linux-native.sh")
+
+        XCTAssertTrue(script.contains("verify_mlx_swift_cuda_bridge"))
+        XCTAssertTrue(script.contains("mlx_swift_cuda_link_flags"))
+        XCTAssertTrue(script.contains("export MERERUN_MLX_SWIFT_LINKAGE=\"cuda-prebuilt\""))
+        XCTAssertTrue(script.contains("export MERERUN_MLX_SWIFT_BUILD_DIR=\"$native_root/build/mlx-swift-cuda-smoke\""))
+        XCTAssertTrue(script.contains("export MERERUN_MLX_SWIFT_SOURCE_DIR=\"$repo_root/.build/native/src/mlx-swift\""))
+        XCTAssertTrue(script.contains("export MERERUN_MLX_SWIFT_LINK_FLAGS=\"$mlx_link_flags\""))
+        XCTAssertTrue(script.contains("$mlx_cmake_build/MLX.swiftmodule"))
+        XCTAssertTrue(script.contains("$mlx_cmake_build/libMLX.a"))
+        XCTAssertTrue(script.contains("$mlx_cmake_build/_deps/mlx-c-build/libmlxc.a"))
+        XCTAssertTrue(script.contains("$mlx_cmake_build/_deps/mlx-build/libmlx.a"))
+        XCTAssertTrue(script.contains("$mlx_cmake_build/lib/libNumerics.a"))
+        XCTAssertFalse(script.contains("whose Linux path remains CPU-oriented until a package bridge is added"))
+    }
+
+    private func readRepositoryFile(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(relativePath, isDirectory: false)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -14,6 +14,8 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(package.contains("useLinuxPrebuiltMLX ? [] : [.product(name: name, package: \"mlx-swift\")]"))
         XCTAssertTrue(package.contains("prebuiltMLXLinkerSettings"))
         XCTAssertTrue(package.contains("-lMLXFast"))
+        XCTAssertTrue(package.contains("$ORIGIN/lib"))
+        XCTAssertTrue(package.contains("linuxNativeLlamaLibraryPath"))
         XCTAssertFalse(
             package.contains(".product(name: \"MLXFast\", package: \"mlx-swift\")"),
             "Direct MLX product dependencies must go through mlxDependency so cuda-prebuilt mode can import CMake-built modules."

--- a/Tests/MereRunCoreTests/DeepseekV4FlashResolverTests.swift
+++ b/Tests/MereRunCoreTests/DeepseekV4FlashResolverTests.swift
@@ -41,9 +41,55 @@ final class DeepseekV4FlashResolverTests: XCTestCase {
         XCTAssertEqual(resolved?.standardizedFileURL, symlink.standardizedFileURL)
     }
 
+    func testBinaryLocateAcceptsPlatformSubdirectoryUnderOverride() throws {
+        let root = try makeTemporaryDirectory()
+        let platformDir = root.appendingPathComponent("linux-arm64", isDirectory: true)
+        let server = platformDir.appendingPathComponent(DeepseekV4FlashBinary.Kind.server.rawValue)
+        try makeExecutable(at: server)
+
+        let resolved = try DeepseekV4FlashBinary.locate(
+            .server,
+            environment: [
+                "MERERUN_DS4_BIN_DIR": root.path,
+                "MERERUN_DS4_PLATFORM_DIR": "linux-arm64",
+            ]
+        )
+
+        XCTAssertEqual(resolved.standardizedFileURL, server.standardizedFileURL)
+    }
+
+    func testBinaryLocatePreservesFlatOverrideDirectory() throws {
+        let root = try makeTemporaryDirectory()
+        let flatServer = root.appendingPathComponent(DeepseekV4FlashBinary.Kind.server.rawValue)
+        let platformServer = root
+            .appendingPathComponent("linux-arm64", isDirectory: true)
+            .appendingPathComponent(DeepseekV4FlashBinary.Kind.server.rawValue)
+        try makeExecutable(at: flatServer)
+        try makeExecutable(at: platformServer)
+
+        let resolved = try DeepseekV4FlashBinary.locate(
+            .server,
+            environment: [
+                "MERERUN_DS4_BIN_DIR": root.path,
+                "MERERUN_DS4_PLATFORM_DIR": "linux-arm64",
+            ]
+        )
+
+        XCTAssertEqual(resolved.standardizedFileURL, flatServer.standardizedFileURL)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let root = try TestFileSystem.makeTempDir(prefix: "mererun-ds4-resolver-tests")
         temporaryRoots.append(root)
         return root
+    }
+
+    private func makeExecutable(at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data("binary".utf8)))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
     }
 }

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -3,7 +3,7 @@ import MLX
 import MLXRandom
 @testable import MereRunCore
 
-final class Gemma4KVQuantizationTests: XCTestCase {
+final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
     func testUniformRejectsFractionalBits() {
         let config = Gemma4KVCacheQuantization(bits: 3.5, scheme: .uniform, groupSize: 64, quantizedStart: 0)
         XCTAssertThrowsError(try config.validated())

--- a/Tests/MereRunCoreTests/GoldenGenerationSmokeTests.swift
+++ b/Tests/MereRunCoreTests/GoldenGenerationSmokeTests.swift
@@ -1,7 +1,11 @@
-import CryptoKit
 import Foundation
 import XCTest
 @testable import MereRunCore
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
 
 final class GoldenGenerationSmokeTests: XCTestCase {
 

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -67,7 +67,7 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(report.reasons, [])
     }
 
-    func testNonAppleSiliconMacIsRejected() throws {
+    func testUnsupportedRuntimeIsRejected() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
         let machine = MereRunMachineProfile(
             physicalMemoryBytes: 32 * 1_073_741_824,
@@ -78,7 +78,22 @@ final class ManagedModelSupportTests: XCTestCase {
         let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
 
         XCTAssertFalse(report.isSupported)
-        XCTAssertEqual(report.reasons, ["Apple Silicon macOS is required."])
+        XCTAssertEqual(report.reasons, ["Apple Silicon macOS or Linux is required."])
+    }
+
+    func testLinuxRuntimeIsSupportedWhenMemoryThresholdIsMet() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "Linux",
+            isAppleSiliconMac: false,
+            isLinux: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertEqual(report.reasons, [])
     }
 
     func testRecommendedSetupOnlyContainsSupportedModels() {
@@ -210,5 +225,19 @@ final class ManagedModelSupportTests: XCTestCase {
         )
 
         XCTAssertNil(MereRunAgentModelCatalog.recommendation(for: .tier, on: machine))
+    }
+
+    func testAgentTierSelectsCoderOnLinuxWithEnoughMemory() throws {
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "Linux",
+            isAppleSiliconMac: false,
+            isLinux: true
+        )
+
+        let recommendation = try XCTUnwrap(MereRunAgentModelCatalog.recommendation(for: .tier, on: machine))
+
+        XCTAssertEqual(recommendation.id, CodeGenResources.defaultModelId)
+        XCTAssertTrue(recommendation.isStartableByMereRun)
     }
 }

--- a/Tests/MereRunCoreTests/MediaIOTests.swift
+++ b/Tests/MereRunCoreTests/MediaIOTests.swift
@@ -1,0 +1,75 @@
+import AudioCodecs
+import Foundation
+import MediaIO
+import XCTest
+
+final class MediaIOTests: XCTestCase {
+    func testImageResizeAndCenterCropUseStableRGBAStorage() throws {
+        let image = try MediaImage(
+            width: 2,
+            height: 2,
+            rgba8: [
+                255, 0, 0, 255,
+                0, 255, 0, 255,
+                0, 0, 255, 255,
+                255, 255, 255, 255,
+            ]
+        )
+
+        let resized = try MediaImageIO.resized(image, width: 4, height: 4)
+        XCTAssertEqual(resized.width, 4)
+        XCTAssertEqual(resized.height, 4)
+        XCTAssertEqual(resized.rgba8.count, 4 * 4 * 4)
+
+        let cropped = try MediaImageIO.centerCropped(image, width: 1, height: 1)
+        XCTAssertEqual(cropped.width, 1)
+        XCTAssertEqual(cropped.height, 1)
+        XCTAssertEqual(cropped.rgba8.count, 4)
+    }
+
+    func testFloatWAVWriterProducesPortableHeader() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mediaio-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        try MediaAudioIO.writeFloatWAV(
+            samples: [0.0, 0.5, -0.5, 1.0],
+            sampleRate: 16_000,
+            channels: 1,
+            to: tempURL
+        )
+
+        let data = try Data(contentsOf: tempURL)
+        XCTAssertEqual(String(decoding: data[0..<4], as: UTF8.self), "RIFF")
+        XCTAssertEqual(String(decoding: data[8..<12], as: UTF8.self), "WAVE")
+        XCTAssertEqual(readUInt16LE(data, offset: 20), 3)
+        XCTAssertEqual(readUInt32LE(data, offset: 24), 16_000)
+        XCTAssertEqual(readUInt32LE(data, offset: 40), 4 * UInt32(MemoryLayout<Float>.size))
+    }
+
+    func testRealFFTPlanSupportsASRAndPowerOfTwoFrameSizes() throws {
+        for size in [400, 512, 1024] {
+            let plan = try RealFFTPlan(size: size)
+            let samples = (0..<size).map { index in
+                sin(Float(index) * 0.01)
+            }
+            let spectrum = plan.powerSpectrum(samples)
+            XCTAssertEqual(spectrum.count, (size / 2) + 1)
+            XCTAssertTrue(spectrum.allSatisfy { $0.isFinite && $0 >= 0 })
+        }
+    }
+
+    private func readUInt16LE(_ data: Data, offset: Int) -> UInt16 {
+        let bytes = [UInt8](data[offset..<(offset + 2)])
+        return UInt16(bytes[0]) | (UInt16(bytes[1]) << 8)
+    }
+
+    private func readUInt32LE(_ data: Data, offset: Int) -> UInt32 {
+        let bytes = [UInt8](data[offset..<(offset + 4)])
+        return UInt32(bytes[0])
+            | (UInt32(bytes[1]) << 8)
+            | (UInt32(bytes[2]) << 16)
+            | (UInt32(bytes[3]) << 24)
+    }
+}

--- a/Tests/MereRunCoreTests/MereRunCoreTestCase.swift
+++ b/Tests/MereRunCoreTests/MereRunCoreTestCase.swift
@@ -10,6 +10,20 @@ class MereRunCoreTestCase: XCTestCase {
             print("[MereRunCoreTestCase] invokeTest \(type(of: self)) \(name)")
         }
 
+        #if os(Linux)
+        let raw = (env["MERERUN_TEST_LINUX_MLX"] ?? "").lowercased()
+        let enabled = raw == "1" || raw == "true" || raw == "yes"
+        guard enabled else {
+            if debugEnabled {
+                print("[MereRunCoreTestCase] skipping Linux MLX test \(type(of: self)) \(name)")
+            }
+            return
+        }
+
+        Device.withDefaultDevice(Device(.cpu)) {
+            super.invokeTest()
+        }
+        #else
         // IMPORTANT: MLX will attempt to initialize Metal resources while creating
         // default CPU/GPU streams. Install the metallib/bundle first.
         MLXTestSupport.ensureMetalLibraryAvailable()
@@ -21,5 +35,6 @@ class MereRunCoreTestCase: XCTestCase {
         Device.withDefaultDevice(device) {
             super.invokeTest()
         }
+        #endif
     }
 }

--- a/Tests/MereRunCoreTests/NativeMediaAssemblerCaptionTests.swift
+++ b/Tests/MereRunCoreTests/NativeMediaAssemblerCaptionTests.swift
@@ -1,3 +1,4 @@
+#if canImport(AVFoundation) && canImport(CoreGraphics)
 import AVFoundation
 import CoreGraphics
 import Foundation
@@ -233,3 +234,4 @@ final class NativeMediaAssemblerCaptionTests: XCTestCase {
         return changedPixels
     }
 }
+#endif

--- a/Tests/MereRunCoreTests/StreamingWAVWriterTests.swift
+++ b/Tests/MereRunCoreTests/StreamingWAVWriterTests.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import XCTest
 @testable import MereRunCore
 import AudioCodecs
@@ -17,8 +16,25 @@ final class StreamingWAVWriterTests: XCTestCase {
             try writer.append(samples: [0.4, 0.5])
         }
 
-        let file = try AVAudioFile(forReading: outputURL)
-        XCTAssertEqual(Int(file.processingFormat.sampleRate), 24_000)
-        XCTAssertEqual(Int(file.length), 5)
+        let data = try Data(contentsOf: outputURL)
+        XCTAssertEqual(String(decoding: data[0..<4], as: UTF8.self), "RIFF")
+        XCTAssertEqual(String(decoding: data[8..<12], as: UTF8.self), "WAVE")
+        XCTAssertEqual(readUInt16LE(data, offset: 20), 3)
+        XCTAssertEqual(readUInt16LE(data, offset: 22), 1)
+        XCTAssertEqual(readUInt32LE(data, offset: 24), 24_000)
+        XCTAssertEqual(readUInt32LE(data, offset: 40), 5 * UInt32(MemoryLayout<Float>.size))
+    }
+
+    private func readUInt16LE(_ data: Data, offset: Int) -> UInt16 {
+        let bytes = [UInt8](data[offset..<(offset + 2)])
+        return UInt16(bytes[0]) | (UInt16(bytes[1]) << 8)
+    }
+
+    private func readUInt32LE(_ data: Data, offset: Int) -> UInt32 {
+        let bytes = [UInt8](data[offset..<(offset + 4)])
+        return UInt32(bytes[0])
+            | (UInt32(bytes[1]) << 8)
+            | (UInt32(bytes[2]) << 16)
+            | (UInt32(bytes[3]) << 24)
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -667,7 +667,7 @@ Useful options:
 
 Download a managed Hugging Face snapshot into the local model store. The command checks
 the model capability catalog and available disk space before downloading so unsupported
-Macs do not pull models they cannot run and tight disks fail with a useful cache path.
+machines do not pull models they cannot run and tight disks fail with a useful cache path.
 
 ```bash
 swift run mere.run model pull image-zimage-nano
@@ -678,7 +678,7 @@ Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
 ### `mere.run model capabilities`
 
-Show this Mac's supported models, recommended setup package, and a short summary
+Show this machine's supported models, recommended setup package, and a short summary
 of what each model does.
 
 ```bash
@@ -782,17 +782,19 @@ swift run mere.run setup --mode manual
 
 Agent model choices:
 
-- `small`: `text-agent-qwen35-9b`, a Qwen3.5 9B Q4 GGUF setup agent for 16 GB Macs
-- `tier`: the best supported local tier for this Mac, currently 9B, Q35 nano, Qwen3-Coder Next, or DeepSeek V4 Flash on 96 GB+ Macs
+- `small`: `text-agent-qwen35-9b`, a Qwen3.5 9B Q4 GGUF setup agent for 16 GB machines
+- `tier`: the best supported local tier for this machine, currently 9B, Q35 nano, Qwen3-Coder Next, or DeepSeek V4 Flash on 96 GB+ machines
 - `premier`: `text-agent-deepseek-v4-flash`, the preferred managed 96 GB+ setup-agent tier served by the bundled DS4 engine
 
 BYOA prints a ready-to-paste Claude/Codex prompt. Manual mode prints the
 commands for capabilities, model pulls, serving, and optional Pi installation.
+Pi auto-install uses the published macOS release assets; on Linux, put a `pi`
+binary on `PATH` or pass `--pi-path` and the agent runs in the current terminal.
 
 ### `mere.run agent onboard`
 
 Lower-level agent plumbing used by `mere.run setup`. Print a guided setup
-summary for the current Mac. Optional flags can pull the
+summary for the current machine. Optional flags can pull the
 recommended supported model package, install Pi, and write a Pi provider
 extension that points at `mere.run api serve`.
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -14,6 +14,23 @@ For local docs and security checks, install Node.js, pnpm, and Gitleaks:
 brew install node pnpm gitleaks
 ```
 
+For Linux CLI compatibility work, use a headless toolchain. On Ubuntu-style
+systems the baseline packages are:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
+```
+
+`ffmpeg` packages normally include both `ffmpeg` and `ffprobe`. If a runner or
+developer machine installs them somewhere else, use absolute executable
+overrides:
+
+```bash
+export MERERUN_FFMPEG=/opt/ffmpeg/bin/ffmpeg
+export MERERUN_FFPROBE=/opt/ffmpeg/bin/ffprobe
+```
+
 ## The normal loop
 
 For most changes:
@@ -57,6 +74,22 @@ If the change affects installed-model behavior, also run:
 MERERUN_RUN_E2E=installed ./scripts/check.sh
 ```
 
+### Linux CLI compatibility change
+
+Keep this scope to the headless CLI, local API, and test fixtures. Do not move
+SwiftUI, app bundle, installer, or DMG behavior into the Linux target.
+
+```bash
+./scripts/check-linux.sh
+swift run mere.run --help
+```
+
+Linux CI should use CPU MLX-compatible fixtures and mocked or tiny media I/O
+inputs. The Linux gate runs the hidden `MediaIOSmoke` executable against
+`ffmpeg`/`ffprobe` so image, audio, MP4, mux, and frame extraction paths stay
+covered without model checkpoints. CUDA setup belongs in local runtime
+documentation or manual smoke notes, not in the default pull-request gate.
+
 ## Model-store expectations
 
 The public runtime is hard-cut to the canonical OSS model IDs. That means:
@@ -92,6 +125,8 @@ swift run mere.run model info image-klein-max
 - avoid introducing new implicit hosted defaults
 - keep model resolution explicit and canonical
 - add or update the most local tests you can
+- for Linux media I/O, test executable discovery through `MERERUN_FFMPEG`,
+  `MERERUN_FFPROBE`, and `PATH` without requiring real model checkpoints
 
 ### If you touch docs
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,6 +19,8 @@ It does not include hosted-service, billing, or private-deployment surfaces.
 
 ## Prerequisites
 
+For the supported macOS developer path:
+
 - Apple Silicon Mac
 - macOS 15 or newer
 - Xcode command line tools
@@ -26,6 +28,28 @@ It does not include hosted-service, billing, or private-deployment surfaces.
   (`brew install swiftlint ripgrep`)
 - enough disk space for model installs in
   `~/Library/Application Support/MereRun/models`
+
+For Linux CLI compatibility work:
+
+- Swift 6.x toolchain
+- `clang`, `cmake`, `ninja`, `pkg-config`, `gfortran`, curl/zlib/OpenBLAS/LAPACK development headers
+- `ffmpeg` and `ffprobe` for media probing and conversion
+- `gzip`, `unzip`, and `zip` for portable LoRA checkpoint archives
+- enough disk space for a headless model store
+
+On Ubuntu-style runners, the system package layer is:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
+```
+
+If the media tools are not on `PATH`, point the CLI at explicit binaries:
+
+```bash
+export MERERUN_FFMPEG=/opt/ffmpeg/bin/ffmpeg
+export MERERUN_FFPROBE=/opt/ffmpeg/bin/ffprobe
+```
 
 ## Build the package
 
@@ -41,6 +65,15 @@ open "$app_path"
 
 That confirms the package graph, CLI product, optional app product, app bundle,
 and basic command parsing are all working.
+
+On Linux compatibility branches, keep the first pass headless and stop at the
+CLI surface:
+
+```bash
+swift run mere.run --help
+```
+
+The macOS app product is intentionally outside the Linux target.
 
 ## Launch the macOS studio
 
@@ -62,6 +95,10 @@ package checkout. It does not silently install the terminal command on launch;
 open Settings and choose `Install CLI` or `Install Skill` when you want the
 bundled command or `use-mere-run` Codex skill copied into user-visible
 locations.
+
+The studio is macOS-only. Linux users and Linux CI should exercise the CLI and
+local API surfaces directly rather than trying to build or launch
+`mere.run.app`.
 
 ## Understand the command tree
 
@@ -144,7 +181,8 @@ The setup command offers a local Mere agent powered by Pi, a bring-your-own-agen
 handoff prompt for Claude/Codex, or manual commands. Use
 `--mode agent --agent-model small` to select the Qwen3.5 9B GGUF setup agent
 explicitly. On 96 GB+ Apple Silicon Macs, the hardware-tier and premier agent
-path selects DeepSeek V4 Flash as the preferred setup agent.
+path selects DeepSeek V4 Flash as the preferred setup agent. On Linux, install
+or provide Pi separately with `--pi-path` or PATH before using `--start`.
 
 ## Run a first workflow
 

--- a/docs/internals/source-layout.md
+++ b/docs/internals/source-layout.md
@@ -25,6 +25,10 @@ Main areas:
 - `VLM/`: vision-language model support
 - `ZImageI2L/`, `ZImageTurbo/`: image-family support
 
+Linux CLI compatibility should enter through reusable core surfaces here, not
+through app bundle code. Media-tool discovery belongs behind typed APIs and
+should honor `MERERUN_FFMPEG`, `MERERUN_FFPROBE`, and then `PATH`.
+
 ### `AudioCore`
 
 Shared audio types and utilities.
@@ -32,6 +36,9 @@ Shared audio types and utilities.
 ### `AudioCodecs`
 
 Audio codecs and conversion helpers.
+
+Keep Linux audio/video probing fixture-sized: use `ffmpeg` and `ffprobe`
+stubs or tiny generated files in tests, not real model checkpoints.
 
 ### `AudioSTT`
 
@@ -53,6 +60,13 @@ The public executable target.
 
 - `Commands/`
 - `Support/`
+
+This is the product Linux compatibility work should exercise.
+
+### `MereRunApp`
+
+The optional SwiftUI studio target. It stays macOS-only and should not become a
+Linux compatibility dependency.
 
 ## Tests
 
@@ -78,3 +92,5 @@ Use this for:
 - `scripts/check.sh`: main validation gate
 - `scripts/e2e_smoke.sh`: installed-model smoke runner
 - `vendor/llama.xcframework`: vendored native dependency for code and API paths
+- `vendor/mlx-swift_Cmlx.bundle`: macOS MLX shader resources; Linux CI should
+  use CPU MLX-sized fixtures and leave CUDA to optional local runtime checks

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -125,8 +125,8 @@ the prepared snapshot when needed.
 ## Hardware Support Checks
 
 Managed pulls are gated by the local capability catalog before any download. The
-check uses Apple Silicon macOS plus unified-memory thresholds for each model
-family, then blocks models that are unlikely to run reliably on the current Mac.
+check uses supported local runtimes plus memory thresholds for each model
+family, then blocks models that are unlikely to run reliably on the current machine.
 
 Inspect the local recommendation first:
 

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -30,6 +30,10 @@ mere-run/
 Those map cleanly to the main runtime families exposed by the CLI and the
 optional macOS studio.
 
+The Linux compatibility boundary is the headless `mere.run` CLI and reusable
+library code. `mere.run.app`, SwiftUI views, app bundling, installer behavior,
+and DMG packaging remain macOS-only.
+
 ## Source tree
 
 ### `Sources/MereRunCLI`
@@ -49,6 +53,9 @@ The optional macOS studio. It does not own runtime behavior; it turns
 user-facing studio requests into `mere.run` arguments, launches the CLI as a
 child process, streams stdout and stderr, saves local library metadata, and keeps
 the raw command surface available in Advanced details.
+
+Do not make this target part of Linux compatibility work. Linux contributors
+should validate the CLI and local API surfaces directly.
 
 ### `Sources/MereRunCore`
 
@@ -79,7 +86,9 @@ and transcription.
 ### `Sources/AudioCodecs`
 
 Audio conversion and low-level codec support used by speech runtimes and some
-tests.
+tests. Linux media compatibility should use `ffmpeg` and `ffprobe` discovery,
+including `MERERUN_FFMPEG` and `MERERUN_FFPROBE` overrides, instead of depending
+on Apple media frameworks.
 
 ### `Sources/AudioSTT`
 
@@ -136,6 +145,10 @@ monorepo payload structure.
 ### `vendor/mlx-swift_Cmlx.bundle`
 
 Vendored MLX shader resources used by the macOS runtime.
+
+Linux CI should stay CPU MLX-oriented and fixture-sized. CUDA-specific runtime
+smokes are optional local validation, not a requirement for the public pull
+request gate.
 
 ### `THIRD_PARTY_NOTICES.md`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -68,9 +68,9 @@ server answers `/health`, and the model IDs returned by `/v1/models`.
 
 ### `mere.run model capabilities`
 
-Summarizes the current Mac, the managed models it can run, the preferred
+Summarizes the current machine, the managed models it can run, the preferred
 setup-agent tier, and cross-modality starter coverage. Pass `--all` to include
-models that are blocked by Apple Silicon or unified-memory requirements.
+models that are blocked by platform or memory requirements.
 
 ### `mere.run model info`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,7 +66,21 @@ export MERERUN_FFPROBE=/usr/bin/ffprobe
 
 The pull-request fixture should stay CPU MLX-compatible. CUDA machines can run
 additional local smoke tests, but CUDA installation, driver selection, and GPU
-availability are not assumptions in the shared CI contract.
+availability are not assumptions in the shared CI contract. To use the optional
+Linux CUDA bridge, prepare native artifacts and export the environment that the
+script prints:
+
+```bash
+MERERUN_LINUX_ACCEL=cuda scripts/prepare-linux-native.sh
+# then export the printed PKG_CONFIG_PATH, LIBRARY_PATH, LD_LIBRARY_PATH,
+# MERERUN_MLX_SWIFT_LINKAGE, MERERUN_MLX_SWIFT_BUILD_DIR,
+# MERERUN_MLX_SWIFT_SOURCE_DIR, and MERERUN_MLX_SWIFT_LINK_FLAGS values.
+swift build --target mere.run
+```
+
+In this mode `Package.swift` imports the CMake-built `mlx-swift` Swift modules
+and static libraries instead of rebuilding `mlx-swift` through SwiftPM's
+CPU-oriented Linux manifest path.
 
 MediaIO coverage has two layers. `Tests/MereRunCoreTests/MediaIOTests.swift`
 covers pure Swift image, WAV, and FFT behavior in the normal test suite.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,11 @@ This repo has three layers of validation:
 Use the smallest layer that covers your change, then scale up before opening a
 PR.
 
+Linux CLI compatibility uses a narrower fixture boundary: headless CLI behavior,
+media-tool discovery, and CPU MLX-sized checks. CUDA should stay out of default
+CI and be documented as an optional local acceleration path when a runtime needs
+it.
+
 ## Fast validation
 
 ```bash
@@ -38,6 +43,36 @@ This script is the main gate for contributors. It runs:
 - docs and source hygiene sweeps
 
 Use this for almost every change before you stop.
+
+## Linux CLI compatibility fixture
+
+The Linux path is CLI-only. It must not require `mere.run.app`, SwiftUI, the
+macOS installer, or DMG packaging.
+
+Baseline runner packages:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y clang cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
+```
+
+Media probing and conversion should use `ffmpeg` and `ffprobe` from `PATH`.
+When tests or runners need explicit binaries, set:
+
+```bash
+export MERERUN_FFMPEG=/usr/bin/ffmpeg
+export MERERUN_FFPROBE=/usr/bin/ffprobe
+```
+
+The pull-request fixture should stay CPU MLX-compatible. CUDA machines can run
+additional local smoke tests, but CUDA installation, driver selection, and GPU
+availability are not assumptions in the shared CI contract.
+
+MediaIO coverage has two layers. `Tests/MereRunCoreTests/MediaIOTests.swift`
+covers pure Swift image, WAV, and FFT behavior in the normal test suite.
+`scripts/check-linux.sh` also runs the hidden `MediaIOSmoke` SwiftPM executable
+to exercise Linux `ffmpeg`/`ffprobe` image, audio, MP4, mux, and frame
+extraction paths without requiring host media files or model checkpoints.
 
 ## End-to-end smoke tests
 
@@ -79,6 +114,7 @@ when you changed:
 | `./scripts/check.sh` | public CLI regressions, docs hygiene issues, command-tree drift |
 | `./scripts/e2e_smoke.sh --core` | common runtime-path failures against real models |
 | `./scripts/e2e_smoke.sh --installed` | installed-model breakage across the full local matrix |
+| Linux CLI fixture | headless CLI/media compatibility without macOS app or CUDA assumptions |
 
 ## Recommended combinations
 
@@ -117,6 +153,16 @@ swift test
 ./scripts/check.sh
 ./scripts/e2e_smoke.sh --installed
 ```
+
+### Linux CLI compatibility docs or fixtures
+
+```bash
+swift run mere.run --help
+```
+
+If the change only updates Linux documentation, the CI docs fixture is enough.
+If the change adds Linux-compatible code, include the focused unit test or stub
+fixture result that exercises the new behavior.
 
 ## Troubleshooting
 

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-linux.sh [--manifest-only] [--help]
+
+Validate the Linux package/native plumbing for the mere.run CLI.
+
+Options:
+  --manifest-only  Only validate the Linux Package.swift view.
+  -h, --help       Show this help.
+
+Environment:
+  MERERUN_CHECK_LINUX_ALLOW_NON_LINUX=1   Allow --manifest-only from macOS.
+  MERERUN_CHECK_LINUX_MANIFEST_ONLY=1     Same as --manifest-only.
+USAGE
+}
+
+manifest_only="${MERERUN_CHECK_LINUX_MANIFEST_ONLY:-0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest-only)
+      manifest_only=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[check-linux] error: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+host_os="$(uname -s)"
+if [[ "$host_os" != "Linux" ]]; then
+  if [[ "${MERERUN_CHECK_LINUX_ALLOW_NON_LINUX:-0}" != "1" ]]; then
+    echo "[check-linux] error: this check must run on Linux." >&2
+    echo "[check-linux] set MERERUN_CHECK_LINUX_ALLOW_NON_LINUX=1 with --manifest-only for a macOS manifest smoke." >&2
+    exit 64
+  fi
+  manifest_only=1
+fi
+
+missing_tools=()
+for required_tool in swift rg; do
+  if ! command -v "$required_tool" >/dev/null 2>&1; then
+    missing_tools+=("$required_tool")
+  fi
+done
+
+if (( ${#missing_tools[@]} > 0 )); then
+  printf '[check-linux] missing tools: %s\n' "${missing_tools[*]}" >&2
+  exit 127
+fi
+
+package_json="$(mktemp "${TMPDIR:-/tmp}/mere-run-linux-package.XXXXXX")"
+cleanup() {
+  rm -f "$package_json"
+}
+trap cleanup EXIT
+
+check_linux_package_view() {
+  MERERUN_PACKAGE_PLATFORM=linux swift package dump-package >"$package_json"
+
+  if rg -q '"name" : "mere.run.app"|vendor/llama\.xcframework|"linkedFramework"' "$package_json"; then
+    echo "[check-linux] Linux package view still exposes the app, xcframework llama, or framework links." >&2
+    exit 1
+  fi
+}
+
+if [[ "$manifest_only" == "1" ]]; then
+  check_linux_package_view
+  bash ./scripts/prepare-linux-native.sh --check
+  echo "[check-linux] manifest-only Linux package smoke passed."
+  exit 0
+fi
+
+missing_tools=()
+for required_tool in cc ffmpeg ffprobe gzip pkg-config timeout unzip zip; do
+  if ! command -v "$required_tool" >/dev/null 2>&1; then
+    missing_tools+=("$required_tool")
+  fi
+done
+if ! printf '#include <cblas.h>\n' | cc -E -xc - >/dev/null 2>&1; then
+  missing_tools+=("cblas.h (install libopenblas-dev)")
+fi
+if ! printf '#include <lapack.h>\n' | cc -E -xc - >/dev/null 2>&1; then
+  missing_tools+=("lapack.h (install liblapacke-dev)")
+fi
+if [[ "$(cc -print-file-name=libgfortran.so)" == "libgfortran.so" ]]; then
+  missing_tools+=("libgfortran.so (install gfortran)")
+fi
+
+if (( ${#missing_tools[@]} > 0 )); then
+  printf '[check-linux] missing tools: %s\n' "${missing_tools[*]}" >&2
+  exit 127
+fi
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    arch="x86_64"
+    ;;
+  aarch64|arm64)
+    arch="arm64"
+    ;;
+  *)
+    echo "[check-linux] error: unsupported Linux architecture: $(uname -m)" >&2
+    exit 65
+    ;;
+esac
+
+bash ./scripts/prepare-linux-native.sh
+native_root="$repo_root/.build/native/linux-$arch"
+export PKG_CONFIG_PATH="$native_root/pkgconfig:${PKG_CONFIG_PATH:-}"
+export LIBRARY_PATH="$native_root/llama/lib:${LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="$native_root/llama/lib:${LD_LIBRARY_PATH:-}"
+
+check_linux_package_view
+swift build --product mere.run
+swift build --build-tests
+timeout 120s swift run MediaIOSmoke
+
+run_installer_fixture() {
+  local fixture_root
+  local source_dir
+  local dest_dir
+  fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/mere-run-linux-install.XXXXXX")"
+  source_dir="$fixture_root/source"
+  dest_dir="$fixture_root/dest"
+  mkdir -p "$source_dir" "$dest_dir"
+  trap "rm -rf '$fixture_root'; cleanup" EXIT
+
+  cp scripts/install.sh "$source_dir/install.sh"
+  chmod +x "$source_dir/install.sh"
+  cat >"$source_dir/mere.run" <<'EOF'
+#!/usr/bin/env bash
+echo "mere.run fixture"
+EOF
+  chmod +x "$source_dir/mere.run"
+  printf 'fake shared library\n' >"$source_dir/libmere_native.so"
+
+  MERERUN_INSTALL_BIN_DEST="$dest_dir/mere.run" \
+    MERERUN_INSTALL_PLATFORM=Linux \
+    MERERUN_INSTALL_DISABLE_DITTO=1 \
+    bash "$source_dir/install.sh" >/dev/null
+
+  [[ -x "$dest_dir/mere.run" ]]
+  [[ -f "$dest_dir/libmere_native.so" ]]
+}
+
+run_installer_fixture
+
+mere_run_bin=".build/debug/mere.run"
+if [[ ! -x "$mere_run_bin" ]]; then
+  echo "[check-linux] expected built executable at $mere_run_bin." >&2
+  exit 1
+fi
+
+"$mere_run_bin" --help >/dev/null
+"$mere_run_bin" guide --help >/dev/null
+"$mere_run_bin" image generate --help >/dev/null
+"$mere_run_bin" image validate --help >/dev/null
+"$mere_run_bin" text chat --help >/dev/null
+"$mere_run_bin" text code --help >/dev/null
+"$mere_run_bin" text embed --help >/dev/null
+"$mere_run_bin" speech synthesize --help >/dev/null
+"$mere_run_bin" speech transcribe --help >/dev/null
+"$mere_run_bin" speech profile --help >/dev/null
+"$mere_run_bin" vision inspect --help >/dev/null
+"$mere_run_bin" vision ocr --help >/dev/null
+"$mere_run_bin" music generate --help >/dev/null
+"$mere_run_bin" video generate --help >/dev/null
+"$mere_run_bin" video export-latents --help >/dev/null
+"$mere_run_bin" model --help >/dev/null
+"$mere_run_bin" status --help >/dev/null
+"$mere_run_bin" api serve --help >/dev/null
+
+model_list_output="$("$mere_run_bin" model list)"
+rg -q '^ID +Category +Status +Size$' <<<"$model_list_output"
+rg -q '^image-klein-max +image +' <<<"$model_list_output"
+
+status_output="$("$mere_run_bin" status --timeout-seconds 0.1)"
+rg -q '^mere\.run status$' <<<"$status_output"
+rg -q '^  server: ' <<<"$status_output"
+rg -q '^  model store: ' <<<"$status_output"
+rg -q '^  installed models: ' <<<"$status_output"

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -125,6 +125,7 @@ export LIBRARY_PATH="$native_root/llama/lib:${LIBRARY_PATH:-}"
 export LD_LIBRARY_PATH="$native_root/llama/lib:${LD_LIBRARY_PATH:-}"
 
 check_linux_package_view
+mkdir -p ".build/${arch}-unknown-linux-gnu/debug/index/store"
 swift build --disable-index-store --product mere.run
 swift build --disable-index-store --build-tests
 timeout 120s swift run --disable-index-store MediaIOSmoke

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -125,10 +125,9 @@ export LIBRARY_PATH="$native_root/llama/lib:${LIBRARY_PATH:-}"
 export LD_LIBRARY_PATH="$native_root/llama/lib:${LD_LIBRARY_PATH:-}"
 
 check_linux_package_view
-mkdir -p ".build/${arch}-unknown-linux-gnu/debug/index/store"
 swift build --disable-index-store --product mere.run
-swift build --disable-index-store --build-tests
-timeout 120s swift run --disable-index-store MediaIOSmoke
+swift build --disable-index-store --product MediaIOSmoke
+timeout 120s swift run --disable-index-store --skip-build MediaIOSmoke
 
 run_installer_fixture() {
   local fixture_root

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -125,9 +125,9 @@ export LIBRARY_PATH="$native_root/llama/lib:${LIBRARY_PATH:-}"
 export LD_LIBRARY_PATH="$native_root/llama/lib:${LD_LIBRARY_PATH:-}"
 
 check_linux_package_view
-swift build --product mere.run
-swift build --build-tests
-timeout 120s swift run MediaIOSmoke
+swift build --disable-index-store --product mere.run
+swift build --disable-index-store --build-tests
+timeout 120s swift run --disable-index-store MediaIOSmoke
 
 run_installer_fixture() {
   local fixture_root

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$(uname -s)" == "Linux" ]]; then
+  exec bash "$repo_root/scripts/check-linux.sh" "$@"
+fi
+
 for homebrew_bin in /opt/homebrew/bin /usr/local/bin; do
   if [[ -d "$homebrew_bin" && ":$PATH:" != *":$homebrew_bin:"* ]]; then
     PATH="$homebrew_bin:$PATH"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -100,26 +100,53 @@ cleanup() {
 }
 trap cleanup EXIT
 
-cp "$cli_executable" "$staging/mere.run"
+cp -a "$cli_executable" "$staging/mere.run"
 chmod +x "$staging/mere.run"
 
 # Colocated runtime assets that mere.run looks for next to its binary.
 # Each is optional: skipped silently if not built or not present in vendor/.
-for asset in \
-  "${build_dir}/llama.framework" \
-  "${build_dir}/mlx-swift_Cmlx.bundle" \
-  "${build_dir}/Resources"
-do
+stage_asset() {
+  local asset="$1"
   if [[ -e "$asset" ]]; then
-    cp -R "$asset" "$staging/"
+    cp -a "$asset" "$staging/"
   fi
-done
+}
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  for asset in \
+    "${build_dir}/llama.framework" \
+    "${build_dir}/mlx-swift_Cmlx.bundle" \
+    "${build_dir}/Resources" \
+    "${build_dir}"/*.dylib
+  do
+    stage_asset "$asset"
+  done
+else
+  native_lib_dir="${repo_root}/.build/native/linux-$(uname -m)/llama/lib"
+  case "$(uname -m)" in
+    x86_64|amd64)
+      native_lib_dir="${repo_root}/.build/native/linux-x86_64/llama/lib"
+      ;;
+    aarch64|arm64)
+      native_lib_dir="${repo_root}/.build/native/linux-arm64/llama/lib"
+      ;;
+  esac
+  for asset in \
+    "${build_dir}"/*.so \
+    "${build_dir}"/*.so.*
+  do
+    stage_asset "$asset"
+  done
+  if [[ -d "$native_lib_dir" ]]; then
+    cp -a "$native_lib_dir" "$staging/lib"
+  fi
+fi
 
 # vendor/ds4 is the bundled DeepSeek V4 Flash inference engine spawned by the
 # premier agent tier. install.sh expects it at vendor/ds4 under SOURCE_DIR.
 if [[ -d "${repo_root}/vendor/ds4" ]]; then
   mkdir -p "$staging/vendor"
-  cp -R "${repo_root}/vendor/ds4" "$staging/vendor/ds4"
+  cp -a "${repo_root}/vendor/ds4" "$staging/vendor/ds4"
 fi
 
 echo "[install-local] staged $(du -sh "$staging" | cut -f1) of payload at $staging"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,7 @@ Install the packaged mere.run CLI and colocated runtime assets.
 Environment:
   MERERUN_INSTALL_BIN_DEST     Override install path (default: /usr/local/bin/mere.run)
   MERERUN_INSTALL_SOURCE_DIR   Override packaged CLI directory (default: ./CLI if present)
+  MERERUN_INSTALL_SKIP_VERIFY  Skip running the installed binary when set to 1
 USAGE
 }
 
@@ -47,16 +48,68 @@ fi
 
 echo "[mere.run] installing mere.run..."
 echo "[mere.run] source: $SOURCE_DIR"
+install_platform="${MERERUN_INSTALL_PLATFORM:-$(uname -s)}"
 
 copy_path() {
   local src="$1"
   local dest_dir="$2"
   local base
   base="$(basename "$src")"
+  local dest="$dest_dir/$base"
 
   mkdir -p "$dest_dir"
-  rm -rf "$dest_dir/$base"
-  ditto "$src" "$dest_dir/$base"
+  rm -rf "$dest"
+  if [[ "${MERERUN_INSTALL_DISABLE_DITTO:-0}" != "1" ]] && command -v ditto >/dev/null 2>&1; then
+    ditto "$src" "$dest"
+  else
+    cp -a "$src" "$dest"
+  fi
+}
+
+copy_path_sudo() {
+  local src="$1"
+  local dest_dir="$2"
+  local base
+  base="$(basename "$src")"
+  local dest="$dest_dir/$base"
+
+  sudo mkdir -p "$dest_dir"
+  sudo rm -rf "$dest"
+  if [[ "${MERERUN_INSTALL_DISABLE_DITTO:-0}" != "1" ]] && command -v ditto >/dev/null 2>&1; then
+    sudo ditto "$src" "$dest"
+  else
+    sudo cp -a "$src" "$dest"
+  fi
+}
+
+copy_to_path() {
+  local src="$1"
+  local dest="$2"
+  local dest_dir
+  dest_dir="$(dirname "$dest")"
+
+  mkdir -p "$dest_dir"
+  rm -rf "$dest"
+  if [[ "${MERERUN_INSTALL_DISABLE_DITTO:-0}" != "1" ]] && command -v ditto >/dev/null 2>&1; then
+    ditto "$src" "$dest"
+  else
+    cp -a "$src" "$dest"
+  fi
+}
+
+copy_to_path_sudo() {
+  local src="$1"
+  local dest="$2"
+  local dest_dir
+  dest_dir="$(dirname "$dest")"
+
+  sudo mkdir -p "$dest_dir"
+  sudo rm -rf "$dest"
+  if [[ "${MERERUN_INSTALL_DISABLE_DITTO:-0}" != "1" ]] && command -v ditto >/dev/null 2>&1; then
+    sudo ditto "$src" "$dest"
+  else
+    sudo cp -a "$src" "$dest"
+  fi
 }
 
 can_install_without_sudo=false
@@ -66,20 +119,37 @@ fi
 
 # Install binary
 if [[ "$can_install_without_sudo" == true ]]; then
-  copy_path "$BIN_SRC" "$BIN_DEST_DIR"
+  copy_to_path "$BIN_SRC" "$BIN_DEST"
   chmod +x "$BIN_DEST"
 else
   echo "[mere.run] need sudo to write to $BIN_DEST_DIR"
-  sudo mkdir -p "$BIN_DEST_DIR"
-  sudo rm -f "$BIN_DEST"
-  sudo ditto "$BIN_SRC" "$BIN_DEST"
+  copy_to_path_sudo "$BIN_SRC" "$BIN_DEST"
   sudo chmod +x "$BIN_DEST"
 fi
 
 # Install colocated runtime assets needed by the CLI.
-shopt -s nullglob
-support_items=("$SOURCE_DIR"/*.framework "$SOURCE_DIR"/*.bundle)
-shopt -u nullglob
+support_items=()
+if [[ "$install_platform" == "Darwin" ]]; then
+  for item in \
+    "$SOURCE_DIR"/*.framework \
+    "$SOURCE_DIR"/*.bundle \
+    "$SOURCE_DIR"/*.dylib
+  do
+    if [[ -e "$item" ]]; then
+      support_items+=("$item")
+    fi
+  done
+else
+  for item in \
+    "$SOURCE_DIR"/*.so \
+    "$SOURCE_DIR"/*.so.* \
+    "$SOURCE_DIR"/lib
+  do
+    if [[ -e "$item" ]]; then
+      support_items+=("$item")
+    fi
+  done
+fi
 
 if (( ${#support_items[@]} > 0 )); then
   echo "[mere.run] installing runtime assets..."
@@ -89,9 +159,7 @@ if (( ${#support_items[@]} > 0 )); then
     done
   else
     for item in "${support_items[@]}"; do
-      base="$(basename "$item")"
-      sudo rm -rf "$BIN_DEST_DIR/$base"
-      sudo ditto "$item" "$BIN_DEST_DIR/$base"
+      copy_path_sudo "$item" "$BIN_DEST_DIR"
     done
   fi
 fi
@@ -105,22 +173,17 @@ if [[ ! -d "$DS4_SRC" ]]; then
 fi
 if [[ -d "$DS4_SRC" ]]; then
   echo "[mere.run] installing DS4 inference binaries..."
-  DS4_DEST="$BIN_DEST_DIR/vendor/ds4"
   if [[ "$can_install_without_sudo" == true ]]; then
-    mkdir -p "$DS4_DEST"
-    rm -rf "$DS4_DEST"
-    ditto "$DS4_SRC" "$DS4_DEST"
+    copy_path "$DS4_SRC" "$BIN_DEST_DIR/vendor"
   else
-    sudo mkdir -p "$DS4_DEST"
-    sudo rm -rf "$DS4_DEST"
-    sudo ditto "$DS4_SRC" "$DS4_DEST"
+    copy_path_sudo "$DS4_SRC" "$BIN_DEST_DIR/vendor"
   fi
 fi
 
 # Install MLX Metal shader resources alongside the binary.
 # mlx-swift looks for metallib files in a Resources/ directory next to the executable.
 MLX_BUNDLE="$BIN_DEST_DIR/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
-if [[ -f "$MLX_BUNDLE" ]]; then
+if [[ "$install_platform" == "Darwin" && -f "$MLX_BUNDLE" ]]; then
   echo "[mere.run] installing MLX Metal shaders..."
   RESOURCES_DIR="$BIN_DEST_DIR/Resources"
   if [[ "$can_install_without_sudo" == true ]]; then
@@ -148,7 +211,9 @@ fi
 echo ""
 
 # Verify
-if [[ -x "$BIN_DEST" ]]; then
+if [[ "${MERERUN_INSTALL_SKIP_VERIFY:-0}" == "1" ]]; then
+  echo "[mere.run] verification skipped."
+elif [[ -x "$BIN_DEST" ]]; then
   echo "[mere.run] verification:"
   "$BIN_DEST" --help | head -3
   echo ""

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -13,8 +13,9 @@ The script builds a pinned llama.cpp shared-library install into:
 It also writes a pkg-config file at:
   .build/native/linux-<arch>/pkgconfig/llama.pc
 
-On Linux it also resolves SwiftPM dependencies and applies a small mlx-swift
-SwiftPM package fix needed for the MLXNN/MLXFast CPU build path.
+On Linux it also resolves SwiftPM dependencies for CPU builds. CUDA builds validate
+upstream mlx-swift's CMake lane and print a SwiftPM bridge environment that makes
+mere.run consume those prebuilt CUDA artifacts.
 
 Options:
   --check     Verify the current native layout without building.
@@ -42,6 +43,10 @@ Environment:
   MERERUN_SKIP_MLX_CUDA_SMOKE=1
                               Skip the mlx-swift CMake CUDA smoke when
                               MERERUN_LINUX_ACCEL=cuda.
+  MERERUN_MLX_SWIFT_LINKAGE=cuda-prebuilt
+                              Package.swift mode that consumes CMake-built
+                              mlx-swift CUDA artifacts instead of SwiftPM mlx.
+                              prepare-linux-native.sh prints the full export set.
   MERERUN_DS4_LINUX_BIN_DIR   Optional directory containing Linux ds4 binaries
                               to stage under vendor/ds4/linux-<arch>/.
 USAGE
@@ -211,8 +216,8 @@ build_llama() {
 }
 
 patch_mlx_swift_for_linux() {
-  if [[ "${MERERUN_SKIP_MLX_SWIFT_PATCH:-0}" == "1" ]]; then
-    echo "[prepare-linux-native] skipping mlx-swift SwiftPM package fix by request."
+  if [[ "${MERERUN_SKIP_MLX_SWIFT_PATCH:-0}" == "1" || "$linux_accel" == "cuda" ]]; then
+    echo "[prepare-linux-native] skipping mlx-swift SwiftPM package fix; CUDA builds use the CMake prebuilt bridge."
     return
   fi
 
@@ -370,16 +375,103 @@ smoke_mlx_swift_cuda() {
     echo "[prepare-linux-native] warning: mlx-swift CUDA build finished but example1 was not produced; CUDA is not wired into SwiftPM package consumption yet." >&2
   fi
 
-  cat <<'NOTICE'
+  cat <<NOTICE
 [prepare-linux-native] MLX CUDA CMake smoke completed.
-[prepare-linux-native] Note: this validates upstream mlx-swift's Linux/CMake CUDA lane only.
-[prepare-linux-native] The mere.run SwiftPM package still consumes mlx-swift through SwiftPM,
-[prepare-linux-native] whose Linux path remains CPU-oriented until a package bridge is added.
+[prepare-linux-native] The CMake-built MLX Swift artifacts are available for SwiftPM builds via:
+  export MERERUN_MLX_SWIFT_LINKAGE="cuda-prebuilt"
+  export MERERUN_MLX_SWIFT_BUILD_DIR="$mlx_cmake_build"
+  export MERERUN_MLX_SWIFT_SOURCE_DIR="$mlx_cmake_src"
 NOTICE
 }
 
+mlx_swift_cuda_link_flags() {
+  local mlx_cmake_build="$native_root/build/mlx-swift-cuda-smoke"
+  local local_openblas_root="$native_root/deps/apt-root"
+  local flags=()
+
+  flags+=("-L" "$mlx_cmake_build/_deps/mlx-c-build")
+  flags+=("-L" "$mlx_cmake_build/_deps/mlx-build")
+  flags+=("-L" "$mlx_cmake_build/_deps/mlx-build/mlx/io")
+  flags+=("-L" "$mlx_cmake_build/lib")
+
+  if [[ -f "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so" ]]; then
+    flags+=("-L" "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread")
+  fi
+  if [[ -n "${CUDNN_LIBRARY_PATH:-}" ]]; then
+    flags+=("-L" "$CUDNN_LIBRARY_PATH")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$CUDNN_LIBRARY_PATH")
+    for cudnn_lib in \
+      libcudnn.so.9 \
+      libcudnn_graph.so.9 \
+      libcudnn_engines_runtime_compiled.so.9 \
+      libcudnn_ops.so.9 \
+      libcudnn_cnn.so.9 \
+      libcudnn_adv.so.9 \
+      libcudnn_engines_precompiled.so.9 \
+      libcudnn_heuristic.so.9; do
+      if [[ -f "$CUDNN_LIBRARY_PATH/$cudnn_lib" ]]; then
+        flags+=("$CUDNN_LIBRARY_PATH/$cudnn_lib")
+      fi
+    done
+  fi
+  if [[ -d /usr/lib/x86_64-linux-gnu ]]; then
+    flags+=("-L" "/usr/lib/x86_64-linux-gnu")
+  fi
+
+  flags+=(
+    "-lcublasLt"
+    "-lnvrtc"
+    "-lcuda"
+    "-lcudart"
+    "-lnccl"
+    "-lrt"
+  )
+
+  printf '%q ' "${flags[@]}"
+}
+
+verify_mlx_swift_cuda_bridge() {
+  if [[ "$linux_accel" != "cuda" || "${MERERUN_SKIP_MLX_CUDA_SMOKE:-0}" == "1" ]]; then
+    return
+  fi
+
+  local mlx_cmake_src="$repo_root/.build/native/src/mlx-swift"
+  local mlx_cmake_build="$native_root/build/mlx-swift-cuda-smoke"
+  local missing=0
+  local required_paths=(
+    "$mlx_cmake_src/Source/Cmlx/include/module.modulemap"
+    "$mlx_cmake_build/MLX.swiftmodule"
+    "$mlx_cmake_build/MLXFast.swiftmodule"
+    "$mlx_cmake_build/MLXNN.swiftmodule"
+    "$mlx_cmake_build/MLXRandom.swiftmodule"
+    "$mlx_cmake_build/MLXOptimizers.swiftmodule"
+    "$mlx_cmake_build/libMLX.a"
+    "$mlx_cmake_build/libMLXFast.a"
+    "$mlx_cmake_build/libMLXNN.a"
+    "$mlx_cmake_build/libMLXRandom.a"
+    "$mlx_cmake_build/libMLXOptimizers.a"
+    "$mlx_cmake_build/_deps/mlx-c-build/libmlxc.a"
+    "$mlx_cmake_build/_deps/mlx-build/libmlx.a"
+    "$mlx_cmake_build/_deps/mlx-build/mlx/io/libgguflib.a"
+    "$mlx_cmake_build/lib/libNumerics.a"
+    "$mlx_cmake_build/lib/libComplexModule.a"
+    "$mlx_cmake_build/lib/libRealModule.a"
+  )
+
+  for path in "${required_paths[@]}"; do
+    if [[ ! -e "$path" ]]; then
+      echo "[prepare-linux-native] error: missing MLX Swift CUDA bridge artifact: $path" >&2
+      missing=1
+    fi
+  done
+  if [[ "$missing" == "1" ]]; then
+    exit 69
+  fi
+}
+
 verify_mlx_swift_patch() {
-  if [[ "${MERERUN_SKIP_MLX_SWIFT_PATCH:-0}" == "1" ]]; then
+  if [[ "${MERERUN_SKIP_MLX_SWIFT_PATCH:-0}" == "1" || "$linux_accel" == "cuda" ]]; then
     return
   fi
 
@@ -421,6 +513,7 @@ fi
 
 verify_llama
 verify_mlx_swift_patch
+verify_mlx_swift_cuda_bridge
 
 cat <<EOF
 [prepare-linux-native] Linux-native layout ready for $platform_dir (accel: $linux_accel).
@@ -432,8 +525,13 @@ Export these before building/running the Linux CLI:
 EOF
 
 if [[ "$linux_accel" == "cuda" ]]; then
-  cat <<'EOF'
+  mlx_link_flags="$(mlx_swift_cuda_link_flags)"
+  cat <<EOF
   export MERERUN_LINUX_ACCEL="cuda"
+  export MERERUN_MLX_SWIFT_LINKAGE="cuda-prebuilt"
+  export MERERUN_MLX_SWIFT_BUILD_DIR="$native_root/build/mlx-swift-cuda-smoke"
+  export MERERUN_MLX_SWIFT_SOURCE_DIR="$repo_root/.build/native/src/mlx-swift"
+  export MERERUN_MLX_SWIFT_LINK_FLAGS="$mlx_link_flags"
   # Optional: cap llama.cpp GPU offload layers instead of the default all-layers setting.
   # export MERERUN_LLAMA_GPU_LAYERS="999"
 EOF

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -112,6 +112,7 @@ llama_build="$native_root/build/llama.cpp"
 llama_commit="${LLAMA_CPP_COMMIT:-6d957078270f58d4ea14e8c205f5ef4e49be33f3}"
 llama_url="${LLAMA_CPP_URL:-https://github.com/ggml-org/llama.cpp.git}"
 mlx_swift_checkout="$repo_root/.build/checkouts/mlx-swift"
+swift_numerics_checkout="$repo_root/.build/checkouts/swift-numerics"
 linux_accel="${MERERUN_LINUX_ACCEL:-cpu}"
 case "$linux_accel" in
   cpu|cuda)
@@ -236,6 +237,15 @@ patch_mlx_swift_for_linux() {
   fi
   if grep -Fq '"MLXFast.swift",' "$package_file"; then
     sed -i '/"MLXFast.swift",/d;/"MLXFastKernel.swift",/d' "$package_file"
+  fi
+
+  local numerics_header="$swift_numerics_checkout/Sources/_NumericsShims/include/_NumericsShims.h"
+  local numerics_float16="$swift_numerics_checkout/Sources/RealModule/Float16+Real.swift"
+  if [[ -f "$numerics_header" ]] && grep -Fq '#if !defined __wasm__ // No _Float16 on wasm' "$numerics_header"; then
+    sed -i 's/#if !defined __wasm__ \/\/ No _Float16 on wasm/#if !defined __wasm__ \&\& defined(__FLT16_MANT_DIG__) \/\/ No _Float16 on wasm, or on targets whose C compiler lacks _Float16/' "$numerics_header"
+  fi
+  if [[ -f "$numerics_float16" ]] && grep -Fq '#if !arch(wasm32)' "$numerics_float16"; then
+    sed -i 's/#if !arch(wasm32)/#if !arch(wasm32) \&\& !(os(Linux) \&\& arch(x86_64))/' "$numerics_float16"
   fi
 
   echo "[prepare-linux-native] mlx-swift SwiftPM package fix applied."

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prepare-linux-native.sh [--check] [--help]
+
+Build or verify Linux-native runtime artifacts for the mere.run CLI.
+
+The script builds a pinned llama.cpp shared-library install into:
+  .build/native/linux-<arch>/llama
+
+It also writes a pkg-config file at:
+  .build/native/linux-<arch>/pkgconfig/llama.pc
+
+On Linux it also resolves SwiftPM dependencies and applies a small mlx-swift
+SwiftPM package fix needed for the MLXNN/MLXFast CPU build path.
+
+Options:
+  --check     Verify the current native layout without building.
+  -h, --help  Show this help.
+
+Environment:
+  LLAMA_CPP_COMMIT            Override pinned llama.cpp commit.
+  LLAMA_CPP_URL               Override llama.cpp git URL.
+  MERERUN_SKIP_MLX_SWIFT_PATCH=1
+                              Skip the Linux mlx-swift SwiftPM package fix.
+  MERERUN_DS4_LINUX_BIN_DIR   Optional directory containing Linux ds4 binaries
+                              to stage under vendor/ds4/linux-<arch>/.
+USAGE
+}
+
+check_only=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      check_only=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[prepare-linux-native] error: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+host_os="$(uname -s)"
+if [[ "$host_os" != "Linux" ]]; then
+  echo "[prepare-linux-native] non-Linux host; skipping Linux-native asset preparation."
+  exit 0
+fi
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    arch="x86_64"
+    ;;
+  aarch64|arm64)
+    arch="arm64"
+    ;;
+  *)
+    echo "[prepare-linux-native] error: unsupported Linux architecture: $(uname -m)" >&2
+    exit 65
+    ;;
+esac
+
+require_tool() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "[prepare-linux-native] error: required tool not found in PATH: $tool" >&2
+    exit 127
+  fi
+}
+
+platform_dir="linux-$arch"
+native_root="$repo_root/.build/native/$platform_dir"
+llama_prefix="$native_root/llama"
+pkgconfig_dir="$native_root/pkgconfig"
+llama_pc="$pkgconfig_dir/llama.pc"
+llama_src="$repo_root/.build/native/src/llama.cpp"
+llama_build="$native_root/build/llama.cpp"
+llama_commit="${LLAMA_CPP_COMMIT:-6d957078270f58d4ea14e8c205f5ef4e49be33f3}"
+llama_url="${LLAMA_CPP_URL:-https://github.com/ggml-org/llama.cpp.git}"
+mlx_swift_checkout="$repo_root/.build/checkouts/mlx-swift"
+
+stage_ds4() {
+  local ds4_root="$repo_root/vendor/ds4"
+  local ds4_platform_dir="$ds4_root/$platform_dir"
+
+  if [[ -n "${MERERUN_DS4_LINUX_BIN_DIR:-}" ]]; then
+    if [[ "$check_only" == "1" ]]; then
+      echo "[prepare-linux-native] --check set; not staging MERERUN_DS4_LINUX_BIN_DIR."
+    else
+      if [[ ! -d "$MERERUN_DS4_LINUX_BIN_DIR" ]]; then
+        echo "[prepare-linux-native] error: MERERUN_DS4_LINUX_BIN_DIR is not a directory: $MERERUN_DS4_LINUX_BIN_DIR" >&2
+        exit 66
+      fi
+      mkdir -p "$ds4_platform_dir"
+      cp -a "$MERERUN_DS4_LINUX_BIN_DIR"/. "$ds4_platform_dir"/
+      echo "[prepare-linux-native] staged DS4 binaries into vendor/ds4/$platform_dir"
+    fi
+  fi
+
+  if [[ -d "$ds4_platform_dir" ]]; then
+    for executable_name in ds4 ds4-bench ds4-server; do
+      executable_path="$ds4_platform_dir/$executable_name"
+      if [[ -f "$executable_path" ]]; then
+        chmod +x "$executable_path"
+      fi
+    done
+    if [[ ! -x "$ds4_platform_dir/ds4-server" ]]; then
+      echo "[prepare-linux-native] warning: vendor/ds4/$platform_dir/ds4-server is missing or not executable." >&2
+    fi
+  else
+    echo "[prepare-linux-native] warning: vendor/ds4/$platform_dir is not present; DS4 runtime lookup will fall back to PATH." >&2
+  fi
+}
+
+write_llama_pc() {
+  mkdir -p "$pkgconfig_dir"
+  cat >"$llama_pc" <<PC
+prefix=$llama_prefix
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: llama
+Description: llama.cpp runtime for mere.run
+Version: $llama_commit
+Libs: -L\${libdir} -l:libllama.so
+Cflags: -I\${includedir}
+PC
+}
+
+build_llama() {
+  require_tool git
+  require_tool cmake
+  require_tool pkg-config
+
+  mkdir -p "$(dirname "$llama_src")" "$llama_build" "$llama_prefix"
+
+  if [[ ! -d "$llama_src/.git" ]]; then
+    echo "[prepare-linux-native] cloning $llama_url"
+    git clone --filter=blob:none "$llama_url" "$llama_src"
+  fi
+
+  echo "[prepare-linux-native] checking out llama.cpp $llama_commit"
+  git -C "$llama_src" fetch --depth 1 origin "$llama_commit"
+  git -C "$llama_src" checkout --detach "$llama_commit"
+
+  echo "[prepare-linux-native] configuring llama.cpp"
+  cmake -S "$llama_src" -B "$llama_build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$llama_prefix" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DLLAMA_BUILD_TESTS=OFF \
+    -DLLAMA_BUILD_EXAMPLES=OFF \
+    -DLLAMA_CURL=OFF
+
+  echo "[prepare-linux-native] building llama.cpp"
+  cmake --build "$llama_build" --config Release --parallel "$(nproc)"
+
+  echo "[prepare-linux-native] installing llama.cpp into $llama_prefix"
+  cmake --install "$llama_build"
+  write_llama_pc
+}
+
+patch_mlx_swift_for_linux() {
+  if [[ "${MERERUN_SKIP_MLX_SWIFT_PATCH:-0}" == "1" ]]; then
+    echo "[prepare-linux-native] skipping mlx-swift SwiftPM package fix by request."
+    return
+  fi
+
+  require_tool swift
+  echo "[prepare-linux-native] resolving Swift package dependencies"
+  swift package resolve
+
+  local package_file="$mlx_swift_checkout/Package.swift"
+  if [[ ! -f "$package_file" ]]; then
+    echo "[prepare-linux-native] error: expected mlx-swift checkout at $mlx_swift_checkout" >&2
+    exit 68
+  fi
+
+  if grep -Fq '"mlx-c/mlx/c/fast.cpp",  // Exclude on Linux - calls metal_kernel unconditionally' "$package_file"; then
+    sed -i '/"mlx-c\/mlx\/c\/fast.cpp",  \/\/ Exclude on Linux - calls metal_kernel unconditionally/d' "$package_file"
+  fi
+  if grep -Fq '"MLXFast.swift",' "$package_file"; then
+    sed -i '/"MLXFast.swift",/d;/"MLXFastKernel.swift",/d' "$package_file"
+  fi
+
+  echo "[prepare-linux-native] mlx-swift SwiftPM package fix applied."
+}
+
+verify_mlx_swift_patch() {
+  if [[ "${MERERUN_SKIP_MLX_SWIFT_PATCH:-0}" == "1" ]]; then
+    return
+  fi
+
+  local package_file="$mlx_swift_checkout/Package.swift"
+  if [[ ! -f "$package_file" ]]; then
+    return
+  fi
+  if grep -Fq '"mlx-c/mlx/c/fast.cpp",  // Exclude on Linux - calls metal_kernel unconditionally' "$package_file" ||
+     grep -Fq '"MLXFast.swift",' "$package_file" ||
+     grep -Fq '"MLXFastKernel.swift",' "$package_file"; then
+    echo "[prepare-linux-native] error: mlx-swift checkout still has the Linux MLXFast exclusions." >&2
+    echo "[prepare-linux-native] rerun scripts/prepare-linux-native.sh before building." >&2
+    exit 68
+  fi
+}
+
+verify_llama() {
+  require_tool pkg-config
+  if [[ ! -f "$repo_root/Sources/llama/module.modulemap" ]]; then
+    echo "[prepare-linux-native] error: Sources/llama/module.modulemap is missing." >&2
+    exit 67
+  fi
+
+  export PKG_CONFIG_PATH="$pkgconfig_dir:${PKG_CONFIG_PATH:-}"
+  if ! pkg-config --exists llama; then
+    echo "[prepare-linux-native] error: pkg-config could not find llama." >&2
+    echo "[prepare-linux-native] run scripts/prepare-linux-native.sh or export PKG_CONFIG_PATH=$pkgconfig_dir:\$PKG_CONFIG_PATH" >&2
+    exit 67
+  fi
+}
+
+stage_ds4
+
+if [[ "$check_only" != "1" ]]; then
+  build_llama
+  patch_mlx_swift_for_linux
+fi
+
+verify_llama
+verify_mlx_swift_patch
+
+cat <<EOF
+[prepare-linux-native] Linux-native layout ready for $platform_dir.
+
+Export these before building/running the Linux CLI:
+  export PKG_CONFIG_PATH="$pkgconfig_dir:\${PKG_CONFIG_PATH:-}"
+  export LIBRARY_PATH="$llama_prefix/lib:\${LIBRARY_PATH:-}"
+  export LD_LIBRARY_PATH="$llama_prefix/lib:\${LD_LIBRARY_PATH:-}"
+EOF

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -23,8 +23,25 @@ Options:
 Environment:
   LLAMA_CPP_COMMIT            Override pinned llama.cpp commit.
   LLAMA_CPP_URL               Override llama.cpp git URL.
+  MERERUN_LINUX_ACCEL         Native acceleration mode. Set to cuda to build
+                              llama.cpp with GGML_CUDA=ON and run an optional
+                              mlx-swift CMake CUDA smoke. Default: cpu.
+  MERERUN_LLAMA_GPU_LAYERS    Override llama.cpp GPU offload layers on Linux.
+                              Defaults to all layers when MERERUN_LINUX_ACCEL=cuda
+                              and 0 otherwise.
+  CUDNN_INCLUDE_PATH          Optional cuDNN include directory for mlx-swift
+                              CMake CUDA smoke.
+  CUDNN_LIBRARY_PATH          Optional cuDNN library directory for mlx-swift
+                              CMake CUDA smoke.
+  BLAS_LIBRARIES              Optional BLAS library path for mlx-swift CUDA smoke.
+  BLAS_INCLUDE_DIRS           Optional BLAS include directory for mlx-swift CUDA smoke.
+  LAPACK_LIBRARIES            Optional LAPACK library path for mlx-swift CUDA smoke.
+  LAPACK_INCLUDE_DIRS         Optional LAPACK include directory for mlx-swift CUDA smoke.
   MERERUN_SKIP_MLX_SWIFT_PATCH=1
                               Skip the Linux mlx-swift SwiftPM package fix.
+  MERERUN_SKIP_MLX_CUDA_SMOKE=1
+                              Skip the mlx-swift CMake CUDA smoke when
+                              MERERUN_LINUX_ACCEL=cuda.
   MERERUN_DS4_LINUX_BIN_DIR   Optional directory containing Linux ds4 binaries
                               to stage under vendor/ds4/linux-<arch>/.
 USAGE
@@ -90,6 +107,15 @@ llama_build="$native_root/build/llama.cpp"
 llama_commit="${LLAMA_CPP_COMMIT:-6d957078270f58d4ea14e8c205f5ef4e49be33f3}"
 llama_url="${LLAMA_CPP_URL:-https://github.com/ggml-org/llama.cpp.git}"
 mlx_swift_checkout="$repo_root/.build/checkouts/mlx-swift"
+linux_accel="${MERERUN_LINUX_ACCEL:-cpu}"
+case "$linux_accel" in
+  cpu|cuda)
+    ;;
+  *)
+    echo "[prepare-linux-native] error: unsupported MERERUN_LINUX_ACCEL=$linux_accel (expected cpu or cuda)" >&2
+    exit 64
+    ;;
+esac
 
 stage_ds4() {
   local ds4_root="$repo_root/vendor/ds4"
@@ -156,14 +182,25 @@ build_llama() {
   git -C "$llama_src" fetch --depth 1 origin "$llama_commit"
   git -C "$llama_src" checkout --detach "$llama_commit"
 
-  echo "[prepare-linux-native] configuring llama.cpp"
-  cmake -S "$llama_src" -B "$llama_build" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX="$llama_prefix" \
-    -DBUILD_SHARED_LIBS=ON \
-    -DLLAMA_BUILD_TESTS=OFF \
-    -DLLAMA_BUILD_EXAMPLES=OFF \
+  local cmake_args=(
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX="$llama_prefix"
+    -DBUILD_SHARED_LIBS=ON
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
     -DLLAMA_CURL=OFF
+  )
+
+  if [[ "$linux_accel" == "cuda" ]]; then
+    require_tool nvcc
+    echo "[prepare-linux-native] enabling llama.cpp CUDA via GGML_CUDA=ON"
+    cmake_args+=(
+      -DGGML_CUDA=ON
+    )
+  fi
+
+  echo "[prepare-linux-native] configuring llama.cpp"
+  cmake -S "$llama_src" -B "$llama_build" "${cmake_args[@]}"
 
   echo "[prepare-linux-native] building llama.cpp"
   cmake --build "$llama_build" --config Release --parallel "$(nproc)"
@@ -197,6 +234,148 @@ patch_mlx_swift_for_linux() {
   fi
 
   echo "[prepare-linux-native] mlx-swift SwiftPM package fix applied."
+}
+
+smoke_mlx_swift_cuda() {
+  if [[ "$linux_accel" != "cuda" ]]; then
+    return
+  fi
+  if [[ "${MERERUN_SKIP_MLX_CUDA_SMOKE:-0}" == "1" ]]; then
+    echo "[prepare-linux-native] skipping mlx-swift CMake CUDA smoke by request."
+    return
+  fi
+
+  require_tool git
+  require_tool cmake
+  require_tool ninja
+  require_tool nvcc
+  require_tool swift
+
+  if [[ -z "${CUDA_HOME:-}" && -f /usr/include/cuda.h ]]; then
+    export CUDA_HOME=/usr
+  fi
+  if [[ -z "${CUDA_PATH:-}" && -n "${CUDA_HOME:-}" ]]; then
+    export CUDA_PATH="$CUDA_HOME"
+  fi
+
+  local mlx_cmake_src="$repo_root/.build/native/src/mlx-swift"
+  local mlx_cmake_build="$native_root/build/mlx-swift-cuda-smoke"
+
+  if [[ ! -d "$mlx_cmake_src/.git" ]]; then
+    echo "[prepare-linux-native] cloning mlx-swift for CMake CUDA smoke"
+    git clone --filter=blob:none https://github.com/ml-explore/mlx-swift.git "$mlx_cmake_src"
+  fi
+
+  echo "[prepare-linux-native] updating mlx-swift CMake checkout"
+  git -C "$mlx_cmake_src" fetch --depth 1 origin main
+  git -C "$mlx_cmake_src" checkout --detach FETCH_HEAD
+
+  local local_openblas_root="$native_root/deps/apt-root"
+  local local_openblas_lib="$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so"
+  local local_openblas_include="$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread;$local_openblas_root/usr/include"
+
+  if [[ ! -f "$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h" &&
+        ! -f /usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h &&
+        ! -f /usr/include/cblas.h ]]; then
+    if command -v apt-get >/dev/null 2>&1 && command -v dpkg-deb >/dev/null 2>&1; then
+      echo "[prepare-linux-native] downloading local OpenBLAS/LAPACK headers for mlx-swift CUDA smoke"
+      local apt_cache="$native_root/deps/apt-cache"
+      mkdir -p "$apt_cache" "$local_openblas_root"
+      (
+        cd "$apt_cache"
+        apt-get download libopenblas-dev libopenblas-pthread-dev libopenblas0-pthread liblapacke-dev liblapacke
+        for deb in *.deb; do
+          dpkg-deb -x "$deb" "$local_openblas_root"
+        done
+      )
+    else
+      echo "[prepare-linux-native] warning: OpenBLAS/LAPACK headers were not found; set BLAS_INCLUDE_DIRS/LAPACK_INCLUDE_DIRS or install libopenblas-dev liblapacke-dev." >&2
+    fi
+  fi
+  if [[ ! -f "$local_openblas_root/usr/include/lapack.h" &&
+        ! -f /usr/include/lapack.h ]]; then
+    if command -v apt-get >/dev/null 2>&1 && command -v dpkg-deb >/dev/null 2>&1; then
+      echo "[prepare-linux-native] downloading local LAPACK headers for mlx-swift CUDA smoke"
+      local apt_cache="$native_root/deps/apt-cache"
+      mkdir -p "$apt_cache" "$local_openblas_root"
+      (
+        cd "$apt_cache"
+        apt-get download liblapacke-dev liblapacke
+        for deb in *.deb; do
+          dpkg-deb -x "$deb" "$local_openblas_root"
+        done
+      )
+    fi
+  fi
+
+  local mlx_cmake_args=(
+    -DMLX_BUILD_METAL=OFF
+    -DMLX_BUILD_CUDA=ON
+    -DMLX_C_BUILD_EXAMPLES=OFF
+  )
+  if [[ -n "${CUDNN_INCLUDE_PATH:-}" ]]; then
+    mlx_cmake_args+=("-DCUDNN_INCLUDE_PATH=$CUDNN_INCLUDE_PATH")
+  fi
+  if [[ -n "${CUDNN_LIBRARY_PATH:-}" ]]; then
+    mlx_cmake_args+=("-DCUDNN_LIBRARY_PATH=$CUDNN_LIBRARY_PATH")
+  fi
+  local local_openblas_root="$native_root/deps/apt-root"
+  local local_openblas_lib="$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so"
+  local local_openblas_include="$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread;$local_openblas_root/usr/include"
+
+  if [[ -n "${BLAS_LIBRARIES:-}" ]]; then
+    mlx_cmake_args+=("-DBLAS_LIBRARIES=$BLAS_LIBRARIES")
+  elif [[ -f "$local_openblas_lib" ]]; then
+    mlx_cmake_args+=("-DBLAS_LIBRARIES=$local_openblas_lib")
+  elif [[ -f /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so ]]; then
+    mlx_cmake_args+=("-DBLAS_LIBRARIES=/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so")
+  elif [[ -f /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.12.0 ]]; then
+    mlx_cmake_args+=("-DBLAS_LIBRARIES=/usr/lib/x86_64-linux-gnu/blas/libblas.so.3.12.0")
+  fi
+  if [[ -n "${BLAS_INCLUDE_DIRS:-}" ]]; then
+    mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=$BLAS_INCLUDE_DIRS")
+  elif [[ -f "$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h" ]]; then
+    mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=$local_openblas_include")
+  elif [[ -d /usr/include/x86_64-linux-gnu/openblas-pthread ]]; then
+    mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=/usr/include/x86_64-linux-gnu/openblas-pthread")
+  fi
+  if [[ -n "${LAPACK_LIBRARIES:-}" ]]; then
+    mlx_cmake_args+=("-DLAPACK_LIBRARIES=$LAPACK_LIBRARIES")
+  elif [[ -f "$local_openblas_lib" ]]; then
+    mlx_cmake_args+=("-DLAPACK_LIBRARIES=$local_openblas_lib")
+  elif [[ -f /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so ]]; then
+    mlx_cmake_args+=("-DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so")
+  elif [[ -f /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.12.0 ]]; then
+    mlx_cmake_args+=("-DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.12.0")
+  fi
+  if [[ -n "${LAPACK_INCLUDE_DIRS:-}" ]]; then
+    mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=$LAPACK_INCLUDE_DIRS")
+  elif [[ -f "$local_openblas_root/usr/include/lapack.h" ]]; then
+    mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=$local_openblas_include")
+  elif [[ -d /usr/include/x86_64-linux-gnu/openblas-pthread ]]; then
+    mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=/usr/include/x86_64-linux-gnu/openblas-pthread")
+  fi
+
+  echo "[prepare-linux-native] configuring mlx-swift CUDA smoke via CMake"
+  cmake -S "$mlx_cmake_src" -B "$mlx_cmake_build" -G Ninja "${mlx_cmake_args[@]}"
+
+  echo "[prepare-linux-native] building mlx-swift CUDA smoke"
+  cmake --build "$mlx_cmake_build" --parallel "$(nproc)"
+
+  local example="$mlx_cmake_build/example1"
+  if [[ -x "$example" ]]; then
+    echo "[prepare-linux-native] running mlx-swift CUDA smoke example"
+    "$example" --device gpu
+  else
+    echo "[prepare-linux-native] warning: mlx-swift CUDA build finished but example1 was not produced; CUDA is not wired into SwiftPM package consumption yet." >&2
+  fi
+
+  cat <<'NOTICE'
+[prepare-linux-native] MLX CUDA CMake smoke completed.
+[prepare-linux-native] Note: this validates upstream mlx-swift's Linux/CMake CUDA lane only.
+[prepare-linux-native] The mere.run SwiftPM package still consumes mlx-swift through SwiftPM,
+[prepare-linux-native] whose Linux path remains CPU-oriented until a package bridge is added.
+NOTICE
 }
 
 verify_mlx_swift_patch() {
@@ -236,6 +415,7 @@ stage_ds4
 
 if [[ "$check_only" != "1" ]]; then
   build_llama
+  smoke_mlx_swift_cuda
   patch_mlx_swift_for_linux
 fi
 
@@ -243,10 +423,18 @@ verify_llama
 verify_mlx_swift_patch
 
 cat <<EOF
-[prepare-linux-native] Linux-native layout ready for $platform_dir.
+[prepare-linux-native] Linux-native layout ready for $platform_dir (accel: $linux_accel).
 
 Export these before building/running the Linux CLI:
   export PKG_CONFIG_PATH="$pkgconfig_dir:\${PKG_CONFIG_PATH:-}"
   export LIBRARY_PATH="$llama_prefix/lib:\${LIBRARY_PATH:-}"
   export LD_LIBRARY_PATH="$llama_prefix/lib:\${LD_LIBRARY_PATH:-}"
 EOF
+
+if [[ "$linux_accel" == "cuda" ]]; then
+  cat <<'EOF'
+  export MERERUN_LINUX_ACCEL="cuda"
+  # Optional: cap llama.cpp GPU offload layers instead of the default all-layers setting.
+  # export MERERUN_LLAMA_GPU_LAYERS="999"
+EOF
+fi


### PR DESCRIPTION
## Summary
- Adds Linux CLI compatibility plumbing for MediaIO and native llama.cpp builds.
- Adds `MERERUN_LINUX_ACCEL=cuda` native prep for CUDA-enabled llama.cpp.
- Bridges Linux SwiftPM builds to CMake-built `mlx-swift` CUDA artifacts with `MERERUN_MLX_SWIFT_LINKAGE=cuda-prebuilt`.
- Preserves the default SwiftPM/MLX dependency path for non-prebuilt builds.
- Adds portable native setup support for OpenBLAS/LAPACK/cuDNN and local tool staging.
- Repairs the Linux manifest dependency expression so Swift 6.0 can type-check the package manifest in CI.
- Hardens the Linux CLI CI gate for the Swift 6.0 Jammy container: disables index-store emission, creates the expected index-store directory, and patches the `swift-numerics` `_Float16` shim issue.

## CUDA runtime proof
- Built `llama.cpp` with CUDA native artifacts.
- Built `mlx-swift` CUDA CMake artifacts and linked the SwiftPM CLI against them.
- Built the full `mere.run` CLI product with the CUDA-prebuilt MLX bridge.
- Installed `image-zimage-nano` from `filipstrand/Z-Image-Turbo-mflux-4bit`, repaired the MereRun manifest, and generated images on CUDA MLX.

## Verification
- `bash -n scripts/prepare-linux-native.sh`
- `bash -n scripts/check-linux.sh`
- `git diff --check`
- `swift package describe`
- `MERERUN_MLX_SWIFT_LINKAGE=cuda-prebuilt swift package describe`
- `MERERUN_CHECK_LINUX_MANIFEST_ONLY=1 scripts/check-linux.sh`
- `swift build --disable-index-store --product MediaIOSmoke`
- `swift build --scratch-path .build-swiftpm-cuda --product mere.run`
- `mere.run model repair-manifests --models-root "$HOME/Library/Application Support/MereRun/models"`
- 1-step Z-image CUDA smoke generated a valid `256 x 256` PNG.
- 8-step Z-image CUDA smoke generated a valid `512 x 512` PNG (`460337` bytes).

## Runtime notes
For MLX CUDA runtime kernel compilation on Ubuntu, the working runtime env used:

```bash
export MERERUN_LINUX_ACCEL=cuda
export MLX_DEFAULT_DEVICE=gpu
export CUDA_HOME=/usr
export CUDA_PATH=/usr
export CPATH=/usr/include:${CPATH:-}
```

Using `/usr/lib/cuda` alone exposes `cuda.h` but can miss libcudacxx headers such as `cuda/std/tuple`; `/usr` resolves both header families on this host.
