### PR TITLE
fix: wrap Linux package runtime libraries

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -47,6 +47,9 @@ jobs:
             zip \
             zlib1g-dev
 
+      - name: Test packaging symlink handling
+        run: bash scripts/test-package-linux.sh
+
       - name: Build Linux packages
         env:
           MERERUN_RELEASE_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}

--- a/Tests/MereRunCLITests/InstallScriptTests.swift
+++ b/Tests/MereRunCLITests/InstallScriptTests.swift
@@ -172,6 +172,28 @@ final class InstallScriptTests: XCTestCase {
         )
     }
 
+    func testInstallerCopiesLinuxRuntimeBinaryWhenPresent() throws {
+        let fixture = try makeInstallerFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runtimeBinaryURL = fixture.sourceDirURL.appendingPathComponent("mere.run-bin", isDirectory: false)
+        try "fake runtime binary".write(to: runtimeBinaryURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: runtimeBinaryURL.path)
+
+        let result = try runInstaller(
+            scriptURL: fixture.installScriptURL,
+            binDestURL: fixture.destDirURL.appendingPathComponent("mere.run", isDirectory: false),
+            extraEnvironment: ["MERERUN_INSTALL_PLATFORM": "Linux"]
+        )
+
+        XCTAssertEqual(result.status, 0, result.combinedOutput)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: fixture.destDirURL.appendingPathComponent("mere.run-bin").path
+            )
+        )
+    }
+
     func testInstallerCopiesDS4RuntimeWhenPresent() throws {
         let fixture = try makeInstallerFixture()
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,6 +141,7 @@ if [[ "$install_platform" == "Darwin" ]]; then
   done
 else
   for item in \
+    "$SOURCE_DIR"/mere.run-bin \
     "$SOURCE_DIR"/*.so \
     "$SOURCE_DIR"/*.so.* \
     "$SOURCE_DIR"/lib

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -315,7 +315,10 @@ if [[ "${MERERUN_BUNDLE_SWIFT_LIBS:-1}" == "1" ]]; then
     [[ -f "$lib_path" ]] || continue
     case "$(basename "$lib_path")" in
       libswift*|libFoundation*|lib_Foundation*|libdispatch*|libBlocksRuntime*|libopenblas*)
-        cp -a "$lib_path" "$payload_dir/lib/"
+        resolved_lib_path="$(readlink -f "$lib_path")"
+        if [[ -f "$resolved_lib_path" ]]; then
+          cp -aL "$resolved_lib_path" "$payload_dir/lib/$(basename "$lib_path")"
+        fi
         ;;
     esac
   done < <(ldd "$payload_dir/mere.run-bin" 2>/dev/null | awk '/=> \/|^\// { for (i=1; i<=NF; i++) if ($i ~ /^\//) print $i }' | sort -u)

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -258,7 +258,25 @@ payload_name="mere-run-${version}-linux-${platform_arch}"
 payload_dir="$staging/$payload_name"
 mkdir -p "$payload_dir"
 
-cp -a "$cli_executable" "$payload_dir/mere.run"
+cp -a "$cli_executable" "$payload_dir/mere.run-bin"
+chmod +x "$payload_dir/mere.run-bin"
+cat >"$payload_dir/mere.run" <<'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+source_path="${BASH_SOURCE[0]}"
+while [[ -L "$source_path" ]]; do
+  source_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
+  link_target="$(readlink "$source_path")"
+  if [[ "$link_target" == /* ]]; then
+    source_path="$link_target"
+  else
+    source_path="$source_dir/$link_target"
+  fi
+done
+payload_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
+export LD_LIBRARY_PATH="$payload_dir/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$payload_dir/mere.run-bin" "$@"
+WRAPPER
 chmod +x "$payload_dir/mere.run"
 cp -a scripts/install.sh "$payload_dir/install.sh"
 chmod +x "$payload_dir/install.sh"
@@ -287,19 +305,20 @@ if [[ -d "$llama_prefix/lib" ]]; then
   cp -a "$llama_prefix/lib" "$payload_dir/lib"
 fi
 
-# Bundle Swift runtime shared libraries when the official Swift toolchain linked
-# them dynamically. This lets the tarball/deb run on clean Ubuntu hosts without
-# requiring users to install the Swift compiler toolchain first.
+# Bundle Swift/Foundation runtime shared libraries when the official Swift
+# toolchain linked them dynamically, plus OpenBLAS for tarball installs. This
+# lets the tarball/deb run on clean Ubuntu hosts without requiring users to
+# install the Swift compiler toolchain first.
 if [[ "${MERERUN_BUNDLE_SWIFT_LIBS:-1}" == "1" ]]; then
   mkdir -p "$payload_dir/lib"
   while IFS= read -r lib_path; do
     [[ -f "$lib_path" ]] || continue
     case "$(basename "$lib_path")" in
-      libswift*|libFoundation*|libdispatch*|libBlocksRuntime*)
+      libswift*|libFoundation*|lib_Foundation*|libdispatch*|libBlocksRuntime*|libopenblas*)
         cp -a "$lib_path" "$payload_dir/lib/"
         ;;
     esac
-  done < <(ldd "$payload_dir/mere.run" 2>/dev/null | awk '/=> \/|^\// { for (i=1; i<=NF; i++) if ($i ~ /^\//) print $i }' | sort -u)
+  done < <(ldd "$payload_dir/mere.run-bin" 2>/dev/null | awk '/=> \/|^\// { for (i=1; i<=NF; i++) if ($i ~ /^\//) print $i }' | sort -u)
 fi
 
 if [[ -d vendor/ds4 ]]; then

--- a/scripts/test-package-linux.sh
+++ b/scripts/test-package-linux.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/mere-run-package-test.XXXXXX")"
+cleanup() {
+  rm -rf "$fixture_root"
+  if [[ -n "${output_dir:-}" ]]; then
+    rm -rf "$output_dir"
+  fi
+}
+trap cleanup EXIT
+
+fake_bin="$fixture_root/bin"
+fake_build="$fixture_root/build"
+fake_libs="$fixture_root/libs"
+output_dir=".build/package-linux-symlink-test-$$"
+rm -rf "$output_dir"
+mkdir -p "$fake_bin" "$fake_build" "$fake_libs/real" "$fake_libs/alternatives" "$output_dir"
+
+cat >"$fake_build/mere.run" <<'CLI'
+#!/usr/bin/env bash
+echo "mere.run package fixture"
+CLI
+chmod +x "$fake_build/mere.run"
+
+printf 'openblas runtime fixture\n' >"$fake_libs/real/libopenblas.so.0.3.26"
+ln -s "$fake_libs/real/libopenblas.so.0.3.26" "$fake_libs/alternatives/libopenblas.so.0-x86_64-linux-gnu"
+ln -s "$fake_libs/alternatives/libopenblas.so.0-x86_64-linux-gnu" "$fake_libs/libopenblas.so.0"
+
+cat >"$fake_bin/swift" <<SWIFT
+#!/usr/bin/env bash
+if [[ "\$*" == *"--show-bin-path"* ]]; then
+  printf '%s\n' '$fake_build'
+  exit 0
+fi
+echo "unexpected swift invocation: \$*" >&2
+exit 64
+SWIFT
+chmod +x "$fake_bin/swift"
+
+cat >"$fake_bin/ldd" <<LDD
+#!/usr/bin/env bash
+cat <<'EOF'
+	libopenblas.so.0 => $fake_libs/libopenblas.so.0 (0x0000000000000000)
+EOF
+LDD
+chmod +x "$fake_bin/ldd"
+
+PATH="$fake_bin:$PATH" MERERUN_BUNDLE_SWIFT_LIBS=1 \
+  bash scripts/package-linux.sh \
+    --version symlink-fixture \
+    --configuration release \
+    --skip-build \
+    --skip-native \
+    --skip-deb \
+    --output-dir "$output_dir" >/dev/null
+
+tarball="$output_dir/mere-run-symlink-fixture-linux-x86_64.tar.gz"
+[[ -f "$tarball" ]]
+
+tar -xzf "$tarball" -C "$fixture_root"
+staged_lib="$fixture_root/mere-run-symlink-fixture-linux-x86_64/lib/libopenblas.so.0"
+
+if [[ ! -f "$staged_lib" || -L "$staged_lib" ]]; then
+  echo "[test-package-linux] expected libopenblas.so.0 to be bundled as a real file, got:" >&2
+  ls -l "$staged_lib" >&2 || true
+  exit 1
+fi
+
+if ! grep -q 'openblas runtime fixture' "$staged_lib"; then
+  echo "[test-package-linux] bundled libopenblas.so.0 did not contain the resolved library contents" >&2
+  exit 1
+fi
+
+echo "[test-package-linux] package runtime library symlink test passed."


### PR DESCRIPTION
## Summary
- wraps Linux package payloads with a small `mere.run` launcher that resolves symlinks and sets `LD_LIBRARY_PATH` to the colocated `lib/`
- stores the real binary as `mere.run-bin` and teaches `install.sh` to copy it for tarball installs
- bundles Swift/Foundation/OpenBLAS runtime libraries discovered by `ldd` into the payload
- resolves `ldd` runtime-library symlinks before copying so tarballs contain real portable files instead of broken `/etc/alternatives` symlinks
- adds a packaging regression test and runs it in the `linux-release` workflow before building release artifacts

## Verification
- `bash -n scripts/package-linux.sh scripts/test-package-linux.sh`
- `bash scripts/test-package-linux.sh`
- `git diff --check`
- PR CI checks passed on head `f4f812f`
- Manual `linux-release` dispatch passed on head `f4f812f`: https://github.com/sawfwair/mere-run/actions/runs/26333276985
- Downloaded the new `mere-run-linux-packages` artifact, verified `SHA256SUMS`, extracted the tarball, confirmed `lib/libopenblas.so.0` is a real file not a symlink, and ran `./mere.run --help`
- Ran tarball `install.sh` into `/tmp/mere-run-fixed-install/bin`, verified installed `mere.run --help`, and confirmed installed `lib/libopenblas.so.0` remains a real file

## Context
A smoke install from the existing Linux artifact into `~/.local/bin` reached the installer but failed at runtime because transitive native libraries and Swift ICU/OpenBLAS were not resolvable from the colocated payload. A later tarball smoke showed `libopenblas.so.0` had been archived as an absolute `/etc/alternatives` symlink from the GitHub runner. This keeps the tarball self-contained by copying resolved library contents under the original soname, while the `.deb` still declares normal Debian dependencies.