### PR TITLE
fix: make Linux release checksums installable

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           set -euo pipefail
           test -s dist/linux/SHA256SUMS
+          (cd dist/linux && sha256sum -c SHA256SUMS)
           tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
           tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
           dpkg-deb --info dist/linux/mere-run_*_*.deb

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -370,5 +370,8 @@ CONTROL
   fi
 fi
 
-sha256sum "$output_dir"/* >"$output_dir/SHA256SUMS"
+(
+  cd "$output_dir"
+  sha256sum ./* | sed 's#  \./#  #' >SHA256SUMS
+)
 echo "[package-linux] wrote $output_dir/SHA256SUMS"

--- a/scripts/test-package-linux.sh
+++ b/scripts/test-package-linux.sh
@@ -60,6 +60,13 @@ PATH="$fake_bin:$PATH" MERERUN_BUNDLE_SWIFT_LIBS=1 \
 
 tarball="$output_dir/mere-run-symlink-fixture-linux-x86_64.tar.gz"
 [[ -f "$tarball" ]]
+[[ -f "$output_dir/SHA256SUMS" ]]
+if grep -q '/' "$output_dir/SHA256SUMS"; then
+  echo "[test-package-linux] SHA256SUMS should contain artifact basenames, not output-dir paths:" >&2
+  cat "$output_dir/SHA256SUMS" >&2
+  exit 1
+fi
+(cd "$output_dir" && sha256sum -c SHA256SUMS >/dev/null)
 
 tar -xzf "$tarball" -C "$fixture_root"
 staged_lib="$fixture_root/mere-run-symlink-fixture-linux-x86_64/lib/libopenblas.so.0"


### PR DESCRIPTION
## Summary
- Generate Linux package SHA256SUMS with artifact basenames so downloaded release assets verify in-place
- Add the checksum verification to the Linux release workflow
- Extend the package fixture test to catch output-dir paths in SHA256SUMS

## Verification
- bash scripts/test-package-linux.sh
- git diff --check
- Replaced v0.8.0 release SHA256SUMS asset with basename entries and re-downloaded v0.8.0 assets; `sha256sum -c SHA256SUMS` passes
