### PR TITLE
Add native Bonsai image models

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -256,6 +256,7 @@ targets.append(contentsOf: [
       "PrivacyFilter/README.md",
       "Psi/README.md",
       "Q35/README.md",
+      "Quantization/README.md",
       "QwenImageEdit/README.md",
       "QwenImageEdit/Model/Transformer/README.md",
       "QwenImageEdit/Model/VAE/README.md",

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ swift run mere.run image generate \
   --prompt "a ceramic coffee mug in soft morning light" \
   --output ./mug.png
 
+# Pull and run the native Swift Bonsai binary or ternary image model
+swift run mere.run model pull image-bonsai-binary
+swift run mere.run image generate \
+  --model image-bonsai-binary \
+  --prompt "a tiny bonsai tree in a sunlit greenhouse" \
+  --output ./bonsai.png
+
 # HiDream O1 runs natively for text-only, edit, and multi-reference generation.
 swift run mere.run image generate \
   --model image-hidream-o1-dev \

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -152,6 +152,8 @@ enum GuideRegistry {
                 "image-klein-nano",
                 "image-klein-max",
                 "image-klein-base",
+                "image-bonsai-binary",
+                "image-bonsai-ternary",
             ],
             resourceName: "image-generate.md"
         ),

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -158,6 +158,8 @@ struct ImageGenerate: AsyncParsableCommand {
             ?? (manifest.family == .hidream ? (manifest.defaults?.steps ?? 4) : 4)
         let effectiveCFG = cfgScale
             ?? (manifest.family == .hidream ? (manifest.defaults?.cfg ?? 1.0) : 1.0)
+        let effectiveSigmaShift = sigmaShift.map { Float($0) }
+            ?? manifest.defaults?.sigmaShift.map { Float($0) }
 
         let request = GenerationRequest(
             prompt: prompt,
@@ -177,7 +179,7 @@ struct ImageGenerate: AsyncParsableCommand {
             strength: strength,
             keepOriginalAspect: keepOriginalAspect,
             useBetaSigmas: false,
-            sigmaShift: sigmaShift.map { Float($0) }
+            sigmaShift: effectiveSigmaShift
         )
 
         let progressHandler: (@Sendable (GenerationProgress) -> Void)? = quiet ? nil : CLIGenerationProgressPrinter.makeProgressHandler()

--- a/Sources/MereRunCLI/Commands/ImageValidateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageValidateCommand.swift
@@ -110,7 +110,8 @@ struct ImageValidate: AsyncParsableCommand {
             let variant = manifest.variant?.rawValue ?? "unknown"
             let steps = manifest.defaults?.steps.map(String.init) ?? "?"
             let cfg = manifest.defaults?.cfg.map { String(format: "%.2f", $0) } ?? "?"
-            print("  Manifest: engine=\(engine) variant=\(variant) defaults=(steps=\(steps) cfg=\(cfg))")
+            let sigmaShift = manifest.defaults?.sigmaShift.map { String(format: "%.2f", $0) } ?? "?"
+            print("  Manifest: engine=\(engine) variant=\(variant) defaults=(steps=\(steps) cfg=\(cfg) sigma_shift=\(sigmaShift))")
         }
 
         if !report.warnings.isEmpty {

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -98,7 +98,11 @@ struct ModelInfo: ParsableCommand {
             if let defaults = manifest.defaults {
                 let steps = defaults.steps.map(String.init) ?? "?"
                 let cfg = defaults.cfg.map { String(format: "%.2f", $0) } ?? "?"
-                print("  defaults: steps=\(steps) cfg=\(cfg)")
+                if let sigmaShift = defaults.sigmaShift {
+                    print("  defaults: steps=\(steps) cfg=\(cfg) sigma_shift=\(String(format: "%.2f", sigmaShift))")
+                } else {
+                    print("  defaults: steps=\(steps) cfg=\(cfg)")
+                }
             }
 
             if let supports = manifest.supports, !supports.isEmpty {

--- a/Sources/MereRunCLI/Guides/image-generate.md
+++ b/Sources/MereRunCLI/Guides/image-generate.md
@@ -10,12 +10,15 @@ Use one installed image model:
 
 - `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`
 - `image-klein-max`, `image-klein-base`, `image-klein-nano`
+- `image-bonsai-binary`, `image-bonsai-ternary`
 
 ## Install And Check
 
 ```bash
 mere.run model capabilities
 mere.run model pull image-zimage-nano
+mere.run model pull image-bonsai-binary
+mere.run model pull image-bonsai-ternary
 mere.run image generate --help
 mere.run guide image generate --model image-zimage-nano
 ```
@@ -44,6 +47,7 @@ mere.run guide image generate --model image-zimage-nano
 - For product or inspection images, prefer concrete nouns over mood words: size, surface, label text, angle, background.
 - For Z-Image, keep prompts compact and descriptive. Iterate seed, dimensions, and input strength before piling on adjectives.
 - For FLUX.2 Klein, use explicit visual composition and relationships: foreground, background, lens/framing, color palette, and what must be absent.
+- For Bonsai binary or ternary, start with four steps at 512 or 1024 square; the manifest applies its native FlowMatch sigma shift.
 - Use `--input` plus `--strength 0.25` to preserve layout; use `0.65` or higher for stronger reinterpretation.
 
 ## Examples
@@ -55,6 +59,15 @@ mere.run image generate \
   --width 1024 --height 1024 \
   --seed 41 \
   --output ./mug.png
+```
+
+```bash
+mere.run image generate \
+  --model image-bonsai-binary \
+  --prompt "editorial photo of a bonsai tree inside a glass greenhouse, rain on the windows, soft reflected light" \
+  --width 1024 --height 1024 \
+  --seed 17 \
+  --output ./bonsai.png
 ```
 
 ```bash

--- a/Sources/MereRunCore/Flux2Klein/Flux2EulerScheduler.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2EulerScheduler.swift
@@ -17,11 +17,13 @@ public struct Flux2EulerScheduler {
     ///   - imageSeqLen: Number of latent tokens (height * width after patchify)
     ///   - isDistilled: If true, uses terminal stretch + mu=1.0 (distilled models).
     ///                  If false, uses linear 1→0 schedule with dynamic mu (base models).
+    ///   - sigmaShift: Optional scalar FlowMatch shift override.
     public init(
         numInferenceSteps: Int = 4,
         numTrainTimesteps: Int = 1000,
         imageSeqLen: Int,
-        isDistilled: Bool = true
+        isDistilled: Bool = true,
+        sigmaShift: Float? = nil
     ) {
         self.numInferenceSteps = max(numInferenceSteps, 1)
         let steps = self.numInferenceSteps
@@ -62,11 +64,15 @@ public struct Flux2EulerScheduler {
             // NO terminal stretch for base model - schedule goes to 0
         }
 
+        let shiftedSigmas = sigmaShift.map {
+            Self.applyScalarSigmaShift(sigmas: sigmasFinal, shift: $0)
+        } ?? sigmasFinal
+
         // Convert to timesteps
-        let timestepsArr = sigmasFinal.map { $0 * numTrainTimestepsF }
+        let timestepsArr = shiftedSigmas.map { $0 * numTrainTimestepsF }
 
         // Append terminal 0.0 sigma
-        let sigmasWithZero = sigmasFinal + [0.0]
+        let sigmasWithZero = shiftedSigmas + [0.0]
 
         self.sigmas = MLXArray(sigmasWithZero).asType(.float32)
         self.timesteps = MLXArray(timestepsArr).asType(.float32)
@@ -99,6 +105,13 @@ public struct Flux2EulerScheduler {
         let one = MLXArray(Float(1.0))
         let expMuArr = MLXArray(expMu)
         return expMuArr / (expMuArr + (one / sigmas - one))
+    }
+
+    private static func applyScalarSigmaShift(sigmas: [Float], shift: Float) -> [Float] {
+        guard shift > 0 else { return sigmas }
+        return sigmas.map { sigma in
+            shift * sigma / (1.0 + (shift - 1.0) * sigma)
+        }
     }
 
     /// Perform one Euler step

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
@@ -173,7 +173,8 @@ extension Flux2KleinGenerator {
             numInferenceSteps: request.steps,
             numTrainTimesteps: 1000,
             imageSeqLen: seqLen,
-            isDistilled: isDistilled
+            isDistilled: isDistilled,
+            sigmaShift: request.sigmaShift
         )
 
         // Note: FLUX.2 Klein does NOT scale initial latents (unlike SD3/etc)

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
@@ -445,6 +445,16 @@ extension Flux2KleinGenerator {
         to transformer: Flux2Transformer2DModel,
         quantization: ModelWeightsLoader.QuantizationParams?
     ) throws {
+        // Key mapper for mflux format -> our format.
+        // mflux uses to_out.X but we use to_out.0.X (array) for transformer_blocks only.
+        // single_transformer_blocks uses to_out as single Linear (no array).
+        let mfluxKeyMapper: (String) -> String = { key in
+            if key.hasPrefix("transformer_blocks.") && key.contains(".attn.to_out.") && !key.contains(".to_out.0.") {
+                return key.replacingOccurrences(of: ".attn.to_out.", with: ".attn.to_out.0.")
+            }
+            return key
+        }
+
         // Check for single file first (our format)
         let singleFileURL = url.appendingPathComponent("diffusion_pytorch_model.safetensors")
         let indexURL = url.appendingPathComponent("diffusion_pytorch_model.safetensors.index.json")
@@ -455,6 +465,8 @@ extension Flux2KleinGenerator {
                 to: transformer,
                 dtype: .bfloat16,
                 verify: .noUnusedKeys,
+                mapper: { key, value in [(mfluxKeyMapper(key), value)] },
+                keyMapper: mfluxKeyMapper,
                 quantization: quantization
             )
             return
@@ -463,18 +475,6 @@ extension Flux2KleinGenerator {
         let files = try ModelWeightsLoader.safetensorsShards(in: url)
         guard !files.isEmpty else {
             throw NSError(domain: "Flux2KleinGenerator", code: 1, userInfo: [NSLocalizedDescriptionKey: "No transformer weights found at \(url.path)"])
-        }
-
-        // Key mapper for mflux format -> our format
-        // mflux uses to_out.X but we use to_out.0.X (array) for transformer_blocks only
-        // single_transformer_blocks uses to_out as single Linear (no array)
-        let mfluxKeyMapper: (String) -> String = { key in
-            // Only for transformer_blocks (not single_transformer_blocks):
-            // transformer_blocks.X.attn.to_out.weight -> transformer_blocks.X.attn.to_out.0.weight
-            if key.hasPrefix("transformer_blocks.") && key.contains(".attn.to_out.") && !key.contains(".to_out.0.") {
-                return key.replacingOccurrences(of: ".attn.to_out.", with: ".attn.to_out.0.")
-            }
-            return key
         }
 
         try ModelWeightsLoader.applySafetensorsShards(

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Denoising.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+Denoising.swift
@@ -21,6 +21,7 @@ extension Flux2KleinGeneratoriOS {
         transformerDirURL: URL,
         transformerQuantization: ModelWeightsLoader.QuantizationParams?,
         isDistilled: Bool,
+        sigmaShift: Float?,
         outputURL: URL,
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) async throws {
@@ -77,7 +78,8 @@ extension Flux2KleinGeneratoriOS {
             numInferenceSteps: steps,
             numTrainTimesteps: 1000,
             imageSeqLen: seqLen,
-            isDistilled: isDistilled
+            isDistilled: isDistilled,
+            sigmaShift: sigmaShift
         )
 
         let useCFG = guidanceScale > 1.0 && negativePromptEmbeds != nil

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ModelLoading.swift
@@ -159,7 +159,17 @@ extension Flux2KleinGeneratoriOS {
     ) throws -> Flux2Transformer2DModel {
         // Helper to load a tensor from file
         func loadTensor(_ key: String) -> MLXArray? {
-            guard let metadata = tensorMetadata[key] else {
+            let resolvedKey: String
+            if tensorMetadata[key] != nil {
+                resolvedKey = key
+            } else {
+                let mfluxKey = key.replacingOccurrences(of: ".attn.to_out.0.", with: ".attn.to_out.")
+                guard tensorMetadata[mfluxKey] != nil else {
+                    return nil
+                }
+                resolvedKey = mfluxKey
+            }
+            guard let metadata = tensorMetadata[resolvedKey] else {
                 return nil
             }
             let tensorData = fileData.subdata(in: metadata.startOffset..<metadata.endOffset)
@@ -383,6 +393,26 @@ extension Flux2KleinGeneratoriOS {
         to encoder: QwenTextEncoder,
         quantization: ModelWeightsLoader.QuantizationParams?
     ) async throws {
+        let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            var mappedKey = key
+            if key.hasPrefix("model.") {
+                mappedKey = key.replacingOccurrences(of: "model.", with: "encoder.")
+            } else if !key.hasPrefix("encoder.") {
+                mappedKey = "encoder." + key
+            }
+            return [(mappedKey, value)]
+        }
+
+        let keyMapper: (String) -> String = { key in
+            if key.hasPrefix("model.") {
+                return "encoder." + String(key.dropFirst("model.".count))
+            }
+            if key.hasPrefix("encoder.") {
+                return key
+            }
+            return "encoder." + key
+        }
+
         let singleFileURL = url.appendingPathComponent("model.safetensors")
         if FileManager.default.fileExists(atPath: singleFileURL.path) {
             do {
@@ -397,17 +427,16 @@ extension Flux2KleinGeneratoriOS {
                         weights,
                         to: encoder,
                         groupSize: quantization.groupSize,
-                        bits: quantization.bits
+                        bits: quantization.bits,
+                        keyMapper: keyMapper,
+                        mapper: mapper
                     )
                 } else {
                     try HFSafetensorsWeightsLoader.applyWeights(
                         url: singleFileURL,
                         to: encoder,
                         verify: .noUnusedKeys,
-                        mapper: { key, value in
-                            let mappedKey = key.hasPrefix("model.") ? key.replacingOccurrences(of: "model.", with: "encoder.") : key
-                            return [(mappedKey, value)]
-                        }
+                        mapper: mapper
                     )
                 }
             }
@@ -426,16 +455,6 @@ extension Flux2KleinGeneratoriOS {
         do {
             let firstWeights = try MLX.loadArrays(url: files[0])
             let isQuantized = HFSafetensorsWeightsLoader.isQuantized(firstWeights)
-
-            let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
-                var mappedKey = key
-                if key.hasPrefix("model.") {
-                    mappedKey = key.replacingOccurrences(of: "model.", with: "encoder.")
-                } else if !key.hasPrefix("encoder.") {
-                    mappedKey = "encoder." + key
-                }
-                return [(mappedKey, value)]
-            }
 
             if isQuantized {
                 guard let quantization else {

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
@@ -158,6 +158,7 @@ public actor Flux2KleinGeneratoriOS: ImageGenerator {
             transformerDirURL: transformerComponent.directoryURL,
             transformerQuantization: transformerQuantization,
             isDistilled: isDistilled,
+            sigmaShift: request.sigmaShift,
             outputURL: latentsURL,
             progressHandler: progressHandler
         )

--- a/Sources/MereRunCore/HFSafetensorsWeightsLoader.swift
+++ b/Sources/MereRunCore/HFSafetensorsWeightsLoader.swift
@@ -347,6 +347,16 @@ public enum HFSafetensorsWeightsLoader {
                         residualUp: svdUp
                     )
                     residualApplied += 1
+                } else if resolved.bits == 1 {
+                    quantized = PrismBinaryQuantizedLinear(
+                        weight: qWeight,
+                        bias: linearBias,
+                        scales: scales,
+                        biases: qBiases,
+                        groupSize: resolved.groupSize,
+                        bits: resolved.bits,
+                        mode: resolved.mode
+                    )
                 } else {
                     quantized = QuantizedLinear(
                         weight: qWeight,
@@ -557,6 +567,16 @@ public enum HFSafetensorsWeightsLoader {
                         residualUp: svdUp
                     )
                     residualApplied += 1
+                } else if resolved.bits == 1 {
+                    quantized = PrismBinaryQuantizedLinear(
+                        weight: qWeight,
+                        bias: linearBias,
+                        scales: scales,
+                        biases: qBiases,
+                        groupSize: resolved.groupSize,
+                        bits: resolved.bits,
+                        mode: resolved.mode
+                    )
                 } else {
                     quantized = QuantizedLinear(
                         weight: qWeight,

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -23,6 +23,7 @@ public enum ManagedModelInstallShape: Hashable, Sendable {
 
 public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case flux2Klein
+    case bonsaiImage
     case zimageTurbo
     case hidreamO1
     case gemma4
@@ -112,6 +113,8 @@ public enum ManagedModelCatalog {
 
     private static let zImageNanoUpstreamRepoId = "filipstrand/Z-Image-Turbo-mflux-4bit"
     private static let kleinNanoUpstreamRepoId = "stereovoid/flux2-klein-4b-4bit"
+    private static let bonsaiBinaryUpstreamRepoId = "prism-ml/bonsai-image-binary-4B-mlx-1bit"
+    private static let bonsaiTernaryUpstreamRepoId = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
 
     public static let allSpecs: [ManagedModelSpec] = [
         ManagedModelSpec(
@@ -159,6 +162,52 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             validationKind: .flux2Klein,
             runtimeAutoDownloadAllowed: false
+        ),
+        ManagedModelSpec(
+            id: "image-bonsai-binary",
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: bonsaiBinaryUpstreamRepoId,
+                revision: "main",
+                patterns: [
+                    "manifest.json",
+                    "scheduler/scheduler_config.json",
+                    "tokenizer/*",
+                    "text_encoder-mlx-4bit/*",
+                    "transformer-packed-mflux/*",
+                    "vae/*",
+                ]
+            ),
+            upstreamRepoId: bonsaiBinaryUpstreamRepoId,
+            upstreamRevision: "main",
+            validationKind: .bonsaiImage,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 3_428_210_775,
+            defaultCLICommands: ["image generate"]
+        ),
+        ManagedModelSpec(
+            id: "image-bonsai-ternary",
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: bonsaiTernaryUpstreamRepoId,
+                revision: "main",
+                patterns: [
+                    "manifest.json",
+                    "scheduler/scheduler_config.json",
+                    "tokenizer/*",
+                    "text_encoder-mlx-4bit/*",
+                    "transformer-packed-mflux/*",
+                    "vae/*",
+                ]
+            ),
+            upstreamRepoId: bonsaiTernaryUpstreamRepoId,
+            upstreamRevision: "main",
+            validationKind: .bonsaiImage,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 3_888_274_558,
+            defaultCLICommands: ["image generate"]
         ),
         ManagedModelSpec(
             id: "image-zimage-nano",
@@ -703,6 +752,8 @@ public extension ManagedModelSpec {
         switch validationKind {
         case .flux2Klein:
             return Self.missingDiffusersImagePaths(in: rootURL, fileManager: fileManager)
+        case .bonsaiImage:
+            return Self.missingBonsaiImagePaths(in: rootURL, fileManager: fileManager)
         case .zimageTurbo:
             return ZImageTurboResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .hidreamO1:
@@ -1030,6 +1081,46 @@ public extension ManagedModelSpec {
         let transformerWeightsIndex = transformerDir.appendingPathComponent("diffusion_pytorch_model.safetensors.index.json")
         if !fileManager.fileExists(atPath: transformerWeights.path) && !fileManager.fileExists(atPath: transformerWeightsIndex.path) {
             missing.append(transformerWeightsIndex)
+        }
+
+        let vaeWeights = vaeDir.appendingPathComponent("diffusion_pytorch_model.safetensors")
+        if !fileManager.fileExists(atPath: vaeWeights.path) {
+            missing.append(vaeWeights)
+        }
+
+        return missing
+    }
+
+    private static func missingBonsaiImagePaths(in rootURL: URL, fileManager: FileManager) -> [URL] {
+        let tokenizerDir = rootURL.appendingPathComponent("tokenizer", isDirectory: true)
+        let textEncoderDir = rootURL.appendingPathComponent("text_encoder-mlx-4bit", isDirectory: true)
+        let transformerDir = rootURL.appendingPathComponent("transformer-packed-mflux", isDirectory: true)
+        let vaeDir = rootURL.appendingPathComponent("vae", isDirectory: true)
+        let schedulerDir = rootURL.appendingPathComponent("scheduler", isDirectory: true)
+
+        var missing: [URL] = []
+        let required: [URL] = [
+            rootURL.appendingPathComponent("manifest.json"),
+            tokenizerDir.appendingPathComponent("tokenizer_config.json"),
+            textEncoderDir.appendingPathComponent("config.json"),
+            transformerDir.appendingPathComponent("config.json"),
+            transformerDir.appendingPathComponent("quantization_config.json"),
+            vaeDir.appendingPathComponent("config.json"),
+            schedulerDir.appendingPathComponent("scheduler_config.json"),
+        ]
+        for path in required where !fileManager.fileExists(atPath: path.path) {
+            missing.append(path)
+        }
+
+        let textWeights = textEncoderDir.appendingPathComponent("model.safetensors")
+        let textWeightsIndex = textEncoderDir.appendingPathComponent("model.safetensors.index.json")
+        if !fileManager.fileExists(atPath: textWeights.path) && !fileManager.fileExists(atPath: textWeightsIndex.path) {
+            missing.append(textWeightsIndex)
+        }
+
+        let transformerWeights = transformerDir.appendingPathComponent("diffusion_pytorch_model.safetensors")
+        if !fileManager.fileExists(atPath: transformerWeights.path) {
+            missing.append(transformerWeights)
         }
 
         let vaeWeights = vaeDir.appendingPathComponent("diffusion_pytorch_model.safetensors")

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -169,6 +169,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 16
             ),
             descriptor(
+                "image-bonsai-binary",
+                "Image, binary Klein",
+                "Runs the Bonsai Image binary FLUX.2 Klein deployment through the native Swift MLX image runtime.",
+                minimum: 16,
+                recommended: 24
+            ),
+            descriptor(
+                "image-bonsai-ternary",
+                "Image, compact Klein",
+                "Runs the Bonsai Image ternary FLUX.2 Klein deployment through the native Swift MLX image runtime.",
+                minimum: 12,
+                recommended: 16
+            ),
+            descriptor(
                 "image-zimage-nano",
                 "Image Nano",
                 "Creates fast 4-bit Z-Image Turbo outputs for photorealistic and general image generation.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -93,6 +93,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case bf16
         case fp16
         case fp32
+        case int1
+        case int2
         case int8
         case int4
         case unknown
@@ -226,10 +228,18 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     public struct Defaults: Codable, Hashable, Sendable {
         public var steps: Int?
         public var cfg: Double?
+        public var sigmaShift: Double?
 
-        public init(steps: Int? = nil, cfg: Double? = nil) {
+        public init(steps: Int? = nil, cfg: Double? = nil, sigmaShift: Double? = nil) {
             self.steps = steps
             self.cfg = cfg
+            self.sigmaShift = sigmaShift
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case steps
+            case cfg
+            case sigmaShift = "sigma_shift"
         }
     }
 
@@ -419,6 +429,13 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 .model(modelID: ModelResolver.ModelID.kleinShared.rawValue, path: "scheduler"),
             ])
         )
+        let bonsaiComponents = Components(
+            tokenizer: .local(path: "tokenizer"),
+            textEncoder: .local(path: "text_encoder-mlx-4bit"),
+            transformer: .local(path: "transformer-packed-mflux"),
+            vae: .local(path: "vae"),
+            scheduler: .local(path: "scheduler")
+        )
         let mebotTextComponents = Components(
             tokenizer: .anyOf([
                 .local(path: "tokenizer"),
@@ -511,6 +528,36 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 precision: .unknown,
                 supports: [.txt2img, .referenceEdit, .loraInference],
                 components: kleinSharedComponents,
+                createdAt: createdAt
+            )
+        case .bonsaiBinary:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .flux2Klein,
+                family: .klein,
+                tier: .nano,
+                variant: .distilled,
+                precision: .int1,
+                quantization: Quantization(bits: 1, groupSize: 128, scheme: "prism-packed-affine-binary"),
+                defaults: Defaults(steps: 4, cfg: 1.0, sigmaShift: 3.0),
+                supports: [.txt2img],
+                components: bonsaiComponents,
+                upstreamRepoId: "prism-ml/bonsai-image-binary-4B-mlx-1bit@main",
+                createdAt: createdAt
+            )
+        case .bonsaiTernary:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .flux2Klein,
+                family: .klein,
+                tier: .nano,
+                variant: .distilled,
+                precision: .int2,
+                quantization: Quantization(bits: 2, groupSize: 128, scheme: "mlx-packed-affine-ternary"),
+                defaults: Defaults(steps: 4, cfg: 1.0, sigmaShift: 3.0),
+                supports: [.txt2img],
+                components: bonsaiComponents,
+                upstreamRepoId: "prism-ml/bonsai-image-ternary-4B-mlx-2bit@main",
                 createdAt: createdAt
             )
         case .mebot:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -90,8 +90,11 @@ public enum MereRunModelValidator {
         // Root marker checks: diffusers-style models should have model_index.json, but allow fallback markers.
         let modelIndex = rootURL.appendingPathComponent("model_index.json")
         let rootConfig = rootURL.appendingPathComponent("config.json")
+        let sourceManifest = rootURL.appendingPathComponent("manifest.json")
 
-        let hasRootMarker = fileManager.fileExists(atPath: modelIndex.path) || fileManager.fileExists(atPath: rootConfig.path)
+        let hasRootMarker = fileManager.fileExists(atPath: modelIndex.path)
+            || fileManager.fileExists(atPath: rootConfig.path)
+            || fileManager.fileExists(atPath: sourceManifest.path)
         let requiresRootMarker: Bool = {
             guard let spec else { return true }
             switch spec.installShape {
@@ -351,15 +354,15 @@ public enum MereRunModelValidator {
 
         if let precision = manifest.precision {
             switch precision {
-            case .int4, .int8:
+            case .int1, .int2, .int4, .int8:
                 guard let q = manifest.quantization else {
                     if manifestRequiresInlineQuantization(manifest) {
                         errors.append("Quantized precision (\(precision.rawValue)) requires quantization metadata.")
                     }
                     break
                 }
-                if let bits = q.bits, !(2...8).contains(bits) {
-                    errors.append("Invalid quantization.bits=\(bits) (expected 2–8).")
+                if let bits = q.bits, !(1...8).contains(bits) {
+                    errors.append("Invalid quantization.bits=\(bits) (expected 1–8).")
                 }
                 if q.bits == nil {
                     errors.append("Quantized precision (\(precision.rawValue)) requires quantization.bits.")

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -13,6 +13,8 @@ public struct ModelResolver {
         case kleinMax = "image-klein-max"
         case kleinBase = "image-klein-base"
         case kleinShared = "image-klein-shared"
+        case bonsaiBinary = "image-bonsai-binary"
+        case bonsaiTernary = "image-bonsai-ternary"
         case zetaNano = "image-zimage-nano"
         case zetaMax = "image-zimage-max"
         case zetaBase = "image-zimage-base"

--- a/Sources/MereRunCore/ModelWeightsLoader.swift
+++ b/Sources/MereRunCore/ModelWeightsLoader.swift
@@ -27,7 +27,10 @@ public enum ModelWeightsLoader {
         public static func fromManifest(_ manifest: MereRunModelManifest?) throws -> QuantizationParams? {
             guard let manifest else { return nil }
 
-            let precisionImpliesQuant = (manifest.precision == .int4 || manifest.precision == .int8)
+            let precisionImpliesQuant = manifest.precision == .int1
+                || manifest.precision == .int2
+                || manifest.precision == .int4
+                || manifest.precision == .int8
             let hasQuant = manifest.quantization != nil
             guard precisionImpliesQuant || hasQuant else {
                 return nil

--- a/Sources/MereRunCore/Quantization/PrismBinaryQuantizedLinear.swift
+++ b/Sources/MereRunCore/Quantization/PrismBinaryQuantizedLinear.swift
@@ -1,0 +1,176 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+public final class PrismBinaryQuantizedLinear: QuantizedLinear {
+    private var cachedDequantizedWeight: MLXArray?
+
+    public override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        if let packedResult = packedBinaryMatmul(x) {
+            return packedResult
+        }
+
+        let fullWeight = dequantizedBinaryWeight()
+        var result = matmul(x, fullWeight.T)
+        if let bias {
+            result = result + bias
+        }
+        return result
+    }
+
+    private func dequantizedBinaryWeight() -> MLXArray {
+        if let cachedDequantizedWeight {
+            return cachedDequantizedWeight
+        }
+
+        precondition(bits == 1, "PrismBinaryQuantizedLinear only supports 1-bit weights.")
+        precondition(groupSize > 0, "PrismBinaryQuantizedLinear requires a positive group size.")
+
+        let outputDimensions = weight.dim(0)
+        let inputDimensions = weight.dim(1) * 32
+        precondition(inputDimensions % groupSize == 0, "Input dimension must be divisible by group size.")
+        let groupCount = inputDimensions / groupSize
+
+        let bitOffsets = MLXArray((0..<32).map { UInt32($0) }, [1, 1, 32])
+        let packed = weight.expandedDimensions(axis: -1)
+        let unpacked = bitwiseAnd(rightShift(packed, bitOffsets), UInt32(1))
+            .reshaped([outputDimensions, groupCount, groupSize])
+            .asType(scales.dtype)
+
+        var fullWeight = unpacked * scales.expandedDimensions(axis: -1)
+        if let biases {
+            fullWeight = fullWeight + biases.expandedDimensions(axis: -1).asType(fullWeight.dtype)
+        }
+
+        let dequantized = fullWeight.reshaped([outputDimensions, inputDimensions])
+        eval(dequantized)
+        cachedDequantizedWeight = dequantized
+        return dequantized
+    }
+
+    private func packedBinaryMatmul(_ x: MLXArray) -> MLXArray? {
+        guard Device.defaultDevice().deviceType == .gpu,
+              let biases else {
+            return nil
+        }
+
+        precondition(bits == 1, "PrismBinaryQuantizedLinear only supports 1-bit weights.")
+        precondition(groupSize > 0, "PrismBinaryQuantizedLinear requires a positive group size.")
+        guard let inputDimensions = x.shape.last else {
+            return nil
+        }
+
+        let outputDimensions = weight.dim(0)
+        let packedWidth = weight.dim(1)
+        guard packedWidth * 32 == inputDimensions else {
+            return nil
+        }
+        precondition(inputDimensions % groupSize == 0, "Input dimension must be divisible by group size.")
+        let groupCount = inputDimensions / groupSize
+        let rowCount = x.size / inputDimensions
+        let flatInput = x.reshaped([rowCount, inputDimensions])
+
+        let kernel = PrismBinaryMatmulKernels.kernel(
+            inputDimensions: inputDimensions,
+            outputDimensions: outputDimensions,
+            packedWidth: packedWidth,
+            groupSize: groupSize,
+            groupCount: groupCount
+        )
+        var output = kernel(
+            [flatInput, weight, scales, biases],
+            template: [
+                ("InputDimensions", inputDimensions),
+                ("OutputDimensions", outputDimensions),
+                ("PackedWidth", packedWidth),
+                ("GroupSize", groupSize),
+                ("GroupCount", groupCount),
+            ],
+            grid: (32, outputDimensions, rowCount),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[rowCount, outputDimensions]],
+            outputDTypes: [x.dtype]
+        )[0]
+
+        var outputShape = Array(x.shape.dropLast())
+        outputShape.append(outputDimensions)
+        output = output.reshaped(outputShape)
+        if let bias {
+            output = output + bias
+        }
+        return output
+    }
+}
+
+private struct PrismBinaryMatmulKernelKey: Hashable {
+    let inputDimensions: Int
+    let outputDimensions: Int
+    let packedWidth: Int
+    let groupSize: Int
+    let groupCount: Int
+}
+
+private enum PrismBinaryMatmulKernels {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var kernels: [PrismBinaryMatmulKernelKey: MLXFast.MLXFastKernel] = [:]
+
+    static func kernel(
+        inputDimensions: Int,
+        outputDimensions: Int,
+        packedWidth: Int,
+        groupSize: Int,
+        groupCount: Int
+    ) -> MLXFast.MLXFastKernel {
+        let key = PrismBinaryMatmulKernelKey(
+            inputDimensions: inputDimensions,
+            outputDimensions: outputDimensions,
+            packedWidth: packedWidth,
+            groupSize: groupSize,
+            groupCount: groupCount
+        )
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = kernels[key] {
+            return existing
+        }
+
+        let kernel = MLXFast.metalKernel(
+            name: "prism_binary_affine_matmul_i\(inputDimensions)_o\(outputDimensions)_pw\(packedWidth)_g\(groupSize)_gc\(groupCount)",
+            inputNames: ["x", "packed", "scales", "biases"],
+            outputNames: ["out"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto output_idx = thread_position_in_grid.y;
+                auto row_idx = thread_position_in_grid.z;
+                if (output_idx >= OutputDimensions || row_idx >= x_shape[0]) {
+                    return;
+                }
+
+                auto x_ptr = x + row_idx * InputDimensions;
+                auto packed_ptr = packed + output_idx * PackedWidth;
+                auto scale_ptr = scales + output_idx * GroupCount;
+                auto bias_ptr = biases + output_idx * GroupCount;
+
+                float acc = 0.0f;
+                for (int input_idx = lane; input_idx < InputDimensions; input_idx += 32) {
+                    uint packed_word = packed_ptr[input_idx / 32];
+                    uint decoded_bit = (packed_word >> (input_idx % 32)) & 1u;
+                    int group_idx = input_idx / GroupSize;
+                    float decoded = static_cast<float>(decoded_bit) * static_cast<float>(scale_ptr[group_idx])
+                        + static_cast<float>(bias_ptr[group_idx]);
+                    acc += static_cast<float>(x_ptr[input_idx]) * decoded;
+                }
+
+                acc = simd_sum(acc);
+                if (thread_index_in_simdgroup == 0) {
+                    out[row_idx * OutputDimensions + output_idx] = acc;
+                }
+                """
+        )
+        kernels[key] = kernel
+        return kernel
+    }
+}

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -68,6 +68,8 @@ public enum QuantizedModelManifestWriter {
 
         let precision: MereRunModelManifest.Precision = {
             switch bits {
+            case 1: return .int1
+            case 2: return .int2
             case 4: return .int4
             case 8: return .int8
             default: return .unknown

--- a/Sources/MereRunCore/Quantization/README.md
+++ b/Sources/MereRunCore/Quantization/README.md
@@ -1,0 +1,12 @@
+# Quantization
+
+Runtime helpers for loading, writing, and executing quantized MLX weights.
+
+- `QuantizationIO.swift`: typed quantization metadata shared by loaders and manifests.
+- `QuantizedModelManifestWriter.swift`: model manifest emission for quantized checkpoints.
+- `ResidualQuantizedLinear.swift`: residual-aware quantized projection support.
+- `PrismBinaryQuantizedLinear.swift`: Bonsai-compatible packed 1-bit affine projection support.
+
+Keep quantization formats explicit in typed metadata. Do not pass raw checkpoint
+dictionaries past the loader boundary, and prefer narrow format-specific shims
+when a checkpoint layout does not match upstream MLX primitives.

--- a/Tests/MereRunCoreTests/Flux2EulerSchedulerTests.swift
+++ b/Tests/MereRunCoreTests/Flux2EulerSchedulerTests.swift
@@ -56,6 +56,25 @@ final class Flux2EulerSchedulerTests: MereRunCoreTestCase {
         XCTAssertEqual(finalSigma, 0)
     }
 
+    func testScalarSigmaShiftRaisesIntermediateSigmas() {
+        let unshifted = Flux2EulerScheduler(
+            numInferenceSteps: 4,
+            numTrainTimesteps: 1000,
+            imageSeqLen: 64 * 64,
+            isDistilled: true
+        )
+        let shifted = Flux2EulerScheduler(
+            numInferenceSteps: 4,
+            numTrainTimesteps: 1000,
+            imageSeqLen: 64 * 64,
+            isDistilled: true,
+            sigmaShift: 3.0
+        )
+
+        XCTAssertGreaterThan(shifted.sigma(at: 1).item(Float.self), unshifted.sigma(at: 1).item(Float.self))
+        XCTAssertEqual(shifted.sigma(at: 4).item(Float.self), 0)
+    }
+
     func testSingleStepBase() {
         let scheduler = Flux2EulerScheduler(
             numInferenceSteps: 1,

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -52,6 +52,8 @@ final class ManagedModelCatalogTests: XCTestCase {
             "image-klein-nano",
             "image-klein-base",
             "image-klein-max",
+            "image-bonsai-binary",
+            "image-bonsai-ternary",
             "image-zimage-nano",
             "image-zimage-base",
             "image-zimage-max",
@@ -69,6 +71,28 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.repoId, "filipstrand/Z-Image-Turbo-mflux-4bit")
         XCTAssertEqual(spec.upstreamRepoId, "filipstrand/Z-Image-Turbo-mflux-4bit")
         XCTAssertEqual(spec.upstreamRevision, "main")
+    }
+
+    func testBonsaiTernaryUsesPrismMLHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-bonsai-ternary"))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "prism-ml/bonsai-image-ternary-4B-mlx-2bit")
+        XCTAssertEqual(spec.hubFallback?.revision, "main")
+        XCTAssertEqual(spec.upstreamRepoId, "prism-ml/bonsai-image-ternary-4B-mlx-2bit")
+        XCTAssertEqual(spec.upstreamRevision, "main")
+        XCTAssertEqual(spec.validationKind, .bonsaiImage)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 3_888_274_558)
+    }
+
+    func testBonsaiBinaryUsesPrismMLHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-bonsai-binary"))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "prism-ml/bonsai-image-binary-4B-mlx-1bit")
+        XCTAssertEqual(spec.hubFallback?.revision, "main")
+        XCTAssertEqual(spec.upstreamRepoId, "prism-ml/bonsai-image-binary-4B-mlx-1bit")
+        XCTAssertEqual(spec.upstreamRevision, "main")
+        XCTAssertEqual(spec.validationKind, .bonsaiImage)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 3_428_210_775)
     }
 
     func testGemma4TurboUsesNVFP4HubSource() throws {
@@ -97,6 +121,37 @@ final class ManagedModelCatalogTests: XCTestCase {
         let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "image-zimage-nano")
         XCTAssertTrue(report.errors.isEmpty)
         XCTAssertTrue(report.warnings.isEmpty)
+    }
+
+    func testBonsaiTernaryAcceptsPrismMLPackedLayout() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalBonsai(at: root, modelID: .bonsaiTernary, bits: 2, modelVersion: "ternary g128")
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-bonsai-ternary"))
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "image-bonsai-ternary")
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertTrue(report.warnings.isEmpty)
+        XCTAssertEqual(report.manifest?.precision, .int2)
+        XCTAssertEqual(report.manifest?.quantization?.groupSize, 128)
+    }
+
+    func testBonsaiBinaryAcceptsPrismMLPackedLayout() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalBonsai(at: root, modelID: .bonsaiBinary, bits: 1, modelVersion: "binary g128")
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-bonsai-binary"))
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "image-bonsai-binary")
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertTrue(report.warnings.isEmpty)
+        XCTAssertEqual(report.manifest?.precision, .int1)
+        XCTAssertEqual(report.manifest?.quantization?.bits, 1)
+        XCTAssertEqual(report.manifest?.quantization?.groupSize, 128)
     }
 
     func testZImageNanoRejectsStaleManagedSource() throws {
@@ -202,5 +257,71 @@ final class ManagedModelCatalogTests: XCTestCase {
         try indexData.write(to: textEncoder.appendingPathComponent("model.safetensors.index.json"))
         try indexData.write(to: transformer.appendingPathComponent("model.safetensors.index.json"))
         try indexData.write(to: vae.appendingPathComponent("model.safetensors.index.json"))
+    }
+
+    private func writeMinimalBonsai(
+        at root: URL,
+        modelID: ModelResolver.ModelID,
+        bits: Int,
+        modelVersion: String
+    ) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: modelID, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("manifest.json").path,
+            contents: Data(#"{"model_version":"\#(modelVersion)"}"#.utf8)
+        ))
+
+        let tokenizer = root.appendingPathComponent("tokenizer", isDirectory: true)
+        let textEncoder = root.appendingPathComponent("text_encoder-mlx-4bit", isDirectory: true)
+        let transformer = root.appendingPathComponent("transformer-packed-mflux", isDirectory: true)
+        let vae = root.appendingPathComponent("vae", isDirectory: true)
+        let scheduler = root.appendingPathComponent("scheduler", isDirectory: true)
+
+        for dir in [tokenizer, textEncoder, transformer, vae, scheduler] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: tokenizer.appendingPathComponent("tokenizer.json").path,
+            contents: Data("{}".utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: tokenizer.appendingPathComponent("tokenizer_config.json").path,
+            contents: Data("{}".utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: textEncoder.appendingPathComponent("config.json").path,
+            contents: Data(#"{"quantization_config":{"bits":4,"group_size":64}}"#.utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: textEncoder.appendingPathComponent("model.safetensors.index.json").path,
+            contents: Data(#"{"weight_map":{}}"#.utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: transformer.appendingPathComponent("config.json").path,
+            contents: Data("{}".utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: transformer.appendingPathComponent("quantization_config.json").path,
+            contents: Data(#"{"bits":\#(bits),"group_size":128}"#.utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: transformer.appendingPathComponent("diffusion_pytorch_model.safetensors").path,
+            contents: Data()
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: vae.appendingPathComponent("config.json").path,
+            contents: Data("{}".utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: vae.appendingPathComponent("diffusion_pytorch_model.safetensors").path,
+            contents: Data()
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: scheduler.appendingPathComponent("scheduler_config.json").path,
+            contents: Data("{}".utf8)
+        ))
     }
 }

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -56,6 +56,42 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.upstreamRepoId, "filipstrand/Z-Image-Turbo-mflux-4bit@main")
     }
 
+    func testBonsaiTernaryTemplateHasExpectedNativeLayout() throws {
+        let manifest = MereRunModelManifest.template(for: .bonsaiTernary, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, "image-bonsai-ternary")
+        XCTAssertEqual(manifest.engine, .flux2Klein)
+        XCTAssertEqual(manifest.family, .klein)
+        XCTAssertEqual(manifest.variant, .distilled)
+        XCTAssertEqual(manifest.precision, .int2)
+        XCTAssertEqual(manifest.quantization?.bits, 2)
+        XCTAssertEqual(manifest.quantization?.groupSize, 128)
+        XCTAssertEqual(manifest.defaults?.steps, 4)
+        XCTAssertEqual(manifest.defaults?.cfg, 1.0)
+        XCTAssertEqual(manifest.defaults?.sigmaShift, 3.0)
+        XCTAssertEqual(manifest.components?.textEncoder, .local(path: "text_encoder-mlx-4bit"))
+        XCTAssertEqual(manifest.components?.transformer, .local(path: "transformer-packed-mflux"))
+        XCTAssertEqual(manifest.upstreamRepoId, "prism-ml/bonsai-image-ternary-4B-mlx-2bit@main")
+    }
+
+    func testBonsaiBinaryTemplateHasExpectedNativeLayout() throws {
+        let manifest = MereRunModelManifest.template(for: .bonsaiBinary, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, "image-bonsai-binary")
+        XCTAssertEqual(manifest.engine, .flux2Klein)
+        XCTAssertEqual(manifest.family, .klein)
+        XCTAssertEqual(manifest.variant, .distilled)
+        XCTAssertEqual(manifest.precision, .int1)
+        XCTAssertEqual(manifest.quantization?.bits, 1)
+        XCTAssertEqual(manifest.quantization?.groupSize, 128)
+        XCTAssertEqual(manifest.defaults?.steps, 4)
+        XCTAssertEqual(manifest.defaults?.cfg, 1.0)
+        XCTAssertEqual(manifest.defaults?.sigmaShift, 3.0)
+        XCTAssertEqual(manifest.components?.textEncoder, .local(path: "text_encoder-mlx-4bit"))
+        XCTAssertEqual(manifest.components?.transformer, .local(path: "transformer-packed-mflux"))
+        XCTAssertEqual(manifest.upstreamRepoId, "prism-ml/bonsai-image-binary-4B-mlx-1bit@main")
+    }
+
     func testFalconPerceptionTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .visionGroundFalconPerception, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/PrismBinaryQuantizedLinearTests.swift
+++ b/Tests/MereRunCoreTests/PrismBinaryQuantizedLinearTests.swift
@@ -1,0 +1,45 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class PrismBinaryQuantizedLinearTests: XCTestCase {
+    func testBinaryAffineLinearUnpacksOneBitWeights() {
+        let layer = PrismBinaryQuantizedLinear(
+            weight: MLXArray([UInt32.max, UInt32(0)], [2, 1]),
+            bias: nil,
+            scales: MLXArray([Float(2), Float(2)], [2, 1]),
+            biases: MLXArray([Float(-1), Float(-1)], [2, 1]),
+            groupSize: 32,
+            bits: 1
+        )
+        let input = MLXArray(Array(repeating: Float(1), count: 32), [1, 32])
+
+        let output = layer(input)
+        eval(output)
+
+        XCTAssertEqual(output[0, 0].item(Float.self), 32, accuracy: 0.001)
+        XCTAssertEqual(output[0, 1].item(Float.self), -32, accuracy: 0.001)
+    }
+
+    func testBinaryAffineLinearHandlesRankThreeInputAndLinearBias() {
+        let layer = PrismBinaryQuantizedLinear(
+            weight: MLXArray([UInt32(0x0000_FFFF)], [1, 1]),
+            bias: MLXArray([Float(3)], [1]),
+            scales: MLXArray([Float(2), Float(4)], [1, 2]),
+            biases: MLXArray([Float(-1), Float(0.5)], [1, 2]),
+            groupSize: 16,
+            bits: 1
+        )
+        let input = MLXArray(
+            Array(repeating: Float(1), count: 32) + Array(repeating: Float(2), count: 32),
+            [1, 2, 32]
+        )
+
+        let output = layer(input)
+        eval(output)
+
+        XCTAssertEqual(output.shape, [1, 2, 1])
+        XCTAssertEqual(output[0, 0, 0].item(Float.self), 27, accuracy: 0.001)
+        XCTAssertEqual(output[0, 1, 0].item(Float.self), 51, accuracy: 0.001)
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,7 +62,7 @@ including which IDs are pullable from Hugging Face. The most common managed IDs
 are:
 
 - Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`,
-  `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
+  `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
   `image-hidream-o1`, `image-hidream-o1-dev`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q35`, `text-chat-q35-nano`
 - Text code / agents: `text-agent-qwen35-9b`, `text-code-qwen3`
@@ -188,6 +188,7 @@ Examples:
 ```bash
 swift run mere.run image generate --prompt "a black cat on a red sofa"
 swift run mere.run image generate --model image-zimage-nano --prompt "retro robot illustration" --output ./robot.png
+swift run mere.run image generate --model image-bonsai-binary --prompt "sunlit greenhouse bonsai" --output ./bonsai.png
 swift run mere.run image generate --prompt "turn this into a pencil sketch" --input ./photo.png --strength 0.6
 swift run mere.run image generate \
   --model image-hidream-o1-dev \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -193,6 +193,8 @@ Example:
 ```bash
 swift run mere.run model capabilities
 swift run mere.run model pull image-zimage-nano
+# Optional compact FLUX.2 Klein path:
+swift run mere.run model pull image-bonsai-binary
 ```
 
 Set `MERERUN_HUB_CACHE` when you want the Hugging Face cache on another disk.
@@ -219,6 +221,11 @@ or provide Pi separately with `--pi-path` or PATH before using `--start`.
 swift run mere.run image generate \
   --prompt "a ceramic mug in soft morning light" \
   --output ./mug.png
+
+swift run mere.run image generate \
+  --model image-bonsai-binary \
+  --prompt "a tiny bonsai tree in a sunlit greenhouse" \
+  --output ./bonsai.png
 ```
 
 ### Text chat

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -22,7 +22,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 
 | Category | Hugging Face pull IDs |
 | --- | --- |
-| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
+| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
 | Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, `text-agent-deepseek-v4-flash` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
@@ -62,6 +62,35 @@ Swift Gemma runtime.
 Useful environment variables for that path:
 
 - `MERERUN_HUB_CACHE`: override the native Hugging Face snapshot cache path
+
+`image-bonsai-binary` and `image-bonsai-ternary` map to PrismML Apple Silicon
+Bonsai Image snapshots:
+
+- `prism-ml/bonsai-image-binary-4B-mlx-1bit`
+- `prism-ml/bonsai-image-ternary-4B-mlx-2bit`
+
+The snapshot uses a FLUX.2 Klein transformer, but its component names are
+upstream-specific. Managed or local roots are expected to contain:
+
+- `manifest.json`
+- `tokenizer/tokenizer_config.json`
+- `text_encoder-mlx-4bit/config.json`
+- `text_encoder-mlx-4bit/model.safetensors` or `model.safetensors.index.json`
+- `transformer-packed-mflux/config.json`
+- `transformer-packed-mflux/quantization_config.json`
+- `transformer-packed-mflux/diffusion_pytorch_model.safetensors`
+- `vae/config.json`
+- `vae/diffusion_pytorch_model.safetensors`
+- `scheduler/scheduler_config.json`
+
+The binary manifest records the transformer as 1-bit g128 Prism packed affine
+weights; the ternary manifest records 2-bit g128 MLX packed affine ternary
+weights. Both keep the text encoder in the upstream 4-bit MLX layout and run
+generation through the native Swift FLUX.2 Klein pipeline with four steps, CFG
+1.0, and sigma shift 3.0 by default. The binary runtime path uses a native
+Swift/Metal packed 1-bit affine matmul kernel, with a dequantized MLX fallback
+for non-GPU or unsupported shapes while upstream `mlx-swift` lacks `bits=1`
+quantized matmul.
 
 `vision-segment-sam31` packages the native SAM 3.1 segmentation and tracking runtime used by `mere.run vision segment`, `mere.run vision track`, and `mere.run vision track-live`. Managed or local SAM roots are expected to contain:
 

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -13,6 +13,8 @@ model families are supported, and how the code is organized.
 The public image families are:
 
 - `image-klein-*`: Klein image family
+- `image-bonsai-binary`: PrismML Bonsai binary FLUX.2 Klein deployment
+- `image-bonsai-ternary`: PrismML Bonsai ternary FLUX.2 Klein deployment
 - `image-zimage-*`: ZImage image family
 - `image-hidream-o1*`: HiDream O1 unified pixel-transformer family
 
@@ -21,6 +23,8 @@ Common managed IDs:
 - `image-klein-nano`
 - `image-klein-base`
 - `image-klein-max`
+- `image-bonsai-binary`
+- `image-bonsai-ternary`
 - `image-zimage-nano`
 - `image-zimage-base`
 - `image-zimage-max`
@@ -36,6 +40,26 @@ swift run mere.run image generate \
   --model image-zimage-nano \
   --prompt "a ceramic mug in soft morning light" \
   --output ./mug.png
+```
+
+### Bonsai binary and ternary
+
+`image-bonsai-binary` and `image-bonsai-ternary` map to PrismML's Apple Silicon
+Bonsai Image snapshots. They run through the native Swift FLUX.2 Klein runtime
+using the upstream packed transformer layout (`transformer-packed-mflux`) and
+the 4-bit MLX text encoder layout (`text_encoder-mlx-4bit`). Binary is the
+smallest 1-bit g128 deployment; ternary is the larger 2-bit quality-oriented
+variant. The binary path uses a native Swift/Metal packed 1-bit affine matmul
+kernel, with a dequantized MLX fallback for non-GPU or unsupported shapes while
+upstream `mlx-swift` does not expose a `bits=1` quantized matmul kernel.
+
+```bash
+swift run mere.run model pull image-bonsai-binary
+swift run mere.run image generate \
+  --model image-bonsai-binary \
+  --prompt "a tiny bonsai tree in a sunlit greenhouse, editorial product photo" \
+  --width 1024 --height 1024 \
+  --output ./bonsai.png
 ```
 
 ### Image-to-image

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -38,7 +38,7 @@ swift run mere.run --models-root /path/to/models model list
 
 Examples:
 
-- images: `image-klein-nano`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
+- images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
 - text: `text-chat-gemma4`, `text-chat-q35`, `text-chat-q35-nano`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`


### PR DESCRIPTION
## Summary
- add managed `image-bonsai-binary` and `image-bonsai-ternary` PrismML image model specs, manifests, validation, docs, and CLI guide surfacing
- wire Bonsai defaults through native FLUX.2 Klein generation, including manifest-driven sigma shift and mflux component/key layouts
- add a native Swift/Metal packed 1-bit affine matmul path for Bonsai binary, with dequantized MLX fallback for non-GPU/unsupported shapes

## Verification
- `swift test --filter PrismBinaryQuantizedLinearTests`
- `swift run mere.run image generate --model image-bonsai-binary --prompt "a small bonsai tree in a ceramic pot, studio light" --steps 1 --seed 7 --output /tmp/mererun-bonsai-binary-kernel-smoke.png`
- `file /tmp/mererun-bonsai-binary-kernel-smoke.png` -> 1024x1024 PNG
- `./scripts/check.sh`

## Notes
- Checked upstream MLX/mlx-swift: current quantized kernels still exclude `bits == 1`, so the binary model uses the local packed kernel until upstream supports 1-bit quantized matmul.
- Existing unrelated Linux/demo work remains unstaged in the local worktree and is not part of this PR.