### PR TITLE
Add Linux arm64 CUDA packaging path

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -7,6 +7,11 @@ on:
         description: 'Release/package version, e.g. 0.7.1 or v0.7.1'
         required: true
         type: string
+      build_arm64_cuda:
+        description: 'Also build Linux arm64 CUDA packages on a self-hosted arm64 CUDA runner'
+        required: false
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -19,6 +24,7 @@ defaults:
 
 jobs:
   linux-cli-packages:
+    name: Build Linux x86_64
     runs-on: ubuntu-22.04
     container: swift:6.0-jammy
     steps:
@@ -53,19 +59,133 @@ jobs:
       - name: Build Linux packages
         env:
           MERERUN_RELEASE_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
-        run: bash scripts/package-linux.sh --version "$MERERUN_RELEASE_VERSION"
+        run: bash scripts/package-linux.sh --version "$MERERUN_RELEASE_VERSION" --output-dir "dist/linux/x86_64"
 
       - name: Verify package manifests
         run: |
           set -euo pipefail
-          test -s dist/linux/SHA256SUMS
-          (cd dist/linux && sha256sum -c SHA256SUMS)
-          tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
-          tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
-          dpkg-deb --info dist/linux/mere-run_*_*.deb
-          dpkg-deb --contents dist/linux/mere-run_*_*.deb | grep 'usr/bin/mere.run'
+          artifact_dir="dist/linux/x86_64"
+          test -s "$artifact_dir/SHA256SUMS"
+          (cd "$artifact_dir" && sha256sum -c SHA256SUMS)
+          tar -tzf "$artifact_dir"/mere-run-*-linux-x86_64.tar.gz | grep '/mere.run$'
+          tar -tzf "$artifact_dir"/mere-run-*-linux-x86_64.tar.gz | grep '/install.sh$'
+          dpkg-deb --info "$artifact_dir"/mere-run_*_*.deb
+          dpkg-deb --contents "$artifact_dir"/mere-run_*_*.deb | grep 'usr/bin/mere.run'
 
-      - name: Upload Linux package artifacts
+      - name: Upload Linux x86_64 package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mere-run-linux-x86_64-packages
+          path: dist/linux/x86_64/*
+          if-no-files-found: error
+
+  linux-arm64-cuda-packages:
+    name: Build Linux arm64 CUDA
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && inputs.build_arm64_cuda) ||
+        (github.event_name == 'release' && vars.MERERUN_RELEASE_ARM64_CUDA == '1')
+      }}
+    runs-on: [self-hosted, linux, arm64, cuda]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packaging dependencies
+        run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo_cmd=()
+            if [[ "${EUID:-$(id -u)}" != "0" ]]; then
+              sudo_cmd=(sudo)
+            fi
+            "${sudo_cmd[@]}" apt-get update
+            "${sudo_cmd[@]}" apt-get install -y --no-install-recommends \
+              build-essential \
+              ca-certificates \
+              clang \
+              cmake \
+              curl \
+              dpkg-dev \
+              ffmpeg \
+              gfortran \
+              git \
+              gzip \
+              libcurl4-openssl-dev \
+              liblapacke-dev \
+              libopenblas-dev \
+              ninja-build \
+              pkg-config \
+              unzip \
+              zip \
+              zlib1g-dev
+          else
+            echo "apt-get not found; assuming the self-hosted CUDA runner is already provisioned."
+          fi
+          swift --version
+          nvcc --version
+          nvidia-smi
+
+      - name: Test packaging symlink handling
+        env:
+          MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE: 1
+        run: bash scripts/test-package-linux.sh
+
+      - name: Build Linux arm64 CUDA packages
+        env:
+          MERERUN_LINUX_ACCEL: cuda
+          MERERUN_RELEASE_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+        run: bash scripts/package-linux.sh --version "$MERERUN_RELEASE_VERSION" --output-dir "dist/linux/arm64"
+
+      - name: Verify package manifests
+        run: |
+          set -euo pipefail
+          artifact_dir="dist/linux/arm64"
+          test -s "$artifact_dir/SHA256SUMS"
+          (cd "$artifact_dir" && sha256sum -c SHA256SUMS)
+          tar -tzf "$artifact_dir"/mere-run-*-linux-arm64.tar.gz | grep '/mere.run$'
+          tar -tzf "$artifact_dir"/mere-run-*-linux-arm64.tar.gz | grep '/install.sh$'
+          dpkg-deb --info "$artifact_dir"/mere-run_*_*.deb
+          dpkg-deb --contents "$artifact_dir"/mere-run_*_*.deb | grep 'usr/bin/mere.run'
+
+      - name: Upload Linux arm64 CUDA package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mere-run-linux-arm64-cuda-packages
+          path: dist/linux/arm64/*
+          if-no-files-found: error
+
+  linux-release-assets:
+    name: Collect Linux release assets
+    needs:
+      - linux-cli-packages
+      - linux-arm64-cuda-packages
+    if: >-
+      ${{
+        always() &&
+        needs.linux-cli-packages.result == 'success' &&
+        (
+          needs.linux-arm64-cuda-packages.result == 'success' ||
+          needs.linux-arm64-cuda-packages.result == 'skipped'
+        )
+      }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download Linux package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: mere-run-linux-*-packages
+          path: dist/linux-by-arch
+
+      - name: Build combined checksum manifest
+        run: |
+          set -euo pipefail
+          mkdir -p dist/linux
+          find dist/linux-by-arch -type f ! -name SHA256SUMS -exec cp {} dist/linux/ \;
+          test -n "$(find dist/linux -type f -print -quit)"
+          (cd dist/linux && sha256sum ./* | sed 's#  \./#  #' > SHA256SUMS)
+          (cd dist/linux && sha256sum -c SHA256SUMS)
+
+      - name: Upload combined Linux package artifacts
         uses: actions/upload-artifact@v4
         with:
           name: mere-run-linux-packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added a Linux arm64 CUDA package lane to the GitHub Actions `linux-release`
+  workflow for self-hosted arm64 CUDA runners, plus architecture-aware CUDA
+  linker paths and a combined checksum manifest for available Linux artifacts.
+
 ## 0.8.0 - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The public OSS repo currently supports:
 - `swift build` and `swift test` are the supported first-run validation path for macOS contributors
 - Linux CLI compatibility work expects a Swift 6.x toolchain, `clang`, `cmake`, `ninja`, `pkg-config`, `gfortran`, curl/zlib/OpenBLAS/LAPACK development headers, `ffmpeg`, `ffprobe`, `gzip`, `unzip`, and `zip`
 - media I/O should discover `ffmpeg` and `ffprobe` on `PATH`, with `MERERUN_FFMPEG` and `MERERUN_FFPROBE` reserved for absolute executable overrides
-- Linux CI should stay CPU MLX-oriented and fixture-sized; CUDA is an optional local acceleration path, not a baseline for pull-request checks
-- Linux CUDA validation is currently limited to available x86 CUDA hosts with up to 16 GB VRAM; larger x86 CUDA systems and DGX-class machines are not claimed as tested yet
+- hosted Linux CI should stay CPU MLX-oriented and fixture-sized; Linux arm64 release packages must use a real CUDA lane
+- Linux CUDA validation is limited to the exact hosts that have run the CUDA package and smoke path
 - some vendored binaries include additional Apple platform slices for package consumers, while Linux release artifacts stay headless CLI-only
 
 ## Install the latest release
@@ -77,10 +77,12 @@ cd /Volumes/mere.run/.mere-run
 The installer copies `mere.run` and its colocated runtime assets to
 `/usr/local/bin/mere.run`, using `sudo` only when the destination requires it.
 
-Linux release artifacts are headless CLI-only. The release workflow can publish
-both a portable tarball and a Debian package for x86_64/amd64 Ubuntu-style
-hosts. See the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for the
-current validation boundary, CUDA notes, and first commands:
+Linux release artifacts are headless CLI-only. The default release workflow
+publishes portable tarballs and Debian packages for x86_64/amd64 Ubuntu-style
+hosts. Linux arm64 is CUDA-only for release packaging and requires a real arm64
+CUDA host or self-hosted runner; CPU arm64 packages are just local smoke-test
+artifacts. See the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for
+the current validation boundary, CUDA notes, and first commands:
 
 ```bash
 tag=v0.8.0
@@ -98,10 +100,17 @@ sudo apt install ./mere-run.deb
 ```
 
 Linux packages install the `mere.run` CLI plus colocated runtime assets; they do
-not include the macOS SwiftUI studio or DMG layout. Linux arm64 release package
-builds are blocked for now by upstream `mlx-swift` Linux `bf16` support. CUDA is
-optional local acceleration work; current x86 CUDA validation should be treated
-as limited to available hosts with up to 16 GB VRAM.
+not include the macOS SwiftUI studio or DMG layout. On Linux arm64, if a distro
+Clang shadows Swift's bundled Clang and cannot compile MLX bf16 headers, the
+Linux scripts select a bf16-capable C++ driver or report the `CXX` override to
+use. Linux arm64 release packages should be built with CUDA enabled:
+
+```bash
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+```
+
+Current CUDA validation should be treated as limited to the exact hosts that
+have run the CUDA package/smoke path.
 
 ## Build from source
 
@@ -132,7 +141,7 @@ the validation headless:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y clang cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
+sudo apt-get install -y cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
 export MERERUN_FFMPEG=/usr/bin/ffmpeg
 export MERERUN_FFPROBE=/usr/bin/ffprobe
 ./scripts/check-linux.sh
@@ -144,6 +153,12 @@ To build Linux release packages from a Linux x86_64 Swift toolchain host:
 ```bash
 scripts/package-linux.sh --version 0.8.0
 ls dist/linux/
+```
+
+On Linux arm64, use a CUDA-provisioned host:
+
+```bash
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -39,6 +39,53 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertFalse(script.contains("whose Linux path remains CPU-oriented until a package bridge is added"))
     }
 
+    func testLinuxArm64MLXBuildsSelectBF16CapableToolchain() throws {
+        let packageScript = try readRepositoryFile("scripts/package-linux.sh")
+        let checkScript = try readRepositoryFile("scripts/check-linux.sh")
+        let prepareScript = try readRepositoryFile("scripts/prepare-linux-native.sh")
+        let toolchainScript = try readRepositoryFile("scripts/linux-arm64-bf16-toolchain.sh")
+
+        XCTAssertTrue(packageScript.contains("platform_arch=\"arm64\""))
+        XCTAssertTrue(packageScript.contains("deb_arch=\"arm64\""))
+        XCTAssertTrue(packageScript.contains("deb_multiarch=\"aarch64-linux-gnu\""))
+        XCTAssertTrue(packageScript.contains("MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE"))
+        XCTAssertTrue(packageScript.contains("Linux arm64 release packages must use MERERUN_LINUX_ACCEL=cuda"))
+        XCTAssertTrue(
+            packageScript.contains("configure_linux_arm64_bf16_toolchain \"$platform_arch\" \"package-linux\"")
+        )
+        XCTAssertTrue(
+            checkScript.contains("configure_linux_arm64_bf16_toolchain \"$arch\" \"check-linux\"")
+        )
+        XCTAssertTrue(
+            prepareScript.contains("configure_linux_arm64_bf16_toolchain \"$arch\" \"prepare-linux-native\"")
+        )
+        XCTAssertTrue(toolchainScript.contains("#include <arm_bf16.h>"))
+        XCTAssertTrue(toolchainScript.contains("#include <string>"))
+        XCTAssertTrue(toolchainScript.contains(".build/toolchains/linux-arm64-bf16"))
+        XCTAssertTrue(toolchainScript.contains("clang++"))
+        XCTAssertTrue(toolchainScript.contains("clang-17"))
+    }
+
+    func testLinuxReleaseWorkflowKeepsArm64OnCudaRunner() throws {
+        let workflow = try readRepositoryFile(".github/workflows/linux-release.yml")
+        let packageTest = try readRepositoryFile("scripts/test-package-linux.sh")
+
+        XCTAssertTrue(workflow.contains("runs-on: ubuntu-22.04"))
+        XCTAssertFalse(workflow.contains("ubuntu-22.04-arm"))
+        XCTAssertTrue(workflow.contains("Build Linux x86_64"))
+        XCTAssertTrue(workflow.contains("Build Linux arm64 CUDA"))
+        XCTAssertTrue(workflow.contains("runs-on: [self-hosted, linux, arm64, cuda]"))
+        XCTAssertTrue(workflow.contains("MERERUN_LINUX_ACCEL: cuda"))
+        XCTAssertTrue(workflow.contains("MERERUN_RELEASE_ARM64_CUDA == '1'"))
+        XCTAssertTrue(workflow.contains("build_arm64_cuda"))
+        XCTAssertTrue(workflow.contains("pattern: mere-run-linux-*-packages"))
+        XCTAssertTrue(workflow.contains("Build combined checksum manifest"))
+        XCTAssertTrue(workflow.contains("files: dist/linux/*"))
+        XCTAssertTrue(packageTest.contains("platform_arch=\"arm64\""))
+        XCTAssertTrue(packageTest.contains("linux-${platform_arch}.tar.gz"))
+        XCTAssertTrue(packageTest.contains("MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE=1"))
+    }
+
     private func readRepositoryFile(_ relativePath: String) throws -> String {
         let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent(relativePath, isDirectory: false)

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -89,29 +89,33 @@ inputs. The Linux gate runs the hidden `MediaIOSmoke` executable against
 `ffmpeg`/`ffprobe` so image, audio, MP4, mux, and frame extraction paths stay
 covered without model checkpoints. CUDA setup belongs in local runtime
 documentation or manual smoke notes, not in the default pull-request gate.
-Current x86 CUDA validation is limited to available hosts with up to 16 GB VRAM;
-larger x86 CUDA systems and DGX-class machines are future validation targets,
-not current support claims.
+CUDA validation is limited to the exact hosts that have run the CUDA package and
+smoke path. Linux arm64 packages are only meaningful with CUDA; CPU-only arm64
+packages are local smoke artifacts, not support claims.
 
 ### Linux release packaging change
 
-Linux release packaging is a separate x86_64/amd64 path for distributable
-headless CLI artifacts:
+Linux release packaging is a separate path for distributable headless CLI
+artifacts. The default GitHub release workflow publishes x86_64/amd64 artifacts:
 
 ```bash
 scripts/package-linux.sh --version 0.8.0
 ls dist/linux/
 ```
 
-The package script builds `dist/linux/mere-run-<version>-linux-x86_64.tar.gz`,
-`dist/linux/mere-run_<version>_amd64.deb`, and `dist/linux/SHA256SUMS`. It must
-run on Linux; arm64 package builds intentionally fail until upstream
-`mlx-swift` Linux `bf16` support is available.
+The package script builds
+`dist/linux/mere-run-<version>-linux-<arch>.tar.gz`,
+`dist/linux/mere-run_<version>_<deb-arch>.deb`, and
+`dist/linux/SHA256SUMS`. It must run on Linux.
 
 The GitHub `linux-release` workflow can be triggered manually with a version
-input to validate the package build and upload an Actions artifact. On published
-GitHub Release events, the workflow also uploads the Linux artifacts to the
-release.
+input to validate the hosted x86_64 package build and upload an Actions
+artifact. The optional arm64 CUDA lane requires a self-hosted Linux runner
+labeled `self-hosted`, `linux`, `arm64`, and `cuda`; enable it manually with
+`build_arm64_cuda` or on release events with the
+`MERERUN_RELEASE_ARM64_CUDA=1` repository variable. On published GitHub Release
+events, the workflow uploads the available Linux artifacts and checksum manifest
+to the release.
 
 ## Model-store expectations
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,22 +110,26 @@ limits, see [Linux QuickStart](./linux-quickstart.md).
 ```bash
 tag=v0.8.0
 version="${tag#v}"
+case "$(uname -m)" in
+  x86_64|amd64) linux_arch=x86_64; deb_arch=amd64 ;;
+  *) echo "use the Linux arm64 CUDA package path on arm64" >&2; exit 1 ;;
+esac
 
-curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run-${tag}-linux-x86_64.tar.gz" -o mere-run-linux.tar.gz
+curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run-${tag}-linux-${linux_arch}.tar.gz" -o mere-run-linux.tar.gz
 tar -xzf mere-run-linux.tar.gz
-cd "mere-run-${tag}-linux-x86_64"
+cd "mere-run-${tag}-linux-${linux_arch}"
 ./install.sh
 
-curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run_${version}_amd64.deb" -o mere-run.deb
+curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run_${version}_${deb_arch}.deb" -o mere-run.deb
 sudo apt install ./mere-run.deb
 ```
 
 The tarball and `.deb` install the `mere.run` CLI plus colocated runtime assets.
 They do not include `mere.run.app`, SwiftUI studio flows, or the macOS DMG
-layout. Linux release packages are x86_64/amd64-only for now; arm64 package
-builds are blocked by upstream `mlx-swift` Linux `bf16` support. CUDA is
-optional local validation; current x86 CUDA coverage should be treated as
-limited to available hosts with up to 16 GB VRAM.
+layout. The default published Linux release packages are built for
+x86_64/amd64. Linux arm64 packages are CUDA-only and should be built on a real
+arm64 CUDA host with `MERERUN_LINUX_ACCEL=cuda`; CPU arm64 packages are local
+smoke artifacts, not useful release targets.
 
 ## Understand the command tree
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
   - title: Native macOS studio
     details: The optional SwiftUI app opens to a prompt-first canvas, local output library, guided readiness, and advanced CLI details.
   - title: Headless Linux CLI packages
-    details: Linux releases ship portable x86_64 tarballs and Debian packages for CLI-only installs on Ubuntu-style hosts, with CUDA kept as optional local validation.
+    details: Linux releases ship portable x86_64 tarballs plus Debian packages for CLI-only installs on Ubuntu-style hosts; arm64 Linux packages are CUDA-only and require a real arm64 CUDA host.
   - title: Canonical model system
     details: Public model IDs, shared model-store rules, Hugging Face-backed pulls, and `mere.run status` make installs predictable and scriptable.
   - title: Readable runtime families

--- a/docs/internals/source-layout.md
+++ b/docs/internals/source-layout.md
@@ -92,5 +92,6 @@ Use this for:
 - `scripts/check.sh`: main validation gate
 - `scripts/e2e_smoke.sh`: installed-model smoke runner
 - `vendor/llama.xcframework`: vendored native dependency for code and API paths
-- `vendor/mlx-swift_Cmlx.bundle`: macOS MLX shader resources; Linux CI should
-  use CPU MLX-sized fixtures and leave CUDA to optional local runtime checks
+- `vendor/mlx-swift_Cmlx.bundle`: macOS MLX shader resources; hosted Linux CI
+  should use CPU MLX-sized fixtures, while Linux arm64 package validation needs
+  the CUDA path on real arm64 CUDA hardware

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -1,28 +1,28 @@
 # Linux QuickStart
 
 This page is for installing the released headless `mere.run` CLI on Linux.
-The current supported release path is x86_64/amd64 Linux packages published on
-GitHub Releases.
+The default published release path is x86_64/amd64 Linux packages on GitHub
+Releases. Linux arm64 packages are CUDA-only and must be built on a real arm64
+CUDA host or self-hosted runner.
 
 The macOS path remains the primary hands-on development and runtime validation
 environment for this repo. The Linux release path is real, but intentionally
-narrow: CLI-only packages, Ubuntu-style hosts, CPU-oriented CI fixtures, and
-optional local CUDA experiments.
+narrow: CLI-only packages, Ubuntu-style hosts, CPU-oriented x86 CI fixtures,
+and CUDA-gated arm64 package work.
 
 ## Current validation boundary
 
-- Linux release packages are built for x86_64/amd64 hosts.
+- Published default Linux release packages are built for x86_64/amd64 hosts.
 - The release workflow validates the portable tarball, Debian package, runtime
-  library bundling, and package manifests on Ubuntu in GitHub Actions.
+  library bundling, and package manifests on Ubuntu x86_64 in GitHub Actions.
 - Linux packages do not include `MereRun.app`, the SwiftUI studio, the macOS
   installer UI, or the DMG layout.
-- Linux arm64 release packages are blocked for now by upstream `mlx-swift`
-  Linux `bf16` support.
-- CUDA is optional local acceleration work, not part of the default pull-request
-  or release gate.
-- Current x86 CUDA validation should be treated as limited to available hosts
-  with up to 16 GB VRAM. Larger x86 CUDA systems and DGX-class machines are not
-  claimed as tested until they are available for direct validation.
+- Linux arm64 package builds must use `MERERUN_LINUX_ACCEL=cuda`; CPU arm64
+  packages are only local smoke-test artifacts.
+- The optional arm64 CUDA workflow lane targets self-hosted runners labeled
+  `self-hosted`, `linux`, `arm64`, and `cuda`.
+- Current CUDA validation should be treated as limited to the exact hosts that
+  have run the CUDA package and smoke path.
 
 ## Install with apt
 
@@ -31,8 +31,12 @@ Use this path on Debian or Ubuntu-style systems:
 ```bash
 tag=v0.8.0
 version="${tag#v}"
+case "$(uname -m)" in
+  x86_64|amd64) deb_arch=amd64 ;;
+  *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
+esac
 
-curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run_${version}_amd64.deb" -o mere-run.deb
+curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run_${version}_${deb_arch}.deb" -o mere-run.deb
 sudo apt install ./mere-run.deb
 mere.run --version
 mere.run status
@@ -47,10 +51,14 @@ Use this path when you do not want to install a Debian package:
 
 ```bash
 tag=v0.8.0
+case "$(uname -m)" in
+  x86_64|amd64) linux_arch=x86_64 ;;
+  *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
+esac
 
-curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run-${tag}-linux-x86_64.tar.gz" -o mere-run-linux.tar.gz
+curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run-${tag}-linux-${linux_arch}.tar.gz" -o mere-run-linux.tar.gz
 tar -xzf mere-run-linux.tar.gz
-cd "mere-run-${tag}-linux-x86_64"
+cd "mere-run-${tag}-linux-${linux_arch}"
 ./install.sh
 mere.run --version
 mere.run status
@@ -92,27 +100,33 @@ export MERERUN_FFMPEG=/usr/bin/ffmpeg
 export MERERUN_FFPROBE=/usr/bin/ffprobe
 ```
 
-## CUDA notes
+## Linux arm64 CUDA package path
 
-CUDA is not required for the Linux release package quickstart. The shared Linux
-CI path stays CPU-oriented and fixture-sized so package validation remains
-repeatable.
+Linux arm64 is only useful for this project when the CUDA lane works. Do not
+publish or recommend CPU-only arm64 packages as release artifacts.
 
-For source builds that intentionally exercise the optional Linux CUDA bridge,
-prepare the native artifacts and then export the environment printed by the
-script:
+Build arm64 packages on a native arm64 Linux host with an NVIDIA GPU, driver,
+CUDA Toolkit, `nvcc`, Swift, OpenBLAS/LAPACK headers, and `ffmpeg` available:
+
+```bash
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+ls dist/linux/
+```
+
+For source-only CUDA checks, prepare native artifacts and then export the
+environment printed by the script before building:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda scripts/prepare-linux-native.sh
-# Export the printed PKG_CONFIG_PATH, LIBRARY_PATH, LD_LIBRARY_PATH,
-# MERERUN_MLX_SWIFT_LINKAGE, MERERUN_MLX_SWIFT_BUILD_DIR,
-# MERERUN_MLX_SWIFT_SOURCE_DIR, and MERERUN_MLX_SWIFT_LINK_FLAGS values.
-swift build --target mere.run
+swift build --product mere.run
 ```
 
-Do not describe a CUDA configuration as supported unless it has been run on a
-real matching host. Today that means x86 CUDA coverage is limited to available
-machines with up to 16 GB VRAM.
+The GitHub-hosted `ubuntu-22.04-arm` runner is CPU-only for this purpose. The
+arm64 CUDA workflow lane is intentionally self-hosted so the package build runs
+against a real CUDA-capable arm64 machine.
+
+Do not describe a CUDA configuration as supported unless it has been run on that
+matching host.
 
 ## Build from source on Linux
 
@@ -120,8 +134,14 @@ Install the package layer first:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y clang cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
+sudo apt-get install -y cmake ninja-build pkg-config gfortran libcurl4-openssl-dev zlib1g-dev libopenblas-dev liblapacke-dev ffmpeg gzip unzip zip
 ```
+
+On Linux arm64, older distro Clang packages can shadow Swift's bundled Clang and
+fail MLX bf16 header compilation. The Linux scripts probe for this and select a
+bf16-capable C++ driver, including a local `clang++` shim backed by Swift's
+`clang-17` when needed; if not, set `CXX` to the Swift toolchain `clang++` path
+before building.
 
 Then run the headless Linux checks:
 

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -35,7 +35,9 @@ library code. `mere.run.app`, SwiftUI views, app bundling, installer behavior,
 and DMG packaging remain macOS-only.
 
 Linux release packaging follows the same boundary: release artifacts are
-headless x86_64/amd64 CLI tarballs and Debian packages, not app bundles.
+headless CLI tarballs and Debian packages, not app bundles. The hosted release
+workflow publishes x86_64/amd64 artifacts; arm64 package artifacts are CUDA-only
+and require the self-hosted arm64 CUDA lane.
 
 ## Source tree
 
@@ -137,15 +139,16 @@ to validate actual runtime paths instead of just build and parse coverage.
 
 ### `scripts/package-linux.sh`
 
-Builds Linux release artifacts for the headless CLI on x86_64/amd64 Linux:
+Builds Linux release artifacts for the headless CLI on Linux:
 
-- `dist/linux/mere-run-<version>-linux-x86_64.tar.gz`
-- `dist/linux/mere-run_<version>_amd64.deb`
+- `dist/linux/mere-run-<version>-linux-<arch>.tar.gz`
+- `dist/linux/mere-run_<version>_<deb-arch>.deb`
 - `dist/linux/SHA256SUMS`
 
-The companion `.github/workflows/linux-release.yml` workflow runs this script in
-the Swift 6.0 Ubuntu container, verifies the tarball and `.deb` manifests, and
-uploads package artifacts.
+The companion `.github/workflows/linux-release.yml` workflow runs the x86_64
+package path in the Swift 6.0 Ubuntu container, verifies the tarball and `.deb`
+manifests, and uploads package artifacts. Its arm64 package lane is CUDA-only
+and targets a self-hosted Linux runner with `arm64` and `cuda` labels.
 
 ## Vendor artifacts
 
@@ -161,9 +164,9 @@ monorepo payload structure.
 
 Vendored MLX shader resources used by the macOS runtime.
 
-Linux CI should stay CPU MLX-oriented and fixture-sized. CUDA-specific runtime
-smokes are optional local validation, not a requirement for the public pull
-request gate.
+Linux hosted CI should stay CPU MLX-oriented and fixture-sized. CUDA-specific
+runtime smokes are required for meaningful Linux arm64 packages, but they run on
+real CUDA hosts rather than the public pull-request gate.
 
 ### `THIRD_PARTY_NOTICES.md`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,9 +10,9 @@ Use the smallest layer that covers your change, then scale up before opening a
 PR.
 
 Linux CLI compatibility uses a narrower fixture boundary: headless CLI behavior,
-media-tool discovery, and CPU MLX-sized checks. CUDA should stay out of default
-CI and be documented as an optional local acceleration path when a runtime needs
-it.
+media-tool discovery, and CPU MLX-sized checks for hosted x86 CI. Linux arm64 is
+different: CPU-only packages are smoke artifacts, and release-worthy arm64
+packages must exercise the CUDA lane on real arm64 CUDA hardware.
 
 ## Fast validation
 
@@ -64,13 +64,12 @@ export MERERUN_FFMPEG=/usr/bin/ffmpeg
 export MERERUN_FFPROBE=/usr/bin/ffprobe
 ```
 
-The pull-request fixture should stay CPU MLX-compatible. CUDA machines can run
-additional local smoke tests, but CUDA installation, driver selection, and GPU
-availability are not assumptions in the shared CI contract. Current x86 CUDA
-validation is limited to available hosts with up to 16 GB VRAM; larger x86 CUDA
-systems and DGX-class machines should not be described as tested until they are
-run directly. To use the optional Linux CUDA bridge, prepare native artifacts
-and export the environment that the script prints:
+The pull-request fixture should stay CPU MLX-compatible on hosted x86 runners.
+CUDA machines can run additional package and smoke tests, but CUDA installation,
+driver selection, and GPU availability are not assumptions in the shared hosted
+CI contract. Do not describe a CUDA configuration as tested until that exact
+host has run the CUDA path. To use the Linux CUDA bridge, prepare native
+artifacts and export the environment that the script prints:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda scripts/prepare-linux-native.sh
@@ -95,10 +94,19 @@ dpkg-deb --info dist/linux/mere-run_*_*.deb
 dpkg-deb --contents dist/linux/mere-run_*_*.deb | grep 'usr/bin/mere.run'
 ```
 
-The `linux-release` workflow runs the same package and manifest boundary on
-Ubuntu 22.04 in the Swift 6.0 container. Manual workflow runs upload Actions
-artifacts only; published GitHub Release events also upload the Linux assets to
-the release.
+On Linux arm64, use CUDA for the package check:
+
+```bash
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+```
+
+The `linux-release` workflow runs the hosted package and manifest boundary for
+x86_64 on Ubuntu 22.04 in the Swift 6.0 container. Its arm64 CUDA lane is
+optional and targets a self-hosted runner labeled `self-hosted`, `linux`,
+`arm64`, and `cuda`; enable it manually with `build_arm64_cuda` or on release
+events with the `MERERUN_RELEASE_ARM64_CUDA=1` repository variable. Manual
+workflow runs upload Actions artifacts only; published GitHub Release events
+also upload the available Linux assets and checksum manifest to the release.
 
 MediaIO coverage has two layers. `Tests/MereRunCoreTests/MediaIOTests.swift`
 covers pure Swift image, WAV, and FFT behavior in the normal test suite.
@@ -197,8 +205,9 @@ If the change adds Linux-compatible code, include the focused unit test or stub
 fixture result that exercises the new behavior.
 
 If the change touches Linux release packaging or `.github/workflows/linux-release.yml`,
-run the package script on Linux or dispatch the `linux-release` workflow on
-`main` with a test version.
+run the package script on the affected Linux architecture or dispatch the
+`linux-release` workflow on `main` with a test version. For arm64 changes, that
+means a CUDA-provisioned arm64 runner, not the hosted CPU arm64 runner.
 
 ## Troubleshooting
 

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -40,6 +40,9 @@ done
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# shellcheck source=scripts/linux-arm64-bf16-toolchain.sh
+source "$repo_root/scripts/linux-arm64-bf16-toolchain.sh"
+
 host_os="$(uname -s)"
 if [[ "$host_os" != "Linux" ]]; then
   if [[ "${MERERUN_CHECK_LINUX_ALLOW_NON_LINUX:-0}" != "1" ]]; then
@@ -117,6 +120,7 @@ case "$(uname -m)" in
     exit 65
     ;;
 esac
+configure_linux_arm64_bf16_toolchain "$arch" "check-linux"
 
 bash ./scripts/prepare-linux-native.sh
 native_root="$repo_root/.build/native/linux-$arch"

--- a/scripts/linux-arm64-bf16-toolchain.sh
+++ b/scripts/linux-arm64-bf16-toolchain.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+linux_arm64_bf16_compiler_supports() {
+  local compiler="$1"
+  local tmpdir
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/mere-run-bf16-compiler.XXXXXX")" || return 1
+  local source="$tmpdir/bf16.cpp"
+  cat >"$source" <<'CPP'
+#include <arm_bf16.h>
+#include <string>
+bfloat16_t mererun_bf16_probe(bfloat16_t value) { return value; }
+int main() { return std::string("bf16").empty() ? 1 : 0; }
+CPP
+  "$compiler" -x c++ "$source" -o "$tmpdir/bf16" >/dev/null 2>&1
+  local status=$?
+  rm -rf "$tmpdir"
+  return "$status"
+}
+
+configure_linux_arm64_bf16_toolchain() {
+  local arch="$1"
+  local log_prefix="${2:-linux-arm64-bf16}"
+  if [[ "$arch" != "arm64" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${CXX:-}" ]]; then
+    if linux_arm64_bf16_compiler_supports "$CXX"; then
+      return 0
+    fi
+    echo "[$log_prefix] error: CXX=$CXX cannot compile arm_bf16.h on Linux arm64." >&2
+    echo "[$log_prefix] use a Swift toolchain C++ driver with __bf16 support, for example CXX=/usr/bin/clang++-17." >&2
+    return 65
+  fi
+
+  local default_cxx
+  default_cxx="$(command -v clang++ || true)"
+  if [[ -n "$default_cxx" ]] && linux_arm64_bf16_compiler_supports "$default_cxx"; then
+    return 0
+  fi
+
+  local candidate
+  for candidate in clang++-18 clang++-17 /usr/bin/clang++-18 /usr/bin/clang++-17; do
+    if ! command -v "$candidate" >/dev/null 2>&1 && [[ ! -x "$candidate" ]]; then
+      continue
+    fi
+    if linux_arm64_bf16_compiler_supports "$candidate"; then
+      export CXX="$candidate"
+      if [[ -z "${CC:-}" ]]; then
+        export CC="${candidate/++/}"
+      fi
+      echo "[$log_prefix] using CXX=$CXX for Linux arm64 MLX bf16 support." >&2
+      return 0
+    fi
+  done
+
+  local toolchain_dir="${MERERUN_BF16_TOOLCHAIN_DIR:-$PWD/.build/toolchains/linux-arm64-bf16}"
+  for candidate in /usr/bin/clang-18 /usr/bin/clang-17 clang-18 clang-17; do
+    if ! command -v "$candidate" >/dev/null 2>&1 && [[ ! -x "$candidate" ]]; then
+      continue
+    fi
+    mkdir -p "$toolchain_dir"
+    local compiler_path
+    compiler_path="$(command -v "$candidate" || printf '%s' "$candidate")"
+    ln -sf "$compiler_path" "$toolchain_dir/clang++"
+    ln -sf "$compiler_path" "$toolchain_dir/clang"
+    if linux_arm64_bf16_compiler_supports "$toolchain_dir/clang++"; then
+      export CXX="$toolchain_dir/clang++"
+      if [[ -z "${CC:-}" ]]; then
+        export CC="$toolchain_dir/clang"
+      fi
+      echo "[$log_prefix] using CXX=$CXX for Linux arm64 MLX bf16 support." >&2
+      return 0
+    fi
+  done
+
+  echo "[$log_prefix] error: Linux arm64 MLX builds need a Clang that can compile arm_bf16.h." >&2
+  echo "[$log_prefix] install or select the Swift toolchain Clang, then rerun with CXX=/path/to/clang++." >&2
+  return 65
+}

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Build distributable Linux CLI artifacts for mere.run.
 #
 # Outputs:
-#   dist/linux/mere-run-<version>-linux-x86_64.tar.gz
-#   dist/linux/mere-run_<version>_amd64.deb   (when dpkg-deb is available)
+#   dist/linux/mere-run-<version>-linux-<arch>.tar.gz
+#   dist/linux/mere-run_<version>_<deb-arch>.deb   (when dpkg-deb is available)
 #
 # The tarball uses the same payload shape as the macOS DMG's terminal payload:
 # a top-level mere.run executable, install.sh, and colocated runtime assets.
@@ -33,12 +33,17 @@ Environment:
                                 reported by ldd into payload lib/. Default: 1.
   MERERUN_PACKAGE_LINUX_DEPS    Override Debian Depends field.
   MERERUN_LINUX_ACCEL           Passed through to prepare-linux-native.sh (cpu/cuda).
+  MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE=1
+                                Allow an arm64 CPU package for local smoke tests.
   MERERUN_DS4_LINUX_BIN_DIR     Passed through to prepare-linux-native.sh for DS4 staging.
 USAGE
 }
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+
+# shellcheck source=scripts/linux-arm64-bf16-toolchain.sh
+source "$repo_root/scripts/linux-arm64-bf16-toolchain.sh"
 
 configuration="release"
 output_dir="dist/linux"
@@ -105,11 +110,12 @@ case "$(uname -m)" in
   x86_64|amd64)
     platform_arch="x86_64"
     deb_arch="amd64"
+    deb_multiarch="x86_64-linux-gnu"
     ;;
   aarch64|arm64)
-    echo "[package-linux] error: Linux release packaging currently supports x86_64/amd64 only." >&2
-    echo "[package-linux] arm64 package builds are blocked by upstream mlx-swift Linux bf16 support." >&2
-    exit 65
+    platform_arch="arm64"
+    deb_arch="arm64"
+    deb_multiarch="aarch64-linux-gnu"
     ;;
   *)
     echo "[package-linux] error: unsupported Linux architecture: $(uname -m)" >&2
@@ -145,6 +151,16 @@ case "$linux_accel" in
     exit 64
     ;;
 esac
+if [[ "$platform_arch" == "arm64" &&
+      "$linux_accel" != "cuda" &&
+      "${MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE:-0}" != "1" ]]; then
+  echo "[package-linux] error: Linux arm64 release packages must use MERERUN_LINUX_ACCEL=cuda." >&2
+  echo "[package-linux] CPU arm64 packages are for local smoke tests only; set MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE=1 to force one." >&2
+  exit 65
+fi
+if (( do_build || do_native )); then
+  configure_linux_arm64_bf16_toolchain "$platform_arch" "package-linux"
+fi
 
 mlx_swift_cuda_link_flags() {
   local mlx_cmake_build="$native_root/build/mlx-swift-cuda-smoke"
@@ -156,9 +172,9 @@ mlx_swift_cuda_link_flags() {
   flags+=("-L" "$mlx_cmake_build/_deps/mlx-build/mlx/io")
   flags+=("-L" "$mlx_cmake_build/lib")
 
-  if [[ -f "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so" ]]; then
-    flags+=("-L" "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread")
-    flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread")
+  if [[ -f "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so" ]]; then
+    flags+=("-L" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
   fi
   if [[ -n "${CUDNN_LIBRARY_PATH:-}" ]]; then
     flags+=("-L" "$CUDNN_LIBRARY_PATH")
@@ -177,8 +193,8 @@ mlx_swift_cuda_link_flags() {
       fi
     done
   fi
-  if [[ -d /usr/lib/x86_64-linux-gnu ]]; then
-    flags+=("-L" "/usr/lib/x86_64-linux-gnu")
+  if [[ -d /usr/lib/$deb_multiarch ]]; then
+    flags+=("-L" "/usr/lib/$deb_multiarch")
   fi
 
   flags+=(
@@ -246,8 +262,13 @@ if [[ ! -x "$cli_executable" ]]; then
   exit 66
 fi
 
-rm -rf "$output_dir"
-mkdir -p "$output_dir"
+if [[ "$output_dir" == /* ]]; then
+  output_root="$output_dir"
+else
+  output_root="$repo_root/$output_dir"
+fi
+rm -rf "$output_root"
+mkdir -p "$output_root"
 staging="$(mktemp -d "${TMPDIR:-/tmp}/mere-run-linux-package.XXXXXX")"
 cleanup() {
   rm -rf "$staging"
@@ -331,7 +352,7 @@ fi
 
 (
   cd "$staging"
-  tar -czf "$repo_root/$output_dir/${payload_name}.tar.gz" "$payload_name"
+  tar -czf "$output_root/${payload_name}.tar.gz" "$payload_name"
 )
 
 echo "[package-linux] wrote $output_dir/${payload_name}.tar.gz"
@@ -363,7 +384,7 @@ Description: Local-first inference CLI
 CONTROL
 
     chmod 0755 "$deb_root/DEBIAN"
-    dpkg-deb --root-owner-group --build "$deb_root" "$repo_root/$output_dir/mere-run_${deb_version}_${deb_arch}.deb"
+    dpkg-deb --root-owner-group --build "$deb_root" "$output_root/mere-run_${deb_version}_${deb_arch}.deb"
     echo "[package-linux] wrote $output_dir/mere-run_${deb_version}_${deb_arch}.deb"
   else
     echo "[package-linux] warning: dpkg-deb not found; skipping .deb package." >&2
@@ -371,7 +392,7 @@ CONTROL
 fi
 
 (
-  cd "$output_dir"
+  cd "$output_root"
   sha256sum ./* | sed 's#  \./#  #' >SHA256SUMS
 )
 echo "[package-linux] wrote $output_dir/SHA256SUMS"

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -75,6 +75,9 @@ done
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# shellcheck source=scripts/linux-arm64-bf16-toolchain.sh
+source "$repo_root/scripts/linux-arm64-bf16-toolchain.sh"
+
 host_os="$(uname -s)"
 if [[ "$host_os" != "Linux" ]]; then
   echo "[prepare-linux-native] non-Linux host; skipping Linux-native asset preparation."
@@ -84,9 +87,11 @@ fi
 case "$(uname -m)" in
   x86_64|amd64)
     arch="x86_64"
+    deb_multiarch="x86_64-linux-gnu"
     ;;
   aarch64|arm64)
     arch="arm64"
+    deb_multiarch="aarch64-linux-gnu"
     ;;
   *)
     echo "[prepare-linux-native] error: unsupported Linux architecture: $(uname -m)" >&2
@@ -122,6 +127,9 @@ case "$linux_accel" in
     exit 64
     ;;
 esac
+if [[ "$check_only" != "1" ]]; then
+  configure_linux_arm64_bf16_toolchain "$arch" "prepare-linux-native"
+fi
 
 stage_ds4() {
   local ds4_root="$repo_root/vendor/ds4"
@@ -286,11 +294,11 @@ smoke_mlx_swift_cuda() {
   git -C "$mlx_cmake_src" checkout --detach FETCH_HEAD
 
   local local_openblas_root="$native_root/deps/apt-root"
-  local local_openblas_lib="$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so"
-  local local_openblas_include="$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread;$local_openblas_root/usr/include"
+  local local_openblas_lib="$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so"
+  local local_openblas_include="$local_openblas_root/usr/include/$deb_multiarch/openblas-pthread;$local_openblas_root/usr/include"
 
-  if [[ ! -f "$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h" &&
-        ! -f /usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h &&
+  if [[ ! -f "$local_openblas_root/usr/include/$deb_multiarch/openblas-pthread/cblas.h" &&
+        ! -f /usr/include/$deb_multiarch/openblas-pthread/cblas.h &&
         ! -f /usr/include/cblas.h ]]; then
     if command -v apt-get >/dev/null 2>&1 && command -v dpkg-deb >/dev/null 2>&1; then
       echo "[prepare-linux-native] downloading local OpenBLAS/LAPACK headers for mlx-swift CUDA smoke"
@@ -335,40 +343,40 @@ smoke_mlx_swift_cuda() {
     mlx_cmake_args+=("-DCUDNN_LIBRARY_PATH=$CUDNN_LIBRARY_PATH")
   fi
   local local_openblas_root="$native_root/deps/apt-root"
-  local local_openblas_lib="$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so"
-  local local_openblas_include="$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread;$local_openblas_root/usr/include"
+  local local_openblas_lib="$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so"
+  local local_openblas_include="$local_openblas_root/usr/include/$deb_multiarch/openblas-pthread;$local_openblas_root/usr/include"
 
   if [[ -n "${BLAS_LIBRARIES:-}" ]]; then
     mlx_cmake_args+=("-DBLAS_LIBRARIES=$BLAS_LIBRARIES")
   elif [[ -f "$local_openblas_lib" ]]; then
     mlx_cmake_args+=("-DBLAS_LIBRARIES=$local_openblas_lib")
-  elif [[ -f /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so ]]; then
-    mlx_cmake_args+=("-DBLAS_LIBRARIES=/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so")
-  elif [[ -f /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.12.0 ]]; then
-    mlx_cmake_args+=("-DBLAS_LIBRARIES=/usr/lib/x86_64-linux-gnu/blas/libblas.so.3.12.0")
+  elif [[ -f /usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so ]]; then
+    mlx_cmake_args+=("-DBLAS_LIBRARIES=/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so")
+  elif [[ -f /usr/lib/$deb_multiarch/blas/libblas.so.3.12.0 ]]; then
+    mlx_cmake_args+=("-DBLAS_LIBRARIES=/usr/lib/$deb_multiarch/blas/libblas.so.3.12.0")
   fi
   if [[ -n "${BLAS_INCLUDE_DIRS:-}" ]]; then
     mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=$BLAS_INCLUDE_DIRS")
-  elif [[ -f "$local_openblas_root/usr/include/x86_64-linux-gnu/openblas-pthread/cblas.h" ]]; then
+  elif [[ -f "$local_openblas_root/usr/include/$deb_multiarch/openblas-pthread/cblas.h" ]]; then
     mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=$local_openblas_include")
-  elif [[ -d /usr/include/x86_64-linux-gnu/openblas-pthread ]]; then
-    mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=/usr/include/x86_64-linux-gnu/openblas-pthread")
+  elif [[ -d /usr/include/$deb_multiarch/openblas-pthread ]]; then
+    mlx_cmake_args+=("-DBLAS_INCLUDE_DIRS=/usr/include/$deb_multiarch/openblas-pthread")
   fi
   if [[ -n "${LAPACK_LIBRARIES:-}" ]]; then
     mlx_cmake_args+=("-DLAPACK_LIBRARIES=$LAPACK_LIBRARIES")
   elif [[ -f "$local_openblas_lib" ]]; then
     mlx_cmake_args+=("-DLAPACK_LIBRARIES=$local_openblas_lib")
-  elif [[ -f /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so ]]; then
-    mlx_cmake_args+=("-DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so")
-  elif [[ -f /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.12.0 ]]; then
-    mlx_cmake_args+=("-DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.12.0")
+  elif [[ -f /usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so ]]; then
+    mlx_cmake_args+=("-DLAPACK_LIBRARIES=/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so")
+  elif [[ -f /usr/lib/$deb_multiarch/lapack/liblapack.so.3.12.0 ]]; then
+    mlx_cmake_args+=("-DLAPACK_LIBRARIES=/usr/lib/$deb_multiarch/lapack/liblapack.so.3.12.0")
   fi
   if [[ -n "${LAPACK_INCLUDE_DIRS:-}" ]]; then
     mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=$LAPACK_INCLUDE_DIRS")
   elif [[ -f "$local_openblas_root/usr/include/lapack.h" ]]; then
     mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=$local_openblas_include")
-  elif [[ -d /usr/include/x86_64-linux-gnu/openblas-pthread ]]; then
-    mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=/usr/include/x86_64-linux-gnu/openblas-pthread")
+  elif [[ -d /usr/include/$deb_multiarch/openblas-pthread ]]; then
+    mlx_cmake_args+=("-DLAPACK_INCLUDE_DIRS=/usr/include/$deb_multiarch/openblas-pthread")
   fi
 
   echo "[prepare-linux-native] configuring mlx-swift CUDA smoke via CMake"
@@ -404,9 +412,9 @@ mlx_swift_cuda_link_flags() {
   flags+=("-L" "$mlx_cmake_build/_deps/mlx-build/mlx/io")
   flags+=("-L" "$mlx_cmake_build/lib")
 
-  if [[ -f "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblas.so" ]]; then
-    flags+=("-L" "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread")
-    flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/x86_64-linux-gnu/openblas-pthread")
+  if [[ -f "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so" ]]; then
+    flags+=("-L" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
   fi
   if [[ -n "${CUDNN_LIBRARY_PATH:-}" ]]; then
     flags+=("-L" "$CUDNN_LIBRARY_PATH")
@@ -425,8 +433,8 @@ mlx_swift_cuda_link_flags() {
       fi
     done
   fi
-  if [[ -d /usr/lib/x86_64-linux-gnu ]]; then
-    flags+=("-L" "/usr/lib/x86_64-linux-gnu")
+  if [[ -d /usr/lib/$deb_multiarch ]]; then
+    flags+=("-L" "/usr/lib/$deb_multiarch")
   fi
 
   flags+=(

--- a/scripts/test-package-linux.sh
+++ b/scripts/test-package-linux.sh
@@ -16,9 +16,22 @@ trap cleanup EXIT
 fake_bin="$fixture_root/bin"
 fake_build="$fixture_root/build"
 fake_libs="$fixture_root/libs"
-output_dir=".build/package-linux-symlink-test-$$"
-rm -rf "$output_dir"
-mkdir -p "$fake_bin" "$fake_build" "$fake_libs/real" "$fake_libs/alternatives" "$output_dir"
+mkdir -p "$fake_bin" "$fake_build" "$fake_libs/real" "$fake_libs/alternatives"
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    platform_arch="x86_64"
+    ;;
+  aarch64|arm64)
+    platform_arch="arm64"
+    ;;
+  *)
+    echo "[test-package-linux] unsupported Linux architecture: $(uname -m)" >&2
+    exit 65
+    ;;
+esac
+
+output_dir="$fixture_root/output"
 
 cat >"$fake_build/mere.run" <<'CLI'
 #!/usr/bin/env bash
@@ -27,8 +40,8 @@ CLI
 chmod +x "$fake_build/mere.run"
 
 printf 'openblas runtime fixture\n' >"$fake_libs/real/libopenblas.so.0.3.26"
-ln -s "$fake_libs/real/libopenblas.so.0.3.26" "$fake_libs/alternatives/libopenblas.so.0-x86_64-linux-gnu"
-ln -s "$fake_libs/alternatives/libopenblas.so.0-x86_64-linux-gnu" "$fake_libs/libopenblas.so.0"
+ln -s "$fake_libs/real/libopenblas.so.0.3.26" "$fake_libs/alternatives/libopenblas.so.0-${platform_arch}-linux-gnu"
+ln -s "$fake_libs/alternatives/libopenblas.so.0-${platform_arch}-linux-gnu" "$fake_libs/libopenblas.so.0"
 
 cat >"$fake_bin/swift" <<SWIFT
 #!/usr/bin/env bash
@@ -49,7 +62,9 @@ EOF
 LDD
 chmod +x "$fake_bin/ldd"
 
-PATH="$fake_bin:$PATH" MERERUN_BUNDLE_SWIFT_LIBS=1 \
+PATH="$fake_bin:$PATH" \
+  MERERUN_BUNDLE_SWIFT_LIBS=1 \
+  MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE=1 \
   bash scripts/package-linux.sh \
     --version symlink-fixture \
     --configuration release \
@@ -58,7 +73,7 @@ PATH="$fake_bin:$PATH" MERERUN_BUNDLE_SWIFT_LIBS=1 \
     --skip-deb \
     --output-dir "$output_dir" >/dev/null
 
-tarball="$output_dir/mere-run-symlink-fixture-linux-x86_64.tar.gz"
+tarball="$output_dir/mere-run-symlink-fixture-linux-${platform_arch}.tar.gz"
 [[ -f "$tarball" ]]
 [[ -f "$output_dir/SHA256SUMS" ]]
 if grep -q '/' "$output_dir/SHA256SUMS"; then
@@ -69,7 +84,7 @@ fi
 (cd "$output_dir" && sha256sum -c SHA256SUMS >/dev/null)
 
 tar -xzf "$tarball" -C "$fixture_root"
-staged_lib="$fixture_root/mere-run-symlink-fixture-linux-x86_64/lib/libopenblas.so.0"
+staged_lib="$fixture_root/mere-run-symlink-fixture-linux-${platform_arch}/lib/libopenblas.so.0"
 
 if [[ ! -f "$staged_lib" || -L "$staged_lib" ]]; then
   echo "[test-package-linux] expected libopenblas.so.0 to be bundled as a real file, got:" >&2


### PR DESCRIPTION
## Summary
- add an opt-in Linux arm64 CUDA package lane for self-hosted CUDA runners
- teach Linux package/native scripts to select a bf16-capable C++ driver on arm64
- update Linux release docs, tests, and package manifest checks for x86_64 hosted vs arm64 CUDA boundaries

## Validation
- ./scripts/check.sh

## Remaining validation gap
- I did not run the Linux arm64 CUDA package build on real arm64 CUDA hardware in this workspace; that still needs the self-hosted runner or matching host.