### PR TITLE
Add native runtime model pool control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ swift run mere.run api serve \
   --kv-quant-scheme polar \
   --kv-bits 2
 
-# Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs PolarKV
+# Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs decode-deferred PolarKV
 swift run mere.run model benchmark gemma4-kv \
   --model text-chat-gemma4-turbo \
   --decode-tokens 48 \

--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ swift run mere.run api serve \
   --kv-quant-scheme polar \
   --kv-bits 2
 
+# Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs PolarKV
+swift run mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --decode-tokens 48 \
+  --json
+
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
 swift run mere.run api serve \

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The public OSS repo currently supports:
 - native ACEStep music generation and LTX video generation
 - Hugging Face-backed model pulls that resolve into a shared local model store
 - offline command cookbooks through `mere.run guide`
-- a local OpenAI-compatible API surface for supported text engines
-- a quick status snapshot for the local server, loaded API model, and installed model store
+- a local OpenAI-compatible API surface with a native Swift runtime model pool
+- a quick status snapshot for the local server, loaded API models, active requests, runtime capabilities, and installed model store
 - an optional macOS studio that wraps the public CLI instead of reimplementing runtime logic
 
 ## What’s included in this repo
@@ -184,6 +184,13 @@ swift run mere.run model list
 # See the local server, served model, model-store path, and installed models
 swift run mere.run status
 
+# Set API runtime defaults beside the active model store
+swift run mere.run model runtime set text-chat-gemma4 \
+  --alias chat-default \
+  --pinned \
+  --ttl-seconds 3600 \
+  --max-tokens 1024
+
 # See what this Mac can run before pulling large models
 swift run mere.run model capabilities
 swift run mere.run model capabilities --recommended
@@ -228,13 +235,28 @@ swift run mere.run api serve --engine text-chat-gemma4
 # In another terminal, confirm the server and served model
 swift run mere.run status
 
+# Optional Gemma4 prefix KV reuse prototype; status reports cache and timing stats
+MERERUN_GEMMA4_PREFIX_KV_CACHE=1 swift run mere.run api serve --engine text-chat-gemma4
+
+# Optional Q35 text-only prefix KV reuse prototype; vision prompts are excluded
+MERERUN_Q35_PREFIX_KV_CACHE=1 swift run mere.run api serve --engine text-chat-q35
+
+# Optional decode batching; overlap requires max-active > 1
+MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --max-active-requests 2
+MERERUN_Q35_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
+  --engine text-chat-q35 \
+  --max-active-requests 2
+
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
 swift run mere.run api serve \
   --host 0.0.0.0 \
   --port 11434 \
   --api-key "$MERERUN_API_KEY" \
-  --rate-limit-per-minute 120
+  --rate-limit-per-minute 120 \
+  --max-active-requests 1
 
 # Generate speech
 swift run mere.run speech synthesize \
@@ -295,7 +317,7 @@ The public CLI is modality-first:
 - `mere.run music generate`
 - `mere.run video generate`
 - `mere.run video export-latents`
-- `mere.run model { list, capabilities, info, pull, remove, repair-manifests }`
+- `mere.run model { list, capabilities, info, pull, remove, runtime, repair-manifests }`
 - `mere.run status`
 - `mere.run api serve`
 - `mere.run setup`

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ MERERUN_Q35_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
   --engine text-chat-q35 \
   --max-active-requests 2
 
-# Experimental Gemma4 packed PolarKV for memory-pressure testing
+# Experimental Gemma4 packed PolarKV for memory-pressure and long-context decode testing
 swift run mere.run api serve \
   --engine text-chat-gemma4 \
   --kv-quant-scheme polar \

--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ MERERUN_Q35_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
   --engine text-chat-q35 \
   --max-active-requests 2
 
+# Experimental Gemma4 packed PolarKV for memory-pressure testing
+swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --kv-quant-scheme polar \
+  --kv-bits 2
+
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
 swift run mere.run api serve \

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -12,6 +12,49 @@ struct StudioModelInventoryRow: Identifiable, Equatable {
     }
 }
 
+struct StudioRuntimeSettings: Codable, Equatable {
+    var alias: String?
+    var pinned: Bool
+    var ttlSeconds: Int?
+    var maxContextTokens: Int?
+    var maxTokens: Int?
+    var temperature: Double?
+    var topP: Double?
+    var engineOverride: String?
+
+    init(
+        alias: String? = nil,
+        pinned: Bool = false,
+        ttlSeconds: Int? = nil,
+        maxContextTokens: Int? = nil,
+        maxTokens: Int? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        engineOverride: String? = nil
+    ) {
+        self.alias = alias
+        self.pinned = pinned
+        self.ttlSeconds = ttlSeconds
+        self.maxContextTokens = maxContextTokens
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.engineOverride = engineOverride
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        alias = try container.decodeIfPresent(String.self, forKey: .alias)
+        pinned = try container.decodeIfPresent(Bool.self, forKey: .pinned) ?? false
+        ttlSeconds = try container.decodeIfPresent(Int.self, forKey: .ttlSeconds)
+        maxContextTokens = try container.decodeIfPresent(Int.self, forKey: .maxContextTokens)
+        maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens)
+        temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+        topP = try container.decodeIfPresent(Double.self, forKey: .topP)
+        engineOverride = try container.decodeIfPresent(String.self, forKey: .engineOverride)
+    }
+}
+
 enum StudioModelInventoryParser {
     static func rows(from output: String) -> [StudioModelInventoryRow] {
         output
@@ -61,8 +104,17 @@ struct StudioModelsSheet: View {
     @State private var showAll = false
     @State private var isRefreshing = false
     @State private var loadingInfoID: String?
+    @State private var loadingRuntimeID: String?
     @State private var removingID: String?
     @State private var pendingRemoval: StudioModelInventoryRow?
+    @State private var runtimeSettingsByID: [String: StudioRuntimeSettings] = [:]
+    @State private var runtimeAlias = ""
+    @State private var runtimeTTL = ""
+    @State private var runtimeMaxContext = ""
+    @State private var runtimeMaxTokens = ""
+    @State private var runtimeTemperature = ""
+    @State private var runtimeTopP = ""
+    @State private var runtimePinned = false
 
     private var installedRows: [StudioModelInventoryRow] {
         rows.filter(\.isInstalled)
@@ -227,6 +279,14 @@ struct StudioModelsSheet: View {
                         Text(row.category)
                         Text(row.status)
                         Text(row.size)
+                        if let runtime = runtimeSettingsByID[row.id] {
+                            if runtime.pinned {
+                                Text("pinned")
+                            }
+                            if let alias = runtime.alias {
+                                Text(alias)
+                            }
+                        }
                     }
                     .font(MereRunTheme.captionFont)
                     .foregroundStyle(MereRunTheme.textMuted)
@@ -294,6 +354,42 @@ struct StudioModelsSheet: View {
 
             HStack(spacing: 10) {
                 Button {
+                    Task { await runtimeLoad(row) }
+                } label: {
+                    Label("Load", systemImage: "play.fill")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!row.isInstalled || loadingRuntimeID != nil)
+
+                Button {
+                    Task { await runtimeUnload(row) }
+                } label: {
+                    Label("Unload", systemImage: "stop.fill")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!row.isInstalled || loadingRuntimeID != nil)
+
+                Button {
+                    Task { await saveRuntimeSettings(for: row, pinned: true) }
+                } label: {
+                    Label("Pin", systemImage: "pin")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!row.isInstalled || loadingRuntimeID != nil)
+
+                Button {
+                    Task { await saveRuntimeSettings(for: row, pinned: false) }
+                } label: {
+                    Label("Unpin", systemImage: "pin.slash")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!row.isInstalled || loadingRuntimeID != nil)
+            }
+
+            runtimeSettingsEditor(row)
+
+            HStack(spacing: 10) {
+                Button {
                     Task { await loadInfo(for: row) }
                 } label: {
                     Label("Inspect", systemImage: "info.circle")
@@ -318,6 +414,37 @@ struct StudioModelsSheet: View {
                 .buttonStyle(.bordered)
                 .disabled(!row.isInstalled || removingID != nil)
             }
+        }
+    }
+
+    private func runtimeSettingsEditor(_ row: StudioModelInventoryRow) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                TextField("Alias", text: $runtimeAlias)
+                TextField("TTL", text: $runtimeTTL)
+                    .frame(width: 72)
+                TextField("Context", text: $runtimeMaxContext)
+                    .frame(width: 88)
+                TextField("Max tokens", text: $runtimeMaxTokens)
+                    .frame(width: 88)
+                TextField("Temp", text: $runtimeTemperature)
+                    .frame(width: 72)
+                TextField("Top P", text: $runtimeTopP)
+                    .frame(width: 72)
+                Toggle("Pinned", isOn: $runtimePinned)
+                    .toggleStyle(.checkbox)
+
+                Button {
+                    Task { await saveRuntimeSettings(for: row, pinned: runtimePinned) }
+                } label: {
+                    Label("Save", systemImage: "checkmark")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(MereRunTheme.accent)
+                .disabled(!row.isInstalled || loadingRuntimeID != nil)
+            }
+            .textFieldStyle(.roundedBorder)
+            .font(MereRunTheme.captionFont)
         }
     }
 
@@ -348,6 +475,7 @@ struct StudioModelsSheet: View {
         detailText = row.isInstalled ? "" : "\(row.id) is not downloaded."
         guard row.isInstalled else { return }
         Task { await loadInfo(for: row) }
+        Task { await loadRuntimeSettings(for: row) }
     }
 
     @MainActor
@@ -374,6 +502,126 @@ struct StudioModelsSheet: View {
             selectedID = nil
             detailText = ""
         }
+    }
+
+    @MainActor
+    private func loadRuntimeSettings(for row: StudioModelInventoryRow) async {
+        loadingRuntimeID = row.id
+        let result = await controller.utilityCommandResult(args: ["model", "runtime", "get", row.id, "--json"])
+        loadingRuntimeID = nil
+        guard result.exitCode == 0,
+              let data = result.stdout.data(using: .utf8),
+              let settings = try? JSONDecoder().decode(StudioRuntimeSettings.self, from: data) else {
+            return
+        }
+        runtimeSettingsByID[row.id] = settings
+        if selectedID == row.id {
+            applyRuntimeSettings(settings)
+        }
+    }
+
+    private func applyRuntimeSettings(_ settings: StudioRuntimeSettings) {
+        runtimeAlias = settings.alias ?? ""
+        runtimeTTL = settings.ttlSeconds.map(String.init) ?? ""
+        runtimeMaxContext = settings.maxContextTokens.map(String.init) ?? ""
+        runtimeMaxTokens = settings.maxTokens.map(String.init) ?? ""
+        runtimeTemperature = settings.temperature.map { String($0) } ?? ""
+        runtimeTopP = settings.topP.map { String($0) } ?? ""
+        runtimePinned = settings.pinned
+    }
+
+    @MainActor
+    private func saveRuntimeSettings(for row: StudioModelInventoryRow, pinned: Bool) async {
+        loadingRuntimeID = row.id
+        statusMessage = "Saving runtime settings for \(row.id)..."
+        var args = ["model", "runtime", "set", row.id, pinned ? "--pinned" : "--unpinned"]
+        appendRuntimeSettingArgs(to: &args)
+        let result = await controller.utilityCommandResult(args: args)
+        loadingRuntimeID = nil
+        if result.exitCode == 0 {
+            statusMessage = "Saved runtime settings for \(row.id)"
+            await loadRuntimeSettings(for: row)
+        } else {
+            statusMessage = "Could not save runtime settings for \(row.id)"
+            detailText = result.outputText
+        }
+    }
+
+    private func appendRuntimeSettingArgs(to args: inout [String]) {
+        appendStringSetting(runtimeAlias, setFlag: "--alias", clearFlag: "--clear-alias", to: &args)
+        appendStringSetting(runtimeTTL, setFlag: "--ttl-seconds", clearFlag: "--clear-ttl", to: &args)
+        appendStringSetting(
+            runtimeMaxContext,
+            setFlag: "--max-context-tokens",
+            clearFlag: "--clear-max-context-tokens",
+            to: &args
+        )
+        appendStringSetting(runtimeMaxTokens, setFlag: "--max-tokens", clearFlag: "--clear-max-tokens", to: &args)
+        appendStringSetting(
+            runtimeTemperature,
+            setFlag: "--temperature",
+            clearFlag: "--clear-temperature",
+            to: &args
+        )
+        appendStringSetting(runtimeTopP, setFlag: "--top-p", clearFlag: "--clear-top-p", to: &args)
+    }
+
+    private func appendStringSetting(
+        _ value: String,
+        setFlag: String,
+        clearFlag: String,
+        to args: inout [String]
+    ) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            args.append(clearFlag)
+        } else {
+            args += [setFlag, trimmed]
+        }
+    }
+
+    @MainActor
+    private func runtimeLoad(_ row: StudioModelInventoryRow) async {
+        await runtimeServerAction(row, action: "load")
+    }
+
+    @MainActor
+    private func runtimeUnload(_ row: StudioModelInventoryRow) async {
+        await runtimeServerAction(row, action: "unload")
+    }
+
+    @MainActor
+    private func runtimeServerAction(_ row: StudioModelInventoryRow, action: String) async {
+        loadingRuntimeID = row.id
+        statusMessage = "\(action.capitalized)ing \(row.id)..."
+        do {
+            var request = URLRequest(url: runtimeURL(for: row, action: action))
+            request.httpMethod = "POST"
+            if !controller.draft.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                request.setValue("Bearer \(controller.draft.apiKey)", forHTTPHeaderField: "Authorization")
+            }
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let http = response as? HTTPURLResponse
+            if (200..<300).contains(http?.statusCode ?? 500) {
+                statusMessage = "\(action.capitalized)ed \(row.id)"
+            } else {
+                statusMessage = "Runtime \(action) returned HTTP \(http?.statusCode ?? 0)"
+            }
+        } catch {
+            statusMessage = "Runtime server is not reachable"
+        }
+        loadingRuntimeID = nil
+    }
+
+    private func runtimeURL(for row: StudioModelInventoryRow, action: String) -> URL {
+        let host = controller.draft.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let safeHost = host.isEmpty ? "127.0.0.1" : host
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = safeHost
+        components.port = controller.draft.port
+        components.path = "/runtime/models/\(row.id)/\(action)"
+        return components.url ?? URL(string: "http://127.0.0.1:8080/runtime/models/\(row.id)/\(action)")!
     }
 
     @MainActor

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -73,6 +73,9 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Global request limit for /v1/chat/completions per rolling minute.")
     var rateLimitPerMinute: Int = 60
 
+    @Option(name: [.long], help: "Maximum chat completions admitted at once. Defaults to 1 for serialized local inference.")
+    var maxActiveRequests: Int = 1
+
     @Option(name: [.long], help: "Context size (default: 32768).")
     var contextSize: Int = 32768
 
@@ -94,15 +97,40 @@ struct APIServe: AsyncParsableCommand {
         let resolvedModelPath = try resolveModelPath()
         let gemma4KVCacheQuantization = try resolveGemma4KVCacheQuantization()
         let server = try await CodeGenServer(
+            defaultModelID: defaultRuntimeModelID(modelPath: resolvedModelPath),
             modelPath: resolvedModelPath,
             fallbackLoraPath: lora,
             apiKey: resolvedAPIKey,
             rateLimitPerMinute: rateLimitPerMinute,
+            maxActiveRequests: maxActiveRequests,
             engine: engine,
             contextSize: contextSize,
             gemma4KVCacheQuantization: gemma4KVCacheQuantization
         )
         try await server.run(host: host, port: port)
+    }
+
+    private func defaultRuntimeModelID(modelPath: String?) -> String {
+        if let requested = model?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let spec = ManagedModelCatalog.spec(for: requested),
+           spec.defaultRuntimeServingEngine == engine.runtimeServingEngine {
+            return spec.id
+        }
+        if let modelPath, model != nil {
+            return URL(fileURLWithPath: modelPath).lastPathComponent
+        }
+        switch engine {
+        case .textChatKlein:
+            return ModelResolver.ModelID.mebot.rawValue
+        case .textChatGemma4:
+            return ModelResolver.ModelID.gemma4.rawValue
+        case .textChatQ35:
+            return ModelResolver.ModelID.q35.rawValue
+        case .textCode:
+            return CodeGenResources.defaultModelId
+        case .textChatDeepseekV4Flash:
+            return DeepseekV4FlashResources.defaultModelId
+        }
     }
 
     private func resolveModelPath() throws -> String? {
@@ -201,6 +229,9 @@ struct APIServe: AsyncParsableCommand {
         guard rateLimitPerMinute > 0 else {
             throw ValidationError("--rate-limit-per-minute must be greater than zero.")
         }
+        guard maxActiveRequests > 0 else {
+            throw ValidationError("--max-active-requests must be greater than zero.")
+        }
         guard (1...Int(Int32.max)).contains(contextSize) else {
             throw ValidationError("--context-size must be between 1 and \(Int(Int32.max)).")
         }
@@ -222,19 +253,23 @@ enum APIEngine: String, ExpressibleByArgument {
     case textChatQ35 = "text-chat-q35"
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
 
-    var openAICompatibility: APIEngineCapabilities {
+    var runtimeServingEngine: RuntimeServingEngine {
         switch self {
         case .textCode:
-            return .localText
+            return .textCode
         case .textChatKlein:
-            return .localTextWithStructuredJSON
+            return .textChatKlein
         case .textChatGemma4:
-            return .localTextWithTools
+            return .textChatGemma4
         case .textChatQ35:
-            return .localTextWithToolsAndVision
+            return .textChatQ35
         case .textChatDeepseekV4Flash:
-            return .rawProxy
+            return .textChatDeepseekV4Flash
         }
+    }
+
+    var openAICompatibility: APIEngineCapabilities {
+        runtimeServingEngine.openAICompatibility
     }
 }
 
@@ -303,16 +338,20 @@ enum APIServerContract {
     }
 
     static func modelsResponse(modelId: String, createdAt: Date = Date()) -> OpenAIModelsResponse {
+        modelsResponse(modelIds: [modelId], createdAt: createdAt)
+    }
+
+    static func modelsResponse(modelIds: [String], createdAt: Date = Date()) -> OpenAIModelsResponse {
         OpenAIModelsResponse(
             object: "list",
-            data: [
+            data: modelIds.map {
                 OpenAIModel(
-                    id: modelId,
+                    id: $0,
                     object: "model",
                     created: Int(createdAt.timeIntervalSince1970),
                     owned_by: "mere.run"
                 )
-            ]
+            }
         )
     }
 
@@ -691,113 +730,37 @@ enum APIRequestValidationError: LocalizedError, Equatable {
 
 actor CodeGenServer {
     private let apiKey: String?
-    private let engine: APIEngine
-    private let llamaGenerator: CodeGenGenerator?
-    private let mlxGenerator: Flux2KleinGenerator?
-    private let gemma4Generator: Gemma4Generator?
-    private let q35Generator: Q35Generator?
-    private let deepseekV4FlashGenerator: DeepseekV4FlashGenerator?
-    private let modelPath: String?
     private let fallbackLoraPath: String?
-    private let modelId: String
+    private let defaultModelID: String
     private let contextSize: Int
-    private let useStandaloneModel: Bool
     private let requestLimiter: APIRateLimiter
+    private let requestAdmission: RuntimeRequestAdmission
+    private let pool: RuntimeModelPool
 
     init(
+        defaultModelID: String,
         modelPath: String?,
         fallbackLoraPath: String?,
         apiKey: String?,
         rateLimitPerMinute: Int,
+        maxActiveRequests: Int = 1,
         engine: APIEngine,
         contextSize: Int = 32768,
         gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization()
     ) async throws {
         self.apiKey = apiKey
         self.contextSize = contextSize
-        self.engine = engine
         self.fallbackLoraPath = fallbackLoraPath
-        self.modelPath = modelPath
+        self.defaultModelID = defaultModelID
         self.requestLimiter = APIRateLimiter(limitPerMinute: rateLimitPerMinute)
-        self.modelId = modelPath.map { URL(fileURLWithPath: $0).lastPathComponent }
-            ?? {
-                switch engine {
-                case .textChatKlein:
-                    return ModelResolver.ModelID.mebot.rawValue
-                case .textChatGemma4:
-                    return ModelResolver.ModelID.gemma4.rawValue
-                case .textChatQ35:
-                    return ModelResolver.ModelID.q35.rawValue
-                case .textCode:
-                    return CodeGenResources.defaultModelId
-                case .textChatDeepseekV4Flash:
-                    return DeepseekV4FlashResources.defaultModelId
-                }
-            }()
-
-        switch engine {
-        case .textCode:
-            let generator = CodeGenGenerator(modelId: modelPath ?? CodeGenResources.defaultModelId)
-            self.llamaGenerator = generator
-            self.mlxGenerator = nil
-            self.gemma4Generator = nil
-            self.q35Generator = nil
-            self.deepseekV4FlashGenerator = nil
-            self.useStandaloneModel = false
-
-            // Pre-load model
-            try await generator.prepare(modelPath: modelPath) { progress in
-                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
-            }
-        case .textChatKlein:
-            self.llamaGenerator = nil
-            self.mlxGenerator = Flux2KleinGenerator()
-            self.gemma4Generator = nil
-            self.q35Generator = nil
-            self.deepseekV4FlashGenerator = nil
-            // Check if the resolved path is a standalone MeBot Instruct model
-            self.useStandaloneModel = MeBotModelCatalog.resolveModelPath() != nil
-                && modelPath == MeBotModelCatalog.resolveModelPath()
-        case .textChatGemma4:
-            let generator = Gemma4Generator(
-                modelId: Gemma4Resources.defaultModelId,
-                kvCacheQuantization: gemma4KVCacheQuantization
-            )
-            self.llamaGenerator = nil
-            self.mlxGenerator = nil
-            self.gemma4Generator = generator
-            self.q35Generator = nil
-            self.deepseekV4FlashGenerator = nil
-            self.useStandaloneModel = false
-
-            try await generator.prepare(modelPath: modelPath) { progress in
-                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
-            }
-        case .textChatQ35:
-            let generator = Q35Generator(modelId: Q35Resources.defaultModelId)
-            self.llamaGenerator = nil
-            self.mlxGenerator = nil
-            self.gemma4Generator = nil
-            self.q35Generator = generator
-            self.deepseekV4FlashGenerator = nil
-            self.useStandaloneModel = false
-
-            try await generator.prepare(modelPath: modelPath) { progress in
-                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
-            }
-        case .textChatDeepseekV4Flash:
-            let generator = DeepseekV4FlashGenerator()
-            self.llamaGenerator = nil
-            self.mlxGenerator = nil
-            self.gemma4Generator = nil
-            self.q35Generator = nil
-            self.deepseekV4FlashGenerator = generator
-            self.useStandaloneModel = false
-
-            try await generator.prepare(modelPath: modelPath) { progress in
-                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
-            }
-        }
+        self.requestAdmission = RuntimeRequestAdmission(maxActiveRequests: maxActiveRequests)
+        self.pool = RuntimeModelPool(
+            defaultModelID: defaultModelID,
+            defaultEngine: engine.runtimeServingEngine,
+            startupModelPath: modelPath,
+            gemma4KVCacheQuantization: gemma4KVCacheQuantization
+        )
+        try await pool.preloadDefault()
     }
 
     func run(host: String, port: Int) async throws {
@@ -837,6 +800,54 @@ actor CodeGenServer {
             return try await self.handleChatCompletions(request)
         }
 
+        router.get("/runtime/status") { [self] request, _ in
+            return try await self.handleRuntimeStatus(request)
+        }
+
+        router.post("/runtime/models/:id/load") { [self] request, context in
+            guard let id = context.parameters.get("id", as: String.self) else {
+                return self.makeErrorResponse(
+                    status: .badRequest,
+                    message: "Missing model id.",
+                    type: "invalid_request_error"
+                )
+            }
+            return try await self.handleRuntimeLoad(request, id: id)
+        }
+
+        router.post("/runtime/models/:id/unload") { [self] request, context in
+            guard let id = context.parameters.get("id", as: String.self) else {
+                return self.makeErrorResponse(
+                    status: .badRequest,
+                    message: "Missing model id.",
+                    type: "invalid_request_error"
+                )
+            }
+            return try await self.handleRuntimeUnload(request, id: id)
+        }
+
+        router.get("/runtime/models/:id/settings") { [self] request, context in
+            guard let id = context.parameters.get("id", as: String.self) else {
+                return self.makeErrorResponse(
+                    status: .badRequest,
+                    message: "Missing model id.",
+                    type: "invalid_request_error"
+                )
+            }
+            return try await self.handleRuntimeSettings(request, id: id)
+        }
+
+        router.patch("/runtime/models/:id/settings") { [self] request, context in
+            guard let id = context.parameters.get("id", as: String.self) else {
+                return self.makeErrorResponse(
+                    status: .badRequest,
+                    message: "Missing model id.",
+                    type: "invalid_request_error"
+                )
+            }
+            return try await self.handleRuntimeSettingsPatch(request, id: id)
+        }
+
         return router
     }
 
@@ -844,7 +855,7 @@ actor CodeGenServer {
         if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
             return unauthorized
         }
-        let models = APIServerContract.modelsResponse(modelId: modelId)
+        let models = try await pool.modelsResponse()
 
         let data = try JSONEncoder().encode(models)
         return Response(
@@ -881,14 +892,6 @@ actor CodeGenServer {
             return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
         }
 
-        if engine == .textChatDeepseekV4Flash {
-            do {
-                return try await proxyDeepseekV4FlashChatCompletions(body: body, contentType: request.headers[.contentType])
-            } catch {
-                return makeErrorResponse(status: .internalServerError, message: "Request failed.", type: "server_error")
-            }
-        }
-
         let openaiRequest: OpenAIChatRequest
         do {
             openaiRequest = try JSONDecoder().decode(OpenAIChatRequest.self, from: Data(body.readableBytesView))
@@ -896,51 +899,85 @@ actor CodeGenServer {
             return makeErrorResponse(status: .badRequest, message: "Invalid request payload.", type: "invalid_request_error")
         }
 
-        let chatRequest: ChatRequest
+        let admissionLease = try await requestAdmission.acquire()
+        let plan: RuntimeChatPlan
         do {
-            chatRequest = try APIServerContract.chatRequest(
-                from: openaiRequest,
+            plan = try await pool.makeChatPlan(
+                for: openaiRequest,
                 fallbackLoraPath: fallbackLoraPath,
-                contextSize: contextSize,
-                capabilities: engine.openAICompatibility
+                serverContextSize: contextSize
             )
         } catch {
-            return makeErrorResponse(
-                status: .badRequest,
-                message: error.localizedDescription,
-                type: "invalid_request_error"
-            )
+            await admissionLease.release()
+            return runtimeErrorResponse(error)
+        }
+
+        if plan.engine == .textChatDeepseekV4Flash {
+            do {
+                return try await proxyDeepseekV4FlashChatCompletions(
+                    body: body,
+                    contentType: request.headers[.contentType],
+                    lease: plan.lease,
+                    admissionLease: admissionLease
+                )
+            } catch {
+                await plan.lease.release()
+                await admissionLease.release()
+                return makeErrorResponse(status: .internalServerError, message: "Request failed.", type: "server_error")
+            }
         }
 
         do {
             if openaiRequest.stream == true {
-                let includeUsage = try APIServerContract.includeUsageInStreaming(
-                    openaiRequest,
-                    capabilities: engine.openAICompatibility
+                return try await handleStreamingChat(
+                    plan.request,
+                    modelID: plan.modelID,
+                    includeUsage: plan.includeUsage,
+                    lease: plan.lease,
+                    admissionLease: admissionLease
                 )
-                return try await handleStreamingChat(chatRequest, includeUsage: includeUsage)
             } else {
-                return try await handleNonStreamingChat(chatRequest)
+                return try await handleNonStreamingChat(
+                    plan.request,
+                    modelID: plan.modelID,
+                    lease: plan.lease,
+                    admissionLease: admissionLease
+                )
             }
         } catch let error as APIRequestValidationError {
+            await plan.lease.release()
+            await admissionLease.release()
             return makeErrorResponse(
                 status: .badRequest,
                 message: error.localizedDescription,
                 type: "invalid_request_error"
             )
         } catch {
+            await plan.lease.release()
+            await admissionLease.release()
             return makeErrorResponse(status: .internalServerError, message: "Request failed.", type: "server_error")
         }
     }
 
-    private func handleNonStreamingChat(_ request: ChatRequest) async throws -> Response {
-        let result = try await generateChat(request, progressHandler: nil)
+    private func handleNonStreamingChat(
+        _ request: ChatRequest,
+        modelID: String,
+        lease: RuntimeModelLease,
+        admissionLease: RuntimeRequestAdmissionLease
+    ) async throws -> Response {
+        defer {
+            Task {
+                await lease.release()
+                await admissionLease.release()
+            }
+        }
+        let result = try await lease.chat(request, progressHandler: nil)
 
         let response = OpenAIChatResponse(
             id: "chatcmpl-\(UUID().uuidString.prefix(8))",
             object: "chat.completion",
             created: Int(Date().timeIntervalSince1970),
-            model: modelId,
+            model: modelID,
             choices: [
                 OpenAIChatChoice(
                     index: 0,
@@ -967,19 +1004,105 @@ actor CodeGenServer {
         )
     }
 
-    private func proxyDeepseekV4FlashChatCompletions(body: ByteBuffer, contentType: String?) async throws -> Response {
-        guard let generator = deepseekV4FlashGenerator else {
-            throw DeepseekV4FlashError.serverFailedToStart("generator not initialized")
+    private func handleRuntimeStatus(_ request: Request) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
         }
-        let upstreamURL = try await generator.chatCompletionsURL(modelPath: modelPath, progressHandler: nil)
+        let admission = await requestAdmission.snapshot()
+        let data = try JSONEncoder().encode(await pool.status(admission: admission))
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+
+    private func handleRuntimeLoad(_ request: Request, id: String) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        do {
+            let snapshot = try await pool.loadModel(idOrAlias: id)
+            return try jsonResponse(snapshot)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleRuntimeUnload(_ request: Request, id: String) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        do {
+            let snapshot = try await pool.unloadModel(idOrAlias: id)
+            return try jsonResponse(snapshot)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleRuntimeSettings(_ request: Request, id: String) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        do {
+            let settings = try await pool.settings(idOrAlias: id)
+            return try jsonResponse(settings)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleRuntimeSettingsPatch(_ request: Request, id: String) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        guard APIServerContract.acceptsJSONContentType(request.headers[.contentType]) else {
+            return makeErrorResponse(
+                status: .unsupportedMediaType,
+                message: "Content-Type must be application/json.",
+                type: "invalid_request_error"
+            )
+        }
+        let body: ByteBuffer
+        do {
+            body = try await request.body.collect(upTo: 1024 * 1024)
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
+        }
+        do {
+            let settings = try JSONDecoder().decode(RuntimeModelSettings.self, from: Data(body.readableBytesView))
+            let updated = try await pool.updateSettings(idOrAlias: id, settings: settings)
+            return try jsonResponse(updated)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func proxyDeepseekV4FlashChatCompletions(
+        body: ByteBuffer,
+        contentType: String?,
+        lease: RuntimeModelLease,
+        admissionLease: RuntimeRequestAdmissionLease
+    ) async throws -> Response {
+        let upstreamURL = try await lease.deepseekChatCompletionsURL(progressHandler: nil)
         let data = Data(body.readableBytesView)
 
         if !DeepseekV4FlashClient.requestWantsStreamingResponse(data) {
-            let upstreamResponse = try await DeepseekV4FlashClient.normalizedChatCompletionData(
-                url: upstreamURL,
-                requestBody: data,
-                contentType: contentType
-            )
+            let upstreamResponse: DeepseekV4FlashClientResponse
+            do {
+                upstreamResponse = try await DeepseekV4FlashClient.normalizedChatCompletionData(
+                    url: upstreamURL,
+                    requestBody: data,
+                    contentType: contentType
+                )
+            } catch {
+                await lease.release()
+                await admissionLease.release()
+                throw error
+            }
+            await lease.release()
+            await admissionLease.release()
             var headers: HTTPFields = [:]
             headers[.contentType] = upstreamResponse.contentType
             return Response(
@@ -1006,6 +1129,10 @@ actor CodeGenServer {
                 if !upstreamData.isEmpty {
                     continuation.yield(ByteBuffer(bytes: upstreamData))
                 }
+                Task {
+                    await lease.release()
+                    await admissionLease.release()
+                }
                 continuation.finish()
             }
             return Response(
@@ -1018,6 +1145,8 @@ actor CodeGenServer {
             upstreamData,
             contentType: headers[.contentType]
         )
+        await lease.release()
+        await admissionLease.release()
         return Response(
             status: .init(code: http?.statusCode ?? 502),
             headers: headers,
@@ -1046,8 +1175,12 @@ actor CodeGenServer {
                         if !buffer.isEmpty {
                             continuation.yield(ByteBuffer(bytes: buffer))
                         }
+                        await lease.release()
+                        await admissionLease.release()
                         continuation.finish()
                     } catch {
+                        await lease.release()
+                        await admissionLease.release()
                         continuation.finish()
                     }
                 }
@@ -1060,9 +1193,17 @@ actor CodeGenServer {
         }
 
         var upstreamData = Data()
-        for try await byte in upstreamBytes {
-            upstreamData.append(byte)
+        do {
+            for try await byte in upstreamBytes {
+                upstreamData.append(byte)
+            }
+        } catch {
+            await lease.release()
+            await admissionLease.release()
+            throw error
         }
+        await lease.release()
+        await admissionLease.release()
         let repairedData = DeepseekV4FlashClient.normalizedChatCompletionBody(
             upstreamData,
             contentType: headers[.contentType]
@@ -1075,7 +1216,13 @@ actor CodeGenServer {
 #endif
     }
 
-    private func handleStreamingChat(_ request: ChatRequest, includeUsage: Bool) async throws -> Response {
+    private func handleStreamingChat(
+        _ request: ChatRequest,
+        modelID: String,
+        includeUsage: Bool,
+        lease: RuntimeModelLease,
+        admissionLease: RuntimeRequestAdmissionLease
+    ) async throws -> Response {
         let id = "chatcmpl-\(UUID().uuidString.prefix(8))"
         let encoder = JSONEncoder()
 
@@ -1083,11 +1230,11 @@ actor CodeGenServer {
         let (stream, continuation) = AsyncStream<ByteBuffer>.makeStream()
 
         // Start generation in a detached task
-        Task { [self, modelId] in
+        Task {
             do {
                 let streamedContent = StreamingContentTracker()
                 let shouldBufferForToolCalls = request.tools?.isEmpty == false
-                let result = try await self.generateChat(request) { progress in
+                let result = try await lease.chat(request) { progress in
                     guard !shouldBufferForToolCalls else { return }
                     if progress.stage == .generating,
                        let token = progress.message,
@@ -1098,7 +1245,7 @@ actor CodeGenServer {
                             id: id,
                             object: "chat.completion.chunk",
                             created: Int(Date().timeIntervalSince1970),
-                            model: modelId,
+                            model: modelID,
                             choices: [
                                 OpenAIChatChoice(
                                     index: 0,
@@ -1119,7 +1266,7 @@ actor CodeGenServer {
                         id: id,
                         object: "chat.completion.chunk",
                         created: Int(Date().timeIntervalSince1970),
-                        model: modelId,
+                        model: modelID,
                         choices: [
                             OpenAIChatChoice(
                                 index: 0,
@@ -1140,7 +1287,7 @@ actor CodeGenServer {
                         id: id,
                         object: "chat.completion.chunk",
                         created: Int(Date().timeIntervalSince1970),
-                        model: modelId,
+                        model: modelID,
                         choices: [
                             OpenAIChatChoice(
                                 index: 0,
@@ -1160,7 +1307,7 @@ actor CodeGenServer {
                     id: id,
                     object: "chat.completion.chunk",
                     created: Int(Date().timeIntervalSince1970),
-                    model: modelId,
+                    model: modelID,
                     choices: [
                         OpenAIChatChoice(
                             index: 0,
@@ -1179,7 +1326,7 @@ actor CodeGenServer {
                         id: id,
                         object: "chat.completion.chunk",
                         created: Int(Date().timeIntervalSince1970),
-                        model: modelId,
+                        model: modelID,
                         choices: [],
                         usage: OpenAIUsage(
                             prompt_tokens: 0,
@@ -1194,6 +1341,8 @@ actor CodeGenServer {
                 }
 
                 continuation.yield(ByteBuffer(string: "data: [DONE]\n\n"))
+                await lease.release()
+                await admissionLease.release()
                 continuation.finish()
             } catch {
                 // Send error in SSE format
@@ -1204,6 +1353,8 @@ actor CodeGenServer {
                    let json = String(data: data, encoding: .utf8) {
                     continuation.yield(ByteBuffer(string: "data: \(json)\n\n"))
                 }
+                await lease.release()
+                await admissionLease.release()
                 continuation.finish()
             }
         }
@@ -1237,45 +1388,6 @@ actor CodeGenServer {
         return String(data: data, encoding: .utf8) ?? "{}"
     }
 
-    private func generateChat(
-        _ request: ChatRequest,
-        progressHandler: (@Sendable (ChatProgress) -> Void)?
-    ) async throws -> ChatResponse {
-        switch engine {
-        case .textCode:
-            guard let generator = llamaGenerator else {
-                throw CodeGenError.modelNotLoaded
-            }
-            return try await generator.chat(request, progressHandler: progressHandler)
-        case .textChatKlein:
-            guard let generator = mlxGenerator else {
-                throw Flux2Error.modelsNotLoaded
-            }
-            guard let modelPath else {
-                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
-            }
-            if useStandaloneModel {
-                return try await generator.chatStandalone(request, modelPath: modelPath, progressHandler: progressHandler)
-            }
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatGemma4:
-            guard let generator = gemma4Generator else {
-                throw Gemma4Error.modelNotLoaded
-            }
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatQ35:
-            guard let generator = q35Generator else {
-                throw Q35Error.modelNotLoaded
-            }
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatDeepseekV4Flash:
-            guard let generator = deepseekV4FlashGenerator else {
-                throw DeepseekV4FlashError.serverFailedToStart("generator not initialized")
-            }
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        }
-    }
-
     private func unauthorizedResponseIfNeeded(for request: Request) -> Response? {
         guard let apiKey, !apiKey.isEmpty else { return nil }
         guard request.headers[.authorization] == "Bearer \(apiKey)" else {
@@ -1289,7 +1401,57 @@ actor CodeGenServer {
         return nil
     }
 
-    private func makeErrorResponse(
+    private nonisolated func jsonResponse<T: Encodable>(
+        _ payload: T,
+        status: HTTPResponse.Status = .ok
+    ) throws -> Response {
+        let data = try JSONEncoder().encode(payload)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+
+    private nonisolated func runtimeErrorResponse(_ error: Error) -> Response {
+        switch error {
+        case let error as RuntimeModelPoolError:
+            switch error {
+            case .unknownModel, .unsupportedModel, .modelNotInstalled, .incompatibleEngine, .invalidSettings:
+                return makeErrorResponse(
+                    status: .badRequest,
+                    message: error.localizedDescription,
+                    type: "invalid_request_error"
+                )
+            case .unloadConflict:
+                return makeErrorResponse(
+                    status: .conflict,
+                    message: error.localizedDescription,
+                    type: "conflict_error"
+                )
+            case .rawProxyUnavailable:
+                return makeErrorResponse(
+                    status: .internalServerError,
+                    message: error.localizedDescription,
+                    type: "server_error"
+                )
+            }
+        case let error as APIRequestValidationError:
+            return makeErrorResponse(
+                status: .badRequest,
+                message: error.localizedDescription,
+                type: "invalid_request_error"
+            )
+        default:
+            return makeErrorResponse(
+                status: .internalServerError,
+                message: "Request failed.",
+                type: "server_error"
+            )
+        }
+    }
+
+    private nonisolated func makeErrorResponse(
         status: HTTPResponse.Status,
         message: String,
         type: String,

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -79,10 +79,10 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Context size (default: 32768).")
     var contextSize: Int = 32768
 
-    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform and integer/.5 widths for turboquant.")
+    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform/polar and integer/.5 widths for turboquant.")
     var kvBits: Double?
 
-    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform or turboquant.")
+    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform, polar, or turboquant.")
     var kvQuantScheme: String?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization group size.")
@@ -202,7 +202,7 @@ struct APIServe: AsyncParsableCommand {
         guard let scheme = Gemma4KVQuantizationScheme(
             rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ) else {
-            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform' or 'turboquant'.")
+            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform', 'polar', or 'turboquant'.")
         }
         return scheme
     }

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -339,6 +339,20 @@ enum GuideRegistry {
             resourceName: "model-list.md"
         ),
         GuideTopic(
+            topic: "model-runtime",
+            title: "Model Runtime",
+            commandPaths: [["model", "runtime"], ["model", "runtime", "get"], ["model", "runtime", "set"]],
+            models: [
+                "text-code-qwen3",
+                "text-agent-qwen35-9b",
+                "text-chat-gemma4",
+                "text-chat-q35",
+                "text-agent-deepseek-v4-flash",
+                "text-chat-mebot",
+            ],
+            resourceName: "model-runtime.md"
+        ),
+        GuideTopic(
             topic: "model-capabilities",
             title: "Model Capabilities",
             commandPaths: [["model", "capabilities"]],

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -353,6 +353,15 @@ enum GuideRegistry {
             resourceName: "model-runtime.md"
         ),
         GuideTopic(
+            topic: "model-benchmark",
+            title: "Model Benchmark",
+            commandPaths: [["model", "benchmark"], ["model", "benchmark", "gemma4-kv"]],
+            models: [
+                "text-chat-gemma4-turbo",
+            ],
+            resourceName: "model-benchmark.md"
+        ),
+        GuideTopic(
             topic: "model-capabilities",
             title: "Model Capabilities",
             commandPaths: [["model", "capabilities"]],

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -149,6 +149,7 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
             elapsedSeconds: elapsed,
             loadSeconds: timing.loadSeconds,
             prefillSeconds: timing.prefillSeconds,
+            cacheConversionSeconds: timing.cacheConversionSeconds,
             decodeSeconds: timing.decodeSeconds,
             firstTokenSeconds: timing.firstTokenSeconds,
             prefillTokensPerSecond: promptTokens > 0 && timing.prefillSeconds > 0
@@ -234,6 +235,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
     let elapsedSeconds: Double
     let loadSeconds: Double
     let prefillSeconds: Double
+    let cacheConversionSeconds: Double?
     let decodeSeconds: Double
     let firstTokenSeconds: Double?
     let prefillTokensPerSecond: Double?
@@ -244,7 +246,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
 
     var ttftSeconds: Double? {
         guard let firstTokenSeconds else { return nil }
-        return loadSeconds + prefillSeconds + firstTokenSeconds
+        return loadSeconds + prefillSeconds + (cacheConversionSeconds ?? 0) + firstTokenSeconds
     }
 
     enum CodingKeys: String, CodingKey {
@@ -257,6 +259,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         case elapsedSeconds
         case loadSeconds
         case prefillSeconds
+        case cacheConversionSeconds
         case decodeSeconds
         case firstTokenSeconds
         case ttftSeconds
@@ -278,6 +281,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         try container.encode(elapsedSeconds, forKey: .elapsedSeconds)
         try container.encode(loadSeconds, forKey: .loadSeconds)
         try container.encode(prefillSeconds, forKey: .prefillSeconds)
+        try container.encodeIfPresent(cacheConversionSeconds, forKey: .cacheConversionSeconds)
         try container.encode(decodeSeconds, forKey: .decodeSeconds)
         try container.encodeIfPresent(firstTokenSeconds, forKey: .firstTokenSeconds)
         try container.encodeIfPresent(ttftSeconds, forKey: .ttftSeconds)
@@ -292,7 +296,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         [
             "\(name): \(kvScheme)\(kvBits.map { String(format: " %.1f-bit", $0) } ?? "") start=\(quantizedKVStart)",
             "  prompt_tokens=\(promptTokens) generated_tokens=\(generatedTokens)",
-            "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
+            "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s kv_convert=\(formatOptional(cacheConversionSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
             "  throughput prefill=\(formatOptional(prefillTokensPerSecond)) tok/s decode=\(formatOptional(decodeTokensPerSecond)) tok/s e2e=\(formatOptional(endToEndTokensPerSecond)) tok/s",
             "  resident_memory before=\(formatBytes(residentMemoryBeforeBytes)) after=\(formatBytes(residentMemoryAfterBytes))",
             "",

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -1,0 +1,335 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+#if canImport(Darwin)
+import Darwin
+#endif
+
+struct ModelBenchmark: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "benchmark",
+        abstract: "Run focused local model benchmarks.",
+        subcommands: [
+            ModelBenchmarkGemma4KV.self,
+        ]
+    )
+}
+
+struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gemma4-kv",
+        abstract: "Compare Gemma4 default KV cache decode against packed PolarKV."
+    )
+
+    @Option(name: [.long], help: "Gemma4 model id or repo id.")
+    var model: String = Gemma4Resources.turboModelId
+
+    @Option(name: [.customShort("m"), .long], help: "Override model root directory.")
+    var modelRoot: String?
+
+    @Option(name: [.customShort("p"), .long], help: "Benchmark prompt. Defaults to a repeated deterministic fixture.")
+    var prompt: String?
+
+    @Option(name: [.long], help: "Read the benchmark prompt from a UTF-8 file.")
+    var promptFile: String?
+
+    @Option(name: [.long], help: "Repeat count for the built-in fixture prompt.")
+    var promptRepeat: Int = 220
+
+    @Option(name: [.long], help: "Exact number of decode tokens to force per variant.")
+    var decodeTokens: Int = 48
+
+    @Option(name: [.long], help: "Temperature for benchmark sampling.")
+    var temperature: Double = 0
+
+    @Option(name: [.long], help: "Top-p for benchmark sampling.")
+    var topP: Double = 1
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    func validate() throws {
+        if prompt != nil && promptFile != nil {
+            throw ValidationError("Specify either --prompt or --prompt-file, not both.")
+        }
+        guard promptRepeat > 0 else {
+            throw ValidationError("--prompt-repeat must be greater than zero.")
+        }
+        guard decodeTokens > 0 else {
+            throw ValidationError("--decode-tokens must be greater than zero.")
+        }
+        guard Gemma4Resources.handles(modelSpec: model) else {
+            throw ValidationError("model benchmark gemma4-kv only supports Gemma4 model ids or repo ids.")
+        }
+    }
+
+    func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: json)
+        let prompt = try resolvePrompt()
+        let request = ChatRequest(
+            messages: [ChatMessage(role: .user, content: prompt)],
+            maxTokens: decodeTokens,
+            temperature: temperature,
+            topP: topP,
+            showThinking: false,
+            stopOnEOS: false
+        )
+
+        let variants = [
+            Gemma4KVBenchmarkVariant.defaultTurbo(model: model),
+            Gemma4KVBenchmarkVariant.polar2(model: model),
+        ]
+        var results: [Gemma4KVBenchmarkVariantResult] = []
+        results.reserveCapacity(variants.count)
+
+        for variant in variants {
+            let result = try await runVariant(variant, request: request)
+            guard result.generatedTokens == decodeTokens else {
+                throw ValidationError(
+                    "\(variant.name) generated \(result.generatedTokens) tokens, expected \(decodeTokens). Reduce prompt length or decode tokens."
+                )
+            }
+            results.append(result)
+        }
+
+        let report = Gemma4KVBenchmarkReport(
+            model: model,
+            promptCharacters: prompt.count,
+            requestedDecodeTokens: decodeTokens,
+            variants: results
+        )
+        if json {
+            print(try report.jsonString())
+        } else {
+            print(report.renderText())
+        }
+    }
+
+    private func resolvePrompt() throws -> String {
+        if let prompt {
+            return prompt
+        }
+        if let promptFile {
+            return try String(contentsOf: URL(fileURLWithPath: promptFile).standardizedFileURL, encoding: .utf8)
+        }
+        var lines: [String] = []
+        lines.reserveCapacity(promptRepeat + 1)
+        for index in 1...promptRepeat {
+            lines.append(
+                "Record \(index): Gemma turbo benchmark passage about local inference, packed key value cache memory, decode timing, and repeatable measurements. The checksum word is polar."
+            )
+        }
+        lines.append("Question: Write one concise sentence naming the checksum word and benchmark subject.")
+        return lines.joined(separator: "\n")
+    }
+
+    private func runVariant(
+        _ variant: Gemma4KVBenchmarkVariant,
+        request: ChatRequest
+    ) async throws -> Gemma4KVBenchmarkVariantResult {
+        let generator = Gemma4Generator(modelId: model, kvCacheQuantization: variant.quantization)
+        let memoryBefore = ProcessMemorySnapshot.currentResidentBytes()
+        let start = Date()
+        let response = try await generator.chat(request, modelPath: modelRoot, progressHandler: nil)
+        let elapsed = Date().timeIntervalSince(start)
+        let memoryAfter = ProcessMemorySnapshot.currentResidentBytes()
+        await generator.unload()
+
+        guard let timing = response.timing else {
+            throw ValidationError("\(variant.name) did not return timing data.")
+        }
+        let promptTokens = response.promptTokens ?? 0
+        return Gemma4KVBenchmarkVariantResult(
+            name: variant.name,
+            kvScheme: variant.quantization.scheme.rawValue,
+            kvBits: variant.quantization.bits,
+            quantizedKVStart: variant.quantization.quantizedStart,
+            promptTokens: promptTokens,
+            generatedTokens: response.tokensGenerated,
+            elapsedSeconds: elapsed,
+            loadSeconds: timing.loadSeconds,
+            prefillSeconds: timing.prefillSeconds,
+            decodeSeconds: timing.decodeSeconds,
+            firstTokenSeconds: timing.firstTokenSeconds,
+            prefillTokensPerSecond: promptTokens > 0 && timing.prefillSeconds > 0
+                ? Double(promptTokens) / timing.prefillSeconds
+                : nil,
+            decodeTokensPerSecond: timing.decodeSeconds > 0
+                ? Double(response.tokensGenerated) / timing.decodeSeconds
+                : nil,
+            endToEndTokensPerSecond: elapsed > 0 ? Double(response.tokensGenerated) / elapsed : nil,
+            residentMemoryBeforeBytes: memoryBefore,
+            residentMemoryAfterBytes: memoryAfter
+        )
+    }
+}
+
+private struct Gemma4KVBenchmarkVariant {
+    let name: String
+    let quantization: Gemma4KVCacheQuantization
+
+    static func defaultTurbo(model: String) -> Self {
+        let usesTurboDefaults = Gemma4Resources.usesTurboDefaults(modelSpec: model)
+        return Self(
+            name: "default",
+            quantization: Gemma4KVCacheQuantization(
+                bits: usesTurboDefaults ? Gemma4Resources.defaultTurboKVBits : nil,
+                scheme: usesTurboDefaults ? Gemma4Resources.defaultTurboKVQuantizationScheme : .uniform,
+                groupSize: Gemma4Resources.defaultKVGroupSize,
+                quantizedStart: usesTurboDefaults
+                    ? Gemma4Resources.defaultTurboQuantizedKVStart
+                    : Gemma4Resources.defaultQuantizedKVStart
+            )
+        )
+    }
+
+    static func polar2(model: String) -> Self {
+        Self(
+            name: "polar2",
+            quantization: Gemma4KVCacheQuantization(
+                bits: 2,
+                scheme: .polar,
+                groupSize: Gemma4Resources.defaultKVGroupSize,
+                quantizedStart: 0
+            )
+        )
+    }
+}
+
+private struct Gemma4KVBenchmarkReport: Encodable {
+    let model: String
+    let promptCharacters: Int
+    let requestedDecodeTokens: Int
+    let variants: [Gemma4KVBenchmarkVariantResult]
+
+    func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func renderText() -> String {
+        var lines = [
+            "Gemma4 KV benchmark",
+            "model: \(model)",
+            "prompt characters: \(promptCharacters)",
+            "decode tokens: \(requestedDecodeTokens)",
+            "",
+        ]
+        for result in variants {
+            lines.append(result.renderText())
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct Gemma4KVBenchmarkVariantResult: Encodable {
+    let name: String
+    let kvScheme: String
+    let kvBits: Double?
+    let quantizedKVStart: Int
+    let promptTokens: Int
+    let generatedTokens: Int
+    let elapsedSeconds: Double
+    let loadSeconds: Double
+    let prefillSeconds: Double
+    let decodeSeconds: Double
+    let firstTokenSeconds: Double?
+    let prefillTokensPerSecond: Double?
+    let decodeTokensPerSecond: Double?
+    let endToEndTokensPerSecond: Double?
+    let residentMemoryBeforeBytes: UInt64?
+    let residentMemoryAfterBytes: UInt64?
+
+    var ttftSeconds: Double? {
+        guard let firstTokenSeconds else { return nil }
+        return loadSeconds + prefillSeconds + firstTokenSeconds
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case kvScheme
+        case kvBits
+        case quantizedKVStart
+        case promptTokens
+        case generatedTokens
+        case elapsedSeconds
+        case loadSeconds
+        case prefillSeconds
+        case decodeSeconds
+        case firstTokenSeconds
+        case ttftSeconds
+        case prefillTokensPerSecond
+        case decodeTokensPerSecond
+        case endToEndTokensPerSecond
+        case residentMemoryBeforeBytes
+        case residentMemoryAfterBytes
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(kvScheme, forKey: .kvScheme)
+        try container.encodeIfPresent(kvBits, forKey: .kvBits)
+        try container.encode(quantizedKVStart, forKey: .quantizedKVStart)
+        try container.encode(promptTokens, forKey: .promptTokens)
+        try container.encode(generatedTokens, forKey: .generatedTokens)
+        try container.encode(elapsedSeconds, forKey: .elapsedSeconds)
+        try container.encode(loadSeconds, forKey: .loadSeconds)
+        try container.encode(prefillSeconds, forKey: .prefillSeconds)
+        try container.encode(decodeSeconds, forKey: .decodeSeconds)
+        try container.encodeIfPresent(firstTokenSeconds, forKey: .firstTokenSeconds)
+        try container.encodeIfPresent(ttftSeconds, forKey: .ttftSeconds)
+        try container.encodeIfPresent(prefillTokensPerSecond, forKey: .prefillTokensPerSecond)
+        try container.encodeIfPresent(decodeTokensPerSecond, forKey: .decodeTokensPerSecond)
+        try container.encodeIfPresent(endToEndTokensPerSecond, forKey: .endToEndTokensPerSecond)
+        try container.encodeIfPresent(residentMemoryBeforeBytes, forKey: .residentMemoryBeforeBytes)
+        try container.encodeIfPresent(residentMemoryAfterBytes, forKey: .residentMemoryAfterBytes)
+    }
+
+    func renderText() -> String {
+        [
+            "\(name): \(kvScheme)\(kvBits.map { String(format: " %.1f-bit", $0) } ?? "") start=\(quantizedKVStart)",
+            "  prompt_tokens=\(promptTokens) generated_tokens=\(generatedTokens)",
+            "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
+            "  throughput prefill=\(formatOptional(prefillTokensPerSecond)) tok/s decode=\(formatOptional(decodeTokensPerSecond)) tok/s e2e=\(formatOptional(endToEndTokensPerSecond)) tok/s",
+            "  resident_memory before=\(formatBytes(residentMemoryBeforeBytes)) after=\(formatBytes(residentMemoryAfterBytes))",
+            "",
+        ].joined(separator: "\n")
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private func formatOptional(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return format(value)
+    }
+
+    private func formatBytes(_ value: UInt64?) -> String {
+        guard let value else { return "n/a" }
+        return ByteCountFormatter.string(fromByteCount: Int64(value), countStyle: .memory)
+    }
+}
+
+private enum ProcessMemorySnapshot {
+    static func currentResidentBytes() -> UInt64? {
+        #if canImport(Darwin)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return UInt64(info.resident_size)
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/MereRunCLI/Commands/ModelCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCommand.swift
@@ -10,6 +10,7 @@ struct Model: ParsableCommand {
             ModelRemove.self,
             ModelInfo.self,
             ModelCapabilities.self,
+            ModelRuntime.self,
             ModelRepairManifests.self,
         ]
     )

--- a/Sources/MereRunCLI/Commands/ModelCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCommand.swift
@@ -11,6 +11,7 @@ struct Model: ParsableCommand {
             ModelInfo.self,
             ModelCapabilities.self,
             ModelRuntime.self,
+            ModelBenchmark.self,
             ModelRepairManifests.self,
         ]
     )

--- a/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift
@@ -1,0 +1,208 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+extension RuntimeServingEngine: ExpressibleByArgument {}
+
+struct ModelRuntime: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "runtime",
+        abstract: "Read and update per-model API runtime settings.",
+        subcommands: [
+            ModelRuntimeGet.self,
+            ModelRuntimeSet.self,
+        ]
+    )
+}
+
+struct ModelRuntimeGet: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "get",
+        abstract: "Print typed API runtime settings for a managed model."
+    )
+
+    @Argument(help: "Managed model id or configured alias.")
+    var model: String
+
+    @Flag(name: [.long], help: "Emit settings as JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        let store = RuntimeModelSettingsStore()
+        let modelID = try RuntimeModelCLI.resolveModelID(model, store: store)
+        let settings = try store.settings(for: modelID)
+
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(settings)
+            guard let output = String(data: data, encoding: .utf8) else {
+                throw ValidationError("Could not encode runtime settings as UTF-8.")
+            }
+            print(output)
+            return
+        }
+
+        print("Runtime settings")
+        print("  model: \(modelID)")
+        print("  path: \(store.url.path)")
+        print("  alias: \(settings.alias ?? "none")")
+        print("  pinned: \(settings.pinned)")
+        print("  ttlSeconds: \(settings.ttlSeconds.map(String.init) ?? "none")")
+        print("  maxContextTokens: \(settings.maxContextTokens.map(String.init) ?? "none")")
+        print("  maxTokens: \(settings.maxTokens.map(String.init) ?? "none")")
+        print("  temperature: \(settings.temperature.map { String($0) } ?? "none")")
+        print("  topP: \(settings.topP.map { String($0) } ?? "none")")
+        print("  engineOverride: \(settings.engineOverride?.rawValue ?? "none")")
+    }
+}
+
+struct ModelRuntimeSet: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Update typed API runtime settings for a managed model."
+    )
+
+    @Argument(help: "Managed model id or configured alias.")
+    var model: String
+
+    @Option(name: [.long], help: "Set a request-facing alias for this model.")
+    var alias: String?
+
+    @Flag(name: [.long], help: "Clear this model's alias.")
+    var clearAlias: Bool = false
+
+    @Flag(name: [.long], help: "Keep this model loaded across future TTL/LRU passes.")
+    var pinned: Bool = false
+
+    @Flag(name: [.long], help: "Clear the pinned flag.")
+    var unpinned: Bool = false
+
+    @Option(name: [.long], help: "Set unload TTL in seconds.")
+    var ttlSeconds: Int?
+
+    @Flag(name: [.long], help: "Clear unload TTL.")
+    var clearTTL: Bool = false
+
+    @Option(name: [.long], help: "Set the default context token limit.")
+    var maxContextTokens: Int?
+
+    @Flag(name: [.long], help: "Clear the default context token limit.")
+    var clearMaxContextTokens: Bool = false
+
+    @Option(name: [.long], help: "Set the default max output tokens.")
+    var maxTokens: Int?
+
+    @Flag(name: [.long], help: "Clear the default max output tokens.")
+    var clearMaxTokens: Bool = false
+
+    @Option(name: [.long], help: "Set the default temperature.")
+    var temperature: Double?
+
+    @Flag(name: [.long], help: "Clear the default temperature.")
+    var clearTemperature: Bool = false
+
+    @Option(name: [.long], help: "Set the default top_p.")
+    var topP: Double?
+
+    @Flag(name: [.long], help: "Clear the default top_p.")
+    var clearTopP: Bool = false
+
+    @Option(name: [.long], help: "Set an engine override after catalog compatibility checks.")
+    var engine: RuntimeServingEngine?
+
+    @Flag(name: [.long], help: "Clear the engine override.")
+    var clearEngine: Bool = false
+
+    @Flag(name: [.long], help: "Emit updated settings as JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        try validateFlagPairs()
+        let store = RuntimeModelSettingsStore()
+        let modelID = try RuntimeModelCLI.resolveModelID(model, store: store)
+        var settings = try store.settings(for: modelID)
+
+        if clearAlias {
+            settings.alias = nil
+        } else if let alias {
+            settings.alias = alias
+        }
+        if pinned { settings.pinned = true }
+        if unpinned { settings.pinned = false }
+        if clearTTL { settings.ttlSeconds = nil } else if let ttlSeconds { settings.ttlSeconds = ttlSeconds }
+        if clearMaxContextTokens {
+            settings.maxContextTokens = nil
+        } else if let maxContextTokens {
+            settings.maxContextTokens = maxContextTokens
+        }
+        if clearMaxTokens { settings.maxTokens = nil } else if let maxTokens { settings.maxTokens = maxTokens }
+        if clearTemperature {
+            settings.temperature = nil
+        } else if let temperature {
+            settings.temperature = temperature
+        }
+        if clearTopP { settings.topP = nil } else if let topP { settings.topP = topP }
+        if clearEngine { settings.engineOverride = nil } else if let engine { settings.engineOverride = engine }
+
+        try store.writeSettings(settings, for: modelID)
+        let updated = try store.settings(for: modelID)
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(updated)
+            guard let output = String(data: data, encoding: .utf8) else {
+                throw ValidationError("Could not encode runtime settings as UTF-8.")
+            }
+            print(output)
+        } else {
+            print("Updated runtime settings for \(modelID)")
+            print("  \(store.url.path)")
+        }
+    }
+
+    private func validateFlagPairs() throws {
+        if pinned && unpinned {
+            throw ValidationError("Use either --pinned or --unpinned, not both.")
+        }
+        if alias != nil && clearAlias {
+            throw ValidationError("Use either --alias or --clear-alias, not both.")
+        }
+        if ttlSeconds != nil && clearTTL {
+            throw ValidationError("Use either --ttl-seconds or --clear-ttl, not both.")
+        }
+        if maxContextTokens != nil && clearMaxContextTokens {
+            throw ValidationError("Use either --max-context-tokens or --clear-max-context-tokens, not both.")
+        }
+        if maxTokens != nil && clearMaxTokens {
+            throw ValidationError("Use either --max-tokens or --clear-max-tokens, not both.")
+        }
+        if temperature != nil && clearTemperature {
+            throw ValidationError("Use either --temperature or --clear-temperature, not both.")
+        }
+        if topP != nil && clearTopP {
+            throw ValidationError("Use either --top-p or --clear-top-p, not both.")
+        }
+        if engine != nil && clearEngine {
+            throw ValidationError("Use either --engine or --clear-engine, not both.")
+        }
+    }
+}
+
+private enum RuntimeModelCLI {
+    static func resolveModelID(_ value: String, store: RuntimeModelSettingsStore) throws -> String {
+        if let spec = ManagedModelCatalog.spec(for: value) {
+            guard spec.isAPIServableRuntimeModel else {
+                throw ValidationError("Model '\(spec.id)' is not supported by `mere.run api serve`.")
+            }
+            return spec.id
+        }
+        let document = try store.load()
+        if let match = document.models.first(where: { _, settings in
+            settings.alias?.caseInsensitiveCompare(value) == .orderedSame
+        }) {
+            return match.key
+        }
+        throw ValidationError("Unknown runtime model or alias: \(value)")
+    }
+}

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -87,6 +87,8 @@ struct StatusServerSnapshot: Codable, Equatable {
     let detail: String?
     let loadedModels: [String]
     let modelsDetail: String?
+    let runtime: RuntimeModelPoolStatus?
+    let runtimeDetail: String?
 }
 
 struct StatusModelStoreSnapshot: Codable, Equatable {
@@ -144,17 +146,22 @@ struct StatusSnapshotBuilder {
                 health: "down",
                 detail: health.detail,
                 loadedModels: [],
-                modelsDetail: nil
+                modelsDetail: nil,
+                runtime: nil,
+                runtimeDetail: nil
             )
         }
 
         let models = await probeModels(baseURL: baseURL)
+        let runtime = await probeRuntimeStatus(baseURL: baseURL)
         return StatusServerSnapshot(
             url: baseURL,
             health: "up",
             detail: health.detail,
             loadedModels: models.loadedModels,
-            modelsDetail: models.detail
+            modelsDetail: models.detail,
+            runtime: runtime.snapshot,
+            runtimeDetail: runtime.detail
         )
     }
 
@@ -205,6 +212,31 @@ struct StatusSnapshotBuilder {
         }
     }
 
+    private func probeRuntimeStatus(baseURL: String) async -> (snapshot: RuntimeModelPoolStatus?, detail: String?) {
+        guard let url = URL(string: "\(baseURL)/runtime/status") else {
+            return (nil, "invalid runtime status URL")
+        }
+
+        do {
+            let (data, response) = try await data(from: url, authorize: true)
+            guard let http = response as? HTTPURLResponse else {
+                return (nil, "runtime status returned a non-HTTP response")
+            }
+            switch http.statusCode {
+            case 200:
+                return (try JSONDecoder().decode(RuntimeModelPoolStatus.self, from: data), nil)
+            case 401, 403:
+                return (nil, "requires API key")
+            case 404:
+                return (nil, "runtime status endpoint is unavailable")
+            default:
+                return (nil, "runtime status returned HTTP \(http.statusCode)")
+            }
+        } catch {
+            return (nil, StatusSnapshotBuilder.shortNetworkError(error))
+        }
+    }
+
     private func data(from url: URL, authorize: Bool) async throws -> (Data, URLResponse) {
         var request = URLRequest(url: url, timeoutInterval: max(0.1, timeoutSeconds))
         if authorize, let apiKey {
@@ -252,7 +284,35 @@ enum StatusFormatter {
         lines.append(serverLine)
 
         if snapshot.server.health == "up" {
-            if !snapshot.server.loadedModels.isEmpty {
+            if let runtime = snapshot.server.runtime {
+                let activeModels = runtime.models.filter(\.loaded).map(\.id)
+                if activeModels.isEmpty {
+                    lines.append("  loaded models: none reported")
+                } else {
+                    lines.append("  loaded models: \(activeModels.joined(separator: ", "))")
+                }
+                lines.append("  active requests: \(runtime.activeRequests)")
+                if let admission = runtime.admission {
+                    lines.append("  request admission: \(admission.activeRequests)/\(admission.maxActiveRequests) active, \(admission.queuedRequests) queued")
+                }
+                lines.append("  continuous batching: \(capabilityText(runtime.capabilities.continuousBatching))")
+                lines.append("  prefix KV reuse: \(capabilityText(runtime.capabilities.prefixKVReuse))")
+                if let cacheStats = cacheStatsText(runtime.cacheStats) {
+                    lines.append("  cache stats: \(cacheStats)")
+                }
+                if let benchmarkStats = runtime.benchmarkStats.flatMap(benchmarkStatsText) {
+                    lines.append("  benchmark stats: \(benchmarkStats)")
+                }
+                lines.append("  memory: \(memoryText(runtime.memory))")
+                for model in runtime.models {
+                    guard let prefixKVCache = model.prefixKVCache else { continue }
+                    lines.append("    \(model.id) prefix KV: \(prefixKVCache.entries)/\(prefixKVCache.maxEntries) entries, \(prefixKVCache.hits) hits, \(prefixKVCache.reusedTokens) reused tokens")
+                }
+                for model in runtime.models {
+                    guard let batching = model.continuousBatching else { continue }
+                    lines.append("    \(model.id) batching: \(decodeBatchingText(batching))")
+                }
+            } else if !snapshot.server.loadedModels.isEmpty {
                 lines.append("  loaded models: \(snapshot.server.loadedModels.joined(separator: ", "))")
             } else if let modelsDetail = snapshot.server.modelsDetail {
                 lines.append("  loaded models: unavailable (\(modelsDetail))")
@@ -264,6 +324,11 @@ enum StatusFormatter {
         }
 
         lines.append("  model store: \(modelStoreText(snapshot.modelStore))")
+        if let runtime = snapshot.server.runtime {
+            lines.append("  runtime settings: \(runtime.settingsPath)")
+        } else if let detail = snapshot.server.runtimeDetail, snapshot.server.health == "up" {
+            lines.append("  runtime settings: unavailable (\(detail))")
+        }
         lines.append("  installed models: \(snapshot.installedModels.count)/\(snapshot.knownModelCount)")
 
         if snapshot.installedModels.isEmpty {
@@ -283,5 +348,70 @@ enum StatusFormatter {
             return "\(modelStore.path) (source: \(source))"
         }
         return "\(modelStore.path) (source: \(source), fallback from unreadable \(configuredPath))"
+    }
+
+    private static func memoryText(_ memory: RuntimeMemorySnapshot) -> String {
+        let physical = ByteCountFormatter.string(fromByteCount: Int64(memory.physicalBytes), countStyle: .memory)
+        return "\(memory.pressure) pressure, \(memory.activeModelCount) active model(s), \(physical) physical"
+    }
+
+    private static func capabilityText(_ capability: RuntimeCapabilityStatus) -> String {
+        if capability.enabled {
+            return "enabled"
+        }
+        return capability.available ? "available but disabled" : "unavailable"
+    }
+
+    private static func cacheStatsText(_ stats: RuntimeCacheStatsSummary) -> String? {
+        let prefix = stats.prefixKVReuse
+        let batching = stats.decodeBatching
+        guard prefix.reportedModelCount > 0 || batching.reportedModelCount > 0 else {
+            return nil
+        }
+
+        var parts: [String] = []
+        if prefix.reportedModelCount > 0 {
+            parts.append(
+                "prefix \(prefix.entries)/\(prefix.maxEntries) entries, "
+                    + "\(prefix.hits) hits, \(prefix.reusedTokens) reused tokens"
+            )
+        }
+        if batching.reportedModelCount > 0 {
+            parts.append(
+                "decode batching \(batching.batchedDecodeSteps) batched steps, "
+                    + "\(batching.variablePositionBatchedSteps) variable-position, "
+                    + "max batch \(batching.maxBatchSize)"
+            )
+        }
+        return parts.joined(separator: "; ")
+    }
+
+    private static func decodeBatchingText(_ stats: RuntimeDecodeBatchingStats) -> String {
+        "\(stats.batchedDecodeSteps) batched steps, "
+            + "\(stats.samePositionBatchedSteps) same-position, "
+            + "\(stats.variablePositionBatchedSteps) variable-position, "
+            + "max batch \(stats.maxBatchSize), \(stats.queuedRows) queued rows"
+    }
+
+    private static func benchmarkStatsText(_ stats: RuntimeBenchmarkStatsSummary) -> String? {
+        guard stats.completedRequests > 0 || stats.failedRequests > 0 else {
+            return nil
+        }
+
+        var parts = [
+            "\(stats.completedRequests) completed",
+            "\(stats.failedRequests) failed",
+            "\(stats.generatedTokens) tokens",
+        ]
+        if let averagePrefillSeconds = stats.averagePrefillSeconds {
+            parts.append(String(format: "prefill avg %.2fs", averagePrefillSeconds))
+        }
+        if let averageDecodeSeconds = stats.averageDecodeSeconds {
+            parts.append(String(format: "decode avg %.2fs", averageDecodeSeconds))
+        }
+        if let decodeTokensPerSecond = stats.decodeTokensPerSecond {
+            parts.append(String(format: "decode %.2f tok/s", decodeTokensPerSecond))
+        }
+        return parts.joined(separator: ", ")
     }
 }

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -44,10 +44,10 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.long], help: "Top-p.")
     var topP: Double = 0.9
 
-    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform and integer/.5 widths for turboquant.")
+    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform/polar and integer/.5 widths for turboquant.")
     var kvBits: Double?
 
-    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform or turboquant.")
+    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform, polar, or turboquant.")
     var kvQuantScheme: String?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization group size.")
@@ -291,7 +291,7 @@ struct TextChat: AsyncParsableCommand {
         guard let scheme = Gemma4KVQuantizationScheme(
             rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ) else {
-            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform' or 'turboquant'.")
+            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform', 'polar', or 'turboquant'.")
         }
         return scheme
     }

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -19,6 +19,7 @@ Supported engines:
 ```bash
 mere.run model capabilities
 mere.run model pull text-agent-deepseek-v4-flash
+mere.run model runtime get text-chat-gemma4
 mere.run api serve --help
 mere.run status
 ```
@@ -32,6 +33,7 @@ mere.run status
 - `--lora`: default LoRA adapter path for all requests.
 - `--api-key`: bearer token, also read from `MERERUN_API_KEY`.
 - `--rate-limit-per-minute`: global chat completions limit.
+- `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--context-size`: context limit.
 - `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
 
@@ -41,7 +43,40 @@ mere.run status
 - For non-loopback hosts, always set `MERERUN_API_KEY` or pass `--api-key`.
 - Choose the engine first, then the model path/id.
 - Use `mere.run status` as the quick `/health` plus `/v1/models` check.
+- Use `mere.run model runtime set` to configure aliases, pinning, TTL, and
+  default generation limits without starting the server.
 - Test `/v1/chat/completions` after status shows the expected served model.
+- Request `model` resolves by runtime alias, then curated catalog id, then the
+  startup default from `--engine`/`--model`.
+- `/v1/models` returns installed API-capable catalog ids plus aliases.
+- Requests are admitted through a fair FIFO queue. The default
+  `--max-active-requests 1` preserves serialized local inference while making
+  queue depth visible in `/runtime/status`. Queued client cancellations are
+  removed from the FIFO instead of running later.
+- Gemma4 and Q35 use chunked prefill with cancellation/progress checkpoints.
+  This improves long-prompt observability without arbitrary batching.
+- Gemma4 can opt into in-memory prefix KV reuse with
+  `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; `/runtime/status` reports entries, hits,
+  and reused tokens when a Gemma4 model is loaded. The cache records chunk
+  boundaries plus the stable chat prefix before the final message when token
+  prefixes match exactly.
+- Q35 can opt into text-only in-memory prefix KV reuse with
+  `MERERUN_Q35_PREFIX_KV_CACHE=1`; vision prompts are excluded from reuse, and
+  text-only requests use the same stable chat-prefix checkpoint rule as Gemma4.
+- Gemma4 and Q35 can opt into decode batching with
+  `MERERUN_GEMMA4_CONTINUOUS_BATCHING=1` or
+  `MERERUN_Q35_CONTINUOUS_BATCHING=1`; use `--max-active-requests` above `1` to
+  allow overlapping rows, and `/runtime/status` reports actual batched decode
+  steps. Gemma4 full-attention rows stay same-position because that engine still
+  uses scalar RoPE/cache offsets; Q35 full-attention rows use row-offset-aware
+  ragged KV caches, and Q35 linear rows use typed recurrent state, so compatible
+  Q35 rows can batch across decode positions. The scheduler services the
+  earliest decode position first, batching compatible rows there or advancing a
+  single lower-offset row until it can join a compatible batch.
+- `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
+  steps across loaded models under `cacheStats`; it also reports completed chat
+  requests, generated tokens, and average load/prefill/decode timings under
+  `benchmarkStats` so these experiments stay measured.
 - DS4 raw-proxies the complete OpenAI chat request to `ds4-server`.
 - Native engines reject unsupported OpenAI fields explicitly instead of silently dropping them.
 - Use `stream_options.include_usage` when a client expects the OpenAI streaming usage chunk.
@@ -54,6 +89,7 @@ mere.run api serve --engine text-code --port 8080
 
 ```bash
 mere.run model pull text-chat-gemma4
+mere.run model runtime set text-chat-gemma4 --alias chat-default --max-tokens 1024
 mere.run api serve --engine text-chat-gemma4 --port 11434
 ```
 
@@ -66,6 +102,8 @@ mere.run api serve --host 0.0.0.0 --api-key "$MERERUN_API_KEY"
 
 - Use `mere.run status` before connecting an editor.
 - Start with one client and default rate limit.
+- Keep `--max-active-requests 1` unless you have measured that the selected
+  engine and machine benefit from overlapping requests.
 - For Gemma memory pressure, test KV quantization on a local prompt before long sessions.
 
 ## Troubleshooting

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -35,7 +35,7 @@ mere.run status
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--context-size`: context limit.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure and long-context synthetic decode testing.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -35,7 +35,7 @@ mere.run status
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--context-size`: context limit.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -16,12 +16,12 @@ mere.run model benchmark gemma4-kv \
 Gemma4 checkpoint:
 
 - `default`: the model's normal Gemma4 KV cache settings.
-- `polar2`: packed 2-bit PolarKV from token 0.
+- `polar2`: model-default prefill, then packed 2-bit PolarKV from token 0 for decode.
 
 The command disables EOS stopping so both variants decode exactly
 `--decode-tokens`. Output includes prompt tokens, generated tokens, load time,
-prefill time, decode time, TTFT, prefill tok/s, decode tok/s, end-to-end tok/s,
-and process resident memory before and after each variant.
+prefill time, KV conversion time, decode time, TTFT, prefill tok/s, decode tok/s,
+end-to-end tok/s, and process resident memory before and after each variant.
 
 ## Prompt Control
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -1,0 +1,46 @@
+# Model Benchmark
+
+Run focused local model benchmarks that measure implementation tradeoffs without
+changing serving defaults.
+
+```bash
+mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --decode-tokens 48 \
+  --json
+```
+
+## Gemma4 KV Benchmark
+
+`model benchmark gemma4-kv` runs a fixed-token comparison for the selected
+Gemma4 checkpoint:
+
+- `default`: the model's normal Gemma4 KV cache settings.
+- `polar2`: packed 2-bit PolarKV from token 0.
+
+The command disables EOS stopping so both variants decode exactly
+`--decode-tokens`. Output includes prompt tokens, generated tokens, load time,
+prefill time, decode time, TTFT, prefill tok/s, decode tok/s, end-to-end tok/s,
+and process resident memory before and after each variant.
+
+## Prompt Control
+
+Use one of:
+
+- `--prompt`: inline prompt text.
+- `--prompt-file`: UTF-8 prompt file.
+- `--prompt-repeat`: repeat count for the built-in deterministic fixture.
+
+The fixture prompt is for runtime comparison only; it is not a quality eval.
+
+## Notes
+
+- Pull `text-chat-gemma4-turbo` before running the benchmark.
+- Prefer release builds for final numbers.
+- Treat memory values as process resident snapshots, not peak memory.
+
+## Sources
+
+- `Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift`
+- `Sources/MereRunCore/Gemma4/Gemma4Generator.swift`
+- `Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift`

--- a/Sources/MereRunCLI/Guides/model-runtime.md
+++ b/Sources/MereRunCLI/Guides/model-runtime.md
@@ -1,0 +1,81 @@
+# Model Runtime
+
+## Purpose
+
+Read or update typed per-model API serving settings. These settings feed
+`mere.run api serve`, `mere.run status --json`, and the macOS Models sheet.
+
+## Required Models
+
+Use a managed API-capable model id such as `text-chat-gemma4`,
+`text-chat-q35`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, or
+`text-chat-mebot`.
+
+## Install And Check
+
+```bash
+mere.run model runtime get text-chat-gemma4
+mere.run model runtime set text-chat-gemma4 --alias chat-default --pinned
+mere.run status --json
+```
+
+## Parameters
+
+`get`:
+
+- `--json`: emit the typed settings document for the selected model.
+
+`set`:
+
+- `--alias` / `--clear-alias`
+- `--pinned` / `--unpinned`
+- `--ttl-seconds` / `--clear-ttl`
+- `--max-context-tokens` / `--clear-max-context-tokens`
+- `--max-tokens` / `--clear-max-tokens`
+- `--temperature` / `--clear-temperature`
+- `--top-p` / `--clear-top-p`
+- `--engine` / `--clear-engine`
+- `--json`
+
+## Usage Patterns
+
+- Configure aliases before starting `api serve` so clients can request a stable
+  short model name.
+- Keep settings in the model store by using global `--models-root` or
+  `MERERUN_MODELS_DIR` when you use a custom store.
+- Use engine overrides only for catalog-compatible engines. Incompatible
+  overrides are rejected immediately.
+- Treat TTL/LRU as forward-compatible settings. The first runtime-pool
+  milestone records them and exposes them in status; later schedulers can act
+  on them.
+
+## Examples
+
+```bash
+mere.run model runtime set text-chat-gemma4 \
+  --alias chat-default \
+  --pinned \
+  --ttl-seconds 3600 \
+  --max-context-tokens 8192 \
+  --max-tokens 1024 \
+  --temperature 0.6 \
+  --top-p 0.9
+```
+
+```bash
+mere.run model runtime get chat-default --json
+```
+
+## Troubleshooting
+
+- Unknown model: run `mere.run model list` and use a managed id or an existing
+  alias.
+- Unsupported model: choose an API-capable text model rather than image, speech,
+  vision, music, or video ids.
+- Missing model at request time: run `mere.run model pull <id>` before selecting
+  it through `/v1/chat/completions`.
+
+## Sources
+
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCore/RuntimeModelSettings.swift
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift

--- a/Sources/MereRunCLI/Guides/status.md
+++ b/Sources/MereRunCLI/Guides/status.md
@@ -5,6 +5,10 @@
 Show one local snapshot of the mere.run runtime: API server reachability, the
 model currently reported by `/v1/models`, the active model-store path, and the
 managed models installed there.
+When `/runtime/status` is available, the snapshot also includes runtime pool
+entries, active request counts, request admission queue depth, memory pressure,
+runtime capability flags, aggregate cache stats, per-model prefix KV cache
+stats, per-model decode batching stats when enabled, and the settings file path.
 
 ## Required Models
 
@@ -33,6 +37,18 @@ mere.run guide status
 - Use it instead of separate `curl /health`, `curl /v1/models`, and `model list`
   checks when you only need the current local state.
 - Use `--json` in scripts, setup agents, or support tooling.
+- Use it after manual load/unload or runtime settings changes to confirm the
+  server sees the same control-plane state.
+- During overlapping API traffic, check `request admission` to see how many
+  requests are running and how many are queued behind `--max-active-requests`.
+  JSON status also includes admitted, completed, and cancelled admission totals.
+- Use `continuous batching` and `prefix KV reuse` to see which scheduler/cache
+  features are actually enabled instead of assuming they are active.
+- Use `cache stats` to check aggregate prefix hits, reused tokens, and batched
+  decode steps across loaded models, including same-position versus
+  variable-position decode batches when the selected engine can report them.
+- Use `benchmark stats` to compare completed request counts, generated tokens,
+  and average load/prefill/decode timings while cache and batching flags are on.
 
 ## Examples
 
@@ -57,6 +73,8 @@ MERERUN_API_KEY=change-me mere.run status --json
   RAM/process scan for every runtime family.
 - The installed model list follows the same shared inventory path as
   `mere.run model list`.
+- `runtime settings` points at
+  `<active model store>/.mere-run/runtime-model-settings.json`.
 
 ## Troubleshooting
 

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -24,7 +24,7 @@ mere.run text chat --help
 - `--max-tokens`: maximum generated tokens.
 - `--temperature`: randomness. Lower for factual work, higher for brainstorming.
 - `--top-p`: nucleus sampling cutoff.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure and long-context synthetic decode testing.
 - `--model-root`, `-m`: explicit local model root.
 - `--model`: canonical model id.
 - `--thinking`, `--show-thinking`: include hidden reasoning output when supported.

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -24,7 +24,7 @@ mere.run text chat --help
 - `--max-tokens`: maximum generated tokens.
 - `--temperature`: randomness. Lower for factual work, higher for brainstorming.
 - `--top-p`: nucleus sampling cutoff.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
 - `--model-root`, `-m`: explicit local model root.
 - `--model`: canonical model id.
 - `--thinking`, `--show-thinking`: include hidden reasoning output when supported.

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1,0 +1,1177 @@
+import Foundation
+import MereRunCore
+
+struct RuntimeModelPoolStatus: Codable, Equatable, Sendable {
+    let object: String
+    let defaultModel: String
+    let settingsPath: String
+    let activeRequests: Int
+    let admission: RuntimeRequestAdmissionSnapshot?
+    let capabilities: RuntimeControlPlaneCapabilities
+    let memory: RuntimeMemorySnapshot
+    let models: [RuntimeModelPoolEntrySnapshot]
+    let cacheStats: RuntimeCacheStatsSummary
+    let benchmarkStats: RuntimeBenchmarkStatsSummary?
+}
+
+struct RuntimeControlPlaneCapabilities: Codable, Equatable, Sendable {
+    let requestAdmission: RuntimeCapabilityStatus
+    let chunkedPrefill: RuntimeCapabilityStatus
+    let continuousBatching: RuntimeCapabilityStatus
+    let prefixKVReuse: RuntimeCapabilityStatus
+    let ssdKVCache: RuntimeCapabilityStatus
+
+    static func current(
+        gemma4PrefixKVCacheEnabled: Bool,
+        gemma4ContinuousBatchingEnabled: Bool,
+        q35ContinuousBatchingEnabled: Bool,
+        q35PrefixKVCacheEnabled: Bool
+    ) -> RuntimeControlPlaneCapabilities {
+        let prefixKVCacheEnabled = gemma4PrefixKVCacheEnabled || q35PrefixKVCacheEnabled
+        let continuousBatchingEnabled = gemma4ContinuousBatchingEnabled || q35ContinuousBatchingEnabled
+        return RuntimeControlPlaneCapabilities(
+            requestAdmission: RuntimeCapabilityStatus(
+                available: true,
+                enabled: true,
+                detail: "Fair FIFO request admission is active."
+            ),
+            chunkedPrefill: RuntimeCapabilityStatus(
+                available: true,
+                enabled: true,
+                detail: "Gemma4 and Q35 prefill long prompts in cancellable chunks."
+            ),
+            continuousBatching: RuntimeCapabilityStatus(
+                available: true,
+                enabled: continuousBatchingEnabled,
+                detail: continuousBatchingEnabled
+                    ? "Gemma4 and Q35 decode rows are packed when typed cache state is compatible; Q35 linear-only rows may batch across decode positions."
+                    : "Decode batching is available behind MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 and MERERUN_Q35_CONTINUOUS_BATCHING=1; set --max-active-requests above 1 to allow overlap."
+            ),
+            prefixKVReuse: RuntimeCapabilityStatus(
+                available: true,
+                enabled: prefixKVCacheEnabled,
+                detail: prefixKVCacheEnabled
+                    ? "In-memory prefix KV reuse is enabled for matching Gemma4 or Q35 text token prefixes."
+                    : "In-memory prefix KV reuse is available behind MERERUN_GEMMA4_PREFIX_KV_CACHE=1 and MERERUN_Q35_PREFIX_KV_CACHE=1."
+            ),
+            ssdKVCache: RuntimeCapabilityStatus(
+                available: false,
+                enabled: false,
+                detail: "Unavailable until in-memory prefix reuse shows measured TTFT or throughput wins."
+            )
+        )
+    }
+}
+
+struct RuntimeCapabilityStatus: Codable, Equatable, Sendable {
+    let available: Bool
+    let enabled: Bool
+    let detail: String
+}
+
+struct RuntimeRequestAdmissionSnapshot: Codable, Equatable, Sendable {
+    let maxActiveRequests: Int
+    let activeRequests: Int
+    let queuedRequests: Int
+    let totalAdmittedRequests: Int
+    let totalCompletedRequests: Int
+    let totalCancelledRequests: Int
+}
+
+struct RuntimeFutureStats: Codable, Equatable, Sendable {
+    let available: Bool
+    let detail: String
+
+    static let notImplemented = RuntimeFutureStats(
+        available: false,
+        detail: "not implemented"
+    )
+}
+
+struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
+    let completedRequests: Int
+    let failedRequests: Int
+    let generatedTokens: Int
+    let averageLoadSeconds: Double?
+    let averagePrefillSeconds: Double?
+    let averageDecodeSeconds: Double?
+    let averageTotalSeconds: Double?
+    let decodeTokensPerSecond: Double?
+    let lastCompletedAt: Date?
+
+    init(
+        completedRequests: Int,
+        failedRequests: Int,
+        generatedTokens: Int,
+        totalLoadSeconds: Double,
+        totalPrefillSeconds: Double,
+        totalDecodeSeconds: Double,
+        lastCompletedAt: Date?
+    ) {
+        self.completedRequests = completedRequests
+        self.failedRequests = failedRequests
+        self.generatedTokens = generatedTokens
+        self.averageLoadSeconds = Self.average(totalLoadSeconds, count: completedRequests)
+        self.averagePrefillSeconds = Self.average(totalPrefillSeconds, count: completedRequests)
+        self.averageDecodeSeconds = Self.average(totalDecodeSeconds, count: completedRequests)
+        self.averageTotalSeconds = Self.average(
+            totalLoadSeconds + totalPrefillSeconds + totalDecodeSeconds,
+            count: completedRequests
+        )
+        self.decodeTokensPerSecond = totalDecodeSeconds > 0
+            ? Double(generatedTokens) / totalDecodeSeconds
+            : nil
+        self.lastCompletedAt = lastCompletedAt
+    }
+
+    private static func average(_ value: Double, count: Int) -> Double? {
+        guard count > 0 else { return nil }
+        return value / Double(count)
+    }
+}
+
+struct RuntimeBenchmarkStatsSummary: Codable, Equatable, Sendable {
+    let available: Bool
+    let detail: String
+    let reportedModelCount: Int
+    let completedRequests: Int
+    let failedRequests: Int
+    let generatedTokens: Int
+    let averageLoadSeconds: Double?
+    let averagePrefillSeconds: Double?
+    let averageDecodeSeconds: Double?
+    let averageTotalSeconds: Double?
+    let decodeTokensPerSecond: Double?
+
+    init(stats: [RuntimeModelBenchmarkStats]) {
+        available = true
+        detail = "Aggregated from completed native chat requests observed by this runtime pool."
+        reportedModelCount = stats.count
+        completedRequests = stats.reduce(0) { $0 + $1.completedRequests }
+        failedRequests = stats.reduce(0) { $0 + $1.failedRequests }
+        generatedTokens = stats.reduce(0) { $0 + $1.generatedTokens }
+
+        let loadSeconds = stats.weightedTotal(\.averageLoadSeconds, count: \.completedRequests)
+        let prefillSeconds = stats.weightedTotal(\.averagePrefillSeconds, count: \.completedRequests)
+        let decodeSeconds = stats.weightedTotal(\.averageDecodeSeconds, count: \.completedRequests)
+        let totalSeconds = stats.weightedTotal(\.averageTotalSeconds, count: \.completedRequests)
+        averageLoadSeconds = Self.average(loadSeconds, count: completedRequests)
+        averagePrefillSeconds = Self.average(prefillSeconds, count: completedRequests)
+        averageDecodeSeconds = Self.average(decodeSeconds, count: completedRequests)
+        averageTotalSeconds = Self.average(totalSeconds, count: completedRequests)
+        decodeTokensPerSecond = decodeSeconds > 0 ? Double(generatedTokens) / decodeSeconds : nil
+    }
+
+    private static func average(_ value: Double, count: Int) -> Double? {
+        guard count > 0 else { return nil }
+        return value / Double(count)
+    }
+}
+
+private extension Array where Element == RuntimeModelBenchmarkStats {
+    func weightedTotal(
+        _ value: KeyPath<RuntimeModelBenchmarkStats, Double?>,
+        count: KeyPath<RuntimeModelBenchmarkStats, Int>
+    ) -> Double {
+        reduce(0) { partial, stats in
+            guard let average = stats[keyPath: value] else { return partial }
+            return partial + average * Double(stats[keyPath: count])
+        }
+    }
+}
+
+struct RuntimeCacheStatsSummary: Codable, Equatable, Sendable {
+    let available: Bool
+    let detail: String
+    let prefixKVReuse: RuntimePrefixKVCacheSummary
+    let decodeBatching: RuntimeDecodeBatchingSummary
+    let ssdKVCache: RuntimeFutureStats
+
+    static let empty = RuntimeCacheStatsSummary(
+        prefixKVCaches: [],
+        decodeBatchers: []
+    )
+
+    init(
+        prefixKVCaches: [PrefixKVCacheStats],
+        decodeBatchers: [RuntimeDecodeBatchingStats]
+    ) {
+        available = true
+        detail = "Aggregated from loaded model runtime counters."
+        prefixKVReuse = RuntimePrefixKVCacheSummary(stats: prefixKVCaches)
+        decodeBatching = RuntimeDecodeBatchingSummary(stats: decodeBatchers)
+        ssdKVCache = RuntimeFutureStats(
+            available: false,
+            detail: "Unavailable until in-memory prefix reuse shows measured TTFT or throughput wins."
+        )
+    }
+}
+
+struct RuntimePrefixKVCacheSummary: Codable, Equatable, Sendable {
+    let reportedModelCount: Int
+    let enabledModelCount: Int
+    let entries: Int
+    let maxEntries: Int
+    let hits: Int
+    let misses: Int
+    let storedPrefixes: Int
+    let reusedTokens: Int
+    let storedTokens: Int
+
+    init(stats: [PrefixKVCacheStats]) {
+        reportedModelCount = stats.count
+        enabledModelCount = stats.filter(\.enabled).count
+        entries = stats.reduce(0) { $0 + $1.entries }
+        maxEntries = stats.reduce(0) { $0 + $1.maxEntries }
+        hits = stats.reduce(0) { $0 + $1.hits }
+        misses = stats.reduce(0) { $0 + $1.misses }
+        storedPrefixes = stats.reduce(0) { $0 + $1.storedPrefixes }
+        reusedTokens = stats.reduce(0) { $0 + $1.reusedTokens }
+        storedTokens = stats.reduce(0) { $0 + $1.storedTokens }
+    }
+}
+
+struct RuntimeDecodeBatchingSummary: Codable, Equatable, Sendable {
+    let reportedModelCount: Int
+    let enabledModelCount: Int
+    let activeRows: Int
+    let queuedRows: Int
+    let batchedDecodeSteps: Int
+    let samePositionBatchedSteps: Int
+    let variablePositionBatchedSteps: Int
+    let singleDecodeSteps: Int
+    let totalBatchedRows: Int
+    let maxBatchSize: Int
+
+    init(stats: [RuntimeDecodeBatchingStats]) {
+        reportedModelCount = stats.count
+        enabledModelCount = stats.filter(\.enabled).count
+        activeRows = stats.reduce(0) { $0 + $1.activeRows }
+        queuedRows = stats.reduce(0) { $0 + $1.queuedRows }
+        batchedDecodeSteps = stats.reduce(0) { $0 + $1.batchedDecodeSteps }
+        samePositionBatchedSteps = stats.reduce(0) { $0 + $1.samePositionBatchedSteps }
+        variablePositionBatchedSteps = stats.reduce(0) { $0 + $1.variablePositionBatchedSteps }
+        singleDecodeSteps = stats.reduce(0) { $0 + $1.singleDecodeSteps }
+        totalBatchedRows = stats.reduce(0) { $0 + $1.totalBatchedRows }
+        maxBatchSize = stats.map(\.maxBatchSize).max() ?? 0
+    }
+}
+
+struct RuntimeMemorySnapshot: Codable, Equatable, Sendable {
+    let physicalBytes: UInt64
+    let activeRequests: Int
+    let activeModelCount: Int
+    let pressure: String
+}
+
+struct RuntimeModelPoolEntrySnapshot: Codable, Equatable, Sendable {
+    let id: String
+    let category: String
+    let engine: RuntimeServingEngine
+    let installPath: String?
+    let loaded: Bool
+    let activeRequests: Int
+    let lastAccess: Date?
+    let lastError: String?
+    let pinned: Bool
+    let alias: String?
+    let ttlSeconds: Int?
+    let maxContextTokens: Int?
+    let maxTokens: Int?
+    let temperature: Double?
+    let topP: Double?
+    let engineOverride: RuntimeServingEngine?
+    let prefixKVCache: PrefixKVCacheStats?
+    let continuousBatching: RuntimeDecodeBatchingStats?
+    let benchmarkStats: RuntimeModelBenchmarkStats?
+}
+
+struct RuntimeChatPlan: Sendable {
+    let lease: RuntimeModelLease
+    let request: ChatRequest
+    let modelID: String
+    let engine: RuntimeServingEngine
+    let includeUsage: Bool
+}
+
+enum RuntimeModelPoolError: LocalizedError, Equatable {
+    case unknownModel(String)
+    case unsupportedModel(String)
+    case modelNotInstalled(String)
+    case incompatibleEngine(String)
+    case unloadConflict(String, activeRequests: Int)
+    case invalidSettings(String)
+    case rawProxyUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownModel(let id):
+            return "Unknown model '\(id)'. Use a configured alias or a managed model id."
+        case .unsupportedModel(let id):
+            return "Model '\(id)' is not supported by `mere.run api serve`."
+        case .modelNotInstalled(let id):
+            return "Model '\(id)' is not installed. Run `mere.run model pull \(id)` first."
+        case .incompatibleEngine(let detail):
+            return detail
+        case .unloadConflict(let id, let activeRequests):
+            return "Model '\(id)' has \(activeRequests) active request(s); unload it after they finish."
+        case .invalidSettings(let detail):
+            return detail
+        case .rawProxyUnavailable(let id):
+            return "Model '\(id)' is not backed by a raw OpenAI proxy."
+        }
+    }
+}
+
+actor RuntimeModelPool {
+    private struct MutableState {
+        var activeRequests = 0
+        var lastAccess: Date?
+        var lastError: String?
+        var completedRequests = 0
+        var failedRequests = 0
+        var generatedTokens = 0
+        var totalLoadSeconds: Double = 0
+        var totalPrefillSeconds: Double = 0
+        var totalDecodeSeconds: Double = 0
+        var lastCompletedAt: Date?
+
+        var benchmarkStats: RuntimeModelBenchmarkStats {
+            RuntimeModelBenchmarkStats(
+                completedRequests: completedRequests,
+                failedRequests: failedRequests,
+                generatedTokens: generatedTokens,
+                totalLoadSeconds: totalLoadSeconds,
+                totalPrefillSeconds: totalPrefillSeconds,
+                totalDecodeSeconds: totalDecodeSeconds,
+                lastCompletedAt: lastCompletedAt
+            )
+        }
+    }
+
+    private struct ResolvedModel {
+        let id: String
+        let category: String
+        let engine: RuntimeServingEngine
+        let installPath: String?
+        let settings: RuntimeModelSettings
+        let spec: ManagedModelSpec?
+    }
+
+    private let defaultModelID: String
+    private let defaultEngine: RuntimeServingEngine
+    private let startupModelPath: String?
+    private let settingsStore: RuntimeModelSettingsStore
+    private let gemma4KVCacheQuantization: Gemma4KVCacheQuantization
+    private let gemma4PrefixKVCacheEnabled: Bool
+    private let gemma4ContinuousBatchingEnabled: Bool
+    private let q35PrefixKVCacheEnabled: Bool
+    private let q35ContinuousBatchingEnabled: Bool
+
+    private var loadedModels: [String: RuntimeLoadedModel] = [:]
+    private var states: [String: MutableState] = [:]
+
+    init(
+        defaultModelID: String,
+        defaultEngine: RuntimeServingEngine,
+        startupModelPath: String?,
+        settingsStore: RuntimeModelSettingsStore = RuntimeModelSettingsStore(),
+        gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
+        gemma4PrefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PREFIX_KV_CACHE"] == "1",
+        gemma4ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_CONTINUOUS_BATCHING"] == "1",
+        q35PrefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_PREFIX_KV_CACHE"] == "1",
+        q35ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_CONTINUOUS_BATCHING"] == "1"
+    ) {
+        self.defaultModelID = defaultModelID
+        self.defaultEngine = defaultEngine
+        self.startupModelPath = startupModelPath
+        self.settingsStore = settingsStore
+        self.gemma4KVCacheQuantization = gemma4KVCacheQuantization
+        self.gemma4PrefixKVCacheEnabled = gemma4PrefixKVCacheEnabled
+        self.gemma4ContinuousBatchingEnabled = gemma4ContinuousBatchingEnabled
+        self.q35PrefixKVCacheEnabled = q35PrefixKVCacheEnabled
+        self.q35ContinuousBatchingEnabled = q35ContinuousBatchingEnabled
+    }
+
+    func preloadDefault() async throws {
+        _ = try await loadModel(idOrAlias: defaultModelID)
+    }
+
+    func modelsResponse(createdAt: Date = Date()) throws -> OpenAIModelsResponse {
+        APIServerContract.modelsResponse(modelIds: try listedOpenAIModelIDs(), createdAt: createdAt)
+    }
+
+    func status() async -> RuntimeModelPoolStatus {
+        await status(admission: nil)
+    }
+
+    func status(admission: RuntimeRequestAdmissionSnapshot?) async -> RuntimeModelPoolStatus {
+        let settings = (try? settingsStore.load())?.models ?? [:]
+        let installed = installedServableCatalogIDs()
+        let ids = Set(installed + Array(loadedModels.keys) + [defaultModelID] + Array(settings.keys))
+        var prefixStats: [String: PrefixKVCacheStats] = [:]
+        var batchingStats: [String: RuntimeDecodeBatchingStats] = [:]
+        let currentLoadedModels = loadedModels
+        for (id, loaded) in currentLoadedModels {
+            if let stats = await loaded.prefixKVCacheStats() {
+                prefixStats[id] = stats
+            }
+            if let stats = await loaded.continuousBatchingStats() {
+                batchingStats[id] = stats
+            }
+        }
+        let snapshots = ids.sorted().compactMap { id in
+            snapshot(
+                for: id,
+                settings: settings,
+                prefixKVCache: prefixStats[id],
+                continuousBatching: batchingStats[id]
+            )
+        }
+        let activeRequests = snapshots.reduce(0) { $0 + $1.activeRequests }
+        let loadedCount = snapshots.filter(\.loaded).count
+        return RuntimeModelPoolStatus(
+            object: "runtime.status",
+            defaultModel: defaultModelID,
+            settingsPath: settingsStore.url.path,
+            activeRequests: activeRequests,
+            admission: admission,
+            capabilities: .current(
+                gemma4PrefixKVCacheEnabled: gemma4PrefixKVCacheEnabled,
+                gemma4ContinuousBatchingEnabled: gemma4ContinuousBatchingEnabled,
+                q35ContinuousBatchingEnabled: q35ContinuousBatchingEnabled,
+                q35PrefixKVCacheEnabled: q35PrefixKVCacheEnabled
+            ),
+            memory: RuntimeMemorySnapshot(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                activeRequests: activeRequests,
+                activeModelCount: loadedCount,
+                pressure: "unknown"
+            ),
+            models: snapshots,
+            cacheStats: RuntimeCacheStatsSummary(
+                prefixKVCaches: Array(prefixStats.values),
+                decodeBatchers: Array(batchingStats.values)
+            ),
+            benchmarkStats: RuntimeBenchmarkStatsSummary(
+                stats: snapshots.compactMap(\.benchmarkStats).filter {
+                    $0.completedRequests > 0 || $0.failedRequests > 0
+                }
+            )
+        )
+    }
+
+    func loadModel(idOrAlias: String) async throws -> RuntimeModelPoolEntrySnapshot {
+        let resolved = try resolveModel(idOrAlias)
+        _ = try await ensureLoaded(resolved)
+        touch(id: resolved.id, error: nil)
+        return try snapshot(idOrAlias: resolved.id)
+    }
+
+    func unloadModel(idOrAlias: String) async throws -> RuntimeModelPoolEntrySnapshot {
+        let resolved = try resolveModel(idOrAlias)
+        let state = state(for: resolved.id)
+        guard state.activeRequests == 0 else {
+            throw RuntimeModelPoolError.unloadConflict(resolved.id, activeRequests: state.activeRequests)
+        }
+        if let loaded = loadedModels.removeValue(forKey: resolved.id) {
+            await loaded.unload()
+        }
+        touch(id: resolved.id, error: nil)
+        return try snapshot(idOrAlias: resolved.id)
+    }
+
+    func settings(idOrAlias: String) throws -> RuntimeModelSettings {
+        let resolved = try resolveModel(idOrAlias)
+        return resolved.settings
+    }
+
+    func updateSettings(idOrAlias: String, settings: RuntimeModelSettings) throws -> RuntimeModelSettings {
+        let resolved = try resolveModel(idOrAlias, requireInstalled: false)
+        guard let spec = resolved.spec else {
+            throw RuntimeModelPoolError.invalidSettings("Runtime settings require a managed catalog model id.")
+        }
+        do {
+            try settingsStore.writeSettings(settings, for: spec.id)
+            return try settingsStore.settings(for: spec.id)
+        } catch {
+            throw RuntimeModelPoolError.invalidSettings(error.localizedDescription)
+        }
+    }
+
+    func makeChatPlan(
+        for openAIRequest: OpenAIChatRequest,
+        fallbackLoraPath: String?,
+        serverContextSize: Int
+    ) async throws -> RuntimeChatPlan {
+        let resolved = try resolveModel(openAIRequest.model)
+        var effectiveRequest = openAIRequest
+        applyDefaults(from: resolved.settings, to: &effectiveRequest)
+        let contextSize = resolved.settings.maxContextTokens ?? serverContextSize
+        let capabilities = resolved.engine.openAICompatibility
+        let chatRequest = try APIServerContract.chatRequest(
+            from: effectiveRequest,
+            fallbackLoraPath: fallbackLoraPath,
+            contextSize: contextSize,
+            capabilities: capabilities
+        )
+        let includeUsage = try APIServerContract.includeUsageInStreaming(
+            effectiveRequest,
+            capabilities: capabilities
+        )
+        let loaded = try await ensureLoaded(resolved)
+        retainLease(id: resolved.id)
+        let lease = RuntimeModelLease(
+            modelID: resolved.id,
+            engine: resolved.engine,
+            loaded: loaded,
+            pool: self
+        )
+        return RuntimeChatPlan(
+            lease: lease,
+            request: chatRequest,
+            modelID: resolved.id,
+            engine: resolved.engine,
+            includeUsage: includeUsage
+        )
+    }
+
+    fileprivate func releaseLease(modelID: String) {
+        var state = state(for: modelID)
+        state.activeRequests = max(0, state.activeRequests - 1)
+        state.lastAccess = Date()
+        states[modelID] = state
+    }
+
+    fileprivate func recordChatCompletion(modelID: String, response: ChatResponse) {
+        var state = state(for: modelID)
+        state.completedRequests += 1
+        state.generatedTokens += response.tokensGenerated
+        if let timing = response.timing {
+            state.totalLoadSeconds += timing.loadSeconds
+            state.totalPrefillSeconds += timing.prefillSeconds
+            state.totalDecodeSeconds += timing.decodeSeconds
+        }
+        state.lastCompletedAt = Date()
+        state.lastError = nil
+        states[modelID] = state
+    }
+
+    fileprivate func recordChatFailure(modelID: String, error: Error) {
+        var state = state(for: modelID)
+        state.failedRequests += 1
+        state.lastError = error.localizedDescription
+        states[modelID] = state
+    }
+
+    private func ensureLoaded(_ resolved: ResolvedModel) async throws -> RuntimeLoadedModel {
+        if let loaded = loadedModels[resolved.id] {
+            return loaded
+        }
+
+        let loaded = makeLoadedModel(for: resolved)
+        loadedModels[resolved.id] = loaded
+        do {
+            try await loaded.prepare { progress in
+                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
+            }
+            touch(id: resolved.id, error: nil)
+            return loaded
+        } catch {
+            loadedModels.removeValue(forKey: resolved.id)
+            touch(id: resolved.id, error: error.localizedDescription)
+            throw error
+        }
+    }
+
+    private func makeLoadedModel(for resolved: ResolvedModel) -> RuntimeLoadedModel {
+        switch resolved.engine {
+        case .textCode:
+            return .textCode(
+                CodeGenGenerator(modelId: resolved.id),
+                modelPath: resolved.installPath
+            )
+        case .textChatKlein:
+            let useStandalone = resolved.id == ModelResolver.ModelID.mebot.rawValue
+                && resolved.installPath == MeBotModelCatalog.resolveModelPath()
+            return .textChatKlein(
+                Flux2KleinGenerator(),
+                modelPath: resolved.installPath,
+                useStandalone: useStandalone
+            )
+        case .textChatGemma4:
+            return .textChatGemma4(
+                Gemma4Generator(
+                    modelId: resolved.id,
+                    kvCacheQuantization: gemma4KVCacheQuantization,
+                    prefixKVCacheEnabled: gemma4PrefixKVCacheEnabled,
+                    continuousBatchingEnabled: gemma4ContinuousBatchingEnabled
+                ),
+                modelPath: resolved.installPath
+            )
+        case .textChatQ35:
+            return .textChatQ35(
+                Q35Generator(
+                    modelId: resolved.id,
+                    prefixKVCacheEnabled: q35PrefixKVCacheEnabled,
+                    continuousBatchingEnabled: q35ContinuousBatchingEnabled
+                ),
+                modelPath: resolved.installPath
+            )
+        case .textChatDeepseekV4Flash:
+            return .textChatDeepseekV4Flash(
+                DeepseekV4FlashGenerator(modelId: resolved.id),
+                modelPath: resolved.installPath
+            )
+        }
+    }
+
+    private func resolveModel(
+        _ requested: String?,
+        requireInstalled: Bool = true
+    ) throws -> ResolvedModel {
+        let requestedName = requested?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty ?? defaultModelID
+        let resolvedID = try resolveAliasOrID(requestedName)
+        if let spec = ManagedModelCatalog.spec(for: resolvedID) {
+            guard spec.isAPIServableRuntimeModel,
+                  let defaultEngine = spec.defaultRuntimeServingEngine else {
+                throw RuntimeModelPoolError.unsupportedModel(spec.id)
+            }
+            let settings = try settingsForSpec(spec)
+            let engine = settings.engineOverride ?? defaultEngine
+            guard engine == defaultEngine else {
+                throw RuntimeModelPoolError.incompatibleEngine(
+                    "Engine '\(engine.rawValue)' is not compatible with model '\(spec.id)'."
+                )
+            }
+            let installPath = try installPath(for: spec, requireInstalled: requireInstalled)
+            return ResolvedModel(
+                id: spec.id,
+                category: spec.category.rawValue,
+                engine: engine,
+                installPath: installPath,
+                settings: settings,
+                spec: spec
+            )
+        }
+
+        guard resolvedID == defaultModelID else {
+            throw RuntimeModelPoolError.unknownModel(resolvedID)
+        }
+        guard let startupModelPath else {
+            throw RuntimeModelPoolError.unknownModel(resolvedID)
+        }
+        return ResolvedModel(
+            id: resolvedID,
+            category: category(for: defaultEngine),
+            engine: defaultEngine,
+            installPath: startupModelPath,
+            settings: RuntimeModelSettings(),
+            spec: nil
+        )
+    }
+
+    private func resolveAliasOrID(_ requestedName: String) throws -> String {
+        let document = try settingsStore.load()
+        if let match = document.models.first(where: { _, settings in
+            settings.alias?.caseInsensitiveCompare(requestedName) == .orderedSame
+        }) {
+            return match.key
+        }
+        if let spec = ManagedModelCatalog.spec(for: requestedName) {
+            return spec.id
+        }
+        if requestedName == defaultModelID {
+            return defaultModelID
+        }
+        throw RuntimeModelPoolError.unknownModel(requestedName)
+    }
+
+    private func settingsForSpec(_ spec: ManagedModelSpec) throws -> RuntimeModelSettings {
+        do {
+            return try settingsStore.settings(for: spec.id).validated(for: spec)
+        } catch {
+            throw RuntimeModelPoolError.invalidSettings(error.localizedDescription)
+        }
+    }
+
+    private func installPath(for spec: ManagedModelSpec, requireInstalled: Bool) throws -> String? {
+        if spec.id == defaultModelID, let startupModelPath {
+            return startupModelPath
+        }
+        if let runtimeURL = spec.managedRuntimeURL() {
+            return runtimeURL.path
+        }
+        if spec.id == defaultModelID {
+            return nil
+        }
+        if requireInstalled {
+            throw RuntimeModelPoolError.modelNotInstalled(spec.id)
+        }
+        return nil
+    }
+
+    private func listedOpenAIModelIDs() throws -> [String] {
+        let settings = try settingsStore.load().models
+        var ids = Set(installedServableCatalogIDs())
+        ids.insert(defaultModelID)
+        for (modelID, modelSettings) in settings {
+            guard modelSettings.alias != nil,
+                  ids.contains(modelID) || modelID == defaultModelID else {
+                continue
+            }
+            if let alias = modelSettings.alias {
+                ids.insert(alias)
+            }
+        }
+        return ids.sorted()
+    }
+
+    private func installedServableCatalogIDs() -> [String] {
+        ManagedModelCatalog.allSpecs.compactMap { spec in
+            guard spec.isAPIServableRuntimeModel else { return nil }
+            if spec.id == defaultModelID {
+                return spec.id
+            }
+            return spec.managedRuntimeURL() == nil ? nil : spec.id
+        }
+    }
+
+    private func snapshot(idOrAlias: String) throws -> RuntimeModelPoolEntrySnapshot {
+        let resolved = try resolveModel(idOrAlias, requireInstalled: false)
+        let settings = try settingsStore.load().models
+        guard let snapshot = snapshot(for: resolved.id, settings: settings) else {
+            throw RuntimeModelPoolError.unknownModel(idOrAlias)
+        }
+        return snapshot
+    }
+
+    private func snapshot(
+        for id: String,
+        settings: [String: RuntimeModelSettings],
+        prefixKVCache: PrefixKVCacheStats? = nil,
+        continuousBatching: RuntimeDecodeBatchingStats? = nil
+    ) -> RuntimeModelPoolEntrySnapshot? {
+        let spec = ManagedModelCatalog.spec(for: id)
+        let engine = settings[id]?.engineOverride
+            ?? spec?.defaultRuntimeServingEngine
+            ?? (id == defaultModelID ? defaultEngine : nil)
+        guard let engine else { return nil }
+        guard spec?.isAPIServableRuntimeModel != false else { return nil }
+
+        let state = state(for: id)
+        let modelSettings = settings[id] ?? RuntimeModelSettings()
+        let installPath: String?
+        if id == defaultModelID, let startupModelPath {
+            installPath = startupModelPath
+        } else {
+            installPath = spec?.managedRuntimeURL()?.path
+        }
+        return RuntimeModelPoolEntrySnapshot(
+            id: id,
+            category: spec?.category.rawValue ?? category(for: engine),
+            engine: engine,
+            installPath: installPath,
+            loaded: loadedModels[id] != nil,
+            activeRequests: state.activeRequests,
+            lastAccess: state.lastAccess,
+            lastError: state.lastError,
+            pinned: modelSettings.pinned,
+            alias: modelSettings.alias,
+            ttlSeconds: modelSettings.ttlSeconds,
+            maxContextTokens: modelSettings.maxContextTokens,
+            maxTokens: modelSettings.maxTokens,
+            temperature: modelSettings.temperature,
+            topP: modelSettings.topP,
+            engineOverride: modelSettings.engineOverride,
+            prefixKVCache: prefixKVCache,
+            continuousBatching: continuousBatching,
+            benchmarkStats: state.benchmarkStats
+        )
+    }
+
+    private func applyDefaults(
+        from settings: RuntimeModelSettings,
+        to request: inout OpenAIChatRequest
+    ) {
+        if request.max_tokens == nil, request.max_completion_tokens == nil {
+            request.max_tokens = settings.maxTokens
+        }
+        if request.temperature == nil {
+            request.temperature = settings.temperature
+        }
+        if request.top_p == nil {
+            request.top_p = settings.topP
+        }
+    }
+
+    private func state(for id: String) -> MutableState {
+        states[id] ?? MutableState()
+    }
+
+    private func touch(id: String, error: String?) {
+        var state = state(for: id)
+        state.lastAccess = Date()
+        state.lastError = error
+        states[id] = state
+    }
+
+    private func retainLease(id: String) {
+        var state = state(for: id)
+        state.activeRequests += 1
+        state.lastAccess = Date()
+        states[id] = state
+    }
+
+    private func category(for engine: RuntimeServingEngine) -> String {
+        switch engine {
+        case .textCode:
+            return ManagedModelCategory.textCode.rawValue
+        case .textChatKlein, .textChatGemma4, .textChatQ35, .textChatDeepseekV4Flash:
+            return ManagedModelCategory.textChat.rawValue
+        }
+    }
+}
+
+actor RuntimeRequestAdmission {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<RuntimeRequestAdmissionLease, Error>
+    }
+
+    private enum WaiterState {
+        case pending
+        case waiting
+        case cancelled
+    }
+
+    private let maxActiveRequests: Int
+    private var activeRequests = 0
+    private var waiters: [Waiter] = []
+    private var waiterStates: [UUID: WaiterState] = [:]
+    private var totalAdmittedRequests = 0
+    private var totalCompletedRequests = 0
+    private var totalCancelledRequests = 0
+
+    init(maxActiveRequests: Int) {
+        precondition(maxActiveRequests > 0, "maxActiveRequests must be positive")
+        self.maxActiveRequests = maxActiveRequests
+    }
+
+    func acquire() async throws -> RuntimeRequestAdmissionLease {
+        if activeRequests < maxActiveRequests {
+            return admit()
+        }
+
+        let waiterID = UUID()
+        waiterStates[waiterID] = .pending
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                enqueueWaiter(id: waiterID, continuation: continuation)
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task {
+                await self.cancelWaiter(id: waiterID)
+            }
+        }
+    }
+
+    fileprivate func releaseLease() {
+        activeRequests = max(0, activeRequests - 1)
+        totalCompletedRequests += 1
+        drain()
+    }
+
+    func snapshot() -> RuntimeRequestAdmissionSnapshot {
+        RuntimeRequestAdmissionSnapshot(
+            maxActiveRequests: maxActiveRequests,
+            activeRequests: activeRequests,
+            queuedRequests: waiters.count,
+            totalAdmittedRequests: totalAdmittedRequests,
+            totalCompletedRequests: totalCompletedRequests,
+            totalCancelledRequests: totalCancelledRequests
+        )
+    }
+
+    private func enqueueWaiter(
+        id: UUID,
+        continuation: CheckedContinuation<RuntimeRequestAdmissionLease, Error>
+    ) {
+        if waiterStates[id] == .cancelled {
+            waiterStates.removeValue(forKey: id)
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        waiterStates[id] = .waiting
+        waiters.append(Waiter(id: id, continuation: continuation))
+    }
+
+    private func cancelWaiter(id: UUID) {
+        switch waiterStates[id] {
+        case .pending:
+            waiterStates[id] = .cancelled
+            totalCancelledRequests += 1
+        case .waiting:
+            guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+                waiterStates.removeValue(forKey: id)
+                return
+            }
+            let waiter = waiters.remove(at: index)
+            waiterStates.removeValue(forKey: id)
+            totalCancelledRequests += 1
+            waiter.continuation.resume(throwing: CancellationError())
+        case .cancelled, nil:
+            return
+        }
+    }
+
+    private func drain() {
+        while activeRequests < maxActiveRequests, !waiters.isEmpty {
+            let waiter = waiters.removeFirst()
+            guard waiterStates[waiter.id] != .cancelled else {
+                waiterStates.removeValue(forKey: waiter.id)
+                waiter.continuation.resume(throwing: CancellationError())
+                continue
+            }
+            waiterStates.removeValue(forKey: waiter.id)
+            waiter.continuation.resume(returning: admit())
+        }
+    }
+
+    private func admit() -> RuntimeRequestAdmissionLease {
+        activeRequests += 1
+        totalAdmittedRequests += 1
+        return RuntimeRequestAdmissionLease(admission: self)
+    }
+}
+
+final class RuntimeRequestAdmissionLease: @unchecked Sendable {
+    private let admission: RuntimeRequestAdmission
+    private let lock = NSLock()
+    private var released = false
+
+    init(admission: RuntimeRequestAdmission) {
+        self.admission = admission
+    }
+
+    deinit {
+        guard markReleased() else { return }
+        let admission = admission
+        Task {
+            await admission.releaseLease()
+        }
+    }
+
+    func release() async {
+        guard markReleased() else { return }
+        await admission.releaseLease()
+    }
+
+    private func markReleased() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !released else { return false }
+        released = true
+        return true
+    }
+}
+
+final class RuntimeModelLease: @unchecked Sendable {
+    let modelID: String
+    let engine: RuntimeServingEngine
+
+    private let loaded: RuntimeLoadedModel
+    private let pool: RuntimeModelPool
+    private let lock = NSLock()
+    private var released = false
+
+    init(
+        modelID: String,
+        engine: RuntimeServingEngine,
+        loaded: RuntimeLoadedModel,
+        pool: RuntimeModelPool
+    ) {
+        self.modelID = modelID
+        self.engine = engine
+        self.loaded = loaded
+        self.pool = pool
+    }
+
+    deinit {
+        guard markReleased() else { return }
+        let pool = pool
+        let modelID = modelID
+        Task {
+            await pool.releaseLease(modelID: modelID)
+        }
+    }
+
+    func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        do {
+            let response = try await loaded.chat(request, progressHandler: progressHandler)
+            await pool.recordChatCompletion(modelID: modelID, response: response)
+            return response
+        } catch {
+            await pool.recordChatFailure(modelID: modelID, error: error)
+            throw error
+        }
+    }
+
+    func deepseekChatCompletionsURL(
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws -> URL {
+        try await loaded.deepseekChatCompletionsURL(progressHandler: progressHandler)
+    }
+
+    func release() async {
+        guard markReleased() else { return }
+        await pool.releaseLease(modelID: modelID)
+    }
+
+    private func markReleased() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !released else { return false }
+        released = true
+        return true
+    }
+}
+
+enum RuntimeLoadedModel: Sendable {
+    case textCode(CodeGenGenerator, modelPath: String?)
+    case textChatKlein(Flux2KleinGenerator, modelPath: String?, useStandalone: Bool)
+    case textChatGemma4(Gemma4Generator, modelPath: String?)
+    case textChatQ35(Q35Generator, modelPath: String?)
+    case textChatDeepseekV4Flash(DeepseekV4FlashGenerator, modelPath: String?)
+
+    func prepare(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws {
+        switch self {
+        case .textCode(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatKlein(let generator, let modelPath, let useStandalone):
+            guard let modelPath else {
+                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
+            }
+            try await generator.prepareChat(
+                modelPath: modelPath,
+                standalone: useStandalone,
+                progressHandler: progressHandler
+            )
+        case .textChatGemma4(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatQ35(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDeepseekV4Flash(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        }
+    }
+
+    func unload() async {
+        switch self {
+        case .textCode(let generator, _):
+            await generator.unload()
+        case .textChatKlein(let generator, _, _):
+            await generator.unload()
+        case .textChatGemma4(let generator, _):
+            await generator.unload()
+        case .textChatQ35(let generator, _):
+            await generator.unload()
+        case .textChatDeepseekV4Flash(let generator, _):
+            await generator.shutdown()
+        }
+    }
+
+    func prefixKVCacheStats() async -> PrefixKVCacheStats? {
+        switch self {
+        case .textChatGemma4(let generator, _):
+            return await generator.prefixKVCacheStats()
+        case .textChatQ35(let generator, _):
+            return await generator.prefixKVCacheStats()
+        case .textCode, .textChatKlein, .textChatDeepseekV4Flash:
+            return nil
+        }
+    }
+
+    func continuousBatchingStats() async -> RuntimeDecodeBatchingStats? {
+        switch self {
+        case .textChatGemma4(let generator, _):
+            return await generator.continuousBatchingStats()
+        case .textChatQ35(let generator, _):
+            return await generator.continuousBatchingStats()
+        case .textCode, .textChatKlein, .textChatDeepseekV4Flash:
+            return nil
+        }
+    }
+
+    func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        switch self {
+        case .textCode(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatKlein(let generator, let modelPath, let useStandalone):
+            guard let modelPath else {
+                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
+            }
+            if useStandalone {
+                return try await generator.chatStandalone(
+                    request,
+                    modelPath: modelPath,
+                    progressHandler: progressHandler
+                )
+            }
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatGemma4(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatQ35(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDeepseekV4Flash(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        }
+    }
+
+    func deepseekChatCompletionsURL(
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        switch self {
+        case .textChatDeepseekV4Flash(let generator, let modelPath):
+            return try await generator.chatCompletionsURL(
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+        case .textCode, .textChatKlein, .textChatGemma4, .textChatQ35:
+            throw RuntimeModelPoolError.rawProxyUnavailable("")
+        }
+    }
+}
+
+extension RuntimeServingEngine {
+    var openAICompatibility: APIEngineCapabilities {
+        switch self {
+        case .textCode:
+            return .localText
+        case .textChatKlein:
+            return .localTextWithStructuredJSON
+        case .textChatGemma4:
+            return .localTextWithTools
+        case .textChatQ35:
+            return .localTextWithToolsAndVision
+        case .textChatDeepseekV4Flash:
+            return .rawProxy
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Chat.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Chat.swift
@@ -5,6 +5,22 @@ extension Flux2KleinGenerator {
 
     // MARK: - Chat Generation
 
+    public func prepareChat(
+        modelPath: String,
+        standalone: Bool,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws {
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading model"))
+        if loadedModelPath == modelPath, textEncoder != nil, tokenizer != nil {
+            return
+        }
+        if standalone {
+            try await loadStandaloneChatModel(from: modelPath, progressHandler: progressHandler)
+        } else {
+            try await loadTextEncoderOnly(from: modelPath, progressHandler: progressHandler)
+        }
+    }
+
 
     public func chat(
         _ request: ChatRequest,

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -1,7 +1,89 @@
 import Foundation
 import MLX
 
+public typealias Gemma4PrefixKVCacheStats = PrefixKVCacheStats
+public typealias Gemma4ContinuousBatchingStats = RuntimeDecodeBatchingStats
+
+private struct Gemma4PrefixKVCacheKey: Hashable {
+    let modelPath: String
+    let quantization: Gemma4KVCacheQuantization
+    let tokens: [Int]
+}
+
+private struct Gemma4PrefixKVCacheEntry {
+    let caches: [Gemma4AttentionCache]
+    let logits: MLXArray
+    let priority: RuntimePrefixCacheEntryPriority
+    var lastAccess: Date
+}
+
+private struct Gemma4BatchedDecodeResult {
+    let generatedTokens: [Int]
+    let decodeSeconds: Double
+}
+
+private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
+    let id: UUID
+    let eosSet: Set<Int>
+    let generationConfig: GenerationConfig
+    let tokenBudget: Int
+    let progressHandler: (@Sendable (ChatProgress) -> Void)?
+    let decodeStart: Date
+    let continuation: CheckedContinuation<Gemma4BatchedDecodeResult, Error>
+
+    var logits: MLXArray
+    var layerCaches: [Gemma4AttentionCache]
+    var generatedTokens: [Int]
+    var repetitionHistory: [Int]
+    var stopped = false
+
+    init(
+        id: UUID,
+        logits: MLXArray,
+        layerCaches: [Gemma4AttentionCache],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        repetitionHistory: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?,
+        continuation: CheckedContinuation<Gemma4BatchedDecodeResult, Error>
+    ) {
+        self.id = id
+        self.logits = logits
+        self.layerCaches = layerCaches
+        self.eosSet = eosSet
+        self.generationConfig = generationConfig
+        self.tokenBudget = tokenBudget
+        self.repetitionHistory = repetitionHistory
+        self.progressHandler = progressHandler
+        self.continuation = continuation
+        self.decodeStart = Date()
+        self.generatedTokens = []
+        self.generatedTokens.reserveCapacity(tokenBudget)
+    }
+
+    var needsDecodeStep: Bool {
+        !stopped && generatedTokens.count < tokenBudget
+    }
+
+    func finish() {
+        continuation.resume(
+            returning: Gemma4BatchedDecodeResult(
+                generatedTokens: generatedTokens,
+                decodeSeconds: Date().timeIntervalSince(decodeStart)
+            )
+        )
+    }
+
+    func fail(_ error: Error) {
+        continuation.resume(throwing: error)
+    }
+}
+
 public actor Gemma4Generator: ChatGenerator {
+    private static let prefillChunkSize = 512
+    private static let prefixKVCacheMaxEntries = 4
+
     private var model: Gemma4TextCausalLM?
     private var tokenizerAndTemplate: Gemma4TokenizerAndTemplate?
     private var loadedModelPath: String?
@@ -9,13 +91,35 @@ public actor Gemma4Generator: ChatGenerator {
 
     private let modelId: String
     private let kvCacheQuantization: Gemma4KVCacheQuantization
+    private let prefixKVCacheEnabled: Bool
+    private let continuousBatchingEnabled: Bool
+
+    private var prefixKVCache: [Gemma4PrefixKVCacheKey: Gemma4PrefixKVCacheEntry] = [:]
+    private var prefixKVCacheHits = 0
+    private var prefixKVCacheMisses = 0
+    private var prefixKVCacheStores = 0
+    private var prefixKVCacheReusedTokens = 0
+
+    private var decodeQueue: [Gemma4BatchedDecodeRow] = []
+    private var activeDecodeRows: [Gemma4BatchedDecodeRow] = []
+    private var decodeLoopRunning = false
+    private var batchedDecodeSteps = 0
+    private var samePositionBatchedSteps = 0
+    private var variablePositionBatchedSteps = 0
+    private var singleDecodeSteps = 0
+    private var totalBatchedRows = 0
+    private var maxObservedBatchSize = 0
 
     public init(
         modelId: String = Gemma4Resources.defaultModelId,
-        kvCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization()
+        kvCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
+        prefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PREFIX_KV_CACHE"] == "1",
+        continuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_CONTINUOUS_BATCHING"] == "1"
     ) {
         self.modelId = modelId
         self.kvCacheQuantization = kvCacheQuantization
+        self.prefixKVCacheEnabled = prefixKVCacheEnabled
+        self.continuousBatchingEnabled = continuousBatchingEnabled
     }
 
     public func chat(
@@ -58,11 +162,40 @@ public actor Gemma4Generator: ChatGenerator {
     }
 
     public func unload() {
+        failQueuedDecodeRows(CancellationError())
+        resetPrefixKVCache()
         model = nil
         tokenizerAndTemplate = nil
         loadedModelPath = nil
         loadedConfig = nil
         Memory.clearCache()
+    }
+
+    public func prefixKVCacheStats() -> Gemma4PrefixKVCacheStats {
+        Gemma4PrefixKVCacheStats(
+            enabled: prefixKVCacheEnabled,
+            entries: prefixKVCache.count,
+            maxEntries: Self.prefixKVCacheMaxEntries,
+            hits: prefixKVCacheHits,
+            misses: prefixKVCacheMisses,
+            storedPrefixes: prefixKVCacheStores,
+            reusedTokens: prefixKVCacheReusedTokens,
+            storedTokens: prefixKVCache.keys.reduce(0) { $0 + $1.tokens.count }
+        )
+    }
+
+    public func continuousBatchingStats() -> Gemma4ContinuousBatchingStats {
+        Gemma4ContinuousBatchingStats(
+            enabled: continuousBatchingEnabled,
+            activeRows: activeDecodeRows.count,
+            queuedRows: decodeQueue.count,
+            batchedDecodeSteps: batchedDecodeSteps,
+            samePositionBatchedSteps: samePositionBatchedSteps,
+            variablePositionBatchedSteps: variablePositionBatchedSteps,
+            singleDecodeSteps: singleDecodeSteps,
+            totalBatchedRows: totalBatchedRows,
+            maxBatchSize: maxObservedBatchSize
+        )
     }
 
     private func ensureLoaded(
@@ -73,6 +206,7 @@ public actor Gemma4Generator: ChatGenerator {
         if loadedModelPath == normalizedRoot.path, model != nil, tokenizerAndTemplate != nil {
             return
         }
+        resetPrefixKVCache()
 
         let resources = Gemma4Resources(rootURL: normalizedRoot)
         let missing = resources.validate()
@@ -112,8 +246,9 @@ public actor Gemma4Generator: ChatGenerator {
 
         let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
         let prefillStart = Date()
+        let messages = request.messages
         var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
-            messages: request.messages,
+            messages: messages,
             tools: request.tools,
             addGenerationPrompt: true,
             includeThinking: request.showThinking,
@@ -133,22 +268,143 @@ public actor Gemma4Generator: ChatGenerator {
             repetitionContextSize: 64
         )
 
-        let layerCaches = model.makeCache(quantization: kvCacheQuantization)
-        let promptInput = MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count)
-        var logits = model(promptInput, cache: layerCaches)
-        MLX.eval(logits)
+        let prefixSeed = prefixKVCacheSeed(
+            modelPath: loadedModelPath ?? "",
+            quantization: kvCacheQuantization,
+            promptTokens: promptTokens
+        )
+        let prefixCheckpoints = semanticPrefixCheckpoints(
+            tokenizerAndTemplate: tokenizerAndTemplate,
+            messages: messages,
+            tools: request.tools,
+            includeThinking: request.showThinking,
+            promptTokens: promptTokens,
+            maxContextLength: effectiveContext
+        )
+        let layerCaches = try prefixSeed?.caches ?? makeLayerCaches(
+            model: model,
+            quantization: kvCacheQuantization
+        )
+        let logits = try await chunkedPrefill(
+            model: model,
+            promptTokens: promptTokens,
+            cache: layerCaches,
+            startIndex: prefixSeed?.tokenCount ?? 0,
+            existingLogits: prefixSeed?.logits,
+            modelPath: loadedModelPath ?? "",
+            quantization: kvCacheQuantization,
+            checkpointTokenCounts: prefixCheckpoints,
+            progressHandler: progressHandler
+        )
 
         let prefillSeconds = Date().timeIntervalSince(prefillStart)
         let tokenBudget = max(0, min(request.maxTokens, effectiveContext - promptTokens.count))
 
         progressHandler?(ChatProgress(stage: .generating, message: ""))
 
+        let decodeResult = try await decodeTokens(
+            model: model,
+            tokenizerAndTemplate: tokenizerAndTemplate,
+            initialLogits: logits,
+            layerCaches: layerCaches,
+            eosSet: eosSet,
+            generationConfig: generationConfig,
+            tokenBudget: tokenBudget,
+            promptTokens: promptTokens,
+            progressHandler: progressHandler
+        )
+        let generated = decodeResult.generatedTokens
+        let decoded = tokenizerAndTemplate.decode(tokens: generated)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let toolCalls: [ToolCall]? = hasTools ? {
+            let parsed = Gemma4ToolParser.parseToolCalls(decoded)
+            return parsed.isEmpty ? nil : parsed
+        }() : nil
+
+        return ChatResponse(
+            response: decoded,
+            tokensGenerated: generated.count,
+            timing: ChatTiming(
+                loadSeconds: 0,
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decodeResult.decodeSeconds
+            ),
+            toolCalls: toolCalls
+        )
+    }
+
+    private func decodeTokens(
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [Gemma4AttentionCache],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> Gemma4BatchedDecodeResult {
+        guard tokenBudget > 0 else {
+            return Gemma4BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0)
+        }
+        guard continuousBatchingEnabled else {
+            return try await decodeTokensSerially(
+                model: model,
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                initialLogits: initialLogits,
+                layerCaches: layerCaches,
+                eosSet: eosSet,
+                generationConfig: generationConfig,
+                tokenBudget: tokenBudget,
+                promptTokens: promptTokens,
+                progressHandler: progressHandler
+            )
+        }
+
+        let rowID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let row = Gemma4BatchedDecodeRow(
+                    id: rowID,
+                    logits: initialLogits,
+                    layerCaches: layerCaches,
+                    eosSet: eosSet,
+                    generationConfig: generationConfig,
+                    tokenBudget: tokenBudget,
+                    repetitionHistory: promptTokens,
+                    progressHandler: progressHandler,
+                    continuation: continuation
+                )
+                enqueueDecodeRow(row, model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task {
+                await self.cancelDecodeRow(id: rowID)
+            }
+        }
+    }
+
+    private func decodeTokensSerially(
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [Gemma4AttentionCache],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> Gemma4BatchedDecodeResult {
+        var logits = initialLogits
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
         let decodeStart = Date()
 
         for _ in 0..<tokenBudget {
+            try Task.checkCancellation()
             let next = sampleToken(
                 logits: logits[0, -1, 0...],
                 config: generationConfig,
@@ -166,30 +422,413 @@ public actor Gemma4Generator: ChatGenerator {
                 progressHandler?(ChatProgress(stage: .generating, message: piece))
             }
 
+            guard generated.count < tokenBudget else {
+                break
+            }
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
-            logits = model(nextInput, cache: layerCaches)
+            logits = model(nextInput, cache: layerCaches as [AnyObject])
             MLX.eval(logits)
         }
 
-        let decodeSeconds = Date().timeIntervalSince(decodeStart)
-        let decoded = tokenizerAndTemplate.decode(tokens: generated)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        let toolCalls: [ToolCall]? = hasTools ? {
-            let parsed = Gemma4ToolParser.parseToolCalls(decoded)
-            return parsed.isEmpty ? nil : parsed
-        }() : nil
-
-        return ChatResponse(
-            response: decoded,
-            tokensGenerated: generated.count,
-            timing: ChatTiming(
-                loadSeconds: 0,
-                prefillSeconds: prefillSeconds,
-                decodeSeconds: decodeSeconds
-            ),
-            toolCalls: toolCalls
+        return Gemma4BatchedDecodeResult(
+            generatedTokens: generated,
+            decodeSeconds: Date().timeIntervalSince(decodeStart)
         )
+    }
+
+    private func enqueueDecodeRow(
+        _ row: Gemma4BatchedDecodeRow,
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate
+    ) {
+        decodeQueue.append(row)
+        startDecodeLoopIfNeeded(model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+    }
+
+    private func cancelDecodeRow(id: UUID) {
+        if let index = decodeQueue.firstIndex(where: { $0.id == id }) {
+            let row = decodeQueue.remove(at: index)
+            row.fail(CancellationError())
+            return
+        }
+        if let index = activeDecodeRows.firstIndex(where: { $0.id == id }) {
+            let row = activeDecodeRows.remove(at: index)
+            row.fail(CancellationError())
+        }
+    }
+
+    private func startDecodeLoopIfNeeded(
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate
+    ) {
+        guard !decodeLoopRunning else { return }
+        decodeLoopRunning = true
+        Task {
+            await runDecodeLoop(model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+        }
+    }
+
+    private func runDecodeLoop(
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate
+    ) async {
+        defer {
+            decodeLoopRunning = false
+            if !decodeQueue.isEmpty || !activeDecodeRows.isEmpty {
+                startDecodeLoopIfNeeded(model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+            }
+        }
+
+        while !decodeQueue.isEmpty || !activeDecodeRows.isEmpty {
+            if activeDecodeRows.isEmpty {
+                try? await Task.sleep(nanoseconds: 1_000_000)
+            }
+            activateQueuedDecodeRows()
+            guard !activeDecodeRows.isEmpty else {
+                continue
+            }
+
+            let rows = selectDecodeRows()
+            do {
+                try decodeOneStep(
+                    rows: rows,
+                    model: model,
+                    tokenizerAndTemplate: tokenizerAndTemplate
+                )
+            } catch {
+                failRows(rows, with: error)
+            }
+            finishCompletedDecodeRows()
+            await Task.yield()
+        }
+    }
+
+    private func activateQueuedDecodeRows() {
+        guard !decodeQueue.isEmpty else { return }
+        activeDecodeRows.append(contentsOf: decodeQueue)
+        decodeQueue.removeAll(keepingCapacity: true)
+    }
+
+    private func selectDecodeRows() -> [Gemma4BatchedDecodeRow] {
+        let eligible = activeDecodeRows.filter(\.needsDecodeStep)
+        let selectedIDs = Set(RuntimeDecodeBatchPlanner.selectRows(
+            eligible.map { row in
+                RuntimeDecodeBatchRowMetadata(
+                    row: row.id,
+                    signature: decodeBatchSignature(for: row),
+                    position: decodePosition(row)
+                )
+            }
+        ))
+        return eligible.filter { selectedIDs.contains($0.id) }
+    }
+
+    private func decodeBatchSignature(for row: Gemma4BatchedDecodeRow) -> String {
+        row.layerCaches
+            .map { "\(String(describing: type(of: $0))):\($0.offset)" }
+            .joined(separator: "|")
+    }
+
+    private func decodePosition(_ row: Gemma4BatchedDecodeRow) -> Int {
+        row.layerCaches.map(\.offset).min() ?? 0
+    }
+
+    private func decodeOneStep(
+        rows: [Gemma4BatchedDecodeRow],
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate
+    ) throws {
+        let sampledRows = rows.filter(\.needsDecodeStep)
+        guard !sampledRows.isEmpty else { return }
+
+        for row in sampledRows {
+            let next = sampleToken(
+                logits: row.logits[0, -1, 0...],
+                config: row.generationConfig,
+                previousTokens: row.repetitionHistory
+            )
+            guard !row.eosSet.contains(next) else {
+                row.stopped = true
+                continue
+            }
+            row.generatedTokens.append(next)
+            row.repetitionHistory.append(next)
+            let piece = tokenizerAndTemplate.decode(token: next)
+            if !piece.isEmpty {
+                row.progressHandler?(ChatProgress(stage: .generating, message: piece))
+            }
+        }
+
+        let continuingRows = sampledRows.filter(\.needsDecodeStep)
+        guard !continuingRows.isEmpty else { return }
+
+        if continuingRows.count > 1,
+           let batchedCaches = makeBatchedLayerCaches(continuingRows.map(\.layerCaches)) {
+            let nextInput = MLXArray(continuingRows.compactMap { $0.generatedTokens.last }.map(Int32.init))
+                .reshaped(continuingRows.count, 1)
+            let batchedLogits = model(nextInput, cache: batchedCaches as [AnyObject])
+            MLX.eval(batchedLogits)
+            guard let splitCaches = splitBatchedLayerCaches(batchedCaches, rowCount: continuingRows.count) else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 batched decode could not split merged KV cache rows.")
+            }
+            for (index, row) in continuingRows.enumerated() {
+                row.layerCaches = splitCaches[index]
+                row.logits = batchedLogits[index..<(index + 1), 0..., 0...]
+            }
+            batchedDecodeSteps += 1
+            if RuntimeDecodeBatchPositionKind.variablePositionBatchCount(continuingRows.map(decodePosition)) > 0 {
+                variablePositionBatchedSteps += 1
+            } else {
+                samePositionBatchedSteps += 1
+            }
+            totalBatchedRows += continuingRows.count
+            maxObservedBatchSize = max(maxObservedBatchSize, continuingRows.count)
+            return
+        }
+
+        for row in continuingRows {
+            guard let next = row.generatedTokens.last else { continue }
+            let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
+            row.logits = model(nextInput, cache: row.layerCaches as [AnyObject])
+            MLX.eval(row.logits)
+            singleDecodeSteps += 1
+        }
+    }
+
+    private func makeBatchedLayerCaches(_ rowCaches: [[Gemma4AttentionCache]]) -> [Gemma4AttentionCache]? {
+        guard let first = rowCaches.first, !first.isEmpty else { return nil }
+        guard rowCaches.allSatisfy({ $0.count == first.count }) else { return nil }
+
+        var result: [Gemma4AttentionCache] = []
+        result.reserveCapacity(first.count)
+        for layerIndex in first.indices {
+            let layerCaches = rowCaches.map { $0[layerIndex] }
+            guard let batched = layerCaches[0].batched(with: layerCaches) else {
+                return nil
+            }
+            result.append(batched)
+        }
+        return result
+    }
+
+    private func splitBatchedLayerCaches(
+        _ caches: [Gemma4AttentionCache],
+        rowCount: Int
+    ) -> [[Gemma4AttentionCache]]? {
+        guard rowCount > 0 else { return nil }
+        var rows = Array(repeating: [Gemma4AttentionCache](), count: rowCount)
+        for cache in caches {
+            guard let split = cache.unbatchedRows(count: rowCount), split.count == rowCount else {
+                return nil
+            }
+            for index in 0..<rowCount {
+                rows[index].append(split[index])
+            }
+        }
+        return rows
+    }
+
+    private func finishCompletedDecodeRows() {
+        var remaining: [Gemma4BatchedDecodeRow] = []
+        remaining.reserveCapacity(activeDecodeRows.count)
+        for row in activeDecodeRows {
+            if row.needsDecodeStep {
+                remaining.append(row)
+            } else {
+                row.finish()
+            }
+        }
+        activeDecodeRows = remaining
+    }
+
+    private func failRows(_ rows: [Gemma4BatchedDecodeRow], with error: Error) {
+        let ids = Set(rows.map(\.id))
+        activeDecodeRows.removeAll { row in
+            guard ids.contains(row.id) else { return false }
+            row.fail(error)
+            return true
+        }
+    }
+
+    private func failQueuedDecodeRows(_ error: Error) {
+        for row in decodeQueue {
+            row.fail(error)
+        }
+        for row in activeDecodeRows {
+            row.fail(error)
+        }
+        decodeQueue.removeAll()
+        activeDecodeRows.removeAll()
+    }
+
+    private func chunkedPrefill(
+        model: Gemma4TextCausalLM,
+        promptTokens: [Int],
+        cache: [Gemma4AttentionCache],
+        startIndex: Int,
+        existingLogits: MLXArray?,
+        modelPath: String,
+        quantization: Gemma4KVCacheQuantization,
+        checkpointTokenCounts: Set<Int> = [],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> MLXArray {
+        guard !promptTokens.isEmpty else {
+            throw Gemma4Error.unsupportedConfiguration("Prompt is empty after tokenization.")
+        }
+
+        var processed = startIndex
+        var logits = existingLogits
+        if processed > 0, processed < promptTokens.count {
+            progressHandler?(ChatProgress(stage: .encoding, message: "Reusing \(processed) prompt KV tokens"))
+        }
+        while processed < promptTokens.count {
+            try Task.checkCancellation()
+            let end = RuntimePrefillCheckpointPlanner.nextEnd(
+                processed: processed,
+                total: promptTokens.count,
+                chunkSize: Self.prefillChunkSize,
+                checkpoints: checkpointTokenCounts
+            )
+            if promptTokens.count > Self.prefillChunkSize {
+                progressHandler?(ChatProgress(stage: .encoding, message: "Prefilling \(end)/\(promptTokens.count) tokens"))
+            }
+            let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
+                .reshaped(1, end - processed)
+            let chunkLogits = model(chunk, cache: cache as [AnyObject])
+            MLX.eval(chunkLogits)
+            logits = chunkLogits
+            processed = end
+            storePrefixKVCache(
+                modelPath: modelPath,
+                quantization: quantization,
+                promptTokens: promptTokens,
+                tokenCount: processed,
+                cache: cache,
+                logits: chunkLogits,
+                priority: checkpointTokenCounts.contains(processed) ? .semantic : .chunk
+            )
+            await Task.yield()
+        }
+
+        guard let logits else {
+            throw Gemma4Error.unsupportedConfiguration("Prefill did not produce logits.")
+        }
+        return logits
+    }
+
+    private func makeLayerCaches(
+        model: Gemma4TextCausalLM,
+        quantization: Gemma4KVCacheQuantization
+    ) throws -> [Gemma4AttentionCache] {
+        guard let caches = model.makeCache(quantization: quantization) as? [Gemma4AttentionCache] else {
+            throw Gemma4Error.unsupportedConfiguration("Gemma4 cache construction returned an incompatible cache type.")
+        }
+        return caches
+    }
+
+    private func semanticPrefixCheckpoints(
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        messages: [ChatMessage],
+        tools: [ToolDefinition]?,
+        includeThinking: Bool,
+        promptTokens: [Int],
+        maxContextLength: Int
+    ) -> Set<Int> {
+        guard prefixKVCacheEnabled, messages.count > 1 else {
+            return []
+        }
+        let prefixMessages = Array(messages.dropLast())
+        guard !prefixMessages.isEmpty,
+              let prefixTokens = try? tokenizerAndTemplate.encodeForGeneration(
+                  messages: prefixMessages,
+                  tools: tools,
+                  addGenerationPrompt: false,
+                  includeThinking: includeThinking,
+                  maxLength: maxContextLength
+              ),
+              promptTokens.starts(with: prefixTokens) else {
+            return []
+        }
+        return RuntimePrefillCheckpointPlanner.normalizedCheckpoints(
+            [prefixTokens.count],
+            total: promptTokens.count
+        )
+    }
+
+    private func prefixKVCacheSeed(
+        modelPath: String,
+        quantization: Gemma4KVCacheQuantization,
+        promptTokens: [Int]
+    ) -> (tokenCount: Int, caches: [Gemma4AttentionCache], logits: MLXArray)? {
+        guard prefixKVCacheEnabled else { return nil }
+        let matchingKey = prefixKVCache.keys
+            .filter { key in
+                key.modelPath == modelPath
+                    && key.quantization == quantization
+                    && key.tokens.count <= promptTokens.count
+                    && promptTokens.starts(with: key.tokens)
+            }
+            .max { $0.tokens.count < $1.tokens.count }
+
+        guard let matchingKey,
+              var entry = prefixKVCache[matchingKey] else {
+            prefixKVCacheMisses += 1
+            return nil
+        }
+
+        entry.lastAccess = Date()
+        prefixKVCache[matchingKey] = entry
+        prefixKVCacheHits += 1
+        prefixKVCacheReusedTokens += matchingKey.tokens.count
+        return (
+            matchingKey.tokens.count,
+            entry.caches.map { $0.fork() },
+            entry.logits
+        )
+    }
+
+    private func storePrefixKVCache(
+        modelPath: String,
+        quantization: Gemma4KVCacheQuantization,
+        promptTokens: [Int],
+        tokenCount: Int,
+        cache: [Gemma4AttentionCache],
+        logits: MLXArray,
+        priority: RuntimePrefixCacheEntryPriority
+    ) {
+        guard prefixKVCacheEnabled, tokenCount > 0 else { return }
+        let key = Gemma4PrefixKVCacheKey(
+            modelPath: modelPath,
+            quantization: quantization,
+            tokens: Array(promptTokens.prefix(tokenCount))
+        )
+        prefixKVCache[key] = Gemma4PrefixKVCacheEntry(
+            caches: cache.map { $0.fork() },
+            logits: logits,
+            priority: priority,
+            lastAccess: Date()
+        )
+        prefixKVCacheStores += 1
+        prunePrefixKVCache()
+    }
+
+    private func prunePrefixKVCache() {
+        while prefixKVCache.count > Self.prefixKVCacheMaxEntries {
+            let metadata = prefixKVCache.mapValues {
+                RuntimePrefixCacheRetentionMetadata(
+                    priority: $0.priority,
+                    lastAccess: $0.lastAccess
+                )
+            }
+            guard let oldest = RuntimePrefixCacheRetentionPlanner.keyToPrune(entries: metadata) else {
+                return
+            }
+            prefixKVCache.removeValue(forKey: oldest)
+        }
+    }
+
+    private func resetPrefixKVCache() {
+        prefixKVCache.removeAll()
     }
 
     private func resolveModelRoot(

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -246,6 +246,7 @@ public actor Gemma4Generator: ChatGenerator {
             throw Gemma4Error.modelNotLoaded
         }
         let kvCacheQuantization = try self.kvCacheQuantization.validated()
+        let prefillKVCacheQuantization = prefillQuantization(for: kvCacheQuantization)
 
         let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
         let prefillStart = Date()
@@ -288,7 +289,7 @@ public actor Gemma4Generator: ChatGenerator {
         )
         let layerCaches = try prefixSeed?.caches ?? makeLayerCaches(
             model: model,
-            quantization: kvCacheQuantization
+            quantization: prefillKVCacheQuantization
         )
         let logits = try await chunkedPrefill(
             model: model,
@@ -303,6 +304,11 @@ public actor Gemma4Generator: ChatGenerator {
         )
 
         let prefillSeconds = Date().timeIntervalSince(prefillStart)
+        let preparedCaches = try prepareLayerCachesForDecode(
+            layerCaches,
+            quantization: kvCacheQuantization,
+            progressHandler: progressHandler
+        )
         let tokenBudget = max(0, min(request.maxTokens, effectiveContext - promptTokens.count))
 
         progressHandler?(ChatProgress(stage: .generating, message: ""))
@@ -311,7 +317,7 @@ public actor Gemma4Generator: ChatGenerator {
             model: model,
             tokenizerAndTemplate: tokenizerAndTemplate,
             initialLogits: logits,
-            layerCaches: layerCaches,
+            layerCaches: preparedCaches.caches,
             eosSet: eosSet,
             generationConfig: generationConfig,
             tokenBudget: tokenBudget,
@@ -333,12 +339,55 @@ public actor Gemma4Generator: ChatGenerator {
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,
+                cacheConversionSeconds: preparedCaches.conversionSeconds,
                 decodeSeconds: decodeResult.decodeSeconds,
                 firstTokenSeconds: decodeResult.firstTokenSeconds
             ),
             toolCalls: toolCalls,
             promptTokens: promptTokens.count
         )
+    }
+
+    private func prefillQuantization(for quantization: Gemma4KVCacheQuantization) -> Gemma4KVCacheQuantization {
+        guard shouldDeferQuantizationUntilDecode(quantization) else {
+            return quantization
+        }
+
+        if Gemma4Resources.usesTurboDefaults(modelSpec: modelId) {
+            return Gemma4KVCacheQuantization(
+                bits: Gemma4Resources.defaultTurboKVBits,
+                scheme: Gemma4Resources.defaultTurboKVQuantizationScheme,
+                groupSize: quantization.groupSize,
+                quantizedStart: Gemma4Resources.defaultTurboQuantizedKVStart
+            )
+        }
+
+        return Gemma4KVCacheQuantization()
+    }
+
+    private func shouldDeferQuantizationUntilDecode(_ quantization: Gemma4KVCacheQuantization) -> Bool {
+        quantization.isEnabled && quantization.scheme == .polar
+    }
+
+    private func prepareLayerCachesForDecode(
+        _ layerCaches: [Gemma4AttentionCache],
+        quantization: Gemma4KVCacheQuantization,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> (caches: [Gemma4AttentionCache], conversionSeconds: Double?) {
+        guard shouldDeferQuantizationUntilDecode(quantization) else {
+            return (layerCaches, nil)
+        }
+
+        progressHandler?(ChatProgress(stage: .encoding, message: "Packing KV cache for decode"))
+        let start = Date()
+        let converted = try layerCaches.map { cache -> Gemma4AttentionCache in
+            guard let reencoded = cache.reencoded(quantization: quantization) else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 could not reencode the prefill KV cache for decode.")
+            }
+            reencoded.evaluateStorage()
+            return reencoded
+        }
+        return (converted, Date().timeIntervalSince(start))
     }
 
     private func decodeTokens(

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -20,6 +20,7 @@ private struct Gemma4PrefixKVCacheEntry {
 private struct Gemma4BatchedDecodeResult {
     let generatedTokens: [Int]
     let decodeSeconds: Double
+    let firstTokenSeconds: Double?
 }
 
 private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
@@ -35,6 +36,7 @@ private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
     var layerCaches: [Gemma4AttentionCache]
     var generatedTokens: [Int]
     var repetitionHistory: [Int]
+    var firstTokenSeconds: Double?
     var stopped = false
 
     init(
@@ -70,7 +72,8 @@ private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
         continuation.resume(
             returning: Gemma4BatchedDecodeResult(
                 generatedTokens: generatedTokens,
-                decodeSeconds: Date().timeIntervalSince(decodeStart)
+                decodeSeconds: Date().timeIntervalSince(decodeStart),
+                firstTokenSeconds: firstTokenSeconds
             )
         )
     }
@@ -259,7 +262,9 @@ public actor Gemma4Generator: ChatGenerator {
         }
 
         let hasTools = request.tools?.isEmpty == false
-        let eosSet = Set(loadedConfig.eosTokenIds + tokenizerAndTemplate.stopTokenIds(withTools: hasTools))
+        let eosSet = request.stopOnEOS
+            ? Set(loadedConfig.eosTokenIds + tokenizerAndTemplate.stopTokenIds(withTools: hasTools))
+            : []
         let generationConfig = GenerationConfig(
             maxTokens: request.maxTokens,
             temperature: Float(request.temperature),
@@ -328,9 +333,11 @@ public actor Gemma4Generator: ChatGenerator {
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,
-                decodeSeconds: decodeResult.decodeSeconds
+                decodeSeconds: decodeResult.decodeSeconds,
+                firstTokenSeconds: decodeResult.firstTokenSeconds
             ),
-            toolCalls: toolCalls
+            toolCalls: toolCalls,
+            promptTokens: promptTokens.count
         )
     }
 
@@ -346,7 +353,7 @@ public actor Gemma4Generator: ChatGenerator {
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Gemma4BatchedDecodeResult {
         guard tokenBudget > 0 else {
-            return Gemma4BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0)
+            return Gemma4BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0, firstTokenSeconds: nil)
         }
         guard continuousBatchingEnabled else {
             return try await decodeTokensSerially(
@@ -401,6 +408,7 @@ public actor Gemma4Generator: ChatGenerator {
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
+        var firstTokenSeconds: Double?
         let decodeStart = Date()
 
         for _ in 0..<tokenBudget {
@@ -416,6 +424,9 @@ public actor Gemma4Generator: ChatGenerator {
             }
 
             generated.append(next)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(decodeStart)
+            }
             repetitionHistory.append(next)
             let piece = tokenizerAndTemplate.decode(token: next)
             if !piece.isEmpty {
@@ -432,7 +443,8 @@ public actor Gemma4Generator: ChatGenerator {
 
         return Gemma4BatchedDecodeResult(
             generatedTokens: generated,
-            decodeSeconds: Date().timeIntervalSince(decodeStart)
+            decodeSeconds: Date().timeIntervalSince(decodeStart),
+            firstTokenSeconds: firstTokenSeconds
         )
     }
 
@@ -552,6 +564,9 @@ public actor Gemma4Generator: ChatGenerator {
                 continue
             }
             row.generatedTokens.append(next)
+            if row.firstTokenSeconds == nil {
+                row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
+            }
             row.repetitionHistory.append(next)
             let piece = tokenizerAndTemplate.decode(token: next)
             if !piece.isEmpty {

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -1312,6 +1312,56 @@ final class Gemma4PolarKVCache: Gemma4AttentionCache {
         return copy
     }
 
+    static func reencoded(
+        keys: MLXArray,
+        values: MLXArray,
+        configuration: Gemma4KVCacheQuantization,
+        maxSize: Int?,
+        offset: Int
+    ) -> Gemma4PolarKVCache {
+        let cache = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+        cache.repartition(keys: keys, values: values, newOffset: offset)
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        if quantization == configuration {
+            return fork()
+        }
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: maxSize,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let leadingKeys, let leadingValues {
+            MLX.eval(leadingKeys, leadingValues)
+        }
+        if let polarKeys {
+            MLX.eval(
+                polarKeys.packed,
+                polarKeys.norms,
+                polarKeys.rotation,
+                polarKeys.rotationTransposed,
+                polarKeys.centroids
+            )
+        }
+        if let polarValues {
+            MLX.eval(
+                polarValues.packed,
+                polarValues.norms,
+                polarValues.rotation,
+                polarValues.rotationTransposed,
+                polarValues.centroids
+            )
+        }
+    }
+
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
         guard let typed = caches as? [Gemma4PolarKVCache],
               !typed.isEmpty,
@@ -1808,6 +1858,52 @@ final class Gemma4QuantizedKVCache: Gemma4AttentionCache {
         copy.quantizedValues = quantizedValues
         copy.offset = offset
         return copy
+    }
+
+    static func reencoded(
+        keys: MLXArray,
+        values: MLXArray,
+        configuration: Gemma4KVCacheQuantization,
+        maxSize: Int?,
+        offset: Int
+    ) -> Gemma4QuantizedKVCache {
+        let cache = Gemma4QuantizedKVCache(configuration: configuration, maxSize: maxSize)
+        cache.repartition(keys: keys, values: values, newOffset: offset)
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        if quantization == configuration {
+            return fork()
+        }
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: maxSize,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let leadingKeys, let leadingValues {
+            MLX.eval(leadingKeys, leadingValues)
+        }
+        if let quantizedKeys {
+            if let biases = quantizedKeys.biases {
+                MLX.eval(quantizedKeys.weight, quantizedKeys.scales, biases)
+            } else {
+                MLX.eval(quantizedKeys.weight, quantizedKeys.scales)
+            }
+        }
+        if let quantizedValues {
+            if let biases = quantizedValues.biases {
+                MLX.eval(quantizedValues.weight, quantizedValues.scales, biases)
+            } else {
+                MLX.eval(quantizedValues.weight, quantizedValues.scales)
+            }
+        }
     }
 
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -4,6 +4,7 @@ import MLXFast
 
 public enum Gemma4KVQuantizationScheme: String, Sendable, Hashable {
     case uniform
+    case polar
     case turboquant
 }
 
@@ -50,6 +51,11 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
             guard Swift.abs(bits.rounded() - bits) < 0.000_001 else {
                 throw Gemma4Error.unsupportedConfiguration("Gemma4 uniform KV quantization requires an integer bit width. Use turboquant for fractional .5 widths.")
             }
+        case .polar:
+            guard Swift.abs(bits.rounded() - bits) < 0.000_001,
+                  [2, 3, 4].contains(Int(bits.rounded())) else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 PolarKV quantization currently supports 2, 3, or 4 bits (received \(bits)).")
+            }
         case .turboquant:
             guard Swift.abs(roundedHalf - bits) < 0.000_001 else {
                 throw Gemma4Error.unsupportedConfiguration("Gemma4 turboquant currently supports integer and .5 bit widths (received \(bits)).")
@@ -62,7 +68,7 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
     var keyBits: Int? {
         guard let bits else { return nil }
         switch scheme {
-        case .uniform:
+        case .uniform, .polar:
             return Int(bits.rounded())
         case .turboquant:
             return Int(floor(bits))
@@ -72,7 +78,7 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
     var valueBits: Int? {
         guard let bits else { return nil }
         switch scheme {
-        case .uniform:
+        case .uniform, .polar:
             return Int(bits.rounded())
         case .turboquant:
             return Int(ceil(bits))
@@ -549,6 +555,313 @@ private enum Gemma4AffineFastKernels {
     }
 }
 
+private struct Gemma4PolarFastKernelKey: Hashable {
+    enum Kind: Hashable {
+        case pack
+        case unpack
+        case fusedChunkDecode
+    }
+
+    let kind: Kind
+    let bits: Int
+    let dim: Int
+    let packedWidth: Int
+    let repeats: Int
+}
+
+private enum Gemma4PolarCodebook {
+    static func centroids(bits: Int, dim: Int) -> MLXArray {
+        MLXArray(values(for: bits).map { $0 / sqrt(Float32(dim)) }, [1 << bits]).asType(.float32)
+    }
+
+    static func innerBoundaries(bits: Int, dim: Int) -> MLXArray {
+        let values = boundaries(for: bits)
+        let scale = Float32(1) / sqrt(Float32(dim))
+        return MLXArray(values.dropFirst().dropLast().map { $0 * scale }, [(1 << bits) - 1]).asType(.float32)
+    }
+
+    private static func values(for bits: Int) -> [Float32] {
+        switch bits {
+        case 2:
+            return [-1.5104, -0.4528, 0.4528, 1.5104]
+        case 3:
+            return [-2.1519, -1.3439, -0.7560, -0.2451, 0.2451, 0.7560, 1.3439, 2.1519]
+        case 4:
+            return [
+                -2.7331, -2.0698, -1.6189, -1.2570, -0.9431, -0.6573, -0.3884, -0.1285,
+                0.1285, 0.3884, 0.6573, 0.9431, 1.2570, 1.6189, 2.0698, 2.7331,
+            ]
+        default:
+            preconditionFailure("Unsupported PolarKV bit width \(bits).")
+        }
+    }
+
+    private static func boundaries(for bits: Int) -> [Float32] {
+        switch bits {
+        case 2:
+            return [-5.0, -0.9816, 0.0, 0.9816, 5.0]
+        case 3:
+            return [-5.0, -1.7479, -1.0499, -0.5005, 0.0, 0.5005, 1.0499, 1.7479, 5.0]
+        case 4:
+            return [
+                -5.0, -2.4015, -1.8443, -1.4380, -1.1001, -0.8002, -0.5229, -0.2585,
+                0.0, 0.2585, 0.5229, 0.8002, 1.1001, 1.4380, 1.8443, 2.4015, 5.0,
+            ]
+        default:
+            preconditionFailure("Unsupported PolarKV bit width \(bits).")
+        }
+    }
+}
+
+private enum Gemma4PolarRotation {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var matrices: [Int: MLXArray] = [:]
+
+    static func matrix(dim: Int) -> MLXArray {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = matrices[dim] {
+            return existing
+        }
+
+        let scale = Float32(1) / sqrt(Float32(dim))
+        let values: [Float32]
+        // The Python prototype uses seeded QR; a deterministic Hadamard rotation
+        // keeps this native prototype cheap to build for Gemma's power-of-two head dims.
+        if dim > 0 && (dim & (dim - 1)) == 0 {
+            values = (0..<dim).flatMap { row in
+                (0..<dim).map { column in
+                    ((row & column).nonzeroBitCount.isMultiple(of: 2) ? scale : -scale)
+                }
+            }
+        } else {
+            values = (0..<dim).flatMap { row in
+                (0..<dim).map { column in row == column ? Float32(1) : Float32(0) }
+            }
+        }
+
+        let matrix = MLXArray(values, [dim, dim]).asType(.float32)
+        matrices[dim] = matrix
+        return matrix
+    }
+}
+
+private enum Gemma4PolarFastKernels {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var kernels: [Gemma4PolarFastKernelKey: MLXFast.MLXFastKernel] = [:]
+
+    static func packKernel(bits: Int, dim: Int, packedWidth: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(kind: .pack, bits: bits, dim: dim, packedWidth: packedWidth, repeats: 1)
+        return kernel(
+            key: key,
+            inputNames: ["rotated", "inner_boundaries"],
+            outputNames: ["packed"],
+            source: """
+                auto packed_word = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = rotated_shape[2];
+                auto batch = n / token_count;
+                auto token = n % token_count;
+                if (packed_word >= PackedWidth || head_idx >= rotated_shape[1] || batch >= rotated_shape[0]) {
+                    return;
+                }
+
+                constexpr uint value_mask = (1u << Bits) - 1u;
+                constexpr int level_bound_count = (1 << Bits) - 1;
+                int word_start = int(packed_word) * 32;
+                int word_end = word_start + 32;
+                int start_dim = max(0, ((word_start - Bits) / Bits) + 1);
+                int end_dim = min(Dim, (word_end + Bits - 1) / Bits);
+
+                auto rotated_ptr = rotated + (((batch * rotated_shape[1] + head_idx) * token_count + token) * Dim);
+
+                uint packed_value = 0u;
+                for (int d = start_dim; d < end_dim; d++) {
+                    float v = static_cast<float>(rotated_ptr[d]);
+                    uint index = 0u;
+                    for (int boundary = 0; boundary < level_bound_count; boundary++) {
+                        index += static_cast<uint>(v > static_cast<float>(inner_boundaries[boundary]));
+                    }
+                    index &= value_mask;
+
+                    int bit_offset = d * Bits - word_start;
+                    if (bit_offset >= 0) {
+                        packed_value |= index << bit_offset;
+                    } else {
+                        packed_value |= index >> (-bit_offset);
+                    }
+                }
+
+                packed[((batch * rotated_shape[1] + head_idx) * token_count + token) * PackedWidth + packed_word] = packed_value;
+                """
+        )
+    }
+
+    static func unpackKernel(bits: Int, dim: Int, packedWidth: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(kind: .unpack, bits: bits, dim: dim, packedWidth: packedWidth, repeats: 1)
+        return kernel(
+            key: key,
+            inputNames: ["packed", "norms", "centroids"],
+            source: """
+                auto dim_idx = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = packed_shape[2];
+                auto batch = n / token_count;
+                auto token = n % token_count;
+                if (dim_idx >= Dim || head_idx >= packed_shape[1] || batch >= packed_shape[0]) {
+                    return;
+                }
+
+                auto packed_ptr = packed + (((batch * packed_shape[1] + head_idx) * token_count + token) * PackedWidth);
+                int bit_offset = int(dim_idx) * Bits;
+                int word_idx = bit_offset / 32;
+                int offset = bit_offset % 32;
+                constexpr uint value_mask = (1u << Bits) - 1u;
+
+                uint packed_value = packed_ptr[word_idx] >> offset;
+                int spill = offset + Bits - 32;
+                if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                    packed_value |= packed_ptr[word_idx + 1] << (Bits - spill);
+                }
+                packed_value &= value_mask;
+
+                float norm = static_cast<float>(norms[((batch * norms_shape[1] + head_idx) * token_count + token)]);
+                out[((batch * packed_shape[1] + head_idx) * token_count + token) * Dim + dim_idx] =
+                    static_cast<float>(centroids[packed_value]) * norm;
+                """
+        )
+    }
+
+    static func fusedChunkDecodeKernel(bits: Int, dim: Int, packedWidth: Int, repeats: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(
+            kind: .fusedChunkDecode,
+            bits: bits,
+            dim: dim,
+            packedWidth: packedWidth,
+            repeats: repeats
+        )
+        return kernel(
+            key: key,
+            inputNames: [
+                "queries",
+                "key_packed",
+                "key_norms",
+                "value_packed",
+                "value_norms",
+                "centroids",
+                "scale",
+            ],
+            outputNames: ["weighted", "normalizer", "score_max"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = key_packed_shape[2];
+                auto head_count = queries_shape[1];
+                auto batch = n / Dim;
+                auto dim_idx = n % Dim;
+                if (batch >= queries_shape[0] || head_idx >= head_count) {
+                    return;
+                }
+
+                auto kv_head = head_idx / RepeatCount;
+                auto query_ptr = queries + ((batch * head_count + head_idx) * Dim);
+                auto key_packed_ptr = key_packed + ((batch * key_packed_shape[1] + kv_head) * token_count * PackedWidth);
+                auto value_packed_ptr = value_packed + ((batch * value_packed_shape[1] + kv_head) * token_count * PackedWidth);
+                auto key_norms_ptr = key_norms + ((batch * key_norms_shape[1] + kv_head) * token_count);
+                auto value_norms_ptr = value_norms + ((batch * value_norms_shape[1] + kv_head) * token_count);
+
+                constexpr uint value_mask = (1u << Bits) - 1u;
+                int value_bit_offset = dim_idx * Bits;
+                int value_word_idx = value_bit_offset / 32;
+                int value_offset = value_bit_offset % 32;
+
+                float running_max = -INFINITY;
+                float running_sum = 0.0f;
+                float running_acc = 0.0f;
+
+                for (int token = 0; token < token_count; token++) {
+                    auto key_token_packed = key_packed_ptr + token * PackedWidth;
+                    float key_norm = static_cast<float>(key_norms_ptr[token]);
+
+                    float score = 0.0f;
+                    for (int d = lane; d < Dim; d += 32) {
+                        int bit_offset = d * Bits;
+                        int word_idx = bit_offset / 32;
+                        int offset = bit_offset % 32;
+                        uint packed_value = key_token_packed[word_idx] >> offset;
+                        int spill = offset + Bits - 32;
+                        if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                            packed_value |= key_token_packed[word_idx + 1] << (Bits - spill);
+                        }
+                        packed_value &= value_mask;
+
+                        float decoded = static_cast<float>(centroids[packed_value]) * key_norm;
+                        score += static_cast<float>(query_ptr[d]) * decoded;
+                    }
+
+                    score = simd_sum(score) * static_cast<float>(scale);
+
+                    auto value_token_packed = value_packed_ptr + token * PackedWidth;
+                    uint value_packed_word = value_token_packed[value_word_idx] >> value_offset;
+                    int value_spill = value_offset + Bits - 32;
+                    if (value_spill > 0 && (value_word_idx + 1) < PackedWidth) {
+                        value_packed_word |= value_token_packed[value_word_idx + 1] << (Bits - value_spill);
+                    }
+                    value_packed_word &= value_mask;
+
+                    float decoded_value = static_cast<float>(centroids[value_packed_word])
+                        * static_cast<float>(value_norms_ptr[token]);
+
+                    float previous_max = running_max;
+                    running_max = max(running_max, score);
+                    float rescale = isfinite(previous_max) ? exp(previous_max - running_max) : 0.0f;
+                    float weight = exp(score - running_max);
+                    running_sum = running_sum * rescale + weight;
+                    running_acc = running_acc * rescale + weight * decoded_value;
+                }
+
+                if (thread_index_in_simdgroup == 0) {
+                    weighted[((batch * head_count + head_idx) * Dim) + dim_idx] = running_acc;
+                    if (dim_idx == 0) {
+                        normalizer[batch * head_count + head_idx] = running_sum;
+                        score_max[batch * head_count + head_idx] = running_max;
+                    }
+                }
+                """
+        )
+    }
+
+    private static func kernel(
+        key: Gemma4PolarFastKernelKey,
+        inputNames: [String],
+        outputNames: [String] = ["out"],
+        source: @autoclosure () -> String
+    ) -> MLXFast.MLXFastKernel {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = kernels[key] {
+            return existing
+        }
+
+        let kernel = MLXFast.metalKernel(
+            name: "gemma4_polar_\(key.kind)_b\(key.bits)_d\(key.dim)_pw\(key.packedWidth)_r\(key.repeats)",
+            inputNames: inputNames,
+            outputNames: outputNames,
+            source: source()
+        )
+        kernels[key] = kernel
+        return kernel
+    }
+}
+
 private func concatenatedOptional(_ lhs: MLXArray?, _ rhs: MLXArray?, axis: Int) -> MLXArray? {
     switch (lhs, rhs) {
     case (.some(let lhs), .some(let rhs)):
@@ -643,6 +956,545 @@ final class Gemma4QuantizedTensorState {
             mode: .affine,
             dtype: dtype
         )
+    }
+}
+
+final class Gemma4PolarTensorState {
+    let packed: MLXArray
+    let norms: MLXArray
+    let bits: Int
+    let dtype: DType
+    let headDim: Int
+    let rotation: MLXArray
+    let rotationTransposed: MLXArray
+    let centroids: MLXArray
+    let innerBoundaries: MLXArray
+
+    var tokenCount: Int {
+        packed.dim(2)
+    }
+
+    var packedWidth: Int {
+        packed.dim(3)
+    }
+
+    init(source: MLXArray, bits: Int) {
+        let headDim = source.dim(3)
+        let rotation = Gemma4PolarRotation.matrix(dim: headDim)
+        let rotationTransposed = rotation.transposed()
+        let centroids = Gemma4PolarCodebook.centroids(bits: bits, dim: headDim)
+        let innerBoundaries = Gemma4PolarCodebook.innerBoundaries(bits: bits, dim: headDim)
+        let source32 = source.asType(.float32)
+        let norms = MLX.sqrt(MLX.sum(source32 * source32, axis: -1, keepDims: true))
+        let normalized = source32 / MLX.maximum(norms, MLXArray(Float32(1e-8)))
+        let rotated = MLX.matmul(normalized, rotationTransposed)
+        let packedWidth = (headDim * bits + 31) / 32
+        let packKernel = Gemma4PolarFastKernels.packKernel(bits: bits, dim: headDim, packedWidth: packedWidth)
+        let packed = packKernel(
+            [rotated, innerBoundaries],
+            template: [
+                ("Bits", bits),
+                ("Dim", headDim),
+                ("PackedWidth", packedWidth),
+            ],
+            grid: (packedWidth, source.dim(1), source.dim(0) * source.dim(2)),
+            threadGroup: (max(1, min(32, packedWidth)), 1, 1),
+            outputShapes: [[source.dim(0), source.dim(1), source.dim(2), packedWidth]],
+            outputDTypes: [.uint32]
+        )[0]
+
+        self.packed = packed
+        self.norms = norms
+        self.bits = bits
+        self.dtype = source.dtype
+        self.headDim = headDim
+        self.rotation = rotation
+        self.rotationTransposed = rotationTransposed
+        self.centroids = centroids
+        self.innerBoundaries = innerBoundaries
+    }
+
+    init(
+        packed: MLXArray,
+        norms: MLXArray,
+        bits: Int,
+        dtype: DType,
+        headDim: Int,
+        rotation: MLXArray,
+        rotationTransposed: MLXArray,
+        centroids: MLXArray,
+        innerBoundaries: MLXArray
+    ) {
+        self.packed = packed
+        self.norms = norms
+        self.bits = bits
+        self.dtype = dtype
+        self.headDim = headDim
+        self.rotation = rotation
+        self.rotationTransposed = rotationTransposed
+        self.centroids = centroids
+        self.innerBoundaries = innerBoundaries
+    }
+
+    func appending(_ source: MLXArray) -> Gemma4PolarTensorState {
+        let next = Gemma4PolarTensorState(source: source, bits: bits)
+        return Gemma4PolarTensorState(
+            packed: concatenated([packed, next.packed], axis: 2),
+            norms: concatenated([norms, next.norms], axis: 2),
+            bits: bits,
+            dtype: dtype,
+            headDim: headDim,
+            rotation: rotation,
+            rotationTransposed: rotationTransposed,
+            centroids: centroids,
+            innerBoundaries: innerBoundaries
+        )
+    }
+
+    func dequantized() -> MLXArray {
+        dequantized(packed: packed, norms: norms)
+    }
+
+    func dequantized(tokenRange: Range<Int>) -> MLXArray {
+        dequantized(
+            packed: packed[0..., 0..., tokenRange, 0...],
+            norms: norms[0..., 0..., tokenRange, 0...]
+        )
+    }
+
+    private func dequantized(packed: MLXArray, norms: MLXArray) -> MLXArray {
+        let unpackKernel = Gemma4PolarFastKernels.unpackKernel(bits: bits, dim: headDim, packedWidth: packedWidth)
+        let roundedDim = ((headDim + 31) / 32) * 32
+        let rotated = unpackKernel(
+            [packed, norms, centroids],
+            template: [
+                ("Bits", bits),
+                ("Dim", headDim),
+                ("PackedWidth", packedWidth),
+            ],
+            grid: (roundedDim, packed.dim(1), packed.dim(0) * packed.dim(2)),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[packed.dim(0), packed.dim(1), packed.dim(2), headDim]],
+            outputDTypes: [.float32]
+        )[0]
+        return MLX.matmul(rotated, rotation).asType(dtype)
+    }
+}
+
+final class Gemma4PolarKVCache: Gemma4AttentionCache {
+    private static let decodeChunkSize = 2_048
+
+    private let configuration: Gemma4KVCacheQuantization
+    private let maxSize: Int?
+
+    private var leadingKeys: MLXArray?
+    private var leadingValues: MLXArray?
+    private var polarKeys: Gemma4PolarTensorState?
+    private var polarValues: Gemma4PolarTensorState?
+
+    private(set) var offset: Int = 0
+
+    init(configuration: Gemma4KVCacheQuantization, maxSize: Int?) {
+        self.configuration = configuration
+        self.maxSize = maxSize
+    }
+
+    func currentState() -> (MLXArray, MLXArray)? {
+        reconstructState()
+    }
+
+    func append(keys: MLXArray, values: MLXArray) {
+        guard maxSize != nil else {
+            appendUnbounded(keys: keys, values: values)
+            return
+        }
+
+        let existing = reconstructState()
+        let combinedKeys: MLXArray
+        let combinedValues: MLXArray
+        if let existing {
+            combinedKeys = concatenated([existing.0, keys], axis: 2)
+            combinedValues = concatenated([existing.1, values], axis: 2)
+        } else {
+            combinedKeys = keys
+            combinedValues = values
+        }
+
+        let newOffset = offset + keys.dim(2)
+        var keptKeys = combinedKeys
+        var keptValues = combinedValues
+        if let maxSize {
+            let totalLength = combinedKeys.dim(2)
+            if totalLength > maxSize {
+                let start = totalLength - maxSize
+                keptKeys = combinedKeys[0..., 0..., start..., 0...]
+                keptValues = combinedValues[0..., 0..., start..., 0...]
+            }
+        }
+
+        repartition(keys: keptKeys, values: keptValues, newOffset: newOffset)
+    }
+
+    private func appendUnbounded(keys: MLXArray, values: MLXArray) {
+        let tokenCount = keys.dim(2)
+        let newOffset = offset + tokenCount
+        defer { offset = newOffset }
+
+        guard let bits = configuration.keyBits else {
+            appendLeading(keys: keys, values: values)
+            return
+        }
+
+        let plainCount = max(0, min(tokenCount, configuration.quantizedStart - offset))
+        if plainCount > 0 {
+            appendLeading(
+                keys: keys[0..., 0..., ..<plainCount, 0...],
+                values: values[0..., 0..., ..<plainCount, 0...]
+            )
+        }
+
+        guard plainCount < tokenCount else {
+            return
+        }
+
+        appendPolar(
+            keys: keys[0..., 0..., plainCount..., 0...],
+            values: values[0..., 0..., plainCount..., 0...],
+            bits: bits
+        )
+    }
+
+    private func appendLeading(keys: MLXArray, values: MLXArray) {
+        if let existingKeys = leadingKeys, let existingValues = leadingValues {
+            leadingKeys = concatenated([existingKeys, keys], axis: 2)
+            leadingValues = concatenated([existingValues, values], axis: 2)
+        } else {
+            leadingKeys = keys
+            leadingValues = values
+        }
+    }
+
+    private func appendPolar(keys: MLXArray, values: MLXArray, bits: Int) {
+        if let polarKeys {
+            self.polarKeys = polarKeys.appending(keys)
+        } else {
+            polarKeys = Gemma4PolarTensorState(source: keys, bits: bits)
+        }
+
+        if let polarValues {
+            self.polarValues = polarValues.appending(values)
+        } else {
+            polarValues = Gemma4PolarTensorState(source: values, bits: bits)
+        }
+    }
+
+    func fork() -> Gemma4AttentionCache {
+        let copy = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+        copy.leadingKeys = leadingKeys
+        copy.leadingValues = leadingValues
+        copy.polarKeys = polarKeys
+        copy.polarValues = polarValues
+        copy.offset = offset
+        return copy
+    }
+
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
+        guard let typed = caches as? [Gemma4PolarKVCache],
+              !typed.isEmpty,
+              typed.allSatisfy({
+                  $0.offset == offset
+                      && $0.configuration == configuration
+                      && $0.maxSize == maxSize
+              }) else {
+            return nil
+        }
+
+        let states = typed.compactMap { $0.currentState() }
+        guard states.count == typed.count else {
+            return nil
+        }
+
+        let copy = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+        copy.repartition(
+            keys: concatenated(states.map(\.0), axis: 0),
+            values: concatenated(states.map(\.1), axis: 0),
+            newOffset: offset
+        )
+        return copy
+    }
+
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]? {
+        guard count > 0,
+              let state = currentState(),
+              state.0.dim(0) == count,
+              state.1.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+            copy.repartition(
+                keys: state.0[index..<(index + 1), 0..., 0..., 0...],
+                values: state.1[index..<(index + 1), 0..., 0..., 0...],
+                newOffset: offset
+            )
+            return copy
+        }
+    }
+
+    func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
+        guard queries.dim(2) == 1 else {
+            return nil
+        }
+
+        if let fused = fusedSpecializedAttention(queries: queries, repeats: repeats, scale: scale) {
+            return fused
+        }
+        return chunkedSpecializedAttention(queries: queries, repeats: repeats, scale: scale)
+    }
+
+    func fusedSpecializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
+        guard Self.supportsFastKernels,
+              queries.dim(2) == 1,
+              leadingKeys == nil,
+              leadingValues == nil,
+              let polarKeys,
+              let polarValues else {
+            return nil
+        }
+
+        let queries32 = queries.asType(.float32)
+        let rotatedQueries = MLX.matmul(queries32, polarKeys.rotationTransposed)
+        var runningWeighted: MLXArray?
+        var runningNormalizer: MLXArray?
+        var runningMax: MLXArray?
+
+        let totalTokens = polarKeys.tokenCount
+        var start = 0
+        while start < totalTokens {
+            let end = min(start + Self.decodeChunkSize, totalTokens)
+            applyPolarChunkFused(
+                queries: rotatedQueries,
+                keyState: polarKeys,
+                valueState: polarValues,
+                tokenRange: start..<end,
+                repeats: repeats,
+                scale: scale,
+                runningWeighted: &runningWeighted,
+                runningNormalizer: &runningNormalizer,
+                runningMax: &runningMax
+            )
+            start = end
+        }
+
+        guard let runningWeighted, let runningNormalizer else {
+            return nil
+        }
+        return MLX.matmul(runningWeighted / runningNormalizer, polarValues.rotation).asType(queries.dtype)
+    }
+
+    private func chunkedSpecializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
+        let queries32 = queries.asType(.float32)
+
+        var runningWeighted: MLXArray?
+        var runningNormalizer: MLXArray?
+        var runningMax: MLXArray?
+
+        if let leadingKeys, let leadingValues {
+            applyChunk(
+                queries: queries32,
+                keys: leadingKeys,
+                values: leadingValues,
+                repeats: repeats,
+                scale: scale,
+                runningWeighted: &runningWeighted,
+                runningNormalizer: &runningNormalizer,
+                runningMax: &runningMax
+            )
+        }
+
+        if let polarKeys, let polarValues {
+            let totalTokens = polarKeys.tokenCount
+            if totalTokens > 0 {
+                var start = 0
+                while start < totalTokens {
+                    let end = min(start + Self.decodeChunkSize, totalTokens)
+                    applyChunk(
+                        queries: queries32,
+                        keys: polarKeys.dequantized(tokenRange: start..<end),
+                        values: polarValues.dequantized(tokenRange: start..<end),
+                        repeats: repeats,
+                        scale: scale,
+                        runningWeighted: &runningWeighted,
+                        runningNormalizer: &runningNormalizer,
+                        runningMax: &runningMax
+                    )
+                    start = end
+                }
+            }
+        }
+
+        guard let runningWeighted, let runningNormalizer else {
+            return nil
+        }
+        return (runningWeighted / runningNormalizer).asType(queries.dtype)
+    }
+
+    private func applyPolarChunkFused(
+        queries: MLXArray,
+        keyState: Gemma4PolarTensorState,
+        valueState: Gemma4PolarTensorState,
+        tokenRange: Range<Int>,
+        repeats: Int,
+        scale: Float,
+        runningWeighted: inout MLXArray?,
+        runningNormalizer: inout MLXArray?,
+        runningMax: inout MLXArray?
+    ) {
+        let packedKeys = keyState.packed[0..., 0..., tokenRange, 0...]
+        let keyNorms = keyState.norms[0..., 0..., tokenRange, 0...]
+        let packedValues = valueState.packed[0..., 0..., tokenRange, 0...]
+        let valueNorms = valueState.norms[0..., 0..., tokenRange, 0...]
+        let fusedChunkDecodeKernel = Gemma4PolarFastKernels.fusedChunkDecodeKernel(
+            bits: keyState.bits,
+            dim: queries.dim(3),
+            packedWidth: keyState.packedWidth,
+            repeats: repeats
+        )
+
+        let weightedAndStats = fusedChunkDecodeKernel(
+            [queries, packedKeys, keyNorms, packedValues, valueNorms, keyState.centroids, scale],
+            template: [
+                ("Bits", keyState.bits),
+                ("Dim", queries.dim(3)),
+                ("PackedWidth", keyState.packedWidth),
+                ("RepeatCount", repeats),
+            ],
+            grid: (32, queries.dim(1), queries.dim(0) * queries.dim(3)),
+            threadGroup: (32, 1, 1),
+            outputShapes: [
+                [queries.dim(0), queries.dim(1), 1, queries.dim(3)],
+                [queries.dim(0), queries.dim(1), 1, 1],
+                [queries.dim(0), queries.dim(1), 1, 1],
+            ],
+            outputDTypes: [.float32, .float32, .float32]
+        )
+        let chunkWeighted = weightedAndStats[0]
+        let chunkNormalizer = weightedAndStats[1]
+        let chunkMax = weightedAndStats[2]
+
+        guard let currentWeighted = runningWeighted,
+              let currentNormalizer = runningNormalizer,
+              let currentMax = runningMax else {
+            runningWeighted = chunkWeighted
+            runningNormalizer = chunkNormalizer
+            runningMax = chunkMax
+            return
+        }
+
+        let mergedMax = MLX.maximum(currentMax, chunkMax)
+        let currentScale = exp(currentMax - mergedMax)
+        let chunkScale = exp(chunkMax - mergedMax)
+        runningWeighted = currentWeighted * currentScale + chunkWeighted * chunkScale
+        runningNormalizer = currentNormalizer * currentScale + chunkNormalizer * chunkScale
+        runningMax = mergedMax
+    }
+
+    private func repartition(keys: MLXArray, values: MLXArray, newOffset: Int) {
+        let keptLength = keys.dim(2)
+        let keptStart = newOffset - keptLength
+        let plainCount = max(0, min(keptLength, configuration.quantizedStart - keptStart))
+
+        if plainCount > 0 {
+            leadingKeys = keys[0..., 0..., ..<plainCount, 0...]
+            leadingValues = values[0..., 0..., ..<plainCount, 0...]
+        } else {
+            leadingKeys = nil
+            leadingValues = nil
+        }
+
+        let polarLength = keptLength - plainCount
+        if polarLength > 0, let bits = configuration.keyBits {
+            polarKeys = Gemma4PolarTensorState(source: keys[0..., 0..., plainCount..., 0...], bits: bits)
+            polarValues = Gemma4PolarTensorState(source: values[0..., 0..., plainCount..., 0...], bits: bits)
+        } else {
+            polarKeys = nil
+            polarValues = nil
+        }
+
+        offset = newOffset
+    }
+
+    private func reconstructState() -> (MLXArray, MLXArray)? {
+        var keyParts: [MLXArray] = []
+        var valueParts: [MLXArray] = []
+
+        if let leadingKeys, let leadingValues {
+            keyParts.append(leadingKeys)
+            valueParts.append(leadingValues)
+        }
+
+        if let polarKeys, let polarValues {
+            keyParts.append(polarKeys.dequantized())
+            valueParts.append(polarValues.dequantized())
+        }
+
+        guard !keyParts.isEmpty else {
+            return nil
+        }
+
+        if keyParts.count == 1 {
+            return (keyParts[0], valueParts[0])
+        }
+
+        return (concatenated(keyParts, axis: 2), concatenated(valueParts, axis: 2))
+    }
+
+    private func applyChunk(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        repeats: Int,
+        scale: Float,
+        runningWeighted: inout MLXArray?,
+        runningNormalizer: inout MLXArray?,
+        runningMax: inout MLXArray?
+    ) {
+        guard keys.dim(2) > 0 else {
+            return
+        }
+
+        var broadcastKeys = keys.asType(.float32)
+        var broadcastValues = values.asType(.float32)
+        if repeats > 1 {
+            broadcastKeys = MLX.repeated(broadcastKeys, count: repeats, axis: 1)
+            broadcastValues = MLX.repeated(broadcastValues, count: repeats, axis: 1)
+        }
+
+        let scores = MLX.matmul(queries, broadcastKeys.transposed(0, 1, 3, 2)) * MLXArray(scale)
+        let chunkMax = scores.max(axis: -1, keepDims: true)
+        let shifted = exp(scores - chunkMax)
+        let chunkWeighted = MLX.matmul(shifted, broadcastValues)
+        let chunkNormalizer = shifted.sum(axis: -1, keepDims: true)
+
+        guard let currentWeighted = runningWeighted,
+              let currentNormalizer = runningNormalizer,
+              let currentMax = runningMax else {
+            runningWeighted = chunkWeighted
+            runningNormalizer = chunkNormalizer
+            runningMax = chunkMax
+            return
+        }
+
+        let mergedMax = MLX.maximum(currentMax, chunkMax)
+        let currentScale = exp(currentMax - mergedMax)
+        let chunkScale = exp(chunkMax - mergedMax)
+        runningWeighted = currentWeighted * currentScale + chunkWeighted * chunkScale
+        runningNormalizer = currentNormalizer * currentScale + chunkNormalizer * chunkScale
+        runningMax = mergedMax
+    }
+
+    private static var supportsFastKernels: Bool {
+        Device.defaultDevice().deviceType == .gpu
     }
 }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -559,6 +559,8 @@ private struct Gemma4PolarFastKernelKey: Hashable {
     enum Kind: Hashable {
         case pack
         case unpack
+        case score
+        case weightedValue
         case fusedChunkDecode
     }
 
@@ -733,6 +735,118 @@ private enum Gemma4PolarFastKernels {
                 float norm = static_cast<float>(norms[((batch * norms_shape[1] + head_idx) * token_count + token)]);
                 out[((batch * packed_shape[1] + head_idx) * token_count + token) * Dim + dim_idx] =
                     static_cast<float>(centroids[packed_value]) * norm;
+                """
+        )
+    }
+
+    static func scoreKernel(bits: Int, dim: Int, packedWidth: Int, repeats: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(
+            kind: .score,
+            bits: bits,
+            dim: dim,
+            packedWidth: packedWidth,
+            repeats: repeats
+        )
+        return kernel(
+            key: key,
+            inputNames: ["queries", "packed", "norms", "centroids", "scale"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = packed_shape[2];
+                auto head_count = queries_shape[1];
+                auto batch = n / token_count;
+                auto token = n % token_count;
+                if (batch >= queries_shape[0] || head_idx >= head_count) {
+                    return;
+                }
+
+                auto kv_head = head_idx / RepeatCount;
+                auto query_ptr = queries + ((batch * head_count + head_idx) * Dim);
+                auto packed_ptr = packed + (((batch * packed_shape[1] + kv_head) * token_count + token) * PackedWidth);
+                auto norms_ptr = norms + ((batch * norms_shape[1] + kv_head) * token_count);
+                float norm = static_cast<float>(norms_ptr[token]);
+
+                constexpr uint value_mask = (1u << Bits) - 1u;
+                float acc = 0.0f;
+                for (int d = lane; d < Dim; d += 32) {
+                    int bit_offset = d * Bits;
+                    int word_idx = bit_offset / 32;
+                    int offset = bit_offset % 32;
+                    uint packed_value = packed_ptr[word_idx] >> offset;
+                    int spill = offset + Bits - 32;
+                    if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                        packed_value |= packed_ptr[word_idx + 1] << (Bits - spill);
+                    }
+                    packed_value &= value_mask;
+
+                    float decoded = static_cast<float>(centroids[packed_value]) * norm;
+                    acc += static_cast<float>(query_ptr[d]) * decoded;
+                }
+
+                acc = simd_sum(acc);
+                if (thread_index_in_simdgroup == 0) {
+                    out[((batch * head_count + head_idx) * token_count) + token] =
+                        acc * static_cast<float>(scale);
+                }
+                """
+        )
+    }
+
+    static func weightedValueKernel(bits: Int, dim: Int, packedWidth: Int, repeats: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(
+            kind: .weightedValue,
+            bits: bits,
+            dim: dim,
+            packedWidth: packedWidth,
+            repeats: repeats
+        )
+        return kernel(
+            key: key,
+            inputNames: ["weights", "packed", "norms", "centroids"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = packed_shape[2];
+                auto head_count = weights_shape[1];
+                auto batch = n / Dim;
+                auto dim_idx = n % Dim;
+                if (batch >= weights_shape[0] || head_idx >= head_count) {
+                    return;
+                }
+
+                auto kv_head = head_idx / RepeatCount;
+                auto weights_ptr = weights + ((batch * head_count + head_idx) * token_count);
+                auto packed_ptr = packed + ((batch * packed_shape[1] + kv_head) * token_count * PackedWidth);
+                auto norms_ptr = norms + ((batch * norms_shape[1] + kv_head) * token_count);
+
+                int bit_offset = dim_idx * Bits;
+                int word_idx = bit_offset / 32;
+                int offset = bit_offset % 32;
+                constexpr uint value_mask = (1u << Bits) - 1u;
+
+                float acc = 0.0f;
+                for (int token = lane; token < token_count; token += 32) {
+                    auto token_packed = packed_ptr + token * PackedWidth;
+                    uint packed_value = token_packed[word_idx] >> offset;
+                    int spill = offset + Bits - 32;
+                    if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                        packed_value |= token_packed[word_idx + 1] << (Bits - spill);
+                    }
+                    packed_value &= value_mask;
+
+                    float decoded = static_cast<float>(centroids[packed_value]) * static_cast<float>(norms_ptr[token]);
+                    acc += static_cast<float>(weights_ptr[token]) * decoded;
+                }
+
+                acc = simd_sum(acc);
+                if (thread_index_in_simdgroup == 0) {
+                    out[((batch * head_count + head_idx) * Dim) + dim_idx] = acc;
+                }
                 """
         )
     }
@@ -1262,6 +1376,16 @@ final class Gemma4PolarKVCache: Gemma4AttentionCache {
             return nil
         }
 
+        if let scoreValueOutput = scoreValueSpecializedAttention(
+            queries: queries,
+            keyState: polarKeys,
+            valueState: polarValues,
+            repeats: repeats,
+            scale: scale
+        ) {
+            return scoreValueOutput
+        }
+
         let queries32 = queries.asType(.float32)
         let rotatedQueries = MLX.matmul(queries32, polarKeys.rotationTransposed)
         var runningWeighted: MLXArray?
@@ -1290,6 +1414,66 @@ final class Gemma4PolarKVCache: Gemma4AttentionCache {
             return nil
         }
         return MLX.matmul(runningWeighted / runningNormalizer, polarValues.rotation).asType(queries.dtype)
+    }
+
+    private func scoreValueSpecializedAttention(
+        queries: MLXArray,
+        keyState: Gemma4PolarTensorState,
+        valueState: Gemma4PolarTensorState,
+        repeats: Int,
+        scale: Float
+    ) -> MLXArray? {
+        let totalTokens = keyState.tokenCount
+        guard totalTokens > 0 else {
+            return nil
+        }
+
+        let queries32 = queries.asType(.float32)
+        let rotatedQueries = MLX.matmul(queries32, keyState.rotationTransposed)
+        let scoreKernel = Gemma4PolarFastKernels.scoreKernel(
+            bits: keyState.bits,
+            dim: queries.dim(3),
+            packedWidth: keyState.packedWidth,
+            repeats: repeats
+        )
+        let scores = scoreKernel(
+            [rotatedQueries, keyState.packed, keyState.norms, keyState.centroids, scale],
+            template: [
+                ("Bits", keyState.bits),
+                ("Dim", queries.dim(3)),
+                ("PackedWidth", keyState.packedWidth),
+                ("RepeatCount", repeats),
+            ],
+            grid: (32, queries.dim(1), queries.dim(0) * totalTokens),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[queries.dim(0), queries.dim(1), 1, totalTokens]],
+            outputDTypes: [.float32]
+        )[0]
+
+        let scoreMax = scores.max(axis: -1, keepDims: true)
+        let weights = exp(scores - scoreMax)
+        let normalizer = weights.sum(axis: -1, keepDims: true)
+        let weightedValueKernel = Gemma4PolarFastKernels.weightedValueKernel(
+            bits: valueState.bits,
+            dim: queries.dim(3),
+            packedWidth: valueState.packedWidth,
+            repeats: repeats
+        )
+        let weighted = weightedValueKernel(
+            [weights, valueState.packed, valueState.norms, valueState.centroids],
+            template: [
+                ("Bits", valueState.bits),
+                ("Dim", queries.dim(3)),
+                ("PackedWidth", valueState.packedWidth),
+                ("RepeatCount", repeats),
+            ],
+            grid: (32, queries.dim(1), queries.dim(0) * queries.dim(3)),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[queries.dim(0), queries.dim(1), 1, queries.dim(3)]],
+            outputDTypes: [.float32]
+        )[0]
+
+        return MLX.matmul(weighted / normalizer, valueState.rotation).asType(queries.dtype)
     }
 
     private func chunkedSpecializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -764,6 +764,59 @@ final class Gemma4QuantizedKVCache: Gemma4AttentionCache {
         }
     }
 
+    func fork() -> Gemma4AttentionCache {
+        let copy = Gemma4QuantizedKVCache(configuration: configuration, maxSize: maxSize)
+        copy.leadingKeys = leadingKeys
+        copy.leadingValues = leadingValues
+        copy.quantizedKeys = quantizedKeys
+        copy.quantizedValues = quantizedValues
+        copy.offset = offset
+        return copy
+    }
+
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
+        guard let typed = caches as? [Gemma4QuantizedKVCache],
+              !typed.isEmpty,
+              typed.allSatisfy({
+                  $0.offset == offset
+                      && $0.configuration == configuration
+                      && $0.maxSize == maxSize
+              }) else {
+            return nil
+        }
+
+        let states = typed.compactMap { $0.currentState() }
+        guard states.count == typed.count else {
+            return nil
+        }
+
+        let copy = Gemma4QuantizedKVCache(configuration: configuration, maxSize: maxSize)
+        copy.repartition(
+            keys: concatenated(states.map(\.0), axis: 0),
+            values: concatenated(states.map(\.1), axis: 0),
+            newOffset: offset
+        )
+        return copy
+    }
+
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]? {
+        guard count > 0,
+              let state = currentState(),
+              state.0.dim(0) == count,
+              state.1.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = Gemma4QuantizedKVCache(configuration: configuration, maxSize: maxSize)
+            copy.repartition(
+                keys: state.0[index..<(index + 1), 0..., 0..., 0...],
+                values: state.1[index..<(index + 1), 0..., 0..., 0...],
+                newOffset: offset
+            )
+            return copy
+        }
+    }
+
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
         guard queries.dim(2) == 1 else {
             return nil

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -94,6 +94,8 @@ protocol Gemma4AttentionCache: AnyObject {
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache?
     func unbatchedRows(count: Int) -> [Gemma4AttentionCache]?
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray?
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache?
+    func evaluateStorage()
 }
 
 extension Gemma4AttentionCache {
@@ -108,6 +110,12 @@ extension Gemma4AttentionCache {
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
         nil
     }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        nil
+    }
+
+    func evaluateStorage() {}
 }
 
 final class Gemma4FullKVCache: Gemma4AttentionCache {
@@ -137,6 +145,31 @@ final class Gemma4FullKVCache: Gemma4AttentionCache {
         copy.values = values
         copy.offset = offset
         return copy
+    }
+
+    static func reencoded(keys: MLXArray, values: MLXArray, offset: Int) -> Gemma4FullKVCache {
+        let cache = Gemma4FullKVCache()
+        cache.keys = keys
+        cache.values = values
+        cache.offset = offset
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: nil,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let keys, let values {
+            MLX.eval(keys, values)
+        }
     }
 
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
@@ -218,6 +251,43 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
         return copy
     }
 
+    static func reencoded(
+        keys: MLXArray,
+        values: MLXArray,
+        offset: Int,
+        maxSize: Int
+    ) -> Gemma4SlidingKVCache {
+        let cache = Gemma4SlidingKVCache(maxSize: maxSize)
+        let totalLength = keys.dim(2)
+        if totalLength > cache.maxSize {
+            let start = totalLength - cache.maxSize
+            cache.keys = keys[0..., 0..., start..., 0...]
+            cache.values = values[0..., 0..., start..., 0...]
+        } else {
+            cache.keys = keys
+            cache.values = values
+        }
+        cache.offset = offset
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: maxSize,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let keys, let values {
+            MLX.eval(keys, values)
+        }
+    }
+
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
         guard let typed = caches as? [Gemma4SlidingKVCache],
               !typed.isEmpty,
@@ -249,6 +319,38 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
             return copy
         }
     }
+}
+
+func makeGemma4AttentionCache(
+    keys: MLXArray,
+    values: MLXArray,
+    offset: Int,
+    maxSize: Int?,
+    quantization: Gemma4KVCacheQuantization? = nil
+) -> Gemma4AttentionCache {
+    if let quantization, quantization.isEnabled {
+        if quantization.scheme == .polar {
+            return Gemma4PolarKVCache.reencoded(
+                keys: keys,
+                values: values,
+                configuration: quantization,
+                maxSize: maxSize,
+                offset: offset
+            )
+        }
+        return Gemma4QuantizedKVCache.reencoded(
+            keys: keys,
+            values: values,
+            configuration: quantization,
+            maxSize: maxSize,
+            offset: offset
+        )
+    }
+
+    if let maxSize {
+        return Gemma4SlidingKVCache.reencoded(keys: keys, values: values, offset: offset, maxSize: maxSize)
+    }
+    return Gemma4FullKVCache.reencoded(keys: keys, values: values, offset: offset)
 }
 
 final class Gemma4MLP: Module {

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -820,6 +820,9 @@ final class Gemma4LanguageModel: Module {
         config.layerTypes.prefix(firstKVSharedLayerIndex).map { layerType in
             let maxSize: Int? = layerType == "full_attention" ? nil : config.slidingWindow
             if let quantization, quantization.isEnabled {
+                if quantization.scheme == .polar {
+                    return Gemma4PolarKVCache(configuration: quantization, maxSize: maxSize)
+                }
                 return Gemma4QuantizedKVCache(configuration: quantization, maxSize: maxSize)
             }
             if let maxSize {

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -90,10 +90,21 @@ protocol Gemma4AttentionCache: AnyObject {
     var offset: Int { get }
     func currentState() -> (MLXArray, MLXArray)?
     func append(keys: MLXArray, values: MLXArray)
+    func fork() -> Gemma4AttentionCache
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache?
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]?
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray?
 }
 
 extension Gemma4AttentionCache {
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
+        nil
+    }
+
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]? {
+        nil
+    }
+
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
         nil
     }
@@ -118,6 +129,46 @@ final class Gemma4FullKVCache: Gemma4AttentionCache {
             self.values = values
         }
         self.offset += keys.dim(2)
+    }
+
+    func fork() -> Gemma4AttentionCache {
+        let copy = Gemma4FullKVCache()
+        copy.keys = keys
+        copy.values = values
+        copy.offset = offset
+        return copy
+    }
+
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
+        guard let typed = caches as? [Gemma4FullKVCache],
+              !typed.isEmpty,
+              typed.allSatisfy({ $0.offset == offset }) else {
+            return nil
+        }
+
+        let states = typed.compactMap { $0.currentState() }
+        guard states.count == typed.count else {
+            return nil
+        }
+
+        let copy = Gemma4FullKVCache()
+        copy.keys = concatenated(states.map(\.0), axis: 0)
+        copy.values = concatenated(states.map(\.1), axis: 0)
+        copy.offset = offset
+        return copy
+    }
+
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]? {
+        guard count > 0, let keys, let values, keys.dim(0) == count, values.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = Gemma4FullKVCache()
+            copy.keys = keys[index..<(index + 1), 0..., 0..., 0...]
+            copy.values = values[index..<(index + 1), 0..., 0..., 0...]
+            copy.offset = offset
+            return copy
+        }
     }
 }
 
@@ -157,6 +208,46 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
             self.values = combinedValues
         }
         self.offset += keys.dim(2)
+    }
+
+    func fork() -> Gemma4AttentionCache {
+        let copy = Gemma4SlidingKVCache(maxSize: maxSize)
+        copy.keys = keys
+        copy.values = values
+        copy.offset = offset
+        return copy
+    }
+
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
+        guard let typed = caches as? [Gemma4SlidingKVCache],
+              !typed.isEmpty,
+              typed.allSatisfy({ $0.offset == offset && $0.maxSize == maxSize }) else {
+            return nil
+        }
+
+        let states = typed.compactMap { $0.currentState() }
+        guard states.count == typed.count else {
+            return nil
+        }
+
+        let copy = Gemma4SlidingKVCache(maxSize: maxSize)
+        copy.keys = concatenated(states.map(\.0), axis: 0)
+        copy.values = concatenated(states.map(\.1), axis: 0)
+        copy.offset = offset
+        return copy
+    }
+
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]? {
+        guard count > 0, let keys, let values, keys.dim(0) == count, values.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = Gemma4SlidingKVCache(maxSize: maxSize)
+            copy.keys = keys[index..<(index + 1), 0..., 0..., 0...]
+            copy.values = values[index..<(index + 1), 0..., 0..., 0...]
+            copy.offset = offset
+            return copy
+        }
     }
 }
 

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -248,6 +248,7 @@ public struct ChatRequest: Sendable, Hashable {
     public var lora: LoRA?
     public var requiresJSON: Bool
     public var tools: [ToolDefinition]?
+    public var stopOnEOS: Bool
 
     public init(
         messages: [ChatMessage],
@@ -257,7 +258,8 @@ public struct ChatRequest: Sendable, Hashable {
         showThinking: Bool = true,
         lora: LoRA? = nil,
         requiresJSON: Bool = false,
-        tools: [ToolDefinition]? = nil
+        tools: [ToolDefinition]? = nil,
+        stopOnEOS: Bool = true
     ) {
         self.messages = messages
         self.maxTokens = maxTokens
@@ -267,6 +269,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.lora = lora
         self.requiresJSON = requiresJSON
         self.tools = tools
+        self.stopOnEOS = stopOnEOS
     }
 }
 
@@ -274,15 +277,18 @@ public struct ChatTiming: Sendable, Hashable {
     public var loadSeconds: Double
     public var prefillSeconds: Double
     public var decodeSeconds: Double
+    public var firstTokenSeconds: Double?
 
     public init(
         loadSeconds: Double = 0,
         prefillSeconds: Double = 0,
-        decodeSeconds: Double = 0
+        decodeSeconds: Double = 0,
+        firstTokenSeconds: Double? = nil
     ) {
         self.loadSeconds = loadSeconds
         self.prefillSeconds = prefillSeconds
         self.decodeSeconds = decodeSeconds
+        self.firstTokenSeconds = firstTokenSeconds
     }
 }
 
@@ -291,12 +297,20 @@ public struct ChatResponse: Sendable, Hashable {
     public var tokensGenerated: Int
     public var timing: ChatTiming?
     public var toolCalls: [ToolCall]?
+    public var promptTokens: Int?
 
-    public init(response: String, tokensGenerated: Int, timing: ChatTiming? = nil, toolCalls: [ToolCall]? = nil) {
+    public init(
+        response: String,
+        tokensGenerated: Int,
+        timing: ChatTiming? = nil,
+        toolCalls: [ToolCall]? = nil,
+        promptTokens: Int? = nil
+    ) {
         self.response = response
         self.tokensGenerated = tokensGenerated
         self.timing = timing
         self.toolCalls = toolCalls
+        self.promptTokens = promptTokens
     }
 }
 

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -276,17 +276,20 @@ public struct ChatRequest: Sendable, Hashable {
 public struct ChatTiming: Sendable, Hashable {
     public var loadSeconds: Double
     public var prefillSeconds: Double
+    public var cacheConversionSeconds: Double?
     public var decodeSeconds: Double
     public var firstTokenSeconds: Double?
 
     public init(
         loadSeconds: Double = 0,
         prefillSeconds: Double = 0,
+        cacheConversionSeconds: Double? = nil,
         decodeSeconds: Double = 0,
         firstTokenSeconds: Double? = nil
     ) {
         self.loadSeconds = loadSeconds
         self.prefillSeconds = prefillSeconds
+        self.cacheConversionSeconds = cacheConversionSeconds
         self.decodeSeconds = decodeSeconds
         self.firstTokenSeconds = firstTokenSeconds
     }

--- a/Sources/MereRunCore/Q35/Q35FullAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35FullAttention.swift
@@ -78,9 +78,14 @@ final class Q35FullAttention: Module {
         var k = kNorm(keys).transposed(0, 2, 1, 3)
         var v = values.transposed(0, 2, 1, 3)
 
-        let offset = cache?.offset ?? 0
-        q = rope(q, offset: offset)
-        k = rope(k, offset: offset)
+        if let rowOffsets = cache?.rowOffsets, rowOffsets.count == b {
+            q = applyRoPEByRow(q, rowOffsets: rowOffsets)
+            k = applyRoPEByRow(k, rowOffsets: rowOffsets)
+        } else {
+            let offset = cache?.offset ?? 0
+            q = rope(q, offset: offset)
+            k = rope(k, offset: offset)
+        }
 
         if let cache {
             let cached = cache.update(keys: k, values: v)
@@ -107,5 +112,15 @@ final class Q35FullAttention: Module {
             out = out * MLX.sigmoid(gate)
         }
         return oProj(out)
+    }
+
+    private func applyRoPEByRow(_ value: MLXArray, rowOffsets: [Int]) -> MLXArray {
+        guard !rowOffsets.isEmpty else {
+            return rope(value, offset: 0)
+        }
+        let rows = rowOffsets.enumerated().map { index, offset in
+            rope(value[index..<(index + 1), 0..., 0..., 0...], offset: offset)
+        }
+        return concatenated(rows, axis: 0)
     }
 }

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -2,7 +2,90 @@ import Foundation
 import MediaIO
 import MLX
 
+public typealias Q35ContinuousBatchingStats = RuntimeDecodeBatchingStats
+
+private struct Q35PrefixKVCacheKey: Hashable {
+    let modelPath: String
+    let tokens: [Int]
+}
+
+private struct Q35PrefixKVCacheEntry {
+    let caches: [Q35LayerCache?]
+    let logits: MLXArray
+    let priority: RuntimePrefixCacheEntryPriority
+    var lastAccess: Date
+}
+
+private struct Q35BatchedDecodeResult {
+    let generatedTokens: [Int]
+    let decodeSeconds: Double
+}
+
+private final class Q35BatchedDecodeRow: @unchecked Sendable {
+    let id: UUID
+    let eosSet: Set<Int>
+    let generationConfig: GenerationConfig
+    let tokenBudget: Int
+    let progressHandler: (@Sendable (ChatProgress) -> Void)?
+    let decodeStart: Date
+    let prefillTokenCount: Int
+    let continuation: CheckedContinuation<Q35BatchedDecodeResult, Error>
+
+    var logits: MLXArray
+    var layerCaches: [Q35LayerCache?]
+    var generatedTokens: [Int]
+    var repetitionHistory: [Int]
+    var stopped = false
+
+    init(
+        id: UUID,
+        logits: MLXArray,
+        layerCaches: [Q35LayerCache?],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        prefillTokenCount: Int,
+        repetitionHistory: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?,
+        continuation: CheckedContinuation<Q35BatchedDecodeResult, Error>
+    ) {
+        self.id = id
+        self.logits = logits
+        self.layerCaches = layerCaches
+        self.eosSet = eosSet
+        self.generationConfig = generationConfig
+        self.tokenBudget = tokenBudget
+        self.prefillTokenCount = prefillTokenCount
+        self.repetitionHistory = repetitionHistory
+        self.progressHandler = progressHandler
+        self.continuation = continuation
+        self.decodeStart = Date()
+        self.generatedTokens = []
+        self.generatedTokens.reserveCapacity(tokenBudget)
+    }
+
+    var needsDecodeStep: Bool {
+        !stopped && generatedTokens.count < tokenBudget
+    }
+
+    func finish() {
+        continuation.resume(
+            returning: Q35BatchedDecodeResult(
+                generatedTokens: generatedTokens,
+                decodeSeconds: Date().timeIntervalSince(decodeStart)
+            )
+        )
+    }
+
+    func fail(_ error: Error) {
+        continuation.resume(throwing: error)
+    }
+}
+
 public actor Q35Generator: ChatGenerator {
+    private static let prefillChunkSize = 512
+    private static let prefixKVCacheMaxEntries = 4
+
     private var model: Q35Model?
     private var tokenizerAndTemplate: Q35TokenizerAndTemplate?
     private var visionTower: Q35VisionTower?
@@ -11,9 +94,33 @@ public actor Q35Generator: ChatGenerator {
     private var loadedResources: Q35Resources?
 
     private let modelId: String
+    private let prefixKVCacheEnabled: Bool
+    private let continuousBatchingEnabled: Bool
 
-    public init(modelId: String = Q35Resources.defaultModelId) {
+    private var prefixKVCache: [Q35PrefixKVCacheKey: Q35PrefixKVCacheEntry] = [:]
+    private var prefixKVCacheHits = 0
+    private var prefixKVCacheMisses = 0
+    private var prefixKVCacheStores = 0
+    private var prefixKVCacheReusedTokens = 0
+
+    private var decodeQueue: [Q35BatchedDecodeRow] = []
+    private var activeDecodeRows: [Q35BatchedDecodeRow] = []
+    private var decodeLoopRunning = false
+    private var batchedDecodeSteps = 0
+    private var samePositionBatchedSteps = 0
+    private var variablePositionBatchedSteps = 0
+    private var singleDecodeSteps = 0
+    private var totalBatchedRows = 0
+    private var maxObservedBatchSize = 0
+
+    public init(
+        modelId: String = Q35Resources.defaultModelId,
+        prefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_PREFIX_KV_CACHE"] == "1",
+        continuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_CONTINUOUS_BATCHING"] == "1"
+    ) {
         self.modelId = modelId
+        self.prefixKVCacheEnabled = prefixKVCacheEnabled
+        self.continuousBatchingEnabled = continuousBatchingEnabled
     }
 
     public func chat(
@@ -72,6 +179,8 @@ public actor Q35Generator: ChatGenerator {
     }
 
     public func unload() {
+        failQueuedDecodeRows(CancellationError())
+        resetPrefixKVCache()
         model = nil
         tokenizerAndTemplate = nil
         visionTower = nil
@@ -79,6 +188,33 @@ public actor Q35Generator: ChatGenerator {
         loadedConfig = nil
         loadedResources = nil
         Memory.clearCache()
+    }
+
+    public func prefixKVCacheStats() -> PrefixKVCacheStats {
+        PrefixKVCacheStats(
+            enabled: prefixKVCacheEnabled,
+            entries: prefixKVCache.count,
+            maxEntries: Self.prefixKVCacheMaxEntries,
+            hits: prefixKVCacheHits,
+            misses: prefixKVCacheMisses,
+            storedPrefixes: prefixKVCacheStores,
+            reusedTokens: prefixKVCacheReusedTokens,
+            storedTokens: prefixKVCache.keys.reduce(0) { $0 + $1.tokens.count }
+        )
+    }
+
+    public func continuousBatchingStats() -> Q35ContinuousBatchingStats {
+        Q35ContinuousBatchingStats(
+            enabled: continuousBatchingEnabled,
+            activeRows: activeDecodeRows.count,
+            queuedRows: decodeQueue.count,
+            batchedDecodeSteps: batchedDecodeSteps,
+            samePositionBatchedSteps: samePositionBatchedSteps,
+            variablePositionBatchedSteps: variablePositionBatchedSteps,
+            singleDecodeSteps: singleDecodeSteps,
+            totalBatchedRows: totalBatchedRows,
+            maxBatchSize: maxObservedBatchSize
+        )
     }
 
     private func ensureLoaded(
@@ -89,6 +225,7 @@ public actor Q35Generator: ChatGenerator {
         if loadedModelPath == normalizedRoot.path, model != nil, tokenizerAndTemplate != nil {
             return
         }
+        resetPrefixKVCache()
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Q35 config"))
         let configData = try Data(contentsOf: normalizedRoot.appendingPathComponent("config.json"))
@@ -179,7 +316,7 @@ public actor Q35Generator: ChatGenerator {
             repetitionContextSize: 64
         )
 
-        let layerCaches = makeLayerCaches(config: loadedConfig)
+        var layerCaches = makeLayerCaches(config: loadedConfig)
         let promptInput = MLXArray(promptTokens.map { Int32($0) }).reshaped(1, promptTokens.count)
 
         let imageURLs = collectImageURLs(from: messages)
@@ -187,7 +324,31 @@ public actor Q35Generator: ChatGenerator {
         var prefillLength = promptTokens.count
 
         if imageURLs.isEmpty {
-            logits = model(promptInput, cache: layerCaches)
+            let prefixSeed = prefixKVCacheSeed(
+                modelPath: loadedModelPath ?? "",
+                promptTokens: promptTokens
+            )
+            let prefixCheckpoints = semanticPrefixCheckpoints(
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                messages: messages,
+                tools: request.tools,
+                includeThinking: request.showThinking,
+                promptTokens: promptTokens,
+                maxContextLength: effectiveContext
+            )
+            if let prefixSeed {
+                layerCaches = prefixSeed.caches
+            }
+            logits = try await chunkedPrefill(
+                model: model,
+                promptTokens: promptTokens,
+                cache: layerCaches,
+                startIndex: prefixSeed?.tokenCount ?? 0,
+                existingLogits: prefixSeed?.logits,
+                modelPath: loadedModelPath ?? "",
+                checkpointTokenCounts: prefixCheckpoints,
+                progressHandler: progressHandler
+            )
         } else {
             progressHandler?(ChatProgress(stage: .encoding, message: "Encoding images"))
             try ensureVisionWeightsLoaded(progressHandler: progressHandler)
@@ -200,7 +361,12 @@ public actor Q35Generator: ChatGenerator {
                 )
 
                 if replacements.isEmpty {
-                    logits = model(promptInput, cache: layerCaches)
+                    logits = try await chunkedPrefill(
+                        model: model,
+                        promptTokens: promptTokens,
+                        cache: layerCaches,
+                        progressHandler: progressHandler
+                    )
                 } else {
                     var promptEmbeddings = model.embeddings(for: promptInput)
                     promptEmbeddings = insertVisionEmbeddings(
@@ -214,25 +380,133 @@ public actor Q35Generator: ChatGenerator {
                         promptEmbeddings = promptEmbeddings[0..., (promptEmbeddings.dim(1) - effectiveContext)..., 0...]
                     }
                     prefillLength = promptEmbeddings.dim(1)
-                    logits = model(promptInput, cache: layerCaches, inputEmbeddings: promptEmbeddings)
+                    logits = try await chunkedPrefillEmbeddings(
+                        model: model,
+                        inputEmbeddings: promptEmbeddings,
+                        cache: layerCaches,
+                        progressHandler: progressHandler
+                    )
                 }
             } else {
-                logits = model(promptInput, cache: layerCaches)
+                logits = try await chunkedPrefill(
+                    model: model,
+                    promptTokens: promptTokens,
+                    cache: layerCaches,
+                    progressHandler: progressHandler
+                )
             }
         }
-        MLX.eval(logits)
         let prefillSeconds = Date().timeIntervalSince(prefillStart)
 
         let tokenBudget = max(0, min(request.maxTokens, effectiveContext - prefillLength))
 
         progressHandler?(ChatProgress(stage: .generating, message: ""))
 
+        let decodeResult = try await decodeTokens(
+            model: model,
+            tokenizerAndTemplate: tokenizerAndTemplate,
+            initialLogits: logits,
+            layerCaches: layerCaches,
+            eosSet: eosSet,
+            generationConfig: generationConfig,
+            tokenBudget: tokenBudget,
+            prefillTokenCount: prefillLength,
+            promptTokens: promptTokens,
+            progressHandler: progressHandler
+        )
+
+        let decoded = tokenizerAndTemplate.decode(tokens: decodeResult.generatedTokens)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
+            let parsed = Gemma4ToolParser.parseToolCalls(decoded)
+            return parsed.isEmpty ? nil : parsed
+        }() : nil
+
+        return ChatResponse(
+            response: decoded,
+            tokensGenerated: decodeResult.generatedTokens.count,
+            timing: ChatTiming(
+                loadSeconds: 0,
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decodeResult.decodeSeconds
+            ),
+            toolCalls: toolCalls
+        )
+    }
+
+    private func decodeTokens(
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [Q35LayerCache?],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        prefillTokenCount: Int,
+        promptTokens: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> Q35BatchedDecodeResult {
+        guard tokenBudget > 0 else {
+            return Q35BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0)
+        }
+        guard continuousBatchingEnabled else {
+            return try await decodeTokensSerially(
+                model: model,
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                initialLogits: initialLogits,
+                layerCaches: layerCaches,
+                eosSet: eosSet,
+                generationConfig: generationConfig,
+                tokenBudget: tokenBudget,
+                promptTokens: promptTokens,
+                progressHandler: progressHandler
+            )
+        }
+
+        let rowID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let row = Q35BatchedDecodeRow(
+                    id: rowID,
+                    logits: initialLogits,
+                    layerCaches: layerCaches,
+                    eosSet: eosSet,
+                    generationConfig: generationConfig,
+                    tokenBudget: tokenBudget,
+                    prefillTokenCount: prefillTokenCount,
+                    repetitionHistory: promptTokens,
+                    progressHandler: progressHandler,
+                    continuation: continuation
+                )
+                enqueueDecodeRow(row, model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task {
+                await self.cancelDecodeRow(id: rowID)
+            }
+        }
+    }
+
+    private func decodeTokensSerially(
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [Q35LayerCache?],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> Q35BatchedDecodeResult {
+        var logits = initialLogits
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
         let decodeStart = Date()
 
         for _ in 0..<tokenBudget {
+            try Task.checkCancellation()
             let next = sampleToken(
                 logits: logits[0, -1, 0...],
                 config: generationConfig,
@@ -250,29 +524,474 @@ public actor Q35Generator: ChatGenerator {
                 progressHandler?(ChatProgress(stage: .generating, message: piece))
             }
 
+            guard generated.count < tokenBudget else {
+                break
+            }
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
             logits = model(nextInput, cache: layerCaches)
             MLX.eval(logits)
         }
-        let decodeSeconds = Date().timeIntervalSince(decodeStart)
 
-        let decoded = tokenizerAndTemplate.decode(tokens: generated)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
-            let parsed = Gemma4ToolParser.parseToolCalls(decoded)
-            return parsed.isEmpty ? nil : parsed
-        }() : nil
-
-        return ChatResponse(
-            response: decoded,
-            tokensGenerated: generated.count,
-            timing: ChatTiming(
-                loadSeconds: 0,
-                prefillSeconds: prefillSeconds,
-                decodeSeconds: decodeSeconds
-            ),
-            toolCalls: toolCalls
+        return Q35BatchedDecodeResult(
+            generatedTokens: generated,
+            decodeSeconds: Date().timeIntervalSince(decodeStart)
         )
+    }
+
+    private func enqueueDecodeRow(
+        _ row: Q35BatchedDecodeRow,
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate
+    ) {
+        decodeQueue.append(row)
+        startDecodeLoopIfNeeded(model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+    }
+
+    private func cancelDecodeRow(id: UUID) {
+        if let index = decodeQueue.firstIndex(where: { $0.id == id }) {
+            let row = decodeQueue.remove(at: index)
+            row.fail(CancellationError())
+            return
+        }
+        if let index = activeDecodeRows.firstIndex(where: { $0.id == id }) {
+            let row = activeDecodeRows.remove(at: index)
+            row.fail(CancellationError())
+        }
+    }
+
+    private func startDecodeLoopIfNeeded(
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate
+    ) {
+        guard !decodeLoopRunning else { return }
+        decodeLoopRunning = true
+        Task {
+            await runDecodeLoop(model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+        }
+    }
+
+    private func runDecodeLoop(
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate
+    ) async {
+        defer {
+            decodeLoopRunning = false
+            if !decodeQueue.isEmpty || !activeDecodeRows.isEmpty {
+                startDecodeLoopIfNeeded(model: model, tokenizerAndTemplate: tokenizerAndTemplate)
+            }
+        }
+
+        while !decodeQueue.isEmpty || !activeDecodeRows.isEmpty {
+            if activeDecodeRows.isEmpty {
+                try? await Task.sleep(nanoseconds: 1_000_000)
+            }
+            activateQueuedDecodeRows()
+            guard !activeDecodeRows.isEmpty else {
+                continue
+            }
+
+            let rows = selectDecodeRows()
+            do {
+                try decodeOneStep(
+                    rows: rows,
+                    model: model,
+                    tokenizerAndTemplate: tokenizerAndTemplate
+                )
+            } catch {
+                failRows(rows, with: error)
+            }
+            finishCompletedDecodeRows()
+            await Task.yield()
+        }
+    }
+
+    private func activateQueuedDecodeRows() {
+        guard !decodeQueue.isEmpty else { return }
+        activeDecodeRows.append(contentsOf: decodeQueue)
+        decodeQueue.removeAll(keepingCapacity: true)
+    }
+
+    private func selectDecodeRows() -> [Q35BatchedDecodeRow] {
+        let eligible = activeDecodeRows.filter(\.needsDecodeStep)
+        let selectedIDs = Set(RuntimeDecodeBatchPlanner.selectRows(
+            eligible.map { row in
+                RuntimeDecodeBatchRowMetadata(
+                    row: row.id,
+                    signature: decodeBatchSignature(for: row),
+                    position: decodePosition(row)
+                )
+            }
+        ))
+        return eligible.filter { selectedIDs.contains($0.id) }
+    }
+
+    private func decodeBatchSignature(for row: Q35BatchedDecodeRow) -> String {
+        row.layerCaches
+            .map { cache in
+                switch cache {
+                case .full(let kv):
+                    if kv.supportsVariablePositionBatching {
+                        return "full:variable"
+                    }
+                    return "full:\(kv.offset)"
+                case .linear(let linear):
+                    return "linear:\(Q35Generator.linearCacheSignature(linear))"
+                case nil:
+                    return "nil"
+                }
+            }
+            .joined(separator: "|")
+    }
+
+    private static func linearCacheSignature(_ cache: Q35LinearCache) -> String {
+        let convShape = cache.convState?.shape.map(String.init).joined(separator: "x") ?? "nil"
+        let recurrentShape = cache.recurrentState?.shape.map(String.init).joined(separator: "x") ?? "nil"
+        return "\(convShape):\(recurrentShape)"
+    }
+
+    private func decodePosition(_ row: Q35BatchedDecodeRow) -> Int {
+        row.layerCaches.compactMap { cache in
+            if case .full(let kv)? = cache {
+                return kv.offset
+            }
+            return nil
+        }.min() ?? (row.prefillTokenCount + row.generatedTokens.count)
+    }
+
+    private func decodeOneStep(
+        rows: [Q35BatchedDecodeRow],
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate
+    ) throws {
+        let sampledRows = rows.filter(\.needsDecodeStep)
+        guard !sampledRows.isEmpty else { return }
+
+        for row in sampledRows {
+            let next = sampleToken(
+                logits: row.logits[0, -1, 0...],
+                config: row.generationConfig,
+                previousTokens: row.repetitionHistory
+            )
+            guard !row.eosSet.contains(next) else {
+                row.stopped = true
+                continue
+            }
+            row.generatedTokens.append(next)
+            row.repetitionHistory.append(next)
+            let piece = tokenizerAndTemplate.decode(token: next)
+            if !piece.isEmpty {
+                row.progressHandler?(ChatProgress(stage: .generating, message: piece))
+            }
+        }
+
+        let continuingRows = sampledRows.filter(\.needsDecodeStep)
+        guard !continuingRows.isEmpty else { return }
+
+        if continuingRows.count > 1,
+           let batchedCaches = makeBatchedLayerCaches(continuingRows.map(\.layerCaches)) {
+            let nextInput = MLXArray(continuingRows.compactMap { $0.generatedTokens.last }.map(Int32.init))
+                .reshaped(continuingRows.count, 1)
+            let batchedLogits = model(nextInput, cache: batchedCaches)
+            MLX.eval(batchedLogits)
+            guard let splitCaches = splitBatchedLayerCaches(batchedCaches, rowCount: continuingRows.count) else {
+                throw Q35Error.generationFailed("Q35 batched decode could not split merged cache rows.")
+            }
+            for (index, row) in continuingRows.enumerated() {
+                row.layerCaches = splitCaches[index]
+                row.logits = batchedLogits[index..<(index + 1), 0..., 0...]
+            }
+            batchedDecodeSteps += 1
+            if RuntimeDecodeBatchPositionKind.variablePositionBatchCount(continuingRows.map(decodePosition)) > 0 {
+                variablePositionBatchedSteps += 1
+            } else {
+                samePositionBatchedSteps += 1
+            }
+            totalBatchedRows += continuingRows.count
+            maxObservedBatchSize = max(maxObservedBatchSize, continuingRows.count)
+            return
+        }
+
+        for row in continuingRows {
+            guard let next = row.generatedTokens.last else { continue }
+            let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
+            row.logits = model(nextInput, cache: row.layerCaches)
+            MLX.eval(row.logits)
+            singleDecodeSteps += 1
+        }
+    }
+
+    private func makeBatchedLayerCaches(_ rowCaches: [[Q35LayerCache?]]) -> [Q35LayerCache?]? {
+        guard let first = rowCaches.first, !first.isEmpty else { return nil }
+        guard rowCaches.allSatisfy({ $0.count == first.count }) else { return nil }
+
+        var result: [Q35LayerCache?] = []
+        result.reserveCapacity(first.count)
+        for layerIndex in first.indices {
+            let layerCaches = rowCaches.map { $0[layerIndex] }
+            if layerCaches.allSatisfy({ $0 == nil }) {
+                result.append(nil)
+                continue
+            }
+            let nonNil = layerCaches.compactMap { $0 }
+            guard nonNil.count == layerCaches.count,
+                  let batched = nonNil[0].batched(with: nonNil) else {
+                return nil
+            }
+            result.append(batched)
+        }
+        return result
+    }
+
+    private func splitBatchedLayerCaches(
+        _ caches: [Q35LayerCache?],
+        rowCount: Int
+    ) -> [[Q35LayerCache?]]? {
+        guard rowCount > 0 else { return nil }
+        var rows = Array(repeating: [Q35LayerCache?](), count: rowCount)
+        for cache in caches {
+            guard let cache else {
+                for index in 0..<rowCount {
+                    rows[index].append(nil)
+                }
+                continue
+            }
+            guard let split = cache.unbatchedRows(count: rowCount), split.count == rowCount else {
+                return nil
+            }
+            for index in 0..<rowCount {
+                rows[index].append(split[index])
+            }
+        }
+        return rows
+    }
+
+    private func finishCompletedDecodeRows() {
+        var remaining: [Q35BatchedDecodeRow] = []
+        remaining.reserveCapacity(activeDecodeRows.count)
+        for row in activeDecodeRows {
+            if row.needsDecodeStep {
+                remaining.append(row)
+            } else {
+                row.finish()
+            }
+        }
+        activeDecodeRows = remaining
+    }
+
+    private func failRows(_ rows: [Q35BatchedDecodeRow], with error: Error) {
+        let ids = Set(rows.map(\.id))
+        activeDecodeRows.removeAll { row in
+            guard ids.contains(row.id) else { return false }
+            row.fail(error)
+            return true
+        }
+    }
+
+    private func failQueuedDecodeRows(_ error: Error) {
+        for row in decodeQueue {
+            row.fail(error)
+        }
+        for row in activeDecodeRows {
+            row.fail(error)
+        }
+        decodeQueue.removeAll()
+        activeDecodeRows.removeAll()
+    }
+
+    private func chunkedPrefill(
+        model: Q35Model,
+        promptTokens: [Int],
+        cache: [Q35LayerCache?],
+        startIndex: Int = 0,
+        existingLogits: MLXArray? = nil,
+        modelPath: String? = nil,
+        checkpointTokenCounts: Set<Int> = [],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> MLXArray {
+        guard !promptTokens.isEmpty else {
+            throw Q35Error.generationFailed("Prompt is empty after tokenization.")
+        }
+
+        var processed = startIndex
+        var logits = existingLogits
+        if processed > 0, processed < promptTokens.count {
+            progressHandler?(ChatProgress(stage: .encoding, message: "Reusing \(processed) prompt KV tokens"))
+        }
+        while processed < promptTokens.count {
+            try Task.checkCancellation()
+            let end = RuntimePrefillCheckpointPlanner.nextEnd(
+                processed: processed,
+                total: promptTokens.count,
+                chunkSize: Self.prefillChunkSize,
+                checkpoints: checkpointTokenCounts
+            )
+            if promptTokens.count > Self.prefillChunkSize {
+                progressHandler?(ChatProgress(stage: .encoding, message: "Prefilling \(end)/\(promptTokens.count) tokens"))
+            }
+            let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
+                .reshaped(1, end - processed)
+            let chunkLogits = model(chunk, cache: cache)
+            MLX.eval(chunkLogits)
+            logits = chunkLogits
+            processed = end
+            if let modelPath {
+                storePrefixKVCache(
+                    modelPath: modelPath,
+                    promptTokens: promptTokens,
+                    tokenCount: processed,
+                    cache: cache,
+                    logits: chunkLogits,
+                    priority: checkpointTokenCounts.contains(processed) ? .semantic : .chunk
+                )
+            }
+            await Task.yield()
+        }
+
+        guard let logits else {
+            throw Q35Error.generationFailed("Prefill did not produce logits.")
+        }
+        return logits
+    }
+
+    private func chunkedPrefillEmbeddings(
+        model: Q35Model,
+        inputEmbeddings: MLXArray,
+        cache: [Q35LayerCache?],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> MLXArray {
+        let tokenCount = inputEmbeddings.dim(1)
+        guard tokenCount > 0 else {
+            throw Q35Error.generationFailed("Prompt embeddings are empty after tokenization.")
+        }
+
+        var processed = 0
+        var logits: MLXArray?
+        while processed < tokenCount {
+            try Task.checkCancellation()
+            let end = min(processed + Self.prefillChunkSize, tokenCount)
+            if tokenCount > Self.prefillChunkSize {
+                progressHandler?(ChatProgress(stage: .encoding, message: "Prefilling \(end)/\(tokenCount) tokens"))
+            }
+            let chunkEmbeddings = inputEmbeddings[0..., processed..<end, 0...]
+            let chunkInput = MLXArray.zeros([1, end - processed], dtype: .int32)
+            let chunkLogits = model(chunkInput, cache: cache, inputEmbeddings: chunkEmbeddings)
+            MLX.eval(chunkLogits)
+            logits = chunkLogits
+            processed = end
+            await Task.yield()
+        }
+
+        guard let logits else {
+            throw Q35Error.generationFailed("Prefill did not produce logits.")
+        }
+        return logits
+    }
+
+    private func semanticPrefixCheckpoints(
+        tokenizerAndTemplate: Q35TokenizerAndTemplate,
+        messages: [ChatMessage],
+        tools: [ToolDefinition]?,
+        includeThinking: Bool,
+        promptTokens: [Int],
+        maxContextLength: Int
+    ) -> Set<Int> {
+        guard prefixKVCacheEnabled, messages.count > 1 else {
+            return []
+        }
+        let prefixMessages = Array(messages.dropLast())
+        guard !prefixMessages.isEmpty else {
+            return []
+        }
+        let prefixTokens = tokenizerAndTemplate.encodeForGeneration(
+            messages: prefixMessages,
+            tools: tools,
+            addGenerationPrompt: false,
+            includeThinking: includeThinking,
+            maxLength: maxContextLength
+        )
+        guard promptTokens.starts(with: prefixTokens) else {
+            return []
+        }
+        return RuntimePrefillCheckpointPlanner.normalizedCheckpoints(
+            [prefixTokens.count],
+            total: promptTokens.count
+        )
+    }
+
+    private func prefixKVCacheSeed(
+        modelPath: String,
+        promptTokens: [Int]
+    ) -> (tokenCount: Int, caches: [Q35LayerCache?], logits: MLXArray)? {
+        guard prefixKVCacheEnabled else { return nil }
+        let matchingKey = prefixKVCache.keys
+            .filter { key in
+                key.modelPath == modelPath
+                    && key.tokens.count <= promptTokens.count
+                    && promptTokens.starts(with: key.tokens)
+            }
+            .max { $0.tokens.count < $1.tokens.count }
+
+        guard let matchingKey,
+              var entry = prefixKVCache[matchingKey] else {
+            prefixKVCacheMisses += 1
+            return nil
+        }
+
+        entry.lastAccess = Date()
+        prefixKVCache[matchingKey] = entry
+        prefixKVCacheHits += 1
+        prefixKVCacheReusedTokens += matchingKey.tokens.count
+        return (
+            matchingKey.tokens.count,
+            forkLayerCaches(entry.caches),
+            entry.logits
+        )
+    }
+
+    private func storePrefixKVCache(
+        modelPath: String,
+        promptTokens: [Int],
+        tokenCount: Int,
+        cache: [Q35LayerCache?],
+        logits: MLXArray,
+        priority: RuntimePrefixCacheEntryPriority
+    ) {
+        guard prefixKVCacheEnabled, tokenCount > 0 else { return }
+        let key = Q35PrefixKVCacheKey(
+            modelPath: modelPath,
+            tokens: Array(promptTokens.prefix(tokenCount))
+        )
+        prefixKVCache[key] = Q35PrefixKVCacheEntry(
+            caches: forkLayerCaches(cache),
+            logits: logits,
+            priority: priority,
+            lastAccess: Date()
+        )
+        prefixKVCacheStores += 1
+        prunePrefixKVCache()
+    }
+
+    private func prunePrefixKVCache() {
+        while prefixKVCache.count > Self.prefixKVCacheMaxEntries {
+            let metadata = prefixKVCache.mapValues {
+                RuntimePrefixCacheRetentionMetadata(
+                    priority: $0.priority,
+                    lastAccess: $0.lastAccess
+                )
+            }
+            guard let oldest = RuntimePrefixCacheRetentionPlanner.keyToPrune(entries: metadata) else {
+                return
+            }
+            prefixKVCache.removeValue(forKey: oldest)
+        }
+    }
+
+    private func resetPrefixKVCache() {
+        prefixKVCache.removeAll()
+    }
+
+    private func forkLayerCaches(_ caches: [Q35LayerCache?]) -> [Q35LayerCache?] {
+        caches.map { $0?.fork() }
     }
 
     private func resolveModelRoot(

--- a/Sources/MereRunCore/Q35/Q35LinearAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35LinearAttention.swift
@@ -115,6 +115,78 @@ public final class Q35LinearCache: @unchecked Sendable {
         convState = nil
         recurrentState = nil
     }
+
+    public func fork() -> Q35LinearCache {
+        let copy = Q35LinearCache()
+        copy.convState = convState
+        copy.recurrentState = recurrentState
+        return copy
+    }
+
+    public func batched(with caches: [Q35LinearCache]) -> Q35LinearCache? {
+        guard !caches.isEmpty else { return nil }
+
+        let batchedConvState = Self.batchedState(caches.map(\.convState))
+        let batchedRecurrentState = Self.batchedState(caches.map(\.recurrentState))
+        guard batchedConvState.isValid, batchedRecurrentState.isValid else {
+            return nil
+        }
+
+        let copy = Q35LinearCache()
+        copy.convState = batchedConvState.value
+        copy.recurrentState = batchedRecurrentState.value
+        return copy
+    }
+
+    public func unbatchedRows(count: Int) -> [Q35LinearCache]? {
+        guard count > 0 else { return nil }
+        let convRows = Self.unbatchedRows(convState, count: count)
+        let recurrentRows = Self.unbatchedRows(recurrentState, count: count)
+        guard convRows.isValid, recurrentRows.isValid else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = Q35LinearCache()
+            copy.convState = convRows.values?[index]
+            copy.recurrentState = recurrentRows.values?[index]
+            return copy
+        }
+    }
+
+    private static func batchedState(_ states: [MLXArray?]) -> (isValid: Bool, value: MLXArray?) {
+        let present = states.compactMap { $0 }
+        if present.isEmpty {
+            return (true, nil)
+        }
+        guard present.count == states.count else {
+            return (false, nil)
+        }
+        let expectedShape = Array(present[0].shape.dropFirst())
+        guard present.allSatisfy({ Array($0.shape.dropFirst()) == expectedShape }) else {
+            return (false, nil)
+        }
+        return (true, concatenated(present, axis: 0))
+    }
+
+    private static func unbatchedRows(_ state: MLXArray?, count: Int) -> (isValid: Bool, values: [MLXArray]?) {
+        guard let state else {
+            return (true, nil)
+        }
+        guard state.dim(0) == count else {
+            return (false, nil)
+        }
+        let rows = (0..<count).map { index in
+            switch state.ndim {
+            case 3:
+                return state[index..<(index + 1), 0..., 0...]
+            case 4:
+                return state[index..<(index + 1), 0..., 0..., 0...]
+            default:
+                return state[index..<(index + 1)]
+            }
+        }
+        return (true, rows)
+    }
 }
 
 final class Q35LinearAttention: Module {

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -18,7 +18,15 @@ final class Q35SwitchLinear: Module {
     let groupSize: Int
     let bits: Int
 
-    init(inputDims: Int, outputDims: Int, numExperts: Int, groupSize: Int, bits: Int, bias: Bool) {
+    init(
+        inputDims: Int,
+        outputDims: Int,
+        numExperts: Int,
+        groupSize: Int,
+        bits: Int,
+        quantized: Bool,
+        bias: Bool
+    ) {
         self.groupSize = groupSize
         self.bits = bits
 
@@ -29,8 +37,12 @@ final class Q35SwitchLinear: Module {
             [numExperts, outputDims, inputDims]
         )
         let groups = max(1, (inputDims + groupSize - 1) / groupSize)
-        self._scales.wrappedValue = MLXArray.zeros([numExperts, outputDims, groups])
-        self._biases.wrappedValue = MLXArray.zeros([numExperts, outputDims, groups])
+        self._scales.wrappedValue = quantized
+            ? MLXArray.zeros([numExperts, outputDims, groups])
+            : nil
+        self._biases.wrappedValue = quantized
+            ? MLXArray.zeros([numExperts, outputDims, groups])
+            : nil
         if bias {
             self._bias.wrappedValue = MLXArray.zeros([numExperts, outputDims])
         }
@@ -97,6 +109,7 @@ final class Q35SwitchGLU: Module {
         let text = config.textConfig
         let groupSize = config.quantization?.groupSize ?? 64
         let bits = config.quantization?.bits ?? 4
+        let quantized = config.quantization != nil
 
         self._gateProj.wrappedValue = Q35SwitchLinear(
             inputDims: text.hiddenSize,
@@ -104,6 +117,7 @@ final class Q35SwitchGLU: Module {
             numExperts: text.numExperts,
             groupSize: groupSize,
             bits: bits,
+            quantized: quantized,
             bias: false
         )
         self._upProj.wrappedValue = Q35SwitchLinear(
@@ -112,6 +126,7 @@ final class Q35SwitchGLU: Module {
             numExperts: text.numExperts,
             groupSize: groupSize,
             bits: bits,
+            quantized: quantized,
             bias: false
         )
         self._downProj.wrappedValue = Q35SwitchLinear(
@@ -120,6 +135,7 @@ final class Q35SwitchGLU: Module {
             numExperts: text.numExperts,
             groupSize: groupSize,
             bits: bits,
+            quantized: quantized,
             bias: false
         )
 

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -15,6 +15,54 @@ enum Q35AttentionLayerType: String {
 public enum Q35LayerCache: @unchecked Sendable {
     case linear(Q35LinearCache)
     case full(KVCache)
+
+    func fork() -> Q35LayerCache {
+        switch self {
+        case .linear(let cache):
+            return .linear(cache.fork())
+        case .full(let cache):
+            return .full(cache.fork())
+        }
+    }
+
+    func batched(with caches: [Q35LayerCache]) -> Q35LayerCache? {
+        guard !caches.isEmpty else { return nil }
+        switch self {
+        case .linear(let cache):
+            let typed = caches.compactMap { entry -> Q35LinearCache? in
+                if case .linear(let linear) = entry {
+                    return linear
+                }
+                return nil
+            }
+            guard typed.count == caches.count,
+                  let batched = cache.batched(with: typed) else {
+                return nil
+            }
+            return .linear(batched)
+        case .full(let cache):
+            let typed = caches.compactMap { entry -> KVCache? in
+                if case .full(let full) = entry {
+                    return full
+                }
+                return nil
+            }
+            guard typed.count == caches.count,
+                  let batched = cache.batched(with: typed) else {
+                return nil
+            }
+            return .full(batched)
+        }
+    }
+
+    func unbatchedRows(count: Int) -> [Q35LayerCache]? {
+        switch self {
+        case .linear(let cache):
+            return cache.unbatchedRows(count: count)?.map(Q35LayerCache.linear)
+        case .full(let cache):
+            return cache.unbatchedRows(count: count)?.map(Q35LayerCache.full)
+        }
+    }
 }
 
 final class Q35DecoderLayer: Module {

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -135,6 +135,7 @@ public enum Q35Error: LocalizedError {
     case missingFiles([String])
     case downloadFailed(String)
     case extractionFailed
+    case generationFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -148,6 +149,8 @@ public enum Q35Error: LocalizedError {
             return "Download failed: \(message)"
         case .extractionFailed:
             return "Failed to prepare Q35 model files"
+        case .generationFailed(let message):
+            return message
         }
     }
 }

--- a/Sources/MereRunCore/RuntimeCacheStats.swift
+++ b/Sources/MereRunCore/RuntimeCacheStats.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+public struct PrefixKVCacheStats: Codable, Sendable, Hashable {
+    public let enabled: Bool
+    public let entries: Int
+    public let maxEntries: Int
+    public let hits: Int
+    public let misses: Int
+    public let storedPrefixes: Int
+    public let reusedTokens: Int
+    public let storedTokens: Int
+
+    public init(
+        enabled: Bool,
+        entries: Int,
+        maxEntries: Int,
+        hits: Int,
+        misses: Int,
+        storedPrefixes: Int,
+        reusedTokens: Int,
+        storedTokens: Int
+    ) {
+        self.enabled = enabled
+        self.entries = entries
+        self.maxEntries = maxEntries
+        self.hits = hits
+        self.misses = misses
+        self.storedPrefixes = storedPrefixes
+        self.reusedTokens = reusedTokens
+        self.storedTokens = storedTokens
+    }
+}
+
+public struct RuntimeDecodeBatchingStats: Codable, Sendable, Hashable {
+    public let enabled: Bool
+    public let activeRows: Int
+    public let queuedRows: Int
+    public let batchedDecodeSteps: Int
+    public let samePositionBatchedSteps: Int
+    public let variablePositionBatchedSteps: Int
+    public let singleDecodeSteps: Int
+    public let totalBatchedRows: Int
+    public let maxBatchSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case activeRows
+        case queuedRows
+        case batchedDecodeSteps
+        case samePositionBatchedSteps
+        case variablePositionBatchedSteps
+        case singleDecodeSteps
+        case totalBatchedRows
+        case maxBatchSize
+    }
+
+    public init(
+        enabled: Bool,
+        activeRows: Int,
+        queuedRows: Int,
+        batchedDecodeSteps: Int,
+        samePositionBatchedSteps: Int = 0,
+        variablePositionBatchedSteps: Int = 0,
+        singleDecodeSteps: Int,
+        totalBatchedRows: Int,
+        maxBatchSize: Int
+    ) {
+        self.enabled = enabled
+        self.activeRows = activeRows
+        self.queuedRows = queuedRows
+        self.batchedDecodeSteps = batchedDecodeSteps
+        self.samePositionBatchedSteps = samePositionBatchedSteps
+        self.variablePositionBatchedSteps = variablePositionBatchedSteps
+        self.singleDecodeSteps = singleDecodeSteps
+        self.totalBatchedRows = totalBatchedRows
+        self.maxBatchSize = maxBatchSize
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try container.decode(Bool.self, forKey: .enabled)
+        self.activeRows = try container.decode(Int.self, forKey: .activeRows)
+        self.queuedRows = try container.decode(Int.self, forKey: .queuedRows)
+        self.batchedDecodeSteps = try container.decode(Int.self, forKey: .batchedDecodeSteps)
+        self.samePositionBatchedSteps = try container.decodeIfPresent(Int.self, forKey: .samePositionBatchedSteps) ?? 0
+        self.variablePositionBatchedSteps = try container.decodeIfPresent(Int.self, forKey: .variablePositionBatchedSteps) ?? 0
+        self.singleDecodeSteps = try container.decode(Int.self, forKey: .singleDecodeSteps)
+        self.totalBatchedRows = try container.decode(Int.self, forKey: .totalBatchedRows)
+        self.maxBatchSize = try container.decode(Int.self, forKey: .maxBatchSize)
+    }
+}
+
+enum RuntimePrefillCheckpointPlanner {
+    static func nextEnd(
+        processed: Int,
+        total: Int,
+        chunkSize: Int,
+        checkpoints: Set<Int>
+    ) -> Int {
+        let chunkEnd = min(processed + max(1, chunkSize), total)
+        guard let checkpoint = checkpoints
+            .filter({ $0 > processed && $0 < chunkEnd && $0 < total })
+            .min() else {
+            return chunkEnd
+        }
+        return checkpoint
+    }
+
+    static func normalizedCheckpoints(_ counts: [Int], total: Int) -> Set<Int> {
+        Set(counts.filter { $0 > 0 && $0 < total })
+    }
+}
+
+enum RuntimePrefixCacheEntryPriority: Int, Sendable {
+    case chunk = 0
+    case semantic = 1
+}
+
+struct RuntimePrefixCacheRetentionMetadata: Sendable, Hashable {
+    let priority: RuntimePrefixCacheEntryPriority
+    let lastAccess: Date
+}
+
+enum RuntimePrefixCacheRetentionPlanner {
+    static func keyToPrune<Key: Hashable>(
+        entries: [Key: RuntimePrefixCacheRetentionMetadata]
+    ) -> Key? {
+        entries
+            .sorted { lhs, rhs in
+                if lhs.value.priority != rhs.value.priority {
+                    return lhs.value.priority.rawValue < rhs.value.priority.rawValue
+                }
+                return lhs.value.lastAccess < rhs.value.lastAccess
+            }
+            .first?
+            .key
+    }
+}
+
+enum RuntimeDecodeBatchPositionKind {
+    static func variablePositionBatchCount(_ positions: [Int]) -> Int {
+        Set(positions).count > 1 ? 1 : 0
+    }
+}
+
+struct RuntimeDecodeBatchRowMetadata<Row: Hashable>: Sendable where Row: Sendable {
+    let row: Row
+    let signature: String
+    let position: Int
+
+    init(row: Row, signature: String, position: Int) {
+        self.row = row
+        self.signature = signature
+        self.position = position
+    }
+}
+
+enum RuntimeDecodeBatchPlanner {
+    static func selectRows<Row: Hashable & Sendable>(
+        _ rows: [RuntimeDecodeBatchRowMetadata<Row>]
+    ) -> [Row] {
+        guard rows.count > 1 else {
+            return rows.map(\.row)
+        }
+
+        let grouped = Dictionary(grouping: rows, by: \.signature)
+        let compatibleBatches = grouped.values.filter { $0.count > 1 }
+        let earliest = rows.map(\.position).min() ?? 0
+        let earliestBatches = compatibleBatches.filter { earliestPosition($0) == earliest }
+        if let batch = earliestBatches
+            .sorted(by: { lhs, rhs in
+                if lhs.count != rhs.count {
+                    return lhs.count > rhs.count
+                }
+                return earliestPosition(lhs) < earliestPosition(rhs)
+            })
+            .first {
+            return batch.map(\.row)
+        }
+
+        let earliestRows = rows.filter { $0.position == earliest }
+        guard let catchUpRow = earliestRows.min(by: { lhs, rhs in
+            String(describing: lhs.row) < String(describing: rhs.row)
+        }) else {
+            return []
+        }
+        return [catchUpRow.row]
+    }
+
+    private static func earliestPosition<Row: Hashable & Sendable>(
+        _ rows: [RuntimeDecodeBatchRowMetadata<Row>]
+    ) -> Int {
+        rows.map(\.position).min() ?? 0
+    }
+}

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+public enum RuntimeServingEngine: String, Codable, CaseIterable, Hashable, Sendable {
+    case textCode = "text-code"
+    case textChatKlein = "text-chat-klein"
+    case textChatGemma4 = "text-chat-gemma4"
+    case textChatQ35 = "text-chat-q35"
+    case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
+}
+
+public struct RuntimeModelSettings: Codable, Hashable, Sendable {
+    public var alias: String?
+    public var pinned: Bool
+    public var ttlSeconds: Int?
+    public var maxContextTokens: Int?
+    public var maxTokens: Int?
+    public var temperature: Double?
+    public var topP: Double?
+    public var engineOverride: RuntimeServingEngine?
+
+    public init(
+        alias: String? = nil,
+        pinned: Bool = false,
+        ttlSeconds: Int? = nil,
+        maxContextTokens: Int? = nil,
+        maxTokens: Int? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        engineOverride: RuntimeServingEngine? = nil
+    ) {
+        self.alias = alias
+        self.pinned = pinned
+        self.ttlSeconds = ttlSeconds
+        self.maxContextTokens = maxContextTokens
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.engineOverride = engineOverride
+    }
+
+    public var normalized: RuntimeModelSettings {
+        var copy = self
+        copy.alias = normalizedOptionalString(alias)
+        return copy
+    }
+
+    public func validated(for spec: ManagedModelSpec) throws -> RuntimeModelSettings {
+        let settings = normalized
+        if let alias = settings.alias {
+            guard alias.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else {
+                throw RuntimeModelSettingsError.invalidAlias("aliases cannot contain whitespace")
+            }
+            guard !alias.contains("/") else {
+                throw RuntimeModelSettingsError.invalidAlias("aliases cannot contain '/'")
+            }
+        }
+        if let ttlSeconds = settings.ttlSeconds, ttlSeconds <= 0 {
+            throw RuntimeModelSettingsError.invalidValue("ttlSeconds must be greater than zero")
+        }
+        if let maxContextTokens = settings.maxContextTokens, maxContextTokens <= 0 {
+            throw RuntimeModelSettingsError.invalidValue("maxContextTokens must be greater than zero")
+        }
+        if let maxTokens = settings.maxTokens, maxTokens <= 0 {
+            throw RuntimeModelSettingsError.invalidValue("maxTokens must be greater than zero")
+        }
+        if let temperature = settings.temperature, !(0...2).contains(temperature) || !temperature.isFinite {
+            throw RuntimeModelSettingsError.invalidValue("temperature must be between 0 and 2")
+        }
+        if let topP = settings.topP, !(0...1).contains(topP) || !topP.isFinite {
+            throw RuntimeModelSettingsError.invalidValue("topP must be between 0 and 1")
+        }
+        if let override = settings.engineOverride,
+           override != spec.defaultRuntimeServingEngine {
+            throw RuntimeModelSettingsError.incompatibleEngine(
+                modelID: spec.id,
+                requested: override,
+                expected: spec.defaultRuntimeServingEngine
+            )
+        }
+        guard spec.isAPIServableRuntimeModel else {
+            throw RuntimeModelSettingsError.unsupportedModel(spec.id)
+        }
+        return settings
+    }
+
+    private func normalizedOptionalString(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}
+
+public struct RuntimeModelSettingsDocument: Codable, Equatable, Sendable {
+    public var version: Int
+    public var models: [String: RuntimeModelSettings]
+
+    public init(version: Int = 1, models: [String: RuntimeModelSettings] = [:]) {
+        self.version = version
+        self.models = models
+    }
+}
+
+public enum RuntimeModelSettingsError: LocalizedError, Equatable {
+    case unknownModel(String)
+    case unsupportedModel(String)
+    case invalidAlias(String)
+    case invalidValue(String)
+    case incompatibleEngine(modelID: String, requested: RuntimeServingEngine, expected: RuntimeServingEngine?)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownModel(let id):
+            return "Unknown managed model '\(id)'."
+        case .unsupportedModel(let id):
+            return "Model '\(id)' is not supported by `mere.run api serve`."
+        case .invalidAlias(let reason):
+            return "Invalid alias: \(reason)."
+        case .invalidValue(let reason):
+            return "Invalid runtime setting: \(reason)."
+        case .incompatibleEngine(let modelID, let requested, let expected):
+            let expectedText = expected?.rawValue ?? "none"
+            return "Engine override '\(requested.rawValue)' is not compatible with model '\(modelID)' (expected \(expectedText))."
+        }
+    }
+}
+
+public struct RuntimeModelSettingsStore {
+    public let url: URL
+    private let fileManager: FileManager
+
+    public init(modelsDir: URL = MereRunModelPaths.modelsDir, fileManager: FileManager = .default) {
+        self.url = Self.defaultURL(modelsDir: modelsDir)
+        self.fileManager = fileManager
+    }
+
+    public init(url: URL, fileManager: FileManager = .default) {
+        self.url = url
+        self.fileManager = fileManager
+    }
+
+    public static func defaultURL(modelsDir: URL = MereRunModelPaths.modelsDir) -> URL {
+        modelsDir
+            .appendingPathComponent(".mere-run", isDirectory: true)
+            .appendingPathComponent("runtime-model-settings.json", isDirectory: false)
+    }
+
+    public func load() throws -> RuntimeModelSettingsDocument {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return RuntimeModelSettingsDocument()
+        }
+        let data = try Data(contentsOf: url)
+        let document = try JSONDecoder().decode(RuntimeModelSettingsDocument.self, from: data)
+        return RuntimeModelSettingsDocument(
+            version: document.version,
+            models: document.models.mapValues(\.normalized)
+        )
+    }
+
+    public func save(_ document: RuntimeModelSettingsDocument) throws {
+        let parent = url.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let normalized = RuntimeModelSettingsDocument(
+            version: document.version,
+            models: document.models.mapValues(\.normalized)
+        )
+        let data = try encoder.encode(normalized)
+        try data.write(to: url, options: .atomic)
+    }
+
+    public func settings(for modelID: String) throws -> RuntimeModelSettings {
+        try load().models[modelID] ?? RuntimeModelSettings()
+    }
+
+    public func writeSettings(_ settings: RuntimeModelSettings, for modelID: String) throws {
+        guard let spec = ManagedModelCatalog.spec(for: modelID) else {
+            throw RuntimeModelSettingsError.unknownModel(modelID)
+        }
+        let validated = try settings.validated(for: spec)
+        var document = try load()
+        if validated == RuntimeModelSettings() {
+            document.models.removeValue(forKey: spec.id)
+        } else {
+            document.models[spec.id] = validated
+        }
+        try save(document)
+    }
+
+    public func resolveModelID(aliasOrID: String, defaultModelID: String) throws -> String {
+        let requested = aliasOrID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !requested.isEmpty else {
+            return defaultModelID
+        }
+
+        let document = try load()
+        if let match = document.models.first(where: { _, settings in
+            settings.alias?.caseInsensitiveCompare(requested) == .orderedSame
+        }) {
+            return match.key
+        }
+        if let spec = ManagedModelCatalog.spec(for: requested) {
+            return spec.id
+        }
+        if requested == defaultModelID {
+            return defaultModelID
+        }
+        throw RuntimeModelSettingsError.unknownModel(requested)
+    }
+}
+
+public extension ManagedModelSpec {
+    var defaultRuntimeServingEngine: RuntimeServingEngine? {
+        switch validationKind {
+        case .codegenGGUF:
+            return .textCode
+        case .gemma4:
+            return .textChatGemma4
+        case .q35:
+            return .textChatQ35
+        case .deepseekV4FlashIMatrixGGUF:
+            return .textChatDeepseekV4Flash
+        case .hfTextChat where id == ModelResolver.ModelID.mebot.rawValue:
+            return .textChatKlein
+        default:
+            return nil
+        }
+    }
+
+    var isAPIServableRuntimeModel: Bool {
+        defaultRuntimeServingEngine != nil
+    }
+}

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/KVCache.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/KVCache.swift
@@ -7,8 +7,31 @@ import MLXNN
 
 public protocol KVCache: AnyObject {
     var offset: Int { get }
+    var rowOffsets: [Int]? { get }
+    var supportsVariablePositionBatching: Bool { get }
     func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray)
     func makeMask(n: Int) -> MLXFast.ScaledDotProductAttentionMaskMode
+    func fork() -> KVCache
+    func batched(with caches: [KVCache]) -> KVCache?
+    func unbatchedRows(count: Int) -> [KVCache]?
+}
+
+public extension KVCache {
+    var rowOffsets: [Int]? {
+        nil
+    }
+
+    var supportsVariablePositionBatching: Bool {
+        false
+    }
+
+    func batched(with caches: [KVCache]) -> KVCache? {
+        nil
+    }
+
+    func unbatchedRows(count: Int) -> [KVCache]? {
+        nil
+    }
 }
 
 public class KVCacheSimple: KVCache {
@@ -19,6 +42,10 @@ public class KVCacheSimple: KVCache {
 
     public init(step: Int = 256) {
         self.step = step
+    }
+
+    public var supportsVariablePositionBatching: Bool {
+        true
     }
 
     public func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
@@ -67,6 +94,14 @@ public class KVCacheSimple: KVCache {
         return (returnedKeys, returnedValues)
     }
 
+    private func populatedState() -> (MLXArray, MLXArray)? {
+        guard let keys, let values else { return nil }
+        return (
+            keys[.ellipsis, ..<offset, 0...],
+            values[.ellipsis, ..<offset, 0...]
+        )
+    }
+
     public func makeMask(n: Int) -> MLXFast.ScaledDotProductAttentionMaskMode {
         if n == 1 {
             return .none
@@ -78,6 +113,216 @@ public class KVCacheSimple: KVCache {
         keys = nil
         values = nil
         offset = 0
+    }
+
+    public func fork() -> KVCache {
+        let copy = KVCacheSimple(step: step)
+        copy.keys = keys
+        copy.values = values
+        copy.offset = offset
+        return copy
+    }
+
+    public func batched(with caches: [KVCache]) -> KVCache? {
+        guard let typed = caches as? [KVCacheSimple],
+              !typed.isEmpty,
+              typed.allSatisfy({ $0.step == step }) else {
+            return nil
+        }
+
+        let states = typed.compactMap { $0.populatedState() }
+        guard states.count == typed.count else {
+            return nil
+        }
+
+        if !typed.allSatisfy({ $0.offset == offset }) {
+            return KVRaggedBatchCache(
+                states: zip(typed, states).map { cache, state in
+                    KVRaggedBatchCache.RowState(
+                        keys: state.0,
+                        values: state.1,
+                        offset: cache.offset
+                    )
+                },
+                step: step
+            )
+        }
+
+        let copy = KVCacheSimple(step: step)
+        copy.keys = concatenated(states.map(\.0), axis: 0)
+        copy.values = concatenated(states.map(\.1), axis: 0)
+        copy.offset = offset
+        return copy
+    }
+
+    public func unbatchedRows(count: Int) -> [KVCache]? {
+        guard count > 0,
+              let state = populatedState(),
+              state.0.dim(0) == count,
+              state.1.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = KVCacheSimple(step: step)
+            copy.keys = state.0[index..<(index + 1), 0..., 0..., 0...]
+            copy.values = state.1[index..<(index + 1), 0..., 0..., 0...]
+            copy.offset = offset
+            return copy
+        }
+    }
+}
+
+public final class KVRaggedBatchCache: KVCache {
+    struct RowState {
+        let keys: MLXArray
+        let values: MLXArray
+        let offset: Int
+    }
+
+    private let step: Int
+    private var keys: MLXArray
+    private var values: MLXArray
+    private var offsets: [Int]
+
+    public var offset: Int {
+        offsets.min() ?? 0
+    }
+
+    public var rowOffsets: [Int]? {
+        offsets
+    }
+
+    public var supportsVariablePositionBatching: Bool {
+        true
+    }
+
+    init?(states: [RowState], step: Int) {
+        guard !states.isEmpty else { return nil }
+        self.step = step
+        self.offsets = states.map(\.offset)
+
+        let maxOffset = offsets.max() ?? 0
+        guard let padded = Self.padded(states: states, maxOffset: maxOffset) else {
+            return nil
+        }
+        self.keys = padded.keys
+        self.values = padded.values
+    }
+
+    public func update(keys newKeys: MLXArray, values newValues: MLXArray) -> (MLXArray, MLXArray) {
+        let tokenCount = newKeys.dim(2)
+        let newOffsets = offsets.map { $0 + tokenCount }
+        let maxOffset = newOffsets.max() ?? tokenCount
+        let states = offsets.indices.map { index in
+            let existingKeys = keys[index..<(index + 1), 0..., ..<offsets[index], 0...]
+            let existingValues = values[index..<(index + 1), 0..., ..<offsets[index], 0...]
+            return RowState(
+                keys: concatenated([existingKeys, newKeys[index..<(index + 1), 0..., 0..., 0...]], axis: 2),
+                values: concatenated([existingValues, newValues[index..<(index + 1), 0..., 0..., 0...]], axis: 2),
+                offset: newOffsets[index]
+            )
+        }
+
+        if let padded = Self.padded(states: states, maxOffset: maxOffset) {
+            self.keys = padded.keys
+            self.values = padded.values
+            self.offsets = newOffsets
+        }
+        return (keys, values)
+    }
+
+    public func makeMask(n: Int) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        guard n > 0 else { return .none }
+        let maxLength = (offsets.max() ?? 0) + n
+        guard maxLength > 0 else { return .none }
+
+        var mask: [Float] = []
+        mask.reserveCapacity(offsets.count * n * maxLength)
+        for rowOffset in offsets {
+            for queryOffset in rowOffset..<(rowOffset + n) {
+                for keyPosition in 0..<maxLength {
+                    mask.append(keyPosition <= queryOffset ? 0 : -1e9)
+                }
+            }
+        }
+        let array = MLXArray(mask).reshaped(offsets.count, 1, n, maxLength)
+        return .array(array)
+    }
+
+    public func fork() -> KVCache {
+        KVRaggedBatchCache(
+            states: offsets.indices.map { index in
+                RowState(
+                    keys: keys[index..<(index + 1), 0..., ..<offsets[index], 0...],
+                    values: values[index..<(index + 1), 0..., ..<offsets[index], 0...],
+                    offset: offsets[index]
+                )
+            },
+            step: step
+        )!
+    }
+
+    public func unbatchedRows(count: Int) -> [KVCache]? {
+        guard count == offsets.count else { return nil }
+        return offsets.indices.map { index in
+            let copy = KVCacheSimple(step: step)
+            let validKeys = keys[index..<(index + 1), 0..., ..<offsets[index], 0...]
+            let validValues = values[index..<(index + 1), 0..., ..<offsets[index], 0...]
+            _ = copy.update(keys: validKeys, values: validValues)
+            return copy
+        }
+    }
+
+    private static func padded(states: [RowState], maxOffset: Int) -> (keys: MLXArray, values: MLXArray)? {
+        guard let first = states.first else { return nil }
+        let keyPaddingShape = [
+            1,
+            first.keys.dim(1),
+            0,
+            first.keys.dim(3),
+        ]
+        let valuePaddingShape = [
+            1,
+            first.values.dim(1),
+            0,
+            first.values.dim(3),
+        ]
+
+        var paddedKeys: [MLXArray] = []
+        var paddedValues: [MLXArray] = []
+        paddedKeys.reserveCapacity(states.count)
+        paddedValues.reserveCapacity(states.count)
+        for state in states {
+            let keyPadCount = max(0, maxOffset - state.keys.dim(2))
+            let valuePadCount = max(0, maxOffset - state.values.dim(2))
+            let rowKeys = keyPadCount > 0
+                ? concatenated(
+                    [
+                        state.keys,
+                        MLXArray.zeros(
+                            [keyPaddingShape[0], keyPaddingShape[1], keyPadCount, keyPaddingShape[3]],
+                            dtype: state.keys.dtype
+                        ),
+                    ],
+                    axis: 2
+                )
+                : state.keys
+            let rowValues = valuePadCount > 0
+                ? concatenated(
+                    [
+                        state.values,
+                        MLXArray.zeros(
+                            [valuePaddingShape[0], valuePaddingShape[1], valuePadCount, valuePaddingShape[3]],
+                            dtype: state.values.dtype
+                        ),
+                    ],
+                    axis: 2
+                )
+                : state.values
+            paddedKeys.append(rowKeys)
+            paddedValues.append(rowValues)
+        }
+        return (concatenated(paddedKeys, axis: 0), concatenated(paddedValues, axis: 0))
     }
 }
 

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/README.md
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/README.md
@@ -1,0 +1,16 @@
+# LLMGeneration
+
+Shared MLX text-generation helpers used by ZImage text encoders and native chat
+engines that reuse the same primitives.
+
+- `KVCache.swift` owns the reusable full-attention cache protocol and
+  implementations. `KVCacheSimple` stores one scalar-offset row or equal-offset
+  batches; `KVRaggedBatchCache` stores padded multi-row batches with per-row
+  valid lengths so engines such as Q35 can prove variable-position decode
+  batching without treating padding as real KV state.
+- `QwenGeneration.swift` and `Sampling.swift` keep the legacy Qwen-compatible
+  decode helpers and token sampling utilities.
+
+When adding a cache implementation, keep the protocol typed and split/fork
+semantics exact: a batched decode row must produce the same logits as the same
+row decoded independently.

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -159,6 +159,32 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertEqual(root.path, "/Users/example/Library/Application Support/MereRun/models/image-zimage-nano")
     }
 
+    func testStudioRuntimeSettingsDecodesCLIJSON() throws {
+        let data = """
+        {
+          "alias": "chat-default",
+          "pinned": true,
+          "ttlSeconds": 600,
+          "maxContextTokens": 8192,
+          "maxTokens": 512,
+          "temperature": 0.4,
+          "topP": 0.8,
+          "engineOverride": "text-chat-gemma4"
+        }
+        """.data(using: .utf8)!
+
+        let settings = try JSONDecoder().decode(StudioRuntimeSettings.self, from: data)
+
+        XCTAssertEqual(settings.alias, "chat-default")
+        XCTAssertTrue(settings.pinned)
+        XCTAssertEqual(settings.ttlSeconds, 600)
+        XCTAssertEqual(settings.maxContextTokens, 8192)
+        XCTAssertEqual(settings.maxTokens, 512)
+        XCTAssertEqual(settings.temperature, 0.4)
+        XCTAssertEqual(settings.topP, 0.8)
+        XCTAssertEqual(settings.engineOverride, "text-chat-gemma4")
+    }
+
     func testModelReadinessParserFindsInstalledMissingAndUnknown() {
         let output = """
         ID Category Status Size

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -19,6 +19,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertNil(cmd.lora)
         XCTAssertNil(cmd.apiKey)
         XCTAssertEqual(cmd.rateLimitPerMinute, 60)
+        XCTAssertEqual(cmd.maxActiveRequests, 1)
         XCTAssertEqual(cmd.contextSize, 32_768)
         XCTAssertNil(cmd.kvBits)
         XCTAssertNil(cmd.kvQuantScheme)
@@ -35,6 +36,7 @@ final class APIServeCommandTests: XCTestCase {
             "--lora", "/tmp/adapter.safetensors",
             "--api-key", "secret",
             "--rate-limit-per-minute", "120",
+            "--max-active-requests", "2",
             "--context-size", "8192",
             "--kv-bits", "3.5",
             "--kv-quant-scheme", "turboquant",
@@ -49,6 +51,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.lora, "/tmp/adapter.safetensors")
         XCTAssertEqual(cmd.apiKey, "secret")
         XCTAssertEqual(cmd.rateLimitPerMinute, 120)
+        XCTAssertEqual(cmd.maxActiveRequests, 2)
         XCTAssertEqual(cmd.contextSize, 8192)
         XCTAssertEqual(cmd.kvBits, 3.5)
         XCTAssertEqual(cmd.kvQuantScheme, "turboquant")
@@ -103,6 +106,16 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(response.data.first?.object, "model")
         XCTAssertEqual(response.data.first?.owned_by, "mere.run")
         XCTAssertEqual(response.data.first?.created, 123)
+    }
+
+    func testModelsContractCanReturnAliases() {
+        let response = APIServerContract.modelsResponse(
+            modelIds: ["text-chat-gemma4", "chat-default"],
+            createdAt: Date(timeIntervalSince1970: 123)
+        )
+
+        XCTAssertEqual(response.data.map(\.id), ["text-chat-gemma4", "chat-default"])
+        XCTAssertEqual(Set(response.data.map(\.owned_by)), Set(["mere.run"]))
     }
 
     func testChatRequestValidationAcceptsBoundedDefaults() throws {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -90,6 +90,20 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(quantization.quantizedStart, 128)
     }
 
+    func testAPIServeGemma4PolarKVFlagsParse() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-gemma4",
+            "--model-path", Gemma4Resources.turboModelId,
+            "--kv-bits", "2",
+            "--kv-quant-scheme", "polar",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization()
+
+        XCTAssertEqual(quantization.bits, 2)
+        XCTAssertEqual(quantization.scheme, .polar)
+    }
+
     func testHealthContractUsesStablePayload() {
         XCTAssertEqual(APIServerContract.healthStatus(), APIHealthStatus(status: "ok"))
     }

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ModelBenchmarkCommandTests: XCTestCase {
+    func testModelCommandExposesBenchmarkSubcommand() {
+        let commandNames = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("benchmark"))
+    }
+
+    func testGemma4KVBenchmarkParsesDefaults() throws {
+        let cmd = try ModelBenchmarkGemma4KV.parse([])
+
+        XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
+        XCTAssertEqual(cmd.promptRepeat, 220)
+        XCTAssertEqual(cmd.decodeTokens, 48)
+        XCTAssertEqual(cmd.temperature, 0)
+        XCTAssertEqual(cmd.topP, 1)
+        XCTAssertFalse(cmd.json)
+    }
+
+    func testGemma4KVBenchmarkParsesOverrides() throws {
+        let cmd = try ModelBenchmarkGemma4KV.parse([
+            "--model", Gemma4Resources.turboModelId,
+            "--model-root", "/tmp/gemma4",
+            "--prompt", "Benchmark this",
+            "--decode-tokens", "32",
+            "--temperature", "0.2",
+            "--top-p", "0.7",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
+        XCTAssertEqual(cmd.modelRoot, "/tmp/gemma4")
+        XCTAssertEqual(cmd.prompt, "Benchmark this")
+        XCTAssertEqual(cmd.decodeTokens, 32)
+        XCTAssertEqual(cmd.temperature, 0.2)
+        XCTAssertEqual(cmd.topP, 0.7)
+        XCTAssertTrue(cmd.json)
+    }
+}

--- a/Tests/MereRunCLITests/ModelRuntimeCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelRuntimeCommandTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ModelRuntimeCommandTests: XCTestCase {
+    func testModelCommandExposesRuntimeSubcommand() {
+        let commandNames = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("runtime"))
+    }
+
+    func testRuntimeGetParsesJSONFlag() throws {
+        let cmd = try ModelRuntimeGet.parse(["text-chat-gemma4", "--json"])
+
+        XCTAssertEqual(cmd.model, "text-chat-gemma4")
+        XCTAssertTrue(cmd.json)
+    }
+
+    func testRuntimeSetParsesTypedFields() throws {
+        let cmd = try ModelRuntimeSet.parse([
+            "text-chat-gemma4",
+            "--alias", "chat-default",
+            "--pinned",
+            "--ttl-seconds", "600",
+            "--max-context-tokens", "8192",
+            "--max-tokens", "512",
+            "--temperature", "0.4",
+            "--top-p", "0.8",
+            "--engine", "text-chat-gemma4",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.model, "text-chat-gemma4")
+        XCTAssertEqual(cmd.alias, "chat-default")
+        XCTAssertTrue(cmd.pinned)
+        XCTAssertEqual(cmd.ttlSeconds, 600)
+        XCTAssertEqual(cmd.maxContextTokens, 8192)
+        XCTAssertEqual(cmd.maxTokens, 512)
+        XCTAssertEqual(cmd.temperature, 0.4)
+        XCTAssertEqual(cmd.topP, 0.8)
+        XCTAssertEqual(cmd.engine, .textChatGemma4)
+        XCTAssertTrue(cmd.json)
+    }
+}

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class RuntimeModelPoolTests: XCTestCase {
+    func testStatusIncludesLegacyStartupDefaultWithoutCatalogScan() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root)
+        )
+
+        let status = await pool.status()
+
+        XCTAssertEqual(status.defaultModel, "custom.gguf")
+        XCTAssertEqual(status.settingsPath, root.appendingPathComponent(".mere-run/runtime-model-settings.json").path)
+        XCTAssertEqual(status.models.first?.id, "custom.gguf")
+        XCTAssertEqual(status.models.first?.engine, .textCode)
+        XCTAssertFalse(status.models.first?.loaded ?? true)
+        XCTAssertTrue(status.capabilities.chunkedPrefill.enabled)
+        XCTAssertTrue(status.capabilities.continuousBatching.available)
+        XCTAssertFalse(status.capabilities.continuousBatching.enabled)
+        XCTAssertFalse(status.capabilities.prefixKVReuse.enabled)
+    }
+
+    func testModelsResponseIncludesStartupDefault() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root)
+        )
+
+        let response = try await pool.modelsResponse(createdAt: Date(timeIntervalSince1970: 10))
+
+        XCTAssertTrue(response.data.contains { $0.id == "custom.gguf" })
+        XCTAssertEqual(response.data.first { $0.id == "custom.gguf" }?.created, 10)
+    }
+
+    func testStatusReportsGemma4PrefixKVCacheCapabilityWhenEnabled() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            gemma4PrefixKVCacheEnabled: true
+        )
+
+        let status = await pool.status()
+
+        XCTAssertTrue(status.capabilities.prefixKVReuse.available)
+        XCTAssertTrue(status.capabilities.prefixKVReuse.enabled)
+    }
+
+    func testStatusReportsQ35PrefixKVCacheCapabilityWhenEnabled() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            q35PrefixKVCacheEnabled: true
+        )
+
+        let status = await pool.status()
+
+        XCTAssertTrue(status.capabilities.prefixKVReuse.available)
+        XCTAssertTrue(status.capabilities.prefixKVReuse.enabled)
+    }
+
+    func testStatusReportsQ35ContinuousBatchingCapabilityWhenEnabled() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            q35ContinuousBatchingEnabled: true
+        )
+
+        let status = await pool.status()
+
+        XCTAssertTrue(status.capabilities.continuousBatching.available)
+        XCTAssertTrue(status.capabilities.continuousBatching.enabled)
+    }
+
+    func testRequestAdmissionSerializesByDefaultAndReportsQueue() async throws {
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let first = try await admission.acquire()
+        let secondTask = Task {
+            try await admission.acquire()
+        }
+
+        var snapshot = await admission.snapshot()
+        for _ in 0..<20 {
+            guard snapshot.queuedRequests == 0 else { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+            snapshot = await admission.snapshot()
+        }
+
+        XCTAssertEqual(snapshot.maxActiveRequests, 1)
+        XCTAssertEqual(snapshot.activeRequests, 1)
+        XCTAssertEqual(snapshot.queuedRequests, 1)
+        XCTAssertEqual(snapshot.totalAdmittedRequests, 1)
+        XCTAssertEqual(snapshot.totalCompletedRequests, 0)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 0)
+
+        await first.release()
+        let second = try await secondTask.value
+        snapshot = await admission.snapshot()
+
+        XCTAssertEqual(snapshot.activeRequests, 1)
+        XCTAssertEqual(snapshot.queuedRequests, 0)
+        XCTAssertEqual(snapshot.totalAdmittedRequests, 2)
+        XCTAssertEqual(snapshot.totalCompletedRequests, 1)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 0)
+
+        await second.release()
+        snapshot = await admission.snapshot()
+
+        XCTAssertEqual(snapshot.activeRequests, 0)
+        XCTAssertEqual(snapshot.queuedRequests, 0)
+        XCTAssertEqual(snapshot.totalCompletedRequests, 2)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 0)
+    }
+
+    func testRequestAdmissionCancelsQueuedWaiterWithoutLaterAdmission() async throws {
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let first = try await admission.acquire()
+        let queued = Task {
+            try await admission.acquire()
+        }
+
+        var snapshot = await admission.snapshot()
+        for _ in 0..<20 {
+            guard snapshot.queuedRequests == 0 else { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+            snapshot = await admission.snapshot()
+        }
+        XCTAssertEqual(snapshot.queuedRequests, 1)
+
+        queued.cancel()
+        do {
+            _ = try await queued.value
+            XCTFail("Expected queued admission to throw CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        snapshot = await admission.snapshot()
+        XCTAssertEqual(snapshot.activeRequests, 1)
+        XCTAssertEqual(snapshot.queuedRequests, 0)
+        XCTAssertEqual(snapshot.totalAdmittedRequests, 1)
+        XCTAssertEqual(snapshot.totalCompletedRequests, 0)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 1)
+
+        await first.release()
+        snapshot = await admission.snapshot()
+        XCTAssertEqual(snapshot.activeRequests, 0)
+        XCTAssertEqual(snapshot.queuedRequests, 0)
+        XCTAssertEqual(snapshot.totalAdmittedRequests, 1)
+        XCTAssertEqual(snapshot.totalCompletedRequests, 1)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 1)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-runtime-pool-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/Tests/MereRunCLITests/StatusCommandTests.swift
+++ b/Tests/MereRunCLITests/StatusCommandTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MereRunCore
 @testable import MereRunCLI
 
 final class StatusCommandTests: XCTestCase {
@@ -40,7 +41,9 @@ final class StatusCommandTests: XCTestCase {
                 health: "up",
                 detail: nil,
                 loadedModels: ["text-chat-gemma4"],
-                modelsDetail: nil
+                modelsDetail: nil,
+                runtime: nil,
+                runtimeDetail: nil
             ),
             modelStore: StatusModelStoreSnapshot(
                 path: "/Users/test/Library/Application Support/MereRun/models",
@@ -73,7 +76,9 @@ final class StatusCommandTests: XCTestCase {
                 health: "up",
                 detail: nil,
                 loadedModels: [],
-                modelsDetail: "requires API key"
+                modelsDetail: "requires API key",
+                runtime: nil,
+                runtimeDetail: nil
             ),
             modelStore: StatusModelStoreSnapshot(
                 path: "/Users/test/Library/Application Support/MereRun/models",
@@ -90,5 +95,265 @@ final class StatusCommandTests: XCTestCase {
         XCTAssertTrue(output.contains("loaded models: unavailable (requires API key)"))
         XCTAssertTrue(output.contains("installed models: 0/0"))
         XCTAssertTrue(output.contains("    none"))
+    }
+
+    func testFormatterUsesRuntimeStatusWhenAvailable() {
+        let runtime = RuntimeModelPoolStatus(
+            object: "runtime.status",
+            defaultModel: "text-chat-gemma4",
+            settingsPath: "/tmp/models/.mere-run/runtime-model-settings.json",
+            activeRequests: 2,
+            admission: RuntimeRequestAdmissionSnapshot(
+                maxActiveRequests: 1,
+                activeRequests: 1,
+                queuedRequests: 1,
+                totalAdmittedRequests: 3,
+                totalCompletedRequests: 2,
+                totalCancelledRequests: 1
+            ),
+            capabilities: .current(
+                gemma4PrefixKVCacheEnabled: true,
+                gemma4ContinuousBatchingEnabled: true,
+                q35ContinuousBatchingEnabled: false,
+                q35PrefixKVCacheEnabled: false
+            ),
+            memory: RuntimeMemorySnapshot(
+                physicalBytes: 1024 * 1024 * 1024,
+                activeRequests: 2,
+                activeModelCount: 1,
+                pressure: "unknown"
+            ),
+            models: [
+                RuntimeModelPoolEntrySnapshot(
+                    id: "text-chat-gemma4",
+                    category: "text-chat",
+                    engine: .textChatGemma4,
+                    installPath: "/tmp/models/text-chat-gemma4",
+                    loaded: true,
+                    activeRequests: 2,
+                    lastAccess: nil,
+                    lastError: nil,
+                    pinned: true,
+                    alias: "chat-default",
+                    ttlSeconds: 600,
+                    maxContextTokens: 8192,
+                    maxTokens: 512,
+                    temperature: 0.4,
+                    topP: 0.8,
+                    engineOverride: nil,
+                    prefixKVCache: Gemma4PrefixKVCacheStats(
+                        enabled: true,
+                        entries: 1,
+                        maxEntries: 4,
+                        hits: 2,
+                        misses: 1,
+                        storedPrefixes: 3,
+                        reusedTokens: 256,
+                        storedTokens: 512
+                    ),
+                    continuousBatching: Gemma4ContinuousBatchingStats(
+                        enabled: true,
+                        activeRows: 2,
+                        queuedRows: 1,
+                        batchedDecodeSteps: 4,
+                        samePositionBatchedSteps: 3,
+                        variablePositionBatchedSteps: 1,
+                        singleDecodeSteps: 3,
+                        totalBatchedRows: 8,
+                        maxBatchSize: 2
+                    ),
+                    benchmarkStats: RuntimeModelBenchmarkStats(
+                        completedRequests: 2,
+                        failedRequests: 1,
+                        generatedTokens: 40,
+                        totalLoadSeconds: 0.2,
+                        totalPrefillSeconds: 0.6,
+                        totalDecodeSeconds: 2.0,
+                        lastCompletedAt: nil
+                    )
+                ),
+            ],
+            cacheStats: RuntimeCacheStatsSummary(
+                prefixKVCaches: [
+                    PrefixKVCacheStats(
+                        enabled: true,
+                        entries: 1,
+                        maxEntries: 4,
+                        hits: 2,
+                        misses: 1,
+                        storedPrefixes: 3,
+                        reusedTokens: 256,
+                        storedTokens: 512
+                    ),
+                ],
+                decodeBatchers: [
+                    RuntimeDecodeBatchingStats(
+                        enabled: true,
+                        activeRows: 2,
+                        queuedRows: 1,
+                        batchedDecodeSteps: 4,
+                        samePositionBatchedSteps: 3,
+                        variablePositionBatchedSteps: 1,
+                        singleDecodeSteps: 3,
+                        totalBatchedRows: 8,
+                        maxBatchSize: 2
+                    ),
+                ]
+            ),
+            benchmarkStats: RuntimeBenchmarkStatsSummary(stats: [
+                RuntimeModelBenchmarkStats(
+                    completedRequests: 2,
+                    failedRequests: 1,
+                    generatedTokens: 40,
+                    totalLoadSeconds: 0.2,
+                    totalPrefillSeconds: 0.6,
+                    totalDecodeSeconds: 2.0,
+                    lastCompletedAt: nil
+                ),
+            ])
+        )
+        let snapshot = StatusSnapshot(
+            server: StatusServerSnapshot(
+                url: "http://127.0.0.1:8080",
+                health: "up",
+                detail: nil,
+                loadedModels: [],
+                modelsDetail: nil,
+                runtime: runtime,
+                runtimeDetail: nil
+            ),
+            modelStore: StatusModelStoreSnapshot(
+                path: "/tmp/models",
+                source: "default",
+                configuredPath: nil,
+                isFallbackToDefault: false
+            ),
+            knownModelCount: 1,
+            installedModels: []
+        )
+
+        let output = StatusFormatter.text(snapshot)
+
+        XCTAssertTrue(output.contains("loaded models: text-chat-gemma4"))
+        XCTAssertTrue(output.contains("active requests: 2"))
+        XCTAssertTrue(output.contains("request admission: 1/1 active, 1 queued"))
+        XCTAssertTrue(output.contains("continuous batching: enabled"))
+        XCTAssertTrue(output.contains("prefix KV reuse: enabled"))
+        let aggregateCacheLine = "cache stats: prefix 1/4 entries, 2 hits, 256 reused tokens; "
+            + "decode batching 4 batched steps, 1 variable-position, max batch 2"
+        XCTAssertTrue(output.contains(aggregateCacheLine))
+        XCTAssertTrue(output.contains("benchmark stats: 2 completed, 1 failed, 40 tokens"))
+        XCTAssertTrue(output.contains("prefill avg 0.30s"))
+        XCTAssertTrue(output.contains("decode avg 1.00s"))
+        XCTAssertTrue(output.contains("decode 20.00 tok/s"))
+        XCTAssertTrue(output.contains("text-chat-gemma4 prefix KV: 1/4 entries, 2 hits, 256 reused tokens"))
+        XCTAssertTrue(output.contains(
+            "text-chat-gemma4 batching: 4 batched steps, 3 same-position, 1 variable-position, max batch 2, 1 queued rows"
+        ))
+        XCTAssertTrue(output.contains("runtime settings: /tmp/models/.mere-run/runtime-model-settings.json"))
+    }
+
+    func testRuntimeCacheStatsSummaryAggregatesLoadedModelCounters() {
+        let summary = RuntimeCacheStatsSummary(
+            prefixKVCaches: [
+                PrefixKVCacheStats(
+                    enabled: true,
+                    entries: 2,
+                    maxEntries: 4,
+                    hits: 3,
+                    misses: 1,
+                    storedPrefixes: 4,
+                    reusedTokens: 128,
+                    storedTokens: 256
+                ),
+                PrefixKVCacheStats(
+                    enabled: false,
+                    entries: 0,
+                    maxEntries: 4,
+                    hits: 0,
+                    misses: 2,
+                    storedPrefixes: 0,
+                    reusedTokens: 0,
+                    storedTokens: 0
+                ),
+            ],
+            decodeBatchers: [
+                RuntimeDecodeBatchingStats(
+                    enabled: true,
+                    activeRows: 1,
+                    queuedRows: 2,
+                    batchedDecodeSteps: 5,
+                    samePositionBatchedSteps: 4,
+                    variablePositionBatchedSteps: 1,
+                    singleDecodeSteps: 7,
+                    totalBatchedRows: 12,
+                    maxBatchSize: 3
+                ),
+                RuntimeDecodeBatchingStats(
+                    enabled: true,
+                    activeRows: 2,
+                    queuedRows: 0,
+                    batchedDecodeSteps: 11,
+                    samePositionBatchedSteps: 9,
+                    variablePositionBatchedSteps: 2,
+                    singleDecodeSteps: 13,
+                    totalBatchedRows: 18,
+                    maxBatchSize: 4
+                ),
+            ]
+        )
+
+        XCTAssertTrue(summary.available)
+        XCTAssertEqual(summary.prefixKVReuse.reportedModelCount, 2)
+        XCTAssertEqual(summary.prefixKVReuse.enabledModelCount, 1)
+        XCTAssertEqual(summary.prefixKVReuse.entries, 2)
+        XCTAssertEqual(summary.prefixKVReuse.maxEntries, 8)
+        XCTAssertEqual(summary.prefixKVReuse.hits, 3)
+        XCTAssertEqual(summary.prefixKVReuse.misses, 3)
+        XCTAssertEqual(summary.prefixKVReuse.reusedTokens, 128)
+        XCTAssertEqual(summary.decodeBatching.reportedModelCount, 2)
+        XCTAssertEqual(summary.decodeBatching.enabledModelCount, 2)
+        XCTAssertEqual(summary.decodeBatching.activeRows, 3)
+        XCTAssertEqual(summary.decodeBatching.queuedRows, 2)
+        XCTAssertEqual(summary.decodeBatching.batchedDecodeSteps, 16)
+        XCTAssertEqual(summary.decodeBatching.samePositionBatchedSteps, 13)
+        XCTAssertEqual(summary.decodeBatching.variablePositionBatchedSteps, 3)
+        XCTAssertEqual(summary.decodeBatching.singleDecodeSteps, 20)
+        XCTAssertEqual(summary.decodeBatching.totalBatchedRows, 30)
+        XCTAssertEqual(summary.decodeBatching.maxBatchSize, 4)
+        XCTAssertFalse(summary.ssdKVCache.available)
+    }
+
+    func testRuntimeBenchmarkStatsSummaryAggregatesCompletedRequests() {
+        let summary = RuntimeBenchmarkStatsSummary(stats: [
+            RuntimeModelBenchmarkStats(
+                completedRequests: 2,
+                failedRequests: 1,
+                generatedTokens: 20,
+                totalLoadSeconds: 0.2,
+                totalPrefillSeconds: 0.4,
+                totalDecodeSeconds: 1.0,
+                lastCompletedAt: nil
+            ),
+            RuntimeModelBenchmarkStats(
+                completedRequests: 1,
+                failedRequests: 0,
+                generatedTokens: 10,
+                totalLoadSeconds: 0.2,
+                totalPrefillSeconds: 0.5,
+                totalDecodeSeconds: 1.0,
+                lastCompletedAt: nil
+            ),
+        ])
+
+        XCTAssertTrue(summary.available)
+        XCTAssertEqual(summary.reportedModelCount, 2)
+        XCTAssertEqual(summary.completedRequests, 3)
+        XCTAssertEqual(summary.failedRequests, 1)
+        XCTAssertEqual(summary.generatedTokens, 30)
+        XCTAssertEqual(summary.averageLoadSeconds ?? 0, 0.4 / 3, accuracy: 0.000_001)
+        XCTAssertEqual(summary.averagePrefillSeconds ?? 0, 0.9 / 3, accuracy: 0.000_001)
+        XCTAssertEqual(summary.averageDecodeSeconds ?? 0, 2.0 / 3, accuracy: 0.000_001)
+        XCTAssertEqual(summary.decodeTokensPerSecond ?? 0, 15, accuracy: 0.000_001)
     }
 }

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -69,4 +69,18 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertEqual(quantization.groupSize, 32)
         XCTAssertEqual(quantization.quantizedStart, 128)
     }
+
+    func testGemma4PolarKVFlagsParse() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+            "--model", Gemma4Resources.turboModelId,
+            "--kv-bits", "2",
+            "--kv-quant-scheme", "polar",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization(for: Gemma4Resources.turboModelId)
+
+        XCTAssertEqual(quantization.bits, 2)
+        XCTAssertEqual(quantization.scheme, .polar)
+    }
 }

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -215,6 +215,51 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         }
     }
 
+    func testFullCacheReencodesToPolarPreservingOffset() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(36)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0)
+            .validated()
+        let cache = Gemma4FullKVCache()
+        let keys = MLXRandom.normal([1, 1, 4, 32]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, 1, 4, 32]).asType(.bfloat16)
+        cache.append(keys: keys, values: values)
+
+        let reencoded = try XCTUnwrap(cache.reencoded(quantization: config) as? Gemma4PolarKVCache)
+        reencoded.evaluateStorage()
+        let state = try XCTUnwrap(reencoded.currentState())
+
+        XCTAssertEqual(reencoded.offset, 4)
+        XCTAssertEqual(state.0.shape, [1, 1, 4, 32])
+        XCTAssertEqual(state.1.shape, [1, 1, 4, 32])
+    }
+
+    func testSlidingCacheReencodesToPolarPreservingTotalOffset() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(37)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0)
+            .validated()
+        let cache = Gemma4SlidingKVCache(maxSize: 3)
+        cache.append(
+            keys: MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16),
+            values: MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16)
+        )
+        cache.append(
+            keys: MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16),
+            values: MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16)
+        )
+
+        let reencoded = try XCTUnwrap(cache.reencoded(quantization: config) as? Gemma4PolarKVCache)
+        reencoded.evaluateStorage()
+        let state = try XCTUnwrap(reencoded.currentState())
+
+        XCTAssertEqual(reencoded.offset, 5)
+        XCTAssertEqual(state.0.shape, [1, 1, 3, 32])
+        XCTAssertEqual(state.1.shape, [1, 1, 3, 32])
+    }
+
     func testPolarFusedSpecializedAttentionMatchesChunkedDecode() throws {
         try skipUnlessGPUForPolarKV()
 

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -297,6 +297,7 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
 
         XCTAssertLessThan(polarBytes, affineBytes)
         XCTAssertLessThan(polarBytes, denseBytes)
+        XCTAssertLessThan(polarMS, affineMS)
     }
 
     private func denseDecode(

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import MLX
 import MLXRandom
@@ -13,6 +14,17 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         let config = try Gemma4KVCacheQuantization(bits: 3.5, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()
         XCTAssertEqual(config.keyBits, 3)
         XCTAssertEqual(config.valueBits, 4)
+    }
+
+    func testPolarRejectsUnsupportedBits() {
+        let config = Gemma4KVCacheQuantization(bits: 5, scheme: .polar, groupSize: 64, quantizedStart: 0)
+        XCTAssertThrowsError(try config.validated())
+    }
+
+    func testPolarUsesIntegerBits() throws {
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        XCTAssertEqual(config.keyBits, 2)
+        XCTAssertEqual(config.valueBits, 2)
     }
 
     func testQuantizedCacheRoundTripsShapeAndOffset() throws {
@@ -126,6 +138,199 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         XCTAssertEqual(returned.1.shape, [1, 1, 4, 64])
     }
 
+    func testPolarCacheRoundTripsShapeAndOffset() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(31)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        let cache = Gemma4PolarKVCache(configuration: config, maxSize: nil)
+
+        let keys = MLXRandom.normal([1, 2, 3, 64]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, 2, 3, 64]).asType(.bfloat16)
+        cache.append(keys: keys, values: values)
+        let returned = try XCTUnwrap(cache.currentState())
+
+        XCTAssertEqual(cache.offset, 3)
+        XCTAssertEqual(returned.0.shape, [1, 2, 3, 64])
+        XCTAssertEqual(returned.1.shape, [1, 2, 3, 64])
+
+        let keyDelta = returned.0.asType(DType.float32) - keys.asType(DType.float32)
+        let valueDelta = returned.1.asType(DType.float32) - values.asType(DType.float32)
+        let keyMSE = MLX.mean(keyDelta * keyDelta)
+        let valueMSE = MLX.mean(valueDelta * valueDelta)
+        XCTAssertLessThan(keyMSE.item(Float.self), 0.25)
+        XCTAssertLessThan(valueMSE.item(Float.self), 0.25)
+    }
+
+    func testPolarCacheForkCanMutateIndependently() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(32)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0).validated()
+        let cache = Gemma4PolarKVCache(configuration: config, maxSize: nil)
+
+        let firstKeys = MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16)
+        let firstValues = MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16)
+        cache.append(keys: firstKeys, values: firstValues)
+
+        let forked = cache.fork()
+        let nextKeys = MLXRandom.normal([1, 1, 1, 32]).asType(.bfloat16)
+        let nextValues = MLXRandom.normal([1, 1, 1, 32]).asType(.bfloat16)
+        forked.append(keys: nextKeys, values: nextValues)
+
+        let original = try XCTUnwrap(cache.currentState())
+        let copy = try XCTUnwrap(forked.currentState())
+        XCTAssertEqual(cache.offset, 2)
+        XCTAssertEqual(forked.offset, 3)
+        XCTAssertEqual(original.0.shape, [1, 1, 2, 32])
+        XCTAssertEqual(copy.0.shape, [1, 1, 3, 32])
+    }
+
+    func testPolarCachesCanMergeAndSplitBatchRows() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(33)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0).validated()
+        let caches = (0..<2).map { _ in Gemma4PolarKVCache(configuration: config, maxSize: nil) }
+
+        for cache in caches {
+            let keys = MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16)
+            let values = MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16)
+            cache.append(keys: keys, values: values)
+        }
+
+        let batched = try XCTUnwrap(caches[0].batched(with: caches))
+        let state = try XCTUnwrap(batched.currentState())
+        XCTAssertEqual(batched.offset, 3)
+        XCTAssertEqual(state.0.shape, [2, 1, 3, 32])
+        XCTAssertEqual(state.1.shape, [2, 1, 3, 32])
+
+        let rows = try XCTUnwrap(batched.unbatchedRows(count: 2))
+        XCTAssertEqual(rows.count, 2)
+        for row in rows {
+            let rowState = try XCTUnwrap(row.currentState())
+            XCTAssertEqual(row.offset, 3)
+            XCTAssertEqual(rowState.0.shape, [1, 1, 3, 32])
+            XCTAssertEqual(rowState.1.shape, [1, 1, 3, 32])
+        }
+    }
+
+    func testPolarFusedSpecializedAttentionMatchesChunkedDecode() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(34)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        let cache = Gemma4PolarKVCache(configuration: config, maxSize: nil)
+
+        let keys = MLXRandom.normal([1, 2, 48, 64]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, 2, 48, 64]).asType(.bfloat16)
+        cache.append(keys: keys, values: values)
+
+        let queries = MLXRandom.normal([1, 4, 1, 64]).asType(.bfloat16)
+        let scale: Float = 1.0 / sqrt(64.0)
+
+        let fused = try XCTUnwrap(cache.fusedSpecializedAttention(queries: queries, repeats: 2, scale: scale))
+        let state = try XCTUnwrap(cache.currentState())
+        let denseKeys = MLX.repeated(state.0.asType(.float32), count: 2, axis: 1)
+        let denseValues = MLX.repeated(state.1.asType(.float32), count: 2, axis: 1)
+        var denseScores = MLX.matmul(queries.asType(.float32), denseKeys.transposed(0, 1, 3, 2)) * MLXArray(scale)
+        denseScores = softmax(denseScores, axis: -1)
+        let dense = MLX.matmul(denseScores, denseValues).asType(fused.dtype)
+
+        XCTAssertEqual(fused.shape, [1, 4, 1, 64])
+        let delta = fused.asType(.float32) - dense.asType(.float32)
+        let mse = MLX.mean(delta * delta)
+        XCTAssertLessThan(mse.item(Float.self), 0.02)
+    }
+
+    func testPolarKVSyntheticDecodeBenchmark() throws {
+        let enabled = ProcessInfo.processInfo.environment["MERERUN_BENCHMARK_POLARKV"] == "1"
+        guard enabled else {
+            throw XCTSkip("Set MERERUN_BENCHMARK_POLARKV=1 and MERERUN_TEST_MLX_DEVICE=gpu to benchmark PolarKV.")
+        }
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(35)
+        let batch = 1
+        let kvHeads = 4
+        let queryHeads = 16
+        let tokens = Int(ProcessInfo.processInfo.environment["MERERUN_BENCHMARK_POLARKV_TOKENS"] ?? "") ?? 2_048
+        let dim = 256
+        let iterations = 24
+        let scale: Float = 1.0 / sqrt(Float(dim))
+        let keys = MLXRandom.normal([batch, kvHeads, tokens, dim]).asType(.bfloat16)
+        let values = MLXRandom.normal([batch, kvHeads, tokens, dim]).asType(.bfloat16)
+        let queries = MLXRandom.normal([batch, queryHeads, 1, dim]).asType(.bfloat16)
+
+        let affineConfig = try Gemma4KVCacheQuantization(bits: 4, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()
+        let affine = Gemma4QuantizedKVCache(configuration: affineConfig, maxSize: nil)
+        affine.append(keys: keys, values: values)
+
+        let polarConfig = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        let polar = Gemma4PolarKVCache(configuration: polarConfig, maxSize: nil)
+        polar.append(keys: keys, values: values)
+
+        let denseMS = try benchmarkMilliseconds(iterations: iterations) {
+            let output = denseDecode(queries: queries, keys: keys, values: values, repeats: queryHeads / kvHeads, scale: scale)
+            MLX.eval(output)
+        }
+        let affineMS = try benchmarkMilliseconds(iterations: iterations) {
+            let output = try XCTUnwrap(affine.specializedAttention(queries: queries, repeats: queryHeads / kvHeads, scale: scale))
+            MLX.eval(output)
+        }
+        let polarMS = try benchmarkMilliseconds(iterations: iterations) {
+            let output = try XCTUnwrap(polar.fusedSpecializedAttention(queries: queries, repeats: queryHeads / kvHeads, scale: scale))
+            MLX.eval(output)
+        }
+
+        let denseBytes = 2 * batch * kvHeads * tokens * dim * 2
+        let affineBytes = 2 * batch * kvHeads * tokens * (((dim * 4 + 31) / 32) * 4 + (dim / 64) * 8)
+        let polarBytes = 2 * batch * kvHeads * tokens * (((dim * 2 + 31) / 32) * 4 + 4)
+
+        print(
+            """
+            [PolarKV synthetic] dense=\(format(denseMS))ms/decode \
+            affine4=\(format(affineMS))ms/decode polar2=\(format(polarMS))ms/decode \
+            denseKV=\(formatMiB(denseBytes))MiB affineKV~\(formatMiB(affineBytes))MiB polarKV~\(formatMiB(polarBytes))MiB
+            """
+        )
+
+        XCTAssertLessThan(polarBytes, affineBytes)
+        XCTAssertLessThan(polarBytes, denseBytes)
+    }
+
+    private func denseDecode(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        repeats: Int,
+        scale: Float
+    ) -> MLXArray {
+        let broadcastKeys = MLX.repeated(keys.asType(.float32), count: repeats, axis: 1)
+        let broadcastValues = MLX.repeated(values.asType(.float32), count: repeats, axis: 1)
+        var scores = MLX.matmul(queries.asType(.float32), broadcastKeys.transposed(0, 1, 3, 2)) * MLXArray(scale)
+        scores = softmax(scores, axis: -1)
+        return MLX.matmul(scores, broadcastValues).asType(queries.dtype)
+    }
+
+    private func benchmarkMilliseconds(iterations: Int, _ body: () throws -> Void) throws -> Double {
+        try body()
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations {
+            try body()
+        }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        return Double(elapsed) / 1_000_000.0 / Double(iterations)
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private func formatMiB(_ bytes: Int) -> String {
+        format(Double(bytes) / 1_048_576.0)
+    }
+
     func testSpecializedAttentionMatchesDenseDecodeShapeAndValue() throws {
         MLXRandom.seed(13)
         let config = try Gemma4KVCacheQuantization(bits: 4, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()
@@ -178,5 +383,11 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         let delta = fused.asType(.float32) - dense.asType(.float32)
         let mse = MLX.mean(delta * delta)
         XCTAssertLessThan(mse.item(Float.self), 0.02)
+    }
+
+    private func skipUnlessGPUForPolarKV() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("PolarKV uses MLXFast Metal pack/unpack kernels; set MERERUN_TEST_MLX_DEVICE=gpu to run it.")
+        }
     }
 }

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -37,6 +37,76 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         XCTAssertLessThan(valueMSE.item(Float.self), 0.02)
     }
 
+    func testFullCacheForkCanMutateIndependently() throws {
+        MLXRandom.seed(8)
+        let cache = Gemma4FullKVCache()
+
+        let firstKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        let firstValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        cache.append(keys: firstKeys, values: firstValues)
+
+        let forked = cache.fork()
+        let nextKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 1, 8]).asType(.bfloat16)
+        let nextValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 1, 8]).asType(.bfloat16)
+        forked.append(keys: nextKeys, values: nextValues)
+
+        let original = try XCTUnwrap(cache.currentState())
+        let copy = try XCTUnwrap(forked.currentState())
+        XCTAssertEqual(cache.offset, 2)
+        XCTAssertEqual(forked.offset, 3)
+        XCTAssertEqual(original.0.shape, [1, 1, 2, 8])
+        XCTAssertEqual(copy.0.shape, [1, 1, 3, 8])
+    }
+
+    func testQuantizedCacheForkCanMutateIndependently() throws {
+        MLXRandom.seed(10)
+        let config = try Gemma4KVCacheQuantization(bits: 4, scheme: .uniform, groupSize: 32, quantizedStart: 0).validated()
+        let cache = Gemma4QuantizedKVCache(configuration: config, maxSize: nil)
+
+        let firstKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 32]).asType(.bfloat16)
+        let firstValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 32]).asType(.bfloat16)
+        cache.append(keys: firstKeys, values: firstValues)
+
+        let forked = cache.fork()
+        let nextKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 1, 32]).asType(.bfloat16)
+        let nextValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 1, 32]).asType(.bfloat16)
+        forked.append(keys: nextKeys, values: nextValues)
+
+        let original = try XCTUnwrap(cache.currentState())
+        let copy = try XCTUnwrap(forked.currentState())
+        XCTAssertEqual(cache.offset, 2)
+        XCTAssertEqual(forked.offset, 3)
+        XCTAssertEqual(original.0.shape, [1, 1, 2, 32])
+        XCTAssertEqual(copy.0.shape, [1, 1, 3, 32])
+    }
+
+    func testQuantizedCachesCanMergeAndSplitBatchRows() throws {
+        MLXRandom.seed(12)
+        let config = try Gemma4KVCacheQuantization(bits: 4, scheme: .uniform, groupSize: 32, quantizedStart: 0).validated()
+        let caches = (0..<2).map { _ in Gemma4QuantizedKVCache(configuration: config, maxSize: nil) }
+
+        for cache in caches {
+            let keys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 3, 32]).asType(.bfloat16)
+            let values = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 3, 32]).asType(.bfloat16)
+            cache.append(keys: keys, values: values)
+        }
+
+        let batched = try XCTUnwrap(caches[0].batched(with: caches))
+        let state = try XCTUnwrap(batched.currentState())
+        XCTAssertEqual(batched.offset, 3)
+        XCTAssertEqual(state.0.shape, [2, 1, 3, 32])
+        XCTAssertEqual(state.1.shape, [2, 1, 3, 32])
+
+        let rows = try XCTUnwrap(batched.unbatchedRows(count: 2))
+        XCTAssertEqual(rows.count, 2)
+        for row in rows {
+            let rowState = try XCTUnwrap(row.currentState())
+            XCTAssertEqual(row.offset, 3)
+            XCTAssertEqual(rowState.0.shape, [1, 1, 3, 32])
+            XCTAssertEqual(rowState.1.shape, [1, 1, 3, 32])
+        }
+    }
+
     func testSlidingQuantizedCacheRespectsMaxSize() throws {
         MLXRandom.seed(9)
         let config = try Gemma4KVCacheQuantization(bits: 4, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -88,6 +88,18 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         XCTAssertEqual(projected.shape, [1, 1, config.numHiddenLayers * config.hiddenSizePerLayerInput])
     }
 
+    func testMakeCacheUsesPolarKVCacheWhenRequested() throws {
+        let config = try decodeTextConfig(makeBaseConfig())
+        let model = Gemma4LanguageModel(config: config)
+        let quantization = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0)
+            .validated()
+
+        let caches = model.makeCache(quantization: quantization)
+
+        XCTAssertEqual(caches.count, 2)
+        XCTAssertTrue(caches.allSatisfy { $0 is Gemma4PolarKVCache })
+    }
+
     func testAttentionKEqVDisablesValueProjectionForFullAttentionLayers() throws {
         var configObject = makeBaseConfig()
         configObject["attention_k_eq_v"] = true

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 import MLX
+import MLXRandom
 @testable import MereRunCore
 
 final class Gemma4ModelTests: MereRunCoreTestCase {
@@ -45,6 +46,35 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
             "num_kv_shared_layers": 0,
             "tie_word_embeddings": true,
         ]
+    }
+
+    private func mergeLayerCaches(_ rowCaches: [[Gemma4AttentionCache]]) -> [Gemma4AttentionCache]? {
+        guard let first = rowCaches.first, !first.isEmpty else { return nil }
+        guard rowCaches.allSatisfy({ $0.count == first.count }) else { return nil }
+        var mergedCaches: [Gemma4AttentionCache] = []
+        mergedCaches.reserveCapacity(first.count)
+        for index in first.indices {
+            let layerCaches = rowCaches.map { $0[index] }
+            guard let merged = layerCaches[0].batched(with: layerCaches) else { return nil }
+            mergedCaches.append(merged)
+        }
+        return mergedCaches
+    }
+
+    private func splitLayerCaches(
+        _ caches: [Gemma4AttentionCache],
+        rowCount: Int
+    ) -> [[Gemma4AttentionCache]]? {
+        var rows = Array(repeating: [Gemma4AttentionCache](), count: rowCount)
+        for cache in caches {
+            guard let split = cache.unbatchedRows(count: rowCount), split.count == rowCount else {
+                return nil
+            }
+            for index in 0..<rowCount {
+                rows[index].append(split[index])
+            }
+        }
+        return rows
     }
 
     func testPerLayerModelProjectionIsUnscaledLinearWeightPath() throws {
@@ -124,5 +154,139 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
 
         XCTAssertNotNil(layer.router)
         XCTAssertNotNil(layer.experts)
+    }
+
+    func testPrefixCacheForkMatchesFullForwardForSuffixLogits() throws {
+        MLXRandom.seed(19)
+        let config = try decodeTextConfig(makeBaseConfig())
+        let model = Gemma4TextCausalLM(config: config)
+        let tokens = [1, 2, 3, 4, 5]
+        let prefixCount = 2
+
+        let fullCache = try XCTUnwrap(model.makeCache() as? [Gemma4AttentionCache])
+        let fullInput = MLXArray(tokens.map(Int32.init)).reshaped(1, tokens.count)
+        let fullLogits = model(fullInput, cache: fullCache as [AnyObject])
+        MLX.eval(fullLogits)
+
+        let prefixCache = try XCTUnwrap(model.makeCache() as? [Gemma4AttentionCache])
+        let prefixInput = MLXArray(tokens.prefix(prefixCount).map(Int32.init)).reshaped(1, prefixCount)
+        let prefixLogits = model(prefixInput, cache: prefixCache as [AnyObject])
+        MLX.eval(prefixLogits)
+
+        let forkedCache = prefixCache.map { $0.fork() }
+        let suffixTokens = Array(tokens.dropFirst(prefixCount))
+        let suffixInput = MLXArray(suffixTokens.map(Int32.init)).reshaped(1, suffixTokens.count)
+        let cachedSuffixLogits = model(suffixInput, cache: forkedCache as [AnyObject])
+        MLX.eval(cachedSuffixLogits)
+
+        let expectedSuffixLogits = fullLogits[0..., prefixCount..., 0...]
+        let maxDiff = MLX.max(MLX.abs(
+            expectedSuffixLogits.asType(.float32) - cachedSuffixLogits.asType(.float32)
+        )).item(Float.self)
+        XCTAssertLessThan(maxDiff, 0.0001)
+    }
+
+    func testEqualLengthBatchedForwardMatchesIndependentRows() throws {
+        MLXRandom.seed(23)
+        let config = try decodeTextConfig(makeBaseConfig())
+        let model = Gemma4TextCausalLM(config: config)
+        let rows = [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+        ]
+
+        let batchInput = MLXArray(rows.flatMap { $0 }.map(Int32.init)).reshaped(rows.count, rows[0].count)
+        let batchLogits = model(batchInput)
+        MLX.eval(batchLogits)
+
+        for (rowIndex, tokens) in rows.enumerated() {
+            let rowInput = MLXArray(tokens.map(Int32.init)).reshaped(1, tokens.count)
+            let rowLogits = model(rowInput)
+            MLX.eval(rowLogits)
+            let maxDiff = MLX.max(MLX.abs(
+                batchLogits[rowIndex, 0..., 0...].asType(.float32) - rowLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+        }
+    }
+
+    func testEqualLengthBatchedCachedDecodeMatchesIndependentRows() throws {
+        MLXRandom.seed(29)
+        let config = try decodeTextConfig(makeBaseConfig())
+        let model = Gemma4TextCausalLM(config: config)
+        let prefixes = [
+            [1, 2, 3],
+            [4, 5, 6],
+        ]
+        let nextTokens = [7, 8]
+
+        let batchCache = try XCTUnwrap(model.makeCache() as? [Gemma4AttentionCache])
+        let prefixBatch = MLXArray(prefixes.flatMap { $0 }.map(Int32.init)).reshaped(prefixes.count, prefixes[0].count)
+        let prefillLogits = model(prefixBatch, cache: batchCache as [AnyObject])
+        MLX.eval(prefillLogits)
+        let nextBatch = MLXArray(nextTokens.map(Int32.init)).reshaped(nextTokens.count, 1)
+        let batchDecodeLogits = model(nextBatch, cache: batchCache as [AnyObject])
+        MLX.eval(batchDecodeLogits)
+
+        for (rowIndex, prefix) in prefixes.enumerated() {
+            let rowCache = try XCTUnwrap(model.makeCache() as? [Gemma4AttentionCache])
+            let rowPrefix = MLXArray(prefix.map(Int32.init)).reshaped(1, prefix.count)
+            let rowPrefillLogits = model(rowPrefix, cache: rowCache as [AnyObject])
+            MLX.eval(rowPrefillLogits)
+            let rowNext = MLXArray([Int32(nextTokens[rowIndex])]).reshaped(1, 1)
+            let rowDecodeLogits = model(rowNext, cache: rowCache as [AnyObject])
+            MLX.eval(rowDecodeLogits)
+
+            let maxDiff = MLX.max(MLX.abs(
+                batchDecodeLogits[rowIndex, 0..., 0...].asType(.float32) - rowDecodeLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+        }
+    }
+
+    func testMergedIndependentCachesBatchedDecodeMatchesIndependentRows() throws {
+        MLXRandom.seed(31)
+        let config = try decodeTextConfig(makeBaseConfig())
+        let model = Gemma4TextCausalLM(config: config)
+        let prefixes = [
+            [1, 2, 3],
+            [4, 5, 6],
+        ]
+        let nextTokens = [7, 8]
+        let secondTokens = [9, 10]
+
+        var rowCaches: [[Gemma4AttentionCache]] = []
+        for prefix in prefixes {
+            let cache = try XCTUnwrap(model.makeCache() as? [Gemma4AttentionCache])
+            let prefixInput = MLXArray(prefix.map(Int32.init)).reshaped(1, prefix.count)
+            let prefixLogits = model(prefixInput, cache: cache as [AnyObject])
+            MLX.eval(prefixLogits)
+            rowCaches.append(cache)
+        }
+
+        let batchedCaches = try XCTUnwrap(mergeLayerCaches(rowCaches))
+        let nextBatch = MLXArray(nextTokens.map(Int32.init)).reshaped(nextTokens.count, 1)
+        let batchedLogits = model(nextBatch, cache: batchedCaches as [AnyObject])
+        MLX.eval(batchedLogits)
+        let splitCaches = try XCTUnwrap(splitLayerCaches(batchedCaches, rowCount: nextTokens.count))
+
+        for rowIndex in prefixes.indices {
+            let rowNext = MLXArray([Int32(nextTokens[rowIndex])]).reshaped(1, 1)
+            let rowLogits = model(rowNext, cache: rowCaches[rowIndex] as [AnyObject])
+            MLX.eval(rowLogits)
+            var maxDiff = MLX.max(MLX.abs(
+                batchedLogits[rowIndex, 0..., 0...].asType(.float32) - rowLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+
+            let rowSecond = MLXArray([Int32(secondTokens[rowIndex])]).reshaped(1, 1)
+            let splitLogits = model(rowSecond, cache: splitCaches[rowIndex] as [AnyObject])
+            let independentLogits = model(rowSecond, cache: rowCaches[rowIndex] as [AnyObject])
+            MLX.eval(splitLogits, independentLogits)
+            maxDiff = MLX.max(MLX.abs(
+                splitLogits[0, 0..., 0...].asType(.float32) - independentLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+        }
     }
 }

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -1,5 +1,7 @@
 import Foundation
 import XCTest
+import MLX
+import MLXRandom
 @testable import MereRunCore
 
 final class Q35ConfigDecodingTests: MereRunCoreTestCase {
@@ -66,6 +68,93 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         ]
     }
 
+    private func makeTinyRuntimeConfig(layerTypes: [String]) -> [String: Any] {
+        var config = makeBaseConfig()
+        var textConfig = config["text_config"] as? [String: Any] ?? [:]
+        textConfig["hidden_size"] = 8
+        textConfig["num_hidden_layers"] = layerTypes.count
+        textConfig["intermediate_size"] = 8
+        textConfig["shared_expert_intermediate_size"] = 8
+        textConfig["moe_intermediate_size"] = 8
+        textConfig["num_attention_heads"] = 2
+        textConfig["num_key_value_heads"] = 1
+        textConfig["head_dim"] = 4
+        textConfig["num_experts"] = 2
+        textConfig["num_experts_per_tok"] = 1
+        textConfig["layer_types"] = layerTypes
+        textConfig["mlp_only_layers"] = []
+        textConfig["linear_num_value_heads"] = 1
+        textConfig["linear_num_key_heads"] = 1
+        textConfig["linear_key_head_dim"] = 4
+        textConfig["linear_value_head_dim"] = 4
+        textConfig["linear_conv_kernel_dim"] = 2
+        textConfig["max_position_embeddings"] = 128
+        textConfig["attn_output_gate"] = false
+        textConfig["vocab_size"] = 32
+        textConfig["eos_token_id"] = 31
+        config["text_config"] = textConfig
+        config["eos_token_id"] = [31]
+        return config
+    }
+
+    private func makeLayerCaches(config: Q35Config) -> [Q35LayerCache?] {
+        let text = config.textConfig
+        let mlpOnly = Set(text.mlpOnlyLayers)
+        return (0..<text.numHiddenLayers).map { layerIndex in
+            if mlpOnly.contains(layerIndex) {
+                return nil
+            }
+            let layerType = layerIndex < text.layerTypes.count ? text.layerTypes[layerIndex] : "linear_attention"
+            if layerType == "full_attention" {
+                return .full(KVCacheSimple(step: 8))
+            }
+            return .linear(Q35LinearCache())
+        }
+    }
+
+    private func mergeLayerCaches(_ rowCaches: [[Q35LayerCache?]]) -> [Q35LayerCache?]? {
+        guard let first = rowCaches.first, !first.isEmpty else { return nil }
+        guard rowCaches.allSatisfy({ $0.count == first.count }) else { return nil }
+        var mergedCaches: [Q35LayerCache?] = []
+        mergedCaches.reserveCapacity(first.count)
+        for index in first.indices {
+            let layerCaches = rowCaches.map { $0[index] }
+            if layerCaches.allSatisfy({ $0 == nil }) {
+                mergedCaches.append(nil)
+                continue
+            }
+            let nonNil = layerCaches.compactMap { $0 }
+            guard nonNil.count == layerCaches.count,
+                  let merged = nonNil[0].batched(with: nonNil) else {
+                return nil
+            }
+            mergedCaches.append(merged)
+        }
+        return mergedCaches
+    }
+
+    private func splitLayerCaches(
+        _ caches: [Q35LayerCache?],
+        rowCount: Int
+    ) -> [[Q35LayerCache?]]? {
+        var rows = Array(repeating: [Q35LayerCache?](), count: rowCount)
+        for cache in caches {
+            guard let cache else {
+                for index in 0..<rowCount {
+                    rows[index].append(nil)
+                }
+                continue
+            }
+            guard let split = cache.unbatchedRows(count: rowCount), split.count == rowCount else {
+                return nil
+            }
+            for index in 0..<rowCount {
+                rows[index].append(split[index])
+            }
+        }
+        return rows
+    }
+
     func testIntermediateSizeFallsBackToSharedWhenNull() throws {
         var config = makeBaseConfig()
         var textConfig = config["text_config"] as? [String: Any] ?? [:]
@@ -117,5 +206,248 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
 
         let decoded = try decodeConfig(config)
         XCTAssertEqual(decoded.textConfig.intermediateSize, 4096)
+    }
+
+    func testFullAttentionKVCacheForkCanMutateIndependently() {
+        MLXRandom.seed(31)
+        let cache = KVCacheSimple(step: 2)
+        let keys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        let values = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        _ = cache.update(keys: keys, values: values)
+
+        let forked = cache.fork()
+        let nextKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 1, 8]).asType(.bfloat16)
+        let nextValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 1, 8]).asType(.bfloat16)
+        _ = forked.update(keys: nextKeys, values: nextValues)
+
+        XCTAssertEqual(cache.offset, 2)
+        XCTAssertEqual(forked.offset, 3)
+    }
+
+    func testFullAttentionKVCacheBatchingRejectsDifferentGrowthSteps() {
+        MLXRandom.seed(33)
+        let first = KVCacheSimple(step: 2)
+        let second = KVCacheSimple(step: 4)
+        let keys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        let values = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        _ = first.update(keys: keys, values: values)
+        _ = second.update(keys: keys, values: values)
+
+        XCTAssertNil(first.batched(with: [first, second]))
+    }
+
+    func testFullAttentionKVCacheBatchesDifferentOffsetsAsRaggedRows() throws {
+        MLXRandom.seed(35)
+        let first = KVCacheSimple(step: 2)
+        let second = KVCacheSimple(step: 2)
+        let firstKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        let firstValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 2, 8]).asType(.bfloat16)
+        let secondKeys = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 4, 8]).asType(.bfloat16)
+        let secondValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 1, 4, 8]).asType(.bfloat16)
+        _ = first.update(keys: firstKeys, values: firstValues)
+        _ = second.update(keys: secondKeys, values: secondValues)
+
+        let batched = try XCTUnwrap(first.batched(with: [first, second]))
+        XCTAssertEqual(batched.rowOffsets, [2, 4])
+
+        let nextKeys = MLXRandom.uniform(0.0 ..< 1.0, [2, 1, 1, 8]).asType(.bfloat16)
+        let nextValues = MLXRandom.uniform(0.0 ..< 1.0, [2, 1, 1, 8]).asType(.bfloat16)
+        let updated = batched.update(keys: nextKeys, values: nextValues)
+        XCTAssertEqual(batched.rowOffsets, [3, 5])
+        XCTAssertEqual(updated.0.shape, [2, 1, 5, 8])
+        XCTAssertEqual(updated.1.shape, [2, 1, 5, 8])
+
+        let split = try XCTUnwrap(batched.unbatchedRows(count: 2))
+        XCTAssertEqual(split[0].offset, 3)
+        XCTAssertEqual(split[1].offset, 5)
+    }
+
+    func testLinearCacheForkCanMutateIndependently() {
+        MLXRandom.seed(37)
+        let cache = Q35LinearCache()
+        cache.convState = MLXRandom.uniform(0.0 ..< 1.0, [1, 3, 8]).asType(.bfloat16)
+        cache.recurrentState = MLXRandom.uniform(0.0 ..< 1.0, [1, 2, 4, 8]).asType(.bfloat16)
+
+        let forked = cache.fork()
+        forked.convState = MLXArray.zeros([1, 3, 8], dtype: .bfloat16)
+        forked.recurrentState = MLXArray.zeros([1, 2, 4, 8], dtype: .bfloat16)
+
+        let convMax = MLX.max(MLX.abs(cache.convState!.asType(.float32))).item(Float.self)
+        let recurrentMax = MLX.max(MLX.abs(cache.recurrentState!.asType(.float32))).item(Float.self)
+        let forkConvMax = MLX.max(MLX.abs(forked.convState!.asType(.float32))).item(Float.self)
+        let forkRecurrentMax = MLX.max(MLX.abs(forked.recurrentState!.asType(.float32))).item(Float.self)
+
+        XCTAssertGreaterThan(convMax, 0)
+        XCTAssertGreaterThan(recurrentMax, 0)
+        XCTAssertEqual(forkConvMax, 0)
+        XCTAssertEqual(forkRecurrentMax, 0)
+    }
+
+    func testQ35PrefixCacheForkMatchesFullForwardForSuffixLogits() throws {
+        MLXRandom.seed(41)
+        let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["linear_attention", "full_attention"]))
+        let model = Q35Model(config: config)
+        let tokens = [1, 2, 3, 4, 5]
+        let prefixCount = 2
+
+        let fullCache = makeLayerCaches(config: config)
+        let fullInput = MLXArray(tokens.map(Int32.init)).reshaped(1, tokens.count)
+        let fullLogits = model(fullInput, cache: fullCache)
+        MLX.eval(fullLogits)
+
+        let prefixCache = makeLayerCaches(config: config)
+        let prefixInput = MLXArray(tokens.prefix(prefixCount).map(Int32.init)).reshaped(1, prefixCount)
+        let prefixLogits = model(prefixInput, cache: prefixCache)
+        MLX.eval(prefixLogits)
+
+        let forkedCache = prefixCache.map { $0?.fork() }
+        let suffixTokens = Array(tokens.dropFirst(prefixCount))
+        let suffixInput = MLXArray(suffixTokens.map(Int32.init)).reshaped(1, suffixTokens.count)
+        let cachedSuffixLogits = model(suffixInput, cache: forkedCache)
+        MLX.eval(cachedSuffixLogits)
+
+        let expectedSuffixLogits = fullLogits[0..., prefixCount..., 0...]
+        let maxDiff = MLX.max(MLX.abs(
+            expectedSuffixLogits.asType(.float32) - cachedSuffixLogits.asType(.float32)
+        )).item(Float.self)
+        XCTAssertLessThan(maxDiff, 0.0001)
+    }
+
+    func testQ35MergedIndependentCachesBatchedDecodeMatchesIndependentRows() throws {
+        MLXRandom.seed(43)
+        let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["linear_attention", "full_attention"]))
+        let model = Q35Model(config: config)
+        let prefixes = [
+            [1, 2, 3],
+            [4, 5, 6],
+        ]
+        let nextTokens = [7, 8]
+        let secondTokens = [9, 10]
+
+        var rowCaches: [[Q35LayerCache?]] = []
+        for prefix in prefixes {
+            let cache = makeLayerCaches(config: config)
+            let prefixInput = MLXArray(prefix.map(Int32.init)).reshaped(1, prefix.count)
+            let prefixLogits = model(prefixInput, cache: cache)
+            MLX.eval(prefixLogits)
+            rowCaches.append(cache)
+        }
+
+        let batchedCaches = try XCTUnwrap(mergeLayerCaches(rowCaches))
+        let nextBatch = MLXArray(nextTokens.map(Int32.init)).reshaped(nextTokens.count, 1)
+        let batchedLogits = model(nextBatch, cache: batchedCaches)
+        MLX.eval(batchedLogits)
+        let splitCaches = try XCTUnwrap(splitLayerCaches(batchedCaches, rowCount: nextTokens.count))
+
+        for rowIndex in prefixes.indices {
+            let rowNext = MLXArray([Int32(nextTokens[rowIndex])]).reshaped(1, 1)
+            let rowLogits = model(rowNext, cache: rowCaches[rowIndex])
+            MLX.eval(rowLogits)
+            var maxDiff = MLX.max(MLX.abs(
+                batchedLogits[rowIndex, 0..., 0...].asType(.float32) - rowLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+
+            let rowSecond = MLXArray([Int32(secondTokens[rowIndex])]).reshaped(1, 1)
+            let splitLogits = model(rowSecond, cache: splitCaches[rowIndex])
+            let independentLogits = model(rowSecond, cache: rowCaches[rowIndex])
+            MLX.eval(splitLogits, independentLogits)
+            maxDiff = MLX.max(MLX.abs(
+                splitLogits[0, 0..., 0...].asType(.float32) - independentLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+        }
+    }
+
+    func testQ35LinearOnlyDifferentLengthCachesBatchedDecodeMatchesIndependentRows() throws {
+        MLXRandom.seed(47)
+        let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["linear_attention", "linear_attention"]))
+        let model = Q35Model(config: config)
+        let prefixes = [
+            [1, 2],
+            [3, 4, 5, 6],
+        ]
+        let nextTokens = [7, 8]
+        let secondTokens = [9, 10]
+
+        var rowCaches: [[Q35LayerCache?]] = []
+        for prefix in prefixes {
+            let cache = makeLayerCaches(config: config)
+            let prefixInput = MLXArray(prefix.map(Int32.init)).reshaped(1, prefix.count)
+            let prefixLogits = model(prefixInput, cache: cache)
+            MLX.eval(prefixLogits)
+            rowCaches.append(cache)
+        }
+
+        let batchedCaches = try XCTUnwrap(mergeLayerCaches(rowCaches))
+        let nextBatch = MLXArray(nextTokens.map(Int32.init)).reshaped(nextTokens.count, 1)
+        let batchedLogits = model(nextBatch, cache: batchedCaches)
+        MLX.eval(batchedLogits)
+        let splitCaches = try XCTUnwrap(splitLayerCaches(batchedCaches, rowCount: nextTokens.count))
+
+        for rowIndex in prefixes.indices {
+            let rowNext = MLXArray([Int32(nextTokens[rowIndex])]).reshaped(1, 1)
+            let rowLogits = model(rowNext, cache: rowCaches[rowIndex])
+            MLX.eval(rowLogits)
+            var maxDiff = MLX.max(MLX.abs(
+                batchedLogits[rowIndex, 0..., 0...].asType(.float32) - rowLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+
+            let rowSecond = MLXArray([Int32(secondTokens[rowIndex])]).reshaped(1, 1)
+            let splitLogits = model(rowSecond, cache: splitCaches[rowIndex])
+            let independentLogits = model(rowSecond, cache: rowCaches[rowIndex])
+            MLX.eval(splitLogits, independentLogits)
+            maxDiff = MLX.max(MLX.abs(
+                splitLogits[0, 0..., 0...].asType(.float32) - independentLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+        }
+    }
+
+    func testQ35FullAttentionDifferentLengthCachesBatchedDecodeMatchesIndependentRows() throws {
+        MLXRandom.seed(49)
+        let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["full_attention"]))
+        let model = Q35Model(config: config)
+        let prefixes = [
+            [1, 2],
+            [3, 4, 5, 6],
+        ]
+        let nextTokens = [7, 8]
+        let secondTokens = [9, 10]
+
+        var rowCaches: [[Q35LayerCache?]] = []
+        for prefix in prefixes {
+            let cache = makeLayerCaches(config: config)
+            let prefixInput = MLXArray(prefix.map(Int32.init)).reshaped(1, prefix.count)
+            let prefixLogits = model(prefixInput, cache: cache)
+            MLX.eval(prefixLogits)
+            rowCaches.append(cache)
+        }
+
+        let batchedCaches = try XCTUnwrap(mergeLayerCaches(rowCaches))
+        let nextBatch = MLXArray(nextTokens.map(Int32.init)).reshaped(nextTokens.count, 1)
+        let batchedLogits = model(nextBatch, cache: batchedCaches)
+        MLX.eval(batchedLogits)
+        let splitCaches = try XCTUnwrap(splitLayerCaches(batchedCaches, rowCount: nextTokens.count))
+
+        for rowIndex in prefixes.indices {
+            let rowNext = MLXArray([Int32(nextTokens[rowIndex])]).reshaped(1, 1)
+            let rowLogits = model(rowNext, cache: rowCaches[rowIndex])
+            MLX.eval(rowLogits)
+            var maxDiff = MLX.max(MLX.abs(
+                batchedLogits[rowIndex, 0..., 0...].asType(.float32) - rowLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+
+            let rowSecond = MLXArray([Int32(secondTokens[rowIndex])]).reshaped(1, 1)
+            let splitLogits = model(rowSecond, cache: splitCaches[rowIndex])
+            let independentLogits = model(rowSecond, cache: rowCaches[rowIndex])
+            MLX.eval(splitLogits, independentLogits)
+            maxDiff = MLX.max(MLX.abs(
+                splitLogits[0, 0..., 0...].asType(.float32) - independentLogits[0, 0..., 0...].asType(.float32)
+            )).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.0001)
+        }
     }
 }

--- a/Tests/MereRunCoreTests/RuntimeCacheStatsTests.swift
+++ b/Tests/MereRunCoreTests/RuntimeCacheStatsTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import MereRunCore
+
+final class RuntimeCacheStatsTests: XCTestCase {
+    func testPrefillCheckpointPlannerStopsAtSemanticCheckpointInsideChunk() {
+        let end = RuntimePrefillCheckpointPlanner.nextEnd(
+            processed: 0,
+            total: 1_000,
+            chunkSize: 512,
+            checkpoints: [128]
+        )
+
+        XCTAssertEqual(end, 128)
+    }
+
+    func testPrefillCheckpointPlannerFallsBackToChunkAfterCheckpoint() {
+        let end = RuntimePrefillCheckpointPlanner.nextEnd(
+            processed: 128,
+            total: 1_000,
+            chunkSize: 512,
+            checkpoints: [128]
+        )
+
+        XCTAssertEqual(end, 640)
+    }
+
+    func testPrefillCheckpointPlannerNormalizesUsableInteriorCounts() {
+        let checkpoints = RuntimePrefillCheckpointPlanner.normalizedCheckpoints(
+            [-1, 0, 32, 32, 1_000],
+            total: 1_000
+        )
+
+        XCTAssertEqual(checkpoints, [32])
+    }
+
+    func testPrefixCacheRetentionPrunesChunkBeforeSemanticCheckpoint() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let key = RuntimePrefixCacheRetentionPlanner.keyToPrune(entries: [
+            "semantic-old": RuntimePrefixCacheRetentionMetadata(
+                priority: .semantic,
+                lastAccess: base
+            ),
+            "chunk-new": RuntimePrefixCacheRetentionMetadata(
+                priority: .chunk,
+                lastAccess: base.addingTimeInterval(100)
+            ),
+            "chunk-old": RuntimePrefixCacheRetentionMetadata(
+                priority: .chunk,
+                lastAccess: base.addingTimeInterval(50)
+            ),
+        ])
+
+        XCTAssertEqual(key, "chunk-old")
+    }
+
+    func testPrefixCacheRetentionFallsBackToOldestSemanticWhenAllAreSemantic() {
+        let base = Date(timeIntervalSince1970: 2_000)
+        let key = RuntimePrefixCacheRetentionPlanner.keyToPrune(entries: [
+            "semantic-new": RuntimePrefixCacheRetentionMetadata(
+                priority: .semantic,
+                lastAccess: base.addingTimeInterval(10)
+            ),
+            "semantic-old": RuntimePrefixCacheRetentionMetadata(
+                priority: .semantic,
+                lastAccess: base
+            ),
+        ])
+
+        XCTAssertEqual(key, "semantic-old")
+    }
+
+    func testDecodeBatchPlannerSelectsEarliestCompatibleSignatureGroup() {
+        let rows = [
+            RuntimeDecodeBatchRowMetadata(row: "a", signature: "offset:4", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "b", signature: "offset:8", position: 8),
+            RuntimeDecodeBatchRowMetadata(row: "c", signature: "offset:8", position: 8),
+            RuntimeDecodeBatchRowMetadata(row: "d", signature: "offset:8", position: 8),
+            RuntimeDecodeBatchRowMetadata(row: "e", signature: "offset:4", position: 4),
+        ]
+
+        XCTAssertEqual(RuntimeDecodeBatchPlanner.selectRows(rows), ["a", "e"])
+    }
+
+    func testDecodeBatchPlannerSelectsLargestGroupAtEarliestPosition() {
+        let rows = [
+            RuntimeDecodeBatchRowMetadata(row: "a", signature: "offset:4-full", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "b", signature: "offset:4-linear", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "c", signature: "offset:4-linear", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "d", signature: "offset:4-linear", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "e", signature: "offset:4-full", position: 4),
+        ]
+
+        XCTAssertEqual(RuntimeDecodeBatchPlanner.selectRows(rows), ["b", "c", "d"])
+    }
+
+    func testDecodeBatchPlannerCatchesUpEarliestRowBeforeLaterCompatibleBatch() {
+        let rows = [
+            RuntimeDecodeBatchRowMetadata(row: "short", signature: "offset:4", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "long-a", signature: "offset:8", position: 8),
+            RuntimeDecodeBatchRowMetadata(row: "long-b", signature: "offset:8", position: 8),
+        ]
+
+        XCTAssertEqual(RuntimeDecodeBatchPlanner.selectRows(rows), ["short"])
+    }
+
+    func testDecodeBatchPlannerAllowsVariablePositionRowsWithCompatibleSignature() {
+        let rows = [
+            RuntimeDecodeBatchRowMetadata(row: "short", signature: "linear-shape", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "middle", signature: "linear-shape", position: 8),
+            RuntimeDecodeBatchRowMetadata(row: "long", signature: "linear-shape", position: 12),
+        ]
+
+        XCTAssertEqual(RuntimeDecodeBatchPlanner.selectRows(rows), ["short", "middle", "long"])
+    }
+
+    func testDecodeBatchPositionKindCountsVariablePositionBatch() {
+        XCTAssertEqual(RuntimeDecodeBatchPositionKind.variablePositionBatchCount([4, 4, 4]), 0)
+        XCTAssertEqual(RuntimeDecodeBatchPositionKind.variablePositionBatchCount([4, 8]), 1)
+    }
+
+    func testDecodeBatchPlannerCatchesUpShortestRowWhenNoRowsAreCompatible() {
+        let rows = [
+            RuntimeDecodeBatchRowMetadata(row: "long", signature: "offset:12", position: 12),
+            RuntimeDecodeBatchRowMetadata(row: "short", signature: "offset:4", position: 4),
+            RuntimeDecodeBatchRowMetadata(row: "middle", signature: "offset:8", position: 8),
+        ]
+
+        XCTAssertEqual(RuntimeDecodeBatchPlanner.selectRows(rows), ["short"])
+    }
+
+    func testDecodeBatchPlannerPreservesSingleEligibleRow() {
+        let rows = [
+            RuntimeDecodeBatchRowMetadata(row: "only", signature: "offset:4", position: 4),
+        ]
+
+        XCTAssertEqual(RuntimeDecodeBatchPlanner.selectRows(rows), ["only"])
+    }
+}

--- a/Tests/MereRunCoreTests/RuntimeModelSettingsTests.swift
+++ b/Tests/MereRunCoreTests/RuntimeModelSettingsTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class RuntimeModelSettingsTests: XCTestCase {
+    func testSettingsRoundTripAndAliasResolution() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        let settings = RuntimeModelSettings(
+            alias: "chat-default",
+            pinned: true,
+            ttlSeconds: 600,
+            maxContextTokens: 8192,
+            maxTokens: 512,
+            temperature: 0.4,
+            topP: 0.8,
+            engineOverride: .textChatGemma4
+        )
+
+        try store.writeSettings(settings, for: Gemma4Resources.defaultModelId)
+        let loaded = try store.settings(for: Gemma4Resources.defaultModelId)
+
+        XCTAssertEqual(loaded.alias, "chat-default")
+        XCTAssertTrue(loaded.pinned)
+        XCTAssertEqual(loaded.ttlSeconds, 600)
+        XCTAssertEqual(loaded.maxContextTokens, 8192)
+        XCTAssertEqual(loaded.maxTokens, 512)
+        XCTAssertEqual(loaded.temperature, 0.4)
+        XCTAssertEqual(loaded.topP, 0.8)
+        XCTAssertEqual(loaded.engineOverride, .textChatGemma4)
+        XCTAssertEqual(
+            try store.resolveModelID(aliasOrID: "chat-default", defaultModelID: "fallback"),
+            Gemma4Resources.defaultModelId
+        )
+    }
+
+    func testSettingsRejectUnsupportedAndIncompatibleEngine() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+
+        XCTAssertThrowsError(
+            try store.writeSettings(
+                RuntimeModelSettings(engineOverride: .textChatQ35),
+                for: Gemma4Resources.defaultModelId
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("not compatible"))
+        }
+
+        XCTAssertThrowsError(
+            try store.writeSettings(RuntimeModelSettings(alias: "image"), for: "image-zimage-nano")
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("not supported"))
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-runtime-settings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ Public tree:
 - `mere.run music generate`
 - `mere.run video generate`
 - `mere.run video export-latents`
-- `mere.run model { list, capabilities, info, pull, remove, repair-manifests }`
+- `mere.run model { list, capabilities, info, pull, remove, runtime, repair-manifests }`
 - `mere.run status`
 - `mere.run api serve`
 - `mere.run setup`
@@ -93,6 +93,7 @@ For subsystem-specific implementation guides, see:
 swift run mere.run model list
 swift run mere.run status
 swift run mere.run model capabilities
+swift run mere.run model runtime get text-chat-gemma4
 swift run mere.run model pull image-zimage-nano
 swift run mere.run model info image-zimage-nano
 ```
@@ -649,6 +650,11 @@ swift run mere.run model list
 Show a quick local snapshot: whether the API server answers, which model it
 reports as loaded through `/v1/models`, the active model-store path/source, and
 which managed models are installed in that store.
+When the server exposes the native runtime pool, JSON status also includes pool
+entries, active request counts, request admission queue depth, the memory
+snapshot, runtime capability flags, aggregate cache stats, per-model prefix KV
+cache stats, per-model decode batching stats when enabled, aggregate benchmark
+stats from completed native chat requests, and the runtime settings path.
 
 ```bash
 swift run mere.run status
@@ -663,6 +669,37 @@ Useful options:
 - `--api-key`: bearer token for `/v1/models`, also read from `MERERUN_API_KEY`
 - `--timeout-seconds`: network probe timeout
 - `--json`: emit a structured snapshot for scripts and agents
+
+### `mere.run model runtime get`
+
+Read typed per-model API runtime settings from the active model store.
+
+```bash
+swift run mere.run model runtime get text-chat-gemma4
+swift run mere.run model runtime get text-chat-gemma4 --json
+```
+
+Settings are stored at
+`<active model store>/.mere-run/runtime-model-settings.json` and follow
+`--models-root` / `MERERUN_MODELS_DIR`.
+
+### `mere.run model runtime set`
+
+Update typed API serving defaults for a managed API-capable model.
+
+```bash
+swift run mere.run model runtime set text-chat-gemma4 \
+  --alias chat-default \
+  --pinned \
+  --ttl-seconds 3600 \
+  --max-context-tokens 8192 \
+  --max-tokens 1024 \
+  --temperature 0.6 \
+  --top-p 0.9
+```
+
+Use the matching `--clear-*` flags to remove optional values. Engine overrides
+are validated against the curated catalog.
 
 ### `mere.run model pull`
 
@@ -728,6 +765,10 @@ Current endpoint surface:
 - `GET /health`
 - `GET /v1/models`
 - `POST /v1/chat/completions`
+- `GET /runtime/status`
+- `POST /runtime/models/{id}/load`
+- `POST /runtime/models/{id}/unload`
+- `GET/PATCH /runtime/models/{id}/settings`
 
 Security defaults:
 
@@ -735,6 +776,31 @@ Security defaults:
 - non-loopback binds require `--api-key` or `MERERUN_API_KEY`
 - `POST /v1/chat/completions` requires `Content-Type: application/json`
 - `--rate-limit-per-minute` applies basic request throttling to `POST /v1/chat/completions`
+- `--max-active-requests` controls fair FIFO chat admission; the default `1`
+  preserves serialized local inference while exposing queue depth in status;
+  queued client cancellations are removed from the FIFO instead of running later
+- Gemma4 and Q35 use chunked prefill checkpoints for long prompts.
+- Gemma4 can opt into an in-memory prefix KV reuse prototype with
+  `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; runtime status reports entries, hits, and
+  reused tokens when a Gemma4 model is loaded, including semantic chat-prefix
+  checkpoints before the final message when token prefixes match exactly
+- Q35 can opt into text-only in-memory prefix KV reuse with
+  `MERERUN_Q35_PREFIX_KV_CACHE=1`; vision prompts are excluded from reuse, and
+  text-only requests use the same semantic chat-prefix checkpoints as Gemma4
+- Gemma4 and Q35 can opt into decode batching with
+  `MERERUN_GEMMA4_CONTINUOUS_BATCHING=1` or
+  `MERERUN_Q35_CONTINUOUS_BATCHING=1`; use `--max-active-requests` above `1` to
+  allow overlap, and status reports actual batched decode steps and max observed
+  batch size; Gemma4 full-attention rows stay same-position because that path
+  still uses scalar RoPE/cache offsets, while Q35 full-attention rows use
+  row-offset-aware ragged KV caches and Q35 linear rows use typed recurrent
+  state so compatible Q35 rows can batch across decode positions; the scheduler
+  services the earliest decode position first by batching compatible rows there
+  or advancing one lower-offset row until it can join a compatible batch
+- `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
+  batched decode steps, completed chat requests, generated tokens, and average
+  load/prefill/decode timings across loaded models under `cacheStats` and
+  `benchmarkStats`
 - generation parameters are bounded before execution; for example, `max_tokens` must fit the configured context size
 - LoRA adapters for the API server are selected by the operator with `--lora`; request bodies cannot provide local LoRA paths
 
@@ -761,11 +827,11 @@ Examples:
 swift run mere.run api serve
 swift run mere.run api serve --engine text-chat-gemma4
 swift run mere.run api serve --engine text-code --model ./Qwen3-Coder-Next-Q4_K_M.gguf
-swift run mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY" --rate-limit-per-minute 120
+swift run mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY" --rate-limit-per-minute 120 --max-active-requests 1
 ```
 
 After starting a server, run `swift run mere.run status` from another terminal
-to confirm `/health`, `/v1/models`, and the served model.
+to confirm `/health`, `/v1/models`, the runtime pool, and the served model.
 
 ### `mere.run setup`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -714,6 +714,26 @@ swift run mere.run model pull --all
 
 Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
+### `mere.run model benchmark gemma4-kv`
+
+Run a fixed-token real-checkpoint Gemma4 KV cache comparison. The command runs
+the selected Gemma4 model twice in one process: default Gemma4 KV settings first,
+then packed `polar` 2-bit KV from token 0. It disables EOS stopping so both
+variants decode exactly `--decode-tokens`, and reports TTFT, prefill tok/s,
+decode tok/s, end-to-end tok/s, and process resident memory before and after
+each variant.
+
+```bash
+swift run mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --decode-tokens 48 \
+  --json
+```
+
+Use `--prompt`, `--prompt-file`, or `--prompt-repeat` to control prompt length.
+The default fixture prompt is deterministic and intended for local A/B
+comparisons, not model-quality evaluation.
+
 ### `mere.run model capabilities`
 
 Show this machine's supported models, recommended setup package, and a short summary

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ Public tree:
 - `mere.run music generate`
 - `mere.run video generate`
 - `mere.run video export-latents`
-- `mere.run model { list, capabilities, info, pull, remove, runtime, repair-manifests }`
+- `mere.run model { list, capabilities, info, pull, remove, runtime, benchmark, repair-manifests }`
 - `mere.run status`
 - `mere.run api serve`
 - `mere.run setup`
@@ -718,10 +718,10 @@ Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
 Run a fixed-token real-checkpoint Gemma4 KV cache comparison. The command runs
 the selected Gemma4 model twice in one process: default Gemma4 KV settings first,
-then packed `polar` 2-bit KV from token 0. It disables EOS stopping so both
-variants decode exactly `--decode-tokens`, and reports TTFT, prefill tok/s,
-decode tok/s, end-to-end tok/s, and process resident memory before and after
-each variant.
+then model-default prefill with packed `polar` 2-bit KV from token 0 for decode. It
+disables EOS stopping so both variants decode exactly `--decode-tokens`, and
+reports TTFT, prefill tok/s, KV conversion time, decode tok/s, end-to-end tok/s,
+and process resident memory before and after each variant.
 
 ```bash
 swift run mere.run model benchmark gemma4-kv \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -798,9 +798,9 @@ Security defaults:
   services the earliest decode position first by batching compatible rows there
   or advancing one lower-offset row until it can join a compatible batch
 - Gemma4 can opt into experimental packed PolarKV with
-  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
-  not as a default speed path, until real model benchmarks beat dense or affine
-  KV decode
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
+  long-context synthetic decode testing. It is not the default until checkpoint
+  benchmarks prove the end-to-end model path.
 - `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,6 +797,10 @@ Security defaults:
   state so compatible Q35 rows can batch across decode positions; the scheduler
   services the earliest decode position first by batching compatible rows there
   or advancing one lower-offset row until it can join a compatible batch
+- Gemma4 can opt into experimental packed PolarKV with
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
+  not as a default speed path, until real model benchmarks beat dense or affine
+  KV decode
 - `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,57 @@ Provides the bearer token accepted by `mere.run api serve` for `/v1/models` and
 This is optional for loopback-only usage and required for non-loopback binds.
 `mere.run status` also reads it when probing `/v1/models`.
 
+## Runtime experiments
+
+### `MERERUN_GEMMA4_PREFIX_KV_CACHE`
+
+Set to `1` to enable the in-memory Gemma4 prefix KV reuse prototype in
+`mere.run api serve`. This stores bounded, forked Gemma4 prompt-prefix cache
+state for matching token prefixes and reports entries, hits, and reused tokens
+through `/runtime/status`. When the final chat message changes but the earlier
+system/tool/chat prefix is identical, Gemma4 stores that semantic prefix as an
+extra checkpoint before continuing normal prefill chunks. The bounded cache
+keeps semantic checkpoints ahead of ordinary chunk checkpoints when pruning.
+
+Continuous batching and SSD KV cache are not enabled by this flag.
+
+### `MERERUN_Q35_PREFIX_KV_CACHE`
+
+Set to `1` to enable the in-memory Q35 text-only prefix KV reuse prototype in
+`mere.run api serve`. Q35 vision prompts are excluded because image embeddings
+change the effective prefix even when the token ids match. Runtime status uses
+the same prefix KV counters as Gemma4. Text-only Q35 requests also store the
+stable chat prefix before the final message as an extra checkpoint when it is an
+exact token prefix of the full prompt, and the bounded cache gives those
+semantic checkpoints the same pruning priority as Gemma4.
+
+### `MERERUN_GEMMA4_CONTINUOUS_BATCHING`
+
+Set to `1` to enable the Gemma4 same-offset decode batching prototype in
+`mere.run api serve`. It packs overlapping Gemma4 decode rows with equal KV
+offsets into typed batched KV caches, splits the cache rows back after each
+step, and reports same-position batched decode steps, queued rows, and max
+observed batch size through `/runtime/status`. Gemma4 variable-position decode
+batching is not enabled because its current attention path applies RoPE with
+scalar cache offsets.
+
+### `MERERUN_Q35_CONTINUOUS_BATCHING`
+
+Set to `1` to enable the Q35 decode batching prototype in `mere.run api serve`.
+It uses Q35's typed full-attention and linear-attention cache states. Full
+attention can batch different decode positions through row-offset-aware ragged
+KV caches, and linear attention can batch different decode positions through
+typed recurrent state when cache shapes are compatible. Runtime status reports
+same-position and variable-position batched decode steps.
+
+This is deliberately narrower than arbitrary continuous batching: prefill still
+runs as cancellable per-request chunks, and cache rows batch only when their
+typed state proves compatibility. Gemma4 full-attention rows remain
+same-position because that engine still uses scalar cache offsets. The scheduler
+services the earliest decode position first by batching compatible rows there or
+advancing one lower-offset row until it can join a compatible batch. The feature
+needs `--max-active-requests` above `1` before requests can overlap.
+
 ## Debug toggles
 
 These are quiet by default and are intended for troubleshooting deeper runtime paths.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -109,6 +109,10 @@ swift run mere.run api serve \
   decode positions; the scheduler services the earliest decode position first,
   batching compatible rows there or advancing a single lower-offset row until it
   can join one
+- Gemma4 has an experimental packed PolarKV path behind
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
+  not as a default speed path, until real model benchmarks beat dense or affine
+  KV decode
 - `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
   steps across loaded models under `cacheStats`; it also reports completed chat
   request counts, generated tokens, and average load/prefill/decode timings

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -5,6 +5,8 @@ This page covers `mere.run api serve`, the local API surface exposed by the pack
 ## Public surface
 
 - `mere.run api serve`
+- `mere.run model runtime get`
+- `mere.run model runtime set`
 - `mere.run status`
 
 ## What it is for
@@ -44,6 +46,19 @@ reports:
 swift run mere.run status
 ```
 
+Optional per-model defaults live with the active model store:
+
+```bash
+swift run mere.run model runtime set text-chat-gemma4 \
+  --alias chat-default \
+  --pinned \
+  --ttl-seconds 3600 \
+  --max-context-tokens 8192 \
+  --max-tokens 1024 \
+  --temperature 0.6 \
+  --top-p 0.9
+```
+
 Network-exposed example:
 
 ```bash
@@ -53,13 +68,54 @@ swift run mere.run api serve \
   --host 0.0.0.0 \
   --port 11434 \
   --api-key "$MERERUN_API_KEY" \
-  --rate-limit-per-minute 120
+  --rate-limit-per-minute 120 \
+  --max-active-requests 1
 ```
 
 ## Design notes
 
 - the API server follows the same model-resolution and model-store rules as the
   rest of the CLI
+- `ManagedModelCatalog` is the API model authority; the server does not scan
+  arbitrary model folders as request-addressable models
+- `--engine` and `--model` still define and preload the startup default, while
+  each chat request can select another installed API-capable catalog model with
+  the OpenAI `model` field
+- chat completions pass through a fair FIFO request admission actor; the default
+  `--max-active-requests 1` preserves serialized local inference and exposes
+  queue depth in status; queued client cancellations are removed from the FIFO
+  instead of being admitted later
+- Gemma4 and Q35 prefills are chunked with cancellation and progress checkpoints
+  before decode; this is cooperative single-request prefill, not continuous
+  batching
+- Gemma4 has an opt-in in-memory prefix KV reuse prototype behind
+  `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; `/runtime/status` reports cache entries,
+  hits, and reused tokens when the Gemma4 model is loaded; the cache stores
+  chunk boundaries plus the stable chat prefix before the final message when it
+  is an exact token prefix, and pruning keeps that stable prefix ahead of
+  ordinary chunk boundaries
+- Q35 has an opt-in text-only prefix KV reuse prototype behind
+  `MERERUN_Q35_PREFIX_KV_CACHE=1`; vision prompts are excluded because image
+  embeddings alter the effective prefix; text-only requests use the same stable
+  chat-prefix checkpoint and pruning rule as Gemma4
+- Gemma4 and Q35 have opt-in decode batching prototypes behind
+  `MERERUN_GEMMA4_CONTINUOUS_BATCHING=1` and
+  `MERERUN_Q35_CONTINUOUS_BATCHING=1`; set `--max-active-requests` above `1` to
+  allow overlapping rows, and `/runtime/status` reports actual batched decode
+  steps instead of assuming the scheduler is active; Gemma4 full-attention rows
+  remain same-position because that engine still uses scalar RoPE/cache offsets,
+  while Q35 full-attention rows use row-offset-aware ragged KV caches and Q35
+  linear rows use typed recurrent state so compatible Q35 rows may batch across
+  decode positions; the scheduler services the earliest decode position first,
+  batching compatible rows there or advancing a single lower-offset row until it
+  can join one
+- `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
+  steps across loaded models under `cacheStats`; it also reports completed chat
+  request counts, generated tokens, and average load/prefill/decode timings
+  under `benchmarkStats`; SSD KV persistence remains unavailable until the
+  in-memory counters justify it
+- runtime settings are stored at
+  `<active model store>/.mere-run/runtime-model-settings.json`
 - `mere.run status` is the preferred quick check before wiring an editor or
   agent to a local server
 - it is intentionally local-first
@@ -75,6 +131,27 @@ swift run mere.run api serve \
   cannot select local LoRA paths
 - streaming and JSON error paths are sanitized so the local server does not
   reflect raw internal runtime details back to clients
+
+## Runtime control endpoints
+
+The control endpoints use the same bearer-token behavior as `/v1/models` and
+`/v1/chat/completions`.
+
+- `GET /runtime/status`: server health, pool entries, active request counts,
+  request admission state, runtime capability flags, memory snapshot, settings
+  path, aggregate cache stats, per-model prefix KV cache stats, per-model decode
+  batching stats when enabled, and aggregate benchmark stats measured from
+  completed native chat requests.
+- `POST /runtime/models/{id}/load`: explicitly load an installed API-capable
+  catalog model.
+- `POST /runtime/models/{id}/unload`: unload a model; returns `409` while
+  active requests are using it.
+- `GET /runtime/models/{id}/settings`: read typed runtime defaults.
+- `PATCH /runtime/models/{id}/settings`: replace typed runtime defaults.
+
+`GET /v1/models` returns installed API-servable managed IDs plus configured
+aliases. Missing catalog models fail with an OpenAI-style error that tells the
+user to pull the model first.
 
 ## OpenAI chat compatibility
 
@@ -114,6 +191,20 @@ Engine compatibility:
 Streaming responses only emit assistant content tokens. Local progress labels
 stay in logs/stderr, and `stream_options.include_usage` adds the final usage
 chunk before `[DONE]`.
+
+Fair FIFO request admission is part of the runtime pool now, and Gemma4/Q35 use
+engine-specific chunked prefill checkpoints. Gemma4 and Q35 prefix KV reuse are
+available as opt-in in-memory prototypes; Q35 reuse is limited to text-only
+requests. Gemma4 and Q35 decode batching are also available as opt-in
+prototypes: they merge typed cache rows for actual batched decode calls, then
+split the rows back so each request keeps its own state. Gemma4 and Q35
+status reports same-position versus variable-position batched steps separately.
+Q35 full-attention rows can batch across different decode positions through
+row-offset-aware ragged KV caches, and Q35 linear rows can do the same when typed
+linear cache state is compatible. Gemma4 full-attention rows still require
+matching scalar offsets. SSD KV persistence remains later, measured work; use
+`cacheStats` plus `benchmarkStats` to decide whether that experiment is worth
+expanding on a real machine.
 
 If you are working on this area, read [CLI and Runtime Internals](../internals/cli-and-runtime.md) after the command source.
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -110,9 +110,9 @@ swift run mere.run api serve \
   batching compatible rows there or advancing a single lower-offset row until it
   can join one
 - Gemma4 has an experimental packed PolarKV path behind
-  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
-  not as a default speed path, until real model benchmarks beat dense or affine
-  KV decode
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
+  long-context synthetic decode testing. It is not the default until checkpoint
+  benchmarks prove the end-to-end model path.
 - `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
   steps across loaded models under `cacheStats`; it also reports completed chat
   request counts, generated tokens, and average load/prefill/decode timings

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -58,6 +58,9 @@ fi
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null
 "$mere_run_bin" model --help >/dev/null
+"$mere_run_bin" model runtime --help >/dev/null
+"$mere_run_bin" model runtime get --help >/dev/null
+"$mere_run_bin" model runtime set --help >/dev/null
 "$mere_run_bin" status --help >/dev/null
 "$mere_run_bin" api serve --help >/dev/null
 


### PR DESCRIPTION
## Summary
- add a native RuntimeModelPool behind `mere.run api serve` with per-model settings, load/unload/settings endpoints, and `model runtime` CLI controls
- expand runtime/status surfaces with pool state, active request counts, cache stats, and benchmark timing summaries
- add fair request admission, Gemma4/Q35 prefix KV reuse, chunked prefill, opt-in decode batching, and proved Q35 ragged full-attention variable-position batching
- wire SwiftUI model-sheet runtime controls and update docs/guides/check coverage

## Validation
- `swift test --filter 'Q35ConfigDecodingTests|RuntimeCacheStatsTests|StatusCommandTests'`
- `./scripts/check.sh`
- `pnpm docs:build`
- `git diff --check`

## Notes
- Gemma4 full-attention batching remains same-position because that path still uses scalar offsets.
- Q35 full-attention rows can batch across different decode positions via row-offset-aware ragged KV caches, with tests comparing batched logits to independent rows.
- SSD KV persistence remains intentionally out of scope until runtime counters justify it.