### PR TITLE
Add experimental Gemma4 PolarKV cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ swift run mere.run api serve \
   --kv-quant-scheme polar \
   --kv-bits 2
 
-# Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs PolarKV
+# Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs decode-deferred PolarKV
 swift run mere.run model benchmark gemma4-kv \
   --model text-chat-gemma4-turbo \
   --decode-tokens 48 \

--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ swift run mere.run api serve \
   --kv-quant-scheme polar \
   --kv-bits 2
 
+# Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs PolarKV
+swift run mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --decode-tokens 48 \
+  --json
+
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
 swift run mere.run api serve \

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ MERERUN_Q35_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
   --engine text-chat-q35 \
   --max-active-requests 2
 
-# Experimental Gemma4 packed PolarKV for memory-pressure testing
+# Experimental Gemma4 packed PolarKV for memory-pressure and long-context decode testing
 swift run mere.run api serve \
   --engine text-chat-gemma4 \
   --kv-quant-scheme polar \

--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ MERERUN_Q35_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
   --engine text-chat-q35 \
   --max-active-requests 2
 
+# Experimental Gemma4 packed PolarKV for memory-pressure testing
+swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --kv-quant-scheme polar \
+  --kv-bits 2
+
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
 swift run mere.run api serve \

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -79,10 +79,10 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Context size (default: 32768).")
     var contextSize: Int = 32768
 
-    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform and integer/.5 widths for turboquant.")
+    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform/polar and integer/.5 widths for turboquant.")
     var kvBits: Double?
 
-    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform or turboquant.")
+    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform, polar, or turboquant.")
     var kvQuantScheme: String?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization group size.")
@@ -202,7 +202,7 @@ struct APIServe: AsyncParsableCommand {
         guard let scheme = Gemma4KVQuantizationScheme(
             rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ) else {
-            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform' or 'turboquant'.")
+            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform', 'polar', or 'turboquant'.")
         }
         return scheme
     }

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -353,6 +353,15 @@ enum GuideRegistry {
             resourceName: "model-runtime.md"
         ),
         GuideTopic(
+            topic: "model-benchmark",
+            title: "Model Benchmark",
+            commandPaths: [["model", "benchmark"], ["model", "benchmark", "gemma4-kv"]],
+            models: [
+                "text-chat-gemma4-turbo",
+            ],
+            resourceName: "model-benchmark.md"
+        ),
+        GuideTopic(
             topic: "model-capabilities",
             title: "Model Capabilities",
             commandPaths: [["model", "capabilities"]],

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -149,6 +149,7 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
             elapsedSeconds: elapsed,
             loadSeconds: timing.loadSeconds,
             prefillSeconds: timing.prefillSeconds,
+            cacheConversionSeconds: timing.cacheConversionSeconds,
             decodeSeconds: timing.decodeSeconds,
             firstTokenSeconds: timing.firstTokenSeconds,
             prefillTokensPerSecond: promptTokens > 0 && timing.prefillSeconds > 0
@@ -234,6 +235,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
     let elapsedSeconds: Double
     let loadSeconds: Double
     let prefillSeconds: Double
+    let cacheConversionSeconds: Double?
     let decodeSeconds: Double
     let firstTokenSeconds: Double?
     let prefillTokensPerSecond: Double?
@@ -244,7 +246,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
 
     var ttftSeconds: Double? {
         guard let firstTokenSeconds else { return nil }
-        return loadSeconds + prefillSeconds + firstTokenSeconds
+        return loadSeconds + prefillSeconds + (cacheConversionSeconds ?? 0) + firstTokenSeconds
     }
 
     enum CodingKeys: String, CodingKey {
@@ -257,6 +259,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         case elapsedSeconds
         case loadSeconds
         case prefillSeconds
+        case cacheConversionSeconds
         case decodeSeconds
         case firstTokenSeconds
         case ttftSeconds
@@ -278,6 +281,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         try container.encode(elapsedSeconds, forKey: .elapsedSeconds)
         try container.encode(loadSeconds, forKey: .loadSeconds)
         try container.encode(prefillSeconds, forKey: .prefillSeconds)
+        try container.encodeIfPresent(cacheConversionSeconds, forKey: .cacheConversionSeconds)
         try container.encode(decodeSeconds, forKey: .decodeSeconds)
         try container.encodeIfPresent(firstTokenSeconds, forKey: .firstTokenSeconds)
         try container.encodeIfPresent(ttftSeconds, forKey: .ttftSeconds)
@@ -292,7 +296,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         [
             "\(name): \(kvScheme)\(kvBits.map { String(format: " %.1f-bit", $0) } ?? "") start=\(quantizedKVStart)",
             "  prompt_tokens=\(promptTokens) generated_tokens=\(generatedTokens)",
-            "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
+            "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s kv_convert=\(formatOptional(cacheConversionSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
             "  throughput prefill=\(formatOptional(prefillTokensPerSecond)) tok/s decode=\(formatOptional(decodeTokensPerSecond)) tok/s e2e=\(formatOptional(endToEndTokensPerSecond)) tok/s",
             "  resident_memory before=\(formatBytes(residentMemoryBeforeBytes)) after=\(formatBytes(residentMemoryAfterBytes))",
             "",

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -1,0 +1,335 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+#if canImport(Darwin)
+import Darwin
+#endif
+
+struct ModelBenchmark: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "benchmark",
+        abstract: "Run focused local model benchmarks.",
+        subcommands: [
+            ModelBenchmarkGemma4KV.self,
+        ]
+    )
+}
+
+struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gemma4-kv",
+        abstract: "Compare Gemma4 default KV cache decode against packed PolarKV."
+    )
+
+    @Option(name: [.long], help: "Gemma4 model id or repo id.")
+    var model: String = Gemma4Resources.turboModelId
+
+    @Option(name: [.customShort("m"), .long], help: "Override model root directory.")
+    var modelRoot: String?
+
+    @Option(name: [.customShort("p"), .long], help: "Benchmark prompt. Defaults to a repeated deterministic fixture.")
+    var prompt: String?
+
+    @Option(name: [.long], help: "Read the benchmark prompt from a UTF-8 file.")
+    var promptFile: String?
+
+    @Option(name: [.long], help: "Repeat count for the built-in fixture prompt.")
+    var promptRepeat: Int = 220
+
+    @Option(name: [.long], help: "Exact number of decode tokens to force per variant.")
+    var decodeTokens: Int = 48
+
+    @Option(name: [.long], help: "Temperature for benchmark sampling.")
+    var temperature: Double = 0
+
+    @Option(name: [.long], help: "Top-p for benchmark sampling.")
+    var topP: Double = 1
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    func validate() throws {
+        if prompt != nil && promptFile != nil {
+            throw ValidationError("Specify either --prompt or --prompt-file, not both.")
+        }
+        guard promptRepeat > 0 else {
+            throw ValidationError("--prompt-repeat must be greater than zero.")
+        }
+        guard decodeTokens > 0 else {
+            throw ValidationError("--decode-tokens must be greater than zero.")
+        }
+        guard Gemma4Resources.handles(modelSpec: model) else {
+            throw ValidationError("model benchmark gemma4-kv only supports Gemma4 model ids or repo ids.")
+        }
+    }
+
+    func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: json)
+        let prompt = try resolvePrompt()
+        let request = ChatRequest(
+            messages: [ChatMessage(role: .user, content: prompt)],
+            maxTokens: decodeTokens,
+            temperature: temperature,
+            topP: topP,
+            showThinking: false,
+            stopOnEOS: false
+        )
+
+        let variants = [
+            Gemma4KVBenchmarkVariant.defaultTurbo(model: model),
+            Gemma4KVBenchmarkVariant.polar2(model: model),
+        ]
+        var results: [Gemma4KVBenchmarkVariantResult] = []
+        results.reserveCapacity(variants.count)
+
+        for variant in variants {
+            let result = try await runVariant(variant, request: request)
+            guard result.generatedTokens == decodeTokens else {
+                throw ValidationError(
+                    "\(variant.name) generated \(result.generatedTokens) tokens, expected \(decodeTokens). Reduce prompt length or decode tokens."
+                )
+            }
+            results.append(result)
+        }
+
+        let report = Gemma4KVBenchmarkReport(
+            model: model,
+            promptCharacters: prompt.count,
+            requestedDecodeTokens: decodeTokens,
+            variants: results
+        )
+        if json {
+            print(try report.jsonString())
+        } else {
+            print(report.renderText())
+        }
+    }
+
+    private func resolvePrompt() throws -> String {
+        if let prompt {
+            return prompt
+        }
+        if let promptFile {
+            return try String(contentsOf: URL(fileURLWithPath: promptFile).standardizedFileURL, encoding: .utf8)
+        }
+        var lines: [String] = []
+        lines.reserveCapacity(promptRepeat + 1)
+        for index in 1...promptRepeat {
+            lines.append(
+                "Record \(index): Gemma turbo benchmark passage about local inference, packed key value cache memory, decode timing, and repeatable measurements. The checksum word is polar."
+            )
+        }
+        lines.append("Question: Write one concise sentence naming the checksum word and benchmark subject.")
+        return lines.joined(separator: "\n")
+    }
+
+    private func runVariant(
+        _ variant: Gemma4KVBenchmarkVariant,
+        request: ChatRequest
+    ) async throws -> Gemma4KVBenchmarkVariantResult {
+        let generator = Gemma4Generator(modelId: model, kvCacheQuantization: variant.quantization)
+        let memoryBefore = ProcessMemorySnapshot.currentResidentBytes()
+        let start = Date()
+        let response = try await generator.chat(request, modelPath: modelRoot, progressHandler: nil)
+        let elapsed = Date().timeIntervalSince(start)
+        let memoryAfter = ProcessMemorySnapshot.currentResidentBytes()
+        await generator.unload()
+
+        guard let timing = response.timing else {
+            throw ValidationError("\(variant.name) did not return timing data.")
+        }
+        let promptTokens = response.promptTokens ?? 0
+        return Gemma4KVBenchmarkVariantResult(
+            name: variant.name,
+            kvScheme: variant.quantization.scheme.rawValue,
+            kvBits: variant.quantization.bits,
+            quantizedKVStart: variant.quantization.quantizedStart,
+            promptTokens: promptTokens,
+            generatedTokens: response.tokensGenerated,
+            elapsedSeconds: elapsed,
+            loadSeconds: timing.loadSeconds,
+            prefillSeconds: timing.prefillSeconds,
+            decodeSeconds: timing.decodeSeconds,
+            firstTokenSeconds: timing.firstTokenSeconds,
+            prefillTokensPerSecond: promptTokens > 0 && timing.prefillSeconds > 0
+                ? Double(promptTokens) / timing.prefillSeconds
+                : nil,
+            decodeTokensPerSecond: timing.decodeSeconds > 0
+                ? Double(response.tokensGenerated) / timing.decodeSeconds
+                : nil,
+            endToEndTokensPerSecond: elapsed > 0 ? Double(response.tokensGenerated) / elapsed : nil,
+            residentMemoryBeforeBytes: memoryBefore,
+            residentMemoryAfterBytes: memoryAfter
+        )
+    }
+}
+
+private struct Gemma4KVBenchmarkVariant {
+    let name: String
+    let quantization: Gemma4KVCacheQuantization
+
+    static func defaultTurbo(model: String) -> Self {
+        let usesTurboDefaults = Gemma4Resources.usesTurboDefaults(modelSpec: model)
+        return Self(
+            name: "default",
+            quantization: Gemma4KVCacheQuantization(
+                bits: usesTurboDefaults ? Gemma4Resources.defaultTurboKVBits : nil,
+                scheme: usesTurboDefaults ? Gemma4Resources.defaultTurboKVQuantizationScheme : .uniform,
+                groupSize: Gemma4Resources.defaultKVGroupSize,
+                quantizedStart: usesTurboDefaults
+                    ? Gemma4Resources.defaultTurboQuantizedKVStart
+                    : Gemma4Resources.defaultQuantizedKVStart
+            )
+        )
+    }
+
+    static func polar2(model: String) -> Self {
+        Self(
+            name: "polar2",
+            quantization: Gemma4KVCacheQuantization(
+                bits: 2,
+                scheme: .polar,
+                groupSize: Gemma4Resources.defaultKVGroupSize,
+                quantizedStart: 0
+            )
+        )
+    }
+}
+
+private struct Gemma4KVBenchmarkReport: Encodable {
+    let model: String
+    let promptCharacters: Int
+    let requestedDecodeTokens: Int
+    let variants: [Gemma4KVBenchmarkVariantResult]
+
+    func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func renderText() -> String {
+        var lines = [
+            "Gemma4 KV benchmark",
+            "model: \(model)",
+            "prompt characters: \(promptCharacters)",
+            "decode tokens: \(requestedDecodeTokens)",
+            "",
+        ]
+        for result in variants {
+            lines.append(result.renderText())
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct Gemma4KVBenchmarkVariantResult: Encodable {
+    let name: String
+    let kvScheme: String
+    let kvBits: Double?
+    let quantizedKVStart: Int
+    let promptTokens: Int
+    let generatedTokens: Int
+    let elapsedSeconds: Double
+    let loadSeconds: Double
+    let prefillSeconds: Double
+    let decodeSeconds: Double
+    let firstTokenSeconds: Double?
+    let prefillTokensPerSecond: Double?
+    let decodeTokensPerSecond: Double?
+    let endToEndTokensPerSecond: Double?
+    let residentMemoryBeforeBytes: UInt64?
+    let residentMemoryAfterBytes: UInt64?
+
+    var ttftSeconds: Double? {
+        guard let firstTokenSeconds else { return nil }
+        return loadSeconds + prefillSeconds + firstTokenSeconds
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case kvScheme
+        case kvBits
+        case quantizedKVStart
+        case promptTokens
+        case generatedTokens
+        case elapsedSeconds
+        case loadSeconds
+        case prefillSeconds
+        case decodeSeconds
+        case firstTokenSeconds
+        case ttftSeconds
+        case prefillTokensPerSecond
+        case decodeTokensPerSecond
+        case endToEndTokensPerSecond
+        case residentMemoryBeforeBytes
+        case residentMemoryAfterBytes
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(kvScheme, forKey: .kvScheme)
+        try container.encodeIfPresent(kvBits, forKey: .kvBits)
+        try container.encode(quantizedKVStart, forKey: .quantizedKVStart)
+        try container.encode(promptTokens, forKey: .promptTokens)
+        try container.encode(generatedTokens, forKey: .generatedTokens)
+        try container.encode(elapsedSeconds, forKey: .elapsedSeconds)
+        try container.encode(loadSeconds, forKey: .loadSeconds)
+        try container.encode(prefillSeconds, forKey: .prefillSeconds)
+        try container.encode(decodeSeconds, forKey: .decodeSeconds)
+        try container.encodeIfPresent(firstTokenSeconds, forKey: .firstTokenSeconds)
+        try container.encodeIfPresent(ttftSeconds, forKey: .ttftSeconds)
+        try container.encodeIfPresent(prefillTokensPerSecond, forKey: .prefillTokensPerSecond)
+        try container.encodeIfPresent(decodeTokensPerSecond, forKey: .decodeTokensPerSecond)
+        try container.encodeIfPresent(endToEndTokensPerSecond, forKey: .endToEndTokensPerSecond)
+        try container.encodeIfPresent(residentMemoryBeforeBytes, forKey: .residentMemoryBeforeBytes)
+        try container.encodeIfPresent(residentMemoryAfterBytes, forKey: .residentMemoryAfterBytes)
+    }
+
+    func renderText() -> String {
+        [
+            "\(name): \(kvScheme)\(kvBits.map { String(format: " %.1f-bit", $0) } ?? "") start=\(quantizedKVStart)",
+            "  prompt_tokens=\(promptTokens) generated_tokens=\(generatedTokens)",
+            "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
+            "  throughput prefill=\(formatOptional(prefillTokensPerSecond)) tok/s decode=\(formatOptional(decodeTokensPerSecond)) tok/s e2e=\(formatOptional(endToEndTokensPerSecond)) tok/s",
+            "  resident_memory before=\(formatBytes(residentMemoryBeforeBytes)) after=\(formatBytes(residentMemoryAfterBytes))",
+            "",
+        ].joined(separator: "\n")
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private func formatOptional(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return format(value)
+    }
+
+    private func formatBytes(_ value: UInt64?) -> String {
+        guard let value else { return "n/a" }
+        return ByteCountFormatter.string(fromByteCount: Int64(value), countStyle: .memory)
+    }
+}
+
+private enum ProcessMemorySnapshot {
+    static func currentResidentBytes() -> UInt64? {
+        #if canImport(Darwin)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return UInt64(info.resident_size)
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/MereRunCLI/Commands/ModelCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCommand.swift
@@ -11,6 +11,7 @@ struct Model: ParsableCommand {
             ModelInfo.self,
             ModelCapabilities.self,
             ModelRuntime.self,
+            ModelBenchmark.self,
             ModelRepairManifests.self,
         ]
     )

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -44,10 +44,10 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.long], help: "Top-p.")
     var topP: Double = 0.9
 
-    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform and integer/.5 widths for turboquant.")
+    @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform/polar and integer/.5 widths for turboquant.")
     var kvBits: Double?
 
-    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform or turboquant.")
+    @Option(name: [.long], help: "Gemma4 KV cache quantization backend: uniform, polar, or turboquant.")
     var kvQuantScheme: String?
 
     @Option(name: [.long], help: "Gemma4 KV cache quantization group size.")
@@ -291,7 +291,7 @@ struct TextChat: AsyncParsableCommand {
         guard let scheme = Gemma4KVQuantizationScheme(
             rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ) else {
-            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform' or 'turboquant'.")
+            throw ValidationError("Unsupported --kv-quant-scheme '\(raw)'. Expected 'uniform', 'polar', or 'turboquant'.")
         }
         return scheme
     }

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -35,7 +35,7 @@ mere.run status
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--context-size`: context limit.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure and long-context synthetic decode testing.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -35,7 +35,7 @@ mere.run status
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--context-size`: context limit.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -16,12 +16,12 @@ mere.run model benchmark gemma4-kv \
 Gemma4 checkpoint:
 
 - `default`: the model's normal Gemma4 KV cache settings.
-- `polar2`: packed 2-bit PolarKV from token 0.
+- `polar2`: model-default prefill, then packed 2-bit PolarKV from token 0 for decode.
 
 The command disables EOS stopping so both variants decode exactly
 `--decode-tokens`. Output includes prompt tokens, generated tokens, load time,
-prefill time, decode time, TTFT, prefill tok/s, decode tok/s, end-to-end tok/s,
-and process resident memory before and after each variant.
+prefill time, KV conversion time, decode time, TTFT, prefill tok/s, decode tok/s,
+end-to-end tok/s, and process resident memory before and after each variant.
 
 ## Prompt Control
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -1,0 +1,46 @@
+# Model Benchmark
+
+Run focused local model benchmarks that measure implementation tradeoffs without
+changing serving defaults.
+
+```bash
+mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --decode-tokens 48 \
+  --json
+```
+
+## Gemma4 KV Benchmark
+
+`model benchmark gemma4-kv` runs a fixed-token comparison for the selected
+Gemma4 checkpoint:
+
+- `default`: the model's normal Gemma4 KV cache settings.
+- `polar2`: packed 2-bit PolarKV from token 0.
+
+The command disables EOS stopping so both variants decode exactly
+`--decode-tokens`. Output includes prompt tokens, generated tokens, load time,
+prefill time, decode time, TTFT, prefill tok/s, decode tok/s, end-to-end tok/s,
+and process resident memory before and after each variant.
+
+## Prompt Control
+
+Use one of:
+
+- `--prompt`: inline prompt text.
+- `--prompt-file`: UTF-8 prompt file.
+- `--prompt-repeat`: repeat count for the built-in deterministic fixture.
+
+The fixture prompt is for runtime comparison only; it is not a quality eval.
+
+## Notes
+
+- Pull `text-chat-gemma4-turbo` before running the benchmark.
+- Prefer release builds for final numbers.
+- Treat memory values as process resident snapshots, not peak memory.
+
+## Sources
+
+- `Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift`
+- `Sources/MereRunCore/Gemma4/Gemma4Generator.swift`
+- `Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift`

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -24,7 +24,7 @@ mere.run text chat --help
 - `--max-tokens`: maximum generated tokens.
 - `--temperature`: randomness. Lower for factual work, higher for brainstorming.
 - `--top-p`: nucleus sampling cutoff.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure and long-context synthetic decode testing.
 - `--model-root`, `-m`: explicit local model root.
 - `--model`: canonical model id.
 - `--thinking`, `--show-thinking`: include hidden reasoning output when supported.

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -24,7 +24,7 @@ mere.run text chat --help
 - `--max-tokens`: maximum generated tokens.
 - `--temperature`: randomness. Lower for factual work, higher for brainstorming.
 - `--top-p`: nucleus sampling cutoff.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to 4-bit TurboQuant KV cache from token 0; explicit flags override that.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache quantization controls. `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure testing.
 - `--model-root`, `-m`: explicit local model root.
 - `--model`: canonical model id.
 - `--thinking`, `--show-thinking`: include hidden reasoning output when supported.

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -246,6 +246,7 @@ public actor Gemma4Generator: ChatGenerator {
             throw Gemma4Error.modelNotLoaded
         }
         let kvCacheQuantization = try self.kvCacheQuantization.validated()
+        let prefillKVCacheQuantization = prefillQuantization(for: kvCacheQuantization)
 
         let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
         let prefillStart = Date()
@@ -288,7 +289,7 @@ public actor Gemma4Generator: ChatGenerator {
         )
         let layerCaches = try prefixSeed?.caches ?? makeLayerCaches(
             model: model,
-            quantization: kvCacheQuantization
+            quantization: prefillKVCacheQuantization
         )
         let logits = try await chunkedPrefill(
             model: model,
@@ -303,6 +304,11 @@ public actor Gemma4Generator: ChatGenerator {
         )
 
         let prefillSeconds = Date().timeIntervalSince(prefillStart)
+        let preparedCaches = try prepareLayerCachesForDecode(
+            layerCaches,
+            quantization: kvCacheQuantization,
+            progressHandler: progressHandler
+        )
         let tokenBudget = max(0, min(request.maxTokens, effectiveContext - promptTokens.count))
 
         progressHandler?(ChatProgress(stage: .generating, message: ""))
@@ -311,7 +317,7 @@ public actor Gemma4Generator: ChatGenerator {
             model: model,
             tokenizerAndTemplate: tokenizerAndTemplate,
             initialLogits: logits,
-            layerCaches: layerCaches,
+            layerCaches: preparedCaches.caches,
             eosSet: eosSet,
             generationConfig: generationConfig,
             tokenBudget: tokenBudget,
@@ -333,12 +339,55 @@ public actor Gemma4Generator: ChatGenerator {
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,
+                cacheConversionSeconds: preparedCaches.conversionSeconds,
                 decodeSeconds: decodeResult.decodeSeconds,
                 firstTokenSeconds: decodeResult.firstTokenSeconds
             ),
             toolCalls: toolCalls,
             promptTokens: promptTokens.count
         )
+    }
+
+    private func prefillQuantization(for quantization: Gemma4KVCacheQuantization) -> Gemma4KVCacheQuantization {
+        guard shouldDeferQuantizationUntilDecode(quantization) else {
+            return quantization
+        }
+
+        if Gemma4Resources.usesTurboDefaults(modelSpec: modelId) {
+            return Gemma4KVCacheQuantization(
+                bits: Gemma4Resources.defaultTurboKVBits,
+                scheme: Gemma4Resources.defaultTurboKVQuantizationScheme,
+                groupSize: quantization.groupSize,
+                quantizedStart: Gemma4Resources.defaultTurboQuantizedKVStart
+            )
+        }
+
+        return Gemma4KVCacheQuantization()
+    }
+
+    private func shouldDeferQuantizationUntilDecode(_ quantization: Gemma4KVCacheQuantization) -> Bool {
+        quantization.isEnabled && quantization.scheme == .polar
+    }
+
+    private func prepareLayerCachesForDecode(
+        _ layerCaches: [Gemma4AttentionCache],
+        quantization: Gemma4KVCacheQuantization,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> (caches: [Gemma4AttentionCache], conversionSeconds: Double?) {
+        guard shouldDeferQuantizationUntilDecode(quantization) else {
+            return (layerCaches, nil)
+        }
+
+        progressHandler?(ChatProgress(stage: .encoding, message: "Packing KV cache for decode"))
+        let start = Date()
+        let converted = try layerCaches.map { cache -> Gemma4AttentionCache in
+            guard let reencoded = cache.reencoded(quantization: quantization) else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 could not reencode the prefill KV cache for decode.")
+            }
+            reencoded.evaluateStorage()
+            return reencoded
+        }
+        return (converted, Date().timeIntervalSince(start))
     }
 
     private func decodeTokens(

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -20,6 +20,7 @@ private struct Gemma4PrefixKVCacheEntry {
 private struct Gemma4BatchedDecodeResult {
     let generatedTokens: [Int]
     let decodeSeconds: Double
+    let firstTokenSeconds: Double?
 }
 
 private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
@@ -35,6 +36,7 @@ private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
     var layerCaches: [Gemma4AttentionCache]
     var generatedTokens: [Int]
     var repetitionHistory: [Int]
+    var firstTokenSeconds: Double?
     var stopped = false
 
     init(
@@ -70,7 +72,8 @@ private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
         continuation.resume(
             returning: Gemma4BatchedDecodeResult(
                 generatedTokens: generatedTokens,
-                decodeSeconds: Date().timeIntervalSince(decodeStart)
+                decodeSeconds: Date().timeIntervalSince(decodeStart),
+                firstTokenSeconds: firstTokenSeconds
             )
         )
     }
@@ -259,7 +262,9 @@ public actor Gemma4Generator: ChatGenerator {
         }
 
         let hasTools = request.tools?.isEmpty == false
-        let eosSet = Set(loadedConfig.eosTokenIds + tokenizerAndTemplate.stopTokenIds(withTools: hasTools))
+        let eosSet = request.stopOnEOS
+            ? Set(loadedConfig.eosTokenIds + tokenizerAndTemplate.stopTokenIds(withTools: hasTools))
+            : []
         let generationConfig = GenerationConfig(
             maxTokens: request.maxTokens,
             temperature: Float(request.temperature),
@@ -328,9 +333,11 @@ public actor Gemma4Generator: ChatGenerator {
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,
-                decodeSeconds: decodeResult.decodeSeconds
+                decodeSeconds: decodeResult.decodeSeconds,
+                firstTokenSeconds: decodeResult.firstTokenSeconds
             ),
-            toolCalls: toolCalls
+            toolCalls: toolCalls,
+            promptTokens: promptTokens.count
         )
     }
 
@@ -346,7 +353,7 @@ public actor Gemma4Generator: ChatGenerator {
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Gemma4BatchedDecodeResult {
         guard tokenBudget > 0 else {
-            return Gemma4BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0)
+            return Gemma4BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0, firstTokenSeconds: nil)
         }
         guard continuousBatchingEnabled else {
             return try await decodeTokensSerially(
@@ -401,6 +408,7 @@ public actor Gemma4Generator: ChatGenerator {
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
+        var firstTokenSeconds: Double?
         let decodeStart = Date()
 
         for _ in 0..<tokenBudget {
@@ -416,6 +424,9 @@ public actor Gemma4Generator: ChatGenerator {
             }
 
             generated.append(next)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(decodeStart)
+            }
             repetitionHistory.append(next)
             let piece = tokenizerAndTemplate.decode(token: next)
             if !piece.isEmpty {
@@ -432,7 +443,8 @@ public actor Gemma4Generator: ChatGenerator {
 
         return Gemma4BatchedDecodeResult(
             generatedTokens: generated,
-            decodeSeconds: Date().timeIntervalSince(decodeStart)
+            decodeSeconds: Date().timeIntervalSince(decodeStart),
+            firstTokenSeconds: firstTokenSeconds
         )
     }
 
@@ -552,6 +564,9 @@ public actor Gemma4Generator: ChatGenerator {
                 continue
             }
             row.generatedTokens.append(next)
+            if row.firstTokenSeconds == nil {
+                row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
+            }
             row.repetitionHistory.append(next)
             let piece = tokenizerAndTemplate.decode(token: next)
             if !piece.isEmpty {

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -1312,6 +1312,56 @@ final class Gemma4PolarKVCache: Gemma4AttentionCache {
         return copy
     }
 
+    static func reencoded(
+        keys: MLXArray,
+        values: MLXArray,
+        configuration: Gemma4KVCacheQuantization,
+        maxSize: Int?,
+        offset: Int
+    ) -> Gemma4PolarKVCache {
+        let cache = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+        cache.repartition(keys: keys, values: values, newOffset: offset)
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        if quantization == configuration {
+            return fork()
+        }
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: maxSize,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let leadingKeys, let leadingValues {
+            MLX.eval(leadingKeys, leadingValues)
+        }
+        if let polarKeys {
+            MLX.eval(
+                polarKeys.packed,
+                polarKeys.norms,
+                polarKeys.rotation,
+                polarKeys.rotationTransposed,
+                polarKeys.centroids
+            )
+        }
+        if let polarValues {
+            MLX.eval(
+                polarValues.packed,
+                polarValues.norms,
+                polarValues.rotation,
+                polarValues.rotationTransposed,
+                polarValues.centroids
+            )
+        }
+    }
+
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
         guard let typed = caches as? [Gemma4PolarKVCache],
               !typed.isEmpty,
@@ -1808,6 +1858,52 @@ final class Gemma4QuantizedKVCache: Gemma4AttentionCache {
         copy.quantizedValues = quantizedValues
         copy.offset = offset
         return copy
+    }
+
+    static func reencoded(
+        keys: MLXArray,
+        values: MLXArray,
+        configuration: Gemma4KVCacheQuantization,
+        maxSize: Int?,
+        offset: Int
+    ) -> Gemma4QuantizedKVCache {
+        let cache = Gemma4QuantizedKVCache(configuration: configuration, maxSize: maxSize)
+        cache.repartition(keys: keys, values: values, newOffset: offset)
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        if quantization == configuration {
+            return fork()
+        }
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: maxSize,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let leadingKeys, let leadingValues {
+            MLX.eval(leadingKeys, leadingValues)
+        }
+        if let quantizedKeys {
+            if let biases = quantizedKeys.biases {
+                MLX.eval(quantizedKeys.weight, quantizedKeys.scales, biases)
+            } else {
+                MLX.eval(quantizedKeys.weight, quantizedKeys.scales)
+            }
+        }
+        if let quantizedValues {
+            if let biases = quantizedValues.biases {
+                MLX.eval(quantizedValues.weight, quantizedValues.scales, biases)
+            } else {
+                MLX.eval(quantizedValues.weight, quantizedValues.scales)
+            }
+        }
     }
 
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -4,6 +4,7 @@ import MLXFast
 
 public enum Gemma4KVQuantizationScheme: String, Sendable, Hashable {
     case uniform
+    case polar
     case turboquant
 }
 
@@ -50,6 +51,11 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
             guard Swift.abs(bits.rounded() - bits) < 0.000_001 else {
                 throw Gemma4Error.unsupportedConfiguration("Gemma4 uniform KV quantization requires an integer bit width. Use turboquant for fractional .5 widths.")
             }
+        case .polar:
+            guard Swift.abs(bits.rounded() - bits) < 0.000_001,
+                  [2, 3, 4].contains(Int(bits.rounded())) else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 PolarKV quantization currently supports 2, 3, or 4 bits (received \(bits)).")
+            }
         case .turboquant:
             guard Swift.abs(roundedHalf - bits) < 0.000_001 else {
                 throw Gemma4Error.unsupportedConfiguration("Gemma4 turboquant currently supports integer and .5 bit widths (received \(bits)).")
@@ -62,7 +68,7 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
     var keyBits: Int? {
         guard let bits else { return nil }
         switch scheme {
-        case .uniform:
+        case .uniform, .polar:
             return Int(bits.rounded())
         case .turboquant:
             return Int(floor(bits))
@@ -72,7 +78,7 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
     var valueBits: Int? {
         guard let bits else { return nil }
         switch scheme {
-        case .uniform:
+        case .uniform, .polar:
             return Int(bits.rounded())
         case .turboquant:
             return Int(ceil(bits))
@@ -549,6 +555,313 @@ private enum Gemma4AffineFastKernels {
     }
 }
 
+private struct Gemma4PolarFastKernelKey: Hashable {
+    enum Kind: Hashable {
+        case pack
+        case unpack
+        case fusedChunkDecode
+    }
+
+    let kind: Kind
+    let bits: Int
+    let dim: Int
+    let packedWidth: Int
+    let repeats: Int
+}
+
+private enum Gemma4PolarCodebook {
+    static func centroids(bits: Int, dim: Int) -> MLXArray {
+        MLXArray(values(for: bits).map { $0 / sqrt(Float32(dim)) }, [1 << bits]).asType(.float32)
+    }
+
+    static func innerBoundaries(bits: Int, dim: Int) -> MLXArray {
+        let values = boundaries(for: bits)
+        let scale = Float32(1) / sqrt(Float32(dim))
+        return MLXArray(values.dropFirst().dropLast().map { $0 * scale }, [(1 << bits) - 1]).asType(.float32)
+    }
+
+    private static func values(for bits: Int) -> [Float32] {
+        switch bits {
+        case 2:
+            return [-1.5104, -0.4528, 0.4528, 1.5104]
+        case 3:
+            return [-2.1519, -1.3439, -0.7560, -0.2451, 0.2451, 0.7560, 1.3439, 2.1519]
+        case 4:
+            return [
+                -2.7331, -2.0698, -1.6189, -1.2570, -0.9431, -0.6573, -0.3884, -0.1285,
+                0.1285, 0.3884, 0.6573, 0.9431, 1.2570, 1.6189, 2.0698, 2.7331,
+            ]
+        default:
+            preconditionFailure("Unsupported PolarKV bit width \(bits).")
+        }
+    }
+
+    private static func boundaries(for bits: Int) -> [Float32] {
+        switch bits {
+        case 2:
+            return [-5.0, -0.9816, 0.0, 0.9816, 5.0]
+        case 3:
+            return [-5.0, -1.7479, -1.0499, -0.5005, 0.0, 0.5005, 1.0499, 1.7479, 5.0]
+        case 4:
+            return [
+                -5.0, -2.4015, -1.8443, -1.4380, -1.1001, -0.8002, -0.5229, -0.2585,
+                0.0, 0.2585, 0.5229, 0.8002, 1.1001, 1.4380, 1.8443, 2.4015, 5.0,
+            ]
+        default:
+            preconditionFailure("Unsupported PolarKV bit width \(bits).")
+        }
+    }
+}
+
+private enum Gemma4PolarRotation {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var matrices: [Int: MLXArray] = [:]
+
+    static func matrix(dim: Int) -> MLXArray {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = matrices[dim] {
+            return existing
+        }
+
+        let scale = Float32(1) / sqrt(Float32(dim))
+        let values: [Float32]
+        // The Python prototype uses seeded QR; a deterministic Hadamard rotation
+        // keeps this native prototype cheap to build for Gemma's power-of-two head dims.
+        if dim > 0 && (dim & (dim - 1)) == 0 {
+            values = (0..<dim).flatMap { row in
+                (0..<dim).map { column in
+                    ((row & column).nonzeroBitCount.isMultiple(of: 2) ? scale : -scale)
+                }
+            }
+        } else {
+            values = (0..<dim).flatMap { row in
+                (0..<dim).map { column in row == column ? Float32(1) : Float32(0) }
+            }
+        }
+
+        let matrix = MLXArray(values, [dim, dim]).asType(.float32)
+        matrices[dim] = matrix
+        return matrix
+    }
+}
+
+private enum Gemma4PolarFastKernels {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var kernels: [Gemma4PolarFastKernelKey: MLXFast.MLXFastKernel] = [:]
+
+    static func packKernel(bits: Int, dim: Int, packedWidth: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(kind: .pack, bits: bits, dim: dim, packedWidth: packedWidth, repeats: 1)
+        return kernel(
+            key: key,
+            inputNames: ["rotated", "inner_boundaries"],
+            outputNames: ["packed"],
+            source: """
+                auto packed_word = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = rotated_shape[2];
+                auto batch = n / token_count;
+                auto token = n % token_count;
+                if (packed_word >= PackedWidth || head_idx >= rotated_shape[1] || batch >= rotated_shape[0]) {
+                    return;
+                }
+
+                constexpr uint value_mask = (1u << Bits) - 1u;
+                constexpr int level_bound_count = (1 << Bits) - 1;
+                int word_start = int(packed_word) * 32;
+                int word_end = word_start + 32;
+                int start_dim = max(0, ((word_start - Bits) / Bits) + 1);
+                int end_dim = min(Dim, (word_end + Bits - 1) / Bits);
+
+                auto rotated_ptr = rotated + (((batch * rotated_shape[1] + head_idx) * token_count + token) * Dim);
+
+                uint packed_value = 0u;
+                for (int d = start_dim; d < end_dim; d++) {
+                    float v = static_cast<float>(rotated_ptr[d]);
+                    uint index = 0u;
+                    for (int boundary = 0; boundary < level_bound_count; boundary++) {
+                        index += static_cast<uint>(v > static_cast<float>(inner_boundaries[boundary]));
+                    }
+                    index &= value_mask;
+
+                    int bit_offset = d * Bits - word_start;
+                    if (bit_offset >= 0) {
+                        packed_value |= index << bit_offset;
+                    } else {
+                        packed_value |= index >> (-bit_offset);
+                    }
+                }
+
+                packed[((batch * rotated_shape[1] + head_idx) * token_count + token) * PackedWidth + packed_word] = packed_value;
+                """
+        )
+    }
+
+    static func unpackKernel(bits: Int, dim: Int, packedWidth: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(kind: .unpack, bits: bits, dim: dim, packedWidth: packedWidth, repeats: 1)
+        return kernel(
+            key: key,
+            inputNames: ["packed", "norms", "centroids"],
+            source: """
+                auto dim_idx = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = packed_shape[2];
+                auto batch = n / token_count;
+                auto token = n % token_count;
+                if (dim_idx >= Dim || head_idx >= packed_shape[1] || batch >= packed_shape[0]) {
+                    return;
+                }
+
+                auto packed_ptr = packed + (((batch * packed_shape[1] + head_idx) * token_count + token) * PackedWidth);
+                int bit_offset = int(dim_idx) * Bits;
+                int word_idx = bit_offset / 32;
+                int offset = bit_offset % 32;
+                constexpr uint value_mask = (1u << Bits) - 1u;
+
+                uint packed_value = packed_ptr[word_idx] >> offset;
+                int spill = offset + Bits - 32;
+                if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                    packed_value |= packed_ptr[word_idx + 1] << (Bits - spill);
+                }
+                packed_value &= value_mask;
+
+                float norm = static_cast<float>(norms[((batch * norms_shape[1] + head_idx) * token_count + token)]);
+                out[((batch * packed_shape[1] + head_idx) * token_count + token) * Dim + dim_idx] =
+                    static_cast<float>(centroids[packed_value]) * norm;
+                """
+        )
+    }
+
+    static func fusedChunkDecodeKernel(bits: Int, dim: Int, packedWidth: Int, repeats: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(
+            kind: .fusedChunkDecode,
+            bits: bits,
+            dim: dim,
+            packedWidth: packedWidth,
+            repeats: repeats
+        )
+        return kernel(
+            key: key,
+            inputNames: [
+                "queries",
+                "key_packed",
+                "key_norms",
+                "value_packed",
+                "value_norms",
+                "centroids",
+                "scale",
+            ],
+            outputNames: ["weighted", "normalizer", "score_max"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = key_packed_shape[2];
+                auto head_count = queries_shape[1];
+                auto batch = n / Dim;
+                auto dim_idx = n % Dim;
+                if (batch >= queries_shape[0] || head_idx >= head_count) {
+                    return;
+                }
+
+                auto kv_head = head_idx / RepeatCount;
+                auto query_ptr = queries + ((batch * head_count + head_idx) * Dim);
+                auto key_packed_ptr = key_packed + ((batch * key_packed_shape[1] + kv_head) * token_count * PackedWidth);
+                auto value_packed_ptr = value_packed + ((batch * value_packed_shape[1] + kv_head) * token_count * PackedWidth);
+                auto key_norms_ptr = key_norms + ((batch * key_norms_shape[1] + kv_head) * token_count);
+                auto value_norms_ptr = value_norms + ((batch * value_norms_shape[1] + kv_head) * token_count);
+
+                constexpr uint value_mask = (1u << Bits) - 1u;
+                int value_bit_offset = dim_idx * Bits;
+                int value_word_idx = value_bit_offset / 32;
+                int value_offset = value_bit_offset % 32;
+
+                float running_max = -INFINITY;
+                float running_sum = 0.0f;
+                float running_acc = 0.0f;
+
+                for (int token = 0; token < token_count; token++) {
+                    auto key_token_packed = key_packed_ptr + token * PackedWidth;
+                    float key_norm = static_cast<float>(key_norms_ptr[token]);
+
+                    float score = 0.0f;
+                    for (int d = lane; d < Dim; d += 32) {
+                        int bit_offset = d * Bits;
+                        int word_idx = bit_offset / 32;
+                        int offset = bit_offset % 32;
+                        uint packed_value = key_token_packed[word_idx] >> offset;
+                        int spill = offset + Bits - 32;
+                        if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                            packed_value |= key_token_packed[word_idx + 1] << (Bits - spill);
+                        }
+                        packed_value &= value_mask;
+
+                        float decoded = static_cast<float>(centroids[packed_value]) * key_norm;
+                        score += static_cast<float>(query_ptr[d]) * decoded;
+                    }
+
+                    score = simd_sum(score) * static_cast<float>(scale);
+
+                    auto value_token_packed = value_packed_ptr + token * PackedWidth;
+                    uint value_packed_word = value_token_packed[value_word_idx] >> value_offset;
+                    int value_spill = value_offset + Bits - 32;
+                    if (value_spill > 0 && (value_word_idx + 1) < PackedWidth) {
+                        value_packed_word |= value_token_packed[value_word_idx + 1] << (Bits - value_spill);
+                    }
+                    value_packed_word &= value_mask;
+
+                    float decoded_value = static_cast<float>(centroids[value_packed_word])
+                        * static_cast<float>(value_norms_ptr[token]);
+
+                    float previous_max = running_max;
+                    running_max = max(running_max, score);
+                    float rescale = isfinite(previous_max) ? exp(previous_max - running_max) : 0.0f;
+                    float weight = exp(score - running_max);
+                    running_sum = running_sum * rescale + weight;
+                    running_acc = running_acc * rescale + weight * decoded_value;
+                }
+
+                if (thread_index_in_simdgroup == 0) {
+                    weighted[((batch * head_count + head_idx) * Dim) + dim_idx] = running_acc;
+                    if (dim_idx == 0) {
+                        normalizer[batch * head_count + head_idx] = running_sum;
+                        score_max[batch * head_count + head_idx] = running_max;
+                    }
+                }
+                """
+        )
+    }
+
+    private static func kernel(
+        key: Gemma4PolarFastKernelKey,
+        inputNames: [String],
+        outputNames: [String] = ["out"],
+        source: @autoclosure () -> String
+    ) -> MLXFast.MLXFastKernel {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = kernels[key] {
+            return existing
+        }
+
+        let kernel = MLXFast.metalKernel(
+            name: "gemma4_polar_\(key.kind)_b\(key.bits)_d\(key.dim)_pw\(key.packedWidth)_r\(key.repeats)",
+            inputNames: inputNames,
+            outputNames: outputNames,
+            source: source()
+        )
+        kernels[key] = kernel
+        return kernel
+    }
+}
+
 private func concatenatedOptional(_ lhs: MLXArray?, _ rhs: MLXArray?, axis: Int) -> MLXArray? {
     switch (lhs, rhs) {
     case (.some(let lhs), .some(let rhs)):
@@ -643,6 +956,545 @@ final class Gemma4QuantizedTensorState {
             mode: .affine,
             dtype: dtype
         )
+    }
+}
+
+final class Gemma4PolarTensorState {
+    let packed: MLXArray
+    let norms: MLXArray
+    let bits: Int
+    let dtype: DType
+    let headDim: Int
+    let rotation: MLXArray
+    let rotationTransposed: MLXArray
+    let centroids: MLXArray
+    let innerBoundaries: MLXArray
+
+    var tokenCount: Int {
+        packed.dim(2)
+    }
+
+    var packedWidth: Int {
+        packed.dim(3)
+    }
+
+    init(source: MLXArray, bits: Int) {
+        let headDim = source.dim(3)
+        let rotation = Gemma4PolarRotation.matrix(dim: headDim)
+        let rotationTransposed = rotation.transposed()
+        let centroids = Gemma4PolarCodebook.centroids(bits: bits, dim: headDim)
+        let innerBoundaries = Gemma4PolarCodebook.innerBoundaries(bits: bits, dim: headDim)
+        let source32 = source.asType(.float32)
+        let norms = MLX.sqrt(MLX.sum(source32 * source32, axis: -1, keepDims: true))
+        let normalized = source32 / MLX.maximum(norms, MLXArray(Float32(1e-8)))
+        let rotated = MLX.matmul(normalized, rotationTransposed)
+        let packedWidth = (headDim * bits + 31) / 32
+        let packKernel = Gemma4PolarFastKernels.packKernel(bits: bits, dim: headDim, packedWidth: packedWidth)
+        let packed = packKernel(
+            [rotated, innerBoundaries],
+            template: [
+                ("Bits", bits),
+                ("Dim", headDim),
+                ("PackedWidth", packedWidth),
+            ],
+            grid: (packedWidth, source.dim(1), source.dim(0) * source.dim(2)),
+            threadGroup: (max(1, min(32, packedWidth)), 1, 1),
+            outputShapes: [[source.dim(0), source.dim(1), source.dim(2), packedWidth]],
+            outputDTypes: [.uint32]
+        )[0]
+
+        self.packed = packed
+        self.norms = norms
+        self.bits = bits
+        self.dtype = source.dtype
+        self.headDim = headDim
+        self.rotation = rotation
+        self.rotationTransposed = rotationTransposed
+        self.centroids = centroids
+        self.innerBoundaries = innerBoundaries
+    }
+
+    init(
+        packed: MLXArray,
+        norms: MLXArray,
+        bits: Int,
+        dtype: DType,
+        headDim: Int,
+        rotation: MLXArray,
+        rotationTransposed: MLXArray,
+        centroids: MLXArray,
+        innerBoundaries: MLXArray
+    ) {
+        self.packed = packed
+        self.norms = norms
+        self.bits = bits
+        self.dtype = dtype
+        self.headDim = headDim
+        self.rotation = rotation
+        self.rotationTransposed = rotationTransposed
+        self.centroids = centroids
+        self.innerBoundaries = innerBoundaries
+    }
+
+    func appending(_ source: MLXArray) -> Gemma4PolarTensorState {
+        let next = Gemma4PolarTensorState(source: source, bits: bits)
+        return Gemma4PolarTensorState(
+            packed: concatenated([packed, next.packed], axis: 2),
+            norms: concatenated([norms, next.norms], axis: 2),
+            bits: bits,
+            dtype: dtype,
+            headDim: headDim,
+            rotation: rotation,
+            rotationTransposed: rotationTransposed,
+            centroids: centroids,
+            innerBoundaries: innerBoundaries
+        )
+    }
+
+    func dequantized() -> MLXArray {
+        dequantized(packed: packed, norms: norms)
+    }
+
+    func dequantized(tokenRange: Range<Int>) -> MLXArray {
+        dequantized(
+            packed: packed[0..., 0..., tokenRange, 0...],
+            norms: norms[0..., 0..., tokenRange, 0...]
+        )
+    }
+
+    private func dequantized(packed: MLXArray, norms: MLXArray) -> MLXArray {
+        let unpackKernel = Gemma4PolarFastKernels.unpackKernel(bits: bits, dim: headDim, packedWidth: packedWidth)
+        let roundedDim = ((headDim + 31) / 32) * 32
+        let rotated = unpackKernel(
+            [packed, norms, centroids],
+            template: [
+                ("Bits", bits),
+                ("Dim", headDim),
+                ("PackedWidth", packedWidth),
+            ],
+            grid: (roundedDim, packed.dim(1), packed.dim(0) * packed.dim(2)),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[packed.dim(0), packed.dim(1), packed.dim(2), headDim]],
+            outputDTypes: [.float32]
+        )[0]
+        return MLX.matmul(rotated, rotation).asType(dtype)
+    }
+}
+
+final class Gemma4PolarKVCache: Gemma4AttentionCache {
+    private static let decodeChunkSize = 2_048
+
+    private let configuration: Gemma4KVCacheQuantization
+    private let maxSize: Int?
+
+    private var leadingKeys: MLXArray?
+    private var leadingValues: MLXArray?
+    private var polarKeys: Gemma4PolarTensorState?
+    private var polarValues: Gemma4PolarTensorState?
+
+    private(set) var offset: Int = 0
+
+    init(configuration: Gemma4KVCacheQuantization, maxSize: Int?) {
+        self.configuration = configuration
+        self.maxSize = maxSize
+    }
+
+    func currentState() -> (MLXArray, MLXArray)? {
+        reconstructState()
+    }
+
+    func append(keys: MLXArray, values: MLXArray) {
+        guard maxSize != nil else {
+            appendUnbounded(keys: keys, values: values)
+            return
+        }
+
+        let existing = reconstructState()
+        let combinedKeys: MLXArray
+        let combinedValues: MLXArray
+        if let existing {
+            combinedKeys = concatenated([existing.0, keys], axis: 2)
+            combinedValues = concatenated([existing.1, values], axis: 2)
+        } else {
+            combinedKeys = keys
+            combinedValues = values
+        }
+
+        let newOffset = offset + keys.dim(2)
+        var keptKeys = combinedKeys
+        var keptValues = combinedValues
+        if let maxSize {
+            let totalLength = combinedKeys.dim(2)
+            if totalLength > maxSize {
+                let start = totalLength - maxSize
+                keptKeys = combinedKeys[0..., 0..., start..., 0...]
+                keptValues = combinedValues[0..., 0..., start..., 0...]
+            }
+        }
+
+        repartition(keys: keptKeys, values: keptValues, newOffset: newOffset)
+    }
+
+    private func appendUnbounded(keys: MLXArray, values: MLXArray) {
+        let tokenCount = keys.dim(2)
+        let newOffset = offset + tokenCount
+        defer { offset = newOffset }
+
+        guard let bits = configuration.keyBits else {
+            appendLeading(keys: keys, values: values)
+            return
+        }
+
+        let plainCount = max(0, min(tokenCount, configuration.quantizedStart - offset))
+        if plainCount > 0 {
+            appendLeading(
+                keys: keys[0..., 0..., ..<plainCount, 0...],
+                values: values[0..., 0..., ..<plainCount, 0...]
+            )
+        }
+
+        guard plainCount < tokenCount else {
+            return
+        }
+
+        appendPolar(
+            keys: keys[0..., 0..., plainCount..., 0...],
+            values: values[0..., 0..., plainCount..., 0...],
+            bits: bits
+        )
+    }
+
+    private func appendLeading(keys: MLXArray, values: MLXArray) {
+        if let existingKeys = leadingKeys, let existingValues = leadingValues {
+            leadingKeys = concatenated([existingKeys, keys], axis: 2)
+            leadingValues = concatenated([existingValues, values], axis: 2)
+        } else {
+            leadingKeys = keys
+            leadingValues = values
+        }
+    }
+
+    private func appendPolar(keys: MLXArray, values: MLXArray, bits: Int) {
+        if let polarKeys {
+            self.polarKeys = polarKeys.appending(keys)
+        } else {
+            polarKeys = Gemma4PolarTensorState(source: keys, bits: bits)
+        }
+
+        if let polarValues {
+            self.polarValues = polarValues.appending(values)
+        } else {
+            polarValues = Gemma4PolarTensorState(source: values, bits: bits)
+        }
+    }
+
+    func fork() -> Gemma4AttentionCache {
+        let copy = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+        copy.leadingKeys = leadingKeys
+        copy.leadingValues = leadingValues
+        copy.polarKeys = polarKeys
+        copy.polarValues = polarValues
+        copy.offset = offset
+        return copy
+    }
+
+    func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
+        guard let typed = caches as? [Gemma4PolarKVCache],
+              !typed.isEmpty,
+              typed.allSatisfy({
+                  $0.offset == offset
+                      && $0.configuration == configuration
+                      && $0.maxSize == maxSize
+              }) else {
+            return nil
+        }
+
+        let states = typed.compactMap { $0.currentState() }
+        guard states.count == typed.count else {
+            return nil
+        }
+
+        let copy = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+        copy.repartition(
+            keys: concatenated(states.map(\.0), axis: 0),
+            values: concatenated(states.map(\.1), axis: 0),
+            newOffset: offset
+        )
+        return copy
+    }
+
+    func unbatchedRows(count: Int) -> [Gemma4AttentionCache]? {
+        guard count > 0,
+              let state = currentState(),
+              state.0.dim(0) == count,
+              state.1.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = Gemma4PolarKVCache(configuration: configuration, maxSize: maxSize)
+            copy.repartition(
+                keys: state.0[index..<(index + 1), 0..., 0..., 0...],
+                values: state.1[index..<(index + 1), 0..., 0..., 0...],
+                newOffset: offset
+            )
+            return copy
+        }
+    }
+
+    func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
+        guard queries.dim(2) == 1 else {
+            return nil
+        }
+
+        if let fused = fusedSpecializedAttention(queries: queries, repeats: repeats, scale: scale) {
+            return fused
+        }
+        return chunkedSpecializedAttention(queries: queries, repeats: repeats, scale: scale)
+    }
+
+    func fusedSpecializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
+        guard Self.supportsFastKernels,
+              queries.dim(2) == 1,
+              leadingKeys == nil,
+              leadingValues == nil,
+              let polarKeys,
+              let polarValues else {
+            return nil
+        }
+
+        let queries32 = queries.asType(.float32)
+        let rotatedQueries = MLX.matmul(queries32, polarKeys.rotationTransposed)
+        var runningWeighted: MLXArray?
+        var runningNormalizer: MLXArray?
+        var runningMax: MLXArray?
+
+        let totalTokens = polarKeys.tokenCount
+        var start = 0
+        while start < totalTokens {
+            let end = min(start + Self.decodeChunkSize, totalTokens)
+            applyPolarChunkFused(
+                queries: rotatedQueries,
+                keyState: polarKeys,
+                valueState: polarValues,
+                tokenRange: start..<end,
+                repeats: repeats,
+                scale: scale,
+                runningWeighted: &runningWeighted,
+                runningNormalizer: &runningNormalizer,
+                runningMax: &runningMax
+            )
+            start = end
+        }
+
+        guard let runningWeighted, let runningNormalizer else {
+            return nil
+        }
+        return MLX.matmul(runningWeighted / runningNormalizer, polarValues.rotation).asType(queries.dtype)
+    }
+
+    private func chunkedSpecializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
+        let queries32 = queries.asType(.float32)
+
+        var runningWeighted: MLXArray?
+        var runningNormalizer: MLXArray?
+        var runningMax: MLXArray?
+
+        if let leadingKeys, let leadingValues {
+            applyChunk(
+                queries: queries32,
+                keys: leadingKeys,
+                values: leadingValues,
+                repeats: repeats,
+                scale: scale,
+                runningWeighted: &runningWeighted,
+                runningNormalizer: &runningNormalizer,
+                runningMax: &runningMax
+            )
+        }
+
+        if let polarKeys, let polarValues {
+            let totalTokens = polarKeys.tokenCount
+            if totalTokens > 0 {
+                var start = 0
+                while start < totalTokens {
+                    let end = min(start + Self.decodeChunkSize, totalTokens)
+                    applyChunk(
+                        queries: queries32,
+                        keys: polarKeys.dequantized(tokenRange: start..<end),
+                        values: polarValues.dequantized(tokenRange: start..<end),
+                        repeats: repeats,
+                        scale: scale,
+                        runningWeighted: &runningWeighted,
+                        runningNormalizer: &runningNormalizer,
+                        runningMax: &runningMax
+                    )
+                    start = end
+                }
+            }
+        }
+
+        guard let runningWeighted, let runningNormalizer else {
+            return nil
+        }
+        return (runningWeighted / runningNormalizer).asType(queries.dtype)
+    }
+
+    private func applyPolarChunkFused(
+        queries: MLXArray,
+        keyState: Gemma4PolarTensorState,
+        valueState: Gemma4PolarTensorState,
+        tokenRange: Range<Int>,
+        repeats: Int,
+        scale: Float,
+        runningWeighted: inout MLXArray?,
+        runningNormalizer: inout MLXArray?,
+        runningMax: inout MLXArray?
+    ) {
+        let packedKeys = keyState.packed[0..., 0..., tokenRange, 0...]
+        let keyNorms = keyState.norms[0..., 0..., tokenRange, 0...]
+        let packedValues = valueState.packed[0..., 0..., tokenRange, 0...]
+        let valueNorms = valueState.norms[0..., 0..., tokenRange, 0...]
+        let fusedChunkDecodeKernel = Gemma4PolarFastKernels.fusedChunkDecodeKernel(
+            bits: keyState.bits,
+            dim: queries.dim(3),
+            packedWidth: keyState.packedWidth,
+            repeats: repeats
+        )
+
+        let weightedAndStats = fusedChunkDecodeKernel(
+            [queries, packedKeys, keyNorms, packedValues, valueNorms, keyState.centroids, scale],
+            template: [
+                ("Bits", keyState.bits),
+                ("Dim", queries.dim(3)),
+                ("PackedWidth", keyState.packedWidth),
+                ("RepeatCount", repeats),
+            ],
+            grid: (32, queries.dim(1), queries.dim(0) * queries.dim(3)),
+            threadGroup: (32, 1, 1),
+            outputShapes: [
+                [queries.dim(0), queries.dim(1), 1, queries.dim(3)],
+                [queries.dim(0), queries.dim(1), 1, 1],
+                [queries.dim(0), queries.dim(1), 1, 1],
+            ],
+            outputDTypes: [.float32, .float32, .float32]
+        )
+        let chunkWeighted = weightedAndStats[0]
+        let chunkNormalizer = weightedAndStats[1]
+        let chunkMax = weightedAndStats[2]
+
+        guard let currentWeighted = runningWeighted,
+              let currentNormalizer = runningNormalizer,
+              let currentMax = runningMax else {
+            runningWeighted = chunkWeighted
+            runningNormalizer = chunkNormalizer
+            runningMax = chunkMax
+            return
+        }
+
+        let mergedMax = MLX.maximum(currentMax, chunkMax)
+        let currentScale = exp(currentMax - mergedMax)
+        let chunkScale = exp(chunkMax - mergedMax)
+        runningWeighted = currentWeighted * currentScale + chunkWeighted * chunkScale
+        runningNormalizer = currentNormalizer * currentScale + chunkNormalizer * chunkScale
+        runningMax = mergedMax
+    }
+
+    private func repartition(keys: MLXArray, values: MLXArray, newOffset: Int) {
+        let keptLength = keys.dim(2)
+        let keptStart = newOffset - keptLength
+        let plainCount = max(0, min(keptLength, configuration.quantizedStart - keptStart))
+
+        if plainCount > 0 {
+            leadingKeys = keys[0..., 0..., ..<plainCount, 0...]
+            leadingValues = values[0..., 0..., ..<plainCount, 0...]
+        } else {
+            leadingKeys = nil
+            leadingValues = nil
+        }
+
+        let polarLength = keptLength - plainCount
+        if polarLength > 0, let bits = configuration.keyBits {
+            polarKeys = Gemma4PolarTensorState(source: keys[0..., 0..., plainCount..., 0...], bits: bits)
+            polarValues = Gemma4PolarTensorState(source: values[0..., 0..., plainCount..., 0...], bits: bits)
+        } else {
+            polarKeys = nil
+            polarValues = nil
+        }
+
+        offset = newOffset
+    }
+
+    private func reconstructState() -> (MLXArray, MLXArray)? {
+        var keyParts: [MLXArray] = []
+        var valueParts: [MLXArray] = []
+
+        if let leadingKeys, let leadingValues {
+            keyParts.append(leadingKeys)
+            valueParts.append(leadingValues)
+        }
+
+        if let polarKeys, let polarValues {
+            keyParts.append(polarKeys.dequantized())
+            valueParts.append(polarValues.dequantized())
+        }
+
+        guard !keyParts.isEmpty else {
+            return nil
+        }
+
+        if keyParts.count == 1 {
+            return (keyParts[0], valueParts[0])
+        }
+
+        return (concatenated(keyParts, axis: 2), concatenated(valueParts, axis: 2))
+    }
+
+    private func applyChunk(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        repeats: Int,
+        scale: Float,
+        runningWeighted: inout MLXArray?,
+        runningNormalizer: inout MLXArray?,
+        runningMax: inout MLXArray?
+    ) {
+        guard keys.dim(2) > 0 else {
+            return
+        }
+
+        var broadcastKeys = keys.asType(.float32)
+        var broadcastValues = values.asType(.float32)
+        if repeats > 1 {
+            broadcastKeys = MLX.repeated(broadcastKeys, count: repeats, axis: 1)
+            broadcastValues = MLX.repeated(broadcastValues, count: repeats, axis: 1)
+        }
+
+        let scores = MLX.matmul(queries, broadcastKeys.transposed(0, 1, 3, 2)) * MLXArray(scale)
+        let chunkMax = scores.max(axis: -1, keepDims: true)
+        let shifted = exp(scores - chunkMax)
+        let chunkWeighted = MLX.matmul(shifted, broadcastValues)
+        let chunkNormalizer = shifted.sum(axis: -1, keepDims: true)
+
+        guard let currentWeighted = runningWeighted,
+              let currentNormalizer = runningNormalizer,
+              let currentMax = runningMax else {
+            runningWeighted = chunkWeighted
+            runningNormalizer = chunkNormalizer
+            runningMax = chunkMax
+            return
+        }
+
+        let mergedMax = MLX.maximum(currentMax, chunkMax)
+        let currentScale = exp(currentMax - mergedMax)
+        let chunkScale = exp(chunkMax - mergedMax)
+        runningWeighted = currentWeighted * currentScale + chunkWeighted * chunkScale
+        runningNormalizer = currentNormalizer * currentScale + chunkNormalizer * chunkScale
+        runningMax = mergedMax
+    }
+
+    private static var supportsFastKernels: Bool {
+        Device.defaultDevice().deviceType == .gpu
     }
 }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -559,6 +559,8 @@ private struct Gemma4PolarFastKernelKey: Hashable {
     enum Kind: Hashable {
         case pack
         case unpack
+        case score
+        case weightedValue
         case fusedChunkDecode
     }
 
@@ -733,6 +735,118 @@ private enum Gemma4PolarFastKernels {
                 float norm = static_cast<float>(norms[((batch * norms_shape[1] + head_idx) * token_count + token)]);
                 out[((batch * packed_shape[1] + head_idx) * token_count + token) * Dim + dim_idx] =
                     static_cast<float>(centroids[packed_value]) * norm;
+                """
+        )
+    }
+
+    static func scoreKernel(bits: Int, dim: Int, packedWidth: Int, repeats: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(
+            kind: .score,
+            bits: bits,
+            dim: dim,
+            packedWidth: packedWidth,
+            repeats: repeats
+        )
+        return kernel(
+            key: key,
+            inputNames: ["queries", "packed", "norms", "centroids", "scale"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = packed_shape[2];
+                auto head_count = queries_shape[1];
+                auto batch = n / token_count;
+                auto token = n % token_count;
+                if (batch >= queries_shape[0] || head_idx >= head_count) {
+                    return;
+                }
+
+                auto kv_head = head_idx / RepeatCount;
+                auto query_ptr = queries + ((batch * head_count + head_idx) * Dim);
+                auto packed_ptr = packed + (((batch * packed_shape[1] + kv_head) * token_count + token) * PackedWidth);
+                auto norms_ptr = norms + ((batch * norms_shape[1] + kv_head) * token_count);
+                float norm = static_cast<float>(norms_ptr[token]);
+
+                constexpr uint value_mask = (1u << Bits) - 1u;
+                float acc = 0.0f;
+                for (int d = lane; d < Dim; d += 32) {
+                    int bit_offset = d * Bits;
+                    int word_idx = bit_offset / 32;
+                    int offset = bit_offset % 32;
+                    uint packed_value = packed_ptr[word_idx] >> offset;
+                    int spill = offset + Bits - 32;
+                    if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                        packed_value |= packed_ptr[word_idx + 1] << (Bits - spill);
+                    }
+                    packed_value &= value_mask;
+
+                    float decoded = static_cast<float>(centroids[packed_value]) * norm;
+                    acc += static_cast<float>(query_ptr[d]) * decoded;
+                }
+
+                acc = simd_sum(acc);
+                if (thread_index_in_simdgroup == 0) {
+                    out[((batch * head_count + head_idx) * token_count) + token] =
+                        acc * static_cast<float>(scale);
+                }
+                """
+        )
+    }
+
+    static func weightedValueKernel(bits: Int, dim: Int, packedWidth: Int, repeats: Int) -> MLXFast.MLXFastKernel {
+        let key = Gemma4PolarFastKernelKey(
+            kind: .weightedValue,
+            bits: bits,
+            dim: dim,
+            packedWidth: packedWidth,
+            repeats: repeats
+        )
+        return kernel(
+            key: key,
+            inputNames: ["weights", "packed", "norms", "centroids"],
+            source: """
+                auto lane = thread_position_in_grid.x;
+                auto head_idx = thread_position_in_grid.y;
+                auto n = thread_position_in_grid.z;
+
+                auto token_count = packed_shape[2];
+                auto head_count = weights_shape[1];
+                auto batch = n / Dim;
+                auto dim_idx = n % Dim;
+                if (batch >= weights_shape[0] || head_idx >= head_count) {
+                    return;
+                }
+
+                auto kv_head = head_idx / RepeatCount;
+                auto weights_ptr = weights + ((batch * head_count + head_idx) * token_count);
+                auto packed_ptr = packed + ((batch * packed_shape[1] + kv_head) * token_count * PackedWidth);
+                auto norms_ptr = norms + ((batch * norms_shape[1] + kv_head) * token_count);
+
+                int bit_offset = dim_idx * Bits;
+                int word_idx = bit_offset / 32;
+                int offset = bit_offset % 32;
+                constexpr uint value_mask = (1u << Bits) - 1u;
+
+                float acc = 0.0f;
+                for (int token = lane; token < token_count; token += 32) {
+                    auto token_packed = packed_ptr + token * PackedWidth;
+                    uint packed_value = token_packed[word_idx] >> offset;
+                    int spill = offset + Bits - 32;
+                    if (spill > 0 && (word_idx + 1) < PackedWidth) {
+                        packed_value |= token_packed[word_idx + 1] << (Bits - spill);
+                    }
+                    packed_value &= value_mask;
+
+                    float decoded = static_cast<float>(centroids[packed_value]) * static_cast<float>(norms_ptr[token]);
+                    acc += static_cast<float>(weights_ptr[token]) * decoded;
+                }
+
+                acc = simd_sum(acc);
+                if (thread_index_in_simdgroup == 0) {
+                    out[((batch * head_count + head_idx) * Dim) + dim_idx] = acc;
+                }
                 """
         )
     }
@@ -1262,6 +1376,16 @@ final class Gemma4PolarKVCache: Gemma4AttentionCache {
             return nil
         }
 
+        if let scoreValueOutput = scoreValueSpecializedAttention(
+            queries: queries,
+            keyState: polarKeys,
+            valueState: polarValues,
+            repeats: repeats,
+            scale: scale
+        ) {
+            return scoreValueOutput
+        }
+
         let queries32 = queries.asType(.float32)
         let rotatedQueries = MLX.matmul(queries32, polarKeys.rotationTransposed)
         var runningWeighted: MLXArray?
@@ -1290,6 +1414,66 @@ final class Gemma4PolarKVCache: Gemma4AttentionCache {
             return nil
         }
         return MLX.matmul(runningWeighted / runningNormalizer, polarValues.rotation).asType(queries.dtype)
+    }
+
+    private func scoreValueSpecializedAttention(
+        queries: MLXArray,
+        keyState: Gemma4PolarTensorState,
+        valueState: Gemma4PolarTensorState,
+        repeats: Int,
+        scale: Float
+    ) -> MLXArray? {
+        let totalTokens = keyState.tokenCount
+        guard totalTokens > 0 else {
+            return nil
+        }
+
+        let queries32 = queries.asType(.float32)
+        let rotatedQueries = MLX.matmul(queries32, keyState.rotationTransposed)
+        let scoreKernel = Gemma4PolarFastKernels.scoreKernel(
+            bits: keyState.bits,
+            dim: queries.dim(3),
+            packedWidth: keyState.packedWidth,
+            repeats: repeats
+        )
+        let scores = scoreKernel(
+            [rotatedQueries, keyState.packed, keyState.norms, keyState.centroids, scale],
+            template: [
+                ("Bits", keyState.bits),
+                ("Dim", queries.dim(3)),
+                ("PackedWidth", keyState.packedWidth),
+                ("RepeatCount", repeats),
+            ],
+            grid: (32, queries.dim(1), queries.dim(0) * totalTokens),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[queries.dim(0), queries.dim(1), 1, totalTokens]],
+            outputDTypes: [.float32]
+        )[0]
+
+        let scoreMax = scores.max(axis: -1, keepDims: true)
+        let weights = exp(scores - scoreMax)
+        let normalizer = weights.sum(axis: -1, keepDims: true)
+        let weightedValueKernel = Gemma4PolarFastKernels.weightedValueKernel(
+            bits: valueState.bits,
+            dim: queries.dim(3),
+            packedWidth: valueState.packedWidth,
+            repeats: repeats
+        )
+        let weighted = weightedValueKernel(
+            [weights, valueState.packed, valueState.norms, valueState.centroids],
+            template: [
+                ("Bits", valueState.bits),
+                ("Dim", queries.dim(3)),
+                ("PackedWidth", valueState.packedWidth),
+                ("RepeatCount", repeats),
+            ],
+            grid: (32, queries.dim(1), queries.dim(0) * queries.dim(3)),
+            threadGroup: (32, 1, 1),
+            outputShapes: [[queries.dim(0), queries.dim(1), 1, queries.dim(3)]],
+            outputDTypes: [.float32]
+        )[0]
+
+        return MLX.matmul(weighted / normalizer, valueState.rotation).asType(queries.dtype)
     }
 
     private func chunkedSpecializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -94,6 +94,8 @@ protocol Gemma4AttentionCache: AnyObject {
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache?
     func unbatchedRows(count: Int) -> [Gemma4AttentionCache]?
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray?
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache?
+    func evaluateStorage()
 }
 
 extension Gemma4AttentionCache {
@@ -108,6 +110,12 @@ extension Gemma4AttentionCache {
     func specializedAttention(queries: MLXArray, repeats: Int, scale: Float) -> MLXArray? {
         nil
     }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        nil
+    }
+
+    func evaluateStorage() {}
 }
 
 final class Gemma4FullKVCache: Gemma4AttentionCache {
@@ -137,6 +145,31 @@ final class Gemma4FullKVCache: Gemma4AttentionCache {
         copy.values = values
         copy.offset = offset
         return copy
+    }
+
+    static func reencoded(keys: MLXArray, values: MLXArray, offset: Int) -> Gemma4FullKVCache {
+        let cache = Gemma4FullKVCache()
+        cache.keys = keys
+        cache.values = values
+        cache.offset = offset
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: nil,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let keys, let values {
+            MLX.eval(keys, values)
+        }
     }
 
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
@@ -218,6 +251,43 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
         return copy
     }
 
+    static func reencoded(
+        keys: MLXArray,
+        values: MLXArray,
+        offset: Int,
+        maxSize: Int
+    ) -> Gemma4SlidingKVCache {
+        let cache = Gemma4SlidingKVCache(maxSize: maxSize)
+        let totalLength = keys.dim(2)
+        if totalLength > cache.maxSize {
+            let start = totalLength - cache.maxSize
+            cache.keys = keys[0..., 0..., start..., 0...]
+            cache.values = values[0..., 0..., start..., 0...]
+        } else {
+            cache.keys = keys
+            cache.values = values
+        }
+        cache.offset = offset
+        return cache
+    }
+
+    func reencoded(quantization: Gemma4KVCacheQuantization) -> Gemma4AttentionCache? {
+        guard let state = currentState() else { return nil }
+        return makeGemma4AttentionCache(
+            keys: state.0,
+            values: state.1,
+            offset: offset,
+            maxSize: maxSize,
+            quantization: quantization
+        )
+    }
+
+    func evaluateStorage() {
+        if let keys, let values {
+            MLX.eval(keys, values)
+        }
+    }
+
     func batched(with caches: [Gemma4AttentionCache]) -> Gemma4AttentionCache? {
         guard let typed = caches as? [Gemma4SlidingKVCache],
               !typed.isEmpty,
@@ -249,6 +319,38 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
             return copy
         }
     }
+}
+
+func makeGemma4AttentionCache(
+    keys: MLXArray,
+    values: MLXArray,
+    offset: Int,
+    maxSize: Int?,
+    quantization: Gemma4KVCacheQuantization? = nil
+) -> Gemma4AttentionCache {
+    if let quantization, quantization.isEnabled {
+        if quantization.scheme == .polar {
+            return Gemma4PolarKVCache.reencoded(
+                keys: keys,
+                values: values,
+                configuration: quantization,
+                maxSize: maxSize,
+                offset: offset
+            )
+        }
+        return Gemma4QuantizedKVCache.reencoded(
+            keys: keys,
+            values: values,
+            configuration: quantization,
+            maxSize: maxSize,
+            offset: offset
+        )
+    }
+
+    if let maxSize {
+        return Gemma4SlidingKVCache.reencoded(keys: keys, values: values, offset: offset, maxSize: maxSize)
+    }
+    return Gemma4FullKVCache.reencoded(keys: keys, values: values, offset: offset)
 }
 
 final class Gemma4MLP: Module {

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -820,6 +820,9 @@ final class Gemma4LanguageModel: Module {
         config.layerTypes.prefix(firstKVSharedLayerIndex).map { layerType in
             let maxSize: Int? = layerType == "full_attention" ? nil : config.slidingWindow
             if let quantization, quantization.isEnabled {
+                if quantization.scheme == .polar {
+                    return Gemma4PolarKVCache(configuration: quantization, maxSize: maxSize)
+                }
                 return Gemma4QuantizedKVCache(configuration: quantization, maxSize: maxSize)
             }
             if let maxSize {

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -248,6 +248,7 @@ public struct ChatRequest: Sendable, Hashable {
     public var lora: LoRA?
     public var requiresJSON: Bool
     public var tools: [ToolDefinition]?
+    public var stopOnEOS: Bool
 
     public init(
         messages: [ChatMessage],
@@ -257,7 +258,8 @@ public struct ChatRequest: Sendable, Hashable {
         showThinking: Bool = true,
         lora: LoRA? = nil,
         requiresJSON: Bool = false,
-        tools: [ToolDefinition]? = nil
+        tools: [ToolDefinition]? = nil,
+        stopOnEOS: Bool = true
     ) {
         self.messages = messages
         self.maxTokens = maxTokens
@@ -267,6 +269,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.lora = lora
         self.requiresJSON = requiresJSON
         self.tools = tools
+        self.stopOnEOS = stopOnEOS
     }
 }
 
@@ -274,15 +277,18 @@ public struct ChatTiming: Sendable, Hashable {
     public var loadSeconds: Double
     public var prefillSeconds: Double
     public var decodeSeconds: Double
+    public var firstTokenSeconds: Double?
 
     public init(
         loadSeconds: Double = 0,
         prefillSeconds: Double = 0,
-        decodeSeconds: Double = 0
+        decodeSeconds: Double = 0,
+        firstTokenSeconds: Double? = nil
     ) {
         self.loadSeconds = loadSeconds
         self.prefillSeconds = prefillSeconds
         self.decodeSeconds = decodeSeconds
+        self.firstTokenSeconds = firstTokenSeconds
     }
 }
 
@@ -291,12 +297,20 @@ public struct ChatResponse: Sendable, Hashable {
     public var tokensGenerated: Int
     public var timing: ChatTiming?
     public var toolCalls: [ToolCall]?
+    public var promptTokens: Int?
 
-    public init(response: String, tokensGenerated: Int, timing: ChatTiming? = nil, toolCalls: [ToolCall]? = nil) {
+    public init(
+        response: String,
+        tokensGenerated: Int,
+        timing: ChatTiming? = nil,
+        toolCalls: [ToolCall]? = nil,
+        promptTokens: Int? = nil
+    ) {
         self.response = response
         self.tokensGenerated = tokensGenerated
         self.timing = timing
         self.toolCalls = toolCalls
+        self.promptTokens = promptTokens
     }
 }
 

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -276,17 +276,20 @@ public struct ChatRequest: Sendable, Hashable {
 public struct ChatTiming: Sendable, Hashable {
     public var loadSeconds: Double
     public var prefillSeconds: Double
+    public var cacheConversionSeconds: Double?
     public var decodeSeconds: Double
     public var firstTokenSeconds: Double?
 
     public init(
         loadSeconds: Double = 0,
         prefillSeconds: Double = 0,
+        cacheConversionSeconds: Double? = nil,
         decodeSeconds: Double = 0,
         firstTokenSeconds: Double? = nil
     ) {
         self.loadSeconds = loadSeconds
         self.prefillSeconds = prefillSeconds
+        self.cacheConversionSeconds = cacheConversionSeconds
         self.decodeSeconds = decodeSeconds
         self.firstTokenSeconds = firstTokenSeconds
     }

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -90,6 +90,20 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(quantization.quantizedStart, 128)
     }
 
+    func testAPIServeGemma4PolarKVFlagsParse() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-gemma4",
+            "--model-path", Gemma4Resources.turboModelId,
+            "--kv-bits", "2",
+            "--kv-quant-scheme", "polar",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization()
+
+        XCTAssertEqual(quantization.bits, 2)
+        XCTAssertEqual(quantization.scheme, .polar)
+    }
+
     func testHealthContractUsesStablePayload() {
         XCTAssertEqual(APIServerContract.healthStatus(), APIHealthStatus(status: "ok"))
     }

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ModelBenchmarkCommandTests: XCTestCase {
+    func testModelCommandExposesBenchmarkSubcommand() {
+        let commandNames = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("benchmark"))
+    }
+
+    func testGemma4KVBenchmarkParsesDefaults() throws {
+        let cmd = try ModelBenchmarkGemma4KV.parse([])
+
+        XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
+        XCTAssertEqual(cmd.promptRepeat, 220)
+        XCTAssertEqual(cmd.decodeTokens, 48)
+        XCTAssertEqual(cmd.temperature, 0)
+        XCTAssertEqual(cmd.topP, 1)
+        XCTAssertFalse(cmd.json)
+    }
+
+    func testGemma4KVBenchmarkParsesOverrides() throws {
+        let cmd = try ModelBenchmarkGemma4KV.parse([
+            "--model", Gemma4Resources.turboModelId,
+            "--model-root", "/tmp/gemma4",
+            "--prompt", "Benchmark this",
+            "--decode-tokens", "32",
+            "--temperature", "0.2",
+            "--top-p", "0.7",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
+        XCTAssertEqual(cmd.modelRoot, "/tmp/gemma4")
+        XCTAssertEqual(cmd.prompt, "Benchmark this")
+        XCTAssertEqual(cmd.decodeTokens, 32)
+        XCTAssertEqual(cmd.temperature, 0.2)
+        XCTAssertEqual(cmd.topP, 0.7)
+        XCTAssertTrue(cmd.json)
+    }
+}

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -69,4 +69,18 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertEqual(quantization.groupSize, 32)
         XCTAssertEqual(quantization.quantizedStart, 128)
     }
+
+    func testGemma4PolarKVFlagsParse() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+            "--model", Gemma4Resources.turboModelId,
+            "--kv-bits", "2",
+            "--kv-quant-scheme", "polar",
+        ])
+
+        let quantization = try cmd.resolveGemma4KVCacheQuantization(for: Gemma4Resources.turboModelId)
+
+        XCTAssertEqual(quantization.bits, 2)
+        XCTAssertEqual(quantization.scheme, .polar)
+    }
 }

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -215,6 +215,51 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         }
     }
 
+    func testFullCacheReencodesToPolarPreservingOffset() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(36)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0)
+            .validated()
+        let cache = Gemma4FullKVCache()
+        let keys = MLXRandom.normal([1, 1, 4, 32]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, 1, 4, 32]).asType(.bfloat16)
+        cache.append(keys: keys, values: values)
+
+        let reencoded = try XCTUnwrap(cache.reencoded(quantization: config) as? Gemma4PolarKVCache)
+        reencoded.evaluateStorage()
+        let state = try XCTUnwrap(reencoded.currentState())
+
+        XCTAssertEqual(reencoded.offset, 4)
+        XCTAssertEqual(state.0.shape, [1, 1, 4, 32])
+        XCTAssertEqual(state.1.shape, [1, 1, 4, 32])
+    }
+
+    func testSlidingCacheReencodesToPolarPreservingTotalOffset() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(37)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0)
+            .validated()
+        let cache = Gemma4SlidingKVCache(maxSize: 3)
+        cache.append(
+            keys: MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16),
+            values: MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16)
+        )
+        cache.append(
+            keys: MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16),
+            values: MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16)
+        )
+
+        let reencoded = try XCTUnwrap(cache.reencoded(quantization: config) as? Gemma4PolarKVCache)
+        reencoded.evaluateStorage()
+        let state = try XCTUnwrap(reencoded.currentState())
+
+        XCTAssertEqual(reencoded.offset, 5)
+        XCTAssertEqual(state.0.shape, [1, 1, 3, 32])
+        XCTAssertEqual(state.1.shape, [1, 1, 3, 32])
+    }
+
     func testPolarFusedSpecializedAttentionMatchesChunkedDecode() throws {
         try skipUnlessGPUForPolarKV()
 

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -297,6 +297,7 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
 
         XCTAssertLessThan(polarBytes, affineBytes)
         XCTAssertLessThan(polarBytes, denseBytes)
+        XCTAssertLessThan(polarMS, affineMS)
     }
 
     private func denseDecode(

--- a/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4KVQuantizationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import MLX
 import MLXRandom
@@ -13,6 +14,17 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         let config = try Gemma4KVCacheQuantization(bits: 3.5, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()
         XCTAssertEqual(config.keyBits, 3)
         XCTAssertEqual(config.valueBits, 4)
+    }
+
+    func testPolarRejectsUnsupportedBits() {
+        let config = Gemma4KVCacheQuantization(bits: 5, scheme: .polar, groupSize: 64, quantizedStart: 0)
+        XCTAssertThrowsError(try config.validated())
+    }
+
+    func testPolarUsesIntegerBits() throws {
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        XCTAssertEqual(config.keyBits, 2)
+        XCTAssertEqual(config.valueBits, 2)
     }
 
     func testQuantizedCacheRoundTripsShapeAndOffset() throws {
@@ -126,6 +138,199 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         XCTAssertEqual(returned.1.shape, [1, 1, 4, 64])
     }
 
+    func testPolarCacheRoundTripsShapeAndOffset() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(31)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        let cache = Gemma4PolarKVCache(configuration: config, maxSize: nil)
+
+        let keys = MLXRandom.normal([1, 2, 3, 64]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, 2, 3, 64]).asType(.bfloat16)
+        cache.append(keys: keys, values: values)
+        let returned = try XCTUnwrap(cache.currentState())
+
+        XCTAssertEqual(cache.offset, 3)
+        XCTAssertEqual(returned.0.shape, [1, 2, 3, 64])
+        XCTAssertEqual(returned.1.shape, [1, 2, 3, 64])
+
+        let keyDelta = returned.0.asType(DType.float32) - keys.asType(DType.float32)
+        let valueDelta = returned.1.asType(DType.float32) - values.asType(DType.float32)
+        let keyMSE = MLX.mean(keyDelta * keyDelta)
+        let valueMSE = MLX.mean(valueDelta * valueDelta)
+        XCTAssertLessThan(keyMSE.item(Float.self), 0.25)
+        XCTAssertLessThan(valueMSE.item(Float.self), 0.25)
+    }
+
+    func testPolarCacheForkCanMutateIndependently() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(32)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0).validated()
+        let cache = Gemma4PolarKVCache(configuration: config, maxSize: nil)
+
+        let firstKeys = MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16)
+        let firstValues = MLXRandom.normal([1, 1, 2, 32]).asType(.bfloat16)
+        cache.append(keys: firstKeys, values: firstValues)
+
+        let forked = cache.fork()
+        let nextKeys = MLXRandom.normal([1, 1, 1, 32]).asType(.bfloat16)
+        let nextValues = MLXRandom.normal([1, 1, 1, 32]).asType(.bfloat16)
+        forked.append(keys: nextKeys, values: nextValues)
+
+        let original = try XCTUnwrap(cache.currentState())
+        let copy = try XCTUnwrap(forked.currentState())
+        XCTAssertEqual(cache.offset, 2)
+        XCTAssertEqual(forked.offset, 3)
+        XCTAssertEqual(original.0.shape, [1, 1, 2, 32])
+        XCTAssertEqual(copy.0.shape, [1, 1, 3, 32])
+    }
+
+    func testPolarCachesCanMergeAndSplitBatchRows() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(33)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 32, quantizedStart: 0).validated()
+        let caches = (0..<2).map { _ in Gemma4PolarKVCache(configuration: config, maxSize: nil) }
+
+        for cache in caches {
+            let keys = MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16)
+            let values = MLXRandom.normal([1, 1, 3, 32]).asType(.bfloat16)
+            cache.append(keys: keys, values: values)
+        }
+
+        let batched = try XCTUnwrap(caches[0].batched(with: caches))
+        let state = try XCTUnwrap(batched.currentState())
+        XCTAssertEqual(batched.offset, 3)
+        XCTAssertEqual(state.0.shape, [2, 1, 3, 32])
+        XCTAssertEqual(state.1.shape, [2, 1, 3, 32])
+
+        let rows = try XCTUnwrap(batched.unbatchedRows(count: 2))
+        XCTAssertEqual(rows.count, 2)
+        for row in rows {
+            let rowState = try XCTUnwrap(row.currentState())
+            XCTAssertEqual(row.offset, 3)
+            XCTAssertEqual(rowState.0.shape, [1, 1, 3, 32])
+            XCTAssertEqual(rowState.1.shape, [1, 1, 3, 32])
+        }
+    }
+
+    func testPolarFusedSpecializedAttentionMatchesChunkedDecode() throws {
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(34)
+        let config = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        let cache = Gemma4PolarKVCache(configuration: config, maxSize: nil)
+
+        let keys = MLXRandom.normal([1, 2, 48, 64]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, 2, 48, 64]).asType(.bfloat16)
+        cache.append(keys: keys, values: values)
+
+        let queries = MLXRandom.normal([1, 4, 1, 64]).asType(.bfloat16)
+        let scale: Float = 1.0 / sqrt(64.0)
+
+        let fused = try XCTUnwrap(cache.fusedSpecializedAttention(queries: queries, repeats: 2, scale: scale))
+        let state = try XCTUnwrap(cache.currentState())
+        let denseKeys = MLX.repeated(state.0.asType(.float32), count: 2, axis: 1)
+        let denseValues = MLX.repeated(state.1.asType(.float32), count: 2, axis: 1)
+        var denseScores = MLX.matmul(queries.asType(.float32), denseKeys.transposed(0, 1, 3, 2)) * MLXArray(scale)
+        denseScores = softmax(denseScores, axis: -1)
+        let dense = MLX.matmul(denseScores, denseValues).asType(fused.dtype)
+
+        XCTAssertEqual(fused.shape, [1, 4, 1, 64])
+        let delta = fused.asType(.float32) - dense.asType(.float32)
+        let mse = MLX.mean(delta * delta)
+        XCTAssertLessThan(mse.item(Float.self), 0.02)
+    }
+
+    func testPolarKVSyntheticDecodeBenchmark() throws {
+        let enabled = ProcessInfo.processInfo.environment["MERERUN_BENCHMARK_POLARKV"] == "1"
+        guard enabled else {
+            throw XCTSkip("Set MERERUN_BENCHMARK_POLARKV=1 and MERERUN_TEST_MLX_DEVICE=gpu to benchmark PolarKV.")
+        }
+        try skipUnlessGPUForPolarKV()
+
+        MLXRandom.seed(35)
+        let batch = 1
+        let kvHeads = 4
+        let queryHeads = 16
+        let tokens = Int(ProcessInfo.processInfo.environment["MERERUN_BENCHMARK_POLARKV_TOKENS"] ?? "") ?? 2_048
+        let dim = 256
+        let iterations = 24
+        let scale: Float = 1.0 / sqrt(Float(dim))
+        let keys = MLXRandom.normal([batch, kvHeads, tokens, dim]).asType(.bfloat16)
+        let values = MLXRandom.normal([batch, kvHeads, tokens, dim]).asType(.bfloat16)
+        let queries = MLXRandom.normal([batch, queryHeads, 1, dim]).asType(.bfloat16)
+
+        let affineConfig = try Gemma4KVCacheQuantization(bits: 4, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()
+        let affine = Gemma4QuantizedKVCache(configuration: affineConfig, maxSize: nil)
+        affine.append(keys: keys, values: values)
+
+        let polarConfig = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0).validated()
+        let polar = Gemma4PolarKVCache(configuration: polarConfig, maxSize: nil)
+        polar.append(keys: keys, values: values)
+
+        let denseMS = try benchmarkMilliseconds(iterations: iterations) {
+            let output = denseDecode(queries: queries, keys: keys, values: values, repeats: queryHeads / kvHeads, scale: scale)
+            MLX.eval(output)
+        }
+        let affineMS = try benchmarkMilliseconds(iterations: iterations) {
+            let output = try XCTUnwrap(affine.specializedAttention(queries: queries, repeats: queryHeads / kvHeads, scale: scale))
+            MLX.eval(output)
+        }
+        let polarMS = try benchmarkMilliseconds(iterations: iterations) {
+            let output = try XCTUnwrap(polar.fusedSpecializedAttention(queries: queries, repeats: queryHeads / kvHeads, scale: scale))
+            MLX.eval(output)
+        }
+
+        let denseBytes = 2 * batch * kvHeads * tokens * dim * 2
+        let affineBytes = 2 * batch * kvHeads * tokens * (((dim * 4 + 31) / 32) * 4 + (dim / 64) * 8)
+        let polarBytes = 2 * batch * kvHeads * tokens * (((dim * 2 + 31) / 32) * 4 + 4)
+
+        print(
+            """
+            [PolarKV synthetic] dense=\(format(denseMS))ms/decode \
+            affine4=\(format(affineMS))ms/decode polar2=\(format(polarMS))ms/decode \
+            denseKV=\(formatMiB(denseBytes))MiB affineKV~\(formatMiB(affineBytes))MiB polarKV~\(formatMiB(polarBytes))MiB
+            """
+        )
+
+        XCTAssertLessThan(polarBytes, affineBytes)
+        XCTAssertLessThan(polarBytes, denseBytes)
+    }
+
+    private func denseDecode(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        repeats: Int,
+        scale: Float
+    ) -> MLXArray {
+        let broadcastKeys = MLX.repeated(keys.asType(.float32), count: repeats, axis: 1)
+        let broadcastValues = MLX.repeated(values.asType(.float32), count: repeats, axis: 1)
+        var scores = MLX.matmul(queries.asType(.float32), broadcastKeys.transposed(0, 1, 3, 2)) * MLXArray(scale)
+        scores = softmax(scores, axis: -1)
+        return MLX.matmul(scores, broadcastValues).asType(queries.dtype)
+    }
+
+    private func benchmarkMilliseconds(iterations: Int, _ body: () throws -> Void) throws -> Double {
+        try body()
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations {
+            try body()
+        }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        return Double(elapsed) / 1_000_000.0 / Double(iterations)
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private func formatMiB(_ bytes: Int) -> String {
+        format(Double(bytes) / 1_048_576.0)
+    }
+
     func testSpecializedAttentionMatchesDenseDecodeShapeAndValue() throws {
         MLXRandom.seed(13)
         let config = try Gemma4KVCacheQuantization(bits: 4, scheme: .turboquant, groupSize: 64, quantizedStart: 0).validated()
@@ -178,5 +383,11 @@ final class Gemma4KVQuantizationTests: MereRunCoreTestCase {
         let delta = fused.asType(.float32) - dense.asType(.float32)
         let mse = MLX.mean(delta * delta)
         XCTAssertLessThan(mse.item(Float.self), 0.02)
+    }
+
+    private func skipUnlessGPUForPolarKV() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("PolarKV uses MLXFast Metal pack/unpack kernels; set MERERUN_TEST_MLX_DEVICE=gpu to run it.")
+        }
     }
 }

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -88,6 +88,18 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         XCTAssertEqual(projected.shape, [1, 1, config.numHiddenLayers * config.hiddenSizePerLayerInput])
     }
 
+    func testMakeCacheUsesPolarKVCacheWhenRequested() throws {
+        let config = try decodeTextConfig(makeBaseConfig())
+        let model = Gemma4LanguageModel(config: config)
+        let quantization = try Gemma4KVCacheQuantization(bits: 2, scheme: .polar, groupSize: 64, quantizedStart: 0)
+            .validated()
+
+        let caches = model.makeCache(quantization: quantization)
+
+        XCTAssertEqual(caches.count, 2)
+        XCTAssertTrue(caches.allSatisfy { $0 is Gemma4PolarKVCache })
+    }
+
     func testAttentionKEqVDisablesValueProjectionForFullAttentionLayers() throws {
         var configObject = makeBaseConfig()
         configObject["attention_k_eq_v"] = true

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -714,6 +714,26 @@ swift run mere.run model pull --all
 
 Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
+### `mere.run model benchmark gemma4-kv`
+
+Run a fixed-token real-checkpoint Gemma4 KV cache comparison. The command runs
+the selected Gemma4 model twice in one process: default Gemma4 KV settings first,
+then packed `polar` 2-bit KV from token 0. It disables EOS stopping so both
+variants decode exactly `--decode-tokens`, and reports TTFT, prefill tok/s,
+decode tok/s, end-to-end tok/s, and process resident memory before and after
+each variant.
+
+```bash
+swift run mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --decode-tokens 48 \
+  --json
+```
+
+Use `--prompt`, `--prompt-file`, or `--prompt-repeat` to control prompt length.
+The default fixture prompt is deterministic and intended for local A/B
+comparisons, not model-quality evaluation.
+
 ### `mere.run model capabilities`
 
 Show this machine's supported models, recommended setup package, and a short summary

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ Public tree:
 - `mere.run music generate`
 - `mere.run video generate`
 - `mere.run video export-latents`
-- `mere.run model { list, capabilities, info, pull, remove, runtime, repair-manifests }`
+- `mere.run model { list, capabilities, info, pull, remove, runtime, benchmark, repair-manifests }`
 - `mere.run status`
 - `mere.run api serve`
 - `mere.run setup`
@@ -718,10 +718,10 @@ Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
 Run a fixed-token real-checkpoint Gemma4 KV cache comparison. The command runs
 the selected Gemma4 model twice in one process: default Gemma4 KV settings first,
-then packed `polar` 2-bit KV from token 0. It disables EOS stopping so both
-variants decode exactly `--decode-tokens`, and reports TTFT, prefill tok/s,
-decode tok/s, end-to-end tok/s, and process resident memory before and after
-each variant.
+then model-default prefill with packed `polar` 2-bit KV from token 0 for decode. It
+disables EOS stopping so both variants decode exactly `--decode-tokens`, and
+reports TTFT, prefill tok/s, KV conversion time, decode tok/s, end-to-end tok/s,
+and process resident memory before and after each variant.
 
 ```bash
 swift run mere.run model benchmark gemma4-kv \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -798,9 +798,9 @@ Security defaults:
   services the earliest decode position first by batching compatible rows there
   or advancing one lower-offset row until it can join a compatible batch
 - Gemma4 can opt into experimental packed PolarKV with
-  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
-  not as a default speed path, until real model benchmarks beat dense or affine
-  KV decode
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
+  long-context synthetic decode testing. It is not the default until checkpoint
+  benchmarks prove the end-to-end model path.
 - `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,6 +797,10 @@ Security defaults:
   state so compatible Q35 rows can batch across decode positions; the scheduler
   services the earliest decode position first by batching compatible rows there
   or advancing one lower-offset row until it can join a compatible batch
+- Gemma4 can opt into experimental packed PolarKV with
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
+  not as a default speed path, until real model benchmarks beat dense or affine
+  KV decode
 - `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -109,6 +109,10 @@ swift run mere.run api serve \
   decode positions; the scheduler services the earliest decode position first,
   batching compatible rows there or advancing a single lower-offset row until it
   can join one
+- Gemma4 has an experimental packed PolarKV path behind
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
+  not as a default speed path, until real model benchmarks beat dense or affine
+  KV decode
 - `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
   steps across loaded models under `cacheStats`; it also reports completed chat
   request counts, generated tokens, and average load/prefill/decode timings

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -110,9 +110,9 @@ swift run mere.run api serve \
   batching compatible rows there or advancing a single lower-offset row until it
   can join one
 - Gemma4 has an experimental packed PolarKV path behind
-  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure testing,
-  not as a default speed path, until real model benchmarks beat dense or affine
-  KV decode
+  `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
+  long-context synthetic decode testing. It is not the default until checkpoint
+  benchmarks prove the end-to-end model path.
 - `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
   steps across loaded models under `cacheStats`; it also reports completed chat
   request counts, generated tokens, and average load/prefill/decode timings


### PR DESCRIPTION
## Summary
- adds an opt-in Gemma4 `polar` KV quantization path with packed 2/3/4-bit state, deterministic rotation, MLXFast pack/unpack kernels, and a packed decode attention path
- rewrites PolarKV decode from the correctness-first fused kernel to a score/value two-pass path so packed-key scores are computed once and reused instead of recomputed per output dimension
- defers PolarKV packing until after prefill; turbo checkpoints now prefill with the model-default turboquant cache, then reencode once to packed PolarKV for decode
- wires `--kv-quant-scheme polar --kv-bits 2` through `text chat` and `api serve`, while keeping dense/default behavior unchanged
- adds `mere.run model benchmark gemma4-kv`, a fixed-token real-checkpoint benchmark that disables EOS stopping and reports prompt tokens, decode tokens, load/prefill/KV-conversion/decode/TTFT throughput, and resident memory snapshots
- documents PolarKV as an experimental memory-pressure and long-context decode option, still gated from default use until the full model path has more checkpoint coverage

## Measurement
Earlier correctness-first PolarKV benchmark, 8k tokens:

`dense=2.059ms/decode affine4=63.315ms/decode polar2=55.595ms/decode denseKV=32.000MiB affineKV~10.000MiB polarKV~4.250MiB`

After the score/value two-pass packed decode rewrite, 8k tokens:

`dense=2.021ms/decode affine4=61.741ms/decode polar2=1.234ms/decode denseKV=32.000MiB affineKV~10.000MiB polarKV~4.250MiB`

Longer synthetic run, 32k tokens:

`dense=7.274ms/decode affine4=247.917ms/decode polar2=4.079ms/decode denseKV=128.000MiB affineKV~40.000MiB polarKV~17.000MiB`

Initial real checkpoint run with packed PolarKV from token 0 showed the right decode direction but too much prefill cost:

- `default` turboquant: prefill 18.254s / 405.39 tok/s, decode 67.770s / 0.71 tok/s, total 87.260s.
- `polar2` from token 0: prefill 54.437s / 135.94 tok/s, decode 8.029s / 5.98 tok/s, total 63.580s.

After decode-deferred packing, real checkpoint run with downloaded `text-chat-gemma4-turbo` / `mlx-community/gemma-4-26b-a4b-it-nvfp4`, release build, built-in long prompt fixture, 7,400 prompt tokens, forced 48 decode tokens:

```bash
.build/release/mere.run model benchmark gemma4-kv \
  --model text-chat-gemma4-turbo \
  --prompt-repeat 220 \
  --decode-tokens 48 \
  --json
```

Results:

- `default` turboquant: prefill 15.843s / 467.09 tok/s, decode 53.374s / 0.90 tok/s, TTFT 17.008s, total 70.385s, resident after 14.82 GB.
- `polar2` with model-default prefill then packed PolarKV decode: prefill 19.226s / 384.90 tok/s, KV conversion 0.086s, decode 3.226s / 14.88 tok/s, TTFT 20.498s, total 23.724s, resident after 14.82 GB.

Takeaway: this is now a real checkpoint end-to-end speed win on the long-prompt forced-decode benchmark. It is still experimental because the approach needs more prompt shapes, quality/parity checks, and memory-pressure measurements before becoming default serving behavior.

## Validation
- `swiftlint --strict`
- `swift build`
- `swift build -c release --product mere.run`
- `swift test`
- `swift test --filter ModelBenchmarkCommandTests`
- `swift test --filter Gemma4KVQuantizationTests`
- `MERERUN_TEST_MLX_DEVICE=gpu swift test --filter Gemma4KVQuantizationTests`
- `MERERUN_TEST_MLX_DEVICE=gpu MERERUN_BENCHMARK_POLARKV=1 swift test --filter Gemma4KVQuantizationTests/testPolarKVSyntheticDecodeBenchmark`
- `MERERUN_TEST_MLX_DEVICE=gpu MERERUN_BENCHMARK_POLARKV=1 MERERUN_BENCHMARK_POLARKV_TOKENS=8192 swift test --filter Gemma4KVQuantizationTests/testPolarKVSyntheticDecodeBenchmark`
- `MERERUN_TEST_MLX_DEVICE=gpu MERERUN_BENCHMARK_POLARKV=1 MERERUN_BENCHMARK_POLARKV_TOKENS=32768 swift test --filter Gemma4KVQuantizationTests/testPolarKVSyntheticDecodeBenchmark`
- `.build/release/mere.run model benchmark gemma4-kv --model text-chat-gemma4-turbo --prompt-repeat 220 --decode-tokens 48 --json`
- `./scripts/check.sh`

## Stack
Stacked on #34 / `codex/runtime-model-pool-control-plane`.
