### PR TITLE
Promote Gemma4 PolarKV through runtime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,15 @@ swift run mere.run api serve \
   --kv-quant-scheme polar \
   --kv-bits 2
 
+# Conservative per-model runtime policy: default KV for short Gemma4 prompts,
+# decode-deferred PolarKV at or above 1024 prompt tokens
+swift run mere.run model runtime set text-chat-gemma4-turbo --kv-cache-mode auto
+
 # Fixed-token real-checkpoint Gemma4 KV benchmark: default TurboQuant vs decode-deferred PolarKV
 swift run mere.run model benchmark gemma4-kv \
   --model text-chat-gemma4-turbo \
-  --decode-tokens 48 \
+  --prompt-repeat-values 32,128,220 \
+  --decode-token-values 32,128 \
   --json
 
 # Expose the API beyond loopback only with an explicit key

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -36,8 +36,14 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
     @Option(name: [.long], help: "Repeat count for the built-in fixture prompt.")
     var promptRepeat: Int = 220
 
+    @Option(name: [.long], help: "Comma-separated repeat counts for a prompt-size benchmark matrix.")
+    var promptRepeatValues: String?
+
     @Option(name: [.long], help: "Exact number of decode tokens to force per variant.")
     var decodeTokens: Int = 48
+
+    @Option(name: [.long], help: "Comma-separated decode token counts for a decode-length benchmark matrix.")
+    var decodeTokenValues: String?
 
     @Option(name: [.long], help: "Temperature for benchmark sampling.")
     var temperature: Double = 0
@@ -58,6 +64,21 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
         guard decodeTokens > 0 else {
             throw ValidationError("--decode-tokens must be greater than zero.")
         }
+        let promptRepeats = try parsedPositiveIntegers(
+            promptRepeatValues,
+            fallback: [promptRepeat],
+            optionName: "--prompt-repeat-values"
+        )
+        _ = try parsedPositiveIntegers(
+            decodeTokenValues,
+            fallback: [decodeTokens],
+            optionName: "--decode-token-values"
+        )
+        if prompt != nil || promptFile != nil {
+            guard promptRepeats.count == 1 else {
+                throw ValidationError("--prompt-repeat-values can only contain one value when using --prompt or --prompt-file.")
+            }
+        }
         guard Gemma4Resources.handles(modelSpec: model) else {
             throw ValidationError("model benchmark gemma4-kv only supports Gemma4 model ids or repo ids.")
         }
@@ -65,38 +86,60 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
 
     func run() async throws {
         try MLXBundleSupport.ensureAvailable(quiet: json)
-        let prompt = try resolvePrompt()
-        let request = ChatRequest(
-            messages: [ChatMessage(role: .user, content: prompt)],
-            maxTokens: decodeTokens,
-            temperature: temperature,
-            topP: topP,
-            showThinking: false,
-            stopOnEOS: false
+        let promptRepeats = try parsedPositiveIntegers(
+            promptRepeatValues,
+            fallback: [promptRepeat],
+            optionName: "--prompt-repeat-values"
+        )
+        let decodeTokenCounts = try parsedPositiveIntegers(
+            decodeTokenValues,
+            fallback: [decodeTokens],
+            optionName: "--decode-token-values"
         )
 
         let variants = [
             Gemma4KVBenchmarkVariant.defaultTurbo(model: model),
             Gemma4KVBenchmarkVariant.polar2(model: model),
         ]
-        var results: [Gemma4KVBenchmarkVariantResult] = []
-        results.reserveCapacity(variants.count)
 
-        for variant in variants {
-            let result = try await runVariant(variant, request: request)
-            guard result.generatedTokens == decodeTokens else {
-                throw ValidationError(
-                    "\(variant.name) generated \(result.generatedTokens) tokens, expected \(decodeTokens). Reduce prompt length or decode tokens."
+        var scenarios: [Gemma4KVBenchmarkScenarioResult] = []
+        scenarios.reserveCapacity(promptRepeats.count * decodeTokenCounts.count)
+        for repeatCount in promptRepeats {
+            let prompt = try resolvePrompt(repeatCount: repeatCount)
+            for decodeTokenCount in decodeTokenCounts {
+                let request = ChatRequest(
+                    messages: [ChatMessage(role: .user, content: prompt)],
+                    maxTokens: decodeTokenCount,
+                    temperature: temperature,
+                    topP: topP,
+                    showThinking: false,
+                    stopOnEOS: false
+                )
+                var results: [Gemma4KVBenchmarkVariantResult] = []
+                results.reserveCapacity(variants.count)
+                for variant in variants {
+                    let result = try await runVariant(variant, request: request)
+                    guard result.generatedTokens == decodeTokenCount else {
+                        throw ValidationError(
+                            "\(variant.name) generated \(result.generatedTokens) tokens, expected \(decodeTokenCount). Reduce prompt length or decode tokens."
+                        )
+                    }
+                    results.append(result)
+                }
+                scenarios.append(
+                    Gemma4KVBenchmarkScenarioResult(
+                        promptRepeat: self.prompt != nil || self.promptFile != nil ? nil : repeatCount,
+                        promptCharacters: prompt.count,
+                        requestedDecodeTokens: decodeTokenCount,
+                        variants: results
+                    )
                 )
             }
-            results.append(result)
         }
 
         let report = Gemma4KVBenchmarkReport(
             model: model,
-            promptCharacters: prompt.count,
-            requestedDecodeTokens: decodeTokens,
-            variants: results
+            scenarios: scenarios
         )
         if json {
             print(try report.jsonString())
@@ -105,7 +148,7 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
         }
     }
 
-    private func resolvePrompt() throws -> String {
+    private func resolvePrompt(repeatCount: Int) throws -> String {
         if let prompt {
             return prompt
         }
@@ -113,8 +156,8 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
             return try String(contentsOf: URL(fileURLWithPath: promptFile).standardizedFileURL, encoding: .utf8)
         }
         var lines: [String] = []
-        lines.reserveCapacity(promptRepeat + 1)
-        for index in 1...promptRepeat {
+        lines.reserveCapacity(repeatCount + 1)
+        for index in 1...repeatCount {
             lines.append(
                 "Record \(index): Gemma turbo benchmark passage about local inference, packed key value cache memory, decode timing, and repeatable measurements. The checksum word is polar."
             )
@@ -123,11 +166,35 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
         return lines.joined(separator: "\n")
     }
 
+    private func parsedPositiveIntegers(
+        _ rawValue: String?,
+        fallback: [Int],
+        optionName: String
+    ) throws -> [Int] {
+        guard let rawValue else {
+            return fallback
+        }
+        let values = rawValue
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard !values.isEmpty else {
+            throw ValidationError("\(optionName) must contain at least one value.")
+        }
+        return try values.map { value in
+            guard let parsed = Int(value), parsed > 0 else {
+                throw ValidationError("\(optionName) values must be positive integers.")
+            }
+            return parsed
+        }
+    }
+
     private func runVariant(
         _ variant: Gemma4KVBenchmarkVariant,
         request: ChatRequest
     ) async throws -> Gemma4KVBenchmarkVariantResult {
-        let generator = Gemma4Generator(modelId: model, kvCacheQuantization: variant.quantization)
+        var request = request
+        request.kvCacheMode = variant.requestKVCacheMode
+        let generator = Gemma4Generator(modelId: model, kvCacheQuantization: variant.generatorQuantization)
         let memoryBefore = ProcessMemorySnapshot.currentResidentBytes()
         let start = Date()
         let response = try await generator.chat(request, modelPath: modelRoot, progressHandler: nil)
@@ -141,9 +208,9 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
         let promptTokens = response.promptTokens ?? 0
         return Gemma4KVBenchmarkVariantResult(
             name: variant.name,
-            kvScheme: variant.quantization.scheme.rawValue,
-            kvBits: variant.quantization.bits,
-            quantizedKVStart: variant.quantization.quantizedStart,
+            kvScheme: variant.displayQuantization.scheme.rawValue,
+            kvBits: variant.displayQuantization.bits,
+            quantizedKVStart: variant.displayQuantization.quantizedStart,
             promptTokens: promptTokens,
             generatedTokens: response.tokensGenerated,
             elapsedSeconds: elapsed,
@@ -152,6 +219,9 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
             cacheConversionSeconds: timing.cacheConversionSeconds,
             decodeSeconds: timing.decodeSeconds,
             firstTokenSeconds: timing.firstTokenSeconds,
+            kvCacheMode: timing.kvCacheMode,
+            prefillKVCache: timing.prefillKVCache,
+            decodeKVCache: timing.decodeKVCache,
             prefillTokensPerSecond: promptTokens > 0 && timing.prefillSeconds > 0
                 ? Double(promptTokens) / timing.prefillSeconds
                 : nil,
@@ -167,41 +237,47 @@ struct ModelBenchmarkGemma4KV: AsyncParsableCommand {
 
 private struct Gemma4KVBenchmarkVariant {
     let name: String
-    let quantization: Gemma4KVCacheQuantization
+    let displayQuantization: Gemma4KVCacheQuantization
+    let generatorQuantization: Gemma4KVCacheQuantization
+    let requestKVCacheMode: RuntimeKVCacheMode
 
     static func defaultTurbo(model: String) -> Self {
         let usesTurboDefaults = Gemma4Resources.usesTurboDefaults(modelSpec: model)
+        let quantization = Gemma4KVCacheQuantization(
+            bits: usesTurboDefaults ? Gemma4Resources.defaultTurboKVBits : nil,
+            scheme: usesTurboDefaults ? Gemma4Resources.defaultTurboKVQuantizationScheme : .uniform,
+            groupSize: Gemma4Resources.defaultKVGroupSize,
+            quantizedStart: usesTurboDefaults
+                ? Gemma4Resources.defaultTurboQuantizedKVStart
+                : Gemma4Resources.defaultQuantizedKVStart
+        )
         return Self(
             name: "default",
-            quantization: Gemma4KVCacheQuantization(
-                bits: usesTurboDefaults ? Gemma4Resources.defaultTurboKVBits : nil,
-                scheme: usesTurboDefaults ? Gemma4Resources.defaultTurboKVQuantizationScheme : .uniform,
-                groupSize: Gemma4Resources.defaultKVGroupSize,
-                quantizedStart: usesTurboDefaults
-                    ? Gemma4Resources.defaultTurboQuantizedKVStart
-                    : Gemma4Resources.defaultQuantizedKVStart
-            )
+            displayQuantization: quantization,
+            generatorQuantization: quantization,
+            requestKVCacheMode: .default
         )
     }
 
     static func polar2(model: String) -> Self {
-        Self(
+        let fallback = defaultTurbo(model: model).generatorQuantization
+        return Self(
             name: "polar2",
-            quantization: Gemma4KVCacheQuantization(
+            displayQuantization: Gemma4KVCacheQuantization(
                 bits: 2,
                 scheme: .polar,
                 groupSize: Gemma4Resources.defaultKVGroupSize,
                 quantizedStart: 0
-            )
+            ),
+            generatorQuantization: fallback,
+            requestKVCacheMode: .polar2
         )
     }
 }
 
 private struct Gemma4KVBenchmarkReport: Encodable {
     let model: String
-    let promptCharacters: Int
-    let requestedDecodeTokens: Int
-    let variants: [Gemma4KVBenchmarkVariantResult]
+    let scenarios: [Gemma4KVBenchmarkScenarioResult]
 
     func jsonString() throws -> String {
         let encoder = JSONEncoder()
@@ -214,9 +290,24 @@ private struct Gemma4KVBenchmarkReport: Encodable {
         var lines = [
             "Gemma4 KV benchmark",
             "model: \(model)",
-            "prompt characters: \(promptCharacters)",
-            "decode tokens: \(requestedDecodeTokens)",
             "",
+        ]
+        for scenario in scenarios {
+            lines.append(scenario.renderText())
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct Gemma4KVBenchmarkScenarioResult: Encodable {
+    let promptRepeat: Int?
+    let promptCharacters: Int
+    let requestedDecodeTokens: Int
+    let variants: [Gemma4KVBenchmarkVariantResult]
+
+    func renderText() -> String {
+        var lines = [
+            "scenario: prompt_repeat=\(promptRepeat.map(String.init) ?? "custom") prompt_characters=\(promptCharacters) decode_tokens=\(requestedDecodeTokens)",
         ]
         for result in variants {
             lines.append(result.renderText())
@@ -238,6 +329,9 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
     let cacheConversionSeconds: Double?
     let decodeSeconds: Double
     let firstTokenSeconds: Double?
+    let kvCacheMode: RuntimeKVCacheMode?
+    let prefillKVCache: String?
+    let decodeKVCache: String?
     let prefillTokensPerSecond: Double?
     let decodeTokensPerSecond: Double?
     let endToEndTokensPerSecond: Double?
@@ -263,6 +357,9 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         case decodeSeconds
         case firstTokenSeconds
         case ttftSeconds
+        case kvCacheMode
+        case prefillKVCache
+        case decodeKVCache
         case prefillTokensPerSecond
         case decodeTokensPerSecond
         case endToEndTokensPerSecond
@@ -285,6 +382,9 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         try container.encode(decodeSeconds, forKey: .decodeSeconds)
         try container.encodeIfPresent(firstTokenSeconds, forKey: .firstTokenSeconds)
         try container.encodeIfPresent(ttftSeconds, forKey: .ttftSeconds)
+        try container.encodeIfPresent(kvCacheMode, forKey: .kvCacheMode)
+        try container.encodeIfPresent(prefillKVCache, forKey: .prefillKVCache)
+        try container.encodeIfPresent(decodeKVCache, forKey: .decodeKVCache)
         try container.encodeIfPresent(prefillTokensPerSecond, forKey: .prefillTokensPerSecond)
         try container.encodeIfPresent(decodeTokensPerSecond, forKey: .decodeTokensPerSecond)
         try container.encodeIfPresent(endToEndTokensPerSecond, forKey: .endToEndTokensPerSecond)
@@ -296,6 +396,7 @@ private struct Gemma4KVBenchmarkVariantResult: Encodable {
         [
             "\(name): \(kvScheme)\(kvBits.map { String(format: " %.1f-bit", $0) } ?? "") start=\(quantizedKVStart)",
             "  prompt_tokens=\(promptTokens) generated_tokens=\(generatedTokens)",
+            "  kv mode=\(kvCacheMode?.rawValue ?? "default") prefill=\(prefillKVCache ?? "n/a") decode=\(decodeKVCache ?? "n/a")",
             "  time total=\(format(elapsedSeconds))s load=\(format(loadSeconds))s prefill=\(format(prefillSeconds))s kv_convert=\(formatOptional(cacheConversionSeconds))s decode=\(format(decodeSeconds))s ttft=\(formatOptional(ttftSeconds))s",
             "  throughput prefill=\(formatOptional(prefillTokensPerSecond)) tok/s decode=\(formatOptional(decodeTokensPerSecond)) tok/s e2e=\(formatOptional(endToEndTokensPerSecond)) tok/s",
             "  resident_memory before=\(formatBytes(residentMemoryBeforeBytes)) after=\(formatBytes(residentMemoryAfterBytes))",

--- a/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift
@@ -3,6 +3,7 @@ import Foundation
 import MereRunCore
 
 extension RuntimeServingEngine: ExpressibleByArgument {}
+extension RuntimeKVCacheMode: ExpressibleByArgument {}
 
 struct ModelRuntime: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -54,6 +55,7 @@ struct ModelRuntimeGet: ParsableCommand {
         print("  temperature: \(settings.temperature.map { String($0) } ?? "none")")
         print("  topP: \(settings.topP.map { String($0) } ?? "none")")
         print("  engineOverride: \(settings.engineOverride?.rawValue ?? "none")")
+        print("  kvCacheMode: \(settings.kvCacheMode?.rawValue ?? "none")")
     }
 }
 
@@ -114,6 +116,12 @@ struct ModelRuntimeSet: ParsableCommand {
     @Flag(name: [.long], help: "Clear the engine override.")
     var clearEngine: Bool = false
 
+    @Option(name: [.long], help: "Set runtime KV cache mode: default, polar2, or auto. Gemma4 only.")
+    var kvCacheMode: RuntimeKVCacheMode?
+
+    @Flag(name: [.long], help: "Clear the runtime KV cache mode.")
+    var clearKVCacheMode: Bool = false
+
     @Flag(name: [.long], help: "Emit updated settings as JSON.")
     var json: Bool = false
 
@@ -144,6 +152,11 @@ struct ModelRuntimeSet: ParsableCommand {
         }
         if clearTopP { settings.topP = nil } else if let topP { settings.topP = topP }
         if clearEngine { settings.engineOverride = nil } else if let engine { settings.engineOverride = engine }
+        if clearKVCacheMode {
+            settings.kvCacheMode = nil
+        } else if let kvCacheMode {
+            settings.kvCacheMode = kvCacheMode
+        }
 
         try store.writeSettings(settings, for: modelID)
         let updated = try store.settings(for: modelID)
@@ -185,6 +198,9 @@ struct ModelRuntimeSet: ParsableCommand {
         }
         if engine != nil && clearEngine {
             throw ValidationError("Use either --engine or --clear-engine, not both.")
+        }
+        if kvCacheMode != nil && clearKVCacheMode {
+            throw ValidationError("Use either --kv-cache-mode or --clear-kv-cache-mode, not both.")
         }
     }
 }

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -35,7 +35,13 @@ mere.run status
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--context-size`: context limit.
-- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`: Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the existing 4-bit affine TurboQuant KV cache from token 0; explicit flags override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental packed PolarKV path for memory-pressure and long-context synthetic decode testing.
+- `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`:
+  Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the
+  existing 4-bit affine TurboQuant KV cache from token 0; explicit flags
+  override that. `--kv-quant-scheme polar --kv-bits 2` enables the experimental
+  packed PolarKV path for memory-pressure and long-context synthetic decode
+  testing. Per-model runtime settings can also set `kvCacheMode` to `default`,
+  `polar2`, or conservative `auto`.
 
 ## Usage Patterns
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -10,6 +10,16 @@ mere.run model benchmark gemma4-kv \
   --json
 ```
 
+Run a small promotion matrix by varying prompt fixture size and decode length:
+
+```bash
+mere.run model benchmark gemma4-kv \
+  --model text-chat-gemma4-turbo \
+  --prompt-repeat-values 32,128,220 \
+  --decode-token-values 32,128 \
+  --json
+```
+
 ## Gemma4 KV Benchmark
 
 `model benchmark gemma4-kv` runs a fixed-token comparison for the selected
@@ -30,6 +40,8 @@ Use one of:
 - `--prompt`: inline prompt text.
 - `--prompt-file`: UTF-8 prompt file.
 - `--prompt-repeat`: repeat count for the built-in deterministic fixture.
+- `--prompt-repeat-values`: comma-separated fixture sizes for a benchmark matrix.
+- `--decode-token-values`: comma-separated decode lengths for a benchmark matrix.
 
 The fixture prompt is for runtime comparison only; it is not a quality eval.
 

--- a/Sources/MereRunCLI/Guides/model-runtime.md
+++ b/Sources/MereRunCLI/Guides/model-runtime.md
@@ -35,6 +35,7 @@ mere.run status --json
 - `--temperature` / `--clear-temperature`
 - `--top-p` / `--clear-top-p`
 - `--engine` / `--clear-engine`
+- `--kv-cache-mode` / `--clear-kv-cache-mode`
 - `--json`
 
 ## Usage Patterns
@@ -45,6 +46,10 @@ mere.run status --json
   `MERERUN_MODELS_DIR` when you use a custom store.
 - Use engine overrides only for catalog-compatible engines. Incompatible
   overrides are rejected immediately.
+- Use `--kv-cache-mode auto` on Gemma4 to keep the default KV path for shorter
+  prompts and switch to packed 2-bit PolarKV for prompts at or above 1024
+  tokens. `polar2` forces that path for every request, and non-Gemma4 models
+  reject the setting.
 - Treat TTL/LRU as forward-compatible settings. The first runtime-pool
   milestone records them and exposes them in status; later schedulers can act
   on them.
@@ -59,7 +64,8 @@ mere.run model runtime set text-chat-gemma4 \
   --max-context-tokens 8192 \
   --max-tokens 1024 \
   --temperature 0.6 \
-  --top-p 0.9
+  --top-p 0.9 \
+  --kv-cache-mode auto
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -281,6 +281,7 @@ struct RuntimeModelPoolEntrySnapshot: Codable, Equatable, Sendable {
     let temperature: Double?
     let topP: Double?
     let engineOverride: RuntimeServingEngine?
+    let kvCacheMode: RuntimeKVCacheMode?
     let prefixKVCache: PrefixKVCacheStats?
     let continuousBatching: RuntimeDecodeBatchingStats?
     let benchmarkStats: RuntimeModelBenchmarkStats?
@@ -509,12 +510,13 @@ actor RuntimeModelPool {
         applyDefaults(from: resolved.settings, to: &effectiveRequest)
         let contextSize = resolved.settings.maxContextTokens ?? serverContextSize
         let capabilities = resolved.engine.openAICompatibility
-        let chatRequest = try APIServerContract.chatRequest(
+        var chatRequest = try APIServerContract.chatRequest(
             from: effectiveRequest,
             fallbackLoraPath: fallbackLoraPath,
             contextSize: contextSize,
             capabilities: capabilities
         )
+        chatRequest.kvCacheMode = resolved.settings.kvCacheMode
         let includeUsage = try APIServerContract.includeUsageInStreaming(
             effectiveRequest,
             capabilities: capabilities
@@ -786,6 +788,7 @@ actor RuntimeModelPool {
             temperature: modelSettings.temperature,
             topP: modelSettings.topP,
             engineOverride: modelSettings.engineOverride,
+            kvCacheMode: modelSettings.kvCacheMode,
             prefixKVCache: prefixKVCache,
             continuousBatching: continuousBatching,
             benchmarkStats: state.benchmarkStats

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -245,8 +245,7 @@ public actor Gemma4Generator: ChatGenerator {
         guard let model, let tokenizerAndTemplate, let loadedConfig else {
             throw Gemma4Error.modelNotLoaded
         }
-        let kvCacheQuantization = try self.kvCacheQuantization.validated()
-        let prefillKVCacheQuantization = prefillQuantization(for: kvCacheQuantization)
+        let fallbackKVCacheQuantization = try self.kvCacheQuantization.validated()
 
         let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
         let prefillStart = Date()
@@ -261,6 +260,12 @@ public actor Gemma4Generator: ChatGenerator {
         if promptTokens.count > effectiveContext {
             promptTokens = Array(promptTokens.suffix(effectiveContext))
         }
+        let effectiveKVCacheMode = request.kvCacheMode ?? .default
+        let kvCacheQuantization = try effectiveKVCacheMode.gemma4Quantization(
+            fallback: fallbackKVCacheQuantization,
+            promptTokenCount: promptTokens.count
+        ).validated()
+        let prefillKVCacheQuantization = prefillQuantization(for: kvCacheQuantization)
 
         let hasTools = request.tools?.isEmpty == false
         let eosSet = request.stopOnEOS
@@ -341,7 +346,10 @@ public actor Gemma4Generator: ChatGenerator {
                 prefillSeconds: prefillSeconds,
                 cacheConversionSeconds: preparedCaches.conversionSeconds,
                 decodeSeconds: decodeResult.decodeSeconds,
-                firstTokenSeconds: decodeResult.firstTokenSeconds
+                firstTokenSeconds: decodeResult.firstTokenSeconds,
+                kvCacheMode: effectiveKVCacheMode,
+                prefillKVCache: prefillKVCacheQuantization.statusDescription,
+                decodeKVCache: kvCacheQuantization.statusDescription
             ),
             toolCalls: toolCalls,
             promptTokens: promptTokens.count

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -30,6 +30,13 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
         bits != nil
     }
 
+    var statusDescription: String {
+        guard let bits else {
+            return "default"
+        }
+        return "\(scheme.rawValue):\(bits)-bit:start-\(quantizedStart)"
+    }
+
     func validated() throws -> Gemma4KVCacheQuantization {
         guard let bits else {
             return self

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -249,6 +249,7 @@ public struct ChatRequest: Sendable, Hashable {
     public var requiresJSON: Bool
     public var tools: [ToolDefinition]?
     public var stopOnEOS: Bool
+    public var kvCacheMode: RuntimeKVCacheMode?
 
     public init(
         messages: [ChatMessage],
@@ -259,7 +260,8 @@ public struct ChatRequest: Sendable, Hashable {
         lora: LoRA? = nil,
         requiresJSON: Bool = false,
         tools: [ToolDefinition]? = nil,
-        stopOnEOS: Bool = true
+        stopOnEOS: Bool = true,
+        kvCacheMode: RuntimeKVCacheMode? = nil
     ) {
         self.messages = messages
         self.maxTokens = maxTokens
@@ -270,6 +272,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.requiresJSON = requiresJSON
         self.tools = tools
         self.stopOnEOS = stopOnEOS
+        self.kvCacheMode = kvCacheMode
     }
 }
 
@@ -279,19 +282,28 @@ public struct ChatTiming: Sendable, Hashable {
     public var cacheConversionSeconds: Double?
     public var decodeSeconds: Double
     public var firstTokenSeconds: Double?
+    public var kvCacheMode: RuntimeKVCacheMode?
+    public var prefillKVCache: String?
+    public var decodeKVCache: String?
 
     public init(
         loadSeconds: Double = 0,
         prefillSeconds: Double = 0,
         cacheConversionSeconds: Double? = nil,
         decodeSeconds: Double = 0,
-        firstTokenSeconds: Double? = nil
+        firstTokenSeconds: Double? = nil,
+        kvCacheMode: RuntimeKVCacheMode? = nil,
+        prefillKVCache: String? = nil,
+        decodeKVCache: String? = nil
     ) {
         self.loadSeconds = loadSeconds
         self.prefillSeconds = prefillSeconds
         self.cacheConversionSeconds = cacheConversionSeconds
         self.decodeSeconds = decodeSeconds
         self.firstTokenSeconds = firstTokenSeconds
+        self.kvCacheMode = kvCacheMode
+        self.prefillKVCache = prefillKVCache
+        self.decodeKVCache = decodeKVCache
     }
 }
 

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -8,6 +8,42 @@ public enum RuntimeServingEngine: String, Codable, CaseIterable, Hashable, Senda
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
 }
 
+public enum RuntimeKVCacheMode: String, Codable, CaseIterable, Hashable, Sendable {
+    case `default`
+    case polar2
+    case auto
+
+    public static let gemma4AutoPolarPromptTokenThreshold = 1_024
+
+    public func gemma4Quantization(
+        fallback: Gemma4KVCacheQuantization,
+        promptTokenCount: Int
+    ) -> Gemma4KVCacheQuantization {
+        switch self {
+        case .default:
+            return fallback
+        case .polar2:
+            return Self.gemma4Polar2Quantization(fallback: fallback)
+        case .auto:
+            guard promptTokenCount >= Self.gemma4AutoPolarPromptTokenThreshold else {
+                return fallback
+            }
+            return Self.gemma4Polar2Quantization(fallback: fallback)
+        }
+    }
+
+    private static func gemma4Polar2Quantization(
+        fallback: Gemma4KVCacheQuantization
+    ) -> Gemma4KVCacheQuantization {
+        Gemma4KVCacheQuantization(
+            bits: 2,
+            scheme: .polar,
+            groupSize: fallback.groupSize,
+            quantizedStart: 0
+        )
+    }
+}
+
 public struct RuntimeModelSettings: Codable, Hashable, Sendable {
     public var alias: String?
     public var pinned: Bool
@@ -17,6 +53,7 @@ public struct RuntimeModelSettings: Codable, Hashable, Sendable {
     public var temperature: Double?
     public var topP: Double?
     public var engineOverride: RuntimeServingEngine?
+    public var kvCacheMode: RuntimeKVCacheMode?
 
     public init(
         alias: String? = nil,
@@ -26,7 +63,8 @@ public struct RuntimeModelSettings: Codable, Hashable, Sendable {
         maxTokens: Int? = nil,
         temperature: Double? = nil,
         topP: Double? = nil,
-        engineOverride: RuntimeServingEngine? = nil
+        engineOverride: RuntimeServingEngine? = nil,
+        kvCacheMode: RuntimeKVCacheMode? = nil
     ) {
         self.alias = alias
         self.pinned = pinned
@@ -36,6 +74,7 @@ public struct RuntimeModelSettings: Codable, Hashable, Sendable {
         self.temperature = temperature
         self.topP = topP
         self.engineOverride = engineOverride
+        self.kvCacheMode = kvCacheMode
     }
 
     public var normalized: RuntimeModelSettings {
@@ -77,6 +116,15 @@ public struct RuntimeModelSettings: Codable, Hashable, Sendable {
                 expected: spec.defaultRuntimeServingEngine
             )
         }
+        if let kvCacheMode = settings.kvCacheMode,
+           kvCacheMode != .default,
+           spec.defaultRuntimeServingEngine != .textChatGemma4 {
+            throw RuntimeModelSettingsError.incompatibleKVCacheMode(
+                modelID: spec.id,
+                requested: kvCacheMode,
+                expectedEngine: .textChatGemma4
+            )
+        }
         guard spec.isAPIServableRuntimeModel else {
             throw RuntimeModelSettingsError.unsupportedModel(spec.id)
         }
@@ -108,6 +156,7 @@ public enum RuntimeModelSettingsError: LocalizedError, Equatable {
     case invalidAlias(String)
     case invalidValue(String)
     case incompatibleEngine(modelID: String, requested: RuntimeServingEngine, expected: RuntimeServingEngine?)
+    case incompatibleKVCacheMode(modelID: String, requested: RuntimeKVCacheMode, expectedEngine: RuntimeServingEngine)
 
     public var errorDescription: String? {
         switch self {
@@ -122,6 +171,8 @@ public enum RuntimeModelSettingsError: LocalizedError, Equatable {
         case .incompatibleEngine(let modelID, let requested, let expected):
             let expectedText = expected?.rawValue ?? "none"
             return "Engine override '\(requested.rawValue)' is not compatible with model '\(modelID)' (expected \(expectedText))."
+        case .incompatibleKVCacheMode(let modelID, let requested, let expectedEngine):
+            return "KV cache mode '\(requested.rawValue)' is not compatible with model '\(modelID)' (expected \(expectedEngine.rawValue))."
         }
     }
 }

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -13,7 +13,9 @@ final class ModelBenchmarkCommandTests: XCTestCase {
 
         XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
         XCTAssertEqual(cmd.promptRepeat, 220)
+        XCTAssertNil(cmd.promptRepeatValues)
         XCTAssertEqual(cmd.decodeTokens, 48)
+        XCTAssertNil(cmd.decodeTokenValues)
         XCTAssertEqual(cmd.temperature, 0)
         XCTAssertEqual(cmd.topP, 1)
         XCTAssertFalse(cmd.json)
@@ -25,6 +27,8 @@ final class ModelBenchmarkCommandTests: XCTestCase {
             "--model-root", "/tmp/gemma4",
             "--prompt", "Benchmark this",
             "--decode-tokens", "32",
+            "--decode-token-values", "32,128",
+            "--prompt-repeat-values", "64",
             "--temperature", "0.2",
             "--top-p", "0.7",
             "--json",
@@ -34,6 +38,8 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertEqual(cmd.modelRoot, "/tmp/gemma4")
         XCTAssertEqual(cmd.prompt, "Benchmark this")
         XCTAssertEqual(cmd.decodeTokens, 32)
+        XCTAssertEqual(cmd.decodeTokenValues, "32,128")
+        XCTAssertEqual(cmd.promptRepeatValues, "64")
         XCTAssertEqual(cmd.temperature, 0.2)
         XCTAssertEqual(cmd.topP, 0.7)
         XCTAssertTrue(cmd.json)

--- a/Tests/MereRunCLITests/ModelRuntimeCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelRuntimeCommandTests.swift
@@ -26,6 +26,7 @@ final class ModelRuntimeCommandTests: XCTestCase {
             "--temperature", "0.4",
             "--top-p", "0.8",
             "--engine", "text-chat-gemma4",
+            "--kv-cache-mode", "auto",
             "--json",
         ])
 
@@ -38,6 +39,7 @@ final class ModelRuntimeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.temperature, 0.4)
         XCTAssertEqual(cmd.topP, 0.8)
         XCTAssertEqual(cmd.engine, .textChatGemma4)
+        XCTAssertEqual(cmd.kvCacheMode, .auto)
         XCTAssertTrue(cmd.json)
     }
 }

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -94,6 +94,27 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertTrue(status.capabilities.continuousBatching.enabled)
     }
 
+    func testStatusIncludesRuntimeKVCacheMode() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        try store.writeSettings(
+            RuntimeModelSettings(kvCacheMode: .auto),
+            for: Gemma4Resources.defaultModelId
+        )
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: store
+        )
+
+        let status = await pool.status()
+
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        XCTAssertEqual(gemma.kvCacheMode, .auto)
+    }
+
     func testRequestAdmissionSerializesByDefaultAndReportsQueue() async throws {
         let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
         let first = try await admission.acquire()

--- a/Tests/MereRunCLITests/StatusCommandTests.swift
+++ b/Tests/MereRunCLITests/StatusCommandTests.swift
@@ -141,6 +141,7 @@ final class StatusCommandTests: XCTestCase {
                     temperature: 0.4,
                     topP: 0.8,
                     engineOverride: nil,
+                    kvCacheMode: .auto,
                     prefixKVCache: Gemma4PrefixKVCacheStats(
                         enabled: true,
                         entries: 1,

--- a/Tests/MereRunCoreTests/RuntimeModelSettingsTests.swift
+++ b/Tests/MereRunCoreTests/RuntimeModelSettingsTests.swift
@@ -15,7 +15,8 @@ final class RuntimeModelSettingsTests: XCTestCase {
             maxTokens: 512,
             temperature: 0.4,
             topP: 0.8,
-            engineOverride: .textChatGemma4
+            engineOverride: .textChatGemma4,
+            kvCacheMode: .auto
         )
 
         try store.writeSettings(settings, for: Gemma4Resources.defaultModelId)
@@ -29,6 +30,7 @@ final class RuntimeModelSettingsTests: XCTestCase {
         XCTAssertEqual(loaded.temperature, 0.4)
         XCTAssertEqual(loaded.topP, 0.8)
         XCTAssertEqual(loaded.engineOverride, .textChatGemma4)
+        XCTAssertEqual(loaded.kvCacheMode, .auto)
         XCTAssertEqual(
             try store.resolveModelID(aliasOrID: "chat-default", defaultModelID: "fallback"),
             Gemma4Resources.defaultModelId
@@ -54,6 +56,42 @@ final class RuntimeModelSettingsTests: XCTestCase {
         ) { error in
             XCTAssertTrue(error.localizedDescription.contains("not supported"))
         }
+    }
+
+    func testSettingsRejectGemmaKVModeForNonGemmaModel() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+
+        XCTAssertThrowsError(
+            try store.writeSettings(RuntimeModelSettings(kvCacheMode: .polar2), for: Q35Resources.defaultModelId)
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("KV cache mode"))
+        }
+    }
+
+    func testGemmaAutoKVModeUsesPolarOnlyPastPromptThreshold() {
+        let fallback = Gemma4KVCacheQuantization(
+            bits: Gemma4Resources.defaultTurboKVBits,
+            scheme: Gemma4Resources.defaultTurboKVQuantizationScheme,
+            groupSize: Gemma4Resources.defaultKVGroupSize,
+            quantizedStart: Gemma4Resources.defaultTurboQuantizedKVStart
+        )
+
+        let short = RuntimeKVCacheMode.auto.gemma4Quantization(
+            fallback: fallback,
+            promptTokenCount: RuntimeKVCacheMode.gemma4AutoPolarPromptTokenThreshold - 1
+        )
+        XCTAssertEqual(short.scheme, .turboquant)
+        XCTAssertEqual(short.bits, Gemma4Resources.defaultTurboKVBits)
+
+        let long = RuntimeKVCacheMode.auto.gemma4Quantization(
+            fallback: fallback,
+            promptTokenCount: RuntimeKVCacheMode.gemma4AutoPolarPromptTokenThreshold
+        )
+        XCTAssertEqual(long.scheme, .polar)
+        XCTAssertEqual(long.bits, 2)
+        XCTAssertEqual(long.quantizedStart, 0)
     }
 
     private func makeTemporaryDirectory() throws -> URL {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -695,11 +695,14 @@ swift run mere.run model runtime set text-chat-gemma4 \
   --max-context-tokens 8192 \
   --max-tokens 1024 \
   --temperature 0.6 \
-  --top-p 0.9
+  --top-p 0.9 \
+  --kv-cache-mode auto
 ```
 
 Use the matching `--clear-*` flags to remove optional values. Engine overrides
-are validated against the curated catalog.
+are validated against the curated catalog. Gemma4 accepts `--kv-cache-mode`
+values of `default`, `polar2`, and `auto`; non-Gemma4 models reject PolarKV
+runtime modes.
 
 ### `mere.run model pull`
 
@@ -718,7 +721,8 @@ Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
 Run a fixed-token real-checkpoint Gemma4 KV cache comparison. The command runs
 the selected Gemma4 model twice in one process: default Gemma4 KV settings first,
-then model-default prefill with packed `polar` 2-bit KV from token 0 for decode. It
+then the runtime `polar2` mode, which uses model-default prefill with packed
+`polar` 2-bit KV from token 0 for decode. It
 disables EOS stopping so both variants decode exactly `--decode-tokens`, and
 reports TTFT, prefill tok/s, KV conversion time, decode tok/s, end-to-end tok/s,
 and process resident memory before and after each variant.
@@ -731,6 +735,8 @@ swift run mere.run model benchmark gemma4-kv \
 ```
 
 Use `--prompt`, `--prompt-file`, or `--prompt-repeat` to control prompt length.
+Use `--prompt-repeat-values` and `--decode-token-values` with comma-separated
+values to run a prompt-size/decode-length matrix for promotion evidence.
 The default fixture prompt is deterministic and intended for local A/B
 comparisons, not model-quality evaluation.
 
@@ -821,6 +827,10 @@ Security defaults:
   `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
   long-context synthetic decode testing. It is not the default until checkpoint
   benchmarks prove the end-to-end model path.
+- Per-model runtime settings can also set `kvCacheMode` to `default`, `polar2`,
+  or `auto` for Gemma4. `auto` keeps the default KV path below 1024 prompt
+  tokens and switches to decode-deferred packed PolarKV at or above that
+  threshold.
 - `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -113,6 +113,9 @@ swift run mere.run api serve \
   `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
   long-context synthetic decode testing. It is not the default until checkpoint
   benchmarks prove the end-to-end model path.
+- Gemma4 runtime settings can set `kvCacheMode` to `default`, `polar2`, or
+  `auto`. `auto` keeps the default KV path below 1024 prompt tokens and switches
+  to decode-deferred packed PolarKV at or above that threshold.
 - `/runtime/status` aggregates prefix hits, reused tokens, and batched decode
   steps across loaded models under `cacheStats`; it also reports completed chat
   request counts, generated tokens, and average load/prefill/decode timings


### PR DESCRIPTION
## Summary
- add a typed `RuntimeKVCacheMode` setting (`default`, `polar2`, `auto`) to per-model runtime settings
- route API/runtime pool Gemma4 requests through the setting and report the effective KV mode/cache shape in timings and runtime status
- expand `model benchmark gemma4-kv` into a prompt/decode matrix and document the promotion workflow

## Real-checkpoint evidence
Initial single-run matrix on the downloaded `text-chat-gemma4-turbo` checkpoint:

- 284 prompt tokens / 32 decode tokens: polar2 improved total time from 4.93s to 2.58s and decode from 10.1 tok/s to 41.5 tok/s
- 547 prompt tokens / 32 decode tokens: polar2 lost total time due to a prefill spike, so short prompts still need caution
- 1,075 prompt tokens / 32 decode tokens: polar2 improved total time from 28.38s to 11.00s and decode from 2.26 tok/s to 19.57 tok/s
- 4,272 prompt tokens / 32 decode tokens: polar2 improved total time from 71.45s to 19.66s and decode from 0.72 tok/s to 20.03 tok/s

Based on that, `auto` switches Gemma4 to PolarKV at 1,024 prompt tokens. Memory snapshots remain process-resident measurements and are noisy, so this PR does not claim a final memory benchmark.

## Validation
- `git diff --check`
- `./scripts/check.sh`
- real checkpoint runs with `swift build -c release --product mere.run` output:
  - `.build/release/mere.run model benchmark gemma4-kv --model text-chat-gemma4-turbo --prompt-repeat-values 8,16 --decode-token-values 32 --json`
  - `.build/release/mere.run model benchmark gemma4-kv --model text-chat-gemma4-turbo --prompt-repeat-values 32,128 --decode-token-values 32 --json`

## Notes
This keeps continuous batching and SSD KV cache out of scope. The useful promotion line here is typed control, observable behavior, and measured Gemma4-specific switching before broader scheduler/cache work.
