### PR TITLE
Add Linux arm64 CUDA release support

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -110,7 +110,12 @@ jobs:
               gfortran \
               git \
               gzip \
+              cuda-cccl-13-0 \
               libcurl4-openssl-dev \
+              libcudnn9-cuda-13 \
+              libcudnn9-dev-cuda-13 \
+              libnccl2 \
+              libnccl-dev \
               liblapacke-dev \
               libopenblas-dev \
               ninja-build \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on Keep a Changelog.
 
 - added a Linux arm64 CUDA package lane to the GitHub Actions `linux-release`
   workflow for self-hosted arm64 CUDA runners, plus architecture-aware CUDA
-  linker paths and a combined checksum manifest for available Linux artifacts.
+  linker paths, cuDNN/NCCL provisioning, CUDA 13 CCCL runtime JIT include
+  handling, CUDA runtime `.deb` dependencies, and a combined checksum manifest
+  for available Linux artifacts.
 
 ## 0.8.0 - 2026-05-23
 

--- a/Package.swift
+++ b/Package.swift
@@ -73,9 +73,16 @@ let prebuiltMLXSwiftSettings: [SwiftSetting] = useLinuxPrebuiltMLX
       ])
     ]
   : []
+let linuxPackageSwiftSettings: [SwiftSetting] = isLinuxPackage
+  ? [
+      .unsafeFlags([
+        "-strict-concurrency=targeted"
+      ])
+    ]
+  : []
 let commonSwiftSettings: [SwiftSetting] = [
   .interoperabilityMode(.Cxx)
-] + prebuiltMLXSwiftSettings
+] + prebuiltMLXSwiftSettings + linuxPackageSwiftSettings
 let hasMediaIOTarget = packageDirectoryContainsSwiftSources("Sources/MediaIO")
 
 func mlxDependency(_ name: String) -> [Target.Dependency] {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ Linux packages install the `mere.run` CLI plus colocated runtime assets; they do
 not include the macOS SwiftUI studio or DMG layout. On Linux arm64, if a distro
 Clang shadows Swift's bundled Clang and cannot compile MLX bf16 headers, the
 Linux scripts select a bf16-capable C++ driver or report the `CXX` override to
-use. Linux arm64 release packages should be built with CUDA enabled:
+use. Linux arm64 release packages should be built with CUDA enabled on a host
+with the CUDA Toolkit headers, cuDNN, and NCCL installed. CUDA `.deb`
+artifacts declare the linked CUDA 13 runtime packages
+(`cuda-cudart-13-0`, `cuda-nvrtc-13-0`, `libcublas-13-0`,
+`libcudnn9-cuda-13`, and `libnccl2`) by default:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -419,12 +419,14 @@ public actor Gemma4Generator: ChatGenerator {
         }
 
         let rowID = UUID()
+        let initialLogitsBox = RuntimeUncheckedSendable(initialLogits)
+        let layerCachesBox = RuntimeUncheckedSendable(layerCaches)
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 let row = Gemma4BatchedDecodeRow(
                     id: rowID,
-                    logits: initialLogits,
-                    layerCaches: layerCaches,
+                    logits: initialLogitsBox.value,
+                    layerCaches: layerCachesBox.value,
                     eosSet: eosSet,
                     generationConfig: generationConfig,
                     tokenBudget: tokenBudget,

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -958,7 +958,7 @@ final class Gemma4LanguageModel: Module {
     }
 }
 
-public final class Gemma4TextCausalLM: Module {
+public final class Gemma4TextCausalLM: Module, @unchecked Sendable {
     @ModuleInfo(key: "language_model") var languageModel: Gemma4LanguageModel
 
     public let config: Gemma4TextConfig

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @preconcurrency import Hub
 
 public struct HubSnapshotOptions: Sendable {
@@ -67,6 +70,7 @@ public actor HubSnapshot {
 
     private let options: HubSnapshotOptions
     private let hubApi: HubApi
+    private let downloadBase: URL
     private var cachedSnapshotURL: URL?
 
     public init(
@@ -79,6 +83,7 @@ public actor HubSnapshot {
             requested: options.cacheDirectory,
             fileManager: .default
         )
+        self.downloadBase = downloadBase
 
         self.hubApi = hubApi ?? HubApi(
             downloadBase: downloadBase,
@@ -91,6 +96,12 @@ public actor HubSnapshot {
     public func prepare(progressHandler: ProgressHandler? = nil) async throws -> URL {
         if let cachedSnapshotURL, FileManager.default.fileExists(atPath: cachedSnapshotURL.path) {
             return cachedSnapshotURL
+        }
+
+        if !options.offline, !options.patterns.isEmpty {
+            let snapshotURL = try await prepareMaterializedSnapshot(progressHandler: progressHandler)
+            cachedSnapshotURL = snapshotURL
+            return snapshotURL
         }
 
         let repo = Hub.Repo(id: options.repoId, type: options.repoType)
@@ -170,5 +181,377 @@ public actor HubSnapshot {
         let url = fileManager.temporaryDirectory.appending(path: "MereRun/hub")
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private func prepareMaterializedSnapshot(progressHandler: ProgressHandler?) async throws -> URL {
+        let entries = try await remoteTreeEntries()
+            .filter { $0.type == "file" && Self.matchesPath($0.path, patterns: options.patterns) }
+            .sorted { $0.path < $1.path }
+        guard !entries.isEmpty else {
+            throw Hub.HubClientError.fileNotFound(options.patterns.joined(separator: ", "))
+        }
+
+        let snapshotURL = materializedSnapshotURL()
+        let metadataURL = snapshotURL
+            .appending(path: ".cache")
+            .appending(path: "huggingface")
+            .appending(path: "download")
+        try FileManager.default.createDirectory(at: snapshotURL, withIntermediateDirectories: true)
+
+        let totalBytes = max(entries.reduce(Int64(0)) { partial, entry in
+            partial + max(entry.size ?? 0, 0)
+        }, 1)
+        var completedBytes: Int64 = 0
+        progressHandler?(HubSnapshotProgress(completedUnitCount: completedBytes, totalUnitCount: totalBytes))
+
+        for entry in entries {
+            try Self.validateRelativePath(entry.path)
+            let expectedBytes = max(entry.size ?? 0, 0)
+            let destination = snapshotURL.appending(path: entry.path)
+            let metadataDestination = metadataURL.appending(path: entry.path + ".metadata")
+            if Self.fileExists(at: destination, expectedBytes: expectedBytes) {
+                completedBytes += max(expectedBytes, Self.fileSize(at: destination))
+                progressHandler?(HubSnapshotProgress(
+                    completedUnitCount: min(completedBytes, totalBytes),
+                    totalUnitCount: totalBytes
+                ))
+                continue
+            }
+
+            let source = resolveURL(for: entry.path)
+            let remote = try await resolveRemoteFile(source: source, relativePath: entry.path)
+            let startedAt = Date()
+            let completedBeforeDownload = completedBytes
+            let delegate = HubSnapshotDownloadDelegate { written, _, _ in
+                let elapsed = max(Date().timeIntervalSince(startedAt), 0.001)
+                let speed = Double(written) / elapsed
+                progressHandler?(HubSnapshotProgress(
+                    completedUnitCount: min(completedBeforeDownload + written, totalBytes),
+                    totalUnitCount: totalBytes,
+                    estimatedSpeedBytesPerSecond: speed
+                ))
+            }
+            let tempURL = try await download(remote.downloadURL, delegate: delegate, relativePath: entry.path)
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.moveItem(at: tempURL, to: destination)
+            try writeDownloadMetadata(remote, to: metadataDestination)
+            completedBytes += max(expectedBytes, Self.fileSize(at: destination))
+            progressHandler?(HubSnapshotProgress(
+                completedUnitCount: min(completedBytes, totalBytes),
+                totalUnitCount: totalBytes,
+                estimatedSpeedBytesPerSecond: delegate.lastSpeedBytesPerSecond
+            ))
+        }
+
+        progressHandler?(HubSnapshotProgress(completedUnitCount: totalBytes, totalUnitCount: totalBytes))
+        return snapshotURL
+    }
+
+    private func remoteTreeEntries() async throws -> [HubSnapshotTreeEntry] {
+        var url = hostURL()
+            .appending(path: "api")
+            .appending(path: options.repoType.rawValue)
+            .appending(path: options.repoId)
+            .appending(path: "tree")
+            .appending(component: options.revision)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = [URLQueryItem(name: "recursive", value: "true")]
+        if let componentURL = components?.url {
+            url = componentURL
+        }
+        var request = authorizedRequest(url: url)
+        request.httpMethod = "GET"
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try Self.validateHTTPResponse(response, data: data, context: "\(options.repoId)@\(options.revision)")
+        return try JSONDecoder().decode([HubSnapshotTreeEntry].self, from: data)
+    }
+
+    private func resolveRemoteFile(source: URL, relativePath: String) async throws -> HubSnapshotRemoteFile {
+        var request = authorizedRequest(url: source)
+        request.httpMethod = "HEAD"
+        request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+        let delegate = HubSnapshotNoRedirectDelegate()
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        let (data, response) = try await session.data(for: request)
+        let http = try Self.validateHTTPResponse(response, data: data, context: "\(options.repoId)@\(options.revision)/\(relativePath)", allowsRedirect: true)
+
+        let downloadURL: URL
+        if (300..<400).contains(http.statusCode),
+           let location = http.value(forHTTPHeaderField: "Location"),
+           let resolved = Self.redirectURL(from: location, relativeTo: source) {
+            downloadURL = resolved
+        } else {
+            downloadURL = source
+        }
+
+        let commitHash = http.value(forHTTPHeaderField: "X-Repo-Commit") ?? options.revision
+        let etag = Self.normalizedETag(
+            http.value(forHTTPHeaderField: "X-Linked-ETag")
+                ?? http.value(forHTTPHeaderField: "ETag")
+        )
+        return HubSnapshotRemoteFile(commitHash: commitHash, etag: etag, downloadURL: downloadURL)
+    }
+
+    private func download(
+        _ url: URL,
+        delegate: HubSnapshotDownloadDelegate,
+        relativePath: String
+    ) async throws -> URL {
+        var currentURL = url
+        for _ in 0..<8 {
+            var request = authorizedRequest(url: currentURL)
+            request.httpMethod = "GET"
+            let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+            defer { session.invalidateAndCancel() }
+            let (tempURL, response) = try await session.download(for: request)
+            let http = try Self.validateDownloadedResponse(
+                response,
+                errorBodyURL: tempURL,
+                context: "\(options.repoId)@\(options.revision)/\(relativePath)"
+            )
+            if (200..<300).contains(http.statusCode) {
+                return tempURL
+            }
+            try? FileManager.default.removeItem(at: tempURL)
+            guard (300..<400).contains(http.statusCode),
+                  let location = http.value(forHTTPHeaderField: "Location"),
+                  let redirected = Self.redirectURL(from: location, relativeTo: currentURL) else {
+                throw Hub.HubClientError.httpStatusCode(http.statusCode)
+            }
+            currentURL = redirected
+        }
+        throw Hub.HubClientError.downloadError("Too many redirects while downloading \(options.repoId)/\(relativePath)")
+    }
+
+    private func writeDownloadMetadata(_ remote: HubSnapshotRemoteFile, to metadataURL: URL) throws {
+        guard let etag = remote.etag, !etag.isEmpty else { return }
+        try FileManager.default.createDirectory(
+            at: metadataURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let content = "\(remote.commitHash)\n\(etag)\n\(Date().timeIntervalSince1970)\n"
+        try content.write(to: metadataURL, atomically: true, encoding: .utf8)
+    }
+
+    private func materializedSnapshotURL() -> URL {
+        downloadBase
+            .appending(path: options.repoType.rawValue)
+            .appending(path: options.repoId)
+    }
+
+    private func resolveURL(for relativePath: String) -> URL {
+        var url = hostURL()
+        if options.repoType != .models {
+            url = url.appending(path: options.repoType.rawValue)
+        }
+        return url
+            .appending(path: options.repoId)
+            .appending(path: "resolve")
+            .appending(component: options.revision)
+            .appending(path: relativePath)
+    }
+
+    private func authorizedRequest(url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        if let token = accessToken(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private func accessToken() -> String? {
+        if let token = options.accessToken {
+            return token
+        }
+        let env = ProcessInfo.processInfo.environment
+        return env["HF_TOKEN"] ?? env["HUGGING_FACE_HUB_TOKEN"]
+    }
+
+    private func hostURL() -> URL {
+        let endpoint = ProcessInfo.processInfo.environment["HF_ENDPOINT"]
+        if let endpoint, let url = URL(string: endpoint), url.scheme != nil, url.host != nil {
+            return url
+        }
+        return URL(string: "https://huggingface.co")!
+    }
+
+    static func matchesPath(_ path: String, patterns: [String]) -> Bool {
+        guard !patterns.isEmpty else { return true }
+        return patterns.contains { pattern in
+            guard let regex = globRegex(pattern) else {
+                return path == pattern
+            }
+            return path == pattern || regex.firstMatch(
+                in: path,
+                range: NSRange(path.startIndex..<path.endIndex, in: path)
+            ) != nil
+        }
+    }
+
+    static func redirectURL(from location: String, relativeTo source: URL) -> URL? {
+        URL(string: location, relativeTo: source)?.absoluteURL
+    }
+
+    private static func globRegex(_ pattern: String) -> NSRegularExpression? {
+        var regex = "^"
+        for scalar in pattern.unicodeScalars {
+            switch scalar {
+            case "*":
+                regex += ".*"
+            case "?":
+                regex += "."
+            case ".", "\\", "+", "(", ")", "{", "}", "[", "]", "^", "$", "|":
+                regex += "\\\(String(scalar))"
+            default:
+                regex += String(scalar)
+            }
+        }
+        regex += "$"
+        return try? NSRegularExpression(pattern: regex)
+    }
+
+    private static func validateRelativePath(_ path: String) throws {
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.split(separator: "/").contains("..") else {
+            throw Hub.HubClientError.downloadError("Unsafe Hub path: \(path)")
+        }
+    }
+
+    private static func fileExists(at url: URL, expectedBytes: Int64) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return false
+        }
+        return expectedBytes <= 0 || fileSize(at: url) == expectedBytes
+    }
+
+    private static func fileSize(at url: URL) -> Int64 {
+        let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? NSNumber)?
+            .int64Value
+        return size ?? 0
+    }
+
+    private static func normalizedETag(_ etag: String?) -> String? {
+        guard var etag else { return nil }
+        if etag.hasPrefix("W/") {
+            etag = String(etag.dropFirst(2))
+        }
+        return etag.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+
+    @discardableResult
+    private static func validateDownloadedResponse(
+        _ response: URLResponse,
+        errorBodyURL: URL,
+        context: String
+    ) throws -> HTTPURLResponse {
+        guard let http = response as? HTTPURLResponse else {
+            throw Hub.HubClientError.unexpectedError
+        }
+        guard !(200..<300).contains(http.statusCode),
+              !(300..<400).contains(http.statusCode) else {
+            return http
+        }
+        return try validateHTTPResponse(
+            response,
+            data: try? Data(contentsOf: errorBodyURL),
+            context: context,
+            allowsRedirect: true
+        )
+    }
+
+    @discardableResult
+    private static func validateHTTPResponse(
+        _ response: URLResponse,
+        data: Data?,
+        context: String,
+        allowsRedirect: Bool = false
+    ) throws -> HTTPURLResponse {
+        guard let http = response as? HTTPURLResponse else {
+            throw Hub.HubClientError.unexpectedError
+        }
+        if (200..<300).contains(http.statusCode) || (allowsRedirect && (300..<400).contains(http.statusCode)) {
+            return http
+        }
+        if http.statusCode == 401 || http.statusCode == 403 {
+            throw Hub.HubClientError.authorizationRequired
+        }
+        if http.statusCode == 404 {
+            throw Hub.HubClientError.fileNotFound(context)
+        }
+        if let data,
+           let body = String(data: data, encoding: .utf8),
+           !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw Hub.HubClientError.downloadError("\(context): HTTP \(http.statusCode): \(body)")
+        }
+        throw Hub.HubClientError.httpStatusCode(http.statusCode)
+    }
+}
+
+private struct HubSnapshotTreeEntry: Decodable, Sendable {
+    let path: String
+    let type: String
+    let size: Int64?
+}
+
+private struct HubSnapshotRemoteFile: Sendable {
+    let commitHash: String
+    let etag: String?
+    let downloadURL: URL
+}
+
+private final class HubSnapshotNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _: URLSession,
+        task _: URLSessionTask,
+        willPerformHTTPRedirection _: HTTPURLResponse,
+        newRequest _: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+private final class HubSnapshotDownloadDelegate: NSObject, URLSessionTaskDelegate, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let startedAt = Date()
+    private let progressHandler: @Sendable (Int64, Int64, Double?) -> Void
+    private(set) var lastSpeedBytesPerSecond: Double?
+
+    init(progressHandler: @escaping @Sendable (Int64, Int64, Double?) -> Void) {
+        self.progressHandler = progressHandler
+    }
+
+    func urlSession(
+        _: URLSession,
+        task _: URLSessionTask,
+        willPerformHTTPRedirection _: HTTPURLResponse,
+        newRequest _: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
+    func urlSession(
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didFinishDownloadingTo _: URL
+    ) {}
+
+    func urlSession(
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didWriteData _: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let elapsed = max(Date().timeIntervalSince(startedAt), 0.001)
+        let speed = Double(totalBytesWritten) / elapsed
+        lastSpeedBytesPerSecond = speed
+        progressHandler(totalBytesWritten, totalBytesExpectedToWrite, speed)
     }
 }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -110,6 +110,40 @@ public enum ManagedModelCatalog {
         "vae/*",
         "scheduler/*",
     ]
+    private static let kleinNanoSnapshotPatterns = [
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "text_encoder/config.json",
+        "text_encoder/model.safetensors",
+        "tokenizer/added_tokens.json",
+        "tokenizer/chat_template.jinja",
+        "tokenizer/merges.txt",
+        "tokenizer/special_tokens_map.json",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "tokenizer/vocab.json",
+        "transformer/config.json",
+        "transformer/diffusion_pytorch_model.safetensors",
+        "vae/config.json",
+        "vae/diffusion_pytorch_model.safetensors",
+    ]
+    private static let zImageNanoSnapshotPatterns = [
+        "text_encoder/0.safetensors",
+        "text_encoder/1.safetensors",
+        "text_encoder/model.safetensors.index.json",
+        "tokenizer/added_tokens.json",
+        "tokenizer/chat_template.jinja",
+        "tokenizer/merges.txt",
+        "tokenizer/special_tokens_map.json",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "tokenizer/vocab.json",
+        "transformer/0.safetensors",
+        "transformer/1.safetensors",
+        "transformer/model.safetensors.index.json",
+        "vae/0.safetensors",
+        "vae/model.safetensors.index.json",
+    ]
 
     private static let zImageNanoUpstreamRepoId = "filipstrand/Z-Image-Turbo-mflux-4bit"
     private static let kleinNanoUpstreamRepoId = "stereovoid/flux2-klein-4b-4bit"
@@ -123,7 +157,7 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
                 repoId: kleinNanoUpstreamRepoId,
-                patterns: diffusersImageSnapshotPatterns
+                patterns: kleinNanoSnapshotPatterns
             ),
             upstreamRepoId: kleinNanoUpstreamRepoId,
             validationKind: .flux2Klein,
@@ -216,7 +250,7 @@ public enum ManagedModelCatalog {
             hubFallback: HubFallbackConfig(
                 repoId: zImageNanoUpstreamRepoId,
                 revision: "main",
-                patterns: diffusersImageSnapshotPatterns
+                patterns: zImageNanoSnapshotPatterns
             ),
             upstreamRepoId: zImageNanoUpstreamRepoId,
             upstreamRevision: "main",

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -464,11 +464,12 @@ public actor Q35Generator: ChatGenerator {
         }
 
         let rowID = UUID()
+        let initialLogitsBox = RuntimeUncheckedSendable(initialLogits)
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 let row = Q35BatchedDecodeRow(
                     id: rowID,
-                    logits: initialLogits,
+                    logits: initialLogitsBox.value,
                     layerCaches: layerCaches,
                     eosSet: eosSet,
                     generationConfig: generationConfig,

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -182,7 +182,7 @@ final class Q35Transformer: Module {
     }
 }
 
-public final class Q35Model: Module {
+public final class Q35Model: Module, @unchecked Sendable {
     @ModuleInfo(key: "model") var model: Q35Transformer
     @ModuleInfo(key: "lm_head") var lmHead: Linear
 

--- a/Sources/MereRunCore/RuntimeUncheckedSendable.swift
+++ b/Sources/MereRunCore/RuntimeUncheckedSendable.swift
@@ -1,0 +1,7 @@
+struct RuntimeUncheckedSendable<Value>: @unchecked Sendable {
+    let value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
@@ -4,7 +4,7 @@ import Foundation
 import MLX
 import MLXRandom
 
-public struct GenerationConfig {
+public struct GenerationConfig: Sendable {
     public var maxTokens: Int
     public var temperature: Float
     public var topK: Int

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -16,6 +16,8 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(package.contains("-lMLXFast"))
         XCTAssertTrue(package.contains("$ORIGIN/lib"))
         XCTAssertTrue(package.contains("linuxNativeLlamaLibraryPath"))
+        XCTAssertTrue(package.contains("linuxPackageSwiftSettings"))
+        XCTAssertTrue(package.contains("-strict-concurrency=targeted"))
         XCTAssertFalse(
             package.contains(".product(name: \"MLXFast\", package: \"mlx-swift\")"),
             "Direct MLX product dependencies must go through mlxDependency so cuda-prebuilt mode can import CMake-built modules."
@@ -36,6 +38,14 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(script.contains("$mlx_cmake_build/_deps/mlx-c-build/libmlxc.a"))
         XCTAssertTrue(script.contains("$mlx_cmake_build/_deps/mlx-build/libmlx.a"))
         XCTAssertTrue(script.contains("$mlx_cmake_build/lib/libNumerics.a"))
+        XCTAssertTrue(script.contains("detect_cuda_dependency_defaults"))
+        XCTAssertTrue(script.contains("patch_mlx_cuda_jit_include_path"))
+        XCTAssertTrue(script.contains("MERERUN_CUDA_CCCL_INCLUDE"))
+        XCTAssertTrue(script.contains("Source/Cmlx/mlx/mlx/backend/cuda/jit_module.cpp"))
+        XCTAssertTrue(script.contains("/usr/include/$deb_multiarch"))
+        XCTAssertTrue(script.contains("/usr/lib/$deb_multiarch"))
+        XCTAssertTrue(script.contains("CUDA_LIBRARY_PATH"))
+        XCTAssertTrue(script.contains("/usr/local/cuda/targets/sbsa-linux/lib"))
         XCTAssertFalse(script.contains("whose Linux path remains CPU-oriented until a package bridge is added"))
     }
 
@@ -50,6 +60,13 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(packageScript.contains("deb_multiarch=\"aarch64-linux-gnu\""))
         XCTAssertTrue(packageScript.contains("MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE"))
         XCTAssertTrue(packageScript.contains("Linux arm64 release packages must use MERERUN_LINUX_ACCEL=cuda"))
+        XCTAssertTrue(packageScript.contains("CUDA_LIBRARY_PATH"))
+        XCTAssertTrue(packageScript.contains("/usr/local/cuda/targets/sbsa-linux/lib"))
+        XCTAssertTrue(packageScript.contains("cuda-cudart-13-0"))
+        XCTAssertTrue(packageScript.contains("cuda-nvrtc-13-0"))
+        XCTAssertTrue(packageScript.contains("libcublas-13-0"))
+        XCTAssertTrue(packageScript.contains("libcudnn9-cuda-13"))
+        XCTAssertTrue(packageScript.contains("libnccl2"))
         XCTAssertTrue(
             packageScript.contains("configure_linux_arm64_bf16_toolchain \"$platform_arch\" \"package-linux\"")
         )
@@ -76,6 +93,9 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(workflow.contains("Build Linux arm64 CUDA"))
         XCTAssertTrue(workflow.contains("runs-on: [self-hosted, linux, arm64, cuda]"))
         XCTAssertTrue(workflow.contains("MERERUN_LINUX_ACCEL: cuda"))
+        XCTAssertTrue(workflow.contains("cuda-cccl-13-0"))
+        XCTAssertTrue(workflow.contains("libcudnn9-dev-cuda-13"))
+        XCTAssertTrue(workflow.contains("libnccl-dev"))
         XCTAssertTrue(workflow.contains("MERERUN_RELEASE_ARM64_CUDA == '1'"))
         XCTAssertTrue(workflow.contains("build_arm64_cuda"))
         XCTAssertTrue(workflow.contains("pattern: mere-run-linux-*-packages"))

--- a/Tests/MereRunCoreTests/HubSnapshotTests.swift
+++ b/Tests/MereRunCoreTests/HubSnapshotTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MereRunCore
+
+final class HubSnapshotTests: XCTestCase {
+    func testHubSnapshotPatternMatchingPreservesNestedPaths() {
+        XCTAssertTrue(HubSnapshot.matchesPath(
+            "tokenizer/added_tokens.json",
+            patterns: ["tokenizer/*"]
+        ))
+        XCTAssertTrue(HubSnapshot.matchesPath(
+            "tokenizer/added_tokens.json",
+            patterns: ["tokenizer/added_tokens.json"]
+        ))
+        XCTAssertTrue(HubSnapshot.matchesPath(
+            "Qwen3-Coder-Next-Q4_K_M/subdir/model.gguf",
+            patterns: ["Qwen3-Coder-Next-Q4_K_M/*"]
+        ))
+        XCTAssertTrue(HubSnapshot.matchesPath(
+            "model-q4.gguf",
+            patterns: ["*.gguf"]
+        ))
+
+        XCTAssertFalse(HubSnapshot.matchesPath(
+            "added_tokens.json",
+            patterns: ["tokenizer/*"]
+        ))
+        XCTAssertFalse(HubSnapshot.matchesPath(
+            "tokenizer_config.json",
+            patterns: ["tokenizer/*"]
+        ))
+    }
+
+    func testRedirectResolutionDoesNotDoubleEncodeNestedHubPath() throws {
+        let source = try XCTUnwrap(URL(string: "https://huggingface.co/org/repo/resolve/main/tokenizer/added_tokens.json"))
+        let location = "/api/resolve-cache/models/org/repo/commit/tokenizer%2Fadded_tokens.json?etag=%22abc%22"
+        let redirected = try XCTUnwrap(HubSnapshot.redirectURL(from: location, relativeTo: source))
+
+        XCTAssertTrue(redirected.absoluteString.contains("tokenizer%2Fadded_tokens.json"))
+        XCTAssertFalse(redirected.absoluteString.contains("tokenizer%252Fadded_tokens.json"))
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -71,6 +71,18 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.repoId, "filipstrand/Z-Image-Turbo-mflux-4bit")
         XCTAssertEqual(spec.upstreamRepoId, "filipstrand/Z-Image-Turbo-mflux-4bit")
         XCTAssertEqual(spec.upstreamRevision, "main")
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/added_tokens.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("transformer/model.safetensors.index.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/*"), false)
+    }
+
+    func testKleinNanoUsesExplicitHubSourceFiles() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "stereovoid/flux2-klein-4b-4bit")
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/added_tokens.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("transformer/diffusion_pytorch_model.safetensors"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/*"), false)
     }
 
     func testBonsaiTernaryUsesPrismMLHubSource() throws {

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -113,7 +113,11 @@ input to validate the hosted x86_64 package build and upload an Actions
 artifact. The optional arm64 CUDA lane requires a self-hosted Linux runner
 labeled `self-hosted`, `linux`, `arm64`, and `cuda`; enable it manually with
 `build_arm64_cuda` or on release events with the
-`MERERUN_RELEASE_ARM64_CUDA=1` repository variable. On published GitHub Release
+`MERERUN_RELEASE_ARM64_CUDA=1` repository variable. That runner must provide
+the CUDA Toolkit headers, CUDA CCCL headers, cuDNN, NCCL, Swift, and the normal
+Linux packaging dependencies. CUDA `.deb` artifacts add default runtime
+dependencies on `cuda-cudart-13-0`, `cuda-nvrtc-13-0`, `libcublas-13-0`,
+`libcudnn9-cuda-13`, and `libnccl2`. On published GitHub Release
 events, the workflow uploads the available Linux artifacts and checksum manifest
 to the release.
 

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -106,12 +106,19 @@ Linux arm64 is only useful for this project when the CUDA lane works. Do not
 publish or recommend CPU-only arm64 packages as release artifacts.
 
 Build arm64 packages on a native arm64 Linux host with an NVIDIA GPU, driver,
-CUDA Toolkit, `nvcc`, Swift, OpenBLAS/LAPACK headers, and `ffmpeg` available:
+CUDA Toolkit, `nvcc`, CUDA CCCL headers, cuDNN, NCCL, Swift,
+OpenBLAS/LAPACK headers, and `ffmpeg` available. On NVIDIA's Ubuntu 24.04 SBSA
+repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
+`libnccl-dev`:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
 ls dist/linux/
 ```
+
+CUDA `.deb` packages declare the CUDA 13 runtime packages they link against:
+`cuda-cudart-13-0`, `cuda-nvrtc-13-0`, `libcublas-13-0`,
+`libcudnn9-cuda-13`, and `libnccl2`.
 
 For source-only CUDA checks, prepare native artifacts and then export the
 environment printed by the script before building:

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -33,6 +33,9 @@ Environment:
                                 reported by ldd into payload lib/. Default: 1.
   MERERUN_PACKAGE_LINUX_DEPS    Override Debian Depends field.
   MERERUN_LINUX_ACCEL           Passed through to prepare-linux-native.sh (cpu/cuda).
+  CUDA_LIBRARY_PATH             Optional CUDA toolkit library directory for
+                                SwiftPM MLX CUDA linking. Linux SBSA and lib64
+                                defaults are detected when unset.
   MERERUN_LINUX_ALLOW_ARM64_CPU_PACKAGE=1
                                 Allow an arm64 CPU package for local smoke tests.
   MERERUN_DS4_LINUX_BIN_DIR     Passed through to prepare-linux-native.sh for DS4 staging.
@@ -165,6 +168,8 @@ fi
 mlx_swift_cuda_link_flags() {
   local mlx_cmake_build="$native_root/build/mlx-swift-cuda-smoke"
   local local_openblas_root="$native_root/deps/apt-root"
+  local cudnn_library_path="${CUDNN_LIBRARY_PATH:-}"
+  local cuda_library_path="${CUDA_LIBRARY_PATH:-}"
   local flags=()
 
   flags+=("-L" "$mlx_cmake_build/_deps/mlx-c-build")
@@ -176,9 +181,20 @@ mlx_swift_cuda_link_flags() {
     flags+=("-L" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
     flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
   fi
-  if [[ -n "${CUDNN_LIBRARY_PATH:-}" ]]; then
-    flags+=("-L" "$CUDNN_LIBRARY_PATH")
-    flags+=("-Xlinker" "-rpath" "-Xlinker" "$CUDNN_LIBRARY_PATH")
+  if [[ -z "$cudnn_library_path" ]]; then
+    for candidate in \
+      "/usr/lib/$deb_multiarch" \
+      /usr/local/cuda/lib64 \
+      /usr/local/cuda/targets/sbsa-linux/lib; do
+      if [[ -f "$candidate/libcudnn.so" || -f "$candidate/libcudnn.so.9" ]]; then
+        cudnn_library_path="$candidate"
+        break
+      fi
+    done
+  fi
+  if [[ -n "$cudnn_library_path" ]]; then
+    flags+=("-L" "$cudnn_library_path")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$cudnn_library_path")
     for cudnn_lib in \
       libcudnn.so.9 \
       libcudnn_graph.so.9 \
@@ -188,10 +204,28 @@ mlx_swift_cuda_link_flags() {
       libcudnn_adv.so.9 \
       libcudnn_engines_precompiled.so.9 \
       libcudnn_heuristic.so.9; do
-      if [[ -f "$CUDNN_LIBRARY_PATH/$cudnn_lib" ]]; then
-        flags+=("$CUDNN_LIBRARY_PATH/$cudnn_lib")
+      if [[ -f "$cudnn_library_path/$cudnn_lib" ]]; then
+        flags+=("$cudnn_library_path/$cudnn_lib")
       fi
     done
+  fi
+  if [[ -z "$cuda_library_path" ]]; then
+    for candidate in \
+      "${CUDA_HOME:-}/lib64" \
+      "${CUDA_HOME:-}/targets/sbsa-linux/lib" \
+      "${CUDA_PATH:-}/lib64" \
+      "${CUDA_PATH:-}/targets/sbsa-linux/lib" \
+      /usr/local/cuda/lib64 \
+      /usr/local/cuda/targets/sbsa-linux/lib; do
+      if [[ -f "$candidate/libcublasLt.so" || -f "$candidate/libnvrtc.so" || -f "$candidate/libcudart.so" ]]; then
+        cuda_library_path="$candidate"
+        break
+      fi
+    done
+  fi
+  if [[ -n "$cuda_library_path" ]]; then
+    flags+=("-L" "$cuda_library_path")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$cuda_library_path")
   fi
   if [[ -d /usr/lib/$deb_multiarch ]]; then
     flags+=("-L" "/usr/lib/$deb_multiarch")
@@ -365,7 +399,11 @@ if (( do_deb )); then
     cp -a "$payload_dir"/. "$install_root/"
     ln -s ../lib/mere-run/mere.run "$deb_root/usr/bin/mere.run"
 
-    depends="${MERERUN_PACKAGE_LINUX_DEPS:-ffmpeg, libcurl4, zlib1g, libopenblas0-pthread | libopenblas0, liblapacke}"
+    default_depends="ffmpeg, libcurl4, zlib1g, libopenblas0-pthread | libopenblas0, liblapacke"
+    if [[ "$linux_accel" == "cuda" ]]; then
+      default_depends="$default_depends, cuda-cudart-13-0, cuda-nvrtc-13-0, libcublas-13-0, libcudnn9-cuda-13, libnccl2"
+    fi
+    depends="${MERERUN_PACKAGE_LINUX_DEPS:-$default_depends}"
     installed_size="$(du -sk "$deb_root/usr" | awk '{print $1}')"
     cat >"$deb_root/DEBIAN/control" <<CONTROL
 Package: mere-run

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -34,6 +34,12 @@ Environment:
                               CMake CUDA smoke.
   CUDNN_LIBRARY_PATH          Optional cuDNN library directory for mlx-swift
                               CMake CUDA smoke.
+                              When unset, Linux defaults are detected from
+                              /usr/include/<multiarch> and
+                              /usr/lib/<multiarch>.
+  CUDA_LIBRARY_PATH           Optional CUDA toolkit library directory for the
+                              SwiftPM MLX CUDA bridge. When unset, Linux SBSA
+                              and lib64 defaults are detected.
   BLAS_LIBRARIES              Optional BLAS library path for mlx-swift CUDA smoke.
   BLAS_INCLUDE_DIRS           Optional BLAS include directory for mlx-swift CUDA smoke.
   LAPACK_LIBRARIES            Optional LAPACK library path for mlx-swift CUDA smoke.
@@ -104,6 +110,61 @@ require_tool() {
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "[prepare-linux-native] error: required tool not found in PATH: $tool" >&2
     exit 127
+  fi
+}
+
+patch_mlx_cuda_jit_include_path() {
+  local mlx_jit_module="$1"
+  if [[ ! -f "$mlx_jit_module" ]] ||
+     grep -Fq "MERERUN_CUDA_CCCL_INCLUDE" "$mlx_jit_module"; then
+    return
+  fi
+
+  local mlx_jit_tmp
+  mlx_jit_tmp="$(mktemp "${TMPDIR:-/tmp}/mererun-mlx-jit.XXXXXX")"
+  awk '
+    {
+      print
+      if ($0 ~ /args\.push_back\(fmt::format\("--include-path=\{\}\/include", home\)\);/) {
+        print "        // MERERUN_CUDA_CCCL_INCLUDE: CUDA 13 SBSA installs cuda/std under include/cccl."
+        print "        auto cuda_cccl_path = std::filesystem::path(home) / \"include\" / \"cccl\";"
+        print "        if (std::filesystem::exists(cuda_cccl_path)) {"
+        print "          args.push_back(fmt::format(\"--include-path={}\", cuda_cccl_path.string()));"
+        print "        }"
+      }
+    }
+  ' "$mlx_jit_module" >"$mlx_jit_tmp"
+  mv "$mlx_jit_tmp" "$mlx_jit_module"
+  echo "[prepare-linux-native] patched mlx-swift CUDA JIT include path in ${mlx_jit_module#$repo_root/}."
+}
+
+detect_cuda_dependency_defaults() {
+  if [[ "$linux_accel" != "cuda" ]]; then
+    return
+  fi
+
+  if [[ -z "${CUDNN_INCLUDE_PATH:-}" ]]; then
+    for candidate in \
+      "/usr/include/$deb_multiarch" \
+      /usr/local/cuda/include \
+      /usr/local/cuda/targets/sbsa-linux/include; do
+      if [[ -f "$candidate/cudnn.h" ]]; then
+        export CUDNN_INCLUDE_PATH="$candidate"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "${CUDNN_LIBRARY_PATH:-}" ]]; then
+    for candidate in \
+      "/usr/lib/$deb_multiarch" \
+      /usr/local/cuda/lib64 \
+      /usr/local/cuda/targets/sbsa-linux/lib; do
+      if [[ -f "$candidate/libcudnn.so" || -f "$candidate/libcudnn.so.9" ]]; then
+        export CUDNN_LIBRARY_PATH="$candidate"
+        break
+      fi
+    done
   fi
 }
 
@@ -293,6 +354,9 @@ smoke_mlx_swift_cuda() {
   git -C "$mlx_cmake_src" fetch --depth 1 origin main
   git -C "$mlx_cmake_src" checkout --detach FETCH_HEAD
 
+  patch_mlx_cuda_jit_include_path "$mlx_cmake_src/Source/Cmlx/mlx/mlx/backend/cuda/jit_module.cpp"
+  patch_mlx_cuda_jit_include_path "$mlx_cmake_build/_deps/mlx-src/mlx/backend/cuda/jit_module.cpp"
+
   local local_openblas_root="$native_root/deps/apt-root"
   local local_openblas_lib="$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so"
   local local_openblas_include="$local_openblas_root/usr/include/$deb_multiarch/openblas-pthread;$local_openblas_root/usr/include"
@@ -336,6 +400,7 @@ smoke_mlx_swift_cuda() {
     -DMLX_BUILD_CUDA=ON
     -DMLX_C_BUILD_EXAMPLES=OFF
   )
+  detect_cuda_dependency_defaults
   if [[ -n "${CUDNN_INCLUDE_PATH:-}" ]]; then
     mlx_cmake_args+=("-DCUDNN_INCLUDE_PATH=$CUDNN_INCLUDE_PATH")
   fi
@@ -405,6 +470,8 @@ NOTICE
 mlx_swift_cuda_link_flags() {
   local mlx_cmake_build="$native_root/build/mlx-swift-cuda-smoke"
   local local_openblas_root="$native_root/deps/apt-root"
+  local cudnn_library_path="${CUDNN_LIBRARY_PATH:-}"
+  local cuda_library_path="${CUDA_LIBRARY_PATH:-}"
   local flags=()
 
   flags+=("-L" "$mlx_cmake_build/_deps/mlx-c-build")
@@ -416,9 +483,20 @@ mlx_swift_cuda_link_flags() {
     flags+=("-L" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
     flags+=("-Xlinker" "-rpath" "-Xlinker" "$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread")
   fi
-  if [[ -n "${CUDNN_LIBRARY_PATH:-}" ]]; then
-    flags+=("-L" "$CUDNN_LIBRARY_PATH")
-    flags+=("-Xlinker" "-rpath" "-Xlinker" "$CUDNN_LIBRARY_PATH")
+  if [[ -z "$cudnn_library_path" ]]; then
+    for candidate in \
+      "/usr/lib/$deb_multiarch" \
+      /usr/local/cuda/lib64 \
+      /usr/local/cuda/targets/sbsa-linux/lib; do
+      if [[ -f "$candidate/libcudnn.so" || -f "$candidate/libcudnn.so.9" ]]; then
+        cudnn_library_path="$candidate"
+        break
+      fi
+    done
+  fi
+  if [[ -n "$cudnn_library_path" ]]; then
+    flags+=("-L" "$cudnn_library_path")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$cudnn_library_path")
     for cudnn_lib in \
       libcudnn.so.9 \
       libcudnn_graph.so.9 \
@@ -428,10 +506,28 @@ mlx_swift_cuda_link_flags() {
       libcudnn_adv.so.9 \
       libcudnn_engines_precompiled.so.9 \
       libcudnn_heuristic.so.9; do
-      if [[ -f "$CUDNN_LIBRARY_PATH/$cudnn_lib" ]]; then
-        flags+=("$CUDNN_LIBRARY_PATH/$cudnn_lib")
+      if [[ -f "$cudnn_library_path/$cudnn_lib" ]]; then
+        flags+=("$cudnn_library_path/$cudnn_lib")
       fi
     done
+  fi
+  if [[ -z "$cuda_library_path" ]]; then
+    for candidate in \
+      "${CUDA_HOME:-}/lib64" \
+      "${CUDA_HOME:-}/targets/sbsa-linux/lib" \
+      "${CUDA_PATH:-}/lib64" \
+      "${CUDA_PATH:-}/targets/sbsa-linux/lib" \
+      /usr/local/cuda/lib64 \
+      /usr/local/cuda/targets/sbsa-linux/lib; do
+      if [[ -f "$candidate/libcublasLt.so" || -f "$candidate/libnvrtc.so" || -f "$candidate/libcudart.so" ]]; then
+        cuda_library_path="$candidate"
+        break
+      fi
+    done
+  fi
+  if [[ -n "$cuda_library_path" ]]; then
+    flags+=("-L" "$cuda_library_path")
+    flags+=("-Xlinker" "-rpath" "-Xlinker" "$cuda_library_path")
   fi
   if [[ -d /usr/lib/$deb_multiarch ]]; then
     flags+=("-L" "/usr/lib/$deb_multiarch")


### PR DESCRIPTION
## Summary

- add the Linux arm64 CUDA release lane and native package-prep support so release artifacts can cover macOS, Linux x86_64, and Linux aarch64 CUDA
- harden Linux packaging around Swift bundled Clang/CUDA multiarch paths and add tests for the arm64 bridge behavior
- fix `model pull` for patterned Hugging Face snapshots on Linux by materializing matched files directly and preserving nested redirect paths like `tokenizer%2Fadded_tokens.json`
- pin explicit source-file pull patterns for `image-zimage-nano` and `image-klein-nano` so image models install without unnecessary repo sprawl

## Validation

- `./scripts/check.sh` from a clean `origin/main` worktree: 534 tests, 32 skipped, 0 failures
- DGX Spark arm64 CUDA package build:
  - `MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --skip-native --version 0.0.0-dgx-spark-smoke --output-dir dist/linux/arm64`
  - wrote `mere-run-0.0.0-dgx-spark-smoke-linux-arm64.tar.gz`, `.deb`, and `SHA256SUMS`
- DGX Spark fresh-package `model pull --allow-unsupported image-zimage-nano` with an isolated cache and forced fetch of `tokenizer/added_tokens.json`: passed
- DGX Spark `model info image-zimage-nano --components`: `Validation isValid: true`; scheduler unresolved is expected for the mflux Z-Image layout
- DGX Spark `image generate --model image-zimage-nano --width 512 --height 512 --steps 1 --seed 7`: produced a valid 512x512 PNG
