### PR TITLE
Bump release version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.9.0 - 2026-05-28
+
 ### Added
 
 - added a Linux arm64 CUDA package lane to the GitHub Actions `linux-release`
@@ -13,6 +15,12 @@ The format is based on Keep a Changelog.
   linker paths, cuDNN/NCCL provisioning, CUDA 13 CCCL runtime JIT include
   handling, CUDA runtime `.deb` dependencies, and a combined checksum manifest
   for available Linux artifacts.
+
+### Fixed
+
+- fixed Linux patterned Hugging Face model pulls so nested files like
+  `tokenizer/added_tokens.json` resolve through redirect URLs without double
+  encoding and image nano models can install on Linux CUDA hosts.
 
 ## 0.8.0 - 2026-05-23
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ artifacts. See the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for
 the current validation boundary, CUDA notes, and first commands:
 
 ```bash
-tag=v0.8.0
+tag=v0.9.0
 version="${tag#v}"
 
 # Portable tarball
@@ -110,7 +110,7 @@ artifacts declare the linked CUDA 13 runtime packages
 `libcudnn9-cuda-13`, and `libnccl2`) by default:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.9.0
 ```
 
 Current CUDA validation should be treated as limited to the exact hosts that
@@ -155,14 +155,14 @@ swift run mere.run --help
 To build Linux release packages from a Linux x86_64 Swift toolchain host:
 
 ```bash
-scripts/package-linux.sh --version 0.8.0
+scripts/package-linux.sh --version 0.9.0
 ls dist/linux/
 ```
 
 On Linux arm64, use a CUDA-provisioned host:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.9.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.8.0"
+    static let current = "0.9.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.8.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.9.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -99,7 +99,7 @@ Linux release packaging is a separate path for distributable headless CLI
 artifacts. The default GitHub release workflow publishes x86_64/amd64 artifacts:
 
 ```bash
-scripts/package-linux.sh --version 0.8.0
+scripts/package-linux.sh --version 0.9.0
 ls dist/linux/
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Linux-only setup path, first commands, release checks, and CUDA validation
 limits, see [Linux QuickStart](./linux-quickstart.md).
 
 ```bash
-tag=v0.8.0
+tag=v0.9.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64; deb_arch=amd64 ;;

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -29,7 +29,7 @@ and CUDA-gated arm64 package work.
 Use this path on Debian or Ubuntu-style systems:
 
 ```bash
-tag=v0.8.0
+tag=v0.9.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) deb_arch=amd64 ;;
@@ -50,7 +50,7 @@ assets that the CLI needs at runtime.
 Use this path when you do not want to install a Debian package:
 
 ```bash
-tag=v0.8.0
+tag=v0.9.0
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -112,7 +112,7 @@ repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.9.0
 ls dist/linux/
 ```
 
@@ -167,7 +167,7 @@ studio, and DMG packaging are macOS-only.
 Each Linux release includes `SHA256SUMS` beside the tarball and `.deb`:
 
 ```bash
-tag=v0.8.0
+tag=v0.9.0
 
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/SHA256SUMS" -o SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,7 +86,7 @@ CPU-oriented Linux manifest path.
 Linux release packaging has its own artifact check:
 
 ```bash
-scripts/package-linux.sh --version 0.8.0
+scripts/package-linux.sh --version 0.9.0
 test -s dist/linux/SHA256SUMS
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
@@ -97,7 +97,7 @@ dpkg-deb --contents dist/linux/mere-run_*_*.deb | grep 'usr/bin/mere.run'
 On Linux arm64, use CUDA for the package check:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.8.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.9.0
 ```
 
 The `linux-release` workflow runs the hosted package and manifest boundary for

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 configuration="${1:-debug}"
-app_version="${MERERUN_APP_VERSION:-0.8.0}"
-app_build="${MERERUN_APP_BUILD:-20}"
+app_version="${MERERUN_APP_VERSION:-0.9.0}"
+app_build="${MERERUN_APP_BUILD:-21}"
 case "$configuration" in
   debug|release) ;;
   *)


### PR DESCRIPTION
## Summary

- bump the public CLI version from `0.8.0` to `0.9.0`
- promote the Linux arm64 CUDA + model pull work from `Unreleased` into a dated `0.9.0` changelog section
- update install/package examples and the macOS app bundle default version/build number

## Validation

- `./scripts/check.sh`: 534 tests, 32 skipped, 0 failures
