### PR TITLE
ci: pin release upload action

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -199,6 +199,7 @@ jobs:
 
       - name: Upload release assets
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        # softprops/action-gh-release v3 pinned to an immutable commit for release-path safety.
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           files: dist/linux/*


### PR DESCRIPTION
Pins the release asset uploader to the current softprops/action-gh-release v3 commit instead of a mutable major tag. This keeps the release publishing path on the Node 24 action runtime while avoiding tag-move risk.\n\nPinned upstream ref:\n- softprops/action-gh-release v3 -> b4309332981a82ec1c5618f44dd2e27cc8bfbfda\n\nLocal verification:\n- Parsed .github/workflows/linux-release.yml as YAML\n- Confirmed pinned action.yml at the commit uses node24 / dist/index.js\n- ./scripts/check.sh