### PR TITLE
Add Qwen3.6 nano MTP speculative decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added `text-chat-q36-nano`, a managed Qwen3.6 35B-A3B OptiQ 4-bit MLX
+  snapshot that pulls from Hugging Face and runs through the native Q35-family
+  chat runtime.
+
 ## 0.10.0 - 2026-05-29
 
 ### Fixed

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -178,6 +178,7 @@ enum GuideRegistry {
                 "text-chat-gemma4-max",
                 "text-chat-q35",
                 "text-chat-q35-nano",
+                "text-chat-q36-nano",
                 "text-chat-psi-agent",
             ],
             resourceName: "text-chat.md"
@@ -320,6 +321,7 @@ enum GuideRegistry {
                 "text-chat-gemma4-max",
                 "text-chat-q35",
                 "text-chat-q35-nano",
+                "text-chat-q36-nano",
                 "text-chat-mebot",
             ],
             resourceName: "api-serve.md"
@@ -347,6 +349,7 @@ enum GuideRegistry {
                 "text-agent-qwen35-9b",
                 "text-chat-gemma4",
                 "text-chat-q35",
+                "text-chat-q36-nano",
                 "text-agent-deepseek-v4-flash",
                 "text-chat-mebot",
             ],

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -22,6 +22,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-gemma4-nano (Gemma 4 4B native Swift runtime)
           - text-chat-q35-nano (Qwen3.5-35B-A3B 4-bit)
           - text-chat-q35
+          - text-chat-q36-nano (Qwen3.6-35B-A3B OptiQ 4-bit)
           - text-chat-psi-agent
         Models are cached under ~/Library/Application Support/MereRun/models/<model-id>.
         Thinking output is hidden by default; pass --thinking to include it.
@@ -59,7 +60,7 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.customShort("m"), .long], help: "Override model root directory (skips auto-download).")
     var modelRoot: String?
 
-    @Option(name: [.long], help: "Canonical model id: text-chat-gemma4 (default alias), text-chat-gemma4-turbo, text-chat-gemma4-max, text-chat-gemma4-nano, text-chat-q35, text-chat-q35-nano, or text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id: text-chat-gemma4 (default alias), text-chat-gemma4-turbo, text-chat-gemma4-max, text-chat-gemma4-nano, text-chat-q35, text-chat-q35-nano, text-chat-q36-nano, or text-chat-psi-agent.")
     var model: String = Gemma4Resources.defaultModelId
 
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -11,6 +11,7 @@ Supported engines:
 - `text-code`: default GGUF code model, usually `text-code-qwen3`.
 - `text-chat-gemma4`: Gemma text chat models.
 - `text-chat-q35`: Qwen3.5 text chat models.
+- `text-chat-q36-nano`: Qwen3.6 35B-A3B OptiQ chat weights served through the Q35-family engine.
 - `text-chat-deepseek-v4-flash`: DeepSeek V4 Flash via the bundled DS4 server.
 - `text-chat-klein`: local Klein/MeBot chat path when installed.
 

--- a/Sources/MereRunCLI/Guides/model-runtime.md
+++ b/Sources/MereRunCLI/Guides/model-runtime.md
@@ -8,8 +8,8 @@ Read or update typed per-model API serving settings. These settings feed
 ## Required Models
 
 Use a managed API-capable model id such as `text-chat-gemma4`,
-`text-chat-q35`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, or
-`text-chat-mebot`.
+`text-chat-q35`, `text-chat-q36-nano`, `text-agent-deepseek-v4-flash`,
+`text-agent-qwen35-9b`, or `text-chat-mebot`.
 
 ## Install And Check
 

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,8 +6,9 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, `text-chat-q36-nano`, and `text-chat-psi-agent`.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
+`text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head, but this command currently uses the main chat weights only.
 
 ## Install And Check
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -453,6 +453,17 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["chat", "api serve"]
         ),
         ManagedModelSpec(
+            id: Q35Resources.q36NanoModelId,
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: Q35Resources.profile(for: Q35Resources.q36NanoModelId)?.hubFallbackConfig,
+            upstreamRepoId: Q35Resources.q36NanoUpstreamRepoId,
+            upstreamRevision: Q35Resources.q36NanoUpstreamRevision,
+            validationKind: .q35,
+            estimatedDownloadBytes: 24 * 1_073_741_824,
+            defaultCLICommands: ["chat", "api serve"]
+        ),
+        ManagedModelSpec(
             id: AgentModelResources.qwen35NineBModelId,
             category: .textCode,
             installShape: .singleFile(relativePath: AgentModelResources.qwen35NineBRelativePath),

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -279,6 +279,14 @@ public enum ManagedModelCapabilityCatalog {
                 setup: true
             ),
             descriptor(
+                Q35Resources.q36NanoModelId,
+                "Qwen3.6 A3B chat nano",
+                "Runs the Qwen3.6 35B-A3B OptiQ 4-bit MLX/MTP snapshot through the native Q35-family runtime.",
+                minimum: 24,
+                recommended: 32,
+                setup: true
+            ),
+            descriptor(
                 AgentModelResources.qwen35NineBModelId,
                 "Qwen3.5 9B agent",
                 "Runs the Qwen3.5 9B Q4 GGUF setup agent for lower-memory Macs.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -658,6 +658,21 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "\(Q35Resources.nanoUpstreamRepoId)@\(Q35Resources.nanoUpstreamRevision)",
                 createdAt: createdAt
             )
+        case .q36Nano:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .qwen35HybridMoE,
+                family: .qwen,
+                tier: .nano,
+                variant: .base,
+                precision: .int4,
+                quantization: Quantization(bits: 4, groupSize: 64, scheme: "mlx-optiq-mixed-affine"),
+                defaults: nil,
+                supports: [.chat],
+                components: q35TextComponents,
+                upstreamRepoId: "\(Q35Resources.q36NanoUpstreamRepoId)@\(Q35Resources.q36NanoUpstreamRevision)",
+                createdAt: createdAt
+            )
         case .qwen35Agent9B:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -472,7 +472,9 @@ public enum MereRunModelValidator {
             || modelId == ModelResolver.ModelID.gemma4Turbo.rawValue {
             return .gemma
         }
-        if modelId == ModelResolver.ModelID.q35.rawValue || modelId == ModelResolver.ModelID.q35Nano.rawValue {
+        if modelId == ModelResolver.ModelID.q35.rawValue
+            || modelId == ModelResolver.ModelID.q35Nano.rawValue
+            || modelId == ModelResolver.ModelID.q36Nano.rawValue {
             return .qwen
         }
         return nil

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -28,6 +28,7 @@ public struct ModelResolver {
         case gemma4Turbo = "text-chat-gemma4-turbo"
         case q35 = "text-chat-q35"
         case q35Nano = "text-chat-q35-nano"
+        case q36Nano = "text-chat-q36-nano"
         case qwen35Agent9B = "text-agent-qwen35-9b"
         case deepseekV4Flash = "text-agent-deepseek-v4-flash"
         case qwen3TTSNano = "speech-tts-qwen3-nano"

--- a/Sources/MereRunCore/Q35/Q35Config.swift
+++ b/Sources/MereRunCore/Q35/Q35Config.swift
@@ -116,7 +116,7 @@ public struct Q35TextConfig: Codable, Sendable, Hashable {
         self.numExperts = try container.decode(Int.self, forKey: .numExperts)
         self.numExpertsPerTok = try container.decode(Int.self, forKey: .numExpertsPerTok)
         self.layerTypes = try container.decode([String].self, forKey: .layerTypes)
-        self.mlpOnlyLayers = try container.decode([Int].self, forKey: .mlpOnlyLayers)
+        self.mlpOnlyLayers = try container.decodeIfPresent([Int].self, forKey: .mlpOnlyLayers) ?? []
         self.linearNumValueHeads = try container.decode(Int.self, forKey: .linearNumValueHeads)
         self.linearNumKeyHeads = try container.decode(Int.self, forKey: .linearNumKeyHeads)
         self.linearKeyHeadDim = try container.decode(Int.self, forKey: .linearKeyHeadDim)
@@ -212,7 +212,7 @@ public struct Q35Config: Codable, Sendable, Hashable {
     public let visionEndTokenId: Int?
     public let quantization: Q35QuantizationConfig?
     public let textConfig: Q35TextConfig
-    public let visionConfig: Q35VisionConfig
+    public let visionConfig: Q35VisionConfig?
 
     private enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
@@ -239,7 +239,7 @@ public struct Q35Config: Codable, Sendable, Hashable {
         self.visionStartTokenId = try container.decodeIfPresent(Int.self, forKey: .visionStartTokenId)
         self.visionEndTokenId = try container.decodeIfPresent(Int.self, forKey: .visionEndTokenId)
         self.textConfig = try container.decode(Q35TextConfig.self, forKey: .textConfig)
-        self.visionConfig = try container.decode(Q35VisionConfig.self, forKey: .visionConfig)
+        self.visionConfig = try container.decodeIfPresent(Q35VisionConfig.self, forKey: .visionConfig)
 
         if let direct = try container.decodeIfPresent([Int].self, forKey: .eosTokenId) {
             self.eosTokenIds = direct
@@ -270,6 +270,6 @@ public struct Q35Config: Codable, Sendable, Hashable {
         try container.encodeIfPresent(visionEndTokenId, forKey: .visionEndTokenId)
         try container.encodeIfPresent(quantization, forKey: .quantization)
         try container.encode(textConfig, forKey: .textConfig)
-        try container.encode(visionConfig, forKey: .visionConfig)
+        try container.encodeIfPresent(visionConfig, forKey: .visionConfig)
     }
 }

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -12,8 +12,14 @@ private struct Q35PrefixKVCacheKey: Hashable {
 private struct Q35PrefixKVCacheEntry {
     let caches: [Q35LayerCache?]
     let logits: MLXArray
+    let hidden: MLXArray
     let priority: RuntimePrefixCacheEntryPriority
     var lastAccess: Date
+}
+
+private struct Q35PrefillOutput {
+    let logits: MLXArray
+    let hidden: MLXArray?
 }
 
 private struct Q35BatchedDecodeResult {
@@ -89,6 +95,7 @@ public actor Q35Generator: ChatGenerator {
     private var model: Q35Model?
     private var tokenizerAndTemplate: Q35TokenizerAndTemplate?
     private var visionTower: Q35VisionTower?
+    private var mtpModel: Q35MTPModel?
     private var loadedModelPath: String?
     private var loadedConfig: Q35Config?
     private var loadedResources: Q35Resources?
@@ -184,6 +191,7 @@ public actor Q35Generator: ChatGenerator {
         model = nil
         tokenizerAndTemplate = nil
         visionTower = nil
+        mtpModel = nil
         loadedModelPath = nil
         loadedConfig = nil
         loadedResources = nil
@@ -271,11 +279,40 @@ public actor Q35Generator: ChatGenerator {
             )
         }
 
-        let tower = Q35VisionTower(config: config)
+        let tower = config.visionConfig == nil ? nil : Q35VisionTower(config: config)
+        let mtpURL = normalizedRoot.appendingPathComponent("mtp.safetensors")
+        let mtpDisabled = {
+            guard let raw = ProcessInfo.processInfo.environment["MERERUN_Q35_MTP_SPECULATION"]?.lowercased() else {
+                return false
+            }
+            return raw == "0" || raw == "false" || raw == "no"
+        }()
+        let loadedMTP: Q35MTPModel?
+        if !mtpDisabled, FileManager.default.fileExists(atPath: mtpURL.path) {
+            progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Q35 MTP weights"))
+            let mtp = Q35MTPModel(config: config)
+            let arrays = try MLX.loadArrays(url: mtpURL)
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                arrays,
+                to: mtp,
+                groupSize: groupSize,
+                bits: bits,
+                keyMapper: { key in
+                    if key.hasPrefix("mtp.") {
+                        return String(key.dropFirst("mtp.".count))
+                    }
+                    return "__unused__.\(key)"
+                }
+            )
+            loadedMTP = mtp
+        } else {
+            loadedMTP = nil
+        }
 
         model = q35Model
         tokenizerAndTemplate = tokenizer
         visionTower = tower
+        mtpModel = loadedMTP
         loadedConfig = config
         loadedResources = resources
         loadedModelPath = normalizedRoot.path
@@ -296,7 +333,7 @@ public actor Q35Generator: ChatGenerator {
         let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
         let prefillStart = Date()
 
-        var promptTokens = tokenizerAndTemplate.encodeForGeneration(
+        var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
             messages: messages,
             tools: request.tools,
             addGenerationPrompt: true,
@@ -320,7 +357,7 @@ public actor Q35Generator: ChatGenerator {
         let promptInput = MLXArray(promptTokens.map { Int32($0) }).reshaped(1, promptTokens.count)
 
         let imageURLs = collectImageURLs(from: messages)
-        var logits: MLXArray
+        var prefillOutput: Q35PrefillOutput
         var prefillLength = promptTokens.count
 
         if imageURLs.isEmpty {
@@ -339,18 +376,22 @@ public actor Q35Generator: ChatGenerator {
             if let prefixSeed {
                 layerCaches = prefixSeed.caches
             }
-            logits = try await chunkedPrefill(
+            prefillOutput = try await chunkedPrefill(
                 model: model,
                 promptTokens: promptTokens,
                 cache: layerCaches,
                 startIndex: prefixSeed?.tokenCount ?? 0,
                 existingLogits: prefixSeed?.logits,
+                existingHidden: prefixSeed?.hidden,
                 modelPath: loadedModelPath ?? "",
                 checkpointTokenCounts: prefixCheckpoints,
                 progressHandler: progressHandler
             )
         } else {
             progressHandler?(ChatProgress(stage: .encoding, message: "Encoding images"))
+            guard visionTower != nil else {
+                throw Q35Error.generationFailed("Model \(modelId) does not include a vision tower; use text-only prompts.")
+            }
             try ensureVisionWeightsLoaded(progressHandler: progressHandler)
 
             if let visionTower,
@@ -361,7 +402,7 @@ public actor Q35Generator: ChatGenerator {
                 )
 
                 if replacements.isEmpty {
-                    logits = try await chunkedPrefill(
+                    prefillOutput = try await chunkedPrefill(
                         model: model,
                         promptTokens: promptTokens,
                         cache: layerCaches,
@@ -380,7 +421,7 @@ public actor Q35Generator: ChatGenerator {
                         promptEmbeddings = promptEmbeddings[0..., (promptEmbeddings.dim(1) - effectiveContext)..., 0...]
                     }
                     prefillLength = promptEmbeddings.dim(1)
-                    logits = try await chunkedPrefillEmbeddings(
+                    prefillOutput = try await chunkedPrefillEmbeddings(
                         model: model,
                         inputEmbeddings: promptEmbeddings,
                         cache: layerCaches,
@@ -388,7 +429,7 @@ public actor Q35Generator: ChatGenerator {
                     )
                 }
             } else {
-                logits = try await chunkedPrefill(
+                prefillOutput = try await chunkedPrefill(
                     model: model,
                     promptTokens: promptTokens,
                     cache: layerCaches,
@@ -405,7 +446,8 @@ public actor Q35Generator: ChatGenerator {
         let decodeResult = try await decodeTokens(
             model: model,
             tokenizerAndTemplate: tokenizerAndTemplate,
-            initialLogits: logits,
+            initialLogits: prefillOutput.logits,
+            initialHidden: prefillOutput.hidden,
             layerCaches: layerCaches,
             eosSet: eosSet,
             generationConfig: generationConfig,
@@ -438,6 +480,7 @@ public actor Q35Generator: ChatGenerator {
         model: Q35Model,
         tokenizerAndTemplate: Q35TokenizerAndTemplate,
         initialLogits: MLXArray,
+        initialHidden: MLXArray?,
         layerCaches: [Q35LayerCache?],
         eosSet: Set<Int>,
         generationConfig: GenerationConfig,
@@ -454,10 +497,13 @@ public actor Q35Generator: ChatGenerator {
                 model: model,
                 tokenizerAndTemplate: tokenizerAndTemplate,
                 initialLogits: initialLogits,
+                initialHidden: initialHidden,
+                mtpModel: mtpModel,
                 layerCaches: layerCaches,
                 eosSet: eosSet,
                 generationConfig: generationConfig,
                 tokenBudget: tokenBudget,
+                prefillTokenCount: prefillTokenCount,
                 promptTokens: promptTokens,
                 progressHandler: progressHandler
             )
@@ -493,20 +539,46 @@ public actor Q35Generator: ChatGenerator {
         model: Q35Model,
         tokenizerAndTemplate: Q35TokenizerAndTemplate,
         initialLogits: MLXArray,
+        initialHidden: MLXArray?,
+        mtpModel: Q35MTPModel?,
         layerCaches: [Q35LayerCache?],
         eosSet: Set<Int>,
         generationConfig: GenerationConfig,
         tokenBudget: Int,
+        prefillTokenCount: Int,
         promptTokens: [Int],
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Q35BatchedDecodeResult {
         var logits = initialLogits
+        var layerCaches = layerCaches
+        var previousHidden = initialHidden.map(lastTokenHidden)
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
+        var pendingProgressWhitespace = ""
         let decodeStart = Date()
 
-        for _ in 0..<tokenBudget {
+        func emit(_ token: Int) {
+            generated.append(token)
+            repetitionHistory.append(token)
+            let piece = tokenizerAndTemplate.decode(token: token)
+            guard !piece.isEmpty else { return }
+            if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                pendingProgressWhitespace += piece
+                return
+            }
+
+            let visiblePiece: String
+            if pendingProgressWhitespace.isEmpty {
+                visiblePiece = piece
+            } else {
+                visiblePiece = pendingProgressWhitespace + piece
+                pendingProgressWhitespace = ""
+            }
+            progressHandler?(ChatProgress(stage: .generating, message: visiblePiece))
+        }
+
+        while generated.count < tokenBudget {
             try Task.checkCancellation()
             let next = sampleToken(
                 logits: logits[0, -1, 0...],
@@ -518,19 +590,82 @@ public actor Q35Generator: ChatGenerator {
                 break
             }
 
-            generated.append(next)
-            repetitionHistory.append(next)
-            let piece = tokenizerAndTemplate.decode(token: next)
-            if !piece.isEmpty {
-                progressHandler?(ChatProgress(stage: .generating, message: piece))
-            }
+            emit(next)
 
             guard generated.count < tokenBudget else {
                 break
             }
+
+            if let mtpModel, let hidden = previousHidden {
+                let positionOffset = prefillTokenCount + generated.count - 1
+                let draftLogits = mtpModel.draftLogits(
+                    token: next,
+                    previousHidden: hidden,
+                    positionOffset: positionOffset,
+                    baseModel: model
+                )
+                MLX.eval(draftLogits)
+
+                let draftProbs = samplingProbabilities(
+                    logits: draftLogits[0, -1, 0...],
+                    config: generationConfig,
+                    previousTokens: repetitionHistory
+                )
+                let draft = sampleToken(probabilities: draftProbs)
+
+                let candidateCaches = forkLayerCaches(layerCaches)
+                let candidateInput = MLXArray([Int32(next), Int32(draft)]).reshaped(1, 2)
+                let candidate = model.forward(candidateInput, cache: candidateCaches)
+                MLX.eval(candidate.logits)
+                MLX.eval(candidate.hidden)
+
+                let targetProbs = samplingProbabilities(
+                    logits: candidate.logits[0, 0, 0...],
+                    config: generationConfig,
+                    previousTokens: repetitionHistory
+                )
+                let draftProb = max(draftProbs[draft].item(Float.self), Float.leastNonzeroMagnitude)
+                let targetProb = targetProbs[draft].item(Float.self)
+                let acceptProbability = min(1.0, targetProb / draftProb)
+
+                if Float.random(in: 0..<1) <= acceptProbability {
+                    if eosSet.contains(draft) {
+                        break
+                    }
+                    emit(draft)
+                    layerCaches = candidateCaches
+                    logits = lastTokenLogits(candidate.logits)
+                    previousHidden = lastTokenHidden(candidate.hidden)
+                    continue
+                }
+
+                let residualProbs = MLX.maximum(targetProbs - draftProbs, MLXArray(0.0))
+                let residualMass = residualProbs.sum().item(Float.self)
+                let replacement = residualMass > 1e-6
+                    ? sampleToken(probabilities: residualProbs / residualProbs.sum())
+                    : sampleToken(probabilities: targetProbs)
+                if eosSet.contains(replacement) {
+                    break
+                }
+
+                let replacementCaches = forkLayerCaches(layerCaches)
+                let replacementInput = MLXArray([Int32(next), Int32(replacement)]).reshaped(1, 2)
+                let replacementForward = model.forward(replacementInput, cache: replacementCaches)
+                MLX.eval(replacementForward.logits)
+                MLX.eval(replacementForward.hidden)
+                emit(replacement)
+                layerCaches = replacementCaches
+                logits = lastTokenLogits(replacementForward.logits)
+                previousHidden = lastTokenHidden(replacementForward.hidden)
+                continue
+            }
+
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
-            logits = model(nextInput, cache: layerCaches)
+            let output = model.forward(nextInput, cache: layerCaches)
+            logits = output.logits
+            previousHidden = lastTokenHidden(output.hidden)
             MLX.eval(logits)
+            MLX.eval(previousHidden!)
         }
 
         return Q35BatchedDecodeResult(
@@ -799,22 +934,34 @@ public actor Q35Generator: ChatGenerator {
         activeDecodeRows.removeAll()
     }
 
+    private func lastTokenHidden(_ hidden: MLXArray) -> MLXArray {
+        let start = max(0, hidden.dim(1) - 1)
+        return hidden[0..., start..<(start + 1), 0...]
+    }
+
+    private func lastTokenLogits(_ logits: MLXArray) -> MLXArray {
+        let start = max(0, logits.dim(1) - 1)
+        return logits[0..., start..<(start + 1), 0...]
+    }
+
     private func chunkedPrefill(
         model: Q35Model,
         promptTokens: [Int],
         cache: [Q35LayerCache?],
         startIndex: Int = 0,
         existingLogits: MLXArray? = nil,
+        existingHidden: MLXArray? = nil,
         modelPath: String? = nil,
         checkpointTokenCounts: Set<Int> = [],
         progressHandler: (@Sendable (ChatProgress) -> Void)?
-    ) async throws -> MLXArray {
+    ) async throws -> Q35PrefillOutput {
         guard !promptTokens.isEmpty else {
             throw Q35Error.generationFailed("Prompt is empty after tokenization.")
         }
 
         var processed = startIndex
         var logits = existingLogits
+        var hidden = existingHidden
         if processed > 0, processed < promptTokens.count {
             progressHandler?(ChatProgress(stage: .encoding, message: "Reusing \(processed) prompt KV tokens"))
         }
@@ -831,9 +978,11 @@ public actor Q35Generator: ChatGenerator {
             }
             let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
                 .reshaped(1, end - processed)
-            let chunkLogits = model(chunk, cache: cache)
-            MLX.eval(chunkLogits)
-            logits = chunkLogits
+            let output = model.forward(chunk, cache: cache)
+            MLX.eval(output.logits)
+            MLX.eval(output.hidden)
+            logits = output.logits
+            hidden = output.hidden
             processed = end
             if let modelPath {
                 storePrefixKVCache(
@@ -841,7 +990,8 @@ public actor Q35Generator: ChatGenerator {
                     promptTokens: promptTokens,
                     tokenCount: processed,
                     cache: cache,
-                    logits: chunkLogits,
+                    logits: output.logits,
+                    hidden: output.hidden,
                     priority: checkpointTokenCounts.contains(processed) ? .semantic : .chunk
                 )
             }
@@ -851,7 +1001,7 @@ public actor Q35Generator: ChatGenerator {
         guard let logits else {
             throw Q35Error.generationFailed("Prefill did not produce logits.")
         }
-        return logits
+        return Q35PrefillOutput(logits: logits, hidden: hidden)
     }
 
     private func chunkedPrefillEmbeddings(
@@ -859,7 +1009,7 @@ public actor Q35Generator: ChatGenerator {
         inputEmbeddings: MLXArray,
         cache: [Q35LayerCache?],
         progressHandler: (@Sendable (ChatProgress) -> Void)?
-    ) async throws -> MLXArray {
+    ) async throws -> Q35PrefillOutput {
         let tokenCount = inputEmbeddings.dim(1)
         guard tokenCount > 0 else {
             throw Q35Error.generationFailed("Prompt embeddings are empty after tokenization.")
@@ -867,6 +1017,7 @@ public actor Q35Generator: ChatGenerator {
 
         var processed = 0
         var logits: MLXArray?
+        var hidden: MLXArray?
         while processed < tokenCount {
             try Task.checkCancellation()
             let end = min(processed + Self.prefillChunkSize, tokenCount)
@@ -875,9 +1026,11 @@ public actor Q35Generator: ChatGenerator {
             }
             let chunkEmbeddings = inputEmbeddings[0..., processed..<end, 0...]
             let chunkInput = MLXArray.zeros([1, end - processed], dtype: .int32)
-            let chunkLogits = model(chunkInput, cache: cache, inputEmbeddings: chunkEmbeddings)
-            MLX.eval(chunkLogits)
-            logits = chunkLogits
+            let output = model.forward(chunkInput, cache: cache, inputEmbeddings: chunkEmbeddings)
+            MLX.eval(output.logits)
+            MLX.eval(output.hidden)
+            logits = output.logits
+            hidden = output.hidden
             processed = end
             await Task.yield()
         }
@@ -885,7 +1038,7 @@ public actor Q35Generator: ChatGenerator {
         guard let logits else {
             throw Q35Error.generationFailed("Prefill did not produce logits.")
         }
-        return logits
+        return Q35PrefillOutput(logits: logits, hidden: hidden)
     }
 
     private func semanticPrefixCheckpoints(
@@ -903,13 +1056,15 @@ public actor Q35Generator: ChatGenerator {
         guard !prefixMessages.isEmpty else {
             return []
         }
-        let prefixTokens = tokenizerAndTemplate.encodeForGeneration(
+        guard let prefixTokens = try? tokenizerAndTemplate.encodeForGeneration(
             messages: prefixMessages,
             tools: tools,
             addGenerationPrompt: false,
             includeThinking: includeThinking,
             maxLength: maxContextLength
-        )
+        ) else {
+            return []
+        }
         guard promptTokens.starts(with: prefixTokens) else {
             return []
         }
@@ -922,7 +1077,7 @@ public actor Q35Generator: ChatGenerator {
     private func prefixKVCacheSeed(
         modelPath: String,
         promptTokens: [Int]
-    ) -> (tokenCount: Int, caches: [Q35LayerCache?], logits: MLXArray)? {
+    ) -> (tokenCount: Int, caches: [Q35LayerCache?], logits: MLXArray, hidden: MLXArray)? {
         guard prefixKVCacheEnabled else { return nil }
         let matchingKey = prefixKVCache.keys
             .filter { key in
@@ -945,7 +1100,8 @@ public actor Q35Generator: ChatGenerator {
         return (
             matchingKey.tokens.count,
             forkLayerCaches(entry.caches),
-            entry.logits
+            entry.logits,
+            entry.hidden
         )
     }
 
@@ -955,6 +1111,7 @@ public actor Q35Generator: ChatGenerator {
         tokenCount: Int,
         cache: [Q35LayerCache?],
         logits: MLXArray,
+        hidden: MLXArray,
         priority: RuntimePrefixCacheEntryPriority
     ) {
         guard prefixKVCacheEnabled, tokenCount > 0 else { return }
@@ -965,6 +1122,7 @@ public actor Q35Generator: ChatGenerator {
         prefixKVCache[key] = Q35PrefixKVCacheEntry(
             caches: forkLayerCaches(cache),
             logits: logits,
+            hidden: hidden,
             priority: priority,
             lastAccess: Date()
         )

--- a/Sources/MereRunCore/Q35/Q35MTP.swift
+++ b/Sources/MereRunCore/Q35/Q35MTP.swift
@@ -1,0 +1,196 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+@inline(__always)
+private func q35MTPSwiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
+    MLXNN.silu(gate) * up
+}
+
+private final class Q35MTPPositionCache: KVCache {
+    public private(set) var offset: Int
+
+    init(offset: Int) {
+        self.offset = offset
+    }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        offset += keys.dim(2)
+        return (keys, values)
+    }
+
+    func makeMask(n: Int) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        n == 1 ? .none : .causal
+    }
+
+    func fork() -> KVCache {
+        Q35MTPPositionCache(offset: offset)
+    }
+}
+
+final class Q35MTPExperts: Module {
+    @ModuleInfo(key: "gate_up_proj") var gateUpProj: MLXArray
+    @ModuleInfo(key: "down_proj") var downProj: MLXArray
+
+    private let intermediateSize: Int
+
+    init(config: Q35Config) {
+        let text = config.textConfig
+        self.intermediateSize = text.moeIntermediateSize
+        self._gateUpProj.wrappedValue = MLXArray.zeros(
+            [text.numExperts, text.moeIntermediateSize * 2, text.hiddenSize],
+            dtype: .bfloat16
+        )
+        self._downProj.wrappedValue = MLXArray.zeros(
+            [text.numExperts, text.hiddenSize, text.moeIntermediateSize],
+            dtype: .bfloat16
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let batchTokens = x.dim(0) * x.dim(1)
+        let topK = indices.dim(2)
+        let inputDim = x.dim(x.ndim - 1)
+
+        var expanded = x.reshaped([batchTokens, 1, inputDim])
+        expanded = MLX.expandedDimensions(expanded, axis: 1)
+        expanded = MLX.repeated(expanded, count: topK, axis: 1)
+        let flatX = expanded.reshaped([batchTokens * topK, 1, inputDim])
+        let flatIndices = indices.reshaped([batchTokens * topK])
+
+        let gateUp = gatherMM(
+            flatX,
+            gateUpProj.swappedAxes(-1, -2),
+            rhsIndices: flatIndices,
+            sortedIndices: false
+        )
+        let gate = gateUp[.ellipsis, 0..<intermediateSize]
+        let up = gateUp[.ellipsis, intermediateSize...]
+        let activated = q35MTPSwiglu(gate, up)
+
+        let output = gatherMM(
+            activated,
+            downProj.swappedAxes(-1, -2),
+            rhsIndices: flatIndices,
+            sortedIndices: false
+        )
+        let outDim = output.dim(2)
+        return output.reshaped([x.dim(0), x.dim(1), topK, outDim])
+    }
+}
+
+final class Q35MTPMoE: Module {
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ModuleInfo(key: "experts") var experts: Q35MTPExperts
+    @ModuleInfo(key: "shared_expert") var sharedExpert: Q35MLP
+    @ModuleInfo(key: "shared_expert_gate") var sharedExpertGate: Linear
+
+    private let topK: Int
+
+    init(config: Q35Config) {
+        let text = config.textConfig
+        self.topK = max(1, text.numExpertsPerTok)
+        self._gate.wrappedValue = Linear(text.hiddenSize, text.numExperts, bias: false)
+        self._experts.wrappedValue = Q35MTPExperts(config: config)
+        self._sharedExpert.wrappedValue = Q35MLP(
+            hiddenSize: text.hiddenSize,
+            intermediateSize: text.sharedExpertIntermediateSize
+        )
+        self._sharedExpertGate.wrappedValue = Linear(text.hiddenSize, 1, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var scores = softmax(gate(x), axis: -1)
+        let k = min(topK, scores.dim(-1))
+        let indices = argPartition(-scores, kth: k - 1, axis: -1)[.ellipsis, 0..<k]
+        scores = takeAlong(scores, indices, axis: -1)
+        if k > 1 {
+            scores = scores / scores.sum(axis: -1, keepDims: true)
+        }
+
+        let routed = (experts(x, indices: indices) * MLX.expandedDimensions(scores, axis: scores.ndim))
+            .sum(axis: -2)
+        let shared = sharedExpert(x)
+        return routed + MLX.sigmoid(sharedExpertGate(x)) * shared
+    }
+}
+
+final class Q35MTPDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: Q35FullAttention
+    @ModuleInfo(key: "mlp") var mlp: Q35MTPMoE
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(config: Q35Config) {
+        let text = config.textConfig
+        self._selfAttention.wrappedValue = Q35FullAttention(config: config)
+        self._mlp.wrappedValue = Q35MTPMoE(config: config)
+        self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let h = x + selfAttention(inputLayerNorm(x), mask: mask, cache: cache)
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+final class Q35MTPModel: Module {
+    @ModuleInfo(key: "pre_fc_norm_embedding") var preFCNormEmbedding: RMSNorm
+    @ModuleInfo(key: "pre_fc_norm_hidden") var preFCNormHidden: RMSNorm
+    @ModuleInfo(key: "fc") var fc: Linear
+    @ModuleInfo(key: "layers") var layers: [Q35MTPDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(config: Q35Config) {
+        let text = config.textConfig
+        self._preFCNormEmbedding.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        self._preFCNormHidden.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        self._fc.wrappedValue = Linear(text.hiddenSize * 2, text.hiddenSize, bias: false)
+        self._layers.wrappedValue = [Q35MTPDecoderLayer(config: config)]
+        self._norm.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        inputEmbeddings: MLXArray,
+        hiddenStates: MLXArray,
+        positionOffset: Int
+    ) -> MLXArray {
+        let normalizedEmbeddings = preFCNormEmbedding(inputEmbeddings)
+        let normalizedHidden = preFCNormHidden(hiddenStates)
+        var hidden = MLX.concatenated([normalizedEmbeddings, normalizedHidden], axis: -1)
+        hidden = fc(hidden)
+
+        let cache = Q35MTPPositionCache(offset: positionOffset)
+        let mask = cache.makeMask(n: hidden.dim(1))
+        for layer in layers {
+            hidden = layer(hidden, mask: mask, cache: cache)
+        }
+        return norm(hidden)
+    }
+
+    func draftLogits(
+        token: Int,
+        previousHidden: MLXArray,
+        positionOffset: Int,
+        baseModel: Q35Model
+    ) -> MLXArray {
+        let inputIds = MLXArray([Int32(token)]).reshaped(1, 1)
+        let embeddings = baseModel.embeddings(for: inputIds)
+        let hidden = self(
+            inputEmbeddings: embeddings,
+            hiddenStates: previousHidden,
+            positionOffset: positionOffset
+        )
+        return baseModel.logits(from: hidden)
+    }
+}

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -68,6 +68,7 @@ final class Q35SwitchLinear: Module {
 
         let output: MLXArray
         if let scales {
+            let resolved = resolvedQuantization(inputDim: inputDim, scales: scales)
             output = portableGatherQuantizedMM(
                 flatX,
                 weight,
@@ -75,8 +76,8 @@ final class Q35SwitchLinear: Module {
                 biases: biases,
                 rhsIndices: flatIndices,
                 transpose: true,
-                groupSize: groupSize,
-                bits: bits,
+                groupSize: resolved.groupSize,
+                bits: resolved.bits,
                 mode: .affine,
                 sortedIndices: false
             )
@@ -97,6 +98,26 @@ final class Q35SwitchLinear: Module {
             return reshaped + bias.reshaped([1, 1, 1, outDim])
         }
         return reshaped
+    }
+
+    private func resolvedQuantization(inputDim: Int, scales: MLXArray) -> (groupSize: Int, bits: Int) {
+        var resolvedBits = bits
+        let packedInputDim = weight.dim(weight.ndim - 1)
+        let numerator = packedInputDim * 32
+        if inputDim > 0, numerator % inputDim == 0 {
+            let inferredBits = numerator / inputDim
+            if (2...8).contains(inferredBits) {
+                resolvedBits = inferredBits
+            }
+        }
+
+        var resolvedGroupSize = groupSize
+        let scaleGroups = scales.dim(scales.ndim - 1)
+        if inputDim > 0, scaleGroups > 0, inputDim % scaleGroups == 0 {
+            resolvedGroupSize = inputDim / scaleGroups
+        }
+
+        return (resolvedGroupSize, resolvedBits)
     }
 }
 

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -182,6 +182,11 @@ final class Q35Transformer: Module {
     }
 }
 
+struct Q35ForwardOutput {
+    let hidden: MLXArray
+    let logits: MLXArray
+}
+
 public final class Q35Model: Module, @unchecked Sendable {
     @ModuleInfo(key: "model") var model: Q35Transformer
     @ModuleInfo(key: "lm_head") var lmHead: Linear
@@ -203,12 +208,24 @@ public final class Q35Model: Module, @unchecked Sendable {
         model.embeddings(for: inputIds)
     }
 
+    func logits(from hidden: MLXArray) -> MLXArray {
+        lmHead(hidden)
+    }
+
+    func forward(
+        _ inputIds: MLXArray,
+        cache: [Q35LayerCache?]?,
+        inputEmbeddings: MLXArray? = nil
+    ) -> Q35ForwardOutput {
+        let hidden = model(inputIds, cache: cache, inputEmbeddings: inputEmbeddings)
+        return Q35ForwardOutput(hidden: hidden, logits: lmHead(hidden))
+    }
+
     public func callAsFunction(
         _ inputIds: MLXArray,
         cache: [Q35LayerCache?]?,
         inputEmbeddings: MLXArray? = nil
     ) -> MLXArray {
-        let hidden = model(inputIds, cache: cache, inputEmbeddings: inputEmbeddings)
-        return lmHead(hidden)
+        forward(inputIds, cache: cache, inputEmbeddings: inputEmbeddings).logits
     }
 }

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -27,12 +27,16 @@ public struct Q35Resources: Sendable, Hashable {
 
     public static let defaultModelId = "text-chat-q35"
     public static let nanoModelId = "text-chat-q35-nano"
+    public static let q36NanoModelId = "text-chat-q36-nano"
 
     public static let upstreamRepoId = "mlx-community/Qwen3.5-122B-A10B-4bit"
     public static let upstreamRevision = "e9c67b08899964be5fdd069bb1b4bc8907fe68f5"
 
     public static let nanoUpstreamRepoId = "mlx-community/Qwen3.5-35B-A3B-4bit"
     public static let nanoUpstreamRevision = "1e20fd8d42056f870933bf98ca6211024744f7ec"
+
+    public static let q36NanoUpstreamRepoId = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit"
+    public static let q36NanoUpstreamRevision = "63d520640ca7461f31ba66104612135770090340"
 
     private static let profilesByModelId: [String: Profile] = [
         defaultModelId: Profile(
@@ -44,6 +48,11 @@ public struct Q35Resources: Sendable, Hashable {
             modelId: nanoModelId,
             upstreamRepoId: nanoUpstreamRepoId,
             upstreamRevision: nanoUpstreamRevision
+        ),
+        q36NanoModelId: Profile(
+            modelId: q36NanoModelId,
+            upstreamRepoId: q36NanoUpstreamRepoId,
+            upstreamRevision: q36NanoUpstreamRevision
         ),
     ]
 

--- a/Sources/MereRunCore/Q35/Q35TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Q35/Q35TokenizerAndTemplate.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import Tokenizers
 
 public struct Q35TokenizerAndTemplate {
     public let tokenizer: QwenTokenizer
@@ -18,18 +19,15 @@ public struct Q35TokenizerAndTemplate {
         addGenerationPrompt: Bool = true,
         includeThinking: Bool = true,
         maxLength: Int
-    ) -> [Int] {
-        let rendered = render(
-            messages: messages,
-            tools: tools,
+    ) throws -> [Int] {
+        let toolSpecs: [ToolSpec]? = tools?.isEmpty == false ? tools!.map { $0.toToolSpec() } : nil
+        return try tokenizer.encodeChatTemplate(
+            messages: Self.renderMessages(messages),
+            tools: toolSpecs,
             addGenerationPrompt: addGenerationPrompt,
-            includeThinking: includeThinking
+            includeThinking: includeThinking,
+            maxLength: maxLength
         )
-        let encoded = tokenizer.encodeText(rendered)
-        if encoded.count <= maxLength {
-            return encoded
-        }
-        return Array(encoded.suffix(maxLength))
     }
 
     public func decode(tokens: [Int]) -> String {
@@ -58,6 +56,28 @@ public struct Q35TokenizerAndTemplate {
         )
     }
 
+    static func renderMessages(_ messages: [ChatMessage]) -> [Message] {
+        messages.map(renderMessage)
+    }
+
+    private static func renderMessage(_ message: ChatMessage) -> Message {
+        var rendered: Message = [
+            "role": message.role.rawValue,
+        ]
+
+        if message.role != .system, let imageURL = message.imageUrl, !imageURL.isEmpty {
+            let content: [[String: String]] = [
+                ["type": "image", "image_url": imageURL],
+                ["type": "text", "text": message.content],
+            ]
+            rendered["content"] = content
+        } else {
+            rendered["content"] = message.content
+        }
+
+        return rendered
+    }
+
     static func renderPrompt(
         messages: [ChatMessage],
         tools: [ToolDefinition]? = nil,
@@ -68,37 +88,37 @@ public struct Q35TokenizerAndTemplate {
 
         if let tools, !tools.isEmpty {
             prompt += "<|im_start|>system\n"
-            prompt += "# Tools\\n\\nYou have access to the following functions:\\n\\n<tools>"
+            prompt += "# Tools\n\nYou have access to the following functions:\n\n<tools>"
             for tool in tools {
                 if let json = try? tool.promptSchemaJSONString() {
-                    prompt += "\\n\(json)"
+                    prompt += "\n\(json)"
                 }
             }
-            prompt += "\\n</tools>"
-            prompt += "\\n\\nIf you choose to call a function ONLY reply in the XML tool_call format."
-            prompt += "<|im_end|>\\n"
+            prompt += "\n</tools>"
+            prompt += "\n\nIf you choose to call a function ONLY reply in the XML tool_call format."
+            prompt += "<|im_end|>\n"
         }
 
         for message in messages {
             let role = message.role.rawValue
-            prompt += "<|im_start|>\(role)\\n"
+            prompt += "<|im_start|>\(role)\n"
 
             if message.role != .system, let imageURL = message.imageUrl, !imageURL.isEmpty {
-                prompt += "<|vision_start|><|image_pad|><|vision_end|>\\n"
+                prompt += "<|vision_start|><|image_pad|><|vision_end|>\n"
             }
 
             if !message.content.isEmpty {
                 prompt += message.content
             }
 
-            prompt += "<|im_end|>\\n"
+            prompt += "<|im_end|>\n"
         }
 
         if addGenerationPrompt {
             if includeThinking {
-                prompt += "<|im_start|>assistant\\n<think>\\n"
+                prompt += "<|im_start|>assistant\n<think>\n"
             } else {
-                prompt += "<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n"
+                prompt += "<|im_start|>assistant\n<think>\n\n</think>\n\n"
             }
         }
 

--- a/Sources/MereRunCore/Q35/Q35VisionTower.swift
+++ b/Sources/MereRunCore/Q35/Q35VisionTower.swift
@@ -12,7 +12,9 @@ public final class Q35VisionTower: Module {
     public private(set) var isLoaded: Bool = false
 
     public init(config: Q35Config) {
-        let vision = config.visionConfig
+        guard let vision = config.visionConfig else {
+            preconditionFailure("Q35VisionTower requires a Q35 vision config.")
+        }
         let activation: QwenVisionConfiguration.Activation
         switch vision.hiddenAct?.lowercased() {
         case "gelu_pytorch_tanh", "gelu_tanh", "gelu":

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -1,6 +1,6 @@
 # Q35
 
-Qwen 3.5 text and vision-language runtime.
+Qwen 3.5/3.6 hybrid MoE text and vision-language runtime.
 
 - `Q35Config.swift`: typed text/vision configuration.
 - `Q35TokenizerAndTemplate.swift`: prompt rendering and tokenization.

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
@@ -134,3 +134,54 @@ public func sampleToken(
         return categoricalSample(logits: logits, temperature: config.temperature)
     }
 }
+
+public func samplingProbabilities(
+    logits: MLXArray,
+    config: GenerationConfig,
+    previousTokens: [Int]
+) -> MLXArray {
+    var logits = logits
+
+    if let penalty = config.repetitionPenalty, !previousTokens.isEmpty {
+        let contextTokens = Array(previousTokens.suffix(config.repetitionContextSize))
+        logits = applyRepetitionPenalty(logits: logits, tokens: contextTokens, penalty: penalty)
+    }
+
+    if logits.dtype == .bfloat16 {
+        logits = logits.asType(.float32)
+    }
+
+    if config.topK > 0 && config.topK < logits.dim(-1) {
+        let sortedIndices = argSort(logits, axis: -1)
+        let sortedLogits = logits.take(sortedIndices, axis: -1)
+        let threshold = sortedLogits[sortedLogits.dim(-1) - config.topK]
+        logits = MLX.where(logits .< threshold, MLXArray(-Float.infinity), logits)
+    }
+
+    if config.temperature == 0 {
+        let token = argMaxSample(logits: logits)
+        let result = MLXArray.zeros(like: logits)
+        result[token] = MLXArray(1.0)
+        return result
+    }
+
+    var probs = softmax(logits / config.temperature, axis: -1)
+    if config.topP > 0 && config.topP < 1 {
+        let sortedIndices = argSort(probs, axis: -1)
+        let sortedProbs = probs.take(sortedIndices, axis: -1)
+        let cumulativeProbs = cumsum(sortedProbs, axis: -1)
+        let kept = MLX.where(
+            cumulativeProbs .> (1 - config.topP),
+            sortedProbs,
+            MLXArray(Float.infinity)
+        )
+        let threshold = kept.min(axis: -1, keepDims: true)
+        probs = MLX.where(probs .>= threshold, probs, MLXArray.zeros(like: probs))
+        probs = probs / probs.sum(axis: -1, keepDims: true)
+    }
+    return probs
+}
+
+public func sampleToken(probabilities: MLXArray) -> Int {
+    categorical(MLX.log(probabilities + 1e-10)).item(Int.self)
+}

--- a/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
@@ -41,6 +41,30 @@ public final class QwenTokenizer {
     encodeFunction(text)
   }
 
+  /// Apply the tokenizer's configured chat template and return raw token IDs.
+  public func encodeChatTemplate(
+    messages: [Message],
+    tools: [ToolSpec]? = nil,
+    addGenerationPrompt: Bool = true,
+    includeThinking: Bool = true,
+    maxLength: Int? = nil
+  ) throws -> [Int] {
+    var encoded = try tokenizer.applyChatTemplate(
+      messages: messages,
+      chatTemplate: nil,
+      addGenerationPrompt: addGenerationPrompt,
+      truncation: false,
+      maxLength: nil,
+      tools: tools,
+      additionalContext: ["enable_thinking": includeThinking]
+    )
+    let targetLength = min(maxLength ?? self.maxLength, self.maxLength)
+    if encoded.count > targetLength {
+      encoded = Array(encoded.suffix(targetLength))
+    }
+    return encoded
+  }
+
   public init(
     padTokenId: Int,
     maxLength: Int,

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -115,6 +115,16 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.validationKind, .gemma4)
     }
 
+    func testQ36NanoUsesOptiQHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.q36NanoModelId))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit")
+        XCTAssertEqual(spec.hubFallback?.revision, "63d520640ca7461f31ba66104612135770090340")
+        XCTAssertEqual(spec.upstreamRepoId, "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit")
+        XCTAssertEqual(spec.validationKind, .q35)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("*.safetensors"), true)
+    }
+
     func testZImageNanoAcceptsMFluxLayoutWithoutDiffusersConfigs() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -67,6 +67,20 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(report.reasons, [])
     }
 
+    func testQ36NanoIsSupportedOnThirtyTwoGB() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.q36NanoModelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M2 Max",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertEqual(report.reasons, [])
+    }
+
     func testUnsupportedRuntimeIsRejected() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -29,9 +29,9 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(schedulerDir.appendingPathComponent("scheduler_config.json"), contents: Data("{}".utf8))
     }
 
-    private func writeMinimalValidQ35Model(at root: URL) throws {
+    private func writeMinimalValidQ35Model(at root: URL, id: ModelResolver.ModelID = .q35) throws {
         try TestFileSystem.createDirectory(root)
-        try MereRunModelManifest.template(for: .q35, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
 
         try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data("{}".utf8))
         try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
@@ -162,6 +162,21 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "text-chat-q35")
         XCTAssertTrue(report.isValid)
         XCTAssertTrue(report.errors.isEmpty)
+    }
+
+    func testQ36NanoChatOnlyRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("text-chat-q36-nano", isDirectory: true)
+        try writeMinimalValidQ35Model(at: root, id: .q36Nano)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "text-chat-q36-nano")
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.tier, .nano)
+        XCTAssertEqual(report.manifest?.family, .qwen)
+        XCTAssertEqual(report.manifest?.upstreamRepoId, "\(Q35Resources.q36NanoUpstreamRepoId)@\(Q35Resources.q36NanoUpstreamRevision)")
     }
 
     func testGemma4ChatOnlyRootLayoutPassesValidation() throws {

--- a/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
+++ b/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
@@ -1,8 +1,61 @@
 import MLX
+import MLXNN
 import XCTest
 @testable import MereRunCore
 
 final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
+    func testQ35SwitchLinearInfersMixedPrecisionExpertBits() throws {
+        let weightValues = (0..<384).map { Float($0 % 19) / 18.0 - 0.5 }
+        let denseWeight = MLXArray(weightValues, [3, 4, 32])
+        let (weight, scales, biases) = MLX.quantized(denseWeight, groupSize: 32, bits: 8)
+        let x = MLXArray([
+            0.10, -0.20, 0.30, -0.40, 0.50, -0.60, 0.70, -0.80,
+            0.15, -0.25, 0.35, -0.45, 0.55, -0.65, 0.75, -0.85,
+            0.12, -0.22, 0.32, -0.42, 0.52, -0.62, 0.72, -0.82,
+            0.18, -0.28, 0.38, -0.48, 0.58, -0.68, 0.78, -0.88,
+            -0.15, 0.25, -0.35, 0.45, -0.55, 0.65, -0.75, 0.85,
+            -0.10, 0.20, -0.30, 0.40, -0.50, 0.60, -0.70, 0.80,
+            -0.12, 0.22, -0.32, 0.42, -0.52, 0.62, -0.72, 0.82,
+            -0.18, 0.28, -0.38, 0.48, -0.58, 0.68, -0.78, 0.88,
+        ] as [Float], [1, 2, 32])
+        let indices = MLXArray([0, 2] as [Int32], [1, 2, 1])
+
+        let layer = Q35SwitchLinear(
+            inputDims: 32,
+            outputDims: 4,
+            numExperts: 3,
+            groupSize: 32,
+            bits: 4,
+            quantized: true,
+            bias: false
+        )
+        var updates = [
+            ("weight", weight),
+            ("scales", scales),
+        ]
+        if let biases {
+            updates.append(("biases", biases))
+        }
+        try layer.update(parameters: ModuleParameters.unflattened(updates), verify: .none)
+
+        let expected = MLX.gatherQuantizedMM(
+            x.reshaped([2, 1, 32]),
+            weight,
+            scales: scales,
+            biases: biases,
+            rhsIndices: MLXArray([0, 2] as [Int32], [2]),
+            transpose: true,
+            groupSize: 32,
+            bits: 8,
+            mode: .affine,
+            sortedIndices: false
+        ).reshaped([1, 2, 1, 4])
+
+        let actual = layer(x, indices: indices)
+        let maxDiff = MLX.max(MLX.abs(expected.asType(.float32) - actual.asType(.float32))).item(Float.self)
+        XCTAssertLessThan(maxDiff, 0.001)
+    }
+
     func testDequantizedGatherFallbackMatchesGatherQMM() {
         let weightValues = (0..<384).map { Float($0 % 17) / 16.0 - 0.5 }
         let denseWeight = MLXArray(weightValues, [3, 4, 32])

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -12,7 +12,7 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
             includeThinking: false
         )
 
-        XCTAssertTrue(rendered.hasSuffix("<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n"))
+        XCTAssertTrue(rendered.hasSuffix("<|im_start|>assistant\n<think>\n\n</think>\n\n"))
     }
 
     func testQ35TemplateLeavesThinkingOpenWhenRequested() {
@@ -22,8 +22,8 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
             includeThinking: true
         )
 
-        XCTAssertTrue(rendered.hasSuffix("<|im_start|>assistant\\n<think>\\n"))
-        XCTAssertFalse(rendered.hasSuffix("</think>\\n\\n"))
+        XCTAssertTrue(rendered.hasSuffix("<|im_start|>assistant\n<think>\n"))
+        XCTAssertFalse(rendered.hasSuffix("</think>\n\n"))
     }
 
     private func decodeConfig(_ object: [String: Any]) throws -> Q35Config {
@@ -130,6 +130,66 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
             }
             return .linear(Q35LinearCache())
         }
+    }
+
+    func testSamplingProbabilitiesGreedyReturnsOneHotDistribution() {
+        let logits = MLXArray([0.1, 2.0, -1.0, 0.7])
+        let config = GenerationConfig(
+            maxTokens: 1,
+            temperature: 0,
+            topK: 0,
+            topP: 1,
+            repetitionPenalty: nil
+        )
+
+        let probs = samplingProbabilities(logits: logits, config: config, previousTokens: [])
+        MLX.eval(probs)
+
+        XCTAssertEqual(probs[1].item(Float.self), 1, accuracy: 0.0001)
+        XCTAssertEqual(probs.sum().item(Float.self), 1, accuracy: 0.0001)
+    }
+
+    func testQ35MTPDraftLogitsSupportsDenseExpertWeightLayout() throws {
+        MLXRandom.seed(39)
+        let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["full_attention"]))
+        let model = Q35Model(config: config)
+        let mtp = Q35MTPModel(config: config)
+        let tokens = [1, 2, 3]
+        let cache = makeLayerCaches(config: config)
+        let input = MLXArray(tokens.map(Int32.init)).reshaped(1, tokens.count)
+        let output = model.forward(input, cache: cache)
+        MLX.eval(output.hidden)
+
+        let lastIndex = output.hidden.dim(1) - 1
+        let previousHidden = output.hidden[0..., lastIndex..<(lastIndex + 1), 0...]
+        let draftLogits = mtp.draftLogits(
+            token: 4,
+            previousHidden: previousHidden,
+            positionOffset: tokens.count,
+            baseModel: model
+        )
+        MLX.eval(draftLogits)
+
+        XCTAssertEqual(draftLogits.shape, [1, 1, config.textConfig.vocabSize])
+        XCTAssertTrue(MLX.max(MLX.abs(draftLogits.asType(.float32))).item(Float.self).isFinite)
+    }
+
+    func testQ35ConfigAllowsTextOnlyQwen36Layout() throws {
+        var configObject = makeBaseConfig()
+        configObject["model_type"] = "qwen3_5_moe"
+        configObject["architectures"] = ["Qwen3_5MoeForConditionalGeneration"]
+        if var textConfig = configObject["text_config"] as? [String: Any] {
+            textConfig.removeValue(forKey: "mlp_only_layers")
+            configObject["text_config"] = textConfig
+        }
+        configObject.removeValue(forKey: "vision_config")
+
+        let config = try decodeConfig(configObject)
+
+        XCTAssertEqual(config.modelType, "qwen3_5_moe")
+        XCTAssertNil(config.visionConfig)
+        XCTAssertEqual(config.textConfig.mlpOnlyLayers, [])
+        XCTAssertEqual(config.textConfig.numExperts, 256)
     }
 
     private func mergeLayerCaches(_ rowCaches: [[Q35LayerCache?]]) -> [Q35LayerCache?]? {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ are:
 - Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`,
   `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
   `image-hidream-o1`, `image-hidream-o1-dev`
-- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q35`, `text-chat-q35-nano`
+- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q35`, `text-chat-q35-nano`, `text-chat-q36-nano`
 - Text code / agents: `text-agent-qwen35-9b`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Text anonymize: `text-anonymize-privacy-filter`
@@ -244,7 +244,7 @@ Examples:
 
 ```bash
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
-swift run mere.run text chat --model text-chat-q35-nano --prompt "Explain speculative decoding."
+swift run mere.run text chat --model text-chat-q36-nano --prompt "Explain speculative decoding."
 swift run mere.run text chat --stream --prompt "Write a short welcome message."
 swift run mere.run text chat --thinking --stats --prompt "How would you design a tokenizer?"
 ```

--- a/docs/internals/cli-and-runtime.md
+++ b/docs/internals/cli-and-runtime.md
@@ -51,6 +51,7 @@ The runtime uses explicit public IDs such as:
 - `image-klein-max`
 - `text-chat-gemma4`
 - `text-chat-q35`
+- `text-chat-q36-nano`
 - `text-agent-deepseek-v4-flash`
 - `speech-tts-qwen3-nano`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -23,7 +23,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Category | Hugging Face pull IDs |
 | --- | --- |
 | Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
-| Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, `text-agent-deepseek-v4-flash` |
+| Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q35`, `text-chat-q35-nano`, `text-chat-q36-nano`, `text-agent-deepseek-v4-flash` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
 | Text anonymize | `text-anonymize-privacy-filter` |
@@ -53,6 +53,14 @@ Hugging Face source `unsloth/Qwen3.5-9B-GGUF` and selects
 `text-agent-deepseek-v4-flash` is the preferred managed setup-agent tier on
 96 GB+ Apple Silicon Macs. Q35/Qwen setup agents are lower-memory or comparison
 alternatives, not upgrades from DeepSeek V4 Flash.
+
+`text-chat-q36-nano` uses the public `mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit`
+snapshot. That Hugging Face repo includes an MTP head (`mtp.safetensors`) for
+OptiQ serving; mere.run currently loads the main MLX chat weights through its
+native Q35-family runtime and does not consume the MTP head for speculative
+decode yet. The dense `mlx-community/Qwen3.6-27B-OptiQ-4bit` MTP quant also
+exists on Hugging Face, but is not a managed native target until the dense
+Qwen3.6 layer path is implemented.
 
 `text-chat-gemma4` is the dense bf16 Gemma 4 31B alias and is gated for larger
 machines. On 32 GB Apple Silicon Macs, use `text-chat-gemma4-turbo`, which

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -189,6 +189,8 @@ Engine compatibility:
   responses when the model generates a tool call.
 - `text-chat-q35`: accepts function tools and one image content part per
   message.
+- `text-chat-q36-nano`: uses the Q35-family serving engine with Qwen3.6
+  35B-A3B OptiQ chat weights.
 - `text-chat-klein`: supports `response_format: {"type":"json_object"}` with
   local JSON retry behavior.
 - `text-code`: accepts plain text chat requests and rejects tools, images,

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -39,7 +39,7 @@ swift run mere.run --models-root /path/to/models model list
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-q35`, `text-chat-q35-nano`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text: `text-chat-gemma4`, `text-chat-q35`, `text-chat-q35-nano`, `text-chat-q36-nano`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -18,6 +18,7 @@ embeddings, and PII anonymization.
 - `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
 - `text-chat-q35`
 - `text-chat-q35-nano`
+- `text-chat-q36-nano`
 - `text-agent-deepseek-v4-flash` (API/agent serving)
 - `text-chat-mebot`
 - `text-chat-psi-agent`


### PR DESCRIPTION
## Summary
- add the managed text-chat-q36-nano model and docs/catalog support
- load q36 mtp.safetensors natively and run one-token MTP speculative verification in serial Q35 decode
- harden Q35 mixed-precision quantized expert loading and add focused regressions

## Validation
- swift run mere.run text chat --model text-chat-q36-nano --prompt 'Reply with exactly: OK' --max-tokens 8 --temperature 0 --top-p 1
- swift run mere.run text chat --model text-chat-q36-nano --prompt 'Say hi in three words.' --max-tokens 12
- swift test --filter Q35ConfigDecodingTests
- ./scripts/check.sh