### PR TITLE
Bump MereRunCLIVersion to 0.11.0

### DIFF
--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.10.0"
+    static let current = "0.11.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.10.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.11.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 


### PR DESCRIPTION
The CLI version constant `MereRunCLIVersion.current` was never bumped past `0.10.0`, so **every v0.11.0 binary** (macOS dmg, arm64 CUDA `.deb`, x86_64 CUDA `.deb`) reports `--version 0.10.0`. This aligns the constant with the released `v0.11.0` tag so the next build reports correctly.

One-line change; no behavior change beyond the reported version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)