### PR TITLE
Fix q36 API MTP context gating

### DIFF
--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -406,7 +406,8 @@ enum APIServerContract {
             topP: topP,
             lora: lora,
             requiresJSON: requiresJSON,
-            tools: tools
+            tools: tools,
+            maxContextTokens: contextSize
         )
     }
 

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -34,7 +34,7 @@ mere.run status
 - `--api-key`: bearer token, also read from `MERERUN_API_KEY`.
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
-- `--context-size`: context limit.
+- `--context-size`: context limit used for request validation and native prompt truncation.
 - `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`:
   Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the
   existing 4-bit affine TurboQuant KV cache from token 0; explicit flags

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -8,7 +8,7 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, and `text-chat-psi-agent`.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
-`text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head, but this command currently uses the main chat weights only.
+`text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head that is used only by the adaptive long-context speculative decode path.
 
 ## Install And Check
 

--- a/Sources/MereRunCLI/Support/FileSystemHelper.swift
+++ b/Sources/MereRunCLI/Support/FileSystemHelper.swift
@@ -7,15 +7,19 @@ enum FileSystemHelper {
         let root = url.resolvingSymlinksInPath()
         guard let enumerator = fm.enumerator(
             at: root,
-            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey],
             options: [.skipsHiddenFiles]
         ) else { return 0 }
 
         var total: Int64 = 0
         for case let fileURL as URL in enumerator {
-            guard let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
-                  values.isRegularFile == true,
-                  let size = values.fileSize else { continue }
+            guard let values = try? fileURL.resourceValues(forKeys: [.isSymbolicLinkKey]) else {
+                continue
+            }
+            let measuredURL = values.isSymbolicLink == true ? fileURL.resolvingSymlinksInPath() : fileURL
+            guard let measuredValues = try? measuredURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+                  measuredValues.isRegularFile == true,
+                  let size = measuredValues.fileSize else { continue }
             total += Int64(size)
         }
         return total

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -247,7 +247,15 @@ public actor Gemma4Generator: ChatGenerator {
         }
         let fallbackKVCacheQuantization = try self.kvCacheQuantization.validated()
 
-        let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
+        let requestedContextLength = request.maxContextTokens ?? maxContextLength
+        guard requestedContextLength > 0 else {
+            throw Gemma4Error.unsupportedConfiguration("maxContextTokens must be greater than zero.")
+        }
+        let effectiveContext = min(
+            maxContextLength,
+            requestedContextLength,
+            loadedConfig.textConfig.maxPositionEmbeddings
+        )
         let prefillStart = Date()
         let messages = request.messages
         var promptTokens = try tokenizerAndTemplate.encodeForGeneration(

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -250,6 +250,7 @@ public struct ChatRequest: Sendable, Hashable {
     public var tools: [ToolDefinition]?
     public var stopOnEOS: Bool
     public var kvCacheMode: RuntimeKVCacheMode?
+    public var maxContextTokens: Int?
 
     public init(
         messages: [ChatMessage],
@@ -261,7 +262,8 @@ public struct ChatRequest: Sendable, Hashable {
         requiresJSON: Bool = false,
         tools: [ToolDefinition]? = nil,
         stopOnEOS: Bool = true,
-        kvCacheMode: RuntimeKVCacheMode? = nil
+        kvCacheMode: RuntimeKVCacheMode? = nil,
+        maxContextTokens: Int? = nil
     ) {
         self.messages = messages
         self.maxTokens = maxTokens
@@ -273,6 +275,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.tools = tools
         self.stopOnEOS = stopOnEOS
         self.kvCacheMode = kvCacheMode
+        self.maxContextTokens = maxContextTokens
     }
 }
 

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -334,7 +334,15 @@ public actor Q35Generator: ChatGenerator {
         }
 
         let messages = request.messages
-        let effectiveContext = min(maxContextLength, loadedConfig.textConfig.maxPositionEmbeddings)
+        let requestedContextLength = request.maxContextTokens ?? maxContextLength
+        guard requestedContextLength > 0 else {
+            throw Q35Error.generationFailed("maxContextTokens must be greater than zero.")
+        }
+        let effectiveContext = min(
+            maxContextLength,
+            requestedContextLength,
+            loadedConfig.textConfig.maxPositionEmbeddings
+        )
         let prefillStart = Date()
 
         var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
@@ -458,6 +466,7 @@ public actor Q35Generator: ChatGenerator {
             tokenBudget: tokenBudget,
             prefillTokenCount: prefillLength,
             promptTokens: promptTokens,
+            maxContextTokens: effectiveContext,
             progressHandler: progressHandler
         )
 
@@ -486,16 +495,34 @@ public actor Q35Generator: ChatGenerator {
     /// more expensive as the KV cache grows, so verifying several drafted tokens per
     /// pass amortizes — but at short prompts the draft-head overhead dominates.
     /// Measured (Qwen3.6-35B-A3B OptiQ-4bit, M4 Max): ~20-tok ctx -31%, ~4K -22%,
-    /// ~12K +1.5-2.5x. Default to speculating only when the prompt is long; the env
-    /// forces it on/off, and MERERUN_Q35_MTP_MIN_PROMPT_TOKENS tunes the threshold.
-    static func shouldSpeculate(promptTokenCount: Int) -> Bool {
-        let env = ProcessInfo.processInfo.environment
+    /// ~12K +1.5-2.5x. Default to speculating only when the prompt and request
+    /// context are long; MERERUN_Q35_MTP_SPECULATION can enable/disable it, and
+    /// MERERUN_Q35_MTP_MIN_PROMPT_TOKENS tunes the threshold.
+    static func shouldSpeculate(promptTokenCount: Int, maxContextTokens: Int? = nil) -> Bool {
+        shouldSpeculate(
+            promptTokenCount: promptTokenCount,
+            maxContextTokens: maxContextTokens,
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+
+    static func shouldSpeculate(
+        promptTokenCount: Int,
+        maxContextTokens: Int?,
+        environment env: [String: String]
+    ) -> Bool {
+        let threshold = env["MERERUN_Q35_MTP_MIN_PROMPT_TOKENS"].flatMap { Int($0) } ?? 6144
+        let contextAllowsSpeculation = maxContextTokens.map { $0 >= threshold } ?? true
         if let raw = env["MERERUN_Q35_MTP_SPECULATION"]?.lowercased() {
             if raw == "0" || raw == "false" || raw == "no" { return false }
-            if raw == "1" || raw == "true" || raw == "yes" || raw == "on" { return true }
+            if raw == "1" || raw == "true" || raw == "yes" || raw == "on" {
+                return contextAllowsSpeculation
+            }
             // any other value (e.g. "auto") falls through to the adaptive threshold
         }
-        let threshold = env["MERERUN_Q35_MTP_MIN_PROMPT_TOKENS"].flatMap { Int($0) } ?? 6144
+        if !contextAllowsSpeculation {
+            return false
+        }
         return promptTokenCount >= threshold
     }
 
@@ -510,6 +537,7 @@ public actor Q35Generator: ChatGenerator {
         tokenBudget: Int,
         prefillTokenCount: Int,
         promptTokens: [Int],
+        maxContextTokens: Int,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Q35BatchedDecodeResult {
         guard tokenBudget > 0 else {
@@ -518,7 +546,10 @@ public actor Q35Generator: ChatGenerator {
         guard continuousBatchingEnabled else {
             // Use the loaded MTP head only when the prompt is long enough for
             // speculation to pay off; otherwise decode without it (nil).
-            let speculationMTP = Self.shouldSpeculate(promptTokenCount: promptTokens.count) ? mtpModel : nil
+            let speculationMTP = Self.shouldSpeculate(
+                promptTokenCount: promptTokens.count,
+                maxContextTokens: maxContextTokens
+            ) ? mtpModel : nil
             return try await decodeTokensSerially(
                 model: model,
                 tokenizerAndTemplate: tokenizerAndTemplate,

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -147,6 +147,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.maxTokens, APIServerContract.defaultMaxTokens)
         XCTAssertEqual(chatRequest.temperature, 1.0)
         XCTAssertEqual(chatRequest.topP, 0.95)
+        XCTAssertEqual(chatRequest.maxContextTokens, 4_096)
         XCTAssertEqual(chatRequest.messages, [ChatMessage(role: .user, content: "hello")])
         guard case .local(let path, let scale) = chatRequest.lora else {
             return XCTFail("Expected server-configured LoRA to be applied")

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -246,6 +246,26 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(FileSystemHelper.directorySize(at: link), 4)
     }
 
+    func testDirectorySizeFollowsSymlinkedFilesInsideModelRoots() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-size-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let target = root.appendingPathComponent("target", isDirectory: true)
+        let modelRoot = root.appendingPathComponent("text-chat-q36-nano", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
+        let weights = target.appendingPathComponent("model.safetensors")
+        try Data(repeating: 1, count: 7).write(to: weights)
+        try FileManager.default.createSymbolicLink(
+            at: modelRoot.appendingPathComponent("model.safetensors"),
+            withDestinationURL: weights
+        )
+
+        XCTAssertEqual(FileSystemHelper.directorySize(at: modelRoot), 7)
+    }
+
     func testPiBinaryFinderSkipsDirectoryNamedPi() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-pi-finder-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -174,6 +174,33 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertTrue(MLX.max(MLX.abs(draftLogits.asType(.float32))).item(Float.self).isFinite)
     }
 
+    func testQ35MTPSpeculationRequiresAdaptiveContextWindow() {
+        XCTAssertFalse(
+            Q35Generator.shouldSpeculate(
+                promptTokenCount: 8_192,
+                maxContextTokens: 4_096,
+                environment: ["MERERUN_Q35_MTP_SPECULATION": "1"]
+            )
+        )
+        XCTAssertTrue(
+            Q35Generator.shouldSpeculate(
+                promptTokenCount: 8_192,
+                maxContextTokens: 8_192,
+                environment: ["MERERUN_Q35_MTP_SPECULATION": "1"]
+            )
+        )
+        XCTAssertTrue(
+            Q35Generator.shouldSpeculate(
+                promptTokenCount: 2_048,
+                maxContextTokens: 4_096,
+                environment: [
+                    "MERERUN_Q35_MTP_SPECULATION": "1",
+                    "MERERUN_Q35_MTP_MIN_PROMPT_TOKENS": "2048",
+                ]
+            )
+        )
+    }
+
     func testQ35ConfigAllowsTextOnlyQwen36Layout() throws {
         var configObject = makeBaseConfig()
         configObject["model_type"] = "qwen3_5_moe"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -835,7 +835,7 @@ Security defaults:
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and
   `benchmarkStats`
-- generation parameters are bounded before execution; for example, `max_tokens` must fit the configured context size
+- generation parameters are bounded before execution; for example, `max_tokens` must fit the configured context size, and native chat engines receive that same context cap for prompt truncation
 - LoRA adapters for the API server are selected by the operator with `--lora`; request bodies cannot provide local LoRA paths
 
 Engine values:

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -56,11 +56,12 @@ alternatives, not upgrades from DeepSeek V4 Flash.
 
 `text-chat-q36-nano` uses the public `mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit`
 snapshot. That Hugging Face repo includes an MTP head (`mtp.safetensors`) for
-OptiQ serving; mere.run currently loads the main MLX chat weights through its
-native Qwen-family runtime and does not consume the MTP head for speculative
-decode yet. The dense `mlx-community/Qwen3.6-27B-OptiQ-4bit` MTP quant also
-exists on Hugging Face, but is not a managed native target until the dense
-Qwen3.6 layer path is implemented.
+OptiQ serving; mere.run loads that draft head when present, but only uses it for
+adaptive speculative decode when the effective prompt and context window are
+long enough. Short-context requests decode with the main chat weights. The dense
+`mlx-community/Qwen3.6-27B-OptiQ-4bit` MTP quant also exists on Hugging Face,
+but is not a managed native target until the dense Qwen3.6 layer path is
+implemented.
 
 `text-chat-gemma4` is the dense bf16 Gemma 4 31B alias and is gated for larger
 machines. On 32 GB Apple Silicon Macs, use `text-chat-gemma4-turbo`, which


### PR DESCRIPTION
## Summary
- propagate API context caps into native chat requests so q36/Gemma4 generation truncates to the served context window
- gate q36 MTP speculation on the effective context window as well as prompt length, preventing short-context API token-salad even with speculation enabled
- follow symlinked files inside model roots when reporting model inventory size, so q36 materialized installs show the real linked checkpoint size

## Validation
- swift test --filter APIServeCommandTests
- swift test --filter Q35ConfigDecodingTests
- swift test --filter SetupCommandParsingTests/testDirectorySizeFollowsSymlinkedFilesInsideModelRoots
- swiftlint --strict Sources/MereRunCLI/Support/FileSystemHelper.swift Tests/MereRunCLITests/SetupCommandParsingTests.swift
- ./scripts/check.sh
- .build/debug/mere.run model list | rg -n "text-chat-q36-nano|ID +Category"  # text-chat-q36-nano installed 23.8 GB
- live local API smoke with MERERUN_Q35_MTP_SPECULATION=1, q36, --context-size 4096 returned finish_reason=stop without token-salad