### PR TITLE
Add Swift-native LFM2 text chat runtime

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e029af69e0f9a89e4d7012e2dc4398dc7b2f5ea9565edf0b8ead7eeffffc9125",
+  "originHash" : "e3cc2cb855571c72c4187a54806f08cee45cc57ff4d854629bed1e87f4c36160",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "476538ccb827f2dd18efc5de754cc87d77127a47",
+        "version" : "4.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -257,6 +257,7 @@ targets.append(contentsOf: [
       "Flux2Klein/Model/Transformer/README.md",
       "Gemma4/README.md",
       "HiDreamO1/README.md",
+      "LFM2/README.md",
       "LightOnOCR/README.md",
       "LTX/README.md",
       "LoRA/README.md",
@@ -274,6 +275,7 @@ targets.append(contentsOf: [
       "ZImageI2L/Model/README.md",
       "ZImageTurbo/README.md",
       "ZImageTurbo/Model/TextEncoder/README.md",
+      "ZImageTurbo/Model/TextEncoder/LLMGeneration/README.md",
       "ZImageTurbo/Model/TextEncoder/Vision/README.md",
       "ZImageTurbo/Model/Transformer/README.md",
       "ZImageTurbo/Model/VAE/README.md",
@@ -385,7 +387,7 @@ let packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
     url: "https://github.com/huggingface/swift-transformers",
     from: "1.3.0"
   ),
-  .package(url: "https://github.com/apple/swift-crypto.git", from: "4.0.0"),
+  .package(url: "https://github.com/apple/swift-crypto.git", "4.0.0"..<"4.5.0"),
   .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")
 ]

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ swift run mere.run setup
 
 # Pull a Hugging Face-backed model into the local model store
 swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull text-chat-lfm25-a1b-8bit
 
 # Generate an image
 swift run mere.run image generate \
@@ -229,12 +230,18 @@ swift run mere.run text chat \
   --stream \
   --prompt "Summarize diffusion models in one paragraph."
 
+# Run LiquidAI LFM2.5 through the native Swift MLX runtime
+swift run mere.run text chat \
+  --model text-chat-lfm25-a1b-8bit \
+  --prompt "Summarize mixture-of-experts routing in one paragraph."
+
 # Redact PII locally
 swift run mere.run text anonymize \
   "My name is Alice Smith and my email is alice@example.com"
 
 # Serve the OpenAI-compatible local API on loopback
 swift run mere.run api serve --engine text-chat-gemma4
+swift run mere.run api serve --engine text-chat-lfm2
 
 # In another terminal, confirm the server and served model
 swift run mere.run status

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -856,7 +856,7 @@ private struct APIOptions: View {
             VStack(spacing: 10) {
                 Picker("Engine", selection: $controller.draft.engine) {
                     Text("Chat Gemma4").tag("text-chat-gemma4")
-                    Text("Chat Qwen 3.6").tag("text-chat-q35")
+                    Text("Chat Qwen 3.6").tag("text-chat-q36")
                     Text("Chat Klein").tag("text-chat-klein")
                     Text("Code").tag("text-code")
                 }

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -33,7 +33,10 @@ struct APIServe: AsyncParsableCommand {
           mere.run api serve --engine text-chat-gemma4
 
           # Start a Qwen3.6 text-chat server with an explicit model root
-          mere.run api serve --engine text-chat-q35 -m ~/Models/text-chat-q36-nano
+          mere.run api serve --engine text-chat-q36 -m ~/Models/text-chat-q36-nano
+
+          # Start an LFM2.5 text-chat server
+          mere.run api serve --engine text-chat-lfm2
 
           # Start the DeepSeek V4 Flash OpenAI-compatible server
           mere.run api serve --engine text-chat-deepseek-v4-flash
@@ -58,11 +61,11 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Host to bind to.")
     var host: String = "127.0.0.1"
 
-    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-q35, pass a Qwen3.6 text chat model root. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root.")
+    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root.")
     var model: String?
 
-    @Option(name: [.long], help: "Serving engine: text-chat-q35 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, or text-chat-deepseek-v4-flash.")
-    var engine: APIEngine = .textChatQ35
+    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-lfm2, or text-chat-deepseek-v4-flash.")
+    var engine: APIEngine = .textChatQ36
 
     @Option(name: [.long], help: "Default LoRA adapter path for all requests.")
     var lora: String?
@@ -124,8 +127,10 @@ struct APIServe: AsyncParsableCommand {
             return ModelResolver.ModelID.mebot.rawValue
         case .textChatGemma4:
             return ModelResolver.ModelID.gemma4.rawValue
-        case .textChatQ35:
+        case .textChatQ36, .textChatQ35:
             return ModelResolver.ModelID.q36Nano.rawValue
+        case .textChatLFM2:
+            return LFM2Resources.defaultModelId
         case .textCode:
             return CodeGenResources.defaultModelId
         case .textChatDeepseekV4Flash:
@@ -153,14 +158,23 @@ struct APIServe: AsyncParsableCommand {
                 return resolved.rootURL.path
             }
             return nil
-        case .textChatQ35:
+        case .textChatQ36, .textChatQ35:
             if let explicit = model {
                 return explicit
             }
             if let resolved = ModelResolver().resolveIfPresent(.q36Nano) {
                 return resolved.rootURL.path
             }
-            // Allow Q35Generator to auto-download from Hugging Face when model path is omitted.
+            // Allow the Qwen-family generator to auto-download from Hugging Face when model path is omitted.
+            return nil
+        case .textChatLFM2:
+            if let explicit = model {
+                return explicit
+            }
+            if let resolved = ModelResolver().resolveIfPresent(.lfm25A1B8Bit) {
+                return resolved.rootURL.path
+            }
+            // Allow LFM2Generator to auto-download from Hugging Face when model path is omitted.
             return nil
         case .textChatDeepseekV4Flash:
             // DeepseekV4FlashGenerator resolves and (if needed) downloads its own GGUF.
@@ -248,7 +262,9 @@ enum APIEngine: String, ExpressibleByArgument {
     case textCode = "text-code"
     case textChatKlein = "text-chat-klein"
     case textChatGemma4 = "text-chat-gemma4"
+    case textChatQ36 = "text-chat-q36"
     case textChatQ35 = "text-chat-q35"
+    case textChatLFM2 = "text-chat-lfm2"
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
 
     var runtimeServingEngine: RuntimeServingEngine {
@@ -259,8 +275,12 @@ enum APIEngine: String, ExpressibleByArgument {
             return .textChatKlein
         case .textChatGemma4:
             return .textChatGemma4
+        case .textChatQ36:
+            return .textChatQ36
         case .textChatQ35:
-            return .textChatQ35
+            return .textChatQ36
+        case .textChatLFM2:
+            return .textChatLFM2
         case .textChatDeepseekV4Flash:
             return .textChatDeepseekV4Flash
         }

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -211,6 +211,7 @@ enum GuideRegistry {
                 "text-chat-gemma4-nano",
                 "text-chat-gemma4-max",
                 "text-chat-q36-nano",
+                "text-chat-lfm25-a1b-8bit",
                 "text-chat-psi-agent",
             ],
             resourceName: "text-chat.md"
@@ -352,6 +353,7 @@ enum GuideRegistry {
                 "text-chat-gemma4-nano",
                 "text-chat-gemma4-max",
                 "text-chat-q36-nano",
+                "text-chat-lfm25-a1b-8bit",
                 "text-chat-mebot",
             ],
             resourceName: "api-serve.md"
@@ -379,6 +381,7 @@ enum GuideRegistry {
                 "text-agent-qwen35-9b",
                 "text-chat-gemma4",
                 "text-chat-q36-nano",
+                "text-chat-lfm25-a1b-8bit",
                 "text-agent-deepseek-v4-flash",
                 "text-chat-mebot",
             ],

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -195,7 +195,7 @@ struct ImageGenerate: AsyncParsableCommand {
         case .hidream:
             let generator = HiDreamO1Generator()
             result = try await generator.generate(request, progressHandler: progressHandler)
-        case .gemma, .qwen, .sam, .falcon, .tts, .asr, .embed, .code, .ocr, .music, .video, .psi, .privacy, .deepseek, nil:
+        case .gemma, .liquid, .qwen, .sam, .falcon, .tts, .asr, .embed, .code, .ocr, .music, .video, .psi, .privacy, .deepseek, nil:
             throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")
         }
 

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -8,7 +8,7 @@ struct ModelPull: AsyncParsableCommand {
         abstract: "Download a managed model into the local model store."
     )
 
-    @Argument(help: "Canonical model id (for example: image-zimage-nano, text-chat-gemma4-max, or text-chat-q36-nano). Omit when using --all.")
+    @Argument(help: "Canonical model id (for example: image-zimage-nano, text-chat-gemma4-max, or text-chat-lfm25-a1b-8bit). Omit when using --all.")
     var target: String?
 
     @Flag(name: [.long], help: "Pull every model that has a Hugging Face source.")

--- a/Sources/MereRunCLI/Commands/SetupCommand.swift
+++ b/Sources/MereRunCLI/Commands/SetupCommand.swift
@@ -469,8 +469,10 @@ struct SetupAgentRuntime {
         switch recommendation.servingEngine {
         case .textCode:
             engine = .textCode
+        case .textChatQ36:
+            engine = .textChatQ36
         case .textChatQ35:
-            engine = .textChatQ35
+            engine = .textChatQ36
         case .deepseekV4Flash:
             engine = .textChatDeepseekV4Flash
         case .sourceConfigured:
@@ -507,7 +509,7 @@ struct SetupAgentRuntime {
 
     private static func contextWindow(for recommendation: MereRunAgentModelRecommendation) -> Int {
         switch recommendation.servingEngine {
-        case .textChatQ35:
+        case .textChatQ36, .textChatQ35:
             return Q35Resources.defaultContextLength
         case .deepseekV4Flash:
             return DeepseekV4FlashResources.defaultContextLength

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -24,6 +24,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-gemma4 (Gemma 4 31B; large/slow, kept for compatibility)
           - text-chat-gemma4-max (Gemma 4 31B native Swift runtime)
           - text-chat-gemma4-nano (Gemma 4 4B native Swift runtime)
+          - text-chat-lfm25-a1b-8bit (LiquidAI LFM2.5 8B-A1B MLX 8-bit native Swift runtime)
           - text-chat-psi-agent
         Models are cached under ~/Library/Application Support/MereRun/models/<model-id>.
         Thinking output is hidden by default; pass --thinking to include it.
@@ -88,7 +89,7 @@ struct TextChat: AsyncParsableCommand {
         return Gemma4Resources.nanoModelId
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-gemma4[-turbo|-max|-nano], text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-gemma4[-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")
@@ -180,6 +181,10 @@ struct TextChat: AsyncParsableCommand {
                 // `text code` uses). On Linux CUDA this is the GB10-optimized
                 // llama.cpp runtime, which has fast quantized-MoE kernels MLX lacks.
                 let generator = CodeGenGenerator(modelId: normalizedModelId)
+                return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
+            } else if LFM2Resources.handles(modelSpec: normalizedModelId) {
+                let effectiveModelId = normalizedModelId.isEmpty ? LFM2Resources.defaultModelId : normalizedModelId
+                let generator = LFM2Generator(modelId: effectiveModelId)
                 return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
             } else {
                 let effectiveModelId = normalizedModelId.isEmpty ? Q35Resources.defaultModelId : normalizedModelId
@@ -293,15 +298,23 @@ struct TextChat: AsyncParsableCommand {
         }
     }
 
-    private func cleanResponse(_ response: String, showThinking: Bool) -> String {
+    func cleanResponse(_ response: String, showThinking: Bool) -> String {
         guard !showThinking else { return response }
         var cleaned = response.replacingOccurrences(
             of: "(?is)<think>.*?</think>",
             with: "",
             options: .regularExpression
         )
-        cleaned = cleaned.replacingOccurrences(of: "<think>", with: "")
-        cleaned = cleaned.replacingOccurrences(of: "</think>", with: "")
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?is)<think>.*\\z",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?i)</think>",
+            with: "",
+            options: .regularExpression
+        )
         return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -10,7 +10,8 @@ Supported engines:
 
 - `text-code`: default GGUF code model, usually `text-code-qwen3`.
 - `text-chat-gemma4`: Gemma text chat models.
-- `text-chat-q35`: Qwen-family serving engine; defaults to `text-chat-q36-nano`.
+- `text-chat-q36`: Qwen-family serving engine; defaults to `text-chat-q36-nano`.
+- `text-chat-lfm2`: LFM2 serving engine; defaults to `text-chat-lfm25-a1b-8bit`.
 - `text-chat-deepseek-v4-flash`: DeepSeek V4 Flash via the bundled DS4 server.
 - `text-chat-klein`: local Klein/MeBot chat path when installed.
 
@@ -29,7 +30,7 @@ mere.run status
 - `--port`, `-p`: listen port, default `8080`.
 - `--host`: bind host, default `127.0.0.1`.
 - `--model`, `-m`, `--model-path`: model path or engine-specific model root.
-- `--engine`: `text-code`, `text-chat-klein`, `text-chat-gemma4`, `text-chat-q35`, or `text-chat-deepseek-v4-flash`.
+- `--engine`: `text-code`, `text-chat-klein`, `text-chat-gemma4`, `text-chat-q36`, `text-chat-lfm2`, or `text-chat-deepseek-v4-flash`.
 - `--lora`: default LoRA adapter path for all requests.
 - `--api-key`: bearer token, also read from `MERERUN_API_KEY`.
 - `--rate-limit-per-minute`: global chat completions limit.
@@ -97,6 +98,11 @@ mere.run api serve --engine text-code --port 8080
 mere.run model pull text-chat-gemma4
 mere.run model runtime set text-chat-gemma4 --alias chat-default --max-tokens 1024
 mere.run api serve --engine text-chat-gemma4 --port 11434
+```
+
+```bash
+mere.run model pull text-chat-lfm25-a1b-8bit
+mere.run api serve --engine text-chat-lfm2 --port 11434
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -36,6 +36,7 @@ mere.run model list
 
 ```bash
 mere.run model pull text-chat-gemma4-nano
+mere.run model pull text-chat-lfm25-a1b-8bit
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/model-runtime.md
+++ b/Sources/MereRunCLI/Guides/model-runtime.md
@@ -8,7 +8,7 @@ Read or update typed per-model API serving settings. These settings feed
 ## Required Models
 
 Use a managed API-capable model id such as `text-chat-gemma4`,
-`text-chat-q36-nano`, `text-agent-deepseek-v4-flash`,
+`text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`,
 `text-agent-qwen35-9b`, or `text-chat-mebot`.
 
 ## Install And Check

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,9 +6,10 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
 `text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head that is used only by the adaptive long-context speculative decode path.
+`text-chat-lfm25-a1b-8bit` is the managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot and runs through the native Swift LFM2 runtime.
 
 ## Install And Check
 
@@ -62,6 +63,12 @@ mere.run text chat \
   --prompt "Compare speech transcription backends for meeting notes."
 ```
 
+```bash
+mere.run text chat \
+  --model text-chat-lfm25-a1b-8bit \
+  --prompt "Summarize the tradeoffs of mixture-of-experts chat models."
+```
+
 ## Iteration Tips
 
 - For deterministic summaries, lower temperature to `0.2` and keep top-p near default.
@@ -79,4 +86,5 @@ mere.run text chat \
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/TextChatCommand.swift
 - https://ai.google.dev/gemma/docs/core/prompt-structure
 - https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
+- https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-MLX-8bit
 - https://huggingface.co/google/gemma-4-31B

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -611,13 +611,18 @@ actor RuntimeModelPool {
                 ),
                 modelPath: resolved.installPath
             )
-        case .textChatQ35:
+        case .textChatQ36, .textChatQ35:
             return .textChatQ35(
                 Q35Generator(
                     modelId: resolved.id,
                     prefixKVCacheEnabled: q35PrefixKVCacheEnabled,
                     continuousBatchingEnabled: q35ContinuousBatchingEnabled
                 ),
+                modelPath: resolved.installPath
+            )
+        case .textChatLFM2:
+            return .textChatLFM2(
+                LFM2Generator(modelId: resolved.id),
                 modelPath: resolved.installPath
             )
         case .textChatDeepseekV4Flash:
@@ -643,7 +648,7 @@ actor RuntimeModelPool {
             }
             let settings = try settingsForSpec(spec)
             let engine = settings.engineOverride ?? defaultEngine
-            guard engine == defaultEngine else {
+            guard engine.isCompatible(with: defaultEngine) else {
                 throw RuntimeModelPoolError.incompatibleEngine(
                     "Engine '\(engine.rawValue)' is not compatible with model '\(spec.id)'."
                 )
@@ -832,7 +837,12 @@ actor RuntimeModelPool {
         switch engine {
         case .textCode:
             return ManagedModelCategory.textCode.rawValue
-        case .textChatKlein, .textChatGemma4, .textChatQ35, .textChatDeepseekV4Flash:
+        case .textChatKlein,
+             .textChatGemma4,
+             .textChatQ36,
+             .textChatQ35,
+             .textChatLFM2,
+             .textChatDeepseekV4Flash:
             return ManagedModelCategory.textChat.rawValue
         }
     }
@@ -1052,6 +1062,7 @@ enum RuntimeLoadedModel: Sendable {
     case textChatKlein(Flux2KleinGenerator, modelPath: String?, useStandalone: Bool)
     case textChatGemma4(Gemma4Generator, modelPath: String?)
     case textChatQ35(Q35Generator, modelPath: String?)
+    case textChatLFM2(LFM2Generator, modelPath: String?)
     case textChatDeepseekV4Flash(DeepseekV4FlashGenerator, modelPath: String?)
 
     func prepare(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws {
@@ -1071,6 +1082,8 @@ enum RuntimeLoadedModel: Sendable {
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         case .textChatQ35(let generator, let modelPath):
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatLFM2(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         case .textChatDeepseekV4Flash(let generator, let modelPath):
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         }
@@ -1086,6 +1099,8 @@ enum RuntimeLoadedModel: Sendable {
             await generator.unload()
         case .textChatQ35(let generator, _):
             await generator.unload()
+        case .textChatLFM2(let generator, _):
+            await generator.unload()
         case .textChatDeepseekV4Flash(let generator, _):
             await generator.shutdown()
         }
@@ -1097,7 +1112,7 @@ enum RuntimeLoadedModel: Sendable {
             return await generator.prefixKVCacheStats()
         case .textChatQ35(let generator, _):
             return await generator.prefixKVCacheStats()
-        case .textCode, .textChatKlein, .textChatDeepseekV4Flash:
+        case .textCode, .textChatKlein, .textChatLFM2, .textChatDeepseekV4Flash:
             return nil
         }
     }
@@ -1108,7 +1123,7 @@ enum RuntimeLoadedModel: Sendable {
             return await generator.continuousBatchingStats()
         case .textChatQ35(let generator, _):
             return await generator.continuousBatchingStats()
-        case .textCode, .textChatKlein, .textChatDeepseekV4Flash:
+        case .textCode, .textChatKlein, .textChatLFM2, .textChatDeepseekV4Flash:
             return nil
         }
     }
@@ -1136,6 +1151,8 @@ enum RuntimeLoadedModel: Sendable {
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         case .textChatQ35(let generator, let modelPath):
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatLFM2(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         case .textChatDeepseekV4Flash(let generator, let modelPath):
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         }
@@ -1150,7 +1167,7 @@ enum RuntimeLoadedModel: Sendable {
                 modelPath: modelPath,
                 progressHandler: progressHandler
             )
-        case .textCode, .textChatKlein, .textChatGemma4, .textChatQ35:
+        case .textCode, .textChatKlein, .textChatGemma4, .textChatQ35, .textChatLFM2:
             throw RuntimeModelPoolError.rawProxyUnavailable("")
         }
     }
@@ -1165,8 +1182,10 @@ extension RuntimeServingEngine {
             return .localTextWithStructuredJSON
         case .textChatGemma4:
             return .localTextWithTools
-        case .textChatQ35:
+        case .textChatQ36, .textChatQ35:
             return .localTextWithToolsAndVision
+        case .textChatLFM2:
+            return .localTextWithTools
         case .textChatDeepseekV4Flash:
             return .rawProxy
         }

--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -17,6 +17,7 @@ public struct AgentModelResources: Sendable, Hashable {
 
 public enum MereRunAgentServingEngine: String, Hashable, Sendable {
     case textCode = "text-code"
+    case textChatQ36 = "text-chat-q36"
     case textChatQ35 = "text-chat-q35"
     case deepseekV4Flash = "text-chat-deepseek-v4-flash"
     case sourceConfigured = "external"
@@ -162,7 +163,7 @@ public enum MereRunAgentModelCatalog {
             summary: "Higher-quality Qwen3.6 MLX agent tier for Macs with enough memory.",
             minimumUnifiedMemoryGB: 24,
             recommendedUnifiedMemoryGB: 32,
-            servingEngine: .textChatQ35,
+            servingEngine: .textChatQ36,
             managedModelID: Q35Resources.q36NanoModelId
         )
     }

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -145,7 +145,7 @@ public actor Gemma4Generator: ChatGenerator {
         var response = try await generate(
             request,
             progressHandler: progressHandler,
-            maxContextLength: Gemma4Resources.defaultContextLength
+            maxContextLength: request.maxContextTokens ?? Gemma4Resources.defaultContextLength
         )
         if var timing = response.timing {
             timing.loadSeconds = loadSeconds

--- a/Sources/MereRunCore/LFM2/LFM2Config.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Config.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+public struct LFM2QuantizationConfig: Codable, Sendable, Hashable {
+    public let groupSize: Int
+    public let bits: Int
+    public let mode: String
+
+    private enum CodingKeys: String, CodingKey {
+        case groupSize = "group_size"
+        case bits
+        case mode
+    }
+}
+
+public struct LFM2RopeParameters: Codable, Sendable, Hashable {
+    public let ropeTheta: Float?
+    public let ropeType: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case ropeTheta = "rope_theta"
+        case ropeType = "rope_type"
+    }
+}
+
+public struct LFM2Config: Decodable, Sendable, Hashable {
+    public let architectures: [String]
+    public let bosTokenId: Int?
+    public let eosTokenIds: [Int]
+    public let padTokenId: Int?
+    public let modelType: String
+    public let vocabSize: Int
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let moeIntermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numExperts: Int
+    public let numExpertsPerTok: Int
+    public let normTopKProb: Bool
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let maxPositionEmbeddings: Int
+    public let useExpertBias: Bool
+    public let numDenseLayers: Int
+    public let normEps: Float
+    public let convBias: Bool
+    public let convLCache: Int
+    public let ropeTheta: Float
+    public let ropeParameters: LFM2RopeParameters?
+    public let layerTypes: [String]
+    public let quantization: LFM2QuantizationConfig?
+    public let tieWordEmbeddings: Bool
+
+    public var headDim: Int {
+        hiddenSize / max(1, numAttentionHeads)
+    }
+
+    public var fullAttentionLayerIndexes: Set<Int> {
+        Set(layerTypes.enumerated().compactMap { index, layerType in
+            layerType == "full_attention" ? index : nil
+        })
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case architectures
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+        case modelType = "model_type"
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numExperts = "num_experts"
+        case numExpertsPerTok = "num_experts_per_tok"
+        case normTopKProb = "norm_topk_prob"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case useExpertBias = "use_expert_bias"
+        case numDenseLayers = "num_dense_layers"
+        case normEps = "norm_eps"
+        case convBias = "conv_bias"
+        case convLCache = "conv_L_cache"
+        case ropeTheta = "rope_theta"
+        case ropeParameters = "rope_parameters"
+        case layerTypes = "layer_types"
+        case quantization
+        case quantizationConfig = "quantization_config"
+        case tieWordEmbeddings = "tie_word_embeddings"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        self.bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId)
+        self.padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId)
+        self.modelType = try container.decode(String.self, forKey: .modelType)
+        self.vocabSize = try container.decode(Int.self, forKey: .vocabSize)
+        self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        self.intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        self.moeIntermediateSize = try container.decode(Int.self, forKey: .moeIntermediateSize)
+        self.numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+        self.numExperts = try container.decode(Int.self, forKey: .numExperts)
+        self.numExpertsPerTok = try container.decode(Int.self, forKey: .numExpertsPerTok)
+        self.normTopKProb = try container.decodeIfPresent(Bool.self, forKey: .normTopKProb) ?? true
+        self.numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+        self.numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
+        self.maxPositionEmbeddings = try container.decode(Int.self, forKey: .maxPositionEmbeddings)
+        self.useExpertBias = try container.decodeIfPresent(Bool.self, forKey: .useExpertBias) ?? false
+        self.numDenseLayers = try container.decodeIfPresent(Int.self, forKey: .numDenseLayers) ?? 0
+        self.normEps = try container.decode(Float.self, forKey: .normEps)
+        self.convBias = try container.decodeIfPresent(Bool.self, forKey: .convBias) ?? false
+        self.convLCache = try container.decode(Int.self, forKey: .convLCache)
+        self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 1_000_000
+        self.ropeParameters = try container.decodeIfPresent(LFM2RopeParameters.self, forKey: .ropeParameters)
+        self.layerTypes = try container.decode([String].self, forKey: .layerTypes)
+        self.tieWordEmbeddings = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+
+        if let direct = try? container.decodeIfPresent([Int].self, forKey: .eosTokenId) {
+            self.eosTokenIds = direct
+        } else if let single = try container.decodeIfPresent(Int.self, forKey: .eosTokenId) {
+            self.eosTokenIds = [single]
+        } else {
+            self.eosTokenIds = []
+        }
+
+        if let q = try container.decodeIfPresent(LFM2QuantizationConfig.self, forKey: .quantization) {
+            self.quantization = q
+        } else {
+            self.quantization = try container.decodeIfPresent(LFM2QuantizationConfig.self, forKey: .quantizationConfig)
+        }
+    }
+}
+
+public enum LFM2Error: LocalizedError {
+    case modelNotLoaded
+    case unsupportedModelId(String)
+    case missingFiles([String])
+    case downloadFailed(String)
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotLoaded:
+            return "LFM2 model is not loaded."
+        case .unsupportedModelId(let id):
+            return "Unsupported LFM2 model id: \(id)"
+        case .missingFiles(let files):
+            return "Missing required LFM2 files: \(files.joined(separator: ", "))"
+        case .downloadFailed(let message):
+            return "LFM2 download failed: \(message)"
+        case .generationFailed(let message):
+            return message
+        }
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -1,0 +1,354 @@
+import Foundation
+import MLX
+
+private struct LFM2PrefillOutput {
+    let logits: MLXArray
+    let hidden: MLXArray
+}
+
+private struct LFM2DecodeResult {
+    let generatedTokens: [Int]
+    let decodeSeconds: Double
+}
+
+public actor LFM2Generator: ChatGenerator {
+    private static let prefillChunkSize = 512
+
+    private var model: LFM2Model?
+    private var tokenizerAndTemplate: LFM2TokenizerAndTemplate?
+    private var loadedModelPath: String?
+    private var loadedConfig: LFM2Config?
+
+    private let modelId: String
+
+    public init(modelId: String = LFM2Resources.defaultModelId) {
+        self.modelId = modelId
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await chat(request, modelPath: nil, progressHandler: progressHandler)
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+        let loadStart = Date()
+        try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
+        let loadSeconds = Date().timeIntervalSince(loadStart)
+
+        var response = try await generate(request, progressHandler: progressHandler)
+        if var timing = response.timing {
+            timing.loadSeconds = loadSeconds
+            response.timing = timing
+        } else {
+            response.timing = ChatTiming(loadSeconds: loadSeconds)
+        }
+        return response
+    }
+
+    public func prepare(
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws {
+        let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+        try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
+    }
+
+    public func unload() {
+        model = nil
+        tokenizerAndTemplate = nil
+        loadedModelPath = nil
+        loadedConfig = nil
+        Memory.clearCache()
+    }
+
+    private func ensureLoaded(
+        rootURL: URL,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        let normalizedRoot = LFM2Resources.normalizedRootURL(rootURL)
+        if loadedModelPath == normalizedRoot.path, model != nil, tokenizerAndTemplate != nil {
+            return
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 config"))
+        let configData = try Data(contentsOf: normalizedRoot.appendingPathComponent("config.json"))
+        let config = try JSONDecoder().decode(LFM2Config.self, from: configData)
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 tokenizer"))
+        let tokenizer = try await LFM2TokenizerAndTemplate.load(
+            from: normalizedRoot,
+            maxLengthOverride: min(LFM2Resources.defaultContextLength, config.maxPositionEmbeddings)
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 weights"))
+        let lfm2Model = LFM2Model(config: config)
+        let resources = LFM2Resources(rootURL: normalizedRoot)
+        let groupSize = config.quantization?.groupSize ?? 64
+        let bits = config.quantization?.bits ?? 8
+
+        if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                indexURL: resources.modelIndexURL,
+                to: lfm2Model,
+                groupSize: groupSize,
+                bits: bits,
+                mapper: LFM2Resources.mapWeight(key:value:),
+                progressHandler: { progress in
+                    progressHandler?(ChatProgress(
+                        stage: .loadingModel,
+                        message: "Loading LFM2 shard \(progress.shardIndex + 1)/\(progress.shardCount)"
+                    ))
+                }
+            )
+        } else {
+            let arrays = try MLX.loadArrays(url: resources.modelWeightsURL)
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                arrays,
+                to: lfm2Model,
+                groupSize: groupSize,
+                bits: bits,
+                mapper: LFM2Resources.mapWeight(key:value:)
+            )
+        }
+
+        self.model = lfm2Model
+        self.tokenizerAndTemplate = tokenizer
+        self.loadedConfig = config
+        self.loadedModelPath = normalizedRoot.path
+    }
+
+    private func generate(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        guard let model,
+              let tokenizerAndTemplate,
+              let loadedConfig else {
+            throw LFM2Error.modelNotLoaded
+        }
+
+        let requestedContextLength = request.maxContextTokens ?? LFM2Resources.defaultContextLength
+        guard requestedContextLength > 0 else {
+            throw LFM2Error.generationFailed("maxContextTokens must be greater than zero.")
+        }
+        let effectiveContext = min(
+            LFM2Resources.defaultContextLength,
+            requestedContextLength,
+            loadedConfig.maxPositionEmbeddings
+        )
+
+        let prefillStart = Date()
+        var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
+            messages: request.messages,
+            tools: request.tools,
+            addGenerationPrompt: true,
+            includeThinking: request.showThinking,
+            maxLength: effectiveContext
+        )
+        if promptTokens.count > effectiveContext {
+            promptTokens = Array(promptTokens.suffix(effectiveContext))
+        }
+
+        let eosSet = Set(
+            loadedConfig.eosTokenIds
+                + tokenizerAndTemplate.stopTokenIds(withTools: request.tools?.isEmpty == false)
+        )
+        let generationConfig = GenerationConfig(
+            maxTokens: request.maxTokens,
+            temperature: Float(request.temperature),
+            topP: Float(request.topP),
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 64
+        )
+
+        let layerCaches = makeLayerCaches(config: loadedConfig)
+        let prefillOutput = try await chunkedPrefill(
+            model: model,
+            promptTokens: promptTokens,
+            cache: layerCaches,
+            progressHandler: progressHandler
+        )
+        let prefillSeconds = Date().timeIntervalSince(prefillStart)
+        let tokenBudget = max(0, min(request.maxTokens, effectiveContext - promptTokens.count))
+
+        progressHandler?(ChatProgress(stage: .generating, message: ""))
+        let decodeResult = try await decodeTokensSerially(
+            model: model,
+            tokenizerAndTemplate: tokenizerAndTemplate,
+            initialLogits: prefillOutput.logits,
+            layerCaches: layerCaches,
+            eosSet: eosSet,
+            generationConfig: generationConfig,
+            tokenBudget: tokenBudget,
+            promptTokens: promptTokens,
+            progressHandler: progressHandler
+        )
+
+        let decoded = tokenizerAndTemplate.decode(tokens: decodeResult.generatedTokens)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
+            let parsed = Gemma4ToolParser.parseToolCalls(decoded)
+            return parsed.isEmpty ? nil : parsed
+        }() : nil
+
+        return ChatResponse(
+            response: decoded,
+            tokensGenerated: decodeResult.generatedTokens.count,
+            timing: ChatTiming(
+                loadSeconds: 0,
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decodeResult.decodeSeconds
+            ),
+            toolCalls: toolCalls,
+            promptTokens: promptTokens.count
+        )
+    }
+
+    private func decodeTokensSerially(
+        model: LFM2Model,
+        tokenizerAndTemplate: LFM2TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [LFM2LayerCache?],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> LFM2DecodeResult {
+        guard tokenBudget > 0 else {
+            return LFM2DecodeResult(generatedTokens: [], decodeSeconds: 0)
+        }
+
+        var logits = initialLogits
+        var generated: [Int] = []
+        generated.reserveCapacity(tokenBudget)
+        var repetitionHistory = promptTokens
+        var pendingProgressWhitespace = ""
+        let decodeStart = Date()
+
+        func emit(_ token: Int) {
+            generated.append(token)
+            repetitionHistory.append(token)
+            let piece = tokenizerAndTemplate.decode(token: token)
+            guard !piece.isEmpty else { return }
+            if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                pendingProgressWhitespace += piece
+                return
+            }
+            let visiblePiece = pendingProgressWhitespace.isEmpty
+                ? piece
+                : pendingProgressWhitespace + piece
+            pendingProgressWhitespace = ""
+            progressHandler?(ChatProgress(stage: .generating, message: visiblePiece))
+        }
+
+        while generated.count < tokenBudget {
+            try Task.checkCancellation()
+            let next = sampleToken(
+                logits: logits[0, -1, 0...],
+                config: generationConfig,
+                previousTokens: repetitionHistory
+            )
+            if eosSet.contains(next) {
+                break
+            }
+            emit(next)
+
+            guard generated.count < tokenBudget else {
+                break
+            }
+            let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
+            logits = model(nextInput, cache: layerCaches)
+            MLX.eval(logits)
+        }
+
+        return LFM2DecodeResult(
+            generatedTokens: generated,
+            decodeSeconds: Date().timeIntervalSince(decodeStart)
+        )
+    }
+
+    private func chunkedPrefill(
+        model: LFM2Model,
+        promptTokens: [Int],
+        cache: [LFM2LayerCache?],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> LFM2PrefillOutput {
+        guard !promptTokens.isEmpty else {
+            throw LFM2Error.generationFailed("Prompt tokenization produced no tokens.")
+        }
+
+        var offset = 0
+        var lastOutput: LFM2ForwardOutput?
+        while offset < promptTokens.count {
+            try Task.checkCancellation()
+            let end = min(promptTokens.count, offset + Self.prefillChunkSize)
+            let chunk = Array(promptTokens[offset..<end])
+            let input = MLXArray(chunk.map(Int32.init)).reshaped(1, chunk.count)
+            let output = model.forward(input, cache: cache)
+            MLX.eval(output.logits)
+            MLX.eval(output.hidden)
+            lastOutput = output
+            offset = end
+            progressHandler?(ChatProgress(
+                stage: .encoding,
+                message: "Prefilled \(offset)/\(promptTokens.count) tokens"
+            ))
+            await Task.yield()
+        }
+
+        guard let lastOutput else {
+            throw LFM2Error.generationFailed("LFM2 prefill produced no logits.")
+        }
+        return LFM2PrefillOutput(logits: lastOutput.logits, hidden: lastOutput.hidden)
+    }
+
+    private func resolveModelRoot(
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        let requestedModel = modelPath ?? modelId
+        guard requestedModel == LFM2Resources.defaultModelId
+            || requestedModel.caseInsensitiveCompare(LFM2Resources.upstreamRepoId) == .orderedSame
+            || requestedModel.hasPrefix("/")
+            || requestedModel.hasPrefix("~")
+            || requestedModel.hasPrefix(".") else {
+            throw LFM2Error.unsupportedModelId(requestedModel)
+        }
+
+        do {
+            let root = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: requestedModel,
+                defaultModelID: LFM2Resources.defaultModelId,
+                progress: { event in
+                    switch event {
+                    case .downloading(let percent):
+                        progressHandler?(ChatProgress(stage: .loadingModel, message: "Downloading model... \(percent)%"))
+                    case .extracting:
+                        progressHandler?(ChatProgress(stage: .loadingModel, message: "Extracting model..."))
+                    }
+                }
+            )
+            return LFM2Resources.normalizedRootURL(root.url)
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw LFM2Error.downloadFailed(error.localizedDescription)
+        }
+    }
+
+    private func makeLayerCaches(config: LFM2Config) -> [LFM2LayerCache?] {
+        let attentionLayers = config.fullAttentionLayerIndexes
+        return (0..<config.numHiddenLayers).map { layerIndex in
+            if attentionLayers.contains(layerIndex) {
+                return .attention(KVCacheSimple(step: 256))
+            }
+            return .conv(LFM2ConvCache())
+        }
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2Model.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Model.swift
@@ -1,0 +1,552 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+@inline(__always)
+private func lfm2Swiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
+    MLXNN.silu(gate) * up
+}
+
+private func lfm2RepeatAlongHeads(_ x: MLXArray, heads: Int) -> MLXArray {
+    MLX.repeated(x, count: heads, axis: 1)
+}
+
+public final class LFM2ConvCache: @unchecked Sendable {
+    var state: MLXArray?
+
+    public init() {}
+
+    public func fork() -> LFM2ConvCache {
+        let copy = LFM2ConvCache()
+        copy.state = state
+        return copy
+    }
+}
+
+public enum LFM2LayerCache: @unchecked Sendable {
+    case attention(KVCache)
+    case conv(LFM2ConvCache)
+
+    func fork() -> LFM2LayerCache {
+        switch self {
+        case .attention(let cache):
+            return .attention(cache.fork())
+        case .conv(let cache):
+            return .conv(cache.fork())
+        }
+    }
+}
+
+final class LFM2Attention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+    @ModuleInfo(key: "q_layernorm") var qLayerNorm: RMSNorm
+    @ModuleInfo(key: "k_layernorm") var kLayerNorm: RMSNorm
+
+    private let numHeads: Int
+    private let numKVHeads: Int
+    private let headDim: Int
+    private let scale: Float
+    private let rope: RoPE
+
+    init(config: LFM2Config) {
+        self.numHeads = config.numAttentionHeads
+        self.numKVHeads = config.numKeyValueHeads
+        self.headDim = config.headDim
+        self.scale = 1.0 / sqrt(Float(max(1, config.headDim)))
+        self.rope = RoPE(
+            dimensions: max(1, config.headDim),
+            traditional: false,
+            base: config.ropeParameters?.ropeTheta ?? config.ropeTheta
+        )
+
+        self._qProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numAttentionHeads * config.headDim,
+            bias: false
+        )
+        self._kProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numKeyValueHeads * config.headDim,
+            bias: false
+        )
+        self._vProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numKeyValueHeads * config.headDim,
+            bias: false
+        )
+        self._outProj.wrappedValue = Linear(
+            config.numAttentionHeads * config.headDim,
+            config.hiddenSize,
+            bias: false
+        )
+        self._qLayerNorm.wrappedValue = RMSNorm(dimensions: config.headDim, eps: config.normEps)
+        self._kLayerNorm.wrappedValue = RMSNorm(dimensions: config.headDim, eps: config.normEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+
+        let queriesProjected = qProj(x).reshaped(batch, sequence, numHeads, headDim)
+        let keysProjected = kProj(x).reshaped(batch, sequence, numKVHeads, headDim)
+        let valuesProjected = vProj(x).reshaped(batch, sequence, numKVHeads, headDim)
+
+        var queries = qLayerNorm(queriesProjected).transposed(0, 2, 1, 3)
+        var keys = kLayerNorm(keysProjected).transposed(0, 2, 1, 3)
+        var values = valuesProjected.transposed(0, 2, 1, 3)
+
+        if let rowOffsets = cache?.rowOffsets, rowOffsets.count == batch {
+            queries = applyRoPEByRow(queries, rowOffsets: rowOffsets)
+            keys = applyRoPEByRow(keys, rowOffsets: rowOffsets)
+        } else {
+            let offset = cache?.offset ?? 0
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+        }
+
+        if let cache {
+            let cached = cache.update(keys: keys, values: values)
+            keys = cached.0
+            values = cached.1
+        }
+
+        let repeats = max(1, numHeads / max(1, numKVHeads))
+        if repeats > 1 {
+            keys = lfm2RepeatAlongHeads(keys, heads: repeats)
+            values = lfm2RepeatAlongHeads(values, heads: repeats)
+        }
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: mask
+        )
+        let output = attended.transposed(0, 2, 1, 3)
+            .reshaped(batch, sequence, numHeads * headDim)
+        return outProj(output)
+    }
+
+    private func applyRoPEByRow(_ value: MLXArray, rowOffsets: [Int]) -> MLXArray {
+        guard !rowOffsets.isEmpty else {
+            return rope(value, offset: 0)
+        }
+        let rows = rowOffsets.enumerated().map { index, offset in
+            rope(value[index..<(index + 1), 0..., 0..., 0...], offset: offset)
+        }
+        return concatenated(rows, axis: 0)
+    }
+}
+
+final class LFM2ShortConv: Module {
+    @ModuleInfo(key: "conv") var conv: Conv1d
+    @ModuleInfo(key: "in_proj") var inProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    private let hiddenSize: Int
+    private let cacheLength: Int
+
+    init(config: LFM2Config) {
+        self.hiddenSize = config.hiddenSize
+        self.cacheLength = max(1, config.convLCache)
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.hiddenSize,
+            kernelSize: max(1, config.convLCache),
+            stride: 1,
+            padding: 0,
+            dilation: 1,
+            groups: config.hiddenSize,
+            bias: config.convBias
+        )
+        self._inProj.wrappedValue = Linear(
+            config.hiddenSize,
+            3 * config.hiddenSize,
+            bias: config.convBias
+        )
+        self._outProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.hiddenSize,
+            bias: config.convBias
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: LFM2ConvCache?) -> MLXArray {
+        let projected = inProj(x)
+        let bGate = projected[.ellipsis, 0..<hiddenSize]
+        let cGate = projected[.ellipsis, hiddenSize..<(2 * hiddenSize)]
+        let values = projected[.ellipsis, (2 * hiddenSize)...]
+        var convInput = bGate * values
+        let keep = max(0, cacheLength - 1)
+
+        if let cache {
+            let state = cache.state ?? MLXArray.zeros(
+                [x.dim(0), keep, hiddenSize],
+                dtype: x.dtype
+            )
+            convInput = concatenated([state, convInput], axis: 1)
+            if keep > 0 {
+                cache.state = convInput[0..., (convInput.dim(1) - keep)..., 0...]
+            } else {
+                cache.state = MLXArray.zeros([x.dim(0), 0, hiddenSize], dtype: x.dtype)
+            }
+        } else {
+            convInput = padded(
+                convInput,
+                widths: [[0, 0], [keep, 0], [0, 0]],
+                value: MLXArray(0.0).asType(x.dtype)
+            )
+        }
+
+        return outProj(cGate * conv(convInput))
+    }
+}
+
+final class LFM2SwitchLinear: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "scales") var scales: MLXArray?
+    @ModuleInfo(key: "biases") var biases: MLXArray?
+
+    let groupSize: Int
+    let bits: Int
+
+    init(
+        inputDims: Int,
+        outputDims: Int,
+        numExperts: Int,
+        groupSize: Int,
+        bits: Int,
+        quantized: Bool
+    ) {
+        self.groupSize = groupSize
+        self.bits = bits
+
+        let scale = sqrt(1.0 / Float(max(1, inputDims)))
+        self._weight.wrappedValue = MLXRandom.uniform(
+            low: -scale,
+            high: scale,
+            [numExperts, outputDims, inputDims]
+        )
+        let groups = max(1, (inputDims + groupSize - 1) / groupSize)
+        self._scales.wrappedValue = quantized
+            ? MLXArray.zeros([numExperts, outputDims, groups])
+            : nil
+        self._biases.wrappedValue = quantized
+            ? MLXArray.zeros([numExperts, outputDims, groups])
+            : nil
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let batchTokens = x.dim(0) * x.dim(1)
+        let topK = indices.dim(2)
+        let inputDim = x.dim(x.ndim - 1)
+
+        let flatX: MLXArray
+        if x.ndim == 4 && x.dim(2) == topK {
+            flatX = x.reshaped([batchTokens * topK, 1, inputDim])
+        } else {
+            var expanded = x.reshaped([batchTokens, 1, inputDim])
+            expanded = MLX.expandedDimensions(expanded, axis: 1)
+            expanded = MLX.repeated(expanded, count: topK, axis: 1)
+            flatX = expanded.reshaped([batchTokens * topK, 1, inputDim])
+        }
+
+        let flatIndices = indices.reshaped([batchTokens * topK])
+        let output: MLXArray
+        if let scales {
+            let resolved = resolvedQuantization(inputDim: inputDim, scales: scales)
+            output = portableGatherQuantizedMM(
+                flatX,
+                weight,
+                scales: scales,
+                biases: biases,
+                rhsIndices: flatIndices,
+                transpose: true,
+                groupSize: resolved.groupSize,
+                bits: resolved.bits,
+                mode: .affine,
+                sortedIndices: false
+            )
+        } else {
+            output = gatherMM(
+                flatX,
+                weight.swappedAxes(-1, -2),
+                rhsIndices: flatIndices,
+                sortedIndices: false
+            )
+        }
+
+        let outDim = output.dim(2)
+        return output
+            .reshaped([batchTokens, topK, outDim])
+            .reshaped([x.dim(0), x.dim(1), topK, outDim])
+    }
+
+    private func resolvedQuantization(inputDim: Int, scales: MLXArray) -> (groupSize: Int, bits: Int) {
+        var resolvedBits = bits
+        let packedInputDim = weight.dim(weight.ndim - 1)
+        let numerator = packedInputDim * 32
+        if inputDim > 0, numerator % inputDim == 0 {
+            let inferredBits = numerator / inputDim
+            if (2...8).contains(inferredBits) {
+                resolvedBits = inferredBits
+            }
+        }
+
+        var resolvedGroupSize = groupSize
+        let scaleGroups = scales.dim(scales.ndim - 1)
+        if inputDim > 0, scaleGroups > 0, inputDim % scaleGroups == 0 {
+            resolvedGroupSize = inputDim / scaleGroups
+        }
+        return (resolvedGroupSize, resolvedBits)
+    }
+}
+
+final class LFM2SwitchGLU: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: LFM2SwitchLinear
+    @ModuleInfo(key: "up_proj") var upProj: LFM2SwitchLinear
+    @ModuleInfo(key: "down_proj") var downProj: LFM2SwitchLinear
+
+    init(config: LFM2Config) {
+        let groupSize = config.quantization?.groupSize ?? 64
+        let bits = config.quantization?.bits ?? 8
+        let quantized = config.quantization != nil
+
+        self._gateProj.wrappedValue = LFM2SwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: config.moeIntermediateSize,
+            numExperts: config.numExperts,
+            groupSize: groupSize,
+            bits: bits,
+            quantized: quantized
+        )
+        self._upProj.wrappedValue = LFM2SwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: config.moeIntermediateSize,
+            numExperts: config.numExperts,
+            groupSize: groupSize,
+            bits: bits,
+            quantized: quantized
+        )
+        self._downProj.wrappedValue = LFM2SwitchLinear(
+            inputDims: config.moeIntermediateSize,
+            outputDims: config.hiddenSize,
+            numExperts: config.numExperts,
+            groupSize: groupSize,
+            bits: bits,
+            quantized: quantized
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let up = upProj(x, indices: indices)
+        let gate = gateProj(x, indices: indices)
+        return downProj(lfm2Swiglu(gate, up), indices: indices)
+    }
+}
+
+final class LFM2FeedForward: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ModuleInfo(key: "switch_mlp") var switchMLP: LFM2SwitchGLU
+    @ModuleInfo(key: "expert_bias") var expertBias: MLXArray?
+
+    private let usesDense: Bool
+    private let topK: Int
+    private let normTopKProb: Bool
+
+    init(config: LFM2Config, layerIndex: Int) {
+        self.usesDense = layerIndex < config.numDenseLayers
+        self.topK = max(1, config.numExpertsPerTok)
+        self.normTopKProb = config.normTopKProb
+        self._gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        self._gate.wrappedValue = Linear(config.hiddenSize, config.numExperts, bias: false)
+        self._switchMLP.wrappedValue = LFM2SwitchGLU(config: config)
+        self._expertBias.wrappedValue = config.useExpertBias
+            ? MLXArray.zeros([config.numExperts])
+            : nil
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        if usesDense {
+            return downProj(lfm2Swiglu(gateProj(x), upProj(x)))
+        }
+
+        var scores = softmax(gate(x).asType(.float32), axis: -1)
+        if let expertBias {
+            scores = scores + expertBias
+        }
+
+        let indices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, 0..<topK]
+        scores = takeAlong(scores, indices, axis: -1)
+        if normTopKProb, topK > 1 {
+            scores = scores / (scores.sum(axis: -1, keepDims: true) + MLXArray(1e-20))
+        }
+        scores = scores.asType(x.dtype)
+
+        let switched = switchMLP(x, indices: indices)
+        var routed = switched * MLX.expandedDimensions(scores, axis: scores.ndim)
+        routed = routed.sum(axis: -2)
+        return routed
+    }
+}
+
+final class LFM2DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: LFM2Attention
+    @ModuleInfo(key: "conv") var conv: LFM2ShortConv
+    @ModuleInfo(key: "feed_forward") var feedForward: LFM2FeedForward
+    @ModuleInfo(key: "operator_norm") var operatorNorm: RMSNorm
+    @ModuleInfo(key: "ffn_norm") var ffnNorm: RMSNorm
+
+    let isAttentionLayer: Bool
+
+    init(config: LFM2Config, layerIndex: Int) {
+        self.isAttentionLayer = config.fullAttentionLayerIndexes.contains(layerIndex)
+        self._selfAttention.wrappedValue = LFM2Attention(config: config)
+        self._conv.wrappedValue = LFM2ShortConv(config: config)
+        self._feedForward.wrappedValue = LFM2FeedForward(config: config, layerIndex: layerIndex)
+        self._operatorNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.normEps)
+        self._ffnNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.normEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        attentionMask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: LFM2LayerCache?
+    ) -> MLXArray {
+        let normed = operatorNorm(x)
+        let operatorOut: MLXArray
+        if isAttentionLayer {
+            let attentionCache: KVCache?
+            if case .attention(let kv)? = cache {
+                attentionCache = kv
+            } else {
+                attentionCache = nil
+            }
+            operatorOut = selfAttention(normed, mask: attentionMask, cache: attentionCache)
+        } else {
+            let convCache: LFM2ConvCache?
+            if case .conv(let c)? = cache {
+                convCache = c
+            } else {
+                convCache = nil
+            }
+            operatorOut = conv(normed, cache: convCache)
+        }
+
+        let hidden = x + operatorOut
+        return hidden + feedForward(ffnNorm(hidden))
+    }
+}
+
+final class LFM2Transformer: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "layers") var layers: [LFM2DecoderLayer]
+    @ModuleInfo(key: "embedding_norm") var embeddingNorm: RMSNorm
+
+    init(config: LFM2Config) {
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.hiddenSize
+        )
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map { index in
+            LFM2DecoderLayer(config: config, layerIndex: index)
+        }
+        self._embeddingNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.normEps)
+        super.init()
+    }
+
+    func embeddings(for inputIds: MLXArray) -> MLXArray {
+        var tokenIds = inputIds
+        if tokenIds.dtype != .int32 {
+            tokenIds = tokenIds.asType(.int32)
+        }
+        return embedTokens(tokenIds)
+    }
+
+    private func firstAttentionCache(from cache: [LFM2LayerCache?]?) -> KVCache? {
+        guard let cache else { return nil }
+        for entry in cache {
+            if case .attention(let kv)? = entry {
+                return kv
+            }
+        }
+        return nil
+    }
+
+    func callAsFunction(
+        _ inputIds: MLXArray,
+        cache: [LFM2LayerCache?]?,
+        inputEmbeddings: MLXArray? = nil
+    ) -> MLXArray {
+        var hidden = inputEmbeddings ?? embeddings(for: inputIds)
+        let attentionMask = createAttentionMask(h: hidden, cache: firstAttentionCache(from: cache))
+
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(
+                hidden,
+                attentionMask: attentionMask,
+                cache: cache?[index] ?? nil
+            )
+        }
+        return embeddingNorm(hidden)
+    }
+}
+
+struct LFM2ForwardOutput {
+    let hidden: MLXArray
+    let logits: MLXArray
+}
+
+public final class LFM2Model: Module, @unchecked Sendable {
+    @ModuleInfo(key: "model") var model: LFM2Transformer
+
+    public let config: LFM2Config
+
+    public init(config: LFM2Config) {
+        self.config = config
+        self._model.wrappedValue = LFM2Transformer(config: config)
+        super.init()
+    }
+
+    public func embeddings(for inputIds: MLXArray) -> MLXArray {
+        model.embeddings(for: inputIds)
+    }
+
+    func forward(
+        _ inputIds: MLXArray,
+        cache: [LFM2LayerCache?]?,
+        inputEmbeddings: MLXArray? = nil
+    ) -> LFM2ForwardOutput {
+        let hidden = model(inputIds, cache: cache, inputEmbeddings: inputEmbeddings)
+        return LFM2ForwardOutput(hidden: hidden, logits: model.embedTokens.asLinear(hidden))
+    }
+
+    public func callAsFunction(
+        _ inputIds: MLXArray,
+        cache: [LFM2LayerCache?]?,
+        inputEmbeddings: MLXArray? = nil
+    ) -> MLXArray {
+        forward(inputIds, cache: cache, inputEmbeddings: inputEmbeddings).logits
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2Resources.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Resources.swift
@@ -1,0 +1,89 @@
+import Foundation
+import MLX
+
+public struct LFM2Resources: Sendable, Hashable {
+    public static let defaultModelId = "text-chat-lfm25-a1b-8bit"
+    public static let upstreamRepoId = "LiquidAI/LFM2.5-8B-A1B-MLX-8bit"
+    public static let upstreamRevision = "984aa3f7b00ab3deb00d987ae79b9bbe326eef3a"
+    public static let defaultContextLength = 32_768
+
+    public static let snapshotPatterns = [
+        "config.json",
+        "generation_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "*.safetensors",
+    ]
+
+    public static func handles(modelSpec: String) -> Bool {
+        let normalized = modelSpec.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return false }
+        return normalized == defaultModelId
+            || normalized == upstreamRepoId.lowercased()
+            || normalized.contains("lfm2")
+            || normalized.contains("liquidai/")
+    }
+
+    public var rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var configURL: URL { rootURL.appending(path: "config.json") }
+    public var modelIndexURL: URL { rootURL.appending(path: "model.safetensors.index.json") }
+    public var modelWeightsURL: URL { rootURL.appending(path: "model.safetensors") }
+    public var tokenizerURL: URL { rootURL.appending(path: "tokenizer.json") }
+    public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
+    public var chatTemplateURL: URL { rootURL.appending(path: "chat_template.jinja") }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing: [URL] = []
+        if !fileManager.fileExists(atPath: configURL.path) {
+            missing.append(configURL)
+        }
+        let hasIndex = fileManager.fileExists(atPath: modelIndexURL.path)
+        let hasSingle = fileManager.fileExists(atPath: modelWeightsURL.path)
+        if !hasIndex && !hasSingle {
+            missing.append(modelIndexURL)
+        }
+        if !fileManager.fileExists(atPath: tokenizerURL.path) {
+            missing.append(tokenizerURL)
+        }
+        if !fileManager.fileExists(atPath: tokenizerConfigURL.path) {
+            missing.append(tokenizerConfigURL)
+        }
+        return missing
+    }
+
+    public static func normalizedRootURL(_ rootURL: URL, fileManager: FileManager = .default) -> URL {
+        let standardized = rootURL.standardizedFileURL
+        if fileManager.fileExists(atPath: standardized.appendingPathComponent("config.json").path) {
+            return standardized
+        }
+        if let children = try? fileManager.contentsOfDirectory(
+            at: standardized,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for child in children {
+                if fileManager.fileExists(atPath: child.appendingPathComponent("config.json").path) {
+                    return child.standardizedFileURL
+                }
+            }
+        }
+        return standardized
+    }
+
+    static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key.hasSuffix(".conv.conv.weight"),
+           value.ndim == 3,
+           value.dim(2) > value.dim(1) {
+            return [(key, value.transposed(0, 2, 1))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TokenizerAndTemplate.swift
@@ -1,0 +1,158 @@
+import Foundation
+@preconcurrency import Hub
+@preconcurrency import Tokenizers
+
+public final class LFM2TokenizerAndTemplate: @unchecked Sendable {
+    public let tokenizer: any Tokenizer
+    public let maxLength: Int
+    public let eosTokenId: Int?
+    public let imEndTokenId: Int?
+    public let toolCallEndTokenId: Int?
+
+    public init(
+        tokenizer: any Tokenizer,
+        maxLength: Int,
+        eosTokenId: Int?,
+        imEndTokenId: Int?,
+        toolCallEndTokenId: Int?
+    ) {
+        self.tokenizer = tokenizer
+        self.maxLength = maxLength
+        self.eosTokenId = eosTokenId
+        self.imEndTokenId = imEndTokenId
+        self.toolCallEndTokenId = toolCallEndTokenId
+    }
+
+    public static func load(
+        from rootURL: URL,
+        maxLengthOverride: Int? = nil,
+        hubApi: HubApi = .shared
+    ) async throws -> LFM2TokenizerAndTemplate {
+        let tokenizer = try await AutoTokenizer.from(modelFolder: rootURL, hubApi: hubApi)
+        return LFM2TokenizerAndTemplate(
+            tokenizer: tokenizer,
+            maxLength: maxLengthOverride ?? LFM2Resources.defaultContextLength,
+            eosTokenId: tokenizer.eosTokenId,
+            imEndTokenId: tokenizer.convertTokenToId("<|im_end|>"),
+            toolCallEndTokenId: tokenizer.convertTokenToId("<|tool_call_end|>")
+        )
+    }
+
+    public func encodeForGeneration(
+        messages: [ChatMessage],
+        tools: [ToolDefinition]? = nil,
+        addGenerationPrompt: Bool = true,
+        includeThinking: Bool,
+        maxLength: Int
+    ) throws -> [Int] {
+        var encoded = tokenizer.encode(
+            text: try Self.renderPrompt(
+                messages: messages,
+                tools: tools,
+                addGenerationPrompt: addGenerationPrompt,
+                includeThinking: includeThinking
+            ),
+            addSpecialTokens: false
+        )
+        let targetLength = min(maxLength, self.maxLength)
+        if encoded.count > targetLength {
+            encoded = Array(encoded.suffix(targetLength))
+        }
+        return encoded
+    }
+
+    public func decode(tokens: [Int]) -> String {
+        tokenizer.decode(tokens: tokens)
+    }
+
+    public func decode(token: Int) -> String {
+        tokenizer.decode(tokens: [token])
+    }
+
+    public func stopTokenIds(withTools: Bool) -> [Int] {
+        var ids = [eosTokenId, imEndTokenId].compactMap { $0 }
+        if withTools, let toolCallEndTokenId {
+            ids.append(toolCallEndTokenId)
+        }
+        return Array(Set(ids))
+    }
+
+    static func renderMessages(_ messages: [ChatMessage]) -> [Message] {
+        messages.map { message in
+            var rendered: Message = [
+                "role": message.role.rawValue,
+            ]
+            if let imageURL = message.imageUrl, !imageURL.isEmpty {
+                rendered["content"] = [
+                    ["type": "text", "text": message.content],
+                    ["type": "image", "image": imageURL],
+                ] as [[String: String]]
+            } else {
+                rendered["content"] = message.content
+            }
+            return rendered
+        }
+    }
+
+    public static func renderPrompt(
+        messages: [ChatMessage],
+        tools: [ToolDefinition]? = nil,
+        addGenerationPrompt: Bool = true,
+        includeThinking: Bool
+    ) throws -> String {
+        var prompt = "<|startoftext|>"
+        var remaining = messages
+        var systemPrompt = ""
+
+        if let first = remaining.first, first.role == .system {
+            systemPrompt = renderContent(for: first)
+            remaining.removeFirst()
+        }
+
+        if let tools, !tools.isEmpty {
+            if !systemPrompt.isEmpty {
+                systemPrompt += "\n"
+            }
+            systemPrompt += "List of tools: ["
+            systemPrompt += try tools.map { try $0.promptSchemaJSONString() }.joined(separator: ", ")
+            systemPrompt += "]"
+        }
+
+        if !systemPrompt.isEmpty {
+            prompt += "<|im_start|>system\n"
+            prompt += systemPrompt
+            prompt += "<|im_end|>\n"
+        }
+
+        let lastUserIndex = remaining.lastIndex { $0.role == .user } ?? -1
+
+        for (index, message) in remaining.enumerated() {
+            prompt += "<|im_start|>\(message.role.rawValue)\n"
+
+            if message.role == .assistant {
+                var content = renderContent(for: message)
+                if !includeThinking, index <= lastUserIndex, let range = content.range(of: "</think>") {
+                    content = String(content[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                prompt += content
+            } else {
+                prompt += renderContent(for: message)
+            }
+
+            prompt += "<|im_end|>\n"
+        }
+
+        if addGenerationPrompt {
+            prompt += "<|im_start|>assistant\n"
+        }
+
+        return prompt
+    }
+
+    private static func renderContent(for message: ChatMessage) -> String {
+        if let imageURL = message.imageUrl, !imageURL.isEmpty {
+            return "\(message.content)<image>"
+        }
+        return message.content
+    }
+}

--- a/Sources/MereRunCore/LFM2/README.md
+++ b/Sources/MereRunCore/LFM2/README.md
@@ -1,0 +1,40 @@
+# LFM2 Runtime
+
+Native Swift MLX runtime for LiquidAI LFM2 text-chat checkpoints.
+
+## Managed model
+
+- Canonical id: `text-chat-lfm25-a1b-8bit`
+- Upstream: `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
+- Serving engine: `text-chat-lfm2`
+
+The runtime loads MLX-converted directory-root snapshots with:
+
+- `config.json`
+- `tokenizer.json`
+- `tokenizer_config.json`
+- `model.safetensors` or `model.safetensors.index.json` plus shards
+
+## Architecture
+
+`LFM2Model.swift` mirrors the `lfm2_moe` MLX layout:
+
+- token embedding with tied output projection
+- hybrid decoder layers selected from `layer_types`
+- full-attention layers with q/k RMSNorm, RoPE, GQA KV repetition, and `KVCache`
+- short depthwise-conv layers with recurrent convolution state
+- dense feed-forward layers for the configured dense prefix
+- sparse MoE feed-forward layers with router top-k, optional `expert_bias`, and
+  `SwitchGLU` expert projections
+
+`LFM2Generator.swift` is the chat entrypoint. It resolves managed installs or
+downloads through `ManagedModelResolver`, loads tokenizer/template resources,
+applies sharded safetensor weights with `HFSafetensorsWeightsLoader`, pre-fills
+in cancellable chunks, then decodes serially.
+
+## Notes
+
+- This runtime is Swift-native and does not bridge to Python.
+- LFM2 is currently text-only. API requests with image content parts are rejected
+  by the `text-chat-lfm2` capability profile.
+- Prefix KV reuse and continuous decode batching are not implemented for LFM2 yet.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -28,6 +28,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case hidreamO1
     case gemma4
     case q35
+    case lfm2
     case qwen3TTS
     case qwen3ASR
     case parakeet
@@ -461,6 +462,21 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["api serve", "agent"]
         ),
         ManagedModelSpec(
+            id: LFM2Resources.defaultModelId,
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: LFM2Resources.upstreamRepoId,
+                revision: LFM2Resources.upstreamRevision,
+                patterns: LFM2Resources.snapshotPatterns
+            ),
+            upstreamRepoId: LFM2Resources.upstreamRepoId,
+            upstreamRevision: LFM2Resources.upstreamRevision,
+            validationKind: .lfm2,
+            estimatedDownloadBytes: 10 * 1_073_741_824,
+            defaultCLICommands: ["text chat", "api serve"]
+        ),
+        ManagedModelSpec(
             id: "speech-tts-qwen3-nano",
             category: .speechTTS,
             installShape: .directoryRoot,
@@ -784,6 +800,8 @@ public extension ManagedModelSpec {
             return Gemma4Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .q35:
             return Q35Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .lfm2:
+            return LFM2Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .sam31:
             return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -271,6 +271,14 @@ public enum ManagedModelCapabilityCatalog {
                 setup: true
             ),
             descriptor(
+                LFM2Resources.defaultModelId,
+                "LFM2.5 A1B 8-bit",
+                "Runs the LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot through the native Swift LFM2 runtime.",
+                minimum: 16,
+                recommended: 24,
+                setup: true
+            ),
+            descriptor(
                 "text-chat-q36-nano-gguf",
                 "Qwen3.6 A3B chat nano (GGUF)",
                 "Runs Qwen3.6 35B-A3B GGUF through llama.cpp; the default chat model on Linux CUDA hosts.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -22,6 +22,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case hidreamO1 = "hidream-o1"
         /// Gemma 4 family via the native Swift runtime.
         case gemma4 = "gemma-4"
+        /// LiquidAI LFM2 family via the native Swift runtime.
+        case lfm2 = "lfm2"
         /// Q35 family (Qwen3.5 hybrid MoE + hybrid attention).
         case qwen35HybridMoE = "qwen3.5-hybrid-moe"
         /// SAM image segmentation family.
@@ -57,6 +59,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case zimage
         case hidream
         case gemma
+        case liquid
         case qwen
         case sam
         case falcon
@@ -641,6 +644,21 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.chat],
                 components: q35TextComponents,
                 upstreamRepoId: "\(Q35Resources.q36NanoUpstreamRepoId)@\(Q35Resources.q36NanoUpstreamRevision)",
+                createdAt: createdAt
+            )
+        case .lfm25A1B8Bit:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .lfm2,
+                family: .liquid,
+                tier: .nano,
+                variant: .standard,
+                precision: .int8,
+                quantization: Quantization(bits: 8, groupSize: 64, scheme: "mlx-affine"),
+                defaults: nil,
+                supports: [.chat],
+                components: q35TextComponents,
+                upstreamRepoId: "\(LFM2Resources.upstreamRepoId)@\(LFM2Resources.upstreamRevision)",
                 createdAt: createdAt
             )
         case .qwen35Agent9B:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -323,6 +323,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=hidream expects hidream-o1.")
             case .gemma where engine != .gemma4:
                 warnings.append("Manifest engine mismatch: family=gemma expects gemma-4.")
+            case .liquid where engine != .lfm2:
+                warnings.append("Manifest engine mismatch: family=liquid expects lfm2.")
             case .qwen where engine != .qwen35HybridMoE:
                 warnings.append("Manifest engine mismatch: family=qwen expects qwen3.5-hybrid-moe.")
             case .sam where engine != .samSegmentation:
@@ -471,6 +473,9 @@ public enum MereRunModelValidator {
             || modelId == ModelResolver.ModelID.gemma4Max.rawValue
             || modelId == ModelResolver.ModelID.gemma4Turbo.rawValue {
             return .gemma
+        }
+        if modelId == ModelResolver.ModelID.lfm25A1B8Bit.rawValue {
+            return .liquid
         }
         if modelId == ModelResolver.ModelID.q36Nano.rawValue
             || modelId == ModelResolver.ModelID.q36NanoGGUF.rawValue {

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -27,6 +27,7 @@ public struct ModelResolver {
         case gemma4Max = "text-chat-gemma4-max"
         case gemma4Turbo = "text-chat-gemma4-turbo"
         case q36Nano = "text-chat-q36-nano"
+        case lfm25A1B8Bit = "text-chat-lfm25-a1b-8bit"
         case qwen35Agent9B = "text-agent-qwen35-9b"
         case q36NanoGGUF = "text-chat-q36-nano-gguf"
         case deepseekV4Flash = "text-agent-deepseek-v4-flash"

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -142,7 +142,7 @@ public actor Q35Generator: ChatGenerator {
         var response = try await generate(
             request,
             progressHandler: progressHandler,
-            maxContextLength: Q35Resources.defaultContextLength
+            maxContextLength: request.maxContextTokens ?? Q35Resources.defaultContextLength
         )
         if var timing = response.timing {
             timing.loadSeconds = loadSeconds
@@ -166,7 +166,7 @@ public actor Q35Generator: ChatGenerator {
         var response = try await generate(
             request,
             progressHandler: progressHandler,
-            maxContextLength: Q35Resources.defaultContextLength
+            maxContextLength: request.maxContextTokens ?? Q35Resources.defaultContextLength
         )
         if var timing = response.timing {
             timing.loadSeconds = loadSeconds

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -42,6 +42,7 @@ public enum QuantizedModelManifestWriter {
             case .zimageTurbo: return .zimage
             case .hidreamO1: return .hidream
             case .gemma4: return .gemma
+            case .lfm2: return .liquid
             case .qwen35HybridMoE: return .qwen
             case .samSegmentation: return .sam
             case .falconPerception: return .falcon
@@ -86,6 +87,8 @@ public enum QuantizedModelManifestWriter {
                 case .hidreamO1:
                     return [.txt2img, .referenceEdit, .subjectPersonalization]
                 case .gemma4:
+                    return [.chat]
+                case .lfm2:
                     return [.chat]
                 case .qwen35HybridMoE:
                     return [.chat]
@@ -166,6 +169,8 @@ public enum QuantizedModelManifestWriter {
             case .hidreamO1:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 28, cfg: 0.0)
             case .gemma4:
+                break
+            case .lfm2:
                 break
             case .qwen35HybridMoE:
                 break

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -4,8 +4,23 @@ public enum RuntimeServingEngine: String, Codable, CaseIterable, Hashable, Senda
     case textCode = "text-code"
     case textChatKlein = "text-chat-klein"
     case textChatGemma4 = "text-chat-gemma4"
+    case textChatQ36 = "text-chat-q36"
     case textChatQ35 = "text-chat-q35"
+    case textChatLFM2 = "text-chat-lfm2"
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
+
+    public var canonical: RuntimeServingEngine {
+        switch self {
+        case .textChatQ35:
+            return .textChatQ36
+        default:
+            return self
+        }
+    }
+
+    public func isCompatible(with expected: RuntimeServingEngine) -> Bool {
+        canonical == expected.canonical
+    }
 }
 
 public enum RuntimeKVCacheMode: String, Codable, CaseIterable, Hashable, Sendable {
@@ -109,11 +124,12 @@ public struct RuntimeModelSettings: Codable, Hashable, Sendable {
             throw RuntimeModelSettingsError.invalidValue("topP must be between 0 and 1")
         }
         if let override = settings.engineOverride,
-           override != spec.defaultRuntimeServingEngine {
+           let expected = spec.defaultRuntimeServingEngine,
+           !override.isCompatible(with: expected) {
             throw RuntimeModelSettingsError.incompatibleEngine(
                 modelID: spec.id,
                 requested: override,
-                expected: spec.defaultRuntimeServingEngine
+                expected: expected
             )
         }
         if let kvCacheMode = settings.kvCacheMode,
@@ -270,7 +286,9 @@ public extension ManagedModelSpec {
         case .gemma4:
             return .textChatGemma4
         case .q35:
-            return .textChatQ35
+            return .textChatQ36
+        case .lfm2:
+            return .textChatLFM2
         case .deepseekV4FlashIMatrixGGUF:
             return .textChatDeepseekV4Flash
         case .hfTextChat where id == ModelResolver.ModelID.mebot.rawValue:

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -14,7 +14,7 @@ final class APIServeCommandTests: XCTestCase {
 
         XCTAssertEqual(cmd.port, 8080)
         XCTAssertEqual(cmd.host, "127.0.0.1")
-        XCTAssertEqual(cmd.engine, .textChatQ35)
+        XCTAssertEqual(cmd.engine, .textChatQ36)
         XCTAssertNil(cmd.model)
         XCTAssertNil(cmd.lora)
         XCTAssertNil(cmd.apiKey)
@@ -71,6 +71,25 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(quantization.scheme, .turboquant)
         XCTAssertEqual(quantization.groupSize, Gemma4Resources.defaultKVGroupSize)
         XCTAssertEqual(quantization.quantizedStart, Gemma4Resources.defaultTurboQuantizedKVStart)
+    }
+
+    func testAPIServeParsesLFM2Engine() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-lfm2",
+            "--model-path", LFM2Resources.defaultModelId,
+        ])
+
+        XCTAssertEqual(cmd.engine, .textChatLFM2)
+        XCTAssertEqual(cmd.model, LFM2Resources.defaultModelId)
+    }
+
+    func testAPIServeParsesLegacyQ35EngineAlias() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-q35",
+        ])
+
+        XCTAssertEqual(cmd.engine, .textChatQ35)
+        XCTAssertEqual(cmd.engine.runtimeServingEngine, .textChatQ36)
     }
 
     func testAPIServeGemma4TurboKVFlagsOverrideIndependently() throws {
@@ -145,6 +164,7 @@ final class APIServeCommandTests: XCTestCase {
         )
 
         XCTAssertEqual(chatRequest.maxTokens, APIServerContract.defaultMaxTokens)
+        XCTAssertEqual(chatRequest.maxContextTokens, 4_096)
         XCTAssertEqual(chatRequest.temperature, 1.0)
         XCTAssertEqual(chatRequest.topP, 0.95)
         XCTAssertEqual(chatRequest.maxContextTokens, 4_096)

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -83,4 +83,24 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertEqual(quantization.bits, 2)
         XCTAssertEqual(quantization.scheme, .polar)
     }
+
+    func testCleanResponseRemovesCompletedThinkingBlock() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+        ])
+
+        let cleaned = cmd.cleanResponse("<think>\nworking\n</think>\n4", showThinking: false)
+
+        XCTAssertEqual(cleaned, "4")
+    }
+
+    func testCleanResponseRemovesDanglingThinkingBlock() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Say hello",
+        ])
+
+        let cleaned = cmd.cleanResponse("<think>\nThe user asks for a short answer.", showThinking: false)
+
+        XCTAssertEqual(cleaned, "")
+    }
 }

--- a/Tests/MereRunCoreTests/LFM2ConfigAndModelTests.swift
+++ b/Tests/MereRunCoreTests/LFM2ConfigAndModelTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import XCTest
+import MLX
+import MLXRandom
+@testable import MereRunCore
+
+final class LFM2ConfigAndModelTests: MereRunCoreTestCase {
+    private func decodeConfig(_ object: [String: Any]) throws -> LFM2Config {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        return try JSONDecoder().decode(LFM2Config.self, from: data)
+    }
+
+    private func makeBaseConfig(includeQuantization: Bool = true) -> [String: Any] {
+        var config: [String: Any] = [
+            "architectures": ["Lfm2MoeForCausalLM"],
+            "model_type": "lfm2_moe",
+            "vocab_size": 124_928,
+            "hidden_size": 2_048,
+            "intermediate_size": 7_168,
+            "moe_intermediate_size": 1_792,
+            "num_hidden_layers": 24,
+            "num_experts": 32,
+            "num_experts_per_tok": 4,
+            "norm_topk_prob": true,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "max_position_embeddings": 128_000,
+            "use_expert_bias": true,
+            "num_dense_layers": 2,
+            "norm_eps": 0.000001,
+            "conv_bias": false,
+            "conv_L_cache": 3,
+            "rope_theta": 5_000_000.0,
+            "rope_parameters": [
+                "rope_theta": 5_000_000.0,
+                "rope_type": "default",
+            ],
+            "layer_types": [
+                "conv",
+                "conv",
+                "full_attention",
+                "conv",
+                "conv",
+                "conv",
+                "full_attention",
+                "conv",
+                "conv",
+                "conv",
+                "full_attention",
+                "conv",
+                "conv",
+                "conv",
+                "full_attention",
+                "conv",
+                "conv",
+                "conv",
+                "full_attention",
+                "conv",
+                "conv",
+                "full_attention",
+                "conv",
+                "conv",
+            ],
+            "eos_token_id": 124_900,
+            "tie_word_embeddings": true,
+        ]
+        if includeQuantization {
+            config["quantization"] = [
+                "group_size": 64,
+                "bits": 8,
+                "mode": "affine",
+            ]
+        }
+        return config
+    }
+
+    private func makeTinyConfig() throws -> LFM2Config {
+        var config = makeBaseConfig(includeQuantization: false)
+        config["vocab_size"] = 32
+        config["hidden_size"] = 16
+        config["intermediate_size"] = 32
+        config["moe_intermediate_size"] = 8
+        config["num_hidden_layers"] = 4
+        config["num_experts"] = 4
+        config["num_experts_per_tok"] = 2
+        config["num_attention_heads"] = 4
+        config["num_key_value_heads"] = 2
+        config["max_position_embeddings"] = 128
+        config["num_dense_layers"] = 2
+        config["conv_L_cache"] = 2
+        config["layer_types"] = ["conv", "full_attention", "conv", "full_attention"]
+        config["eos_token_id"] = [31]
+        return try decodeConfig(config)
+    }
+
+    private func makeLayerCaches(config: LFM2Config) -> [LFM2LayerCache?] {
+        let attentionLayers = config.fullAttentionLayerIndexes
+        return (0..<config.numHiddenLayers).map { layerIndex in
+            if attentionLayers.contains(layerIndex) {
+                return .attention(KVCacheSimple(step: 8))
+            }
+            return .conv(LFM2ConvCache())
+        }
+    }
+
+    func testDecodesLiquidAILFM25Config() throws {
+        let config = try decodeConfig(makeBaseConfig())
+
+        XCTAssertEqual(config.modelType, "lfm2_moe")
+        XCTAssertEqual(config.architectures, ["Lfm2MoeForCausalLM"])
+        XCTAssertEqual(config.hiddenSize, 2_048)
+        XCTAssertEqual(config.headDim, 64)
+        XCTAssertEqual(config.numHiddenLayers, 24)
+        XCTAssertEqual(config.fullAttentionLayerIndexes, Set([2, 6, 10, 14, 18, 21]))
+        XCTAssertEqual(config.numDenseLayers, 2)
+        XCTAssertEqual(config.numExperts, 32)
+        XCTAssertEqual(config.numExpertsPerTok, 4)
+        XCTAssertEqual(config.moeIntermediateSize, 1_792)
+        XCTAssertEqual(config.convLCache, 3)
+        XCTAssertEqual(config.eosTokenIds, [124_900])
+        XCTAssertEqual(config.quantization?.bits, 8)
+        XCTAssertEqual(config.quantization?.groupSize, 64)
+        XCTAssertEqual(config.ropeParameters?.ropeTheta, 5_000_000)
+    }
+
+    func testDecodesQuantizationConfigAliasAndArrayEOS() throws {
+        var object = makeBaseConfig(includeQuantization: false)
+        object["eos_token_id"] = [1, 2]
+        object["quantization_config"] = [
+            "group_size": 32,
+            "bits": 4,
+            "mode": "affine",
+        ]
+
+        let config = try decodeConfig(object)
+
+        XCTAssertEqual(config.eosTokenIds, [1, 2])
+        XCTAssertEqual(config.quantization?.bits, 4)
+        XCTAssertEqual(config.quantization?.groupSize, 32)
+    }
+
+    func testRendersLiquidAIChatTemplateShape() throws {
+        let prompt = try LFM2TokenizerAndTemplate.renderPrompt(
+            messages: [
+                ChatMessage(role: .system, content: "Be brief."),
+                ChatMessage(role: .user, content: "What is 2+2?"),
+            ],
+            addGenerationPrompt: true,
+            includeThinking: false
+        )
+
+        XCTAssertEqual(
+            prompt,
+            """
+            <|startoftext|><|im_start|>system
+            Be brief.<|im_end|>
+            <|im_start|>user
+            What is 2+2?<|im_end|>
+            <|im_start|>assistant
+
+            """
+        )
+    }
+
+    func testTinyLFM2ForwardProducesLogits() throws {
+        MLXRandom.seed(42)
+        let config = try makeTinyConfig()
+        let model = LFM2Model(config: config)
+        let caches = makeLayerCaches(config: config)
+        let input = MLXArray([Int32(1), Int32(2), Int32(3)]).reshaped(1, 3)
+
+        let logits = model(input, cache: caches)
+        MLX.eval(logits)
+
+        XCTAssertEqual(logits.shape, [1, 3, config.vocabSize])
+        XCTAssertTrue(MLX.max(MLX.abs(logits.asType(.float32))).item(Float.self).isFinite)
+    }
+
+    func testTransposesConvertedConvWeightsWhenNeeded() {
+        let value = MLXArray(0..<12).reshaped(1, 3, 4)
+
+        let mapped = LFM2Resources.mapWeight(key: "model.layers.0.conv.conv.weight", value: value)
+
+        XCTAssertEqual(mapped.count, 1)
+        XCTAssertEqual(mapped[0].0, "model.layers.0.conv.conv.weight")
+        XCTAssertEqual(mapped[0].1.shape, [1, 4, 3])
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -133,6 +133,21 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("*.safetensors"), true)
     }
 
+    func testLFM2UsesLiquidAIHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: LFM2Resources.defaultModelId))
+
+        XCTAssertEqual(spec.category, .textChat)
+        XCTAssertEqual(spec.installShape, .directoryRoot)
+        XCTAssertEqual(spec.hubFallback?.repoId, LFM2Resources.upstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, LFM2Resources.upstreamRevision)
+        XCTAssertEqual(spec.upstreamRepoId, LFM2Resources.upstreamRepoId)
+        XCTAssertEqual(spec.upstreamRevision, LFM2Resources.upstreamRevision)
+        XCTAssertEqual(spec.validationKind, .lfm2)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatLFM2)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("model.safetensors.index.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("*.safetensors"), true)
+    }
+
     func testZImageNanoAcceptsMFluxLayoutWithoutDiffusersConfigs() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -39,6 +39,16 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
     }
 
+    private func writeMinimalValidLFM2Model(at root: URL) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: .lfm25A1B8Bit, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data(#"{"model_type":"lfm2_moe"}"#.utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
+    }
+
     private func writeMinimalValidGemma4Model(at root: URL, id: ModelResolver.ModelID = .gemma4) throws {
         try TestFileSystem.createDirectory(root)
         try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
@@ -165,6 +175,22 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(report.manifest?.tier, .nano)
         XCTAssertEqual(report.manifest?.family, .qwen)
         XCTAssertEqual(report.manifest?.upstreamRepoId, "\(Q35Resources.q36NanoUpstreamRepoId)@\(Q35Resources.q36NanoUpstreamRevision)")
+    }
+
+    func testLFM2ChatOnlyRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("text-chat-lfm25-a1b-8bit", isDirectory: true)
+        try writeMinimalValidLFM2Model(at: root)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: LFM2Resources.defaultModelId)
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.engine, .lfm2)
+        XCTAssertEqual(report.manifest?.family, .liquid)
+        XCTAssertEqual(report.manifest?.precision, .int8)
+        XCTAssertEqual(report.manifest?.upstreamRepoId, "\(LFM2Resources.upstreamRepoId)@\(LFM2Resources.upstreamRevision)")
     }
 
     func testGemma4ChatOnlyRootLayoutPassesValidation() throws {

--- a/Tests/MereRunCoreTests/RuntimeModelSettingsTests.swift
+++ b/Tests/MereRunCoreTests/RuntimeModelSettingsTests.swift
@@ -44,7 +44,7 @@ final class RuntimeModelSettingsTests: XCTestCase {
 
         XCTAssertThrowsError(
             try store.writeSettings(
-                RuntimeModelSettings(engineOverride: .textChatQ35),
+                RuntimeModelSettings(engineOverride: .textChatQ36),
                 for: Gemma4Resources.defaultModelId
             )
         ) { error in
@@ -68,6 +68,24 @@ final class RuntimeModelSettingsTests: XCTestCase {
         ) { error in
             XCTAssertTrue(error.localizedDescription.contains("KV cache mode"))
         }
+    }
+
+    func testQ36DefaultRuntimeEngineAcceptsLegacyQ35Alias() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.defaultModelId))
+
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
+
+        try store.writeSettings(
+            RuntimeModelSettings(engineOverride: .textChatQ35),
+            for: Q35Resources.defaultModelId
+        )
+        let settings = try store.settings(for: Q35Resources.defaultModelId)
+
+        XCTAssertEqual(settings.engineOverride, .textChatQ35)
+        XCTAssertTrue(settings.engineOverride?.isCompatible(with: .textChatQ36) == true)
     }
 
     func testGemmaAutoKVModeUsesPolarOnlyPastPromptThreshold() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ are:
 - Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`,
   `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
   `image-hidream-o1`, `image-hidream-o1-dev`
-- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`
+- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`
 - Text code / agents: `text-agent-qwen35-9b`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Text anonymize: `text-anonymize-privacy-filter`
@@ -220,7 +220,7 @@ Key options:
 
 ### `mere.run text chat`
 
-Run local text chat with the Gemma 4, Qwen3.6, or Psi family.
+Run local text chat with the Gemma 4, Qwen3.6, LFM2, or Psi family.
 
 ```bash
 swift run mere.run text chat --prompt "<text>" [options]
@@ -245,6 +245,7 @@ Examples:
 ```bash
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
 swift run mere.run text chat --model text-chat-q36-nano --prompt "Explain speculative decoding."
+swift run mere.run text chat --model text-chat-lfm25-a1b-8bit --prompt "Summarize LFM2 in one paragraph."
 swift run mere.run text chat --stream --prompt "Write a short welcome message."
 swift run mere.run text chat --thinking --stats --prompt "How would you design a tokenizer?"
 ```
@@ -843,7 +844,8 @@ Engine values:
 - `text-code`
 - `text-chat-klein`
 - `text-chat-gemma4`
-- `text-chat-q35`
+- `text-chat-q36`
+- `text-chat-lfm2`
 - `text-chat-deepseek-v4-flash`
 
 OpenAI chat compatibility:
@@ -860,6 +862,7 @@ Examples:
 ```bash
 swift run mere.run api serve
 swift run mere.run api serve --engine text-chat-gemma4
+swift run mere.run api serve --engine text-chat-lfm2
 swift run mere.run api serve --engine text-code --model ./Qwen3-Coder-Next-Q4_K_M.gguf
 swift run mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY" --rate-limit-per-minute 120 --max-active-requests 1
 ```
@@ -919,7 +922,7 @@ swift run mere.run agent install-pi
 
 Start a local API server for a selected managed agent model and launch Pi
 against the `mere-run` provider. GGUF code models use `--engine text-code`,
-Qwen3.6 uses `--engine text-chat-q35`, and DeepSeek V4 Flash uses the DS4-backed
+Qwen3.6 uses `--engine text-chat-q36`, and DeepSeek V4 Flash uses the DS4-backed
 `--engine text-chat-deepseek-v4-flash`. If `--model` is omitted, `agent start`
 uses the best installed startable setup agent first, then a valid persisted Pi
 provider model, then the current machine's startable hardware tier. On 96 GB+

--- a/docs/internals/cli-and-runtime.md
+++ b/docs/internals/cli-and-runtime.md
@@ -51,6 +51,7 @@ The runtime uses explicit public IDs such as:
 - `image-klein-max`
 - `text-chat-gemma4`
 - `text-chat-q36-nano`
+- `text-chat-lfm25-a1b-8bit`
 - `text-agent-deepseek-v4-flash`
 - `speech-tts-qwen3-nano`
 

--- a/docs/internals/source-layout.md
+++ b/docs/internals/source-layout.md
@@ -18,7 +18,7 @@ Main areas:
 - `LightOnOCR/`: OCR
 - `LoRA/`: LoRA support
 - `MLX/`: MLX utilities
-- `Gemma4/`, `MeBot/`, `Psi/`, `Q35/`: text model families
+- `Gemma4/`, `LFM2/`, `MeBot/`, `Psi/`, `Q35/`: text model families
 - `QwenImageEdit/`: image editing
 - `Support/`: model paths, manifests, resolver, config helpers
 - `Training/`: training-specific support retained in the package

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -23,7 +23,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Category | Hugging Face pull IDs |
 | --- | --- |
 | Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
-| Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-agent-deepseek-v4-flash` |
+| Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
 | Text anonymize | `text-anonymize-privacy-filter` |
@@ -67,6 +67,12 @@ implemented.
 machines. On 32 GB Apple Silicon Macs, use `text-chat-gemma4-turbo`, which
 installs the MLX NVFP4 Gemma 4 26B-A4B-it MoE snapshot and runs through the native
 Swift Gemma runtime.
+
+`text-chat-lfm25-a1b-8bit` uses the public
+`LiquidAI/LFM2.5-8B-A1B-MLX-8bit` snapshot at the pinned catalog revision. It is
+a text-only MLX 8-bit directory-root model with `config.json`,
+`tokenizer.json`, `tokenizer_config.json`, and sharded `*.safetensors` weights.
+mere.run runs it through the native Swift LFM2 runtime; no Python bridge is used.
 
 Useful environment variables for that path:
 
@@ -193,6 +199,7 @@ swift run mere.run model pull image-zimage-nano
 
 # Pull into a custom SSD-backed store
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-q36-nano
+MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25-a1b-8bit
 
 # Inspect what is currently installed
 swift run mere.run status

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -72,7 +72,7 @@ Key subdirectories:
 - `ZImageTurbo/`: ZImage image-family runtime
 - `HiDreamO1/`: HiDream O1 image-family runtime
 - `QwenImageEdit/`: image editing flow
-- `Gemma4/`, `Q35/`, `Psi/`, `MeBot/`: text/chat model families
+- `Gemma4/`, `Q35/`, `LFM2/`, `Psi/`, `MeBot/`: text/chat model families
 - `Embeddings/`: embedding-generation support
 - `LightOnOCR/`: OCR runtime
 - `VLM/`: vision-language model helpers

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -39,6 +39,13 @@ package-scoped.
 swift run mere.run api serve --engine text-chat-gemma4
 ```
 
+For the LiquidAI LFM2.5 MLX 8-bit model:
+
+```bash
+swift run mere.run model pull text-chat-lfm25-a1b-8bit
+swift run mere.run api serve --engine text-chat-lfm2
+```
+
 In another terminal, confirm that the server is reachable and which model it
 reports:
 
@@ -190,6 +197,9 @@ Engine compatibility:
 - `text-chat-q36-nano`: uses the Qwen-family serving engine with Qwen3.6
   35B-A3B OptiQ chat weights, accepts function tools, and accepts one image
   content part per message.
+- `text-chat-lfm25-a1b-8bit`: uses the LFM2 serving engine with the
+  LiquidAI LFM2.5 8B-A1B MLX 8-bit weights, accepts function tools, and rejects
+  image content parts.
 - `text-chat-klein`: supports `response_format: {"type":"json_object"}` with
   local JSON retry behavior.
 - `text-code`: accepts plain text chat requests and rejects tools, images,

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -39,7 +39,7 @@ swift run mere.run --models-root /path/to/models model list
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -17,6 +17,7 @@ embeddings, and PII anonymization.
 - `text-chat-gemma4`
 - `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
 - `text-chat-q36-nano`
+- `text-chat-lfm25-a1b-8bit` (managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot)
 - `text-agent-deepseek-v4-flash` (API/agent serving)
 - `text-chat-mebot`
 - `text-chat-psi-agent`
@@ -47,6 +48,10 @@ swift run mere.run text chat \
 On 32 GB Apple Silicon Macs, avoid pulling the dense bf16
 `text-chat-gemma4`/31B path. Use `text-chat-gemma4-turbo` for the managed
 Gemma 4 26B-A4B-it NVFP4 snapshot, which uses the native Swift Gemma MoE runtime.
+
+`text-chat-lfm25-a1b-8bit` installs `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
+and runs through the native Swift LFM2 runtime. It is text-only; use
+`--model text-chat-lfm25-a1b-8bit` for CLI chat or `api serve --engine text-chat-lfm2`.
 
 ### Local code generation
 
@@ -83,6 +88,7 @@ swift run mere.run text anonymize \
 
 - `Sources/MereRunCore/Q35/`
 - `Sources/MereRunCore/Gemma4/`
+- `Sources/MereRunCore/LFM2/`
 - `Sources/MereRunCore/Psi/`
 - `Sources/MereRunCore/MeBot/`
 


### PR DESCRIPTION
## Summary

- add a Swift-native LiquidAI LFM2.5 8B-A1B MLX 8-bit runtime, tokenizer/template renderer, config decoding, MoE/short-conv model path, and generator
- register `text-chat-lfm25-a1b-8bit` for managed pull, manifest writing, validation, model info, API serving, setup recommendations, docs, and guides
- make `text-chat-q36` the canonical Qwen3.6 serving engine across CLI/API/app surfaces while keeping `text-chat-q35` only as a legacy API alias
- carry resolved API/runtime context size through `ChatRequest.maxContextTokens` so native text runtimes honor runtime context settings on current `main`

## Validation

- `swift test --filter 'LFM2ConfigAndModelTests|APIServeCommandTests|RuntimeModelSettingsTests|TextChatCommandParsingTests|ManagedModelCatalogTests|MereRunModelValidatorTests'`
- `./scripts/check.sh`
- checkpoint smoke before PR packaging: pulled `text-chat-lfm25-a1b-8bit`, verified `model info`, ran CLI chat, and served it through `/v1/chat/completions`
