### PR TITLE
Add Gemma4 12B VLM support and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,17 @@ swift run mere.run model benchmark gemma4-kv \
   --decode-token-values 32,128 \
   --json
 
+# Tiny synthetic VLM eval: Gemma4 12B vision chat vs existing Qwen3-VL inspect backend
+swift run mere.run model benchmark vlm --json
+
+# Existing-dataset VLM eval via lmms-eval; dry-run prints the exact command first
+swift run mere.run model benchmark vlm \
+  --dataset mathvista-testmini \
+  --limit 16 \
+  --lmms-eval-root ~/src/lmms-eval \
+  --dry-run \
+  --json
+
 # Expose the API beyond loopback only with an explicit key
 export MERERUN_API_KEY=change-me
 swift run mere.run api serve \

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -424,6 +424,7 @@ enum APIServerContract {
             maxTokens: maxTokens,
             temperature: temperature,
             topP: topP,
+            showThinking: false,
             lora: lora,
             requiresJSON: requiresJSON,
             tools: tools,

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -208,6 +208,7 @@ enum GuideRegistry {
             commandPaths: [["text", "chat"]],
             models: [
                 "text-chat-gemma4",
+                "text-chat-gemma4-12b",
                 "text-chat-gemma4-nano",
                 "text-chat-gemma4-max",
                 "text-chat-q36-nano",
@@ -350,6 +351,8 @@ enum GuideRegistry {
             models: [
                 "text-code-qwen3",
                 "text-chat-gemma4",
+                "text-chat-gemma4-12b",
+                "vision-chat-gemma4-12b",
                 "text-chat-gemma4-nano",
                 "text-chat-gemma4-max",
                 "text-chat-q36-nano",
@@ -380,6 +383,8 @@ enum GuideRegistry {
                 "text-code-qwen3",
                 "text-agent-qwen35-9b",
                 "text-chat-gemma4",
+                "text-chat-gemma4-12b",
+                "vision-chat-gemma4-12b",
                 "text-chat-q36-nano",
                 "text-chat-lfm25-a1b-8bit",
                 "text-agent-deepseek-v4-flash",

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -11,6 +11,7 @@ struct ModelBenchmark: ParsableCommand {
         abstract: "Run focused local model benchmarks.",
         subcommands: [
             ModelBenchmarkGemma4KV.self,
+            ModelBenchmarkVLM.self,
         ]
     )
 }

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
@@ -1,0 +1,1215 @@
+import ArgumentParser
+import Foundation
+import MediaIO
+import MereRunCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(Darwin)
+import Darwin
+#endif
+
+struct ModelBenchmarkVLM: AsyncParsableCommand {
+    static let qwenInspectModelID = "vision-inspect-qwen3-vl-2b"
+
+    static let configuration = CommandConfiguration(
+        commandName: "vlm",
+        abstract: "Compare vision-language chat models on synthetic or lmms-eval datasets."
+    )
+
+    @Option(name: [.long], help: "Comma-separated model ids or aliases to compare.")
+    var models: String?
+
+    @Option(name: [.long], help: "Benchmark dataset: synthetic-vqa-v1, mathvista-testmini, mmmu-val, chartqa, docvqa-val, or mme.")
+    var dataset: VLMBenchmarkDataset = .syntheticVQA
+
+    @Option(name: [.long], help: "Raw lmms-eval task list. Overrides --dataset and uses the external lmms-eval runner.")
+    var lmmsTasks: String?
+
+    @Option(name: [.long], help: "Directory for generated benchmark fixture images. Defaults to a temp directory.")
+    var fixtureDir: String?
+
+    @Option(name: [.long], help: "Directory for external lmms-eval output. Defaults under .build/vlm-benchmarks.")
+    var outputDir: String?
+
+    @Option(name: [.long], help: "Optional lmms-eval source checkout; runs python -m lmms_eval from this directory.")
+    var lmmsEvalRoot: String?
+
+    @Option(name: [.long], help: "Python executable used for lmms-eval.")
+    var lmmsEvalPython: String = "python3"
+
+    @Flag(name: [.long], help: "Print external lmms-eval commands without starting servers or running them.")
+    var dryRun: Bool = false
+
+    @Flag(name: [.long], help: "Use an already running OpenAI-compatible endpoint instead of starting mere.run api serve.")
+    var externalEndpoint: Bool = false
+
+    @Option(name: [.long], help: "OpenAI-compatible base URL for --external-endpoint, or generated server URL otherwise.")
+    var baseURL: String?
+
+    @Option(name: [.long], help: "API key passed to mere.run api serve and lmms-eval.")
+    var apiKey: String = "mere-run-local-eval"
+
+    @Option(name: [.long], help: "Host for generated mere.run api serve processes.")
+    var host: String = "127.0.0.1"
+
+    @Option(name: [.long], help: "First port used for generated mere.run api serve processes.")
+    var port: Int = 11934
+
+    @Option(name: [.long], help: "Limit examples per lmms-eval task. Omit for a full benchmark.")
+    var limit: String?
+
+    @Flag(name: [.long], help: "Ask lmms-eval to write per-sample logs.")
+    var logSamples: Bool = false
+
+    @Option(name: [.long], help: "Maximum output tokens per image question.")
+    var maxTokens: Int = 24
+
+    @Option(name: [.long], help: "Context size for managed API-runtime models.")
+    var contextSize: Int = 4096
+
+    @Option(name: [.long], help: "Sampling temperature.")
+    var temperature: Double = 0
+
+    @Option(name: [.long], help: "Top-p sampling.")
+    var topP: Double = 1
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    private var usesExternalBenchmark: Bool {
+        if let lmmsTasks = lmmsTasks?.trimmingCharacters(in: .whitespacesAndNewlines), !lmmsTasks.isEmpty {
+            return true
+        }
+        return dataset.lmmsEvalTasks != nil
+    }
+
+    func validate() throws {
+        guard maxTokens > 0 else {
+            throw ValidationError("--max-tokens must be greater than zero.")
+        }
+        guard contextSize > 0 else {
+            throw ValidationError("--context-size must be greater than zero.")
+        }
+        guard (0...2).contains(temperature), temperature.isFinite else {
+            throw ValidationError("--temperature must be finite and between 0 and 2.")
+        }
+        guard (0...1).contains(topP), topP.isFinite else {
+            throw ValidationError("--top-p must be finite and between 0 and 1.")
+        }
+        guard port > 0, port <= Int(UInt16.max) else {
+            throw ValidationError("--port must be between 1 and \(UInt16.max).")
+        }
+        if let limit {
+            guard Double(limit) != nil else {
+                throw ValidationError("--limit must be numeric.")
+            }
+        }
+        if externalEndpoint, baseURL?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+            throw ValidationError("--external-endpoint requires --base-url.")
+        }
+        _ = try modelIDs()
+    }
+
+    func run() async throws {
+        if let external = try externalBenchmarkPlanIfNeeded() {
+            try await runExternalBenchmark(external)
+            return
+        }
+
+        try MLXBundleSupport.ensureAvailable(quiet: json)
+
+        let fixtureURL = try resolvedFixtureDirectory()
+        let suite = try VLMBenchmarkSuite.writeDefaultFixtures(to: fixtureURL)
+        let requestedModels = try modelIDs()
+        let pool = RuntimeModelPool(
+            defaultModelID: requestedModels.first ?? Gemma4Resources.visionTwelveBModelId,
+            defaultEngine: .textChatGemma4,
+            startupModelPath: nil
+        )
+
+        var modelResults: [VLMBenchmarkModelResult] = []
+        modelResults.reserveCapacity(requestedModels.count)
+
+        for modelID in requestedModels {
+            if !json {
+                CLIStderr.write("Benchmarking \(modelID)...\n")
+            }
+            do {
+                let result: VLMBenchmarkModelResult
+                if Self.isQwenInspectModelID(modelID) {
+                    result = try await runQwenInspectModel(modelID: modelID, suite: suite)
+                } else {
+                    result = try await runManagedModel(modelID: modelID, suite: suite, pool: pool)
+                    _ = try? await pool.unloadModel(idOrAlias: modelID)
+                }
+                modelResults.append(result)
+            } catch {
+                modelResults.append(
+                    VLMBenchmarkModelResult.failed(
+                        model: modelID,
+                        error: error.localizedDescription
+                    )
+                )
+            }
+        }
+
+        let report = VLMBenchmarkReport(
+            suite: suite.name,
+            fixtureDirectory: suite.fixtureDirectory.path,
+            cases: suite.cases.map(VLMBenchmarkCaseSummary.init),
+            models: modelResults
+        )
+        if json {
+            print(try report.jsonString())
+        } else {
+            print(report.renderText())
+        }
+    }
+
+    private func modelIDs() throws -> [String] {
+        let defaultModels = usesExternalBenchmark
+            ? Gemma4Resources.visionTwelveBModelId
+            : "\(Gemma4Resources.visionTwelveBModelId),\(Self.qwenInspectModelID)"
+        let parsed = (models ?? defaultModels)
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !parsed.isEmpty else {
+            throw ValidationError("--models must contain at least one model id.")
+        }
+        return parsed
+    }
+
+    private func externalBenchmarkPlanIfNeeded() throws -> VLMExternalBenchmarkPlan? {
+        if let lmmsTasks = lmmsTasks?.trimmingCharacters(in: .whitespacesAndNewlines), !lmmsTasks.isEmpty {
+            return try VLMExternalBenchmarkPlan(
+                dataset: "lmms-eval",
+                tasks: lmmsTasks,
+                outputDirectory: resolvedExternalOutputDirectory(datasetSlug: "lmms-eval")
+            )
+        }
+        guard let tasks = dataset.lmmsEvalTasks else {
+            return nil
+        }
+        return try VLMExternalBenchmarkPlan(
+            dataset: dataset.rawValue,
+            tasks: tasks,
+            outputDirectory: resolvedExternalOutputDirectory(datasetSlug: dataset.rawValue)
+        )
+    }
+
+    private func resolvedExternalOutputDirectory(datasetSlug: String) throws -> URL {
+        let url: URL
+        if let outputDir {
+            url = URL(fileURLWithPath: outputDir).standardizedFileURL
+        } else {
+            let timestamp = ISO8601DateFormatter()
+                .string(from: Date())
+                .replacingOccurrences(of: ":", with: "-")
+            url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(".build/vlm-benchmarks/\(datasetSlug)-\(timestamp)", isDirectory: true)
+        }
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func runExternalBenchmark(_ plan: VLMExternalBenchmarkPlan) async throws {
+        let requestedModels = try modelIDs()
+        var results: [VLMExternalModelResult] = []
+        results.reserveCapacity(requestedModels.count)
+
+        for (offset, modelID) in requestedModels.enumerated() {
+            let modelPort = port + offset
+            let endpointURL = externalEndpoint
+                ? try resolvedExternalBaseURL()
+                : "http://\(host):\(modelPort)/v1"
+            let serverProcess: Process?
+            if dryRun || externalEndpoint {
+                serverProcess = nil
+            } else {
+                serverProcess = try startAPIServer(modelID: modelID, port: modelPort)
+                try waitForAPIHealth(host: host, port: modelPort, modelID: modelID)
+            }
+            defer {
+                if let serverProcess, serverProcess.isRunning {
+                    serverProcess.terminate()
+                    serverProcess.waitUntilExit()
+                }
+            }
+
+            let invocation = try makeLMMSEvalInvocation(
+                modelID: modelID,
+                plan: plan,
+                baseURL: endpointURL
+            )
+            if dryRun {
+                results.append(
+                    VLMExternalModelResult(
+                        model: modelID,
+                        command: invocation.shellDescription,
+                        outputPath: invocation.outputDirectory.path,
+                        exitStatus: nil,
+                        elapsedSeconds: nil
+                    )
+                )
+                continue
+            }
+
+            let start = Date()
+            let processResult = try runExternalProcess(invocation)
+            results.append(
+                VLMExternalModelResult(
+                    model: modelID,
+                    command: invocation.shellDescription,
+                    outputPath: invocation.outputDirectory.path,
+                    exitStatus: processResult.status,
+                    elapsedSeconds: Date().timeIntervalSince(start)
+                )
+            )
+            guard processResult.status == 0 else {
+                throw ValidationError(
+                    "lmms-eval failed for \(modelID) with status \(processResult.status). Stderr tail: \(processResult.stderrTail)"
+                )
+            }
+        }
+
+        let report = VLMExternalBenchmarkReport(
+            dataset: plan.dataset,
+            tasks: plan.tasks,
+            outputDirectory: plan.outputDirectory.path,
+            dryRun: dryRun,
+            models: results
+        )
+        if json || dryRun {
+            print(try report.jsonString())
+        } else {
+            print(report.renderText())
+        }
+    }
+
+    private func resolvedExternalBaseURL() throws -> String {
+        guard let raw = baseURL?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            throw ValidationError("--external-endpoint requires --base-url.")
+        }
+        return raw.hasSuffix("/") ? String(raw.dropLast()) : raw
+    }
+
+    private func startAPIServer(modelID: String, port: Int) throws -> Process {
+        let engine = try apiEngine(for: modelID)
+        let process = Process()
+        process.executableURL = CurrentExecutable.url()
+        process.arguments = [
+            "api", "serve",
+            "--engine", engine.rawValue,
+            "--model", modelID,
+            "--host", host,
+            "--port", String(port),
+            "--context-size", String(contextSize),
+            "--api-key", apiKey,
+        ]
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        forwardPipe(stdout, prefix: "[api serve] ")
+        forwardPipe(stderr, prefix: "[api serve] ")
+        try process.run()
+        return process
+    }
+
+    private func apiEngine(for modelID: String) throws -> APIEngine {
+        guard let spec = ManagedModelCatalog.spec(for: modelID),
+              let engine = spec.defaultRuntimeServingEngine else {
+            throw ValidationError("External VLM datasets require an API-servable managed model; '\(modelID)' is not one.")
+        }
+        switch engine.canonical {
+        case .textChatGemma4:
+            return .textChatGemma4
+        case .textChatQ35:
+            return .textChatQ35
+        case .textChatQ36:
+            return .textChatQ36
+        case .textChatKlein:
+            return .textChatKlein
+        case .textChatLFM2:
+            return .textChatLFM2
+        case .textChatDeepseekV4Flash:
+            return .textChatDeepseekV4Flash
+        case .textCode:
+            return .textCode
+        }
+    }
+
+    private func waitForAPIHealth(host: String, port: Int, modelID: String) throws {
+        guard let healthURL = URL(string: "http://\(host):\(port)/health") else {
+            throw ValidationError("Invalid API health URL for \(host):\(port).")
+        }
+        let deadline = Date().addingTimeInterval(120)
+        while Date() < deadline {
+            if let data = try? Data(contentsOf: healthURL),
+               String(decoding: data, as: UTF8.self).contains("\"ok\"") {
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        throw ValidationError("Timed out waiting for API server for \(modelID) on \(healthURL.absoluteString).")
+    }
+
+    private func makeLMMSEvalInvocation(
+        modelID: String,
+        plan: VLMExternalBenchmarkPlan,
+        baseURL: String
+    ) throws -> VLMExternalInvocation {
+        let outputDirectory = plan.outputDirectory.appendingPathComponent(safePathComponent(modelID), isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+
+        let modelArgs = [
+            "model_version=\(modelID)",
+            "base_url=\(baseURL)",
+            "api_key=\(apiKey)",
+        ].joined(separator: ",")
+        var arguments = [
+            "-m", "lmms_eval",
+            "--model", "openai",
+            "--model_args", modelArgs,
+            "--tasks", plan.tasks,
+            "--batch_size", "1",
+            "--output_path", outputDirectory.path,
+            "--gen_kwargs", "temperature=\(temperature),top_p=\(topP),max_new_tokens=\(maxTokens)",
+        ]
+        if let limit {
+            arguments += ["--limit", limit]
+        }
+        if logSamples {
+            arguments.append("--log_samples")
+        }
+
+        let rootURL = lmmsEvalRoot.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        return VLMExternalInvocation(
+            executable: lmmsEvalPython,
+            arguments: arguments,
+            currentDirectory: rootURL,
+            outputDirectory: outputDirectory
+        )
+    }
+
+    private func safePathComponent(_ raw: String) -> String {
+        raw.replacingOccurrences(of: "[^A-Za-z0-9._-]+", with: "-", options: .regularExpression)
+    }
+
+    private func runExternalProcess(_ invocation: VLMExternalInvocation) throws -> VLMExternalProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [invocation.executable] + invocation.arguments
+        process.currentDirectoryURL = invocation.currentDirectory
+        var environment = ProcessInfo.processInfo.environment
+        if let currentDirectory = invocation.currentDirectory {
+            let existing = environment["PYTHONPATH"].map { ":\($0)" } ?? ""
+            environment["PYTHONPATH"] = currentDirectory.path + existing
+        }
+        process.environment = environment
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        let capture = VLMExternalProcessCapture()
+        capture.forward(stdout, prefix: "[lmms-eval] ", storeTail: false)
+        capture.forward(stderr, prefix: "[lmms-eval] ", storeTail: true)
+        try process.run()
+        process.waitUntilExit()
+        capture.finish(stdout, storeTail: false)
+        capture.finish(stderr, storeTail: true)
+        return VLMExternalProcessResult(
+            status: process.terminationStatus,
+            stderrTail: capture.stderrTail()
+        )
+    }
+
+    private func forwardPipe(_ pipe: Pipe, prefix: String) {
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            if let text = String(data: data, encoding: .utf8) {
+                CLIStderr.write(text.linePrefixed(prefix))
+            } else {
+                FileHandle.standardError.write(data)
+            }
+        }
+    }
+
+    private func resolvedFixtureDirectory() throws -> URL {
+        let url: URL
+        if let fixtureDir {
+            url = URL(fileURLWithPath: fixtureDir).standardizedFileURL
+        } else {
+            url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("mererun-vlm-benchmark-\(UUID().uuidString)", isDirectory: true)
+        }
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func isQwenInspectModelID(_ modelID: String) -> Bool {
+        let normalized = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == qwenInspectModelID
+            || normalized == Qwen3VLAutoCaptioner.modelId.lowercased()
+    }
+
+    private func runManagedModel(
+        modelID: String,
+        suite: VLMBenchmarkSuite,
+        pool: RuntimeModelPool
+    ) async throws -> VLMBenchmarkModelResult {
+        let modelStart = Date()
+        var caseResults: [VLMBenchmarkCaseResult] = []
+        caseResults.reserveCapacity(suite.cases.count)
+
+        for benchmarkCase in suite.cases {
+            do {
+                caseResults.append(
+                    try await runManagedCase(
+                        benchmarkCase,
+                        modelID: modelID,
+                        pool: pool
+                    )
+                )
+            } catch {
+                caseResults.append(
+                    benchmarkCase.failedResult(
+                        model: modelID,
+                        error: error.localizedDescription
+                    )
+                )
+            }
+        }
+
+        return VLMBenchmarkModelResult(
+            model: modelID,
+            backend: "managed-api-runtime",
+            elapsedSeconds: Date().timeIntervalSince(modelStart),
+            cases: caseResults,
+            error: nil
+        )
+    }
+
+    private func runManagedCase(
+        _ benchmarkCase: VLMBenchmarkCase,
+        modelID: String,
+        pool: RuntimeModelPool
+    ) async throws -> VLMBenchmarkCaseResult {
+        let request = OpenAIChatRequest(
+            model: modelID,
+            messages: [
+                OpenAIChatMessage(
+                    role: "user",
+                    content: benchmarkCase.prompt,
+                    imageURLs: [benchmarkCase.imageURL.path]
+                ),
+            ],
+            temperature: temperature,
+            top_p: topP,
+            max_tokens: maxTokens,
+            stream: false
+        )
+        let memoryBefore = VLMBenchmarkMemorySnapshot.currentResidentBytes()
+        let caseStart = Date()
+        let plan = try await pool.makeChatPlan(
+            for: request,
+            fallbackLoraPath: nil,
+            serverContextSize: contextSize
+        )
+        let response: ChatResponse
+        do {
+            response = try await plan.lease.chat(plan.request, progressHandler: progressHandler())
+        } catch {
+            await plan.lease.release()
+            throw error
+        }
+        await plan.lease.release()
+        let elapsed = Date().timeIntervalSince(caseStart)
+        let memoryAfter = VLMBenchmarkMemorySnapshot.currentResidentBytes()
+        return benchmarkCase.result(
+            model: modelID,
+            response: response.response,
+            elapsedSeconds: elapsed,
+            promptTokens: response.promptTokens,
+            generatedTokens: response.tokensGenerated,
+            timing: response.timing,
+            residentMemoryBeforeBytes: memoryBefore,
+            residentMemoryAfterBytes: memoryAfter
+        )
+    }
+
+    private func runQwenInspectModel(
+        modelID: String,
+        suite: VLMBenchmarkSuite
+    ) async throws -> VLMBenchmarkModelResult {
+        let modelStart = Date()
+        let autoCaptioner = Qwen3VLAutoCaptioner()
+        let verb = await autoCaptioner.isModelCached() ? "Loading cached" : "Downloading"
+        if !json {
+            CLIStderr.write("\(verb) \(Qwen3VLAutoCaptioner.modelId)...\n")
+        }
+        let modelURL = try await autoCaptioner.ensureReady { progress in
+            guard !json else { return }
+            CLIStderr.write("\r\(progress.status) (\(Int(progress.fraction * 100))%)")
+        }
+        if !json {
+            CLIStderr.write("\n")
+        }
+
+        let captioner = try QwenVLCaptioner(modelRoot: modelURL)
+        let config = QwenVLCaptioner.ModelConfig(
+            maxNewTokens: maxTokens,
+            temperature: Float(temperature),
+            topP: Float(topP)
+        )
+        var caseResults: [VLMBenchmarkCaseResult] = []
+        caseResults.reserveCapacity(suite.cases.count)
+
+        for benchmarkCase in suite.cases {
+            let memoryBefore = VLMBenchmarkMemorySnapshot.currentResidentBytes()
+            let caseStart = Date()
+            do {
+                let response = try captioner.caption(
+                    imageURL: benchmarkCase.imageURL,
+                    prompt: benchmarkCase.prompt,
+                    config: config
+                )
+                caseResults.append(
+                    benchmarkCase.result(
+                        model: modelID,
+                        response: response,
+                        elapsedSeconds: Date().timeIntervalSince(caseStart),
+                        promptTokens: nil,
+                        generatedTokens: nil,
+                        timing: nil,
+                        residentMemoryBeforeBytes: memoryBefore,
+                        residentMemoryAfterBytes: VLMBenchmarkMemorySnapshot.currentResidentBytes()
+                    )
+                )
+            } catch {
+                caseResults.append(
+                    benchmarkCase.failedResult(
+                        model: modelID,
+                        error: error.localizedDescription
+                    )
+                )
+            }
+        }
+
+        return VLMBenchmarkModelResult(
+            model: modelID,
+            backend: Qwen3VLAutoCaptioner.modelId,
+            elapsedSeconds: Date().timeIntervalSince(modelStart),
+            cases: caseResults,
+            error: nil
+        )
+    }
+
+    private func progressHandler() -> (@Sendable (ChatProgress) -> Void)? {
+        guard !json else { return nil }
+        return { progress in
+            let suffix = progress.message?.isEmpty == false ? ": \(progress.message!)" : ""
+            CLIStderr.write("[\(progress.stage.rawValue)]\(suffix)\n")
+        }
+    }
+}
+
+private struct VLMBenchmarkSuite {
+    let name: String
+    let fixtureDirectory: URL
+    let cases: [VLMBenchmarkCase]
+
+    static func writeDefaultFixtures(to directory: URL) throws -> Self {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let redURL = directory.appendingPathComponent("solid-red.png")
+        try writeImage(
+            width: 160,
+            height: 160,
+            fill: .white,
+            rectangles: [VLMBenchmarkRectangle(x: 0, y: 0, width: 160, height: 160, color: .red)],
+            to: redURL
+        )
+
+        let cornerURL = directory.appendingPathComponent("blue-top-right.png")
+        try writeImage(
+            width: 160,
+            height: 160,
+            fill: .white,
+            rectangles: [
+                VLMBenchmarkRectangle(x: 16, y: 16, width: 48, height: 48, color: .green),
+                VLMBenchmarkRectangle(x: 96, y: 16, width: 48, height: 48, color: .blue),
+                VLMBenchmarkRectangle(x: 16, y: 96, width: 48, height: 48, color: .yellow),
+                VLMBenchmarkRectangle(x: 96, y: 96, width: 48, height: 48, color: .red),
+            ],
+            to: cornerURL
+        )
+
+        let countURL = directory.appendingPathComponent("three-black-squares.png")
+        try writeImage(
+            width: 192,
+            height: 96,
+            fill: .white,
+            rectangles: [
+                VLMBenchmarkRectangle(x: 18, y: 28, width: 34, height: 34, color: .black),
+                VLMBenchmarkRectangle(x: 78, y: 28, width: 34, height: 34, color: .black),
+                VLMBenchmarkRectangle(x: 138, y: 28, width: 34, height: 34, color: .black),
+            ],
+            to: countURL
+        )
+
+        return VLMBenchmarkSuite(
+            name: "synthetic-vqa-v1",
+            fixtureDirectory: directory,
+            cases: [
+                VLMBenchmarkCase(
+                    id: "dominant-red",
+                    imageURL: redURL,
+                    prompt: "What is the dominant color in this image? Answer with one lowercase color word.",
+                    expectedRegex: "\\bred\\b",
+                    expectedDescription: "red"
+                ),
+                VLMBenchmarkCase(
+                    id: "blue-corner",
+                    imageURL: cornerURL,
+                    prompt: "Which corner contains the blue square? Answer with two words, like top left.",
+                    expectedRegex: "\\b(top right|upper right)\\b",
+                    expectedDescription: "top right"
+                ),
+                VLMBenchmarkCase(
+                    id: "count-black-squares",
+                    imageURL: countURL,
+                    prompt: "How many black squares are visible? Answer with one digit.",
+                    expectedRegex: "\\b(3|three)\\b",
+                    expectedDescription: "3"
+                ),
+            ]
+        )
+    }
+
+    private static func writeImage(
+        width: Int,
+        height: Int,
+        fill: VLMBenchmarkColor,
+        rectangles: [VLMBenchmarkRectangle],
+        to url: URL
+    ) throws {
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                setPixel(x: x, y: y, width: width, color: fill, pixels: &pixels)
+            }
+        }
+        for rectangle in rectangles {
+            let minX = max(0, rectangle.x)
+            let minY = max(0, rectangle.y)
+            let maxX = min(width, rectangle.x + rectangle.width)
+            let maxY = min(height, rectangle.y + rectangle.height)
+            guard minX < maxX, minY < maxY else { continue }
+            for y in minY..<maxY {
+                for x in minX..<maxX {
+                    setPixel(x: x, y: y, width: width, color: rectangle.color, pixels: &pixels)
+                }
+            }
+        }
+        try MediaImageIO.writePNG(try MediaImage(width: width, height: height, rgba8: pixels), to: url)
+    }
+
+    private static func setPixel(
+        x: Int,
+        y: Int,
+        width: Int,
+        color: VLMBenchmarkColor,
+        pixels: inout [UInt8]
+    ) {
+        let offset = ((y * width) + x) * 4
+        pixels[offset] = color.red
+        pixels[offset + 1] = color.green
+        pixels[offset + 2] = color.blue
+        pixels[offset + 3] = color.alpha
+    }
+}
+
+private struct VLMBenchmarkCase {
+    let id: String
+    let imageURL: URL
+    let prompt: String
+    let expectedRegex: String
+    let expectedDescription: String
+
+    func result(
+        model: String,
+        response: String,
+        elapsedSeconds: Double,
+        promptTokens: Int?,
+        generatedTokens: Int?,
+        timing: ChatTiming?,
+        residentMemoryBeforeBytes: UInt64?,
+        residentMemoryAfterBytes: UInt64?
+    ) -> VLMBenchmarkCaseResult {
+        let normalized = Self.normalized(response)
+        let passed = normalized.range(of: expectedRegex, options: .regularExpression) != nil
+        return VLMBenchmarkCaseResult(
+            id: id,
+            imagePath: imageURL.path,
+            prompt: prompt,
+            expected: expectedDescription,
+            expectedRegex: expectedRegex,
+            passed: passed,
+            response: response.trimmingCharacters(in: .whitespacesAndNewlines),
+            normalizedResponse: normalized,
+            elapsedSeconds: elapsedSeconds,
+            promptTokens: promptTokens,
+            generatedTokens: generatedTokens,
+            loadSeconds: timing?.loadSeconds,
+            prefillSeconds: timing?.prefillSeconds,
+            decodeSeconds: timing?.decodeSeconds,
+            firstTokenSeconds: timing?.firstTokenSeconds,
+            residentMemoryBeforeBytes: residentMemoryBeforeBytes,
+            residentMemoryAfterBytes: residentMemoryAfterBytes,
+            error: nil
+        )
+    }
+
+    func failedResult(model _: String, error: String) -> VLMBenchmarkCaseResult {
+        VLMBenchmarkCaseResult(
+            id: id,
+            imagePath: imageURL.path,
+            prompt: prompt,
+            expected: expectedDescription,
+            expectedRegex: expectedRegex,
+            passed: false,
+            response: "",
+            normalizedResponse: "",
+            elapsedSeconds: nil,
+            promptTokens: nil,
+            generatedTokens: nil,
+            loadSeconds: nil,
+            prefillSeconds: nil,
+            decodeSeconds: nil,
+            firstTokenSeconds: nil,
+            residentMemoryBeforeBytes: nil,
+            residentMemoryAfterBytes: nil,
+            error: error
+        )
+    }
+
+    private static func normalized(_ text: String) -> String {
+        text
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .lowercased()
+            .replacingOccurrences(
+                of: "[^a-z0-9]+",
+                with: " ",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private struct VLMBenchmarkColor {
+    let red: UInt8
+    let green: UInt8
+    let blue: UInt8
+    let alpha: UInt8
+
+    static let black = VLMBenchmarkColor(red: 0, green: 0, blue: 0, alpha: 255)
+    static let blue = VLMBenchmarkColor(red: 0, green: 84, blue: 255, alpha: 255)
+    static let green = VLMBenchmarkColor(red: 0, green: 170, blue: 80, alpha: 255)
+    static let red = VLMBenchmarkColor(red: 230, green: 0, blue: 0, alpha: 255)
+    static let white = VLMBenchmarkColor(red: 255, green: 255, blue: 255, alpha: 255)
+    static let yellow = VLMBenchmarkColor(red: 255, green: 210, blue: 0, alpha: 255)
+}
+
+private struct VLMBenchmarkRectangle {
+    let x: Int
+    let y: Int
+    let width: Int
+    let height: Int
+    let color: VLMBenchmarkColor
+}
+
+private struct VLMBenchmarkCaseSummary: Encodable {
+    let id: String
+    let imagePath: String
+    let prompt: String
+    let expected: String
+    let expectedRegex: String
+
+    init(_ benchmarkCase: VLMBenchmarkCase) {
+        id = benchmarkCase.id
+        imagePath = benchmarkCase.imageURL.path
+        prompt = benchmarkCase.prompt
+        expected = benchmarkCase.expectedDescription
+        expectedRegex = benchmarkCase.expectedRegex
+    }
+}
+
+private struct VLMBenchmarkReport: Encodable {
+    let suite: String
+    let fixtureDirectory: String
+    let cases: [VLMBenchmarkCaseSummary]
+    let models: [VLMBenchmarkModelResult]
+
+    func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func renderText() -> String {
+        var lines = [
+            "VLM benchmark",
+            "suite: \(suite)",
+            "fixtures: \(fixtureDirectory)",
+            "",
+        ]
+        for model in models {
+            lines.append(model.renderText())
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct VLMBenchmarkModelResult: Encodable {
+    let model: String
+    let backend: String?
+    let elapsedSeconds: Double?
+    let cases: [VLMBenchmarkCaseResult]
+    let error: String?
+
+    var passedCases: Int {
+        cases.filter(\.passed).count
+    }
+
+    var completedCases: Int {
+        cases.filter { $0.error == nil }.count
+    }
+
+    var totalCases: Int {
+        cases.count
+    }
+
+    var score: Double {
+        guard totalCases > 0 else { return 0 }
+        return Double(passedCases) / Double(totalCases)
+    }
+
+    static func failed(model: String, error: String) -> Self {
+        Self(
+            model: model,
+            backend: nil,
+            elapsedSeconds: nil,
+            cases: [],
+            error: error
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case backend
+        case elapsedSeconds
+        case passedCases
+        case completedCases
+        case totalCases
+        case score
+        case cases
+        case error
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model, forKey: .model)
+        try container.encodeIfPresent(backend, forKey: .backend)
+        try container.encodeIfPresent(elapsedSeconds, forKey: .elapsedSeconds)
+        try container.encode(passedCases, forKey: .passedCases)
+        try container.encode(completedCases, forKey: .completedCases)
+        try container.encode(totalCases, forKey: .totalCases)
+        try container.encode(score, forKey: .score)
+        try container.encode(cases, forKey: .cases)
+        try container.encodeIfPresent(error, forKey: .error)
+    }
+
+    func renderText() -> String {
+        if let error {
+            return [
+                "model: \(model)",
+                "  error: \(error)",
+                "",
+            ].joined(separator: "\n")
+        }
+
+        var lines = [
+            "model: \(model)",
+            "  backend: \(backend ?? "unknown")",
+            "  score: \(passedCases)/\(totalCases) (\(formatPercent(score))) elapsed=\(formatOptional(elapsedSeconds))s",
+        ]
+        for result in cases {
+            lines.append(result.renderText())
+        }
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct VLMBenchmarkCaseResult: Encodable {
+    let id: String
+    let imagePath: String
+    let prompt: String
+    let expected: String
+    let expectedRegex: String
+    let passed: Bool
+    let response: String
+    let normalizedResponse: String
+    let elapsedSeconds: Double?
+    let promptTokens: Int?
+    let generatedTokens: Int?
+    let loadSeconds: Double?
+    let prefillSeconds: Double?
+    let decodeSeconds: Double?
+    let firstTokenSeconds: Double?
+    let residentMemoryBeforeBytes: UInt64?
+    let residentMemoryAfterBytes: UInt64?
+    let error: String?
+
+    func renderText() -> String {
+        let status = passed ? "PASS" : "FAIL"
+        var lines = [
+            "  \(id): \(status) elapsed=\(formatOptional(elapsedSeconds))s",
+            "    expected: \(expected)",
+        ]
+        if let error {
+            lines.append("    error: \(error)")
+            return lines.joined(separator: "\n")
+        }
+        lines.append("    response: \(oneLine(response))")
+        lines.append(
+            "    tokens: prompt=\(promptTokens.map(String.init) ?? "n/a") generated=\(generatedTokens.map(String.init) ?? "n/a")"
+        )
+        lines.append(
+            "    timing: load=\(formatOptional(loadSeconds))s prefill=\(formatOptional(prefillSeconds))s decode=\(formatOptional(decodeSeconds))s first_token=\(formatOptional(firstTokenSeconds))s"
+        )
+        lines.append(
+            "    resident_memory: before=\(formatBytes(residentMemoryBeforeBytes)) after=\(formatBytes(residentMemoryAfterBytes))"
+        )
+        return lines.joined(separator: "\n")
+    }
+
+    private func oneLine(_ text: String) -> String {
+        let collapsed = text
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard collapsed.count > 180 else { return collapsed }
+        return String(collapsed.prefix(177)) + "..."
+    }
+}
+
+private func formatOptional(_ value: Double?) -> String {
+    guard let value else { return "n/a" }
+    return String(format: "%.3f", value)
+}
+
+private func formatPercent(_ value: Double) -> String {
+    String(format: "%.1f%%", value * 100)
+}
+
+private func formatBytes(_ value: UInt64?) -> String {
+    guard let value else { return "n/a" }
+    return ByteCountFormatter.string(fromByteCount: Int64(value), countStyle: .memory)
+}
+
+enum VLMBenchmarkDataset: String, ExpressibleByArgument, CaseIterable {
+    case syntheticVQA = "synthetic-vqa-v1"
+    case mathvistaTestMini = "mathvista-testmini"
+    case mmmuVal = "mmmu-val"
+    case chartQA = "chartqa"
+    case docVQAVal = "docvqa-val"
+    case mme
+
+    init?(argument: String) {
+        self.init(rawValue: argument)
+    }
+
+    var lmmsEvalTasks: String? {
+        switch self {
+        case .syntheticVQA:
+            return nil
+        case .mathvistaTestMini:
+            return "mathvista_testmini"
+        case .mmmuVal:
+            return "mmmu_val"
+        case .chartQA:
+            return "chartqa"
+        case .docVQAVal:
+            return "docvqa_val"
+        case .mme:
+            return "mme"
+        }
+    }
+}
+
+private struct VLMExternalBenchmarkPlan {
+    let dataset: String
+    let tasks: String
+    let outputDirectory: URL
+}
+
+private struct VLMExternalBenchmarkReport: Encodable {
+    let dataset: String
+    let tasks: String
+    let outputDirectory: String
+    let dryRun: Bool
+    let models: [VLMExternalModelResult]
+
+    func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func renderText() -> String {
+        var lines = [
+            "VLM external benchmark",
+            "dataset: \(dataset)",
+            "tasks: \(tasks)",
+            "output: \(outputDirectory)",
+            "",
+        ]
+        for model in models {
+            lines.append(model.renderText())
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct VLMExternalModelResult: Encodable {
+    let model: String
+    let command: String
+    let outputPath: String
+    let exitStatus: Int32?
+    let elapsedSeconds: Double?
+
+    func renderText() -> String {
+        [
+            "model: \(model)",
+            "  command: \(command)",
+            "  output: \(outputPath)",
+            "  exit_status: \(exitStatus.map(String.init) ?? "dry-run")",
+            "  elapsed: \(formatOptional(elapsedSeconds))s",
+            "",
+        ].joined(separator: "\n")
+    }
+}
+
+private struct VLMExternalInvocation {
+    let executable: String
+    let arguments: [String]
+    let currentDirectory: URL?
+    let outputDirectory: URL
+
+    var shellDescription: String {
+        let workingDirectory = currentDirectory.map { "cd \(Self.shellEscape($0.path)) && " } ?? ""
+        return workingDirectory + ([executable] + arguments)
+            .map(Self.shellEscape)
+            .joined(separator: " ")
+    }
+
+    private static func shellEscape(_ value: String) -> String {
+        guard !value.isEmpty else { return "''" }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_./:=,+-")
+        if value.rangeOfCharacter(from: allowed.inverted) == nil {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+private struct VLMExternalProcessResult {
+    let status: Int32
+    let stderrTail: String
+}
+
+private final class VLMExternalProcessCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stderr = Data()
+    private let maxTailBytes = 16 * 1024
+
+    func forward(_ pipe: Pipe, prefix: String, storeTail: Bool) {
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            if storeTail {
+                self?.appendStderr(data)
+            }
+            if let text = String(data: data, encoding: .utf8) {
+                CLIStderr.write(text.linePrefixed(prefix))
+            } else {
+                FileHandle.standardError.write(data)
+            }
+        }
+    }
+
+    func finish(_ pipe: Pipe, storeTail: Bool) {
+        pipe.fileHandleForReading.readabilityHandler = nil
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard !data.isEmpty else { return }
+        if storeTail {
+            appendStderr(data)
+        }
+    }
+
+    func stderrTail() -> String {
+        lock.lock()
+        let data = stderr
+        lock.unlock()
+        return String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: \.isNewline)
+            .suffix(12)
+            .joined(separator: "\n")
+    }
+
+    private func appendStderr(_ data: Data) {
+        lock.lock()
+        stderr.append(data)
+        if stderr.count > maxTailBytes {
+            stderr.removeFirst(stderr.count - maxTailBytes)
+        }
+        lock.unlock()
+    }
+}
+
+private extension String {
+    func linePrefixed(_ prefix: String) -> String {
+        split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.isEmpty ? String($0) : prefix + $0 }
+            .joined(separator: "\n")
+    }
+}
+
+private enum VLMBenchmarkMemorySnapshot {
+    static func currentResidentBytes() -> UInt64? {
+        #if canImport(Darwin)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return UInt64(info.resident_size)
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -20,6 +20,7 @@ struct TextChat: AsyncParsableCommand {
         Known model IDs:
           - text-chat-q36-nano (Qwen3.6-35B-A3B OptiQ 4-bit, default on Apple Silicon)
           - text-chat-q36-nano-gguf (Qwen3.6-35B-A3B GGUF, default on Linux CUDA)
+          - text-chat-gemma4-12b (Gemma 4 12B dense native Swift runtime)
           - text-chat-gemma4-turbo (Gemma 4 26B-A4B NVFP4 native Swift runtime)
           - text-chat-gemma4 (Gemma 4 31B; large/slow, kept for compatibility)
           - text-chat-gemma4-max (Gemma 4 31B native Swift runtime)
@@ -89,7 +90,7 @@ struct TextChat: AsyncParsableCommand {
         return Gemma4Resources.nanoModelId
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-gemma4[-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-gemma4[-12b|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -9,7 +9,8 @@ Start a local OpenAI-compatible HTTP server for chat completions. Use this when 
 Supported engines:
 
 - `text-code`: default GGUF code model, usually `text-code-qwen3`.
-- `text-chat-gemma4`: Gemma text chat models.
+- `text-chat-gemma4`: Gemma text chat models, including `text-chat-gemma4-12b`.
+- `vision-chat-gemma4-12b`: Gemma 4 12B vision chat over the Gemma4 API serving engine.
 - `text-chat-q36`: Qwen-family serving engine; defaults to `text-chat-q36-nano`.
 - `text-chat-lfm2`: LFM2 serving engine; defaults to `text-chat-lfm25-a1b-8bit`.
 - `text-chat-deepseek-v4-flash`: DeepSeek V4 Flash via the bundled DS4 server.
@@ -86,6 +87,7 @@ mere.run status
   `benchmarkStats` so these experiments stay measured.
 - DS4 raw-proxies the complete OpenAI chat request to `ds4-server`.
 - Native engines reject unsupported OpenAI fields explicitly instead of silently dropping them.
+- `vision-chat-gemma4-12b` accepts one OpenAI image content part per message through `/v1/chat/completions`; use a file path, `file://` URL, or base64 data URL because the local runtime does not fetch remote images.
 - Use `stream_options.include_usage` when a client expects the OpenAI streaming usage chunk.
 
 ## Examples
@@ -98,6 +100,11 @@ mere.run api serve --engine text-code --port 8080
 mere.run model pull text-chat-gemma4
 mere.run model runtime set text-chat-gemma4 --alias chat-default --max-tokens 1024
 mere.run api serve --engine text-chat-gemma4 --port 11434
+```
+
+```bash
+mere.run model pull vision-chat-gemma4-12b
+mere.run api serve --engine text-chat-gemma4 --model vision-chat-gemma4-12b --port 11434
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -21,6 +21,33 @@ mere.run model benchmark gemma4-kv \
   --json
 ```
 
+Compare Gemma4 12B vision chat against the existing Qwen3-VL inspect backend:
+
+```bash
+mere.run model benchmark vlm --json
+```
+
+Prepare an external VLM quality run against an existing `lmms-eval` dataset:
+
+```bash
+git clone https://github.com/EvolvingLMMs-Lab/lmms-eval.git ~/src/lmms-eval
+mere.run model benchmark vlm \
+  --dataset mathvista-testmini \
+  --limit 16 \
+  --lmms-eval-root ~/src/lmms-eval \
+  --dry-run \
+  --json
+```
+
+Probe another installed chat model to confirm whether its package can accept
+image prompts:
+
+```bash
+mere.run model benchmark vlm \
+  --models vision-chat-gemma4-12b,vision-inspect-qwen3-vl-2b,text-chat-q36-nano \
+  --json
+```
+
 ## Gemma4 KV Benchmark
 
 `model benchmark gemma4-kv` runs a fixed-token comparison for the selected
@@ -46,14 +73,96 @@ Use one of:
 
 The fixture prompt is for runtime comparison only; it is not a quality eval.
 
+## VLM Benchmark
+
+`model benchmark vlm` writes a tiny deterministic image-question suite to a
+fixture directory, runs each requested vision-language backend, and grades
+answers with simple regex checks. The default suite covers:
+
+- dominant color recognition
+- corner/location recognition
+- simple object counting
+
+The default comparison is:
+
+- `vision-chat-gemma4-12b`: the managed Gemma4 12B unified vision-chat runtime.
+- `vision-inspect-qwen3-vl-2b`: the existing `vision inspect` Qwen3-VL 2B backend.
+
+Pass `--models` with comma-separated ids or aliases to compare a different set.
+Managed API-runtime models must already be installed. If a chat model does not
+include a usable vision tower, the benchmark records that as a case failure
+instead of treating it as a VLM peer. The Qwen3-VL inspect backend follows
+`vision inspect` behavior and downloads its small model on first use if needed.
+
+Output includes pass/fail, model response, elapsed time, prompt/generated token
+counts when the runtime exposes them, timing when available, and process
+resident memory before and after each case. This is an onboarding and regression
+benchmark, not a public leaderboard.
+
+### Existing VLM Datasets
+
+`model benchmark vlm` can also prepare and run `lmms-eval` tasks through
+mere.run's OpenAI-compatible API server. Presets map to upstream task names:
+
+| Dataset flag | lmms-eval task |
+| --- | --- |
+| `mathvista-testmini` | `mathvista_testmini` |
+| `mmmu-val` | `mmmu_val` |
+| `chartqa` | `chartqa` |
+| `docvqa-val` | `docvqa_val` |
+| `mme` | `mme` |
+
+Use `--dry-run --json` first to print the exact command without starting a
+server or running downloads. A non-dry run starts one local `mere.run api serve`
+process per requested model, waits for `/health`, then launches:
+
+```bash
+python3 -m lmms_eval \
+  --model openai \
+  --model_args model_version=vision-chat-gemma4-12b,base_url=http://127.0.0.1:11934/v1,api_key=mere-run-local-eval \
+  --tasks mathvista_testmini
+```
+
+Use `--lmms-tasks` to pass raw upstream task names instead of a preset:
+
+```bash
+mere.run model benchmark vlm \
+  --lmms-tasks mathvista_testmini,chartqa \
+  --limit 32 \
+  --lmms-eval-root ~/src/lmms-eval \
+  --json
+```
+
+Use `--external-endpoint --base-url` when the API server is already running:
+
+```bash
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model vision-chat-gemma4-12b \
+  --port 11934 \
+  --api-key mere-run-local-eval
+
+mere.run model benchmark vlm \
+  --dataset mathvista-testmini \
+  --external-endpoint \
+  --base-url http://127.0.0.1:11934/v1 \
+  --limit 16 \
+  --json
+```
+
 ## Notes
 
 - Pull `text-chat-gemma4-turbo` before running the benchmark.
+- Pull `vision-chat-gemma4-12b` before using it in the VLM benchmark.
+- Install `lmms-eval` dependencies in the selected Python environment before
+  running external datasets; dataset downloads and licenses are handled by the
+  upstream task definitions.
 - Prefer release builds for final numbers.
 - Treat memory values as process resident snapshots, not peak memory.
 
 ## Sources
 
 - `Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift`
+- `Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift`
 - `Sources/MereRunCore/Gemma4/Gemma4Generator.swift`
 - `Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift`

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,7 +6,8 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
+`text-chat-gemma4-12b` is the managed dense Google Gemma 4 12B-it checkpoint, routed through the native Swift Gemma 4 runtime for text chat.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
 `text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head that is used only by the adaptive long-context speculative decode path.
 `text-chat-lfm25-a1b-8bit` is the managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot and runs through the native Swift LFM2 runtime.
@@ -54,6 +55,12 @@ mere.run text chat \
   --model text-chat-gemma4 \
   --stream \
   --prompt "Explain local-first inference in one concise paragraph."
+```
+
+```bash
+mere.run text chat \
+  --model text-chat-gemma4-12b \
+  --prompt "Draft a compact Swift package release checklist."
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -357,6 +357,14 @@ actor RuntimeModelPool {
         let installPath: String?
         let settings: RuntimeModelSettings
         let spec: ManagedModelSpec?
+
+        var openAICompatibility: APIEngineCapabilities {
+            var capabilities = engine.openAICompatibility
+            if spec?.category == .visionChat {
+                capabilities.supportsVisionContentParts = true
+            }
+            return capabilities
+        }
     }
 
     private let defaultModelID: String
@@ -509,7 +517,7 @@ actor RuntimeModelPool {
         var effectiveRequest = openAIRequest
         applyDefaults(from: resolved.settings, to: &effectiveRequest)
         let contextSize = resolved.settings.maxContextTokens ?? serverContextSize
-        let capabilities = resolved.engine.openAICompatibility
+        let capabilities = resolved.openAICompatibility
         var chatRequest = try APIServerContract.chatRequest(
             from: effectiveRequest,
             fallbackLoraPath: fallbackLoraPath,

--- a/Sources/MereRunCore/Gemma4/Gemma4Config.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Config.swift
@@ -136,12 +136,54 @@ public struct Gemma4TextConfig: Decodable, Sendable, Hashable {
     }
 }
 
+public struct Gemma4UnifiedVisionConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let patchSize: Int
+    public let poolingKernelSize: Int
+    public let modelPatchSize: Int
+    public let mmEmbedDim: Int
+    public let mmPosembSize: Int
+    public let numSoftTokens: Int
+    public let rmsNormEps: Float
+    public let outputProjDims: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case patchSize = "patch_size"
+        case poolingKernelSize = "pooling_kernel_size"
+        case modelPatchSize = "model_patch_size"
+        case mmEmbedDim = "mm_embed_dim"
+        case mmPosembSize = "mm_posemb_size"
+        case numSoftTokens = "num_soft_tokens"
+        case rmsNormEps = "rms_norm_eps"
+        case outputProjDims = "output_proj_dims"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4_unified_vision"
+        self.patchSize = try container.decodeIfPresent(Int.self, forKey: .patchSize) ?? 16
+        self.poolingKernelSize = try container.decodeIfPresent(Int.self, forKey: .poolingKernelSize) ?? 3
+        self.modelPatchSize = try container.decodeIfPresent(Int.self, forKey: .modelPatchSize)
+            ?? (self.patchSize * self.poolingKernelSize)
+        self.mmEmbedDim = try container.decodeIfPresent(Int.self, forKey: .mmEmbedDim) ?? 3_840
+        self.mmPosembSize = try container.decodeIfPresent(Int.self, forKey: .mmPosembSize) ?? 1_120
+        self.numSoftTokens = try container.decodeIfPresent(Int.self, forKey: .numSoftTokens) ?? 280
+        self.rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        self.outputProjDims = try container.decodeIfPresent(Int.self, forKey: .outputProjDims) ?? self.mmEmbedDim
+    }
+}
+
 public struct Gemma4Config: Decodable, Sendable, Hashable {
     public let modelType: String
     public let architectures: [String]
     public let tieWordEmbeddings: Bool
     public let eosTokenIds: [Int]
     public let textConfig: Gemma4TextConfig
+    public let visionConfig: Gemma4UnifiedVisionConfig?
+    public let imageTokenId: Int?
+    public let boiTokenId: Int?
+    public let eoiTokenId: Int?
 
     private enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
@@ -149,6 +191,10 @@ public struct Gemma4Config: Decodable, Sendable, Hashable {
         case tieWordEmbeddings = "tie_word_embeddings"
         case eosTokenId = "eos_token_id"
         case textConfig = "text_config"
+        case visionConfig = "vision_config"
+        case imageTokenId = "image_token_id"
+        case boiTokenId = "boi_token_id"
+        case eoiTokenId = "eoi_token_id"
     }
 
     public init(from decoder: Decoder) throws {
@@ -157,6 +203,10 @@ public struct Gemma4Config: Decodable, Sendable, Hashable {
         self.architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
         self.tieWordEmbeddings = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
         self.textConfig = try container.decode(Gemma4TextConfig.self, forKey: .textConfig)
+        self.visionConfig = try container.decodeIfPresent(Gemma4UnifiedVisionConfig.self, forKey: .visionConfig)
+        self.imageTokenId = try container.decodeIfPresent(Int.self, forKey: .imageTokenId)
+        self.boiTokenId = try container.decodeIfPresent(Int.self, forKey: .boiTokenId)
+        self.eoiTokenId = try container.decodeIfPresent(Int.self, forKey: .eoiTokenId)
 
         if let direct = try container.decodeIfPresent([Int].self, forKey: .eosTokenId) {
             self.eosTokenIds = direct

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -87,7 +87,7 @@ public actor Gemma4Generator: ChatGenerator {
     private static let prefillChunkSize = 512
     private static let prefixKVCacheMaxEntries = 4
 
-    private var model: Gemma4TextCausalLM?
+    private var model: (any Gemma4CausalModel)?
     private var tokenizerAndTemplate: Gemma4TokenizerAndTemplate?
     private var loadedModelPath: String?
     private var loadedConfig: Gemma4Config?
@@ -228,10 +228,15 @@ public actor Gemma4Generator: ChatGenerator {
         )
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 weights"))
-        let textModel = Gemma4TextCausalLM(config: config.textConfig)
-        try loadWeights(into: textModel, from: resources, config: config)
-
-        model = textModel
+        if Gemma4Resources.supportsVision(modelSpec: modelId) {
+            let unifiedModel = try Gemma4UnifiedCausalLM(config: config)
+            try loadWeights(into: unifiedModel, from: resources, config: config)
+            model = unifiedModel
+        } else {
+            let textModel = Gemma4TextCausalLM(config: config.textConfig)
+            try loadWeights(into: textModel, from: resources, config: config)
+            model = textModel
+        }
         tokenizerAndTemplate = tokenizer
         loadedConfig = config
         loadedModelPath = normalizedRoot.path
@@ -258,6 +263,31 @@ public actor Gemma4Generator: ChatGenerator {
         )
         let prefillStart = Date()
         let messages = request.messages
+        let imageReferences = messages.compactMap { message -> String? in
+            guard let imageURL = message.imageUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !imageURL.isEmpty else {
+                return nil
+            }
+            return imageURL
+        }
+        let imageBatch: Gemma4UnifiedImageBatch?
+        if imageReferences.isEmpty {
+            imageBatch = nil
+        } else {
+            guard let visionConfig = loadedConfig.visionConfig,
+                  loadedConfig.imageTokenId != nil,
+                  loadedConfig.boiTokenId != nil,
+                  loadedConfig.eoiTokenId != nil else {
+                throw Gemma4Error.unsupportedConfiguration("This Gemma4 model does not support image inputs.")
+            }
+            guard model is Gemma4UnifiedCausalLM else {
+                throw Gemma4Error.unsupportedConfiguration("Image inputs require \(Gemma4Resources.visionTwelveBModelId).")
+            }
+            imageBatch = try Gemma4UnifiedImageProcessor.makeBatch(
+                imageReferences: imageReferences,
+                visionConfig: visionConfig
+            )
+        }
         var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
             messages: messages,
             tools: request.tools,
@@ -265,6 +295,20 @@ public actor Gemma4Generator: ChatGenerator {
             includeThinking: request.showThinking,
             maxLength: effectiveContext
         )
+        if let imageBatch {
+            guard let imageTokenId = loadedConfig.imageTokenId,
+                  let boiTokenId = loadedConfig.boiTokenId,
+                  let eoiTokenId = loadedConfig.eoiTokenId else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 unified prompt expansion requires image token IDs.")
+            }
+            promptTokens = try Gemma4UnifiedImageProcessor.expandedPromptTokens(
+                promptTokens,
+                softTokenCounts: imageBatch.softTokenCounts,
+                imageTokenId: imageTokenId,
+                boiTokenId: boiTokenId,
+                eoiTokenId: eoiTokenId
+            )
+        }
         if promptTokens.count > effectiveContext {
             promptTokens = Array(promptTokens.suffix(effectiveContext))
         }
@@ -287,34 +331,51 @@ public actor Gemma4Generator: ChatGenerator {
             repetitionContextSize: 64
         )
 
-        let prefixSeed = prefixKVCacheSeed(
+        let usePrefixKVCache = imageBatch == nil
+        let prefixSeed = usePrefixKVCache ? prefixKVCacheSeed(
             modelPath: loadedModelPath ?? "",
             quantization: kvCacheQuantization,
             promptTokens: promptTokens
-        )
-        let prefixCheckpoints = semanticPrefixCheckpoints(
+        ) : nil
+        let prefixCheckpoints = usePrefixKVCache ? semanticPrefixCheckpoints(
             tokenizerAndTemplate: tokenizerAndTemplate,
             messages: messages,
             tools: request.tools,
             includeThinking: request.showThinking,
             promptTokens: promptTokens,
             maxContextLength: effectiveContext
-        )
+        ) : []
         let layerCaches = try prefixSeed?.caches ?? makeLayerCaches(
             model: model,
             quantization: prefillKVCacheQuantization
         )
-        let logits = try await chunkedPrefill(
-            model: model,
-            promptTokens: promptTokens,
-            cache: layerCaches,
-            startIndex: prefixSeed?.tokenCount ?? 0,
-            existingLogits: prefixSeed?.logits,
-            modelPath: loadedModelPath ?? "",
-            quantization: kvCacheQuantization,
-            checkpointTokenCounts: prefixCheckpoints,
-            progressHandler: progressHandler
-        )
+        let logits: MLXArray
+        if let imageBatch {
+            guard let unifiedModel = model as? Gemma4UnifiedCausalLM,
+                  let imageTokenId = loadedConfig.imageTokenId else {
+                throw Gemma4Error.unsupportedConfiguration("Gemma4 unified prefill requires a unified runtime model.")
+            }
+            logits = try await unifiedPrefill(
+                model: unifiedModel,
+                promptTokens: promptTokens,
+                imageBatch: imageBatch,
+                imageTokenId: imageTokenId,
+                cache: layerCaches,
+                progressHandler: progressHandler
+            )
+        } else {
+            logits = try await chunkedPrefill(
+                model: model,
+                promptTokens: promptTokens,
+                cache: layerCaches,
+                startIndex: prefixSeed?.tokenCount ?? 0,
+                existingLogits: prefixSeed?.logits,
+                modelPath: loadedModelPath ?? "",
+                quantization: kvCacheQuantization,
+                checkpointTokenCounts: prefixCheckpoints,
+                progressHandler: progressHandler
+            )
+        }
 
         let prefillSeconds = Date().timeIntervalSince(prefillStart)
         let preparedCaches = try prepareLayerCachesForDecode(
@@ -338,7 +399,10 @@ public actor Gemma4Generator: ChatGenerator {
             progressHandler: progressHandler
         )
         let generated = decodeResult.generatedTokens
-        let decoded = tokenizerAndTemplate.decode(tokens: generated)
+        let decoded = Self.cleanedResponse(
+            tokenizerAndTemplate.decode(tokens: generated),
+            showThinking: request.showThinking
+        )
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         let toolCalls: [ToolCall]? = hasTools ? {
@@ -386,6 +450,62 @@ public actor Gemma4Generator: ChatGenerator {
         quantization.isEnabled && quantization.scheme == .polar
     }
 
+    static func cleanedResponse(_ response: String, showThinking: Bool) -> String {
+        guard !showThinking else { return response }
+
+        if let finalRange = response.range(
+            of: #"(?is)<\|channel>final\s*"#,
+            options: .regularExpression
+        ) {
+            return String(response[finalRange.upperBound...])
+                .replacingOccurrences(
+                    of: #"(?is)<\|channel>[a-z_]+\s*"#,
+                    with: "",
+                    options: .regularExpression
+                )
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let thoughtCloseRange = response.range(
+            of: #"(?is)<\|channel>thought\b.*?<channel\|>\s*"#,
+            options: .regularExpression
+        ) {
+            return String(response[thoughtCloseRange.upperBound...])
+                .replacingOccurrences(
+                    of: #"(?is)<\|channel>[a-z_]+\s*|<channel\|>"#,
+                    with: "",
+                    options: .regularExpression
+                )
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var cleaned = response.replacingOccurrences(
+            of: #"(?is)<\|channel>thought\b.*\z"#,
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?is)<think>.*?</think>",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?is)<think>.*\\z",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?i)</think>",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: #"(?is)<\|channel>[a-z_]+\s*|<channel\|>"#,
+            with: "",
+            options: .regularExpression
+        )
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func prepareLayerCachesForDecode(
         _ layerCaches: [Gemma4AttentionCache],
         quantization: Gemma4KVCacheQuantization,
@@ -408,7 +528,7 @@ public actor Gemma4Generator: ChatGenerator {
     }
 
     private func decodeTokens(
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
         initialLogits: MLXArray,
         layerCaches: [Gemma4AttentionCache],
@@ -462,7 +582,7 @@ public actor Gemma4Generator: ChatGenerator {
     }
 
     private func decodeTokensSerially(
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
         initialLogits: MLXArray,
         layerCaches: [Gemma4AttentionCache],
@@ -505,7 +625,7 @@ public actor Gemma4Generator: ChatGenerator {
                 break
             }
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
-            logits = model(nextInput, cache: layerCaches as [AnyObject])
+            logits = model.forward(inputIds: nextInput, cache: layerCaches as [AnyObject])
             MLX.eval(logits)
         }
 
@@ -518,7 +638,7 @@ public actor Gemma4Generator: ChatGenerator {
 
     private func enqueueDecodeRow(
         _ row: Gemma4BatchedDecodeRow,
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         tokenizerAndTemplate: Gemma4TokenizerAndTemplate
     ) {
         decodeQueue.append(row)
@@ -538,7 +658,7 @@ public actor Gemma4Generator: ChatGenerator {
     }
 
     private func startDecodeLoopIfNeeded(
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         tokenizerAndTemplate: Gemma4TokenizerAndTemplate
     ) {
         guard !decodeLoopRunning else { return }
@@ -549,7 +669,7 @@ public actor Gemma4Generator: ChatGenerator {
     }
 
     private func runDecodeLoop(
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         tokenizerAndTemplate: Gemma4TokenizerAndTemplate
     ) async {
         defer {
@@ -615,7 +735,7 @@ public actor Gemma4Generator: ChatGenerator {
 
     private func decodeOneStep(
         rows: [Gemma4BatchedDecodeRow],
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         tokenizerAndTemplate: Gemma4TokenizerAndTemplate
     ) throws {
         let sampledRows = rows.filter(\.needsDecodeStep)
@@ -649,7 +769,7 @@ public actor Gemma4Generator: ChatGenerator {
            let batchedCaches = makeBatchedLayerCaches(continuingRows.map(\.layerCaches)) {
             let nextInput = MLXArray(continuingRows.compactMap { $0.generatedTokens.last }.map(Int32.init))
                 .reshaped(continuingRows.count, 1)
-            let batchedLogits = model(nextInput, cache: batchedCaches as [AnyObject])
+            let batchedLogits = model.forward(inputIds: nextInput, cache: batchedCaches as [AnyObject])
             MLX.eval(batchedLogits)
             guard let splitCaches = splitBatchedLayerCaches(batchedCaches, rowCount: continuingRows.count) else {
                 throw Gemma4Error.unsupportedConfiguration("Gemma4 batched decode could not split merged KV cache rows.")
@@ -672,7 +792,7 @@ public actor Gemma4Generator: ChatGenerator {
         for row in continuingRows {
             guard let next = row.generatedTokens.last else { continue }
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
-            row.logits = model(nextInput, cache: row.layerCaches as [AnyObject])
+            row.logits = model.forward(inputIds: nextInput, cache: row.layerCaches as [AnyObject])
             MLX.eval(row.logits)
             singleDecodeSteps += 1
         }
@@ -745,7 +865,7 @@ public actor Gemma4Generator: ChatGenerator {
     }
 
     private func chunkedPrefill(
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         promptTokens: [Int],
         cache: [Gemma4AttentionCache],
         startIndex: Int,
@@ -777,7 +897,7 @@ public actor Gemma4Generator: ChatGenerator {
             }
             let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
                 .reshaped(1, end - processed)
-            let chunkLogits = model(chunk, cache: cache as [AnyObject])
+            let chunkLogits = model.forward(inputIds: chunk, cache: cache as [AnyObject])
             MLX.eval(chunkLogits)
             logits = chunkLogits
             processed = end
@@ -799,8 +919,42 @@ public actor Gemma4Generator: ChatGenerator {
         return logits
     }
 
+    private func unifiedPrefill(
+        model: Gemma4UnifiedCausalLM,
+        promptTokens: [Int],
+        imageBatch: Gemma4UnifiedImageBatch,
+        imageTokenId: Int,
+        cache: [Gemma4AttentionCache],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> MLXArray {
+        guard !promptTokens.isEmpty else {
+            throw Gemma4Error.unsupportedConfiguration("Prompt is empty after tokenization.")
+        }
+
+        progressHandler?(ChatProgress(
+            stage: .encoding,
+            message: "Prefilling \(promptTokens.count) multimodal tokens"
+        ))
+        let inputIds = MLXArray(promptTokens.map(Int32.init))
+            .reshaped(1, promptTokens.count)
+        let mmTokenTypeIds = Gemma4UnifiedImageProcessor.mmTokenTypeIds(
+            tokens: promptTokens,
+            imageTokenId: imageTokenId
+        )
+        let logits = try model.forward(
+            inputIds: inputIds,
+            pixelValues: imageBatch.pixelValues,
+            imagePositionIds: imageBatch.imagePositionIds,
+            mmTokenTypeIds: mmTokenTypeIds,
+            cache: cache as [AnyObject]
+        )
+        MLX.eval(logits)
+        await Task.yield()
+        return logits
+    }
+
     private func makeLayerCaches(
-        model: Gemma4TextCausalLM,
+        model: any Gemma4CausalModel,
         quantization: Gemma4KVCacheQuantization
     ) throws -> [Gemma4AttentionCache] {
         guard let caches = model.makeCache(quantization: quantization) as? [Gemma4AttentionCache] else {
@@ -1097,5 +1251,68 @@ public actor Gemma4Generator: ChatGenerator {
         } else {
             throw Gemma4Error.missingFiles([resources.modelIndexURL.lastPathComponent, resources.modelWeightsURL.lastPathComponent])
         }
+    }
+
+    private func loadWeights(
+        into model: Gemma4UnifiedCausalLM,
+        from resources: Gemma4Resources,
+        config: Gemma4Config
+    ) throws {
+        let include: (String) -> Bool = { key in
+            Self.normalizedUnifiedWeightKey(key) != nil
+        }
+        let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            guard let mapped = Self.normalizedUnifiedWeightKey(key) else {
+                return []
+            }
+            return [(mapped, value)]
+        }
+
+        if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
+            try HFSafetensorsWeightsLoader.applyShardedWeights(
+                indexURL: resources.modelIndexURL,
+                to: model,
+                dtype: .bfloat16,
+                verify: .none,
+                mapper: mapper
+            )
+        } else if FileManager.default.fileExists(atPath: resources.modelWeightsURL.path) {
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: resources.modelWeightsURL,
+                to: model,
+                dtype: .bfloat16,
+                verify: .none,
+                include: include,
+                mapper: mapper,
+                batchSize: 24
+            )
+        } else {
+            throw Gemma4Error.missingFiles([resources.modelIndexURL.lastPathComponent, resources.modelWeightsURL.lastPathComponent])
+        }
+        _ = config
+    }
+
+    private static func normalizedUnifiedWeightKey(_ key: String) -> String? {
+        guard !key.contains("rotary_emb"),
+              key != "lm_head.weight",
+              !key.contains("embed_audio") else {
+            return nil
+        }
+
+        let withoutModelPrefix = key.hasPrefix("model.")
+            ? String(key.dropFirst("model.".count))
+            : key
+
+        if withoutModelPrefix.hasPrefix("language_model.model.") {
+            return "language_model.\(withoutModelPrefix.dropFirst("language_model.model.".count))"
+        }
+        if withoutModelPrefix.hasPrefix("language_model.") {
+            return withoutModelPrefix
+        }
+        if withoutModelPrefix.hasPrefix("vision_embedder.")
+            || withoutModelPrefix.hasPrefix("embed_vision.") {
+            return withoutModelPrefix
+        }
+        return nil
     }
 }

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -18,6 +18,11 @@ private func gemma4RMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
     return normalized.asType(dtype)
 }
 
+protocol Gemma4CausalModel: AnyObject {
+    func forward(inputIds: MLXArray, cache: [AnyObject]?) -> MLXArray
+    func makeCache(quantization: Gemma4KVCacheQuantization?) -> [AnyObject]
+}
+
 /// Proportional RoPE for Gemma 4 full-attention layers.
 ///
 /// Frequencies are computed relative to the **full** head dimension (not just the
@@ -606,7 +611,8 @@ final class Gemma4Attention: Module {
 
     func callAsFunction(
         _ x: MLXArray,
-        cache: Gemma4AttentionCache?
+        cache: Gemma4AttentionCache?,
+        visionBlockIDs: MLXArray? = nil
     ) -> MLXArray {
         let batchSize = x.dim(0)
         let sequenceLength = x.dim(1)
@@ -690,7 +696,8 @@ final class Gemma4Attention: Module {
             queryOffset: offset,
             keyLength: broadcastKeys.dim(2),
             windowSize: layerType == "sliding_attention" ? windowSize : nil,
-            dtype: x.dtype
+            dtype: x.dtype,
+            visionBlockIDs: visionBlockIDs
         )
 
         let attended = MLXFast.scaledDotProductAttention(
@@ -709,7 +716,8 @@ final class Gemma4Attention: Module {
         queryOffset: Int,
         keyLength: Int,
         windowSize: Int?,
-        dtype: DType
+        dtype: DType,
+        visionBlockIDs: MLXArray?
     ) -> MLXFast.ScaledDotProductAttentionMaskMode {
         guard queryLength > 1 else {
             return .none
@@ -722,6 +730,16 @@ final class Gemma4Attention: Module {
         var allowed = keyPositions .<= queryPositions
         if let windowSize {
             allowed = allowed .&& (keyPositions .> (queryPositions - Int32(windowSize)))
+        }
+        if let visionBlockIDs,
+           queryOffset == 0,
+           keyStart == 0,
+           visionBlockIDs.dim(0) == queryLength,
+           keyLength == queryLength {
+            let queryBlocks = visionBlockIDs.reshaped(queryLength, 1)
+            let keyBlocks = visionBlockIDs.reshaped(1, keyLength)
+            let sameVisionBlock = (queryBlocks .>= MLXArray(Int32(0))) .&& (queryBlocks .== keyBlocks)
+            allowed = (allowed.asType(.int32) + sameVisionBlock.asType(.int32)) .> MLXArray(Int32(0))
         }
 
         let allowedTyped = allowed.asType(dtype).reshaped(1, 1, queryLength, keyLength)
@@ -781,11 +799,12 @@ final class Gemma4DecoderLayer: Module {
     func callAsFunction(
         _ x: MLXArray,
         cache: Gemma4AttentionCache?,
-        perLayerInput: MLXArray?
+        perLayerInput: MLXArray?,
+        visionBlockIDs: MLXArray? = nil
     ) -> MLXArray {
         let attentionResidual = x
         var hidden = inputLayerNorm(x)
-        hidden = selfAttention(hidden, cache: cache)
+        hidden = selfAttention(hidden, cache: cache, visionBlockIDs: visionBlockIDs)
         hidden = postAttentionLayerNorm(hidden)
         hidden = attentionResidual + hidden
 
@@ -894,20 +913,43 @@ final class Gemma4LanguageModel: Module {
             tokenIds = tokenIds.asType(.int32)
         }
 
-        var hidden = embedTokens(tokenIds) * MLXArray(embedScale).asType(embedTokens.weight.dtype)
-        let perLayerInputs = projectPerLayerInputs(
-            hiddenStates: hidden,
-            inputIds: tokenIds
+        let hidden = embeddings(inputIds: tokenIds)
+        return forward(
+            embeddings: hidden,
+            inputIds: tokenIds,
+            cache: cache,
+            mmTokenTypeIds: nil
         )
+    }
 
+    func embeddings(inputIds: MLXArray) -> MLXArray {
+        embedTokens(inputIds) * MLXArray(embedScale).asType(embedTokens.weight.dtype)
+    }
+
+    func forward(
+        embeddings: MLXArray,
+        inputIds: MLXArray?,
+        cache: [Gemma4AttentionCache]? = nil,
+        mmTokenTypeIds: MLXArray? = nil
+    ) -> MLXArray {
+        var hidden = embeddings
+        let perLayerInputs = inputIds.flatMap { tokenIds -> MLXArray? in
+            guard config.hiddenSizePerLayerInput > 0 else { return nil }
+            return projectPerLayerInputs(
+                hiddenStates: hidden,
+                inputIds: tokenIds
+            )
+        }
+        let visionBlockIDs = Self.visionBlockIDs(from: mmTokenTypeIds, sequenceLength: hidden.dim(1))
         let caches = cache ?? makeCache()
         for (index, layer) in layers.enumerated() {
             let cacheIndex = index < layerIndexToCacheIndex.count ? layerIndexToCacheIndex[index] : index
-            let perLayerInput = perLayerInputs[0..., 0..., index, 0...]
+            let perLayerInput = perLayerInputs?[0..., 0..., index, 0...]
             hidden = layer(
                 hidden,
                 cache: cacheIndex < caches.count ? caches[cacheIndex] : nil,
-                perLayerInput: perLayerInput
+                perLayerInput: perLayerInput,
+                visionBlockIDs: visionBlockIDs
             )
         }
         return norm(hidden)
@@ -915,6 +957,21 @@ final class Gemma4LanguageModel: Module {
 
     func logits(_ inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> MLXArray {
         let hidden = self(inputIds, cache: cache)
+        return embedTokens.asLinear(hidden)
+    }
+
+    func logits(
+        embeddings: MLXArray,
+        inputIds: MLXArray?,
+        cache: [Gemma4AttentionCache]? = nil,
+        mmTokenTypeIds: MLXArray? = nil
+    ) -> MLXArray {
+        let hidden = forward(
+            embeddings: embeddings,
+            inputIds: inputIds,
+            cache: cache,
+            mmTokenTypeIds: mmTokenTypeIds
+        )
         return embedTokens.asLinear(hidden)
     }
 
@@ -956,9 +1013,33 @@ final class Gemma4LanguageModel: Module {
         projected = perLayerProjectionNorm(projected)
         return (projected + reshapedEmbedding) * MLXArray(perLayerInputScale).asType(hiddenStates.dtype)
     }
+
+    private static func visionBlockIDs(from mmTokenTypeIds: MLXArray?, sequenceLength: Int) -> MLXArray? {
+        guard let mmTokenTypeIds, sequenceLength > 1 else { return nil }
+        let typed = mmTokenTypeIds.asType(.int32)
+        MLX.eval(typed)
+        let values = typed.asArray(Int32.self)
+        guard values.count >= sequenceLength else { return nil }
+
+        var blockIDs = [Int32](repeating: -1, count: sequenceLength)
+        var currentBlock: Int32 = -1
+        var previousWasVision = false
+        for index in 0..<sequenceLength {
+            let value = values[index]
+            let isVision = value == 1 || value == 2
+            if isVision && !previousWasVision {
+                currentBlock += 1
+            }
+            if isVision {
+                blockIDs[index] = currentBlock
+            }
+            previousWasVision = isVision
+        }
+        return MLXArray(blockIDs)
+    }
 }
 
-public final class Gemma4TextCausalLM: Module, @unchecked Sendable {
+public final class Gemma4TextCausalLM: Module, Gemma4CausalModel, @unchecked Sendable {
     @ModuleInfo(key: "language_model") var languageModel: Gemma4LanguageModel
 
     public let config: Gemma4TextConfig
@@ -984,7 +1065,217 @@ public final class Gemma4TextCausalLM: Module, @unchecked Sendable {
         return logits
     }
 
+    func forward(inputIds: MLXArray, cache: [AnyObject]? = nil) -> MLXArray {
+        self(inputIds, cache: cache)
+    }
+
     public func makeCache(quantization: Gemma4KVCacheQuantization? = nil) -> [AnyObject] {
         languageModel.makeCache(quantization: quantization)
+    }
+}
+
+final class Gemma4UnifiedVisionEmbedder: Module {
+    @ModuleInfo(key: "patch_ln1") var patchLN1: LayerNorm
+    @ModuleInfo(key: "patch_dense") var patchDense: Linear
+    @ModuleInfo(key: "patch_ln2") var patchLN2: LayerNorm
+    @ParameterInfo(key: "pos_embedding") var positionEmbedding: MLXArray
+    @ModuleInfo(key: "pos_norm") var positionNorm: LayerNorm
+
+    private let patchDim: Int
+
+    init(config: Gemma4UnifiedVisionConfig) {
+        self.patchDim = config.modelPatchSize * config.modelPatchSize * 3
+        self._patchLN1.wrappedValue = LayerNorm(dimensions: patchDim, eps: config.rmsNormEps)
+        self._patchDense.wrappedValue = Linear(patchDim, config.mmEmbedDim, bias: true)
+        self._patchLN2.wrappedValue = LayerNorm(dimensions: config.mmEmbedDim, eps: config.rmsNormEps)
+        self._positionEmbedding.wrappedValue = MLXArray.zeros([config.mmPosembSize, 2, config.mmEmbedDim])
+        self._positionNorm.wrappedValue = LayerNorm(dimensions: config.mmEmbedDim, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        pixelValues: MLXArray,
+        imagePositionIds: MLXArray?
+    ) -> MLXArray {
+        var hidden = pixelValues
+        if hidden.ndim == 4 && hidden.dim(-1) == patchDim {
+            hidden = hidden.reshaped(hidden.dim(0), -1, patchDim)
+        }
+        hidden = patchLN1(hidden)
+        hidden = patchDense(hidden)
+        hidden = patchLN2(hidden)
+
+        if let imagePositionIds {
+            let xIds = MLX.maximum(imagePositionIds[0..., 0..., 0], MLXArray(Int32(0))).asType(.int32)
+            let yIds = MLX.maximum(imagePositionIds[0..., 0..., 1], MLXArray(Int32(0))).asType(.int32)
+            let xValid = (imagePositionIds[0..., 0..., 0] .>= MLXArray(Int32(0)))
+                .asType(hidden.dtype)
+                .expandedDimensions(axis: -1)
+            let yValid = (imagePositionIds[0..., 0..., 1] .>= MLXArray(Int32(0)))
+                .asType(hidden.dtype)
+                .expandedDimensions(axis: -1)
+            let xTable = positionEmbedding[0..., 0, 0...]
+            let yTable = positionEmbedding[0..., 1, 0...]
+            let xPos = take(xTable, xIds, axis: 0)
+            let yPos = take(yTable, yIds, axis: 0)
+            hidden = hidden + (xPos * xValid + yPos * yValid).asType(hidden.dtype)
+        }
+
+        return positionNorm(hidden)
+    }
+}
+
+final class Gemma4UnifiedMultimodalEmbedder: Module {
+    @ModuleInfo(key: "embedding_projection") var embeddingProjection: Linear
+
+    private let eps: Float
+
+    init(embeddingDim: Int, textHiddenSize: Int, eps: Float) {
+        self.eps = eps
+        self._embeddingProjection.wrappedValue = Linear(embeddingDim, textHiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ inputsEmbeds: MLXArray) -> MLXArray {
+        embeddingProjection(gemma4RMSNormNoScale(inputsEmbeds, eps: eps))
+    }
+}
+
+public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked Sendable {
+    @ModuleInfo(key: "language_model") var languageModel: Gemma4LanguageModel
+    @ModuleInfo(key: "vision_embedder") var visionEmbedder: Gemma4UnifiedVisionEmbedder
+    @ModuleInfo(key: "embed_vision") var embedVision: Gemma4UnifiedMultimodalEmbedder
+
+    public let config: Gemma4Config
+    private let finalLogitSoftcapping: Float?
+    private let imageTokenId: Int
+
+    public init(config: Gemma4Config) throws {
+        guard let visionConfig = config.visionConfig else {
+            throw Gemma4Error.unsupportedConfiguration("Gemma4 unified runtime requires vision_config.")
+        }
+        guard let imageTokenId = config.imageTokenId else {
+            throw Gemma4Error.unsupportedConfiguration("Gemma4 unified runtime requires image_token_id.")
+        }
+        self.config = config
+        self.finalLogitSoftcapping = config.textConfig.finalLogitSoftcapping
+        self.imageTokenId = imageTokenId
+        self._languageModel.wrappedValue = Gemma4LanguageModel(config: config.textConfig)
+        self._visionEmbedder.wrappedValue = Gemma4UnifiedVisionEmbedder(config: visionConfig)
+        self._embedVision.wrappedValue = Gemma4UnifiedMultimodalEmbedder(
+            embeddingDim: visionConfig.outputProjDims,
+            textHiddenSize: config.textConfig.hiddenSize,
+            eps: visionConfig.rmsNormEps
+        )
+        super.init()
+    }
+
+    func forward(inputIds: MLXArray, cache: [AnyObject]? = nil) -> MLXArray {
+        let typedCache = cache as? [Gemma4AttentionCache]
+        var logits = languageModel.logits(inputIds, cache: typedCache)
+        if let finalLogitSoftcapping {
+            let softcap = MLXArray(finalLogitSoftcapping).asType(logits.dtype)
+            logits = tanh(logits / softcap) * softcap
+        }
+        return logits
+    }
+
+    func forward(
+        inputIds: MLXArray,
+        pixelValues: MLXArray,
+        imagePositionIds: MLXArray,
+        mmTokenTypeIds: MLXArray,
+        cache: [AnyObject]? = nil
+    ) throws -> MLXArray {
+        let typedCache = cache as? [Gemma4AttentionCache]
+        var tokenIds = inputIds
+        if tokenIds.dtype != .int32 {
+            tokenIds = tokenIds.asType(.int32)
+        }
+        var embeddings = languageModel.embeddings(inputIds: tokenIds)
+        let imageFeatures = try compactImageFeatures(
+            pixelValues: pixelValues,
+            imagePositionIds: imagePositionIds,
+            dtype: embeddings.dtype
+        )
+        embeddings = try replaceImageEmbeddings(
+            embeddings,
+            inputIds: tokenIds,
+            imageFeatures: imageFeatures
+        )
+        var logits = languageModel.logits(
+            embeddings: embeddings,
+            inputIds: tokenIds,
+            cache: typedCache,
+            mmTokenTypeIds: mmTokenTypeIds
+        )
+        if let finalLogitSoftcapping {
+            let softcap = MLXArray(finalLogitSoftcapping).asType(logits.dtype)
+            logits = tanh(logits / softcap) * softcap
+        }
+        return logits
+    }
+
+    public func makeCache(quantization: Gemma4KVCacheQuantization? = nil) -> [AnyObject] {
+        languageModel.makeCache(quantization: quantization)
+    }
+
+    private func compactImageFeatures(
+        pixelValues: MLXArray,
+        imagePositionIds: MLXArray,
+        dtype: DType
+    ) throws -> MLXArray {
+        let embedded = visionEmbedder(pixelValues: pixelValues, imagePositionIds: imagePositionIds)
+        let projected = embedVision(embedded).asType(dtype)
+        let typedPositions = imagePositionIds.asType(.int32)
+        MLX.eval(typedPositions)
+        let positions = typedPositions.asArray(Int32.self)
+        let batch = projected.dim(0)
+        let tokenCount = projected.dim(1)
+        let hiddenSize = projected.dim(2)
+        guard positions.count >= batch * tokenCount * 2 else {
+            throw Gemma4Error.unsupportedConfiguration("Gemma4 unified image positions have an invalid shape.")
+        }
+
+        var rows: [MLXArray] = []
+        rows.reserveCapacity(batch * tokenCount)
+        for batchIndex in 0..<batch {
+            for tokenIndex in 0..<tokenCount {
+                let offset = ((batchIndex * tokenCount) + tokenIndex) * 2
+                guard positions[offset] >= 0, positions[offset + 1] >= 0 else {
+                    continue
+                }
+                rows.append(projected[batchIndex, tokenIndex, 0...].reshaped(1, hiddenSize))
+            }
+        }
+        guard !rows.isEmpty else {
+            throw Gemma4Error.unsupportedConfiguration("Gemma4 unified image preprocessing produced no visual tokens.")
+        }
+        return concatenated(rows, axis: 0)
+    }
+
+    private func replaceImageEmbeddings(
+        _ embeddings: MLXArray,
+        inputIds: MLXArray,
+        imageFeatures: MLXArray
+    ) throws -> MLXArray {
+        let tokenIds = inputIds.asType(.int32)
+        MLX.eval(tokenIds)
+        let values = tokenIds.asArray(Int32.self)
+        let sequenceLength = embeddings.dim(1)
+        let imagePositions = values.prefix(sequenceLength).enumerated().compactMap { index, value in
+            value == Int32(imageTokenId) ? index : nil
+        }
+        guard imagePositions.count == imageFeatures.dim(0) else {
+            throw Gemma4Error.unsupportedConfiguration(
+                "Gemma4 unified prompt has \(imagePositions.count) image tokens but image preprocessing produced \(imageFeatures.dim(0)) visual features."
+            )
+        }
+
+        let merged = embeddings
+        for (featureIndex, position) in imagePositions.enumerated() {
+            merged[0, position, 0...] = imageFeatures[featureIndex, 0...]
+        }
+        return merged
     }
 }

--- a/Sources/MereRunCore/Gemma4/Gemma4Resources.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Resources.swift
@@ -5,9 +5,12 @@ public struct Gemma4Resources: Sendable, Hashable {
     public static let nanoModelId = "text-chat-gemma4-nano"
     public static let maxModelId = "text-chat-gemma4-max"
     public static let turboModelId = "text-chat-gemma4-turbo"
+    public static let twelveBModelId = "text-chat-gemma4-12b"
+    public static let visionTwelveBModelId = "vision-chat-gemma4-12b"
     public static let nanoUpstreamModelId = "google/gemma-4-E4B-it"
     public static let maxUpstreamModelId = "google/gemma-4-31B-it"
     public static let turboUpstreamModelId = "mlx-community/gemma-4-26b-a4b-it-nvfp4"
+    public static let twelveBUpstreamModelId = "google/gemma-4-12B-it"
     public static let defaultUpstreamModelId = maxUpstreamModelId
     public static let defaultContextLength = 32_768
     public static let defaultKVGroupSize = 64
@@ -28,6 +31,9 @@ public struct Gemma4Resources: Sendable, Hashable {
         "generation_config.json",
         "tokenizer.json",
         "tokenizer_config.json",
+        "processor_config.json",
+        "preprocessor_config.json",
+        "video_preprocessor_config.json",
         "chat_template.jinja",
         "chat_template.json",
         "model.safetensors",
@@ -46,9 +52,11 @@ public struct Gemma4Resources: Sendable, Hashable {
     public var modelWeightsURL: URL { rootURL.appending(path: "model.safetensors") }
     public var tokenizerURL: URL { rootURL.appending(path: "tokenizer.json") }
     public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
+    public var processorConfigURL: URL { rootURL.appending(path: "processor_config.json") }
+    public var preprocessorConfigURL: URL { rootURL.appending(path: "preprocessor_config.json") }
     public var chatTemplateURL: URL { rootURL.appending(path: "chat_template.jinja") }
 
-    public func validate(fileManager: FileManager = .default) -> [URL] {
+    public func validate(fileManager: FileManager = .default, requireUnifiedProcessor: Bool = false) -> [URL] {
         var missing: [URL] = []
 
         if !fileManager.fileExists(atPath: configURL.path) {
@@ -67,6 +75,12 @@ public struct Gemma4Resources: Sendable, Hashable {
 
         if !fileManager.fileExists(atPath: tokenizerConfigURL.path) {
             missing.append(tokenizerConfigURL)
+        }
+
+        if requireUnifiedProcessor,
+           !fileManager.fileExists(atPath: processorConfigURL.path),
+           !fileManager.fileExists(atPath: preprocessorConfigURL.path) {
+            missing.append(processorConfigURL)
         }
 
         return missing
@@ -100,6 +114,14 @@ public struct Gemma4Resources: Sendable, Hashable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         return normalized == turboModelId || normalized == turboUpstreamModelId.lowercased()
+    }
+
+    public static func supportsVision(modelSpec raw: String) -> Bool {
+        let normalized = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized == visionTwelveBModelId
+            || normalized == twelveBUpstreamModelId.lowercased()
     }
 }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4UnifiedImageProcessor.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4UnifiedImageProcessor.swift
@@ -1,0 +1,206 @@
+import Foundation
+import MediaIO
+import MLX
+
+struct Gemma4UnifiedImageBatch {
+    let pixelValues: MLXArray
+    let imagePositionIds: MLXArray
+    let softTokenCounts: [Int]
+}
+
+enum Gemma4UnifiedImageProcessor {
+    static func makeBatch(
+        imageReferences: [String],
+        visionConfig: Gemma4UnifiedVisionConfig
+    ) throws -> Gemma4UnifiedImageBatch {
+        guard !imageReferences.isEmpty else {
+            throw Gemma4Error.unsupportedConfiguration("Gemma4 unified image batch is empty.")
+        }
+
+        let maxSoftTokens = max(1, visionConfig.numSoftTokens)
+        let modelPatchSize = max(1, visionConfig.modelPatchSize)
+        let patchDim = modelPatchSize * modelPatchSize * 3
+
+        var allPatches: [Float] = []
+        var allPositions: [Int32] = []
+        var softTokenCounts: [Int] = []
+        allPatches.reserveCapacity(imageReferences.count * maxSoftTokens * patchDim)
+        allPositions.reserveCapacity(imageReferences.count * maxSoftTokens * 2)
+        softTokenCounts.reserveCapacity(imageReferences.count)
+
+        for reference in imageReferences {
+            let image = try decodeImage(reference)
+            let processed = try preprocess(
+                image,
+                visionConfig: visionConfig,
+                maxSoftTokens: maxSoftTokens,
+                modelPatchSize: modelPatchSize
+            )
+            softTokenCounts.append(processed.softTokenCount)
+            allPatches.append(contentsOf: processed.patches)
+            allPositions.append(contentsOf: processed.positions)
+        }
+
+        return Gemma4UnifiedImageBatch(
+            pixelValues: MLXArray(allPatches, [imageReferences.count, maxSoftTokens, patchDim]),
+            imagePositionIds: MLXArray(allPositions, [imageReferences.count, maxSoftTokens, 2]),
+            softTokenCounts: softTokenCounts
+        )
+    }
+
+    static func expandedPromptTokens(
+        _ tokens: [Int],
+        softTokenCounts: [Int],
+        imageTokenId: Int,
+        boiTokenId: Int,
+        eoiTokenId: Int
+    ) throws -> [Int] {
+        guard !softTokenCounts.isEmpty else { return tokens }
+        let imageOccurrences = tokens.filter { $0 == imageTokenId }.count
+        let expandedImageTokenCount = softTokenCounts.reduce(0, +)
+        if imageOccurrences == expandedImageTokenCount {
+            return tokens
+        }
+        guard imageOccurrences == softTokenCounts.count else {
+            throw Gemma4Error.unsupportedConfiguration(
+                "Gemma4 unified prompt has \(imageOccurrences) image placeholders for \(softTokenCounts.count) image(s)."
+            )
+        }
+
+        var countIndex = 0
+        var expanded: [Int] = []
+        expanded.reserveCapacity(tokens.count + expandedImageTokenCount + (softTokenCounts.count * 2))
+        for token in tokens {
+            guard token == imageTokenId else {
+                expanded.append(token)
+                continue
+            }
+            let softTokenCount = softTokenCounts[countIndex]
+            expanded.append(boiTokenId)
+            expanded.append(contentsOf: Array(repeating: imageTokenId, count: softTokenCount))
+            expanded.append(eoiTokenId)
+            countIndex += 1
+        }
+        return expanded
+    }
+
+    static func mmTokenTypeIds(tokens: [Int], imageTokenId: Int) -> MLXArray {
+        let values = tokens.map { token -> Int32 in
+            token == imageTokenId ? 1 : 0
+        }
+        return MLXArray(values, [1, values.count])
+    }
+
+    private static func decodeImage(_ reference: String) throws -> MediaImage {
+        let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw Gemma4Error.unsupportedConfiguration("Image URL is empty.")
+        }
+        if trimmed.lowercased().hasPrefix("data:") {
+            guard let comma = trimmed.firstIndex(of: ",") else {
+                throw Gemma4Error.unsupportedConfiguration("Invalid image data URL.")
+            }
+            let metadata = trimmed[..<comma].lowercased()
+            guard metadata.contains(";base64") else {
+                throw Gemma4Error.unsupportedConfiguration("Only base64 image data URLs are supported.")
+            }
+            let payload = String(trimmed[trimmed.index(after: comma)...])
+            guard let data = Data(base64Encoded: payload, options: [.ignoreUnknownCharacters]) else {
+                throw Gemma4Error.unsupportedConfiguration("Invalid base64 image data URL.")
+            }
+            return try MediaImageIO.decode(data: data)
+        }
+
+        if let url = URL(string: trimmed), url.scheme?.lowercased() == "file" {
+            return try MediaImageIO.decode(url)
+        }
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            throw Gemma4Error.unsupportedConfiguration("Remote image URLs are not fetched by the local Gemma4 runtime; use a file path or data URL.")
+        }
+
+        return try MediaImageIO.decode(URL(fileURLWithPath: trimmed).standardizedFileURL)
+    }
+
+    private static func preprocess(
+        _ image: MediaImage,
+        visionConfig: Gemma4UnifiedVisionConfig,
+        maxSoftTokens: Int,
+        modelPatchSize: Int
+    ) throws -> (patches: [Float], positions: [Int32], softTokenCount: Int) {
+        let (targetWidth, targetHeight) = targetSize(
+            originalWidth: image.width,
+            originalHeight: image.height,
+            patchSize: max(1, visionConfig.patchSize),
+            poolingKernelSize: max(1, visionConfig.poolingKernelSize),
+            maxSoftTokens: maxSoftTokens
+        )
+        let resized = try MediaImageIO.resized(image, width: targetWidth, height: targetHeight)
+        let chw = MediaImageIO.rgbCHWFloat(resized, normalizedToMinusOneToOne: false)
+        let patchRows = max(1, resized.height / modelPatchSize)
+        let patchCols = max(1, resized.width / modelPatchSize)
+        let patchDim = modelPatchSize * modelPatchSize * 3
+        let actualPatches = min(maxSoftTokens, patchRows * patchCols)
+
+        var patches = [Float](repeating: 0, count: maxSoftTokens * patchDim)
+        var positions = [Int32](repeating: -1, count: maxSoftTokens * 2)
+        let channelPlane = resized.width * resized.height
+
+        var patchIndex = 0
+        for patchY in 0..<patchRows {
+            for patchX in 0..<patchCols {
+                guard patchIndex < maxSoftTokens else { break }
+                var writeOffset = patchIndex * patchDim
+                for y in 0..<modelPatchSize {
+                    let sourceY = (patchY * modelPatchSize) + y
+                    for x in 0..<modelPatchSize {
+                        let sourceX = (patchX * modelPatchSize) + x
+                        let pixelOffset = (sourceY * resized.width) + sourceX
+                        for channel in 0..<3 {
+                            patches[writeOffset] = chw[(channel * channelPlane) + pixelOffset]
+                            writeOffset += 1
+                        }
+                    }
+                }
+                positions[patchIndex * 2] = Int32(patchX)
+                positions[(patchIndex * 2) + 1] = Int32(patchY)
+                patchIndex += 1
+            }
+        }
+
+        return (patches, positions, actualPatches)
+    }
+
+    private static func targetSize(
+        originalWidth width: Int,
+        originalHeight height: Int,
+        patchSize: Int,
+        poolingKernelSize: Int,
+        maxSoftTokens: Int
+    ) -> (width: Int, height: Int) {
+        let maxPatches = maxSoftTokens * poolingKernelSize * poolingKernelSize
+        let targetPixels = maxPatches * patchSize * patchSize
+        let factor = sqrt(Double(targetPixels) / Double(max(1, width * height)))
+        let sideMultiple = max(1, patchSize * poolingKernelSize)
+
+        var targetHeight = Int(floor((factor * Double(height)) / Double(sideMultiple))) * sideMultiple
+        var targetWidth = Int(floor((factor * Double(width)) / Double(sideMultiple))) * sideMultiple
+
+        if targetHeight == 0 && targetWidth == 0 {
+            targetHeight = sideMultiple
+            targetWidth = sideMultiple
+        } else if targetHeight == 0 {
+            targetHeight = sideMultiple
+            let aspect = max(1, Int(floor(Double(width) / Double(max(1, height)))))
+            let maxSideLength = max(1, (maxPatches / max(1, poolingKernelSize * poolingKernelSize)) * sideMultiple)
+            targetWidth = min(aspect * sideMultiple, maxSideLength)
+        } else if targetWidth == 0 {
+            targetWidth = sideMultiple
+            let aspect = max(1, Int(floor(Double(height) / Double(max(1, width)))))
+            let maxSideLength = max(1, (maxPatches / max(1, poolingKernelSize * poolingKernelSize)) * sideMultiple)
+            targetHeight = min(aspect * sideMultiple, maxSideLength)
+        }
+
+        return (max(sideMultiple, targetWidth), max(sideMultiple, targetHeight))
+    }
+}

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -9,6 +9,7 @@ public enum ManagedModelCategory: String, CaseIterable, Hashable, Sendable {
     case speechTTS = "speech-tts"
     case speechASR = "speech-asr"
     case visionOCR = "vision-ocr"
+    case visionChat = "vision-chat"
     case visionSegment = "vision-segment"
     case visionGround = "vision-ground"
     case music = "music"
@@ -27,6 +28,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case zimageTurbo
     case hidreamO1
     case gemma4
+    case gemma4Unified
     case q35
     case lfm2
     case qwen3TTS
@@ -386,6 +388,32 @@ public enum ManagedModelCatalog {
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 31 * 1_073_741_824,
             defaultCLICommands: ["text chat", "api serve"]
+        ),
+        ManagedModelSpec(
+            id: Gemma4Resources.twelveBModelId,
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Gemma4Resources.twelveBUpstreamModelId,
+                patterns: Gemma4Resources.snapshotPatterns
+            ),
+            upstreamRepoId: Gemma4Resources.twelveBUpstreamModelId,
+            validationKind: .gemma4,
+            estimatedDownloadBytes: 25 * 1_073_741_824,
+            defaultCLICommands: ["text chat", "api serve"]
+        ),
+        ManagedModelSpec(
+            id: Gemma4Resources.visionTwelveBModelId,
+            category: .visionChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Gemma4Resources.twelveBUpstreamModelId,
+                patterns: Gemma4Resources.snapshotPatterns
+            ),
+            upstreamRepoId: Gemma4Resources.twelveBUpstreamModelId,
+            validationKind: .gemma4Unified,
+            estimatedDownloadBytes: 25 * 1_073_741_824,
+            defaultCLICommands: ["api serve"]
         ),
         ManagedModelSpec(
             id: "text-chat-gemma4-nano",
@@ -798,6 +826,11 @@ public extension ManagedModelSpec {
             return HiDreamO1Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .gemma4:
             return Gemma4Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .gemma4Unified:
+            return Gemma4Resources(rootURL: rootURL).validate(
+                fileManager: fileManager,
+                requireUnifiedProcessor: true
+            )
         case .q35:
             return Q35Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .lfm2:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -248,6 +248,20 @@ public enum ManagedModelCapabilityCatalog {
                 setup: true
             ),
             descriptor(
+                Gemma4Resources.twelveBModelId,
+                "Gemma 4 12B chat",
+                "Runs the dense Gemma 4 12B instruction model through the native Swift text runtime.",
+                minimum: 24,
+                recommended: 32
+            ),
+            descriptor(
+                Gemma4Resources.visionTwelveBModelId,
+                "Gemma 4 12B vision chat",
+                "Runs the dense Gemma 4 12B unified model for single-image chat through the native Swift runtime.",
+                minimum: 32,
+                recommended: 48
+            ),
+            descriptor(
                 "text-chat-gemma4-nano",
                 "Gemma 4 chat nano",
                 "Runs the smaller Gemma 4 native Swift chat model for lower-memory machines.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -114,6 +114,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case textAnonymization = "text_anonymization"
         case speechSynthesis = "speech_synthesis"
         case speechRecognition = "speech_recognition"
+        case visionChat = "vision_chat"
         case visionOCR = "vision_ocr"
         case musicGeneration = "music_generation"
         case videoGeneration = "video_generation"
@@ -629,6 +630,34 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.chat],
                 components: gemma4TextComponents,
                 upstreamRepoId: Gemma4Resources.turboUpstreamModelId,
+                createdAt: createdAt
+            )
+        case .gemma4TwelveB:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .gemma4,
+                family: .gemma,
+                tier: .latest,
+                variant: .standard,
+                precision: .bf16,
+                defaults: nil,
+                supports: [.chat, .codeGeneration],
+                components: gemma4TextComponents,
+                upstreamRepoId: Gemma4Resources.twelveBUpstreamModelId,
+                createdAt: createdAt
+            )
+        case .gemma4VisionTwelveB:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .gemma4,
+                family: .gemma,
+                tier: .latest,
+                variant: .standard,
+                precision: .bf16,
+                defaults: nil,
+                supports: [.chat, .codeGeneration, .visionChat],
+                components: gemma4TextComponents,
+                upstreamRepoId: Gemma4Resources.twelveBUpstreamModelId,
                 createdAt: createdAt
             )
         case .q36Nano:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -410,6 +410,7 @@ public enum MereRunModelValidator {
                 || supports.contains(.visionDetection)
                 || supports.contains(.visionSegmentation)
                 || supports.contains(.visionTracking)
+                || supports.contains(.visionChat)
                 || manifest.family == .sam
                 || manifest.family == .falcon
         }()
@@ -471,7 +472,9 @@ public enum MereRunModelValidator {
         if modelId == ModelResolver.ModelID.gemma4.rawValue
             || modelId == ModelResolver.ModelID.gemma4Nano.rawValue
             || modelId == ModelResolver.ModelID.gemma4Max.rawValue
-            || modelId == ModelResolver.ModelID.gemma4Turbo.rawValue {
+            || modelId == ModelResolver.ModelID.gemma4Turbo.rawValue
+            || modelId == ModelResolver.ModelID.gemma4TwelveB.rawValue
+            || modelId == ModelResolver.ModelID.gemma4VisionTwelveB.rawValue {
             return .gemma
         }
         if modelId == ModelResolver.ModelID.lfm25A1B8Bit.rawValue {

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -26,6 +26,8 @@ public struct ModelResolver {
         case gemma4Nano = "text-chat-gemma4-nano"
         case gemma4Max = "text-chat-gemma4-max"
         case gemma4Turbo = "text-chat-gemma4-turbo"
+        case gemma4TwelveB = "text-chat-gemma4-12b"
+        case gemma4VisionTwelveB = "vision-chat-gemma4-12b"
         case q36Nano = "text-chat-q36-nano"
         case lfm25A1B8Bit = "text-chat-lfm25-a1b-8bit"
         case qwen35Agent9B = "text-agent-qwen35-9b"

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -283,7 +283,7 @@ public extension ManagedModelSpec {
         switch validationKind {
         case .codegenGGUF:
             return .textCode
-        case .gemma4:
+        case .gemma4, .gemma4Unified:
             return .textChatGemma4
         case .q35:
             return .textChatQ36

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -167,6 +167,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.maxContextTokens, 4_096)
         XCTAssertEqual(chatRequest.temperature, 1.0)
         XCTAssertEqual(chatRequest.topP, 0.95)
+        XCTAssertFalse(chatRequest.showThinking)
         XCTAssertEqual(chatRequest.maxContextTokens, 4_096)
         XCTAssertEqual(chatRequest.messages, [ChatMessage(role: .user, content: "hello")])
         guard case .local(let path, let scale) = chatRequest.lora else {

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -8,6 +8,11 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertTrue(commandNames.contains("benchmark"))
     }
 
+    func testBenchmarkCommandExposesVLMSubcommand() {
+        let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("vlm"))
+    }
+
     func testGemma4KVBenchmarkParsesDefaults() throws {
         let cmd = try ModelBenchmarkGemma4KV.parse([])
 
@@ -42,6 +47,89 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertEqual(cmd.promptRepeatValues, "64")
         XCTAssertEqual(cmd.temperature, 0.2)
         XCTAssertEqual(cmd.topP, 0.7)
+        XCTAssertTrue(cmd.json)
+    }
+
+    func testVLMBenchmarkParsesDefaults() throws {
+        let cmd = try ModelBenchmarkVLM.parse([])
+
+        XCTAssertNil(cmd.models)
+        XCTAssertEqual(cmd.dataset, .syntheticVQA)
+        XCTAssertNil(cmd.lmmsTasks)
+        XCTAssertNil(cmd.fixtureDir)
+        XCTAssertNil(cmd.outputDir)
+        XCTAssertNil(cmd.lmmsEvalRoot)
+        XCTAssertEqual(cmd.lmmsEvalPython, "python3")
+        XCTAssertFalse(cmd.dryRun)
+        XCTAssertFalse(cmd.externalEndpoint)
+        XCTAssertNil(cmd.baseURL)
+        XCTAssertEqual(cmd.apiKey, "mere-run-local-eval")
+        XCTAssertEqual(cmd.host, "127.0.0.1")
+        XCTAssertEqual(cmd.port, 11934)
+        XCTAssertNil(cmd.limit)
+        XCTAssertFalse(cmd.logSamples)
+        XCTAssertEqual(cmd.maxTokens, 24)
+        XCTAssertEqual(cmd.contextSize, 4096)
+        XCTAssertEqual(cmd.temperature, 0)
+        XCTAssertEqual(cmd.topP, 1)
+        XCTAssertFalse(cmd.json)
+    }
+
+    func testVLMBenchmarkParsesOverrides() throws {
+        let cmd = try ModelBenchmarkVLM.parse([
+            "--models", "vision-chat-gemma4-12b,text-chat-q36-nano",
+            "--dataset", "mathvista-testmini",
+            "--lmms-eval-root", "/tmp/lmms-eval",
+            "--lmms-eval-python", "/tmp/venv/bin/python",
+            "--dry-run",
+            "--output-dir", "/tmp/vlm-results",
+            "--external-endpoint",
+            "--base-url", "http://127.0.0.1:11934/v1",
+            "--api-key", "test-key",
+            "--host", "localhost",
+            "--port", "12000",
+            "--limit", "4",
+            "--log-samples",
+            "--fixture-dir", "/tmp/vlm-fixtures",
+            "--max-tokens", "12",
+            "--context-size", "2048",
+            "--temperature", "0.1",
+            "--top-p", "0.8",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.models, "vision-chat-gemma4-12b,text-chat-q36-nano")
+        XCTAssertEqual(cmd.dataset, .mathvistaTestMini)
+        XCTAssertNil(cmd.lmmsTasks)
+        XCTAssertEqual(cmd.lmmsEvalRoot, "/tmp/lmms-eval")
+        XCTAssertEqual(cmd.lmmsEvalPython, "/tmp/venv/bin/python")
+        XCTAssertTrue(cmd.dryRun)
+        XCTAssertEqual(cmd.outputDir, "/tmp/vlm-results")
+        XCTAssertTrue(cmd.externalEndpoint)
+        XCTAssertEqual(cmd.baseURL, "http://127.0.0.1:11934/v1")
+        XCTAssertEqual(cmd.apiKey, "test-key")
+        XCTAssertEqual(cmd.host, "localhost")
+        XCTAssertEqual(cmd.port, 12000)
+        XCTAssertEqual(cmd.limit, "4")
+        XCTAssertTrue(cmd.logSamples)
+        XCTAssertEqual(cmd.fixtureDir, "/tmp/vlm-fixtures")
+        XCTAssertEqual(cmd.maxTokens, 12)
+        XCTAssertEqual(cmd.contextSize, 2048)
+        XCTAssertEqual(cmd.temperature, 0.1)
+        XCTAssertEqual(cmd.topP, 0.8)
+        XCTAssertTrue(cmd.json)
+    }
+
+    func testVLMBenchmarkParsesRawLMMSTasks() throws {
+        let cmd = try ModelBenchmarkVLM.parse([
+            "--lmms-tasks", "mathvista_testmini,chartqa",
+            "--dry-run",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.dataset, .syntheticVQA)
+        XCTAssertEqual(cmd.lmmsTasks, "mathvista_testmini,chartqa")
+        XCTAssertTrue(cmd.dryRun)
         XCTAssertTrue(cmd.json)
     }
 }

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -10,6 +10,11 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         return try JSONDecoder().decode(Gemma4TextConfig.self, from: data)
     }
 
+    private func decodeConfig(_ object: [String: Any]) throws -> Gemma4Config {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        return try JSONDecoder().decode(Gemma4Config.self, from: data)
+    }
+
     private func makeBaseConfig() -> [String: Any] {
         [
             "model_type": "gemma4_text",
@@ -98,6 +103,56 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
 
         XCTAssertEqual(caches.count, 2)
         XCTAssertTrue(caches.allSatisfy { $0 is Gemma4PolarKVCache })
+    }
+
+    func testUnifiedModelReplacesImageTokenEmbeddings() throws {
+        var textConfig = makeBaseConfig()
+        textConfig["num_hidden_layers"] = 1
+        textConfig["layer_types"] = ["full_attention"]
+        textConfig["hidden_size_per_layer_input"] = 0
+        textConfig["num_kv_shared_layers"] = 0
+        textConfig["vocab_size"] = 64
+        let config = try decodeConfig([
+            "model_type": "gemma4_unified",
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "tie_word_embeddings": true,
+            "eos_token_id": [1, 2],
+            "image_token_id": 5,
+            "boi_token_id": 6,
+            "eoi_token_id": 7,
+            "text_config": textConfig,
+            "vision_config": [
+                "model_type": "gemma4_unified_vision",
+                "patch_size": 1,
+                "pooling_kernel_size": 2,
+                "model_patch_size": 2,
+                "mm_embed_dim": 8,
+                "mm_posemb_size": 4,
+                "num_soft_tokens": 2,
+                "rms_norm_eps": 0.000001,
+                "output_proj_dims": 8,
+            ],
+        ])
+        let model = try Gemma4UnifiedCausalLM(config: config)
+        let inputIds = MLXArray([Int32(6), Int32(5), Int32(5), Int32(7)])
+            .reshaped(1, 4)
+        let pixelValues = MLXRandom.uniform(0.0 ..< 1.0, [1, 2, 12])
+        let imagePositionIds = MLXArray([
+            Int32(0), Int32(0),
+            Int32(1), Int32(0),
+        ], [1, 2, 2])
+        let mmTokenTypeIds = MLXArray([Int32(0), Int32(1), Int32(1), Int32(0)])
+            .reshaped(1, 4)
+
+        let logits = try model.forward(
+            inputIds: inputIds,
+            pixelValues: pixelValues,
+            imagePositionIds: imagePositionIds,
+            mmTokenTypeIds: mmTokenTypeIds
+        )
+
+        MLX.eval(logits)
+        XCTAssertEqual(logits.shape, [1, 4, 64])
     }
 
     func testAttentionKEqVDisablesValueProjectionForFullAttentionLayers() throws {

--- a/Tests/MereRunCoreTests/Gemma4ResponseCleaningTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ResponseCleaningTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import MereRunCore
+
+final class Gemma4ResponseCleaningTests: MereRunCoreTestCase {
+    func testKeepsFinalChannelWhenThinkingIsHidden() {
+        let cleaned = Gemma4Generator.cleanedResponse(
+            """
+            <|channel>thought
+            Work privately.
+            <|channel>final
+            gemma4 text ok
+            """,
+            showThinking: false
+        )
+
+        XCTAssertEqual(cleaned, "gemma4 text ok")
+    }
+
+    func testKeepsTextAfterThoughtCloseMarkerWhenThinkingIsHidden() {
+        let cleaned = Gemma4Generator.cleanedResponse(
+            """
+            <|channel>thought
+            Work privately.<channel|>gemma4 text ok
+            """,
+            showThinking: false
+        )
+
+        XCTAssertEqual(cleaned, "gemma4 text ok")
+    }
+
+    func testRemovesDanglingThoughtChannelWhenThinkingIsHidden() {
+        let cleaned = Gemma4Generator.cleanedResponse(
+            """
+            <|channel>thought
+            Work privately.
+            """,
+            showThinking: false
+        )
+
+        XCTAssertEqual(cleaned, "")
+    }
+
+    func testPreservesThinkingWhenRequested() {
+        let response = "<|channel>thought\nWork privately."
+
+        XCTAssertEqual(
+            Gemma4Generator.cleanedResponse(response, showThinking: true),
+            response
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/Gemma4UnifiedImageProcessorTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4UnifiedImageProcessorTests.swift
@@ -1,0 +1,54 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Gemma4UnifiedImageProcessorTests: MereRunCoreTestCase {
+    func testExpandsBareImagePlaceholdersToUnifiedSoftTokens() throws {
+        let expanded = try Gemma4UnifiedImageProcessor.expandedPromptTokens(
+            [10, 258_880, 20, 258_880, 30],
+            softTokenCounts: [2, 3],
+            imageTokenId: 258_880,
+            boiTokenId: 255_999,
+            eoiTokenId: 258_882
+        )
+
+        XCTAssertEqual(expanded, [
+            10,
+            255_999,
+            258_880,
+            258_880,
+            258_882,
+            20,
+            255_999,
+            258_880,
+            258_880,
+            258_880,
+            258_882,
+            30,
+        ])
+    }
+
+    func testAlreadyExpandedPromptIsLeftUnchanged() throws {
+        let tokens = [255_999, 258_880, 258_880, 258_882, 42]
+        let expanded = try Gemma4UnifiedImageProcessor.expandedPromptTokens(
+            tokens,
+            softTokenCounts: [2],
+            imageTokenId: 258_880,
+            boiTokenId: 255_999,
+            eoiTokenId: 258_882
+        )
+
+        XCTAssertEqual(expanded, tokens)
+    }
+
+    func testMultimodalTokenTypesMarkImageTokensOnly() {
+        let mmTokenTypeIds = Gemma4UnifiedImageProcessor.mmTokenTypeIds(
+            tokens: [255_999, 258_880, 258_880, 258_882, 42],
+            imageTokenId: 258_880
+        )
+
+        MLX.eval(mmTokenTypeIds)
+        XCTAssertEqual(mmTokenTypeIds.shape, [1, 5])
+        XCTAssertEqual(mmTokenTypeIds.asArray(Int32.self), [0, 1, 1, 0, 0])
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -123,6 +123,28 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.validationKind, .gemma4)
     }
 
+    func testGemma4TwelveBUsesGoogleUnifiedHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Gemma4Resources.twelveBModelId))
+
+        XCTAssertEqual(spec.category, .textChat)
+        XCTAssertEqual(spec.hubFallback?.repoId, Gemma4Resources.twelveBUpstreamModelId)
+        XCTAssertEqual(spec.upstreamRepoId, Gemma4Resources.twelveBUpstreamModelId)
+        XCTAssertEqual(spec.validationKind, .gemma4)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatGemma4)
+    }
+
+    func testGemma4TwelveBVisionRequiresUnifiedProcessorFiles() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Gemma4Resources.visionTwelveBModelId))
+
+        XCTAssertEqual(spec.category, .visionChat)
+        XCTAssertEqual(spec.hubFallback?.repoId, Gemma4Resources.twelveBUpstreamModelId)
+        XCTAssertEqual(spec.upstreamRepoId, Gemma4Resources.twelveBUpstreamModelId)
+        XCTAssertEqual(spec.validationKind, .gemma4Unified)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatGemma4)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("processor_config.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("preprocessor_config.json"), true)
+    }
+
     func testQ36NanoUsesOptiQHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.q36NanoModelId))
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -741,6 +741,45 @@ values to run a prompt-size/decode-length matrix for promotion evidence.
 The default fixture prompt is deterministic and intended for local A/B
 comparisons, not model-quality evaluation.
 
+### `mere.run model benchmark vlm`
+
+Run a tiny synthetic VLM smoke, or use `lmms-eval` to compare an installed
+vision-chat model against existing multimodal datasets.
+
+```bash
+swift run mere.run model benchmark vlm --json
+```
+
+The default synthetic suite compares `vision-chat-gemma4-12b` with the existing
+`vision-inspect-qwen3-vl-2b` backend on deterministic color, location, and
+counting fixtures.
+
+For existing datasets, install or check out `lmms-eval`, then start with a
+dry-run:
+
+```bash
+swift run mere.run model benchmark vlm \
+  --dataset mathvista-testmini \
+  --limit 16 \
+  --lmms-eval-root ~/src/lmms-eval \
+  --dry-run \
+  --json
+```
+
+Preset dataset flags map to upstream task names:
+
+| Dataset flag | lmms-eval task |
+| --- | --- |
+| `mathvista-testmini` | `mathvista_testmini` |
+| `mmmu-val` | `mmmu_val` |
+| `chartqa` | `chartqa` |
+| `docvqa-val` | `docvqa_val` |
+| `mme` | `mme` |
+
+Use `--lmms-tasks` for raw upstream task names, `--external-endpoint --base-url`
+for an already-running OpenAI-compatible server, and omit `--dry-run` to let the
+command start a local `mere.run api serve` process per requested model.
+
 ### `mere.run model capabilities`
 
 Show this machine's supported models, recommended setup package, and a short summary

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -23,7 +23,8 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Category | Hugging Face pull IDs |
 | --- | --- |
 | Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev` |
-| Text chat | `text-chat-gemma4`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash` |
+| Text chat | `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash` |
+| Vision chat | `vision-chat-gemma4-12b` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
 | Text anonymize | `text-anonymize-privacy-filter` |
@@ -63,8 +64,11 @@ long enough. Short-context requests decode with the main chat weights. The dense
 but is not a managed native target until the dense Qwen3.6 layer path is
 implemented.
 
-`text-chat-gemma4` is the dense bf16 Gemma 4 31B alias and is gated for larger
-machines. On 32 GB Apple Silicon Macs, use `text-chat-gemma4-turbo`, which
+`text-chat-gemma4-12b` and `vision-chat-gemma4-12b` share Google's dense Gemma
+4 12B-it checkpoint; the text id uses the native chat path, while the vision id
+enables OpenAI image content parts through `api serve`. `text-chat-gemma4` is
+the dense bf16 Gemma 4 31B alias and is gated for larger machines. On 32 GB
+Apple Silicon Macs, use `text-chat-gemma4-turbo`, which
 installs the MLX NVFP4 Gemma 4 26B-A4B-it MoE snapshot and runs through the native
 Swift Gemma runtime.
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -39,6 +39,15 @@ package-scoped.
 swift run mere.run api serve --engine text-chat-gemma4
 ```
 
+For Gemma 4 12B vision chat:
+
+```bash
+swift run mere.run model pull vision-chat-gemma4-12b
+swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model vision-chat-gemma4-12b
+```
+
 For the LiquidAI LFM2.5 MLX 8-bit model:
 
 ```bash
@@ -194,6 +203,9 @@ Engine compatibility:
   `ds4-server`, preserving DS4's OpenAI-compatible behavior.
 - `text-chat-gemma4`: accepts function tools and emits OpenAI tool-call
   responses when the model generates a tool call.
+- `vision-chat-gemma4-12b`: uses the Gemma4 serving engine and accepts one
+  OpenAI image content part per message. The native runtime accepts local file
+  paths, `file://` URLs, or base64 data URLs; it does not fetch remote images.
 - `text-chat-q36-nano`: uses the Qwen-family serving engine with Qwen3.6
   35B-A3B OptiQ chat weights, accepts function tools, and accepts one image
   content part per message.

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -15,6 +15,7 @@ embeddings, and PII anonymization.
 ### Chat
 
 - `text-chat-gemma4`
+- `text-chat-gemma4-12b` (managed dense Google Gemma 4 12B-it snapshot)
 - `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
 - `text-chat-q36-nano`
 - `text-chat-lfm25-a1b-8bit` (managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot)
@@ -45,9 +46,11 @@ swift run mere.run text chat \
   --prompt "Summarize diffusion models in one paragraph."
 ```
 
-On 32 GB Apple Silicon Macs, avoid pulling the dense bf16
-`text-chat-gemma4`/31B path. Use `text-chat-gemma4-turbo` for the managed
-Gemma 4 26B-A4B-it NVFP4 snapshot, which uses the native Swift Gemma MoE runtime.
+`text-chat-gemma4-12b` runs Google's dense Gemma 4 12B-it checkpoint through
+the native Swift Gemma runtime. On 32 GB Apple Silicon Macs, avoid pulling the
+dense bf16 `text-chat-gemma4`/31B path. Use `text-chat-gemma4-turbo` for the
+managed Gemma 4 26B-A4B-it NVFP4 snapshot, which uses the native Swift Gemma
+MoE runtime.
 
 `text-chat-lfm25-a1b-8bit` installs `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
 and runs through the native Swift LFM2 runtime. It is text-only; use


### PR DESCRIPTION
## Summary
- add managed Gemma4 12B vision-chat catalog/runtime support and unified image preprocessing
- add `model benchmark vlm` for synthetic VLM smoke and lmms-eval existing-dataset runs
- document API/text/model benchmark behavior and add parser/runtime tests

## Validation
- `swift test --filter ModelBenchmarkCommandTests`
- `swiftlint lint --strict Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift`
- `.build/debug/mere.run model benchmark vlm --dataset mathvista-testmini --limit 1 --dry-run --output-dir /tmp/mere-vlm-benchmark-dry-run --json`
- `./scripts/check.sh`