### PR TITLE
Fix MLX CUDA CCCL fallback for Linux arm64 builds

### DIFF
--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -42,6 +42,8 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(script.contains("patch_mlx_cuda_jit_include_path"))
         XCTAssertTrue(script.contains("MERERUN_CUDA_CCCL_INCLUDE"))
         XCTAssertTrue(script.contains("MERERUN_CUDA_CCCL_INCLUDE_PATH"))
+        XCTAssertTrue(script.contains(#"return std::filesystem::path(\"/usr/local/cuda\");"#))
+        XCTAssertFalse(script.contains("return default_cuda_toolkit_path();"))
         XCTAssertTrue(script.contains("detect_cuda_cccl_include_path"))
         XCTAssertTrue(script.contains("cuda_toolkit_root_candidates"))
         XCTAssertTrue(script.contains("Source/Cmlx/mlx/mlx/backend/cuda/jit_module.cpp"))

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -206,7 +206,7 @@ patch_mlx_cuda_jit_include_path() {
       print "      auto mererun_cuda_home = []() -> std::filesystem::path {"
       print "        if (auto home = std::getenv(\"CUDA_HOME\")) { return home; }"
       print "        if (auto path = std::getenv(\"CUDA_PATH\")) { return path; }"
-      print "        return default_cuda_toolkit_path();"
+      print "        return std::filesystem::path(\"/usr/local/cuda\");"
       print "      }();"
       print "      add_mererun_cuda_cccl_include(mererun_cuda_home / \"include\" / \"cccl\");"
       print "      add_mererun_cuda_cccl_include(mererun_cuda_home / \"targets\" / \"sbsa-linux\" / \"include\" / \"cccl\");"


### PR DESCRIPTION
## Summary
- stop the Linux CUDA MLX JIT patch from calling upstream's removed default_cuda_toolkit_path helper
- fall back to /usr/local/cuda when CUDA_HOME/CUDA_PATH are unset, matching current MLX Linux behavior
- add focused coverage so the script does not regress to the removed helper

## Validation
- swift test --filter LinuxNativeBridgeTests
- ./scripts/check.sh

## Spark evidence
- v0.12.0 arm64 CUDA package build on spark-02 reached MLX CUDA smoke only after this generated-source fallback was patched manually
