### PR TITLE
Add native Magenta RT2 realtime music

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/magentart.xcframework/**/Resources/*.metallib filter=lfs diff=lfs merge=lfs -text

--- a/Package.swift
+++ b/Package.swift
@@ -84,6 +84,7 @@ let commonSwiftSettings: [SwiftSetting] = [
   .interoperabilityMode(.Cxx)
 ] + prebuiltMLXSwiftSettings + linuxPackageSwiftSettings
 let hasMediaIOTarget = packageDirectoryContainsSwiftSources("Sources/MediaIO")
+let hasMagentaRT2Binary = !isLinuxPackage && packagePathExists("vendor/magentart.xcframework")
 
 func mlxDependency(_ name: String) -> [Target.Dependency] {
   useLinuxPrebuiltMLX ? [] : [.product(name: name, package: "mlx-swift")]
@@ -186,7 +187,7 @@ if isLinuxPackage {
         pkgConfig: "llama"
       )
     )
-    mereRunCoreDependencies.append("llama")
+    mereRunCoreDependencies.append(.target(name: "llama"))
   }
 } else {
   targets.append(
@@ -195,7 +196,16 @@ if isLinuxPackage {
       path: "vendor/llama.xcframework"
     )
   )
-  mereRunCoreDependencies.append("llama")
+  mereRunCoreDependencies.append(.target(name: "llama"))
+}
+if hasMagentaRT2Binary {
+  targets.append(
+    .binaryTarget(
+      name: "magentart",
+      path: "vendor/magentart.xcframework"
+    )
+  )
+  mereRunCoreDependencies.append(.target(name: "magentart"))
 }
 
 let linuxNativeLlamaLibraryPath = packagePath(".build/native/linux-\(hostArch)/llama/lib").path

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
 
+# Stream and optionally capture Magenta RT2 music on Apple Silicon macOS
+swift run mere.run music realtime \
+  "ambient modular synths with brushed drums" \
+  --model music-magenta-rt2-small \
+  --duration 4 \
+  --output ./live.wav \
+  --no-play
+
 # Generate video
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
@@ -375,6 +383,7 @@ The public CLI is modality-first:
 - `mere.run vision track-live`
 - `mere.run vision ocr`
 - `mere.run music generate`
+- `mere.run music realtime`
 - `mere.run video generate`
 - `mere.run video export-latents`
 - `mere.run model { list, capabilities, info, pull, remove, runtime, repair-manifests }`

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -762,7 +762,7 @@ enum CommandCatalog {
             id: .musicGenerate,
             category: .media,
             title: "Generate music",
-            subtitle: "ACE-Step music generation",
+            subtitle: "ACE-Step or Magenta RT2 music generation",
             systemImage: "music.note",
             promptLabel: "Caption",
             secondaryLabel: "Lyrics",

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -327,7 +327,11 @@ enum GuideRegistry {
             topic: "music-generate",
             title: "Music Generate",
             commandPaths: [["music", "generate"]],
-            models: ["music-acestep"],
+            models: [
+                "music-acestep",
+                "music-magenta-rt2-small",
+                "music-magenta-rt2-base",
+            ],
             resourceName: "music-generate.md"
         ),
         GuideTopic(

--- a/Sources/MereRunCLI/Commands/MusicCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicCommand.swift
@@ -6,6 +6,7 @@ struct Music: ParsableCommand {
         abstract: "Generate music locally.",
         subcommands: [
             MusicGenerate.self,
+            MusicRealtime.self,
         ]
     )
 }

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import AudioCodecs
 import Foundation
 import MLX
 import MereRunCore
@@ -6,7 +7,7 @@ import MereRunCore
 struct MusicGenerate: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "generate",
-        abstract: "Generate audio from caption + optional lyrics using ACE-Step.",
+        abstract: "Generate audio from a music prompt.",
         discussion: """
         Prints the output WAV path to stdout.
         Progress and diagnostics are printed to stderr.
@@ -16,6 +17,11 @@ struct MusicGenerate: AsyncParsableCommand {
             --model music-acestep \
             --lyrics "[verse]\\nwe dance all night" \
             --text-subdirectory Qwen3-Embedding-0.6B \
+            -o out.wav
+
+          mere.run music generate "ambient modular synths with brushed drums" \
+            --model music-magenta-rt2-small \
+            --duration 4 \
             -o out.wav
         """
     )
@@ -119,6 +125,39 @@ struct MusicGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
+    @Option(name: [.customLong("temperature")], help: "Magenta RT2 sampling temperature.")
+    var magentaTemperature: Float = 1.0
+
+    @Option(name: [.customLong("style-conditioning")], help: "Magenta RT2 style conditioning detail: streaming or full.")
+    var magentaStyleConditioning: MagentaRT2StyleConditioning = .streaming
+
+    @Option(name: [.customLong("top-k")], help: "Magenta RT2 top-k sampling.")
+    var magentaTopK: Int = 100
+
+    @Option(name: [.customLong("cfg-musiccoca")], help: "Magenta RT2 MusicCoCa guidance scale.")
+    var magentaCFGMusicCoCa: Float = 3.0
+
+    @Option(name: [.customLong("cfg-notes")], help: "Magenta RT2 MIDI-notes guidance scale.")
+    var magentaCFGNotes: Float = 5.0
+
+    @Option(name: [.customLong("cfg-drums")], help: "Magenta RT2 drums guidance scale.")
+    var magentaCFGDrums: Float = 1.0
+
+    @Flag(name: [.customLong("drumless")], help: "Enable Magenta RT2 drumless mode.")
+    var magentaDrumless: Bool = false
+
+    @Option(name: [.customLong("unmask-width")], help: "Magenta RT2 token unmask width.")
+    var magentaUnmaskWidth: Int = 0
+
+    @Option(name: [.customLong("seed-rotation")], help: "Magenta RT2 seed rotation.")
+    var magentaSeedRotation: Int = 0
+
+    @Flag(name: [.customLong("prefill-silence")], help: "Prefill Magenta RT2 state with silence before generation.")
+    var magentaPrefillSilence: Bool = false
+
+    @Option(name: [.customLong("prefill-duration")], help: "Magenta RT2 silent prefill duration in seconds.")
+    var magentaPrefillDuration: Float = 1.64
+
     func run() async throws {
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
@@ -145,6 +184,11 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         if lyricsFile != nil, !lyrics.isEmpty {
             throw ValidationError("Pass either --lyrics or --lyrics-file, not both.")
+        }
+
+        if isMagentaRT2Request {
+            try await runMagentaRT2()
+            return
         }
 
         let checkpointsRootURL = try await resolveACEStepCheckpointsRoot()
@@ -267,6 +311,108 @@ struct MusicGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+    }
+
+    private var isMagentaRT2Request: Bool {
+        if MagentaRT2Resources.isMagentaRT2Model(model) {
+            return true
+        }
+        let url = URL(fileURLWithPath: model).standardizedFileURL
+        return MagentaRT2Resources.looksLikeMagentaRT2Root(url)
+    }
+
+    private func runMagentaRT2() async throws {
+        try validateMagentaRT2Options()
+
+        let outputURL = CLIOutput.resolveOutputURL(output, defaultPrefix: "mererun-magenta-rt2", defaultExtension: "wav")
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        let resources = try await MagentaRT2Resources.resolve(
+            requestedModel: model,
+            progress: { event in
+                guard !quiet else { return }
+                switch event {
+                case .downloading(let percent):
+                    CLIStderr.write("Downloading Magenta RT2 assets... \(percent)%\n")
+                case .extracting:
+                    CLIStderr.write("Extracting Magenta RT2 assets...\n")
+                }
+            }
+        )
+        let controls = try magentaControls()
+        if !quiet {
+            CLIStderr.write("Loading Magenta RT2 model from \(resources.modelURL.path)\n")
+        }
+        let audio = try await MagentaRT2Renderer.render(
+            MagentaRT2RenderRequest(
+                prompt: caption,
+                resources: resources,
+                durationSeconds: durationSeconds,
+                controls: controls
+            ),
+            progress: { frame, total in
+                guard !quiet, frame % 10 == 0 || frame + 1 == total else { return }
+                CLIStderr.write("Generated Magenta RT2 frame \(frame + 1)/\(total)\n")
+            }
+        )
+        let writer = try StreamingWAVWriter(
+            outputURL: outputURL,
+            sampleRate: MagentaRT2Resources.sampleRate,
+            channels: MagentaRT2Resources.channels
+        )
+        try writer.append(samples: audio)
+        try writer.close()
+        if !quiet {
+            CLIStderr.write("Saved audio: \(outputURL.path)\n")
+        }
+        print(outputURL.path)
+    }
+
+    private func validateMagentaRT2Options() throws {
+        if !lyrics.isEmpty || lyricsFile != nil {
+            throw ValidationError("Magenta RT2 does not support --lyrics or --lyrics-file. Put musical direction in the prompt.")
+        }
+        if useLM {
+            throw ValidationError("Magenta RT2 does not support --use-lm; that option is ACE-Step only.")
+        }
+        if taskType != "text2music" {
+            throw ValidationError("Magenta RT2 does not support --task-type; that option is ACE-Step only.")
+        }
+        if trackName != nil || completeTrackClasses != nil || nonCover {
+            throw ValidationError("Magenta RT2 does not support ACE-Step cover/extract/lego options.")
+        }
+        if seed != nil {
+            throw ValidationError("Magenta RT2 uses --seed-rotation instead of --seed.")
+        }
+        if steps != 8 || shift != 1.0 {
+            throw ValidationError("Magenta RT2 does not use ACE-Step --steps or --shift.")
+        }
+        _ = try magentaControls()
+    }
+
+    private func magentaControls() throws -> MagentaRT2Controls {
+        guard magentaTopK >= 0 else {
+            throw ValidationError("--top-k must be >= 0")
+        }
+        guard magentaUnmaskWidth >= 0 else {
+            throw ValidationError("--unmask-width must be >= 0")
+        }
+        guard magentaPrefillDuration > 0 else {
+            throw ValidationError("--prefill-duration must be > 0")
+        }
+        return MagentaRT2Controls(
+            styleConditioning: magentaStyleConditioning,
+            temperature: magentaTemperature,
+            topK: Int32(magentaTopK),
+            cfgMusicCoCa: magentaCFGMusicCoCa,
+            cfgNotes: magentaCFGNotes,
+            cfgDrums: magentaCFGDrums,
+            drumless: magentaDrumless,
+            unmaskWidth: Int32(magentaUnmaskWidth),
+            seedRotation: Int32(magentaSeedRotation),
+            prefillSilence: magentaPrefillSilence,
+            prefillDurationSeconds: magentaPrefillDuration
+        )
     }
 
     private func loadLyrics() throws -> String {

--- a/Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift
@@ -1,0 +1,457 @@
+import ArgumentParser
+import AudioCodecs
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+import Foundation
+import MereRunCore
+
+extension MagentaRT2StyleConditioning: ExpressibleByArgument {}
+
+struct MusicRealtime: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "realtime",
+        abstract: "Run Magenta RealTime 2 music generation.",
+        discussion: """
+        Plays generated audio to the default output device by default.
+        Pass --output to capture the stream to a WAV file at the same time.
+
+        Example:
+          mere.run music realtime "ambient pads with sub bass" \
+            --model music-magenta-rt2-small \
+            --duration 4 \
+            --output live.wav
+        """
+    )
+
+    @Argument(help: "Text prompt describing the target music.")
+    var prompt: String
+
+    @Option(name: [.customShort("m"), .long], help: "Managed Magenta RT2 model id or local Magenta RT2 root.")
+    var model: String = MagentaRT2Resources.smallModelId
+
+    @Option(name: [.customLong("duration")], help: "Realtime run duration in seconds.")
+    var durationSeconds: Float = 30.0
+
+    @Option(name: [.customShort("o"), .long], help: "Optional output WAV path for stream capture.")
+    var output: String?
+
+    @Flag(name: [.long], inversion: .prefixedNo, help: "Play realtime audio through the default output device.")
+    var play: Bool = true
+
+    @Option(name: [.customLong("style-conditioning")], help: "Magenta RT2 style conditioning detail: streaming or full.")
+    var styleConditioning: MagentaRT2StyleConditioning = .streaming
+
+    @Option(name: [.customLong("temperature")], help: "Magenta RT2 sampling temperature.")
+    var temperature: Float = 1.0
+
+    @Option(name: [.customLong("top-k")], help: "Magenta RT2 top-k sampling.")
+    var topK: Int = 100
+
+    @Option(name: [.customLong("cfg-musiccoca")], help: "Magenta RT2 MusicCoCa guidance scale.")
+    var cfgMusicCoCa: Float = 3.0
+
+    @Option(name: [.customLong("cfg-notes")], help: "Magenta RT2 MIDI-notes guidance scale.")
+    var cfgNotes: Float = 5.0
+
+    @Option(name: [.customLong("cfg-drums")], help: "Magenta RT2 drums guidance scale.")
+    var cfgDrums: Float = 1.0
+
+    @Flag(name: [.customLong("drumless")], help: "Enable Magenta RT2 drumless mode.")
+    var drumless: Bool = false
+
+    @Option(name: [.customLong("unmask-width")], help: "Magenta RT2 token unmask width.")
+    var unmaskWidth: Int = 0
+
+    @Option(name: [.customLong("seed-rotation")], help: "Magenta RT2 seed rotation.")
+    var seedRotation: Int = 0
+
+    @Flag(name: [.customLong("prefill-silence")], help: "Prefill Magenta RT2 state with silence before generation.")
+    var prefillSilence: Bool = false
+
+    @Option(name: [.customLong("prefill-duration")], help: "Magenta RT2 silent prefill duration in seconds.")
+    var prefillDuration: Float = 1.64
+
+    @Flag(name: [.customLong("interactive")], help: "Read live steering commands from stdin while generation runs.")
+    var interactive: Bool = false
+
+    @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
+    var quiet: Bool = false
+
+    func run() async throws {
+        guard MagentaRT2Resources.isMagentaRT2Model(model)
+            || MagentaRT2Resources.looksLikeMagentaRT2Root(URL(fileURLWithPath: model).standardizedFileURL) else {
+            throw ValidationError("music realtime requires a Magenta RT2 model id or local Magenta RT2 root.")
+        }
+        guard durationSeconds > 0 else {
+            throw ValidationError("--duration must be > 0")
+        }
+        guard play || output != nil else {
+            throw ValidationError("Use --play or provide --output when --no-play is set.")
+        }
+
+        let resources = try await MagentaRT2Resources.resolve(
+            requestedModel: model,
+            progress: { event in
+                guard !quiet else { return }
+                switch event {
+                case .downloading(let percent):
+                    CLIStderr.write("Downloading Magenta RT2 assets... \(percent)%\n")
+                case .extracting:
+                    CLIStderr.write("Extracting Magenta RT2 assets...\n")
+                }
+            }
+        )
+        let outputURL = output.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        if let outputURL {
+            try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        }
+        let initialControls = try controls()
+        let liveControls = interactive ? MagentaRT2InteractiveControls(initialControls: initialControls) : nil
+        let sink = try MagentaRT2RealtimeOutputSink(outputURL: outputURL, play: play)
+        defer { try? sink.close() }
+
+        if !quiet {
+            CLIStderr.write("Starting Magenta RT2 realtime model \(resources.modelID)\n")
+        }
+        if let liveControls, !quiet {
+            CLIStderr.write(liveControls.helpText)
+        }
+        let inputTask = liveControls.map { controls in
+            Task.detached {
+                while let line = readLine(strippingNewline: true) {
+                    let response = controls.applyCommand(line)
+                    if !response.isEmpty {
+                        CLIStderr.write(response + "\n")
+                    }
+                    if controls.shouldStop {
+                        break
+                    }
+                }
+            }
+        }
+        defer { inputTask?.cancel() }
+
+        let startedAt = Date()
+        do {
+            try await MagentaRT2RealtimeSession.run(
+                MagentaRT2RealtimeRequest(
+                    prompt: prompt,
+                    resources: resources,
+                    durationSeconds: durationSeconds,
+                    controls: initialControls
+                ),
+                liveControls: { frameIndex in
+                    liveControls?.snapshot(frameIndex: frameIndex)
+                }
+            ) { frameIndex, frame in
+                try sink.consume(frameIndex: frameIndex, frame: frame)
+                if !quiet, frameIndex % 25 == 0 {
+                    CLIStderr.write("Realtime frame \(frameIndex + 1)\n")
+                }
+                paceFrameIfNeeded(frameIndex: frameIndex, startedAt: startedAt)
+            }
+        } catch is CancellationError {
+            if liveControls?.shouldStop != true {
+                throw CancellationError()
+            }
+        }
+
+        if let outputURL {
+            print(outputURL.path)
+        }
+    }
+
+    private func controls() throws -> MagentaRT2Controls {
+        guard topK >= 0 else {
+            throw ValidationError("--top-k must be >= 0")
+        }
+        guard unmaskWidth >= 0 else {
+            throw ValidationError("--unmask-width must be >= 0")
+        }
+        guard prefillDuration > 0 else {
+            throw ValidationError("--prefill-duration must be > 0")
+        }
+        return MagentaRT2Controls(
+            styleConditioning: styleConditioning,
+            temperature: temperature,
+            topK: Int32(topK),
+            cfgMusicCoCa: cfgMusicCoCa,
+            cfgNotes: cfgNotes,
+            cfgDrums: cfgDrums,
+            drumless: drumless,
+            unmaskWidth: Int32(unmaskWidth),
+            seedRotation: Int32(seedRotation),
+            prefillSilence: prefillSilence,
+            prefillDurationSeconds: prefillDuration
+        )
+    }
+
+    private func paceFrameIfNeeded(frameIndex: Int, startedAt: Date) {
+        guard play || interactive else { return }
+        let targetElapsed = Double(frameIndex + 1) / Double(MagentaRT2Resources.frameRate)
+        let actualElapsed = Date().timeIntervalSince(startedAt)
+        let sleepSeconds = targetElapsed - actualElapsed
+        if sleepSeconds > 0 {
+            Thread.sleep(forTimeInterval: sleepSeconds)
+        }
+    }
+}
+
+private final class MagentaRT2InteractiveControls: @unchecked Sendable {
+    private let lock = NSLock()
+    private var controls: MagentaRT2Controls
+    private var pendingPrompt: String?
+    private var pendingNoteOn: [Int32] = []
+    private var pendingNoteOff: [Int32] = []
+    private var pendingOnsetMode: Int32?
+    private var pendingControls: Bool = false
+    private var pendingReset: Bool = false
+    private(set) var shouldStop: Bool = false
+
+    let helpText = """
+    Interactive steering enabled. Commands:
+      prompt <text>
+      style streaming|full
+      temp <value> | topk <value> | mc <value> | notes <value> | drums <value>
+      noteon <0-131> | noteoff <0-131> | onset 0|1
+      drumless on|off | unmask <value> | seed <value> | reset | quit | help
+
+    """
+
+    init(initialControls: MagentaRT2Controls) {
+        controls = initialControls
+    }
+
+    func applyCommand(_ rawLine: String) -> String {
+        let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty else { return "" }
+        let parts = line.split(maxSplits: 1, whereSeparator: \.isWhitespace).map(String.init)
+        let command = parts[0].lowercased()
+        let value = parts.count > 1 ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        switch command {
+        case "prompt":
+            guard !value.isEmpty else { return "usage: prompt <text>" }
+            pendingPrompt = value
+            return "queued prompt"
+        case "style", "style-conditioning":
+            guard let parsed = MagentaRT2StyleConditioning(rawValue: value.lowercased()) else {
+                return "usage: style streaming|full"
+            }
+            controls.styleConditioning = parsed
+            pendingControls = true
+            return "style-conditioning \(parsed.rawValue)"
+        case "temp", "temperature":
+            guard let parsed = Float(value) else { return "usage: temp <value>" }
+            controls.temperature = parsed
+            pendingControls = true
+            return "temperature \(parsed)"
+        case "topk", "top-k":
+            guard let parsed = Int32(value), parsed >= 0 else { return "usage: topk <value>" }
+            controls.topK = parsed
+            pendingControls = true
+            return "top-k \(parsed)"
+        case "mc", "musiccoca", "cfg-musiccoca":
+            guard let parsed = Float(value) else { return "usage: mc <value>" }
+            controls.cfgMusicCoCa = parsed
+            pendingControls = true
+            return "cfg-musiccoca \(parsed)"
+        case "notes", "cfg-notes":
+            guard let parsed = Float(value) else { return "usage: notes <value>" }
+            controls.cfgNotes = parsed
+            pendingControls = true
+            return "cfg-notes \(parsed)"
+        case "drums", "cfg-drums":
+            guard let parsed = Float(value) else { return "usage: drums <value>" }
+            controls.cfgDrums = parsed
+            pendingControls = true
+            return "cfg-drums \(parsed)"
+        case "drumless":
+            guard let parsed = parseBool(value) else { return "usage: drumless on|off" }
+            controls.drumless = parsed
+            pendingControls = true
+            return "drumless \(parsed ? "on" : "off")"
+        case "unmask", "unmask-width":
+            guard let parsed = Int32(value), parsed >= 0 else { return "usage: unmask <value>" }
+            controls.unmaskWidth = parsed
+            pendingControls = true
+            return "unmask-width \(parsed)"
+        case "seed", "seed-rotation":
+            guard let parsed = Int32(value) else { return "usage: seed <value>" }
+            controls.seedRotation = parsed
+            pendingControls = true
+            return "seed-rotation \(parsed)"
+        case "noteon", "note-on":
+            guard let parsed = parseMIDINote(value) else { return "usage: noteon <0-131>" }
+            pendingNoteOn.append(parsed)
+            return "note on \(parsed)"
+        case "noteoff", "note-off":
+            guard let parsed = parseMIDINote(value) else { return "usage: noteoff <0-131>" }
+            pendingNoteOff.append(parsed)
+            return "note off \(parsed)"
+        case "onset", "onset-mode":
+            guard let parsed = Int32(value), parsed == 0 || parsed == 1 else { return "usage: onset 0|1" }
+            pendingOnsetMode = parsed
+            return "onset \(parsed)"
+        case "reset":
+            pendingReset = true
+            return "queued reset"
+        case "quit", "exit", "stop":
+            shouldStop = true
+            return "stopping"
+        case "help", "?":
+            return helpText
+        default:
+            return "unknown command: \(command)"
+        }
+    }
+
+    func snapshot(frameIndex: Int) -> MagentaRT2LiveControlSnapshot? {
+        _ = frameIndex
+        lock.lock()
+        defer { lock.unlock() }
+        if shouldStop {
+            return MagentaRT2LiveControlSnapshot(shouldStop: true)
+        }
+        guard pendingPrompt != nil
+            || pendingControls
+            || !pendingNoteOn.isEmpty
+            || !pendingNoteOff.isEmpty
+            || pendingOnsetMode != nil
+            || pendingReset else {
+            return nil
+        }
+        let snapshot = MagentaRT2LiveControlSnapshot(
+            prompt: pendingPrompt,
+            controls: pendingControls ? controls : nil,
+            noteOn: pendingNoteOn,
+            noteOff: pendingNoteOff,
+            onsetMode: pendingOnsetMode,
+            resetState: pendingReset
+        )
+        pendingPrompt = nil
+        pendingNoteOn = []
+        pendingNoteOff = []
+        pendingOnsetMode = nil
+        pendingControls = false
+        pendingReset = false
+        return snapshot
+    }
+
+    private func parseBool(_ value: String) -> Bool? {
+        switch value.lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    private func parseMIDINote(_ value: String) -> Int32? {
+        guard let parsed = Int32(value), parsed >= 0, parsed < 132 else {
+            return nil
+        }
+        return parsed
+    }
+}
+
+private final class MagentaRT2RealtimeOutputSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private let writer: StreamingWAVWriter?
+    private let player: MagentaRT2AudioPlayer?
+
+    init(outputURL: URL?, play: Bool) throws {
+        if let outputURL {
+            writer = try StreamingWAVWriter(
+                outputURL: outputURL,
+                sampleRate: MagentaRT2Resources.sampleRate,
+                channels: MagentaRT2Resources.channels
+            )
+        } else {
+            writer = nil
+        }
+        player = play ? try MagentaRT2AudioPlayer() : nil
+    }
+
+    func consume(frameIndex: Int, frame: MagentaRT2Frame) throws {
+        _ = frameIndex
+        lock.lock()
+        defer { lock.unlock() }
+        let samples = frame.interleavedStereo
+        try writer?.append(samples: samples)
+        try player?.enqueue(frame)
+    }
+
+    func close() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        player?.stop()
+        try writer?.close()
+    }
+}
+
+#if canImport(AVFoundation)
+private final class MagentaRT2AudioPlayer: @unchecked Sendable {
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let format: AVAudioFormat
+
+    init() throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(MagentaRT2Resources.sampleRate),
+            channels: AVAudioChannelCount(MagentaRT2Resources.channels),
+            interleaved: false
+        ) else {
+            throw ValidationError("Could not create audio output format.")
+        }
+        self.format = format
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+        try engine.start()
+        player.play()
+    }
+
+    func enqueue(_ frame: MagentaRT2Frame) throws {
+        let count = min(frame.left.count, frame.right.count)
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(count)
+        ) else {
+            throw ValidationError("Could not allocate audio output buffer.")
+        }
+        buffer.frameLength = AVAudioFrameCount(count)
+        guard let channels = buffer.floatChannelData else {
+            throw ValidationError("Audio output buffer has no float channels.")
+        }
+        for index in 0..<count {
+            channels[0][index] = frame.left[index]
+            channels[1][index] = frame.right[index]
+        }
+        player.scheduleBuffer(buffer, completionHandler: nil)
+    }
+
+    func stop() {
+        player.stop()
+        engine.stop()
+    }
+}
+#else
+private final class MagentaRT2AudioPlayer: @unchecked Sendable {
+    init() throws {
+        throw ValidationError("Audio playback requires AVFoundation on macOS.")
+    }
+
+    func enqueue(_ frame: MagentaRT2Frame) throws {
+        _ = frame
+    }
+
+    func stop() {}
+}
+#endif

--- a/Sources/MereRunCLI/Guides/model-info.md
+++ b/Sources/MereRunCLI/Guides/model-info.md
@@ -34,6 +34,7 @@ mere.run model info image-zimage-nano --components
 
 ```bash
 mere.run model info music-acestep --components
+mere.run model info music-magenta-rt2-small --components
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -42,6 +42,8 @@ mere.run model pull text-chat-lfm25-a1b-8bit
 ```bash
 MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
   mere.run model pull music-acestep
+MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
+  mere.run model pull music-magenta-rt2-small
 ```
 
 ## Iteration Tips

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -2,18 +2,27 @@
 
 ## Purpose
 
-Generate a WAV music clip from a caption and optional structured lyrics using ACE-Step. This is the main cookbook for "make a good song" requests.
+Generate a WAV music clip from a caption. ACE-Step supports optional structured
+lyrics, while Magenta RT2 supports native Apple Silicon offline and realtime
+prompt-to-music generation.
 
 ## Required Models
 
-Managed id: `music-acestep`. The expected layout includes ACE-Step turbo, VAE, Qwen3 text encoder, and optionally the 5 Hz LM subdirectory.
+Managed ids:
+
+- `music-acestep`: ACE-Step turbo, VAE, Qwen3 text encoder, and optionally the
+  5 Hz LM subdirectory.
+- `music-magenta-rt2-small`: Magenta RealTime 2 small exported runtime assets.
+- `music-magenta-rt2-base`: Magenta RealTime 2 base exported runtime assets.
 
 ## Install And Check
 
 ```bash
 mere.run model pull music-acestep
+mere.run model pull music-magenta-rt2-small
 mere.run music generate --help
 mere.run guide music generate --model music-acestep
+mere.run guide music generate --model music-magenta-rt2-small
 ```
 
 ## Parameters
@@ -41,7 +50,20 @@ mere.run guide music generate --model music-acestep
 - `--lm-top-k`, `--lm-top-p`: constrained LM sampling controls.
 - `--metadata-duration`, `--metadata-language`: metadata overrides for LM.
 - `--no-tiled-vae`, `--vae-chunk-size`, `--vae-overlap`: VAE decode memory controls.
+- `--temperature`, `--top-k`: Magenta RT2 sampling controls.
+- `--style-conditioning streaming|full`: choose realtime C++ style-token
+  masking or Python-like full MusicCoCa style conditioning.
+- `--cfg-musiccoca`, `--cfg-notes`, `--cfg-drums`: Magenta RT2 guidance scales.
+- `--drumless`: Magenta RT2 drumless generation.
+- `--unmask-width`, `--seed-rotation`: Magenta RT2 generation controls.
+- `--prefill-silence`, `--prefill-duration`: Magenta RT2 realtime prefill controls.
 - `--quiet`, `-q`: suppress diagnostics.
+
+For realtime Magenta RT2 runs, use `mere.run music realtime`. It accepts the
+same Magenta controls plus `--play` or `--no-play` and optional `--output` WAV
+capture. Add `--interactive` to steer while it runs with stdin commands such as
+`prompt <text>`, `temp <value>`, `noteon <0-131>`, `noteoff <0-131>`,
+`style streaming|full`, `drumless on|off`, `reset`, and `quit`.
 
 ## Prompting Patterns
 
@@ -50,6 +72,8 @@ mere.run guide music generate --model music-acestep
 - Match `--vocal-language` to the lyrics language.
 - Use `--bpm`, `--keyscale`, and `--timesignature` when rhythm or harmony must be stable.
 - Use `--duration 10` to draft, then extend once the caption works.
+- For Magenta RT2, put all musical direction in the prompt; lyrics and ACE-Step
+  task modes are not supported by that runtime.
 
 ## Examples
 
@@ -72,12 +96,32 @@ mere.run music generate \
   --output ./cue.wav
 ```
 
+```bash
+mere.run music generate \
+  "ambient modular synths with brushed drums, slow evolving harmony" \
+  --model music-magenta-rt2-small \
+  --duration 4 \
+  --temperature 0.8 \
+  --output ./magenta-cue.wav
+```
+
+```bash
+mere.run music realtime \
+  "drumless glassy arpeggios with soft tape hiss" \
+  --model music-magenta-rt2-small \
+  --duration 2 \
+  --output ./magenta-live.wav \
+  --no-play
+```
+
 ## Iteration Tips
 
 - First iterate caption and lyrics at 10 to 20 seconds.
 - Lock `--seed` after a promising groove, then adjust metadata.
 - If vocals are garbled, simplify lyrics and add section tags.
 - If structure drifts, try `--use-lm` with BPM/key/time metadata.
+- For Magenta RT2, use `music realtime --output --no-play --duration 2` for a
+  fast headless smoke before running an audible session.
 
 ## Troubleshooting
 
@@ -85,6 +129,12 @@ mere.run music generate \
 - Text encoder missing: set `--text-subdirectory` or keep the default layout.
 - `--use-lm` fails: ensure the LM subdirectory exists or pass `--lm-subdirectory`.
 - Audio decode memory pressure: keep tiled VAE enabled, reduce duration, or tune VAE chunk size.
+- Magenta RT2 unsupported runtime: build `vendor/magentart.xcframework` with
+  `scripts/rebuild_magentart_xcframework.sh` on Apple Silicon macOS, then
+  rebuild `mere.run`.
+- Magenta RT2 missing assets: pull the managed model or provide a local root
+  with exported `.mlxfn` files plus `resources/musiccoca` and
+  `resources/spectrostream`.
 
 ## Sources
 
@@ -92,3 +142,5 @@ mere.run music generate \
 - https://huggingface.co/docs/diffusers/api/pipelines/ace_step
 - https://github.com/ace-step/ACE-Step-1.5/blob/main/docs/en/INFERENCE.md
 - https://huggingface.co/ACE-Step/Ace-Step1.5
+- https://github.com/magenta/magenta-realtime
+- https://huggingface.co/google/magenta-realtime-2

--- a/Sources/MereRunCore/MagentaRT2/MagentaRT2RealtimeSession.swift
+++ b/Sources/MereRunCore/MagentaRT2/MagentaRT2RealtimeSession.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public struct MagentaRT2RealtimeRequest: Hashable, Sendable {
+    public let prompt: String
+    public let resources: MagentaRT2Resources
+    public let durationSeconds: Float
+    public let controls: MagentaRT2Controls
+
+    public init(
+        prompt: String,
+        resources: MagentaRT2Resources,
+        durationSeconds: Float,
+        controls: MagentaRT2Controls = MagentaRT2Controls()
+    ) {
+        self.prompt = prompt
+        self.resources = resources
+        self.durationSeconds = durationSeconds
+        self.controls = controls
+    }
+}
+
+public enum MagentaRT2RealtimeSession {
+    public static func run(
+        _ request: MagentaRT2RealtimeRequest,
+        liveControls: (@Sendable (Int) throws -> MagentaRT2LiveControlSnapshot?)? = nil,
+        onFrame: @escaping @Sendable (Int, MagentaRT2Frame) throws -> Void
+    ) async throws {
+        guard request.durationSeconds > 0 else {
+            throw MagentaRT2Error.invalidDuration(request.durationSeconds)
+        }
+        let missing = request.resources.validate()
+        guard missing.isEmpty else {
+            throw MagentaRT2Error.missingAssets(missing)
+        }
+
+        let frameCount = max(1, Int((request.durationSeconds * Float(MagentaRT2Resources.frameRate)).rounded(.up)))
+        try await MagentaRT2Renderer.renderFrameStream(
+            MagentaRT2RenderRequest(
+                prompt: request.prompt,
+                resources: request.resources,
+                durationSeconds: request.durationSeconds,
+                controls: request.controls
+            ),
+            frameCount: frameCount,
+            liveControls: liveControls,
+            onFrame: onFrame
+        )
+    }
+}

--- a/Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift
+++ b/Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift
@@ -1,0 +1,246 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+#if canImport(magentart)
+@preconcurrency import magentart
+#endif
+
+public struct MagentaRT2RenderRequest: Hashable, Sendable {
+    public let prompt: String
+    public let resources: MagentaRT2Resources
+    public let durationSeconds: Float
+    public let controls: MagentaRT2Controls
+
+    public init(
+        prompt: String,
+        resources: MagentaRT2Resources,
+        durationSeconds: Float,
+        controls: MagentaRT2Controls = MagentaRT2Controls()
+    ) {
+        self.prompt = prompt
+        self.resources = resources
+        self.durationSeconds = durationSeconds
+        self.controls = controls
+    }
+}
+
+public struct MagentaRT2LiveControlSnapshot: Sendable {
+    public let prompt: String?
+    public let controls: MagentaRT2Controls?
+    public let noteOn: [Int32]
+    public let noteOff: [Int32]
+    public let onsetMode: Int32?
+    public let resetState: Bool
+    public let shouldStop: Bool
+
+    public init(
+        prompt: String? = nil,
+        controls: MagentaRT2Controls? = nil,
+        noteOn: [Int32] = [],
+        noteOff: [Int32] = [],
+        onsetMode: Int32? = nil,
+        resetState: Bool = false,
+        shouldStop: Bool = false
+    ) {
+        self.prompt = prompt
+        self.controls = controls
+        self.noteOn = noteOn
+        self.noteOff = noteOff
+        self.onsetMode = onsetMode
+        self.resetState = resetState
+        self.shouldStop = shouldStop
+    }
+}
+
+public enum MagentaRT2Renderer {
+    public static func render(
+        _ request: MagentaRT2RenderRequest,
+        progress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> [Float] {
+        guard request.durationSeconds > 0 else {
+            throw MagentaRT2Error.invalidDuration(request.durationSeconds)
+        }
+        let missing = request.resources.validate()
+        guard missing.isEmpty else {
+            throw MagentaRT2Error.missingAssets(missing)
+        }
+
+        let frameCount = max(1, Int((request.durationSeconds * Float(MagentaRT2Resources.frameRate)).rounded(.up)))
+        return try await renderFrames(request: request, frameCount: frameCount) { frameIndex, frame in
+            progress?(frameIndex, frameCount)
+            return frame.interleavedStereo
+        }
+    }
+
+    public static func renderFrameStream(
+        _ request: MagentaRT2RenderRequest,
+        frameCount: Int,
+        liveControls: (@Sendable (Int) throws -> MagentaRT2LiveControlSnapshot?)? = nil,
+        onFrame: @escaping @Sendable (Int, MagentaRT2Frame) throws -> Void
+    ) async throws {
+        guard request.durationSeconds > 0 else {
+            throw MagentaRT2Error.invalidDuration(request.durationSeconds)
+        }
+        let missing = request.resources.validate()
+        guard missing.isEmpty else {
+            throw MagentaRT2Error.missingAssets(missing)
+        }
+        _ = try await renderFrames(
+            request: request,
+            frameCount: max(1, frameCount),
+            liveControls: liveControls
+        ) { frameIndex, frame in
+            try onFrame(frameIndex, frame)
+            return []
+        }
+    }
+
+    private static func renderFrames(
+        request: MagentaRT2RenderRequest,
+        frameCount: Int,
+        liveControls: (@Sendable (Int) throws -> MagentaRT2LiveControlSnapshot?)? = nil,
+        consumeFrame: @escaping @Sendable (Int, MagentaRT2Frame) throws -> [Float]
+    ) async throws -> [Float] {
+        #if canImport(magentart)
+        return try await Task.detached(priority: .userInitiated) {
+            try withSuppressedNativeStdout {
+                guard let engine = mrt2_engine_create() else {
+                    throw MagentaRT2Error.engineInitializationFailed(request.resources.resourcesURL.path)
+                }
+                defer { mrt2_engine_destroy(engine) }
+
+                guard mrt2_engine_init_assets(engine, request.resources.resourcesURL.path, "musiccoca") else {
+                    throw MagentaRT2Error.engineInitializationFailed(request.resources.resourcesURL.path)
+                }
+                guard mrt2_engine_load_model(engine, request.resources.modelURL.path) else {
+                    throw MagentaRT2Error.modelLoadFailed(request.resources.modelURL.path)
+                }
+
+                applyControls(request.controls, to: engine)
+                if request.controls.prefillSilence {
+                    let frames = max(1, Int32(request.controls.prefillDurationSeconds * Float(MagentaRT2Resources.frameRate)))
+                    guard mrt2_engine_prefill_silence(engine, frames) else {
+                        throw MagentaRT2Error.engineInitializationFailed("silent prefill")
+                    }
+                }
+                mrt2_engine_reset_state(engine)
+                mrt2_engine_set_text_prompt(engine, request.prompt)
+                try waitForPrompt(engine)
+
+                var rendered: [Float] = []
+                rendered.reserveCapacity(frameCount * MagentaRT2Resources.frameSamples * MagentaRT2Resources.channels)
+                var left = [Float](repeating: 0, count: MagentaRT2Resources.frameSamples)
+                var right = [Float](repeating: 0, count: MagentaRT2Resources.frameSamples)
+                for frameIndex in 0..<frameCount {
+                    try Task.checkCancellation()
+                    if let snapshot = try liveControls?(frameIndex) {
+                        if snapshot.shouldStop {
+                            throw CancellationError()
+                        }
+                        if let controls = snapshot.controls {
+                            applyControls(controls, to: engine)
+                        }
+                        if let onsetMode = snapshot.onsetMode {
+                            mrt2_engine_set_onset_mode(engine, onsetMode)
+                        }
+                        snapshot.noteOff.forEach { mrt2_engine_set_note_off(engine, $0) }
+                        snapshot.noteOn.forEach { mrt2_engine_set_note_on(engine, $0) }
+                        if snapshot.resetState {
+                            mrt2_engine_reset_state(engine)
+                        }
+                        if let prompt = snapshot.prompt {
+                            mrt2_engine_set_text_prompt(engine, prompt)
+                            try waitForPrompt(engine)
+                        }
+                    }
+                    let didGenerate = left.withUnsafeMutableBufferPointer { leftBuffer in
+                        right.withUnsafeMutableBufferPointer { rightBuffer in
+                            mrt2_engine_generate_frame(
+                                engine,
+                                leftBuffer.baseAddress,
+                                rightBuffer.baseAddress,
+                                Int32(MagentaRT2Resources.frameSamples)
+                            )
+                        }
+                    }
+                    guard didGenerate else {
+                        throw MagentaRT2Error.generationFailed(frame: frameIndex)
+                    }
+                    let frame = MagentaRT2Frame(left: left, right: right)
+                    rendered.append(contentsOf: try consumeFrame(frameIndex, frame))
+                }
+                return rendered
+            }
+        }.value
+        #else
+        _ = request
+        _ = frameCount
+        _ = consumeFrame
+        throw MagentaRT2Error.unsupportedRuntime
+        #endif
+    }
+
+    #if canImport(magentart)
+    private static let nativeStdoutLock = NSLock()
+
+    private static func applyControls(_ controls: MagentaRT2Controls, to engine: OpaquePointer) {
+        mrt2_engine_set_musiccoca_token_count(engine, controls.styleConditioning.musicCoCaTokenCount)
+        mrt2_engine_set_temperature(engine, controls.temperature)
+        mrt2_engine_set_top_k(engine, controls.topK)
+        mrt2_engine_set_cfg_musiccoca(engine, controls.cfgMusicCoCa)
+        mrt2_engine_set_cfg_notes(engine, controls.cfgNotes)
+        mrt2_engine_set_cfg_drums(engine, controls.cfgDrums)
+        mrt2_engine_set_drumless(engine, controls.drumless)
+        mrt2_engine_set_unmask_width(engine, controls.unmaskWidth)
+        mrt2_engine_set_seed_rotation(engine, controls.seedRotation)
+    }
+
+    private static func waitForPrompt(_ engine: OpaquePointer) throws {
+        let deadline = Date().addingTimeInterval(30)
+        while mrt2_engine_get_text_encoder_status(engine) == 1 || mrt2_engine_get_quantizer_status(engine) == 1 {
+            if Date() > deadline {
+                throw MagentaRT2Error.promptEncodingFailed
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        guard mrt2_engine_get_text_encoder_status(engine) != 3,
+              mrt2_engine_get_quantizer_status(engine) != 3 else {
+            throw MagentaRT2Error.promptEncodingFailed
+        }
+    }
+
+    private static func withSuppressedNativeStdout<T>(_ body: () throws -> T) rethrows -> T {
+        #if canImport(Darwin)
+        nativeStdoutLock.lock()
+        defer { nativeStdoutLock.unlock() }
+
+        fflush(stdout)
+        let savedStdout = dup(STDOUT_FILENO)
+        guard savedStdout >= 0 else {
+            return try body()
+        }
+
+        let devNull = open("/dev/null", O_WRONLY)
+        guard devNull >= 0 else {
+            close(savedStdout)
+            return try body()
+        }
+
+        dup2(devNull, STDOUT_FILENO)
+        close(devNull)
+        defer {
+            fflush(stdout)
+            dup2(savedStdout, STDOUT_FILENO)
+            close(savedStdout)
+        }
+
+        return try body()
+        #else
+        return try body()
+        #endif
+    }
+    #endif
+}

--- a/Sources/MereRunCore/MagentaRT2/MagentaRT2Resources.swift
+++ b/Sources/MereRunCore/MagentaRT2/MagentaRT2Resources.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+public struct MagentaRT2Resources: Hashable, Sendable {
+    public static let upstreamRepoId = "google/magenta-realtime-2"
+    public static let upstreamRevision = "010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc"
+    public static let smallModelId = ModelResolver.ModelID.magentaRT2Small.rawValue
+    public static let baseModelId = ModelResolver.ModelID.magentaRT2Base.rawValue
+    public static let sampleRate = 48_000
+    public static let frameRate = 25
+    public static let frameSamples = 1_920
+    public static let channels = 2
+
+    public let rootURL: URL
+    public let modelID: String
+
+    public init(rootURL: URL, modelID: String) {
+        self.rootURL = rootURL
+        self.modelID = modelID
+    }
+
+    public var modelName: String {
+        Self.modelName(for: modelID)
+    }
+
+    public var modelURL: URL {
+        rootURL.appendingPathComponent("models/\(modelName)/\(modelName).mlxfn", isDirectory: false)
+    }
+
+    public var modelStateURL: URL {
+        rootURL.appendingPathComponent("models/\(modelName)/\(modelName)_state.safetensors", isDirectory: false)
+    }
+
+    public var resourcesURL: URL {
+        rootURL.appendingPathComponent("resources", isDirectory: true)
+    }
+
+    public var spectrostreamEncoderURL: URL {
+        resourcesURL.appendingPathComponent("spectrostream/spectrostream_encoder.mlxfn", isDirectory: false)
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        requiredRelativePaths()
+            .map { rootURL.appendingPathComponent($0, isDirectory: false) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+
+    public static func modelName(for modelID: String) -> String {
+        modelID == baseModelId ? "mrt2_base" : "mrt2_small"
+    }
+
+    public static func isMagentaRT2Model(_ value: String?) -> Bool {
+        guard let value else { return false }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed == smallModelId
+            || trimmed == baseModelId
+            || trimmed == upstreamRepoId.lowercased()
+    }
+
+    public static func resolve(
+        requestedModel: String?,
+        defaultModelID: String = smallModelId,
+        fileManager: FileManager = .default,
+        progress: (@Sendable (PretrainedModelLoader.ProgressEvent) -> Void)? = nil
+    ) async throws -> MagentaRT2Resources {
+        if let explicit = explicitPath(from: requestedModel, fileManager: fileManager) {
+            let modelID = inferredModelID(in: explicit, fileManager: fileManager) ?? defaultModelID
+            return MagentaRT2Resources(rootURL: explicit, modelID: modelID)
+        }
+
+        let resolution = try await ManagedModelResolver.resolveForRuntime(
+            requestedModel: requestedModel,
+            defaultModelID: defaultModelID,
+            fileManager: fileManager,
+            progress: progress
+        )
+        let modelID = resolution.spec.id
+        return MagentaRT2Resources(rootURL: resolution.url, modelID: modelID)
+    }
+
+    public static func inferredModelID(in rootURL: URL, fileManager: FileManager = .default) -> String? {
+        let base = rootURL.appendingPathComponent("models/mrt2_base/mrt2_base.mlxfn")
+        if fileManager.fileExists(atPath: base.path) {
+            return baseModelId
+        }
+        let small = rootURL.appendingPathComponent("models/mrt2_small/mrt2_small.mlxfn")
+        if fileManager.fileExists(atPath: small.path) {
+            return smallModelId
+        }
+        return nil
+    }
+
+    public static func looksLikeMagentaRT2Root(_ rootURL: URL, fileManager: FileManager = .default) -> Bool {
+        guard inferredModelID(in: rootURL, fileManager: fileManager) != nil else {
+            return false
+        }
+        let musicCoCa = rootURL.appendingPathComponent("resources/musiccoca", isDirectory: true)
+        return fileManager.fileExists(atPath: musicCoCa.path)
+    }
+
+    private func requiredRelativePaths() -> [String] {
+        [
+            "models/\(modelName)/\(modelName).mlxfn",
+            "models/\(modelName)/\(modelName)_state.safetensors",
+            "resources/musiccoca/audio_preprocessor.tflite",
+            "resources/musiccoca/mapper.tflite",
+            "resources/musiccoca/music_encoder.tflite",
+            "resources/musiccoca/pretrained_vector_quantizer.tflite",
+            "resources/musiccoca/spm.model",
+            "resources/musiccoca/text_encoder.tflite",
+            "resources/spectrostream/decoder.safetensors",
+            "resources/spectrostream/encoder.safetensors",
+            "resources/spectrostream/quantizer.safetensors",
+            "resources/spectrostream/spectrostream_encoder.mlxfn",
+        ]
+    }
+
+    private static func explicitPath(from requestedModel: String?, fileManager: FileManager) -> URL? {
+        guard let requestedModel else { return nil }
+        let trimmed = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let url = URL(fileURLWithPath: trimmed).standardizedFileURL
+        return fileManager.fileExists(atPath: url.path) ? url : nil
+    }
+}
+
+public struct MagentaRT2Controls: Hashable, Sendable {
+    public var styleConditioning: MagentaRT2StyleConditioning
+    public var temperature: Float
+    public var topK: Int32
+    public var cfgMusicCoCa: Float
+    public var cfgNotes: Float
+    public var cfgDrums: Float
+    public var drumless: Bool
+    public var unmaskWidth: Int32
+    public var seedRotation: Int32
+    public var prefillSilence: Bool
+    public var prefillDurationSeconds: Float
+
+    public init(
+        styleConditioning: MagentaRT2StyleConditioning = .streaming,
+        temperature: Float = 1.0,
+        topK: Int32 = 100,
+        cfgMusicCoCa: Float = 3.0,
+        cfgNotes: Float = 5.0,
+        cfgDrums: Float = 1.0,
+        drumless: Bool = false,
+        unmaskWidth: Int32 = 0,
+        seedRotation: Int32 = 0,
+        prefillSilence: Bool = false,
+        prefillDurationSeconds: Float = 1.64
+    ) {
+        self.styleConditioning = styleConditioning
+        self.temperature = temperature
+        self.topK = topK
+        self.cfgMusicCoCa = cfgMusicCoCa
+        self.cfgNotes = cfgNotes
+        self.cfgDrums = cfgDrums
+        self.drumless = drumless
+        self.unmaskWidth = unmaskWidth
+        self.seedRotation = seedRotation
+        self.prefillSilence = prefillSilence
+        self.prefillDurationSeconds = prefillDurationSeconds
+    }
+}
+
+public enum MagentaRT2StyleConditioning: String, CaseIterable, Hashable, Sendable {
+    case streaming
+    case full
+
+    public var musicCoCaTokenCount: Int32 {
+        switch self {
+        case .streaming:
+            return 6
+        case .full:
+            return 12
+        }
+    }
+}
+
+public struct MagentaRT2Frame: Hashable, Sendable {
+    public let left: [Float]
+    public let right: [Float]
+
+    public init(left: [Float], right: [Float]) {
+        self.left = left
+        self.right = right
+    }
+
+    public var interleavedStereo: [Float] {
+        let count = min(left.count, right.count)
+        var samples: [Float] = []
+        samples.reserveCapacity(count * 2)
+        for index in 0..<count {
+            samples.append(left[index])
+            samples.append(right[index])
+        }
+        return samples
+    }
+}
+
+public enum MagentaRT2Error: LocalizedError, Sendable {
+    case unsupportedRuntime
+    case invalidDuration(Float)
+    case invalidControl(String)
+    case missingAssets([URL])
+    case engineInitializationFailed(String)
+    case modelLoadFailed(String)
+    case promptEncodingFailed
+    case generationFailed(frame: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedRuntime:
+            return "Magenta RT2 requires Apple Silicon macOS and a built vendor/magentart.xcframework. Run scripts/rebuild_magentart_xcframework.sh, then rebuild mere.run."
+        case .invalidDuration(let duration):
+            return "Duration must be > 0 seconds; received \(duration)."
+        case .invalidControl(let message):
+            return message
+        case .missingAssets(let urls):
+            return "Magenta RT2 model is incomplete: \(urls.map(\.path).joined(separator: ", "))"
+        case .engineInitializationFailed(let path):
+            return "Failed to initialize Magenta RT2 assets from \(path)."
+        case .modelLoadFailed(let path):
+            return "Failed to load Magenta RT2 model from \(path)."
+        case .promptEncodingFailed:
+            return "Magenta RT2 prompt encoding failed."
+        case .generationFailed(let frame):
+            return "Magenta RT2 generation failed at frame \(frame)."
+        }
+    }
+}

--- a/Sources/MereRunCore/MagentaRT2/README.md
+++ b/Sources/MereRunCore/MagentaRT2/README.md
@@ -1,0 +1,27 @@
+# Magenta RT2
+
+Native Magenta RealTime 2 support for Apple Silicon macOS.
+
+## Files
+
+- `MagentaRT2Resources.swift` resolves managed or local Magenta RT2 model roots,
+  validates exported `.mlxfn` assets, and defines generation controls.
+- `MagentaRT2Renderer.swift` owns the C ABI bridge to `magentart.xcframework`
+  and renders deterministic frame batches.
+- `MagentaRT2RealtimeSession.swift` adapts the renderer into a paced realtime
+  frame stream for CLI playback, capture, and live steering.
+
+## Runtime Contract
+
+The runtime expects an exported Magenta RT2 layout with `models/mrt2_small` or
+`models/mrt2_base`, plus shared `resources/musiccoca` and
+`resources/spectrostream` assets. Raw upstream checkpoints are not enough.
+
+Swift owns CLI stdout and stderr. Native C++ stdout is suppressed inside the
+renderer so command stdout can stay machine-readable.
+
+## Style Conditioning
+
+`MagentaRT2StyleConditioning.streaming` keeps the upstream realtime C++ policy
+of using the coarsest MusicCoCa style tokens. `full` uses all MusicCoCa style
+tokens, matching the upstream high-level Python `.mlxfn` generator.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -44,6 +44,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case sam31
     case falconPerception
     case aceStep
+    case magentaRT2
     case ltxVideo
     case hfTextChat
 }
@@ -157,6 +158,20 @@ public enum ManagedModelCatalog {
     private static let kleinNanoUpstreamRepoId = "stereovoid/flux2-klein-4b-4bit"
     private static let bonsaiBinaryUpstreamRepoId = "prism-ml/bonsai-image-binary-4B-mlx-1bit"
     private static let bonsaiTernaryUpstreamRepoId = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
+    private static let magentaRT2UpstreamRepoId = "google/magenta-realtime-2"
+    private static let magentaRT2UpstreamRevision = "010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc"
+    private static let magentaRT2ResourcePatterns = [
+        "resources/musiccoca/audio_preprocessor.tflite",
+        "resources/musiccoca/mapper.tflite",
+        "resources/musiccoca/music_encoder.tflite",
+        "resources/musiccoca/pretrained_vector_quantizer.tflite",
+        "resources/musiccoca/spm.model",
+        "resources/musiccoca/text_encoder.tflite",
+        "resources/spectrostream/decoder.safetensors",
+        "resources/spectrostream/encoder.safetensors",
+        "resources/spectrostream/quantizer.safetensors",
+        "resources/spectrostream/spectrostream_encoder.mlxfn",
+    ]
 
     public static let allSpecs: [ManagedModelSpec] = [
         ManagedModelSpec(
@@ -773,6 +788,42 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["music generate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.magentaRT2Small.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: magentaRT2UpstreamRepoId,
+                revision: magentaRT2UpstreamRevision,
+                patterns: [
+                    "models/mrt2_small/mrt2_small.mlxfn",
+                    "models/mrt2_small/mrt2_small_state.safetensors",
+                ] + magentaRT2ResourcePatterns
+            ),
+            upstreamRepoId: magentaRT2UpstreamRepoId,
+            upstreamRevision: magentaRT2UpstreamRevision,
+            validationKind: .magentaRT2,
+            estimatedDownloadBytes: 1_840_072_891,
+            defaultCLICommands: ["music generate", "music realtime"]
+        ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.magentaRT2Base.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: magentaRT2UpstreamRepoId,
+                revision: magentaRT2UpstreamRevision,
+                patterns: [
+                    "models/mrt2_base/mrt2_base.mlxfn",
+                    "models/mrt2_base/mrt2_base_state.safetensors",
+                ] + magentaRT2ResourcePatterns
+            ),
+            upstreamRepoId: magentaRT2UpstreamRepoId,
+            upstreamRevision: magentaRT2UpstreamRevision,
+            validationKind: .magentaRT2,
+            estimatedDownloadBytes: 4_164_096_058,
+            defaultCLICommands: ["music generate", "music realtime"]
+        ),
+        ManagedModelSpec(
             id: "video-ltx-av",
             category: .video,
             installShape: .structuredRoot,
@@ -922,6 +973,8 @@ public extension ManagedModelSpec {
             return Self.missingLightOnOCRPaths(in: rootURL, fileManager: fileManager)
         case .aceStep:
             return Self.missingACEStepPaths(in: rootURL, fileManager: fileManager)
+        case .magentaRT2:
+            return Self.missingMagentaRT2Paths(modelID: id, in: rootURL, fileManager: fileManager)
         case .ltxVideo:
             return Self.missingLTXVideoPaths(in: rootURL, fileManager: fileManager)
         case .hfTextChat:
@@ -938,6 +991,12 @@ public extension ManagedModelSpec {
         case .ltxVideo:
             return Self.missingLTXVideoPaths(in: normalizedRootURL(rootURL, fileManager: fileManager), fileManager: fileManager)
                 .map { "Missing required LTX file: \($0.path)" }
+        case .magentaRT2:
+            return Self.missingMagentaRT2Paths(
+                modelID: id,
+                in: normalizedRootURL(rootURL, fileManager: fileManager),
+                fileManager: fileManager
+            ).map { "Missing required Magenta RT2 file: \($0.path)" }
         default:
             return missingPaths(in: rootURL, fileManager: fileManager).map { "Missing required file: \($0.path)" }
         }
@@ -1171,6 +1230,31 @@ public extension ManagedModelSpec {
         if !fileManager.fileExists(atPath: vaeDir.path) { missing.append(vaeDir) }
         if !fileManager.fileExists(atPath: textDir.path) { missing.append(textDir) }
         return missing
+    }
+
+    private static func missingMagentaRT2Paths(
+        modelID: String,
+        in rootURL: URL,
+        fileManager: FileManager
+    ) -> [URL] {
+        let modelName = modelID == ModelResolver.ModelID.magentaRT2Base.rawValue ? "mrt2_base" : "mrt2_small"
+        let relativePaths = [
+            "models/\(modelName)/\(modelName).mlxfn",
+            "models/\(modelName)/\(modelName)_state.safetensors",
+            "resources/musiccoca/audio_preprocessor.tflite",
+            "resources/musiccoca/mapper.tflite",
+            "resources/musiccoca/music_encoder.tflite",
+            "resources/musiccoca/pretrained_vector_quantizer.tflite",
+            "resources/musiccoca/spm.model",
+            "resources/musiccoca/text_encoder.tflite",
+            "resources/spectrostream/decoder.safetensors",
+            "resources/spectrostream/encoder.safetensors",
+            "resources/spectrostream/quantizer.safetensors",
+            "resources/spectrostream/spectrostream_encoder.mlxfn",
+        ]
+        return relativePaths
+            .map { rootURL.appendingPathComponent($0, isDirectory: false) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
     }
 
     private static func missingLTXVideoPaths(in rootURL: URL, fileManager: FileManager) -> [URL] {

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -462,6 +462,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 32
             ),
             descriptor(
+                ModelResolver.ModelID.magentaRT2Small.rawValue,
+                "Magenta RealTime 2 small",
+                "Streams controllable Magenta RT2 music on Apple Silicon with the 230M model.",
+                minimum: 8,
+                recommended: 16
+            ),
+            descriptor(
+                ModelResolver.ModelID.magentaRT2Base.rawValue,
+                "Magenta RealTime 2 base",
+                "Streams higher-quality Magenta RT2 music on Pro/Max-class Apple Silicon.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
                 "video-ltx-av",
                 "Video generation",
                 "Generates short audio-video clips with the LTX unified AV model stack.",
@@ -496,6 +510,10 @@ public enum ManagedModelCapabilityCatalog {
 
         if !machine.isSupportedRuntime {
             reasons.append("Apple Silicon macOS or Linux is required.")
+        }
+
+        if spec.validationKind == .magentaRT2 && !machine.isAppleSiliconMac {
+            reasons.append("Magenta RT2 requires Apple Silicon macOS.")
         }
 
         if machine.unifiedMemoryGB < descriptor.minimumUnifiedMemoryGB {

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -48,6 +48,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case lightOnOCR = "lighton-ocr"
         /// ACE-Step music family.
         case aceStep = "ace-step"
+        /// Magenta RealTime 2 streaming music family.
+        case magentaRT2 = "magenta-rt2"
         /// LTX video family.
         case ltxVideo = "ltx-video"
         /// Psi agent chat family.
@@ -80,6 +82,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
 
     public enum Tier: String, Codable, CaseIterable, Hashable, Sendable {
         case nano
+        case small
         case base
         case max
         case latest
@@ -1084,6 +1087,21 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.musicGeneration],
                 components: nil,
                 upstreamRepoId: "ACE-Step/Ace-Step1.5",
+                createdAt: createdAt
+            )
+        case .magentaRT2Small, .magentaRT2Base:
+            let isBase = modelID == .magentaRT2Base
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .magentaRT2,
+                family: .music,
+                tier: isBase ? .base : .small,
+                variant: .standard,
+                precision: .unknown,
+                defaults: Defaults(steps: isBase ? 100 : 100, cfg: 3.0),
+                supports: [.musicGeneration],
+                components: nil,
+                upstreamRepoId: "google/magenta-realtime-2@010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc",
                 createdAt: createdAt
             )
         case .ltxVideoAV:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -103,6 +103,7 @@ public enum MereRunModelValidator {
             case .directoryRoot, .structuredRoot:
                 return spec.validationKind != .codegenGGUF
                     && spec.validationKind != .deepseekV4FlashIMatrixGGUF
+                    && spec.validationKind != .magentaRT2
             }
         }()
         if !hasRootMarker && !usesMFluxZImage && requiresRootMarker {
@@ -129,7 +130,7 @@ public enum MereRunModelValidator {
             textEncoderDir = nil
             vaeDir = nil
             tokenizerDir = nil
-        } else if spec?.validationKind == .aceStep || spec?.validationKind == .ltxVideo {
+        } else if spec?.validationKind == .aceStep || spec?.validationKind == .magentaRT2 || spec?.validationKind == .ltxVideo {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil
             textEncoderDir = nil
@@ -357,8 +358,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=code expects qwen3-coder.")
             case .ocr where engine != .lightOnOCR:
                 warnings.append("Manifest engine mismatch: family=ocr expects lighton-ocr.")
-            case .music where engine != .aceStep:
-                warnings.append("Manifest engine mismatch: family=music expects ace-step.")
+            case .music where engine != .aceStep && engine != .magentaRT2:
+                warnings.append("Manifest engine mismatch: family=music expects ace-step or magenta-rt2.")
             case .video where engine != .ltxVideo:
                 warnings.append("Manifest engine mismatch: family=video expects ltx-video.")
             case .psi where engine != .psiChat:
@@ -433,7 +434,7 @@ public enum MereRunModelValidator {
                 return true
             }
             switch manifest.engine {
-            case .qwen3Coder?, .aceStep?, .ltxVideo?:
+            case .qwen3Coder?, .aceStep?, .magentaRT2?, .ltxVideo?:
                 return true
             default:
                 return false
@@ -511,6 +512,7 @@ public enum MereRunModelValidator {
 
     private static func inferTier(from modelId: String) -> MereRunModelManifest.Tier? {
         if modelId.hasSuffix("-nano") { return .nano }
+        if modelId.hasSuffix("-small") { return .small }
         if modelId.hasSuffix("-max") { return .max }
         if modelId.hasSuffix("-base") { return .base }
         return nil

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -47,6 +47,8 @@ public struct ModelResolver {
         case visionSegmentSAM31 = "vision-segment-sam31"
         case visionGroundFalconPerception = "vision-ground-falcon-perception"
         case aceStep = "music-acestep"
+        case magentaRT2Small = "music-magenta-rt2-small"
+        case magentaRT2Base = "music-magenta-rt2-base"
         case ltxVideoAV = "video-ltx-av"
     }
 

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -31,6 +31,7 @@ public enum QuantizedModelManifestWriter {
 
         func inferTier(from id: String) -> MereRunModelManifest.Tier? {
             if id.hasSuffix("-nano") { return .nano }
+            if id.hasSuffix("-small") { return .small }
             if id.hasSuffix("-max") { return .max }
             if id.hasSuffix("-base") { return .base }
             return nil
@@ -53,7 +54,7 @@ public enum QuantizedModelManifestWriter {
             case .openAIPrivacyFilter: return .privacy
             case .qwen3Coder: return .code
             case .lightOnOCR: return .ocr
-            case .aceStep: return .music
+            case .aceStep, .magentaRT2: return .music
             case .ltxVideo: return .video
             case .psiChat: return .psi
             case .deepseekV4Flash: return .deepseek
@@ -111,7 +112,7 @@ public enum QuantizedModelManifestWriter {
                     return [.chat, .codeGeneration]
                 case .lightOnOCR:
                     return [.visionOCR]
-                case .aceStep:
+                case .aceStep, .magentaRT2:
                     return [.musicGeneration]
                 case .ltxVideo:
                     return [.videoGeneration]
@@ -183,7 +184,7 @@ public enum QuantizedModelManifestWriter {
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .qwen3Embedding, .openAIPrivacyFilter, .qwen3Coder, .lightOnOCR, .psiChat, .deepseekV4Flash:
                 break
-            case .aceStep, .ltxVideo:
+            case .aceStep, .magentaRT2, .ltxVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)
             }
         }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -73,6 +73,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### `vendor/magentart.xcframework`
+
+- purpose: optional native Magenta RealTime 2 runtime used by `mere.run music generate --model music-magenta-rt2-*` and `mere.run music realtime`
+- upstream project: [`magenta/magenta-realtime`](https://github.com/magenta/magenta-realtime)
+- pinned upstream commit: `51836beddf5fbb33636830efd919884f40ef56c5`
+- rebuild note: generated from a temporary upstream checkout plus the C ABI shim in [`scripts/rebuild_magentart_xcframework.sh`](./scripts/rebuild_magentart_xcframework.sh)
+- code license: Apache License 2.0
+- model weights: [`google/magenta-realtime-2`](https://huggingface.co/google/magenta-realtime-2), revision `010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc`, Creative Commons Attribution 4.0 International
+
+```
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
 ### `vendor/ds4`
 
 - purpose: packaged DeepSeek V4 Flash runtime used by the premier setup-agent tier

--- a/Tests/MereRunCLITests/GuideCommandTests.swift
+++ b/Tests/MereRunCLITests/GuideCommandTests.swift
@@ -19,12 +19,17 @@ final class GuideCommandTests: XCTestCase {
     }
 
     func testGuideMusicGenerateModelFocusParsesAndRenders() throws {
-        let command = try GuideCommand.parse(["music", "generate", "--model", "music-acestep"])
+        let command = try GuideCommand.parse([
+            "music",
+            "generate",
+            "--model",
+            ModelResolver.ModelID.magentaRT2Small.rawValue,
+        ])
         let entry = try GuideCommand.resolveEntry(commandPath: command.commandPath, model: command.model)
         let rendered = try GuideCommand.render(entry: entry, model: command.model, json: false)
 
-        XCTAssertEqual(command.model, "music-acestep")
-        XCTAssertTrue(rendered.contains("Model focus: `music-acestep`"))
+        XCTAssertEqual(command.model, ModelResolver.ModelID.magentaRT2Small.rawValue)
+        XCTAssertTrue(rendered.contains("Model focus: `\(ModelResolver.ModelID.magentaRT2Small.rawValue)`"))
         XCTAssertTrue(rendered.contains("# Music Generate"))
     }
 
@@ -51,6 +56,7 @@ final class GuideCommandTests: XCTestCase {
             let message = String(describing: error)
             XCTAssertTrue(message.contains("not covered"))
             XCTAssertTrue(message.contains("music-acestep"))
+            XCTAssertTrue(message.contains(ModelResolver.ModelID.magentaRT2Small.rawValue))
         }
     }
 
@@ -63,7 +69,14 @@ final class GuideCommandTests: XCTestCase {
         XCTAssertEqual(payload.topic, "music-generate")
         XCTAssertEqual(payload.title, "Music Generate")
         XCTAssertEqual(payload.commands, ["music generate"])
-        XCTAssertEqual(payload.models, ["music-acestep"])
+        XCTAssertEqual(
+            payload.models,
+            [
+                "music-acestep",
+                ModelResolver.ModelID.magentaRT2Small.rawValue,
+                ModelResolver.ModelID.magentaRT2Base.rawValue,
+            ]
+        )
         XCTAssertTrue(payload.content.contains("# Music Generate"))
     }
 

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -42,4 +42,88 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.durationSeconds, 18.0, accuracy: 0.0001)
         XCTAssertEqual(cmd.steps, 12)
     }
+
+    func testMusicGenerateParsesMagentaControls() throws {
+        let cmd = try MusicGenerate.parse([
+            "ambient modular synths",
+            "--model", ModelResolver.ModelID.magentaRT2Small.rawValue,
+            "--duration", "4",
+            "--style-conditioning", "full",
+            "--temperature", "0.8",
+            "--top-k", "64",
+            "--cfg-musiccoca", "2.5",
+            "--cfg-notes", "4.5",
+            "--cfg-drums", "0.75",
+            "--drumless",
+            "--unmask-width", "8",
+            "--seed-rotation", "3",
+            "--prefill-silence",
+            "--prefill-duration", "1.25",
+        ])
+
+        XCTAssertEqual(cmd.model, ModelResolver.ModelID.magentaRT2Small.rawValue)
+        XCTAssertEqual(cmd.durationSeconds, 4.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.magentaStyleConditioning, .full)
+        XCTAssertEqual(cmd.magentaTemperature, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(cmd.magentaTopK, 64)
+        XCTAssertEqual(cmd.magentaCFGMusicCoCa, 2.5, accuracy: 0.0001)
+        XCTAssertEqual(cmd.magentaCFGNotes, 4.5, accuracy: 0.0001)
+        XCTAssertEqual(cmd.magentaCFGDrums, 0.75, accuracy: 0.0001)
+        XCTAssertTrue(cmd.magentaDrumless)
+        XCTAssertEqual(cmd.magentaUnmaskWidth, 8)
+        XCTAssertEqual(cmd.magentaSeedRotation, 3)
+        XCTAssertTrue(cmd.magentaPrefillSilence)
+        XCTAssertEqual(cmd.magentaPrefillDuration, 1.25, accuracy: 0.0001)
+    }
+
+    func testMusicRealtimeParsesMagentaDefaults() throws {
+        let cmd = try MusicRealtime.parse([
+            "ambient pads",
+        ])
+
+        XCTAssertEqual(cmd.prompt, "ambient pads")
+        XCTAssertEqual(cmd.model, ModelResolver.ModelID.magentaRT2Small.rawValue)
+        XCTAssertEqual(cmd.durationSeconds, 30.0, accuracy: 0.0001)
+        XCTAssertTrue(cmd.play)
+        XCTAssertNil(cmd.output)
+    }
+
+    func testMusicRealtimeParsesHeadlessCapture() throws {
+        let cmd = try MusicRealtime.parse([
+            "ambient pads",
+            "--model", ModelResolver.ModelID.magentaRT2Base.rawValue,
+            "--duration", "2",
+            "--output", "/tmp/live.wav",
+            "--no-play",
+            "--interactive",
+            "--style-conditioning", "full",
+            "--temperature", "0.7",
+            "--top-k", "32",
+            "--cfg-musiccoca", "2",
+            "--cfg-notes", "3",
+            "--cfg-drums", "0.5",
+            "--drumless",
+            "--unmask-width", "4",
+            "--seed-rotation", "9",
+            "--prefill-silence",
+            "--prefill-duration", "1.5",
+        ])
+
+        XCTAssertEqual(cmd.model, ModelResolver.ModelID.magentaRT2Base.rawValue)
+        XCTAssertEqual(cmd.durationSeconds, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.output, "/tmp/live.wav")
+        XCTAssertFalse(cmd.play)
+        XCTAssertTrue(cmd.interactive)
+        XCTAssertEqual(cmd.styleConditioning, .full)
+        XCTAssertEqual(cmd.temperature, 0.7, accuracy: 0.0001)
+        XCTAssertEqual(cmd.topK, 32)
+        XCTAssertEqual(cmd.cfgMusicCoCa, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.cfgNotes, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.cfgDrums, 0.5, accuracy: 0.0001)
+        XCTAssertTrue(cmd.drumless)
+        XCTAssertEqual(cmd.unmaskWidth, 4)
+        XCTAssertEqual(cmd.seedRotation, 9)
+        XCTAssertTrue(cmd.prefillSilence)
+        XCTAssertEqual(cmd.prefillDuration, 1.5, accuracy: 0.0001)
+    }
 }

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -352,6 +352,40 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(spec.isManagedRootComplete(legacyRoot, fileManager: .default))
     }
 
+    func testMagentaRT2SpecsUsePinnedExportedRuntimeAssets() throws {
+        let small = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.magentaRT2Small.rawValue))
+        XCTAssertEqual(small.category, .music)
+        XCTAssertEqual(small.hubFallback?.repoId, "google/magenta-realtime-2")
+        XCTAssertEqual(small.hubFallback?.revision, "010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc")
+        XCTAssertEqual(small.validationKind, .magentaRT2)
+        XCTAssertEqual(small.hubFallback?.patterns.contains("models/mrt2_small/mrt2_small.mlxfn"), true)
+        XCTAssertEqual(small.hubFallback?.patterns.contains("checkpoints/mrt2_small.safetensors"), false)
+
+        let base = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.magentaRT2Base.rawValue))
+        XCTAssertEqual(base.category, .music)
+        XCTAssertEqual(base.hubFallback?.repoId, "google/magenta-realtime-2")
+        XCTAssertEqual(base.hubFallback?.revision, "010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc")
+        XCTAssertEqual(base.validationKind, .magentaRT2)
+        XCTAssertEqual(base.hubFallback?.patterns.contains("models/mrt2_base/mrt2_base.mlxfn"), true)
+        XCTAssertEqual(base.hubFallback?.patterns.contains("checkpoints/mrt2_base.safetensors"), false)
+    }
+
+    func testMagentaRT2RootValidationRequiresModelAndSharedResources() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.magentaRT2Small.rawValue))
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalMagentaRT2Root(at: root, modelName: "mrt2_small")
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+
+        try FileManager.default.removeItem(at: root.appendingPathComponent("resources/musiccoca/text_encoder.tflite"))
+        XCTAssertFalse(spec.isManagedRootComplete(root, fileManager: .default))
+        XCTAssertEqual(
+            spec.missingPaths(in: root, fileManager: .default).map(\.lastPathComponent),
+            ["text_encoder.tflite"]
+        )
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-managed-model-catalog-\(UUID().uuidString)", isDirectory: true)
@@ -365,6 +399,36 @@ final class ManagedModelCatalogTests: XCTestCase {
                 at: root.appendingPathComponent(subdirectory, isDirectory: true),
                 withIntermediateDirectories: true
             )
+        }
+    }
+
+    private func writeMinimalMagentaRT2Root(at root: URL, modelName: String) throws {
+        let modelDir = root.appendingPathComponent("models/\(modelName)", isDirectory: true)
+        let musicCoCa = root.appendingPathComponent("resources/musiccoca", isDirectory: true)
+        let spectrostream = root.appendingPathComponent("resources/spectrostream", isDirectory: true)
+        for directory in [modelDir, musicCoCa, spectrostream] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        for file in ["\(modelName).mlxfn", "\(modelName)_state.safetensors"] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: modelDir.appendingPathComponent(file).path, contents: Data()))
+        }
+        for file in [
+            "audio_preprocessor.tflite",
+            "mapper.tflite",
+            "music_encoder.tflite",
+            "pretrained_vector_quantizer.tflite",
+            "spm.model",
+            "text_encoder.tflite",
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: musicCoCa.appendingPathComponent(file).path, contents: Data()))
+        }
+        for file in [
+            "decoder.safetensors",
+            "encoder.safetensors",
+            "quantizer.safetensors",
+            "spectrostream_encoder.mlxfn",
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: spectrostream.appendingPathComponent(file).path, contents: Data()))
         }
     }
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -131,6 +131,38 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("Qwen3.5-9B-Q4_K_M.gguf"), contents: Data())
     }
 
+    private func writeMinimalValidMagentaRT2Model(at root: URL, modelID: ModelResolver.ModelID = .magentaRT2Small) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: modelID, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        let modelName = MagentaRT2Resources.modelName(for: modelID.rawValue)
+        let modelDir = root.appendingPathComponent("models/\(modelName)", isDirectory: true)
+        let musicCoCa = root.appendingPathComponent("resources/musiccoca", isDirectory: true)
+        let spectrostream = root.appendingPathComponent("resources/spectrostream", isDirectory: true)
+        for directory in [modelDir, musicCoCa, spectrostream] {
+            try TestFileSystem.createDirectory(directory)
+        }
+        try TestFileSystem.writeFile(modelDir.appendingPathComponent("\(modelName).mlxfn"), contents: Data())
+        try TestFileSystem.writeFile(modelDir.appendingPathComponent("\(modelName)_state.safetensors"), contents: Data())
+        for file in [
+            "audio_preprocessor.tflite",
+            "mapper.tflite",
+            "music_encoder.tflite",
+            "pretrained_vector_quantizer.tflite",
+            "spm.model",
+            "text_encoder.tflite",
+        ] {
+            try TestFileSystem.writeFile(musicCoCa.appendingPathComponent(file), contents: Data())
+        }
+        for file in [
+            "decoder.safetensors",
+            "encoder.safetensors",
+            "quantizer.safetensors",
+            "spectrostream_encoder.mlxfn",
+        ] {
+            try TestFileSystem.writeFile(spectrostream.appendingPathComponent(file), contents: Data())
+        }
+    }
+
     func testValidModelPasses() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
@@ -141,6 +173,41 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: "image-klein-nano")
         XCTAssertTrue(report.isValid)
         XCTAssertTrue(report.errors.isEmpty)
+    }
+
+    func testMagentaRT2RootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("music-magenta-rt2-small", isDirectory: true)
+        try writeMinimalValidMagentaRT2Model(at: root)
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: ModelResolver.ModelID.magentaRT2Small.rawValue
+        )
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertFalse(report.warnings.contains { $0.contains("model root marker") })
+        XCTAssertEqual(report.manifest?.engine, .magentaRT2)
+        XCTAssertEqual(report.manifest?.family, .music)
+        XCTAssertEqual(report.manifest?.tier, .small)
+    }
+
+    func testMagentaRT2MissingRuntimeAssetFailsValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent("music-magenta-rt2-small", isDirectory: true)
+        try writeMinimalValidMagentaRT2Model(at: root)
+        try FileManager.default.removeItem(at: root.appendingPathComponent("models/mrt2_small/mrt2_small.mlxfn"))
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: ModelResolver.ModelID.magentaRT2Small.rawValue
+        )
+        XCTAssertFalse(report.isValid)
+        XCTAssertTrue(report.errors.contains { $0.contains("mrt2_small.mlxfn") })
     }
 
     func testMissingWeightsFails() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,7 @@ Public tree:
 - `mere.run vision track-live`
 - `mere.run vision ocr`
 - `mere.run music generate`
+- `mere.run music realtime`
 - `mere.run video generate`
 - `mere.run video export-latents`
 - `mere.run model { list, capabilities, info, pull, remove, runtime, benchmark, repair-manifests }`
@@ -73,7 +74,7 @@ are:
 - Vision OCR: `vision-ocr-lighton`
 - Vision segmentation / tracking: `vision-segment-sam31`
 - Vision grounding: `vision-ground-falcon-perception`
-- Music: `music-acestep`
+- Music: `music-acestep`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - Video: `video-ltx-av`
 
 For subsystem-specific implementation guides, see:
@@ -139,6 +140,14 @@ swift run mere.run model pull music-acestep
 swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
+
+swift run mere.run model pull music-magenta-rt2-small
+swift run mere.run music realtime \
+  "ambient modular synths with brushed drums" \
+  --model music-magenta-rt2-small \
+  --duration 4 \
+  --output ./live.wav \
+  --no-play
 ```
 
 ### Generate video
@@ -552,7 +561,9 @@ swift run mere.run vision ocr ./page.png --backend glm
 
 ### `mere.run music generate`
 
-Generate music from a caption and optional lyrics using the native ACE-Step pipeline.
+Generate music from a caption. The default model uses the native ACE-Step
+pipeline with optional lyrics; Magenta RT2 models use the native Apple Silicon
+Magenta bridge and ignore ACE-Step-only controls.
 
 ```bash
 swift run mere.run music generate "<caption>" [options]
@@ -572,6 +583,20 @@ Key options:
 - `--seed`
 - `--quiet`
 
+Magenta RT2 options:
+
+- `--style-conditioning`: `streaming` keeps the realtime C++ coarse style-token policy; `full` uses all MusicCoCa style tokens like the Python high-level generator
+- `--temperature`
+- `--top-k`
+- `--cfg-musiccoca`
+- `--cfg-notes`
+- `--cfg-drums`
+- `--drumless`
+- `--unmask-width`
+- `--seed-rotation`
+- `--prefill-silence`
+- `--prefill-duration`
+
 Environment:
 
 - `MERERUN_MUSIC_ACESTEP_ROOT`
@@ -586,6 +611,74 @@ swift run mere.run music generate \
   --duration 8 \
   --steps 4 \
   --output ./ambient.wav
+swift run mere.run music generate \
+  "ambient modular synths with brushed drums" \
+  --model music-magenta-rt2-small \
+  --duration 4 \
+  --output ./magenta.wav
+```
+
+### `mere.run music realtime`
+
+Run Magenta RealTime 2 generation. On macOS the command plays to the default
+audio device by default; pass `--output` to capture a WAV file. Use `--no-play`
+with `--output` and `--duration` for a headless smoke run.
+
+```bash
+swift run mere.run music realtime "<prompt>" [options]
+```
+
+Key options:
+
+- `--model`: `music-magenta-rt2-small`, `music-magenta-rt2-base`, or a local Magenta RT2 root
+- `--duration`
+- `--output`
+- `--play`, `--no-play`
+- `--style-conditioning`: `streaming` keeps the realtime C++ coarse style-token policy; `full` uses all MusicCoCa style tokens like the Python high-level generator
+- `--temperature`
+- `--top-k`
+- `--cfg-musiccoca`
+- `--cfg-notes`
+- `--cfg-drums`
+- `--drumless`
+- `--unmask-width`
+- `--seed-rotation`
+- `--prefill-silence`
+- `--prefill-duration`
+- `--interactive`: read live steering commands from stdin
+- `--quiet`
+
+Interactive commands:
+
+- `prompt <text>`
+- `style streaming|full`
+- `temp <value>`, `topk <value>`
+- `mc <value>`, `notes <value>`, `drums <value>`
+- `noteon <0-131>`, `noteoff <0-131>`, `onset 0|1`
+- `drumless on|off`, `unmask <value>`, `seed <value>`
+- `reset`, `quit`, `help`
+
+Examples:
+
+```bash
+swift run mere.run music realtime \
+  "ambient pads with sub bass" \
+  --model music-magenta-rt2-small \
+  --duration 4 \
+  --output ./live.wav
+
+swift run mere.run music realtime \
+  "drumless glassy arpeggios" \
+  --model music-magenta-rt2-small \
+  --duration 2 \
+  --output ./smoke.wav \
+  --no-play
+
+swift run mere.run music realtime \
+  "ambient modular synths" \
+  --model music-magenta-rt2-small \
+  --duration 30 \
+  --interactive
 ```
 
 ### `mere.run video generate`

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -7,6 +7,7 @@ Markdown by default and can emit JSON for agents or tools.
 mere.run guide --list
 mere.run guide image generate
 mere.run guide music generate --model music-acestep
+mere.run guide music generate --model music-magenta-rt2-small
 mere.run guide video generate --json
 ```
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -31,7 +31,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Speech TTS | `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice` |
 | Speech ASR | `speech-asr-qwen3`, `speech-asr-parakeet` |
 | Vision | `vision-ocr-lighton`, `vision-segment-sam31`, `vision-ground-falcon-perception` |
-| Music | `music-acestep` |
+| Music | `music-acestep`, `music-magenta-rt2-small`, `music-magenta-rt2-base` |
 | Video | `video-ltx-av` |
 
 Some legacy/local IDs remain in the catalog so existing installs and explicit
@@ -267,6 +267,28 @@ supported.
 
 `mere.run music generate` auto-discovers that layout unless you override the root
 with `--checkpoints-root` or `MERERUN_MUSIC_ACESTEP_ROOT`.
+
+### `music-magenta-rt2-small` and `music-magenta-rt2-base`
+
+Magenta RT2 models use exported runtime assets from
+`google/magenta-realtime-2` at revision
+`010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc`. The managed pull keeps only the
+files needed by the native runtime:
+
+```text
+.../models/music-magenta-rt2-small
+├── models/mrt2_small/mrt2_small.mlxfn
+├── models/mrt2_small/mrt2_small_state.safetensors
+├── resources/musiccoca/
+└── resources/spectrostream/
+```
+
+The base model uses `models/mrt2_base/` with matching `mrt2_base` filenames.
+Raw `checkpoints/*.safetensors` files are not a complete `mere.run` layout.
+
+`mere.run music generate --model music-magenta-rt2-small` renders an offline
+WAV. `mere.run music realtime --model music-magenta-rt2-small` plays on the
+default macOS audio device and can capture to WAV with `--output`.
 
 ### `video-ltx-av`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -42,7 +42,7 @@ Examples:
 - text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
-- music: `music-acestep`
+- music: `music-acestep`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - video: `video-ltx-av`
 
 The public runtime resolves these IDs directly, so docs and examples should use

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -1,15 +1,18 @@
 # Music Runtime
 
-This page covers the native music-generation path exposed through
-`mere.run music generate`.
+This page covers the native music-generation paths exposed through
+`mere.run music generate` and `mere.run music realtime`.
 
 ## Public surface
 
 - `mere.run music generate`
+- `mere.run music realtime`
 
 ## Model family
 
 - `music-acestep`
+- `music-magenta-rt2-small`
+- `music-magenta-rt2-base`
 
 ## Typical workflow
 
@@ -17,19 +20,47 @@ This page covers the native music-generation path exposed through
 swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
+
+swift run mere.run music realtime \
+  "ambient modular synths with brushed drums" \
+  --model music-magenta-rt2-small \
+  --duration 4 \
+  --output ./live.wav \
+  --no-play
 ```
+
+For demo-style steering, pass `--interactive`. The command reads stdin while it
+runs, paces generation to realtime, and applies changes between native frames:
+
+```bash
+swift run mere.run music realtime \
+  "ambient modular synths" \
+  --model music-magenta-rt2-small \
+  --duration 30 \
+  --interactive
+```
+
+Supported steering commands are `prompt <text>`, `style streaming|full`,
+`temp <value>`, `topk <value>`, `mc <value>`, `notes <value>`,
+`drums <value>`, `noteon <0-131>`, `noteoff <0-131>`, `onset 0|1`,
+`drumless on|off`, `unmask <value>`, `seed <value>`, `reset`, `quit`, and
+`help`.
 
 ## Runtime entrypoints
 
 ### CLI
 
 - `Sources/MereRunCLI/Commands/MusicGenerateCommand.swift`
+- `Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift`
 
 ### Runtime
 
 - `Sources/MereRunCore/ACEStep/ACEStepPipeline.swift`
 - `Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift`
 - `Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift`
+- `Sources/MereRunCore/MagentaRT2/MagentaRT2Resources.swift`
+- `Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift`
+- `Sources/MereRunCore/MagentaRT2/MagentaRT2RealtimeSession.swift`
 
 ## Reading order
 
@@ -41,8 +72,20 @@ The ACEStep runtime now follows a clean phase split:
 
 That makes it much easier to follow than a single pipeline monolith.
 
+Magenta RT2 is a native Apple Silicon macOS runtime. The managed model layout
+contains exported `.mlxfn` models, matching state files, and shared MusicCoCa and
+SpectroStream resources; raw upstream checkpoint files are not enough for
+`mere.run`.
+
+`--style-conditioning streaming` matches upstream's realtime C++ path by using
+the coarsest MusicCoCa style tokens. `--style-conditioning full` uses all style
+tokens, matching upstream's high-level Python `.mlxfn` generator more closely.
+
 ## Contributor notes
 
 - this is a native Swift/MLX path, not a Python bridge
+- Magenta RT2 uses a pinned C ABI bridge built by
+  `scripts/rebuild_magentart_xcframework.sh`; Linux builds keep compiling with
+  an unsupported-runtime error for Magenta
 - model resolution and storage still follow the same canonical public rules as
   the rest of the repo

--- a/scripts/rebuild_magentart_xcframework.sh
+++ b/scripts/rebuild_magentart_xcframework.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENDOR_DIR="${ROOT_DIR}/vendor/magentart.xcframework"
+MAGENTART_URL="${MAGENTART_URL:-https://github.com/magenta/magenta-realtime.git}"
+MAGENTART_COMMIT="${MAGENTART_COMMIT:-51836beddf5fbb33636830efd919884f40ef56c5}"
+CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+  echo "[magentart-xcframework] error: Magenta RT2 native runtime must be built on Apple Silicon macOS." >&2
+  exit 1
+fi
+
+for tool in git cmake xcodebuild install_name_tool; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "[magentart-xcframework] error: missing required tool: $tool" >&2
+    exit 1
+  fi
+done
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/magentart-xcframework.XXXXXX")"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+src_dir="$tmpdir/magenta-realtime"
+shim_dir="$tmpdir/magentart-shim"
+build_dir="$tmpdir/build"
+framework_root="$tmpdir/framework"
+framework_dir="$framework_root/magentart.framework"
+
+echo "[magentart-xcframework] cloning ${MAGENTART_URL}"
+git clone --filter=blob:none --recurse-submodules "$MAGENTART_URL" "$src_dir"
+git -C "$src_dir" checkout "$MAGENTART_COMMIT"
+git -C "$src_dir" submodule update --init --recursive
+
+python3 - "$src_dir" <<'PY'
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+header = src / "core/include/magentart/mlx_engine.h"
+runner_header = src / "core/include/magentart/realtime_runner.h"
+impl = src / "core/src/mlx_engine.cpp"
+
+header_text = header.read_text()
+header_text = header_text.replace(
+    "  void set_unmask_width(int w);\n  int get_unmask_width() const;\n",
+    "  void set_unmask_width(int w);\n  int get_unmask_width() const;\n"
+    "  void set_musiccoca_token_count(int count);\n"
+    "  int get_musiccoca_token_count() const;\n",
+)
+header.write_text(header_text)
+
+runner_text = runner_header.read_text()
+runner_text = runner_text.replace(
+    "    void set_unmask_width(int w) { engine_.set_unmask_width(w); }\n"
+    "    int get_unmask_width() const { return engine_.get_unmask_width(); }\n",
+    "    void set_unmask_width(int w) { engine_.set_unmask_width(w); }\n"
+    "    int get_unmask_width() const { return engine_.get_unmask_width(); }\n"
+    "    void set_musiccoca_token_count(int count) { engine_.set_musiccoca_token_count(count); }\n"
+    "    int get_musiccoca_token_count() const { return engine_.get_musiccoca_token_count(); }\n",
+)
+runner_header.write_text(runner_text)
+
+impl_text = impl.read_text()
+impl_text = impl_text.replace(
+    "  std::atomic<int> unmask_width_{0};\n",
+    "  std::atomic<int> unmask_width_{0};\n"
+    "  std::atomic<int> musiccoca_token_count_{static_cast<int>(kMusicCoCaRVQLevels - kMusicCoCaMaskedTailLevels)};\n",
+)
+impl_text = impl_text.replace(
+    "    const int kept_mc_levels =\n"
+    "        static_cast<int>(kMusicCoCaRVQLevels - kMusicCoCaMaskedTailLevels);\n",
+    "    const int kept_mc_levels = std::max(0, std::min(\n"
+    "        static_cast<int>(kMusicCoCaRVQLevels),\n"
+    "        musiccoca_token_count_.load(std::memory_order_relaxed)));\n",
+)
+impl_text = impl_text.replace(
+    "  const int kept_mc_levels =\n"
+    "      static_cast<int>(kMusicCoCaRVQLevels - kMusicCoCaMaskedTailLevels);\n",
+    "  const int kept_mc_levels = std::max(0, std::min(\n"
+    "      static_cast<int>(kMusicCoCaRVQLevels),\n"
+    "      musiccoca_token_count_.load(std::memory_order_relaxed)));\n",
+)
+impl_text = impl_text.replace(
+    "int MLXEngine::get_unmask_width() const {\n"
+    "  return impl_->unmask_width_.load(std::memory_order_relaxed);\n"
+    "}\n",
+    "int MLXEngine::get_unmask_width() const {\n"
+    "  return impl_->unmask_width_.load(std::memory_order_relaxed);\n"
+    "}\n"
+    "void MLXEngine::set_musiccoca_token_count(int count) {\n"
+    "  const int clamped = std::max(0, std::min(static_cast<int>(kMusicCoCaRVQLevels), count));\n"
+    "  impl_->musiccoca_token_count_.store(clamped, std::memory_order_relaxed);\n"
+    "}\n"
+    "int MLXEngine::get_musiccoca_token_count() const {\n"
+    "  return impl_->musiccoca_token_count_.load(std::memory_order_relaxed);\n"
+    "}\n",
+)
+impl.write_text(impl_text)
+PY
+
+mkdir -p "$shim_dir/include/magentart" "$shim_dir/src"
+cat >"$shim_dir/include/magentart/mrt2_c_api.h" <<'HEADER'
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define MRT2_EXPORT __attribute__((visibility("default")))
+#else
+#define MRT2_EXPORT
+#endif
+
+typedef struct mrt2_engine mrt2_engine_t;
+typedef struct mrt2_runner mrt2_runner_t;
+
+MRT2_EXPORT mrt2_engine_t *mrt2_engine_create(void);
+MRT2_EXPORT void mrt2_engine_destroy(mrt2_engine_t *engine);
+MRT2_EXPORT bool mrt2_engine_init_assets(mrt2_engine_t *engine, const char *resource_dir, const char *model_subfolder);
+MRT2_EXPORT bool mrt2_engine_load_model(mrt2_engine_t *engine, const char *mlxfn_path);
+MRT2_EXPORT bool mrt2_engine_prefill_silence(mrt2_engine_t *engine, int32_t duration_frames);
+MRT2_EXPORT void mrt2_engine_reset_state(mrt2_engine_t *engine);
+MRT2_EXPORT void mrt2_engine_set_text_prompt(mrt2_engine_t *engine, const char *prompt);
+MRT2_EXPORT int32_t mrt2_engine_get_text_encoder_status(mrt2_engine_t *engine);
+MRT2_EXPORT int32_t mrt2_engine_get_quantizer_status(mrt2_engine_t *engine);
+MRT2_EXPORT bool mrt2_engine_generate_frame(mrt2_engine_t *engine, float *left, float *right, int32_t sample_count);
+MRT2_EXPORT void mrt2_engine_set_temperature(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_top_k(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_cfg_musiccoca(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_cfg_notes(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_cfg_drums(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_drumless(mrt2_engine_t *engine, bool value);
+MRT2_EXPORT void mrt2_engine_set_unmask_width(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_musiccoca_token_count(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_seed_rotation(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_note_on(mrt2_engine_t *engine, int32_t note);
+MRT2_EXPORT void mrt2_engine_set_note_off(mrt2_engine_t *engine, int32_t note);
+MRT2_EXPORT void mrt2_engine_set_onset_mode(mrt2_engine_t *engine, int32_t mode);
+
+MRT2_EXPORT mrt2_runner_t *mrt2_runner_create(void);
+MRT2_EXPORT void mrt2_runner_destroy(mrt2_runner_t *runner);
+MRT2_EXPORT bool mrt2_runner_init_assets(mrt2_runner_t *runner, const char *resource_dir);
+MRT2_EXPORT bool mrt2_runner_load_model(mrt2_runner_t *runner, const char *mlxfn_path);
+MRT2_EXPORT bool mrt2_runner_prefill_silence(mrt2_runner_t *runner, int32_t duration_frames);
+MRT2_EXPORT void mrt2_runner_start(mrt2_runner_t *runner);
+MRT2_EXPORT void mrt2_runner_stop(mrt2_runner_t *runner);
+MRT2_EXPORT void mrt2_runner_set_text_prompt(mrt2_runner_t *runner, const char *prompt);
+MRT2_EXPORT int32_t mrt2_runner_get_text_encoder_status(mrt2_runner_t *runner);
+MRT2_EXPORT int32_t mrt2_runner_get_quantizer_status(mrt2_runner_t *runner);
+MRT2_EXPORT bool mrt2_runner_read_audio_stereo(mrt2_runner_t *runner, float *left, float *right, int32_t sample_count, bool blocking);
+MRT2_EXPORT void mrt2_runner_set_temperature(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_top_k(mrt2_runner_t *runner, int32_t value);
+MRT2_EXPORT void mrt2_runner_set_cfg_musiccoca(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_cfg_notes(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_cfg_drums(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_drumless(mrt2_runner_t *runner, bool value);
+MRT2_EXPORT void mrt2_runner_set_unmask_width(mrt2_runner_t *runner, int32_t value);
+MRT2_EXPORT void mrt2_runner_set_musiccoca_token_count(mrt2_runner_t *runner, int32_t value);
+MRT2_EXPORT void mrt2_runner_set_seed_rotation(mrt2_runner_t *runner, int32_t value);
+
+#undef MRT2_EXPORT
+
+#ifdef __cplusplus
+}
+#endif
+HEADER
+
+cat >"$shim_dir/src/mrt2_c_api.cpp" <<'SOURCE'
+#include <magentart/mrt2_c_api.h>
+
+#include <magentart/mlx_engine.h>
+#include <magentart/realtime_runner.h>
+
+#include <exception>
+
+struct mrt2_engine {
+  magentart::core::MLXEngine impl;
+};
+
+struct mrt2_runner {
+  magentart::core::RealtimeRunner impl;
+};
+
+extern "C" {
+
+mrt2_engine_t *mrt2_engine_create(void) {
+  try {
+    return new mrt2_engine();
+  } catch (...) {
+    return nullptr;
+  }
+}
+void mrt2_engine_destroy(mrt2_engine_t *engine) {
+  try {
+    delete engine;
+  } catch (...) {}
+}
+
+bool mrt2_engine_init_assets(mrt2_engine_t *engine, const char *resource_dir, const char *model_subfolder) {
+  try {
+    return engine && resource_dir && engine->impl.init_assets(resource_dir, model_subfolder ? model_subfolder : "musiccoca");
+  } catch (...) {
+    return false;
+  }
+}
+
+bool mrt2_engine_load_model(mrt2_engine_t *engine, const char *mlxfn_path) {
+  try {
+    return engine && mlxfn_path && engine->impl.load_model(mlxfn_path);
+  } catch (...) {
+    return false;
+  }
+}
+
+bool mrt2_engine_prefill_silence(mrt2_engine_t *engine, int32_t duration_frames) {
+  try {
+    return engine && engine->impl.prefill_silence(duration_frames);
+  } catch (...) {
+    return false;
+  }
+}
+
+void mrt2_engine_reset_state(mrt2_engine_t *engine) {
+  try {
+    if (engine) engine->impl.reset_state();
+  } catch (...) {}
+}
+
+void mrt2_engine_set_text_prompt(mrt2_engine_t *engine, const char *prompt) {
+  try {
+    if (engine) engine->impl.set_text_prompt(prompt ? prompt : "");
+  } catch (...) {}
+}
+
+int32_t mrt2_engine_get_text_encoder_status(mrt2_engine_t *engine) {
+  try {
+    return engine ? engine->impl.get_text_encoder_status() : 3;
+  } catch (...) {
+    return 3;
+  }
+}
+
+int32_t mrt2_engine_get_quantizer_status(mrt2_engine_t *engine) {
+  try {
+    return engine ? engine->impl.get_quantizer_status() : 3;
+  } catch (...) {
+    return 3;
+  }
+}
+
+bool mrt2_engine_generate_frame(mrt2_engine_t *engine, float *left, float *right, int32_t sample_count) {
+  try {
+    return engine && left && right && sample_count >= static_cast<int32_t>(magentart::core::kFrameSamples)
+        && engine->impl.generate_frame(left, right);
+  } catch (...) {
+    return false;
+  }
+}
+
+void mrt2_engine_set_temperature(mrt2_engine_t *engine, float value) { try { if (engine) engine->impl.set_temperature(value); } catch (...) {} }
+void mrt2_engine_set_top_k(mrt2_engine_t *engine, int32_t value) { try { if (engine) engine->impl.set_top_k(value); } catch (...) {} }
+void mrt2_engine_set_cfg_musiccoca(mrt2_engine_t *engine, float value) { try { if (engine) engine->impl.set_cfg_musiccoca(value); } catch (...) {} }
+void mrt2_engine_set_cfg_notes(mrt2_engine_t *engine, float value) { try { if (engine) engine->impl.set_cfg_notes(value); } catch (...) {} }
+void mrt2_engine_set_cfg_drums(mrt2_engine_t *engine, float value) { try { if (engine) engine->impl.set_cfg_drums(value); } catch (...) {} }
+void mrt2_engine_set_drumless(mrt2_engine_t *engine, bool value) { try { if (engine) engine->impl.set_drumless(value); } catch (...) {} }
+void mrt2_engine_set_unmask_width(mrt2_engine_t *engine, int32_t value) { try { if (engine) engine->impl.set_unmask_width(value); } catch (...) {} }
+void mrt2_engine_set_musiccoca_token_count(mrt2_engine_t *engine, int32_t value) { try { if (engine) engine->impl.set_musiccoca_token_count(value); } catch (...) {} }
+void mrt2_engine_set_seed_rotation(mrt2_engine_t *engine, int32_t value) { try { if (engine) engine->impl.set_seed_rotation(value); } catch (...) {} }
+void mrt2_engine_set_note_on(mrt2_engine_t *engine, int32_t note) { try { if (engine) engine->impl.set_note_on(note); } catch (...) {} }
+void mrt2_engine_set_note_off(mrt2_engine_t *engine, int32_t note) { try { if (engine) engine->impl.set_note_off(note); } catch (...) {} }
+void mrt2_engine_set_onset_mode(mrt2_engine_t *engine, int32_t mode) { try { if (engine) engine->impl.set_onset_mode(mode); } catch (...) {} }
+
+mrt2_runner_t *mrt2_runner_create(void) {
+  try {
+    return new mrt2_runner();
+  } catch (...) {
+    return nullptr;
+  }
+}
+void mrt2_runner_destroy(mrt2_runner_t *runner) {
+  try {
+    delete runner;
+  } catch (...) {}
+}
+
+bool mrt2_runner_init_assets(mrt2_runner_t *runner, const char *resource_dir) {
+  try {
+    return runner && resource_dir && runner->impl.init_assets(resource_dir);
+  } catch (...) {
+    return false;
+  }
+}
+
+bool mrt2_runner_load_model(mrt2_runner_t *runner, const char *mlxfn_path) {
+  try {
+    return runner && mlxfn_path && runner->impl.load_model(mlxfn_path);
+  } catch (...) {
+    return false;
+  }
+}
+
+bool mrt2_runner_prefill_silence(mrt2_runner_t *runner, int32_t duration_frames) {
+  try {
+    return runner && runner->impl.prefill_silence(duration_frames);
+  } catch (...) {
+    return false;
+  }
+}
+
+void mrt2_runner_start(mrt2_runner_t *runner) { try { if (runner) runner->impl.start(); } catch (...) {} }
+void mrt2_runner_stop(mrt2_runner_t *runner) { try { if (runner) runner->impl.stop(); } catch (...) {} }
+void mrt2_runner_set_text_prompt(mrt2_runner_t *runner, const char *prompt) { try { if (runner) runner->impl.set_text_prompt(prompt ? prompt : ""); } catch (...) {} }
+int32_t mrt2_runner_get_text_encoder_status(mrt2_runner_t *runner) { try { return runner ? runner->impl.get_text_encoder_status() : 3; } catch (...) { return 3; } }
+int32_t mrt2_runner_get_quantizer_status(mrt2_runner_t *runner) { try { return runner ? runner->impl.get_quantizer_status() : 3; } catch (...) { return 3; } }
+
+bool mrt2_runner_read_audio_stereo(mrt2_runner_t *runner, float *left, float *right, int32_t sample_count, bool blocking) {
+  try {
+    return runner && left && right && sample_count > 0
+        && runner->impl.read_audio_stereo(left, right, static_cast<std::size_t>(sample_count), blocking);
+  } catch (...) {
+    return false;
+  }
+}
+
+void mrt2_runner_set_temperature(mrt2_runner_t *runner, float value) { try { if (runner) runner->impl.set_temperature(value); } catch (...) {} }
+void mrt2_runner_set_top_k(mrt2_runner_t *runner, int32_t value) { try { if (runner) runner->impl.set_top_k(value); } catch (...) {} }
+void mrt2_runner_set_cfg_musiccoca(mrt2_runner_t *runner, float value) { try { if (runner) runner->impl.set_cfg_musiccoca(value); } catch (...) {} }
+void mrt2_runner_set_cfg_notes(mrt2_runner_t *runner, float value) { try { if (runner) runner->impl.set_cfg_notes(value); } catch (...) {} }
+void mrt2_runner_set_cfg_drums(mrt2_runner_t *runner, float value) { try { if (runner) runner->impl.set_cfg_drums(value); } catch (...) {} }
+void mrt2_runner_set_drumless(mrt2_runner_t *runner, bool value) { try { if (runner) runner->impl.set_drumless(value); } catch (...) {} }
+void mrt2_runner_set_unmask_width(mrt2_runner_t *runner, int32_t value) { try { if (runner) runner->impl.set_unmask_width(value); } catch (...) {} }
+void mrt2_runner_set_musiccoca_token_count(mrt2_runner_t *runner, int32_t value) { try { if (runner) runner->impl.set_musiccoca_token_count(value); } catch (...) {} }
+void mrt2_runner_set_seed_rotation(mrt2_runner_t *runner, int32_t value) { try { if (runner) runner->impl.set_seed_rotation(value); } catch (...) {} }
+
+}
+SOURCE
+
+cat >"$shim_dir/CMakeLists.txt" <<CMAKE
+cmake_minimum_required(VERSION 3.27)
+project(MereRunMagentaRT2 LANGUAGES C CXX OBJCXX)
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET "15.0" CACHE STRING "Minimum macOS deployment version" FORCE)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_OBJCXX_STANDARD 20)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_subdirectory("${src_dir}" magenta-realtime)
+
+add_library(magentart SHARED src/mrt2_c_api.cpp)
+target_include_directories(magentart PUBLIC "\${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(magentart PRIVATE magentart::core)
+target_compile_options(magentart PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
+set_target_properties(magentart PROPERTIES
+  OUTPUT_NAME magentart
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN YES
+)
+CMAKE
+
+echo "[magentart-xcframework] configuring"
+cmake -S "$shim_dir" -B "$build_dir" \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  -DCMAKE_OSX_ARCHITECTURES=arm64
+
+echo "[magentart-xcframework] building"
+cmake --build "$build_dir" --config "$CMAKE_BUILD_TYPE" --target magentart --parallel "$(sysctl -n hw.ncpu)"
+
+mkdir -p "$framework_dir/Headers" "$framework_dir/Modules" "$framework_dir/Resources"
+cp "$build_dir/libmagentart.dylib" "$framework_dir/magentart"
+install_name_tool -id "@rpath/magentart.framework/magentart" "$framework_dir/magentart"
+cp "$shim_dir/include/magentart/mrt2_c_api.h" "$framework_dir/Headers/mrt2_c_api.h"
+mlx_metallib="$(find "$build_dir" -name 'mlx.metallib' -type f -print -quit)"
+if [[ -z "$mlx_metallib" ]]; then
+  echo "[magentart-xcframework] error: mlx.metallib was not produced by the MLX build." >&2
+  exit 1
+fi
+cp "$mlx_metallib" "$framework_dir/Resources/mlx.metallib"
+cp "$mlx_metallib" "$framework_dir/Resources/default.metallib"
+cat >"$framework_dir/Modules/module.modulemap" <<'MODULEMAP'
+framework module magentart {
+  umbrella header "mrt2_c_api.h"
+  export *
+  module * { export * }
+}
+MODULEMAP
+cat >"$framework_dir/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>magentart</string>
+  <key>CFBundleIdentifier</key>
+  <string>run.mere.magentart</string>
+  <key>CFBundleName</key>
+  <string>magentart</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.0.1</string>
+  <key>CFBundleVersion</key>
+  <string>0.0.1</string>
+  <key>MinimumOSVersion</key>
+  <string>15.0</string>
+</dict>
+</plist>
+PLIST
+
+rm -rf "$VENDOR_DIR"
+echo "[magentart-xcframework] creating ${VENDOR_DIR}"
+xcodebuild -create-xcframework -framework "$framework_dir" -output "$VENDOR_DIR"
+echo "[magentart-xcframework] done"

--- a/vendor/magentart.xcframework/Info.plist
+++ b/vendor/magentart.xcframework/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<dict>
+			<key>BinaryPath</key>
+			<string>magentart.framework/magentart</string>
+			<key>LibraryIdentifier</key>
+			<string>macos-arm64</string>
+			<key>LibraryPath</key>
+			<string>magentart.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>macos</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/vendor/magentart.xcframework/macos-arm64/magentart.framework/Headers/mrt2_c_api.h
+++ b/vendor/magentart.xcframework/macos-arm64/magentart.framework/Headers/mrt2_c_api.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define MRT2_EXPORT __attribute__((visibility("default")))
+#else
+#define MRT2_EXPORT
+#endif
+
+typedef struct mrt2_engine mrt2_engine_t;
+typedef struct mrt2_runner mrt2_runner_t;
+
+MRT2_EXPORT mrt2_engine_t *mrt2_engine_create(void);
+MRT2_EXPORT void mrt2_engine_destroy(mrt2_engine_t *engine);
+MRT2_EXPORT bool mrt2_engine_init_assets(mrt2_engine_t *engine, const char *resource_dir, const char *model_subfolder);
+MRT2_EXPORT bool mrt2_engine_load_model(mrt2_engine_t *engine, const char *mlxfn_path);
+MRT2_EXPORT bool mrt2_engine_prefill_silence(mrt2_engine_t *engine, int32_t duration_frames);
+MRT2_EXPORT void mrt2_engine_reset_state(mrt2_engine_t *engine);
+MRT2_EXPORT void mrt2_engine_set_text_prompt(mrt2_engine_t *engine, const char *prompt);
+MRT2_EXPORT int32_t mrt2_engine_get_text_encoder_status(mrt2_engine_t *engine);
+MRT2_EXPORT int32_t mrt2_engine_get_quantizer_status(mrt2_engine_t *engine);
+MRT2_EXPORT bool mrt2_engine_generate_frame(mrt2_engine_t *engine, float *left, float *right, int32_t sample_count);
+MRT2_EXPORT void mrt2_engine_set_temperature(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_top_k(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_cfg_musiccoca(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_cfg_notes(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_cfg_drums(mrt2_engine_t *engine, float value);
+MRT2_EXPORT void mrt2_engine_set_drumless(mrt2_engine_t *engine, bool value);
+MRT2_EXPORT void mrt2_engine_set_unmask_width(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_musiccoca_token_count(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_seed_rotation(mrt2_engine_t *engine, int32_t value);
+MRT2_EXPORT void mrt2_engine_set_note_on(mrt2_engine_t *engine, int32_t note);
+MRT2_EXPORT void mrt2_engine_set_note_off(mrt2_engine_t *engine, int32_t note);
+MRT2_EXPORT void mrt2_engine_set_onset_mode(mrt2_engine_t *engine, int32_t mode);
+
+MRT2_EXPORT mrt2_runner_t *mrt2_runner_create(void);
+MRT2_EXPORT void mrt2_runner_destroy(mrt2_runner_t *runner);
+MRT2_EXPORT bool mrt2_runner_init_assets(mrt2_runner_t *runner, const char *resource_dir);
+MRT2_EXPORT bool mrt2_runner_load_model(mrt2_runner_t *runner, const char *mlxfn_path);
+MRT2_EXPORT bool mrt2_runner_prefill_silence(mrt2_runner_t *runner, int32_t duration_frames);
+MRT2_EXPORT void mrt2_runner_start(mrt2_runner_t *runner);
+MRT2_EXPORT void mrt2_runner_stop(mrt2_runner_t *runner);
+MRT2_EXPORT void mrt2_runner_set_text_prompt(mrt2_runner_t *runner, const char *prompt);
+MRT2_EXPORT int32_t mrt2_runner_get_text_encoder_status(mrt2_runner_t *runner);
+MRT2_EXPORT int32_t mrt2_runner_get_quantizer_status(mrt2_runner_t *runner);
+MRT2_EXPORT bool mrt2_runner_read_audio_stereo(mrt2_runner_t *runner, float *left, float *right, int32_t sample_count, bool blocking);
+MRT2_EXPORT void mrt2_runner_set_temperature(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_top_k(mrt2_runner_t *runner, int32_t value);
+MRT2_EXPORT void mrt2_runner_set_cfg_musiccoca(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_cfg_notes(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_cfg_drums(mrt2_runner_t *runner, float value);
+MRT2_EXPORT void mrt2_runner_set_drumless(mrt2_runner_t *runner, bool value);
+MRT2_EXPORT void mrt2_runner_set_unmask_width(mrt2_runner_t *runner, int32_t value);
+MRT2_EXPORT void mrt2_runner_set_musiccoca_token_count(mrt2_runner_t *runner, int32_t value);
+MRT2_EXPORT void mrt2_runner_set_seed_rotation(mrt2_runner_t *runner, int32_t value);
+
+#undef MRT2_EXPORT
+
+#ifdef __cplusplus
+}
+#endif

--- a/vendor/magentart.xcframework/macos-arm64/magentart.framework/Info.plist
+++ b/vendor/magentart.xcframework/macos-arm64/magentart.framework/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>magentart</string>
+  <key>CFBundleIdentifier</key>
+  <string>run.mere.magentart</string>
+  <key>CFBundleName</key>
+  <string>magentart</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.0.1</string>
+  <key>CFBundleVersion</key>
+  <string>0.0.1</string>
+  <key>MinimumOSVersion</key>
+  <string>15.0</string>
+</dict>
+</plist>

--- a/vendor/magentart.xcframework/macos-arm64/magentart.framework/Modules/module.modulemap
+++ b/vendor/magentart.xcframework/macos-arm64/magentart.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module magentart {
+  umbrella header "mrt2_c_api.h"
+  export *
+  module * { export * }
+}

--- a/vendor/magentart.xcframework/macos-arm64/magentart.framework/Resources/default.metallib
+++ b/vendor/magentart.xcframework/macos-arm64/magentart.framework/Resources/default.metallib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a3a3b6c8b433adc2201f59e417619a6351e55d848ff23559803bab59a543a99
+size 107392404

--- a/vendor/magentart.xcframework/macos-arm64/magentart.framework/Resources/mlx.metallib
+++ b/vendor/magentart.xcframework/macos-arm64/magentart.framework/Resources/mlx.metallib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a3a3b6c8b433adc2201f59e417619a6351e55d848ff23559803bab59a543a99
+size 107392404


### PR DESCRIPTION
## Summary

- add native Magenta RT2 managed models, validation, and model metadata for `music-magenta-rt2-small` and `music-magenta-rt2-base`
- add `mere.run music realtime` with live stdin steering for prompt, style-conditioning, sampling, drumless, MIDI-style note/onset controls, reset, and capture/playback
- route `music generate` to the native Magenta RT2 bridge when a Magenta model/root is selected, including `--style-conditioning streaming|full`
- vendor the `magentart.xcframework` C ABI bridge and rebuild script, with oversized Metal libraries tracked via Git LFS
- update docs, guides, third-party notices, model catalog tests, CLI parsing tests, and validator tests

## Verification

- `swift build`
- `swift test --filter MusicGenerateCommandParsingTests`
- `./scripts/check.sh`
- `git diff --check`
- Python vs native WAV parity:
  - `--style-conditioning full` matched upstream Python full MusicCoCa style-token output byte-for-byte
  - `--style-conditioning streaming` matched the C++ realtime masked-tail style-token policy byte-for-byte
- realtime native smoke:
  - accepted `style full`, live `prompt`, then `style streaming`
  - wrote `/tmp/magenta-rt2-style-live.wav` as 6.0s stereo 48 kHz Float32 with nonzero samples
- stdout/stderr contract smoke:
  - quiet `music generate` stdout is only the output WAV path
  - realtime capture stdout is only the output WAV path; diagnostics/steering stay on stderr

## Notes

`assets/avatar.png` was present as an unrelated untracked local file and is intentionally not included.
