### PR TITLE
Fix Linux package resources and q36 GGUF pull

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -69,8 +69,10 @@ jobs:
           (cd "$artifact_dir" && sha256sum -c SHA256SUMS)
           tar -tzf "$artifact_dir"/mere-run-*-linux-x86_64.tar.gz | grep '/mere.run$'
           tar -tzf "$artifact_dir"/mere-run-*-linux-x86_64.tar.gz | grep '/install.sh$'
+          tar -tzf "$artifact_dir"/mere-run-*-linux-x86_64.tar.gz | grep '/MereRun_MereRunCLI.resources/'
           dpkg-deb --info "$artifact_dir"/mere-run_*_*.deb
           dpkg-deb --contents "$artifact_dir"/mere-run_*_*.deb | grep 'usr/bin/mere.run'
+          dpkg-deb --contents "$artifact_dir"/mere-run_*_*.deb | grep 'usr/lib/mere-run/MereRun_MereRunCLI.resources/'
 
       - name: Upload Linux x86_64 package artifacts
         uses: actions/upload-artifact@v7
@@ -152,8 +154,10 @@ jobs:
           (cd "$artifact_dir" && sha256sum -c SHA256SUMS)
           tar -tzf "$artifact_dir"/mere-run-*-linux-arm64.tar.gz | grep '/mere.run$'
           tar -tzf "$artifact_dir"/mere-run-*-linux-arm64.tar.gz | grep '/install.sh$'
+          tar -tzf "$artifact_dir"/mere-run-*-linux-arm64.tar.gz | grep '/MereRun_MereRunCLI.resources/'
           dpkg-deb --info "$artifact_dir"/mere-run_*_*.deb
           dpkg-deb --contents "$artifact_dir"/mere-run_*_*.deb | grep 'usr/bin/mere.run'
+          dpkg-deb --contents "$artifact_dir"/mere-run_*_*.deb | grep 'usr/lib/mere-run/MereRun_MereRunCLI.resources/'
 
       - name: Upload Linux arm64 CUDA package artifacts
         uses: actions/upload-artifact@v7

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -523,7 +523,8 @@ public enum ManagedModelCatalog {
             hubFallback: HubFallbackConfig(
                 repoId: "unsloth/Qwen3.6-35B-A3B-GGUF",
                 revision: "main",
-                patterns: ["Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"]
+                patterns: ["Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"],
+                filePath: "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
             ),
             upstreamRepoId: "unsloth/Qwen3.6-35B-A3B-GGUF",
             upstreamRevision: "main",

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -192,6 +192,17 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("*.safetensors"), true)
     }
 
+    func testQ36NanoGGUFUsesUpstreamFilePath() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "text-chat-q36-nano-gguf"))
+
+        XCTAssertEqual(spec.installShape, .singleFile(relativePath: "text-chat-q36-nano-gguf.gguf"))
+        XCTAssertEqual(spec.hubFallback?.repoId, "unsloth/Qwen3.6-35B-A3B-GGUF")
+        XCTAssertEqual(spec.hubFallback?.patterns, ["Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"])
+        XCTAssertEqual(spec.hubFallback?.filePath, "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf")
+        XCTAssertEqual(spec.upstreamRepoId, "unsloth/Qwen3.6-35B-A3B-GGUF")
+        XCTAssertEqual(spec.validationKind, .codegenGGUF)
+    }
+
     func testLFM2UsesLiquidAIHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: LFM2Resources.defaultModelId))
 

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -140,7 +140,7 @@ run_installer_fixture() {
   fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/mere-run-linux-install.XXXXXX")"
   source_dir="$fixture_root/source"
   dest_dir="$fixture_root/dest"
-  mkdir -p "$source_dir" "$dest_dir"
+  mkdir -p "$source_dir/MereRun_MereRunCLI.resources/Guides" "$dest_dir"
   trap "rm -rf '$fixture_root'; cleanup" EXIT
 
   cp scripts/install.sh "$source_dir/install.sh"
@@ -151,6 +151,7 @@ echo "mere.run fixture"
 EOF
   chmod +x "$source_dir/mere.run"
   printf 'fake shared library\n' >"$source_dir/libmere_native.so"
+  printf '# Text Chat\n' >"$source_dir/MereRun_MereRunCLI.resources/Guides/text-chat.md"
 
   MERERUN_INSTALL_BIN_DEST="$dest_dir/mere.run" \
     MERERUN_INSTALL_PLATFORM=Linux \
@@ -159,6 +160,7 @@ EOF
 
   [[ -x "$dest_dir/mere.run" ]]
   [[ -f "$dest_dir/libmere_native.so" ]]
+  [[ -f "$dest_dir/MereRun_MereRunCLI.resources/Guides/text-chat.md" ]]
 }
 
 run_installer_fixture

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -142,6 +142,7 @@ if [[ "$install_platform" == "Darwin" ]]; then
 else
   for item in \
     "$SOURCE_DIR"/mere.run-bin \
+    "$SOURCE_DIR"/*.resources \
     "$SOURCE_DIR"/*.so \
     "$SOURCE_DIR"/*.so.* \
     "$SOURCE_DIR"/lib

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -417,7 +417,8 @@ stage_asset() {
 
 for asset in \
   "$build_dir"/*.so \
-  "$build_dir"/*.so.*
+  "$build_dir"/*.so.* \
+  "$build_dir"/*.resources
 do
   stage_asset "$asset"
 done

--- a/scripts/test-package-linux.sh
+++ b/scripts/test-package-linux.sh
@@ -17,6 +17,7 @@ fake_bin="$fixture_root/bin"
 fake_build="$fixture_root/build"
 fake_libs="$fixture_root/libs"
 mkdir -p "$fake_bin" "$fake_build" "$fake_libs/real" "$fake_libs/alternatives"
+mkdir -p "$fake_build/MereRun_MereRunCLI.resources/Guides"
 
 case "$(uname -m)" in
   x86_64|amd64)
@@ -43,6 +44,7 @@ fi
 echo "mere.run package fixture"
 CLI
 chmod +x "$fake_build/mere.run"
+printf '# Text Chat\n' >"$fake_build/MereRun_MereRunCLI.resources/Guides/text-chat.md"
 
 printf 'openblas runtime fixture\n' >"$fake_libs/real/libopenblas.so.0.3.26"
 ln -s "$fake_libs/real/libopenblas.so.0.3.26" "$fake_libs/alternatives/libopenblas.so.0-${platform_arch}-linux-gnu"
@@ -91,6 +93,13 @@ fi
 tar -xzf "$tarball" -C "$fixture_root"
 payload_dir="$fixture_root/mere-run-symlink-fixture-linux-${platform_arch}"
 staged_lib="$payload_dir/lib/libopenblas.so.0"
+staged_guide="$payload_dir/MereRun_MereRunCLI.resources/Guides/text-chat.md"
+
+if [[ ! -f "$staged_guide" ]]; then
+  echo "[test-package-linux] expected SwiftPM CLI resources to be bundled at $staged_guide" >&2
+  find "$payload_dir" -maxdepth 3 \( -type f -o -type d \) -print >&2
+  exit 1
+fi
 
 if [[ ! -f "$staged_lib" || -L "$staged_lib" ]]; then
   echo "[test-package-linux] expected libopenblas.so.0 to be bundled as a real file, got:" >&2


### PR DESCRIPTION
## Summary
- bundle SwiftPM CLI resources into Linux tar/deb payloads and install them with colocated runtime assets
- make Linux release checks assert `MereRun_MereRunCLI.resources` is present
- fix `text-chat-q36-nano-gguf` to fetch the upstream GGUF filename while keeping the managed local alias

## Verification
- `swift test --filter ManagedModelCatalogTests`
- `bash -n scripts/package-linux.sh scripts/test-package-linux.sh scripts/check-linux.sh scripts/install.sh`
- `./scripts/check.sh`

## Notes
- Spark currently has an older installed `mere.run` that does not support `guide --list --markdown`, so it cannot reproduce Dave's exact crash until rebuilt from this branch or current main.
