### PR TITLE
Fix GGUF stats and GB10 smoke coverage

### DIFF
--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -278,10 +278,9 @@ struct TextChat: AsyncParsableCommand {
             if stats {
                 let e2eTps = elapsed > 0 ? Double(result.tokensGenerated) / elapsed : 0
                 if let timing = result.timing {
-                    let decodeTps = timing.decodeSeconds > 0
-                        ? Double(result.tokensGenerated) / timing.decodeSeconds
-                        : 0
-                    let line = String(
+                    let decodeTps = timing.decodeTokensPerSecond
+                        ?? (timing.decodeSeconds > 0 ? Double(result.tokensGenerated) / timing.decodeSeconds : 0)
+                    var line = String(
                         format: "time=%.2fs load=%.2fs prefill=%.2fs decode=%.2fs tokens=%d decode_tps=%.2f e2e_tps=%.2f",
                         elapsed,
                         timing.loadSeconds,
@@ -291,6 +290,9 @@ struct TextChat: AsyncParsableCommand {
                         decodeTps,
                         e2eTps
                     )
+                    if let prefillTps = timing.prefillTokensPerSecond {
+                        line += String(format: " prefill_tps=%.2f", prefillTps)
+                    }
                     CLIStderr.write("\(line)\n")
                     if let mtp = lastGemma4MTPStats {
                         CLIStderr.write(Self.formatGemma4MTPStats(mtp) + "\n")

--- a/Sources/MereRunCore/CodeGen/LlamaCLIProcess.swift
+++ b/Sources/MereRunCore/CodeGen/LlamaCLIProcess.swift
@@ -23,6 +23,11 @@ enum LlamaCLIProcessError: LocalizedError {
 struct LlamaCLIProcess {
     let executableURL: URL
 
+    struct Performance: Sendable, Hashable {
+        var promptTokensPerSecond: Double?
+        var generationTokensPerSecond: Double?
+    }
+
     static func discover(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         arguments: [String] = CommandLine.arguments,
@@ -73,13 +78,15 @@ struct LlamaCLIProcess {
             progressHandler?(ChatProgress(stage: .generating, message: "Generating..."))
             let result = try run(arguments: invocation.arguments)
             let response = Self.extractResponse(from: result.stdout)
+            let performance = Self.extractPerformance(from: result.stdout)
             guard !response.isEmpty else {
                 throw LlamaCLIProcessError.emptyResponse(stderr: Self.tail(result.stderr))
             }
             progressHandler?(ChatProgress(stage: .generating, message: response))
             return ChatResponse(
                 response: response,
-                tokensGenerated: max(1, response.split(whereSeparator: { $0.isWhitespace }).count)
+                tokensGenerated: max(1, response.split(whereSeparator: { $0.isWhitespace }).count),
+                timing: performance.chatTiming
             )
         }.value
     }
@@ -228,8 +235,43 @@ struct LlamaCLIProcess {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    static func extractPerformance(from stdout: String) -> Performance {
+        let pattern = #"\[\s*Prompt:\s*([0-9.]+)\s*t/s\s*\|\s*Generation:\s*([0-9.]+)\s*t/s\s*\]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return Performance()
+        }
+
+        let range = NSRange(stdout.startIndex..<stdout.endIndex, in: stdout)
+        guard let match = regex.matches(in: stdout, range: range).last else {
+            return Performance()
+        }
+
+        func value(at index: Int) -> Double? {
+            let nsRange = match.range(at: index)
+            guard let range = Range(nsRange, in: stdout) else { return nil }
+            return Double(stdout[range])
+        }
+
+        return Performance(
+            promptTokensPerSecond: value(at: 1),
+            generationTokensPerSecond: value(at: 2)
+        )
+    }
+
     private static func tail(_ text: String, maxLines: Int = 40) -> String {
         text.components(separatedBy: .newlines).suffix(maxLines).joined(separator: "\n")
+    }
+}
+
+private extension LlamaCLIProcess.Performance {
+    var chatTiming: ChatTiming? {
+        guard promptTokensPerSecond != nil || generationTokensPerSecond != nil else {
+            return nil
+        }
+        return ChatTiming(
+            prefillTokensPerSecond: promptTokensPerSecond,
+            decodeTokensPerSecond: generationTokensPerSecond
+        )
     }
 }
 #endif

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -288,6 +288,8 @@ public struct ChatTiming: Sendable, Hashable {
     public var kvCacheMode: RuntimeKVCacheMode?
     public var prefillKVCache: String?
     public var decodeKVCache: String?
+    public var prefillTokensPerSecond: Double?
+    public var decodeTokensPerSecond: Double?
 
     public init(
         loadSeconds: Double = 0,
@@ -297,7 +299,9 @@ public struct ChatTiming: Sendable, Hashable {
         firstTokenSeconds: Double? = nil,
         kvCacheMode: RuntimeKVCacheMode? = nil,
         prefillKVCache: String? = nil,
-        decodeKVCache: String? = nil
+        decodeKVCache: String? = nil,
+        prefillTokensPerSecond: Double? = nil,
+        decodeTokensPerSecond: Double? = nil
     ) {
         self.loadSeconds = loadSeconds
         self.prefillSeconds = prefillSeconds
@@ -307,6 +311,8 @@ public struct ChatTiming: Sendable, Hashable {
         self.kvCacheMode = kvCacheMode
         self.prefillKVCache = prefillKVCache
         self.decodeKVCache = decodeKVCache
+        self.prefillTokensPerSecond = prefillTokensPerSecond
+        self.decodeTokensPerSecond = decodeTokensPerSecond
     }
 }
 

--- a/Tests/MereRunCoreTests/LlamaCLIProcessTests.swift
+++ b/Tests/MereRunCoreTests/LlamaCLIProcessTests.swift
@@ -1,0 +1,33 @@
+#if os(Linux)
+import XCTest
+@testable import MereRunCore
+
+final class LlamaCLIProcessTests: XCTestCase {
+    func testExtractPerformanceParsesLlamaTimingLine() {
+        let stdout = """
+        READY READY
+
+        [ Prompt: 100.4 t/s | Generation: 65.1 t/s ]
+
+        Exiting...
+        """
+
+        let performance = LlamaCLIProcess.extractPerformance(from: stdout)
+
+        XCTAssertEqual(performance.promptTokensPerSecond, 100.4)
+        XCTAssertEqual(performance.generationTokensPerSecond, 65.1)
+    }
+
+    func testExtractPerformanceUsesLastTimingLine() {
+        let stdout = """
+        [ Prompt: 1.0 t/s | Generation: 2.0 t/s ]
+        [ Prompt: 3.5 t/s | Generation: 4.5 t/s ]
+        """
+
+        let performance = LlamaCLIProcess.extractPerformance(from: stdout)
+
+        XCTAssertEqual(performance.promptTokensPerSecond, 3.5)
+        XCTAssertEqual(performance.generationTokensPerSecond, 4.5)
+    }
+}
+#endif

--- a/scripts/e2e_gb10.sh
+++ b/scripts/e2e_gb10.sh
@@ -142,7 +142,7 @@ SPEECH_WAV="$ASSETS/tts.wav"
 OCR_IMG="$ASSETS/ocr.png"
 
 # ---- text ----
-want text-chat && for m in text-chat-q36-nano \
+want text-chat && for m in text-chat-q36-nano text-chat-q36-nano-gguf \
                            text-chat-gemma4-turbo text-chat-gemma4-nano \
                            text-chat-gemma4 text-chat-gemma4-max; do
   run_case text-chat "$m" text "" 900 \
@@ -175,12 +175,36 @@ want speech-tts && for m in speech-tts-qwen3-nano speech-tts-qwen3-customvoice; 
     "$BIN" speech synthesize "mere run end to end test one two three" --model "$m" --quiet --output "$wav"
 done
 if want speech-asr; then
-  [[ -f "$SPEECH_WAV" ]] || "$BIN" speech synthesize "mere run end to end test one two three" --model speech-tts-qwen3-nano --quiet --output "$SPEECH_WAV" >/dev/null 2>&1 || true
-  for m in speech-asr-parakeet speech-asr-qwen3; do
-    backend=parakeet; [[ "$m" == *qwen3* ]] && backend=qwen
-    run_case speech-asr "$m" text "" 400 \
-      "$BIN" speech transcribe "$SPEECH_WAV" --model "$m" --backend "$backend" --quiet
-  done
+  if [[ ! -f "$SPEECH_WAV" ]]; then
+    if installed speech-tts-qwen3-nano; then
+      "$BIN" speech synthesize "mere run end to end test one two three" \
+        --model speech-tts-qwen3-nano --quiet --output "$SPEECH_WAV" >/dev/null 2>&1 || true
+    elif [[ "$DO_PULL" == "1" ]]; then
+      echo "[pull] speech-tts-qwen3-nano for speech-asr fixture"
+      if "$BIN" model pull speech-tts-qwen3-nano; then
+        "$BIN" speech synthesize "mere run end to end test one two three" \
+          --model speech-tts-qwen3-nano --quiet --output "$SPEECH_WAV" >/dev/null 2>&1 || true
+      else
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+          "speech-asr" "speech-tts-qwen3-nano" "PULL_FAIL" "0" "-" "-" "fixture pull failed" >>"$TSV"
+      fi
+    else
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "speech-asr" "speech-tts-qwen3-nano" "SKIP" "0" "-" "-" "fixture model not installed (use --pull)" >>"$TSV"
+    fi
+  fi
+  if [[ -f "$SPEECH_WAV" ]]; then
+    for m in speech-asr-parakeet speech-asr-qwen3; do
+      backend=parakeet; [[ "$m" == *qwen3* ]] && backend=qwen
+      run_case speech-asr "$m" text "" 400 \
+        "$BIN" speech transcribe "$SPEECH_WAV" --model "$m" --backend "$backend" --quiet
+    done
+  else
+    for m in speech-asr-parakeet speech-asr-qwen3; do
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "speech-asr" "$m" "SKIP" "0" "-" "-" "missing speech fixture (use --pull)" >>"$TSV"
+    done
+  fi
 fi
 
 # ---- vision (needs an input image; reuse a generated one) ----


### PR DESCRIPTION
## Summary
- parse llama.cpp prompt/generation t/s from packaged GGUF subprocess output and surface it in `text chat --stats` as `decode_tps`/`prefill_tps`
- add a Linux-only parser regression test for llama.cpp timing output
- include `text-chat-q36-nano-gguf` as a separate row in the GB10 e2e sweep
- keep no-pull GB10 speech ASR sweeps from accidentally downloading the TTS fixture model

## Verification
- `swift test --filter TextChatCommandParsingTests`
- `./scripts/check.sh`
- Spark direct packaged llama.cpp smoke: `Prompt: 100.4 t/s | Generation: 65.1 t/s`, GPU peak ~95%
- Spark `/usr/bin/mere.run` smoke confirmed subprocess args include `-ngl 999`
- Spark patched `scripts/e2e_gb10.sh --bin /usr/bin/mere.run --only text-chat` now emits a separate `text-chat-q36-nano-gguf` PASS row

## Notes
- The earlier `0.19 tps` value was wrapper end-to-end word/sec on a tiny GGUF run, not llama.cpp decode speed. The direct packaged runtime reported ~65 generated tokens/sec on the same installed GGUF.
