### PR TITLE
Add cuFFT dependency to Linux CUDA deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ use. Linux arm64 release packages should be built with CUDA enabled on a host
 with the CUDA Toolkit headers, CUDA CCCL headers, cuDNN, and NCCL installed.
 CUDA `.deb` artifacts declare the linked CUDA 13 runtime/JIT packages
 (`cuda-cccl-13-0`, `cuda-cudart-13-0`, `cuda-nvrtc-13-0`,
-`libcublas-13-0`, `libcudnn9-cuda-13`, and `libnccl2`) by default. The
+`libcublas-13-0`, `libcufft-13-0`, `libcudnn9-cuda-13`, and `libnccl2`) by default. The
 installed launcher also exports the resolved CUDA CCCL include root through
 `MERERUN_CUDA_CCCL_INCLUDE_PATH` so MLX CUDA kernels can find `cuda/std/*`
 during NVRTC JIT compilation:

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -117,7 +117,7 @@ labeled `self-hosted`, `linux`, `arm64`, and `cuda`; enable it manually with
 the CUDA Toolkit headers, CUDA CCCL headers, cuDNN, NCCL, Swift, and the normal
 Linux packaging dependencies. CUDA `.deb` artifacts add default runtime/JIT
 dependencies on `cuda-cccl-13-0`, `cuda-cudart-13-0`, `cuda-nvrtc-13-0`,
-`libcublas-13-0`, `libcudnn9-cuda-13`, and `libnccl2`. On published GitHub Release
+`libcublas-13-0`, `libcufft-13-0`, `libcudnn9-cuda-13`, and `libnccl2`. On published GitHub Release
 events, the workflow uploads the available Linux artifacts and checksum manifest
 to the release.
 

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -122,7 +122,7 @@ ls dist/linux/
 
 CUDA `.deb` packages declare the CUDA 13 runtime/JIT packages they need:
 `cuda-cccl-13-0`, `cuda-cudart-13-0`, `cuda-nvrtc-13-0`,
-`libcublas-13-0`, `libcudnn9-cuda-13`, and `libnccl2`.
+`libcublas-13-0`, `libcufft-13-0`, `libcudnn9-cuda-13`, and `libnccl2`.
 
 For source-only CUDA checks, prepare native artifacts and then export the
 environment printed by the script before building:

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -480,7 +480,7 @@ if (( do_deb )); then
 
     default_depends="ffmpeg, libcurl4, zlib1g, libopenblas0-pthread | libopenblas0, liblapacke"
     if [[ "$linux_accel" == "cuda" ]]; then
-      default_depends="$default_depends, cuda-cccl-13-0, cuda-cudart-13-0, cuda-nvrtc-13-0, libcublas-13-0, libcudnn9-cuda-13, libnccl2"
+      default_depends="$default_depends, cuda-cccl-13-0, cuda-cudart-13-0, cuda-nvrtc-13-0, libcublas-13-0, libcufft-13-0, libcudnn9-cuda-13, libnccl2"
     fi
     depends="${MERERUN_PACKAGE_LINUX_DEPS:-$default_depends}"
     installed_size="$(du -sk "$deb_root/usr" | awk '{print $1}')"

--- a/scripts/test-package-linux.sh
+++ b/scripts/test-package-linux.sh
@@ -22,9 +22,11 @@ mkdir -p "$fake_build/MereRun_MereRunCLI.resources/Guides"
 case "$(uname -m)" in
   x86_64|amd64)
     platform_arch="x86_64"
+    deb_arch="amd64"
     ;;
   aarch64|arm64)
     platform_arch="arm64"
+    deb_arch="arm64"
     ;;
   *)
     echo "[test-package-linux] unsupported Linux architecture: $(uname -m)" >&2
@@ -128,3 +130,24 @@ if ! grep -q "^CPATH=$cuda_cccl_fixture" <<<"$wrapper_env_output"; then
 fi
 
 echo "[test-package-linux] package runtime library symlink test passed."
+
+cuda_output_dir="$fixture_root/output-cuda"
+PATH="$fake_bin:$PATH" \
+  MERERUN_LINUX_ACCEL=cuda \
+  MERERUN_MLX_SWIFT_LINK_FLAGS="-lcuda" \
+  bash scripts/package-linux.sh \
+    --version 0.0.0+cuda-deps-fixture \
+    --configuration release \
+    --skip-build \
+    --skip-native \
+    --output-dir "$cuda_output_dir" >/dev/null
+
+cuda_deb="$cuda_output_dir/mere-run_0.0.0+cuda-deps-fixture_${deb_arch}.deb"
+[[ -f "$cuda_deb" ]]
+if ! dpkg-deb --field "$cuda_deb" Depends | grep -q 'libcufft-13-0'; then
+  echo "[test-package-linux] expected CUDA .deb dependencies to include libcufft-13-0:" >&2
+  dpkg-deb --field "$cuda_deb" Depends >&2
+  exit 1
+fi
+
+echo "[test-package-linux] CUDA deb dependency test passed."


### PR DESCRIPTION
## Summary
- add `libcufft-13-0` to CUDA `.deb` default dependencies
- mirror the dependency list in Linux docs
- extend the Linux package fixture to assert CUDA deb dependencies include cuFFT

## Verification
- `bash -n scripts/package-linux.sh scripts/test-package-linux.sh`
- `git diff --check`
- `./scripts/check.sh`
- Spark: `bash scripts/test-package-linux.sh` in `/tmp/mere-run-cufft-dep-test`
- Spark Docker clean-container proof: clean Ubuntu 24.04 arm64 install of `mere-run_0.13.0_arm64.deb` failed to run without cuFFT (`libcufft.so.12` missing); adding `libcufft-13-0` allowed `mere.run --help` and `mere.run model list` to run with the host driver library path mounted