### PR TITLE
Add structured Ideogram prompting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added `image generate --structured-prompt` / `--json-prompt`, an opt-in local
+  text-chat adapter that expands short image prompts into typed structured JSON
+  captions before generation, defaulting the adapter to
+  `text-chat-gemma4-12b-4bit` with reviewable `--structured-prompt-output`
+  artifacts and Ideogram-friendly prompt token budgeting.
+
+### Fixed
+
+- fixed model-store size reporting for real directories that contain symlinked
+  payload directories, and added `model info` storage layout details so wrapper
+  directories no longer look like tiny installs.
+- added native runtime backend diagnostics on stderr for text and image
+  generation so MLX/Metal vs GGUF backend selection is visible during smoke
+  tests.
+
 ## 0.13.1 - 2026-06-05
 
 ### Fixed

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -64,6 +64,24 @@ struct ImageGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("max-sequence-length")], help: "Max text sequence length.")
     var maxSequenceLength: Int = 512
 
+    @Flag(
+        name: [.customLong("structured-prompt"), .customLong("json-prompt")],
+        help: "Expand --prompt into a structured JSON caption with a local text chat model before image generation."
+    )
+    var structuredPrompt: Bool = false
+
+    @Option(name: [.customLong("structured-prompt-model")], help: "Text chat model id for --structured-prompt.")
+    var structuredPromptModel: String = StructuredImagePromptAdapter.defaultModelID
+
+    @Option(name: [.customLong("structured-prompt-model-root")], help: "Optional local model root for --structured-prompt-model.")
+    var structuredPromptModelRoot: String?
+
+    @Option(name: [.customLong("structured-prompt-max-tokens")], help: "Max new tokens for the structured prompt adapter.")
+    var structuredPromptMaxTokens: Int = StructuredImagePromptAdapter.defaultMaxTokens
+
+    @Option(name: [.customLong("structured-prompt-output")], help: "Write the generated structured JSON caption to this path.")
+    var structuredPromptOutput: String?
+
     @Option(name: [.customShort("l"), .long], help: "LoRA safetensors file path.")
     var lora: String?
 
@@ -161,8 +179,47 @@ struct ImageGenerate: AsyncParsableCommand {
         let effectiveSigmaShift = sigmaShift.map { Float($0) }
             ?? manifest.defaults?.sigmaShift.map { Float($0) }
 
+        var effectivePrompt = prompt
+        var effectiveMaxSequenceLength = maxSequenceLength
+        if structuredPrompt {
+            if !quiet {
+                let backend = StructuredImagePromptAdapter.backendDescription(for: structuredPromptModel)
+                CLIStderr.write("[structured-prompt] Expanding prompt with \(structuredPromptModel) (\(backend))...\n")
+            }
+            let adapterProgressHandler: (@Sendable (String) -> Void)?
+            if quiet {
+                adapterProgressHandler = nil
+            } else {
+                adapterProgressHandler = { message in
+                    CLIStderr.write("[structured-prompt] \(message)\n")
+                }
+            }
+            effectivePrompt = try await StructuredImagePromptAdapter.expand(
+                prompt: prompt,
+                modelID: structuredPromptModel,
+                modelRoot: structuredPromptModelRoot,
+                maxTokens: structuredPromptMaxTokens,
+                progressHandler: adapterProgressHandler
+            )
+            effectiveMaxSequenceLength = max(
+                effectiveMaxSequenceLength,
+                StructuredImagePromptAdapter.recommendedImagePromptTokens
+            )
+            if let structuredPromptOutput {
+                let jsonURL = URL(fileURLWithPath: structuredPromptOutput).standardizedFileURL
+                try FileManager.default.createDirectory(
+                    at: jsonURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try Data(effectivePrompt.utf8).write(to: jsonURL)
+                if !quiet {
+                    CLIStderr.write("[structured-prompt] JSON: \(jsonURL.path)\n")
+                }
+            }
+        }
+
         let request = GenerationRequest(
-            prompt: prompt,
+            prompt: effectivePrompt,
             negativePrompt: negativePrompt,
             referenceImages: referenceImageURLs,
             width: width,
@@ -172,7 +229,7 @@ struct ImageGenerate: AsyncParsableCommand {
             seed: seed,
             outputURL: outputURL,
             model: resolvedModel,
-            maxSequenceLength: maxSequenceLength,
+            maxSequenceLength: effectiveMaxSequenceLength,
             lora: loraConfig,
             enhancePrompt: false,
             inputImage: inputURL,
@@ -183,6 +240,9 @@ struct ImageGenerate: AsyncParsableCommand {
         )
 
         let progressHandler: (@Sendable (GenerationProgress) -> Void)? = quiet ? nil : CLIGenerationProgressPrinter.makeProgressHandler()
+        if !quiet {
+            CLIStderr.write("[runtime] image backend: \(NativeMLXRuntime.backendDescription)\n")
+        }
 
         let result: GenerationResult
         switch manifest.family {

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -70,6 +70,24 @@ struct ModelInfo: ParsableCommand {
             print("Source: \(resolved.source.rawValue)")
         }
 
+        let usage = FileSystemHelper.directoryUsage(at: rootURL)
+        print("\nStorage")
+        print("  layout: \(usage.layoutDescription)")
+        print("  size: \(ByteCountFormatter.string(fromByteCount: usage.resolvedBytes, countStyle: .file))")
+        if usage.localBytes != usage.resolvedBytes {
+            print("  localWrapperSize: \(ByteCountFormatter.string(fromByteCount: usage.localBytes, countStyle: .file))")
+        }
+        let standardizedRoot = rootURL.standardizedFileURL.path
+        let resolvedRoot = rootURL.resolvingSymlinksInPath().standardizedFileURL.path
+        if resolvedRoot != standardizedRoot {
+            print("  resolvedRoot: \(resolvedRoot)")
+        }
+        if usage.symlinkCount > 0 {
+            print(
+                "  symlinks: \(usage.symlinkCount) total, \(usage.symlinkedDirectoryCount) directories, \(usage.symlinkedFileCount) files"
+            )
+        }
+
         if let manifest {
             print("\nManifest (\(MereRunModelManifest.filename))")
             print("  schemaVersion: \(manifest.schemaVersion)")

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -94,6 +94,14 @@ struct TextChat: AsyncParsableCommand {
         return Gemma4Resources.nanoModelId
     }
 
+    static func backendDescription(for modelID: String) -> String {
+        let normalizedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if ManagedModelCatalog.spec(for: normalizedModelID)?.validationKind == .codegenGGUF {
+            return "llama.cpp/GGUF"
+        }
+        return NativeMLXRuntime.backendDescription
+    }
+
     @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
@@ -168,6 +176,9 @@ struct TextChat: AsyncParsableCommand {
 
         let startTime = Date()
         let normalizedModelId = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if !quiet {
+            CLIStderr.write("[runtime] text backend: \(Self.backendDescription(for: normalizedModelId))\n")
+        }
         var lastGemma4MTPStats: Gemma4MTPStats?
 
         let chatOnce: (ChatRequest) async throws -> ChatResponse = { req in

--- a/Sources/MereRunCLI/Guides/image-generate.md
+++ b/Sources/MereRunCLI/Guides/image-generate.md
@@ -11,6 +11,8 @@ Use one installed image model:
 - `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`
 - `image-klein-max`, `image-klein-base`, `image-klein-nano`
 - `image-bonsai-binary`, `image-bonsai-ternary`
+- `image-ideogram4-sdnq-uint4`
+- `image-hidream-o1`, `image-hidream-o1-dev`
 
 ## Install And Check
 
@@ -37,6 +39,11 @@ mere.run guide image generate --model image-zimage-nano
 - `--input`, `-i`: source image for image-to-image.
 - `--strength`, `--str`: image-to-image change strength from `0.0` to `1.0`.
 - `--max-sequence-length`: prompt token budget.
+- `--structured-prompt`, `--json-prompt`: expand the prompt into a structured JSON caption with a local text chat model before generation.
+- `--structured-prompt-model`: text chat model id for the adapter. Defaults to `text-chat-gemma4-12b-4bit`.
+- `--structured-prompt-model-root`: optional local model root for the adapter.
+- `--structured-prompt-max-tokens`: max new tokens for the adapter.
+- `--structured-prompt-output`: write the generated JSON caption for review or reuse.
 - `--lora`, `-l`: LoRA safetensors path.
 - `--lora-scale`: LoRA strength.
 - `--quiet`, `-q`: print only the output path.
@@ -47,6 +54,7 @@ mere.run guide image generate --model image-zimage-nano
 - For product or inspection images, prefer concrete nouns over mood words: size, surface, label text, angle, background.
 - For Z-Image, keep prompts compact and descriptive. Iterate seed, dimensions, and input strength before piling on adjectives.
 - For FLUX.2 Klein, use explicit visual composition and relationships: foreground, background, lens/framing, color palette, and what must be absent.
+- For Ideogram 4 SDNQ, use `--structured-prompt` when a short prompt needs stronger object, spatial, lighting, camera, or text-render control. The adapter converts the prompt into a long JSON caption and raises the prompt token budget to 2048.
 - For Bonsai binary or ternary, start with four steps at 512 or 1024 square; the manifest applies its native FlowMatch sigma shift.
 - Use `--input` plus `--strength 0.25` to preserve layout; use `0.65` or higher for stronger reinterpretation.
 
@@ -77,6 +85,15 @@ mere.run image generate \
   --strength 0.45 \
   --prompt "architectural watercolor rendering of the same cabin, pine forest, late afternoon light" \
   --output ./cabin-watercolor.png
+```
+
+```bash
+mere.run image generate \
+  --model image-ideogram4-sdnq-uint4 \
+  --prompt "a knight and a white horse in a meadow, remove the helmet, make it sunny" \
+  --structured-prompt \
+  --structured-prompt-output ./knight-prompt.json \
+  --output ./knight.png
 ```
 
 ## Iteration Tips

--- a/Sources/MereRunCLI/Guides/model-info.md
+++ b/Sources/MereRunCLI/Guides/model-info.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-Inspect a managed model id or local model root: manifest, validation status, and component directories.
+Inspect a managed model id or local model root: storage layout, resolved size,
+manifest, validation status, and component directories.
 
 ## Required Models
 
@@ -27,6 +28,9 @@ mere.run model info image-zimage-nano --components
 
 - Use before debugging a failed generation command.
 - Start with `status` when you are unsure which model store is active.
+- Check the Storage section when a model store is a wrapper directory with
+  symlinked payload directories; `size` is resolved payload size and
+  `localWrapperSize` is only the local wrapper files.
 - Use `--components` for structured roots with tokenizer, transformer, VAE, scheduler, or text encoder folders.
 - Use `--json` when scripts need the manifest.
 

--- a/Sources/MereRunCLI/Guides/model-list.md
+++ b/Sources/MereRunCLI/Guides/model-list.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-Show all known managed model ids, categories, install status, and local size. Use this before pulling or running models.
+Show all known managed model ids, categories, install status, and resolved local
+payload size. Use this before pulling or running models.
 Use `mere.run status` when you also need the active API server and currently
 served model.
 
@@ -43,7 +44,9 @@ MERERUN_MODELS_DIR=/Volumes/Models/mere.run mere.run model list
 ## Iteration Tips
 
 - Look for `missing` vs `installed`, not just whether the id exists.
-- If a size looks too small, inspect with `model info` or repair manifests.
+- The size follows symlinked payload files and directories in managed model
+  stores. If layout is confusing, inspect with `model info`.
+- If validation looks wrong, inspect with `model info` or repair manifests.
 
 ## Troubleshooting
 

--- a/Sources/MereRunCLI/Support/FileSystemHelper.swift
+++ b/Sources/MereRunCLI/Support/FileSystemHelper.swift
@@ -1,23 +1,143 @@
 import Foundation
 
 enum FileSystemHelper {
+    struct DirectoryUsage: Equatable {
+        let resolvedBytes: Int64
+        let localBytes: Int64
+        let rootIsSymlink: Bool
+        let symlinkCount: Int
+        let symlinkedDirectoryCount: Int
+        let symlinkedFileCount: Int
+
+        var layoutDescription: String {
+            if rootIsSymlink, symlinkCount > 0 {
+                return "symlinked root with symlinked entries"
+            }
+            if rootIsSymlink {
+                return "symlinked root"
+            }
+            if symlinkedDirectoryCount > 0, symlinkedFileCount > 0 {
+                return "directory with symlinked entries"
+            }
+            if symlinkedDirectoryCount > 0 {
+                return "directory with symlinked directories"
+            }
+            if symlinkedFileCount > 0 {
+                return "directory with symlinked files"
+            }
+            if symlinkCount > 0 {
+                return "directory with symlinks"
+            }
+            return "direct directory"
+        }
+    }
+
     /// Recursively compute the total size of all regular files under a directory.
     static func directorySize(at url: URL) -> Int64 {
+        directoryUsage(at: url).resolvedBytes
+    }
+
+    /// Recursively inspect a directory, following symlinked model payload files and directories.
+    static func directoryUsage(at url: URL) -> DirectoryUsage {
+        DirectoryUsageScanner(fileManager: .default).usage(at: url)
+    }
+
+    private final class DirectoryUsageScanner {
+        private let fileManager: FileManager
+        private var resolvedBytes: Int64 = 0
+        private var localBytes: Int64 = 0
+        private var symlinkCount = 0
+        private var symlinkedDirectoryCount = 0
+        private var symlinkedFileCount = 0
+        private var visitedDirectories: Set<String> = []
+        private var visitedFiles: Set<String> = []
+
+        init(fileManager: FileManager) {
+            self.fileManager = fileManager
+        }
+
+        func usage(at url: URL) -> DirectoryUsage {
+            let rootIsSymlink = (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+            let root = rootIsSymlink ? url.resolvingSymlinksInPath() : url
+            scan(root, reachedThroughSymlink: rootIsSymlink)
+            return DirectoryUsage(
+                resolvedBytes: resolvedBytes,
+                localBytes: localBytes,
+                rootIsSymlink: rootIsSymlink,
+                symlinkCount: symlinkCount,
+                symlinkedDirectoryCount: symlinkedDirectoryCount,
+                symlinkedFileCount: symlinkedFileCount
+            )
+        }
+
+        private func scan(_ url: URL, reachedThroughSymlink: Bool) {
+            guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey, .fileSizeKey]) else {
+                return
+            }
+
+            if values.isRegularFile == true {
+                addFile(url, reachedThroughSymlink: reachedThroughSymlink)
+                return
+            }
+
+            guard values.isDirectory == true else { return }
+            let directoryKey = url.resolvingSymlinksInPath().standardizedFileURL.path
+            guard visitedDirectories.insert(directoryKey).inserted else { return }
+
+            let contents = (try? fileManager.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+            )) ?? []
+
+            for item in contents {
+                let itemIsSymlink = (try? item.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+                if itemIsSymlink {
+                    symlinkCount += 1
+                    let resolved = item.resolvingSymlinksInPath()
+                    guard let resolvedValues = try? resolved.resourceValues(
+                        forKeys: [.isDirectoryKey, .isRegularFileKey, .fileSizeKey]
+                    ) else {
+                        continue
+                    }
+                    if resolvedValues.isDirectory == true {
+                        symlinkedDirectoryCount += 1
+                        scan(resolved, reachedThroughSymlink: true)
+                    } else if resolvedValues.isRegularFile == true {
+                        symlinkedFileCount += 1
+                        addFile(resolved, reachedThroughSymlink: true)
+                    }
+                } else {
+                    scan(item, reachedThroughSymlink: reachedThroughSymlink)
+                }
+            }
+        }
+
+        private func addFile(_ url: URL, reachedThroughSymlink: Bool) {
+            let fileKey = url.resolvingSymlinksInPath().standardizedFileURL.path
+            guard visitedFiles.insert(fileKey).inserted else { return }
+            guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+                  let size = values.fileSize else { return }
+            let byteCount = Int64(size)
+            resolvedBytes += byteCount
+            if !reachedThroughSymlink {
+                localBytes += byteCount
+            }
+        }
+    }
+
+    /// Recursively compute the total size of all regular files under a directory without following symlinked children.
+    static func localDirectorySize(at url: URL) -> Int64 {
         let fm = FileManager.default
         let root = url.resolvingSymlinksInPath()
         guard let enumerator = fm.enumerator(
             at: root,
-            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey, .isSymbolicLinkKey],
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else { return 0 }
 
         var total: Int64 = 0
         for case let fileURL as URL in enumerator {
-            guard let values = try? fileURL.resourceValues(forKeys: [.isSymbolicLinkKey]) else {
-                continue
-            }
-            let measuredURL = values.isSymbolicLink == true ? fileURL.resolvingSymlinksInPath() : fileURL
-            guard let measuredValues = try? measuredURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+            guard let measuredValues = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
                   measuredValues.isRegularFile == true,
                   let size = measuredValues.fileSize else { continue }
             total += Int64(size)

--- a/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
+++ b/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
@@ -1,0 +1,893 @@
+import Foundation
+import MereRunCore
+
+enum StructuredImagePromptAdapterError: LocalizedError {
+    case invalidMaxTokens(Int)
+    case invalidModelRoot(String)
+    case invalidCaptionJSON(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidMaxTokens(let value):
+            return "--structured-prompt-max-tokens must be >= 1. Received: \(value)."
+        case .invalidModelRoot(let path):
+            return "Structured prompt model root not found: \(path)"
+        case .invalidCaptionJSON(let detail):
+            return "Structured prompt adapter did not produce valid caption JSON. \(detail)"
+        }
+    }
+}
+
+enum StructuredImagePromptAdapter {
+    static let defaultModelID = Gemma4Resources.twelveB4BitModelId
+    static let defaultMaxTokens = 2_048
+    static let recommendedImagePromptTokens = 2_048
+
+    static func backendDescription(for modelID: String) -> String {
+        let normalizedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalizedModelID == "text-agent-deepseek-v4-flash" {
+            return "external DeepSeek V4 Flash bridge"
+        }
+        if ManagedModelCatalog.spec(for: normalizedModelID)?.validationKind == .codegenGGUF {
+            return "llama.cpp/GGUF"
+        }
+        return NativeMLXRuntime.backendDescription
+    }
+
+    static func expand(
+        prompt: String,
+        modelID: String,
+        modelRoot: String?,
+        maxTokens: Int,
+        progressHandler: (@Sendable (String) -> Void)? = nil
+    ) async throws -> String {
+        guard maxTokens > 0 else {
+            throw StructuredImagePromptAdapterError.invalidMaxTokens(maxTokens)
+        }
+
+        let session = try makeChatSession(modelID: modelID, modelRoot: modelRoot)
+        do {
+            let expanded = try await expand(
+                prompt: prompt,
+                maxTokens: maxTokens,
+                session: session,
+                progressHandler: progressHandler
+            )
+            await session.unload()
+            return expanded
+        } catch {
+            await session.unload()
+            throw error
+        }
+    }
+
+    @discardableResult
+    static func validateCaptionJSON(_ rawJSON: String) throws -> StructuredImageCaption {
+        guard let data = rawJSON.data(using: .utf8), !data.isEmpty else {
+            throw StructuredImagePromptAdapterError.invalidCaptionJSON("Output was empty.")
+        }
+        do {
+            return try JSONDecoder().decode(StructuredImageCaption.self, from: data)
+        } catch {
+            throw StructuredImagePromptAdapterError.invalidCaptionJSON(error.localizedDescription)
+        }
+    }
+
+    static func normalizedCaptionJSON(from rawJSON: String, fallbackPrompt: String) throws -> String {
+        let candidate = cleanedJSONCandidate(from: rawJSON)
+        do {
+            let caption = try validateCaptionJSON(candidate)
+            return try encodeCaptionJSON(caption)
+        } catch {
+            guard let data = candidate.data(using: .utf8), !data.isEmpty else {
+                throw StructuredImagePromptAdapterError.invalidCaptionJSON("Output was empty.")
+            }
+            do {
+                let flexibleCaption = try JSONDecoder().decode(FlexibleStructuredImageCaption.self, from: data)
+                let normalizedCaption = flexibleCaption.normalized(fallbackPrompt: fallbackPrompt)
+                let normalizedJSON = try encodeCaptionJSON(normalizedCaption)
+                _ = try validateCaptionJSON(normalizedJSON)
+                return normalizedJSON
+            } catch {
+                throw StructuredImagePromptAdapterError.invalidCaptionJSON(
+                    validationFailureDetail(error: error, candidate: candidate)
+                )
+            }
+        }
+    }
+
+    static func cleanedJSONCandidate(from response: String) -> String {
+        var cleaned = response.replacingOccurrences(
+            of: #"(?is)<\|channel>final\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: #"(?is)<\|channel>thought\b.*?<channel\|>\s*"#,
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: #"(?is)<\|channel>thought\b.*\z"#,
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: #"(?is)<\|channel>[a-z_]+\s*|<channel\|>"#,
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?is)<think>.*?</think>",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?is)<think>.*\\z",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.replacingOccurrences(
+            of: "(?i)</think>",
+            with: "",
+            options: .regularExpression
+        )
+        cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if cleaned.hasPrefix("```") {
+            cleaned = cleaned.replacingOccurrences(
+                of: #"(?is)^```(?:json)?\s*|\s*```$"#,
+                with: "",
+                options: .regularExpression
+            )
+            cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        if let firstBrace = cleaned.firstIndex(of: "{"),
+           let lastBrace = cleaned.lastIndex(of: "}"),
+           firstBrace <= lastBrace {
+            return String(cleaned[firstBrace...lastBrace])
+        }
+        return cleaned
+    }
+
+    private static func expand(
+        prompt: String,
+        maxTokens: Int,
+        session: ChatSession,
+        progressHandler: (@Sendable (String) -> Void)?
+    ) async throws -> String {
+        var messages = [
+            ChatMessage(role: .system, content: structuredCaptionSystemPrompt),
+            ChatMessage(
+                role: .user,
+                content: """
+                Convert this text-to-image prompt into the required structured JSON caption.
+
+                Prompt:
+                \(prompt)
+                """
+            ),
+        ]
+        var lastDetail = "No response was generated."
+
+        for attempt in 1...3 {
+            progressHandler?("running structured prompt adapter attempt \(attempt)/3")
+            let request = ChatRequest(
+                messages: messages,
+                maxTokens: maxTokens,
+                temperature: 0.2,
+                topP: 0.9,
+                showThinking: false,
+                requiresJSON: true
+            )
+            let response = try await session.chat(request, nil)
+            do {
+                return try normalizedCaptionJSON(from: response.response, fallbackPrompt: prompt)
+            } catch {
+                lastDetail = validationFailureDetail(error: error, candidate: cleanedJSONCandidate(from: response.response))
+                messages.append(ChatMessage(role: .assistant, content: response.response))
+                messages.append(ChatMessage(
+                    role: .user,
+                    content: """
+                    The previous response was invalid for this task:
+                    \(lastDetail)
+
+                    Return only one valid JSON object matching the exact template from the system message. Do not use "name" or "attributes" as object keys. "text render" must be an array; use [] when no text should appear. Use null only for optional nested values.
+                    """
+                ))
+            }
+        }
+
+        throw StructuredImagePromptAdapterError.invalidCaptionJSON(lastDetail)
+    }
+
+    private static func makeChatSession(modelID: String, modelRoot: String?) throws -> ChatSession {
+        let normalizedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedRoot = try modelRoot.flatMap { rawRoot -> String in
+            let root = URL(fileURLWithPath: rawRoot).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: root.path) else {
+                throw StructuredImagePromptAdapterError.invalidModelRoot(root.path)
+            }
+            return root.path
+        }
+
+        if normalizedModelID == Psi3ChatResources.defaultModelId {
+            let generator = Psi3ChatGenerator(modelId: Psi3ChatResources.defaultModelId)
+            return ChatSession(
+                chat: { request, progress in
+                    try await generator.chat(request, modelPath: normalizedRoot, progressHandler: progress)
+                },
+                unload: { await generator.unload() }
+            )
+        }
+
+        if Gemma4Resources.handles(modelSpec: normalizedModelID) {
+            let effectiveModelID = normalizedModelID.isEmpty ? Gemma4Resources.defaultModelId : normalizedModelID
+            let generator = Gemma4Generator(modelId: effectiveModelID)
+            return ChatSession(
+                chat: { request, progress in
+                    try await generator.chat(request, modelPath: normalizedRoot, progressHandler: progress)
+                },
+                unload: { await generator.unload() }
+            )
+        }
+
+        if ManagedModelCatalog.spec(for: normalizedModelID)?.validationKind == .codegenGGUF {
+            let generator = CodeGenGenerator(modelId: normalizedModelID)
+            return ChatSession(
+                chat: { request, progress in
+                    try await generator.chat(request, modelPath: normalizedRoot, progressHandler: progress)
+                },
+                unload: { await generator.unload() }
+            )
+        }
+
+        if LFM2Resources.handles(modelSpec: normalizedModelID) {
+            let effectiveModelID = normalizedModelID.isEmpty ? LFM2Resources.defaultModelId : normalizedModelID
+            let generator = LFM2Generator(modelId: effectiveModelID)
+            return ChatSession(
+                chat: { request, progress in
+                    try await generator.chat(request, modelPath: normalizedRoot, progressHandler: progress)
+                },
+                unload: { await generator.unload() }
+            )
+        }
+
+        if normalizedModelID == "text-agent-deepseek-v4-flash" {
+            let generator = DeepseekV4FlashGenerator()
+            return ChatSession(
+                chat: { request, progress in
+                    try await generator.chat(request, modelPath: normalizedRoot, progressHandler: progress)
+                },
+                unload: { await generator.shutdown() }
+            )
+        }
+
+        let effectiveModelID = normalizedModelID.isEmpty ? Q35Resources.defaultModelId : normalizedModelID
+        let generator = Q35Generator(modelId: effectiveModelID)
+        return ChatSession(
+            chat: { request, progress in
+                try await generator.chat(request, modelPath: normalizedRoot, progressHandler: progress)
+            },
+            unload: { await generator.unload() }
+        )
+    }
+
+    private static let structuredCaptionSystemPrompt = """
+    Convert the user's text-to-image prompt into one valid JSON object for an image model.
+    Output only JSON. No markdown, code fences, explanation, or extra text.
+    Preserve all explicit constraints. Add plausible visual detail only when it does not contradict the prompt.
+
+    Required top-level keys:
+    "short description", "objects", "background setting", "lighting", "aesthetics",
+    "photographic characteristics", "style medium", "artistic style", "context", "text render".
+
+    "objects" should describe up to 5 prominent subjects. Prefer object keys:
+    "description", "location", "relative size", "shape and color", "texture",
+    "appearance details", "relationship", "orientation", "pose", "expression",
+    "clothing", "action", "gender", "skin tone and texture", "number of objects".
+
+    "lighting" should cover conditions, direction, and shadows.
+    "aesthetics" should cover composition, color scheme, and mood atmosphere.
+    "photographic characteristics" should cover depth of field, focus, camera angle, and lens focal length.
+    "text render" must be an array; use [] when no visible text is requested.
+    """
+}
+
+private func encodeCaptionJSON(_ caption: StructuredImageCaption) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
+    let data = try encoder.encode(caption)
+    return String(decoding: data, as: UTF8.self)
+}
+
+private func validationFailureDetail(error: Error, candidate: String) -> String {
+    let base: String
+    if case StructuredImagePromptAdapterError.invalidCaptionJSON(let detail) = error {
+        base = detail
+    } else {
+        base = error.localizedDescription
+    }
+    let preview = candidate
+        .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .prefix(700)
+    guard !preview.isEmpty else { return base }
+    return "\(base) Candidate preview: \(preview)"
+}
+
+private struct FlexibleStructuredImageCaption: Decodable {
+    let shortDescription: String?
+    let objects: [FlexibleStructuredImageObject]
+    let backgroundSetting: String?
+    let lighting: FlexibleStructuredImageLighting?
+    let lightingText: String?
+    let aesthetics: FlexibleStructuredImageAesthetics?
+    let aestheticsText: String?
+    let photographicCharacteristics: FlexibleStructuredImagePhotographicCharacteristics?
+    let photographicCharacteristicsText: String?
+    let styleMedium: String?
+    let artisticStyle: String?
+    let context: String?
+    let textRender: [FlexibleStructuredImageTextRender]
+
+    enum CodingKeys: String, CodingKey {
+        case shortDescription = "short description"
+        case objects
+        case backgroundSetting = "background setting"
+        case lighting
+        case aesthetics
+        case photographicCharacteristics = "photographic characteristics"
+        case styleMedium = "style medium"
+        case artisticStyle = "artistic style"
+        case context
+        case textRender = "text render"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        shortDescription = container.flexibleString(forKey: .shortDescription)
+        objects = container.flexibleStructuredImageObjects(forKey: .objects)
+        backgroundSetting = container.flexibleString(forKey: .backgroundSetting)
+        lighting = container.flexibleObject(FlexibleStructuredImageLighting.self, forKey: .lighting)
+        lightingText = container.flexibleString(forKey: .lighting)
+        aesthetics = container.flexibleObject(FlexibleStructuredImageAesthetics.self, forKey: .aesthetics)
+        aestheticsText = container.flexibleString(forKey: .aesthetics)
+        photographicCharacteristics = container.flexibleObject(
+            FlexibleStructuredImagePhotographicCharacteristics.self,
+            forKey: .photographicCharacteristics
+        )
+        photographicCharacteristicsText = container.flexibleString(forKey: .photographicCharacteristics)
+        styleMedium = container.flexibleString(forKey: .styleMedium)
+        artisticStyle = container.flexibleString(forKey: .artisticStyle)
+        context = container.flexibleString(forKey: .context)
+        textRender = container.flexibleArray([FlexibleStructuredImageTextRender].self, forKey: .textRender)
+    }
+
+    func normalized(fallbackPrompt: String) -> StructuredImageCaption {
+        let normalizedObjects = objects.prefix(5).enumerated().map { offset, object in
+            object.normalized(index: offset)
+        }
+        let finalObjects = normalizedObjects.isEmpty
+            ? [StructuredImageObject.defaultObject(description: fallbackPrompt)]
+            : Array(normalizedObjects)
+
+        return StructuredImageCaption(
+            shortDescription: shortDescription.nonEmpty ?? fallbackPrompt,
+            objects: finalObjects,
+            backgroundSetting: backgroundSetting.nonEmpty ?? "Minimal background consistent with the requested image.",
+            lighting: lighting?.normalized ?? .defaultLighting(description: lightingText),
+            aesthetics: aesthetics?.normalized ?? .defaultAesthetics(description: aestheticsText),
+            photographicCharacteristics: photographicCharacteristics?.normalized
+                ?? .defaultPhotographicCharacteristics(description: photographicCharacteristicsText),
+            styleMedium: styleMedium.nonEmpty ?? "photograph",
+            textRender: Array(textRender.prefix(5).map(\.normalized)),
+            context: context.nonEmpty ?? "Text-to-image generation prompt.",
+            artisticStyle: artisticStyle.nonEmpty ?? "natural realism"
+        )
+    }
+}
+
+private struct FlexibleStructuredImageObject: Decodable {
+    let description: String?
+    let name: String?
+    let attributes: [String]
+    let location: String?
+    let relationship: String?
+    let relativeSize: String?
+    let shapeAndColor: String?
+    let texture: String?
+    let appearanceDetails: String?
+    let numberOfObjects: Int?
+    let pose: String?
+    let expression: String?
+    let clothing: String?
+    let action: String?
+    let gender: String?
+    let skinToneAndTexture: String?
+    let orientation: String?
+
+    enum CodingKeys: String, CodingKey {
+        case description
+        case name
+        case attributes
+        case location
+        case relationship
+        case relativeSize = "relative size"
+        case shapeAndColor = "shape and color"
+        case texture
+        case appearanceDetails = "appearance details"
+        case numberOfObjects = "number of objects"
+        case pose
+        case expression
+        case clothing
+        case action
+        case gender
+        case skinToneAndTexture = "skin tone and texture"
+        case orientation
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        description = container.flexibleString(forKey: .description)
+        name = container.flexibleString(forKey: .name)
+        attributes = container.flexibleStringArray(forKey: .attributes)
+        location = container.flexibleString(forKey: .location)
+        relationship = container.flexibleString(forKey: .relationship)
+        relativeSize = container.flexibleString(forKey: .relativeSize)
+        shapeAndColor = container.flexibleString(forKey: .shapeAndColor)
+        texture = container.flexibleString(forKey: .texture)
+        appearanceDetails = container.flexibleString(forKey: .appearanceDetails)
+        numberOfObjects = container.flexibleInt(forKey: .numberOfObjects)
+        pose = container.flexibleString(forKey: .pose)
+        expression = container.flexibleString(forKey: .expression)
+        clothing = container.flexibleString(forKey: .clothing)
+        action = container.flexibleString(forKey: .action)
+        gender = container.flexibleString(forKey: .gender)
+        skinToneAndTexture = container.flexibleString(forKey: .skinToneAndTexture)
+        orientation = container.flexibleString(forKey: .orientation)
+    }
+
+    init(description: String) {
+        self.description = description
+        self.name = nil
+        self.attributes = []
+        self.location = nil
+        self.relationship = nil
+        self.relativeSize = nil
+        self.shapeAndColor = nil
+        self.texture = nil
+        self.appearanceDetails = nil
+        self.numberOfObjects = nil
+        self.pose = nil
+        self.expression = nil
+        self.clothing = nil
+        self.action = nil
+        self.gender = nil
+        self.skinToneAndTexture = nil
+        self.orientation = nil
+    }
+
+    func normalized(index: Int) -> StructuredImageObject {
+        let attributeSummary = attributes.nonEmptyJoined
+        let objectName = name.nonEmpty
+        let objectDescription = description.nonEmpty
+            ?? [objectName, attributeSummary].compactMap(\.nonEmpty).joined(separator: ", ").nonEmpty
+            ?? "Prominent image subject"
+        let shapeSummary = shapeAndColor.nonEmpty
+            ?? [objectName, attributeSummary].compactMap(\.nonEmpty).joined(separator: ", ").nonEmpty
+            ?? "visually prominent subject"
+
+        return StructuredImageObject(
+            description: objectDescription,
+            location: location.nonEmpty ?? (index == 0 ? "center foreground" : "supporting area"),
+            relationship: relationship.nonEmpty ?? "part of the requested scene",
+            relativeSize: relativeSize.nonEmpty ?? inferredRelativeSize(from: attributes),
+            shapeAndColor: shapeSummary,
+            texture: texture.nonEmpty ?? inferredTexture(from: attributes),
+            appearanceDetails: appearanceDetails.nonEmpty ?? attributeSummary,
+            numberOfObjects: numberOfObjects,
+            pose: pose.nonEmpty,
+            expression: expression.nonEmpty,
+            clothing: clothing.nonEmpty,
+            action: action.nonEmpty,
+            gender: gender.nonEmpty,
+            skinToneAndTexture: skinToneAndTexture.nonEmpty,
+            orientation: orientation.nonEmpty
+        )
+    }
+
+    private func inferredRelativeSize(from attributes: [String]) -> String {
+        let lowercased = attributes.joined(separator: " ").lowercased()
+        if lowercased.contains("small") { return "small within frame" }
+        if lowercased.contains("large") { return "large within frame" }
+        return "medium within frame"
+    }
+
+    private func inferredTexture(from attributes: [String]) -> String? {
+        let lowercased = attributes.map { $0.lowercased() }
+        if lowercased.contains(where: { $0.contains("matte") }) { return "matte surface" }
+        if lowercased.contains(where: { $0.contains("gloss") }) { return "glossy surface" }
+        if lowercased.contains(where: { $0.contains("metal") }) { return "metallic texture" }
+        return nil
+    }
+}
+
+private struct FlexibleStructuredImageLighting: Decodable {
+    let conditions: String?
+    let direction: String?
+    let shadows: String?
+
+    enum CodingKeys: String, CodingKey {
+        case conditions
+        case direction
+        case shadows
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        conditions = container.flexibleString(forKey: .conditions)
+        direction = container.flexibleString(forKey: .direction)
+        shadows = container.flexibleString(forKey: .shadows)
+    }
+
+    var normalized: StructuredImageLighting {
+        let defaults = StructuredImageLighting.defaultLighting(description: nil)
+        return StructuredImageLighting(
+            conditions: conditions.nonEmpty ?? defaults.conditions,
+            direction: direction.nonEmpty ?? defaults.direction,
+            shadows: shadows.nonEmpty
+        )
+    }
+}
+
+private struct FlexibleStructuredImageAesthetics: Decodable {
+    let composition: String?
+    let colorScheme: String?
+    let moodAtmosphere: String?
+
+    enum CodingKeys: String, CodingKey {
+        case composition
+        case colorScheme = "color scheme"
+        case moodAtmosphere = "mood atmosphere"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        composition = container.flexibleString(forKey: .composition)
+        colorScheme = container.flexibleString(forKey: .colorScheme)
+        moodAtmosphere = container.flexibleString(forKey: .moodAtmosphere)
+    }
+
+    var normalized: StructuredImageAesthetics {
+        let defaults = StructuredImageAesthetics.defaultAesthetics(description: nil)
+        return StructuredImageAesthetics(
+            composition: composition.nonEmpty ?? defaults.composition,
+            colorScheme: colorScheme.nonEmpty ?? defaults.colorScheme,
+            moodAtmosphere: moodAtmosphere.nonEmpty ?? defaults.moodAtmosphere
+        )
+    }
+}
+
+private struct FlexibleStructuredImagePhotographicCharacteristics: Decodable {
+    let depthOfField: String?
+    let focus: String?
+    let cameraAngle: String?
+    let lensFocalLength: String?
+
+    enum CodingKeys: String, CodingKey {
+        case depthOfField = "depth of field"
+        case focus
+        case cameraAngle = "camera angle"
+        case lensFocalLength = "lens focal length"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        depthOfField = container.flexibleString(forKey: .depthOfField)
+        focus = container.flexibleString(forKey: .focus)
+        cameraAngle = container.flexibleString(forKey: .cameraAngle)
+        lensFocalLength = container.flexibleString(forKey: .lensFocalLength)
+    }
+
+    var normalized: StructuredImagePhotographicCharacteristics {
+        let defaults = StructuredImagePhotographicCharacteristics.defaultPhotographicCharacteristics(description: nil)
+        return StructuredImagePhotographicCharacteristics(
+            depthOfField: depthOfField.nonEmpty ?? defaults.depthOfField,
+            focus: focus.nonEmpty ?? defaults.focus,
+            cameraAngle: cameraAngle.nonEmpty ?? defaults.cameraAngle,
+            lensFocalLength: lensFocalLength.nonEmpty ?? defaults.lensFocalLength
+        )
+    }
+}
+
+private struct FlexibleStructuredImageTextRender: Decodable {
+    let text: String?
+    let location: String?
+    let size: String?
+    let color: String?
+    let font: String?
+    let appearanceDetails: String?
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case location
+        case size
+        case color
+        case font
+        case appearanceDetails = "appearance details"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        text = container.flexibleString(forKey: .text)
+        location = container.flexibleString(forKey: .location)
+        size = container.flexibleString(forKey: .size)
+        color = container.flexibleString(forKey: .color)
+        font = container.flexibleString(forKey: .font)
+        appearanceDetails = container.flexibleString(forKey: .appearanceDetails)
+    }
+
+    var normalized: StructuredImageTextRender {
+        StructuredImageTextRender(
+            text: text.nonEmpty ?? "",
+            location: location.nonEmpty ?? "unspecified",
+            size: size.nonEmpty ?? "medium",
+            color: color.nonEmpty ?? "unspecified",
+            font: font.nonEmpty ?? "unspecified",
+            appearanceDetails: appearanceDetails.nonEmpty
+        )
+    }
+}
+
+private extension StructuredImageObject {
+    static func defaultObject(description: String) -> StructuredImageObject {
+        StructuredImageObject(
+            description: description,
+            location: "center foreground",
+            relationship: "primary subject of the requested image",
+            relativeSize: "medium within frame",
+            shapeAndColor: description,
+            texture: nil,
+            appearanceDetails: nil,
+            numberOfObjects: nil,
+            pose: nil,
+            expression: nil,
+            clothing: nil,
+            action: nil,
+            gender: nil,
+            skinToneAndTexture: nil,
+            orientation: nil
+        )
+    }
+}
+
+private extension StructuredImageLighting {
+    static func defaultLighting(description: String?) -> StructuredImageLighting {
+        StructuredImageLighting(
+            conditions: description.nonEmpty ?? "natural lighting consistent with the requested image",
+            direction: "unspecified direction",
+            shadows: nil
+        )
+    }
+}
+
+private extension StructuredImageAesthetics {
+    static func defaultAesthetics(description: String?) -> StructuredImageAesthetics {
+        StructuredImageAesthetics(
+            composition: description.nonEmpty ?? "clear composition centered on the main subject",
+            colorScheme: "colors consistent with the requested image",
+            moodAtmosphere: "natural atmosphere"
+        )
+    }
+}
+
+private extension StructuredImagePhotographicCharacteristics {
+    static func defaultPhotographicCharacteristics(description: String?) -> StructuredImagePhotographicCharacteristics {
+        StructuredImagePhotographicCharacteristics(
+            depthOfField: description.nonEmpty ?? "moderate depth of field",
+            focus: "sharp focus on the primary subject",
+            cameraAngle: "eye-level",
+            lensFocalLength: "normal lens"
+        )
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func flexibleString(forKey key: Key) -> String? {
+        if let string = try? decode(String.self, forKey: key) {
+            return string.nonEmpty
+        }
+        if let int = try? decode(Int.self, forKey: key) {
+            return String(int)
+        }
+        if let double = try? decode(Double.self, forKey: key) {
+            return String(double)
+        }
+        if let bool = try? decode(Bool.self, forKey: key) {
+            return String(bool)
+        }
+        return nil
+    }
+
+    func flexibleInt(forKey key: Key) -> Int? {
+        if let int = try? decode(Int.self, forKey: key) {
+            return int
+        }
+        if let string = flexibleString(forKey: key) {
+            return Int(string)
+        }
+        return nil
+    }
+
+    func flexibleObject<T: Decodable>(_ type: T.Type, forKey key: Key) -> T? {
+        try? decode(type, forKey: key)
+    }
+
+    func flexibleArray<T: Decodable>(_ type: [T].Type, forKey key: Key) -> [T] {
+        (try? decode(type, forKey: key)) ?? []
+    }
+
+    func flexibleStringArray(forKey key: Key) -> [String] {
+        if let values = try? decode([String].self, forKey: key) {
+            return values.compactMap(\.nonEmpty)
+        }
+        if let value = flexibleString(forKey: key) {
+            return [value]
+        }
+        return []
+    }
+
+    func flexibleStructuredImageObjects(forKey key: Key) -> [FlexibleStructuredImageObject] {
+        if let objects = try? decode([FlexibleStructuredImageObject].self, forKey: key) {
+            return objects
+        }
+        if let strings = try? decode([String].self, forKey: key) {
+            return strings.compactMap { value in
+                value.nonEmpty.map(FlexibleStructuredImageObject.init(description:))
+            }
+        }
+        if let value = flexibleString(forKey: key) {
+            return [FlexibleStructuredImageObject(description: value)]
+        }
+        return []
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var nonEmpty: String? {
+        self?.nonEmpty
+    }
+}
+
+private extension String {
+    var nonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+private extension Array where Element == String {
+    var nonEmptyJoined: String? {
+        let joined = compactMap(\.nonEmpty).joined(separator: ", ")
+        return joined.nonEmpty
+    }
+}
+
+private struct ChatSession {
+    let chat: (ChatRequest, (@Sendable (ChatProgress) -> Void)?) async throws -> ChatResponse
+    let unload: () async -> Void
+}
+
+struct StructuredImageCaption: Codable, Equatable {
+    let shortDescription: String
+    let objects: [StructuredImageObject]
+    let backgroundSetting: String
+    let lighting: StructuredImageLighting
+    let aesthetics: StructuredImageAesthetics
+    let photographicCharacteristics: StructuredImagePhotographicCharacteristics
+    let styleMedium: String
+    let textRender: [StructuredImageTextRender]
+    let context: String
+    let artisticStyle: String
+
+    enum CodingKeys: String, CodingKey {
+        case shortDescription = "short description"
+        case objects
+        case backgroundSetting = "background setting"
+        case lighting
+        case aesthetics
+        case photographicCharacteristics = "photographic characteristics"
+        case styleMedium = "style medium"
+        case textRender = "text render"
+        case context
+        case artisticStyle = "artistic style"
+    }
+}
+
+struct StructuredImageObject: Codable, Equatable {
+    let description: String
+    let location: String
+    let relationship: String
+    let relativeSize: String
+    let shapeAndColor: String
+    let texture: String?
+    let appearanceDetails: String?
+    let numberOfObjects: Int?
+    let pose: String?
+    let expression: String?
+    let clothing: String?
+    let action: String?
+    let gender: String?
+    let skinToneAndTexture: String?
+    let orientation: String?
+
+    enum CodingKeys: String, CodingKey {
+        case description
+        case location
+        case relationship
+        case relativeSize = "relative size"
+        case shapeAndColor = "shape and color"
+        case texture
+        case appearanceDetails = "appearance details"
+        case numberOfObjects = "number of objects"
+        case pose
+        case expression
+        case clothing
+        case action
+        case gender
+        case skinToneAndTexture = "skin tone and texture"
+        case orientation
+    }
+}
+
+struct StructuredImageLighting: Codable, Equatable {
+    let conditions: String
+    let direction: String
+    let shadows: String?
+}
+
+struct StructuredImageAesthetics: Codable, Equatable {
+    let composition: String
+    let colorScheme: String
+    let moodAtmosphere: String
+
+    enum CodingKeys: String, CodingKey {
+        case composition
+        case colorScheme = "color scheme"
+        case moodAtmosphere = "mood atmosphere"
+    }
+}
+
+struct StructuredImagePhotographicCharacteristics: Codable, Equatable {
+    let depthOfField: String
+    let focus: String
+    let cameraAngle: String
+    let lensFocalLength: String
+
+    enum CodingKeys: String, CodingKey {
+        case depthOfField = "depth of field"
+        case focus
+        case cameraAngle = "camera angle"
+        case lensFocalLength = "lens focal length"
+    }
+}
+
+struct StructuredImageTextRender: Codable, Equatable {
+    let text: String
+    let location: String
+    let size: String
+    let color: String
+    let font: String
+    let appearanceDetails: String?
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case location
+        case size
+        case color
+        case font
+        case appearanceDetails = "appearance details"
+    }
+}

--- a/Sources/MereRunCore/Support/NativeMLXRuntime.swift
+++ b/Sources/MereRunCore/Support/NativeMLXRuntime.swift
@@ -1,0 +1,18 @@
+import Foundation
+import MLX
+
+public enum NativeMLXRuntime {
+    public static var defaultDeviceType: String {
+        Device.defaultDevice().deviceType?.rawValue ?? "unknown"
+    }
+
+    public static var backendDescription: String {
+        let device = defaultDeviceType
+        #if os(macOS) || os(iOS)
+        let accelerator = device == "gpu" ? "Metal" : "CPU"
+        return "native MLX/\(accelerator) (default device: \(device))"
+        #else
+        return "native MLX (default device: \(device))"
+        #endif
+    }
+}

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -39,4 +39,181 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.steps, 4)
         XCTAssertEqual(cmd.cfgScale, 1.0)
     }
+
+    func testParsesStructuredPromptOptions() throws {
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "a knight and a white horse",
+            "--model", "image-ideogram4-sdnq-uint4",
+            "--structured-prompt",
+            "--structured-prompt-model", "text-chat-q36-nano",
+            "--structured-prompt-model-root", "/tmp/q36",
+            "--structured-prompt-max-tokens", "3072",
+            "--structured-prompt-output", "/tmp/prompt.json",
+        ])
+
+        XCTAssertTrue(cmd.structuredPrompt)
+        XCTAssertEqual(cmd.structuredPromptModel, "text-chat-q36-nano")
+        XCTAssertEqual(cmd.structuredPromptModelRoot, "/tmp/q36")
+        XCTAssertEqual(cmd.structuredPromptMaxTokens, 3_072)
+        XCTAssertEqual(cmd.structuredPromptOutput, "/tmp/prompt.json")
+    }
+
+    func testParsesJSONPromptAlias() throws {
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "editorial product photo",
+            "--json-prompt",
+        ])
+
+        XCTAssertTrue(cmd.structuredPrompt)
+        XCTAssertEqual(cmd.structuredPromptModel, "text-chat-gemma4-12b-4bit")
+    }
+
+    func testStructuredPromptAdapterValidatesPaperSchema() throws {
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(Self.validStructuredCaptionJSON)
+
+        XCTAssertEqual(caption.shortDescription, "A knight riding a white horse in a sunlit meadow.")
+        XCTAssertEqual(caption.objects.first?.shapeAndColor, "armored human figure in silver and blue")
+        XCTAssertEqual(caption.textRender, [])
+    }
+
+    func testStructuredPromptAdapterCleansJSONCodeFence() throws {
+        let wrapped = """
+        <think>draft</think>
+        ```json
+        \(Self.validStructuredCaptionJSON)
+        ```
+        """
+
+        let cleaned = StructuredImagePromptAdapter.cleanedJSONCandidate(from: wrapped)
+        XCTAssertNoThrow(try StructuredImagePromptAdapter.validateCaptionJSON(cleaned))
+    }
+
+    func testStructuredPromptAdapterNormalizesQ36NearSchema() throws {
+        let normalized = try StructuredImagePromptAdapter.normalizedCaptionJSON(
+            from: Self.q36NearStructuredCaptionJSON,
+            fallbackPrompt: "a small matte red cube on a white table"
+        )
+
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(normalized)
+        XCTAssertEqual(caption.shortDescription, "A clean product photograph featuring a small matte red cube.")
+        XCTAssertEqual(caption.objects.first?.description, "matte red cube, small, matte finish, red color")
+        XCTAssertEqual(caption.objects.first?.texture, "matte surface")
+        XCTAssertEqual(caption.textRender, [])
+    }
+
+    func testStructuredPromptAdapterNormalizesCompactGemmaSchema() throws {
+        let normalized = try StructuredImagePromptAdapter.normalizedCaptionJSON(
+            from: Self.gemmaCompactStructuredCaptionJSON,
+            fallbackPrompt: "a small matte red cube on a white table"
+        )
+
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(normalized)
+        XCTAssertEqual(caption.objects.first?.description, "small matte red cube")
+        XCTAssertEqual(caption.lighting.conditions, "Soft window light, natural diffusion")
+        XCTAssertEqual(caption.photographicCharacteristics.depthOfField, "Product photography, sharp focus")
+        XCTAssertEqual(caption.textRender, [])
+    }
+
+    private static let validStructuredCaptionJSON = """
+    {
+      "short description": "A knight riding a white horse in a sunlit meadow.",
+      "objects": [
+        {
+          "description": "A calm medieval knight seated on a horse, wearing polished armor and a blue cloak.",
+          "location": "center foreground",
+          "relationship": "The knight is riding the horse and looking toward the horizon.",
+          "relative size": "large within frame",
+          "shape and color": "armored human figure in silver and blue",
+          "texture": "metallic armor and woven fabric",
+          "appearance details": "helmet visor raised, cloak moving lightly",
+          "number of objects": null,
+          "pose": "upright seated riding pose",
+          "expression": "calm and focused",
+          "clothing": "plate armor and blue cloak",
+          "action": "riding a horse",
+          "gender": "unspecified",
+          "skin tone and texture": null,
+          "orientation": "facing right"
+        }
+      ],
+      "background setting": "Open meadow with distant trees and low hills under a clear sky.",
+      "lighting": {
+        "conditions": "bright daylight",
+        "direction": "side-lit from left",
+        "shadows": "soft shadows falling to the right"
+      },
+      "aesthetics": {
+        "composition": "centered heroic composition",
+        "color scheme": "natural greens with silver and blue accents",
+        "mood atmosphere": "noble and serene"
+      },
+      "photographic characteristics": {
+        "depth of field": "moderate",
+        "focus": "sharp focus on knight and horse",
+        "camera angle": "eye-level",
+        "lens focal length": "normal lens"
+      },
+      "style medium": "digital illustration",
+      "text render": [],
+      "context": "Fantasy character illustration suitable for concept art.",
+      "artistic style": "cinematic realism"
+    }
+    """
+
+    private static let q36NearStructuredCaptionJSON = """
+    {
+      "short description": "A clean product photograph featuring a small matte red cube.",
+      "objects": [
+        {
+          "name": "matte red cube",
+          "attributes": [
+            "small",
+            "matte finish",
+            "red color"
+          ]
+        }
+      ],
+      "background setting": "Minimalist white tabletop and clean neutral background.",
+      "lighting": {
+        "conditions": "Soft, diffused natural light",
+        "direction": "From a side window",
+        "shadows": "Soft, subtle shadows"
+      },
+      "aesthetics": {
+        "composition": "Centered product composition",
+        "color scheme": "Red and white with neutral tones",
+        "mood atmosphere": "Clean and professional"
+      },
+      "photographic characteristics": {
+        "depth of field": "Shallow to medium",
+        "focus": "Sharp focus on the cube",
+        "camera angle": "Slightly elevated",
+        "lens focal length": "50mm"
+      },
+      "style medium": "photograph",
+      "artistic style": "minimal product",
+      "context": "Product showcase",
+      "text render": null
+    }
+    """
+
+    private static let gemmaCompactStructuredCaptionJSON = """
+    ```json
+    {
+      "short description": "A small matte red cube on a white table.",
+      "objects": [
+        "small matte red cube",
+        "white table"
+      ],
+      "background setting": "Minimalist interior, clean studio environment",
+      "lighting": "Soft window light, natural diffusion",
+      "aesthetics": "Minimalist, clean, modern",
+      "photographic characteristics": "Product photography, sharp focus",
+      "style medium": "Photography",
+      "artistic style": "Commercial product photography",
+      "context": "Product showcase",
+      "text render": "none"
+    }
+    ```
+    """
 }

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -266,6 +266,59 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(FileSystemHelper.directorySize(at: modelRoot), 7)
     }
 
+    func testDirectorySizeFollowsSymlinkedDirectoriesInsideModelRoots() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-size-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let target = root.appendingPathComponent("target", isDirectory: true)
+        let modelRoot = root.appendingPathComponent("image-ideogram4-sdnq-uint4", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
+        try Data(repeating: 1, count: 3).write(to: modelRoot.appendingPathComponent("mererun_model.json"))
+        try Data(repeating: 1, count: 11).write(to: target.appendingPathComponent("model.safetensors"))
+        try FileManager.default.createSymbolicLink(
+            at: modelRoot.appendingPathComponent("transformer", isDirectory: true),
+            withDestinationURL: target
+        )
+
+        let usage = FileSystemHelper.directoryUsage(at: modelRoot)
+        XCTAssertEqual(usage.resolvedBytes, 14)
+        XCTAssertEqual(usage.localBytes, 3)
+        XCTAssertEqual(usage.symlinkCount, 1)
+        XCTAssertEqual(usage.symlinkedDirectoryCount, 1)
+        XCTAssertEqual(usage.layoutDescription, "directory with symlinked directories")
+        XCTAssertEqual(FileSystemHelper.directorySize(at: modelRoot), 14)
+    }
+
+    func testModelInventoryUsesResolvedSizeForSymlinkedModelDirectories() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-inventory-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? FileManager.default.removeItem(at: root)
+        }
+        MereRunModelPaths.setProcessModelsDirOverride(root)
+
+        let target = root.appendingPathComponent("hub/ideogram-transformer", isDirectory: true)
+        let modelRoot = root.appendingPathComponent(ModelResolver.ModelID.ideogram4SDNQUInt4.rawValue, isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
+        try Data(repeating: 1, count: 13).write(to: modelRoot.appendingPathComponent("mererun_model.json"))
+        try Data(repeating: 1, count: 29).write(to: target.appendingPathComponent("diffusion_pytorch_model.safetensors"))
+        try FileManager.default.createSymbolicLink(
+            at: modelRoot.appendingPathComponent("transformer", isDirectory: true),
+            withDestinationURL: target
+        )
+
+        let row = try XCTUnwrap(
+            ModelInventory.rows().first { $0.id == ModelResolver.ModelID.ideogram4SDNQUInt4.rawValue }
+        )
+        XCTAssertEqual(row.status, "installed")
+        XCTAssertEqual(row.size, ByteCountFormatter.string(fromByteCount: 42, countStyle: .file))
+    }
+
     func testPiBinaryFinderSkipsDirectoryNamedPi() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-pi-finder-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -21,6 +21,18 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.stream)
     }
 
+    func testTextChatBackendDescriptionIdentifiesNativeMLXModels() {
+        let backend = TextChat.backendDescription(for: Gemma4Resources.twelveB4BitModelId)
+
+        XCTAssertTrue(backend.contains("native MLX"))
+    }
+
+    func testTextChatBackendDescriptionIdentifiesGGUFModels() {
+        let backend = TextChat.backendDescription(for: ModelResolver.ModelID.q36NanoGGUF.rawValue)
+
+        XCTAssertEqual(backend, "llama.cpp/GGUF")
+    }
+
     func testGemma4TurboDefaultsToTurboQuantKVCache() throws {
         let cmd = try TextChat.parse([
             "--prompt", "Say hello",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -190,8 +190,14 @@ Key options:
 - `--ref-image`: repeatable HiDream O1 reference image
 - `--keep-original-aspect`: preserve one HiDream reference image's aspect ratio
 - `--strength`: image-to-image strength
+- `--structured-prompt`, `--json-prompt`: expand the prompt into a structured JSON caption with a local text chat model before image generation
+- `--structured-prompt-model`: text chat model id for the adapter; defaults to `text-chat-gemma4-12b-4bit`
+- `--structured-prompt-output`: write the generated structured JSON caption to a file
 - `--lora`, `--lora-scale`
 - `--quiet`
+
+Unless `--quiet` is set, progress diagnostics on stderr include the native image
+backend, for example `native MLX/Metal (default device: gpu)` on Apple Silicon.
 
 Examples:
 
@@ -200,6 +206,7 @@ swift run mere.run image generate --prompt "a black cat on a red sofa"
 swift run mere.run image generate --model image-zimage-nano --prompt "retro robot illustration" --output ./robot.png
 swift run mere.run image generate --model image-bonsai-binary --prompt "sunlit greenhouse bonsai" --output ./bonsai.png
 swift run mere.run image generate --prompt "turn this into a pencil sketch" --input ./photo.png --strength 0.6
+swift run mere.run image generate --model image-ideogram4-sdnq-uint4 --prompt "a knight and a white horse in a sunny meadow" --structured-prompt --structured-prompt-output ./knight-prompt.json --output ./knight.png
 swift run mere.run image generate \
   --model image-hidream-o1-dev \
   --prompt "put this subject in a studio portrait" \
@@ -248,6 +255,10 @@ Key options:
 - `--thinking`
 - `--stats`: includes Gemma4 MTP state and accept/draft counts when a Gemma4 model is used
 - `--quiet`
+
+Unless `--quiet` is set, diagnostics on stderr include the selected text
+backend, for example native MLX/Metal for MLX models or llama.cpp/GGUF for GGUF
+models.
 
 Examples:
 
@@ -733,7 +744,8 @@ swift run mere.run video export-latents \
 
 ### `mere.run model list`
 
-List all managed model IDs and whether they are installed.
+List all managed model IDs, whether they are installed, and their resolved
+payload size. Sizes follow symlinked payload directories in the model store.
 
 ```bash
 swift run mere.run model list
@@ -940,7 +952,9 @@ swift run mere.run model capabilities --all
 
 ### `mere.run model info`
 
-Inspect a canonical model ID or a local model root.
+Inspect a canonical model ID or a local model root. The Storage section reports
+the layout, resolved payload size, wrapper size when different, and symlink
+counts.
 
 ```bash
 swift run mere.run model info image-zimage-nano

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -124,6 +124,14 @@ through the Flux2-style VAE. Plain text-to-image generation is wired through
 `image generate`; image-to-image, reference inputs, and LoRA are not supported
 for this family yet.
 
+Ideogram also works with the `image generate --structured-prompt` adapter. The
+adapter uses a local text chat model to expand a short prompt into a long,
+FIBO-style structured JSON caption covering objects, background, lighting,
+aesthetics, camera characteristics, style, context, and text renders. When the
+adapter is enabled, the CLI raises the image prompt token budget to 2048 unless
+the user already requested a larger value. Use `--structured-prompt-output` to
+save the generated JSON for review or later refinement.
+
 ### Deterministic validation
 
 ```bash


### PR DESCRIPTION
## Summary
- add a structured prompt adapter for image generation, including `--structured-prompt` / `--json-prompt` and model/root/token/output controls
- default the adapter to the native Gemma 4 12B 4-bit text model and normalize near-JSON into the structured image prompt schema
- report native runtime backends in text and image generation so smokes show MLX/Metal GPU vs other paths
- make model inventory follow symlinked model directories and expose resolved size, wrapper size, and symlink layout in `model info`

## Verification
- `swift test --filter TextChatCommandParsingTests --filter ImageGenerateCommandParsingTests`
- `./scripts/check.sh` — 631 tests, 0 failures, 32 skipped
- live structured Ideogram smoke produced a valid nonblank 256x256 PNG plus valid structured prompt JSON
- live backend smoke printed `native MLX/Metal (default device: gpu)` for text and image generation
- live Ideogram inventory reports `14.8 GB` resolved size with `localWrapperSize: 990 bytes` and symlink counts

## Notes
- The existing SwiftPM unhandled-file warning for `Sources/MereRunCore/MagentaRT2/README.md` still appears during the full check, but does not fail the gate.