### PR TITLE
Add ACE-Step XL cover parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ The format is based on Keep a Changelog.
   captions before generation, defaulting the adapter to
   `text-chat-gemma4-12b-4bit` with reviewable `--structured-prompt-output`
   artifacts and Ideogram-friendly prompt token budgeting.
+- added runtime-pool TTL eviction so loaded API models with `ttlSeconds` unload
+  after they sit idle, while pinned models stay protected from automatic
+  TTL/LRU eviction.
+- added runtime-pool memory-guard tiers (`off`, `safe`, `balanced`,
+  `aggressive`, `custom`) so pressure LRU uses tiered soft/hard ceilings rather
+  than fixed resident-memory ratios. Elevated pressure pauses extra concurrent
+  admissions and evicts the least-recently-used idle unpinned model; critical
+  pressure evicts every idle unpinned model.
+- added `music generate --source-audio` and `--reference-audio` so ACE-Step can
+  run source-conditioned cover generation from regular audio files.
+- added ACE-Step Haar DCW sampler correction with upstream defaults for cleaner
+  native diffusion output.
+- added managed ACE-Step 1.5 XL Turbo pulls with `music-acestep-xl-turbo`, plus
+  optional 4B 5 Hz LM installation through `music-acestep-xl-turbo-lm4b`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on Keep a Changelog.
 - added `music generate --analyze-source-audio` so ACE-Step covers can use
   5 Hz LM audio understanding to fill missing BPM, key/scale, language, and
   time-signature metadata from the source song before direct DiT generation.
+- added `music analyze` so ACE-Step can inspect regular audio files and emit
+  JSON metadata from the 5 Hz LM audio-understanding path before cover/remix
+  workflows.
 - added ACE-Step Haar DCW sampler correction with upstream defaults for cleaner
   native diffusion output.
 - added managed ACE-Step 1.5 XL Turbo pulls with `music-acestep-xl-turbo`, plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on Keep a Changelog.
   pressure evicts every idle unpinned model.
 - added `music generate --source-audio` and `--reference-audio` so ACE-Step can
   run source-conditioned cover generation from regular audio files.
+- added `music generate --analyze-source-audio` so ACE-Step covers can use
+  5 Hz LM audio understanding to fill missing BPM, key/scale, language, and
+  time-signature metadata from the source song before direct DiT generation.
 - added ACE-Step Haar DCW sampler correction with upstream defaults for cleaner
   native diffusion output.
 - added managed ACE-Step 1.5 XL Turbo pulls with `music-acestep-xl-turbo`, plus

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ swift run mere.run music generate \
 swift run mere.run music generate \
   "dream-pop cover with soft vocals" \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --audio-cover-strength 1.0 \
   --output ./cover.wav
 
@@ -368,6 +369,7 @@ swift run mere.run music generate \
   "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion" \
   --model music-acestep-xl-turbo \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --audio-cover-strength 0.20 \
   --cover-noise-strength 0.0 \
   --output ./reggaeton-cover.wav

--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ swift run mere.run music generate \
   --audio-cover-strength 1.0 \
   --output ./cover.wav
 
+# Analyze a source song before cover/remix work
+swift run mere.run music analyze ./song.mp3 \
+  --model music-acestep-xl-turbo-lm4b \
+  --lm-subdirectory acestep-5Hz-lm-4B \
+  > ./song-analysis.json
+
 # Generate a style-transfer cover from a source song
 swift run mere.run music generate \
   "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion" \
@@ -411,6 +417,7 @@ The public CLI is modality-first:
 - `mere.run vision track`
 - `mere.run vision track-live`
 - `mere.run vision ocr`
+- `mere.run music analyze`
 - `mere.run music generate`
 - `mere.run music realtime`
 - `mere.run video generate`

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ swift run mere.run model runtime set text-chat-gemma4 \
   --pinned \
   --ttl-seconds 3600 \
   --max-tokens 1024
+# Runtime TTLs unload idle loaded models during pool operations.
+# Memory-guard tiers drive pressure LRU and admission pauses.
+# Pinned models are kept out of automatic eviction.
 
 # See what this Mac can run before pulling large models
 swift run mere.run model capabilities
@@ -341,9 +344,33 @@ swift run mere.run vision track ./clip.mp4 --prompt "a person"
 swift run mere.run vision track-live --output ./live.mp4 --prompt "a person"
 
 # Generate music
+swift run mere.run model pull music-acestep
 swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
+
+# Generate with ACE-Step XL Turbo on larger Macs
+swift run mere.run model pull music-acestep-xl-turbo
+swift run mere.run music generate \
+  "cinematic synth pop with bright vocal harmonies" \
+  --model music-acestep-xl-turbo \
+  --output ./xl-track.wav
+
+# Generate an ACE-Step cover from a source song
+swift run mere.run music generate \
+  "dream-pop cover with soft vocals" \
+  --source-audio ./song.mp3 \
+  --audio-cover-strength 1.0 \
+  --output ./cover.wav
+
+# Generate a style-transfer cover from a source song
+swift run mere.run music generate \
+  "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion" \
+  --model music-acestep-xl-turbo \
+  --source-audio ./song.mp3 \
+  --audio-cover-strength 0.20 \
+  --cover-noise-strength 0.0 \
+  --output ./reggaeton-cover.wav
 
 # Stream and optionally capture Magenta RT2 music on Apple Silicon macOS
 swift run mere.run music realtime \

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -329,10 +329,22 @@ enum GuideRegistry {
             commandPaths: [["music", "generate"]],
             models: [
                 "music-acestep",
+                "music-acestep-xl-turbo",
+                "music-acestep-xl-turbo-lm4b",
                 "music-magenta-rt2-small",
                 "music-magenta-rt2-base",
             ],
             resourceName: "music-generate.md"
+        ),
+        GuideTopic(
+            topic: "music-analyze",
+            title: "Music Analyze",
+            commandPaths: [["music", "analyze"]],
+            models: [
+                "music-acestep",
+                "music-acestep-xl-turbo-lm4b",
+            ],
+            resourceName: "music-analyze.md"
         ),
         GuideTopic(
             topic: "video-generate",

--- a/Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift
@@ -1,0 +1,181 @@
+import ArgumentParser
+import Foundation
+import MLX
+import MereRunCore
+
+struct MusicAnalyze: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "analyze",
+        abstract: "Analyze source audio with ACE-Step audio understanding.",
+        discussion: """
+        Prints JSON metadata to stdout.
+        Progress and diagnostics are printed to stderr.
+
+        Example:
+          mere.run music analyze ~/Downloads/song.mp3 \
+            --model music-acestep-xl-turbo-lm4b \
+            --lm-subdirectory acestep-5Hz-lm-4B
+        """
+    )
+
+    @Argument(help: "Input audio file to analyze.")
+    var audio: String
+
+    @Option(name: [.customShort("m"), .long], help: "Managed ACE-Step model id or local model/checkpoints root.")
+    var model: String = ModelResolver.ModelID.aceStep.rawValue
+
+    @Option(name: [.customLong("checkpoints-root")], help: "Root directory containing ACE-Step checkpoint subdirectories. Auto-discovered if not set.")
+    var checkpointsRoot: String?
+
+    @Option(name: [.customLong("turbo-subdirectory")], help: "Turbo decoder subdirectory under checkpoints root.")
+    var turboSubdirectory: String = "acestep-v15-turbo"
+
+    @Option(name: [.customLong("vae-subdirectory")], help: "VAE subdirectory under checkpoints root.")
+    var vaeSubdirectory: String = "vae"
+
+    @Option(name: [.customLong("lm-subdirectory")], help: "5Hz LM subdirectory under checkpoints root. Auto-detected when omitted.")
+    var lmSubdirectory: String?
+
+    @Option(name: [.customLong("duration")], help: "Analyze the first N seconds instead of the full decoded input.")
+    var durationSeconds: Float?
+
+    @Option(name: [.customLong("max-new-tokens")], help: "Maximum LM tokens to emit during analysis.")
+    var maxNewTokens: Int = 2048
+
+    @Option(name: [.customLong("lm-temperature")], help: "LM sampling temperature.")
+    var lmTemperature: Float = 0.3
+
+    @Option(name: [.customLong("lm-top-k")], help: "LM top-k sampling (0 = disabled).")
+    var lmTopK: Int = 0
+
+    @Option(name: [.customLong("lm-top-p")], help: "LM top-p nucleus sampling (1.0 = disabled).")
+    var lmTopP: Float = 0.9
+
+    @Flag(name: [.customLong("include-raw-lm")], help: "Include the raw LM analysis text in stdout JSON.")
+    var includeRawLM: Bool = false
+
+    @Flag(name: [.customLong("include-audio-codes")], help: "Include serialized ACE audio-code tokens in stdout JSON.")
+    var includeAudioCodes: Bool = false
+
+    @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
+    var quiet: Bool = false
+
+    func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+
+        if let durationSeconds {
+            guard durationSeconds > 0 else {
+                throw ValidationError("--duration must be > 0")
+            }
+        }
+        guard maxNewTokens > 0 else {
+            throw ValidationError("--max-new-tokens must be > 0")
+        }
+        guard lmTopK >= 0 else {
+            throw ValidationError("--lm-top-k must be >= 0")
+        }
+        guard (0.0...1.0).contains(lmTopP) else {
+            throw ValidationError("--lm-top-p must be between 0.0 and 1.0")
+        }
+        guard lmTemperature >= 0 else {
+            throw ValidationError("--lm-temperature must be >= 0")
+        }
+
+        let checkpointsRootURL = try await ACEStepCLIHelper.resolveCheckpointsRoot(
+            model: model,
+            checkpointsRoot: checkpointsRoot,
+            turboSubdirectory: turboSubdirectory,
+            vaeSubdirectory: vaeSubdirectory,
+            lmSubdirectory: lmSubdirectory,
+            textSubdirectory: nil
+        )
+        let resolvedTurboSubdirectory = try ACEStepCLIHelper.resolveTurboSubdirectory(
+            at: checkpointsRootURL,
+            explicit: turboSubdirectory
+        )
+        let resolvedLMSubdirectory = try ACEStepCLIHelper.resolveLMSubdirectory(
+            at: checkpointsRootURL,
+            explicit: lmSubdirectory
+        )
+        guard let resolvedLMSubdirectory else {
+            throw ValidationError(
+                "music analyze requires an ACE-Step 5Hz LM subdirectory. "
+                    + "Pull `music-acestep` or `music-acestep-xl-turbo-lm4b`, "
+                    + "or pass --lm-subdirectory."
+            )
+        }
+
+        let inputURL = ACEStepCLIHelper.resolveUserPath(audio)
+        let audio48kHz = try ACEStepCLIHelper.loadAudio48kHz(audio, label: "audio")
+        let inputDurationSeconds = ACEStepCLIHelper.durationSeconds(of: audio48kHz, fallback: 0)
+        let analyzedDurationSeconds = durationSeconds ?? inputDurationSeconds
+
+        if !quiet {
+            CLIStderr.write("Using ACE-Step source audio: \(inputURL.path)\n")
+            CLIStderr.write("Loading ACE-Step checkpoints from \(checkpointsRootURL.path)\n")
+            CLIStderr.write("Analyzing ACE-Step source audio with 5Hz LM\n")
+        }
+
+        let container = ACEStepModelContainer(
+            checkpointsRootURL: checkpointsRootURL,
+            turboSubdirectory: resolvedTurboSubdirectory,
+            vaeSubdirectory: vaeSubdirectory,
+            lmSubdirectory: resolvedLMSubdirectory,
+            textEncoderSubdirectory: nil
+        )
+        let resources = try await container.resources()
+        let pipeline = try ACEStepPipeline(
+            decoderResources: resources.decoderResources,
+            vaeResources: resources.vaeResources,
+            lmResources: resources.lmResources,
+            textEncoderResources: nil
+        )
+        let analysis = try pipeline.understandSourceAudio(
+            sourceAudio48kHz: audio48kHz,
+            durationSeconds: analyzedDurationSeconds,
+            lmConfig: .init(
+                maxNewTokens: maxNewTokens,
+                temperature: lmTemperature,
+                topK: lmTopK,
+                topP: lmTopP
+            )
+        )
+
+        if !quiet {
+            CLIStderr.write("ACE-Step source analysis: \(analysis.metadata.understandingSummary)\n")
+        }
+
+        let output = MusicAnalyzeOutput(
+            audio: inputURL.path,
+            model: model,
+            checkpointsRoot: checkpointsRootURL.path,
+            turboSubdirectory: resolvedTurboSubdirectory,
+            lmSubdirectory: resolvedLMSubdirectory,
+            inputDurationSeconds: inputDurationSeconds,
+            analyzedDurationSeconds: analyzedDurationSeconds,
+            metadata: analysis.metadata,
+            rawLMOutput: includeRawLM ? analysis.lmResult.generatedText : nil,
+            audioCodes: includeAudioCodes ? analysis.audioCodes : nil
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(output)
+        guard let rendered = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Could not encode music analysis JSON as UTF-8.")
+        }
+        print(rendered)
+    }
+}
+
+struct MusicAnalyzeOutput: Codable, Equatable {
+    let audio: String
+    let model: String
+    let checkpointsRoot: String
+    let turboSubdirectory: String
+    let lmSubdirectory: String
+    let inputDurationSeconds: Float
+    let analyzedDurationSeconds: Float
+    let metadata: ACEStepMusicUnderstandingMetadata
+    let rawLMOutput: String?
+    let audioCodes: String?
+}

--- a/Sources/MereRunCLI/Commands/MusicCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicCommand.swift
@@ -5,6 +5,7 @@ struct Music: ParsableCommand {
         commandName: "music",
         abstract: "Generate music locally.",
         subcommands: [
+            MusicAnalyze.self,
             MusicGenerate.self,
             MusicRealtime.self,
         ]

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -65,6 +65,12 @@ struct MusicGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong("use-lm")], help: "Use 5Hz LM constrained decoding for supported ACE-Step tasks.")
     var useLM: Bool = false
 
+    @Flag(
+        name: [.customLong("analyze-source-audio")],
+        help: "Use ACE-Step 5Hz LM audio understanding to fill missing cover metadata from --source-audio."
+    )
+    var analyzeSourceAudio: Bool = false
+
     @Option(name: [.customLong("duration")], help: "Output duration in seconds.")
     var durationSeconds: Float = 10.0
 
@@ -212,21 +218,28 @@ struct MusicGenerate: AsyncParsableCommand {
         let isCover = resolvedACEStepIsCover
         let effectiveTaskType = resolvedACEStepTaskType(isCover: isCover)
         let effectiveUseLM = resolvedACEStepUsesLM(taskType: effectiveTaskType)
+        if analyzeSourceAudio && !isCover {
+            throw ValidationError("--analyze-source-audio requires ACE-Step cover mode with --source-audio.")
+        }
+        let needsLMResources = effectiveUseLM || analyzeSourceAudio
 
         let checkpointsRootURL = try await resolveACEStepCheckpointsRoot()
         let resolvedTurboSubdirectory = try resolveACEStepTurboSubdirectory(
             at: checkpointsRootURL,
             explicit: turboSubdirectory
         )
-        let resolvedLMSubdirectory = try effectiveUseLM
+        let resolvedLMSubdirectory = try needsLMResources
             ? resolveACEStepLMSubdirectory(at: checkpointsRootURL, explicit: lmSubdirectory)
             : nil
         let resolvedTextSubdirectory = try resolveACEStepTextSubdirectory(
             at: checkpointsRootURL,
             explicit: textSubdirectory
         )
-        if effectiveUseLM && resolvedLMSubdirectory == nil {
-            throw ValidationError("--use-lm requires --lm-subdirectory. Set --lm-subdirectory or keep a default layout like 'acestep-5Hz-lm-1.7B'.")
+        if needsLMResources && resolvedLMSubdirectory == nil {
+            throw ValidationError(
+                "--use-lm and --analyze-source-audio require --lm-subdirectory. "
+                    + "Set --lm-subdirectory or keep a default layout like 'acestep-5Hz-lm-1.7B'."
+            )
         }
         if resolvedTextSubdirectory == nil {
             throw ValidationError("ACE-Step text encoder not found. Set --text-subdirectory or keep a default layout like 'Qwen3-Embedding-0.6B'.")
@@ -252,7 +265,7 @@ struct MusicGenerate: AsyncParsableCommand {
             completeTrackClasses: completeTrackClasses
         )
 
-        let userMetadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
+        var userMetadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
             bpm: bpm.map(String.init),
             caption: caption,
             duration: resolvedMetadataDuration(effectiveDurationSeconds: effectiveDurationSeconds),
@@ -272,7 +285,7 @@ struct MusicGenerate: AsyncParsableCommand {
             checkpointsRootURL: checkpointsRootURL,
             turboSubdirectory: resolvedTurboSubdirectory,
             vaeSubdirectory: vaeSubdirectory,
-            lmSubdirectory: effectiveUseLM ? resolvedLMSubdirectory : nil,
+            lmSubdirectory: needsLMResources ? resolvedLMSubdirectory : nil,
             textEncoderSubdirectory: resolvedTextSubdirectory
         )
         let resources = try await container.resources()
@@ -282,6 +295,31 @@ struct MusicGenerate: AsyncParsableCommand {
             lmResources: resources.lmResources,
             textEncoderResources: resources.textEncoderResources
         )
+
+        if analyzeSourceAudio {
+            guard let sourceAudio48kHz else {
+                throw ValidationError("--analyze-source-audio requires --source-audio.")
+            }
+            if !quiet {
+                CLIStderr.write("Analyzing ACE-Step source audio with 5Hz LM\n")
+            }
+            let sourceAnalysis = try pipeline.understandSourceAudio(
+                sourceAudio48kHz: sourceAudio48kHz,
+                durationSeconds: effectiveDurationSeconds,
+                lmConfig: .init(maxNewTokens: 2048, temperature: 0.3, topK: lmTopK, topP: lmTopP)
+            )
+            let merge = mergedMetadataWithSourceAnalysis(userMetadata, sourceAnalysis.metadata)
+            userMetadata = merge.metadata
+            if !quiet {
+                let summary = sourceAnalysis.metadata.understandingSummary
+                CLIStderr.write("ACE-Step source analysis: \(summary)\n")
+                if merge.filledFields.isEmpty {
+                    CLIStderr.write("No missing ACE-Step metadata fields were filled from source analysis\n")
+                } else {
+                    CLIStderr.write("Filled ACE-Step metadata from source analysis: \(merge.filledFields.joined(separator: ", "))\n")
+                }
+            }
+        }
 
         let inference = ACEStepInferenceConfig(
             durationSeconds: effectiveDurationSeconds,
@@ -589,6 +627,54 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         let seconds = max(1, Int(effectiveDurationSeconds))
         return "\(seconds) seconds"
+    }
+
+    func mergedMetadataWithSourceAnalysis(
+        _ metadata: ACEStep5HzLMConstrainedSampler.UserMetadata,
+        _ analysis: ACEStepMusicUnderstandingMetadata
+    ) -> (metadata: ACEStep5HzLMConstrainedSampler.UserMetadata, filledFields: [String]) {
+        var filledFields: [String] = []
+
+        let analyzedBPM = analysis.bpm.map(String.init)
+        let mergedBPM = fillMissing(metadata.bpm, with: analyzedBPM, field: "bpm", filledFields: &filledFields)
+        let mergedKeyscale = fillMissing(metadata.keyscale, with: analysis.keyscale, field: "keyscale", filledFields: &filledFields)
+        let mergedLanguage = fillMissing(metadata.language, with: analysis.language, field: "language", filledFields: &filledFields)
+        let mergedTimeSignature = fillMissing(
+            metadata.timesignature,
+            with: analysis.timesignature,
+            field: "timesignature",
+            filledFields: &filledFields
+        )
+
+        return (
+            ACEStep5HzLMConstrainedSampler.UserMetadata(
+                bpm: mergedBPM,
+                caption: metadata.caption,
+                duration: metadata.duration,
+                keyscale: mergedKeyscale,
+                language: mergedLanguage,
+                timesignature: mergedTimeSignature
+            ),
+            filledFields
+        )
+    }
+
+    private func fillMissing(
+        _ existing: String?,
+        with analyzed: String?,
+        field: String,
+        filledFields: inout [String]
+    ) -> String? {
+        let trimmedExisting = existing?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedExisting.isEmpty {
+            return existing
+        }
+        let trimmedAnalyzed = analyzed?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedAnalyzed.isEmpty else {
+            return existing
+        }
+        filledFields.append(field)
+        return trimmedAnalyzed
     }
 
     private func resolveInstruction(

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -566,48 +566,11 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     private func loadACEStepAudio48kHz(_ path: String, label: String) throws -> MLXArray {
-        let url = resolveUserPath(path)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            throw ValidationError("\(label) not found: \(url.path)")
-        }
-
-        let buffer = try AudioReader.readAudioBuffer(from: url, sampleRate: 48_000, channels: 2)
-        guard buffer.isInterleaved else {
-            throw ValidationError("\(label) decoded to a non-interleaved buffer: \(url.path)")
-        }
-        guard buffer.channelCount == 2 else {
-            throw ValidationError("\(label) must decode to stereo at 48 kHz; got \(buffer.channelCount) channel(s).")
-        }
-        guard buffer.samples.count >= buffer.channelCount else {
-            throw ValidationError("\(label) contains no audio samples: \(url.path)")
-        }
-
-        let frames = buffer.samples.count / buffer.channelCount
-        let trimmedSampleCount = frames * buffer.channelCount
-        let samples = trimmedSampleCount == buffer.samples.count
-            ? buffer.samples
-            : Array(buffer.samples.prefix(trimmedSampleCount))
-        let clamped = samples.map { sample -> Float in
-            guard sample.isFinite else {
-                return 0
-            }
-            return max(-1.0, min(1.0, sample))
-        }
-        return MLXArray(clamped, [1, frames, buffer.channelCount]).asType(.float32)
+        try ACEStepCLIHelper.loadAudio48kHz(path, label: label)
     }
 
     private func resolveUserPath(_ path: String) -> URL {
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed == "~" {
-            return URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL
-        }
-        if trimmed.hasPrefix("~/") {
-            let suffix = String(trimmed.dropFirst(2))
-            return URL(fileURLWithPath: NSHomeDirectory())
-                .appendingPathComponent(suffix)
-                .standardizedFileURL
-        }
-        return URL(fileURLWithPath: trimmed).standardizedFileURL
+        ACEStepCLIHelper.resolveUserPath(path)
     }
 
     func resolvedACEStepDurationSeconds(isCover: Bool, sourceAudio48kHz: MLXArray?) -> Float {
@@ -731,265 +694,33 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     private func resolveACEStepCheckpointsRoot() async throws -> URL {
-        let candidates = buildAcestepCheckpointCandidates()
-
-        for candidate in candidates {
-            if isUsableCheckpointsRoot(candidate) {
-                return candidate
-            }
-            let nested = candidate.appendingPathComponent("checkpoints", isDirectory: true)
-            if isUsableCheckpointsRoot(nested) {
-                return nested
-            }
-        }
-
-        if let explicit = checkpointsRoot, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            throw ValidationError("Checkpoints root not found or incomplete: \(explicit)")
-        }
-
-        do {
-            let resolved = try await ManagedModelResolver.resolveForRuntime(
-                requestedModel: model,
-                defaultModelID: ModelResolver.ModelID.aceStep.rawValue
-            )
-            let root = resolved.url
-            if isUsableCheckpointsRoot(root) {
-                return root
-            }
-            let nested = root.appendingPathComponent("checkpoints", isDirectory: true)
-            if isUsableCheckpointsRoot(nested) {
-                return nested
-            }
-        } catch let error as ManagedModelResolver.ResolverError {
-            throw ValidationError(error.localizedDescription)
-        }
-
-        throw ValidationError("Music Acestep checkpoints not found. Add --checkpoints-root or set MERERUN_MUSIC_ACESTEP_ROOT.")
+        try await ACEStepCLIHelper.resolveCheckpointsRoot(
+            model: model,
+            checkpointsRoot: checkpointsRoot,
+            turboSubdirectory: turboSubdirectory,
+            vaeSubdirectory: vaeSubdirectory,
+            lmSubdirectory: useLM ? lmSubdirectory : nil,
+            textSubdirectory: textSubdirectory
+        )
     }
 
     private func resolveACEStepLMSubdirectory(at root: URL, explicit: String?) throws -> String? {
-        let fm = FileManager.default
-
-        func isDirectory(_ url: URL) -> Bool {
-            var isDir: ObjCBool = false
-            return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
-        }
-        func isUsableLMDirectory(_ url: URL) -> Bool {
-            isDirectory(url) && ACEStep5HzLMResources(rootURL: url).validate(fileManager: fm).isEmpty
-        }
-
-        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
-            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
-            guard isUsableLMDirectory(explicitRoot) else {
-                throw ValidationError("--lm-subdirectory not found: \(explicitNormalized)")
-            }
-            return explicitNormalized
-        }
-
-        let preferredCandidates = [
-            "acestep-5Hz-lm-1.7B",
-            "acestep-5hz-lm-1.7b",
-            "acestep-5Hz-lm-4B",
-            "acestep-5hz-lm-4b",
-            "acestep-5Hz-lm",
-            "acestep-5hz-lm",
-            "music-acestep-5hz-lm-1.7b",
-            "music-acestep-5Hz-lm-1.7B",
-            "music-acestep-5hz-lm-4b",
-            "music-acestep-5Hz-lm-4B",
-            "music-acestep-5hz-lm",
-            "music-acestep-5Hz-lm",
-            "lm",
-            "music-acestep-lm"
-        ]
-
-        for candidate in preferredCandidates {
-            if isUsableLMDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
-                return candidate
-            }
-        }
-
-        let discovered = (try? fm.contentsOfDirectory(
-            at: root,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ))?.first(where: { directory in
-            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            return isDirectory
-                && directory.lastPathComponent.lowercased().contains("lm")
-                && directory.lastPathComponent.lowercased().contains("5hz")
-                && ACEStep5HzLMResources(rootURL: directory).validate(fileManager: fm).isEmpty
-        })
-
-        return discovered?.lastPathComponent
+        try ACEStepCLIHelper.resolveLMSubdirectory(at: root, explicit: explicit)
     }
 
     private func resolveACEStepTextSubdirectory(at root: URL, explicit: String?) throws -> String? {
-        let fm = FileManager.default
-
-        func isDirectory(_ url: URL) -> Bool {
-            var isDir: ObjCBool = false
-            return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
-        }
-
-        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
-            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
-            guard isDirectory(explicitRoot) else {
-                throw ValidationError("--text-subdirectory not found: \(explicitNormalized)")
-            }
-            return explicitNormalized
-        }
-
-        let preferredCandidates = [
-            "Qwen3-Embedding-0.6B",
-            "qwen3-embedding-0.6b",
-            "Qwen3-Embedding-4B",
-            "qwen3-embedding-4b",
-            "Qwen3-Embedding",
-            "qwen3-embedding",
-            "text_encoder",
-            "text-encoder"
-        ]
-
-        for candidate in preferredCandidates {
-            if isDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
-                return candidate
-            }
-        }
-
-        let discovered = (try? fm.contentsOfDirectory(
-            at: root,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ))?.first(where: { directory in
-            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            let name = directory.lastPathComponent.lowercased()
-            return isDirectory && (
-                (name.contains("qwen3") && name.contains("embedding"))
-                || name == "text_encoder"
-                || name == "text-encoder"
-            )
-        })
-
-        return discovered?.lastPathComponent
+        try ACEStepCLIHelper.resolveTextSubdirectory(at: root, explicit: explicit)
     }
 
     func buildAcestepCheckpointCandidates() -> [URL] {
-        var candidates: [URL] = []
-
-        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
-            candidates.append(URL(fileURLWithPath: explicit).standardizedFileURL)
-        }
-
-        var modelPathExists = false
-        let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty {
-            let url = URL(fileURLWithPath: explicitModel).standardizedFileURL
-            if FileManager.default.fileExists(atPath: url.path) {
-                modelPathExists = true
-                candidates.append(url)
-            }
-        }
-
-        if let envRoot = ProcessInfo.processInfo.environment["MERERUN_MUSIC_ACESTEP_ROOT"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !envRoot.isEmpty
-        {
-            candidates.append(URL(fileURLWithPath: envRoot).standardizedFileURL)
-        }
-
-        let managedModelID = explicitModel.lowercased()
-        if !managedModelID.isEmpty && !modelPathExists {
-            let requestedRoot = MereRunModelPaths.modelsDir
-                .appendingPathComponent(managedModelID, isDirectory: true)
-                .standardizedFileURL
-            candidates.append(requestedRoot)
-            candidates.append(requestedRoot.appendingPathComponent("checkpoints", isDirectory: true))
-        }
-
-        if managedModelID.isEmpty {
-            let localModelRoot = MereRunModelPaths.modelsDir
-                .appendingPathComponent(ModelResolver.ModelID.aceStep.rawValue, isDirectory: true)
-                .standardizedFileURL
-            candidates.append(localModelRoot)
-            candidates.append(localModelRoot.appendingPathComponent("checkpoints", isDirectory: true))
-        }
-
-        return candidates
+        ACEStepCLIHelper.buildCheckpointCandidates(model: model, checkpointsRoot: checkpointsRoot)
     }
 
     private func resolveACEStepTurboSubdirectory(at root: URL, explicit: String) throws -> String {
-        let fm = FileManager.default
-        func isDirectory(_ url: URL) -> Bool {
-            var isDir: ObjCBool = false
-            return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
-        }
-        func isUsableTurboDirectory(_ url: URL) -> Bool {
-            isDirectory(url) && ACEStepResources(rootURL: url).validate(fileManager: fm).isEmpty
-        }
-
-        let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
-        let upstreamDefault = "acestep-v15-turbo"
-        let compatibilityDefault = "music-acestep-v15-turbo"
-        let xlTurboDefault = "acestep-v15-xl-turbo"
-        let candidates = trimmed == upstreamDefault
-            ? [upstreamDefault, compatibilityDefault, xlTurboDefault]
-            : [trimmed]
-
-        for candidate in candidates where isUsableTurboDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
-            return candidate
-        }
-        throw ValidationError("--turbo-subdirectory not found: \(trimmed)")
-    }
-
-    private func isUsableCheckpointsRoot(_ root: URL) -> Bool {
-        let fm = FileManager.default
-
-        func isDirectory(_ url: URL) -> Bool {
-            var isDir: ObjCBool = false
-            return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
-        }
-        func isUsableTurboDirectory(_ url: URL) -> Bool {
-            isDirectory(url) && ACEStepResources(rootURL: url).validate(fileManager: fm).isEmpty
-        }
-
-        guard isDirectory(root) else {
-            return false
-        }
-        let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
-            ? ["acestep-v15-turbo", "music-acestep-v15-turbo", "acestep-v15-xl-turbo"]
-            : [turboSubdirectory]
-        guard turboCandidates.contains(where: { isUsableTurboDirectory(root.appendingPathComponent($0, isDirectory: true)) }) else {
-            return false
-        }
-        guard isDirectory(root.appendingPathComponent(vaeSubdirectory)) else {
-            return false
-        }
-
-        if useLM, let lmSubdirectory, !lmSubdirectory.isEmpty {
-            guard isDirectory(root.appendingPathComponent(lmSubdirectory)) else {
-                return false
-            }
-        }
-
-        if let textSubdirectory, !textSubdirectory.isEmpty {
-            guard isDirectory(root.appendingPathComponent(textSubdirectory)) else {
-                return false
-            }
-        }
-
-        return true
+        try ACEStepCLIHelper.resolveTurboSubdirectory(at: root, explicit: explicit)
     }
 
     private static let defaultACEStepShift: Float = 3.0
-}
-
-private extension String {
-    var nonEmpty: String? {
-        isEmpty ? nil : self
-    }
 }
 
 private enum ACEStepWAVWriter {

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -23,6 +23,12 @@ struct MusicGenerate: AsyncParsableCommand {
             --model music-magenta-rt2-small \
             --duration 4 \
             -o out.wav
+
+          mere.run music generate "dream-pop cover with soft vocals" \
+            --source-audio ~/Downloads/song.mp3 \
+            --lyrics "[verse]\\nnew words over the old shape" \
+            --audio-cover-strength 1.0 \
+            -o cover.wav
         """
     )
 
@@ -56,7 +62,7 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("text-subdirectory")], help: "Text encoder subdirectory under checkpoints root. Auto-detected as 'Qwen3-Embedding-0.6B' when omitted.")
     var textSubdirectory: String?
 
-    @Flag(name: [.customLong("use-lm")], help: "Use 5Hz LM constrained decoding.")
+    @Flag(name: [.customLong("use-lm")], help: "Use 5Hz LM constrained decoding for supported ACE-Step tasks.")
     var useLM: Bool = false
 
     @Option(name: [.customLong("duration")], help: "Output duration in seconds.")
@@ -66,13 +72,16 @@ struct MusicGenerate: AsyncParsableCommand {
     var steps: Int = 8
 
     @Option(name: [.customLong("shift")], help: "Turbo scheduler shift.")
-    var shift: Float = 1.0
+    var shift: Float = Self.defaultACEStepShift
 
     @Option(name: [.long], help: "Seed for deterministic generation.")
     var seed: UInt64?
 
     @Option(name: [.customLong("audio-cover-strength")], help: "Cover-conditioning strength in [0, 1].")
     var audioCoverStrength: Float = 1.0
+
+    @Option(name: [.customLong("cover-noise-strength")], help: "Source-latent noise initialization strength in [0, 1] for ACE-Step covers.")
+    var coverNoiseStrength: Float = 0.0
 
     @Option(name: [.customLong("vocal-language")], help: "Language tag used in lyric prompt formatting.")
     var vocalLanguage: String = "en"
@@ -83,13 +92,19 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("task-type"), .customLong("task")], help: "Task type: text2music, cover, repaint, extract, lego, complete.")
     var taskType: String = "text2music"
 
+    @Option(name: [.customLong("source-audio")], help: "Source audio file for ACE-Step cover conditioning. Implies cover mode unless --non-cover is set.")
+    var sourceAudio: String?
+
+    @Option(name: [.customLong("reference-audio")], parsing: .upToNextOption, help: "Optional reference audio file(s) for ACE-Step timbre conditioning.")
+    var referenceAudio: [String] = []
+
     @Option(name: [.customLong("track-name")], help: "Track name for extract/lego tasks.")
     var trackName: String?
 
     @Option(name: [.customLong("complete-track-classes")], help: "Comma-separated track classes for complete task (e.g. Drums,Bass).")
     var completeTrackClasses: String?
 
-    @Flag(name: [.customLong("non-cover")], help: "Generate as non-cover (isCover=false).")
+    @Flag(name: [.customLong("non-cover")], help: "Force non-cover conditioning for cover-style tasks.")
     var nonCover: Bool = false
 
     @Option(name: [.customLong("bpm")], help: "Optional BPM metadata for constrained LM / prompt metadata.")
@@ -170,6 +185,9 @@ struct MusicGenerate: AsyncParsableCommand {
         guard (0.0...1.0).contains(audioCoverStrength) else {
             throw ValidationError("--audio-cover-strength must be between 0.0 and 1.0")
         }
+        guard (0.0...1.0).contains(coverNoiseStrength) else {
+            throw ValidationError("--cover-noise-strength must be between 0.0 and 1.0")
+        }
         guard lmTopK >= 0 else {
             throw ValidationError("--lm-top-k must be >= 0")
         }
@@ -191,20 +209,23 @@ struct MusicGenerate: AsyncParsableCommand {
             return
         }
 
+        let isCover = resolvedACEStepIsCover
+        let effectiveTaskType = resolvedACEStepTaskType(isCover: isCover)
+        let effectiveUseLM = resolvedACEStepUsesLM(taskType: effectiveTaskType)
+
         let checkpointsRootURL = try await resolveACEStepCheckpointsRoot()
         let resolvedTurboSubdirectory = try resolveACEStepTurboSubdirectory(
             at: checkpointsRootURL,
             explicit: turboSubdirectory
         )
-        let resolvedLMSubdirectory = try resolveACEStepLMSubdirectory(
-            at: checkpointsRootURL,
-            explicit: lmSubdirectory
-        )
+        let resolvedLMSubdirectory = try effectiveUseLM
+            ? resolveACEStepLMSubdirectory(at: checkpointsRootURL, explicit: lmSubdirectory)
+            : nil
         let resolvedTextSubdirectory = try resolveACEStepTextSubdirectory(
             at: checkpointsRootURL,
             explicit: textSubdirectory
         )
-        if useLM && resolvedLMSubdirectory == nil {
+        if effectiveUseLM && resolvedLMSubdirectory == nil {
             throw ValidationError("--use-lm requires --lm-subdirectory. Set --lm-subdirectory or keep a default layout like 'acestep-5Hz-lm-1.7B'.")
         }
         if resolvedTextSubdirectory == nil {
@@ -215,9 +236,17 @@ struct MusicGenerate: AsyncParsableCommand {
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         let resolvedLyrics = try loadLyrics()
-        let isCover = !nonCover
+        let sourceAudio48kHz = try loadACEStepSourceAudio48kHz()
+        let referenceAudio48kHz = try loadACEStepReferenceAudio48kHz()
+        if isCover && sourceAudio48kHz == nil {
+            throw ValidationError("--source-audio is required for ACE-Step cover mode.")
+        }
+        let effectiveDurationSeconds = resolvedACEStepDurationSeconds(
+            isCover: isCover,
+            sourceAudio48kHz: sourceAudio48kHz
+        )
         let resolvedInstruction = resolveInstruction(
-            taskType: taskType,
+            taskType: effectiveTaskType,
             explicitInstruction: instruction,
             trackName: trackName,
             completeTrackClasses: completeTrackClasses
@@ -226,7 +255,7 @@ struct MusicGenerate: AsyncParsableCommand {
         let userMetadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
             bpm: bpm.map(String.init),
             caption: caption,
-            duration: resolvedMetadataDuration(),
+            duration: resolvedMetadataDuration(effectiveDurationSeconds: effectiveDurationSeconds),
             keyscale: keyscale,
             language: metadataLanguage,
             timesignature: timesignature
@@ -234,13 +263,16 @@ struct MusicGenerate: AsyncParsableCommand {
 
         if !quiet {
             CLIStderr.write("Loading ACE-Step checkpoints from \(checkpointsRootURL.path)\n")
+            if useLM && !effectiveUseLM {
+                CLIStderr.write("Skipping 5Hz LM for ACE-Step \(effectiveTaskType) task; upstream uses direct DiT conditioning for this task.\n")
+            }
         }
 
         let container = ACEStepModelContainer(
             checkpointsRootURL: checkpointsRootURL,
             turboSubdirectory: resolvedTurboSubdirectory,
             vaeSubdirectory: vaeSubdirectory,
-            lmSubdirectory: useLM ? resolvedLMSubdirectory : nil,
+            lmSubdirectory: effectiveUseLM ? resolvedLMSubdirectory : nil,
             textEncoderSubdirectory: resolvedTextSubdirectory
         )
         let resources = try await container.resources()
@@ -252,10 +284,11 @@ struct MusicGenerate: AsyncParsableCommand {
         )
 
         let inference = ACEStepInferenceConfig(
-            durationSeconds: durationSeconds,
+            durationSeconds: effectiveDurationSeconds,
             fixNFE: steps,
             shift: shift,
             timesteps: nil,
+            coverNoiseStrength: coverNoiseStrength,
             inferMethod: .ode,
             useTiledVaeDecode: !noTiledVAE,
             vaeChunkSize: vaeChunkSize,
@@ -264,7 +297,7 @@ struct MusicGenerate: AsyncParsableCommand {
         )
 
         let audio: MLXArray
-        if useLM {
+        if effectiveUseLM {
             if !quiet {
                 CLIStderr.write("Running constrained 5Hz LM + diffusion\n")
             }
@@ -275,8 +308,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 lmConfig: .init(maxNewTokens: 4096, temperature: 0.85, topK: lmTopK, topP: lmTopP),
                 lmUserMetadata: userMetadata,
                 sourceLatents25Hz: nil,
+                sourceAudio48kHz: sourceAudio48kHz,
                 referenceTimbreLatents25Hz: nil,
-                referenceTimbreAudio48kHz: nil,
+                referenceTimbreAudio48kHz: referenceAudio48kHz,
                 audioCoverStrength: audioCoverStrength,
                 vocalLanguage: vocalLanguage,
                 instruction: resolvedInstruction,
@@ -296,8 +330,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 config: inference,
                 lmUserMetadata: userMetadata,
                 sourceLatents25Hz: nil,
+                sourceAudio48kHz: sourceAudio48kHz,
                 referenceTimbreLatents25Hz: nil,
-                referenceTimbreAudio48kHz: nil,
+                referenceTimbreAudio48kHz: referenceAudio48kHz,
                 audioCoverStrength: audioCoverStrength,
                 vocalLanguage: vocalLanguage,
                 instruction: resolvedInstruction,
@@ -320,6 +355,39 @@ struct MusicGenerate: AsyncParsableCommand {
         let url = URL(fileURLWithPath: model).standardizedFileURL
         return MagentaRT2Resources.looksLikeMagentaRT2Root(url)
     }
+
+    var resolvedACEStepIsCover: Bool {
+        guard !nonCover else {
+            return false
+        }
+        if sourceAudio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return true
+        }
+        return taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "cover"
+    }
+
+    func resolvedACEStepTaskType(isCover: Bool) -> String {
+        let normalized = taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if isCover && normalized == "text2music" {
+            return "cover"
+        }
+        return normalized
+    }
+
+    func resolvedACEStepUsesLM(taskType: String) -> Bool {
+        guard useLM else {
+            return false
+        }
+        let normalized = taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return !Self.aceStepTasksSkippingLM.contains(normalized)
+    }
+
+    private static let aceStepTasksSkippingLM: Set<String> = [
+        "cover",
+        "cover-nofsq",
+        "repaint",
+        "extract"
+    ]
 
     private func runMagentaRT2() async throws {
         try validateMagentaRT2Options()
@@ -378,13 +446,19 @@ struct MusicGenerate: AsyncParsableCommand {
         if taskType != "text2music" {
             throw ValidationError("Magenta RT2 does not support --task-type; that option is ACE-Step only.")
         }
-        if trackName != nil || completeTrackClasses != nil || nonCover {
+        if trackName != nil
+            || completeTrackClasses != nil
+            || nonCover
+            || sourceAudio != nil
+            || coverNoiseStrength != 0.0
+            || !referenceAudio.isEmpty
+        {
             throw ValidationError("Magenta RT2 does not support ACE-Step cover/extract/lego options.")
         }
         if seed != nil {
             throw ValidationError("Magenta RT2 uses --seed-rotation instead of --seed.")
         }
-        if steps != 8 || shift != 1.0 {
+        if steps != 8 || shift != Self.defaultACEStepShift {
             throw ValidationError("Magenta RT2 does not use ACE-Step --steps or --shift.")
         }
         _ = try magentaControls()
@@ -417,7 +491,7 @@ struct MusicGenerate: AsyncParsableCommand {
 
     private func loadLyrics() throws -> String {
         if let lyricsFile {
-            let lyricsURL = URL(fileURLWithPath: lyricsFile).standardizedFileURL
+            let lyricsURL = resolveUserPath(lyricsFile)
             guard FileManager.default.fileExists(atPath: lyricsURL.path) else {
                 throw ValidationError("Lyrics file not found: \(lyricsURL.path)")
             }
@@ -426,12 +500,95 @@ struct MusicGenerate: AsyncParsableCommand {
         return lyrics
     }
 
-    private func resolvedMetadataDuration() -> String {
+    private func loadACEStepSourceAudio48kHz() throws -> MLXArray? {
+        guard let sourceAudio,
+              !sourceAudio.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        let audio = try loadACEStepAudio48kHz(sourceAudio, label: "--source-audio")
+        if !quiet {
+            CLIStderr.write("Using ACE-Step source audio: \(resolveUserPath(sourceAudio).path)\n")
+        }
+        return audio
+    }
+
+    private func loadACEStepReferenceAudio48kHz() throws -> [MLXArray]? {
+        let paths = referenceAudio
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !paths.isEmpty else {
+            return nil
+        }
+        let audios = try paths.map { try loadACEStepAudio48kHz($0, label: "--reference-audio") }
+        if !quiet {
+            CLIStderr.write("Using \(audios.count) ACE-Step reference audio file(s)\n")
+        }
+        return audios
+    }
+
+    private func loadACEStepAudio48kHz(_ path: String, label: String) throws -> MLXArray {
+        let url = resolveUserPath(path)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ValidationError("\(label) not found: \(url.path)")
+        }
+
+        let buffer = try AudioReader.readAudioBuffer(from: url, sampleRate: 48_000, channels: 2)
+        guard buffer.isInterleaved else {
+            throw ValidationError("\(label) decoded to a non-interleaved buffer: \(url.path)")
+        }
+        guard buffer.channelCount == 2 else {
+            throw ValidationError("\(label) must decode to stereo at 48 kHz; got \(buffer.channelCount) channel(s).")
+        }
+        guard buffer.samples.count >= buffer.channelCount else {
+            throw ValidationError("\(label) contains no audio samples: \(url.path)")
+        }
+
+        let frames = buffer.samples.count / buffer.channelCount
+        let trimmedSampleCount = frames * buffer.channelCount
+        let samples = trimmedSampleCount == buffer.samples.count
+            ? buffer.samples
+            : Array(buffer.samples.prefix(trimmedSampleCount))
+        let clamped = samples.map { sample -> Float in
+            guard sample.isFinite else {
+                return 0
+            }
+            return max(-1.0, min(1.0, sample))
+        }
+        return MLXArray(clamped, [1, frames, buffer.channelCount]).asType(.float32)
+    }
+
+    private func resolveUserPath(_ path: String) -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "~" {
+            return URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL
+        }
+        if trimmed.hasPrefix("~/") {
+            let suffix = String(trimmed.dropFirst(2))
+            return URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent(suffix)
+                .standardizedFileURL
+        }
+        return URL(fileURLWithPath: trimmed).standardizedFileURL
+    }
+
+    func resolvedACEStepDurationSeconds(isCover: Bool, sourceAudio48kHz: MLXArray?) -> Float {
+        guard isCover, let sourceAudio48kHz, sourceAudio48kHz.ndim >= 2 else {
+            return durationSeconds
+        }
+        let sourceFrames = sourceAudio48kHz.dim(1)
+        guard sourceFrames > 0 else {
+            return durationSeconds
+        }
+        return Float(sourceFrames) / 48_000.0
+    }
+
+    func resolvedMetadataDuration(effectiveDurationSeconds: Float) -> String {
         if let metadataDuration, !metadataDuration.isEmpty {
             return metadataDuration
         }
-        let rounded = max(1, Int(durationSeconds.rounded()))
-        return String(rounded)
+        let seconds = max(1, Int(effectiveDurationSeconds))
+        return "\(seconds) seconds"
     }
 
     private func resolveInstruction(
@@ -531,11 +688,14 @@ struct MusicGenerate: AsyncParsableCommand {
             var isDir: ObjCBool = false
             return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
         }
+        func isUsableLMDirectory(_ url: URL) -> Bool {
+            isDirectory(url) && ACEStep5HzLMResources(rootURL: url).validate(fileManager: fm).isEmpty
+        }
 
         if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
             let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
-            guard isDirectory(explicitRoot) else {
+            guard isUsableLMDirectory(explicitRoot) else {
                 throw ValidationError("--lm-subdirectory not found: \(explicitNormalized)")
             }
             return explicitNormalized
@@ -544,10 +704,14 @@ struct MusicGenerate: AsyncParsableCommand {
         let preferredCandidates = [
             "acestep-5Hz-lm-1.7B",
             "acestep-5hz-lm-1.7b",
+            "acestep-5Hz-lm-4B",
+            "acestep-5hz-lm-4b",
             "acestep-5Hz-lm",
             "acestep-5hz-lm",
             "music-acestep-5hz-lm-1.7b",
             "music-acestep-5Hz-lm-1.7B",
+            "music-acestep-5hz-lm-4b",
+            "music-acestep-5Hz-lm-4B",
             "music-acestep-5hz-lm",
             "music-acestep-5Hz-lm",
             "lm",
@@ -555,7 +719,7 @@ struct MusicGenerate: AsyncParsableCommand {
         ]
 
         for candidate in preferredCandidates {
-            if isDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
+            if isUsableLMDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
                 return candidate
             }
         }
@@ -569,6 +733,7 @@ struct MusicGenerate: AsyncParsableCommand {
             return isDirectory
                 && directory.lastPathComponent.lowercased().contains("lm")
                 && directory.lastPathComponent.lowercased().contains("5hz")
+                && ACEStep5HzLMResources(rootURL: directory).validate(fileManager: fm).isEmpty
         })
 
         return discovered?.lastPathComponent
@@ -625,16 +790,19 @@ struct MusicGenerate: AsyncParsableCommand {
         return discovered?.lastPathComponent
     }
 
-    private func buildAcestepCheckpointCandidates() -> [URL] {
+    func buildAcestepCheckpointCandidates() -> [URL] {
         var candidates: [URL] = []
 
         if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
             candidates.append(URL(fileURLWithPath: explicit).standardizedFileURL)
         }
 
+        var modelPathExists = false
+        let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
         if let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty {
             let url = URL(fileURLWithPath: explicitModel).standardizedFileURL
             if FileManager.default.fileExists(atPath: url.path) {
+                modelPathExists = true
                 candidates.append(url)
             }
         }
@@ -646,11 +814,23 @@ struct MusicGenerate: AsyncParsableCommand {
             candidates.append(URL(fileURLWithPath: envRoot).standardizedFileURL)
         }
 
-        let localModelRoot = MereRunModelPaths.modelsDir
-            .appendingPathComponent("music-acestep", isDirectory: true)
-            .standardizedFileURL
-        candidates.append(localModelRoot)
-        candidates.append(localModelRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        let managedModelID = explicitModel.lowercased()
+        if !managedModelID.isEmpty && !modelPathExists {
+            let requestedRoot = MereRunModelPaths.modelsDir
+                .appendingPathComponent(managedModelID, isDirectory: true)
+                .standardizedFileURL
+            candidates.append(requestedRoot)
+            candidates.append(requestedRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        }
+
+        if managedModelID.isEmpty {
+            let localModelRoot = MereRunModelPaths.modelsDir
+                .appendingPathComponent(ModelResolver.ModelID.aceStep.rawValue, isDirectory: true)
+                .standardizedFileURL
+            candidates.append(localModelRoot)
+            candidates.append(localModelRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        }
+
         return candidates
     }
 
@@ -660,15 +840,19 @@ struct MusicGenerate: AsyncParsableCommand {
             var isDir: ObjCBool = false
             return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
         }
+        func isUsableTurboDirectory(_ url: URL) -> Bool {
+            isDirectory(url) && ACEStepResources(rootURL: url).validate(fileManager: fm).isEmpty
+        }
 
         let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
         let upstreamDefault = "acestep-v15-turbo"
         let compatibilityDefault = "music-acestep-v15-turbo"
+        let xlTurboDefault = "acestep-v15-xl-turbo"
         let candidates = trimmed == upstreamDefault
-            ? [upstreamDefault, compatibilityDefault]
+            ? [upstreamDefault, compatibilityDefault, xlTurboDefault]
             : [trimmed]
 
-        for candidate in candidates where isDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
+        for candidate in candidates where isUsableTurboDirectory(root.appendingPathComponent(candidate, isDirectory: true)) {
             return candidate
         }
         throw ValidationError("--turbo-subdirectory not found: \(trimmed)")
@@ -681,14 +865,17 @@ struct MusicGenerate: AsyncParsableCommand {
             var isDir: ObjCBool = false
             return fm.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
         }
+        func isUsableTurboDirectory(_ url: URL) -> Bool {
+            isDirectory(url) && ACEStepResources(rootURL: url).validate(fileManager: fm).isEmpty
+        }
 
         guard isDirectory(root) else {
             return false
         }
         let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
-            ? ["acestep-v15-turbo", "music-acestep-v15-turbo"]
+            ? ["acestep-v15-turbo", "music-acestep-v15-turbo", "acestep-v15-xl-turbo"]
             : [turboSubdirectory]
-        guard turboCandidates.contains(where: { isDirectory(root.appendingPathComponent($0, isDirectory: true)) }) else {
+        guard turboCandidates.contains(where: { isUsableTurboDirectory(root.appendingPathComponent($0, isDirectory: true)) }) else {
             return false
         }
         guard isDirectory(root.appendingPathComponent(vaeSubdirectory)) else {
@@ -709,6 +896,8 @@ struct MusicGenerate: AsyncParsableCommand {
 
         return true
     }
+
+    private static let defaultACEStepShift: Float = 3.0
 }
 
 private extension String {
@@ -738,8 +927,9 @@ private enum ACEStepWAVWriter {
             throw WriterError.invalidChannels(channels)
         }
 
-        let int16Samples = interleaved.map { sample -> Int16 in
-            let clamped = max(-1.0, min(1.0, sample))
+        let int16Samples = peakNormalized(interleaved).map { sample -> Int16 in
+            let finiteSample = sample.isFinite ? sample : 0.0
+            let clamped = max(-1.0, min(1.0, finiteSample))
             return Int16(clamped * 32767.0)
         }
 
@@ -806,6 +996,19 @@ private enum ACEStepWAVWriter {
         let channels = sampleChannel.dim(1)
         let interleaved = sampleChannel.asType(.float32).reshaped(-1).asArray(Float.self)
         return (interleaved, channels)
+    }
+
+    private static func peakNormalized(_ samples: [Float]) -> [Float] {
+        var peak: Float = 0
+        for sample in samples where sample.isFinite {
+            peak = max(peak, abs(sample))
+        }
+        guard peak > 1 else {
+            return samples
+        }
+        return samples.map { sample in
+            sample.isFinite ? sample / peak : 0.0
+        }
     }
 
     private static func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {

--- a/Sources/MereRunCLI/Guides/music-analyze.md
+++ b/Sources/MereRunCLI/Guides/music-analyze.md
@@ -1,0 +1,106 @@
+# Music Analyze
+
+## Purpose
+
+Analyze an audio file with ACE-Step 5 Hz LM audio understanding and print
+structured metadata for cover, remix, or catalog workflows. The command decodes
+regular audio files to 48 kHz stereo, converts the source into ACE audio-code
+tokens, runs the LM understanding phase, and returns JSON on stdout.
+
+## Required Models
+
+Managed ids:
+
+- `music-acestep`: ACE-Step turbo, VAE, and 5 Hz LM.
+- `music-acestep-xl-turbo-lm4b`: ACE-Step XL turbo plus the optional 4B 5 Hz
+  LM.
+
+## Install And Check
+
+```bash
+mere.run model pull music-acestep
+mere.run model pull music-acestep-xl-turbo-lm4b
+mere.run music analyze --help
+mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
+```
+
+## Parameters
+
+- positional audio: audio file to analyze.
+- `--model`, `-m`: managed ACE-Step id, model root, or checkpoints root.
+- `--checkpoints-root`: root containing ACE-Step subdirectories.
+- `--turbo-subdirectory`, `--vae-subdirectory`, `--lm-subdirectory`: component
+  layout overrides.
+- `--duration`: analyze the first N seconds instead of the full decoded input.
+- `--max-new-tokens`: maximum LM tokens for the understanding pass.
+- `--lm-temperature`, `--lm-top-k`, `--lm-top-p`: LM sampling controls.
+- `--include-raw-lm`: include the raw LM output in the JSON.
+- `--include-audio-codes`: include serialized ACE audio-code tokens in the
+  JSON. This can be very large for full songs.
+- `--quiet`, `-q`: suppress diagnostics.
+
+## Output
+
+stdout is JSON. Diagnostics go to stderr.
+
+Important fields:
+
+- `metadata.bpm`
+- `metadata.keyscale`
+- `metadata.timesignature`
+- `metadata.language`
+- `metadata.caption`
+- `metadata.lyrics`
+- `inputDurationSeconds`
+- `analyzedDurationSeconds`
+
+## Examples
+
+```bash
+mere.run music analyze ./song.mp3 \
+  --model music-acestep-xl-turbo-lm4b \
+  --lm-subdirectory acestep-5Hz-lm-4B
+```
+
+```bash
+mere.run music analyze ./song.mp3 \
+  --duration 30 \
+  --include-raw-lm \
+  > ./song-analysis.json
+```
+
+```bash
+mere.run music generate \
+  "modern reggaeton dance club remix, dembow rhythm, punchy bass" \
+  --model music-acestep-xl-turbo-lm4b \
+  --source-audio ./song.mp3 \
+  --analyze-source-audio \
+  --audio-cover-strength 0.20 \
+  --cover-noise-strength 0.0 \
+  --output ./reggaeton-cover.wav
+```
+
+## Iteration Tips
+
+- Use `music analyze` before a cover when you want to inspect source tempo,
+  key/scale, and time signature without generating audio.
+- Use `--duration 30` for quick probes on long songs, then run without
+  `--duration` when you want whole-song understanding.
+- Keep user-provided generation metadata explicit when you want to override the
+  source analysis.
+- Use `--include-raw-lm` when debugging parser behavior or unexpected missing
+  metadata.
+
+## Troubleshooting
+
+- Missing LM: pull `music-acestep` or `music-acestep-xl-turbo-lm4b`, or pass
+  `--lm-subdirectory`.
+- XL turbo without LM: use `music-acestep-xl-turbo-lm4b` for analysis.
+- Huge JSON: avoid `--include-audio-codes` for full songs unless you are
+  debugging the token stream.
+- Slow analysis: pass `--duration` to inspect a shorter prefix first.
+
+## Sources
+
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -27,6 +27,7 @@ mere.run model pull music-acestep-xl-turbo
 mere.run model pull music-acestep-xl-turbo-lm4b
 mere.run model pull music-magenta-rt2-small
 mere.run music generate --help
+mere.run music analyze --help
 mere.run guide music generate --model music-acestep
 mere.run guide music generate --model music-acestep-xl-turbo
 mere.run guide music generate --model music-magenta-rt2-small
@@ -99,6 +100,8 @@ capture. Add `--interactive` to steer while it runs with stdin commands such as
 - Lyrics work best with tags like `[verse]`, `[chorus]`, `[bridge]`.
 - Match `--vocal-language` to the lyrics language.
 - Use `--bpm`, `--keyscale`, and `--timesignature` when rhythm or harmony must be stable.
+- Use `music analyze` first when you want to inspect source BPM, key/scale, and
+  time signature before choosing generation overrides.
 - Use `--duration 10` to draft, then extend once the caption works.
 - For Magenta RT2, put all musical direction in the prompt; lyrics and ACE-Step
   task modes are not supported by that runtime.

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -12,6 +12,10 @@ Managed ids:
 
 - `music-acestep`: ACE-Step turbo, VAE, Qwen3 text encoder, and optionally the
   5 Hz LM subdirectory.
+- `music-acestep-xl-turbo`: ACE-Step 1.5 XL turbo DiT, VAE, and Qwen3 text
+  encoder.
+- `music-acestep-xl-turbo-lm4b`: ACE-Step 1.5 XL turbo plus the optional 4B
+  5 Hz LM subdirectory.
 - `music-magenta-rt2-small`: Magenta RealTime 2 small exported runtime assets.
 - `music-magenta-rt2-base`: Magenta RealTime 2 base exported runtime assets.
 
@@ -19,9 +23,12 @@ Managed ids:
 
 ```bash
 mere.run model pull music-acestep
+mere.run model pull music-acestep-xl-turbo
+mere.run model pull music-acestep-xl-turbo-lm4b
 mere.run model pull music-magenta-rt2-small
 mere.run music generate --help
 mere.run guide music generate --model music-acestep
+mere.run guide music generate --model music-acestep-xl-turbo
 mere.run guide music generate --model music-magenta-rt2-small
 ```
 
@@ -34,12 +41,19 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--model`, `-m`: managed id, model root, or checkpoints root.
 - `--checkpoints-root`: root containing ACE-Step subdirectories.
 - `--turbo-subdirectory`, `--vae-subdirectory`, `--lm-subdirectory`, `--text-subdirectory`: component layout overrides.
-- `--use-lm`: enable 5 Hz constrained LM.
+- `--use-lm`: enable 5 Hz constrained LM for supported text-to-music tasks.
+- `--lm-subdirectory acestep-5Hz-lm-4B`: force the optional 4B LM when using
+  `music-acestep-xl-turbo-lm4b`.
 - `--duration`: output seconds.
 - `--steps`, `-s`: turbo denoise steps.
-- `--shift`: turbo scheduler shift.
+- `--shift`: turbo scheduler shift; ACE-Step CLI default is `3.0`, matching upstream.
 - `--seed`: deterministic generation.
+- `--source-audio`: source song for ACE-Step cover conditioning; implies cover mode unless `--non-cover` is set.
+- `--reference-audio`: optional ACE-Step timbre reference audio file(s).
 - `--audio-cover-strength`: cover conditioning strength from `0` to `1`.
+- `--cover-noise-strength`: source-latent noise initialization strength from
+  `0` to `1` for ACE-Step covers. `0` starts from pure noise; higher values
+  start closer to the source song.
 - `--vocal-language`: language tag for lyric formatting.
 - `--instruction`: caption instruction prefix.
 - `--task-type`, `--task`: `text2music`, `cover`, `repaint`, `extract`, `lego`, or `complete`.
@@ -58,6 +72,16 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--unmask-width`, `--seed-rotation`: Magenta RT2 generation controls.
 - `--prefill-silence`, `--prefill-duration`: Magenta RT2 realtime prefill controls.
 - `--quiet`, `-q`: suppress diagnostics.
+
+ACE-Step uses upstream-style native Haar DCW sampler correction by default for
+cleaner diffusion latents before VAE decode.
+
+The default ACE-Step managed ID uses the smaller 1.5 turbo DiT. Use
+`music-acestep-xl-turbo` for the ACE-Step 1.5 XL turbo DiT on larger machines,
+or `music-acestep-xl-turbo-lm4b` with `--use-lm` and
+`--lm-subdirectory acestep-5Hz-lm-4B` when you want the optional 4B 5 Hz LM.
+ACE-Step cover/repaint/extract tasks skip the LM phase, matching upstream,
+because they use source-audio conditioning directly.
 
 For realtime Magenta RT2 runs, use `mere.run music realtime`. It accepts the
 same Magenta controls plus `--play` or `--no-play` and optional `--output` WAV
@@ -98,6 +122,27 @@ mere.run music generate \
 
 ```bash
 mere.run music generate \
+  "dream-pop cover with soft vocals, lush guitars, wide chorus" \
+  --source-audio ./song.mp3 \
+  --lyrics-file ./cover-lyrics.txt \
+  --audio-cover-strength 1.0 \
+  --duration 20 \
+  --output ./cover.wav
+```
+
+```bash
+mere.run music generate \
+  "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion, perreo club energy, chopped pop vocals, glossy synth stabs" \
+  --model music-acestep-xl-turbo \
+  --source-audio ./song.mp3 \
+  --lyrics-file ./lyrics.txt \
+  --audio-cover-strength 0.20 \
+  --cover-noise-strength 0.0 \
+  --output ./reggaeton-cover.wav
+```
+
+```bash
+mere.run music generate \
   "ambient modular synths with brushed drums, slow evolving harmony" \
   --model music-magenta-rt2-small \
   --duration 4 \
@@ -119,7 +164,16 @@ mere.run music realtime \
 - First iterate caption and lyrics at 10 to 20 seconds.
 - Lock `--seed` after a promising groove, then adjust metadata.
 - If vocals are garbled, simplify lyrics and add section tags.
-- If structure drifts, try `--use-lm` with BPM/key/time metadata.
+- If a cover drifts, keep `--audio-cover-strength 1.0`, avoid `--use-lm`, and
+  make the caption explicitly ask to preserve melody, tempo, phrasing, and structure.
+- For style-transfer covers, start around `--audio-cover-strength 0.2` and keep
+  `--cover-noise-strength 0.0` so the prompt can steer genre and arrangement.
+  Lower `--audio-cover-strength` if the original still dominates; only raise
+  `--cover-noise-strength` when you want to re-anchor the result to the source
+  song's contour.
+- For stronger style transfer, generate or provide a short style/timbre example
+  and pass it with `--reference-audio` while keeping the original song in
+  `--source-audio`.
 - For Magenta RT2, use `music realtime --output --no-play --duration 2` for a
   fast headless smoke before running an audible session.
 
@@ -128,6 +182,7 @@ mere.run music realtime \
 - `--lyrics` and `--lyrics-file` conflict: use only one.
 - Text encoder missing: set `--text-subdirectory` or keep the default layout.
 - `--use-lm` fails: ensure the LM subdirectory exists or pass `--lm-subdirectory`.
+  Cover/repaint/extract tasks skip LM even if the flag is present.
 - Audio decode memory pressure: keep tiled VAE enabled, reduce duration, or tune VAE chunk size.
 - Magenta RT2 unsupported runtime: build `vendor/magentart.xcframework` with
   `scripts/rebuild_magentart_xcframework.sh` on Apple Silicon macOS, then
@@ -142,5 +197,7 @@ mere.run music realtime \
 - https://huggingface.co/docs/diffusers/api/pipelines/ace_step
 - https://github.com/ace-step/ACE-Step-1.5/blob/main/docs/en/INFERENCE.md
 - https://huggingface.co/ACE-Step/Ace-Step1.5
+- https://huggingface.co/ACE-Step/acestep-v15-xl-turbo
+- https://huggingface.co/ACE-Step/acestep-5Hz-lm-4B
 - https://github.com/magenta/magenta-realtime
 - https://huggingface.co/google/magenta-realtime-2

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -49,6 +49,10 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--shift`: turbo scheduler shift; ACE-Step CLI default is `3.0`, matching upstream.
 - `--seed`: deterministic generation.
 - `--source-audio`: source song for ACE-Step cover conditioning; implies cover mode unless `--non-cover` is set.
+- `--analyze-source-audio`: run ACE-Step 5 Hz LM audio understanding before a
+  cover and fill missing BPM, key/scale, language, and time signature metadata
+  from the source audio. Explicit `--bpm`, `--keyscale`, `--timesignature`, and
+  `--metadata-language` values always win.
 - `--reference-audio`: optional ACE-Step timbre reference audio file(s).
 - `--audio-cover-strength`: cover conditioning strength from `0` to `1`.
 - `--cover-noise-strength`: source-latent noise initialization strength from
@@ -124,6 +128,7 @@ mere.run music generate \
 mere.run music generate \
   "dream-pop cover with soft vocals, lush guitars, wide chorus" \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --lyrics-file ./cover-lyrics.txt \
   --audio-cover-strength 1.0 \
   --duration 20 \
@@ -135,6 +140,7 @@ mere.run music generate \
   "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion, perreo club energy, chopped pop vocals, glossy synth stabs" \
   --model music-acestep-xl-turbo \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --lyrics-file ./lyrics.txt \
   --audio-cover-strength 0.20 \
   --cover-noise-strength 0.0 \
@@ -166,6 +172,9 @@ mere.run music realtime \
 - If vocals are garbled, simplify lyrics and add section tags.
 - If a cover drifts, keep `--audio-cover-strength 1.0`, avoid `--use-lm`, and
   make the caption explicitly ask to preserve melody, tempo, phrasing, and structure.
+- For covers with unknown metadata, add `--analyze-source-audio` so the 5 Hz LM
+  can infer BPM, key/scale, language, and time signature from the source's audio
+  codes before direct DiT cover generation. User-provided metadata stays pinned.
 - For style-transfer covers, start around `--audio-cover-strength 0.2` and keep
   `--cover-noise-strength 0.0` so the prompt can steer genre and arrangement.
   Lower `--audio-cover-strength` if the original still dominates; only raise

--- a/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
+++ b/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
@@ -1,0 +1,352 @@
+import ArgumentParser
+import AudioCodecs
+import Foundation
+import MLX
+import MereRunCore
+
+enum ACEStepCLIHelper {
+    static func resolveUserPath(_ path: String) -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "~" {
+            return URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL
+        }
+        if trimmed.hasPrefix("~/") {
+            let suffix = String(trimmed.dropFirst(2))
+            return URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent(suffix)
+                .standardizedFileURL
+        }
+        return URL(fileURLWithPath: trimmed).standardizedFileURL
+    }
+
+    static func loadAudio48kHz(_ path: String, label: String) throws -> MLXArray {
+        let url = resolveUserPath(path)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ValidationError("\(label) not found: \(url.path)")
+        }
+
+        let buffer = try AudioReader.readAudioBuffer(from: url, sampleRate: 48_000, channels: 2)
+        guard buffer.isInterleaved else {
+            throw ValidationError("\(label) decoded to a non-interleaved buffer: \(url.path)")
+        }
+        guard buffer.channelCount == 2 else {
+            throw ValidationError("\(label) must decode to stereo at 48 kHz; got \(buffer.channelCount) channel(s).")
+        }
+        guard buffer.samples.count >= buffer.channelCount else {
+            throw ValidationError("\(label) contains no audio samples: \(url.path)")
+        }
+
+        let frames = buffer.samples.count / buffer.channelCount
+        let trimmedSampleCount = frames * buffer.channelCount
+        let samples = trimmedSampleCount == buffer.samples.count
+            ? buffer.samples
+            : Array(buffer.samples.prefix(trimmedSampleCount))
+        let clamped = samples.map { sample -> Float in
+            guard sample.isFinite else {
+                return 0
+            }
+            return max(-1.0, min(1.0, sample))
+        }
+        return MLXArray(clamped, [1, frames, buffer.channelCount]).asType(.float32)
+    }
+
+    static func durationSeconds(of audio48kHz: MLXArray, fallback: Float) -> Float {
+        guard audio48kHz.ndim >= 2 else {
+            return fallback
+        }
+        let frames = audio48kHz.dim(1)
+        guard frames > 0 else {
+            return fallback
+        }
+        return Float(frames) / 48_000.0
+    }
+
+    static func resolveCheckpointsRoot(
+        model: String,
+        checkpointsRoot: String?,
+        turboSubdirectory: String,
+        vaeSubdirectory: String,
+        lmSubdirectory: String?,
+        textSubdirectory: String?
+    ) async throws -> URL {
+        let candidates = buildCheckpointCandidates(
+            model: model,
+            checkpointsRoot: checkpointsRoot
+        )
+
+        for candidate in candidates {
+            if isUsableCheckpointsRoot(
+                candidate,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return candidate
+            }
+            let nested = candidate.appendingPathComponent("checkpoints", isDirectory: true)
+            if isUsableCheckpointsRoot(
+                nested,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return nested
+            }
+        }
+
+        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            throw ValidationError("Checkpoints root not found or incomplete: \(explicit)")
+        }
+
+        do {
+            let resolved = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: model,
+                defaultModelID: ModelResolver.ModelID.aceStep.rawValue
+            )
+            let root = resolved.url
+            if isUsableCheckpointsRoot(
+                root,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return root
+            }
+            let nested = root.appendingPathComponent("checkpoints", isDirectory: true)
+            if isUsableCheckpointsRoot(
+                nested,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return nested
+            }
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw ValidationError(error.localizedDescription)
+        }
+
+        throw ValidationError("Music Acestep checkpoints not found. Add --checkpoints-root or set MERERUN_MUSIC_ACESTEP_ROOT.")
+    }
+
+    static func resolveTurboSubdirectory(at root: URL, explicit: String) throws -> String {
+        let fm = FileManager.default
+
+        let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+        let upstreamDefault = "acestep-v15-turbo"
+        let compatibilityDefault = "music-acestep-v15-turbo"
+        let xlTurboDefault = "acestep-v15-xl-turbo"
+        let candidates = trimmed == upstreamDefault
+            ? [upstreamDefault, compatibilityDefault, xlTurboDefault]
+            : [trimmed]
+
+        for candidate in candidates where isUsableTurboDirectory(
+            root.appendingPathComponent(candidate, isDirectory: true),
+            fileManager: fm
+        ) {
+            return candidate
+        }
+        throw ValidationError("--turbo-subdirectory not found: \(trimmed)")
+    }
+
+    static func resolveLMSubdirectory(at root: URL, explicit: String?) throws -> String? {
+        let fm = FileManager.default
+
+        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
+            guard isUsableLMDirectory(explicitRoot, fileManager: fm) else {
+                throw ValidationError("--lm-subdirectory not found: \(explicitNormalized)")
+            }
+            return explicitNormalized
+        }
+
+        let preferredCandidates = [
+            "acestep-5Hz-lm-1.7B",
+            "acestep-5hz-lm-1.7b",
+            "acestep-5Hz-lm-4B",
+            "acestep-5hz-lm-4b",
+            "acestep-5Hz-lm",
+            "acestep-5hz-lm",
+            "music-acestep-5hz-lm-1.7b",
+            "music-acestep-5Hz-lm-1.7B",
+            "music-acestep-5hz-lm-4b",
+            "music-acestep-5Hz-lm-4B",
+            "music-acestep-5hz-lm",
+            "music-acestep-5Hz-lm",
+            "lm",
+            "music-acestep-lm"
+        ]
+
+        for candidate in preferredCandidates {
+            if isUsableLMDirectory(root.appendingPathComponent(candidate, isDirectory: true), fileManager: fm) {
+                return candidate
+            }
+        }
+
+        let discovered = (try? fm.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ))?.first(where: { directory in
+            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            let name = directory.lastPathComponent.lowercased()
+            return isDirectory
+                && name.contains("lm")
+                && name.contains("5hz")
+                && isUsableLMDirectory(directory, fileManager: fm)
+        })
+
+        return discovered?.lastPathComponent
+    }
+
+    static func resolveTextSubdirectory(at root: URL, explicit: String?) throws -> String? {
+        let fm = FileManager.default
+
+        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
+            guard isDirectory(explicitRoot, fileManager: fm) else {
+                throw ValidationError("--text-subdirectory not found: \(explicitNormalized)")
+            }
+            return explicitNormalized
+        }
+
+        let preferredCandidates = [
+            "Qwen3-Embedding-0.6B",
+            "qwen3-embedding-0.6b",
+            "Qwen3-Embedding-4B",
+            "qwen3-embedding-4b",
+            "Qwen3-Embedding",
+            "qwen3-embedding",
+            "text_encoder",
+            "text-encoder"
+        ]
+
+        for candidate in preferredCandidates {
+            if isDirectory(root.appendingPathComponent(candidate, isDirectory: true), fileManager: fm) {
+                return candidate
+            }
+        }
+
+        let discovered = (try? fm.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ))?.first(where: { directory in
+            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            let name = directory.lastPathComponent.lowercased()
+            return isDirectory && (
+                (name.contains("qwen3") && name.contains("embedding"))
+                || name == "text_encoder"
+                || name == "text-encoder"
+            )
+        })
+
+        return discovered?.lastPathComponent
+    }
+
+    static func buildCheckpointCandidates(
+        model: String,
+        checkpointsRoot: String?
+    ) -> [URL] {
+        var candidates: [URL] = []
+
+        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            candidates.append(URL(fileURLWithPath: explicit).standardizedFileURL)
+        }
+
+        var modelPathExists = false
+        let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !explicitModel.isEmpty {
+            let url = URL(fileURLWithPath: explicitModel).standardizedFileURL
+            if FileManager.default.fileExists(atPath: url.path) {
+                modelPathExists = true
+                candidates.append(url)
+            }
+        }
+
+        if let envRoot = ProcessInfo.processInfo.environment["MERERUN_MUSIC_ACESTEP_ROOT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !envRoot.isEmpty
+        {
+            candidates.append(URL(fileURLWithPath: envRoot).standardizedFileURL)
+        }
+
+        let managedModelID = explicitModel.lowercased()
+        if !managedModelID.isEmpty && !modelPathExists {
+            let requestedRoot = MereRunModelPaths.modelsDir
+                .appendingPathComponent(managedModelID, isDirectory: true)
+                .standardizedFileURL
+            candidates.append(requestedRoot)
+            candidates.append(requestedRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        }
+
+        if managedModelID.isEmpty {
+            let localModelRoot = MereRunModelPaths.modelsDir
+                .appendingPathComponent(ModelResolver.ModelID.aceStep.rawValue, isDirectory: true)
+                .standardizedFileURL
+            candidates.append(localModelRoot)
+            candidates.append(localModelRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        }
+
+        return candidates
+    }
+
+    private static func isUsableCheckpointsRoot(
+        _ root: URL,
+        turboSubdirectory: String,
+        vaeSubdirectory: String,
+        lmSubdirectory: String?,
+        textSubdirectory: String?
+    ) -> Bool {
+        let fm = FileManager.default
+
+        guard isDirectory(root, fileManager: fm) else {
+            return false
+        }
+        let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
+            ? ["acestep-v15-turbo", "music-acestep-v15-turbo", "acestep-v15-xl-turbo"]
+            : [turboSubdirectory]
+        guard turboCandidates.contains(where: {
+            isUsableTurboDirectory(root.appendingPathComponent($0, isDirectory: true), fileManager: fm)
+        }) else {
+            return false
+        }
+        guard isDirectory(root.appendingPathComponent(vaeSubdirectory), fileManager: fm) else {
+            return false
+        }
+
+        if let lmSubdirectory, !lmSubdirectory.isEmpty {
+            guard isDirectory(root.appendingPathComponent(lmSubdirectory), fileManager: fm) else {
+                return false
+            }
+        }
+
+        if let textSubdirectory, !textSubdirectory.isEmpty {
+            guard isDirectory(root.appendingPathComponent(textSubdirectory), fileManager: fm) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private static func isUsableTurboDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        isDirectory(url, fileManager: fileManager)
+            && ACEStepResources(rootURL: url).validate(fileManager: fileManager).isEmpty
+    }
+
+    private static func isUsableLMDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        isDirectory(url, fileManager: fileManager)
+            && ACEStep5HzLMResources(rootURL: url).validate(fileManager: fileManager).isEmpty
+    }
+
+    private static func isDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
@@ -81,7 +81,8 @@ public final class ACEStep5HzLM {
             promptDropIndex: 0,
             headDim: config.headDim,
             mropeSection: nil,
-            mropeInterleaved: false
+            mropeInterleaved: false,
+            useFloat32Activations: true
         )
 
         let encoder = QwenEncoder(configuration: qwenConfig)
@@ -91,7 +92,7 @@ public final class ACEStep5HzLM {
             to: encoder,
             dtype: dtype,
             verify: verify,
-            mapper: { key, value in [(key, value)] },
+            mapper: QwenEncoder.mapHFSafetensorWeight,
             fileManager: fileManager
         )
         self.model = encoder

--- a/Sources/MereRunCore/ACEStep/ACEStepDCW.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepDCW.swift
@@ -1,0 +1,98 @@
+import Foundation
+import MLX
+
+enum ACEStepDCW {
+    static func applyHaar(
+        xNext: MLXArray,
+        denoised: MLXArray,
+        tCurr: Float,
+        enabled: Bool,
+        mode: ACEStepDCWMode,
+        scaler: Float,
+        highScaler: Float
+    ) -> MLXArray {
+        guard enabled else {
+            return xNext
+        }
+
+        let rawLow = scaler
+        let rawHigh = highScaler
+        let lowScale = tCurr * rawLow
+        let highScale = (1.0 - tCurr) * rawLow
+        let doubleHighScale = (1.0 - tCurr) * rawHigh
+
+        switch mode {
+        case .pix:
+            guard rawLow != 0 else {
+                return xNext
+            }
+            return xNext + MLXArray(rawLow).asType(xNext.dtype) * (xNext - denoised)
+        case .low:
+            guard lowScale != 0 else {
+                return xNext
+            }
+        case .high:
+            guard highScale != 0 else {
+                return xNext
+            }
+        case .double:
+            guard lowScale != 0 || doubleHighScale != 0 else {
+                return xNext
+            }
+        }
+
+        let targetFrames = xNext.dim(1)
+        var (xLow, xHigh) = haarDWT1D(xNext)
+        let (yLow, yHigh) = haarDWT1D(denoised)
+
+        switch mode {
+        case .low:
+            let s = MLXArray(lowScale).asType(xLow.dtype)
+            xLow = xLow + s * (xLow - yLow)
+        case .high:
+            let s = MLXArray(highScale).asType(xHigh.dtype)
+            xHigh = xHigh + s * (xHigh - yHigh)
+        case .double:
+            if lowScale != 0 {
+                let s = MLXArray(lowScale).asType(xLow.dtype)
+                xLow = xLow + s * (xLow - yLow)
+            }
+            if doubleHighScale != 0 {
+                let s = MLXArray(doubleHighScale).asType(xHigh.dtype)
+                xHigh = xHigh + s * (xHigh - yHigh)
+            }
+        case .pix:
+            break
+        }
+
+        return haarIDWT1D(low: xLow, high: xHigh, targetFrames: targetFrames)
+    }
+
+    static func haarDWT1D(_ x: MLXArray) -> (low: MLXArray, high: MLXArray) {
+        precondition(x.ndim == 3, "DCW expects [B,T,C] latents.")
+
+        var padded = x
+        if x.dim(1) % 2 == 1 {
+            let pad = MLXArray.zeros([x.dim(0), 1, x.dim(2)], dtype: x.dtype)
+            padded = MLX.concatenated([x, pad], axis: 1)
+        }
+
+        let even = padded[0..., 0..<padded.dim(1), 0...][0..., .stride(by: 2), 0...]
+        let odd = padded[0..., 1..<padded.dim(1), 0...][0..., .stride(by: 2), 0...]
+        let invSqrt2 = MLXArray(Float(1.0 / sqrt(2.0))).asType(x.dtype)
+        let low = (even + odd) * invSqrt2
+        let high = (even - odd) * invSqrt2
+        return (low, high)
+    }
+
+    static func haarIDWT1D(low: MLXArray, high: MLXArray, targetFrames: Int) -> MLXArray {
+        precondition(low.ndim == 3 && high.ndim == 3, "DCW expects [B,T,C] wavelet bands.")
+
+        let invSqrt2 = MLXArray(Float(1.0 / sqrt(2.0))).asType(low.dtype)
+        let even = (low + high) * invSqrt2
+        let odd = (low - high) * invSqrt2
+        let interleaved = MLX.stacked([even, odd], axis: 2)
+            .reshaped(even.dim(0), even.dim(1) * 2, even.dim(2))
+        return interleaved[0..., 0..<targetFrames, 0...]
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepInferenceConfig.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepInferenceConfig.swift
@@ -5,6 +5,13 @@ public enum ACEStepInferenceMethod: String, Sendable, Hashable {
     case sde
 }
 
+public enum ACEStepDCWMode: String, Sendable, Hashable {
+    case low
+    case high
+    case double
+    case pix
+}
+
 public struct ACEStepInferenceConfig: Sendable, Hashable {
     /// Seconds of audio to synthesize.
     public var durationSeconds: Float
@@ -12,11 +19,16 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
     /// Turbo "fix_nfe" (default 8).
     public var fixNFE: Int
 
-    /// Turbo shift factor. Upstream ACE-Step defaults to 1.0.
+    /// Turbo shift factor. The upstream model API defaults to 1.0; the public
+    /// CLI overrides to 3.0 for its default generation path.
     public var shift: Float
 
     /// Optional custom timesteps in `[0, 1]` (terminal zeros are ignored).
     public var timesteps: [Float]?
+
+    /// Cover noise initialization strength. `0` starts from pure noise; `1`
+    /// starts closest to the source latents at the nearest schedule step.
+    public var coverNoiseStrength: Float
 
     /// ODE is deterministic and matches the default turbo inference path.
     public var inferMethod: ACEStepInferenceMethod
@@ -25,6 +37,13 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
     public var vaeChunkSize: Int
     public var vaeOverlap: Int
 
+    /// Differential Correction in Wavelet domain. Upstream ACE-Step enables
+    /// native Haar double-band correction by default.
+    public var dcwEnabled: Bool
+    public var dcwMode: ACEStepDCWMode
+    public var dcwScaler: Float
+    public var dcwHighScaler: Float
+
     public var seed: UInt64?
 
     public init(
@@ -32,20 +51,30 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
         fixNFE: Int = 8,
         shift: Float = 1.0,
         timesteps: [Float]? = nil,
+        coverNoiseStrength: Float = 0.0,
         inferMethod: ACEStepInferenceMethod = .ode,
         useTiledVaeDecode: Bool = true,
         vaeChunkSize: Int = 512,
         vaeOverlap: Int = 64,
+        dcwEnabled: Bool = true,
+        dcwMode: ACEStepDCWMode = .double,
+        dcwScaler: Float = 0.05,
+        dcwHighScaler: Float = 0.02,
         seed: UInt64? = nil
     ) {
         self.durationSeconds = durationSeconds
         self.fixNFE = fixNFE
         self.shift = shift
         self.timesteps = timesteps
+        self.coverNoiseStrength = coverNoiseStrength
         self.inferMethod = inferMethod
         self.useTiledVaeDecode = useTiledVaeDecode
         self.vaeChunkSize = vaeChunkSize
         self.vaeOverlap = vaeOverlap
+        self.dcwEnabled = dcwEnabled
+        self.dcwMode = dcwMode
+        self.dcwScaler = dcwScaler
+        self.dcwHighScaler = dcwHighScaler
         self.seed = seed
     }
 }

--- a/Sources/MereRunCore/ACEStep/ACEStepModelContainer.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepModelContainer.swift
@@ -58,7 +58,7 @@ public actor ACEStepModelContainer {
         vaeResources: OobleckVAEResources,
         lmResources: ACEStep5HzLMResources? = nil,
         textEncoderResources: ACEStep5HzLMResources? = nil,
-        dtype: DType? = .bfloat16,
+        dtype: DType? = .float32,
         verify: Module.VerifyUpdate = .noUnusedKeys
     ) {
         self.configuredResources = ACEStepModelResources(
@@ -76,7 +76,7 @@ public actor ACEStepModelContainer {
         vaeRootURL: URL,
         lmRootURL: URL? = nil,
         textEncoderRootURL: URL? = nil,
-        dtype: DType? = .bfloat16,
+        dtype: DType? = .float32,
         verify: Module.VerifyUpdate = .noUnusedKeys
     ) {
         self.configuredResources = ACEStepModelResources(
@@ -95,7 +95,7 @@ public actor ACEStepModelContainer {
         vaeSubdirectory: String = "vae",
         lmSubdirectory: String? = nil,
         textEncoderSubdirectory: String? = nil,
-        dtype: DType? = .bfloat16,
+        dtype: DType? = .float32,
         verify: Module.VerifyUpdate = .noUnusedKeys
     ) {
         self.configuredResources = ACEStepModelResources(

--- a/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MLX
 
-public struct ACEStepMusicUnderstandingMetadata: Sendable, Hashable {
+public struct ACEStepMusicUnderstandingMetadata: Sendable, Hashable, Codable {
     public var caption: String?
     public var lyrics: String?
     public var bpm: Int?

--- a/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
@@ -1,0 +1,243 @@
+import Foundation
+import MLX
+
+public struct ACEStepMusicUnderstandingMetadata: Sendable, Hashable {
+    public var caption: String?
+    public var lyrics: String?
+    public var bpm: Int?
+    public var durationSeconds: Float?
+    public var keyscale: String?
+    public var language: String?
+    public var timesignature: String?
+
+    public init(
+        caption: String? = nil,
+        lyrics: String? = nil,
+        bpm: Int? = nil,
+        durationSeconds: Float? = nil,
+        keyscale: String? = nil,
+        language: String? = nil,
+        timesignature: String? = nil
+    ) {
+        self.caption = caption
+        self.lyrics = lyrics
+        self.bpm = bpm
+        self.durationSeconds = durationSeconds
+        self.keyscale = keyscale
+        self.language = language
+        self.timesignature = timesignature
+    }
+
+    public var understandingSummary: String {
+        var fields: [String] = []
+        if let bpm {
+            fields.append("bpm=\(bpm)")
+        }
+        if let keyscale {
+            fields.append("keyscale=\(keyscale)")
+        }
+        if let timesignature {
+            fields.append("timesignature=\(timesignature)")
+        }
+        if let language {
+            fields.append("language=\(language)")
+        }
+        if let durationSeconds {
+            fields.append("duration=\(durationSeconds)s")
+        }
+        return fields.isEmpty ? "no metadata detected" : fields.joined(separator: ", ")
+    }
+}
+
+public struct ACEStepMusicUnderstandingResult: Sendable, Hashable {
+    public var audioCodes: String
+    public var metadata: ACEStepMusicUnderstandingMetadata
+    public var lmResult: ACEStep5HzLMResult
+
+    public init(
+        audioCodes: String,
+        metadata: ACEStepMusicUnderstandingMetadata,
+        lmResult: ACEStep5HzLMResult
+    ) {
+        self.audioCodes = audioCodes
+        self.metadata = metadata
+        self.lmResult = lmResult
+    }
+}
+
+extension ACEStepPipeline {
+    public func audioCodeString(
+        sourceAudio48kHz: MLXArray,
+        durationSeconds: Float
+    ) throws -> String {
+        let targetFrames = max(1, Int((Double(durationSeconds) * 25.0).rounded()))
+        let sourceLatents = try normalizeSourceLatents(
+            nil,
+            sourceAudio48kHz: sourceAudio48kHz,
+            targetFrames: targetFrames
+        )
+        let attentionMask = MLXArray.ones([sourceLatents.dim(0), sourceLatents.dim(1)], dtype: .int32)
+        let (_, indices, _) = tokenizeForLMHints(
+            hiddenStates: sourceLatents,
+            attentionMask: attentionMask,
+            silenceLatent: silenceLatent
+        )
+        MLX.eval(indices)
+        return Self.audioCodeString(fromIndices: indices)
+    }
+
+    public func understandSourceAudio(
+        sourceAudio48kHz: MLXArray,
+        durationSeconds: Float,
+        lmConfig: ACEStep5HzLMGenerationConfig = .init(maxNewTokens: 2048, temperature: 0.3)
+    ) throws -> ACEStepMusicUnderstandingResult {
+        guard let lm else {
+            throw PipelineError.lmNotConfigured
+        }
+
+        let audioCodes = try audioCodeString(
+            sourceAudio48kHz: sourceAudio48kHz,
+            durationSeconds: durationSeconds
+        )
+        let promptTokens = lm.buildPromptTokens(
+            systemInstruction: ACEStepLMInstructions.understandInstruction,
+            userContent: audioCodes
+        )
+        let sampler = lm.makeConstrainedSampler(
+            enabled: true,
+            skipCaption: false,
+            skipLanguage: false,
+            stopAtReasoning: false,
+            generationPhase: .understand
+        )
+        let result = lm.generateConstrained(
+            promptTokens: promptTokens,
+            config: lmConfig,
+            sampler: sampler
+        )
+        let metadata = Self.parseUnderstandingOutput(result.generatedText)
+        return ACEStepMusicUnderstandingResult(audioCodes: audioCodes, metadata: metadata, lmResult: result)
+    }
+
+    public static func audioCodeString(fromIndices indices: MLXArray) -> String {
+        indices
+            .reshaped(-1)
+            .asType(.int32)
+            .asArray(Int32.self)
+            .map { "<|audio_code_\(max(0, min(Int($0), 63_999)))|>" }
+            .joined()
+    }
+
+    public static func parseUnderstandingOutput(_ output: String) -> ACEStepMusicUnderstandingMetadata {
+        var metadata = ACEStepMusicUnderstandingMetadata()
+        metadata.lyrics = parsedLyrics(from: output)
+
+        let reasoningText = parsedReasoningText(from: output)
+        var currentField: UnderstandingField?
+        var currentLines: [String] = []
+
+        func saveCurrentField() {
+            guard let field = currentField else {
+                currentLines = []
+                return
+            }
+            let value = currentLines.joined(separator: "\n")
+            switch field {
+            case .bpm:
+                metadata.bpm = parseInt(value)
+            case .caption:
+                metadata.caption = cleanMetadataString(value)
+            case .duration:
+                metadata.durationSeconds = parseFloat(value)
+            case .keyscale:
+                metadata.keyscale = cleanMetadataString(value)
+            case .language:
+                metadata.language = cleanMetadataString(value)
+            case .timesignature:
+                metadata.timesignature = cleanMetadataString(value)
+            case .genres:
+                break
+            }
+            currentField = nil
+            currentLines = []
+        }
+
+        for line in reasoningText.split(separator: "\n", omittingEmptySubsequences: false) {
+            let rawLine = String(line)
+            let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("<") {
+                continue
+            }
+            if let separatorIndex = rawLine.firstIndex(of: ":"),
+               rawLine.first?.isWhitespace != true {
+                saveCurrentField()
+                let key = rawLine[..<separatorIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+                currentField = UnderstandingField(rawValue: key.lowercased())
+                let valueStart = rawLine.index(after: separatorIndex)
+                let firstValue = rawLine[valueStart...]
+                if !firstValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    currentLines.append(String(firstValue))
+                }
+            } else if rawLine.first?.isWhitespace == true, currentField != nil {
+                currentLines.append(rawLine.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+        saveCurrentField()
+
+        return metadata
+    }
+
+    private enum UnderstandingField: String {
+        case bpm
+        case caption
+        case duration
+        case genres
+        case keyscale
+        case language
+        case timesignature
+    }
+
+    private static func parsedReasoningText(from output: String) -> String {
+        guard
+            let start = output.range(of: "<think>")?.upperBound,
+            let end = output.range(of: "</think>", range: start..<output.endIndex)?.lowerBound
+        else {
+            let firstAudioCode = output.range(of: "<|audio_code_")?.lowerBound ?? output.endIndex
+            return String(output[..<firstAudioCode]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return String(output[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func parsedLyrics(from output: String) -> String? {
+        guard let end = output.range(of: "</think>")?.upperBound else {
+            return nil
+        }
+        return cleanMetadataString(String(output[end...]))
+    }
+
+    private static func cleanMetadataString(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "N/A", trimmed.lowercased() != "unknown" else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func parseInt(_ value: String) -> Int? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let direct = Int(trimmed) {
+            return direct
+        }
+        let prefix = trimmed.prefix { $0.isNumber }
+        return prefix.isEmpty ? nil : Int(prefix)
+    }
+
+    private static func parseFloat(_ value: String) -> Float? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let direct = Float(trimmed) {
+            return direct
+        }
+        let prefix = trimmed.prefix { $0.isNumber || $0 == "." }
+        return prefix.isEmpty ? nil : Float(prefix)
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift
@@ -1,6 +1,5 @@
 import Foundation
 import MLX
-import MLXNN
 
 // Owns LM fallback, condition assembly, and denoising helpers for
 // ACEStepPipeline. Public entrypoints stay in the main pipeline file.
@@ -97,33 +96,23 @@ extension ACEStepPipeline {
         let B = conditionInputs.srcLatents.dim(0)
         let T = conditionInputs.srcLatents.dim(1)
 
-        let zeroSrcLatents = MLXArray.zeros(conditionInputs.srcLatents.shape, dtype: conditionInputs.srcLatents.dtype)
-        let zeroChunkMasks = MLXArray.zeros(conditionInputs.chunkMasks.shape, dtype: conditionInputs.chunkMasks.dtype)
-        let zeroLyricHiddenStates = MLXArray.zeros(conditionInputs.lyricHiddenStates.shape, dtype: conditionInputs.lyricHiddenStates.dtype)
-        let zeroLyricAttentionMask = MLXArray.zeros(conditionInputs.lyricAttentionMask.shape, dtype: conditionInputs.lyricAttentionMask.dtype)
-        let zeroReferAudioPacked = MLXArray.zeros(
-            conditionInputs.referAudioAcousticHiddenStatesPacked.shape,
-            dtype: conditionInputs.referAudioAcousticHiddenStatesPacked.dtype
-        )
-        let zeroReferOrderMask = MLXArray.zeros(
-            conditionInputs.referAudioOrderMask.shape,
-            dtype: conditionInputs.referAudioOrderMask.dtype
-        )
-        let nonCoverAttentionMask = MLXArray.ones([B, T], dtype: .int32)
+        let nonCoverSrcLatents = defaultSourceLatents(targetFrames: T, batchSize: B)
+            .asType(conditionInputs.srcLatents.dtype)
+        let nonCoverAttentionMask = conditionInputs.attentionMask ?? MLXArray.ones([B, T], dtype: .int32)
         let nonCoverIsCovers = MLXArray.zeros(conditionInputs.isCovers.shape, dtype: conditionInputs.isCovers.dtype)
 
         return prepareCondition(
             textHiddenStates: nonCoverTextHiddenStates,
             textAttentionMask: nonCoverTextAttentionMask,
-            lyricHiddenStates: zeroLyricHiddenStates,
-            lyricAttentionMask: zeroLyricAttentionMask,
-            referAudioAcousticHiddenStatesPacked: zeroReferAudioPacked,
-            referAudioOrderMask: zeroReferOrderMask,
-            hiddenStates: zeroSrcLatents,
+            lyricHiddenStates: conditionInputs.lyricHiddenStates,
+            lyricAttentionMask: conditionInputs.lyricAttentionMask,
+            referAudioAcousticHiddenStatesPacked: conditionInputs.referAudioAcousticHiddenStatesPacked,
+            referAudioOrderMask: conditionInputs.referAudioOrderMask,
+            hiddenStates: nonCoverSrcLatents,
             attentionMask: nonCoverAttentionMask,
             silenceLatent: conditionInputs.silenceLatent,
-            srcLatents: zeroSrcLatents,
-            chunkMasks: zeroChunkMasks,
+            srcLatents: nonCoverSrcLatents,
+            chunkMasks: conditionInputs.chunkMasks,
             isCovers: nonCoverIsCovers
         )
     }
@@ -135,24 +124,40 @@ extension ACEStepPipeline {
         encoderHiddenStates: MLXArray,
         encoderAttentionMask: MLXArray,
         contextLatents: MLXArray,
+        sourceLatentsForCoverNoise: MLXArray? = nil,
         nonCoverEncoderHiddenStates: MLXArray? = nil,
         nonCoverEncoderAttentionMask: MLXArray? = nil,
         nonCoverContextLatents: MLXArray? = nil,
-        audioCoverStrength: Float = 1.0
+        audioCoverStrength: Float = 1.0,
+        coverNoiseStrength: Float = 0.0,
+        dcwEnabled: Bool = true,
+        dcwMode: ACEStepDCWMode = .double,
+        dcwScaler: Float = 0.05,
+        dcwHighScaler: Float = 0.02
     ) -> MLXArray {
         precondition(!timesteps.isEmpty, "Turbo timesteps must not be empty.")
 
-        var xt = noise
+        let coverNoise = Self.prepareCoverNoiseSchedule(
+            noise: noise,
+            sourceLatents: sourceLatentsForCoverNoise,
+            timesteps: timesteps,
+            coverNoiseStrength: coverNoiseStrength
+        )
+        var xt = coverNoise.latents
+        let activeTimesteps = coverNoise.timesteps
         let B = xt.dim(0)
         let hasNonCoverCondition =
             nonCoverEncoderHiddenStates != nil
             && nonCoverEncoderAttentionMask != nil
             && nonCoverContextLatents != nil
         let clampedCoverStrength = min(max(audioCoverStrength, 0.0), 1.0)
-        let coverSteps = hasNonCoverCondition ? Int(Float(timesteps.count) * clampedCoverStrength) : timesteps.count
+        let coverSteps = hasNonCoverCondition ? Int(Float(activeTimesteps.count) * clampedCoverStrength) : activeTimesteps.count
+        let dcwActive =
+            dcwEnabled
+            && (dcwScaler != 0 || (dcwMode == .double && dcwHighScaler != 0))
 
-        for i in 0..<timesteps.count {
-            let t = timesteps[i]
+        for i in 0..<activeTimesteps.count {
+            let t = activeTimesteps[i]
             let tBatch = MLXArray((0..<B).map { _ in t }).asType(.float32)
             let useNonCoverCondition = hasNonCoverCondition && i >= coverSteps
             let currentEncoderHiddenStates = useNonCoverCondition ? nonCoverEncoderHiddenStates! : encoderHiddenStates
@@ -168,26 +173,86 @@ extension ACEStepPipeline {
                 contextLatents: currentContextLatents
             )
 
-            if i == timesteps.count - 1 {
+            let xtBeforeStep = xt
+            let vtForDenoise = vt
+
+            if i == activeTimesteps.count - 1 {
                 let tBroadcast = tBatch.asType(vt.dtype).reshaped(B, 1, 1)
                 xt = xt - vt * tBroadcast
                 MLX.eval(xt)
-                Memory.clearCache()
-                break
+            } else {
+                switch inferMethod {
+                case .sde:
+                    let tBroadcast = tBatch.asType(vt.dtype).reshaped(B, 1, 1)
+                    let predClean = xt - vt * tBroadcast
+                    let nextT = activeTimesteps[i + 1]
+                    let newNoise = MLXRandom.normal(xt.shape).asType(xt.dtype)
+                    xt = MLXArray(nextT).asType(xt.dtype) * newNoise
+                        + (MLXArray(Float(1.0 - nextT)).asType(xt.dtype) * predClean)
+                    MLX.eval(xt)
+                case .ode:
+                    let dt = t - activeTimesteps[i + 1]
+                    xt = xt - vt * MLXArray(dt).asType(vt.dtype)
+                    MLX.eval(xt)
+                }
             }
 
-            switch inferMethod {
-            case .sde:
-                fallthrough
-            case .ode:
-                let dt = t - timesteps[i + 1]
-                xt = xt - vt * MLXArray(dt).asType(vt.dtype)
+            if dcwActive {
+                let tBroadcast = tBatch.asType(vtForDenoise.dtype).reshaped(B, 1, 1)
+                let denoised = xtBeforeStep - vtForDenoise * tBroadcast
+                xt = ACEStepDCW.applyHaar(
+                    xNext: xt,
+                    denoised: denoised,
+                    tCurr: t,
+                    enabled: true,
+                    mode: dcwMode,
+                    scaler: dcwScaler,
+                    highScaler: dcwHighScaler
+                )
                 MLX.eval(xt)
-                Memory.clearCache()
             }
+
+            Memory.clearCache()
         }
 
         return xt
+    }
+
+    static func prepareCoverNoiseSchedule(
+        noise: MLXArray,
+        sourceLatents: MLXArray?,
+        timesteps: [Float],
+        coverNoiseStrength: Float
+    ) -> (latents: MLXArray, timesteps: [Float]) {
+        precondition(!timesteps.isEmpty, "Turbo timesteps must not be empty.")
+
+        let clamped = min(max(coverNoiseStrength, 0.0), 1.0)
+        guard clamped > 0, let sourceLatents else {
+            return (noise, timesteps)
+        }
+        precondition(
+            sourceLatents.shape == noise.shape,
+            "sourceLatentsForCoverNoise must match noise shape \(noise.shape); got \(sourceLatents.shape)."
+        )
+
+        let effectiveNoiseLevel = Float(1.0) - clamped
+        var nearestIndex = 0
+        var nearestDistance = abs(timesteps[0] - effectiveNoiseLevel)
+        for index in timesteps.indices.dropFirst() {
+            let distance = abs(timesteps[index] - effectiveNoiseLevel)
+            if distance < nearestDistance {
+                nearestIndex = index
+                nearestDistance = distance
+            }
+        }
+
+        let nearestT = timesteps[nearestIndex]
+        let t = MLXArray(nearestT).asType(noise.dtype)
+        let oneMinusT = MLXArray(Float(1.0 - nearestT)).asType(noise.dtype)
+        let initialLatents = t * noise + oneMinusT * sourceLatents.asType(noise.dtype)
+        MLX.eval(initialLatents)
+
+        return (initialLatents, Array(timesteps[nearestIndex...]))
     }
 
     func prepareCondition(
@@ -279,9 +344,7 @@ extension ACEStepPipeline {
         let T5 = x.dim(1) / P
         let patched = x.reshaped(B, T5, P, D)
 
-        let chunk = Int(ceil(Double(mask.dim(1)) / Double(T5)))
-        let pool = MaxPool1d(kernelSize: chunk, stride: chunk)
-        let pooled = pool(mask.asType(.float32).expandedDimensions(axis: 1)).squeezed(axis: 1).asType(.int32)
+        let pooled = mask.asType(.float32).reshaped(B, T5, P).max(axis: -1).asType(.int32)
 
         let (quantized, indices) = tokenizer(patched)
         return (quantized, indices, pooled)

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift
@@ -6,14 +6,32 @@ import MLX
 // generation entrypoints and denoising loop live elsewhere.
 
 extension ACEStepPipeline {
-    func normalizeSourceLatents(_ sourceLatents25Hz: MLXArray?, targetFrames: Int) throws -> MLXArray {
+    func normalizeSourceLatents(
+        _ sourceLatents25Hz: MLXArray?,
+        sourceAudio48kHz: MLXArray? = nil,
+        targetFrames: Int
+    ) throws -> MLXArray {
         let B = 1
-        guard let sourceLatents25Hz else {
-            return MLXArray.zeros([B, targetFrames, decoderConfig.audioAcousticHiddenDim], dtype: .bfloat16)
+        if let sourceLatents25Hz {
+            return try normalizeEncodedSourceLatents(sourceLatents25Hz, targetFrames: targetFrames, batchSize: B)
         }
 
+        if let sourceAudio48kHz {
+            let normalizedAudio = try normalizeReferenceTimbreAudio(sourceAudio48kHz)
+            let encodedLatents = vae.tiledEncode(normalizedAudio)
+            return try normalizeEncodedSourceLatents(encodedLatents, targetFrames: targetFrames, batchSize: B)
+        }
+
+        return defaultSourceLatents(targetFrames: targetFrames, batchSize: B)
+    }
+
+    private func normalizeEncodedSourceLatents(
+        _ sourceLatents25Hz: MLXArray,
+        targetFrames: Int,
+        batchSize: Int
+    ) throws -> MLXArray {
         guard sourceLatents25Hz.ndim == 3,
-              sourceLatents25Hz.dim(0) == B,
+              sourceLatents25Hz.dim(0) == batchSize,
               sourceLatents25Hz.dim(2) == decoderConfig.audioAcousticHiddenDim
         else {
             throw PipelineError.invalidConditioningInput(
@@ -22,17 +40,59 @@ extension ACEStepPipeline {
         }
 
         if sourceLatents25Hz.dim(1) == targetFrames {
-            return sourceLatents25Hz.asType(.bfloat16)
+            return sourceLatents25Hz.asType(.float32)
         }
         if sourceLatents25Hz.dim(1) > targetFrames {
-            return sourceLatents25Hz[0..., 0..<targetFrames, 0...].asType(.bfloat16)
+            return sourceLatents25Hz[0..., 0..<targetFrames, 0...].asType(.float32)
         }
 
-        let pad = MLXArray.zeros(
-            [B, targetFrames - sourceLatents25Hz.dim(1), decoderConfig.audioAcousticHiddenDim],
-            dtype: sourceLatents25Hz.dtype
+        let pad = defaultSourceLatents(
+            targetFrames: targetFrames - sourceLatents25Hz.dim(1),
+            batchSize: batchSize
+        ).asType(sourceLatents25Hz.dtype)
+        return MLX.concatenated([sourceLatents25Hz, pad], axis: 1).asType(.float32)
+    }
+
+    func defaultSourceLatents(targetFrames: Int, batchSize: Int = 1) -> MLXArray {
+        precondition(targetFrames > 0, "targetFrames must be positive.")
+        precondition(batchSize > 0, "batchSize must be positive.")
+
+        let fallback = {
+            MLXArray.zeros(
+                [batchSize, targetFrames, self.decoderConfig.audioAcousticHiddenDim],
+                dtype: .float32
+            )
+        }
+
+        guard let silenceLatent,
+              silenceLatent.ndim == 3,
+              silenceLatent.dim(0) == 1,
+              silenceLatent.dim(1) > 0,
+              silenceLatent.dim(2) == decoderConfig.audioAcousticHiddenDim
+        else {
+            return fallback()
+        }
+
+        let base = silenceLatent.asType(.float32)
+        let sourceFrames = base.dim(1)
+        var chunks: [MLXArray] = []
+        chunks.reserveCapacity(Int(ceil(Double(targetFrames) / Double(sourceFrames))))
+
+        var remaining = targetFrames
+        while remaining > 0 {
+            let take = min(remaining, sourceFrames)
+            chunks.append(base[0..., 0..<take, 0...])
+            remaining -= take
+        }
+
+        let tiled = chunks.count == 1 ? chunks[0] : MLX.concatenated(chunks, axis: 1)
+        if batchSize == 1 {
+            return tiled
+        }
+        return MLX.broadcast(
+            tiled,
+            to: [batchSize, targetFrames, decoderConfig.audioAcousticHiddenDim]
         )
-        return MLX.concatenated([sourceLatents25Hz, pad], axis: 1).asType(.bfloat16)
     }
 
     func chunkChannelsForPromptConditioning() -> Int {
@@ -74,9 +134,9 @@ extension ACEStepPipeline {
         ) = {
             guard let conditionTextTokenizer, let conditionTextEncoder else {
                 return (
-                    textHiddenStates: MLXArray.zeros([B, 1, decoderConfig.textHiddenDim], dtype: .bfloat16),
+                    textHiddenStates: MLXArray.zeros([B, 1, decoderConfig.textHiddenDim], dtype: .float32),
                     textAttentionMask: MLXArray.ones([B, 1], dtype: .int32),
-                    lyricHiddenStates: MLXArray.zeros([B, 1, decoderConfig.textHiddenDim], dtype: .bfloat16),
+                    lyricHiddenStates: MLXArray.zeros([B, 1, decoderConfig.textHiddenDim], dtype: .float32),
                     lyricAttentionMask: MLXArray.ones([B, 1], dtype: .int32),
                     nonCoverTextHiddenStates: nil,
                     nonCoverTextAttentionMask: nil
@@ -159,11 +219,11 @@ extension ACEStepPipeline {
             referAudioAcousticHiddenStatesPacked: timbre.packed,
             referAudioOrderMask: timbre.orderMask,
             srcLatents: srcLatents,
-            chunkMasks: MLXArray.ones([B, T, chunkChannels], dtype: .bfloat16),
+            chunkMasks: MLXArray.ones([B, T, chunkChannels], dtype: .float32),
             isCovers: MLXArray([isCover ? Int32(1) : Int32(0)]).asType(.int32),
             hiddenStates: srcLatents,
             attentionMask: MLXArray.ones([B, T], dtype: .int32),
-            silenceLatent: nil,
+            silenceLatent: silenceLatent,
             nonCoverTextHiddenStates: textConditioning.nonCoverTextHiddenStates,
             nonCoverTextAttentionMask: textConditioning.nonCoverTextAttentionMask
         )
@@ -174,7 +234,8 @@ extension ACEStepPipeline {
         referenceTimbreAudio48kHz: [MLXArray]?,
         fallbackLatents25Hz: MLXArray
     ) throws -> (packed: MLXArray, orderMask: MLXArray) {
-        let targetFrames = min(max(1, fallbackLatents25Hz.dim(1)), decoderConfig.timbreFixFrame)
+        let referenceTargetFrames = min(max(1, fallbackLatents25Hz.dim(1)), decoderConfig.timbreFixFrame)
+        let fallbackTargetFrames = max(1, decoderConfig.timbreFixFrame)
         let latentDim = decoderConfig.audioAcousticHiddenDim
 
         let references: [MLXArray]
@@ -190,9 +251,8 @@ extension ACEStepPipeline {
         }
 
         if references.isEmpty {
-            let fallback = try normalizeReferenceTimbreLatents(
-                fallbackLatents25Hz,
-                targetFrames: targetFrames,
+            let fallback = try defaultReferenceTimbreLatents(
+                targetFrames: fallbackTargetFrames,
                 latentDim: latentDim
             )
             return (fallback, MLXArray([Int32(0)]).asType(.int32))
@@ -202,7 +262,7 @@ extension ACEStepPipeline {
             try references.map {
                 try normalizeReferenceTimbreLatents(
                     $0,
-                    targetFrames: targetFrames,
+                    targetFrames: referenceTargetFrames,
                     latentDim: latentDim
                 )
             },
@@ -210,6 +270,15 @@ extension ACEStepPipeline {
         )
         let order = MLXArray(Array(repeating: Int32(0), count: references.count)).asType(.int32)
         return (packed, order)
+    }
+
+    func defaultReferenceTimbreLatents(targetFrames: Int, latentDim: Int) throws -> MLXArray {
+        let encoded = defaultSourceLatents(targetFrames: targetFrames, batchSize: 1)
+        return try normalizeReferenceTimbreLatents(
+            encoded,
+            targetFrames: targetFrames,
+            latentDim: latentDim
+        )
     }
 
     func normalizeReferenceTimbreAudio(_ audio: MLXArray) throws -> MLXArray {
@@ -244,10 +313,10 @@ extension ACEStepPipeline {
                 )
             }
             if audio.dim(2) == vaeConfig.audioChannels {
-                return audio.asType(.bfloat16)
+                return audio.asType(.float32)
             }
             if audio.dim(1) == vaeConfig.audioChannels {
-                return audio.transposed(0, 2, 1).asType(.bfloat16)
+                return audio.transposed(0, 2, 1).asType(.float32)
             }
             throw PipelineError.invalidConditioningInput(
                 "referenceTimbreAudio48kHz 3D tensors must be [1,S,\(vaeConfig.audioChannels)] or [1,\(vaeConfig.audioChannels),S]; got \(audio.shape)."
@@ -258,7 +327,7 @@ extension ACEStepPipeline {
             )
         }
 
-        return stereo2D.reshaped(1, stereo2D.dim(0), vaeConfig.audioChannels).asType(.bfloat16)
+        return stereo2D.reshaped(1, stereo2D.dim(0), vaeConfig.audioChannels).asType(.float32)
     }
 
     func normalizeReferenceTimbreLatents(
@@ -291,14 +360,14 @@ extension ACEStepPipeline {
 
         let frames = normalized.dim(1)
         if frames == targetFrames {
-            return normalized.asType(.bfloat16)
+            return normalized.asType(.float32)
         }
         if frames > targetFrames {
-            return normalized[0..., 0..<targetFrames, 0...].asType(.bfloat16)
+            return normalized[0..., 0..<targetFrames, 0...].asType(.float32)
         }
 
         let pad = MLXArray.zeros([1, targetFrames - frames, latentDim], dtype: normalized.dtype)
-        return MLX.concatenated([normalized, pad], axis: 1).asType(.bfloat16)
+        return MLX.concatenated([normalized, pad], axis: 1).asType(.float32)
     }
 
     func tokenizePrompt(
@@ -325,46 +394,34 @@ extension ACEStepPipeline {
     }
 
     func makePromptMetasString(_ metadata: ACEStep5HzLMConstrainedSampler.UserMetadata) -> String {
-        var rows: [String] = []
-        if let value = metadata.bpm {
-            rows.append("- bpm: \(value)")
+        func normalized(_ value: String?, default defaultValue: String) -> String {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? defaultValue : trimmed
         }
-        if let value = metadata.timesignature {
-            rows.append("- timesignature: \(value)")
-        }
-        if let value = metadata.keyscale {
-            rows.append("- keyscale: \(value)")
-        }
-        if let value = metadata.duration {
-            rows.append("- duration: \(value)")
-        }
-        if rows.isEmpty {
-            return ""
-        }
-        return rows.joined(separator: "\n") + "\n"
+
+        let bpm = normalized(metadata.bpm, default: "N/A")
+        let timesignature = normalized(metadata.timesignature, default: "N/A")
+        let keyscale = normalized(metadata.keyscale, default: "N/A")
+        let duration = normalized(metadata.duration, default: "30 seconds")
+        return "- bpm: \(bpm)\n"
+            + "- timesignature: \(timesignature)\n"
+            + "- keyscale: \(keyscale)\n"
+            + "- duration: \(duration)\n"
     }
 
     func makeCaptionPrompt(instruction: String, caption: String, metas: String) -> String {
-        """
-        # Instruction
-        \(instruction)
-
-        # Caption
-        \(caption)
-
-        # Metas
-        \(metas)<|endoftext|>
-        """
-        + "\n"
+        "# Instruction\n"
+            + "\(instruction)\n\n"
+            + "# Caption\n"
+            + "\(caption)\n\n"
+            + "# Metas\n"
+            + "\(metas)<|endoftext|>\n"
     }
 
     func makeLyricsPrompt(lyrics: String, language: String) -> String {
-        """
-        # Languages
-        \(language)
-
-        # Lyric
-        \(lyrics)<|endoftext|>
-        """
+        "# Languages\n"
+            + "\(language)\n\n"
+            + "# Lyric\n"
+            + "\(lyrics)<|endoftext|>"
     }
 }

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline.swift
@@ -95,6 +95,7 @@ public final class ACEStepPipeline {
     let tokenizer: ACEStepAudioTokenizer
     let detokenizer: ACEStepAudioTokenDetokenizer
     let nullConditionEmbedding: MLXArray
+    let silenceLatent: MLXArray?
 
     let vaeConfig: OobleckVAEConfig
     let vae: OobleckVAE
@@ -110,7 +111,7 @@ public final class ACEStepPipeline {
         vaeResources: OobleckVAEResources,
         lmResources: ACEStep5HzLMResources? = nil,
         textEncoderResources: ACEStep5HzLMResources? = nil,
-        dtype: DType? = .bfloat16,
+        dtype: DType? = .float32,
         verify: Module.VerifyUpdate = .noUnusedKeys,
         fileManager: FileManager = .default
     ) throws {
@@ -142,11 +143,17 @@ public final class ACEStepPipeline {
         self.tokenizer = bundle.tokenizer
         self.detokenizer = bundle.detokenizer
         self.nullConditionEmbedding = bundle.nullConditionEmbedding
+        self.silenceLatent = try ACEStepCheckpointLoader.loadSilenceLatentIfPresent(
+            resources: decoderResources,
+            latentDim: decoderConfig.audioAcousticHiddenDim,
+            dtype: dtype,
+            fileManager: fileManager
+        )
 
         self.vaeConfig = try OobleckVAECheckpointLoader.loadConfig(resources: vaeResources, fileManager: fileManager)
         self.vae = try OobleckVAECheckpointLoader.loadVAE(
             resources: vaeResources,
-            dtype: dtype,
+            dtype: .float32,
             verify: verify,
             fileManager: fileManager
         )
@@ -178,7 +185,8 @@ public final class ACEStepPipeline {
                 promptDropIndex: 0,
                 headDim: textConfig.headDim,
                 mropeSection: nil,
-                mropeInterleaved: false
+                mropeInterleaved: false,
+                useFloat32Activations: true
             )
 
             let promptTextEncoder = QwenEncoder(configuration: qwenConfig)
@@ -188,7 +196,7 @@ public final class ACEStepPipeline {
                 to: promptTextEncoder,
                 dtype: dtype,
                 verify: verify,
-                mapper: { key, value in [(key, value)] },
+                mapper: QwenEncoder.mapHFSafetensorWeight,
                 fileManager: fileManager
             )
 
@@ -210,9 +218,9 @@ public final class ACEStepPipeline {
         let noise: MLXArray
         if let seed = config.seed {
             let key = MLXRandom.key(seed)
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.bfloat16)
+            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.float32)
         } else {
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.bfloat16)
+            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.float32)
         }
 
         let encoderHiddenStates = MLX.broadcast(
@@ -227,8 +235,9 @@ public final class ACEStepPipeline {
         // Heuristic: model expects `context_latents = concat([src_latents, chunk_masks], -1)`.
         let srcChannels = contextChannels / 2
         let chunkChannels = contextChannels - srcChannels
-        let srcLatents = MLXArray.zeros([B, T, srcChannels], dtype: noise.dtype)
-        let chunkMask = MLXArray.ones([B, T, chunkChannels], dtype: noise.dtype)
+        let srcLatents = defaultSourceLatents(targetFrames: T).asType(noise.dtype)
+        precondition(srcLatents.dim(2) == srcChannels, "Expected source latent channels to match context layout.")
+        let chunkMask = MLXArray.ones([B, T, chunkChannels], dtype: noise.dtype) * MLXArray(Float(2.0)).asType(noise.dtype)
         let contextLatents = MLX.concatenated([srcLatents, chunkMask], axis: -1)
 
         let schedule = ACEStepTurboScheduler(fixNFE: config.fixNFE, shift: config.shift, timesteps: config.timesteps)
@@ -238,7 +247,11 @@ public final class ACEStepPipeline {
             inferMethod: config.inferMethod,
             encoderHiddenStates: encoderHiddenStates,
             encoderAttentionMask: encoderAttentionMask,
-            contextLatents: contextLatents
+            contextLatents: contextLatents,
+            dcwEnabled: config.dcwEnabled,
+            dcwMode: config.dcwMode,
+            dcwScaler: config.dcwScaler,
+            dcwHighScaler: config.dcwHighScaler
         )
 
         if config.useTiledVaeDecode {
@@ -317,9 +330,9 @@ public final class ACEStepPipeline {
         let noise: MLXArray
         if let seed = config.seed {
             let key = MLXRandom.key(seed)
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.bfloat16)
+            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.float32)
         } else {
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.bfloat16)
+            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.float32)
         }
 
         let schedule = ACEStepTurboScheduler(fixNFE: config.fixNFE, shift: config.shift, timesteps: config.timesteps)
@@ -330,10 +343,16 @@ public final class ACEStepPipeline {
             encoderHiddenStates: prepared.encoderHiddenStates.asType(noise.dtype),
             encoderAttentionMask: prepared.encoderAttentionMask,
             contextLatents: prepared.contextLatents.asType(noise.dtype),
+            sourceLatentsForCoverNoise: conditionInputs.srcLatents.asType(noise.dtype),
             nonCoverEncoderHiddenStates: nonCoverPrepared?.encoderHiddenStates.asType(noise.dtype),
             nonCoverEncoderAttentionMask: nonCoverPrepared?.encoderAttentionMask,
             nonCoverContextLatents: nonCoverPrepared?.contextLatents.asType(noise.dtype),
-            audioCoverStrength: audioCoverStrength
+            audioCoverStrength: audioCoverStrength,
+            coverNoiseStrength: config.coverNoiseStrength,
+            dcwEnabled: config.dcwEnabled,
+            dcwMode: config.dcwMode,
+            dcwScaler: config.dcwScaler,
+            dcwHighScaler: config.dcwHighScaler
         )
 
         let audio: MLXArray
@@ -353,15 +372,20 @@ public final class ACEStepPipeline {
         config: ACEStepInferenceConfig = .init(),
         lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
         sourceLatents25Hz: MLXArray? = nil,
+        sourceAudio48kHz: MLXArray? = nil,
         referenceTimbreLatents25Hz: [MLXArray]? = nil,
         referenceTimbreAudio48kHz: [MLXArray]? = nil,
         audioCoverStrength: Float = 1.0,
         vocalLanguage: String = "en",
         instruction: String = "Fill the audio semantic mask based on the given conditions:",
-        isCover: Bool = true
+        isCover: Bool = false
     ) throws -> MLXArray {
         let T = max(1, Int((Double(config.durationSeconds) * 25.0).rounded()))
-        let srcLatents = try normalizeSourceLatents(sourceLatents25Hz, targetFrames: T)
+        let srcLatents = try normalizeSourceLatents(
+            sourceLatents25Hz,
+            sourceAudio48kHz: sourceAudio48kHz,
+            targetFrames: T
+        )
         let chunkChannels = chunkChannelsForPromptConditioning()
 
         let conditionInputs = try preparePromptConditionInputs(
@@ -404,9 +428,9 @@ public final class ACEStepPipeline {
         let noise: MLXArray
         if let seed = config.seed {
             let key = MLXRandom.key(seed)
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.bfloat16)
+            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.float32)
         } else {
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.bfloat16)
+            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.float32)
         }
 
         let schedule = ACEStepTurboScheduler(fixNFE: config.fixNFE, shift: config.shift, timesteps: config.timesteps)
@@ -417,10 +441,16 @@ public final class ACEStepPipeline {
             encoderHiddenStates: prepared.encoderHiddenStates.asType(noise.dtype),
             encoderAttentionMask: prepared.encoderAttentionMask,
             contextLatents: prepared.contextLatents.asType(noise.dtype),
+            sourceLatentsForCoverNoise: conditionInputs.srcLatents.asType(noise.dtype),
             nonCoverEncoderHiddenStates: nonCoverPrepared?.encoderHiddenStates.asType(noise.dtype),
             nonCoverEncoderAttentionMask: nonCoverPrepared?.encoderAttentionMask,
             nonCoverContextLatents: nonCoverPrepared?.contextLatents.asType(noise.dtype),
-            audioCoverStrength: audioCoverStrength
+            audioCoverStrength: audioCoverStrength,
+            coverNoiseStrength: config.coverNoiseStrength,
+            dcwEnabled: config.dcwEnabled,
+            dcwMode: config.dcwMode,
+            dcwScaler: config.dcwScaler,
+            dcwHighScaler: config.dcwHighScaler
         )
 
         if config.useTiledVaeDecode {
@@ -436,16 +466,21 @@ public final class ACEStepPipeline {
         lmConfig: ACEStep5HzLMGenerationConfig = .init(),
         lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
         sourceLatents25Hz: MLXArray? = nil,
+        sourceAudio48kHz: MLXArray? = nil,
         referenceTimbreLatents25Hz: [MLXArray]? = nil,
         referenceTimbreAudio48kHz: [MLXArray]? = nil,
         audioCoverStrength: Float = 1.0,
         vocalLanguage: String = "en",
         instruction: String = "Fill the audio semantic mask based on the given conditions:",
         lmSystemInstruction: String = ACEStepLMInstructions.defaultInstruction,
-        isCover: Bool = true
+        isCover: Bool = false
     ) throws -> (audio: MLXArray, lmResult: ACEStep5HzLMResult) {
         let T = max(1, Int((Double(config.durationSeconds) * 25.0).rounded()))
-        let srcLatents = try normalizeSourceLatents(sourceLatents25Hz, targetFrames: T)
+        let srcLatents = try normalizeSourceLatents(
+            sourceLatents25Hz,
+            sourceAudio48kHz: sourceAudio48kHz,
+            targetFrames: T
+        )
         let chunkChannels = chunkChannelsForPromptConditioning()
 
 

--- a/Sources/MereRunCore/ACEStep/ACEStepResources.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepResources.swift
@@ -21,6 +21,10 @@ public struct ACEStepResources: Sendable, Hashable {
         modelRootURL.appending(path: "model.safetensors")
     }
 
+    public var silenceLatentURL: URL {
+        modelRootURL.appending(path: "silence_latent.pt")
+    }
+
     public func validate(fileManager: FileManager = .default) -> [URL] {
         var urls: [URL] = [configURL]
 
@@ -38,12 +42,15 @@ public struct ACEStepResources: Sendable, Hashable {
 enum ACEStepCheckpointLoader {
     enum LoaderError: LocalizedError {
         case missingFiles([URL])
+        case invalidSilenceLatent(String)
 
         var errorDescription: String? {
             switch self {
             case .missingFiles(let urls):
                 let list = urls.map { $0.path }.joined(separator: "\n")
                 return "Missing ACE-Step resources:\n\(list)"
+            case .invalidSilenceLatent(let reason):
+                return "Invalid ACE-Step silence latent: \(reason)"
             }
         }
     }
@@ -152,6 +159,22 @@ enum ACEStepCheckpointLoader {
         return (model.decoder, model.nullConditionEmbedding)
     }
 
+    static func loadSilenceLatentIfPresent(
+        resources: ACEStepResources,
+        latentDim: Int,
+        dtype: DType? = .bfloat16,
+        fileManager: FileManager = .default
+    ) throws -> MLXArray? {
+        guard fileManager.fileExists(atPath: resources.silenceLatentURL.path) else {
+            return nil
+        }
+        return try ACEStepSilenceLatentLoader.load(
+            from: resources.silenceLatentURL,
+            latentDim: latentDim,
+            dtype: dtype
+        )
+    }
+
     static func loadTurboBundle(
         resources: ACEStepResources,
         dtype: DType? = .bfloat16,
@@ -208,6 +231,171 @@ enum ACEStepCheckpointLoader {
             detokenizer: model.detokenizer,
             nullConditionEmbedding: model.nullConditionEmbedding
         )
+    }
+}
+
+private enum ACEStepSilenceLatentLoader {
+    private struct ZipEntry {
+        var name: String
+        var compressionMethod: UInt16
+        var compressedSize: Int
+        var localHeaderOffset: Int
+    }
+
+    static func load(from url: URL, latentDim: Int, dtype: DType?) throws -> MLXArray {
+        guard latentDim > 0 else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent("latentDim must be positive.")
+        }
+        let archive = try Data(contentsOf: url)
+        let tensorData = try storedEntryData(namedSuffix: "/data/0", in: archive)
+
+        if let byteOrder = try? storedEntryData(namedSuffix: "/byteorder", in: archive) {
+            let value = String(decoding: byteOrder, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard value == "little" else {
+                throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                    "unsupported byte order '\(value)' in \(url.lastPathComponent)."
+                )
+            }
+        }
+
+        guard tensorData.count % MemoryLayout<Float>.size == 0 else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                "tensor byte count \(tensorData.count) is not divisible by float32 size."
+            )
+        }
+
+        let valueCount = tensorData.count / MemoryLayout<Float>.size
+        guard valueCount % latentDim == 0 else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                "float count \(valueCount) is not divisible by latent dim \(latentDim)."
+            )
+        }
+
+        var values: [Float] = []
+        values.reserveCapacity(valueCount)
+        for index in 0..<valueCount {
+            let bits = try tensorData.readUInt32LE(at: index * MemoryLayout<Float>.size)
+            values.append(Float(bitPattern: bits))
+        }
+
+        let frames = valueCount / latentDim
+        let channelFirst = MLXArray(values, [1, latentDim, frames])
+        return channelFirst.transposed(0, 2, 1).asType(dtype ?? .float32)
+    }
+
+    private static func storedEntryData(namedSuffix suffix: String, in archive: Data) throws -> Data {
+        let entries = try readCentralDirectory(from: archive)
+        guard let entry = entries.first(where: { $0.name.hasSuffix(suffix) }) else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                "missing zip entry matching \(suffix)."
+            )
+        }
+        guard entry.compressionMethod == 0 else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                "\(entry.name) uses unsupported compression method \(entry.compressionMethod)."
+            )
+        }
+
+        let localOffset = entry.localHeaderOffset
+        guard try archive.readUInt32LE(at: localOffset) == 0x0403_4b50 else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                "\(entry.name) local header has an invalid signature."
+            )
+        }
+        let nameLength = Int(try archive.readUInt16LE(at: localOffset + 26))
+        let extraLength = Int(try archive.readUInt16LE(at: localOffset + 28))
+        let dataStart = localOffset + 30 + nameLength + extraLength
+        let dataEnd = dataStart + entry.compressedSize
+        guard dataStart >= 0, dataEnd <= archive.count else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                "\(entry.name) data range is outside the archive."
+            )
+        }
+        return archive.subdata(in: dataStart..<dataEnd)
+    }
+
+    private static func readCentralDirectory(from archive: Data) throws -> [ZipEntry] {
+        let eocdOffset = try findEndOfCentralDirectory(in: archive)
+        let entryCount = Int(try archive.readUInt16LE(at: eocdOffset + 10))
+        let centralDirectoryOffset = Int(try archive.readUInt32LE(at: eocdOffset + 16))
+
+        var entries: [ZipEntry] = []
+        entries.reserveCapacity(entryCount)
+        var offset = centralDirectoryOffset
+        for _ in 0..<entryCount {
+            guard try archive.readUInt32LE(at: offset) == 0x0201_4b50 else {
+                throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                    "central directory has an invalid signature."
+                )
+            }
+
+            let compressionMethod = try archive.readUInt16LE(at: offset + 10)
+            let compressedSize = Int(try archive.readUInt32LE(at: offset + 20))
+            let nameLength = Int(try archive.readUInt16LE(at: offset + 28))
+            let extraLength = Int(try archive.readUInt16LE(at: offset + 30))
+            let commentLength = Int(try archive.readUInt16LE(at: offset + 32))
+            let localHeaderOffset = Int(try archive.readUInt32LE(at: offset + 42))
+            let nameStart = offset + 46
+            let nameEnd = nameStart + nameLength
+            guard nameEnd <= archive.count else {
+                throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+                    "central directory filename is outside the archive."
+                )
+            }
+
+            let name = String(decoding: archive[nameStart..<nameEnd], as: UTF8.self)
+            entries.append(
+                ZipEntry(
+                    name: name,
+                    compressionMethod: compressionMethod,
+                    compressedSize: compressedSize,
+                    localHeaderOffset: localHeaderOffset
+                )
+            )
+            offset = nameEnd + extraLength + commentLength
+        }
+
+        return entries
+    }
+
+    private static func findEndOfCentralDirectory(in archive: Data) throws -> Int {
+        guard archive.count >= 22 else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent("zip archive is too small.")
+        }
+
+        let minOffset = max(0, archive.count - 22 - 65_535)
+        var offset = archive.count - 22
+        while offset >= minOffset {
+            if try archive.readUInt32LE(at: offset) == 0x0605_4b50 {
+                return offset
+            }
+            offset -= 1
+        }
+
+        throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent(
+            "missing zip end-of-central-directory record."
+        )
+    }
+}
+
+private extension Data {
+    func readUInt16LE(at offset: Int) throws -> UInt16 {
+        guard offset >= 0, offset + 2 <= count else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent("unexpected end of data.")
+        }
+        return UInt16(self[offset])
+            | (UInt16(self[offset + 1]) << 8)
+    }
+
+    func readUInt32LE(at offset: Int) throws -> UInt32 {
+        guard offset >= 0, offset + 4 <= count else {
+            throw ACEStepCheckpointLoader.LoaderError.invalidSilenceLatent("unexpected end of data.")
+        }
+        return UInt32(self[offset])
+            | (UInt32(self[offset + 1]) << 8)
+            | (UInt32(self[offset + 2]) << 16)
+            | (UInt32(self[offset + 3]) << 24)
     }
 }
 

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepAttention.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepAttention.swift
@@ -8,6 +8,7 @@ final class ACEStepAttention: Module {
     let numKVHeads: Int
     let headDim: Int
     let scale: Float
+    let ropeTheta: Float
 
     @ModuleInfo(key: "q_proj") var qProj: Linear
     @ModuleInfo(key: "k_proj") var kProj: Linear
@@ -22,6 +23,7 @@ final class ACEStepAttention: Module {
         self.numKVHeads = config.numKeyValueHeads
         self.headDim = config.headDim
         self.scale = pow(Float(headDim), -0.5)
+        self.ropeTheta = config.ropeTheta
 
         self._qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: config.attentionBias)
         self._kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: config.attentionBias)
@@ -53,9 +55,9 @@ final class ACEStepAttention: Module {
         k = kNorm(k.reshaped(B, kLen, numKVHeads, headDim)).transposed(0, 2, 1, 3)
         v = v.reshaped(B, kLen, numKVHeads, headDim).transposed(0, 2, 1, 3)
 
-        if encoderHiddenStates == nil, let rope {
-            q = rope(q.asType(.bfloat16), offset: ropeOffset).asType(q.dtype)
-            k = rope(k.asType(.bfloat16), offset: ropeOffset).asType(k.dtype)
+        if encoderHiddenStates == nil, rope != nil {
+            q = applySplitRoPE(q, offset: ropeOffset)
+            k = applySplitRoPE(k, offset: ropeOffset)
         }
 
         if numKVHeads != numHeads {
@@ -78,6 +80,26 @@ final class ACEStepAttention: Module {
 
         out = out.transposed(0, 2, 1, 3).reshaped(B, qLen, -1)
         return oProj(out)
+    }
+
+    private func applySplitRoPE(_ x: MLXArray, offset: Int) -> MLXArray {
+        let dtype = x.dtype
+        let x32 = x.asType(.float32)
+        let seqLen = x32.dim(2)
+        let half = headDim / 2
+
+        let positions = MLXArray((offset..<(offset + seqLen)).map { Float($0) }).asType(.float32)
+        let indices = MLXArray((0..<half).map { Float($0) }).asType(.float32)
+        let freqs = MLX.exp(-MLXArray(Float(log(ropeTheta))) * indices / Float(half))
+        let args = positions[0..., .newAxis] * freqs[.newAxis]
+        let cos = MLX.cos(args).reshaped(1, 1, seqLen, half)
+        let sin = MLX.sin(args).reshaped(1, 1, seqLen, half)
+
+        let x1 = x32[0..., 0..., 0..., 0..<half]
+        let x2 = x32[0..., 0..., 0..., half...]
+        let out1 = x1 * cos - x2 * sin
+        let out2 = x2 * cos + x1 * sin
+        return MLX.concatenated([out1, out2], axis: 3).asType(dtype)
     }
 
     private func expandKeyValue(_ x: MLXArray, repeats: Int) -> MLXArray {

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepAudioTokenDetokenizer.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepAudioTokenDetokenizer.swift
@@ -14,19 +14,22 @@ final class ACEStepAudioTokenDetokenizer: Module {
     @ModuleInfo(key: "proj_out") var projOut: Linear
 
     init(config: ACEStepConfig) {
-        self.config = config
+        let encoderConfig = config.conditionEncoderConfig
+        self.config = encoderConfig
         self.rope = RoPE(
-            dimensions: config.headDim,
+            dimensions: encoderConfig.headDim,
             traditional: false,
-            base: config.ropeTheta,
+            base: encoderConfig.ropeTheta,
             scale: 1.0
         )
 
-        self._embedTokens.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
-        self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
-        self._specialTokens.wrappedValue = MLXArray.zeros([1, config.poolWindowSize, config.hiddenSize])
-        self._layers.wrappedValue = (0..<config.numAttentionPoolerHiddenLayers).map { ACEStepEncoderLayer(config: config, layerIdx: $0) }
-        self._projOut.wrappedValue = Linear(config.hiddenSize, config.audioAcousticHiddenDim, bias: true)
+        self._embedTokens.wrappedValue = Linear(encoderConfig.hiddenSize, encoderConfig.hiddenSize, bias: true)
+        self._norm.wrappedValue = RMSNorm(dimensions: encoderConfig.hiddenSize, eps: encoderConfig.rmsNormEps)
+        self._specialTokens.wrappedValue = MLXArray.zeros([1, encoderConfig.poolWindowSize, encoderConfig.hiddenSize])
+        self._layers.wrappedValue = (0..<encoderConfig.numAttentionPoolerHiddenLayers).map {
+            ACEStepEncoderLayer(config: encoderConfig, layerIdx: $0)
+        }
+        self._projOut.wrappedValue = Linear(encoderConfig.hiddenSize, encoderConfig.audioAcousticHiddenDim, bias: true)
     }
 
     /// Detokenize quantized 5Hz tokens `[B, T5, 2048]` back to 25Hz latents `[B, T25, 64]`.
@@ -63,4 +66,3 @@ final class ACEStepAudioTokenDetokenizer: Module {
         return h.reshaped(B, T5 * P, config.audioAcousticHiddenDim)
     }
 }
-

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepAudioTokenizer.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepAudioTokenizer.swift
@@ -8,8 +8,9 @@ final class ACEStepAudioTokenizer: Module {
     @ModuleInfo(key: "quantizer") var quantizer: ACEStepResidualFSQ
 
     init(config: ACEStepConfig) {
-        self._audioAcousticProj.wrappedValue = Linear(config.audioAcousticHiddenDim, config.hiddenSize, bias: true)
-        self._attentionPooler.wrappedValue = ACEStepAttentionPooler(config: config)
+        let encoderConfig = config.conditionEncoderConfig
+        self._audioAcousticProj.wrappedValue = Linear(config.audioAcousticHiddenDim, config.encoderHiddenSize, bias: true)
+        self._attentionPooler.wrappedValue = ACEStepAttentionPooler(config: encoderConfig)
         self._quantizer.wrappedValue = ACEStepResidualFSQ(config: config)
     }
 
@@ -20,4 +21,3 @@ final class ACEStepAudioTokenizer: Module {
         return quantizer(h)
     }
 }
-

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepConditionEncoder.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepConditionEncoder.swift
@@ -8,9 +8,10 @@ final class ACEStepConditionEncoder: Module {
     @ModuleInfo(key: "timbre_encoder") var timbreEncoder: ACEStepTimbreEncoder
 
     init(config: ACEStepConfig) {
-        self._textProjector.wrappedValue = Linear(config.textHiddenDim, config.hiddenSize, bias: false)
-        self._lyricEncoder.wrappedValue = ACEStepLyricEncoder(config: config)
-        self._timbreEncoder.wrappedValue = ACEStepTimbreEncoder(config: config)
+        let encoderConfig = config.conditionEncoderConfig
+        self._textProjector.wrappedValue = Linear(config.textHiddenDim, config.encoderHiddenSize, bias: false)
+        self._lyricEncoder.wrappedValue = ACEStepLyricEncoder(config: encoderConfig)
+        self._timbreEncoder.wrappedValue = ACEStepTimbreEncoder(config: encoderConfig)
     }
 
     func callAsFunction(
@@ -44,4 +45,3 @@ final class ACEStepConditionEncoder: Module {
         return packed
     }
 }
-

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepConfig.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepConfig.swift
@@ -10,6 +10,10 @@ public struct ACEStepConfig: Decodable, Sendable, Hashable {
     public let numHiddenLayers: Int
     public let numAttentionHeads: Int
     public let numKeyValueHeads: Int
+    public let encoderHiddenSize: Int
+    public let encoderIntermediateSize: Int
+    public let encoderNumAttentionHeads: Int
+    public let encoderNumKeyValueHeads: Int
     public let headDim: Int
     public let hiddenAct: String
     public let maxPositionEmbeddings: Int
@@ -46,6 +50,10 @@ public struct ACEStepConfig: Decodable, Sendable, Hashable {
         case numHiddenLayers = "num_hidden_layers"
         case numAttentionHeads = "num_attention_heads"
         case numKeyValueHeads = "num_key_value_heads"
+        case encoderHiddenSize = "encoder_hidden_size"
+        case encoderIntermediateSize = "encoder_intermediate_size"
+        case encoderNumAttentionHeads = "encoder_num_attention_heads"
+        case encoderNumKeyValueHeads = "encoder_num_key_value_heads"
         case headDim = "head_dim"
         case hiddenAct = "hidden_act"
         case maxPositionEmbeddings = "max_position_embeddings"
@@ -83,6 +91,10 @@ public struct ACEStepConfig: Decodable, Sendable, Hashable {
         numHiddenLayers: Int = 24,
         numAttentionHeads: Int = 16,
         numKeyValueHeads: Int = 8,
+        encoderHiddenSize: Int? = nil,
+        encoderIntermediateSize: Int? = nil,
+        encoderNumAttentionHeads: Int? = nil,
+        encoderNumKeyValueHeads: Int? = nil,
         headDim: Int = 128,
         hiddenAct: String = "silu",
         maxPositionEmbeddings: Int = 32768,
@@ -115,6 +127,10 @@ public struct ACEStepConfig: Decodable, Sendable, Hashable {
         self.numHiddenLayers = numHiddenLayers
         self.numAttentionHeads = numAttentionHeads
         self.numKeyValueHeads = numKeyValueHeads
+        self.encoderHiddenSize = encoderHiddenSize ?? hiddenSize
+        self.encoderIntermediateSize = encoderIntermediateSize ?? intermediateSize
+        self.encoderNumAttentionHeads = encoderNumAttentionHeads ?? numAttentionHeads
+        self.encoderNumKeyValueHeads = encoderNumKeyValueHeads ?? numKeyValueHeads
         self.headDim = headDim
         self.hiddenAct = hiddenAct
         self.maxPositionEmbeddings = maxPositionEmbeddings
@@ -151,6 +167,10 @@ public struct ACEStepConfig: Decodable, Sendable, Hashable {
         numHiddenLayers = try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 24
         numAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 16
         numKeyValueHeads = try container.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 8
+        encoderHiddenSize = try container.decodeIfPresent(Int.self, forKey: .encoderHiddenSize) ?? hiddenSize
+        encoderIntermediateSize = try container.decodeIfPresent(Int.self, forKey: .encoderIntermediateSize) ?? intermediateSize
+        encoderNumAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .encoderNumAttentionHeads) ?? numAttentionHeads
+        encoderNumKeyValueHeads = try container.decodeIfPresent(Int.self, forKey: .encoderNumKeyValueHeads) ?? numKeyValueHeads
         headDim = try container.decodeIfPresent(Int.self, forKey: .headDim) ?? (hiddenSize / max(1, numAttentionHeads))
         hiddenAct = try container.decodeIfPresent(String.self, forKey: .hiddenAct) ?? "silu"
         maxPositionEmbeddings = try container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 32768
@@ -176,5 +196,45 @@ public struct ACEStepConfig: Decodable, Sendable, Hashable {
         timbreFixFrame = try container.decodeIfPresent(Int.self, forKey: .timbreFixFrame) ?? 750
 
         isTurbo = try container.decodeIfPresent(Bool.self, forKey: .isTurbo) ?? false
+    }
+
+    public var conditionEncoderConfig: ACEStepConfig {
+        ACEStepConfig(
+            vocabSize: vocabSize,
+            fsqDim: fsqDim,
+            fsqInputLevels: fsqInputLevels,
+            fsqInputNumQuantizers: fsqInputNumQuantizers,
+            hiddenSize: encoderHiddenSize,
+            intermediateSize: encoderIntermediateSize,
+            numHiddenLayers: numHiddenLayers,
+            numAttentionHeads: encoderNumAttentionHeads,
+            numKeyValueHeads: encoderNumKeyValueHeads,
+            encoderHiddenSize: encoderHiddenSize,
+            encoderIntermediateSize: encoderIntermediateSize,
+            encoderNumAttentionHeads: encoderNumAttentionHeads,
+            encoderNumKeyValueHeads: encoderNumKeyValueHeads,
+            headDim: headDim,
+            hiddenAct: hiddenAct,
+            maxPositionEmbeddings: maxPositionEmbeddings,
+            rmsNormEps: rmsNormEps,
+            ropeTheta: ropeTheta,
+            attentionBias: attentionBias,
+            attentionDropout: attentionDropout,
+            useSlidingWindow: useSlidingWindow,
+            slidingWindow: slidingWindow,
+            layerTypes: layerTypes,
+            audioAcousticHiddenDim: audioAcousticHiddenDim,
+            poolWindowSize: poolWindowSize,
+            textHiddenDim: textHiddenDim,
+            inChannels: inChannels,
+            patchSize: patchSize,
+            numLyricEncoderHiddenLayers: numLyricEncoderHiddenLayers,
+            numAttentionPoolerHiddenLayers: numAttentionPoolerHiddenLayers,
+            numAudioDecoderHiddenLayers: numAudioDecoderHiddenLayers,
+            timbreHiddenDim: timbreHiddenDim,
+            numTimbreEncoderHiddenLayers: numTimbreEncoderHiddenLayers,
+            timbreFixFrame: timbreFixFrame,
+            isTurbo: isTurbo
+        )
     }
 }

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepDiT.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepDiT.swift
@@ -56,7 +56,7 @@ final class ACEStepDiT: Module {
         self._timeEmbed.wrappedValue = ACEStepTimestepEmbedding(inChannels: 256, timeEmbedDim: config.hiddenSize)
         self._timeEmbedR.wrappedValue = ACEStepTimestepEmbedding(inChannels: 256, timeEmbedDim: config.hiddenSize)
 
-        self._conditionEmbedder.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        self._conditionEmbedder.wrappedValue = Linear(config.encoderHiddenSize, config.hiddenSize, bias: true)
 
         self._normOut.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
         self._scaleShiftTable.wrappedValue = MLXArray.zeros([1, 2, config.hiddenSize])
@@ -96,11 +96,10 @@ final class ACEStepDiT: Module {
             return .array(mask)
         }()
 
-        let encoderMask: MLXFast.ScaledDotProductAttentionMaskMode = {
-            guard let encoderAttentionMask else { return .none }
-            let mask = makeCrossAttentionMask(attentionMask: encoderAttentionMask, queryLen: seqLen)
-            return .array(mask)
-        }()
+        // The upstream ACE-Step MLX DiT accepts encoder masks at the service
+        // boundary but does not apply them inside the decoder.
+        let encoderMask: MLXFast.ScaledDotProductAttentionMaskMode = .none
+        _ = encoderAttentionMask
 
         for layer in layers {
             let selfMask: MLXFast.ScaledDotProductAttentionMaskMode = (layer.attentionType == "sliding_attention") ? slidingMask : fullMask
@@ -137,17 +136,4 @@ final class ACEStepDiT: Module {
         return additive.reshaped(1, 1, seqLen, seqLen)
     }
 
-    private func makeCrossAttentionMask(attentionMask: MLXArray, queryLen: Int) -> MLXArray {
-        // attentionMask: [B, S] (1 = keep, 0 = mask)
-        let B = attentionMask.dim(0)
-        let S = attentionMask.dim(1)
-
-        let keep = (attentionMask .> MLXArray(Float(0))).asType(.bool)
-        let keepExpanded = keep.reshaped(B, 1, 1, S)
-        let keepBroadcast = MLX.broadcast(keepExpanded, to: [B, 1, queryLen, S])
-
-        let zeros = MLX.zeros([B, 1, queryLen, S], dtype: .float32)
-        let negInf = MLXArray(-1.0e9)
-        return MLX.where(keepBroadcast, zeros, zeros + negInf)
-    }
 }

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepResidualFSQ.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepResidualFSQ.swift
@@ -11,6 +11,7 @@ final class ACEStepResidualFSQ: Module {
 
     let levels: [Int]
     private let levelsMinus1: MLXArray
+    private let softClampValues: MLXArray
     private let basis: MLXArray
 
     init(config: ACEStepConfig) {
@@ -25,6 +26,10 @@ final class ACEStepResidualFSQ: Module {
 
         let minus1 = config.fsqInputLevels.map { Float32(max(1, $0 - 1)) }
         self.levelsMinus1 = MLXArray(minus1, [1, 1, d]).asType(.float32)
+        self.softClampValues = MLXArray(
+            minus1.map { Float32(1.0) + (Float32(1.0) / $0) },
+            [1, 1, d]
+        ).asType(.float32)
 
         var basisVals: [Int32] = []
         basisVals.reserveCapacity(d)
@@ -42,12 +47,13 @@ final class ACEStepResidualFSQ: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> (quantized: MLXArray, indices: MLXArray) {
-        // Project to scalar code dims.
+        // vector-quantize-pytorch ResidualFSQ soft-clamps before the
+        // symmetry-preserving one-layer FSQ used by ACE-Step.
         var y = projectIn(x).asType(.float32)
-        y = MLX.tanh(y)
+        y = MLX.tanh(y / softClampValues) * softClampValues
+        y = minimum(maximum(y, MLXArray(Float32(-1))), MLXArray(Float32(1)))
 
-        // Map [-1, 1] -> [0, L-1], quantize, then map back to [-1, 1].
-        let qFloat = round((y + 1) * 0.5 * levelsMinus1)
+        let qFloat = floor(levelsMinus1 * ((y + 1) * 0.5) + MLXArray(Float32(0.5)))
         let qClamped = minimum(maximum(qFloat, MLXArray(Float32(0))), levelsMinus1)
         let qInt = qClamped.asType(.int32)
 
@@ -83,4 +89,3 @@ final class ACEStepResidualFSQ: Module {
         return projectOut(scalars).asType(dtype)
     }
 }
-

--- a/Sources/MereRunCore/ACEStep/Model/ACEStepTimbreEncoder.swift
+++ b/Sources/MereRunCore/ACEStep/Model/ACEStepTimbreEncoder.swift
@@ -56,7 +56,6 @@ final class ACEStepTimbreEncoder: Module {
         packedEmbeddings: MLXArray, // [N, D]
         referAudioOrderMask: MLXArray // [N]
     ) -> (embeddings: MLXArray, attentionMask: MLXArray) {
-        let N = packedEmbeddings.dim(0)
         let D = packedEmbeddings.dim(1)
 
         let order = referAudioOrderMask.asType(.int32)
@@ -105,4 +104,3 @@ final class ACEStepTimbreEncoder: Module {
         return (unpacked, mask)
     }
 }
-

--- a/Sources/MereRunCore/ACEStep/VAE/OobleckDecoder.swift
+++ b/Sources/MereRunCore/ACEStep/VAE/OobleckDecoder.swift
@@ -63,7 +63,7 @@ final class OobleckDecoderBlock: Module {
         self._snake1.wrappedValue = OobleckSnakeBeta(channels: inputChannels)
 
         let kernelSize = stride * 2
-        let padding = stride / 2
+        let padding = (stride + 1) / 2
         self._convT1.wrappedValue = OobleckWNConvTranspose1d(
             inputChannels: inputChannels,
             outputChannels: outputChannels,
@@ -104,7 +104,7 @@ final class OobleckEncoderBlock: Module {
         self._resUnit3.wrappedValue = OobleckResUnit(channels: inputChannels, dilation: 9)
 
         let kernelSize = stride * 2
-        let padding = stride / 2
+        let padding = (stride + 1) / 2
         self._conv1.wrappedValue = WNConv1d(
             inputChannels: inputChannels,
             outputChannels: outputChannels,
@@ -117,10 +117,10 @@ final class OobleckEncoderBlock: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var h = snake1(x)
-        h = resUnit1(h)
+        var h = resUnit1(x)
         h = resUnit2(h)
         h = resUnit3(h)
+        h = snake1(h)
         return conv1(h)
     }
 }

--- a/Sources/MereRunCore/ACEStep/VAE/OobleckVAE.swift
+++ b/Sources/MereRunCore/ACEStep/VAE/OobleckVAE.swift
@@ -28,9 +28,12 @@ final class OobleckVAE: Module {
             return mean
         }
 
-        let logvar = stats[0..., 0..., latentChannels..<(latentChannels * 2)]
-        let clampedLogvar = MLX.clip(logvar, min: -30.0, max: 20.0)
-        let std = MLX.exp(clampedLogvar * 0.5)
+        let scale = stats[0..., 0..., latentChannels..<(latentChannels * 2)]
+        let std = MLX.where(
+            scale .> MLXArray(Float(20.0)).asType(scale.dtype),
+            scale,
+            MLX.log(MLXArray(Float(1.0)).asType(scale.dtype) + MLX.exp(scale))
+        ) + MLXArray(Float(1e-4)).asType(scale.dtype)
 
         let noise: MLXArray
         if let seed {
@@ -119,11 +122,12 @@ final class OobleckVAE: Module {
         let stride = chunkSize - 2 * overlap
         precondition(stride > 0, "chunkSize \(chunkSize) must be > 2 * overlap \(overlap)")
 
-        let upsampleFactor = config.downsamplingRatios.reduce(1, *)
         let numSteps = (T + stride - 1) / stride
 
         var decoded: [MLXArray] = []
         decoded.reserveCapacity(numSteps)
+
+        var upsampleFactor: Double?
 
         for i in 0..<numSteps {
             let coreStart = i * stride
@@ -135,8 +139,13 @@ final class OobleckVAE: Module {
             let latentChunk = latents[0..., winStart..<winEnd, 0...]
             let audioChunk = decode(latentChunk)
 
-            let trimStart = (coreStart - winStart) * upsampleFactor
-            let trimEnd = (winEnd - coreEnd) * upsampleFactor
+            if upsampleFactor == nil {
+                upsampleFactor = Double(audioChunk.dim(1)) / Double(latentChunk.dim(1))
+            }
+
+            let factor = upsampleFactor!
+            let trimStart = Int(round(Double(coreStart - winStart) * factor))
+            let trimEnd = Int(round(Double(winEnd - coreEnd) * factor))
 
             let audioLen = audioChunk.dim(1)
             let endIndex = trimEnd > 0 ? (audioLen - trimEnd) : audioLen

--- a/Sources/MereRunCore/Embeddings/Qwen3EmbeddingModel.swift
+++ b/Sources/MereRunCore/Embeddings/Qwen3EmbeddingModel.swift
@@ -64,7 +64,7 @@ public final class Qwen3EmbeddingModel {
             singleURL: resources.weightsURL,
             to: qwen,
             dtype: dtype,
-            mapper: { key, value in [(key, value)] },
+            mapper: QwenEncoder.mapHFSafetensorWeight,
             fileManager: fileManager
         )
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -789,7 +789,7 @@ public enum ManagedModelCatalog {
             upstreamRevision: "main",
             validationKind: .aceStep,
             normalizationKind: .musicACEStep,
-            defaultCLICommands: ["music generate"]
+            defaultCLICommands: ["music generate", "music analyze"]
         ),
         ManagedModelSpec(
             id: ModelResolver.ModelID.aceStepXLTurbo.rawValue,
@@ -875,7 +875,7 @@ public enum ManagedModelCatalog {
             validationKind: .aceStep,
             normalizationKind: .musicACEStep,
             estimatedDownloadBytes: 32 * 1_073_741_824,
-            defaultCLICommands: ["music generate"]
+            defaultCLICommands: ["music generate", "music analyze"]
         ),
         ManagedModelSpec(
             id: ModelResolver.ModelID.magentaRT2Small.rawValue,

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -66,6 +66,7 @@ public struct ManagedModelSpec: Hashable, Sendable {
     public let category: ManagedModelCategory
     public let installShape: ManagedModelInstallShape
     public let hubFallback: HubFallbackConfig?
+    public let mountedHubFallbacks: [MountedHubFallbackConfig]
     public let upstreamRepoId: String?
     public let upstreamRevision: String?
     public let validationKind: ManagedModelValidationKind
@@ -82,6 +83,7 @@ public struct ManagedModelSpec: Hashable, Sendable {
         category: ManagedModelCategory,
         installShape: ManagedModelInstallShape,
         hubFallback: HubFallbackConfig? = nil,
+        mountedHubFallbacks: [MountedHubFallbackConfig] = [],
         upstreamRepoId: String? = nil,
         upstreamRevision: String? = nil,
         validationKind: ManagedModelValidationKind,
@@ -97,6 +99,7 @@ public struct ManagedModelSpec: Hashable, Sendable {
         self.category = category
         self.installShape = installShape
         self.hubFallback = hubFallback
+        self.mountedHubFallbacks = mountedHubFallbacks
         self.upstreamRepoId = upstreamRepoId
         self.upstreamRevision = upstreamRevision
         self.validationKind = validationKind
@@ -789,6 +792,92 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["music generate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.aceStepXLTurbo.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "ACE-Step/Ace-Step1.5",
+                revision: "main",
+                patterns: [
+                    "Qwen3-Embedding-0.6B/*",
+                    "vae/*",
+                ]
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "acestep-v15-xl-turbo",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "ACE-Step/acestep-v15-xl-turbo",
+                        revision: "main",
+                        patterns: [
+                            "config.json",
+                            "configuration_acestep_v15.py",
+                            "model*.safetensors",
+                            "model.safetensors.index.json",
+                            "modeling_acestep_v15_xl_turbo.py",
+                            "silence_latent.pt",
+                        ]
+                    )
+                ),
+            ],
+            upstreamRepoId: "ACE-Step/acestep-v15-xl-turbo",
+            upstreamRevision: "main",
+            validationKind: .aceStep,
+            normalizationKind: .musicACEStep,
+            estimatedDownloadBytes: 23 * 1_073_741_824,
+            defaultCLICommands: ["music generate"]
+        ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "ACE-Step/Ace-Step1.5",
+                revision: "main",
+                patterns: [
+                    "Qwen3-Embedding-0.6B/*",
+                    "vae/*",
+                ]
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "acestep-v15-xl-turbo",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "ACE-Step/acestep-v15-xl-turbo",
+                        revision: "main",
+                        patterns: [
+                            "config.json",
+                            "configuration_acestep_v15.py",
+                            "model*.safetensors",
+                            "model.safetensors.index.json",
+                            "modeling_acestep_v15_xl_turbo.py",
+                            "silence_latent.pt",
+                        ]
+                    )
+                ),
+                MountedHubFallbackConfig(
+                    destinationPath: "acestep-5Hz-lm-4B",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "ACE-Step/acestep-5Hz-lm-4B",
+                        revision: "main",
+                        patterns: [
+                            "*.json",
+                            "*.safetensors",
+                            "*.jinja",
+                            "merges.txt",
+                            "vocab.json",
+                        ]
+                    )
+                ),
+            ],
+            upstreamRepoId: "ACE-Step/acestep-v15-xl-turbo + ACE-Step/acestep-5Hz-lm-4B",
+            upstreamRevision: "main",
+            validationKind: .aceStep,
+            normalizationKind: .musicACEStep,
+            estimatedDownloadBytes: 32 * 1_073_741_824,
+            defaultCLICommands: ["music generate"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.magentaRT2Small.rawValue,
             category: .music,
             installShape: .structuredRoot,
@@ -891,11 +980,11 @@ public extension ManagedModelSpec {
     }
 
     var canBePulledWithoutConfiguration: Bool {
-        hubFallback != nil
+        hubFallback != nil || !mountedHubFallbacks.isEmpty
     }
 
     func hasAnyManagedDownloadSource() -> Bool {
-        hubFallback != nil
+        hubFallback != nil || !mountedHubFallbacks.isEmpty
     }
 
     func normalizedRootURL(_ rootURL: URL, fileManager: FileManager = .default) -> URL {
@@ -973,7 +1062,7 @@ public extension ManagedModelSpec {
         case .lightOnOCR:
             return Self.missingLightOnOCRPaths(in: rootURL, fileManager: fileManager)
         case .aceStep:
-            return Self.missingACEStepPaths(in: rootURL, fileManager: fileManager)
+            return Self.missingACEStepPaths(modelID: id, in: rootURL, fileManager: fileManager)
         case .magentaRT2:
             return Self.missingMagentaRT2Paths(modelID: id, in: rootURL, fileManager: fileManager)
         case .ltxVideo:
@@ -1219,17 +1308,27 @@ public extension ManagedModelSpec {
         return missing
     }
 
-    private static func missingACEStepPaths(in rootURL: URL, fileManager: FileManager) -> [URL] {
+    private static func missingACEStepPaths(modelID: String, in rootURL: URL, fileManager: FileManager) -> [URL] {
         var missing: [URL] = []
-        let upstreamTurboDir = rootURL.appendingPathComponent("acestep-v15-turbo", isDirectory: true)
-        let compatibilityTurboDir = rootURL.appendingPathComponent("music-acestep-v15-turbo", isDirectory: true)
+        let turboSubdirectories = modelID == ModelResolver.ModelID.aceStep.rawValue
+            ? ["acestep-v15-turbo", "music-acestep-v15-turbo"]
+            : ["acestep-v15-xl-turbo"]
         let vaeDir = rootURL.appendingPathComponent("vae", isDirectory: true)
         let textDir = rootURL.appendingPathComponent("Qwen3-Embedding-0.6B", isDirectory: true)
-        if !fileManager.fileExists(atPath: upstreamTurboDir.path) && !fileManager.fileExists(atPath: compatibilityTurboDir.path) {
-            missing.append(upstreamTurboDir)
+        if !turboSubdirectories.contains(where: {
+            fileManager.fileExists(atPath: rootURL.appendingPathComponent($0, isDirectory: true).path)
+        }) {
+            missing.append(rootURL.appendingPathComponent(turboSubdirectories[0], isDirectory: true))
         }
         if !fileManager.fileExists(atPath: vaeDir.path) { missing.append(vaeDir) }
         if !fileManager.fileExists(atPath: textDir.path) { missing.append(textDir) }
+        if modelID == ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue {
+            let lmDir = rootURL.appendingPathComponent("acestep-5Hz-lm-4B", isDirectory: true)
+            let lmMissing = ACEStep5HzLMResources(rootURL: lmDir).validate(fileManager: fileManager)
+            if !lmMissing.isEmpty {
+                missing.append(lmDir)
+            }
+        }
         return missing
     }
 

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -114,6 +114,33 @@ public enum ManagedModelResolver {
             throw ResolverError.autoDownloadDisabled(spec.id)
         }
 
+        if !spec.mountedHubFallbacks.isEmpty {
+            let result = try await installManagedModel(
+                id: spec.id,
+                fileManager: fileManager,
+                progress: { installProgress in
+                    switch installProgress {
+                    case .downloadingBytes(let completed, let total):
+                        guard let total, total > 0 else {
+                            progress?(.downloading(percent: 0))
+                            return
+                        }
+                        let percent = min(100, max(0, Int(Double(completed) / Double(total) * 100)))
+                        progress?(.downloading(percent: percent))
+                    case .downloadingPercent(let percent, _):
+                        progress?(.downloading(percent: percent))
+                    case .extracting:
+                        progress?(.extracting)
+                    }
+                }
+            )
+            return RuntimeResolution(
+                spec: spec,
+                url: spec.normalizedRootURL(result.installURL, fileManager: fileManager),
+                source: .managedStore
+            )
+        }
+
         switch spec.installShape {
         case .directoryRoot:
             guard let hubFallback = spec.hubFallback else {
@@ -208,11 +235,16 @@ public enum ManagedModelResolver {
             config: hubFallback,
             progress: progress
         )
+        let mountedSnapshots = try await downloadMountedHubSnapshots(
+            for: spec,
+            progress: progress
+        )
         try normalizeManagedLayoutIfNeeded(for: spec, in: snapshotURL, fileManager: fileManager)
         try fileManager.createDirectory(at: modelDir.deletingLastPathComponent(), withIntermediateDirectories: true)
         let manifest = try materializeManagedInstallRoot(
             for: spec,
             snapshotURL: snapshotURL,
+            mountedSnapshots: mountedSnapshots,
             modelDir: modelDir,
             fileManager: fileManager
         )
@@ -316,6 +348,24 @@ public enum ManagedModelResolver {
         }
     }
 
+    private static func downloadMountedHubSnapshots(
+        for spec: ManagedModelSpec,
+        progress: (@Sendable (InstallProgress) -> Void)?
+    ) async throws -> [(MountedHubFallbackConfig, URL)] {
+        var snapshots: [(MountedHubFallbackConfig, URL)] = []
+        snapshots.reserveCapacity(spec.mountedHubFallbacks.count)
+
+        for mounted in spec.mountedHubFallbacks {
+            let snapshotURL = try await downloadHubSnapshotWithByteProgress(
+                config: mounted.hubFallback,
+                progress: progress
+            )
+            snapshots.append((mounted, snapshotURL))
+        }
+
+        return snapshots
+    }
+
     private static func normalizeManagedLayoutIfNeeded(
         for spec: ManagedModelSpec,
         in rootURL: URL,
@@ -330,20 +380,36 @@ public enum ManagedModelResolver {
     static func materializeManagedInstallRoot(
         for spec: ManagedModelSpec,
         snapshotURL: URL,
+        mountedSnapshots: [(MountedHubFallbackConfig, URL)] = [],
         modelDir: URL,
         fileManager: FileManager
     ) throws -> MereRunModelManifest? {
         try fileManager.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try materializeSnapshotEntries(from: snapshotURL, to: modelDir, fileManager: fileManager)
+
+        for (mounted, mountedSnapshotURL) in mountedSnapshots {
+            let destinationURL = modelDir.appendingPathComponent(mounted.destinationPath, isDirectory: true)
+            try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+            try materializeSnapshotEntries(from: mountedSnapshotURL, to: destinationURL, fileManager: fileManager)
+        }
+
+        return try MereRunModelManifest.writeTemplateIfKnown(modelId: spec.id, to: modelDir)
+    }
+
+    private static func materializeSnapshotEntries(
+        from snapshotURL: URL,
+        to destinationRoot: URL,
+        fileManager: FileManager
+    ) throws {
         let entries = try fileManager.contentsOfDirectory(
             at: snapshotURL,
             includingPropertiesForKeys: nil,
             options: []
         )
         for entry in entries where entry.lastPathComponent != MereRunModelManifest.filename {
-            let linkURL = modelDir.appendingPathComponent(entry.lastPathComponent)
+            let linkURL = destinationRoot.appendingPathComponent(entry.lastPathComponent)
             try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: entry)
         }
-        return try MereRunModelManifest.writeTemplateIfKnown(modelId: spec.id, to: modelDir)
     }
 
     private static func installManagedAliasesIfNeeded(

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -462,6 +462,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 32
             ),
             descriptor(
+                ModelResolver.ModelID.aceStepXLTurbo.rawValue,
+                "ACE-Step XL Turbo",
+                "Generates higher-quality music with the ACE-Step 1.5 XL turbo DiT.",
+                minimum: 24,
+                recommended: 32
+            ),
+            descriptor(
+                ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue,
+                "ACE-Step XL Turbo + 4B LM",
+                "Adds the optional 4B 5Hz LM to the ACE-Step 1.5 XL turbo stack.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
                 ModelResolver.ModelID.magentaRT2Small.rawValue,
                 "Magenta RealTime 2 small",
                 "Streams controllable Magenta RT2 music on Apple Silicon with the 230M model.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1075,18 +1075,19 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "lightonai/LightOnOCR-2-1B",
                 createdAt: createdAt
             )
-        case .aceStep:
+        case .aceStep, .aceStepXLTurbo, .aceStepXLTurboLM4B:
+            let isXL = modelID == .aceStepXLTurbo || modelID == .aceStepXLTurboLM4B
             return MereRunModelManifest(
                 id: modelID.rawValue,
                 engine: .aceStep,
                 family: .music,
-                tier: .latest,
-                variant: .standard,
+                tier: isXL ? .turbo : .latest,
+                variant: isXL ? .distilled : .standard,
                 precision: .bf16,
                 defaults: Defaults(steps: 8, cfg: 1.0),
                 supports: [.musicGeneration],
                 components: nil,
-                upstreamRepoId: "ACE-Step/Ace-Step1.5",
+                upstreamRepoId: isXL ? "ACE-Step/acestep-v15-xl-turbo" : "ACE-Step/Ace-Step1.5",
                 createdAt: createdAt
             )
         case .magentaRT2Small, .magentaRT2Base:

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -47,6 +47,8 @@ public struct ModelResolver {
         case visionSegmentSAM31 = "vision-segment-sam31"
         case visionGroundFalconPerception = "vision-ground-falcon-perception"
         case aceStep = "music-acestep"
+        case aceStepXLTurbo = "music-acestep-xl-turbo"
+        case aceStepXLTurboLM4B = "music-acestep-xl-turbo-lm4b"
         case magentaRT2Small = "music-magenta-rt2-small"
         case magentaRT2Base = "music-magenta-rt2-base"
         case ltxVideoAV = "video-ltx-av"

--- a/Sources/MereRunCore/Support/PretrainedModelLoader.swift
+++ b/Sources/MereRunCore/Support/PretrainedModelLoader.swift
@@ -19,6 +19,16 @@ public struct HubFallbackConfig: Sendable, Hashable {
     }
 }
 
+public struct MountedHubFallbackConfig: Sendable, Hashable {
+    public let destinationPath: String
+    public let hubFallback: HubFallbackConfig
+
+    public init(destinationPath: String, hubFallback: HubFallbackConfig) {
+        self.destinationPath = destinationPath
+        self.hubFallback = hubFallback
+    }
+}
+
 /// Shared model-loading utilities for local path resolution and managed model directories.
 public enum PretrainedModelLoader {
     public enum ProgressEvent: Sendable, Hashable {

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -124,8 +124,8 @@ public final class QwenAttention: Module {
         mropeSection: mropeSection
       )
     } else if let rope {
-      queries = rope(queries.asType(.bfloat16), offset: offset)
-      keys = rope(keys.asType(.bfloat16), offset: offset)
+      queries = rope(queries, offset: offset)
+      keys = rope(keys, offset: offset)
     }
 
     if debug {
@@ -326,7 +326,8 @@ public final class QwenEncoder: Module {
       tokenIds = tokenIds.asType(.int32)
     }
 
-    var h = embedTokens(tokenIds).asType(.bfloat16)
+    let computeDType: DType = configuration.useFloat32Activations ? .float32 : .bfloat16
+    var h = embedTokens(tokenIds).asType(computeDType)
 
     let mask = createAttentionMask(h: h, attentionMask: attentionMask)
 
@@ -356,7 +357,8 @@ public final class QwenEncoder: Module {
     tokenTypes: MLXArray? = nil,
     outputHiddenStates: Bool = false
   ) -> (lastHiddenState: MLXArray, hiddenStates: [MLXArray]?) {
-    var h = embeddings.dtype == .bfloat16 ? embeddings : embeddings.asType(.bfloat16)
+    let computeDType: DType = configuration.useFloat32Activations ? .float32 : .bfloat16
+    var h = embeddings.dtype == computeDType ? embeddings : embeddings.asType(computeDType)
 
     let mask = createAttentionMask(h: h, attentionMask: attentionMask, tokenTypes: tokenTypes)
 
@@ -391,7 +393,8 @@ public final class QwenEncoder: Module {
 
     let wantedLayers = Set(activationLayers)
     var captured: [Int: MLXArray] = [:]
-    var h = embedTokens(tokenIds).asType(.bfloat16)
+    let computeDType: DType = configuration.useFloat32Activations ? .float32 : .bfloat16
+    var h = embedTokens(tokenIds).asType(computeDType)
     let mask = createAttentionMask(h: h, attentionMask: attentionMask)
 
     for (index, layer) in layers.enumerated() {
@@ -413,7 +416,8 @@ public final class QwenEncoder: Module {
   ) -> [MLXArray] {
     let wantedLayers = Set(activationLayers)
     var captured: [Int: MLXArray] = [:]
-    var h = embeddings.dtype == .bfloat16 ? embeddings : embeddings.asType(.bfloat16)
+    let computeDType: DType = configuration.useFloat32Activations ? .float32 : .bfloat16
+    var h = embeddings.dtype == computeDType ? embeddings : embeddings.asType(computeDType)
     let mask = createAttentionMask(h: h, attentionMask: attentionMask, tokenTypes: tokenTypes)
 
     for (index, layer) in layers.enumerated() {
@@ -491,6 +495,13 @@ public final class QwenEncoder: Module {
 }
 
 extension QwenEncoder {
+  public static func mapHFSafetensorWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+    if key.hasPrefix("model.") {
+      return [(String(key.dropFirst("model.".count)), value)]
+    }
+    return [(key, value)]
+  }
+
   public func embed(inputIds: MLXArray) -> MLXArray {
     var tokenIds = inputIds
     if tokenIds.dtype != .int32 {

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder.swift
@@ -26,6 +26,7 @@ public struct QwenTextEncoderConfiguration {
   public var headDim: Int
   public var mropeSection: [Int]?
   public var mropeInterleaved: Bool
+  public var useFloat32Activations: Bool
 
   public init(
     vocabSize: Int = 151_936,
@@ -40,7 +41,8 @@ public struct QwenTextEncoderConfiguration {
     promptDropIndex: Int = 0,
     headDim: Int = 128,
     mropeSection: [Int]? = nil,
-    mropeInterleaved: Bool = false
+    mropeInterleaved: Bool = false,
+    useFloat32Activations: Bool = false
   ) {
     self.vocabSize = vocabSize
     self.hiddenSize = hiddenSize
@@ -55,6 +57,7 @@ public struct QwenTextEncoderConfiguration {
     self.headDim = headDim
     self.mropeSection = mropeSection
     self.mropeInterleaved = mropeInterleaved
+    self.useFloat32Activations = useFloat32Activations
   }
 }
 

--- a/Tests/MereRunCLITests/GuideCommandTests.swift
+++ b/Tests/MereRunCLITests/GuideCommandTests.swift
@@ -18,6 +18,14 @@ final class GuideCommandTests: XCTestCase {
         XCTAssertEqual(entry.topic, "music-generate")
     }
 
+    func testGuideMusicAnalyzeParsesAndResolves() throws {
+        let command = try GuideCommand.parse(["music", "analyze"])
+        let entry = try GuideCommand.resolveEntry(commandPath: command.commandPath, model: command.model)
+
+        XCTAssertEqual(command.commandPath, ["music", "analyze"])
+        XCTAssertEqual(entry.topic, "music-analyze")
+    }
+
     func testGuideMusicGenerateModelFocusParsesAndRenders() throws {
         let command = try GuideCommand.parse([
             "music",
@@ -73,6 +81,8 @@ final class GuideCommandTests: XCTestCase {
             payload.models,
             [
                 "music-acestep",
+                ModelResolver.ModelID.aceStepXLTurbo.rawValue,
+                ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue,
                 ModelResolver.ModelID.magentaRT2Small.rawValue,
                 ModelResolver.ModelID.magentaRT2Base.rawValue,
             ]

--- a/Tests/MereRunCLITests/MusicAnalyzeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicAnalyzeCommandParsingTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class MusicAnalyzeCommandParsingTests: XCTestCase {
+    func testMusicAnalyzeParsesDefaults() throws {
+        let cmd = try MusicAnalyze.parse([
+            "/tmp/song.mp3",
+        ])
+
+        XCTAssertEqual(cmd.audio, "/tmp/song.mp3")
+        XCTAssertEqual(cmd.model, ModelResolver.ModelID.aceStep.rawValue)
+        XCTAssertNil(cmd.checkpointsRoot)
+        XCTAssertEqual(cmd.turboSubdirectory, "acestep-v15-turbo")
+        XCTAssertEqual(cmd.vaeSubdirectory, "vae")
+        XCTAssertNil(cmd.lmSubdirectory)
+        XCTAssertNil(cmd.durationSeconds)
+        XCTAssertEqual(cmd.maxNewTokens, 2048)
+        XCTAssertEqual(cmd.lmTemperature, 0.3, accuracy: 0.0001)
+        XCTAssertEqual(cmd.lmTopK, 0)
+        XCTAssertEqual(cmd.lmTopP, 0.9, accuracy: 0.0001)
+        XCTAssertFalse(cmd.includeRawLM)
+        XCTAssertFalse(cmd.includeAudioCodes)
+        XCTAssertFalse(cmd.quiet)
+    }
+
+    func testMusicAnalyzeParsesModelAndLMOverrides() throws {
+        let cmd = try MusicAnalyze.parse([
+            "/tmp/song.mp3",
+            "--model", ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue,
+            "--checkpoints-root", "/tmp/acestep",
+            "--turbo-subdirectory", "acestep-v15-xl-turbo",
+            "--vae-subdirectory", "vae-custom",
+            "--lm-subdirectory", "acestep-5Hz-lm-4B",
+            "--duration", "30",
+            "--max-new-tokens", "512",
+            "--lm-temperature", "0.2",
+            "--lm-top-k", "32",
+            "--lm-top-p", "0.75",
+            "--include-raw-lm",
+            "--include-audio-codes",
+            "--quiet",
+        ])
+
+        XCTAssertEqual(cmd.model, ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue)
+        XCTAssertEqual(cmd.checkpointsRoot, "/tmp/acestep")
+        XCTAssertEqual(cmd.turboSubdirectory, "acestep-v15-xl-turbo")
+        XCTAssertEqual(cmd.vaeSubdirectory, "vae-custom")
+        XCTAssertEqual(cmd.lmSubdirectory, "acestep-5Hz-lm-4B")
+        XCTAssertEqual(cmd.durationSeconds, 30)
+        XCTAssertEqual(cmd.maxNewTokens, 512)
+        XCTAssertEqual(cmd.lmTemperature, 0.2, accuracy: 0.0001)
+        XCTAssertEqual(cmd.lmTopK, 32)
+        XCTAssertEqual(cmd.lmTopP, 0.75, accuracy: 0.0001)
+        XCTAssertTrue(cmd.includeRawLM)
+        XCTAssertTrue(cmd.includeAudioCodes)
+        XCTAssertTrue(cmd.quiet)
+    }
+
+    func testMusicAnalyzeOutputRoundTrips() throws {
+        let output = MusicAnalyzeOutput(
+            audio: "/tmp/song.mp3",
+            model: ModelResolver.ModelID.aceStep.rawValue,
+            checkpointsRoot: "/tmp/acestep",
+            turboSubdirectory: "acestep-v15-turbo",
+            lmSubdirectory: "acestep-5Hz-lm-1.7B",
+            inputDurationSeconds: 180,
+            analyzedDurationSeconds: 30,
+            metadata: ACEStepMusicUnderstandingMetadata(
+                caption: "bright source song",
+                lyrics: "[Verse]\nhello",
+                bpm: 125,
+                durationSeconds: 30,
+                keyscale: "D major",
+                language: "en",
+                timesignature: "4"
+            ),
+            rawLMOutput: nil,
+            audioCodes: nil
+        )
+
+        let data = try JSONEncoder().encode(output)
+        let decoded = try JSONDecoder().decode(MusicAnalyzeOutput.self, from: data)
+
+        XCTAssertEqual(decoded, output)
+    }
+
+    func testMusicCommandExposesAnalyze() {
+        let commandNames = Set(Music.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertEqual(commandNames, Set(["analyze", "generate", "realtime"]))
+    }
+}

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -92,12 +92,14 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "dream-pop cover",
             "--source-audio", "~/Downloads/song.mp3",
             "--reference-audio", "/tmp/ref-a.wav", "/tmp/ref-b.wav",
+            "--analyze-source-audio",
             "--audio-cover-strength", "0.75",
             "--cover-noise-strength", "0.45",
         ])
 
         XCTAssertEqual(cmd.sourceAudio, "~/Downloads/song.mp3")
         XCTAssertEqual(cmd.referenceAudio, ["/tmp/ref-a.wav", "/tmp/ref-b.wav"])
+        XCTAssertTrue(cmd.analyzeSourceAudio)
         XCTAssertEqual(cmd.audioCoverStrength, 0.75, accuracy: 0.0001)
         XCTAssertEqual(cmd.coverNoiseStrength, 0.45, accuracy: 0.0001)
         XCTAssertTrue(cmd.resolvedACEStepIsCover)
@@ -140,6 +142,38 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
 
         XCTAssertEqual(duration, 2.0, accuracy: 0.0001)
         XCTAssertEqual(cmd.resolvedMetadataDuration(effectiveDurationSeconds: duration), "2 seconds")
+    }
+
+    func testMusicGenerateSourceAnalysisFillsOnlyMissingMetadata() throws {
+        let cmd = try MusicGenerate.parse([
+            "reggaeton cover",
+            "--source-audio", "~/Downloads/song.mp3",
+        ])
+        let metadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
+            bpm: nil,
+            caption: "reggaeton cover",
+            duration: "180 seconds",
+            keyscale: "A minor",
+            language: nil,
+            timesignature: nil
+        )
+        let analysis = ACEStepMusicUnderstandingMetadata(
+            bpm: 95,
+            durationSeconds: 180,
+            keyscale: "G major",
+            language: "en",
+            timesignature: "4"
+        )
+
+        let merged = cmd.mergedMetadataWithSourceAnalysis(metadata, analysis)
+
+        XCTAssertEqual(merged.metadata.bpm, "95")
+        XCTAssertEqual(merged.metadata.caption, "reggaeton cover")
+        XCTAssertEqual(merged.metadata.duration, "180 seconds")
+        XCTAssertEqual(merged.metadata.keyscale, "A minor")
+        XCTAssertEqual(merged.metadata.language, "en")
+        XCTAssertEqual(merged.metadata.timesignature, "4")
+        XCTAssertEqual(merged.filledFields, ["bpm", "language", "timesignature"])
     }
 
     func testMusicGenerateParsesMagentaControls() throws {

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MLX
 @testable import MereRunCLI
 @testable import MereRunCore
 
@@ -15,7 +16,9 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.vaeSubdirectory, "vae")
         XCTAssertFalse(cmd.useLM)
         XCTAssertEqual(cmd.durationSeconds, 10.0, accuracy: 0.0001)
-        XCTAssertEqual(cmd.shift, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.shift, 3.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.coverNoiseStrength, 0.0, accuracy: 0.0001)
+        XCTAssertFalse(cmd.resolvedACEStepIsCover)
     }
 
     func testMusicGenerateParsesModelAndAdvancedOverrides() throws {
@@ -41,6 +44,102 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.useLM)
         XCTAssertEqual(cmd.durationSeconds, 18.0, accuracy: 0.0001)
         XCTAssertEqual(cmd.steps, 12)
+    }
+
+    func testMusicGenerateCheckpointCandidatesHonorRequestedManagedModel() throws {
+        let cmd = try MusicGenerate.parse([
+            "xl track",
+            "--model", ModelResolver.ModelID.aceStepXLTurbo.rawValue,
+        ])
+
+        let candidates = cmd.buildAcestepCheckpointCandidates().map(\.standardizedFileURL.path)
+        let requestedRoot = MereRunModelPaths.modelsDir
+            .appendingPathComponent(ModelResolver.ModelID.aceStepXLTurbo.rawValue, isDirectory: true)
+            .standardizedFileURL
+            .path
+        let defaultRoot = MereRunModelPaths.modelsDir
+            .appendingPathComponent(ModelResolver.ModelID.aceStep.rawValue, isDirectory: true)
+            .standardizedFileURL
+            .path
+
+        XCTAssertTrue(candidates.contains(requestedRoot))
+        XCTAssertFalse(candidates.contains(defaultRoot))
+    }
+
+    func testMusicGenerateResolvesCoverOnlyForCoverTask() throws {
+        let cover = try MusicGenerate.parse([
+            "cover this",
+            "--task-type", "cover",
+        ])
+        XCTAssertTrue(cover.resolvedACEStepIsCover)
+
+        let forcedNonCover = try MusicGenerate.parse([
+            "cover this",
+            "--task-type", "cover",
+            "--non-cover",
+        ])
+        XCTAssertFalse(forcedNonCover.resolvedACEStepIsCover)
+
+        let textToMusic = try MusicGenerate.parse([
+            "new song",
+            "--task-type", "text2music",
+        ])
+        XCTAssertFalse(textToMusic.resolvedACEStepIsCover)
+    }
+
+    func testMusicGenerateSourceAudioImpliesCoverMode() throws {
+        let cmd = try MusicGenerate.parse([
+            "dream-pop cover",
+            "--source-audio", "~/Downloads/song.mp3",
+            "--reference-audio", "/tmp/ref-a.wav", "/tmp/ref-b.wav",
+            "--audio-cover-strength", "0.75",
+            "--cover-noise-strength", "0.45",
+        ])
+
+        XCTAssertEqual(cmd.sourceAudio, "~/Downloads/song.mp3")
+        XCTAssertEqual(cmd.referenceAudio, ["/tmp/ref-a.wav", "/tmp/ref-b.wav"])
+        XCTAssertEqual(cmd.audioCoverStrength, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(cmd.coverNoiseStrength, 0.45, accuracy: 0.0001)
+        XCTAssertTrue(cmd.resolvedACEStepIsCover)
+        XCTAssertEqual(cmd.resolvedACEStepTaskType(isCover: cmd.resolvedACEStepIsCover), "cover")
+    }
+
+    func testMusicGenerateSkipsLMForCoverParity() throws {
+        let cover = try MusicGenerate.parse([
+            "faithful cover",
+            "--source-audio", "~/Downloads/song.mp3",
+            "--use-lm",
+            "--lm-subdirectory", "acestep-5Hz-lm-4B",
+        ])
+        let taskType = cover.resolvedACEStepTaskType(isCover: cover.resolvedACEStepIsCover)
+
+        XCTAssertEqual(taskType, "cover")
+        XCTAssertFalse(cover.resolvedACEStepUsesLM(taskType: taskType))
+
+        let textToMusic = try MusicGenerate.parse([
+            "fresh song",
+            "--use-lm",
+            "--lm-subdirectory", "acestep-5Hz-lm-4B",
+        ])
+
+        XCTAssertTrue(textToMusic.resolvedACEStepUsesLM(taskType: "text2music"))
+    }
+
+    func testMusicGenerateCoverDurationUsesSourceAudioLength() throws {
+        let cmd = try MusicGenerate.parse([
+            "dream-pop cover",
+            "--source-audio", "~/Downloads/song.mp3",
+            "--duration", "30",
+        ])
+        let sourceAudio = MLXArray(Array(repeating: Float(0), count: 48_000 * 2 * 2), [1, 48_000 * 2, 2])
+
+        let duration = cmd.resolvedACEStepDurationSeconds(
+            isCover: cmd.resolvedACEStepIsCover,
+            sourceAudio48kHz: sourceAudio
+        )
+
+        XCTAssertEqual(duration, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.resolvedMetadataDuration(effectiveDurationSeconds: duration), "2 seconds")
     }
 
     func testMusicGenerateParsesMagentaControls() throws {

--- a/Tests/MereRunCoreTests/ACEStepCoverNoiseScheduleTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepCoverNoiseScheduleTests.swift
@@ -1,0 +1,37 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepCoverNoiseScheduleTests: MereRunCoreTestCase {
+    func testDisabledCoverNoiseKeepsPureNoiseSchedule() {
+        let noise = MLXArray([Float(10), 20, 30, 40], [1, 2, 2]).asType(.float32)
+        let source = MLXArray([Float(2), 4, 6, 8], [1, 2, 2]).asType(.float32)
+        let timesteps: [Float] = [1.0, 0.75, 0.5, 0.25]
+
+        let prepared = ACEStepPipeline.prepareCoverNoiseSchedule(
+            noise: noise,
+            sourceLatents: source,
+            timesteps: timesteps,
+            coverNoiseStrength: 0.0
+        )
+
+        XCTAssertEqual(prepared.timesteps, timesteps)
+        XCTAssertEqual(prepared.latents.asArray(Float.self), [10, 20, 30, 40])
+    }
+
+    func testCoverNoiseStartsFromNearestRenoisedSourceLatents() {
+        let noise = MLXArray([Float(10), 20, 30, 40], [1, 2, 2]).asType(.float32)
+        let source = MLXArray([Float(2), 4, 6, 8], [1, 2, 2]).asType(.float32)
+        let timesteps: [Float] = [1.0, 0.75, 0.5, 0.25]
+
+        let prepared = ACEStepPipeline.prepareCoverNoiseSchedule(
+            noise: noise,
+            sourceLatents: source,
+            timesteps: timesteps,
+            coverNoiseStrength: 0.5
+        )
+
+        XCTAssertEqual(prepared.timesteps, [0.5, 0.25])
+        XCTAssertEqual(prepared.latents.asArray(Float.self), [6, 12, 18, 24])
+    }
+}

--- a/Tests/MereRunCoreTests/ACEStepDCWTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepDCWTests.swift
@@ -1,0 +1,54 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepDCWTests: MereRunCoreTestCase {
+
+    func testHaarRoundTripsOddLengthLatents() {
+        let latents = MLXArray([Float(1), 3, 5], [1, 3, 1]).asType(.float32)
+
+        let (low, high) = ACEStepDCW.haarDWT1D(latents)
+        let reconstructed = ACEStepDCW.haarIDWT1D(low: low, high: high, targetFrames: 3).asType(.float32)
+
+        XCTAssertEqual(reconstructed.shape, latents.shape)
+        let maxDiff = MLX.max(MLX.abs(reconstructed - latents)).item(Float.self)
+        XCTAssertEqual(maxDiff, 0, accuracy: 1e-5)
+    }
+
+    func testDoubleModeMatchesNativeHaarSchedule() {
+        let xNext = MLXArray([Float(1), 3, 5], [1, 3, 1]).asType(.float32)
+        let denoised = MLXArray.zeros([1, 3, 1], dtype: .float32)
+
+        let corrected = ACEStepDCW.applyHaar(
+            xNext: xNext,
+            denoised: denoised,
+            tCurr: 0.5,
+            enabled: true,
+            mode: .double,
+            scaler: 0.1,
+            highScaler: 0.2
+        ).asType(.float32)
+
+        XCTAssertEqual(corrected[0, 0, 0].item(Float.self), 1.0, accuracy: 1e-4)
+        XCTAssertEqual(corrected[0, 1, 0].item(Float.self), 3.2, accuracy: 1e-4)
+        XCTAssertEqual(corrected[0, 2, 0].item(Float.self), 5.375, accuracy: 1e-4)
+    }
+
+    func testDisabledDCWIsIdentity() {
+        let xNext = MLXArray([Float(1), 3, 5], [1, 3, 1]).asType(.float32)
+        let denoised = MLXArray.zeros([1, 3, 1], dtype: .float32)
+
+        let corrected = ACEStepDCW.applyHaar(
+            xNext: xNext,
+            denoised: denoised,
+            tCurr: 0.5,
+            enabled: false,
+            mode: .double,
+            scaler: 0.1,
+            highScaler: 0.2
+        ).asType(.float32)
+
+        let maxDiff = MLX.max(MLX.abs(corrected - xNext)).item(Float.self)
+        XCTAssertEqual(maxDiff, 0, accuracy: 1e-5)
+    }
+}

--- a/Tests/MereRunCoreTests/ACEStepDiTShapeTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepDiTShapeTests.swift
@@ -12,6 +12,10 @@ final class ACEStepDiTShapeTests: MereRunCoreTestCase {
             numHiddenLayers: 2,
             numAttentionHeads: 8,
             numKeyValueHeads: 4,
+            encoderHiddenSize: 48,
+            encoderIntermediateSize: 192,
+            encoderNumAttentionHeads: 6,
+            encoderNumKeyValueHeads: 3,
             headDim: 8,
             maxPositionEmbeddings: 1024,
             useSlidingWindow: true,
@@ -31,7 +35,7 @@ final class ACEStepDiTShapeTests: MereRunCoreTestCase {
 
         let hidden = MLXRandom.normal([B, T, audioDim]).asType(.float32)
         let context = MLXRandom.normal([B, T, contextDim]).asType(.float32)
-        let encoder = MLXRandom.normal([B, 7, config.hiddenSize]).asType(.float32)
+        let encoder = MLXRandom.normal([B, 7, config.encoderHiddenSize]).asType(.float32)
 
         let t = MLXArray(Array(repeating: Float(0.5), count: B))
         let out = model(
@@ -46,5 +50,29 @@ final class ACEStepDiTShapeTests: MereRunCoreTestCase {
         XCTAssertEqual(out.dim(0), B)
         XCTAssertEqual(out.dim(1), T)
         XCTAssertEqual(out.dim(2), audioDim)
+    }
+
+    func testDecodesSeparateXLConditionEncoderDimensions() throws {
+        let json = """
+        {
+          "hidden_size": 2560,
+          "intermediate_size": 9728,
+          "num_attention_heads": 32,
+          "num_key_value_heads": 8,
+          "encoder_hidden_size": 2048,
+          "encoder_intermediate_size": 6144,
+          "encoder_num_attention_heads": 16,
+          "encoder_num_key_value_heads": 8,
+          "head_dim": 128
+        }
+        """
+
+        let config = try JSONDecoder().decode(ACEStepConfig.self, from: Data(json.utf8))
+
+        XCTAssertEqual(config.hiddenSize, 2560)
+        XCTAssertEqual(config.encoderHiddenSize, 2048)
+        XCTAssertEqual(config.conditionEncoderConfig.hiddenSize, 2048)
+        XCTAssertEqual(config.conditionEncoderConfig.numAttentionHeads, 16)
+        XCTAssertEqual(config.conditionEncoderConfig.intermediateSize, 6144)
     }
 }

--- a/Tests/MereRunCoreTests/ACEStepMusicUnderstandingTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepMusicUnderstandingTests.swift
@@ -1,0 +1,63 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepMusicUnderstandingTests: MereRunCoreTestCase {
+    func testAudioCodeStringSerializesClampedIndices() {
+        let indices = MLXArray([Int32(1), Int32(64_500), Int32(-4)], [1, 3, 1])
+
+        XCTAssertEqual(
+            ACEStepPipeline.audioCodeString(fromIndices: indices),
+            "<|audio_code_1|><|audio_code_63999|><|audio_code_0|>"
+        )
+    }
+
+    func testParseUnderstandingOutputExtractsReasoningMetadataAndLyrics() {
+        let output = """
+        <think>
+        bpm: 95
+        caption: Latin pop groove.
+          Bright percussion and club bass.
+        duration: 273
+        genres: reggaeton
+        keyscale: G major
+        language: en
+        timesignature: 4
+        </think>
+        [Verse]
+        We move around the room
+        """
+
+        let metadata = ACEStepPipeline.parseUnderstandingOutput(output)
+
+        XCTAssertEqual(metadata.bpm, 95)
+        XCTAssertEqual(metadata.caption, "Latin pop groove.\nBright percussion and club bass.")
+        XCTAssertEqual(metadata.durationSeconds, 273)
+        XCTAssertEqual(metadata.keyscale, "G major")
+        XCTAssertEqual(metadata.language, "en")
+        XCTAssertEqual(metadata.timesignature, "4")
+        XCTAssertEqual(metadata.lyrics, "[Verse]\nWe move around the room")
+    }
+
+    func testParseUnderstandingOutputTreatsNAAsMissing() {
+        let output = """
+        <think>
+        bpm: N/A
+        caption: N/A
+        duration: N/A
+        keyscale: N/A
+        language: unknown
+        timesignature: N/A
+        </think>
+        """
+
+        let metadata = ACEStepPipeline.parseUnderstandingOutput(output)
+
+        XCTAssertNil(metadata.bpm)
+        XCTAssertNil(metadata.caption)
+        XCTAssertNil(metadata.durationSeconds)
+        XCTAssertNil(metadata.keyscale)
+        XCTAssertNil(metadata.language)
+        XCTAssertNil(metadata.timesignature)
+    }
+}

--- a/Tests/MereRunCoreTests/ACEStepPipelineIntegrationTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepPipelineIntegrationTests.swift
@@ -257,6 +257,24 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
         let nonCoverSlice = nonCoverHiddenStates[0..., 0..<compareLength, 0...].asType(.float32)
         let maxDiff = MLX.max(MLX.abs(coverSlice - nonCoverSlice)).item(Float.self)
         XCTAssertGreaterThan(maxDiff, 1e-4)
+
+        let nonCoverPrepared = try XCTUnwrap(pipeline.prepareNonCoverConditionIfNeeded(conditionInputs: partialCoverInputs))
+        let contextLatents = nonCoverPrepared.contextLatents.asType(.float32)
+        XCTAssertEqual(contextLatents.dim(1), latentFrames)
+        XCTAssertEqual(contextLatents.dim(2), config.inChannels - config.audioAcousticHiddenDim)
+
+        let expectedSilence = pipeline.defaultSourceLatents(targetFrames: latentFrames)
+            .asType(partialCoverInputs.srcLatents.dtype)
+            .asType(.float32)
+        let nonCoverSource = contextLatents[0..., 0..<latentFrames, 0..<config.audioAcousticHiddenDim]
+        let silenceDiff = MLX.max(MLX.abs(nonCoverSource - expectedSilence)).item(Float.self)
+        XCTAssertEqual(silenceDiff, 0, accuracy: 1e-4)
+        XCTAssertGreaterThan(MLX.sum(MLX.abs(nonCoverSource)).item(Float.self), 0)
+
+        let chunkStart = config.audioAcousticHiddenDim
+        let nonCoverChunks = contextLatents[0..., 0..<latentFrames, chunkStart..<contextLatents.dim(2)]
+        let chunkDiff = MLX.max(MLX.abs(nonCoverChunks - MLXArray(Float(1.0)))).item(Float.self)
+        XCTAssertEqual(chunkDiff, 0, accuracy: 1e-4)
     }
 
     func testPreparePromptConditionInputsUsesReferenceTimbreLatentsWhenProvided() throws {
@@ -401,6 +419,57 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             audioCoverStrength: 0.5,
             vocalLanguage: "en",
             instruction: "Strong cover conditioning instruction",
+            isCover: true
+        )
+
+        XCTAssertEqual(audio.dim(0), 1)
+        XCTAssertEqual(audio.dim(1), expectedSamples)
+        XCTAssertEqual(audio.dim(2), vaeConfig.audioChannels)
+
+        let maxAbs = MLX.max(MLX.abs(audio.asType(.float32))).item(Float.self)
+        XCTAssertFalse(maxAbs.isNaN)
+        XCTAssertFalse(maxAbs.isInfinite)
+        XCTAssertGreaterThan(maxAbs, 0)
+    }
+
+    func testPromptTurboEndToEndWithSourceAudioCover() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let turboRoot = env["MERERUN_TEST_ACESTEP_TURBO_ROOT"], !turboRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_TURBO_ROOT=/path/to/ACE-Step-1.5/checkpoints/acestep-v15-turbo to run this test.")
+        }
+        guard let vaeRoot = env["MERERUN_TEST_ACESTEP_VAE_ROOT"], !vaeRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_VAE_ROOT=/path/to/ACE-Step-1.5/checkpoints/vae to run this test.")
+        }
+
+        let decoderResources = ACEStepResources(rootURL: URL(fileURLWithPath: turboRoot))
+        let vaeResources = OobleckVAEResources(rootURL: URL(fileURLWithPath: vaeRoot))
+        let vaeConfig = try OobleckVAECheckpointLoader.loadConfig(resources: vaeResources)
+        let factor = vaeConfig.downsamplingRatios.reduce(1, *)
+
+        let pipeline = try ACEStepPipeline(decoderResources: decoderResources, vaeResources: vaeResources)
+
+        let durationSeconds: Float = 0.2
+        let sourceSamples = max(1, Int(durationSeconds * 48_000))
+        let left = (0..<sourceSamples).map { index in
+            Float(sin((Double(index) / 48_000.0) * 2.0 * Double.pi * 220.0) * 0.1)
+        }
+        var interleaved: [Float] = []
+        interleaved.reserveCapacity(sourceSamples * 2)
+        for sample in left {
+            interleaved.append(sample)
+            interleaved.append(sample)
+        }
+        let sourceAudio = MLXArray(interleaved, [1, sourceSamples, 2]).asType(.float32)
+
+        let expectedLatentFrames = Int((Double(durationSeconds) * 25.0).rounded())
+        let expectedSamples = expectedLatentFrames * factor
+
+        let audio = try pipeline.generatePromptToAudio(
+            caption: "soft synth-pop cover with gentle drums",
+            lyrics: "[verse]\ncover smoke test",
+            config: .init(durationSeconds: durationSeconds, seed: 91),
+            sourceAudio48kHz: sourceAudio,
+            audioCoverStrength: 0.8,
             isCover: true
         )
 

--- a/Tests/MereRunCoreTests/ACEStepSilenceLatentLoaderTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepSilenceLatentLoaderTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepSilenceLatentLoaderTests: XCTestCase {
+    func testLoadsPyTorchZipSilenceLatentAsFrameMajorMLXArray() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acestep-silence-latent-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        var tensorData = Data()
+        for value in [Float](arrayLiteral: 1, 2, 3, 4, 5, 6) {
+            appendFloat32(value, to: &tensorData)
+        }
+
+        let archive = makeStoredZip(entries: [
+            ("silence_latent/byteorder", Data("little".utf8)),
+            ("silence_latent/data/0", tensorData)
+        ])
+        try archive.write(to: root.appendingPathComponent("silence_latent.pt"))
+
+        let loaded = try XCTUnwrap(
+            try ACEStepCheckpointLoader.loadSilenceLatentIfPresent(
+                resources: ACEStepResources(rootURL: root),
+                latentDim: 2,
+                dtype: .float32
+            )
+        )
+        MLX.eval(loaded)
+
+        XCTAssertEqual(loaded.shape, [1, 3, 2])
+        XCTAssertEqual(loaded.asArray(Float.self), [1, 4, 2, 5, 3, 6])
+    }
+}
+
+private func makeStoredZip(entries: [(name: String, data: Data)]) -> Data {
+    struct CentralDirectoryEntry {
+        var name: String
+        var size: UInt32
+        var localHeaderOffset: UInt32
+    }
+
+    var archive = Data()
+    var centralDirectoryEntries: [CentralDirectoryEntry] = []
+
+    for entry in entries {
+        let nameData = Data(entry.name.utf8)
+        let size = UInt32(entry.data.count)
+        let localHeaderOffset = UInt32(archive.count)
+
+        append(UInt32(0x0403_4b50), to: &archive)
+        append(UInt16(20), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt32(0), to: &archive)
+        append(size, to: &archive)
+        append(size, to: &archive)
+        append(UInt16(nameData.count), to: &archive)
+        append(UInt16(0), to: &archive)
+        archive.append(nameData)
+        archive.append(entry.data)
+
+        centralDirectoryEntries.append(
+            CentralDirectoryEntry(
+                name: entry.name,
+                size: size,
+                localHeaderOffset: localHeaderOffset
+            )
+        )
+    }
+
+    let centralDirectoryOffset = UInt32(archive.count)
+    for entry in centralDirectoryEntries {
+        let nameData = Data(entry.name.utf8)
+
+        append(UInt32(0x0201_4b50), to: &archive)
+        append(UInt16(20), to: &archive)
+        append(UInt16(20), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt32(0), to: &archive)
+        append(entry.size, to: &archive)
+        append(entry.size, to: &archive)
+        append(UInt16(nameData.count), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt16(0), to: &archive)
+        append(UInt32(0), to: &archive)
+        append(entry.localHeaderOffset, to: &archive)
+        archive.append(nameData)
+    }
+
+    let centralDirectorySize = UInt32(archive.count) - centralDirectoryOffset
+    append(UInt32(0x0605_4b50), to: &archive)
+    append(UInt16(0), to: &archive)
+    append(UInt16(0), to: &archive)
+    append(UInt16(centralDirectoryEntries.count), to: &archive)
+    append(UInt16(centralDirectoryEntries.count), to: &archive)
+    append(centralDirectorySize, to: &archive)
+    append(centralDirectoryOffset, to: &archive)
+    append(UInt16(0), to: &archive)
+
+    return archive
+}
+
+private func appendFloat32(_ value: Float, to data: inout Data) {
+    append(value.bitPattern, to: &data)
+}
+
+private func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+    var littleEndian = value.littleEndian
+    withUnsafeBytes(of: &littleEndian) { bytes in
+        data.append(bytes.bindMemory(to: UInt8.self))
+    }
+}

--- a/Tests/MereRunCoreTests/Ideogram4RuntimeTests.swift
+++ b/Tests/MereRunCoreTests/Ideogram4RuntimeTests.swift
@@ -3,6 +3,17 @@ import XCTest
 @testable import MereRunCore
 
 final class Ideogram4RuntimeTests: XCTestCase {
+    func testQwenEncoderWeightMapperStripsUpstreamModelPrefix() {
+        let value = MLXArray([Float(1)], [1])
+
+        let mapped = QwenEncoder.mapHFSafetensorWeight(
+            key: "model.embed_tokens.weight",
+            value: value
+        )
+
+        XCTAssertEqual(mapped.map(\.0), ["embed_tokens.weight"])
+    }
+
     func testTransformerConfigurationDecodesDiffusersConfig() throws {
         let json = """
         {

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -363,6 +363,40 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(spec.isManagedRootComplete(legacyRoot, fileManager: .default))
     }
 
+    func testACEStepXLTurboUsesMountedXLLayout() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.aceStepXLTurbo.rawValue))
+        XCTAssertEqual(spec.hubFallback?.repoId, "ACE-Step/Ace-Step1.5")
+        XCTAssertEqual(spec.mountedHubFallbacks.map(\.destinationPath), ["acestep-v15-xl-turbo"])
+        XCTAssertEqual(spec.mountedHubFallbacks.first?.hubFallback.repoId, "ACE-Step/acestep-v15-xl-turbo")
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalACEStepRoot(at: root, turboSubdirectory: "acestep-v15-xl-turbo")
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+
+        let standardRoot = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: standardRoot) }
+        try writeMinimalACEStepRoot(at: standardRoot, turboSubdirectory: "acestep-v15-turbo")
+        XCTAssertFalse(spec.isManagedRootComplete(standardRoot, fileManager: .default))
+    }
+
+    func testACEStepXLTurboLM4BRequiresMountedLM() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue))
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.map(\.destinationPath),
+            ["acestep-v15-xl-turbo", "acestep-5Hz-lm-4B"]
+        )
+        XCTAssertEqual(spec.mountedHubFallbacks.last?.hubFallback.repoId, "ACE-Step/acestep-5Hz-lm-4B")
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalACEStepRoot(at: root, turboSubdirectory: "acestep-v15-xl-turbo")
+        XCTAssertFalse(spec.isManagedRootComplete(root, fileManager: .default))
+
+        try writeMinimalACEStepLMRoot(at: root.appendingPathComponent("acestep-5Hz-lm-4B", isDirectory: true))
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+    }
+
     func testMagentaRT2SpecsUsePinnedExportedRuntimeAssets() throws {
         let small = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.magentaRT2Small.rawValue))
         XCTAssertEqual(small.category, .music)
@@ -410,6 +444,19 @@ final class ManagedModelCatalogTests: XCTestCase {
                 at: root.appendingPathComponent(subdirectory, isDirectory: true),
                 withIntermediateDirectories: true
             )
+        }
+    }
+
+    private func writeMinimalACEStepLMRoot(at root: URL) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for file in [
+            "config.json",
+            "tokenizer_config.json",
+            "added_tokens.json",
+            "tokenizer.json",
+            "model.safetensors.index.json",
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: root.appendingPathComponent(file).path, contents: Data()))
         }
     }
 

--- a/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
@@ -61,6 +61,49 @@ final class ManagedModelResolverTests: XCTestCase {
         XCTAssertFalse(ManagedModelResolver.isManagedInstallComplete(spec: maxSpec, at: root))
     }
 
+    func testMaterializedInstallRootMountsAdditionalHubSnapshots() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let baseSnapshot = root.appendingPathComponent("hub/base", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: baseSnapshot.appendingPathComponent("vae", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: baseSnapshot.appendingPathComponent("Qwen3-Embedding-0.6B", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let mountedSnapshot = root.appendingPathComponent("hub/xl", isDirectory: true)
+        try FileManager.default.createDirectory(at: mountedSnapshot, withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: mountedSnapshot.appendingPathComponent("config.json").path,
+            contents: Data("{}".utf8)
+        ))
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.aceStepXLTurbo.rawValue))
+        let install = root.appendingPathComponent("models/music-acestep-xl-turbo", isDirectory: true)
+        let mounted = try XCTUnwrap(spec.mountedHubFallbacks.first)
+
+        let manifest = try ManagedModelResolver.materializeManagedInstallRoot(
+            for: spec,
+            snapshotURL: baseSnapshot,
+            mountedSnapshots: [(mounted, mountedSnapshot)],
+            modelDir: install,
+            fileManager: .default
+        )
+
+        XCTAssertEqual(manifest?.id, ModelResolver.ModelID.aceStepXLTurbo.rawValue)
+        let mountedConfig = install.appendingPathComponent("acestep-v15-xl-turbo/config.json")
+        XCTAssertEqual(
+            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: mountedConfig.path))
+                .standardizedFileURL.path,
+            mountedSnapshot.appendingPathComponent("config.json").standardizedFileURL.path
+        )
+        XCTAssertTrue(spec.isManagedRootComplete(install, fileManager: .default))
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-managed-model-resolver-\(UUID().uuidString)", isDirectory: true)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -593,6 +593,7 @@ Key options:
 - `--lyrics`
 - `--lyrics-file`
 - `--source-audio`: source song for ACE-Step cover conditioning; implies cover mode unless `--non-cover` is set
+- `--analyze-source-audio`: use ACE-Step 5 Hz LM audio understanding to fill missing cover metadata from `--source-audio`
 - `--reference-audio`: optional ACE-Step timbre reference audio file(s)
 - `--duration`
 - `--steps`
@@ -633,6 +634,7 @@ swift run mere.run music generate \
 swift run mere.run music generate \
   "dream-pop cover with soft vocals" \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --lyrics-file ./cover-lyrics.txt \
   --audio-cover-strength 0.85 \
   --output ./cover.wav

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,7 @@ Public tree:
 - `mere.run vision track`
 - `mere.run vision track-live`
 - `mere.run vision ocr`
+- `mere.run music analyze`
 - `mere.run music generate`
 - `mere.run music realtime`
 - `mere.run video generate`
@@ -146,6 +147,10 @@ swift run mere.run music generate \
   "upbeat electronic groove" \
   --model music-acestep-xl-turbo \
   --output ./xl-track.wav
+
+swift run mere.run music analyze ./song.mp3 \
+  --model music-acestep-xl-turbo-lm4b \
+  --lm-subdirectory acestep-5Hz-lm-4B
 
 swift run mere.run model pull music-magenta-rt2-small
 swift run mere.run music realtime \
@@ -574,6 +579,40 @@ Examples:
 swift run mere.run model pull vision-ocr-lighton
 swift run mere.run vision ocr ./page.png --backend lighton --model ~/Library/Application\ Support/MereRun/models/vision-ocr-lighton
 swift run mere.run vision ocr ./page.png --backend glm
+```
+
+### `mere.run music analyze`
+
+Analyze an audio file with ACE-Step 5 Hz LM audio understanding and print JSON
+metadata to stdout.
+
+```bash
+swift run mere.run music analyze "<audio>" [options]
+```
+
+Key options:
+
+- `--model`, `-m`
+- `--checkpoints-root`
+- `--turbo-subdirectory`
+- `--vae-subdirectory`
+- `--lm-subdirectory`
+- `--duration`: analyze the first N seconds instead of the full decoded input
+- `--max-new-tokens`
+- `--lm-temperature`
+- `--lm-top-k`
+- `--lm-top-p`
+- `--include-raw-lm`
+- `--include-audio-codes`
+- `--quiet`
+
+Examples:
+
+```bash
+swift run mere.run music analyze ./song.mp3 \
+  --model music-acestep-xl-turbo-lm4b \
+  --lm-subdirectory acestep-5Hz-lm-4B
+swift run mere.run music analyze ./song.mp3 --duration 30 > ./song-analysis.json
 ```
 
 ### `mere.run music generate`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,7 +74,7 @@ are:
 - Vision OCR: `vision-ocr-lighton`
 - Vision segmentation / tracking: `vision-segment-sam31`
 - Vision grounding: `vision-ground-falcon-perception`
-- Music: `music-acestep`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
+- Music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - Video: `video-ltx-av`
 
 For subsystem-specific implementation guides, see:
@@ -140,6 +140,12 @@ swift run mere.run model pull music-acestep
 swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
+
+swift run mere.run model pull music-acestep-xl-turbo
+swift run mere.run music generate \
+  "upbeat electronic groove" \
+  --model music-acestep-xl-turbo \
+  --output ./xl-track.wav
 
 swift run mere.run model pull music-magenta-rt2-small
 swift run mere.run music realtime \
@@ -586,10 +592,12 @@ Key options:
 - `--checkpoints-root`
 - `--lyrics`
 - `--lyrics-file`
+- `--source-audio`: source song for ACE-Step cover conditioning; implies cover mode unless `--non-cover` is set
+- `--reference-audio`: optional ACE-Step timbre reference audio file(s)
 - `--duration`
 - `--steps`
 - `--use-lm`
-- `--lm-subdirectory`
+- `--lm-subdirectory` (for example `acestep-5Hz-lm-4B` with `music-acestep-xl-turbo-lm4b`)
 - `--text-subdirectory`
 - `--seed`
 - `--quiet`
@@ -622,6 +630,12 @@ swift run mere.run music generate \
   --duration 8 \
   --steps 4 \
   --output ./ambient.wav
+swift run mere.run music generate \
+  "dream-pop cover with soft vocals" \
+  --source-audio ./song.mp3 \
+  --lyrics-file ./cover-lyrics.txt \
+  --audio-cover-strength 0.85 \
+  --output ./cover.wav
 swift run mere.run music generate \
   "ambient modular synths with brushed drums" \
   --model music-magenta-rt2-small \
@@ -808,7 +822,13 @@ swift run mere.run model runtime set text-chat-gemma4 \
 Use the matching `--clear-*` flags to remove optional values. Engine overrides
 are validated against the curated catalog. Gemma4 accepts `--kv-cache-mode`
 values of `default`, `polar2`, and `auto`; non-Gemma4 models reject PolarKV
-runtime modes.
+runtime modes. `--ttl-seconds` unloads idle loaded models during the runtime
+pool's opportunistic eviction passes, while `--pinned` protects a model from
+automatic TTL/LRU eviction without blocking explicit unload. Memory-pressure LRU
+uses the API server's `--memory-guard` tier. The guard derives soft/hard
+ceilings from process resident memory, host memory headroom, and a tier reserve;
+elevated pressure evicts the least-recently-used idle unpinned model, while
+critical pressure evicts every idle unpinned model.
 
 ### `mere.run model pull`
 
@@ -1007,6 +1027,11 @@ Security defaults:
 - `--max-active-requests` controls fair FIFO chat admission; the default `1`
   preserves serialized local inference while exposing queue depth in status;
   queued client cancellations are removed from the FIFO instead of running later
+- `--memory-guard` controls runtime memory pressure behavior. Accepted values
+  are `off`, `safe`, `balanced`, `aggressive`, and `custom`; `custom` also
+  requires `--memory-guard-custom-ceiling-gb`.
+- elevated or critical memory pressure pauses extra concurrent admissions while
+  letting one request run so the server can make progress
 - Gemma4 and Qwen-family chat use chunked prefill checkpoints for long prompts.
 - Gemma4 can opt into an in-memory prefix KV reuse prototype with
   `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; runtime status reports entries, hits, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,9 @@ Sets the default root used by `mere.run video generate` and `mere.run video expo
 
 ### `MERERUN_MUSIC_ACESTEP_ROOT`
 
-Sets the default checkpoint root used by `mere.run music generate` when the command is not resolving from the shared model store.
+Sets the default checkpoint root used by `mere.run music generate` and
+`mere.run music analyze` when the command is not resolving from the shared model
+store.
 
 ## API server security
 

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -6,6 +6,7 @@ Markdown by default and can emit JSON for agents or tools.
 ```bash
 mere.run guide --list
 mere.run guide image generate
+mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
 mere.run guide music generate --model music-acestep
 mere.run guide music generate --model music-magenta-rt2-small
 mere.run guide video generate --json
@@ -36,6 +37,7 @@ Creative and runtime workflows:
 - `vision track`
 - `vision track-live`
 - `vision ocr`
+- `music analyze`
 - `music generate`
 - `video generate`
 - `video export-latents`

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -31,7 +31,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Speech TTS | `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice` |
 | Speech ASR | `speech-asr-qwen3`, `speech-asr-parakeet` |
 | Vision | `vision-ocr-lighton`, `vision-segment-sam31`, `vision-ground-falcon-perception` |
-| Music | `music-acestep`, `music-magenta-rt2-small`, `music-magenta-rt2-base` |
+| Music | `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base` |
 | Video | `video-ltx-av` |
 
 Some legacy/local IDs remain in the catalog so existing installs and explicit
@@ -247,26 +247,37 @@ swift run mere.run model info image-klein-max
 
 Two retained surfaces have more structure than a flat model root.
 
-### `music-acestep`
+### `music-acestep`, `music-acestep-xl-turbo`, and `music-acestep-xl-turbo-lm4b`
 
-The top-level model root is:
+The top-level model roots are:
 
 ```text
 .../models/music-acestep
+.../models/music-acestep-xl-turbo
+.../models/music-acestep-xl-turbo-lm4b
 ```
 
-That root may contain:
+Those roots may contain:
 
 - `acestep-v15-turbo/`
+- `acestep-v15-xl-turbo/`
 - `acestep-5Hz-lm-1.7B/` or another supported LM subdirectory
+- `acestep-5Hz-lm-4B/`
 - `Qwen3-Embedding-0.6B/`
 - `vae/`
 
 Older local installs that still use `music-acestep-v15-turbo/` remain
 supported.
 
-`mere.run music generate` auto-discovers that layout unless you override the root
-with `--checkpoints-root` or `MERERUN_MUSIC_ACESTEP_ROOT`.
+`music-acestep-xl-turbo` pulls the ACE-Step 1.5 XL turbo DiT into
+`acestep-v15-xl-turbo/` and reuses the base ACE-Step 1.5 VAE and Qwen3 text
+encoder components. `music-acestep-xl-turbo-lm4b` adds the optional
+`acestep-5Hz-lm-4B/` 5 Hz LM. The default `music generate` component discovery
+continues to prefer the smaller `acestep-5Hz-lm-1.7B/` when both LM directories
+are present; pass `--lm-subdirectory acestep-5Hz-lm-4B` to force the 4B LM.
+
+`mere.run music generate` auto-discovers these layouts unless you override the
+root with `--checkpoints-root` or `MERERUN_MUSIC_ACESTEP_ROOT`.
 
 ### `music-magenta-rt2-small` and `music-magenta-rt2-base`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -272,12 +272,13 @@ supported.
 `music-acestep-xl-turbo` pulls the ACE-Step 1.5 XL turbo DiT into
 `acestep-v15-xl-turbo/` and reuses the base ACE-Step 1.5 VAE and Qwen3 text
 encoder components. `music-acestep-xl-turbo-lm4b` adds the optional
-`acestep-5Hz-lm-4B/` 5 Hz LM. The default `music generate` component discovery
+`acestep-5Hz-lm-4B/` 5 Hz LM. The default ACE-Step LM component discovery
 continues to prefer the smaller `acestep-5Hz-lm-1.7B/` when both LM directories
 are present; pass `--lm-subdirectory acestep-5Hz-lm-4B` to force the 4B LM.
 
-`mere.run music generate` auto-discovers these layouts unless you override the
-root with `--checkpoints-root` or `MERERUN_MUSIC_ACESTEP_ROOT`.
+`mere.run music generate` and `mere.run music analyze` auto-discover these
+layouts unless you override the root with `--checkpoints-root` or
+`MERERUN_MUSIC_ACESTEP_ROOT`.
 
 ### `music-magenta-rt2-small` and `music-magenta-rt2-base`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -42,7 +42,7 @@ Examples:
 - text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
-- music: `music-acestep`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
+- music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - video: `video-ltx-av`
 
 The public runtime resolves these IDs directly, so docs and examples should use

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -11,6 +11,8 @@ This page covers the native music-generation paths exposed through
 ## Model family
 
 - `music-acestep`
+- `music-acestep-xl-turbo`
+- `music-acestep-xl-turbo-lm4b`
 - `music-magenta-rt2-small`
 - `music-magenta-rt2-base`
 
@@ -21,6 +23,34 @@ swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
 
+swift run mere.run music generate \
+  "dream-pop cover with soft vocals" \
+  --source-audio ./song.mp3 \
+  --audio-cover-strength 1.0 \
+  --output ./cover.wav
+
+swift run mere.run music generate \
+  "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion" \
+  --model music-acestep-xl-turbo \
+  --source-audio ./song.mp3 \
+  --audio-cover-strength 0.20 \
+  --cover-noise-strength 0.0 \
+  --output ./reggaeton-cover.wav
+
+swift run mere.run model pull music-acestep-xl-turbo
+swift run mere.run music generate \
+  "cinematic synth pop with bright vocal harmonies" \
+  --model music-acestep-xl-turbo \
+  --output ./xl-track.wav
+
+swift run mere.run model pull music-acestep-xl-turbo-lm4b
+swift run mere.run music generate \
+  "arena-scale rock anthem with stacked vocals" \
+  --model music-acestep-xl-turbo-lm4b \
+  --use-lm \
+  --lm-subdirectory acestep-5Hz-lm-4B \
+  --output ./xl-lm4b-track.wav
+
 swift run mere.run music realtime \
   "ambient modular synths with brushed drums" \
   --model music-magenta-rt2-small \
@@ -28,6 +58,20 @@ swift run mere.run music realtime \
   --output ./live.wav \
   --no-play
 ```
+
+ACE-Step generation uses the upstream CLI turbo shift default (`--shift 3.0`)
+and the native Haar DCW sampler correction (`double`, low `0.05`, high `0.02`)
+before VAE decode. The XL turbo managed ID installs the 4B DiT decoder plus the
+base ACE-Step VAE and Qwen3 text encoder; the `-lm4b` variant also installs the
+optional 4B 5 Hz LM for `--use-lm` runs. ACE-Step cover/repaint/extract tasks
+follow upstream and skip the 5 Hz LM phase so source-audio conditioning stays
+faithful.
+
+For faithful covers, keep `--audio-cover-strength 1.0` and leave
+`--cover-noise-strength` at its default `0.0`. For style-transfer covers, lower
+`--audio-cover-strength` so the text prompt can steer genre, keep
+`--cover-noise-strength 0.0` while exploring, and use `--reference-audio` for an
+optional target-style/timbre example.
 
 For demo-style steering, pass `--interactive`. The command reads stdin while it
 runs, paces generation to realtime, and applies changes between native frames:

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -26,6 +26,7 @@ swift run mere.run music generate \
 swift run mere.run music generate \
   "dream-pop cover with soft vocals" \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --audio-cover-strength 1.0 \
   --output ./cover.wav
 
@@ -33,6 +34,7 @@ swift run mere.run music generate \
   "modern reggaeton dance club remix, 96 bpm dembow rhythm, syncopated kick-snare groove, punchy 808 sub bass, bright Latin percussion" \
   --model music-acestep-xl-turbo \
   --source-audio ./song.mp3 \
+  --analyze-source-audio \
   --audio-cover-strength 0.20 \
   --cover-noise-strength 0.0 \
   --output ./reggaeton-cover.wav
@@ -66,6 +68,11 @@ base ACE-Step VAE and Qwen3 text encoder; the `-lm4b` variant also installs the
 optional 4B 5 Hz LM for `--use-lm` runs. ACE-Step cover/repaint/extract tasks
 follow upstream and skip the 5 Hz LM phase so source-audio conditioning stays
 faithful.
+
+For covers, `--analyze-source-audio` runs ACE-Step audio understanding before
+the direct DiT cover pass. It converts the source audio to 5 Hz audio codes,
+asks the LM for source BPM, key/scale, language, and time signature, and fills
+only metadata fields you did not pass explicitly.
 
 For faithful covers, keep `--audio-cover-strength 1.0` and leave
 `--cover-noise-strength` at its default `0.0`. For style-transfer covers, lower

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -1,11 +1,13 @@
 # Music Runtime
 
 This page covers the native music-generation paths exposed through
-`mere.run music generate` and `mere.run music realtime`.
+`mere.run music analyze`, `mere.run music generate`, and
+`mere.run music realtime`.
 
 ## Public surface
 
 - `mere.run music generate`
+- `mere.run music analyze`
 - `mere.run music realtime`
 
 ## Model family
@@ -38,6 +40,11 @@ swift run mere.run music generate \
   --audio-cover-strength 0.20 \
   --cover-noise-strength 0.0 \
   --output ./reggaeton-cover.wav
+
+swift run mere.run music analyze ./song.mp3 \
+  --model music-acestep-xl-turbo-lm4b \
+  --lm-subdirectory acestep-5Hz-lm-4B \
+  > ./song-analysis.json
 
 swift run mere.run model pull music-acestep-xl-turbo
 swift run mere.run music generate \
@@ -74,6 +81,11 @@ the direct DiT cover pass. It converts the source audio to 5 Hz audio codes,
 asks the LM for source BPM, key/scale, language, and time signature, and fills
 only metadata fields you did not pass explicitly.
 
+Use `music analyze` when you want that same ACE-Step audio-understanding result
+as a standalone JSON artifact before deciding how to prompt a cover or remix.
+It accepts the same ACE-Step model/checkpoint layout flags plus an optional
+`--duration` prefix limit for fast probes.
+
 For faithful covers, keep `--audio-cover-strength 1.0` and leave
 `--cover-noise-strength` at its default `0.0`. For style-transfer covers, lower
 `--audio-cover-strength` so the text prompt can steer genre, keep
@@ -101,6 +113,7 @@ Supported steering commands are `prompt <text>`, `style streaming|full`,
 
 ### CLI
 
+- `Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift`
 - `Sources/MereRunCLI/Commands/MusicGenerateCommand.swift`
 - `Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift`
 

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -183,6 +183,7 @@ fi
 "$mere_run_bin" speech profile --help >/dev/null
 "$mere_run_bin" vision inspect --help >/dev/null
 "$mere_run_bin" vision ocr --help >/dev/null
+"$mere_run_bin" music analyze --help >/dev/null
 "$mere_run_bin" music generate --help >/dev/null
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -54,6 +54,7 @@ fi
 "$mere_run_bin" speech profile --help >/dev/null
 "$mere_run_bin" vision inspect --help >/dev/null
 "$mere_run_bin" vision ocr --help >/dev/null
+"$mere_run_bin" music analyze --help >/dev/null
 "$mere_run_bin" music generate --help >/dev/null
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null


### PR DESCRIPTION
## Summary
- add managed ACE-Step 1.5 XL Turbo and XL Turbo + 4B LM model entries with mounted-Hub fallback support
- add source/reference audio cover generation, source-length covers, upstream-style cover noise, silence-latent loading, DCW correction, and XL config/loading parity
- add optional `music generate --analyze-source-audio` for ACE-Step covers, using the 5Hz LM audio-understanding pass to fill missing BPM/key/scale/language/time-signature metadata from `--source-audio`
- add standalone `music analyze` so ACE-Step can inspect regular audio files and emit JSON metadata from the same 5Hz LM audio-understanding path before cover/remix workflows
- document prompt-driven cover settings and add focused CLI, catalog, resolver, scheduler, DCW, silence-latent, audio-understanding, analyze-command, and pipeline tests

## Upstream parity notes
- ACE-Step cover mode treats `src_audio` / `--source-audio` as semantic structure control for melody, rhythm, chords, and arrangement
- `reference_audio` / `--reference-audio` stays separate as global acoustic/timbre/mix conditioning
- source analysis mirrors upstream `analyze_src_audio`: VAE/tokenize source audio into ACE audio-code tokens, run the 5Hz LM understanding phase, then parse metadata from the LM reasoning block
- `music analyze` exposes that analysis as stdout JSON; `music generate --analyze-source-audio` uses it only to fill missing metadata fields (`bpm`, `keyscale`, `language`, `timesignature`)
- user-provided generation metadata still wins, and cover generation itself still skips the LM phase
- XL Turbo does not use CFG, so style-transfer covers are steered with prompt/lyrics plus `--audio-cover-strength` and `--cover-noise-strength`; docs now recommend starting near `--audio-cover-strength 0.20 --cover-noise-strength 0.0`

## Validation
- `swift test --filter 'MusicAnalyzeCommandParsingTests|MusicGenerateCommandParsingTests|GuideCommandTests|ACEStepMusicUnderstandingTests|ManagedModelCatalogTests'`
- `./scripts/check.sh` (`657 tests, 33 skipped, 0 failures`)
- local ACE-Step XL Turbo cover smoke with `--audio-cover-strength 0.20 --cover-noise-strength 0.0`
- local 8s/1-step source-analysis cover smoke against `Bouncing Around the Room.mp3`: detected `bpm=125, duration=8.0s`, filled `bpm`, and wrote `/tmp/bouncing-acestep-analyze-smoke-out-2.wav`
- local standalone `music analyze` smoke against `/tmp/bouncing-acestep-analyze-smoke.wav` with `music-acestep-xl-turbo-lm4b`: emitted JSON, detected `bpm=125`, `inputDurationSeconds=8`, `analyzedDurationSeconds=8`, and resolved `turboSubdirectory=acestep-v15-xl-turbo`

## Notes
- This PR was cut from a clean `origin/main` worktree so it excludes unrelated local image/API work on `main`.
- The local tensor-dump harness remains out of the PR because it is scratch/debug-only unless we decide to productize it.
- SwiftPM still warns about the unhandled MagentaRT2 README resource in this worktree; the separate MagentaRT2 cleanup PR handles that packaging warning.
