### PR TITLE
Harden structured image retries and local runtime cleanup

### DIFF
--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -79,6 +79,12 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Maximum chat completions admitted at once. Defaults to 1 for serialized local inference.")
     var maxActiveRequests: Int = 1
 
+    @Option(name: [.long], help: "Runtime memory guard tier: off, safe, balanced, aggressive, or custom.")
+    var memoryGuard: RuntimeMemoryGuardTier = .default
+
+    @Option(name: [.long], help: "Custom memory guard ceiling in GiB. Requires --memory-guard custom.")
+    var memoryGuardCustomCeilingGB: Double?
+
     @Option(name: [.long], help: "Context size (default: 32768).")
     var contextSize: Int = 32768
 
@@ -99,6 +105,7 @@ struct APIServe: AsyncParsableCommand {
         try validateServerSecurity(apiKey: resolvedAPIKey)
         let resolvedModelPath = try resolveModelPath()
         let gemma4KVCacheQuantization = try resolveGemma4KVCacheQuantization()
+        let memoryPressurePolicy = try resolveMemoryPressurePolicy()
         let server = try await CodeGenServer(
             defaultModelID: defaultRuntimeModelID(modelPath: resolvedModelPath),
             modelPath: resolvedModelPath,
@@ -108,7 +115,8 @@ struct APIServe: AsyncParsableCommand {
             maxActiveRequests: maxActiveRequests,
             engine: engine,
             contextSize: contextSize,
-            gemma4KVCacheQuantization: gemma4KVCacheQuantization
+            gemma4KVCacheQuantization: gemma4KVCacheQuantization,
+            memoryPressurePolicy: memoryPressurePolicy
         )
         try await server.run(host: host, port: port)
     }
@@ -244,6 +252,14 @@ struct APIServe: AsyncParsableCommand {
         guard maxActiveRequests > 0 else {
             throw ValidationError("--max-active-requests must be greater than zero.")
         }
+        if let memoryGuardCustomCeilingGB {
+            guard memoryGuard == .custom else {
+                throw ValidationError("--memory-guard-custom-ceiling-gb requires --memory-guard custom.")
+            }
+            guard memoryGuardCustomCeilingGB.isFinite, memoryGuardCustomCeilingGB > 0 else {
+                throw ValidationError("--memory-guard-custom-ceiling-gb must be greater than zero.")
+            }
+        }
         guard (1...Int(Int32.max)).contains(contextSize) else {
             throw ValidationError("--context-size must be between 1 and \(Int(Int32.max)).")
         }
@@ -252,11 +268,25 @@ struct APIServe: AsyncParsableCommand {
         }
     }
 
+    private func resolveMemoryPressurePolicy() throws -> RuntimeMemoryPressurePolicy {
+        let gib = Double(1024 * 1024 * 1024)
+        let customCeilingBytes = memoryGuardCustomCeilingGB.map { UInt64(($0 * gib).rounded(.down)) }
+        if memoryGuard == .custom, customCeilingBytes == nil {
+            throw ValidationError("--memory-guard custom requires --memory-guard-custom-ceiling-gb.")
+        }
+        return RuntimeMemoryPressurePolicy(
+            tier: memoryGuard,
+            customCeilingBytes: customCeilingBytes
+        )
+    }
+
     private static func isLoopbackHost(_ host: String) -> Bool {
         let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return normalized == "127.0.0.1" || normalized == "localhost" || normalized == "::1"
     }
 }
+
+extension RuntimeMemoryGuardTier: ExpressibleByArgument {}
 
 enum APIEngine: String, ExpressibleByArgument {
     case textCode = "text-code"
@@ -766,19 +796,27 @@ actor CodeGenServer {
         maxActiveRequests: Int = 1,
         engine: APIEngine,
         contextSize: Int = 32768,
-        gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization()
+        gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
+        memoryPressurePolicy: RuntimeMemoryPressurePolicy = .default
     ) async throws {
         self.apiKey = apiKey
         self.contextSize = contextSize
         self.fallbackLoraPath = fallbackLoraPath
         self.defaultModelID = defaultModelID
         self.requestLimiter = APIRateLimiter(limitPerMinute: rateLimitPerMinute)
-        self.requestAdmission = RuntimeRequestAdmission(maxActiveRequests: maxActiveRequests)
-        self.pool = RuntimeModelPool(
+        let runtimePool = RuntimeModelPool(
             defaultModelID: defaultModelID,
             defaultEngine: engine.runtimeServingEngine,
             startupModelPath: modelPath,
-            gemma4KVCacheQuantization: gemma4KVCacheQuantization
+            gemma4KVCacheQuantization: gemma4KVCacheQuantization,
+            memoryPressurePolicy: memoryPressurePolicy
+        )
+        self.pool = runtimePool
+        self.requestAdmission = RuntimeRequestAdmission(
+            maxActiveRequests: maxActiveRequests,
+            pressureProvider: {
+                await runtimePool.currentMemoryPressure()
+            }
         )
         try await pool.preloadDefault()
     }

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -349,6 +349,12 @@ struct APIEngineCapabilities: Equatable, Sendable {
         supportsToolChoice: true
     )
 
+    static let localTextWithToolsAndStructuredJSON = APIEngineCapabilities(
+        supportsTools: true,
+        supportsToolChoice: true,
+        supportsStructuredOutputs: true
+    )
+
     static let localTextWithToolsAndVision = APIEngineCapabilities(
         supportsTools: true,
         supportsToolChoice: true,

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -254,9 +254,11 @@ struct ImageGenerate: AsyncParsableCommand {
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .hidream:
             let generator = HiDreamO1Generator()
+            defer { generator.unload() }
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .ideogram:
             let generator = Ideogram4Generator()
+            defer { generator.unload() }
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .gemma, .liquid, .qwen, .sam, .falcon, .tts, .asr, .embed, .code, .ocr, .music, .video, .psi, .privacy, .deepseek, nil:
             throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")

--- a/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelRuntimeCommand.swift
@@ -74,7 +74,7 @@ struct ModelRuntimeSet: ParsableCommand {
     @Flag(name: [.long], help: "Clear this model's alias.")
     var clearAlias: Bool = false
 
-    @Flag(name: [.long], help: "Keep this model loaded across future TTL/LRU passes.")
+    @Flag(name: [.long], help: "Keep this model loaded across automatic TTL/LRU eviction.")
     var pinned: Bool = false
 
     @Flag(name: [.long], help: "Clear the pinned flag.")

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -293,7 +293,11 @@ enum StatusFormatter {
                 }
                 lines.append("  active requests: \(runtime.activeRequests)")
                 if let admission = runtime.admission {
-                    lines.append("  request admission: \(admission.activeRequests)/\(admission.maxActiveRequests) active, \(admission.queuedRequests) queued")
+                    var admissionLine = "  request admission: \(admission.activeRequests)/\(admission.maxActiveRequests) active, \(admission.queuedRequests) queued"
+                    if admission.admissionPaused == true {
+                        admissionLine += " (paused by \(admission.pressure ?? "memory") pressure)"
+                    }
+                    lines.append(admissionLine)
                 }
                 lines.append("  continuous batching: \(capabilityText(runtime.capabilities.continuousBatching))")
                 lines.append("  prefix KV reuse: \(capabilityText(runtime.capabilities.prefixKVReuse))")
@@ -356,7 +360,26 @@ enum StatusFormatter {
 
     private static func memoryText(_ memory: RuntimeMemorySnapshot) -> String {
         let physical = ByteCountFormatter.string(fromByteCount: Int64(memory.physicalBytes), countStyle: .memory)
-        return "\(memory.pressure) pressure, \(memory.activeModelCount) active model(s), \(physical) physical"
+        let guardText = "guard \(memory.guardTier.rawValue)"
+        let limitsText: String
+        if let currentBytes = memory.currentBytes,
+           let ceilingBytes = memory.ceilingBytes,
+           let softLimitBytes = memory.softLimitBytes,
+           let hardLimitBytes = memory.hardLimitBytes {
+            let current = ByteCountFormatter.string(fromByteCount: Int64(currentBytes), countStyle: .memory)
+            let ceiling = ByteCountFormatter.string(fromByteCount: Int64(ceilingBytes), countStyle: .memory)
+            let soft = ByteCountFormatter.string(fromByteCount: Int64(softLimitBytes), countStyle: .memory)
+            let hard = ByteCountFormatter.string(fromByteCount: Int64(hardLimitBytes), countStyle: .memory)
+            limitsText = ", current \(current), ceiling \(ceiling), soft \(soft), hard \(hard)"
+        } else {
+            limitsText = ""
+        }
+        if let residentBytes = memory.residentBytes {
+            let resident = ByteCountFormatter.string(fromByteCount: Int64(residentBytes), countStyle: .memory)
+            return "\(memory.pressure) pressure, \(guardText), \(memory.activeModelCount) active model(s), "
+                + "\(resident) resident, \(physical) physical\(limitsText)"
+        }
+        return "\(memory.pressure) pressure, \(guardText), \(memory.activeModelCount) active model(s), \(physical) physical\(limitsText)"
     }
 
     private static func capabilityText(_ capability: RuntimeCapabilityStatus) -> String {

--- a/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
@@ -67,6 +67,7 @@ struct VisionGround: AsyncParsableCommand {
             modelRootURL: resolvedModel.rootURL,
             expectedModelID: resolvedModel.isManaged ? resolvedModel.modelID : nil
         )
+        defer { grounder.unload() }
         let result = try grounder.ground(
             imageURL: imageURL,
             queries: query,

--- a/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
@@ -99,6 +99,7 @@ struct VisionSegment: AsyncParsableCommand {
             modelRootURL: resolvedModel.rootURL,
             expectedModelID: resolvedModel.isManaged ? resolvedModel.modelID : nil
         )
+        defer { segmenter.unload() }
         let result = try segmenter.segment(
             imageURL: imageURL,
             promptSet: promptSet,

--- a/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
@@ -92,6 +92,7 @@ struct VisionTrack: AsyncParsableCommand {
             modelRootURL: resolvedModel.rootURL,
             expectedModelID: resolvedModel.isManaged ? resolvedModel.modelID : nil
         )
+        defer { segmenter.unload() }
         let tracker = SAM31VideoTracker(segmenter: segmenter)
         let result = try tracker.track(
             videoURL: videoURL,

--- a/Sources/MereRunCLI/Commands/VisionTrackLiveCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionTrackLiveCommand.swift
@@ -96,6 +96,7 @@ struct VisionTrackLive: AsyncParsableCommand {
             modelRootURL: resolvedModel.rootURL,
             expectedModelID: resolvedModel.isManaged ? resolvedModel.modelID : nil
         )
+        defer { segmenter.unload() }
         let tracker = SAM31VideoTracker(segmenter: segmenter)
         let result = try tracker.track(
             videoURL: captureURL,

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -36,6 +36,10 @@ mere.run status
 - `--api-key`: bearer token, also read from `MERERUN_API_KEY`.
 - `--rate-limit-per-minute`: global chat completions limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
+- `--memory-guard`: runtime memory guard tier, default `balanced`. Accepted
+  values are `off`, `safe`, `balanced`, `aggressive`, and `custom`.
+- `--memory-guard-custom-ceiling-gb`: custom process-memory ceiling in GiB.
+  Requires `--memory-guard custom`.
 - `--context-size`: context limit used for request validation and native prompt truncation.
 - `--kv-bits`, `--kv-quant-scheme`, `--kv-group-size`, `--quantized-kv-start`:
   Gemma4 KV cache controls. Serving `text-chat-gemma4-turbo` defaults to the
@@ -52,7 +56,13 @@ mere.run status
 - Choose the engine first, then the model path/id.
 - Use `mere.run status` as the quick `/health` plus `/v1/models` check.
 - Use `mere.run model runtime set` to configure aliases, pinning, TTL, and
-  default generation limits without starting the server.
+  default generation limits without starting the server. TTL unloads idle
+  models during runtime pool operations, and pinned models skip automatic
+  TTL/LRU eviction. `--memory-guard` computes tiered soft/hard ceilings from
+  process resident memory and host memory headroom. Under elevated pressure,
+  chat admission pauses extra concurrent prefills and the pool evicts the
+  least-recently-used idle unpinned model; under critical pressure, it evicts
+  every idle unpinned model. Active requests are never evicted.
 - Test `/v1/chat/completions` after status shows the expected served model.
 - Request `model` resolves by runtime alias, then curated catalog id, then the
   startup default from `--engine`/`--model`.

--- a/Sources/MereRunCLI/Guides/model-runtime.md
+++ b/Sources/MereRunCLI/Guides/model-runtime.md
@@ -50,9 +50,15 @@ mere.run status --json
   prompts and switch to packed 2-bit PolarKV for prompts at or above 1024
   tokens. `polar2` forces that path for every request, and non-Gemma4 models
   reject the setting.
-- Treat TTL/LRU as forward-compatible settings. The first runtime-pool
-  milestone records them and exposes them in status; later schedulers can act
-  on them.
+- `ttlSeconds` unloads an idle, loaded model after that many seconds during the
+  pool's opportunistic eviction passes. `pinned` exempts the model from
+  automatic TTL/LRU eviction, but explicit unload still works.
+- Memory-pressure LRU uses the API server's `--memory-guard` tier. The guard
+  derives soft/hard ceilings from process resident memory, host memory
+  headroom, and a tier reserve (`safe`, `balanced`, `aggressive`, or
+  `custom`). Elevated pressure evicts the least-recently-used idle unpinned
+  model; critical pressure evicts every idle unpinned model. Active requests
+  are never evicted, and pinned models are skipped.
 
 ## Examples
 

--- a/Sources/MereRunCLI/Guides/status.md
+++ b/Sources/MereRunCLI/Guides/status.md
@@ -41,7 +41,10 @@ mere.run guide status
   server sees the same control-plane state.
 - During overlapping API traffic, check `request admission` to see how many
   requests are running and how many are queued behind `--max-active-requests`.
-  JSON status also includes admitted, completed, and cancelled admission totals.
+  JSON status also includes admitted, completed, cancelled, pressure, and
+  whether admission is currently paused by the memory guard.
+- Use `memory` to see the active memory guard tier, pressure level, current
+  resident usage, and the computed soft/hard/ceiling limits.
 - Use `continuous batching` and `prefix KV reuse` to see which scheduler/cache
   features are actually enabled instead of assuming they are active.
 - Use `cache stats` to check aggregate prefix hits, reused tokens, and batched

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -784,7 +784,11 @@ actor RuntimeModelPool {
         let memoryLimits = memoryPressurePolicy.limits(for: memorySample)
         let settings = (try? settingsStore.load())?.models ?? [:]
         let installed = installedServableCatalogIDs()
-        let ids = Set(installed + Array(loadedModels.keys) + [defaultModelID] + Array(settings.keys))
+        var ids = Set<String>(installed)
+        ids.formUnion(loadedModels.keys)
+        ids.formUnion(states.keys)
+        ids.insert(defaultModelID)
+        ids.formUnion(settings.keys)
         var prefixStats: [String: PrefixKVCacheStats] = [:]
         var batchingStats: [String: RuntimeDecodeBatchingStats] = [:]
         var mtpStats: [String: Gemma4MTPStats] = [:]
@@ -800,7 +804,7 @@ actor RuntimeModelPool {
                 mtpStats[id] = stats
             }
         }
-        let snapshots = ids.sorted().compactMap { id in
+        let snapshots: [RuntimeModelPoolEntrySnapshot] = ids.sorted().compactMap { id in
             snapshot(
                 for: id,
                 settings: settings,
@@ -810,7 +814,7 @@ actor RuntimeModelPool {
             )
         }
         let activeRequests = snapshots.reduce(0) { $0 + $1.activeRequests }
-        let loadedCount = snapshots.filter(\.loaded).count
+        let loadedCount = snapshots.filter { $0.loaded }.count
         return RuntimeModelPoolStatus(
             object: "runtime.status",
             defaultModel: defaultModelID,
@@ -841,7 +845,7 @@ actor RuntimeModelPool {
                 decodeBatchers: Array(batchingStats.values)
             ),
             benchmarkStats: RuntimeBenchmarkStatsSummary(
-                stats: snapshots.compactMap(\.benchmarkStats).filter {
+                stats: snapshots.compactMap { $0.benchmarkStats }.filter {
                     $0.completedRequests > 0 || $0.failedRequests > 0
                 }
             )

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1,5 +1,8 @@
 import Foundation
 import MereRunCore
+#if canImport(Darwin)
+import Darwin
+#endif
 
 struct RuntimeModelPoolStatus: Codable, Equatable, Sendable {
     let object: String
@@ -76,6 +79,28 @@ struct RuntimeRequestAdmissionSnapshot: Codable, Equatable, Sendable {
     let totalAdmittedRequests: Int
     let totalCompletedRequests: Int
     let totalCancelledRequests: Int
+    let admissionPaused: Bool?
+    let pressure: String?
+
+    init(
+        maxActiveRequests: Int,
+        activeRequests: Int,
+        queuedRequests: Int,
+        totalAdmittedRequests: Int,
+        totalCompletedRequests: Int,
+        totalCancelledRequests: Int,
+        admissionPaused: Bool? = nil,
+        pressure: String? = nil
+    ) {
+        self.maxActiveRequests = maxActiveRequests
+        self.activeRequests = activeRequests
+        self.queuedRequests = queuedRequests
+        self.totalAdmittedRequests = totalAdmittedRequests
+        self.totalCompletedRequests = totalCompletedRequests
+        self.totalCancelledRequests = totalCancelledRequests
+        self.admissionPaused = admissionPaused
+        self.pressure = pressure
+    }
 }
 
 struct RuntimeFutureStats: Codable, Equatable, Sendable {
@@ -259,9 +284,333 @@ struct RuntimeDecodeBatchingSummary: Codable, Equatable, Sendable {
 
 struct RuntimeMemorySnapshot: Codable, Equatable, Sendable {
     let physicalBytes: UInt64
+    let residentBytes: UInt64?
+    let currentBytes: UInt64?
+    let ceilingBytes: UInt64?
+    let softLimitBytes: UInt64?
+    let hardLimitBytes: UInt64?
     let activeRequests: Int
     let activeModelCount: Int
+    let guardTier: RuntimeMemoryGuardTier
     let pressure: String
+
+    init(
+        physicalBytes: UInt64,
+        residentBytes: UInt64? = nil,
+        currentBytes: UInt64? = nil,
+        ceilingBytes: UInt64? = nil,
+        softLimitBytes: UInt64? = nil,
+        hardLimitBytes: UInt64? = nil,
+        activeRequests: Int,
+        activeModelCount: Int,
+        guardTier: RuntimeMemoryGuardTier = .balanced,
+        pressure: String
+    ) {
+        self.physicalBytes = physicalBytes
+        self.residentBytes = residentBytes
+        self.currentBytes = currentBytes
+        self.ceilingBytes = ceilingBytes
+        self.softLimitBytes = softLimitBytes
+        self.hardLimitBytes = hardLimitBytes
+        self.activeRequests = activeRequests
+        self.activeModelCount = activeModelCount
+        self.guardTier = guardTier
+        self.pressure = pressure
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case physicalBytes
+        case residentBytes
+        case currentBytes
+        case ceilingBytes
+        case softLimitBytes
+        case hardLimitBytes
+        case activeRequests
+        case activeModelCount
+        case guardTier
+        case pressure
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        physicalBytes = try container.decode(UInt64.self, forKey: .physicalBytes)
+        residentBytes = try container.decodeIfPresent(UInt64.self, forKey: .residentBytes)
+        currentBytes = try container.decodeIfPresent(UInt64.self, forKey: .currentBytes)
+        ceilingBytes = try container.decodeIfPresent(UInt64.self, forKey: .ceilingBytes)
+        softLimitBytes = try container.decodeIfPresent(UInt64.self, forKey: .softLimitBytes)
+        hardLimitBytes = try container.decodeIfPresent(UInt64.self, forKey: .hardLimitBytes)
+        activeRequests = try container.decode(Int.self, forKey: .activeRequests)
+        activeModelCount = try container.decode(Int.self, forKey: .activeModelCount)
+        guardTier = try container.decodeIfPresent(RuntimeMemoryGuardTier.self, forKey: .guardTier) ?? .balanced
+        pressure = try container.decode(String.self, forKey: .pressure)
+    }
+}
+
+enum RuntimeMemoryPressureLevel: String, Codable, Equatable, Sendable {
+    case disabled
+    case unknown
+    case nominal
+    case elevated
+    case critical
+}
+
+enum RuntimeMemoryGuardTier: String, Codable, CaseIterable, Equatable, Sendable {
+    case off
+    case safe
+    case balanced
+    case aggressive
+    case custom
+
+    static let `default` = RuntimeMemoryGuardTier.balanced
+}
+
+struct RuntimeMemorySample: Equatable, Sendable {
+    let physicalBytes: UInt64
+    let residentBytes: UInt64?
+    let availableBytes: UInt64?
+    let freeBytes: UInt64?
+    let activeBytes: UInt64?
+    let inactiveBytes: UInt64?
+
+    init(
+        physicalBytes: UInt64,
+        residentBytes: UInt64?,
+        availableBytes: UInt64? = nil,
+        freeBytes: UInt64? = nil,
+        activeBytes: UInt64? = nil,
+        inactiveBytes: UInt64? = nil
+    ) {
+        self.physicalBytes = physicalBytes
+        self.residentBytes = residentBytes
+        self.availableBytes = availableBytes
+        self.freeBytes = freeBytes
+        self.activeBytes = activeBytes
+        self.inactiveBytes = inactiveBytes
+    }
+
+    static func current() -> RuntimeMemorySample {
+        RuntimeProcessMemory.currentSample()
+    }
+}
+
+struct RuntimeMemoryPressurePolicy: Equatable, Sendable {
+    let tier: RuntimeMemoryGuardTier
+    let customCeilingBytes: UInt64?
+    let softLimitFraction: Double
+    let hardLimitFraction: Double
+
+    static let `default` = RuntimeMemoryPressurePolicy(
+        tier: .default
+    )
+
+    init(
+        tier: RuntimeMemoryGuardTier = .default,
+        customCeilingBytes: UInt64? = nil,
+        softLimitFraction: Double = 0.90,
+        hardLimitFraction: Double = 0.95
+    ) {
+        self.tier = tier
+        self.customCeilingBytes = customCeilingBytes
+        self.softLimitFraction = softLimitFraction
+        self.hardLimitFraction = hardLimitFraction
+    }
+
+    func pressure(for sample: RuntimeMemorySample) -> RuntimeMemoryPressureLevel {
+        guard tier != .off else {
+            return .disabled
+        }
+        guard let currentBytes = currentBytes(for: sample),
+              let limits = limits(for: sample) else {
+            return .unknown
+        }
+        if currentBytes >= limits.hard {
+            return .critical
+        }
+        if currentBytes >= limits.soft {
+            return .elevated
+        }
+        return .nominal
+    }
+
+    func currentBytes(for sample: RuntimeMemorySample) -> UInt64? {
+        sample.residentBytes
+    }
+
+    func limits(for sample: RuntimeMemorySample) -> (ceiling: UInt64, soft: UInt64, hard: UInt64)? {
+        guard tier != .off, sample.physicalBytes > 0 else {
+            return nil
+        }
+        let ceiling: UInt64
+        switch tier {
+        case .off:
+            return nil
+        case .custom:
+            let custom = customCeilingBytes ?? 0
+            guard custom > 0 else {
+                return nil
+            }
+            ceiling = min(custom, staticCeiling(for: sample))
+        case .safe, .balanced, .aggressive:
+            ceiling = min(staticCeiling(for: sample), dynamicCeiling(for: sample))
+        }
+        guard ceiling > 0 else {
+            return nil
+        }
+        let soft = UInt64((Double(ceiling) * softLimitFraction).rounded(.down))
+        let hard = UInt64((Double(ceiling) * hardLimitFraction).rounded(.down))
+        return (ceiling, soft, hard)
+    }
+
+    private func staticCeiling(for sample: RuntimeMemorySample) -> UInt64 {
+        let reserve = staticReserveBytes(forPhysicalBytes: sample.physicalBytes)
+        guard sample.physicalBytes > reserve else {
+            return 0
+        }
+        return sample.physicalBytes - reserve
+    }
+
+    private func dynamicCeiling(for sample: RuntimeMemorySample) -> UInt64 {
+        guard let residentBytes = sample.residentBytes else {
+            return staticCeiling(for: sample)
+        }
+        if let freeBytes = sample.freeBytes,
+           let inactiveBytes = sample.inactiveBytes,
+           let activeBytes = sample.activeBytes {
+            return residentBytes
+                + freeBytes
+                + inactiveBytes
+                + UInt64((Double(activeBytes) * activeReclaimRatio).rounded(.down))
+        }
+        if let availableBytes = sample.availableBytes {
+            return residentBytes + availableBytes
+        }
+        return sample.physicalBytes
+    }
+
+    private var activeReclaimRatio: Double {
+        switch tier {
+        case .off, .custom:
+            return 0
+        case .safe:
+            return 0.20
+        case .balanced:
+            return 0.50
+        case .aggressive:
+            return 0.80
+        }
+    }
+
+    private func staticReserveBytes(forPhysicalBytes physicalBytes: UInt64) -> UInt64 {
+        let gib = UInt64(1024 * 1024 * 1024)
+        let smallSystemThreshold = 24 * gib
+        if physicalBytes < smallSystemThreshold {
+            return 4 * gib
+        }
+        switch tier {
+        case .off:
+            return physicalBytes
+        case .safe:
+            return 8 * gib
+        case .balanced:
+            return 6 * gib
+        case .aggressive:
+            return 4 * gib
+        case .custom:
+            return 2 * gib
+        }
+    }
+}
+
+private enum RuntimeProcessMemory {
+    static func currentSample() -> RuntimeMemorySample {
+        let physicalBytes = ProcessInfo.processInfo.physicalMemory
+        let residentBytes = currentResidentBytes()
+        let host = currentHostMemory()
+        return RuntimeMemorySample(
+            physicalBytes: physicalBytes,
+            residentBytes: residentBytes,
+            availableBytes: host.availableBytes,
+            freeBytes: host.freeBytes,
+            activeBytes: host.activeBytes,
+            inactiveBytes: host.inactiveBytes
+        )
+    }
+
+    private static func currentResidentBytes() -> UInt64? {
+        #if canImport(Darwin)
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return UInt64(info.resident_size)
+        #elseif os(Linux)
+        guard let status = try? String(contentsOfFile: "/proc/self/status") else {
+            return nil
+        }
+        for line in status.split(separator: "\n") where line.hasPrefix("VmRSS:") {
+            let parts = line.split(separator: " ").compactMap { UInt64($0) }
+            guard let kilobytes = parts.first else {
+                return nil
+            }
+            return kilobytes * 1024
+        }
+        return nil
+        #else
+        return nil
+        #endif
+    }
+
+    private static func currentHostMemory() -> (
+        availableBytes: UInt64?,
+        freeBytes: UInt64?,
+        activeBytes: UInt64?,
+        inactiveBytes: UInt64?
+    ) {
+        #if canImport(Darwin)
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size) / 4
+        let result = withUnsafeMutablePointer(to: &stats) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return (nil, nil, nil, nil)
+        }
+        let pageSize = UInt64(getpagesize())
+        let free = UInt64(stats.free_count) * pageSize
+        let active = UInt64(stats.active_count) * pageSize
+        let inactive = UInt64(stats.inactive_count) * pageSize
+        return (free + inactive, free, active, inactive)
+        #elseif os(Linux)
+        guard let meminfo = try? String(contentsOfFile: "/proc/meminfo") else {
+            return (nil, nil, nil, nil)
+        }
+        var values: [String: UInt64] = [:]
+        for line in meminfo.split(separator: "\n") {
+            let parts = line.split(separator: " ")
+            guard let key = parts.first?.dropLast(),
+                  let kilobytes = parts.dropFirst().compactMap({ UInt64($0) }).first else {
+                continue
+            }
+            values[String(key)] = kilobytes * 1024
+        }
+        return (
+            values["MemAvailable"],
+            values["MemFree"],
+            values["Active"],
+            values["Inactive"]
+        )
+        #else
+        return (nil, nil, nil, nil)
+        #endif
+    }
 }
 
 struct RuntimeModelPoolEntrySnapshot: Codable, Equatable, Sendable {
@@ -368,6 +717,11 @@ actor RuntimeModelPool {
         }
     }
 
+    private struct RuntimeLRUEvictionCandidate {
+        let id: String
+        let lastAccess: Date
+    }
+
     private let defaultModelID: String
     private let defaultEngine: RuntimeServingEngine
     private let startupModelPath: String?
@@ -377,6 +731,9 @@ actor RuntimeModelPool {
     private let gemma4ContinuousBatchingEnabled: Bool
     private let q35PrefixKVCacheEnabled: Bool
     private let q35ContinuousBatchingEnabled: Bool
+    private let currentDate: @Sendable () -> Date
+    private let currentMemorySample: @Sendable () -> RuntimeMemorySample
+    private let memoryPressurePolicy: RuntimeMemoryPressurePolicy
 
     private var loadedModels: [String: RuntimeLoadedModel] = [:]
     private var states: [String: MutableState] = [:]
@@ -390,7 +747,10 @@ actor RuntimeModelPool {
         gemma4PrefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PREFIX_KV_CACHE"] == "1",
         gemma4ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_CONTINUOUS_BATCHING"] == "1",
         q35PrefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_PREFIX_KV_CACHE"] == "1",
-        q35ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_CONTINUOUS_BATCHING"] == "1"
+        q35ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_CONTINUOUS_BATCHING"] == "1",
+        currentDate: @escaping @Sendable () -> Date = { Date() },
+        currentMemorySample: @escaping @Sendable () -> RuntimeMemorySample = { RuntimeMemorySample.current() },
+        memoryPressurePolicy: RuntimeMemoryPressurePolicy = .default
     ) {
         self.defaultModelID = defaultModelID
         self.defaultEngine = defaultEngine
@@ -401,6 +761,9 @@ actor RuntimeModelPool {
         self.gemma4ContinuousBatchingEnabled = gemma4ContinuousBatchingEnabled
         self.q35PrefixKVCacheEnabled = q35PrefixKVCacheEnabled
         self.q35ContinuousBatchingEnabled = q35ContinuousBatchingEnabled
+        self.currentDate = currentDate
+        self.currentMemorySample = currentMemorySample
+        self.memoryPressurePolicy = memoryPressurePolicy
     }
 
     func preloadDefault() async throws {
@@ -416,6 +779,9 @@ actor RuntimeModelPool {
     }
 
     func status(admission: RuntimeRequestAdmissionSnapshot?) async -> RuntimeModelPoolStatus {
+        await evictIdleModels()
+        let memorySample = currentMemorySample()
+        let memoryLimits = memoryPressurePolicy.limits(for: memorySample)
         let settings = (try? settingsStore.load())?.models ?? [:]
         let installed = installedServableCatalogIDs()
         let ids = Set(installed + Array(loadedModels.keys) + [defaultModelID] + Array(settings.keys))
@@ -458,10 +824,16 @@ actor RuntimeModelPool {
                 q35PrefixKVCacheEnabled: q35PrefixKVCacheEnabled
             ),
             memory: RuntimeMemorySnapshot(
-                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                physicalBytes: memorySample.physicalBytes,
+                residentBytes: memorySample.residentBytes,
+                currentBytes: memoryPressurePolicy.currentBytes(for: memorySample),
+                ceilingBytes: memoryLimits?.ceiling,
+                softLimitBytes: memoryLimits?.soft,
+                hardLimitBytes: memoryLimits?.hard,
                 activeRequests: activeRequests,
                 activeModelCount: loadedCount,
-                pressure: "unknown"
+                guardTier: memoryPressurePolicy.tier,
+                pressure: memoryPressurePolicy.pressure(for: memorySample).rawValue
             ),
             models: snapshots,
             cacheStats: RuntimeCacheStatsSummary(
@@ -478,6 +850,7 @@ actor RuntimeModelPool {
 
     func loadModel(idOrAlias: String) async throws -> RuntimeModelPoolEntrySnapshot {
         let resolved = try resolveModel(idOrAlias)
+        await evictIdleModels(excluding: [resolved.id])
         _ = try await ensureLoaded(resolved)
         touch(id: resolved.id, error: nil)
         return try snapshot(idOrAlias: resolved.id)
@@ -496,22 +869,28 @@ actor RuntimeModelPool {
         return try snapshot(idOrAlias: resolved.id)
     }
 
-    func settings(idOrAlias: String) throws -> RuntimeModelSettings {
+    func settings(idOrAlias: String) async throws -> RuntimeModelSettings {
+        await evictIdleModels()
         let resolved = try resolveModel(idOrAlias)
         return resolved.settings
     }
 
-    func updateSettings(idOrAlias: String, settings: RuntimeModelSettings) throws -> RuntimeModelSettings {
+    func updateSettings(idOrAlias: String, settings: RuntimeModelSettings) async throws -> RuntimeModelSettings {
         let resolved = try resolveModel(idOrAlias, requireInstalled: false)
         guard let spec = resolved.spec else {
             throw RuntimeModelPoolError.invalidSettings("Runtime settings require a managed catalog model id.")
         }
         do {
             try settingsStore.writeSettings(settings, for: spec.id)
+            await evictIdleModels()
             return try settingsStore.settings(for: spec.id)
         } catch {
             throw RuntimeModelPoolError.invalidSettings(error.localizedDescription)
         }
+    }
+
+    func currentMemoryPressure() -> RuntimeMemoryPressureLevel {
+        memoryPressurePolicy.pressure(for: currentMemorySample())
     }
 
     func makeChatPlan(
@@ -520,6 +899,7 @@ actor RuntimeModelPool {
         serverContextSize: Int
     ) async throws -> RuntimeChatPlan {
         let resolved = try resolveModel(openAIRequest.model)
+        await evictIdleModels(excluding: [resolved.id])
         var effectiveRequest = openAIRequest
         applyDefaults(from: resolved.settings, to: &effectiveRequest)
         let contextSize = resolved.settings.maxContextTokens ?? serverContextSize
@@ -555,7 +935,7 @@ actor RuntimeModelPool {
     fileprivate func releaseLease(modelID: String) {
         var state = state(for: modelID)
         state.activeRequests = max(0, state.activeRequests - 1)
-        state.lastAccess = Date()
+        state.lastAccess = currentDate()
         states[modelID] = state
     }
 
@@ -568,7 +948,7 @@ actor RuntimeModelPool {
             state.totalPrefillSeconds += timing.prefillSeconds
             state.totalDecodeSeconds += timing.decodeSeconds
         }
-        state.lastCompletedAt = Date()
+        state.lastCompletedAt = currentDate()
         state.lastError = nil
         states[modelID] = state
     }
@@ -578,6 +958,101 @@ actor RuntimeModelPool {
         state.failedRequests += 1
         state.lastError = error.localizedDescription
         states[modelID] = state
+    }
+
+    @discardableResult
+    func evictIdleModels(
+        now: Date? = nil,
+        memorySample: RuntimeMemorySample? = nil,
+        excluding excludedIDs: Set<String> = []
+    ) async -> [String] {
+        let expired = await evictExpiredIdleModels(now: now, excluding: excludedIDs)
+        let lru = await evictIdleModelsForMemoryPressure(sample: memorySample, excluding: excludedIDs)
+        return Array(Set(expired + lru)).sorted()
+    }
+
+    @discardableResult
+    func evictExpiredIdleModels(
+        now: Date? = nil,
+        excluding excludedIDs: Set<String> = []
+    ) async -> [String] {
+        let referenceDate = now ?? currentDate()
+        let settings = (try? settingsStore.load())?.models ?? [:]
+        let loadedEntries = loadedModels
+        var evicted: [String] = []
+
+        for (id, loaded) in loadedEntries {
+            let state = state(for: id)
+            guard loadedModels[id] != nil,
+                  !excludedIDs.contains(id),
+                  let modelSettings = settings[id],
+                  !modelSettings.pinned,
+                  let ttlSeconds = modelSettings.ttlSeconds,
+                  let lastAccess = state.lastAccess,
+                  state.activeRequests == 0,
+                  referenceDate.timeIntervalSince(lastAccess) >= Double(ttlSeconds) else {
+                continue
+            }
+
+            loadedModels.removeValue(forKey: id)
+            await loaded.unload()
+            evicted.append(id)
+        }
+
+        return evicted.sorted()
+    }
+
+    @discardableResult
+    func evictIdleModelsForMemoryPressure(
+        sample: RuntimeMemorySample? = nil,
+        excluding excludedIDs: Set<String> = []
+    ) async -> [String] {
+        let memorySample = sample ?? currentMemorySample()
+        let pressure = memoryPressurePolicy.pressure(for: memorySample)
+        let evictionLimit: Int?
+        switch pressure {
+        case .disabled, .unknown, .nominal:
+            return []
+        case .elevated:
+            evictionLimit = 1
+        case .critical:
+            evictionLimit = nil
+        }
+
+        let settings = (try? settingsStore.load())?.models ?? [:]
+        let candidates = loadedModels.compactMap { id, _ -> RuntimeLRUEvictionCandidate? in
+            let state = state(for: id)
+            let modelSettings = settings[id] ?? RuntimeModelSettings()
+            guard !excludedIDs.contains(id),
+                  state.activeRequests == 0,
+                  !modelSettings.pinned else {
+                return nil
+            }
+            return RuntimeLRUEvictionCandidate(
+                id: id,
+                lastAccess: state.lastAccess ?? .distantPast
+            )
+        }
+        .sorted {
+            if $0.lastAccess == $1.lastAccess {
+                return $0.id < $1.id
+            }
+            return $0.lastAccess < $1.lastAccess
+        }
+
+        var evicted: [String] = []
+        for candidate in candidates {
+            guard evictionLimit.map({ evicted.count < $0 }) ?? true else {
+                break
+            }
+            guard let loaded = loadedModels.removeValue(forKey: candidate.id) else {
+                continue
+            }
+            await loaded.unload()
+            evicted.append(candidate.id)
+        }
+
+        return evicted.sorted()
     }
 
     private func ensureLoaded(_ resolved: ResolvedModel) async throws -> RuntimeLoadedModel {
@@ -837,7 +1312,7 @@ actor RuntimeModelPool {
 
     private func touch(id: String, error: String?) {
         var state = state(for: id)
-        state.lastAccess = Date()
+        state.lastAccess = currentDate()
         state.lastError = error
         states[id] = state
     }
@@ -845,7 +1320,7 @@ actor RuntimeModelPool {
     private func retainLease(id: String) {
         var state = state(for: id)
         state.activeRequests += 1
-        state.lastAccess = Date()
+        state.lastAccess = currentDate()
         states[id] = state
     }
 
@@ -862,6 +1337,20 @@ actor RuntimeModelPool {
             return ManagedModelCategory.textChat.rawValue
         }
     }
+
+    #if DEBUG
+    func seedLoadedModelForTesting(
+        id: String,
+        lastAccess: Date,
+        activeRequests: Int = 0
+    ) {
+        loadedModels[id] = .textCode(CodeGenGenerator(modelId: id), modelPath: nil)
+        var state = state(for: id)
+        state.activeRequests = activeRequests
+        state.lastAccess = lastAccess
+        states[id] = state
+    }
+    #endif
 }
 
 actor RuntimeRequestAdmission {
@@ -877,6 +1366,7 @@ actor RuntimeRequestAdmission {
     }
 
     private let maxActiveRequests: Int
+    private let pressureProvider: @Sendable () async -> RuntimeMemoryPressureLevel
     private var activeRequests = 0
     private var waiters: [Waiter] = []
     private var waiterStates: [UUID: WaiterState] = [:]
@@ -884,13 +1374,18 @@ actor RuntimeRequestAdmission {
     private var totalCompletedRequests = 0
     private var totalCancelledRequests = 0
 
-    init(maxActiveRequests: Int) {
+    init(
+        maxActiveRequests: Int,
+        pressureProvider: @escaping @Sendable () async -> RuntimeMemoryPressureLevel = { .nominal }
+    ) {
         precondition(maxActiveRequests > 0, "maxActiveRequests must be positive")
         self.maxActiveRequests = maxActiveRequests
+        self.pressureProvider = pressureProvider
     }
 
     func acquire() async throws -> RuntimeRequestAdmissionLease {
-        if activeRequests < maxActiveRequests {
+        await drain()
+        if await canAdmitNow() {
             return admit()
         }
 
@@ -908,20 +1403,23 @@ actor RuntimeRequestAdmission {
         }
     }
 
-    fileprivate func releaseLease() {
+    fileprivate func releaseLease() async {
         activeRequests = max(0, activeRequests - 1)
         totalCompletedRequests += 1
-        drain()
+        await drain()
     }
 
-    func snapshot() -> RuntimeRequestAdmissionSnapshot {
-        RuntimeRequestAdmissionSnapshot(
+    func snapshot() async -> RuntimeRequestAdmissionSnapshot {
+        let pressure = await pressureProvider()
+        return RuntimeRequestAdmissionSnapshot(
             maxActiveRequests: maxActiveRequests,
             activeRequests: activeRequests,
             queuedRequests: waiters.count,
             totalAdmittedRequests: totalAdmittedRequests,
             totalCompletedRequests: totalCompletedRequests,
-            totalCancelledRequests: totalCancelledRequests
+            totalCancelledRequests: totalCancelledRequests,
+            admissionPaused: admissionPaused(for: pressure),
+            pressure: pressure.rawValue
         )
     }
 
@@ -958,8 +1456,11 @@ actor RuntimeRequestAdmission {
         }
     }
 
-    private func drain() {
+    private func drain() async {
         while activeRequests < maxActiveRequests, !waiters.isEmpty {
+            guard await canAdmitNow() else {
+                return
+            }
             let waiter = waiters.removeFirst()
             guard waiterStates[waiter.id] != .cancelled else {
                 waiterStates.removeValue(forKey: waiter.id)
@@ -975,6 +1476,26 @@ actor RuntimeRequestAdmission {
         activeRequests += 1
         totalAdmittedRequests += 1
         return RuntimeRequestAdmissionLease(admission: self)
+    }
+
+    private func canAdmitNow() async -> Bool {
+        guard activeRequests < maxActiveRequests else {
+            return false
+        }
+        let pressure = await pressureProvider()
+        guard admissionPaused(for: pressure) else {
+            return true
+        }
+        return activeRequests == 0
+    }
+
+    private func admissionPaused(for pressure: RuntimeMemoryPressureLevel) -> Bool {
+        switch pressure {
+        case .elevated, .critical:
+            return true
+        case .disabled, .unknown, .nominal:
+            return false
+        }
     }
 }
 

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1727,7 +1727,7 @@ extension RuntimeServingEngine {
         case .textChatKlein:
             return .localTextWithStructuredJSON
         case .textChatGemma4:
-            return .localTextWithTools
+            return .localTextWithToolsAndStructuredJSON
         case .textChatQ36, .textChatQ35:
             return .localTextWithToolsAndVision
         case .textChatLFM2:

--- a/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
+++ b/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
@@ -77,14 +77,17 @@ enum StructuredImagePromptAdapter {
         let candidate = cleanedJSONCandidate(from: rawJSON)
         do {
             let caption = try validateCaptionJSON(candidate)
-            return try encodeCaptionJSON(caption)
+            return try encodeCaptionJSON(ensuringTextRender(caption, prompt: fallbackPrompt))
         } catch {
             guard let data = candidate.data(using: .utf8), !data.isEmpty else {
                 throw StructuredImagePromptAdapterError.invalidCaptionJSON("Output was empty.")
             }
             do {
                 let flexibleCaption = try JSONDecoder().decode(FlexibleStructuredImageCaption.self, from: data)
-                let normalizedCaption = flexibleCaption.normalized(fallbackPrompt: fallbackPrompt)
+                let normalizedCaption = ensuringTextRender(
+                    flexibleCaption.normalized(fallbackPrompt: fallbackPrompt),
+                    prompt: fallbackPrompt
+                )
                 let normalizedJSON = try encodeCaptionJSON(normalizedCaption)
                 _ = try validateCaptionJSON(normalizedJSON)
                 return normalizedJSON
@@ -94,6 +97,61 @@ enum StructuredImagePromptAdapter {
                 )
             }
         }
+    }
+
+    /// Deterministic safety net: if the adapter model left "text render" empty but the
+    /// original prompt asks for visible text in quotes, copy those strings in verbatim.
+    /// Without this, requested glyphs silently degrade into garbled texture.
+    static func ensuringTextRender(_ caption: StructuredImageCaption, prompt: String) -> StructuredImageCaption {
+        guard caption.textRender.isEmpty else { return caption }
+        let quoted = quotedStrings(in: prompt)
+        guard !quoted.isEmpty else { return caption }
+        let entries = quoted.prefix(5).map { text in
+            StructuredImageTextRender(
+                text: text,
+                location: "as described in the prompt",
+                size: "medium",
+                color: "unspecified",
+                font: "unspecified",
+                appearanceDetails: nil
+            )
+        }
+        return StructuredImageCaption(
+            shortDescription: caption.shortDescription,
+            objects: caption.objects,
+            backgroundSetting: caption.backgroundSetting,
+            lighting: caption.lighting,
+            aesthetics: caption.aesthetics,
+            photographicCharacteristics: caption.photographicCharacteristics,
+            styleMedium: caption.styleMedium,
+            textRender: Array(entries),
+            context: caption.context,
+            artisticStyle: caption.artisticStyle
+        )
+    }
+
+    /// Extracts double-, curly-, and single-quoted strings. Single quotes must sit on
+    /// word boundaries so apostrophes ("the sign's letters") do not produce matches.
+    static func quotedStrings(in prompt: String) -> [String] {
+        let patterns = [
+            #""([^"\n]{1,120})""#,
+            #"“([^”\n]{1,120})”"#,
+            #"(?<=^|[\s(])'([^'\n]{1,120})'(?=$|[\s,.!?;:)])"#,
+        ]
+        var seen = Set<String>()
+        var results: [String] = []
+        let range = NSRange(prompt.startIndex..., in: prompt)
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            for match in regex.matches(in: prompt, range: range) {
+                guard match.numberOfRanges > 1,
+                      let captureRange = Range(match.range(at: 1), in: prompt) else { continue }
+                let text = String(prompt[captureRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty, seen.insert(text.lowercased()).inserted else { continue }
+                results.append(text)
+            }
+        }
+        return results
     }
 
     static func cleanedJSONCandidate(from response: String) -> String {
@@ -157,7 +215,7 @@ enum StructuredImagePromptAdapter {
         session: ChatSession,
         progressHandler: (@Sendable (String) -> Void)?
     ) async throws -> String {
-        var messages = [
+        let initialMessages = [
             ChatMessage(role: .system, content: structuredCaptionSystemPrompt),
             ChatMessage(
                 role: .user,
@@ -169,6 +227,7 @@ enum StructuredImagePromptAdapter {
                 """
             ),
         ]
+        var messages = initialMessages
         var lastDetail = "No response was generated."
 
         for attempt in 1...3 {
@@ -182,24 +241,44 @@ enum StructuredImagePromptAdapter {
                 requiresJSON: true
             )
             let response = try await session.chat(request, nil)
+            if let debugRoot = ProcessInfo.processInfo.environment["MERERUN_STRUCTURED_PROMPT_DEBUG"] {
+                let url = URL(fileURLWithPath: debugRoot).appendingPathComponent("adapter_attempt_\(attempt).txt")
+                try? response.response.write(to: url, atomically: true, encoding: .utf8)
+            }
             do {
                 return try normalizedCaptionJSON(from: response.response, fallbackPrompt: prompt)
             } catch {
-                lastDetail = validationFailureDetail(error: error, candidate: cleanedJSONCandidate(from: response.response))
-                messages.append(ChatMessage(role: .assistant, content: response.response))
-                messages.append(ChatMessage(
-                    role: .user,
-                    content: """
-                    The previous response was invalid for this task:
-                    \(lastDetail)
+                let candidate = cleanedJSONCandidate(from: response.response)
+                lastDetail = validationFailureDetail(error: error, candidate: candidate)
+                if isParseableJSON(candidate) {
+                    // Near miss: valid JSON, wrong shape. Keep the exchange and correct it.
+                    messages.append(ChatMessage(role: .assistant, content: response.response))
+                    messages.append(ChatMessage(
+                        role: .user,
+                        content: """
+                        The previous response was invalid for this task:
+                        \(lastDetail)
 
-                    Return only one valid JSON object matching the exact template from the system message. Do not use "name" or "attributes" as object keys. "text render" must be an array; use [] when no text should appear. Use null only for optional nested values.
-                    """
-                ))
+                        Return only one valid JSON object matching the exact template from the system message. Do not use "name" or "attributes" as object keys. "text render" must be an array; use [] when no text should appear. Use null only for optional nested values.
+                        """
+                    ))
+                } else {
+                    // Gross failure (token salad / truncation / empty): feeding it back as
+                    // context would poison every remaining attempt, and a corrupted runtime
+                    // state would survive into them. Reload the model and retry fresh.
+                    progressHandler?("adapter output was not JSON; reloading model for a fresh attempt")
+                    await session.unload()
+                    messages = initialMessages
+                }
             }
         }
 
         throw StructuredImagePromptAdapterError.invalidCaptionJSON(lastDetail)
+    }
+
+    static func isParseableJSON(_ candidate: String) -> Bool {
+        guard let data = candidate.data(using: .utf8), !data.isEmpty else { return false }
+        return (try? JSONDecoder().decode(OpenAIJSONValue.self, from: data)) != nil
     }
 
     private static func makeChatSession(modelID: String, modelRoot: String?) throws -> ChatSession {
@@ -291,7 +370,13 @@ enum StructuredImagePromptAdapter {
     "lighting" should cover conditions, direction, and shadows.
     "aesthetics" should cover composition, color scheme, and mood atmosphere.
     "photographic characteristics" should cover depth of field, focus, camera angle, and lens focal length.
-    "text render" must be an array; use [] when no visible text is requested.
+    "text render" must be an array of objects with keys:
+    "text", "location", "size", "color", "font", "appearance details".
+    Any words the image must display — strings in quotes, or text introduced by phrases
+    like "reads", "says", "labeled", "titled", or "captioned" — MUST be copied verbatim
+    (preserving case) into "text render", one entry per distinct string.
+    Describe the surface carrying the text (sign, screen, label) in "objects", but put
+    the exact strings only in "text render". Use [] only when no visible text is requested.
     """
 }
 
@@ -309,12 +394,15 @@ private func validationFailureDetail(error: Error, candidate: String) -> String 
     } else {
         base = error.localizedDescription
     }
-    let preview = candidate
+    let collapsed = candidate
         .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
         .trimmingCharacters(in: .whitespacesAndNewlines)
-        .prefix(700)
-    guard !preview.isEmpty else { return base }
-    return "\(base) Candidate preview: \(preview)"
+    guard !collapsed.isEmpty else { return base }
+    var detail = "\(base) Candidate length: \(collapsed.count) characters. Candidate preview: \(collapsed.prefix(700))"
+    if collapsed.count > 900 {
+        detail += " […] Candidate tail: \(collapsed.suffix(200))"
+    }
+    return detail
 }
 
 private struct FlexibleStructuredImageCaption: Decodable {

--- a/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
+++ b/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
@@ -76,26 +76,45 @@ enum StructuredImagePromptAdapter {
     static func normalizedCaptionJSON(from rawJSON: String, fallbackPrompt: String) throws -> String {
         let candidate = cleanedJSONCandidate(from: rawJSON)
         do {
+            return try normalizedCaptionJSONCandidate(candidate, fallbackPrompt: fallbackPrompt)
+        } catch {
+            if let repaired = repairedJSONPrefixCandidate(from: candidate) {
+                do {
+                    return try normalizedCaptionJSONCandidate(repaired, fallbackPrompt: fallbackPrompt)
+                } catch {
+                    if let salvaged = salvagedCaptionJSON(from: candidate, fallbackPrompt: fallbackPrompt) {
+                        return salvaged
+                    }
+                    throw StructuredImagePromptAdapterError.invalidCaptionJSON(
+                        validationFailureDetail(error: error, candidate: repaired)
+                    )
+                }
+            }
+            if let salvaged = salvagedCaptionJSON(from: candidate, fallbackPrompt: fallbackPrompt) {
+                return salvaged
+            }
+            throw StructuredImagePromptAdapterError.invalidCaptionJSON(
+                validationFailureDetail(error: error, candidate: candidate)
+            )
+        }
+    }
+
+    private static func normalizedCaptionJSONCandidate(_ candidate: String, fallbackPrompt: String) throws -> String {
+        do {
             let caption = try validateCaptionJSON(candidate)
             return try encodeCaptionJSON(ensuringTextRender(caption, prompt: fallbackPrompt))
         } catch {
             guard let data = candidate.data(using: .utf8), !data.isEmpty else {
                 throw StructuredImagePromptAdapterError.invalidCaptionJSON("Output was empty.")
             }
-            do {
-                let flexibleCaption = try JSONDecoder().decode(FlexibleStructuredImageCaption.self, from: data)
-                let normalizedCaption = ensuringTextRender(
-                    flexibleCaption.normalized(fallbackPrompt: fallbackPrompt),
-                    prompt: fallbackPrompt
-                )
-                let normalizedJSON = try encodeCaptionJSON(normalizedCaption)
-                _ = try validateCaptionJSON(normalizedJSON)
-                return normalizedJSON
-            } catch {
-                throw StructuredImagePromptAdapterError.invalidCaptionJSON(
-                    validationFailureDetail(error: error, candidate: candidate)
-                )
-            }
+            let flexibleCaption = try JSONDecoder().decode(FlexibleStructuredImageCaption.self, from: data)
+            let normalizedCaption = ensuringTextRender(
+                flexibleCaption.normalized(fallbackPrompt: fallbackPrompt),
+                prompt: fallbackPrompt
+            )
+            let normalizedJSON = try encodeCaptionJSON(normalizedCaption)
+            _ = try validateCaptionJSON(normalizedJSON)
+            return normalizedJSON
         }
     }
 
@@ -204,9 +223,273 @@ enum StructuredImagePromptAdapter {
         if let firstBrace = cleaned.firstIndex(of: "{"),
            let lastBrace = cleaned.lastIndex(of: "}"),
            firstBrace <= lastBrace {
-            return String(cleaned[firstBrace...lastBrace])
+            let balancedCandidate = String(cleaned[firstBrace...lastBrace])
+            if isParseableJSON(balancedCandidate) {
+                return balancedCandidate
+            }
+            return String(cleaned[firstBrace...])
+        }
+        if let firstBrace = cleaned.firstIndex(of: "{") {
+            return String(cleaned[firstBrace...])
         }
         return cleaned
+    }
+
+    static func repairedJSONPrefixCandidate(from candidate: String) -> String? {
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              (trimmed.first == "{" || trimmed.first == "["),
+              !isParseableJSON(trimmed) else {
+            return nil
+        }
+
+        var output = ""
+        output.reserveCapacity(trimmed.count + 8)
+        var stack: [Character] = []
+        var inString = false
+        var escaping = false
+        var completed = false
+
+        func appendEscapedControl(_ scalar: UnicodeScalar) {
+            switch scalar.value {
+            case 0x08:
+                output += "\\b"
+            case 0x09:
+                output += "\\t"
+            case 0x0A:
+                output += "\\n"
+            case 0x0C:
+                output += "\\f"
+            case 0x0D:
+                output += "\\r"
+            case 0x00...0x1F:
+                output += String(format: "\\u%04x", scalar.value)
+            default:
+                output.append(Character(scalar))
+            }
+        }
+
+        scan: for scalar in trimmed.unicodeScalars {
+            if completed {
+                if CharacterSet.whitespacesAndNewlines.contains(scalar) {
+                    output.append(Character(scalar))
+                    continue
+                }
+                break
+            }
+            if inString {
+                if escaping {
+                    if #"\"/bfnrtu"#.unicodeScalars.contains(scalar) {
+                        output.append("\\")
+                    } else {
+                        output += "\\\\"
+                    }
+                    appendEscapedControl(scalar)
+                    escaping = false
+                    continue
+                }
+                if scalar == "\\" {
+                    escaping = true
+                    continue
+                }
+                if scalar == "\"" {
+                    inString = false
+                    output.append("\"")
+                    continue
+                }
+                appendEscapedControl(scalar)
+                continue
+            }
+
+            switch scalar {
+            case "\"":
+                inString = true
+                output.append("\"")
+            case "{":
+                stack.append("}")
+                output.append("{")
+            case "[":
+                stack.append("]")
+                output.append("[")
+            case "}", "]":
+                guard stack.last == Character(scalar) else { break scan }
+                output = output.removingTrailingCommaAndWhitespace()
+                _ = stack.popLast()
+                output.append(Character(scalar))
+                completed = stack.isEmpty
+            default:
+                output.append(Character(scalar))
+            }
+        }
+
+        if escaping {
+            output += "\\\\"
+        }
+        if inString {
+            output.append("\"")
+        }
+        while let closing = stack.popLast() {
+            output = output.removingTrailingCommaAndWhitespace()
+            output.append(closing)
+        }
+        output = output.removingDanglingJSONCommas()
+
+        guard output != trimmed,
+              isParseableJSON(output) else {
+            return nil
+        }
+        return output
+    }
+
+    private static func salvagedCaptionJSON(from candidate: String, fallbackPrompt: String) -> String? {
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.first == "{",
+              !isParseableJSON(trimmed),
+              hasStructuredCaptionSignal(trimmed) else {
+            return nil
+        }
+
+        let defaults = (
+            lighting: StructuredImageLighting.defaultLighting(description: nil),
+            aesthetics: StructuredImageAesthetics.defaultAesthetics(description: nil),
+            photo: StructuredImagePhotographicCharacteristics.defaultPhotographicCharacteristics(description: nil)
+        )
+        let objectDescriptions = salvagedObjectDescriptions(from: trimmed, fallbackPrompt: fallbackPrompt)
+        let caption = StructuredImageCaption(
+            shortDescription: firstJSONStringField(
+                in: trimmed,
+                keys: ["short description", "short_description"]
+            ) ?? fallbackPrompt,
+            objects: Array(objectDescriptions.prefix(5)).map(StructuredImageObject.defaultObject(description:)),
+            backgroundSetting: firstJSONStringField(
+                in: trimmed,
+                keys: ["background setting", "background_setting"]
+            ) ?? "Minimal background consistent with the requested image.",
+            lighting: StructuredImageLighting(
+                conditions: firstJSONStringField(in: trimmed, keys: ["conditions", "lighting"])
+                    ?? defaults.lighting.conditions,
+                direction: firstJSONStringField(in: trimmed, keys: ["direction"]) ?? defaults.lighting.direction,
+                shadows: firstJSONStringField(in: trimmed, keys: ["shadows"])
+            ),
+            aesthetics: StructuredImageAesthetics(
+                composition: firstJSONStringField(in: trimmed, keys: ["composition"])
+                    ?? defaults.aesthetics.composition,
+                colorScheme: firstJSONStringField(in: trimmed, keys: ["color scheme", "color_scheme"])
+                    ?? defaults.aesthetics.colorScheme,
+                moodAtmosphere: firstJSONStringField(in: trimmed, keys: ["mood atmosphere", "mood_atmosphere"])
+                    ?? defaults.aesthetics.moodAtmosphere
+            ),
+            photographicCharacteristics: StructuredImagePhotographicCharacteristics(
+                depthOfField: firstJSONStringField(in: trimmed, keys: ["depth of field", "depth_of_field"])
+                    ?? defaults.photo.depthOfField,
+                focus: firstJSONStringField(in: trimmed, keys: ["focus"]) ?? defaults.photo.focus,
+                cameraAngle: firstJSONStringField(in: trimmed, keys: ["camera angle", "camera_angle"])
+                    ?? defaults.photo.cameraAngle,
+                lensFocalLength: firstJSONStringField(in: trimmed, keys: ["lens focal length", "lens_focal_length"])
+                    ?? defaults.photo.lensFocalLength
+            ),
+            styleMedium: firstJSONStringField(in: trimmed, keys: ["style medium", "style_medium"]) ?? "photograph",
+            textRender: salvagedTextRender(from: trimmed, fallbackPrompt: fallbackPrompt),
+            context: firstJSONStringField(in: trimmed, keys: ["context"]) ?? "Text-to-image generation prompt.",
+            artisticStyle: firstJSONStringField(in: trimmed, keys: ["artistic style", "artistic_style"])
+                ?? "natural realism"
+        )
+
+        guard let encoded = try? encodeCaptionJSON(caption),
+              (try? validateCaptionJSON(encoded)) != nil else {
+            return nil
+        }
+        return encoded
+    }
+
+    private static func hasStructuredCaptionSignal(_ candidate: String) -> Bool {
+        [
+            #""objects"\s*:"#,
+            #""text[_ ]render"\s*:"#,
+            #""short[_ ]description"\s*:"#,
+            #""background[_ ]setting"\s*:"#,
+        ].contains { pattern in
+            candidate.range(of: pattern, options: .regularExpression) != nil
+        }
+    }
+
+    private static func salvagedObjectDescriptions(from candidate: String, fallbackPrompt: String) -> [String] {
+        var descriptions = allJSONStringFields(in: candidate, key: "description")
+        if descriptions.isEmpty,
+           let firstObjectString = firstJSONStringArrayElement(in: candidate, key: "objects") {
+            descriptions.append(firstObjectString)
+        }
+        if descriptions.isEmpty {
+            descriptions.append(fallbackPrompt)
+        }
+        return uniqueNonEmptyStrings(descriptions)
+    }
+
+    private static func salvagedTextRender(from candidate: String, fallbackPrompt: String) -> [StructuredImageTextRender] {
+        let texts = uniqueNonEmptyStrings(
+            allJSONStringFields(in: candidate, key: "text") + quotedStrings(in: fallbackPrompt)
+        ).prefix(5)
+        return texts.map { text in
+            StructuredImageTextRender(
+                text: text,
+                location: "as described in the prompt",
+                size: "medium",
+                color: "unspecified",
+                font: "unspecified",
+                appearanceDetails: nil
+            )
+        }
+    }
+
+    private static func firstJSONStringField(in candidate: String, keys: [String]) -> String? {
+        keys.lazy.compactMap { key in
+            allJSONStringFields(in: candidate, key: key).first
+        }.first
+    }
+
+    private static func allJSONStringFields(in candidate: String, key: String) -> [String] {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        let pattern = #""\#(escapedKey)"\s*:\s*"((?:\\.|[^"\\])*)""#
+        return regexCaptures(in: candidate, pattern: pattern)
+    }
+
+    private static func firstJSONStringArrayElement(in candidate: String, key: String) -> String? {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        let pattern = #""\#(escapedKey)"\s*:\s*\[\s*"((?:\\.|[^"\\])*)""#
+        return regexCaptures(in: candidate, pattern: pattern).first
+    }
+
+    private static func regexCaptures(in candidate: String, pattern: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(candidate.startIndex..., in: candidate)
+        return regex.matches(in: candidate, range: range).compactMap { match in
+            guard match.numberOfRanges > 1,
+                  let captureRange = Range(match.range(at: 1), in: candidate) else {
+                return nil
+            }
+            return decodedJSONStringFragment(String(candidate[captureRange]))?.nonEmpty
+        }
+    }
+
+    private static func decodedJSONStringFragment(_ fragment: String) -> String? {
+        let literal = "\"\(fragment)\""
+        if let data = literal.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode(String.self, from: data) {
+            return decoded
+        }
+        return fragment.replacingOccurrences(of: #"\\(.)"#, with: "$1", options: .regularExpression)
+    }
+
+    private static func uniqueNonEmptyStrings(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, trimmed.count <= 200 else { continue }
+            guard seen.insert(trimmed.lowercased()).inserted else { continue }
+            result.append(trimmed)
+        }
+        return result
     }
 
     private static func expand(
@@ -422,35 +705,43 @@ private struct FlexibleStructuredImageCaption: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case shortDescription = "short description"
+        case shortDescriptionSnake = "short_description"
         case objects
         case backgroundSetting = "background setting"
+        case backgroundSettingSnake = "background_setting"
         case lighting
         case aesthetics
         case photographicCharacteristics = "photographic characteristics"
+        case photographicCharacteristicsSnake = "photographic_characteristics"
         case styleMedium = "style medium"
+        case styleMediumSnake = "style_medium"
         case artisticStyle = "artistic style"
+        case artisticStyleSnake = "artistic_style"
         case context
         case textRender = "text render"
+        case textRenderSnake = "text_render"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        shortDescription = container.flexibleString(forKey: .shortDescription)
+        shortDescription = container.flexibleString(forKeys: [.shortDescription, .shortDescriptionSnake])
         objects = container.flexibleStructuredImageObjects(forKey: .objects)
-        backgroundSetting = container.flexibleString(forKey: .backgroundSetting)
+        backgroundSetting = container.flexibleString(forKeys: [.backgroundSetting, .backgroundSettingSnake])
         lighting = container.flexibleObject(FlexibleStructuredImageLighting.self, forKey: .lighting)
         lightingText = container.flexibleString(forKey: .lighting)
         aesthetics = container.flexibleObject(FlexibleStructuredImageAesthetics.self, forKey: .aesthetics)
         aestheticsText = container.flexibleString(forKey: .aesthetics)
         photographicCharacteristics = container.flexibleObject(
             FlexibleStructuredImagePhotographicCharacteristics.self,
-            forKey: .photographicCharacteristics
+            forKeys: [.photographicCharacteristics, .photographicCharacteristicsSnake]
         )
-        photographicCharacteristicsText = container.flexibleString(forKey: .photographicCharacteristics)
-        styleMedium = container.flexibleString(forKey: .styleMedium)
-        artisticStyle = container.flexibleString(forKey: .artisticStyle)
+        photographicCharacteristicsText = container.flexibleString(
+            forKeys: [.photographicCharacteristics, .photographicCharacteristicsSnake]
+        )
+        styleMedium = container.flexibleString(forKeys: [.styleMedium, .styleMediumSnake])
+        artisticStyle = container.flexibleString(forKeys: [.artisticStyle, .artisticStyleSnake])
         context = container.flexibleString(forKey: .context)
-        textRender = container.flexibleArray([FlexibleStructuredImageTextRender].self, forKey: .textRender)
+        textRender = container.flexibleArray([FlexibleStructuredImageTextRender].self, forKeys: [.textRender, .textRenderSnake])
     }
 
     func normalized(fallbackPrompt: String) -> StructuredImageCaption {
@@ -638,14 +929,16 @@ private struct FlexibleStructuredImageAesthetics: Decodable {
     enum CodingKeys: String, CodingKey {
         case composition
         case colorScheme = "color scheme"
+        case colorSchemeSnake = "color_scheme"
         case moodAtmosphere = "mood atmosphere"
+        case moodAtmosphereSnake = "mood_atmosphere"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         composition = container.flexibleString(forKey: .composition)
-        colorScheme = container.flexibleString(forKey: .colorScheme)
-        moodAtmosphere = container.flexibleString(forKey: .moodAtmosphere)
+        colorScheme = container.flexibleString(forKeys: [.colorScheme, .colorSchemeSnake])
+        moodAtmosphere = container.flexibleString(forKeys: [.moodAtmosphere, .moodAtmosphereSnake])
     }
 
     var normalized: StructuredImageAesthetics {
@@ -666,17 +959,20 @@ private struct FlexibleStructuredImagePhotographicCharacteristics: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case depthOfField = "depth of field"
+        case depthOfFieldSnake = "depth_of_field"
         case focus
         case cameraAngle = "camera angle"
+        case cameraAngleSnake = "camera_angle"
         case lensFocalLength = "lens focal length"
+        case lensFocalLengthSnake = "lens_focal_length"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        depthOfField = container.flexibleString(forKey: .depthOfField)
+        depthOfField = container.flexibleString(forKeys: [.depthOfField, .depthOfFieldSnake])
         focus = container.flexibleString(forKey: .focus)
-        cameraAngle = container.flexibleString(forKey: .cameraAngle)
-        lensFocalLength = container.flexibleString(forKey: .lensFocalLength)
+        cameraAngle = container.flexibleString(forKeys: [.cameraAngle, .cameraAngleSnake])
+        lensFocalLength = container.flexibleString(forKeys: [.lensFocalLength, .lensFocalLengthSnake])
     }
 
     var normalized: StructuredImagePhotographicCharacteristics {
@@ -799,6 +1095,10 @@ private extension KeyedDecodingContainer {
         return nil
     }
 
+    func flexibleString(forKeys keys: [Key]) -> String? {
+        keys.lazy.compactMap { flexibleString(forKey: $0) }.first
+    }
+
     func flexibleInt(forKey key: Key) -> Int? {
         if let int = try? decode(Int.self, forKey: key) {
             return int
@@ -813,8 +1113,16 @@ private extension KeyedDecodingContainer {
         try? decode(type, forKey: key)
     }
 
+    func flexibleObject<T: Decodable>(_ type: T.Type, forKeys keys: [Key]) -> T? {
+        keys.lazy.compactMap { flexibleObject(type, forKey: $0) }.first
+    }
+
     func flexibleArray<T: Decodable>(_ type: [T].Type, forKey key: Key) -> [T] {
         (try? decode(type, forKey: key)) ?? []
+    }
+
+    func flexibleArray<T: Decodable>(_ type: [T].Type, forKeys keys: [Key]) -> [T] {
+        keys.lazy.map { flexibleArray(type, forKey: $0) }.first { !$0.isEmpty } ?? []
     }
 
     func flexibleStringArray(forKey key: Key) -> [String] {
@@ -853,6 +1161,30 @@ private extension String {
     var nonEmpty: String? {
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    func removingTrailingCommaAndWhitespace() -> String {
+        var result = self
+        while let last = result.last, last.isWhitespace {
+            result.removeLast()
+        }
+        if result.last == "," {
+            result.removeLast()
+        }
+        return result
+    }
+
+    func removingDanglingJSONCommas() -> String {
+        var current = self
+        while true {
+            let next = current.replacingOccurrences(
+                of: #",(\s*[}\]])"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            guard next != current else { return current }
+            current = next
+        }
     }
 }
 

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
@@ -168,6 +168,20 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
         }
     }
 
+    deinit {
+        unload()
+    }
+
+    public func unload() {
+        loadedState?.model.resetGroundingState()
+        loadedState = nil
+        clearCache()
+    }
+
+    public func clearCache() {
+        clearGPUMemory()
+    }
+
     public static func defaultAnnotatedOutputURL(for imageURL: URL) -> URL {
         let parent = imageURL.deletingLastPathComponent()
         let stem = imageURL.deletingPathExtension().lastPathComponent
@@ -195,6 +209,9 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
         }.filter { !$0.isEmpty }
         guard !normalizedQueries.isEmpty else {
             throw GrounderError.failedToEncodeMetadata("At least one non-empty query is required.")
+        }
+        defer {
+            clearCache()
         }
 
         let imageWidth: Int
@@ -232,6 +249,8 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
                     segmentationThreshold: segmentationThreshold
                 )
             )
+            state.model.resetGroundingState()
+            clearCache()
         }
 
         try createParentDirectoryIfNeeded(for: annotatedImageURL)
@@ -323,6 +342,14 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
         return state
     }
 
+    private func clearGPUMemory(synchronize: Bool = true) {
+        if synchronize {
+            Stream.gpu.synchronize()
+        }
+        MLX.eval(MLXArray([]))
+        Memory.clearCache()
+    }
+
     private func groundSingleQuery(
         query: String,
         imageURL: URL,
@@ -351,6 +378,9 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
 
         let processed = try state.processor.process(imageURL: imageURL, query: query)
         let model = state.model
+        defer {
+            model.resetGroundingState()
+        }
         let config = state.config
         model.resetGroundingState()
         trace("TRACE runtime query: \(query)")

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
@@ -555,6 +555,8 @@ final class FalconPerceptionLanguageModel: Module {
     }
 
     func resetGroundingState() {
+        model.lastHiddenState = nil
+        model.capturedLayerOutputs.removeAll(keepingCapacity: false)
         ropeDelta = nil
         prefillPositionIDs = nil
         prefillPosHW = nil

--- a/Sources/MereRunCore/Gemma4/Gemma4Config.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Config.swift
@@ -182,7 +182,11 @@ public struct Gemma4Config: Decodable, Sendable, Hashable {
     public let textConfig: Gemma4TextConfig
     public let visionConfig: Gemma4UnifiedVisionConfig?
     public let imageTokenId: Int?
+    public let audioTokenId: Int?
+    public let videoTokenId: Int?
+    public let boaTokenId: Int?
     public let boiTokenId: Int?
+    public let eoaTokenId: Int?
     public let eoiTokenId: Int?
 
     private enum CodingKeys: String, CodingKey {
@@ -193,7 +197,12 @@ public struct Gemma4Config: Decodable, Sendable, Hashable {
         case textConfig = "text_config"
         case visionConfig = "vision_config"
         case imageTokenId = "image_token_id"
+        case audioTokenId = "audio_token_id"
+        case videoTokenId = "video_token_id"
+        case boaTokenId = "boa_token_id"
         case boiTokenId = "boi_token_id"
+        case eoaTokenId = "eoa_token_id"
+        case eoaTokenIndex = "eoa_token_index"
         case eoiTokenId = "eoi_token_id"
     }
 
@@ -205,7 +214,12 @@ public struct Gemma4Config: Decodable, Sendable, Hashable {
         self.textConfig = try container.decode(Gemma4TextConfig.self, forKey: .textConfig)
         self.visionConfig = try container.decodeIfPresent(Gemma4UnifiedVisionConfig.self, forKey: .visionConfig)
         self.imageTokenId = try container.decodeIfPresent(Int.self, forKey: .imageTokenId)
+        self.audioTokenId = try container.decodeIfPresent(Int.self, forKey: .audioTokenId)
+        self.videoTokenId = try container.decodeIfPresent(Int.self, forKey: .videoTokenId)
+        self.boaTokenId = try container.decodeIfPresent(Int.self, forKey: .boaTokenId)
         self.boiTokenId = try container.decodeIfPresent(Int.self, forKey: .boiTokenId)
+        self.eoaTokenId = try container.decodeIfPresent(Int.self, forKey: .eoaTokenId)
+            ?? container.decodeIfPresent(Int.self, forKey: .eoaTokenIndex)
         self.eoiTokenId = try container.decodeIfPresent(Int.self, forKey: .eoiTokenId)
 
         if let direct = try container.decodeIfPresent([Int].self, forKey: .eosTokenId) {

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -360,8 +360,12 @@ public actor Gemma4Generator: ChatGenerator {
             // A corrupted or degenerate decode otherwise surfaces them as token salad.
             generationConfig.bannedTokens = [
                 loadedConfig.imageTokenId,
+                loadedConfig.audioTokenId,
+                loadedConfig.videoTokenId,
                 loadedConfig.boiTokenId,
+                loadedConfig.boaTokenId,
                 loadedConfig.eoiTokenId,
+                loadedConfig.eoaTokenId,
             ].compactMap { $0 }
         }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -348,13 +348,22 @@ public actor Gemma4Generator: ChatGenerator {
         let eosSet = request.stopOnEOS
             ? Set(loadedConfig.eosTokenIds + tokenizerAndTemplate.stopTokenIds(withTools: hasTools))
             : []
-        let generationConfig = GenerationConfig(
+        var generationConfig = GenerationConfig(
             maxTokens: request.maxTokens,
             temperature: Float(request.temperature),
             topP: Float(request.topP),
             repetitionPenalty: 1.05,
             repetitionContextSize: 64
         )
+        if imageBatch == nil {
+            // Text-only generation must never emit multimodal placeholder tokens.
+            // A corrupted or degenerate decode otherwise surfaces them as token salad.
+            generationConfig.bannedTokens = [
+                loadedConfig.imageTokenId,
+                loadedConfig.boiTokenId,
+                loadedConfig.eoiTokenId,
+            ].compactMap { $0 }
+        }
 
         let usePrefixKVCache = imageBatch == nil
         let prefixSeed = usePrefixKVCache ? prefixKVCacheSeed(
@@ -378,6 +387,11 @@ public actor Gemma4Generator: ChatGenerator {
         )
         if continuousBatchingEnabled, mtpReason == nil {
             mtpReason = "continuous batching"
+        }
+        if request.requiresJSON, mtpReason == nil {
+            // Speculative drafting verifies tokens against the unconstrained
+            // distribution; JSON-constrained decoding must stay on the serial path.
+            mtpReason = "json constrained decoding"
         }
         let useMTP = mtpReason == nil
         let layerCaches = try prefixSeed?.caches ?? makeLayerCaches(
@@ -454,6 +468,7 @@ public actor Gemma4Generator: ChatGenerator {
             sharedKVStates: mtpTemplate.active ? mtpSharedKVStates : [:],
             prefillTokenCount: promptTokens.count,
             mtpStatsTemplate: mtpTemplate,
+            jsonConstrained: request.requiresJSON,
             progressHandler: progressHandler
         )
         lastMTPStats = decodeResult.mtpStats ?? mtpTemplate
@@ -600,6 +615,7 @@ public actor Gemma4Generator: ChatGenerator {
         sharedKVStates: [String: Gemma4SharedKVState],
         prefillTokenCount: Int,
         mtpStatsTemplate: Gemma4MTPStats,
+        jsonConstrained: Bool = false,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Gemma4BatchedDecodeResult {
         guard tokenBudget > 0 else {
@@ -610,7 +626,9 @@ public actor Gemma4Generator: ChatGenerator {
                 mtpStats: mtpStatsTemplate
             )
         }
-        guard continuousBatchingEnabled else {
+        // JSON-constrained requests always decode serially: the batched rows share
+        // one sampling path and cannot carry per-request scanner state.
+        guard continuousBatchingEnabled, !jsonConstrained else {
             return try await decodeTokensSerially(
                 model: model,
                 tokenizerAndTemplate: tokenizerAndTemplate,
@@ -625,6 +643,7 @@ public actor Gemma4Generator: ChatGenerator {
                 sharedKVStates: sharedKVStates,
                 prefillTokenCount: prefillTokenCount,
                 mtpStatsTemplate: mtpStatsTemplate,
+                jsonConstrained: jsonConstrained,
                 progressHandler: progressHandler
             )
         }
@@ -669,6 +688,7 @@ public actor Gemma4Generator: ChatGenerator {
         sharedKVStates: [String: Gemma4SharedKVState],
         prefillTokenCount: Int,
         mtpStatsTemplate: Gemma4MTPStats,
+        jsonConstrained: Bool = false,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Gemma4BatchedDecodeResult {
         var logits = initialLogits
@@ -681,11 +701,12 @@ public actor Gemma4Generator: ChatGenerator {
         var mtpStats = mtpStatsTemplate
         var firstTokenSeconds: Double?
         var pendingSampledToken: Int?
+        var jsonScanner = JSONPrefixScanner()
         let decodeStart = Date()
 
         while generated.count < tokenBudget {
             try Task.checkCancellation()
-            let next: Int
+            var next: Int
             if let pending = pendingSampledToken {
                 next = pending
                 pendingSampledToken = nil
@@ -695,6 +716,20 @@ public actor Gemma4Generator: ChatGenerator {
                     config: generationConfig,
                     previousTokens: repetitionHistory
                 )
+            }
+            if jsonConstrained {
+                guard let constrained = jsonConstrainedToken(
+                    initial: next,
+                    logits: logits[0, -1, 0...],
+                    config: generationConfig,
+                    previousTokens: repetitionHistory,
+                    eosSet: eosSet,
+                    scanner: &jsonScanner,
+                    decode: { tokenizerAndTemplate.decode(token: $0) }
+                ) else {
+                    break
+                }
+                next = constrained
             }
 
             if eosSet.contains(next) {
@@ -709,6 +744,10 @@ public actor Gemma4Generator: ChatGenerator {
             let piece = tokenizerAndTemplate.decode(token: next)
             if !piece.isEmpty {
                 progressHandler?(ChatProgress(stage: .generating, message: piece))
+            }
+
+            if jsonConstrained, jsonScanner.isComplete {
+                break
             }
 
             guard generated.count < tokenBudget else {

--- a/Sources/MereRunCore/Gemma4/Gemma4JSONConstrainedDecoding.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4JSONConstrainedDecoding.swift
@@ -1,0 +1,152 @@
+import Foundation
+import MLX
+
+/// Incremental validity filter for JSON prefixes — deliberately permissive.
+///
+/// This is NOT a grammar: it never rejects a valid JSON prefix, but it does allow
+/// some invalid ones (e.g. stray punctuation between values). Its job is to keep
+/// constrained decoding cheap while making degenerate output — special-token salad,
+/// prose, markdown fences, non-JSON characters outside strings — unsampleable.
+public struct JSONPrefixScanner: Sendable {
+    private enum Container { case object, array }
+    private static let literals = ["true", "false", "null"]
+
+    private var stack: [Container] = []
+    private var inString = false
+    private var escaped = false
+    private var started = false
+    private var literal = ""
+    public private(set) var isComplete = false
+
+    public init() {}
+
+    /// Feeds text into the scanner. Returns false at the first character that cannot
+    /// extend a valid JSON prefix; state is undefined after a rejection, so callers
+    /// must probe on a copy.
+    @discardableResult
+    public mutating func accept(_ text: String) -> Bool {
+        for character in text where !acceptCharacter(character) {
+            return false
+        }
+        return true
+    }
+
+    private mutating func acceptCharacter(_ character: Character) -> Bool {
+        if isComplete {
+            return character.isWhitespace
+        }
+        if inString {
+            if escaped {
+                escaped = false
+                return true
+            }
+            if character == "\\" {
+                escaped = true
+                return true
+            }
+            if character == "\"" {
+                inString = false
+                return true
+            }
+            // Everything is legal string content — including U+FFFD, which is how a
+            // single byte-fallback BPE token (one piece of a multibyte character)
+            // decodes in isolation. Rejecting it walls off any string containing
+            // é, em-dashes, curly quotes, CJK, …
+            return true
+        }
+        if !started {
+            if character.isWhitespace { return true }
+            if character == "{" {
+                stack.append(.object)
+                started = true
+                return true
+            }
+            if character == "[" {
+                stack.append(.array)
+                started = true
+                return true
+            }
+            return false
+        }
+        if character.isLetter {
+            // A lone e/E is a number exponent (e.g. -2.5e3); any other letters
+            // outside strings may only spell `true`, `false`, or `null`.
+            if literal.isEmpty, character == "e" || character == "E" { return true }
+            literal.append(character)
+            return Self.literals.contains { $0.hasPrefix(literal) }
+        }
+        literal = ""
+        if character.isWhitespace { return true }
+        switch character {
+        case "\"":
+            inString = true
+            return true
+        case "{":
+            stack.append(.object)
+            return true
+        case "[":
+            stack.append(.array)
+            return true
+        case "}":
+            guard stack.last == .object else { return false }
+            stack.removeLast()
+            if stack.isEmpty { isComplete = true }
+            return true
+        case "]":
+            guard stack.last == .array else { return false }
+            stack.removeLast()
+            if stack.isEmpty { isComplete = true }
+            return true
+        case ",", ":", "-", "+", ".":
+            return true
+        case "0"..."9":
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+/// Sample-then-validate constrained decoding: keep the sampled token when it extends
+/// a valid JSON prefix, otherwise walk the remaining candidates by descending LOGIT
+/// (not post-top-p probability: outside the nucleus the probabilities are all zero
+/// and their sort order is arbitrary — resampling from it injects random tokens that
+/// poison the context and trigger degeneration). EOS is only valid once the JSON
+/// value has closed. Returns nil when no candidate extends the prefix — the caller
+/// must stop generation rather than emit garbage.
+func jsonConstrainedToken(
+    initial: Int,
+    logits: MLXArray,
+    config: GenerationConfig,
+    previousTokens: [Int],
+    eosSet: Set<Int>,
+    scanner: inout JSONPrefixScanner,
+    decode: (Int) -> String
+) -> Int? {
+    func admit(_ token: Int, into scanner: inout JSONPrefixScanner) -> Bool {
+        if eosSet.contains(token) { return scanner.isComplete }
+        let piece = decode(token)
+        if piece.isEmpty { return true }
+        var probe = scanner
+        guard probe.accept(piece) else { return false }
+        scanner = probe
+        return true
+    }
+
+    if admit(initial, into: &scanner) { return initial }
+
+    let masked = applyTokenBan(logits: logits, tokens: config.bannedTokens)
+    let ascending = argSort(masked, axis: -1)
+    let vocabularySize = ascending.dim(-1)
+    let maxCandidates = min(64, vocabularySize)
+    for offset in 1...maxCandidates {
+        let candidate = ascending[vocabularySize - offset].item(Int.self)
+        if candidate == initial { continue }
+        if admit(candidate, into: &scanner) { return candidate }
+    }
+
+    // Nothing in the head of the distribution extends the prefix. Terminating with
+    // truncated-but-clean JSON beats emitting salad; the caller's validation and
+    // retry loop handle the rest.
+    return nil
+}

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift
@@ -15,10 +15,22 @@ public enum HiDreamO1GeneratorError: LocalizedError, Sendable {
 public final class HiDreamO1Generator: ImageGenerator {
     public init() {}
 
+    deinit {
+        unload()
+    }
+
+    public func unload() {
+        clearGPUMemory()
+    }
+
     public func generate(
         _ request: GenerationRequest,
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) async throws -> GenerationResult {
+        defer {
+            clearGPUMemory()
+        }
+
         progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 0, totalSteps: 1))
         let rootURL = try resolveModelRoot(request)
         let resources = HiDreamO1Resources(rootURL: rootURL)
@@ -237,5 +249,13 @@ public final class HiDreamO1Generator: ImageGenerator {
                 maxSize: maxSize
             )
         }
+    }
+
+    private func clearGPUMemory(synchronize: Bool = true) {
+        if synchronize {
+            Stream.gpu.synchronize()
+        }
+        MLX.eval(MLXArray([]))
+        Memory.clearCache()
     }
 }

--- a/Sources/MereRunCore/Ideogram4/Ideogram4Generator.swift
+++ b/Sources/MereRunCore/Ideogram4/Ideogram4Generator.swift
@@ -30,10 +30,28 @@ public final class Ideogram4Generator: ImageGenerator {
 
     public init() {}
 
+    deinit {
+        unload()
+    }
+
+    public func unload() {
+        loadedModelPath = nil
+        conditionalTransformer = nil
+        unconditionalTransformer = nil
+        textEncoder = nil
+        tokenizer = nil
+        vae = nil
+        clearGPUMemory()
+    }
+
     public func generate(
         _ request: GenerationRequest,
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) async throws -> GenerationResult {
+        defer {
+            clearGPUMemory()
+        }
+
         guard request.referenceImages.isEmpty else {
             throw Ideogram4GeneratorError.unsupportedMode("reference images")
         }
@@ -52,7 +70,13 @@ public final class Ideogram4Generator: ImageGenerator {
         }
 
         if loadedModelPath != rootURL.path || conditionalTransformer == nil {
-            try loadModels(from: resources, progressHandler: progressHandler)
+            do {
+                unload()
+                try loadModels(from: resources, progressHandler: progressHandler)
+            } catch {
+                unload()
+                throw error
+            }
             loadedModelPath = rootURL.path
         }
 
@@ -247,5 +271,13 @@ public final class Ideogram4Generator: ImageGenerator {
             hash &*= 0x0000_0100_0000_01b3
         }
         return hash
+    }
+
+    private func clearGPUMemory(synchronize: Bool = true) {
+        if synchronize {
+            Stream.gpu.synchronize()
+        }
+        MLX.eval(MLXArray([]))
+        Memory.clearCache()
     }
 }

--- a/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
+++ b/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
@@ -202,6 +202,19 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         }
     }
 
+    deinit {
+        unload()
+    }
+
+    public func unload() {
+        loadedState = nil
+        clearCache()
+    }
+
+    public func clearCache() {
+        clearGPUMemory()
+    }
+
     public static func defaultAnnotatedOutputURL(for imageURL: URL) -> URL {
         let parent = imageURL.deletingLastPathComponent()
         let stem = imageURL.deletingPathExtension().lastPathComponent
@@ -254,6 +267,9 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         }
         guard !promptSet.isEmpty else {
             throw SegmenterError.failedToEncodeMetadata("At least one prompt is required.")
+        }
+        defer {
+            clearCache()
         }
 
         #if canImport(CoreGraphics)
@@ -442,6 +458,14 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         let state = LoadedState(config: config, tokenizer: tokenizer, model: model)
         self.loadedState = state
         return state
+    }
+
+    private func clearGPUMemory(synchronize: Bool = true) {
+        if synchronize {
+            Stream.gpu.synchronize()
+        }
+        MLX.eval(MLXArray([]))
+        Memory.clearCache()
     }
 
     private static func loadWeights(resources: SAM31Resources, into model: SAM31Model) throws {

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
@@ -11,6 +11,9 @@ public struct GenerationConfig: Sendable {
     public var topP: Float
     public var repetitionPenalty: Float?
     public var repetitionContextSize: Int
+    /// Token ids that must never be sampled (e.g. multimodal special tokens
+    /// during text-only generation). Applied as a -inf logit mask.
+    public var bannedTokens: [Int]
 
     public init(
         maxTokens: Int = 256,
@@ -18,7 +21,8 @@ public struct GenerationConfig: Sendable {
         topK: Int = 0,
         topP: Float = 0.9,
         repetitionPenalty: Float? = 1.05,
-        repetitionContextSize: Int = 20
+        repetitionContextSize: Int = 20,
+        bannedTokens: [Int] = []
     ) {
         self.maxTokens = maxTokens
         self.temperature = temperature
@@ -26,7 +30,21 @@ public struct GenerationConfig: Sendable {
         self.topP = topP
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.bannedTokens = bannedTokens
     }
+}
+
+public func applyTokenBan(logits: MLXArray, tokens: [Int]) -> MLXArray {
+    guard !tokens.isEmpty else { return logits }
+    let vocabularySize = logits.dim(-1)
+    let valid = tokens.filter { $0 >= 0 && $0 < vocabularySize }
+    guard !valid.isEmpty else { return logits }
+    // Build the ban as an additive mask on a fresh array — MLXArray is a reference
+    // type, so writing into `logits` directly would mutate the caller's tensor.
+    let indices = MLXArray(valid.map(Int32.init))
+    let mask = MLXArray.zeros(like: logits)
+    mask[indices] = MLXArray(Array(repeating: -Float.infinity, count: valid.count)).asType(logits.dtype)
+    return logits + mask
 }
 
 public func argMaxSample(logits: MLXArray) -> Int {
@@ -103,6 +121,8 @@ public func sampleToken(
 ) -> Int {
     var logits = logits
 
+    logits = applyTokenBan(logits: logits, tokens: config.bannedTokens)
+
     if let penalty = config.repetitionPenalty, !previousTokens.isEmpty {
         let contextTokens = Array(previousTokens.suffix(config.repetitionContextSize))
         logits = applyRepetitionPenalty(logits: logits, tokens: contextTokens, penalty: penalty)
@@ -141,6 +161,8 @@ public func samplingProbabilities(
     previousTokens: [Int]
 ) -> MLXArray {
     var logits = logits
+
+    logits = applyTokenBan(logits: logits, tokens: config.bannedTokens)
 
     if let penalty = config.repetitionPenalty, !previousTokens.isEmpty {
         let contextTokens = Array(previousTokens.suffix(config.repetitionContextSize))

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -373,6 +373,22 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertTrue(chatRequest.requiresJSON)
     }
 
+    func testGemma4EngineCapabilityAcceptsJSONMode() throws {
+        let request = OpenAIChatRequest(
+            model: "text-chat-gemma4-12b-4bit",
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            response_format: OpenAIResponseFormat(type: "json_object")
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: RuntimeServingEngine.textChatGemma4.openAICompatibility
+        )
+        XCTAssertTrue(chatRequest.requiresJSON)
+    }
+
     func testChatRequestRejectsUnsupportedHighImpactFields() {
         let request = OpenAIChatRequest(
             model: "mererun-test-model",

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -20,6 +20,8 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertNil(cmd.apiKey)
         XCTAssertEqual(cmd.rateLimitPerMinute, 60)
         XCTAssertEqual(cmd.maxActiveRequests, 1)
+        XCTAssertEqual(cmd.memoryGuard, .balanced)
+        XCTAssertNil(cmd.memoryGuardCustomCeilingGB)
         XCTAssertEqual(cmd.contextSize, 32_768)
         XCTAssertNil(cmd.kvBits)
         XCTAssertNil(cmd.kvQuantScheme)
@@ -37,6 +39,8 @@ final class APIServeCommandTests: XCTestCase {
             "--api-key", "secret",
             "--rate-limit-per-minute", "120",
             "--max-active-requests", "2",
+            "--memory-guard", "custom",
+            "--memory-guard-custom-ceiling-gb", "42.5",
             "--context-size", "8192",
             "--kv-bits", "3.5",
             "--kv-quant-scheme", "turboquant",
@@ -52,6 +56,8 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.apiKey, "secret")
         XCTAssertEqual(cmd.rateLimitPerMinute, 120)
         XCTAssertEqual(cmd.maxActiveRequests, 2)
+        XCTAssertEqual(cmd.memoryGuard, .custom)
+        XCTAssertEqual(cmd.memoryGuardCustomCeilingGB, 42.5)
         XCTAssertEqual(cmd.contextSize, 8192)
         XCTAssertEqual(cmd.kvBits, 3.5)
         XCTAssertEqual(cmd.kvQuantScheme, "turboquant")

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -114,6 +114,47 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(caption.textRender, [])
     }
 
+    func testStructuredPromptAdapterNormalizesGemmaSnakeCaseSchema() throws {
+        let normalized = try StructuredImagePromptAdapter.normalizedCaptionJSON(
+            from: Self.gemmaSnakeCaseStructuredCaptionJSON,
+            fallbackPrompt: "a cafe sign reads 'TOKENS: FREE TODAY'"
+        )
+
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(normalized)
+        XCTAssertEqual(caption.backgroundSetting, "quiet sidewalk cafe")
+        XCTAssertEqual(caption.aesthetics.colorScheme, "warm earth tones")
+        XCTAssertEqual(caption.photographicCharacteristics.cameraAngle, "eye-level")
+        XCTAssertEqual(caption.styleMedium, "Photography")
+        XCTAssertEqual(caption.artisticStyle, "Candid street photography")
+        XCTAssertEqual(caption.textRender.map(\.text), ["TOKENS: FREE TODAY"])
+    }
+
+    func testStructuredPromptAdapterRepairsGemmaJSONPrefix() throws {
+        let normalized = try StructuredImagePromptAdapter.normalizedCaptionJSON(
+            from: Self.gemmaTruncatedStructuredCaptionJSON,
+            fallbackPrompt: "a cafe sign reads 'TOKENS: FREE TODAY' and 'ask for Dewane'"
+        )
+
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(normalized)
+        XCTAssertEqual(caption.shortDescription, "A hand-painted cafe sign.")
+        XCTAssertEqual(caption.backgroundSetting, "quiet sidewalk cafe")
+        XCTAssertEqual(caption.textRender.map(\.text), ["TOKENS: FREE TODAY", "ask for Dewane"])
+        XCTAssertEqual(caption.textRender.last?.font, "unspecified")
+    }
+
+    func testStructuredPromptAdapterSalvagesGemmaNonsenseTail() throws {
+        let normalized = try StructuredImagePromptAdapter.normalizedCaptionJSON(
+            from: Self.gemmaNonsenseTailStructuredCaptionJSON,
+            fallbackPrompt: "a cafe sign reads 'TOKENS: FREE TODAY' and 'ask for Dewane'"
+        )
+
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(normalized)
+        XCTAssertEqual(caption.shortDescription, "A hand-painted cafe sign.")
+        XCTAssertEqual(caption.backgroundSetting, "quiet sidewalk cafe")
+        XCTAssertEqual(caption.textRender.map(\.text), ["TOKENS: FREE TODAY", "ask for Dewane"])
+        XCTAssertFalse(normalized.contains("<audio|>"))
+    }
+
     func testQuotedStringsExtraction() {
         let prompt = """
         a trailhead sign reads 'THE LOCAL WILD' with a smaller line below reading \
@@ -274,5 +315,115 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
       "text render": "none"
     }
     ```
+    """
+
+    private static let gemmaSnakeCaseStructuredCaptionJSON = """
+    {
+      "short description": "A hand-painted cafe sign.",
+      "objects": [
+        {
+          "description": "wooden sandwich board",
+          "location": "sidewalk",
+          "relative size": "medium",
+          "shape and color": "brown A-frame board",
+          "texture": "painted wood",
+          "appearance details": "chalk lettering",
+          "relationship": "foreground",
+          "number of objects": 1
+        }
+      ],
+      "background_setting": "quiet sidewalk cafe",
+      "lighting": "soft morning light",
+      "aesthetics": {
+        "composition": "off-center street photo",
+        "color_scheme": "warm earth tones",
+        "mood_atmosphere": "inviting"
+      },
+      "photographic_characteristics": {
+        "depth_of_field": "shallow",
+        "focus": "sharp sign text",
+        "camera_angle": "eye-level",
+        "lens_focal_length": "35mm"
+      },
+      "style_medium": "Photography",
+      "artistic_style": "Candid street photography",
+      "context": "morning cafe promotion",
+      "text_render": [
+        {
+          "text": "TOKENS: FREE TODAY",
+          "location": "main board",
+          "size": "large",
+          "color": "white chalk",
+          "font": "handwritten",
+          "appearance details": "chalk texture"
+        }
+      ]
+    }
+    """
+
+    private static let gemmaTruncatedStructuredCaptionJSON = """
+    {
+      "short_description": "A hand-painted cafe sign.",
+      "objects": ["wooden sandwich board"],
+      "background_setting": "quiet sidewalk cafe",
+      "lighting": "soft morning light",
+      "aesthetics": "warm street photo",
+      "photographic_characteristics": "35mm lens, eye-level",
+      "style_medium": "Photography",
+      "artistic_style": "Candid street photography",
+      "context": "morning cafe promotion",
+      "text_render": [
+        {
+          "text": "TOKENS: FREE TODAY",
+          "location": "main board",
+          "size": "large",
+          "color": "white chalk",
+          "font": "handwritten"
+        },
+        {
+          "text": "ask for Dewane",
+          "location": "bottom of board",
+          "size": "small",
+          "color": "White chalk",
+    """
+
+    private static let gemmaNonsenseTailStructuredCaptionJSON = """
+    {
+      "short_description": "A hand-painted cafe sign.",
+      "objects": ["wooden sandwich board"],
+      "background_setting": "quiet sidewalk cafe",
+      "lighting": {
+        "conditions": "soft morning light",
+        "direction": "front-left"
+      },
+      "aesthetics": {
+        "composition": "off-center street photo",
+        "color_scheme": "warm earth tones",
+        "mood_atmosphere": "inviting"
+      },
+      "photographic_characteristics": {
+        "depth_of_field": "shallow",
+        "focus": "sharp sign text",
+        "camera_angle": "eye-level",
+        "lens_focal_length": "35mm"
+      },
+      "style_medium": "Photography",
+      "artistic_style": "Candid street photography",
+      "context": "morning cafe promotion",
+      "text_render": [
+        {
+          "text": "TOKENS: FREE TODAY",
+          "location": "main board",
+          "size": "large",
+          "color": "white chalk",
+          "font": "handwritten",
+          "appearance details": "chalk texture"
+        },
+        {
+          "text": "ask for Dewane",
+          "location": "bottom of board",
+          "size": "small",
+          "color": "White chalk",
+          "font": "Handwritten, rustic $" loose token salad <audio|> still spilling,
     """
 }

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -114,6 +114,65 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(caption.textRender, [])
     }
 
+    func testQuotedStringsExtraction() {
+        let prompt = """
+        a trailhead sign reads 'THE LOCAL WILD' with a smaller line below reading \
+        'do not feed the models', the sign's letters carved into wood, titled "Field Notes"
+        """
+        let quoted = StructuredImagePromptAdapter.quotedStrings(in: prompt)
+        XCTAssertEqual(quoted, ["Field Notes", "THE LOCAL WILD", "do not feed the models"])
+    }
+
+    func testQuotedStringsIgnoresApostrophes() {
+        let quoted = StructuredImagePromptAdapter.quotedStrings(
+            in: "the sign's weathered face catches the morning's first light"
+        )
+        XCTAssertEqual(quoted, [])
+    }
+
+    func testEnsuringTextRenderInjectsQuotedPromptText() throws {
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(Self.validStructuredCaptionJSON)
+        XCTAssertEqual(caption.textRender, [])
+
+        let ensured = StructuredImagePromptAdapter.ensuringTextRender(
+            caption,
+            prompt: "a banner above the knight reads 'ONWARD'"
+        )
+        XCTAssertEqual(ensured.textRender.count, 1)
+        XCTAssertEqual(ensured.textRender.first?.text, "ONWARD")
+    }
+
+    func testEnsuringTextRenderKeepsModelProvidedEntries() throws {
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(Self.validStructuredCaptionJSON)
+        let withEntry = StructuredImagePromptAdapter.ensuringTextRender(
+            caption,
+            prompt: "a banner reads 'ONWARD'"
+        )
+        // A second pass must not duplicate or overwrite the existing entry.
+        let unchanged = StructuredImagePromptAdapter.ensuringTextRender(
+            withEntry,
+            prompt: "a banner reads 'SOMETHING ELSE'"
+        )
+        XCTAssertEqual(unchanged.textRender, withEntry.textRender)
+    }
+
+    func testNormalizedCaptionJSONInjectsTextRenderForQuotedPrompt() throws {
+        let normalized = try StructuredImagePromptAdapter.normalizedCaptionJSON(
+            from: Self.validStructuredCaptionJSON,
+            fallbackPrompt: "a knight under a banner that reads 'ONWARD', sunny meadow"
+        )
+        let caption = try StructuredImagePromptAdapter.validateCaptionJSON(normalized)
+        XCTAssertEqual(caption.textRender.map(\.text), ["ONWARD"])
+    }
+
+    func testIsParseableJSONDistinguishesNearMissFromTokenSalad() {
+        XCTAssertTrue(StructuredImagePromptAdapter.isParseableJSON(#"{"objects": "wrong shape"}"#))
+        XCTAssertFalse(StructuredImagePromptAdapter.isParseableJSON(
+            "{ed feetization mas Dod asked Lolamente lesser0 or<audio|>"
+        ))
+        XCTAssertFalse(StructuredImagePromptAdapter.isParseableJSON(""))
+    }
+
     private static let validStructuredCaptionJSON = """
     {
       "short description": "A knight riding a white horse in a sunlit meadow.",

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -4,6 +4,8 @@ import XCTest
 @testable import MereRunCore
 
 final class RuntimeModelPoolTests: XCTestCase {
+    private let gib = UInt64(1024 * 1024 * 1024)
+
     func testStatusIncludesLegacyStartupDefaultWithoutCatalogScan() async throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -115,6 +117,262 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertEqual(gemma.kvCacheMode, .auto)
     }
 
+    func testTTLEvictsExpiredIdleUnpinnedModel() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        try store.writeSettings(
+            RuntimeModelSettings(ttlSeconds: 60),
+            for: Gemma4Resources.defaultModelId
+        )
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: store
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 0)
+        )
+
+        let evicted = await pool.evictExpiredIdleModels(now: Date(timeIntervalSince1970: 61))
+
+        XCTAssertEqual(evicted, [Gemma4Resources.defaultModelId])
+        let status = await pool.status()
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        XCTAssertFalse(gemma.loaded)
+        XCTAssertEqual(gemma.ttlSeconds, 60)
+    }
+
+    func testTTLEvictionSkipsPinnedModel() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        try store.writeSettings(
+            RuntimeModelSettings(pinned: true, ttlSeconds: 60),
+            for: Gemma4Resources.defaultModelId
+        )
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: store
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 0)
+        )
+
+        let evicted = await pool.evictExpiredIdleModels(now: Date(timeIntervalSince1970: 61))
+
+        XCTAssertTrue(evicted.isEmpty)
+        let status = await pool.status()
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        XCTAssertTrue(gemma.loaded)
+        XCTAssertTrue(gemma.pinned)
+    }
+
+    func testTTLEvictionSkipsActiveModel() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        try store.writeSettings(
+            RuntimeModelSettings(ttlSeconds: 60),
+            for: Gemma4Resources.defaultModelId
+        )
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: store
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 0),
+            activeRequests: 1
+        )
+
+        let evicted = await pool.evictExpiredIdleModels(now: Date(timeIntervalSince1970: 61))
+
+        XCTAssertTrue(evicted.isEmpty)
+        let status = await pool.status()
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        XCTAssertTrue(gemma.loaded)
+        XCTAssertEqual(gemma.activeRequests, 1)
+    }
+
+    func testMemoryPressureLRUEvictsOldestIdleUnpinnedModel() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root)
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 10)
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Q35Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 20)
+        )
+
+        let evicted = await pool.evictIdleModelsForMemoryPressure(
+            sample: RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 85 * gib)
+        )
+
+        XCTAssertEqual(evicted, [Gemma4Resources.defaultModelId])
+        let status = await pool.status()
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        let q35 = try XCTUnwrap(status.models.first { $0.id == Q35Resources.defaultModelId })
+        XCTAssertFalse(gemma.loaded)
+        XCTAssertTrue(q35.loaded)
+    }
+
+    func testMemoryPressureLRUHonorsExcludedModel() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root)
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 10)
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Q35Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 20)
+        )
+
+        let evicted = await pool.evictIdleModelsForMemoryPressure(
+            sample: RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 85 * gib),
+            excluding: [Gemma4Resources.defaultModelId]
+        )
+
+        XCTAssertEqual(evicted, [Q35Resources.defaultModelId])
+        let status = await pool.status()
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        let q35 = try XCTUnwrap(status.models.first { $0.id == Q35Resources.defaultModelId })
+        XCTAssertTrue(gemma.loaded)
+        XCTAssertFalse(q35.loaded)
+    }
+
+    func testCriticalMemoryPressureLRUSkipsPinnedAndActiveModels() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        try store.writeSettings(
+            RuntimeModelSettings(pinned: true),
+            for: Gemma4Resources.defaultModelId
+        )
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: store
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 0)
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Q35Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 1),
+            activeRequests: 1
+        )
+        await pool.seedLoadedModelForTesting(
+            id: LFM2Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 2)
+        )
+
+        let evicted = await pool.evictIdleModelsForMemoryPressure(
+            sample: RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 95 * gib)
+        )
+
+        XCTAssertEqual(evicted, [LFM2Resources.defaultModelId])
+        let status = await pool.status()
+        let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
+        let q35 = try XCTUnwrap(status.models.first { $0.id == Q35Resources.defaultModelId })
+        let lfm2 = try XCTUnwrap(status.models.first { $0.id == LFM2Resources.defaultModelId })
+        XCTAssertTrue(gemma.loaded)
+        XCTAssertTrue(gemma.pinned)
+        XCTAssertTrue(q35.loaded)
+        XCTAssertEqual(q35.activeRequests, 1)
+        XCTAssertFalse(lfm2.loaded)
+    }
+
+    func testStatusReportsResidentMemoryPressure() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let gibibyte = gib
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            currentMemorySample: {
+                RuntimeMemorySample(physicalBytes: 100 * gibibyte, residentBytes: 85 * gibibyte)
+            }
+        )
+
+        let status = await pool.status()
+
+        XCTAssertEqual(status.memory.physicalBytes, 100 * gib)
+        XCTAssertEqual(status.memory.residentBytes, 85 * gib)
+        XCTAssertEqual(status.memory.currentBytes, 85 * gib)
+        XCTAssertEqual(status.memory.ceilingBytes, 94 * gib)
+        XCTAssertEqual(status.memory.pressure, RuntimeMemoryPressureLevel.elevated.rawValue)
+        XCTAssertEqual(status.memory.guardTier, .balanced)
+    }
+
+    func testMemoryGuardOffDisablesPressureEviction() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            memoryPressurePolicy: RuntimeMemoryPressurePolicy(tier: .off)
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 10)
+        )
+
+        let evicted = await pool.evictIdleModelsForMemoryPressure(
+            sample: RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 99 * gib)
+        )
+
+        XCTAssertTrue(evicted.isEmpty)
+        let status = await pool.status()
+        XCTAssertEqual(status.memory.pressure, RuntimeMemoryPressureLevel.disabled.rawValue)
+    }
+
+    func testCustomMemoryGuardUsesConfiguredCeiling() {
+        let policy = RuntimeMemoryPressurePolicy(
+            tier: .custom,
+            customCeilingBytes: 40 * gib
+        )
+        let sample = RuntimeMemorySample(
+            physicalBytes: 100 * gib,
+            residentBytes: 37 * gib
+        )
+
+        let limits = policy.limits(for: sample)
+
+        XCTAssertEqual(limits?.ceiling, 40 * gib)
+        XCTAssertEqual(limits?.soft, 36 * gib)
+        XCTAssertEqual(limits?.hard, 38 * gib)
+        XCTAssertEqual(policy.pressure(for: sample), .elevated)
+    }
+
     func testRequestAdmissionSerializesByDefaultAndReportsQueue() async throws {
         let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
         let first = try await admission.acquire()
@@ -135,6 +393,8 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertEqual(snapshot.totalAdmittedRequests, 1)
         XCTAssertEqual(snapshot.totalCompletedRequests, 0)
         XCTAssertEqual(snapshot.totalCancelledRequests, 0)
+        XCTAssertEqual(snapshot.admissionPaused, false)
+        XCTAssertEqual(snapshot.pressure, RuntimeMemoryPressureLevel.nominal.rawValue)
 
         await first.release()
         let second = try await secondTask.value
@@ -153,6 +413,45 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertEqual(snapshot.queuedRequests, 0)
         XCTAssertEqual(snapshot.totalCompletedRequests, 2)
         XCTAssertEqual(snapshot.totalCancelledRequests, 0)
+    }
+
+    func testRequestAdmissionPausesAdditionalWorkUnderPressure() async throws {
+        let pressure = RuntimeMemoryPressureProbe(.elevated)
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 2) {
+            await pressure.current()
+        }
+        let first = try await admission.acquire()
+        let secondTask = Task {
+            try await admission.acquire()
+        }
+
+        var snapshot = await admission.snapshot()
+        for _ in 0..<20 {
+            guard snapshot.queuedRequests == 0 else { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+            snapshot = await admission.snapshot()
+        }
+
+        XCTAssertEqual(snapshot.activeRequests, 1)
+        XCTAssertEqual(snapshot.queuedRequests, 1)
+        XCTAssertEqual(snapshot.admissionPaused, true)
+        XCTAssertEqual(snapshot.pressure, RuntimeMemoryPressureLevel.elevated.rawValue)
+
+        await pressure.set(.nominal)
+        let thirdTask = Task {
+            try await admission.acquire()
+        }
+        let second = try await secondTask.value
+        snapshot = await admission.snapshot()
+
+        XCTAssertEqual(snapshot.activeRequests, 2)
+        XCTAssertEqual(snapshot.queuedRequests, 1)
+        XCTAssertEqual(snapshot.admissionPaused, false)
+
+        await first.release()
+        let third = try await thirdTask.value
+        await second.release()
+        await third.release()
     }
 
     func testRequestAdmissionCancelsQueuedWaiterWithoutLaterAdmission() async throws {
@@ -199,5 +498,21 @@ final class RuntimeModelPoolTests: XCTestCase {
             .appendingPathComponent("mere-run-runtime-pool-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+}
+
+private actor RuntimeMemoryPressureProbe {
+    private var level: RuntimeMemoryPressureLevel
+
+    init(_ level: RuntimeMemoryPressureLevel) {
+        self.level = level
+    }
+
+    func set(_ level: RuntimeMemoryPressureLevel) {
+        self.level = level
+    }
+
+    func current() -> RuntimeMemoryPressureLevel {
+        level
     }
 }

--- a/Tests/MereRunCoreTests/Gemma4JSONConstrainedDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4JSONConstrainedDecodingTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Gemma4JSONConstrainedDecodingTests: XCTestCase {
+    // MARK: - JSONPrefixScanner
+
+    func testAcceptsValidJSONIncrementally() {
+        var scanner = JSONPrefixScanner()
+        // Pieces shaped like real BPE output: fragments that split tokens mid-string.
+        let pieces = ["{\"short", " desc", "ription\": \"A sign", " in a forest\",", " \"count\": 12.5,", " \"ok\": true}", ""]
+        for piece in pieces {
+            XCTAssertTrue(scanner.accept(piece), "rejected valid piece: \(piece)")
+        }
+        XCTAssertTrue(scanner.isComplete)
+    }
+
+    func testAcceptsNestedContainersAndEscapes() {
+        var scanner = JSONPrefixScanner()
+        XCTAssertTrue(scanner.accept(#"{"a": [{"b": "she said \"hi\""}, [1, -2.5e3, null]], "c": false}"#))
+        XCTAssertTrue(scanner.isComplete)
+    }
+
+    func testAcceptsNonASCIIInsideStringsOnly() {
+        var inString = JSONPrefixScanner()
+        XCTAssertTrue(inString.accept(#"{"título": "señal — 標識 🌲"#))
+
+        var outside = JSONPrefixScanner()
+        XCTAssertFalse(outside.accept(#"{標識"#))
+    }
+
+    func testRejectsTokenSalad() {
+        var scanner = JSONPrefixScanner()
+        XCTAssertFalse(scanner.accept("{ed feetization mas Dod asked or<audio|>"))
+
+        var fresh = JSONPrefixScanner()
+        XCTAssertFalse(fresh.accept("<|image>"))
+    }
+
+    func testRejectsProseAndFencesBeforeJSONStarts() {
+        var scanner = JSONPrefixScanner()
+        XCTAssertFalse(scanner.accept("Here is the JSON you asked for: {"))
+
+        var fenced = JSONPrefixScanner()
+        XCTAssertFalse(fenced.accept("```json"))
+
+        var leadingWhitespace = JSONPrefixScanner()
+        XCTAssertTrue(leadingWhitespace.accept("  \n\t{"))
+    }
+
+    func testRejectsMismatchedBrackets() {
+        var scanner = JSONPrefixScanner()
+        XCTAssertFalse(scanner.accept(#"{"a": [1, 2}"#))
+
+        var underflow = JSONPrefixScanner()
+        XCTAssertTrue(underflow.accept("{}"))
+        XCTAssertFalse(underflow.accept("}"))
+    }
+
+    func testCompleteAllowsOnlyTrailingWhitespace() {
+        var scanner = JSONPrefixScanner()
+        XCTAssertTrue(scanner.accept(#"{"done": true}"#))
+        XCTAssertTrue(scanner.isComplete)
+        XCTAssertTrue(scanner.accept(" \n"))
+        XCTAssertFalse(scanner.accept("extra"))
+    }
+
+    func testAllowsOnlyJSONLiteralsOutsideStrings() {
+        var literals = JSONPrefixScanner()
+        XCTAssertTrue(literals.accept(#"{"a": true, "b": false, "c": null}"#))
+        XCTAssertTrue(literals.isComplete)
+
+        // Split across BPE-style pieces.
+        var split = JSONPrefixScanner()
+        XCTAssertTrue(split.accept(#"{"a": tr"#))
+        XCTAssertTrue(split.accept("ue}"))
+
+        // Arbitrary words made of literal letters must not slip through —
+        // this was the context-poisoning vector for mid-generation salad.
+        var junk = JSONPrefixScanner()
+        XCTAssertFalse(junk.accept(#"{"a": ensure"#))
+
+        var uppercase = JSONPrefixScanner()
+        XCTAssertFalse(uppercase.accept(#"{"a": True"#))
+    }
+
+    // MARK: - Token ban mask
+
+    func testApplyTokenBanMakesTokensUnsampleable() {
+        // Token 3 has by far the highest logit; banning it must reroute argmax.
+        let logits = MLXArray([Float](
+            [0.1, 0.2, 0.3, 10.0, 0.4]
+        ))
+        let banned = applyTokenBan(logits: logits, tokens: [3])
+        XCTAssertEqual(argMaxSample(logits: banned), 4)
+        // Out-of-range ids are ignored rather than crashing.
+        let unchanged = applyTokenBan(logits: logits, tokens: [99, -1])
+        XCTAssertEqual(argMaxSample(logits: unchanged), 3)
+    }
+
+    func testGenerationConfigBannedTokensFlowThroughSampleToken() {
+        let logits = MLXArray([Float]([0.0, 8.0, 0.0, 0.0]))
+        var config = GenerationConfig(temperature: 0)
+        config.bannedTokens = [1]
+        let token = sampleToken(logits: logits, config: config, previousTokens: [])
+        XCTAssertNotEqual(token, 1)
+    }
+}

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -155,6 +155,31 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         XCTAssertEqual(logits.shape, [1, 4, 64])
     }
 
+    func testUnifiedConfigDecodesMultimodalTokenIds() throws {
+        let config = try decodeConfig([
+            "model_type": "gemma4_unified",
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "tie_word_embeddings": true,
+            "eos_token_id": [1, 106, 50],
+            "image_token_id": 258_880,
+            "audio_token_id": 258_881,
+            "video_token_id": 258_884,
+            "boi_token_id": 255_999,
+            "boa_token_id": 256_000,
+            "eoa_token_index": 258_883,
+            "eoi_token_id": 258_882,
+            "text_config": makeBaseConfig(),
+        ])
+
+        XCTAssertEqual(config.imageTokenId, 258_880)
+        XCTAssertEqual(config.audioTokenId, 258_881)
+        XCTAssertEqual(config.videoTokenId, 258_884)
+        XCTAssertEqual(config.boiTokenId, 255_999)
+        XCTAssertEqual(config.boaTokenId, 256_000)
+        XCTAssertEqual(config.eoaTokenId, 258_883)
+        XCTAssertEqual(config.eoiTokenId, 258_882)
+    }
+
     func testAttentionKEqVDisablesValueProjectionForFullAttentionLayers() throws {
         var configObject = makeBaseConfig()
         configObject["attention_k_eq_v"] = true

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -144,6 +144,15 @@ swift run mere.run api serve \
   in-memory counters justify it
 - runtime settings are stored at
   `<active model store>/.mere-run/runtime-model-settings.json`
+- the runtime pool applies `ttlSeconds` opportunistically when handling pool
+  operations; expired idle models unload automatically unless their settings are
+  pinned. Explicit unload remains available for pinned models.
+- memory-pressure LRU uses the API server's `--memory-guard` tier. The guard
+  derives soft/hard ceilings from process resident memory, host memory
+  headroom, and a tier reserve (`safe`, `balanced`, `aggressive`, or
+  `custom`). Elevated pressure pauses extra concurrent admissions and evicts the
+  least-recently-used idle unpinned model; critical pressure evicts every idle
+  unpinned model. Active requests are never evicted.
 - `mere.run status` is the preferred quick check before wiring an editor or
   agent to a local server
 - it is intentionally local-first


### PR DESCRIPTION
## Summary
- clean up local runtime pooling/status surfaces and structured image retry handling
- add Gemma4 JSON-constrained decoding, JSON-mode compatibility, and multimodal sentinel-token filtering
- recover structured image captions from snake_case, truncated, or token-salad Gemma JSON output

## Validation
- `./scripts/check.sh`

## Notes
- Cut from a clean `origin/main` worktree; ACE-Step cover changes remain isolated in PR #67.
