### PR TITLE
Exclude MagentaRT2 README from SwiftPM target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -272,6 +272,7 @@ targets.append(contentsOf: [
       "LightOnOCR/README.md",
       "LTX/README.md",
       "LoRA/README.md",
+      "MagentaRT2/README.md",
       "PrivacyFilter/README.md",
       "Psi/README.md",
       "Q35/README.md",


### PR DESCRIPTION
## Summary
- exclude the MagentaRT2 README from SwiftPM target discovery
- removes the unhandled README warning emitted during package builds/checks

## Validation
- `./scripts/check.sh`
