### PR TITLE
Clarify music guide workflow shape

### DIFF
--- a/Sources/MereRunCLI/Guides/music-analyze.md
+++ b/Sources/MereRunCLI/Guides/music-analyze.md
@@ -54,6 +54,28 @@ Important fields:
 - `inputDurationSeconds`
 - `analyzedDurationSeconds`
 
+## Workflow Choices
+
+Use this guide as the command topic for ACE-Step audio understanding:
+
+```bash
+mere.run guide music analyze --model music-acestep
+mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
+```
+
+Use standalone `music analyze` when you want a reviewable JSON artifact before
+generation, when you are cataloging source files, or when you want to decide
+which metadata to override manually.
+
+Use `music generate --analyze-source-audio` when analysis is only an input to a
+cover or remix. In that path, analysis fills missing generation metadata before
+the direct ACE-Step DiT cover pass. Explicit generation flags such as `--bpm`,
+`--keyscale`, `--timesignature`, and `--metadata-language` still take priority.
+
+Use `--duration 30` for fast probes on long songs. Run without `--duration` when
+the entire song structure matters, or add `--include-raw-lm` when debugging why
+metadata was missing or parsed unexpectedly.
+
 ## Examples
 
 ```bash
@@ -67,6 +89,15 @@ mere.run music analyze ./song.mp3 \
   --duration 30 \
   --include-raw-lm \
   > ./song-analysis.json
+```
+
+```bash
+mere.run music generate \
+  "dream-pop cover with soft vocals, preserve melody and phrasing" \
+  --source-audio ./song.mp3 \
+  --analyze-source-audio \
+  --audio-cover-strength 1.0 \
+  --output ./faithful-cover.wav
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -94,6 +94,36 @@ capture. Add `--interactive` to steer while it runs with stdin commands such as
 `prompt <text>`, `temp <value>`, `noteon <0-131>`, `noteoff <0-131>`,
 `style streaming|full`, `drumless on|off`, `reset`, and `quit`.
 
+## Workflow Choices
+
+Use this guide as a command topic, then focus it with `--model` when needed:
+
+```bash
+mere.run guide music generate --model music-acestep
+mere.run guide music generate --model music-acestep-xl-turbo
+mere.run guide music generate --model music-magenta-rt2-small
+```
+
+For ACE-Step text-to-music, start with a direct caption and optional structured
+lyrics. Add `--use-lm` only when you want the 5 Hz LM planning phase for
+text-to-music; cover, repaint, extract, lego, and complete tasks use direct DiT
+conditioning instead.
+
+For ACE-Step covers, keep the source song in `--source-audio` and put the target
+arrangement in the caption. Add `--analyze-source-audio` when you want missing
+BPM, key/scale, language, and time signature filled from the source before
+generation. Keep `--audio-cover-strength 1.0` for a faithful cover.
+
+For ACE-Step style-transfer covers or remixes, lower `--audio-cover-strength`
+so the caption can steer genre and arrangement. Start around `0.20`, keep
+`--cover-noise-strength 0.0`, and only raise source noise when the result needs
+more of the original song's contour.
+
+For analysis-first workflows, run `mere.run music analyze` separately, inspect
+the JSON, then pass explicit `--bpm`, `--keyscale`, `--timesignature`, or
+`--metadata-language` values to pin the generated result. Explicit generation
+flags always win over source analysis.
+
 ## Prompting Patterns
 
 - Caption formula: genre + instrumentation + vocal style + mood + tempo + mix/production references.
@@ -102,6 +132,13 @@ capture. Add `--interactive` to steer while it runs with stdin commands such as
 - Use `--bpm`, `--keyscale`, and `--timesignature` when rhythm or harmony must be stable.
 - Use `music analyze` first when you want to inspect source BPM, key/scale, and
   time signature before choosing generation overrides.
+- For faithful covers, say what must stay fixed: melody, tempo, phrasing,
+  structure, language, and vocal range.
+- For style-transfer covers, make the new genre concrete with rhythm, drums,
+  bass, percussion, mix, and club/stage/room context.
+- Keep source lyrics sectioned with tags like `[verse]`, `[chorus]`, and
+  `[bridge]`; the model responds better to visible song structure than to a
+  plain paragraph.
 - Use `--duration 10` to draft, then extend once the caption works.
 - For Magenta RT2, put all musical direction in the prompt; lyrics and ACE-Step
   task modes are not supported by that runtime.

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -66,6 +66,8 @@ covered by the guide before printing:
 mere.run guide image generate --model image-zimage-nano
 mere.run guide text chat --model text-chat-gemma4
 mere.run guide speech transcribe --model speech-asr-parakeet
+mere.run guide music generate --model music-acestep-xl-turbo
+mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
 ```
 
 If the model does not belong to the topic, the command prints a validation error

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -18,6 +18,22 @@ This page covers the native music-generation paths exposed through
 - `music-magenta-rt2-small`
 - `music-magenta-rt2-base`
 
+## Guides
+
+Music guidance follows the command/cookbook shape used by the rest of
+`mere.run`: choose the command first, then focus the guide with a model id.
+
+```bash
+mere.run guide music generate --model music-acestep
+mere.run guide music generate --model music-acestep-xl-turbo
+mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
+mere.run guide music generate --model music-magenta-rt2-small
+```
+
+There is no separate `ace-step` guide topic. ACE-Step text-to-music, covers,
+style-transfer covers, and source-audio understanding are documented under
+`music generate` and `music analyze`, because those are the public CLI surfaces.
+
 ## Typical workflow
 
 ```bash


### PR DESCRIPTION
## Summary

- keeps ACE-Step docs in the existing command-first guide shape
- adds workflow choices to `music generate` for text-to-music, faithful covers, style-transfer covers, and analysis-first generation
- clarifies standalone `music analyze` vs inline `--analyze-source-audio`
- documents the model-focused music guide pattern in runtime and cookbook docs

## Validation

- `swift run mere.run guide music generate --model music-acestep-xl-turbo`
- `swift run mere.run guide music analyze --model music-acestep-xl-turbo-lm4b`
- `pnpm docs:build`
- `./scripts/check.sh`
