### PR TITLE
Add Open WebUI companion integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added native OpenAI-compatible `/v1/embeddings` to `mere.run api serve`,
+  backed by `text-embed-qwen3-0.6b`, and documented Open WebUI as an optional
+  companion UI with Docker and pip connection recipes.
+- added OpenAI-ish `/v1/images/generations`, `/v1/images/edits`,
+  `/v1/audio/speech`, and `/v1/audio/transcriptions` endpoints backed by
+  native image, Qwen3-TTS, and ASR runtime paths, with installed-only sidecar
+  model listing plus MP3/Opus/AAC/FLAC speech transcoding and SRT/VTT
+  transcription output.
+- added an Open WebUI smoke harness, native function-calling settings guidance,
+  conservative model capability metadata, Open WebUI chat model filtering,
+  per-model metadata wrapper import, and Open WebUI-style image edit multipart
+  compatibility for `image[]` uploads plus optional masks.
+- added `mere.run open-webui quickstart` to start a local mere.run API server,
+  launch the official Open WebUI Docker image, and apply the same native
+  chat/RAG/image/TTS/STT configuration used by the smoke harness.
+- documented Docker Compose and `uvx` Open WebUI companion paths for longer-lived
+  Linux/DGX Spark and same-host Python installs.
+
 ### Fixed
 
 - fixed `scripts/install-local.sh` on macOS so local installs stage every built

--- a/Package.swift
+++ b/Package.swift
@@ -250,6 +250,19 @@ audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXFast"))
 audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXNN"))
 audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXRandom"))
 
+var mereRunCLIDependencies: [Target.Dependency] = [
+  "MereRunCore",
+  "AudioCore",
+  "AudioCodecs",
+  "AudioSTT",
+  "AudioTTS",
+  .product(name: "ArgumentParser", package: "swift-argument-parser"),
+  .product(name: "Hummingbird", package: "hummingbird")
+]
+if hasMediaIOTarget {
+  mereRunCLIDependencies.append("MediaIO")
+}
+
 targets.append(contentsOf: [
   .target(
     name: "MereRunCore",
@@ -336,15 +349,7 @@ targets.append(contentsOf: [
   ),
   .executableTarget(
     name: "MereRunCLI",
-    dependencies: [
-      "MereRunCore",
-      "AudioCore",
-      "AudioCodecs",
-      "AudioSTT",
-      "AudioTTS",
-      .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      .product(name: "Hummingbird", package: "hummingbird")
-    ],
+    dependencies: mereRunCLIDependencies,
     path: "Sources/MereRunCLI",
     exclude: [
       "Commands/README.md",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The public OSS repo currently supports:
 - native ACEStep music generation and LTX video generation
 - Hugging Face-backed model pulls that resolve into a shared local model store
 - offline command cookbooks through `mere.run guide`
-- a local OpenAI-compatible API surface with a native Swift runtime model pool
+- a local OpenAI-compatible API surface for chat, embeddings, image generation,
+  TTS, and STT
 - a quick status snapshot for the local server, loaded API models, active requests, runtime capabilities, and installed model store
 - an optional macOS studio that wraps the public CLI instead of reimplementing runtime logic
 
@@ -257,6 +258,34 @@ swift run mere.run api serve --engine text-chat-lfm2
 # In another terminal, confirm the server and served model
 swift run mere.run status
 
+# Native embeddings for local RAG clients
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H "Content-Type: application/json" \
+  --data '{"model":"text-embed-qwen3-0.6b","input":"mere.run native embeddings"}'
+
+# Native image generation and audio through the same /v1 API
+curl http://127.0.0.1:8080/v1/images/generations \
+  -H "Content-Type: application/json" \
+  --data '{"model":"image-zimage-nano","prompt":"a compact local AI workstation","size":"1024x1024"}'
+curl http://127.0.0.1:8080/v1/images/edits \
+  -F model=qwen-image-edit \
+  -F prompt="make the workstation dusk-lit while preserving the layout" \
+  -F image=@input.png
+curl http://127.0.0.1:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  --output speech.wav \
+  --data '{"model":"speech-tts-qwen3-nano","input":"mere.run is online","voice":"nova","response_format":"wav"}'
+curl http://127.0.0.1:8080/v1/audio/transcriptions \
+  -F model=speech-asr-parakeet \
+  -F file=@speech.wav
+
+# Optional Open WebUI companion smoke
+swift run mere.run open-webui quickstart --dry-run
+swift run mere.run open-webui quickstart --pull
+swift run mere.run guide open-webui
+scripts/smoke-open-webui.sh print-env
+scripts/smoke-open-webui.sh live-smoke
+
 # Optional Gemma4 prefix KV reuse prototype; status reports cache and timing stats
 MERERUN_GEMMA4_PREFIX_KV_CACHE=1 swift run mere.run api serve --engine text-chat-gemma4
 
@@ -474,7 +503,7 @@ point `MERERUN_HUB_CACHE` at your existing `huggingface/hub` directory.
 The public OSS build keeps local-first behavior by default and requires explicit opt-in for higher-risk modes:
 
 - `mere.run api serve` can bind to loopback without auth, but non-loopback hosts require `--api-key` or `MERERUN_API_KEY`
-- the OpenAI-compatible chat route requires `Content-Type: application/json`, supports `--rate-limit-per-minute` for basic abuse control, decodes the common Chat Completions request shape, and rejects unsupported high-impact fields before generation
+- the OpenAI-compatible chat and embedding routes require `Content-Type: application/json`, support `--rate-limit-per-minute` for basic abuse control, decode the common OpenAI request shapes, and reject unsupported high-impact fields before generation
 - API LoRA adapters are operator-controlled with `--lora`; per-request LoRA paths are rejected
 - tool-loop execution in `mere.run text chat` requires interactive approval unless `--auto-approve-tools` is passed for non-shell tools
 - `shell_exec` is disabled unless `--allow-shell-exec` is set, and still requires interactive approval when enabled

--- a/Sources/MediaIO/FFmpegMediaIO.swift
+++ b/Sources/MediaIO/FFmpegMediaIO.swift
@@ -94,6 +94,45 @@ enum FFmpegMediaIO {
         }
     }
 
+    static func transcodeAudio(
+        _ inputURL: URL,
+        to outputURL: URL,
+        format: String
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let normalized = format.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var arguments = [
+            "-v", "error",
+            "-y",
+            "-i", inputURL.path,
+            "-vn"
+        ]
+        switch normalized {
+        case "mp3":
+            arguments += ["-c:a", "libmp3lame", "-b:a", "192k", "-f", "mp3"]
+        case "opus":
+            arguments += ["-c:a", "libopus", "-b:a", "96k", "-f", "opus"]
+        case "aac":
+            arguments += ["-c:a", "aac", "-b:a", "192k", "-f", "adts"]
+        case "flac":
+            arguments += ["-c:a", "flac", "-f", "flac"]
+        default:
+            throw MediaIOError.audioEncodeFailed(outputURL, "Unsupported audio format: \(format)")
+        }
+        arguments.append(outputURL.path)
+
+        do {
+            _ = try FFmpegProcess.run(tool: MediaTool.ffmpegPath, arguments: arguments)
+        } catch let error as MediaIOError {
+            throw MediaIOError.audioEncodeFailed(outputURL, error.localizedDescription)
+        } catch {
+            throw MediaIOError.audioEncodeFailed(outputURL, error.localizedDescription)
+        }
+    }
+
     static func writeMP4(
         rgb24: [UInt8],
         width: Int,

--- a/Sources/MediaIO/MediaAudioIO.swift
+++ b/Sources/MediaIO/MediaAudioIO.swift
@@ -49,6 +49,14 @@ public enum MediaAudioIO {
         }
         try data.write(to: url)
     }
+
+    public static func transcode(
+        _ inputURL: URL,
+        to outputURL: URL,
+        format: String
+    ) throws {
+        try FFmpegMediaIO.transcodeAudio(inputURL, to: outputURL, format: format)
+    }
 }
 
 extension Data {

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5,6 +5,10 @@ import FoundationNetworking
 #endif
 import Hummingbird
 import NIOCore
+import AudioCore
+import AudioSTT
+import AudioTTS
+import MediaIO
 import MereRunCore
 
 struct APIServe: AsyncParsableCommand {
@@ -12,15 +16,20 @@ struct APIServe: AsyncParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "serve",
-        abstract: "Start an OpenAI-compatible API server for local text-code or text-chat models.",
+        abstract: "Start an OpenAI-compatible API server for local chat and embedding models.",
         discussion: """
-        Runs an HTTP server that exposes an OpenAI-compatible API for the selected engine.
+        Runs an HTTP server that exposes an OpenAI-compatible API for the selected local runtime.
         Compatible with any OpenAI client (VS Code extensions, Continue, Cursor, etc.).
 
         Endpoints:
           GET  /health              - Health check
           GET  /v1/models           - List available models
           POST /v1/chat/completions - Chat completions (streaming supported)
+          POST /v1/embeddings       - Native Qwen3 text embeddings
+          POST /v1/images/generations - Native image generation
+          POST /v1/images/edits       - Native image editing
+          POST /v1/audio/speech      - Native text to speech
+          POST /v1/audio/transcriptions - Native speech to text
 
         Example:
           # Start with the default local code model
@@ -48,10 +57,37 @@ struct APIServe: AsyncParsableCommand {
           # Check server health and the served model from another terminal
           mere.run status --port 11434
 
-          # Test with curl (request.json contains an OpenAI chat payload)
+          # Test chat with curl (request.json contains an OpenAI chat payload)
           curl http://localhost:8080/v1/chat/completions \\
             -H "Content-Type: application/json" \\
             --data @request.json
+
+          # Test embeddings with curl
+          curl http://localhost:8080/v1/embeddings \\
+            -H "Content-Type: application/json" \\
+            --data '{"model":"text-embed-qwen3-0.6b","input":"hello"}'
+
+          # Generate an image as base64 PNG JSON
+          curl http://localhost:8080/v1/images/generations \\
+            -H "Content-Type: application/json" \\
+            --data '{"model":"image-zimage-nano","prompt":"a tiny workstation in morning light","size":"1024x1024"}'
+
+          # Edit an image as base64 PNG JSON
+          curl http://localhost:8080/v1/images/edits \\
+            -F model=image-zimage-nano \\
+            -F prompt='make the workstation dusk-lit' \\
+            -F image=@input.png
+
+          # Generate speech
+          curl http://localhost:8080/v1/audio/speech \\
+            -H "Content-Type: application/json" \\
+            --output speech.wav \\
+            --data '{"model":"speech-tts-qwen3-nano","input":"mere.run is online","voice":"nova","response_format":"wav"}'
+
+          # Transcribe audio
+          curl http://localhost:8080/v1/audio/transcriptions \\
+            -F model=speech-asr-parakeet \\
+            -F file=@speech.wav
         """
     )
 
@@ -70,10 +106,10 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Default LoRA adapter path for all requests.")
     var lora: String?
 
-    @Option(name: [.long], help: "Bearer token required by /v1/models and /v1/chat/completions. Also read from MERERUN_API_KEY.")
+    @Option(name: [.long], help: "Bearer token required by API endpoints. Also read from MERERUN_API_KEY.")
     var apiKey: String?
 
-    @Option(name: [.long], help: "Global request limit for /v1/chat/completions per rolling minute.")
+    @Option(name: [.long], help: "Global request limit for /v1/chat/completions and /v1/embeddings per rolling minute.")
     var rateLimitPerMinute: Int = 60
 
     @Option(name: [.long], help: "Maximum chat completions admitted at once. Defaults to 1 for serialized local inference.")
@@ -386,6 +422,72 @@ struct APIHealthStatus: Codable, Equatable, Sendable {
 
 enum APIServerContract {
     static let defaultMaxTokens = 2048
+    static let defaultImageModelID = ModelResolver.ModelID.zetaNano.rawValue
+    static let defaultSpeechModelID = Qwen3TTSResources.defaultModelId
+    static let defaultTranscriptionModelID = ParakeetResources.defaultModelId
+
+    struct ImageGenerationPlan: Equatable, Sendable {
+        let modelID: String
+        let prompt: String
+        let width: Int
+        let height: Int
+        let responseFormat: String
+        let seed: UInt64?
+        let negativePrompt: String?
+        let steps: Int?
+        let guidanceScale: Double?
+        let inputImage: URL?
+        let additionalInputImages: [URL]
+        let maskImage: URL?
+        let strength: Double?
+
+        init(
+            modelID: String,
+            prompt: String,
+            width: Int,
+            height: Int,
+            responseFormat: String,
+            seed: UInt64?,
+            negativePrompt: String?,
+            steps: Int?,
+            guidanceScale: Double?,
+            inputImage: URL?,
+            additionalInputImages: [URL] = [],
+            maskImage: URL? = nil,
+            strength: Double?
+        ) {
+            self.modelID = modelID
+            self.prompt = prompt
+            self.width = width
+            self.height = height
+            self.responseFormat = responseFormat
+            self.seed = seed
+            self.negativePrompt = negativePrompt
+            self.steps = steps
+            self.guidanceScale = guidanceScale
+            self.inputImage = inputImage
+            self.additionalInputImages = additionalInputImages
+            self.maskImage = maskImage
+            self.strength = strength
+        }
+    }
+
+    struct SpeechPlan: Equatable, Sendable {
+        let modelID: String
+        let input: String
+        let voiceDescription: String
+        let responseFormat: String
+        let speed: Float
+        let temperature: Float
+    }
+
+    struct TranscriptionPlan: Equatable, Sendable {
+        let modelID: String
+        let language: String?
+        let responseFormat: String
+        let task: ASRTask
+        let maxTokens: Int
+    }
 
     static func healthStatus() -> APIHealthStatus {
         APIHealthStatus(status: "ok")
@@ -407,6 +509,245 @@ enum APIServerContract {
                 )
             }
         )
+    }
+
+    static func embeddingTexts(from request: OpenAIEmbeddingRequest) throws -> [String] {
+        guard !request.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw APIRequestValidationError.invalidField("model", "must not be empty")
+        }
+        if let encodingFormat = request.encoding_format?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+           !encodingFormat.isEmpty,
+           encodingFormat != "float" {
+            throw APIRequestValidationError.invalidField(
+                "encoding_format",
+                "only float embeddings are supported"
+            )
+        }
+        if request.dimensions != nil {
+            throw APIRequestValidationError.invalidField(
+                "dimensions",
+                "dimension overrides are not supported by this embedding model"
+            )
+        }
+
+        let texts = request.input.texts
+        guard !texts.isEmpty else {
+            throw APIRequestValidationError.invalidField("input", "must contain at least one text")
+        }
+        return texts
+    }
+
+    static func embeddingResponse(
+        modelId: String,
+        embeddings: [[Float]],
+        tokenCounts: [Int]
+    ) -> OpenAIEmbeddingResponse {
+        let promptTokens = tokenCounts.reduce(0, +)
+        return OpenAIEmbeddingResponse(
+            model: modelId,
+            data: embeddings.enumerated().map { index, vector in
+                OpenAIEmbeddingDatum(index: index, embedding: vector)
+            },
+            usage: OpenAIEmbeddingUsage(
+                prompt_tokens: promptTokens,
+                total_tokens: promptTokens
+            )
+        )
+    }
+
+    static func companionModelIDs(
+        fileManager: FileManager = .default,
+        installedModelIDs: Set<String>? = nil
+    ) -> [String] {
+        let categories: Set<ManagedModelCategory> = [.image, .speechTTS, .speechASR, .textEmbed]
+        let ids = ManagedModelCatalog.allSpecs
+            .filter { categories.contains($0.category) }
+            .filter { isCompanionModelInstalled($0, fileManager: fileManager, installedModelIDs: installedModelIDs) }
+            .map(\.id)
+        var uniqueIDs = Set(ids)
+        if isQwenImageEditInstalled(fileManager: fileManager, installedModelIDs: installedModelIDs) {
+            uniqueIDs.insert(QwenImageEditRepository.modelId)
+        }
+        return Array(uniqueIDs).sorted()
+    }
+
+    static func imageGenerationPlan(
+        from request: OpenAIImageGenerationRequest
+    ) throws -> ImageGenerationPlan {
+        let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw APIRequestValidationError.invalidField("prompt", "must not be empty")
+        }
+        if let n = request.n, n != 1 {
+            throw APIRequestValidationError.invalidField("n", "only n=1 is supported")
+        }
+        if let steps = request.steps, steps <= 0 {
+            throw APIRequestValidationError.invalidField("steps", "must be greater than zero")
+        }
+        if let guidanceScale = request.guidance_scale,
+           (!guidanceScale.isFinite || guidanceScale < 0) {
+            throw APIRequestValidationError.invalidField("guidance_scale", "must be a positive number")
+        }
+        let size = try imageSize(from: request.size)
+        let responseFormat = try imageResponseFormat(request.response_format)
+        return ImageGenerationPlan(
+            modelID: normalizedImageModelID(request.model),
+            prompt: prompt,
+            width: size.width,
+            height: size.height,
+            responseFormat: responseFormat,
+            seed: request.seed,
+            negativePrompt: normalizedOptional(request.negative_prompt),
+            steps: request.steps,
+            guidanceScale: request.guidance_scale,
+            inputImage: nil,
+            strength: nil
+        )
+    }
+
+    static func imageEditPlan(
+        from form: MultipartFormData,
+        inputImageURL: URL
+    ) throws -> ImageGenerationPlan {
+        try imageEditPlan(from: form, inputImageURLs: [inputImageURL], maskImageURL: nil)
+    }
+
+    static func imageEditPlan(
+        from form: MultipartFormData,
+        inputImageURLs: [URL],
+        maskImageURL: URL?
+    ) throws -> ImageGenerationPlan {
+        guard let inputImageURL = inputImageURLs.first else {
+            throw APIRequestValidationError.invalidField("image", "image file is required")
+        }
+        let prompt = normalizedOptional(form.field("prompt")) ?? ""
+        guard !prompt.isEmpty else {
+            throw APIRequestValidationError.invalidField("prompt", "must not be empty")
+        }
+        if let rawN = normalizedOptional(form.field("n")) {
+            guard let n = Int(rawN), n == 1 else {
+                throw APIRequestValidationError.invalidField("n", "only n=1 is supported")
+            }
+        }
+        let steps = try optionalPositiveIntField(form.field("steps"), field: "steps")
+        let guidanceScale = try optionalPositiveDoubleField(form.field("guidance_scale"), field: "guidance_scale")
+        let strength = try optionalUnitDoubleField(form.field("strength"), field: "strength")
+        let size = try imageSize(from: form.field("size"))
+        return ImageGenerationPlan(
+            modelID: normalizedImageModelID(form.field("model")),
+            prompt: prompt,
+            width: size.width,
+            height: size.height,
+            responseFormat: try imageResponseFormat(form.field("response_format")),
+            seed: try optionalUInt64Field(form.field("seed")),
+            negativePrompt: normalizedOptional(form.field("negative_prompt")),
+            steps: steps,
+            guidanceScale: guidanceScale,
+            inputImage: inputImageURL,
+            additionalInputImages: Array(inputImageURLs.dropFirst()),
+            maskImage: maskImageURL,
+            strength: strength
+        )
+    }
+
+    static func imageResponse(
+        outputURL: URL,
+        plan: ImageGenerationPlan,
+        createdAt: Date = Date()
+    ) throws -> OpenAIImageGenerationResponse {
+        let datum: OpenAIImageGenerationData
+        switch plan.responseFormat {
+        case "url":
+            datum = OpenAIImageGenerationData(url: outputURL.absoluteString, revised_prompt: plan.prompt)
+        case "b64_json":
+            let data = try Data(contentsOf: outputURL)
+            datum = OpenAIImageGenerationData(
+                b64_json: data.base64EncodedString(),
+                revised_prompt: plan.prompt
+            )
+        default:
+            throw APIRequestValidationError.invalidField("response_format", "unsupported response format")
+        }
+        return OpenAIImageGenerationResponse(
+            created: Int(createdAt.timeIntervalSince1970),
+            data: [datum]
+        )
+    }
+
+    static func speechPlan(from request: OpenAIAudioSpeechRequest) throws -> SpeechPlan {
+        let input = request.input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !input.isEmpty else {
+            throw APIRequestValidationError.invalidField("input", "must not be empty")
+        }
+        let responseFormat = try speechResponseFormat(request.response_format)
+        let speed = try speechSpeed(request.speed)
+        let temperature = request.temperature ?? 0.6
+        guard temperature.isFinite, (0...2).contains(temperature) else {
+            throw APIRequestValidationError.invalidField("temperature", "must be between 0 and 2")
+        }
+        return SpeechPlan(
+            modelID: normalizedSpeechModelID(request.model),
+            input: input,
+            voiceDescription: voiceDescription(for: request.voice, instructions: request.instructions),
+            responseFormat: responseFormat,
+            speed: speed,
+            temperature: temperature
+        )
+    }
+
+    static func transcriptionPlan(from form: MultipartFormData) throws -> TranscriptionPlan {
+        let modelID = normalizedTranscriptionModelID(form.field("model"))
+        return TranscriptionPlan(
+            modelID: modelID,
+            language: normalizedOptional(form.field("language")),
+            responseFormat: try transcriptionResponseFormat(form.field("response_format")),
+            task: try transcriptionTask(form.field("task")),
+            maxTokens: try transcriptionMaxTokens(form.field("max_tokens"))
+        )
+    }
+
+    static func transcriptionResponse(
+        from result: ASRResult,
+        verbose: Bool
+    ) -> OpenAIAudioTranscriptionResponse {
+        OpenAIAudioTranscriptionResponse(
+            text: result.text,
+            language: result.language,
+            duration: verbose ? result.duration : nil,
+            segments: verbose ? transcriptionSegments(from: result) : nil
+        )
+    }
+
+    static func transcriptionSubtitle(from result: ASRResult, format: String) -> String {
+        let segments = transcriptionSegments(from: result) ?? [
+            OpenAIAudioTranscriptionSegment(
+                id: 0,
+                start: 0,
+                end: max(result.duration, 0.001),
+                text: result.text
+            ),
+        ]
+        switch format {
+        case "srt":
+            return segments.enumerated()
+                .map { index, segment in
+                    let start = subtitleTimestamp(segment.start, separator: ",")
+                    let end = subtitleTimestamp(max(segment.end, segment.start + 0.001), separator: ",")
+                    return "\(index + 1)\n\(start) --> \(end)\n\(segment.text)"
+                }
+                .joined(separator: "\n\n") + "\n"
+        default:
+            let body = segments
+                .map { segment in
+                    let start = subtitleTimestamp(segment.start, separator: ".")
+                    let end = subtitleTimestamp(max(segment.end, segment.start + 0.001), separator: ".")
+                    return "\(start) --> \(end)\n\(segment.text)"
+                }
+                .joined(separator: "\n\n")
+            return body.isEmpty ? "WEBVTT\n" : "WEBVTT\n\n\(body)\n"
+        }
     }
 
     static func chatRequest(
@@ -623,21 +964,25 @@ enum APIServerContract {
             throw APIRequestValidationError.invalidField("tools", "tools are not supported by this engine")
         }
 
+        let convertedTools = try tools.map { try toolDefinition(from: $0) }
         switch request.tool_choice {
         case nil, .mode("auto")?, .mode("required")?:
-            break
+            return convertedTools
         case .mode("none")?:
             return nil
-        case .function?, .custom?:
-            throw APIRequestValidationError.invalidField(
-                "tool_choice",
-                "specific tool forcing is not supported by this engine"
-            )
+        case .function(let name)?:
+            guard let selected = convertedTools.first(where: { $0.name == name }) else {
+                throw APIRequestValidationError.invalidField(
+                    "tool_choice",
+                    "requested tool '\(name)' is not present in tools"
+                )
+            }
+            return [selected]
+        case .custom?:
+            throw APIRequestValidationError.invalidField("tool_choice", "unsupported object shape")
         case .mode(let value)?:
             throw APIRequestValidationError.invalidField("tool_choice", "unsupported mode '\(value)'")
         }
-
-        return try tools.map { try toolDefinition(from: $0) }
     }
 
     private static func toolDefinition(from tool: OpenAIChatTool) throws -> ToolDefinition {
@@ -730,6 +1075,28 @@ enum APIServerContract {
         return mediaType == "application/json" || mediaType.hasSuffix("+json")
     }
 
+    static func multipartBoundary(from rawValue: String?) -> String? {
+        guard let pieces = rawValue?.split(separator: ";", omittingEmptySubsequences: true),
+              let mediaType = pieces.first?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              mediaType == "multipart/form-data" else {
+            return nil
+        }
+        for piece in pieces.dropFirst() {
+            let pair = piece.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard pair.count == 2,
+                  pair[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "boundary" else {
+                continue
+            }
+            var boundary = pair[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if boundary.hasPrefix("\""), boundary.hasSuffix("\""), boundary.count >= 2 {
+                boundary.removeFirst()
+                boundary.removeLast()
+            }
+            return boundary.isEmpty ? nil : String(boundary)
+        }
+        return nil
+    }
+
     static func isStreamingStatusMessage(_ message: String) -> Bool {
         switch message {
         case "Generating...", "Generating response", "Retrying generation", "DS4 chat completion":
@@ -769,6 +1136,263 @@ enum APIServerContract {
         }
         return value
     }
+
+    private static func imageSize(from rawValue: String?) throws -> (width: Int, height: Int) {
+        guard let rawValue = normalizedOptional(rawValue), rawValue.lowercased() != "auto" else {
+            return (1024, 1024)
+        }
+        let parts = rawValue.lowercased().split(separator: "x", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let width = Int(parts[0]),
+              let height = Int(parts[1]),
+              width > 0,
+              height > 0 else {
+            throw APIRequestValidationError.invalidField("size", "expected WIDTHxHEIGHT, for example 1024x1024")
+        }
+        return (width, height)
+    }
+
+    private static func imageResponseFormat(_ rawValue: String?) throws -> String {
+        let value = normalizedOptional(rawValue)?.lowercased() ?? "b64_json"
+        guard value == "b64_json" || value == "url" else {
+            throw APIRequestValidationError.invalidField("response_format", "expected b64_json or url")
+        }
+        return value
+    }
+
+    private static func speechResponseFormat(_ rawValue: String?) throws -> String {
+        let value = normalizedOptional(rawValue)?.lowercased() ?? "wav"
+        guard ["wav", "mp3", "opus", "aac", "flac"].contains(value) else {
+            throw APIRequestValidationError.invalidField(
+                "response_format",
+                "expected wav, mp3, opus, aac, or flac"
+            )
+        }
+        return value
+    }
+
+    static func speechContentType(for responseFormat: String) -> String {
+        switch responseFormat {
+        case "mp3":
+            return "audio/mpeg"
+        case "opus":
+            return "audio/ogg"
+        case "aac":
+            return "audio/aac"
+        case "flac":
+            return "audio/flac"
+        default:
+            return "audio/wav"
+        }
+    }
+
+    private static func speechSpeed(_ rawValue: Double?) throws -> Float {
+        let value = rawValue ?? 1.0
+        guard value.isFinite, (0.25...4.0).contains(value) else {
+            throw APIRequestValidationError.invalidField("speed", "must be between 0.25 and 4.0")
+        }
+        return Float(value)
+    }
+
+    private static func transcriptionResponseFormat(_ rawValue: String?) throws -> String {
+        let value = normalizedOptional(rawValue)?.lowercased() ?? "json"
+        guard ["json", "text", "verbose_json", "srt", "vtt"].contains(value) else {
+            throw APIRequestValidationError.invalidField(
+                "response_format",
+                "expected json, text, verbose_json, srt, or vtt"
+            )
+        }
+        return value
+    }
+
+    private static func transcriptionTask(_ rawValue: String?) throws -> ASRTask {
+        let value = normalizedOptional(rawValue)?.lowercased() ?? ASRTask.transcribe.rawValue
+        guard let task = ASRTask(rawValue: value) else {
+            throw APIRequestValidationError.invalidField("task", "expected transcribe or translate")
+        }
+        return task
+    }
+
+    private static func transcriptionMaxTokens(_ rawValue: String?) throws -> Int {
+        guard let rawValue = normalizedOptional(rawValue) else {
+            return 448
+        }
+        guard let value = Int(rawValue), (1...Int(Int32.max)).contains(value) else {
+            throw APIRequestValidationError.invalidField("max_tokens", "must be a positive integer")
+        }
+        return value
+    }
+
+    private static func optionalUInt64Field(_ rawValue: String?) throws -> UInt64? {
+        guard let rawValue = normalizedOptional(rawValue) else {
+            return nil
+        }
+        guard let value = UInt64(rawValue) else {
+            throw APIRequestValidationError.invalidField("seed", "must be an unsigned integer")
+        }
+        return value
+    }
+
+    private static func optionalPositiveIntField(_ rawValue: String?, field: String) throws -> Int? {
+        guard let rawValue = normalizedOptional(rawValue) else {
+            return nil
+        }
+        guard let value = Int(rawValue), value > 0 else {
+            throw APIRequestValidationError.invalidField(field, "must be greater than zero")
+        }
+        return value
+    }
+
+    private static func optionalPositiveDoubleField(_ rawValue: String?, field: String) throws -> Double? {
+        guard let rawValue = normalizedOptional(rawValue) else {
+            return nil
+        }
+        guard let value = Double(rawValue), value.isFinite, value >= 0 else {
+            throw APIRequestValidationError.invalidField(field, "must be a positive number")
+        }
+        return value
+    }
+
+    private static func optionalUnitDoubleField(_ rawValue: String?, field: String) throws -> Double? {
+        guard let rawValue = normalizedOptional(rawValue) else {
+            return nil
+        }
+        guard let value = Double(rawValue), value.isFinite, (0...1).contains(value) else {
+            throw APIRequestValidationError.invalidField(field, "must be between 0 and 1")
+        }
+        return value
+    }
+
+    private static func normalizedModelID(_ rawValue: String?, defaultID: String) -> String {
+        normalizedOptional(rawValue) ?? defaultID
+    }
+
+    private static func normalizedImageModelID(_ rawValue: String?) -> String {
+        let modelID = normalizedModelID(rawValue, defaultID: defaultImageModelID)
+        switch modelID.lowercased() {
+        case "gpt-image-1", "dall-e-3", "dall-e-2":
+            return defaultImageModelID
+        default:
+            return modelID
+        }
+    }
+
+    private static func normalizedSpeechModelID(_ rawValue: String?) -> String {
+        let modelID = normalizedModelID(rawValue, defaultID: defaultSpeechModelID)
+        switch modelID.lowercased() {
+        case "tts-1", "tts-1-hd", "gpt-4o-mini-tts":
+            return defaultSpeechModelID
+        default:
+            return modelID
+        }
+    }
+
+    private static func normalizedTranscriptionModelID(_ rawValue: String?) -> String {
+        let modelID = normalizedModelID(rawValue, defaultID: defaultTranscriptionModelID)
+        switch modelID.lowercased() {
+        case "whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe":
+            return defaultTranscriptionModelID
+        default:
+            return modelID
+        }
+    }
+
+    private static func normalizedOptional(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func isCompanionModelInstalled(
+        _ spec: ManagedModelSpec,
+        fileManager: FileManager,
+        installedModelIDs: Set<String>?
+    ) -> Bool {
+        if let installedModelIDs {
+            return installedModelIDs.contains(spec.id)
+        }
+        return spec.managedRuntimeURL(fileManager: fileManager) != nil
+    }
+
+    private static func isQwenImageEditInstalled(
+        fileManager: FileManager,
+        installedModelIDs: Set<String>?
+    ) -> Bool {
+        if let installedModelIDs {
+            return installedModelIDs.contains(QwenImageEditRepository.modelId)
+        }
+        return QwenImageEditRepository.resolveInstalledModelRoot(fileManager: fileManager) != nil
+    }
+
+    private static func voiceDescription(for rawVoice: String?, instructions: String?) -> String {
+        let instructionText = normalizedOptional(instructions)
+        let voice = normalizedOptional(rawVoice)?.lowercased() ?? "nova"
+        let base: String
+        switch voice {
+        case "alloy":
+            base = "A balanced, natural voice with clear pronunciation"
+        case "ash":
+            base = "A calm, low voice with a steady delivery"
+        case "ballad":
+            base = "A warm, expressive voice with a storytelling cadence"
+        case "coral":
+            base = "A bright, friendly voice with gentle energy"
+        case "echo":
+            base = "A clear male voice with an even, conversational tone"
+        case "fable":
+            base = "A warm narrative voice with a measured pace"
+        case "nova":
+            base = "A calm female voice with clear pronunciation"
+        case "onyx":
+            base = "A deep, confident voice with crisp articulation"
+        case "sage":
+            base = "A thoughtful, composed voice with soft emphasis"
+        case "shimmer":
+            base = "A bright, gentle voice with smooth pronunciation"
+        default:
+            base = rawVoice?.trimmingCharacters(in: .whitespacesAndNewlines)
+                ?? "A calm female voice with clear pronunciation"
+        }
+        if let instructionText {
+            return "\(base). \(instructionText)"
+        }
+        return base
+    }
+
+    private static func transcriptionSegments(
+        from result: ASRResult
+    ) -> [OpenAIAudioTranscriptionSegment]? {
+        if let sentences = result.sentenceAlignments, !sentences.isEmpty {
+            return sentences.enumerated().map { index, sentence in
+                OpenAIAudioTranscriptionSegment(
+                    id: index,
+                    start: sentence.startSeconds,
+                    end: sentence.endSeconds,
+                    text: sentence.text
+                )
+            }
+        }
+        if let tokens = result.tokenAlignments, !tokens.isEmpty {
+            return tokens.enumerated().map { index, token in
+                OpenAIAudioTranscriptionSegment(
+                    id: index,
+                    start: token.startSeconds,
+                    end: token.endSeconds,
+                    text: token.text
+                )
+            }
+        }
+        return nil
+    }
+
+    private static func subtitleTimestamp(_ seconds: Double, separator: String) -> String {
+        let milliseconds = max(0, Int((seconds * 1_000).rounded()))
+        let hours = milliseconds / 3_600_000
+        let minutes = (milliseconds % 3_600_000) / 60_000
+        let secs = (milliseconds % 60_000) / 1_000
+        let millis = milliseconds % 1_000
+        return String(format: "%02d:%02d:%02d%@%03d", hours, minutes, secs, separator, millis)
+    }
 }
 
 enum APIRequestValidationError: LocalizedError, Equatable {
@@ -782,6 +1406,163 @@ enum APIRequestValidationError: LocalizedError, Equatable {
     }
 }
 
+struct MultipartFormData: Equatable, Sendable {
+    struct Part: Equatable, Sendable {
+        let name: String
+        let filename: String?
+        let contentType: String?
+        let body: Data
+    }
+
+    enum ParseError: LocalizedError, Equatable {
+        case missingBoundary
+        case malformedBody
+        case missingName
+
+        var errorDescription: String? {
+            switch self {
+            case .missingBoundary:
+                return "Missing multipart boundary."
+            case .malformedBody:
+                return "Malformed multipart body."
+            case .missingName:
+                return "Multipart part is missing a form-data name."
+            }
+        }
+    }
+
+    let parts: [Part]
+
+    static func parse(body: Data, boundary: String?) throws -> MultipartFormData {
+        guard let boundary, !boundary.isEmpty else {
+            throw ParseError.missingBoundary
+        }
+        let marker = Data("--\(boundary)".utf8)
+        guard !marker.isEmpty,
+              let firstMarker = body.range(of: marker, options: [], in: body.startIndex..<body.endIndex) else {
+            throw ParseError.malformedBody
+        }
+
+        var parts: [Part] = []
+        var markerRange = firstMarker
+        while true {
+            let afterMarker = markerRange.upperBound
+            if body.hasBytes(Data("--".utf8), at: afterMarker) {
+                break
+            }
+            let partStart = body.indexAfterLineBreak(at: afterMarker)
+            guard let nextMarker = body.range(of: marker, options: [], in: partStart..<body.endIndex) else {
+                throw ParseError.malformedBody
+            }
+            let partEnd = body.indexTrimmingLineBreak(before: nextMarker.lowerBound)
+            if partStart < partEnd {
+                parts.append(try parsePart(Data(body[partStart..<partEnd])))
+            }
+            markerRange = nextMarker
+        }
+
+        return MultipartFormData(parts: parts)
+    }
+
+    func field(_ name: String) -> String? {
+        guard let part = parts.first(where: { $0.name == name && $0.filename == nil }) else {
+            return nil
+        }
+        return String(data: part.body, encoding: .utf8)
+    }
+
+    func file(named name: String) -> Part? {
+        parts.first { $0.name == name && $0.filename != nil }
+    }
+
+    func files(named name: String) -> [Part] {
+        parts.filter { $0.name == name && $0.filename != nil }
+    }
+
+    private static func parsePart(_ data: Data) throws -> Part {
+        let separator = Data("\r\n\r\n".utf8)
+        let fallbackSeparator = Data("\n\n".utf8)
+        let separatorRange = data.range(of: separator, options: [], in: data.startIndex..<data.endIndex)
+            ?? data.range(of: fallbackSeparator, options: [], in: data.startIndex..<data.endIndex)
+        guard let separatorRange,
+              let headerText = String(data: data[data.startIndex..<separatorRange.lowerBound], encoding: .utf8) else {
+            throw ParseError.malformedBody
+        }
+        let body = Data(data[separatorRange.upperBound..<data.endIndex])
+        let headers = parseHeaders(headerText)
+        guard let disposition = headers["content-disposition"] else {
+            throw ParseError.missingName
+        }
+        let params = parseDispositionParameters(disposition)
+        guard let name = params["name"], !name.isEmpty else {
+            throw ParseError.missingName
+        }
+        return Part(
+            name: name,
+            filename: params["filename"],
+            contentType: headers["content-type"],
+            body: body
+        )
+    }
+
+    private static func parseHeaders(_ text: String) -> [String: String] {
+        var headers: [String: String] = [:]
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[..<colon].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespacesAndNewlines)
+            headers[name] = value
+        }
+        return headers
+    }
+
+    private static func parseDispositionParameters(_ value: String) -> [String: String] {
+        var params: [String: String] = [:]
+        for part in value.split(separator: ";", omittingEmptySubsequences: false).dropFirst() {
+            let pair = part.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard pair.count == 2 else { continue }
+            let key = pair[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            var rawValue = pair[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if rawValue.hasPrefix("\""), rawValue.hasSuffix("\""), rawValue.count >= 2 {
+                rawValue.removeFirst()
+                rawValue.removeLast()
+            }
+            params[key] = rawValue
+        }
+        return params
+    }
+}
+
+private extension Data {
+    func hasBytes(_ bytes: Data, at index: Data.Index) -> Bool {
+        guard index >= startIndex, index + bytes.count <= endIndex else {
+            return false
+        }
+        return self[index..<(index + bytes.count)].elementsEqual(bytes)
+    }
+
+    func indexAfterLineBreak(at index: Data.Index) -> Data.Index {
+        if hasBytes(Data("\r\n".utf8), at: index) {
+            return index + 2
+        }
+        if hasBytes(Data("\n".utf8), at: index) {
+            return index + 1
+        }
+        return index
+    }
+
+    func indexTrimmingLineBreak(before index: Data.Index) -> Data.Index {
+        if index >= 2, self[(index - 2)..<index].elementsEqual(Data("\r\n".utf8)) {
+            return index - 2
+        }
+        if index >= 1, self[(index - 1)..<index].elementsEqual(Data("\n".utf8)) {
+            return index - 1
+        }
+        return index
+    }
+}
+
 // MARK: - Server Implementation
 
 actor CodeGenServer {
@@ -792,6 +1573,7 @@ actor CodeGenServer {
     private let requestLimiter: APIRateLimiter
     private let requestAdmission: RuntimeRequestAdmission
     private let pool: RuntimeModelPool
+    private var embeddingModels: [String: Qwen3EmbeddingModel] = [:]
 
     init(
         defaultModelID: String,
@@ -835,7 +1617,13 @@ actor CodeGenServer {
         )
 
         print("Starting server at http://\(host):\(port)")
-        print("OpenAI-compatible endpoint: http://\(host):\(port)/v1/chat/completions")
+        print("OpenAI-compatible base URL: http://\(host):\(port)/v1")
+        print("Chat endpoint: http://\(host):\(port)/v1/chat/completions")
+        print("Embeddings endpoint: http://\(host):\(port)/v1/embeddings")
+        print("Images endpoint: http://\(host):\(port)/v1/images/generations")
+        print("Image edits endpoint: http://\(host):\(port)/v1/images/edits")
+        print("Speech endpoint: http://\(host):\(port)/v1/audio/speech")
+        print("Transcriptions endpoint: http://\(host):\(port)/v1/audio/transcriptions")
         print("Press Ctrl+C to stop.")
 
         try await app.runService()
@@ -862,6 +1650,27 @@ actor CodeGenServer {
         // Chat completions
         router.post("/v1/chat/completions") { [self] request, _ in
             return try await self.handleChatCompletions(request)
+        }
+
+        // Embeddings
+        router.post("/v1/embeddings") { [self] request, _ in
+            return try await self.handleEmbeddings(request)
+        }
+
+        router.post("/v1/images/generations") { [self] request, _ in
+            return try await self.handleImageGenerations(request)
+        }
+
+        router.post("/v1/images/edits") { [self] request, _ in
+            return try await self.handleImageEdits(request)
+        }
+
+        router.post("/v1/audio/speech") { [self] request, _ in
+            return try await self.handleAudioSpeech(request)
+        }
+
+        router.post("/v1/audio/transcriptions") { [self] request, _ in
+            return try await self.handleAudioTranscriptions(request)
         }
 
         router.get("/runtime/status") { [self] request, _ in
@@ -919,7 +1728,19 @@ actor CodeGenServer {
         if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
             return unauthorized
         }
-        let models = try await pool.modelsResponse()
+        var models = try await pool.modelsResponse()
+        for modelID in APIServerContract.companionModelIDs()
+            where !models.data.contains(where: { $0.id == modelID }) {
+            models.data.append(
+                OpenAIModel(
+                    id: modelID,
+                    object: "model",
+                    created: Int(Date().timeIntervalSince1970),
+                    owned_by: "mere.run"
+                )
+            )
+        }
+        models.data.sort { $0.id < $1.id }
 
         let data = try JSONEncoder().encode(models)
         return Response(
@@ -1023,6 +1844,247 @@ actor CodeGenServer {
         }
     }
 
+    private func handleEmbeddings(_ request: Request) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        guard APIServerContract.acceptsJSONContentType(request.headers[.contentType]) else {
+            return makeErrorResponse(
+                status: .unsupportedMediaType,
+                message: "Content-Type must be application/json.",
+                type: "invalid_request_error"
+            )
+        }
+        guard await requestLimiter.allowRequest() else {
+            return makeErrorResponse(
+                status: .tooManyRequests,
+                message: "Rate limit exceeded.",
+                type: "rate_limit_error"
+            )
+        }
+
+        let body: ByteBuffer
+        do {
+            body = try await request.body.collect(upTo: 10 * 1024 * 1024)
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
+        }
+
+        let openaiRequest: OpenAIEmbeddingRequest
+        do {
+            openaiRequest = try JSONDecoder().decode(OpenAIEmbeddingRequest.self, from: Data(body.readableBytesView))
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request payload.", type: "invalid_request_error")
+        }
+
+        do {
+            let texts = try APIServerContract.embeddingTexts(from: openaiRequest)
+            let resolved = try await embeddingModel(for: openaiRequest.model)
+            let result = try resolved.model.embed(texts: texts)
+            let response = APIServerContract.embeddingResponse(
+                modelId: resolved.modelID,
+                embeddings: result.embeddings,
+                tokenCounts: result.tokenCounts
+            )
+            return try jsonResponse(response)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleImageGenerations(_ request: Request) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        guard APIServerContract.acceptsJSONContentType(request.headers[.contentType]) else {
+            return makeErrorResponse(
+                status: .unsupportedMediaType,
+                message: "Content-Type must be application/json.",
+                type: "invalid_request_error"
+            )
+        }
+        guard await requestLimiter.allowRequest() else {
+            return makeErrorResponse(
+                status: .tooManyRequests,
+                message: "Rate limit exceeded.",
+                type: "rate_limit_error"
+            )
+        }
+
+        let body: ByteBuffer
+        do {
+            body = try await request.body.collect(upTo: 10 * 1024 * 1024)
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
+        }
+
+        do {
+            let openaiRequest = try JSONDecoder().decode(
+                OpenAIImageGenerationRequest.self,
+                from: Data(body.readableBytesView)
+            )
+            let plan = try APIServerContract.imageGenerationPlan(from: openaiRequest)
+            let outputURL = try await generateImage(plan)
+            let response = try APIServerContract.imageResponse(outputURL: outputURL, plan: plan)
+            return try jsonResponse(response)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleImageEdits(_ request: Request) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        let boundary = APIServerContract.multipartBoundary(from: request.headers[.contentType])
+        guard boundary != nil else {
+            return makeErrorResponse(
+                status: .unsupportedMediaType,
+                message: "Content-Type must be multipart/form-data.",
+                type: "invalid_request_error"
+            )
+        }
+        guard await requestLimiter.allowRequest() else {
+            return makeErrorResponse(
+                status: .tooManyRequests,
+                message: "Rate limit exceeded.",
+                type: "rate_limit_error"
+            )
+        }
+
+        let body: ByteBuffer
+        do {
+            body = try await request.body.collect(upTo: 100 * 1024 * 1024)
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
+        }
+
+        do {
+            let form = try MultipartFormData.parse(body: Data(body.readableBytesView), boundary: boundary)
+            let imageFiles = (form.files(named: "image") + form.files(named: "image[]"))
+                .filter { !$0.body.isEmpty }
+            guard !imageFiles.isEmpty else {
+                throw APIRequestValidationError.invalidField("image", "image file is required")
+            }
+            let inputImageURLs = try imageFiles.map {
+                try writeMultipartFile($0, directoryName: "mere-run-api-image-edits")
+            }
+            let maskImageURL = try form.file(named: "mask").flatMap { mask -> URL? in
+                guard !mask.body.isEmpty else { return nil }
+                return try writeMultipartFile(mask, directoryName: "mere-run-api-image-edits")
+            }
+            let plan = try APIServerContract.imageEditPlan(
+                from: form,
+                inputImageURLs: inputImageURLs,
+                maskImageURL: maskImageURL
+            )
+            let outputURL = try await generateImage(plan)
+            let response = try APIServerContract.imageResponse(outputURL: outputURL, plan: plan)
+            return try jsonResponse(response)
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleAudioSpeech(_ request: Request) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        guard APIServerContract.acceptsJSONContentType(request.headers[.contentType]) else {
+            return makeErrorResponse(
+                status: .unsupportedMediaType,
+                message: "Content-Type must be application/json.",
+                type: "invalid_request_error"
+            )
+        }
+        guard await requestLimiter.allowRequest() else {
+            return makeErrorResponse(
+                status: .tooManyRequests,
+                message: "Rate limit exceeded.",
+                type: "rate_limit_error"
+            )
+        }
+
+        let body: ByteBuffer
+        do {
+            body = try await request.body.collect(upTo: 10 * 1024 * 1024)
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
+        }
+
+        do {
+            let openaiRequest = try JSONDecoder().decode(
+                OpenAIAudioSpeechRequest.self,
+                from: Data(body.readableBytesView)
+            )
+            let plan = try APIServerContract.speechPlan(from: openaiRequest)
+            let outputURL = try await synthesizeSpeech(plan)
+            let responseURL = try speechResponseURL(outputURL, responseFormat: plan.responseFormat)
+            let data = try Data(contentsOf: responseURL)
+            return binaryResponse(data, contentType: APIServerContract.speechContentType(for: plan.responseFormat))
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
+    private func handleAudioTranscriptions(_ request: Request) async throws -> Response {
+        if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
+            return unauthorized
+        }
+        let boundary = APIServerContract.multipartBoundary(from: request.headers[.contentType])
+        guard boundary != nil else {
+            return makeErrorResponse(
+                status: .unsupportedMediaType,
+                message: "Content-Type must be multipart/form-data.",
+                type: "invalid_request_error"
+            )
+        }
+        guard await requestLimiter.allowRequest() else {
+            return makeErrorResponse(
+                status: .tooManyRequests,
+                message: "Rate limit exceeded.",
+                type: "rate_limit_error"
+            )
+        }
+
+        let body: ByteBuffer
+        do {
+            body = try await request.body.collect(upTo: 100 * 1024 * 1024)
+        } catch {
+            return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
+        }
+
+        do {
+            let form = try MultipartFormData.parse(body: Data(body.readableBytesView), boundary: boundary)
+            let plan = try APIServerContract.transcriptionPlan(from: form)
+            guard let file = form.file(named: "file"), !file.body.isEmpty else {
+                throw APIRequestValidationError.invalidField("file", "audio file is required")
+            }
+            let audioURL = try writeMultipartFile(file, directoryName: "mere-run-api-audio")
+            let result = try await transcribeAudio(audioURL: audioURL, plan: plan)
+            switch plan.responseFormat {
+            case "text":
+                return binaryResponse(Data(result.text.utf8), contentType: "text/plain; charset=utf-8")
+            case "srt", "vtt":
+                let subtitle = APIServerContract.transcriptionSubtitle(from: result, format: plan.responseFormat)
+                let contentType = plan.responseFormat == "srt"
+                    ? "application/x-subrip; charset=utf-8"
+                    : "text/vtt; charset=utf-8"
+                return binaryResponse(Data(subtitle.utf8), contentType: contentType)
+            case "verbose_json":
+                return try jsonResponse(
+                    APIServerContract.transcriptionResponse(from: result, verbose: true)
+                )
+            default:
+                return try jsonResponse(
+                    APIServerContract.transcriptionResponse(from: result, verbose: false)
+                )
+            }
+        } catch {
+            return runtimeErrorResponse(error)
+        }
+    }
+
     private func handleNonStreamingChat(
         _ request: ChatRequest,
         modelID: String,
@@ -1066,6 +2128,259 @@ actor CodeGenServer {
             headers: [.contentType: "application/json"],
             body: .init(byteBuffer: ByteBuffer(bytes: data))
         )
+    }
+
+    private func embeddingModel(for requestedModel: String) async throws -> (modelID: String, model: Qwen3EmbeddingModel) {
+        let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let spec = ManagedModelCatalog.spec(for: normalized),
+           spec.id != Qwen3EmbeddingCatalog.modelId {
+            throw APIRequestValidationError.invalidField(
+                "model",
+                "use \(Qwen3EmbeddingCatalog.modelId) or a local Qwen3 embedding model path"
+            )
+        }
+
+        if let model = embeddingModels[normalized] {
+            let modelID = ManagedModelCatalog.spec(for: normalized)?.id ?? normalized
+            return (modelID, model)
+        }
+
+        let resolution = try await ManagedModelResolver.resolveForRuntime(
+            requestedModel: normalized,
+            defaultModelID: Qwen3EmbeddingCatalog.modelId,
+            progress: nil
+        )
+        let modelID = resolution.source == .explicitPath ? normalized : resolution.spec.id
+        let model = try Qwen3EmbeddingModel(
+            resources: Qwen3EmbeddingResources(rootURL: resolution.url)
+        )
+        embeddingModels[normalized] = model
+        if modelID != normalized {
+            embeddingModels[modelID] = model
+        }
+        return (modelID, model)
+    }
+
+    private func generateImage(_ plan: APIServerContract.ImageGenerationPlan) async throws -> URL {
+        try MLXBundleSupport.ensureAvailable(quiet: true)
+        if plan.inputImage != nil,
+           QwenImageEditRepository.canonicalModelId(for: plan.modelID) != nil {
+            return try await generateQwenImageEdit(plan)
+        }
+        let resolved = try resolveImageModel(plan.modelID)
+        let effectiveSteps = plan.steps
+            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .ideogram)
+                ? (resolved.manifest.defaults?.steps ?? 4)
+                : 4)
+        let effectiveCFG = plan.guidanceScale
+            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .ideogram)
+                ? (resolved.manifest.defaults?.cfg ?? 1.0)
+                : 1.0)
+        let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
+        let request = GenerationRequest(
+            prompt: plan.prompt,
+            negativePrompt: plan.negativePrompt,
+            referenceImages: plan.additionalInputImages,
+            width: plan.width,
+            height: plan.height,
+            steps: effectiveSteps,
+            guidanceScale: effectiveCFG,
+            seed: plan.seed,
+            outputURL: outputURL,
+            model: resolved.rootURL.path,
+            maxSequenceLength: 512,
+            lora: nil,
+            enhancePrompt: false,
+            inputImage: plan.inputImage,
+            strength: plan.strength ?? 0.75,
+            keepOriginalAspect: false,
+            useBetaSigmas: false,
+            sigmaShift: resolved.manifest.defaults?.sigmaShift.map { Float($0) }
+        )
+
+        switch resolved.manifest.family {
+        case .klein:
+            _ = try await Flux2KleinGenerator().generate(request, progressHandler: nil)
+        case .zimage:
+            _ = try await ZImageTurboGenerator().generate(request, progressHandler: nil)
+        case .hidream:
+            let generator = HiDreamO1Generator()
+            defer { generator.unload() }
+            _ = try await generator.generate(request, progressHandler: nil)
+        case .ideogram:
+            let generator = Ideogram4Generator()
+            defer { generator.unload() }
+            _ = try await generator.generate(request, progressHandler: nil)
+        case .gemma, .liquid, .qwen, .sam, .falcon, .tts, .asr, .embed, .code, .ocr, .music, .video, .psi, .privacy, .deepseek, nil:
+            throw APIRequestValidationError.invalidField(
+                "model",
+                "model \(resolved.modelID) is not an image generation model"
+            )
+        }
+        return outputURL
+    }
+
+    private func generateQwenImageEdit(_ plan: APIServerContract.ImageGenerationPlan) async throws -> URL {
+        let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
+        let request = GenerationRequest(
+            prompt: plan.prompt,
+            negativePrompt: plan.negativePrompt,
+            width: plan.width,
+            height: plan.height,
+            steps: plan.steps ?? 20,
+            guidanceScale: plan.guidanceScale ?? 4.0,
+            seed: plan.seed,
+            outputURL: outputURL,
+            model: plan.modelID,
+            maxSequenceLength: 512,
+            inputImage: plan.inputImage,
+            strength: plan.strength ?? 0.75
+        )
+        let generator = QwenImageEditGenerator()
+        _ = try await generator.generate(request, progressHandler: nil)
+        return outputURL
+    }
+
+    private func synthesizeSpeech(_ plan: APIServerContract.SpeechPlan) async throws -> URL {
+        try MLXBundleSupport.ensureAvailable(quiet: true)
+        let selection = try resolveSpeechModel(plan.modelID)
+        let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-speech", extension: "wav")
+        let request = TTSRequest(
+            text: plan.input,
+            voiceDescription: plan.voiceDescription,
+            voiceMode: .style,
+            cloneReference: nil,
+            language: "auto",
+            speed: plan.speed,
+            temperature: plan.temperature,
+            outputURL: outputURL
+        )
+        let generator = Qwen3TTSGenerator(modelId: selection.modelID)
+        _ = try await generator.generate(
+            request,
+            modelPath: selection.modelPath,
+            progressHandler: nil
+        )
+        return outputURL
+    }
+
+    private func speechResponseURL(_ wavURL: URL, responseFormat: String) throws -> URL {
+        guard responseFormat != "wav" else {
+            return wavURL
+        }
+        let outputURL = try temporaryOutputURL(
+            directoryName: "mere-run-api-speech",
+            extension: responseFormat
+        )
+        try MediaAudioIO.transcode(wavURL, to: outputURL, format: responseFormat)
+        return outputURL
+    }
+
+    private func transcribeAudio(
+        audioURL: URL,
+        plan: APIServerContract.TranscriptionPlan
+    ) async throws -> ASRResult {
+        try MLXBundleSupport.ensureAvailable(quiet: true)
+        let selection = try resolveTranscriptionModel(plan.modelID)
+        let request = ASRRequest(
+            audioURL: audioURL,
+            language: plan.language,
+            task: plan.task,
+            maxTokens: plan.maxTokens
+        )
+        let execution = try await CLIASRRouting.transcribe(
+            request: request,
+            preferredBackend: selection.backend,
+            modelOverride: selection.modelOverride,
+            progressHandler: nil
+        )
+        return execution.result
+    }
+
+    private func resolveImageModel(
+        _ requestedModel: String
+    ) throws -> (modelID: String, rootURL: URL, manifest: MereRunModelManifest) {
+        let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let asPath = URL(fileURLWithPath: normalized).standardizedFileURL
+        if FileManager.default.fileExists(atPath: asPath.path) {
+            let manifest = try MereRunModelManifest.loadRequired(from: asPath)
+            return (manifest.id, asPath, manifest)
+        }
+        guard let modelID = ModelResolver.ModelID(rawValue: normalized) else {
+            throw APIRequestValidationError.invalidField(
+                "model",
+                "use a mere.run image model id or a local model path"
+            )
+        }
+        let resolution = try ModelResolver().resolve(modelID)
+        let manifest = try MereRunModelManifest.loadRequired(from: resolution.rootURL)
+        return (modelID.rawValue, resolution.rootURL, manifest)
+    }
+
+    private func resolveSpeechModel(
+        _ requestedModel: String
+    ) throws -> (modelID: String, modelPath: String?) {
+        let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let asPath = URL(fileURLWithPath: normalized).standardizedFileURL
+        if FileManager.default.fileExists(atPath: asPath.path) {
+            return (Qwen3TTSResources.defaultModelId, asPath.path)
+        }
+        if let spec = ManagedModelCatalog.spec(for: normalized),
+           spec.category == .speechTTS {
+            return (spec.id, nil)
+        }
+        throw APIRequestValidationError.invalidField(
+            "model",
+            "use a mere.run TTS model id or a local Qwen3-TTS model path"
+        )
+    }
+
+    private func resolveTranscriptionModel(
+        _ requestedModel: String
+    ) throws -> (modelOverride: String?, backend: ASRBackend) {
+        let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let asPath = URL(fileURLWithPath: normalized).standardizedFileURL
+        if FileManager.default.fileExists(atPath: asPath.path) {
+            return (asPath.path, .auto)
+        }
+        guard let spec = ManagedModelCatalog.spec(for: normalized),
+              spec.category == .speechASR else {
+            throw APIRequestValidationError.invalidField(
+                "model",
+                "use a mere.run ASR model id or a local ASR model path"
+            )
+        }
+        let backend: ASRBackend = spec.id.contains("parakeet") ? .parakeet : .qwen
+        return (spec.id, backend)
+    }
+
+    private nonisolated func temporaryOutputURL(
+        directoryName: String,
+        extension pathExtension: String
+    ) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("\(UUID().uuidString).\(pathExtension)")
+    }
+
+    private nonisolated func writeMultipartFile(
+        _ file: MultipartFormData.Part,
+        directoryName: String
+    ) throws -> URL {
+        let pathExtension = sanitizedPathExtension(from: file.filename) ?? "wav"
+        let outputURL = try temporaryOutputURL(directoryName: directoryName, extension: pathExtension)
+        try file.body.write(to: outputURL)
+        return outputURL
+    }
+
+    private nonisolated func sanitizedPathExtension(from filename: String?) -> String? {
+        guard let rawExtension = filename.flatMap({ URL(fileURLWithPath: $0).pathExtension.lowercased() }),
+              !rawExtension.isEmpty,
+              rawExtension.allSatisfy({ $0.isLetter || $0.isNumber }) else {
+            return nil
+        }
+        return rawExtension
     }
 
     private func handleRuntimeStatus(_ request: Request) async throws -> Response {
@@ -1477,6 +2792,14 @@ actor CodeGenServer {
         )
     }
 
+    private nonisolated func binaryResponse(_ data: Data, contentType: String) -> Response {
+        Response(
+            status: .ok,
+            headers: [.contentType: contentType],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+
     private nonisolated func runtimeErrorResponse(_ error: Error) -> Response {
         switch error {
         case let error as RuntimeModelPoolError:
@@ -1501,6 +2824,24 @@ actor CodeGenServer {
                 )
             }
         case let error as APIRequestValidationError:
+            return makeErrorResponse(
+                status: .badRequest,
+                message: error.localizedDescription,
+                type: "invalid_request_error"
+            )
+        case let error as MultipartFormData.ParseError:
+            return makeErrorResponse(
+                status: .badRequest,
+                message: error.localizedDescription,
+                type: "invalid_request_error"
+            )
+        case let error as ManagedModelResolver.ResolverError:
+            return makeErrorResponse(
+                status: .badRequest,
+                message: error.localizedDescription,
+                type: "invalid_request_error"
+            )
+        case let error as Qwen3EmbeddingModel.EmbeddingError:
             return makeErrorResponse(
                 status: .badRequest,
                 message: error.localizedDescription,

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -374,8 +374,22 @@ enum GuideRegistry {
                 "text-chat-q36-nano",
                 "text-chat-lfm25-a1b-8bit",
                 "text-chat-mebot",
+                "text-embed-qwen3-0.6b",
             ],
             resourceName: "api-serve.md"
+        ),
+        GuideTopic(
+            topic: "open-webui",
+            title: "Open WebUI",
+            commandPaths: [["open-webui"]],
+            models: [
+                "text-chat-gemma4",
+                "text-chat-gemma4-12b",
+                "vision-chat-gemma4-12b",
+                "text-chat-q36-nano",
+                "text-embed-qwen3-0.6b",
+            ],
+            resourceName: "open-webui.md"
         ),
         GuideTopic(
             topic: "status",

--- a/Sources/MereRunCLI/Commands/ImageValidateCommand+EncoderTransformer.swift
+++ b/Sources/MereRunCLI/Commands/ImageValidateCommand+EncoderTransformer.swift
@@ -15,13 +15,13 @@ extension ImageValidate {
         let testPrompt = "a red cube on a white background"
         print("  Prompt: \"\(testPrompt)\"")
 
-        let resources = ZImageTurboResources(rootURL: modelURL)
+        let (resources, manifest) = try resolvedZImageResources(modelURL: modelURL)
         let configs = try ZImageTurboModelConfigs.load(from: resources)
         print("  Model path: \(modelURL.path)")
         print("  Config: vocabSize=\(configs.textEncoder.vocabSize), hiddenSize=\(configs.textEncoder.hiddenSize), numLayers=\(configs.textEncoder.numHiddenLayers)")
 
         let tokenizer = try QwenTokenizer.load(
-            from: modelURL.appendingPathComponent("tokenizer"),
+            from: resources.tokenizerDirURL,
             maxLengthOverride: configs.textEncoder.maxPositionEmbeddings
         )
 
@@ -30,7 +30,11 @@ extension ImageValidate {
         MLX.eval(batch.inputIds)
         print("  Tokens: \(batch.inputIds.dim(1)) tokens (padded to \(maxLength))")
 
-        let textEncoder = try loadValidationTextEncoder(resources: resources, configs: configs)
+        let textEncoder = try loadValidationTextEncoder(
+            resources: resources,
+            configs: configs,
+            manifest: manifest
+        )
         let (embeddings, mask) = textEncoder(inputIds: batch.inputIds, attentionMask: batch.attentionMask)
         MLX.eval(embeddings)
 
@@ -75,22 +79,25 @@ extension ImageValidate {
         print("  Size: \(width)x\(height)")
         print("  Steps: \(steps)")
 
-        let resources = ZImageTurboResources(rootURL: modelURL)
+        let (resources, manifest) = try resolvedZImageResources(modelURL: modelURL)
         let configs = try ZImageTurboModelConfigs.load(from: resources)
         print("  Loading components...")
 
         let tokenizer = try QwenTokenizer.load(
-            from: modelURL.appendingPathComponent("tokenizer"),
+            from: resources.tokenizerDirURL,
             maxLengthOverride: configs.textEncoder.maxPositionEmbeddings
         )
-        let textEncoder = try loadValidationTextEncoder(resources: resources, configs: configs)
+        let textEncoder = try loadValidationTextEncoder(
+            resources: resources,
+            configs: configs,
+            manifest: manifest
+        )
 
         let transformer = ZImageTransformer2DModel(configuration: configs.transformer)
-        try HFSafetensorsWeightsLoader.applyShardedWeights(
-            indexURL: resources.transformerWeightsIndexURL,
-            to: transformer,
-            dtype: .bfloat16,
-            verify: .none
+        try loadValidationTransformerWeights(
+            resources: resources,
+            manifest: manifest,
+            into: transformer
         )
         MLX.eval(transformer)
         print("  Components loaded")
@@ -168,7 +175,8 @@ extension ImageValidate {
 
     private func loadValidationTextEncoder(
         resources: ZImageTurboResources,
-        configs: ZImageTurboModelConfigs
+        configs: ZImageTurboModelConfigs,
+        manifest: MereRunModelManifest?
     ) throws -> QwenTextEncoder {
         print("  Loading text encoder...")
         let encoderConfig = QwenTextEncoderConfiguration(
@@ -186,22 +194,90 @@ extension ImageValidate {
         let textEncoder = QwenTextEncoder(configuration: encoderConfig)
 
         print("  Weight index: \(resources.textEncoderWeightsIndexURL.path)")
-        try HFSafetensorsWeightsLoader.applyShardedWeights(
+        let quantization = try ModelWeightsLoader.QuantizationParams.fromManifest(manifest)
+        let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            if key.hasPrefix("model.") {
+                let remainder = String(key.dropFirst("model.".count))
+                return [("encoder.\(remainder)", value)]
+            }
+            return [("encoder.\(key)", value)]
+        }
+        let keyMapper: (String) -> String = { key in
+            if key.hasPrefix("model.") {
+                return "encoder." + String(key.dropFirst("model.".count))
+            }
+            if key.hasPrefix("encoder.") {
+                return key
+            }
+            return "encoder.\(key)"
+        }
+        try ModelWeightsLoader.applyHFSafetensors(
             indexURL: resources.textEncoderWeightsIndexURL,
+            singleURL: resources.textEncoderWeightsURL,
             to: textEncoder,
             dtype: .bfloat16,
             verify: .none,
-            mapper: { key, value in
-                if key.hasPrefix("model.") {
-                    let remainder = String(key.dropFirst("model.".count))
-                    return [("encoder.\(remainder)", value)]
-                }
-                return [("encoder.\(key)", value)]
-            }
+            mapper: mapper,
+            keyMapper: keyMapper,
+            quantization: quantization
         )
         print("  Weights loaded, evaluating...")
         MLX.eval(textEncoder)
         print("  Text encoder ready")
         return textEncoder
+    }
+
+    private func loadValidationTransformerWeights(
+        resources: ZImageTurboResources,
+        manifest: MereRunModelManifest?,
+        into transformer: ZImageTransformer2DModel
+    ) throws {
+        let quantization = try ModelWeightsLoader.QuantizationParams.fromManifest(manifest)
+        let fileManager = FileManager.default
+        let hasDiffusersWeights =
+            fileManager.fileExists(atPath: resources.transformerWeightsIndexURL.path)
+            || fileManager.fileExists(atPath: resources.transformerWeightsURL.path)
+        let indexURL = hasDiffusersWeights
+            ? resources.transformerWeightsIndexURL
+            : resources.transformerMFluxWeightsIndexURL
+        let singleURL = hasDiffusersWeights
+            ? resources.transformerWeightsURL
+            : resources.transformerMFluxWeightsURL
+
+        if fileManager.fileExists(atPath: indexURL.path) || fileManager.fileExists(atPath: singleURL.path) {
+            try ModelWeightsLoader.applyHFSafetensors(
+                indexURL: indexURL,
+                singleURL: singleURL,
+                to: transformer,
+                dtype: .bfloat16,
+                verify: .none,
+                keyMapper: zimageTransformerKeyMapper,
+                quantization: quantization
+            )
+            return
+        }
+
+        let shardFiles = try ModelWeightsLoader.safetensorsShards(in: resources.transformerDirURL)
+        try ModelWeightsLoader.applySafetensorsShards(
+            files: shardFiles,
+            to: transformer,
+            dtype: .bfloat16,
+            verify: .none,
+            keyMapper: zimageTransformerKeyMapper,
+            quantization: quantization
+        )
+    }
+
+    private func zimageTransformerKeyMapper(_ key: String) -> String {
+        if key.contains("t_embedder.linear1") {
+            return key.replacingOccurrences(of: "t_embedder.linear1", with: "t_embedder.mlp.0")
+        }
+        if key.contains("t_embedder.linear2") {
+            return key.replacingOccurrences(of: "t_embedder.linear2", with: "t_embedder.mlp.2")
+        }
+        if key.contains("all_final_layer") && key.contains("adaLN_modulation.0.") {
+            return key.replacingOccurrences(of: "adaLN_modulation.0.", with: "adaLN_modulation.1.")
+        }
+        return key
     }
 }

--- a/Sources/MereRunCLI/Commands/ImageValidateCommand+VAE.swift
+++ b/Sources/MereRunCLI/Commands/ImageValidateCommand+VAE.swift
@@ -11,13 +11,14 @@ extension ImageValidate {
     func runVAETests(modelURL: URL, outputDir: URL) async throws {
         print("\n== VAE validation (\(family.uppercased())) ==")
 
-        let vaeWeightsPath = modelURL.appendingPathComponent("vae/diffusion_pytorch_model.safetensors")
-        let (vaeConfig, latentChannels) = try loadVAEConfig(from: modelURL)
+        let (vaeConfig, latentChannels, resources, manifest) = try loadVAEConfig(from: modelURL)
         let vae = AutoencoderKL(configuration: vaeConfig)
 
         try loadVAEWeights(
             into: vae,
-            from: vaeWeightsPath,
+            modelURL: modelURL,
+            resources: resources,
+            manifest: manifest,
             family: family.lowercased(),
             config: vaeConfig
         )
@@ -29,7 +30,12 @@ extension ImageValidate {
         Memory.clearCache()
     }
 
-    private func loadVAEConfig(from modelURL: URL) throws -> (VAEConfig, Int) {
+    private func loadVAEConfig(from modelURL: URL) throws -> (
+        config: VAEConfig,
+        latentChannels: Int,
+        resources: ZImageTurboResources?,
+        manifest: MereRunModelManifest?
+    ) {
         if family.lowercased() == "klein" {
             let configURL = modelURL.appendingPathComponent("vae/config.json")
             let data = try Data(contentsOf: configURL)
@@ -49,21 +55,38 @@ extension ImageValidate {
                 usePostQuantConv: flux2Config.usePostQuantConv ?? false
             )
             print("  Config: Klein VAE (latentChannels=\(flux2Config.latentChannels), useQuantConv=\(vaeConfig.useQuantConv))")
-            return (vaeConfig, flux2Config.latentChannels)
+            return (vaeConfig, flux2Config.latentChannels, nil, nil)
         }
 
-        let vaeConfig = VAEConfig()
+        let (resources, manifest) = try resolvedZImageResources(modelURL: modelURL)
+        let configs = try ZImageTurboModelConfigs.load(from: resources)
+        let zimageConfig = configs.vae
+        let vaeConfig = VAEConfig(
+            inChannels: zimageConfig.inChannels,
+            outChannels: zimageConfig.outChannels,
+            latentChannels: zimageConfig.latentChannels,
+            scalingFactor: zimageConfig.scalingFactor,
+            shiftFactor: zimageConfig.shiftFactor,
+            blockOutChannels: zimageConfig.blockOutChannels,
+            layersPerBlock: zimageConfig.layersPerBlock,
+            normNumGroups: zimageConfig.normNumGroups,
+            sampleSize: zimageConfig.sampleSize ?? ZImageModelMetadata.VAE.sampleSize,
+            midBlockAddAttention: zimageConfig.midBlockAddAttention
+        )
         print("  Config: Z-Image Turbo VAE (latentChannels=\(vaeConfig.latentChannels))")
-        return (vaeConfig, vaeConfig.latentChannels)
+        return (vaeConfig, vaeConfig.latentChannels, resources, manifest)
     }
 
     private func loadVAEWeights(
         into vae: AutoencoderKL,
-        from weightsURL: URL,
+        modelURL: URL,
+        resources: ZImageTurboResources?,
+        manifest: MereRunModelManifest?,
         family: String,
         config: VAEConfig
     ) throws {
         if family == "klein" {
+            let weightsURL = modelURL.appendingPathComponent("vae/diffusion_pytorch_model.safetensors")
             let hasQuantConv = config.useQuantConv
             let hasPostQuantConv = config.usePostQuantConv
             try HFSafetensorsWeightsLoader.applyWeights(
@@ -90,12 +113,60 @@ extension ImageValidate {
             return
         }
 
-        try HFSafetensorsWeightsLoader.applyWeights(
-            url: weightsURL,
+        guard let resources else {
+            throw ImageValidateRuntimeError("Could not resolve Z-Image VAE resources.")
+        }
+        let quantization = try ModelWeightsLoader.QuantizationParams.fromManifest(manifest)
+
+        if FileManager.default.fileExists(atPath: resources.vaeWeightsURL.path) {
+            try HFSafetensorsWeightsLoader.applyWeights(
+                url: resources.vaeWeightsURL,
+                to: vae,
+                dtype: .bfloat16,
+                verify: [],
+                mapper: { key, value in
+                    let converted = value.ndim == 4
+                        ? HFSafetensorsWeightsLoader.convWeightOIHWToOHWI(value)
+                        : value
+                    return [(key, converted)]
+                }
+            )
+            return
+        }
+
+        if FileManager.default.fileExists(atPath: resources.vaeWeightsIndexURL.path)
+            || FileManager.default.fileExists(atPath: resources.vaeMFluxWeightsURL.path) {
+            try ModelWeightsLoader.applyHFSafetensors(
+                indexURL: resources.vaeWeightsIndexURL,
+                singleURL: resources.vaeMFluxWeightsURL,
+                to: vae,
+                dtype: .bfloat16,
+                verify: [],
+                mapper: zimageMFluxVAEMapper,
+                quantization: quantization
+            )
+            return
+        }
+
+        let shardFiles = try ModelWeightsLoader.safetensorsShards(in: resources.vaeDirURL)
+        try ModelWeightsLoader.applySafetensorsShards(
+            files: shardFiles,
             to: vae,
             dtype: .bfloat16,
-            verify: []
+            verify: [],
+            mapper: zimageMFluxVAEMapper,
+            quantization: quantization
         )
+    }
+
+    private func zimageMFluxVAEMapper(_ key: String, _ value: MLXArray) -> [(String, MLXArray)] {
+        let mapped = key
+            .replacingOccurrences(of: ".conv_in.conv.", with: ".conv_in.")
+            .replacingOccurrences(of: ".conv_in.conv2d.", with: ".conv_in.")
+            .replacingOccurrences(of: ".conv_out.conv.", with: ".conv_out.")
+            .replacingOccurrences(of: ".conv_out.conv2d.", with: ".conv_out.")
+            .replacingOccurrences(of: ".conv_norm_out.norm.", with: ".conv_norm_out.")
+        return [(mapped, value)]
     }
 
     private func runVAEDecodeTest(

--- a/Sources/MereRunCLI/Commands/ImageValidateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageValidateCommand.swift
@@ -126,7 +126,9 @@ struct ImageValidate: AsyncParsableCommand {
             for error in report.errors {
                 print("    - \(error)")
             }
-            throw ValidationError("Model directory is incomplete. Repair the manifest or pull the model again with `mere.run model pull \(modelId.rawValue)`.")
+            throw ImageValidateRuntimeError(
+                "Model directory is incomplete. Repair the manifest or pull the model again with `mere.run model pull \(modelId.rawValue)`."
+            )
         }
 
         return resolved.rootURL
@@ -146,5 +148,44 @@ struct ImageValidate: AsyncParsableCommand {
 
     func print(_ message: String) {
         CLIStderr.write(message + "\n")
+    }
+}
+
+struct ImageValidateRuntimeError: LocalizedError, Sendable {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+extension ImageValidate {
+    func resolvedZImageResources(modelURL: URL) throws -> (ZImageTurboResources, MereRunModelManifest?) {
+        guard let manifest = try MereRunModelManifest.loadIfPresent(from: modelURL) else {
+            return (ZImageTurboResources(rootURL: modelURL), nil)
+        }
+
+        let componentResolver = ModelComponentResolver(modelRootURL: modelURL, manifest: manifest)
+        let tokenizer = try componentResolver.resolveDirectory(for: .tokenizer, fallbackLocalPath: "tokenizer")
+        let textEncoder = try componentResolver.resolveDirectory(for: .textEncoder, fallbackLocalPath: "text_encoder")
+        let transformer = try componentResolver.resolveDirectory(for: .transformer, fallbackLocalPath: "transformer")
+        let vae = try componentResolver.resolveDirectory(for: .vae, fallbackLocalPath: "vae")
+        let scheduler = try? componentResolver.resolveDirectory(for: .scheduler, fallbackLocalPath: "scheduler")
+
+        return (
+            ZImageTurboResources(
+                modelRootURL: modelURL,
+                tokenizerDirURL: tokenizer.directoryURL,
+                textEncoderDirURL: textEncoder.directoryURL,
+                transformerDirURL: transformer.directoryURL,
+                vaeDirURL: vae.directoryURL,
+                schedulerDirURL: scheduler?.directoryURL ?? modelURL.appendingPathComponent("scheduler", isDirectory: true)
+            ),
+            manifest
+        )
     }
 }

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -105,33 +105,49 @@ struct ModelPull: AsyncParsableCommand {
             stderr("  warning: \(warning)")
         }
 
-        let result = try await ManagedModelResolver.installManagedModel(
-            id: spec.id,
-            force: force,
-            progress: { progress in
-                guard !quiet else { return }
-                switch progress {
-                case .downloadingBytes(let completed, let total):
-                    let done = ByteCountFormatter.string(fromByteCount: completed, countStyle: .file)
-                    if let total, total > 0 {
-                        let totalText = ByteCountFormatter.string(fromByteCount: total, countStyle: .file)
-                        let pct = min(100, max(0, Int(Double(completed) / Double(total) * 100)))
-                        stderrRaw("\r[\(spec.id)] \(pct)%  \(done) / \(totalText)          ")
-                    } else {
-                        stderrRaw("\r[\(spec.id)] \(done)          ")
+        let result: ManagedModelResolver.InstallResult
+        do {
+            result = try await ManagedModelResolver.installManagedModel(
+                id: spec.id,
+                force: force,
+                progress: { progress in
+                    guard !quiet else { return }
+                    switch progress {
+                    case .downloadingBytes(let completed, let total):
+                        let done = ByteCountFormatter.string(fromByteCount: completed, countStyle: .file)
+                        if let total, total > 0 {
+                            let totalText = ByteCountFormatter.string(fromByteCount: total, countStyle: .file)
+                            let pct = min(100, max(0, Int(Double(completed) / Double(total) * 100)))
+                            stderrRaw("\r[\(spec.id)] \(pct)%  \(done) / \(totalText)          ")
+                        } else {
+                            stderrRaw("\r[\(spec.id)] \(done)          ")
+                        }
+                    case .downloadingPercent(let percent, let speed):
+                        if let speed, speed > 0 {
+                            let speedText = ByteCountFormatter.string(fromByteCount: Int64(speed), countStyle: .file)
+                            stderrRaw("\r[\(spec.id)] \(percent)%  (\(speedText)/s)          ")
+                        } else {
+                            stderrRaw("\r[\(spec.id)] \(percent)%          ")
+                        }
+                    case .extracting:
+                        stderrRaw("\r[\(spec.id)] extracting…          ")
                     }
-                case .downloadingPercent(let percent, let speed):
-                    if let speed, speed > 0 {
-                        let speedText = ByteCountFormatter.string(fromByteCount: Int64(speed), countStyle: .file)
-                        stderrRaw("\r[\(spec.id)] \(percent)%  (\(speedText)/s)          ")
-                    } else {
-                        stderrRaw("\r[\(spec.id)] \(percent)%          ")
-                    }
-                case .extracting:
-                    stderrRaw("\r[\(spec.id)] extracting…          ")
                 }
+            )
+        } catch let error as ManagedModelResolver.ResolverError {
+            if !quiet {
+                stderrRaw("\n")
             }
-        )
+            if case .invalidInstalledModel(let message) = error {
+                throw ModelPullInstallError(
+                    modelID: spec.id,
+                    modelDir: modelDir,
+                    hubRepoID: spec.hubFallback?.repoId,
+                    details: [message]
+                )
+            }
+            throw error
+        }
         if !quiet {
             stderrRaw("\n")
         }
@@ -151,11 +167,11 @@ struct ModelPull: AsyncParsableCommand {
                 errors.append("Model was pulled but is not discoverable by `mere.run model list`.")
             }
             if !errors.isEmpty {
-                throw ValidationError(
-                    """
-                    Model \(spec.id) was not installed cleanly.
-                    \(errors.map { "- \($0)" }.joined(separator: "\n"))
-                    """
+                throw ModelPullInstallError(
+                    modelID: spec.id,
+                    modelDir: modelDir,
+                    hubRepoID: spec.hubFallback?.repoId,
+                    details: errors
                 )
             }
         }
@@ -169,6 +185,30 @@ struct ModelPull: AsyncParsableCommand {
 
     private func stderrRaw(_ message: String) {
         CLIStderr.write(message)
+    }
+}
+
+struct ModelPullInstallError: LocalizedError, Sendable {
+    let modelID: String
+    let modelDir: URL
+    let hubRepoID: String?
+    let details: [String]
+
+    var errorDescription: String? {
+        var lines: [String] = []
+        lines.append("Model \(modelID) was not installed cleanly.")
+        lines.append(contentsOf: details.map { "- \($0)" })
+        lines.append("")
+        lines.append("Model store: \(modelDir.path)")
+        lines.append("Retry with: mere.run model pull \(modelID)")
+        lines.append("Use --force only if you intentionally want to replace a complete install.")
+        if let hubRepoID,
+           let hubCache = try? HubSnapshot.resolvedDownloadBase() {
+            lines.append(
+                "If this repeats, remove the stale Hub cache for \(hubRepoID) under \(hubCache.path)/models/ and retry."
+            )
+        }
+        return lines.joined(separator: "\n")
     }
 }
 

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -1,0 +1,897 @@
+import ArgumentParser
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import AudioSTT
+import AudioTTS
+import MereRunCore
+
+struct OpenWebUI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "open-webui",
+        abstract: "Start the optional Open WebUI companion against a local mere.run API.",
+        subcommands: [
+            OpenWebUIQuickstart.self,
+        ],
+        defaultSubcommand: OpenWebUIQuickstart.self
+    )
+}
+
+struct OpenWebUIQuickstart: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "quickstart",
+        abstract: "Start mere.run, run the official Open WebUI Docker image, and configure the connection."
+    )
+
+    @Option(name: [.long], help: "Host for the local mere.run API server.")
+    var host: String = "0.0.0.0"
+
+    @Option(name: [.long], help: "Port for the local mere.run API server.")
+    var port: Int = 8080
+
+    @Option(name: [.long], help: "Serving engine for the text model. Defaults to the managed model's API engine.")
+    var engine: APIEngine?
+
+    @Option(name: [.long], help: "Open WebUI host bind and browser host.")
+    var webuiHost: String = "127.0.0.1"
+
+    @Option(name: [.long], help: "Open WebUI host port.")
+    var webuiPort: Int = 3000
+
+    @Option(name: [.long], help: "Open WebUI container name.")
+    var containerName: String = "open-webui-mere-run"
+
+    @Option(name: [.long], help: "Open WebUI Docker volume name.")
+    var volumeName: String = "open-webui-mere-run"
+
+    @Option(name: [.long], help: "Open WebUI Docker image.")
+    var image: String = "ghcr.io/open-webui/open-webui:main"
+
+    @Option(name: [.long], help: "Bearer API key for the local mere.run API. Defaults to MERERUN_API_KEY or change-me.")
+    var apiKey: String?
+
+    @Option(name: [.long], help: "Installed text chat model to expose as Open WebUI's default chat model.")
+    var textModel: String = Gemma4Resources.twelveBModelId
+
+    @Option(name: [.long], help: "Installed vision chat model to expose in Open WebUI's chat selector.")
+    var visionModel: String = Gemma4Resources.visionTwelveBModelId
+
+    @Option(name: [.long], help: "Installed embedding model for Open WebUI RAG.")
+    var embeddingModel: String = Qwen3EmbeddingCatalog.modelId
+
+    @Option(name: [.long], help: "Installed image-generation model for Open WebUI.")
+    var imageModel: String = ModelResolver.ModelID.zetaNano.rawValue
+
+    @Option(name: [.long], help: "Installed text-to-speech model for Open WebUI.")
+    var ttsModel: String = Qwen3TTSResources.defaultModelId
+
+    @Option(name: [.long], help: "Installed speech-to-text model for Open WebUI.")
+    var sttModel: String = ParakeetResources.defaultModelId
+
+    @Option(name: [.long], help: "OpenAI speech response format for Open WebUI TTS.")
+    var ttsFormat: String = "wav"
+
+    @Option(name: [.long], help: "Open WebUI no-auth signin email used while configuring the fresh container.")
+    var adminEmail: String = "admin@localhost"
+
+    @Option(name: [.long], help: "Open WebUI no-auth signin password used while configuring the fresh container.")
+    var adminPassword: String = "admin"
+
+    @Option(name: [.long], help: "Seconds to wait for mere.run and Open WebUI health checks.")
+    var waitSeconds: Int = 180
+
+    @Flag(name: [.long], help: "Pull the configured managed models before starting.")
+    var pull: Bool = false
+
+    @Flag(name: [.long], help: "Use an already-running mere.run API server.")
+    var skipServer: Bool = false
+
+    @Flag(name: [.long], help: "Use an already-running Open WebUI instance.")
+    var skipDocker: Bool = false
+
+    @Flag(name: [.long], help: "Skip Open WebUI admin API configuration.")
+    var skipConfigure: Bool = false
+
+    @Flag(name: [.long], help: "Remove any existing Open WebUI container and volume before starting Docker.")
+    var reset: Bool = false
+
+    @Flag(name: [.long], help: "Print the planned commands without starting anything.")
+    var dryRun: Bool = false
+
+    @Flag(name: [.short, .long], help: "Suppress model pull progress output.")
+    var quiet: Bool = false
+
+    func run() async throws {
+        let resolvedKey = Self.resolvedAPIKey(explicit: apiKey)
+        if dryRun {
+            print(try makePlan(apiKey: resolvedKey).render())
+            return
+        }
+
+        if pull {
+            try await pullConfiguredModels()
+        }
+
+        let serverProcess: Process?
+        if skipServer {
+            serverProcess = nil
+            CLIStderr.write("[open-webui] Using existing mere.run API at \(localAPIBaseURL.absoluteString)\n")
+        } else {
+            let started = try startAPIServer(apiKey: resolvedKey)
+            serverProcess = started.process
+            CLIStderr.write("[open-webui] Loading \(textModel). Server log: \(started.logURL.path)\n")
+            try await waitForHTTP200(
+                url: serverHealthURL,
+                timeoutSeconds: waitSeconds,
+                label: "mere.run API"
+            )
+        }
+        defer {
+            if let serverProcess, serverProcess.isRunning {
+                serverProcess.terminate()
+            }
+        }
+
+        if skipDocker {
+            CLIStderr.write("[open-webui] Using existing Open WebUI at \(openWebUIBaseURL.absoluteString)\n")
+        } else {
+            try startDockerContainer(apiKey: resolvedKey)
+        }
+
+        if !skipConfigure {
+            try await waitForHTTP200(
+                url: openWebUIHealthURL,
+                timeoutSeconds: waitSeconds,
+                label: "Open WebUI"
+            )
+            let configuredModels = try await configureOpenWebUI(apiKey: resolvedKey)
+            CLIStderr.write("[open-webui] Configured chat models: \(configuredModels.joined(separator: ", "))\n")
+        }
+
+        print("Open WebUI is ready: \(openWebUIBaseURL.absoluteString)")
+        print("mere.run API: \(dockerAPIBaseURL.absoluteString)")
+        print("Chat models: \(textModel), \(visionModel)")
+        print("RAG embeddings: \(embeddingModel)")
+        print("Image/TTS/STT: \(imageModel), \(ttsModel), \(sttModel)")
+        if serverProcess == nil {
+            return
+        }
+        print("Press Ctrl+C to stop the local mere.run API server.")
+        waitForServerProcess()
+    }
+
+    static func resolvedAPIKey(explicit: String?, environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        if let explicit = normalized(explicit) {
+            return explicit
+        }
+        if let fromEnvironment = normalized(environment["MERERUN_API_KEY"]) {
+            return fromEnvironment
+        }
+        return "change-me"
+    }
+
+    func makePlan(apiKey: String) throws -> OpenWebUIQuickstartPlan {
+        let engine = try resolvedEngine()
+        return OpenWebUIQuickstartPlan(
+            apiKey: apiKey,
+            apiServeCommand: apiServeDisplayCommand(engine: engine, apiKey: "$MERERUN_API_KEY"),
+            dockerCommand: dockerDisplayCommand(apiKey: "$MERERUN_API_KEY"),
+            configureCommand: CLICommandDisplay.command(
+                [
+                    "open-webui quickstart",
+                    "--skip-server",
+                    "--skip-docker",
+                    "--host \(ShellQuote.quote(host))",
+                    "--port \(port)",
+                    "--webui-host \(ShellQuote.quote(webuiHost))",
+                    "--webui-port \(webuiPort)",
+                    "--text-model \(ShellQuote.quote(textModel))",
+                    "--vision-model \(ShellQuote.quote(visionModel))",
+                    "--api-key \"$MERERUN_API_KEY\"",
+                ].joined(separator: " ")
+            )
+        )
+    }
+
+    private var localAPIBaseURL: URL {
+        URL(string: "http://\(serverHealthHost):\(port)/v1")!
+    }
+
+    private var dockerAPIBaseURL: URL {
+        URL(string: "http://host.docker.internal:\(port)/v1")!
+    }
+
+    private var serverHealthURL: URL {
+        URL(string: "http://\(serverHealthHost):\(port)/health")!
+    }
+
+    private var serverHealthHost: String {
+        let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedHost == "0.0.0.0" || normalizedHost == "::" {
+            return "127.0.0.1"
+        }
+        return normalizedHost.isEmpty ? "127.0.0.1" : normalizedHost
+    }
+
+    private var openWebUIBaseURL: URL {
+        URL(string: "http://\(browserHost):\(webuiPort)")!
+    }
+
+    private var openWebUIHealthURL: URL {
+        openWebUIBaseURL.appendingPathComponent("health")
+    }
+
+    private var browserHost: String {
+        let normalizedHost = webuiHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedHost == "0.0.0.0" || normalizedHost == "::" {
+            return "127.0.0.1"
+        }
+        return normalizedHost.isEmpty ? "127.0.0.1" : normalizedHost
+    }
+
+    private func resolvedEngine() throws -> APIEngine {
+        if let engine {
+            return engine
+        }
+        if let spec = ManagedModelCatalog.spec(for: textModel),
+           let runtimeEngine = spec.defaultRuntimeServingEngine {
+            return try APIEngine(runtimeEngine: runtimeEngine)
+        }
+        throw ValidationError(
+            "Could not infer an API engine for \(textModel). Pass --engine for a local path or custom model."
+        )
+    }
+
+    private func pullConfiguredModels() async throws {
+        for modelID in uniqueModelIDs([textModel, visionModel, embeddingModel, imageModel, ttsModel, sttModel]) {
+            guard let spec = ManagedModelCatalog.spec(for: modelID) else {
+                CLIStderr.write("[open-webui] Skipping pull for custom model \(modelID)\n")
+                continue
+            }
+            guard spec.hasAnyManagedDownloadSource() else {
+                CLIStderr.write("[open-webui] \(modelID) has no managed download source; install it from a local path.\n")
+                continue
+            }
+            if !quiet {
+                CLIStderr.write("[open-webui] Pulling \(modelID)\n")
+            }
+            _ = try await ManagedModelResolver.installManagedModel(
+                id: modelID,
+                force: false,
+                progress: { progress in
+                    guard !quiet else { return }
+                    switch progress {
+                    case .downloadingBytes(let completed, let total):
+                        let done = ByteCountFormatter.string(fromByteCount: completed, countStyle: .file)
+                        if let total, total > 0 {
+                            let totalText = ByteCountFormatter.string(fromByteCount: total, countStyle: .file)
+                            CLIStderr.write("\r[\(modelID)] \(done) / \(totalText)          ")
+                        } else {
+                            CLIStderr.write("\r[\(modelID)] \(done)          ")
+                        }
+                    case .downloadingPercent(let percent, let speed):
+                        if let speed, speed > 0 {
+                            let speedText = ByteCountFormatter.string(
+                                fromByteCount: Int64(speed),
+                                countStyle: .file
+                            )
+                            CLIStderr.write("\r[\(modelID)] \(percent)% (\(speedText)/s)          ")
+                        } else {
+                            CLIStderr.write("\r[\(modelID)] \(percent)%          ")
+                        }
+                    case .extracting:
+                        CLIStderr.write("\r[\(modelID)] extracting          ")
+                    }
+                }
+            )
+            if !quiet {
+                CLIStderr.write("\n")
+            }
+        }
+    }
+
+    private func startAPIServer(apiKey: String) throws -> (process: Process, logURL: URL) {
+        let engine = try resolvedEngine()
+        let log = try AgentServerLog.makeLogHandle(prefix: "open-webui-api-server")
+        let process = Process()
+        process.executableURL = CurrentExecutable.url()
+        process.arguments = [
+            "api",
+            "serve",
+            "--engine",
+            engine.rawValue,
+            "--model",
+            textModel,
+            "--host",
+            host,
+            "--port",
+            String(port),
+            "--api-key",
+            apiKey,
+        ]
+        process.standardInput = AgentServerLog.nullInputHandle()
+        process.standardOutput = log.handle
+        process.standardError = log.handle
+        try process.run()
+        CLIStderr.write("[open-webui] Started mere.run API server on \(host):\(port)\n")
+        return (process, log.url)
+    }
+
+    private func startDockerContainer(apiKey: String) throws {
+        _ = try runDocker(["--version"])
+        if reset {
+            _ = try? runDocker(["rm", "-f", containerName])
+            _ = try? runDocker(["volume", "rm", volumeName])
+        } else if try dockerContainerExists() {
+            throw ValidationError(
+                "Docker container \(containerName) already exists. Pass --reset to recreate it or --skip-docker to reuse it."
+            )
+        }
+        let result = try runDocker(dockerRunArguments(apiKey: apiKey))
+        CLIStderr.write("[open-webui] Open WebUI container: \(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))\n")
+        CLIStderr.write("[open-webui] Starting at \(openWebUIBaseURL.absoluteString)\n")
+    }
+
+    private func dockerContainerExists() throws -> Bool {
+        let result = try runDocker(["ps", "-a", "--format", "{{.Names}}"])
+        return result.stdout
+            .split(whereSeparator: \.isNewline)
+            .contains { $0 == containerName }
+    }
+
+    private func dockerRunArguments(apiKey: String) -> [String] {
+        [
+            "run",
+            "-d",
+            "--name",
+            containerName,
+            "--restart",
+            "unless-stopped",
+            "-p",
+            "\(webuiHost):\(webuiPort):8080",
+            "--add-host=host.docker.internal:host-gateway",
+        ] + dockerEnvironmentArguments(apiKey: apiKey)
+            + [
+                "-v",
+                "\(volumeName):/app/backend/data",
+                image,
+            ]
+    }
+
+    private func dockerEnvironmentArguments(apiKey: String) -> [String] {
+        dockerEnvironment(apiKey: apiKey)
+            .flatMap { ["-e", "\($0.name)=\($0.value)"] }
+    }
+
+    private func dockerEnvironment(apiKey: String) -> [OpenWebUIEnvironmentValue] {
+        [
+            OpenWebUIEnvironmentValue("OPENAI_API_BASE_URL", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("OPENAI_API_BASE_URLS", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("OPENAI_API_KEY", apiKey),
+            OpenWebUIEnvironmentValue("OPENAI_API_KEYS", apiKey),
+            OpenWebUIEnvironmentValue("DEFAULT_MODELS", textModel),
+            OpenWebUIEnvironmentValue("DEFAULT_MODEL_PARAMS", OpenWebUIModelParams.defaultJSONString),
+            OpenWebUIEnvironmentValue("DEFAULT_MODEL_METADATA", OpenWebUIModelMetadata.defaultJSONString),
+            OpenWebUIEnvironmentValue("RAG_EMBEDDING_ENGINE", "openai"),
+            OpenWebUIEnvironmentValue("RAG_OPENAI_API_BASE_URL", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("RAG_OPENAI_API_KEY", apiKey),
+            OpenWebUIEnvironmentValue("RAG_EMBEDDING_MODEL", embeddingModel),
+            OpenWebUIEnvironmentValue("ENABLE_IMAGE_GENERATION", "True"),
+            OpenWebUIEnvironmentValue("ENABLE_IMAGE_EDIT", "False"),
+            OpenWebUIEnvironmentValue("IMAGE_GENERATION_ENGINE", "openai"),
+            OpenWebUIEnvironmentValue("IMAGE_GENERATION_MODEL", imageModel),
+            OpenWebUIEnvironmentValue("IMAGE_SIZE", "1024x1024"),
+            OpenWebUIEnvironmentValue("IMAGE_EDIT_ENGINE", "openai"),
+            OpenWebUIEnvironmentValue("IMAGE_EDIT_MODEL", "qwen-image-edit"),
+            OpenWebUIEnvironmentValue("IMAGE_EDIT_SIZE", "1024x1024"),
+            OpenWebUIEnvironmentValue("IMAGES_OPENAI_API_BASE_URL", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("IMAGES_OPENAI_API_KEY", apiKey),
+            OpenWebUIEnvironmentValue("IMAGES_EDIT_OPENAI_API_BASE_URL", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("IMAGES_EDIT_OPENAI_API_KEY", apiKey),
+            OpenWebUIEnvironmentValue("AUDIO_TTS_ENGINE", "openai"),
+            OpenWebUIEnvironmentValue("AUDIO_TTS_MODEL", ttsModel),
+            OpenWebUIEnvironmentValue("AUDIO_TTS_VOICE", "nova"),
+            OpenWebUIEnvironmentValue("AUDIO_TTS_OPENAI_API_BASE_URL", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("AUDIO_TTS_OPENAI_API_KEY", apiKey),
+            OpenWebUIEnvironmentValue("AUDIO_TTS_OPENAI_PARAMS", "{\"response_format\":\"\(ttsFormat)\"}"),
+            OpenWebUIEnvironmentValue("AUDIO_STT_ENGINE", "openai"),
+            OpenWebUIEnvironmentValue("AUDIO_STT_MODEL", sttModel),
+            OpenWebUIEnvironmentValue("AUDIO_STT_OPENAI_API_BASE_URL", dockerAPIBaseURL.absoluteString),
+            OpenWebUIEnvironmentValue("AUDIO_STT_OPENAI_API_KEY", apiKey),
+            OpenWebUIEnvironmentValue("ENABLE_PERSISTENT_CONFIG", "False"),
+            OpenWebUIEnvironmentValue("WEBUI_AUTH", "False"),
+        ]
+    }
+
+    private func configureOpenWebUI(apiKey: String) async throws -> [String] {
+        let availableModelIDs = try await fetchMereRunModelIDs(apiKey: apiKey)
+        let requestedChatModels = uniqueModelIDs([textModel, visionModel])
+        let selectedChatModels = requestedChatModels.filter { availableModelIDs.contains($0) }
+        let chatModels = selectedChatModels.isEmpty ? requestedChatModels : selectedChatModels
+        let token = try await fetchOpenWebUIToken()
+        try await postOpenWebUIJSON(
+            path: "/openai/config/update",
+            token: token,
+            payload: OpenWebUIOpenAIConfigPayload(
+                apiBaseURL: dockerAPIBaseURL.absoluteString,
+                apiKey: apiKey,
+                modelIDs: chatModels
+            )
+        )
+        try await postOpenWebUIJSON(
+            path: "/api/v1/configs/models",
+            token: token,
+            payload: OpenWebUIModelsConfigPayload(
+                defaultModels: textModel,
+                modelOrderList: chatModels
+            )
+        )
+        try await postOpenWebUIJSON(
+            path: "/api/v1/models/import",
+            token: token,
+            payload: OpenWebUIModelsImportPayload(
+                models: wrappers(for: chatModels)
+            )
+        )
+        let openWebUIModels: OpenWebUIModelListPayload = try await getOpenWebUIJSON(
+            path: "/api/models",
+            token: token
+        )
+        let listedIDs = Set(openWebUIModels.data.map(\.id))
+        let missing = chatModels.filter { !listedIDs.contains($0) }
+        if !missing.isEmpty {
+            throw ValidationError(
+                "Open WebUI model list is missing configured ids: \(missing.joined(separator: ", "))"
+            )
+        }
+        return chatModels
+    }
+
+    private func fetchMereRunModelIDs(apiKey: String) async throws -> Set<String> {
+        var request = URLRequest(url: localAPIBaseURL.appendingPathComponent("models"))
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let data = try await send(request: request, label: "mere.run /v1/models")
+        let payload = try JSONDecoder().decode(OpenWebUIModelListPayload.self, from: data)
+        return Set(payload.data.map(\.id))
+    }
+
+    private func fetchOpenWebUIToken() async throws -> String {
+        let payload = OpenWebUIAuthSigninRequest(email: adminEmail, password: adminPassword)
+        let response: OpenWebUIAuthSigninResponse = try await postOpenWebUIJSON(
+            path: "/api/v1/auths/signin",
+            token: nil,
+            payload: payload
+        )
+        guard let token = Self.normalized(response.token) else {
+            throw ValidationError("Open WebUI signin did not return a token.")
+        }
+        return token
+    }
+
+    @discardableResult
+    private func postOpenWebUIJSON<Payload: Encodable>(
+        path: String,
+        token: String?,
+        payload: Payload
+    ) async throws -> Data {
+        let url = try joinedURL(base: openWebUIBaseURL, path: path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONEncoder().encode(payload)
+        return try await send(request: request, label: "Open WebUI \(path)")
+    }
+
+    private func postOpenWebUIJSON<Response: Decodable, Payload: Encodable>(
+        path: String,
+        token: String?,
+        payload: Payload
+    ) async throws -> Response {
+        let data = try await postOpenWebUIJSON(path: path, token: token, payload: payload)
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+
+    private func getOpenWebUIJSON<Response: Decodable>(path: String, token: String) async throws -> Response {
+        let url = try joinedURL(base: openWebUIBaseURL, path: path)
+        var request = URLRequest(url: url)
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        let data = try await send(request: request, label: "Open WebUI \(path)")
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+
+    private func waitForHTTP200(url: URL, timeoutSeconds: Int, label: String) async throws {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutSeconds))
+        while Date() < deadline {
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 5
+            if let (_, response) = try? await URLSession.shared.data(for: request),
+               let http = response as? HTTPURLResponse,
+               http.statusCode == 200 {
+                return
+            }
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        throw ValidationError("Timed out waiting for \(label) at \(url.absoluteString).")
+    }
+
+    private func send(request: URLRequest, label: String) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ValidationError("\(label) returned a non-HTTP response.")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let text = String(data: data.prefix(500), encoding: .utf8) ?? ""
+            throw ValidationError("\(label) returned HTTP \(http.statusCode). \(text)")
+        }
+        return data
+    }
+
+    private func joinedURL(base: URL, path: String) throws -> URL {
+        var rawBase = base.absoluteString
+        while rawBase.hasSuffix("/") {
+            rawBase.removeLast()
+        }
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        guard let url = URL(string: rawBase + normalizedPath) else {
+            throw ValidationError("Invalid URL path \(path) for \(base.absoluteString).")
+        }
+        return url
+    }
+
+    private func wrappers(for chatModels: [String]) -> [OpenWebUIModelWrapper] {
+        chatModels.map { modelID in
+            let isVision = modelID == visionModel
+            return OpenWebUIModelWrapper(
+                id: modelID,
+                baseModelID: modelID,
+                name: "mere.run \(modelID)",
+                meta: OpenWebUIModelMetadata(
+                    capabilities: OpenWebUIModelCapabilities.default(vision: isVision),
+                    description: "mere.run serves \(modelID) locally."
+                ),
+                params: OpenWebUIModelParams.default,
+                isActive: true
+            )
+        }
+    }
+
+    private func uniqueModelIDs(_ ids: [String]) -> [String] {
+        var seen: Set<String> = []
+        var ordered: [String] = []
+        for id in ids {
+            guard let normalized = Self.normalized(id),
+                  !seen.contains(normalized) else {
+                continue
+            }
+            seen.insert(normalized)
+            ordered.append(normalized)
+        }
+        return ordered
+    }
+
+    private static func normalized(_ rawValue: String?) -> String? {
+        guard let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private func apiServeDisplayCommand(engine: APIEngine, apiKey: String) -> String {
+        CLICommandDisplay.command(
+            [
+                "api serve",
+                "--engine \(ShellQuote.quote(engine.rawValue))",
+                "--model \(ShellQuote.quote(textModel))",
+                "--host \(ShellQuote.quote(host))",
+                "--port \(port)",
+                "--api-key \(apiKey)",
+            ].joined(separator: " ")
+        )
+    }
+
+    private func dockerDisplayCommand(apiKey: String) -> String {
+        let args = dockerRunArguments(apiKey: apiKey)
+        var lines: [String] = ["docker run -d \\"]
+        var index = 2
+        while index < args.count {
+            let item = args[index]
+            let next = index + 1 < args.count ? args[index + 1] : nil
+            if item == "-e", let next {
+                lines.append("  -e \(ShellQuote.quote(next)) \\")
+                index += 2
+            } else if item == "-p" || item == "--name" || item == "--restart" || item == "-v",
+                      let next {
+                lines.append("  \(item) \(ShellQuote.quote(next)) \\")
+                index += 2
+            } else if item.hasPrefix("--add-host=") {
+                lines.append("  \(ShellQuote.quote(item)) \\")
+                index += 1
+            } else {
+                lines.append("  \(ShellQuote.quote(item))")
+                index += 1
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func runDocker(_ arguments: [String]) throws -> OpenWebUIProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["docker"] + arguments
+        process.standardInput = AgentServerLog.nullInputHandle()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            throw ValidationError("docker \(arguments.joined(separator: " ")) failed: \(stderrText)")
+        }
+        return OpenWebUIProcessResult(stdout: stdoutText, stderr: stderrText)
+    }
+
+    private func waitForServerProcess() -> Never {
+        while true {
+            Thread.sleep(forTimeInterval: 3600)
+        }
+    }
+}
+
+struct OpenWebUIQuickstartPlan {
+    let apiKey: String
+    let apiServeCommand: String
+    let dockerCommand: String
+    let configureCommand: String
+
+    func render() -> String {
+        """
+        mere.run Open WebUI quickstart plan
+
+        1. Export the API key:
+           export MERERUN_API_KEY=\(ShellQuote.quote(apiKey))
+
+        2. Start the local API:
+           \(apiServeCommand)
+
+        3. Start the official Open WebUI container:
+        \(dockerCommand)
+
+        4. Configure an already-running Open WebUI instance:
+           \(configureCommand)
+
+        Run without --dry-run to execute the Docker path.
+        """
+    }
+}
+
+private struct OpenWebUIEnvironmentValue {
+    let name: String
+    let value: String
+
+    init(_ name: String, _ value: String) {
+        self.name = name
+        self.value = value
+    }
+}
+
+private struct OpenWebUIProcessResult {
+    let stdout: String
+    let stderr: String
+}
+
+private struct OpenWebUIModelListPayload: Decodable {
+    let data: [OpenWebUIListedModel]
+}
+
+private struct OpenWebUIListedModel: Decodable {
+    let id: String
+}
+
+private struct OpenWebUIAuthSigninRequest: Encodable {
+    let email: String
+    let password: String
+}
+
+private struct OpenWebUIAuthSigninResponse: Decodable {
+    let token: String?
+}
+
+private struct OpenWebUIOpenAIConfigPayload: Encodable {
+    let enableOpenAIAPI: Bool
+    let openAIAPIBaseURLs: [String]
+    let openAIAPIKeys: [String]
+    let openAIAPIConfigs: [String: OpenWebUIOpenAIConnectionConfig]
+
+    init(apiBaseURL: String, apiKey: String, modelIDs: [String]) {
+        self.enableOpenAIAPI = true
+        self.openAIAPIBaseURLs = [apiBaseURL]
+        self.openAIAPIKeys = [apiKey]
+        self.openAIAPIConfigs = [
+            "0": OpenWebUIOpenAIConnectionConfig(enable: true, modelIDs: modelIDs),
+        ]
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enableOpenAIAPI = "ENABLE_OPENAI_API"
+        case openAIAPIBaseURLs = "OPENAI_API_BASE_URLS"
+        case openAIAPIKeys = "OPENAI_API_KEYS"
+        case openAIAPIConfigs = "OPENAI_API_CONFIGS"
+    }
+}
+
+private struct OpenWebUIOpenAIConnectionConfig: Encodable {
+    let enable: Bool
+    let modelIDs: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case enable
+        case modelIDs = "model_ids"
+    }
+}
+
+private struct OpenWebUIModelsConfigPayload: Encodable {
+    let defaultModels: String
+    let defaultPinnedModels: String
+    let modelOrderList: [String]
+    let defaultModelMetadata: OpenWebUIModelMetadata
+    let defaultModelParams: OpenWebUIModelParams
+
+    init(defaultModels: String, modelOrderList: [String]) {
+        self.defaultModels = defaultModels
+        self.defaultPinnedModels = defaultModels
+        self.modelOrderList = modelOrderList
+        self.defaultModelMetadata = .default
+        self.defaultModelParams = .default
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case defaultModels = "DEFAULT_MODELS"
+        case defaultPinnedModels = "DEFAULT_PINNED_MODELS"
+        case modelOrderList = "MODEL_ORDER_LIST"
+        case defaultModelMetadata = "DEFAULT_MODEL_METADATA"
+        case defaultModelParams = "DEFAULT_MODEL_PARAMS"
+    }
+}
+
+private struct OpenWebUIModelsImportPayload: Encodable {
+    let models: [OpenWebUIModelWrapper]
+}
+
+private struct OpenWebUIModelWrapper: Encodable {
+    let id: String
+    let baseModelID: String
+    let name: String
+    let meta: OpenWebUIModelMetadata
+    let params: OpenWebUIModelParams
+    let isActive: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case baseModelID = "base_model_id"
+        case name
+        case meta
+        case params
+        case isActive = "is_active"
+    }
+}
+
+private struct OpenWebUIModelMetadata: Codable {
+    let capabilities: OpenWebUIModelCapabilities
+    let description: String?
+
+    static let `default` = OpenWebUIModelMetadata(
+        capabilities: .default(vision: false),
+        description: nil
+    )
+
+    static var defaultJSONString: String {
+        encodeCompact(OpenWebUIModelMetadata.default)
+    }
+}
+
+private struct OpenWebUIModelCapabilities: Codable {
+    let fileContext: Bool
+    let vision: Bool
+    let fileUpload: Bool
+    let webSearch: Bool
+    let imageGeneration: Bool
+    let codeInterpreter: Bool
+    let terminal: Bool
+    let citations: Bool
+    let statusUpdates: Bool
+    let builtinTools: Bool
+
+    static func `default`(vision: Bool) -> OpenWebUIModelCapabilities {
+        OpenWebUIModelCapabilities(
+            fileContext: true,
+            vision: vision,
+            fileUpload: true,
+            webSearch: false,
+            imageGeneration: true,
+            codeInterpreter: false,
+            terminal: false,
+            citations: true,
+            statusUpdates: true,
+            builtinTools: true
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case fileContext = "file_context"
+        case vision
+        case fileUpload = "file_upload"
+        case webSearch = "web_search"
+        case imageGeneration = "image_generation"
+        case codeInterpreter = "code_interpreter"
+        case terminal
+        case citations
+        case statusUpdates = "status_updates"
+        case builtinTools = "builtin_tools"
+    }
+}
+
+private struct OpenWebUIModelParams: Codable {
+    let functionCalling: String
+
+    static let `default` = OpenWebUIModelParams(functionCalling: "native")
+
+    static var defaultJSONString: String {
+        encodeCompact(OpenWebUIModelParams.default)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case functionCalling = "function_calling"
+    }
+}
+
+private func encodeCompact<Value: Encodable>(_ value: Value) -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    guard let data = try? encoder.encode(value),
+          let text = String(data: data, encoding: .utf8) else {
+        return "{}"
+    }
+    return text
+}
+
+private extension APIEngine {
+    init(runtimeEngine: RuntimeServingEngine) throws {
+        switch runtimeEngine.canonical {
+        case .textCode:
+            self = .textCode
+        case .textChatKlein:
+            self = .textChatKlein
+        case .textChatGemma4:
+            self = .textChatGemma4
+        case .textChatQ36:
+            self = .textChatQ36
+        case .textChatQ35:
+            self = .textChatQ36
+        case .textChatLFM2:
+            self = .textChatLFM2
+        case .textChatDeepseekV4Flash:
+            self = .textChatDeepseekV4Flash
+        }
+    }
+}
+
+private enum ShellQuote {
+    static func quote(_ value: String) -> String {
+        if value.isEmpty {
+            return "''"
+        }
+        let safeScalars = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_./:=@%+,$")
+        if value.unicodeScalars.allSatisfy({ safeScalars.contains($0) }) {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/MereRunCLI/Commands/TextEmbedCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextEmbedCommand.swift
@@ -39,14 +39,15 @@ struct TextEmbed: AsyncParsableCommand {
         let model = try Qwen3EmbeddingModel(resources: resources)
         let result = try model.embed(texts: texts, maxTokens: maxTokens)
 
-        let payload = EmbeddingResponse(
+        let promptTokens = result.tokenCounts.reduce(0, +)
+        let payload = OpenAIEmbeddingResponse(
             model: Qwen3EmbeddingCatalog.modelId,
             data: result.embeddings.enumerated().map { index, vector in
-                EmbeddingDatum(index: index, embedding: vector)
+                OpenAIEmbeddingDatum(index: index, embedding: vector)
             },
-            usage: EmbeddingUsage(
-                promptTokens: result.tokenCounts.reduce(0, +),
-                totalTokens: result.tokenCounts.reduce(0, +)
+            usage: OpenAIEmbeddingUsage(
+                prompt_tokens: promptTokens,
+                total_tokens: promptTokens
             )
         )
 
@@ -83,28 +84,5 @@ struct TextEmbed: AsyncParsableCommand {
         } catch let error as ManagedModelResolver.ResolverError {
             throw ValidationError(error.localizedDescription)
         }
-    }
-}
-
-private struct EmbeddingResponse: Encodable, Sendable {
-    let object = "list"
-    let model: String
-    let data: [EmbeddingDatum]
-    let usage: EmbeddingUsage
-}
-
-private struct EmbeddingDatum: Encodable, Sendable {
-    let object = "embedding"
-    let index: Int
-    let embedding: [Float]
-}
-
-private struct EmbeddingUsage: Encodable, Sendable {
-    let promptTokens: Int
-    let totalTokens: Int
-
-    enum CodingKeys: String, CodingKey {
-        case promptTokens = "prompt_tokens"
-        case totalTokens = "total_tokens"
     }
 }

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-Start a local OpenAI-compatible HTTP server for chat completions. Use this when another tool, editor, or agent needs to call mere.run over HTTP.
+Start a local OpenAI-compatible HTTP server for chat completions, native text
+embeddings, image generation/editing, text-to-speech, and speech-to-text. Use
+this when another tool, editor, UI, or agent needs to call mere.run over HTTP.
 
 ## Required Models
 
@@ -15,12 +17,21 @@ Supported engines:
 - `text-chat-lfm2`: LFM2 serving engine; defaults to `text-chat-lfm25-a1b-8bit`.
 - `text-chat-deepseek-v4-flash`: DeepSeek V4 Flash via the bundled DS4 server.
 - `text-chat-klein`: local Klein/MeBot chat path when installed.
+- `text-embed-qwen3-0.6b`: native Qwen3 embedding model served through
+  `/v1/embeddings` for RAG and semantic search.
+- Image generation: any installed `image-*` generation model, such as
+  `image-zimage-nano`.
+- Text-to-speech: `speech-tts-qwen3-nano`.
+- Speech-to-text: `speech-asr-parakeet` or `speech-asr-qwen3`.
 
 ## Install And Check
 
 ```bash
 mere.run model capabilities
 mere.run model pull text-agent-deepseek-v4-flash
+mere.run model pull image-zimage-nano
+mere.run model pull speech-tts-qwen3-nano
+mere.run model pull speech-asr-parakeet
 mere.run model runtime get text-chat-gemma4
 mere.run api serve --help
 mere.run status
@@ -34,7 +45,7 @@ mere.run status
 - `--engine`: `text-code`, `text-chat-klein`, `text-chat-gemma4`, `text-chat-q36`, `text-chat-lfm2`, or `text-chat-deepseek-v4-flash`.
 - `--lora`: default LoRA adapter path for all requests.
 - `--api-key`: bearer token, also read from `MERERUN_API_KEY`.
-- `--rate-limit-per-minute`: global chat completions limit.
+- `--rate-limit-per-minute`: global OpenAI-compatible request limit.
 - `--max-active-requests`: fair FIFO admission limit for concurrent chat completions; default `1`.
 - `--memory-guard`: runtime memory guard tier, default `balanced`. Accepted
   values are `off`, `safe`, `balanced`, `aggressive`, and `custom`.
@@ -64,9 +75,15 @@ mere.run status
   least-recently-used idle unpinned model; under critical pressure, it evicts
   every idle unpinned model. Active requests are never evicted.
 - Test `/v1/chat/completions` after status shows the expected served model.
+- Test `/v1/embeddings` with `text-embed-qwen3-0.6b` when wiring a RAG client.
+- Test `/v1/images/generations` with `image-zimage-nano` when wiring an image client.
+- Test `/v1/images/edits` with multipart `image` uploads when wiring image editing.
+- Test `/v1/audio/speech` with `speech-tts-qwen3-nano` when wiring TTS.
+- Test `/v1/audio/transcriptions` with `speech-asr-parakeet` when wiring STT.
 - Request `model` resolves by runtime alias, then curated catalog id, then the
   startup default from `--engine`/`--model`.
-- `/v1/models` returns installed API-capable catalog ids plus aliases.
+- `/v1/models` returns installed API-capable chat catalog ids, aliases, and
+  installed native embedding, image, TTS, and ASR sidecar model ids.
 - Requests are admitted through a fair FIFO queue. The default
   `--max-active-requests 1` preserves serialized local inference while making
   queue depth visible in `/runtime/status`. Queued client cancellations are
@@ -97,6 +114,27 @@ mere.run status
   `benchmarkStats` so these experiments stay measured.
 - DS4 raw-proxies the complete OpenAI chat request to `ds4-server`.
 - Native engines reject unsupported OpenAI fields explicitly instead of silently dropping them.
+- Function `tool_choice` values are accepted for native tool-capable engines;
+  specific function choices narrow the advertised tools to the named function.
+- `/v1/embeddings` accepts OpenAI-compatible string or string-array `input`
+  payloads and returns float embeddings from `text-embed-qwen3-0.6b`.
+- `/v1/images/generations` accepts `prompt`, `model`, `size`, `n`, and
+  `response_format`. It supports `n=1`, returns base64 PNG JSON by default,
+  and can return a local `file://` URL when `response_format` is `url`.
+- `/v1/images/edits` accepts multipart `image` or Open WebUI-style `image[]`,
+  optional `mask`, `prompt`, `model`, `size`, `n`, and `response_format`. It
+  uses the same native image runtime with `inputImage` conditioning and accepts
+  local extensions such as `strength`, `seed`, `steps`, and `guidance_scale`.
+  Masks are accepted for client compatibility; current native edit models use
+  whole-image conditioning rather than strict masked inpainting.
+- `/v1/audio/speech` accepts `input`, `model`, `voice`, `speed`, and
+  `response_format`. It returns WAV by default and can transcode to `mp3`,
+  `opus`, `aac`, or `flac` when `ffmpeg` is available. OpenAI model names such
+  as `tts-1` map to the local default.
+- `/v1/audio/transcriptions` accepts multipart `file`, `model`, `language`,
+  `task`, and `response_format`. OpenAI model names such as `whisper-1` map to
+  `speech-asr-parakeet`; response formats are `json`, `text`, `verbose_json`,
+  `srt`, and `vtt`.
 - `vision-chat-gemma4-12b` accepts one OpenAI image content part per message through `/v1/chat/completions`; use a file path, `file://` URL, or base64 data URL because the local runtime does not fetch remote images.
 - Use `stream_options.include_usage` when a client expects the OpenAI streaming usage chunk.
 
@@ -127,6 +165,59 @@ export MERERUN_API_KEY=change-me
 mere.run api serve --host 0.0.0.0 --api-key "$MERERUN_API_KEY"
 ```
 
+```bash
+curl http://localhost:8080/v1/embeddings \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "text-embed-qwen3-0.6b",
+    "input": ["mere.run native embeddings", "local RAG"]
+  }'
+```
+
+```bash
+curl http://localhost:8080/v1/images/generations \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "image-zimage-nano",
+    "prompt": "a compact local AI workstation in morning light",
+    "size": "1024x1024",
+    "response_format": "b64_json"
+  }'
+```
+
+```bash
+curl http://localhost:8080/v1/images/edits \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -F model=image-zimage-nano \
+  -F prompt="make the desk dusk-lit while preserving the layout" \
+  -F size=1024x1024 \
+  -F response_format=b64_json \
+  -F image=@input.png
+```
+
+```bash
+curl http://localhost:8080/v1/audio/speech \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --output speech.wav \
+  --data '{
+    "model": "speech-tts-qwen3-nano",
+    "input": "mere.run is serving native speech.",
+    "voice": "nova",
+    "response_format": "wav"
+  }'
+```
+
+```bash
+curl http://localhost:8080/v1/audio/transcriptions \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -F model=speech-asr-parakeet \
+  -F response_format=json \
+  -F file=@speech.wav
+```
+
 ## Iteration Tips
 
 - Use `mere.run status` before connecting an editor.
@@ -141,10 +232,21 @@ mere.run api serve --host 0.0.0.0 --api-key "$MERERUN_API_KEY"
 - Client cannot connect: run `mere.run status --host <host> --port <port>`, then confirm firewall settings.
 - Wrong model family: match `--engine` to the model path.
 - Unsupported OpenAI field: choose a compatible engine or remove the field named in the `invalid_request_error`.
+- RAG client cannot embed: confirm `/v1/models` includes `text-embed-qwen3-0.6b`
+  and call `/v1/embeddings` with `encoding_format` omitted or set to `float`.
+- Image client cannot render: use `response_format` `b64_json` unless the
+  client can read local `file://` image URLs.
+- TTS client expects MP3: set `response_format` to `mp3`, or force `wav` when
+  you want the native Qwen3-TTS output without ffmpeg transcoding.
+- STT client fails upload: send `multipart/form-data` with a `file` part and a
+  supported local ASR model id.
 
 ## Sources
 
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/APIServeCommand.swift
 - https://platform.openai.com/docs/api-reference/chat
+- https://platform.openai.com/docs/api-reference/images/create
+- https://platform.openai.com/docs/api-reference/audio/createSpeech
+- https://platform.openai.com/docs/api-reference/audio/createTranscription
 - https://ai.google.dev/gemma/docs/core/prompt-structure
 - https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit

--- a/Sources/MereRunCLI/Guides/open-webui.md
+++ b/Sources/MereRunCLI/Guides/open-webui.md
@@ -1,0 +1,653 @@
+# Open WebUI
+
+## Purpose
+
+Connect Open WebUI to a local mere.run API server while keeping mere.run as the
+runtime provider. Open WebUI is an optional companion UI; do not vendor,
+rename, or rebrand it unless a deliberate packaging and license review says so.
+
+## Required Models
+
+- Chat: any installed API-capable `text-chat-*` model, such as
+  `text-chat-gemma4-12b`, `text-chat-gemma4`, or `text-chat-q36-nano`.
+- Vision chat: `vision-chat-gemma4-12b`.
+- RAG embeddings: `text-embed-qwen3-0.6b`.
+- Image generation: `image-zimage-nano`.
+- Text-to-speech: `speech-tts-qwen3-nano`.
+- Speech-to-text: `speech-asr-parakeet`.
+
+## Quickstart Command
+
+Use the quickstart command when you want the same path mere.run uses for live
+Open WebUI smoke testing: start the local API, run the official Open WebUI
+Docker image, configure the OpenAI-compatible provider, filter the chat picker
+to text and vision chat models, and keep image/TTS/STT/RAG sidecars in their
+own Open WebUI settings.
+
+```bash
+mere.run open-webui quickstart --pull
+```
+
+The default chat pair is `text-chat-gemma4-12b` and
+`vision-chat-gemma4-12b`. The command binds the mere.run API to `0.0.0.0:8080`
+with a bearer key so Docker can reach it at
+`http://host.docker.internal:8080/v1`, publishes Open WebUI at
+`http://127.0.0.1:3000`, disables image editing for the live smoke path, and
+sets Open WebUI RAG to mere.run's `/v1/embeddings`.
+
+Preview the exact commands without starting Docker:
+
+```bash
+mere.run open-webui quickstart --dry-run
+```
+
+Use an already-running mere.run API and Open WebUI instance when you only want
+to apply the admin API configuration:
+
+```bash
+mere.run open-webui quickstart \
+  --skip-server \
+  --skip-docker \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --webui-port 3000
+```
+
+If an old Open WebUI test container or volume exists, recreate it:
+
+```bash
+mere.run open-webui quickstart --reset
+```
+
+## Install And Check
+
+Pull the models you want Open WebUI to see:
+
+```bash
+mere.run model pull text-chat-gemma4-12b
+mere.run model pull vision-chat-gemma4-12b
+mere.run model pull text-embed-qwen3-0.6b
+mere.run model pull image-zimage-nano
+mere.run model pull speech-tts-qwen3-nano
+mere.run model pull speech-asr-parakeet
+mere.run model list
+```
+
+Start mere.run as the local OpenAI-compatible provider. For Docker bridge
+networking, bind the API to the host interface and protect it with a bearer key:
+
+```bash
+export MERERUN_API_KEY=change-me
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+```
+
+For a same-host Python/pip Open WebUI install, loopback is enough:
+
+```bash
+export MERERUN_API_KEY=change-me
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+```
+
+## Docker Path
+
+The repeatable smoke path uses a dedicated Open WebUI container and volume:
+
+```bash
+MERERUN_API_KEY=change-me \
+MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b \
+MERERUN_OPENWEBUI_RESET=1 \
+scripts/smoke-open-webui.sh docker-run
+
+MERERUN_API_KEY=change-me \
+MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b \
+scripts/smoke-open-webui.sh live-smoke
+```
+
+`live-smoke` waits for Open WebUI, signs in to the disposable no-auth smoke
+admin user, filters the OpenAI chat connection to the configured text and vision
+chat models, imports per-model metadata wrappers, sends text and vision chat
+through Open WebUI's own proxy, then exercises the direct mere.run API surface
+and the Open WebUI model list. Use `configure`, `proxy-smoke`, `api-smoke`, and
+`ui-smoke` separately when debugging one stage.
+
+For the fully expanded Docker command, run the official Open WebUI container and
+point it at the host's mere.run API:
+
+```bash
+DEFAULT_MODEL_METADATA='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+docker run -d \
+  --name open-webui \
+  --restart unless-stopped \
+  -p 3000:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e OPENAI_API_BASE_URLS=http://host.docker.internal:8080/v1 \
+  -e OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e OPENAI_API_KEYS="$MERERUN_API_KEY" \
+  -e DEFAULT_MODELS=text-chat-gemma4-12b \
+  -e DEFAULT_MODEL_PARAMS='{"function_calling":"native"}' \
+  -e DEFAULT_MODEL_METADATA="$DEFAULT_MODEL_METADATA" \
+  -e RAG_EMBEDDING_ENGINE=openai \
+  -e RAG_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e RAG_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b \
+  -e ENABLE_IMAGE_GENERATION=True \
+  -e ENABLE_IMAGE_EDIT=False \
+  -e IMAGE_GENERATION_ENGINE=openai \
+  -e IMAGE_GENERATION_MODEL=image-zimage-nano \
+  -e IMAGE_SIZE=1024x1024 \
+  -e IMAGE_EDIT_ENGINE=openai \
+  -e IMAGE_EDIT_MODEL=qwen-image-edit \
+  -e IMAGE_EDIT_SIZE=1024x1024 \
+  -e IMAGES_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e IMAGES_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e IMAGES_EDIT_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e IMAGES_EDIT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e AUDIO_TTS_ENGINE=openai \
+  -e AUDIO_TTS_MODEL=speech-tts-qwen3-nano \
+  -e AUDIO_TTS_VOICE=nova \
+  -e AUDIO_TTS_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e AUDIO_TTS_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}' \
+  -e AUDIO_STT_ENGINE=openai \
+  -e AUDIO_STT_MODEL=speech-asr-parakeet \
+  -e AUDIO_STT_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e ENABLE_PERSISTENT_CONFIG=False \
+  -e WEBUI_AUTH=False \
+  -v open-webui:/app/backend/data \
+  ghcr.io/open-webui/open-webui:main
+```
+
+Open `http://localhost:3000`. The environment variables above preconfigure the
+OpenAI-compatible chat provider and RAG embedding provider on a fresh Open WebUI
+data volume. Run `scripts/smoke-open-webui.sh configure` after the container is
+healthy to set Open WebUI's OpenAI connection `model_ids` filter and import
+per-model capability wrappers. That keeps image, embedding, TTS, and STT
+sidecars out of the chat selector while still using them in their own settings.
+You can also set the same values in the admin UI:
+
+- Base URL: `http://host.docker.internal:8080/v1`
+- API key: the value of `MERERUN_API_KEY`
+- Chat model: select an installed `text-chat-*` model from `/v1/models`
+- Vision model: select `vision-chat-gemma4-12b`
+- Embedding model for RAG/knowledge: `text-embed-qwen3-0.6b`
+- Image generation engine/model: `openai` / `image-zimage-nano`
+- Image editing: disabled for the live smoke path with `ENABLE_IMAGE_EDIT=False`
+- Image edit engine/model when enabled: `openai` / `qwen-image-edit`
+- TTS engine/model: `openai` / `speech-tts-qwen3-nano`
+- STT engine/model: `openai` / `speech-asr-parakeet`
+- Function calling: set model params to native mode with
+  `{"function_calling":"native"}`
+
+If Docker cannot resolve `host.docker.internal` on your Linux install, keep the
+same Open WebUI settings and add the `--add-host=host.docker.internal:host-gateway`
+flag shown above. If your Docker runtime still cannot reach the host, use the
+host's LAN IP in the Base URL and keep the mere.run API key enabled.
+If an existing Open WebUI volume ignores changed environment variables, update
+the values in the admin UI, set `ENABLE_PERSISTENT_CONFIG=False` for smoke, or
+start with a fresh data volume.
+
+## Docker Compose / DGX Spark Path
+
+Use Compose for a longer-lived Open WebUI companion on Linux, a LAN workstation,
+or DGX Spark. Keep mere.run itself on the host so it owns the local model store
+and GPU/runtime setup, then point the Open WebUI container at the host's
+mere.run `/v1` API.
+
+Start the mere.run provider first:
+
+```bash
+export MERERUN_API_KEY=change-me
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+```
+
+Create a small Compose directory:
+
+```bash
+mkdir -p open-webui-mere-run
+cd open-webui-mere-run
+openssl rand -hex 32
+```
+
+Write `.env` and replace the secret plus URL for your machine:
+
+```dotenv
+MERERUN_API_KEY=change-me
+WEBUI_SECRET_KEY=replace-with-openssl-rand-hex-32
+OPEN_WEBUI_IMAGE=ghcr.io/open-webui/open-webui:main
+OPEN_WEBUI_BIND=0.0.0.0
+OPEN_WEBUI_URL=http://spark.local:3000
+MERERUN_OPENWEBUI_API_URL=http://host.docker.internal:8080/v1
+MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b
+MERERUN_OPENWEBUI_VISION_MODEL=vision-chat-gemma4-12b
+```
+
+For Open WebUI running on the same Linux/Spark host as mere.run, keep
+`host.docker.internal` and the `extra_hosts` entry below. If Open WebUI runs on
+a different machine, set `MERERUN_OPENWEBUI_API_URL` to the mere.run host's LAN
+URL, for example `http://192.168.1.50:8080/v1`, and keep the API key enabled.
+
+Write `compose.yaml`:
+
+```yaml
+services:
+  open-webui:
+    image: ${OPEN_WEBUI_IMAGE:-ghcr.io/open-webui/open-webui:main}
+    container_name: open-webui
+    restart: unless-stopped
+    ports:
+      - "${OPEN_WEBUI_BIND:-0.0.0.0}:3000:8080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      WEBUI_URL: ${OPEN_WEBUI_URL:-http://localhost:3000}
+      WEBUI_AUTH: "True"
+      WEBUI_SECRET_KEY: ${WEBUI_SECRET_KEY}
+      ENABLE_PERSISTENT_CONFIG: "True"
+      OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      OPENAI_API_BASE_URLS: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      OPENAI_API_KEY: ${MERERUN_API_KEY}
+      OPENAI_API_KEYS: ${MERERUN_API_KEY}
+      DEFAULT_MODELS: ${MERERUN_OPENWEBUI_TEXT_MODEL:-text-chat-gemma4-12b}
+      DEFAULT_MODEL_PARAMS: '{"function_calling":"native"}'
+      DEFAULT_MODEL_METADATA: '{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+      RAG_EMBEDDING_ENGINE: openai
+      RAG_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      RAG_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      RAG_EMBEDDING_MODEL: text-embed-qwen3-0.6b
+      ENABLE_IMAGE_GENERATION: "True"
+      ENABLE_IMAGE_EDIT: "False"
+      IMAGE_GENERATION_ENGINE: openai
+      IMAGE_GENERATION_MODEL: image-zimage-nano
+      IMAGE_SIZE: 1024x1024
+      IMAGE_EDIT_ENGINE: openai
+      IMAGE_EDIT_MODEL: qwen-image-edit
+      IMAGE_EDIT_SIZE: 1024x1024
+      IMAGES_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      IMAGES_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      IMAGES_EDIT_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      IMAGES_EDIT_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      AUDIO_TTS_ENGINE: openai
+      AUDIO_TTS_MODEL: speech-tts-qwen3-nano
+      AUDIO_TTS_VOICE: nova
+      AUDIO_TTS_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      AUDIO_TTS_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      AUDIO_TTS_OPENAI_PARAMS: '{"response_format":"wav"}'
+      AUDIO_STT_ENGINE: openai
+      AUDIO_STT_MODEL: speech-asr-parakeet
+      AUDIO_STT_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      AUDIO_STT_OPENAI_API_KEY: ${MERERUN_API_KEY}
+    volumes:
+      - open-webui:/app/backend/data
+
+volumes:
+  open-webui:
+```
+
+Start it:
+
+```bash
+docker compose up -d
+docker compose logs -f open-webui
+```
+
+Open the `OPEN_WEBUI_URL` value from `.env`, create the first admin account,
+then run the configure step if you want the same-host per-model wrappers
+as the quickstart path:
+
+```bash
+mere.run open-webui quickstart \
+  --skip-server \
+  --skip-docker \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --webui-port 3000 \
+  --api-key "$MERERUN_API_KEY" \
+  --admin-email you@example.com \
+  --admin-password your-open-webui-password
+```
+
+For Open WebUI on a different machine, use the admin UI to keep Base URL set to
+that machine's `MERERUN_OPENWEBUI_API_URL` value.
+
+For team or production-like deployments, pin `OPEN_WEBUI_IMAGE` to a release tag
+after testing it, back up the `open-webui` volume before upgrades, and avoid
+`WEBUI_AUTH=False` on a LAN.
+
+## Pip Path
+
+Run Open WebUI directly on the same host:
+
+```bash
+python3.11 -m pip install --upgrade open-webui
+DEFAULT_MODEL_METADATA='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+OPENAI_API_BASE_URLS=http://127.0.0.1:8080/v1 \
+OPENAI_API_KEY="$MERERUN_API_KEY" \
+OPENAI_API_KEYS="$MERERUN_API_KEY" \
+DEFAULT_MODELS=text-chat-gemma4-12b \
+DEFAULT_MODEL_PARAMS='{"function_calling":"native"}' \
+DEFAULT_MODEL_METADATA="$DEFAULT_MODEL_METADATA" \
+RAG_EMBEDDING_ENGINE=openai \
+RAG_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+RAG_OPENAI_API_KEY="$MERERUN_API_KEY" \
+RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b \
+ENABLE_IMAGE_GENERATION=True \
+ENABLE_IMAGE_EDIT=False \
+IMAGE_GENERATION_ENGINE=openai \
+IMAGE_GENERATION_MODEL=image-zimage-nano \
+IMAGE_SIZE=1024x1024 \
+IMAGE_EDIT_ENGINE=openai \
+IMAGE_EDIT_MODEL=qwen-image-edit \
+IMAGE_EDIT_SIZE=1024x1024 \
+IMAGES_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+IMAGES_OPENAI_API_KEY="$MERERUN_API_KEY" \
+IMAGES_EDIT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+IMAGES_EDIT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_ENGINE=openai \
+AUDIO_TTS_MODEL=speech-tts-qwen3-nano \
+AUDIO_TTS_VOICE=nova \
+AUDIO_TTS_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_TTS_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}' \
+AUDIO_STT_ENGINE=openai \
+AUDIO_STT_MODEL=speech-asr-parakeet \
+AUDIO_STT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+ENABLE_PERSISTENT_CONFIG=False \
+WEBUI_AUTH=False \
+open-webui serve --host 127.0.0.1 --port 3000
+```
+
+Open `http://127.0.0.1:3000`. The environment variables above preconfigure the
+same connection values on a fresh Open WebUI data directory. You can also set
+them in the admin UI:
+
+- Base URL: `http://127.0.0.1:8080/v1`
+- API key: the value of `MERERUN_API_KEY`
+- Chat model: select an installed `text-chat-*` model from `/v1/models`
+- Vision model: select `vision-chat-gemma4-12b`
+- Embedding model for RAG/knowledge: `text-embed-qwen3-0.6b`
+- Image generation engine/model: `openai` / `image-zimage-nano`
+- Image editing: disabled for the live smoke path with `ENABLE_IMAGE_EDIT=False`
+- Image edit engine/model when enabled: `openai` / `qwen-image-edit`
+- TTS engine/model: `openai` / `speech-tts-qwen3-nano`
+- STT engine/model: `openai` / `speech-asr-parakeet`
+- Function calling: set model params to native mode with
+  `{"function_calling":"native"}`
+
+For pip-based smoke configuration, use the same-host provider URL:
+
+```bash
+OPEN_WEBUI_MERERUN_API_URL=http://127.0.0.1:8080/v1 \
+scripts/smoke-open-webui.sh configure
+```
+
+## uv Path
+
+Use `uvx` when you want a disposable same-host Open WebUI process without
+managing a virtualenv by hand. This is the same connection shape as the pip
+path: mere.run stays on loopback and Open WebUI talks to `127.0.0.1`.
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export DATA_DIR="$HOME/.open-webui-mere-run"
+export MERERUN_API_KEY=change-me
+
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+```
+
+In another terminal:
+
+```bash
+DEFAULT_MODEL_METADATA='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+DATA_DIR="$HOME/.open-webui-mere-run" \
+OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+OPENAI_API_BASE_URLS=http://127.0.0.1:8080/v1 \
+OPENAI_API_KEY="$MERERUN_API_KEY" \
+OPENAI_API_KEYS="$MERERUN_API_KEY" \
+DEFAULT_MODELS=text-chat-gemma4-12b \
+DEFAULT_MODEL_PARAMS='{"function_calling":"native"}' \
+DEFAULT_MODEL_METADATA="$DEFAULT_MODEL_METADATA" \
+RAG_EMBEDDING_ENGINE=openai \
+RAG_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+RAG_OPENAI_API_KEY="$MERERUN_API_KEY" \
+RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b \
+ENABLE_IMAGE_GENERATION=True \
+ENABLE_IMAGE_EDIT=False \
+IMAGE_GENERATION_ENGINE=openai \
+IMAGE_GENERATION_MODEL=image-zimage-nano \
+IMAGE_SIZE=1024x1024 \
+IMAGES_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+IMAGES_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_ENGINE=openai \
+AUDIO_TTS_MODEL=speech-tts-qwen3-nano \
+AUDIO_TTS_VOICE=nova \
+AUDIO_TTS_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_TTS_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}' \
+AUDIO_STT_ENGINE=openai \
+AUDIO_STT_MODEL=speech-asr-parakeet \
+AUDIO_STT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+ENABLE_PERSISTENT_CONFIG=False \
+WEBUI_AUTH=False \
+uvx --python 3.11 open-webui@latest serve --host 127.0.0.1 --port 3000
+```
+
+Open `http://127.0.0.1:3000`. If you omit `--port 3000`, current Open WebUI
+`uvx` examples default to port `8080`, which conflicts with the mere.run API
+recipe above.
+
+## Model Metadata
+
+Open WebUI defaults many capabilities to enabled. For mere.run, start with
+conservative defaults so text models do not advertise web search, code
+interpreter, terminal access, or vision by accident:
+
+```json
+{
+  "capabilities": {
+    "file_context": true,
+    "vision": false,
+    "file_upload": true,
+    "web_search": false,
+    "image_generation": true,
+    "code_interpreter": false,
+    "terminal": false,
+    "citations": true,
+    "status_updates": true,
+    "builtin_tools": true
+  }
+}
+```
+
+For the specific `vision-chat-gemma4-12b` model, set the per-model capability
+override `vision=true` in Workspace/Admin Models before testing image uploads.
+Keep `function_calling=native` in the model params for Open WebUI tools,
+knowledge tools, and agentic RAG.
+
+The smoke helper applies those wrappers for you:
+
+```bash
+scripts/smoke-open-webui.sh configure
+```
+
+Set `OPEN_WEBUI_CHAT_MODELS` to a semicolon-separated list when you want a
+different chat selector allowlist, for example
+`OPEN_WEBUI_CHAT_MODELS='text-chat-gemma4-12b;vision-chat-gemma4-12b'`.
+
+## Smoke Tests
+
+Check the provider before opening the UI:
+
+```bash
+curl http://127.0.0.1:8080/v1/models \
+  -H "Authorization: Bearer $MERERUN_API_KEY"
+```
+
+Text chat:
+
+```bash
+curl http://127.0.0.1:8080/v1/chat/completions \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "text-chat-gemma4",
+    "messages": [{"role": "user", "content": "Reply with only: mere.run online"}],
+    "max_tokens": 16
+  }'
+```
+
+Embeddings for RAG:
+
+```bash
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "text-embed-qwen3-0.6b",
+    "input": ["mere.run native embeddings", "Open WebUI RAG"]
+}'
+```
+
+Image generation:
+
+```bash
+curl http://127.0.0.1:8080/v1/images/generations \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "image-zimage-nano",
+    "prompt": "a compact local AI workstation in morning light",
+    "size": "1024x1024",
+    "response_format": "b64_json"
+  }'
+```
+
+Text-to-speech:
+
+```bash
+curl http://127.0.0.1:8080/v1/audio/speech \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --output speech.wav \
+  --data '{
+    "model": "speech-tts-qwen3-nano",
+    "input": "Open WebUI is speaking through mere.run.",
+    "voice": "nova",
+    "response_format": "wav"
+  }'
+```
+
+Speech-to-text:
+
+```bash
+curl http://127.0.0.1:8080/v1/audio/transcriptions \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -F model=speech-asr-parakeet \
+  -F response_format=json \
+  -F file=@speech.wav
+```
+
+Vision chat, using a local image encoded as a data URL:
+
+```bash
+IMAGE_DATA_URL="$(python3 - <<'PY'
+import base64
+from pathlib import Path
+
+print("data:image/png;base64," + base64.b64encode(Path("smoke.png").read_bytes()).decode())
+PY
+)"
+curl http://127.0.0.1:8080/v1/chat/completions \
+  -H "Authorization: Bearer $MERERUN_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data "{
+    \"model\": \"vision-chat-gemma4-12b\",
+    \"messages\": [{
+      \"role\": \"user\",
+      \"content\": [
+        {\"type\": \"text\", \"text\": \"Describe this image in one sentence.\"},
+        {\"type\": \"image_url\", \"image_url\": {\"url\": \"$IMAGE_DATA_URL\"}}
+      ]
+    }],
+    \"max_tokens\": 64
+  }"
+```
+
+Then smoke Open WebUI itself:
+
+1. Start a new chat and pick each installed `text-chat-*` model you want to
+   support.
+2. Send a one-line prompt and confirm the response comes from the local mere.run
+   server logs.
+3. Pick `vision-chat-gemma4-12b`, upload a local image, and confirm the model
+   answers about the image. If the upload control is hidden, set that model's
+   per-model `vision` capability to `true`.
+4. Create or update a knowledge/RAG collection with the embedding model set to
+   `text-embed-qwen3-0.6b`, then ask a question that retrieves from it.
+5. Generate an image and confirm Open WebUI receives a rendered PNG.
+6. Keep image editing disabled during the first live smoke; enable it later if
+   you want to exercise `/v1/images/edits` with `qwen-image-edit`.
+7. Use voice playback and audio upload/transcription with the OpenAI-compatible
+   audio engines set to the mere.run base URL.
+8. Attach a small knowledge base and enable native function calling to exercise
+   Open WebUI's knowledge/tool path against mere.run `tool_calls`.
+
+## Troubleshooting
+
+- Open WebUI says no models: check `curl /v1/models` with the same Base URL and
+  API key configured in Open WebUI.
+- Docker cannot reach mere.run: use `--host 0.0.0.0` on the mere.run side and
+  `http://host.docker.internal:8080/v1` on the Open WebUI side.
+- RAG asks for another embedding provider: set the OpenAI-compatible embedding
+  endpoint to the same mere.run Base URL and use `text-embed-qwen3-0.6b`.
+- Image generation fails: set `ENABLE_IMAGE_GENERATION=True`,
+  `IMAGE_GENERATION_ENGINE=openai`, and point `IMAGES_OPENAI_API_BASE_URL` at
+  the same mere.run `/v1` base URL.
+- Image editing controls appear during smoke: set `ENABLE_IMAGE_EDIT=False`.
+- Image editing fails after enabling it: set `IMAGE_EDIT_ENGINE=openai`,
+  `IMAGE_EDIT_MODEL=qwen-image-edit`, and point `IMAGES_EDIT_OPENAI_API_BASE_URL`
+  at the same mere.run `/v1` base URL.
+- Tools or knowledge do not run: set `DEFAULT_MODEL_PARAMS` or the per-model
+  params to `{"function_calling":"native"}`.
+- TTS fails because `ffmpeg` is unavailable: keep
+  `AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}'` so Open WebUI asks for
+  native Qwen3-TTS WAV output. For MP3/Opus/AAC/FLAC, install `ffmpeg`.
+- STT upload fails: set `AUDIO_STT_ENGINE=openai`,
+  `AUDIO_STT_MODEL=speech-asr-parakeet`, and upload an audio file as multipart
+  form data.
+- Vision uploads fail: use `vision-chat-gemma4-12b`; the local runtime accepts
+  one image content part per message as a file path, `file://` URL, or base64
+  data URL.
+- Non-loopback bind rejected: set `MERERUN_API_KEY` or pass `--api-key`.
+
+## Sources
+
+- https://github.com/open-webui/open-webui
+- https://docs.openwebui.com/getting-started/quick-start/
+- https://docs.openwebui.com/openai-compatible/
+- https://docs.openwebui.com/reference/env-configuration/
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/APIServeCommand.swift

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -27,6 +27,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Model.self,
             Status.self,
             API.self,
+            OpenWebUI.self,
             Setup.self,
             Agent.self,
         ]

--- a/Sources/MereRunCore/CodeGen/OpenAITypes.swift
+++ b/Sources/MereRunCore/CodeGen/OpenAITypes.swift
@@ -295,6 +295,103 @@ public struct OpenAIChatRequest: Codable, Sendable {
     }
 }
 
+public enum OpenAIEmbeddingInput: Codable, Hashable, Sendable {
+    case string(String)
+    case array([String])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
+            return
+        }
+        self = .array(try container.decode([String].self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        }
+    }
+
+    public var texts: [String] {
+        switch self {
+        case .string(let value):
+            return [value]
+        case .array(let value):
+            return value
+        }
+    }
+}
+
+public struct OpenAIEmbeddingRequest: Codable, Sendable {
+    public var model: String
+    public var input: OpenAIEmbeddingInput
+    public var encoding_format: String?
+    public var dimensions: Int?
+    public var user: String?
+    public var unknownFields: [String: OpenAIJSONValue]
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case model
+        case input
+        case encoding_format
+        case dimensions
+        case user
+    }
+
+    public init(
+        model: String,
+        input: OpenAIEmbeddingInput,
+        encoding_format: String? = nil,
+        dimensions: Int? = nil,
+        user: String? = nil
+    ) {
+        self.model = model
+        self.input = input
+        self.encoding_format = encoding_format
+        self.dimensions = dimensions
+        self.user = user
+        self.unknownFields = [:]
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = try container.decode(String.self, forKey: .model)
+        input = try container.decode(OpenAIEmbeddingInput.self, forKey: .input)
+        encoding_format = try container.decodeIfPresent(String.self, forKey: .encoding_format)
+        dimensions = try container.decodeIfPresent(Int.self, forKey: .dimensions)
+        user = try container.decodeIfPresent(String.self, forKey: .user)
+
+        let knownKeys = Set(CodingKeys.allCases.map(\.rawValue))
+        let dynamic = try decoder.container(keyedBy: OpenAIDynamicCodingKey.self)
+        var unknown: [String: OpenAIJSONValue] = [:]
+        for key in dynamic.allKeys where !knownKeys.contains(key.stringValue) {
+            unknown[key.stringValue] = try dynamic.decode(OpenAIJSONValue.self, forKey: key)
+        }
+        unknownFields = unknown
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model, forKey: .model)
+        try container.encode(input, forKey: .input)
+        try container.encodeIfPresent(encoding_format, forKey: .encoding_format)
+        try container.encodeIfPresent(dimensions, forKey: .dimensions)
+        try container.encodeIfPresent(user, forKey: .user)
+
+        var dynamic = encoder.container(keyedBy: OpenAIDynamicCodingKey.self)
+        for (key, value) in unknownFields {
+            guard let codingKey = OpenAIDynamicCodingKey(stringValue: key) else { continue }
+            try dynamic.encode(value, forKey: codingKey)
+        }
+    }
+}
+
 public struct OpenAIChatMessage: Codable, Sendable {
     public var role: String
     public var content: String
@@ -661,6 +758,177 @@ public struct OpenAIUsage: Codable, Sendable {
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
         self.total_tokens = total_tokens
+    }
+}
+
+public struct OpenAIEmbeddingResponse: Codable, Sendable {
+    public var object: String
+    public var model: String
+    public var data: [OpenAIEmbeddingDatum]
+    public var usage: OpenAIEmbeddingUsage
+
+    public init(
+        model: String,
+        data: [OpenAIEmbeddingDatum],
+        usage: OpenAIEmbeddingUsage,
+        object: String = "list"
+    ) {
+        self.object = object
+        self.model = model
+        self.data = data
+        self.usage = usage
+    }
+}
+
+public struct OpenAIEmbeddingDatum: Codable, Sendable {
+    public var object: String
+    public var index: Int
+    public var embedding: [Float]
+
+    public init(index: Int, embedding: [Float], object: String = "embedding") {
+        self.object = object
+        self.index = index
+        self.embedding = embedding
+    }
+}
+
+public struct OpenAIEmbeddingUsage: Codable, Sendable {
+    public var prompt_tokens: Int
+    public var total_tokens: Int
+
+    public init(prompt_tokens: Int, total_tokens: Int) {
+        self.prompt_tokens = prompt_tokens
+        self.total_tokens = total_tokens
+    }
+}
+
+// MARK: - Images Endpoint
+
+public struct OpenAIImageGenerationRequest: Codable, Sendable {
+    public var prompt: String
+    public var model: String?
+    public var n: Int?
+    public var size: String?
+    public var response_format: String?
+    public var quality: String?
+    public var style: String?
+    public var user: String?
+    public var seed: UInt64?
+    public var negative_prompt: String?
+    public var steps: Int?
+    public var guidance_scale: Double?
+
+    public init(
+        prompt: String,
+        model: String? = nil,
+        n: Int? = nil,
+        size: String? = nil,
+        response_format: String? = nil,
+        quality: String? = nil,
+        style: String? = nil,
+        user: String? = nil,
+        seed: UInt64? = nil,
+        negative_prompt: String? = nil,
+        steps: Int? = nil,
+        guidance_scale: Double? = nil
+    ) {
+        self.prompt = prompt
+        self.model = model
+        self.n = n
+        self.size = size
+        self.response_format = response_format
+        self.quality = quality
+        self.style = style
+        self.user = user
+        self.seed = seed
+        self.negative_prompt = negative_prompt
+        self.steps = steps
+        self.guidance_scale = guidance_scale
+    }
+}
+
+public struct OpenAIImageGenerationResponse: Codable, Sendable {
+    public var created: Int
+    public var data: [OpenAIImageGenerationData]
+
+    public init(created: Int, data: [OpenAIImageGenerationData]) {
+        self.created = created
+        self.data = data
+    }
+}
+
+public struct OpenAIImageGenerationData: Codable, Sendable {
+    public var url: String?
+    public var b64_json: String?
+    public var revised_prompt: String?
+
+    public init(url: String? = nil, b64_json: String? = nil, revised_prompt: String? = nil) {
+        self.url = url
+        self.b64_json = b64_json
+        self.revised_prompt = revised_prompt
+    }
+}
+
+// MARK: - Audio Endpoint
+
+public struct OpenAIAudioSpeechRequest: Codable, Sendable {
+    public var model: String?
+    public var input: String
+    public var voice: String?
+    public var response_format: String?
+    public var speed: Double?
+    public var instructions: String?
+    public var temperature: Float?
+
+    public init(
+        model: String? = nil,
+        input: String,
+        voice: String? = nil,
+        response_format: String? = nil,
+        speed: Double? = nil,
+        instructions: String? = nil,
+        temperature: Float? = nil
+    ) {
+        self.model = model
+        self.input = input
+        self.voice = voice
+        self.response_format = response_format
+        self.speed = speed
+        self.instructions = instructions
+        self.temperature = temperature
+    }
+}
+
+public struct OpenAIAudioTranscriptionResponse: Codable, Sendable {
+    public var text: String
+    public var language: String?
+    public var duration: Double?
+    public var segments: [OpenAIAudioTranscriptionSegment]?
+
+    public init(
+        text: String,
+        language: String? = nil,
+        duration: Double? = nil,
+        segments: [OpenAIAudioTranscriptionSegment]? = nil
+    ) {
+        self.text = text
+        self.language = language
+        self.duration = duration
+        self.segments = segments
+    }
+}
+
+public struct OpenAIAudioTranscriptionSegment: Codable, Sendable {
+    public var id: Int
+    public var start: Double
+    public var end: Double
+    public var text: String
+
+    public init(id: Int, start: Double, end: Double, text: String) {
+        self.id = id
+        self.start = start
+        self.end = end
+        self.text = text
     }
 }
 

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import AudioCore
 @testable import MereRunCLI
 @testable import MereRunCore
 
@@ -155,6 +156,386 @@ final class APIServeCommandTests: XCTestCase {
 
         XCTAssertEqual(response.data.map(\.id), ["text-chat-gemma4", "chat-default"])
         XCTAssertEqual(Set(response.data.map(\.owned_by)), Set(["mere.run"]))
+    }
+
+    func testEmbeddingRequestDecodesStringInputAndUnknownFields() throws {
+        let data = """
+        {
+          "model": "text-embed-qwen3-0.6b",
+          "input": "semantic search query",
+          "encoding_format": "float",
+          "user": "rag-test",
+          "x-client-extra": { "kept": true }
+        }
+        """.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(OpenAIEmbeddingRequest.self, from: data)
+
+        XCTAssertEqual(request.model, "text-embed-qwen3-0.6b")
+        XCTAssertEqual(request.input.texts, ["semantic search query"])
+        XCTAssertEqual(request.encoding_format, "float")
+        XCTAssertEqual(request.user, "rag-test")
+        XCTAssertEqual(request.unknownFields["x-client-extra"]?.objectValue?["kept"]?.boolValue, true)
+    }
+
+    func testEmbeddingRequestDecodesArrayInput() throws {
+        let data = """
+        {
+          "model": "text-embed-qwen3-0.6b",
+          "input": ["first", "second"]
+        }
+        """.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(OpenAIEmbeddingRequest.self, from: data)
+
+        XCTAssertEqual(request.input.texts, ["first", "second"])
+    }
+
+    func testEmbeddingContractValidatesSupportedOptions() throws {
+        let request = OpenAIEmbeddingRequest(
+            model: "text-embed-qwen3-0.6b",
+            input: .array(["first", "second"]),
+            encoding_format: "float"
+        )
+
+        XCTAssertEqual(try APIServerContract.embeddingTexts(from: request), ["first", "second"])
+
+        let base64Request = OpenAIEmbeddingRequest(
+            model: "text-embed-qwen3-0.6b",
+            input: .string("hello"),
+            encoding_format: "base64"
+        )
+        XCTAssertThrowsError(try APIServerContract.embeddingTexts(from: base64Request)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("encoding_format"))
+        }
+
+        let dimensionsRequest = OpenAIEmbeddingRequest(
+            model: "text-embed-qwen3-0.6b",
+            input: .string("hello"),
+            dimensions: 128
+        )
+        XCTAssertThrowsError(try APIServerContract.embeddingTexts(from: dimensionsRequest)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("dimensions"))
+        }
+
+        let emptyRequest = OpenAIEmbeddingRequest(
+            model: "text-embed-qwen3-0.6b",
+            input: .array([])
+        )
+        XCTAssertThrowsError(try APIServerContract.embeddingTexts(from: emptyRequest)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("input"))
+        }
+    }
+
+    func testEmbeddingContractUsesOpenAICompatibleResponseShape() {
+        let response = APIServerContract.embeddingResponse(
+            modelId: "text-embed-qwen3-0.6b",
+            embeddings: [[0.1, 0.2], [0.3, 0.4]],
+            tokenCounts: [3, 5]
+        )
+
+        XCTAssertEqual(response.object, "list")
+        XCTAssertEqual(response.model, "text-embed-qwen3-0.6b")
+        XCTAssertEqual(response.data.count, 2)
+        XCTAssertEqual(response.data[0].object, "embedding")
+        XCTAssertEqual(response.data[0].index, 0)
+        XCTAssertEqual(response.data[0].embedding, [0.1, 0.2])
+        XCTAssertEqual(response.usage.prompt_tokens, 8)
+        XCTAssertEqual(response.usage.total_tokens, 8)
+    }
+
+    func testCompanionModelIDsIncludeNativeOpenAIStyleModalities() {
+        let ids = APIServerContract.companionModelIDs(installedModelIDs: Set([
+            "image-zimage-nano",
+            "speech-tts-qwen3-nano",
+            "speech-asr-parakeet",
+            "text-embed-qwen3-0.6b",
+            "qwen-image-edit",
+        ]))
+
+        XCTAssertTrue(ids.contains("text-embed-qwen3-0.6b"))
+        XCTAssertTrue(ids.contains("image-zimage-nano"))
+        XCTAssertTrue(ids.contains("speech-tts-qwen3-nano"))
+        XCTAssertTrue(ids.contains("speech-asr-parakeet"))
+        XCTAssertTrue(ids.contains("qwen-image-edit"))
+        XCTAssertFalse(ids.contains("image-zimage-max"))
+        XCTAssertFalse(ids.contains("speech-asr-qwen3"))
+    }
+
+    func testCompanionModelIDsHideMissingSidecarModels() {
+        let ids = APIServerContract.companionModelIDs(installedModelIDs: [])
+
+        XCTAssertFalse(ids.contains("image-zimage-nano"))
+        XCTAssertFalse(ids.contains("speech-tts-qwen3-nano"))
+        XCTAssertFalse(ids.contains("speech-asr-parakeet"))
+        XCTAssertFalse(ids.contains("text-embed-qwen3-0.6b"))
+    }
+
+    func testImageGenerationContractMapsOpenAINamesAndValidatesOptions() throws {
+        let request = OpenAIImageGenerationRequest(
+            prompt: "  workstation in morning light  ",
+            model: "dall-e-3",
+            n: 1,
+            size: "512x768",
+            response_format: "url",
+            seed: 123,
+            negative_prompt: "blur",
+            steps: 4,
+            guidance_scale: 1.2
+        )
+
+        let plan = try APIServerContract.imageGenerationPlan(from: request)
+
+        XCTAssertEqual(plan.modelID, "image-zimage-nano")
+        XCTAssertEqual(plan.prompt, "workstation in morning light")
+        XCTAssertEqual(plan.width, 512)
+        XCTAssertEqual(plan.height, 768)
+        XCTAssertEqual(plan.responseFormat, "url")
+        XCTAssertEqual(plan.seed, 123)
+        XCTAssertEqual(plan.negativePrompt, "blur")
+        XCTAssertEqual(plan.steps, 4)
+        XCTAssertEqual(plan.guidanceScale, 1.2)
+        XCTAssertNil(plan.inputImage)
+        XCTAssertNil(plan.strength)
+
+        XCTAssertThrowsError(
+            try APIServerContract.imageGenerationPlan(
+                from: OpenAIImageGenerationRequest(prompt: "hello", n: 2)
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("n"))
+        }
+
+        XCTAssertThrowsError(
+            try APIServerContract.imageGenerationPlan(
+                from: OpenAIImageGenerationRequest(prompt: "hello", size: "large")
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("size"))
+        }
+    }
+
+    func testImageGenerationResponseCanReturnBase64OrFileURL() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-api-test-\(UUID().uuidString).png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        let plan = APIServerContract.ImageGenerationPlan(
+            modelID: "image-zimage-nano",
+            prompt: "hello",
+            width: 1024,
+            height: 1024,
+            responseFormat: "b64_json",
+            seed: nil,
+            negativePrompt: nil,
+            steps: nil,
+            guidanceScale: nil,
+            inputImage: nil,
+            strength: nil
+        )
+
+        let b64 = try APIServerContract.imageResponse(
+            outputURL: tempURL,
+            plan: plan,
+            createdAt: Date(timeIntervalSince1970: 123)
+        )
+
+        XCTAssertEqual(b64.created, 123)
+        XCTAssertEqual(b64.data.first?.b64_json, Data([0x89, 0x50, 0x4E, 0x47]).base64EncodedString())
+        XCTAssertEqual(b64.data.first?.revised_prompt, "hello")
+
+        let urlPlan = APIServerContract.ImageGenerationPlan(
+            modelID: plan.modelID,
+            prompt: plan.prompt,
+            width: plan.width,
+            height: plan.height,
+            responseFormat: "url",
+            seed: nil,
+            negativePrompt: nil,
+            steps: nil,
+            guidanceScale: nil,
+            inputImage: nil,
+            strength: nil
+        )
+        let urlResponse = try APIServerContract.imageResponse(outputURL: tempURL, plan: urlPlan)
+        XCTAssertEqual(urlResponse.data.first?.url, tempURL.absoluteString)
+    }
+
+    func testImageEditContractReadsMultipartFields() throws {
+        let inputURL = URL(fileURLWithPath: "/tmp/input.png")
+        let secondURL = URL(fileURLWithPath: "/tmp/second.png")
+        let maskURL = URL(fileURLWithPath: "/tmp/mask.png")
+        let form = MultipartFormData(parts: [
+            MultipartFormData.Part(name: "model", filename: nil, contentType: nil, body: Data("gpt-image-1".utf8)),
+            MultipartFormData.Part(name: "prompt", filename: nil, contentType: nil, body: Data("  add warm light  ".utf8)),
+            MultipartFormData.Part(name: "size", filename: nil, contentType: nil, body: Data("768x512".utf8)),
+            MultipartFormData.Part(name: "response_format", filename: nil, contentType: nil, body: Data("url".utf8)),
+            MultipartFormData.Part(name: "seed", filename: nil, contentType: nil, body: Data("42".utf8)),
+            MultipartFormData.Part(name: "strength", filename: nil, contentType: nil, body: Data("0.4".utf8)),
+        ])
+
+        let plan = try APIServerContract.imageEditPlan(
+            from: form,
+            inputImageURLs: [inputURL, secondURL],
+            maskImageURL: maskURL
+        )
+
+        XCTAssertEqual(plan.modelID, "image-zimage-nano")
+        XCTAssertEqual(plan.prompt, "add warm light")
+        XCTAssertEqual(plan.width, 768)
+        XCTAssertEqual(plan.height, 512)
+        XCTAssertEqual(plan.responseFormat, "url")
+        XCTAssertEqual(plan.seed, 42)
+        XCTAssertEqual(plan.inputImage, inputURL)
+        XCTAssertEqual(plan.additionalInputImages, [secondURL])
+        XCTAssertEqual(plan.maskImage, maskURL)
+        XCTAssertEqual(plan.strength, 0.4)
+    }
+
+    func testSpeechContractMapsOpenAINamesAndValidatesOutputFormats() throws {
+        let request = OpenAIAudioSpeechRequest(
+            model: "tts-1",
+            input: "  hello from mere.run  ",
+            voice: "onyx",
+            response_format: "mp3",
+            speed: 1.25,
+            instructions: "Use a friendly pace.",
+            temperature: 0.7
+        )
+
+        let plan = try APIServerContract.speechPlan(from: request)
+
+        XCTAssertEqual(plan.modelID, "speech-tts-qwen3-nano")
+        XCTAssertEqual(plan.input, "hello from mere.run")
+        XCTAssertTrue(plan.voiceDescription.contains("deep"))
+        XCTAssertTrue(plan.voiceDescription.contains("friendly pace"))
+        XCTAssertEqual(plan.responseFormat, "mp3")
+        XCTAssertEqual(APIServerContract.speechContentType(for: plan.responseFormat), "audio/mpeg")
+        XCTAssertEqual(plan.speed, 1.25)
+        XCTAssertEqual(plan.temperature, 0.7)
+
+        XCTAssertThrowsError(
+            try APIServerContract.speechPlan(
+                from: OpenAIAudioSpeechRequest(input: "hello", response_format: "caf")
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("response_format"))
+        }
+    }
+
+    func testMultipartFormDataParserExtractsFieldsAndFile() throws {
+        let boundary = "mere-boundary"
+        let body = [
+            "--mere-boundary",
+            "Content-Disposition: form-data; name=\"model\"",
+            "",
+            "whisper-1",
+            "--mere-boundary",
+            "Content-Disposition: form-data; name=\"file\"; filename=\"speech.wav\"",
+            "Content-Type: audio/wav",
+            "",
+            "WAVDATA",
+            "--mere-boundary--",
+            "",
+        ].joined(separator: "\r\n").data(using: .utf8)!
+
+        let form = try MultipartFormData.parse(body: body, boundary: boundary)
+
+        XCTAssertEqual(form.field("model"), "whisper-1")
+        XCTAssertEqual(form.file(named: "file")?.filename, "speech.wav")
+        XCTAssertEqual(form.files(named: "file").map(\.filename), ["speech.wav"])
+        XCTAssertEqual(form.file(named: "file")?.contentType, "audio/wav")
+        XCTAssertEqual(form.file(named: "file")?.body, Data("WAVDATA".utf8))
+    }
+
+    func testMultipartFormDataParserExtractsRepeatedFiles() throws {
+        let boundary = "mere-boundary"
+        let body = [
+            "--mere-boundary",
+            "Content-Disposition: form-data; name=\"image\"; filename=\"first.png\"",
+            "Content-Type: image/png",
+            "",
+            "FIRST",
+            "--mere-boundary",
+            "Content-Disposition: form-data; name=\"image[]\"; filename=\"second.png\"",
+            "Content-Type: image/png",
+            "",
+            "SECOND",
+            "--mere-boundary",
+            "Content-Disposition: form-data; name=\"mask\"; filename=\"mask.png\"",
+            "Content-Type: image/png",
+            "",
+            "MASK",
+            "--mere-boundary--",
+            "",
+        ].joined(separator: "\r\n").data(using: .utf8)!
+
+        let form = try MultipartFormData.parse(body: body, boundary: boundary)
+
+        XCTAssertEqual(form.files(named: "image").map(\.filename), ["first.png"])
+        XCTAssertEqual(form.files(named: "image[]").map(\.filename), ["second.png"])
+        XCTAssertEqual(form.file(named: "mask")?.body, Data("MASK".utf8))
+    }
+
+    func testTranscriptionContractMapsOpenAINamesAndVerboseResponse() throws {
+        let form = MultipartFormData(parts: [
+            MultipartFormData.Part(name: "model", filename: nil, contentType: nil, body: Data("whisper-1".utf8)),
+            MultipartFormData.Part(name: "language", filename: nil, contentType: nil, body: Data("en".utf8)),
+            MultipartFormData.Part(name: "response_format", filename: nil, contentType: nil, body: Data("verbose_json".utf8)),
+            MultipartFormData.Part(name: "task", filename: nil, contentType: nil, body: Data("transcribe".utf8)),
+        ])
+
+        let plan = try APIServerContract.transcriptionPlan(from: form)
+
+        XCTAssertEqual(plan.modelID, "speech-asr-parakeet")
+        XCTAssertEqual(plan.language, "en")
+        XCTAssertEqual(plan.responseFormat, "verbose_json")
+        XCTAssertEqual(plan.task, .transcribe)
+        XCTAssertEqual(plan.maxTokens, 448)
+
+        let response = APIServerContract.transcriptionResponse(
+            from: ASRResult(
+                text: "hello",
+                language: "en",
+                duration: 1.5,
+                sentenceAlignments: [
+                    ASRSentenceAlignment(
+                        text: "hello",
+                        startSeconds: 0,
+                        durationSeconds: 1.5,
+                        tokens: []
+                    ),
+                ]
+            ),
+            verbose: true
+        )
+
+        XCTAssertEqual(response.text, "hello")
+        XCTAssertEqual(response.language, "en")
+        XCTAssertEqual(response.duration, 1.5)
+        XCTAssertEqual(response.segments?.first?.text, "hello")
+    }
+
+    func testTranscriptionContractCanRenderSubtitleFormats() throws {
+        let srtForm = MultipartFormData(parts: [
+            MultipartFormData.Part(name: "response_format", filename: nil, contentType: nil, body: Data("srt".utf8)),
+        ])
+        let plan = try APIServerContract.transcriptionPlan(from: srtForm)
+        XCTAssertEqual(plan.responseFormat, "srt")
+
+        let result = ASRResult(
+            text: "hello",
+            language: "en",
+            duration: 1.5,
+            sentenceAlignments: [
+                ASRSentenceAlignment(text: "hello", startSeconds: 0, durationSeconds: 1.5, tokens: []),
+            ]
+        )
+        let srt = APIServerContract.transcriptionSubtitle(from: result, format: "srt")
+        XCTAssertTrue(srt.contains("1\n00:00:00,000 --> 00:00:01,500\nhello"))
+
+        let vtt = APIServerContract.transcriptionSubtitle(from: result, format: "vtt")
+        XCTAssertTrue(vtt.hasPrefix("WEBVTT\n\n00:00:00.000 --> 00:00:01.500\nhello"))
     }
 
     func testChatRequestValidationAcceptsBoundedDefaults() throws {
@@ -344,6 +725,65 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.tools?.first?.name, "lookup")
         XCTAssertEqual(chatRequest.tools?.first?.parameters["query"]?.description, "Search query")
         XCTAssertEqual(chatRequest.tools?.first?.required, ["query"])
+    }
+
+    func testChatRequestAcceptsSpecificFunctionToolChoice() throws {
+        let lookup = OpenAIChatTool(
+            function: OpenAIChatToolFunction(
+                name: "lookup",
+                description: "Look up a value.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query": .object(["type": .string("string")]),
+                    ]),
+                ])
+            )
+        )
+        let summarize = OpenAIChatTool(
+            function: OpenAIChatToolFunction(
+                name: "summarize",
+                description: "Summarize text.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object(["type": .string("string")]),
+                    ]),
+                ])
+            )
+        )
+        let request = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            tools: [lookup, summarize],
+            tool_choice: .function(name: "summarize")
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: .localTextWithTools
+        )
+
+        XCTAssertEqual(chatRequest.tools?.map(\.name), ["summarize"])
+
+        let missing = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            tools: [lookup],
+            tool_choice: .function(name: "missing")
+        )
+        XCTAssertThrowsError(
+            try APIServerContract.chatRequest(
+                from: missing,
+                fallbackLoraPath: nil,
+                contextSize: 4_096,
+                capabilities: .localTextWithTools
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("tool_choice"))
+        }
     }
 
     func testChatRequestValidatesStructuredOutputsAgainstEngineCapability() throws {

--- a/Tests/MereRunCLITests/GuideCommandTests.swift
+++ b/Tests/MereRunCLITests/GuideCommandTests.swift
@@ -49,6 +49,21 @@ final class GuideCommandTests: XCTestCase {
         XCTAssertEqual(command.model, "image-zimage-max")
     }
 
+    func testGuideOpenWebUIParsesAndRenders() throws {
+        let command = try GuideCommand.parse(["open-webui"])
+        let entry = try GuideCommand.resolveEntry(commandPath: command.commandPath, model: command.model)
+        let rendered = try GuideCommand.render(entry: entry, model: nil, json: false)
+
+        XCTAssertEqual(entry.topic, "open-webui")
+        XCTAssertTrue(rendered.contains("http://host.docker.internal:8080/v1"))
+        XCTAssertTrue(rendered.contains("text-embed-qwen3-0.6b"))
+        XCTAssertTrue(rendered.contains("scripts/smoke-open-webui.sh live-smoke"))
+        XCTAssertTrue(rendered.contains("proxy-smoke"))
+        XCTAssertTrue(rendered.contains("OPEN_WEBUI_CHAT_MODELS"))
+        XCTAssertTrue(rendered.contains("\"function_calling\":\"native\""))
+        XCTAssertTrue(rendered.contains("IMAGES_EDIT_OPENAI_API_BASE_URL"))
+    }
+
     func testUnknownGuideTopicThrows() {
         XCTAssertThrowsError(
             try GuideCommand.resolveEntry(commandPath: ["banana", "split"], model: nil)

--- a/Tests/MereRunCLITests/ImageValidateCommandTests.swift
+++ b/Tests/MereRunCLITests/ImageValidateCommandTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ImageValidateCommandTests: XCTestCase {
+    func testRuntimeErrorDoesNotEmitUsageText() {
+        let error = ImageValidateRuntimeError(
+            "Model directory is incomplete. Repair the manifest or pull the model again."
+        )
+
+        XCTAssertTrue(error.localizedDescription.contains("Model directory is incomplete."))
+        XCTAssertFalse(error.localizedDescription.contains("Usage:"))
+    }
+
+    func testResolvedZImageResourcesUsesManifestComponentDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var manifest = MereRunModelManifest.template(for: .zetaNano, createdAt: Date(timeIntervalSince1970: 0))
+        manifest.components = .init(
+            tokenizer: .local(path: "tok"),
+            textEncoder: .local(path: "enc-mlx"),
+            transformer: .local(path: "trans-mflux"),
+            vae: .local(path: "vae-mflux"),
+            scheduler: .local(path: "sched")
+        )
+        try manifest.write(to: root)
+
+        let tokenizer = try createDirectory(named: "tok", under: root)
+        let textEncoder = try createDirectory(named: "enc-mlx", under: root)
+        let transformer = try createDirectory(named: "trans-mflux", under: root)
+        let vae = try createDirectory(named: "vae-mflux", under: root)
+        let scheduler = try createDirectory(named: "sched", under: root)
+
+        let (resources, loadedManifest) = try ImageValidate().resolvedZImageResources(modelURL: root)
+
+        XCTAssertEqual(loadedManifest?.id, "image-zimage-nano")
+        XCTAssertEqual(resources.tokenizerDirURL.standardizedFileURL, tokenizer.standardizedFileURL)
+        XCTAssertEqual(resources.textEncoderDirURL.standardizedFileURL, textEncoder.standardizedFileURL)
+        XCTAssertEqual(resources.transformerDirURL.standardizedFileURL, transformer.standardizedFileURL)
+        XCTAssertEqual(resources.vaeDirURL.standardizedFileURL, vae.standardizedFileURL)
+        XCTAssertEqual(resources.schedulerDirURL.standardizedFileURL, scheduler.standardizedFileURL)
+        XCTAssertTrue(resources.transformerMFluxWeightsIndexURL.path.hasSuffix("trans-mflux/model.safetensors.index.json"))
+        XCTAssertTrue(resources.vaeWeightsIndexURL.path.hasSuffix("vae-mflux/model.safetensors.index.json"))
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func createDirectory(named name: String, under root: URL) throws -> URL {
+        let url = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.resolvingSymlinksInPath()
+    }
+}

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -17,6 +17,23 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertTrue(commandNames.contains("capabilities"))
     }
 
+    func testInstallValidationErrorIncludesRetryWithoutUsage() {
+        let error = ModelPullInstallError(
+            modelID: "image-klein-max",
+            modelDir: URL(fileURLWithPath: "/tmp/mere.run/models/image-klein-max"),
+            hubRepoID: "black-forest-labs/FLUX.2-klein-4B",
+            details: ["No *.safetensors weights found in transformer/"]
+        )
+
+        let message = error.localizedDescription
+        XCTAssertTrue(message.contains("Model image-klein-max was not installed cleanly."))
+        XCTAssertTrue(message.contains("- No *.safetensors weights found in transformer/"))
+        XCTAssertTrue(message.contains("Model store: /tmp/mere.run/models/image-klein-max"))
+        XCTAssertTrue(message.contains("Retry with: mere.run model pull image-klein-max"))
+        XCTAssertTrue(message.contains("Use --force only if you intentionally want to replace a complete install."))
+        XCTAssertFalse(message.contains("Usage:"))
+    }
+
     func testDiskPreflightFailsWhenHubCacheCannotFitEstimatedModel() throws {
         XCTAssertThrowsError(
             try ModelPullDiskPreflight.evaluate(

--- a/Tests/MereRunCLITests/OpenWebUICommandTests.swift
+++ b/Tests/MereRunCLITests/OpenWebUICommandTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import AudioSTT
+@testable import AudioTTS
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class OpenWebUICommandTests: XCTestCase {
+    func testOpenWebUICommandExposesQuickstart() {
+        let commandNames = Set(OpenWebUI.configuration.subcommands.map { $0.configuration.commandName })
+
+        XCTAssertEqual(commandNames, Set(["quickstart"]))
+    }
+
+    func testQuickstartParsesDefaults() throws {
+        let command = try OpenWebUIQuickstart.parse([])
+
+        XCTAssertEqual(command.host, "0.0.0.0")
+        XCTAssertEqual(command.port, 8080)
+        XCTAssertNil(command.engine)
+        XCTAssertEqual(command.webuiHost, "127.0.0.1")
+        XCTAssertEqual(command.webuiPort, 3000)
+        XCTAssertEqual(command.containerName, "open-webui-mere-run")
+        XCTAssertEqual(command.volumeName, "open-webui-mere-run")
+        XCTAssertEqual(command.image, "ghcr.io/open-webui/open-webui:main")
+        XCTAssertNil(command.apiKey)
+        XCTAssertEqual(command.textModel, Gemma4Resources.twelveBModelId)
+        XCTAssertEqual(command.visionModel, Gemma4Resources.visionTwelveBModelId)
+        XCTAssertEqual(command.embeddingModel, Qwen3EmbeddingCatalog.modelId)
+        XCTAssertEqual(command.imageModel, ModelResolver.ModelID.zetaNano.rawValue)
+        XCTAssertEqual(command.ttsModel, Qwen3TTSResources.defaultModelId)
+        XCTAssertEqual(command.sttModel, ParakeetResources.defaultModelId)
+        XCTAssertEqual(command.ttsFormat, "wav")
+        XCTAssertFalse(command.pull)
+        XCTAssertFalse(command.skipServer)
+        XCTAssertFalse(command.skipDocker)
+        XCTAssertFalse(command.skipConfigure)
+        XCTAssertFalse(command.reset)
+        XCTAssertFalse(command.dryRun)
+    }
+
+    func testQuickstartParsesOverrides() throws {
+        let command = try OpenWebUIQuickstart.parse([
+            "--host", "127.0.0.1",
+            "--port", "11434",
+            "--engine", "text-chat-lfm2",
+            "--webui-host", "0.0.0.0",
+            "--webui-port", "3001",
+            "--container-name", "owui-test",
+            "--volume-name", "owui-volume",
+            "--image", "ghcr.io/open-webui/open-webui:latest",
+            "--api-key", "secret",
+            "--text-model", LFM2Resources.defaultModelId,
+            "--vision-model", Gemma4Resources.visionTwelveBModelId,
+            "--embedding-model", Qwen3EmbeddingCatalog.modelId,
+            "--image-model", "image-zimage-base",
+            "--tts-model", "speech-tts-qwen3-customvoice",
+            "--stt-model", "speech-asr-qwen3",
+            "--tts-format", "mp3",
+            "--admin-email", "owner@example.test",
+            "--admin-password", "password",
+            "--wait-seconds", "30",
+            "--pull",
+            "--skip-server",
+            "--skip-docker",
+            "--skip-configure",
+            "--reset",
+            "--dry-run",
+            "--quiet",
+        ])
+
+        XCTAssertEqual(command.host, "127.0.0.1")
+        XCTAssertEqual(command.port, 11_434)
+        XCTAssertEqual(command.engine, .textChatLFM2)
+        XCTAssertEqual(command.webuiHost, "0.0.0.0")
+        XCTAssertEqual(command.webuiPort, 3001)
+        XCTAssertEqual(command.containerName, "owui-test")
+        XCTAssertEqual(command.volumeName, "owui-volume")
+        XCTAssertEqual(command.image, "ghcr.io/open-webui/open-webui:latest")
+        XCTAssertEqual(command.apiKey, "secret")
+        XCTAssertEqual(command.textModel, LFM2Resources.defaultModelId)
+        XCTAssertEqual(command.imageModel, "image-zimage-base")
+        XCTAssertEqual(command.ttsModel, "speech-tts-qwen3-customvoice")
+        XCTAssertEqual(command.sttModel, "speech-asr-qwen3")
+        XCTAssertEqual(command.ttsFormat, "mp3")
+        XCTAssertEqual(command.adminEmail, "owner@example.test")
+        XCTAssertEqual(command.adminPassword, "password")
+        XCTAssertEqual(command.waitSeconds, 30)
+        XCTAssertTrue(command.pull)
+        XCTAssertTrue(command.skipServer)
+        XCTAssertTrue(command.skipDocker)
+        XCTAssertTrue(command.skipConfigure)
+        XCTAssertTrue(command.reset)
+        XCTAssertTrue(command.dryRun)
+        XCTAssertTrue(command.quiet)
+    }
+
+    func testQuickstartDryRunPlanUsesDockerBridgeAndChatFilter() throws {
+        let command = try OpenWebUIQuickstart.parse([
+            "--dry-run",
+            "--api-key", "abc123",
+        ])
+
+        let plan = try command.makePlan(apiKey: "abc123").render()
+
+        XCTAssertTrue(plan.contains("export MERERUN_API_KEY=abc123"))
+        XCTAssertTrue(plan.contains("api serve --engine text-chat-gemma4"))
+        XCTAssertTrue(plan.contains("--model text-chat-gemma4-12b"))
+        XCTAssertTrue(plan.contains("OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1"))
+        XCTAssertTrue(plan.contains("RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b"))
+        XCTAssertTrue(plan.contains("ENABLE_IMAGE_EDIT=False"))
+        XCTAssertTrue(plan.contains("AUDIO_TTS_OPENAI_PARAMS={\"response_format\":\"wav\"}"))
+        XCTAssertTrue(plan.contains("open-webui quickstart --skip-server --skip-docker"))
+        XCTAssertTrue(plan.contains("--vision-model vision-chat-gemma4-12b"))
+    }
+
+    func testResolvedAPIKeyPrefersExplicitThenEnvironmentThenLocalDefault() {
+        XCTAssertEqual(
+            OpenWebUIQuickstart.resolvedAPIKey(explicit: " explicit ", environment: ["MERERUN_API_KEY": "env"]),
+            "explicit"
+        )
+        XCTAssertEqual(
+            OpenWebUIQuickstart.resolvedAPIKey(explicit: nil, environment: ["MERERUN_API_KEY": " env "]),
+            "env"
+        )
+        XCTAssertEqual(
+            OpenWebUIQuickstart.resolvedAPIKey(explicit: "", environment: [:]),
+            "change-me"
+        )
+    }
+}

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -72,6 +72,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "model",
             "status",
             "api",
+            "open-webui",
             "setup",
             "agent",
         ]))

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -94,6 +94,20 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/*"), false)
     }
 
+    func testKleinMaxRejectsConfigOnlyPartialInstall() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-max"))
+        try writeConfigOnlyDiffusersImageRoot(at: root, id: .kleinMax)
+
+        XCTAssertFalse(spec.isManagedRootComplete(root, fileManager: .default))
+        let missing = spec.missingPaths(in: root, fileManager: .default).map(\.path)
+        XCTAssertTrue(missing.contains { $0.hasSuffix("text_encoder/model.safetensors.index.json") })
+        XCTAssertTrue(missing.contains { $0.hasSuffix("transformer/diffusion_pytorch_model.safetensors.index.json") })
+        XCTAssertTrue(missing.contains { $0.hasSuffix("vae/diffusion_pytorch_model.safetensors") })
+    }
+
     func testBonsaiTernaryUsesPrismMLHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-bonsai-ternary"))
 
@@ -216,6 +230,29 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatLFM2)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("model.safetensors.index.json"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("*.safetensors"), true)
+    }
+
+    func testQwen3TTSSpecsDownloadSpeechTokenizer() throws {
+        for id in ["speech-tts-qwen3-nano", "speech-tts-qwen3-customvoice"] {
+            let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
+
+            XCTAssertEqual(spec.category, .speechTTS)
+            XCTAssertEqual(spec.validationKind, .qwen3TTS)
+            XCTAssertEqual(spec.hubFallback?.patterns.contains("speech_tokenizer/*"), true)
+        }
+    }
+
+    func testQwen3TTSRejectsRootMissingSpeechTokenizer() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalQwen3TTSRootWithoutSpeechTokenizer(at: root, id: .qwen3TTSNano)
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "speech-tts-qwen3-nano"))
+        XCTAssertFalse(spec.isManagedRootComplete(root, fileManager: .default))
+
+        let missing = spec.missingPaths(in: root, fileManager: .default).map(\.path)
+        XCTAssertTrue(missing.contains { $0.hasSuffix("speech_tokenizer/config.json") })
+        XCTAssertTrue(missing.contains { $0.hasSuffix("speech_tokenizer") })
     }
 
     func testZImageNanoAcceptsMFluxLayoutWithoutDiffusersConfigs() throws {
@@ -438,6 +475,39 @@ final class ManagedModelCatalogTests: XCTestCase {
         return url
     }
 
+    private func writeConfigOnlyDiffusersImageRoot(at root: URL, id: ModelResolver.ModelID) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model_index.json").path,
+            contents: Data("{}".utf8)
+        ))
+
+        let tokenizer = root.appendingPathComponent("tokenizer", isDirectory: true)
+        let textEncoder = root.appendingPathComponent("text_encoder", isDirectory: true)
+        let transformer = root.appendingPathComponent("transformer", isDirectory: true)
+        let vae = root.appendingPathComponent("vae", isDirectory: true)
+        let scheduler = root.appendingPathComponent("scheduler", isDirectory: true)
+        for directory in [tokenizer, textEncoder, transformer, vae, scheduler] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: tokenizer.appendingPathComponent("tokenizer_config.json").path,
+            contents: Data("{}".utf8)
+        ))
+        for directory in [textEncoder, transformer, vae] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: directory.appendingPathComponent("config.json").path,
+                contents: Data("{}".utf8)
+            ))
+        }
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: scheduler.appendingPathComponent("scheduler_config.json").path,
+            contents: Data("{}".utf8)
+        ))
+    }
+
     private func writeMinimalACEStepRoot(at root: URL, turboSubdirectory: String) throws {
         for subdirectory in [turboSubdirectory, "vae", "Qwen3-Embedding-0.6B"] {
             try FileManager.default.createDirectory(
@@ -487,6 +557,30 @@ final class ManagedModelCatalogTests: XCTestCase {
             "spectrostream_encoder.mlxfn",
         ] {
             XCTAssertTrue(FileManager.default.createFile(atPath: spectrostream.appendingPathComponent(file).path, contents: Data()))
+        }
+    }
+
+    private func writeMinimalQwen3TTSRootWithoutSpeechTokenizer(
+        at root: URL,
+        id: ModelResolver.ModelID
+    ) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+
+        let files = [
+            "config.json",
+            "generation_config.json",
+            "merges.txt",
+            "model.safetensors",
+            "tokenizer_config.json",
+            "vocab.json",
+        ]
+
+        for file in files {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: root.appendingPathComponent(file).path,
+                contents: Data("{}".utf8)
+            ))
         }
     }
 

--- a/Tests/MereRunCoreTests/MediaIOTests.swift
+++ b/Tests/MereRunCoreTests/MediaIOTests.swift
@@ -48,6 +48,27 @@ final class MediaIOTests: XCTestCase {
         XCTAssertEqual(readUInt32LE(data, offset: 40), 4 * UInt32(MemoryLayout<Float>.size))
     }
 
+    func testAudioTranscodeWritesRequestedContainer() throws {
+        guard isExecutableAvailable(MediaTool.ffmpegPath) else {
+            throw XCTSkip("ffmpeg is not available")
+        }
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mediaio-transcode-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let wavURL = tempDir.appendingPathComponent("input.wav")
+        let mp3URL = tempDir.appendingPathComponent("output.mp3")
+        let samples = (0..<4_000).map { index in
+            sin(Float(index) * 0.05) * 0.2
+        }
+        try MediaAudioIO.writeFloatWAV(samples: samples, sampleRate: 16_000, channels: 1, to: wavURL)
+        try MediaAudioIO.transcode(wavURL, to: mp3URL, format: "mp3")
+
+        let data = try Data(contentsOf: mp3URL)
+        XCTAssertGreaterThan(data.count, 0)
+    }
+
     func testRealFFTPlanSupportsASRAndPowerOfTwoFrameSizes() throws {
         for size in [400, 512, 1024] {
             let plan = try RealFFTPlan(size: size)
@@ -71,5 +92,17 @@ final class MediaIOTests: XCTestCase {
             | (UInt32(bytes[1]) << 8)
             | (UInt32(bytes[2]) << 16)
             | (UInt32(bytes[3]) << 24)
+    }
+
+    private func isExecutableAvailable(_ tool: String) -> Bool {
+        if tool.contains("/") {
+            return FileManager.default.isExecutableFile(atPath: tool)
+        }
+        let pathEntries = ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":") ?? []
+        return pathEntries.contains { entry in
+            let candidate = URL(fileURLWithPath: String(entry), isDirectory: true)
+                .appendingPathComponent(tool)
+            return FileManager.default.isExecutableFile(atPath: candidate.path)
+        }
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,7 @@ Public tree:
 - `mere.run model { list, capabilities, info, pull, remove, runtime, benchmark, repair-manifests }`
 - `mere.run status`
 - `mere.run api serve`
+- `mere.run open-webui quickstart`
 - `mere.run setup`
 - `mere.run agent { onboard, install-pi, start }`
 
@@ -1054,6 +1055,11 @@ Current endpoint surface:
 - `GET /health`
 - `GET /v1/models`
 - `POST /v1/chat/completions`
+- `POST /v1/embeddings`
+- `POST /v1/images/generations`
+- `POST /v1/images/edits`
+- `POST /v1/audio/speech`
+- `POST /v1/audio/transcriptions`
 - `GET /runtime/status`
 - `POST /runtime/models/{id}/load`
 - `POST /runtime/models/{id}/unload`
@@ -1063,8 +1069,12 @@ Security defaults:
 
 - loopback binds are local-first and do not require auth
 - non-loopback binds require `--api-key` or `MERERUN_API_KEY`
-- `POST /v1/chat/completions` requires `Content-Type: application/json`
-- `--rate-limit-per-minute` applies basic request throttling to `POST /v1/chat/completions`
+- `POST /v1/chat/completions`, `POST /v1/embeddings`,
+  `POST /v1/images/generations`, and `POST /v1/audio/speech` require
+  `Content-Type: application/json`; `POST /v1/images/edits` and
+  `POST /v1/audio/transcriptions` require `multipart/form-data`
+- `--rate-limit-per-minute` applies basic request throttling to the
+  OpenAI-compatible routes
 - `--max-active-requests` controls fair FIFO chat admission; the default `1`
   preserves serialized local inference while exposing queue depth in status;
   queued client cancellations are removed from the FIFO instead of running later
@@ -1128,6 +1138,32 @@ OpenAI chat compatibility:
 - `max_completion_tokens`, `developer` messages, function tools, image content
   parts, structured JSON mode, and streaming usage are capability-gated by
   engine.
+- `tool_choice` accepts `none`, `auto`, `required`, and specific function
+  choices by narrowing the advertised tool list to the named function.
+
+OpenAI embeddings compatibility:
+
+- `POST /v1/embeddings` serves native `text-embed-qwen3-0.6b` embeddings.
+- `input` may be a string or array of strings.
+- `encoding_format` may be omitted or set to `float`; base64 encoding and
+  dimension overrides are rejected.
+
+OpenAI image/audio compatibility:
+
+- `POST /v1/images/generations` serves native image generation models such as
+  `image-zimage-nano`; it supports `prompt`, `size`, `n=1`, `response_format`
+  `b64_json` or `url`, and local extensions such as `seed`.
+- `POST /v1/images/edits` accepts multipart `image` uploads, Open WebUI-style
+  `image[]` repeated uploads, an optional `mask`, and an edit `prompt`; it uses
+  the same image runtime with input-image conditioning. Masks are accepted for
+  client compatibility; current native edit models use whole-image conditioning.
+- `POST /v1/audio/speech` serves `speech-tts-qwen3-nano` and returns WAV by
+  default, with `mp3`, `opus`, `aac`, and `flac` available when `ffmpeg` is
+  installed. OpenAI model names such as `tts-1` map to the local default.
+- `POST /v1/audio/transcriptions` accepts multipart uploads for
+  `speech-asr-parakeet` or `speech-asr-qwen3`, with `json`, `text`,
+  `verbose_json`, `srt`, and `vtt` response formats. OpenAI model names such as
+  `whisper-1` map to the local default.
 
 Examples:
 
@@ -1137,6 +1173,23 @@ swift run mere.run api serve --engine text-chat-gemma4
 swift run mere.run api serve --engine text-chat-lfm2
 swift run mere.run api serve --engine text-code --model ./Qwen3-Coder-Next-Q4_K_M.gguf
 swift run mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY" --rate-limit-per-minute 120 --max-active-requests 1
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H "Content-Type: application/json" \
+  --data '{"model":"text-embed-qwen3-0.6b","input":"local RAG"}'
+curl http://127.0.0.1:8080/v1/images/generations \
+  -H "Content-Type: application/json" \
+  --data '{"model":"image-zimage-nano","prompt":"a compact local AI workstation","size":"1024x1024"}'
+curl http://127.0.0.1:8080/v1/images/edits \
+  -F model=qwen-image-edit \
+  -F prompt="make the workstation dusk-lit while preserving the layout" \
+  -F image=@input.png
+curl http://127.0.0.1:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  --output speech.wav \
+  --data '{"model":"speech-tts-qwen3-nano","input":"mere.run is online","voice":"nova","response_format":"wav"}'
+curl http://127.0.0.1:8080/v1/audio/transcriptions \
+  -F model=speech-asr-parakeet \
+  -F file=@speech.wav
 ```
 
 After starting a server, run `swift run mere.run status` from another terminal

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,8 +49,9 @@ store.
 
 ### `MERERUN_API_KEY`
 
-Provides the bearer token accepted by `mere.run api serve` for `/v1/models` and
-`/v1/chat/completions`.
+Provides the bearer token accepted by `mere.run api serve` for `/v1/models`,
+`/v1/chat/completions`, `/v1/embeddings`, `/v1/images/generations`,
+`/v1/images/edits`, `/v1/audio/speech`, and `/v1/audio/transcriptions`.
 
 This is optional for loopback-only usage and required for non-loopback binds.
 `mere.run status` also reads it when probing `/v1/models`.

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -9,6 +9,7 @@ mere.run guide image generate
 mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
 mere.run guide music generate --model music-acestep
 mere.run guide music generate --model music-magenta-rt2-small
+mere.run guide open-webui
 mere.run guide video generate --json
 ```
 
@@ -42,6 +43,7 @@ Creative and runtime workflows:
 - `video generate`
 - `video export-latents`
 - `api serve`
+- `open-webui`
 - `status`
 
 Operational workflows:

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -8,6 +8,12 @@ This page covers `mere.run api serve`, the local API surface exposed by the pack
 - `mere.run model runtime get`
 - `mere.run model runtime set`
 - `mere.run status`
+- `POST /v1/chat/completions`
+- `POST /v1/embeddings`
+- `POST /v1/images/generations`
+- `POST /v1/images/edits`
+- `POST /v1/audio/speech`
+- `POST /v1/audio/transcriptions`
 
 ## What it is for
 
@@ -16,6 +22,9 @@ instead of shelling out to the CLI for every request. It is useful for:
 
 - local automation
 - editor tooling
+- local RAG and knowledge-base embeddings
+- local image generation
+- local text-to-speech and speech-to-text
 - simple local integrations
 - experimenting with the runtime through HTTP
 
@@ -62,6 +71,58 @@ reports:
 swift run mere.run status
 ```
 
+Native embeddings use the same OpenAI-compatible base URL:
+
+```bash
+swift run mere.run model pull text-embed-qwen3-0.6b
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "text-embed-qwen3-0.6b",
+    "input": ["mere.run native embeddings", "local RAG"]
+}'
+```
+
+Image generation and editing return base64 PNG JSON by default:
+
+```bash
+swift run mere.run model pull image-zimage-nano
+curl http://127.0.0.1:8080/v1/images/generations \
+  -H "Content-Type: application/json" \
+  --data '{
+    "model": "image-zimage-nano",
+    "prompt": "a compact local AI workstation in morning light",
+    "size": "1024x1024"
+  }'
+
+curl http://127.0.0.1:8080/v1/images/edits \
+  -F model=image-zimage-nano \
+  -F prompt="make the workstation dusk-lit while preserving the layout" \
+  -F image=@input.png
+```
+
+Audio endpoints use the same base URL:
+
+```bash
+swift run mere.run model pull speech-tts-qwen3-nano
+swift run mere.run model pull speech-asr-parakeet
+
+curl http://127.0.0.1:8080/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  --output speech.wav \
+  --data '{
+    "model": "speech-tts-qwen3-nano",
+    "input": "mere.run is serving native audio.",
+    "voice": "nova",
+    "response_format": "wav"
+  }'
+
+curl http://127.0.0.1:8080/v1/audio/transcriptions \
+  -F model=speech-asr-parakeet \
+  -F response_format=json \
+  -F file=@speech.wav
+```
+
 Optional per-model defaults live with the active model store:
 
 ```bash
@@ -97,6 +158,12 @@ swift run mere.run api serve \
 - `--engine` and `--model` still define and preload the startup default, while
   each chat request can select another installed API-capable catalog model with
   the OpenAI `model` field
+- `/v1/embeddings` uses the native `text-embed-qwen3-0.6b` sidecar model; it is
+  listed in `/v1/models` when installed even though it is not a chat-serving engine
+- `/v1/images/generations`, `/v1/images/edits`, `/v1/audio/speech`, and
+  `/v1/audio/transcriptions` are sidecar routes over existing native CLI
+  runtime paths. Installed image, TTS, and ASR sidecar catalog ids are listed in
+  `/v1/models` even though they are not chat-serving engines.
 - chat completions pass through a fair FIFO request admission actor; the default
   `--max-active-requests 1` preserves serialized local inference and exposes
   queue depth in status; queued client cancellations are removed from the FIFO
@@ -157,10 +224,12 @@ swift run mere.run api serve \
   agent to a local server
 - it is intentionally local-first
 - it should not reintroduce relay, billing, or hosted-infrastructure concerns
-- non-loopback binds require an API key, and the OpenAI-compatible chat route
-  supports basic rate limiting
-- chat requests must use `Content-Type: application/json`; browser-simple
-  form/text posts are rejected before the request body is processed
+- non-loopback binds require an API key, and the OpenAI-compatible routes
+  support basic rate limiting
+- chat, embedding, image generation, and TTS requests must use
+  `Content-Type: application/json`; image editing and STT requests must use
+  `multipart/form-data`; browser-simple form/text posts are rejected before the
+  request body is processed
 - chat requests are validated before generation; `max_tokens`,
   `max_completion_tokens`, `temperature`, and `top_p` must stay within bounded
   ranges
@@ -171,8 +240,8 @@ swift run mere.run api serve \
 
 ## Runtime control endpoints
 
-The control endpoints use the same bearer-token behavior as `/v1/models` and
-`/v1/chat/completions`.
+The control endpoints use the same bearer-token behavior as `/v1/models`,
+`/v1/chat/completions`, and `/v1/embeddings`.
 
 - `GET /runtime/status`: server health, pool entries, active request counts,
   request admission state, runtime capability flags, memory snapshot, settings
@@ -186,9 +255,10 @@ The control endpoints use the same bearer-token behavior as `/v1/models` and
 - `GET /runtime/models/{id}/settings`: read typed runtime defaults.
 - `PATCH /runtime/models/{id}/settings`: replace typed runtime defaults.
 
-`GET /v1/models` returns installed API-servable managed IDs plus configured
-aliases. Missing catalog models fail with an OpenAI-style error that tells the
-user to pull the model first.
+`GET /v1/models` returns installed API-servable chat managed IDs, configured
+aliases, and installed native sidecar model ids for embeddings, image, TTS, and
+ASR. Missing catalog models fail with an OpenAI-style error that tells the user
+to pull the model first.
 
 ## OpenAI chat compatibility
 
@@ -198,7 +268,9 @@ user to pull the model first.
 - string content, text content parts, nullable assistant content, and image
   content parts when the selected engine supports vision
 - assistant `tool_calls` and tool response messages
-- `tools`, `tool_choice`, `parallel_tool_calls`
+- `tools`, `tool_choice`, `parallel_tool_calls`; `tool_choice` accepts `none`,
+  `auto`, `required`, and specific function choices by narrowing the advertised
+  tool list to the named function
 - `response_format`
 - `stream_options.include_usage`
 - `stop`, `seed`, penalties, logprobs, reasoning controls, and
@@ -235,6 +307,395 @@ Engine compatibility:
 Streaming responses only emit assistant content tokens. Local progress labels
 stay in logs/stderr, and `stream_options.include_usage` adds the final usage
 chunk before `[DONE]`.
+
+## OpenAI embeddings compatibility
+
+`POST /v1/embeddings` accepts the common Embeddings request shape:
+
+- `model`: `text-embed-qwen3-0.6b` or a local Qwen3 embedding model path
+- `input`: a string or an array of strings
+- `encoding_format`: omitted or `float`
+- `user`: accepted as request context
+
+The route returns `object: "list"`, one `embedding` object per input, and
+`prompt_tokens`/`total_tokens` usage counts. Dimension overrides and base64
+embedding encoding are rejected with `invalid_request_error` because the native
+Qwen3 embedding model has a fixed vector size and returns float vectors.
+
+## OpenAI image/audio compatibility
+
+`POST /v1/images/generations` accepts:
+
+- `model`: a mere.run image model id, local image model path, or an OpenAI image
+  model name such as `dall-e-3` mapped to `image-zimage-nano`
+- `prompt`: required text prompt
+- `size`: `WIDTHxHEIGHT`; defaults to `1024x1024`
+- `n`: only `1`
+- `response_format`: `b64_json` by default, or `url` for a local `file://` URL
+- local extensions: `seed`, `negative_prompt`, `steps`, and `guidance_scale`
+
+`POST /v1/images/edits` accepts multipart form fields:
+
+- `image`: required input image file part; Open WebUI-style `image[]` repeated
+  parts are accepted for multi-image edit requests
+- `mask`: optional mask file part
+- `model`: a mere.run image model id, local image model path, `qwen-image-edit`,
+  or an OpenAI image model name such as `gpt-image-1` mapped to
+  `image-zimage-nano`
+- `prompt`: required edit instruction
+- `size`: `WIDTHxHEIGHT`; defaults to `1024x1024`
+- `n`: only `1`
+- `response_format`: `b64_json` by default, or `url` for a local `file://` URL
+- local extensions: `strength`, `seed`, `negative_prompt`, `steps`, and
+  `guidance_scale`
+
+Masks are accepted for client compatibility. Current native edit models use
+whole-image conditioning rather than strict masked inpainting.
+
+`POST /v1/audio/speech` accepts:
+
+- `model`: `speech-tts-qwen3-nano`, a local Qwen3-TTS model path, or OpenAI
+  names such as `tts-1` mapped to the local default
+- `input`: required text
+- `voice`: OpenAI voice names are translated to Qwen3-TTS style descriptions;
+  custom descriptions are passed through
+- `speed`, `instructions`, and `temperature`
+- `response_format`: `wav`, `mp3`, `opus`, `aac`, or `flac`; non-WAV formats
+  require `ffmpeg`
+
+`POST /v1/audio/transcriptions` accepts multipart form fields:
+
+- `file`: required audio file part
+- `model`: `speech-asr-parakeet`, `speech-asr-qwen3`, a local ASR model path,
+  or OpenAI names such as `whisper-1` mapped to `speech-asr-parakeet`
+- `language`
+- `task`: `transcribe` or `translate`
+- `response_format`: `json`, `text`, `verbose_json`, `srt`, or `vtt`
+- `max_tokens`
+
+Unsupported format choices return OpenAI-style `invalid_request_error` payloads
+instead of being ignored.
+
+## Open WebUI companion
+
+Open WebUI can use mere.run as an OpenAI-compatible provider without being
+vendored into this repo. Start mere.run, run the official Open WebUI Docker or
+pip install, then configure Open WebUI with the mere.run `/v1` base URL.
+
+One-command Docker quickstart:
+
+```bash
+mere.run open-webui quickstart --pull
+```
+
+That starts `api serve`, runs the official Open WebUI container, configures the
+OpenAI provider, filters the chat picker to the configured text and vision chat
+models, points RAG at `/v1/embeddings`, and keeps image editing disabled for the
+live-smoke path. Preview the exact commands with:
+
+```bash
+mere.run open-webui quickstart --dry-run
+```
+
+Repeatable smoke harness:
+
+```bash
+export MERERUN_API_KEY=change-me
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+
+MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b \
+MERERUN_OPENWEBUI_RESET=1 scripts/smoke-open-webui.sh docker-run
+MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b \
+scripts/smoke-open-webui.sh live-smoke
+```
+
+`live-smoke` waits for Open WebUI, signs in to the disposable no-auth smoke
+admin user, filters the OpenAI chat connection to the configured text and vision
+chat ids, imports per-model metadata wrappers, sends text and vision chat
+through Open WebUI's own proxy, then exercises the direct mere.run API surface
+and the Open WebUI model list. Use `configure`, `proxy-smoke`, `api-smoke`, and
+`ui-smoke` separately when debugging one stage.
+
+Docker bridge path:
+
+```bash
+export MERERUN_API_KEY=change-me
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+
+DEFAULT_MODEL_METADATA='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+docker run -d \
+  --name open-webui \
+  --restart unless-stopped \
+  -p 3000:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  -e OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e OPENAI_API_BASE_URLS=http://host.docker.internal:8080/v1 \
+  -e OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e OPENAI_API_KEYS="$MERERUN_API_KEY" \
+  -e DEFAULT_MODELS=text-chat-gemma4-12b \
+  -e DEFAULT_MODEL_PARAMS='{"function_calling":"native"}' \
+  -e DEFAULT_MODEL_METADATA="$DEFAULT_MODEL_METADATA" \
+  -e RAG_EMBEDDING_ENGINE=openai \
+  -e RAG_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e RAG_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b \
+  -e ENABLE_IMAGE_GENERATION=True \
+  -e ENABLE_IMAGE_EDIT=False \
+  -e IMAGE_GENERATION_ENGINE=openai \
+  -e IMAGE_GENERATION_MODEL=image-zimage-nano \
+  -e IMAGE_SIZE=1024x1024 \
+  -e IMAGE_EDIT_ENGINE=openai \
+  -e IMAGE_EDIT_MODEL=qwen-image-edit \
+  -e IMAGE_EDIT_SIZE=1024x1024 \
+  -e IMAGES_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e IMAGES_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e IMAGES_EDIT_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e IMAGES_EDIT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e AUDIO_TTS_ENGINE=openai \
+  -e AUDIO_TTS_MODEL=speech-tts-qwen3-nano \
+  -e AUDIO_TTS_VOICE=nova \
+  -e AUDIO_TTS_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e AUDIO_TTS_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}' \
+  -e AUDIO_STT_ENGINE=openai \
+  -e AUDIO_STT_MODEL=speech-asr-parakeet \
+  -e AUDIO_STT_OPENAI_API_BASE_URL=http://host.docker.internal:8080/v1 \
+  -e AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+  -e ENABLE_PERSISTENT_CONFIG=False \
+  -e WEBUI_AUTH=False \
+  -v open-webui:/app/backend/data \
+  ghcr.io/open-webui/open-webui:main
+```
+
+The environment variables above preconfigure Open WebUI on a fresh data volume.
+Run `scripts/smoke-open-webui.sh configure` after the container is healthy to
+set Open WebUI's OpenAI connection `model_ids` filter and import per-model
+capability wrappers. That keeps image, embedding, TTS, and STT sidecars out of
+the chat selector while still using them in their own settings. You can also set
+the same values in the admin UI:
+
+- Base URL: `http://host.docker.internal:8080/v1`
+- API key: the value of `MERERUN_API_KEY`
+- Chat model: an installed `text-chat-*` model from `/v1/models`
+- Vision model: `vision-chat-gemma4-12b`
+- RAG embedding model: `text-embed-qwen3-0.6b`
+- Image generation engine/model: `openai` / `image-zimage-nano`
+- Image editing: disabled for the live smoke path with `ENABLE_IMAGE_EDIT=False`
+- Image edit engine/model when enabled: `openai` / `qwen-image-edit`
+- TTS engine/model: `openai` / `speech-tts-qwen3-nano`
+- STT engine/model: `openai` / `speech-asr-parakeet`
+- Function calling: native mode with `{"function_calling":"native"}`
+
+Docker Compose / DGX Spark path:
+
+Keep mere.run on the host and run only Open WebUI in Docker. This is the
+cleaner path for Linux, DGX Spark, or LAN workstations because the mere.run
+process owns the local model store and runtime/GPU setup while Open WebUI keeps
+its persistent app data in a Docker volume.
+
+```bash
+export MERERUN_API_KEY=change-me
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-12b \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --api-key "$MERERUN_API_KEY"
+```
+
+Create `open-webui-mere-run/.env`:
+
+```dotenv
+MERERUN_API_KEY=change-me
+WEBUI_SECRET_KEY=replace-with-openssl-rand-hex-32
+OPEN_WEBUI_IMAGE=ghcr.io/open-webui/open-webui:main
+OPEN_WEBUI_BIND=0.0.0.0
+OPEN_WEBUI_URL=http://spark.local:3000
+MERERUN_OPENWEBUI_API_URL=http://host.docker.internal:8080/v1
+MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b
+```
+
+Create `open-webui-mere-run/compose.yaml`:
+
+```yaml
+services:
+  open-webui:
+    image: ${OPEN_WEBUI_IMAGE:-ghcr.io/open-webui/open-webui:main}
+    container_name: open-webui
+    restart: unless-stopped
+    ports:
+      - "${OPEN_WEBUI_BIND:-0.0.0.0}:3000:8080"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      WEBUI_URL: ${OPEN_WEBUI_URL:-http://localhost:3000}
+      WEBUI_AUTH: "True"
+      WEBUI_SECRET_KEY: ${WEBUI_SECRET_KEY}
+      ENABLE_PERSISTENT_CONFIG: "True"
+      OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      OPENAI_API_BASE_URLS: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      OPENAI_API_KEY: ${MERERUN_API_KEY}
+      OPENAI_API_KEYS: ${MERERUN_API_KEY}
+      DEFAULT_MODELS: ${MERERUN_OPENWEBUI_TEXT_MODEL:-text-chat-gemma4-12b}
+      DEFAULT_MODEL_PARAMS: '{"function_calling":"native"}'
+      DEFAULT_MODEL_METADATA: '{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+      RAG_EMBEDDING_ENGINE: openai
+      RAG_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      RAG_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      RAG_EMBEDDING_MODEL: text-embed-qwen3-0.6b
+      ENABLE_IMAGE_GENERATION: "True"
+      ENABLE_IMAGE_EDIT: "False"
+      IMAGE_GENERATION_ENGINE: openai
+      IMAGE_GENERATION_MODEL: image-zimage-nano
+      IMAGE_SIZE: 1024x1024
+      IMAGES_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      IMAGES_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      AUDIO_TTS_ENGINE: openai
+      AUDIO_TTS_MODEL: speech-tts-qwen3-nano
+      AUDIO_TTS_VOICE: nova
+      AUDIO_TTS_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      AUDIO_TTS_OPENAI_API_KEY: ${MERERUN_API_KEY}
+      AUDIO_TTS_OPENAI_PARAMS: '{"response_format":"wav"}'
+      AUDIO_STT_ENGINE: openai
+      AUDIO_STT_MODEL: speech-asr-parakeet
+      AUDIO_STT_OPENAI_API_BASE_URL: ${MERERUN_OPENWEBUI_API_URL:-http://host.docker.internal:8080/v1}
+      AUDIO_STT_OPENAI_API_KEY: ${MERERUN_API_KEY}
+    volumes:
+      - open-webui:/app/backend/data
+
+volumes:
+  open-webui:
+```
+
+Then run:
+
+```bash
+cd open-webui-mere-run
+docker compose up -d
+```
+
+For Open WebUI on a different machine, set `MERERUN_OPENWEBUI_API_URL` to the
+mere.run host's LAN URL, for example `http://192.168.1.50:8080/v1`. Keep
+`WEBUI_AUTH=True`, keep a stable `WEBUI_SECRET_KEY`, and pin
+`OPEN_WEBUI_IMAGE` to a tested release tag before treating the instance as
+shared or production-like.
+
+Pip path:
+
+```bash
+python3.11 -m pip install --upgrade open-webui
+DEFAULT_MODEL_METADATA='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+OPENAI_API_BASE_URLS=http://127.0.0.1:8080/v1 \
+OPENAI_API_KEY="$MERERUN_API_KEY" \
+OPENAI_API_KEYS="$MERERUN_API_KEY" \
+DEFAULT_MODELS=text-chat-gemma4-12b \
+DEFAULT_MODEL_PARAMS='{"function_calling":"native"}' \
+DEFAULT_MODEL_METADATA="$DEFAULT_MODEL_METADATA" \
+RAG_EMBEDDING_ENGINE=openai \
+RAG_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+RAG_OPENAI_API_KEY="$MERERUN_API_KEY" \
+RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b \
+ENABLE_IMAGE_GENERATION=True \
+ENABLE_IMAGE_EDIT=False \
+IMAGE_GENERATION_ENGINE=openai \
+IMAGE_GENERATION_MODEL=image-zimage-nano \
+IMAGE_SIZE=1024x1024 \
+IMAGE_EDIT_ENGINE=openai \
+IMAGE_EDIT_MODEL=qwen-image-edit \
+IMAGE_EDIT_SIZE=1024x1024 \
+IMAGES_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+IMAGES_OPENAI_API_KEY="$MERERUN_API_KEY" \
+IMAGES_EDIT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+IMAGES_EDIT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_ENGINE=openai \
+AUDIO_TTS_MODEL=speech-tts-qwen3-nano \
+AUDIO_TTS_VOICE=nova \
+AUDIO_TTS_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_TTS_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}' \
+AUDIO_STT_ENGINE=openai \
+AUDIO_STT_MODEL=speech-asr-parakeet \
+AUDIO_STT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+ENABLE_PERSISTENT_CONFIG=False \
+WEBUI_AUTH=False \
+open-webui serve --host 127.0.0.1 --port 3000
+```
+
+For pip-based smoke configuration, use the same-host provider URL:
+
+```bash
+OPEN_WEBUI_MERERUN_API_URL=http://127.0.0.1:8080/v1 \
+scripts/smoke-open-webui.sh configure
+```
+
+Use Base URL `http://127.0.0.1:8080/v1` for any admin UI edits in the pip
+install. If an existing Open WebUI data directory ignores changed environment
+variables, update the values in the admin UI, set `ENABLE_PERSISTENT_CONFIG=False`
+for smoke, or start with a fresh data directory. Set the
+`vision-chat-gemma4-12b` per-model capability `vision=true` before UI vision
+upload smoke if you use the conservative global model metadata above.
+
+uv path:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export DATA_DIR="$HOME/.open-webui-mere-run"
+export MERERUN_API_KEY=change-me
+
+DEFAULT_MODEL_METADATA='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+DATA_DIR="$HOME/.open-webui-mere-run" \
+OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+OPENAI_API_BASE_URLS=http://127.0.0.1:8080/v1 \
+OPENAI_API_KEY="$MERERUN_API_KEY" \
+OPENAI_API_KEYS="$MERERUN_API_KEY" \
+DEFAULT_MODELS=text-chat-gemma4-12b \
+DEFAULT_MODEL_PARAMS='{"function_calling":"native"}' \
+DEFAULT_MODEL_METADATA="$DEFAULT_MODEL_METADATA" \
+RAG_EMBEDDING_ENGINE=openai \
+RAG_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+RAG_OPENAI_API_KEY="$MERERUN_API_KEY" \
+RAG_EMBEDDING_MODEL=text-embed-qwen3-0.6b \
+ENABLE_IMAGE_GENERATION=True \
+ENABLE_IMAGE_EDIT=False \
+IMAGE_GENERATION_ENGINE=openai \
+IMAGE_GENERATION_MODEL=image-zimage-nano \
+IMAGES_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+IMAGES_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_ENGINE=openai \
+AUDIO_TTS_MODEL=speech-tts-qwen3-nano \
+AUDIO_TTS_VOICE=nova \
+AUDIO_TTS_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_TTS_OPENAI_API_KEY="$MERERUN_API_KEY" \
+AUDIO_TTS_OPENAI_PARAMS='{"response_format":"wav"}' \
+AUDIO_STT_ENGINE=openai \
+AUDIO_STT_MODEL=speech-asr-parakeet \
+AUDIO_STT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
+AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
+ENABLE_PERSISTENT_CONFIG=False \
+WEBUI_AUTH=False \
+uvx --python 3.11 open-webui@latest serve --host 127.0.0.1 --port 3000
+```
+
+Run the mere.run API on `127.0.0.1:8080` in another terminal. The explicit
+Open WebUI `--port 3000` avoids colliding with the mere.run API recipe.
+
+The CLI cookbook has the longer copy-paste recipe:
+
+```bash
+mere.run guide open-webui
+```
 
 Fair FIFO request admission is part of the runtime pool now, and Gemma4/Qwen-family chat use
 engine-specific chunked prefill checkpoints. Gemma4 and Qwen-family prefix KV reuse are

--- a/scripts/smoke-open-webui.sh
+++ b/scripts/smoke-open-webui.sh
@@ -1,0 +1,652 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+MERERUN_API_URL="${MERERUN_API_URL:-http://127.0.0.1:8080/v1}"
+MERERUN_DOCKER_API_URL="${MERERUN_DOCKER_API_URL:-http://host.docker.internal:8080/v1}"
+MERERUN_API_KEY="${MERERUN_API_KEY:-change-me}"
+
+OPEN_WEBUI_CONTAINER="${OPEN_WEBUI_CONTAINER:-open-webui-mere-run-smoke}"
+OPEN_WEBUI_VOLUME="${OPEN_WEBUI_VOLUME:-open-webui-mere-run-smoke}"
+OPEN_WEBUI_IMAGE="${OPEN_WEBUI_IMAGE:-ghcr.io/open-webui/open-webui:main}"
+OPEN_WEBUI_PORT="${OPEN_WEBUI_PORT:-3000}"
+OPEN_WEBUI_URL="${OPEN_WEBUI_URL:-http://127.0.0.1:${OPEN_WEBUI_PORT}}"
+OPEN_WEBUI_AUTH_EMAIL="${OPEN_WEBUI_AUTH_EMAIL:-admin@localhost}"
+OPEN_WEBUI_AUTH_PASSWORD="${OPEN_WEBUI_AUTH_PASSWORD:-admin}"
+OPEN_WEBUI_TOKEN="${OPEN_WEBUI_TOKEN:-}"
+OPEN_WEBUI_WAIT_SECONDS="${OPEN_WEBUI_WAIT_SECONDS:-120}"
+OPEN_WEBUI_MERERUN_API_URL="${OPEN_WEBUI_MERERUN_API_URL:-${MERERUN_DOCKER_API_URL}}"
+
+MERERUN_OPENWEBUI_TEXT_MODEL="${MERERUN_OPENWEBUI_TEXT_MODEL:-text-chat-gemma4-12b}"
+MERERUN_OPENWEBUI_VISION_MODEL="${MERERUN_OPENWEBUI_VISION_MODEL:-vision-chat-gemma4-12b}"
+MERERUN_OPENWEBUI_EMBED_MODEL="${MERERUN_OPENWEBUI_EMBED_MODEL:-text-embed-qwen3-0.6b}"
+MERERUN_OPENWEBUI_IMAGE_MODEL="${MERERUN_OPENWEBUI_IMAGE_MODEL:-image-zimage-nano}"
+MERERUN_OPENWEBUI_IMAGE_EDIT_MODEL="${MERERUN_OPENWEBUI_IMAGE_EDIT_MODEL:-qwen-image-edit}"
+MERERUN_OPENWEBUI_TTS_MODEL="${MERERUN_OPENWEBUI_TTS_MODEL:-speech-tts-qwen3-nano}"
+MERERUN_OPENWEBUI_STT_MODEL="${MERERUN_OPENWEBUI_STT_MODEL:-speech-asr-parakeet}"
+MERERUN_OPENWEBUI_TTS_FORMAT="${MERERUN_OPENWEBUI_TTS_FORMAT:-wav}"
+OPEN_WEBUI_CHAT_MODELS="${OPEN_WEBUI_CHAT_MODELS:-${MERERUN_OPENWEBUI_TEXT_MODEL};${MERERUN_OPENWEBUI_VISION_MODEL}}"
+
+DEFAULT_MODEL_METADATA_JSON='{"capabilities":{"file_context":true,"vision":false,"file_upload":true,"web_search":false,"image_generation":true,"code_interpreter":false,"terminal":false,"citations":true,"status_updates":true,"builtin_tools":true}}'
+DEFAULT_MODEL_PARAMS_JSON='{"function_calling":"native"}'
+OPEN_WEBUI_MODEL_METADATA="${OPEN_WEBUI_MODEL_METADATA:-$DEFAULT_MODEL_METADATA_JSON}"
+OPEN_WEBUI_MODEL_PARAMS="${OPEN_WEBUI_MODEL_PARAMS:-$DEFAULT_MODEL_PARAMS_JSON}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/smoke-open-webui.sh print-env
+  scripts/smoke-open-webui.sh docker-run
+  scripts/smoke-open-webui.sh configure
+  scripts/smoke-open-webui.sh proxy-smoke
+  scripts/smoke-open-webui.sh api-smoke
+  scripts/smoke-open-webui.sh ui-smoke
+  scripts/smoke-open-webui.sh live-smoke
+  scripts/smoke-open-webui.sh stop
+
+Environment:
+  MERERUN_API_URL=http://127.0.0.1:8080/v1
+  MERERUN_DOCKER_API_URL=http://host.docker.internal:8080/v1
+  MERERUN_API_KEY=change-me
+  OPEN_WEBUI_URL=http://127.0.0.1:3000
+  OPEN_WEBUI_AUTH_EMAIL=admin@localhost
+  OPEN_WEBUI_AUTH_PASSWORD=admin
+  OPEN_WEBUI_TOKEN=                    # optional existing admin JWT/API token
+  OPEN_WEBUI_MERERUN_API_URL=http://host.docker.internal:8080/v1
+  MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b
+  MERERUN_OPENWEBUI_VISION_MODEL=vision-chat-gemma4-12b
+  MERERUN_OPENWEBUI_EMBED_MODEL=text-embed-qwen3-0.6b
+  MERERUN_OPENWEBUI_IMAGE_MODEL=image-zimage-nano
+  MERERUN_OPENWEBUI_IMAGE_EDIT_MODEL=qwen-image-edit
+  MERERUN_OPENWEBUI_TTS_MODEL=speech-tts-qwen3-nano
+  MERERUN_OPENWEBUI_STT_MODEL=speech-asr-parakeet
+  MERERUN_OPENWEBUI_TTS_FORMAT=wav
+  OPEN_WEBUI_CHAT_MODELS='text-chat-gemma4;vision-chat-gemma4-12b'
+  MERERUN_OPENWEBUI_RESET=1        # remove the smoke container and volume first
+
+Start mere.run first, for example:
+  MERERUN_API_KEY=change-me mere.run api serve --engine text-chat-gemma4 --model text-chat-gemma4-12b --host 0.0.0.0 --port 8080 --api-key "$MERERUN_API_KEY"
+USAGE
+}
+
+curl_json() {
+  local method="$1"
+  local path="$2"
+  local data="${3:-}"
+  local url="${MERERUN_API_URL%/}${path}"
+  if [[ -n "${data}" ]]; then
+    curl -fsS -X "${method}" "${url}" \
+      -H "Authorization: Bearer ${MERERUN_API_KEY}" \
+      -H "Content-Type: application/json" \
+      --data "${data}"
+  else
+    curl -fsS -X "${method}" "${url}" \
+      -H "Authorization: Bearer ${MERERUN_API_KEY}"
+  fi
+}
+
+openwebui_json() {
+  local method="$1"
+  local path="$2"
+  local token="$3"
+  local data="${4:-}"
+  local url="${OPEN_WEBUI_URL%/}${path}"
+  if [[ -n "${data}" ]]; then
+    curl -fsS -X "${method}" "${url}" \
+      -H "Authorization: Bearer ${token}" \
+      -H "Content-Type: application/json" \
+      --data "${data}"
+  else
+    curl -fsS -X "${method}" "${url}" \
+      -H "Authorization: Bearer ${token}" \
+      -H "Content-Type: application/json"
+  fi
+}
+
+wait_openwebui() {
+  local health_url="${OPEN_WEBUI_URL%/}/health"
+  local deadline=$((SECONDS + OPEN_WEBUI_WAIT_SECONDS))
+  echo "Waiting for Open WebUI at ${health_url}"
+  until curl -fsS "${health_url}" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      echo "Timed out waiting for Open WebUI at ${health_url}" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+}
+
+openwebui_token() {
+  if [[ -n "${OPEN_WEBUI_TOKEN}" ]]; then
+    printf '%s\n' "${OPEN_WEBUI_TOKEN}"
+    return
+  fi
+
+  local signin_payload
+  signin_payload="$(python3 - "${OPEN_WEBUI_AUTH_EMAIL}" "${OPEN_WEBUI_AUTH_PASSWORD}" <<'PY'
+import json
+import sys
+
+print(json.dumps({"email": sys.argv[1], "password": sys.argv[2]}))
+PY
+)"
+
+  local signin_response
+  signin_response="$(curl -fsS -X POST "${OPEN_WEBUI_URL%/}/api/v1/auths/signin" \
+    -H "Content-Type: application/json" \
+    --data "${signin_payload}")"
+
+  python3 -c 'import json, sys
+payload = json.load(sys.stdin)
+token = payload.get("token")
+if not token:
+    raise SystemExit("Open WebUI signin did not return a token")
+print(token)' <<<"${signin_response}"
+}
+
+chat_models_json() {
+  local models_file="$1"
+  python3 - "${models_file}" "${OPEN_WEBUI_CHAT_MODELS}" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+
+available = {item.get("id") for item in payload.get("data", []) if item.get("id")}
+requested = [item for item in re.split(r"[;,]", sys.argv[2]) if item]
+selected = [item for item in requested if item in available]
+if not selected:
+    selected = requested
+print(json.dumps(selected))
+PY
+}
+
+configure_openwebui_payloads() {
+  local output_dir="$1"
+  local chat_models="$2"
+  python3 - "${output_dir}" \
+    "${OPEN_WEBUI_MERERUN_API_URL}" \
+    "${MERERUN_API_KEY}" \
+    "${MERERUN_OPENWEBUI_TEXT_MODEL}" \
+    "${MERERUN_OPENWEBUI_VISION_MODEL}" \
+    "${OPEN_WEBUI_MODEL_METADATA}" \
+    "${OPEN_WEBUI_MODEL_PARAMS}" \
+    "${chat_models}" <<'PY'
+import copy
+import json
+import pathlib
+import sys
+
+output_dir = pathlib.Path(sys.argv[1])
+provider_api_url = sys.argv[2]
+api_key = sys.argv[3]
+text_model = sys.argv[4]
+vision_model = sys.argv[5]
+default_metadata = json.loads(sys.argv[6] or "{}")
+default_params = json.loads(sys.argv[7] or "{}")
+chat_models = json.loads(sys.argv[8])
+
+openai_config = {
+    "ENABLE_OPENAI_API": True,
+    "OPENAI_API_BASE_URLS": [provider_api_url],
+    "OPENAI_API_KEYS": [api_key],
+    "OPENAI_API_CONFIGS": {
+        "0": {
+            "enable": True,
+            "model_ids": chat_models,
+        }
+    },
+}
+
+models_config = {
+    "DEFAULT_MODELS": text_model,
+    "DEFAULT_PINNED_MODELS": text_model,
+    "MODEL_ORDER_LIST": chat_models,
+    "DEFAULT_MODEL_METADATA": default_metadata,
+    "DEFAULT_MODEL_PARAMS": default_params,
+}
+
+def wrapper(model_id: str, *, vision: bool, name: str) -> dict:
+    metadata = copy.deepcopy(default_metadata)
+    capabilities = dict(metadata.get("capabilities") or {})
+    capabilities["vision"] = vision
+    capabilities["file_upload"] = True
+    metadata["capabilities"] = capabilities
+    metadata["description"] = f"{name} served locally by mere.run."
+    return {
+        "id": model_id,
+        "base_model_id": model_id,
+        "name": name,
+        "meta": metadata,
+        "params": default_params,
+        "is_active": True,
+    }
+
+models = []
+if text_model in chat_models:
+    models.append(wrapper(text_model, vision=False, name=f"mere.run {text_model}"))
+if vision_model in chat_models:
+    models.append(wrapper(vision_model, vision=True, name=f"mere.run {vision_model}"))
+
+(output_dir / "openai-config.json").write_text(json.dumps(openai_config), encoding="utf-8")
+(output_dir / "models-config.json").write_text(json.dumps(models_config), encoding="utf-8")
+(output_dir / "models-import.json").write_text(json.dumps({"models": models}), encoding="utf-8")
+PY
+}
+
+configure_openwebui() {
+  wait_openwebui
+  local work_dir
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/mere-openwebui-config.XXXXXX")"
+
+  local models_file="${work_dir}/mere-models.json"
+  echo "Checking mere.run provider models for Open WebUI chat filtering"
+  curl_json GET "/models" >"${models_file}"
+
+  local chat_models
+  chat_models="$(chat_models_json "${models_file}")"
+  echo "Configuring Open WebUI chat models: ${chat_models}"
+
+  local token
+  token="$(openwebui_token)"
+
+  configure_openwebui_payloads "${work_dir}" "${chat_models}"
+
+  openwebui_json POST "/openai/config/update" "${token}" "$(cat "${work_dir}/openai-config.json")" >/dev/null
+  openwebui_json POST "/api/v1/configs/models" "${token}" "$(cat "${work_dir}/models-config.json")" >/dev/null
+  openwebui_json POST "/api/v1/models/import" "${token}" "$(cat "${work_dir}/models-import.json")" >/dev/null
+
+  openwebui_json GET "/api/models" "${token}" >"${work_dir}/openwebui-models.json"
+  python3 - "${work_dir}/openwebui-models.json" "${chat_models}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+expected = set(json.loads(sys.argv[2]))
+ids = {item.get("id") for item in payload.get("data", [])}
+missing = sorted(expected - ids)
+if missing:
+    raise SystemExit(f"Open WebUI model list is missing configured ids: {', '.join(missing)}")
+print("Open WebUI models configured:", ", ".join(sorted(expected)))
+PY
+  rm -rf "${work_dir}"
+}
+
+model_present() {
+  local models_file="$1"
+  local model_id="$2"
+  python3 - "$models_file" "$model_id" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+ids = {item.get("id") for item in payload.get("data", [])}
+raise SystemExit(0 if sys.argv[2] in ids else 1)
+PY
+}
+
+write_smoke_png() {
+  local output="$1"
+  python3 - "$output" <<'PY'
+import base64
+import sys
+
+png = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+    "/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+with open(sys.argv[1], "wb") as fh:
+    fh.write(base64.b64decode(png))
+PY
+}
+
+print_env() {
+  cat <<ENV
+OPENAI_API_BASE_URL=${MERERUN_API_URL}
+OPENAI_API_BASE_URLS=${MERERUN_API_URL}
+OPENAI_API_KEY=${MERERUN_API_KEY}
+OPENAI_API_KEYS=${MERERUN_API_KEY}
+DEFAULT_MODELS=${MERERUN_OPENWEBUI_TEXT_MODEL}
+DEFAULT_MODEL_PARAMS=${OPEN_WEBUI_MODEL_PARAMS}
+DEFAULT_MODEL_METADATA=${OPEN_WEBUI_MODEL_METADATA}
+RAG_EMBEDDING_ENGINE=openai
+RAG_OPENAI_API_BASE_URL=${MERERUN_API_URL}
+RAG_OPENAI_API_KEY=${MERERUN_API_KEY}
+RAG_EMBEDDING_MODEL=${MERERUN_OPENWEBUI_EMBED_MODEL}
+ENABLE_IMAGE_GENERATION=True
+ENABLE_IMAGE_EDIT=False
+IMAGE_GENERATION_ENGINE=openai
+IMAGE_GENERATION_MODEL=${MERERUN_OPENWEBUI_IMAGE_MODEL}
+IMAGE_SIZE=1024x1024
+IMAGE_EDIT_ENGINE=openai
+IMAGE_EDIT_MODEL=${MERERUN_OPENWEBUI_IMAGE_EDIT_MODEL}
+IMAGE_EDIT_SIZE=1024x1024
+IMAGES_OPENAI_API_BASE_URL=${MERERUN_API_URL}
+IMAGES_OPENAI_API_KEY=${MERERUN_API_KEY}
+IMAGES_EDIT_OPENAI_API_BASE_URL=${MERERUN_API_URL}
+IMAGES_EDIT_OPENAI_API_KEY=${MERERUN_API_KEY}
+AUDIO_TTS_ENGINE=openai
+AUDIO_TTS_MODEL=${MERERUN_OPENWEBUI_TTS_MODEL}
+AUDIO_TTS_VOICE=nova
+AUDIO_TTS_OPENAI_API_BASE_URL=${MERERUN_API_URL}
+AUDIO_TTS_OPENAI_API_KEY=${MERERUN_API_KEY}
+AUDIO_TTS_OPENAI_PARAMS={"response_format":"${MERERUN_OPENWEBUI_TTS_FORMAT}"}
+AUDIO_STT_ENGINE=openai
+AUDIO_STT_MODEL=${MERERUN_OPENWEBUI_STT_MODEL}
+AUDIO_STT_OPENAI_API_BASE_URL=${MERERUN_API_URL}
+AUDIO_STT_OPENAI_API_KEY=${MERERUN_API_KEY}
+ENABLE_PERSISTENT_CONFIG=False
+WEBUI_AUTH=False
+ENV
+}
+
+docker_run() {
+  command -v docker >/dev/null 2>&1 || {
+    echo "docker is required for docker-run" >&2
+    exit 127
+  }
+
+  if [[ "${MERERUN_OPENWEBUI_RESET:-0}" == "1" ]]; then
+    docker rm -f "${OPEN_WEBUI_CONTAINER}" >/dev/null 2>&1 || true
+    docker volume rm "${OPEN_WEBUI_VOLUME}" >/dev/null 2>&1 || true
+  elif docker ps -a --format '{{.Names}}' | grep -Fxq "${OPEN_WEBUI_CONTAINER}"; then
+    echo "Container ${OPEN_WEBUI_CONTAINER} already exists. Set MERERUN_OPENWEBUI_RESET=1 to recreate it." >&2
+    exit 1
+  fi
+
+  docker run -d \
+    --name "${OPEN_WEBUI_CONTAINER}" \
+    --restart unless-stopped \
+    -p "${OPEN_WEBUI_PORT}:8080" \
+    --add-host=host.docker.internal:host-gateway \
+    -e OPENAI_API_BASE_URL="${MERERUN_DOCKER_API_URL}" \
+    -e OPENAI_API_BASE_URLS="${MERERUN_DOCKER_API_URL}" \
+    -e OPENAI_API_KEY="${MERERUN_API_KEY}" \
+    -e OPENAI_API_KEYS="${MERERUN_API_KEY}" \
+    -e DEFAULT_MODELS="${MERERUN_OPENWEBUI_TEXT_MODEL}" \
+    -e DEFAULT_MODEL_PARAMS="${OPEN_WEBUI_MODEL_PARAMS}" \
+    -e DEFAULT_MODEL_METADATA="${OPEN_WEBUI_MODEL_METADATA}" \
+    -e RAG_EMBEDDING_ENGINE=openai \
+    -e RAG_OPENAI_API_BASE_URL="${MERERUN_DOCKER_API_URL}" \
+    -e RAG_OPENAI_API_KEY="${MERERUN_API_KEY}" \
+    -e RAG_EMBEDDING_MODEL="${MERERUN_OPENWEBUI_EMBED_MODEL}" \
+    -e ENABLE_IMAGE_GENERATION=True \
+    -e ENABLE_IMAGE_EDIT=False \
+    -e IMAGE_GENERATION_ENGINE=openai \
+    -e IMAGE_GENERATION_MODEL="${MERERUN_OPENWEBUI_IMAGE_MODEL}" \
+    -e IMAGE_SIZE=1024x1024 \
+    -e IMAGE_EDIT_ENGINE=openai \
+    -e IMAGE_EDIT_MODEL="${MERERUN_OPENWEBUI_IMAGE_EDIT_MODEL}" \
+    -e IMAGE_EDIT_SIZE=1024x1024 \
+    -e IMAGES_OPENAI_API_BASE_URL="${MERERUN_DOCKER_API_URL}" \
+    -e IMAGES_OPENAI_API_KEY="${MERERUN_API_KEY}" \
+    -e IMAGES_EDIT_OPENAI_API_BASE_URL="${MERERUN_DOCKER_API_URL}" \
+    -e IMAGES_EDIT_OPENAI_API_KEY="${MERERUN_API_KEY}" \
+    -e AUDIO_TTS_ENGINE=openai \
+    -e AUDIO_TTS_MODEL="${MERERUN_OPENWEBUI_TTS_MODEL}" \
+    -e AUDIO_TTS_VOICE=nova \
+    -e AUDIO_TTS_OPENAI_API_BASE_URL="${MERERUN_DOCKER_API_URL}" \
+    -e AUDIO_TTS_OPENAI_API_KEY="${MERERUN_API_KEY}" \
+    -e AUDIO_TTS_OPENAI_PARAMS="{\"response_format\":\"${MERERUN_OPENWEBUI_TTS_FORMAT}\"}" \
+    -e AUDIO_STT_ENGINE=openai \
+    -e AUDIO_STT_MODEL="${MERERUN_OPENWEBUI_STT_MODEL}" \
+    -e AUDIO_STT_OPENAI_API_BASE_URL="${MERERUN_DOCKER_API_URL}" \
+    -e AUDIO_STT_OPENAI_API_KEY="${MERERUN_API_KEY}" \
+    -e ENABLE_PERSISTENT_CONFIG=False \
+    -e WEBUI_AUTH=False \
+    -v "${OPEN_WEBUI_VOLUME}:/app/backend/data" \
+    "${OPEN_WEBUI_IMAGE}"
+
+  echo "Open WebUI smoke container starting at http://127.0.0.1:${OPEN_WEBUI_PORT}"
+}
+
+api_smoke() {
+  local work_dir
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/mere-openwebui-smoke.XXXXXX")"
+
+  local models_file="${work_dir}/models.json"
+  echo "Checking ${MERERUN_API_URL%/}/models"
+  curl_json GET "/models" >"${models_file}"
+
+  python3 - "$models_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+ids = [item.get("id") for item in payload.get("data", [])]
+print("Models:", ", ".join(ids))
+PY
+
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_TEXT_MODEL}"; then
+    echo "Smoking text chat: ${MERERUN_OPENWEBUI_TEXT_MODEL}"
+    curl_json POST "/chat/completions" "{
+      \"model\":\"${MERERUN_OPENWEBUI_TEXT_MODEL}\",
+      \"messages\":[{\"role\":\"user\",\"content\":\"Reply with only: mere.run online\"}],
+      \"max_tokens\":16
+    }" >/dev/null
+  else
+    echo "Skipping text chat; ${MERERUN_OPENWEBUI_TEXT_MODEL} is not listed."
+  fi
+
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_VISION_MODEL}"; then
+    echo "Smoking vision chat: ${MERERUN_OPENWEBUI_VISION_MODEL}"
+    local image_path="${work_dir}/smoke.png"
+    write_smoke_png "${image_path}"
+    local image_data_url
+    image_data_url="$(python3 - "$image_path" <<'PY'
+import base64
+import sys
+
+with open(sys.argv[1], "rb") as fh:
+    print("data:image/png;base64," + base64.b64encode(fh.read()).decode())
+PY
+)"
+    curl_json POST "/chat/completions" "{
+      \"model\":\"${MERERUN_OPENWEBUI_VISION_MODEL}\",
+      \"messages\":[{
+        \"role\":\"user\",
+        \"content\":[
+          {\"type\":\"text\",\"text\":\"Describe this image in one short sentence.\"},
+          {\"type\":\"image_url\",\"image_url\":{\"url\":\"${image_data_url}\"}}
+        ]
+      }],
+      \"max_tokens\":64
+    }" >/dev/null
+  else
+    echo "Skipping vision chat; ${MERERUN_OPENWEBUI_VISION_MODEL} is not listed."
+  fi
+
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_EMBED_MODEL}"; then
+    echo "Smoking embeddings: ${MERERUN_OPENWEBUI_EMBED_MODEL}"
+    curl_json POST "/embeddings" "{
+      \"model\":\"${MERERUN_OPENWEBUI_EMBED_MODEL}\",
+      \"input\":[\"mere.run native embeddings\",\"Open WebUI RAG\"]
+    }" >/dev/null
+  else
+    echo "Skipping embeddings; ${MERERUN_OPENWEBUI_EMBED_MODEL} is not listed."
+  fi
+
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_IMAGE_MODEL}"; then
+    echo "Smoking image generation: ${MERERUN_OPENWEBUI_IMAGE_MODEL}"
+    curl_json POST "/images/generations" "{
+      \"model\":\"${MERERUN_OPENWEBUI_IMAGE_MODEL}\",
+      \"prompt\":\"a compact local AI workstation in morning light\",
+      \"size\":\"1024x1024\",
+      \"response_format\":\"b64_json\"
+    }" >/dev/null
+  else
+    echo "Skipping image generation; ${MERERUN_OPENWEBUI_IMAGE_MODEL} is not listed."
+  fi
+
+  local speech_file="${work_dir}/speech.${MERERUN_OPENWEBUI_TTS_FORMAT}"
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_TTS_MODEL}"; then
+    echo "Smoking TTS: ${MERERUN_OPENWEBUI_TTS_MODEL} (${MERERUN_OPENWEBUI_TTS_FORMAT})"
+    curl -fsS -X POST "${MERERUN_API_URL%/}/audio/speech" \
+      -H "Authorization: Bearer ${MERERUN_API_KEY}" \
+      -H "Content-Type: application/json" \
+      --output "${speech_file}" \
+      --data "{
+        \"model\":\"${MERERUN_OPENWEBUI_TTS_MODEL}\",
+        \"input\":\"Open WebUI is speaking through mere.run.\",
+        \"voice\":\"nova\",
+        \"response_format\":\"${MERERUN_OPENWEBUI_TTS_FORMAT}\"
+      }"
+    test -s "${speech_file}"
+  else
+    echo "Skipping TTS; ${MERERUN_OPENWEBUI_TTS_MODEL} is not listed."
+  fi
+
+  if [[ -s "${speech_file}" ]] && model_present "${models_file}" "${MERERUN_OPENWEBUI_STT_MODEL}"; then
+    echo "Smoking STT: ${MERERUN_OPENWEBUI_STT_MODEL}"
+    curl -fsS -X POST "${MERERUN_API_URL%/}/audio/transcriptions" \
+      -H "Authorization: Bearer ${MERERUN_API_KEY}" \
+      -F "model=${MERERUN_OPENWEBUI_STT_MODEL}" \
+      -F "response_format=json" \
+      -F "file=@${speech_file}" >/dev/null
+  else
+    echo "Skipping STT; missing speech file or ${MERERUN_OPENWEBUI_STT_MODEL} is not listed."
+  fi
+  rm -rf "${work_dir}"
+}
+
+proxy_smoke() {
+  wait_openwebui
+  local work_dir
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/mere-openwebui-proxy.XXXXXX")"
+
+  local token
+  token="$(openwebui_token)"
+
+  local models_file="${work_dir}/openwebui-models.json"
+  openwebui_json GET "/api/models" "${token}" >"${models_file}"
+
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_TEXT_MODEL}"; then
+    echo "Smoking Open WebUI text proxy: ${MERERUN_OPENWEBUI_TEXT_MODEL}"
+    openwebui_json POST "/api/chat/completions" "${token}" "{
+      \"model\":\"${MERERUN_OPENWEBUI_TEXT_MODEL}\",
+      \"messages\":[{\"role\":\"user\",\"content\":\"Reply with only: mere.run via Open WebUI\"}],
+      \"stream\":false,
+      \"max_tokens\":24
+    }" >/dev/null
+  else
+    echo "Skipping Open WebUI text proxy; ${MERERUN_OPENWEBUI_TEXT_MODEL} is not listed."
+  fi
+
+  if model_present "${models_file}" "${MERERUN_OPENWEBUI_VISION_MODEL}"; then
+    echo "Smoking Open WebUI vision proxy: ${MERERUN_OPENWEBUI_VISION_MODEL}"
+    local image_path="${work_dir}/smoke.png"
+    write_smoke_png "${image_path}"
+    local image_data_url
+    image_data_url="$(python3 - "$image_path" <<'PY'
+import base64
+import sys
+
+with open(sys.argv[1], "rb") as fh:
+    print("data:image/png;base64," + base64.b64encode(fh.read()).decode())
+PY
+)"
+    openwebui_json POST "/api/chat/completions" "${token}" "{
+      \"model\":\"${MERERUN_OPENWEBUI_VISION_MODEL}\",
+      \"messages\":[{
+        \"role\":\"user\",
+        \"content\":[
+          {\"type\":\"text\",\"text\":\"Describe this image in one short sentence.\"},
+          {\"type\":\"image_url\",\"image_url\":{\"url\":\"${image_data_url}\"}}
+        ]
+      }],
+      \"stream\":false,
+      \"max_tokens\":64
+    }" >/dev/null
+  else
+    echo "Skipping Open WebUI vision proxy; ${MERERUN_OPENWEBUI_VISION_MODEL} is not listed."
+  fi
+
+  rm -rf "${work_dir}"
+}
+
+ui_smoke() {
+  wait_openwebui
+  local work_dir
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/mere-openwebui-ui.XXXXXX")"
+
+  curl -fsS "${OPEN_WEBUI_URL%/}/" >"${work_dir}/index.html"
+  if ! grep -Eiq '(<html|Open WebUI)' "${work_dir}/index.html"; then
+    echo "Open WebUI root did not look like an HTML UI." >&2
+    exit 1
+  fi
+
+  local token
+  token="$(openwebui_token)"
+
+  openwebui_json GET "/api/config" "${token}" >"${work_dir}/config.json"
+  openwebui_json GET "/api/models" "${token}" >"${work_dir}/models.json"
+
+  python3 - "${work_dir}/models.json" "${OPEN_WEBUI_CHAT_MODELS}" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+expected = {item for item in re.split(r"[;,]", sys.argv[2]) if item}
+ids = {item.get("id") for item in payload.get("data", []) if item.get("id")}
+missing = sorted(expected - ids)
+if missing:
+    raise SystemExit(f"Open WebUI UI model list is missing: {', '.join(missing)}")
+print("Open WebUI UI smoke models:", ", ".join(sorted(expected)))
+PY
+  rm -rf "${work_dir}"
+}
+
+live_smoke() {
+  configure_openwebui
+  proxy_smoke
+  api_smoke
+  ui_smoke
+}
+
+stop_openwebui() {
+  command -v docker >/dev/null 2>&1 || return 0
+  docker rm -f "${OPEN_WEBUI_CONTAINER}" >/dev/null 2>&1 || true
+}
+
+command_name="${1:-help}"
+case "${command_name}" in
+  print-env)
+    print_env
+    ;;
+  docker-run)
+    docker_run
+    ;;
+  configure)
+    configure_openwebui
+    ;;
+  proxy-smoke)
+    proxy_smoke
+    ;;
+  api-smoke)
+    api_smoke
+    ;;
+  ui-smoke)
+    ui_smoke
+    ;;
+  live-smoke)
+    live_smoke
+    ;;
+  stop)
+    stop_openwebui
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add OpenAI-compatible embeddings, image generation/editing, TTS, and STT routes so Open WebUI can use mere.run-native RAG, image, and audio paths
- add `mere.run open-webui quickstart`, an Open WebUI guide, Docker/pip/uv/Compose recipes, and `scripts/smoke-open-webui.sh` for live companion smoke testing
- polish model listing and compatibility behavior for Open WebUI, including installed-only sidecar exposure, specific `tool_choice` handling, image edit settings, audio response formats, and STT subtitle formats
- include the pathing and runtime-error fixes around image model validation/model roots so the media flows fail clearly and resolve component directories correctly

## Validation
- `pnpm docs:build`
- `./scripts/check.sh`
- `git diff --cached --check`
- live Open WebUI smoke against `text-chat-gemma4-12b` and `vision-chat-gemma4-12b` during development

## Notes
- Open WebUI is linked as an optional companion only; this does not vendor or rebrand it.
- `remixes/` generated artifacts remain untracked and are not part of this PR.