### PR TITLE
Clean up LTX docs language

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,7 +139,7 @@ Video generation:
   - `Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift`
   - `Sources/MereRunCore/LTX/LTXVideoMP4Writer.swift`
 
-The LTX file is still large because it also contains low-level model
+The LTX runtime combines public generation flow with lower-level model
 definitions. Read it in this order:
 
 - public generation types and `LTXDistilledLatentGenerator`

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -69,19 +69,19 @@ swift run mere.run video export-latents \
 
 ### CLI
 
-- `Sources/MereRunCLI/Commands/VideoGenerateCommand.swift`
-- `Sources/MereRunCLI/Commands/VideoExportLatentsCommand.swift`
 - `Sources/MereRunCLI/Commands/VideoCommand.swift`
 
 ### Runtime
 
 - `Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift`
+- `Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift`
+- `Sources/MereRunCore/LTX/LTXVideoMP4Writer.swift`
 
-## Important note on code shape
+## Source Reading Notes
 
-The LTX runtime is still the largest major runtime file in the repo. It is not
-an architecture mess anymore, but it still contains more low-level video-model
-logic than the other family entrypoints.
+The LTX runtime has more low-level model, media, and checkpoint-layout code
+than most other runtime families in this repo. Start from the public generation
+flow before reading the lower-level model definitions.
 
 The best reading order is:
 


### PR DESCRIPTION
## Summary
- replace informal/self-roasty LTX runtime wording with neutral source reading guidance
- update the video runtime docs to point at the current `VideoCommand.swift` entrypoint and supporting LTX files

## Validation
- `pnpm docs:build`
- docs wording scan for informal terms like `mess`, `hacky`, `janky`, `wtf`, and `lol` came back clean

## Notes
- Follow-up to PR #73, which had already merged before the wording cleanup landed on the old branch.
