### PR TITLE
Prepare 0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.16.0 - 2026-06-16
+
+### Added
+
+- added native LTX 2.3 unified audio/video generation through the managed
+  `video-ltx23-av-mlx` model, including the split MLX checkpoint layout,
+  Gemma 3 prompt-conditioning companion model, separate video/audio VAE files,
+  BWE vocoder, and LTX 2.3 upscaler components.
+- added LTX 2.3 guidance across the CLI, runtime, model-source, and testing
+  docs, with examples that pull `video-ltx23-av-mlx` and render synchronized
+  audio/video at the trained 24 fps timing.
+- added `scripts/compare-ltx-av-audio.py` to compare native unified-AV output
+  against upstream LTX-2 media and inspect codec, sample-rate, loudness, and
+  model-root hints when validating audio quality.
+
+### Changed
+
+- changed `video generate --duration` handling for LTX to resolve to valid
+  frame counts and warn when unified-AV renders use timing that can stretch
+  motion relative to audio.
+- changed `model info --components` to render LTX 2.3 split-model components
+  directly, including resolved symlink targets and companion text-encoder
+  readiness, instead of forcing the layout through generic file enumeration.
+
+### Fixed
+
+- fixed LTX unified-AV MP4 assembly so native audio is written at the expected
+  24 kHz path and muxed through the shared media I/O layer on both Apple and
+  FFmpeg-backed platforms.
+- fixed LTX model validation and managed-model metadata for the split LTX 2.3
+  layout so pulls, model info, and video generation agree on the required files.
+
 ## 0.15.0 - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ artifacts. See the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for
 the current validation boundary, CUDA notes, and first commands:
 
 ```bash
-tag=v0.15.0
+tag=v0.16.0
 version="${tag#v}"
 
 # Portable tarball
@@ -114,7 +114,7 @@ installed launcher also exports the resolved CUDA CCCL include root through
 during NVRTC JIT compilation:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.15.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.16.0
 ```
 
 Current CUDA validation should be treated as limited to the exact hosts that
@@ -159,14 +159,14 @@ swift run mere.run --help
 To build Linux release packages from a Linux x86_64 Swift toolchain host:
 
 ```bash
-scripts/package-linux.sh --version 0.15.0
+scripts/package-linux.sh --version 0.16.0
 ls dist/linux/
 ```
 
 On Linux arm64, use a CUDA-provisioned host:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.15.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.16.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.15.0"
+    static let current = "0.16.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.15.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.16.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -99,7 +99,7 @@ Linux release packaging is a separate path for distributable headless CLI
 artifacts. The default GitHub release workflow publishes x86_64/amd64 artifacts:
 
 ```bash
-scripts/package-linux.sh --version 0.15.0
+scripts/package-linux.sh --version 0.16.0
 ls dist/linux/
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Linux-only setup path, first commands, release checks, and CUDA validation
 limits, see [Linux QuickStart](./linux-quickstart.md).
 
 ```bash
-tag=v0.15.0
+tag=v0.16.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64; deb_arch=amd64 ;;

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -29,7 +29,7 @@ and CUDA-gated arm64 package work.
 Use this path on Debian or Ubuntu-style systems:
 
 ```bash
-tag=v0.15.0
+tag=v0.16.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) deb_arch=amd64 ;;
@@ -50,7 +50,7 @@ assets that the CLI needs at runtime.
 Use this path when you do not want to install a Debian package:
 
 ```bash
-tag=v0.15.0
+tag=v0.16.0
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -116,7 +116,7 @@ repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.15.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.16.0
 ls dist/linux/
 ```
 
@@ -183,7 +183,7 @@ studio, and DMG packaging are macOS-only.
 Each Linux release includes `SHA256SUMS` beside the tarball and `.deb`:
 
 ```bash
-tag=v0.15.0
+tag=v0.16.0
 
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/SHA256SUMS" -o SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,7 +86,7 @@ CPU-oriented Linux manifest path.
 Linux release packaging has its own artifact check:
 
 ```bash
-scripts/package-linux.sh --version 0.15.0
+scripts/package-linux.sh --version 0.16.0
 test -s dist/linux/SHA256SUMS
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
@@ -97,7 +97,7 @@ dpkg-deb --contents dist/linux/mere-run_*_*.deb | grep 'usr/bin/mere.run'
 On Linux arm64, use CUDA for the package check:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.15.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.16.0
 ```
 
 The `linux-release` workflow runs the hosted package and manifest boundary for

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 configuration="${1:-debug}"
-app_version="${MERERUN_APP_VERSION:-0.15.0}"
-app_build="${MERERUN_APP_BUILD:-27}"
+app_version="${MERERUN_APP_VERSION:-0.16.0}"
+app_build="${MERERUN_APP_BUILD:-28}"
 case "$configuration" in
   debug|release) ;;
   *)


### PR DESCRIPTION
## Summary
- bump the public CLI/app release version to 0.16.0 and app build to 28
- add 0.16.0 changelog notes for LTX 2.3 unified AV, split MLX model support, model-info layout rendering, and audio validation tooling
- update release/install/package snippets to point at v0.16.0

## Validation
- ./scripts/check.sh
- pnpm docs:build
- swift run mere.run --version