### PR TITLE
Refresh vendored Mere docs theme

### DIFF
--- a/docs/.vitepress/theme/mere/MereLayout.vue
+++ b/docs/.vitepress/theme/mere/MereLayout.vue
@@ -1,25 +1,39 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import DefaultTheme from 'vitepress/theme'
 import MereAtlasMap from './components/MereAtlasMap.vue'
 import MereDocSignal from './components/MereDocSignal.vue'
 import MereDocsNetwork from './components/MereDocsNetwork.vue'
+import { useMereDocsThemeConfig } from './config'
 
 const { Layout } = DefaultTheme
+const themeConfig = useMereDocsThemeConfig()
+
+const keyColorStyle = computed(() => ({
+  '--mere-key': themeConfig.keyColor.light,
+  '--mere-key-hover': themeConfig.keyColor.lightHover,
+  '--mere-key-contrast': themeConfig.keyColor.lightContrast,
+  '--mere-key-dark': themeConfig.keyColor.dark,
+  '--mere-key-dark-hover': themeConfig.keyColor.darkHover,
+  '--mere-key-dark-contrast': themeConfig.keyColor.darkContrast,
+}))
 </script>
 
 <template>
-  <Layout>
-    <template #nav-bar-title-before>
-      <span class="mere-nav-mark" aria-hidden="true" />
-    </template>
-    <template #home-hero-image>
-      <MereAtlasMap />
-    </template>
-    <template #doc-before>
-      <MereDocSignal />
-    </template>
-    <template #aside-outline-after>
-      <MereDocsNetwork />
-    </template>
-  </Layout>
+  <div class="mere-docs-theme" :style="keyColorStyle">
+    <Layout>
+      <template #nav-bar-title-before>
+        <span class="mere-nav-mark" aria-hidden="true" />
+      </template>
+      <template #home-hero-image>
+        <MereAtlasMap />
+      </template>
+      <template #doc-before>
+        <MereDocSignal />
+      </template>
+      <template #aside-outline-after>
+        <MereDocsNetwork />
+      </template>
+    </Layout>
+  </div>
 </template>

--- a/docs/.vitepress/theme/mere/config.ts
+++ b/docs/.vitepress/theme/mere/config.ts
@@ -2,6 +2,61 @@ import { inject, type App, type InjectionKey } from 'vue'
 
 export type MereAtlasAccent = 'green' | 'blue' | 'plum' | 'copper'
 
+export interface MereDocsKeyColor {
+  light: string
+  lightHover: string
+  lightContrast: string
+  dark: string
+  darkHover: string
+  darkContrast: string
+}
+
+function defineMereDocsKeyColor(
+  light: string,
+  lightHover: string,
+  dark: string,
+  darkHover: string,
+  lightContrast = '#FCFCFB',
+  darkContrast = '#171714',
+): MereDocsKeyColor {
+  return {
+    light,
+    lightHover,
+    lightContrast,
+    dark,
+    darkHover,
+    darkContrast,
+  }
+}
+
+export const mereDocsKeyColors = {
+  docs: defineMereDocsKeyColor('#3B4EA0', '#2F3E82', '#AEBBFF', '#CAD2FF'),
+  world: defineMereDocsKeyColor('#0E7A4E', '#0B623F', '#65D6A4', '#96E9C3'),
+  business: defineMereDocsKeyColor('#24566E', '#1B4559', '#75C0DA', '#A0DAEA'),
+  agent: defineMereDocsKeyColor('#6E3878', '#582C61', '#D69CDF', '#E8C2EE'),
+  email: defineMereDocsKeyColor('#2D6C9B', '#22567D', '#8BC9F0', '#B6DDF6'),
+  today: defineMereDocsKeyColor('#9C6F1A', '#7C5814', '#E8C469', '#F2D991', '#171714', '#171714'),
+  gives: defineMereDocsKeyColor('#A84E2C', '#873D22', '#EA9A78', '#F2BCA7'),
+  network: defineMereDocsKeyColor('#1C7373', '#165C5C', '#73D6D1', '#A1E8E3'),
+  dynasite: defineMereDocsKeyColor('#27708B', '#1D5A70', '#81CADF', '#AEE0EA'),
+  video: defineMereDocsKeyColor('#9A4C37', '#7B3A29', '#E69C86', '#F0BEAD'),
+  ink: defineMereDocsKeyColor('#1A1A17', '#11110F', '#D5D2C8', '#E8E5DC'),
+  works: defineMereDocsKeyColor('#415B91', '#334874', '#9DB9F1', '#C0D1F7'),
+  finance: defineMereDocsKeyColor('#1F7044', '#185937', '#7AD39C', '#A6E7BD'),
+  fit: defineMereDocsKeyColor('#527A2A', '#416221', '#A9D477', '#C7E79F', '#171714', '#171714'),
+  earth: defineMereDocsKeyColor('#66712B', '#535C22', '#C3D277', '#DBE79F', '#171714', '#171714'),
+  im: defineMereDocsKeyColor('#23668F', '#1A5273', '#82C6ED', '#AFDCF6'),
+  media: defineMereDocsKeyColor('#873E78', '#6C315F', '#DB9BD0', '#EDBFE7'),
+  news: defineMereDocsKeyColor('#965D24', '#784A1C', '#E2B16A', '#EECF94'),
+  projects: defineMereDocsKeyColor('#7A5B2A', '#614820', '#D8B876', '#E7D09B'),
+  zone: defineMereDocsKeyColor('#733E93', '#5B3175', '#C9A0EC', '#DDC0F4'),
+  deliver: defineMereDocsKeyColor('#A1661B', '#805014', '#E6BE6D', '#F0D493', '#171714', '#171714'),
+  run: defineMereDocsKeyColor('#3159A8', '#274687', '#93B5F4', '#B9CDF8'),
+} satisfies Record<string, MereDocsKeyColor>
+
+export type MereDocsKeyColorName = keyof typeof mereDocsKeyColors
+export type MereDocsKeyColorInput = MereDocsKeyColorName | Partial<MereDocsKeyColor>
+
 export interface MereAtlasPlane {
   name: string
   signal: string
@@ -26,6 +81,7 @@ export interface MereDocSectionSignal {
 }
 
 export interface MereDocsThemeConfig {
+  keyColor: MereDocsKeyColor
   atlas: {
     eyebrowLeft: string
     eyebrowRight: string
@@ -40,6 +96,7 @@ export interface MereDocsThemeConfig {
 }
 
 export type MereDocsThemeUserConfig = Partial<{
+  keyColor: MereDocsKeyColorInput
   atlas: Partial<MereDocsThemeConfig['atlas']>
   docsNetworkLabel: string
   docsNetworkLinks: MereDocsLink[]
@@ -48,6 +105,7 @@ export type MereDocsThemeUserConfig = Partial<{
 }>
 
 export const defaultMereDocsThemeConfig: MereDocsThemeConfig = {
+  keyColor: mereDocsKeyColors.docs,
   atlas: {
     eyebrowLeft: 'mere-docs.mere.world',
     eyebrowRight: 'atlas online',
@@ -159,6 +217,92 @@ export const defaultMereDocsThemeConfig: MereDocsThemeConfig = {
 
 const mereDocsThemeConfigKey: InjectionKey<MereDocsThemeConfig> = Symbol('mereDocsThemeConfig')
 
+export function resolveMereDocsKeyColor(input: MereDocsKeyColorInput = 'docs'): MereDocsKeyColor {
+  if (typeof input === 'string') {
+    return mereDocsKeyColors[input] ?? mereDocsKeyColors.docs
+  }
+
+  return {
+    ...mereDocsKeyColors.docs,
+    ...input,
+  }
+}
+
+const mereProductKeyColorAliases: Array<[string, MereDocsKeyColorName]> = [
+  ['mere-docs', 'docs'],
+  ['mere docs', 'docs'],
+  ['mer-finance', 'finance'],
+  ['mere.fi', 'finance'],
+  ['mere-cli', 'run'],
+  ['cli-docs', 'run'],
+  ['merekit-cli', 'run'],
+  ['merekit link', 'works'],
+  ['merekit-link', 'works'],
+  ['sites.merekit', 'dynasite'],
+  ['merekit sites', 'dynasite'],
+  ['meresmb', 'projects'],
+  ['agent', 'agent'],
+  ['business', 'business'],
+  ['deliver', 'deliver'],
+  ['dynasite', 'dynasite'],
+  ['earth', 'earth'],
+  ['email', 'email'],
+  ['finance', 'finance'],
+  ['fit', 'fit'],
+  ['gives', 'gives'],
+  ['ink', 'ink'],
+  ['media', 'media'],
+  ['network', 'network'],
+  ['news', 'news'],
+  ['projects', 'projects'],
+  ['run', 'run'],
+  ['today', 'today'],
+  ['video', 'video'],
+  ['works', 'works'],
+  ['world', 'world'],
+  ['zone', 'zone'],
+  ['im', 'im'],
+]
+
+function normalizeMereKeyMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function hasMereKeyMatch(term: string, needle: string): boolean {
+  const normalizedNeedle = normalizeMereKeyMatch(needle)
+  return (
+    term === normalizedNeedle ||
+    term.startsWith(`${normalizedNeedle}-`) ||
+    term.endsWith(`-${normalizedNeedle}`) ||
+    term.includes(`-${normalizedNeedle}-`)
+  )
+}
+
+export function resolveMereProductDocsKeyColor(
+  productName: string,
+  productDomain: string,
+  keyColor?: MereDocsKeyColorInput,
+): MereDocsKeyColor {
+  if (keyColor) {
+    return resolveMereDocsKeyColor(keyColor)
+  }
+
+  const searchTerms = Array.from(
+    new Set(
+      [productName, productDomain, productDomain.replace(/^docs\./, '')]
+        .map(normalizeMereKeyMatch)
+        .filter(Boolean),
+    ),
+  )
+  const match = mereProductKeyColorAliases.find(([needle]) =>
+    searchTerms.some((term) => hasMereKeyMatch(term, needle)),
+  )
+  return resolveMereDocsKeyColor(match?.[1] ?? 'docs')
+}
+
 export function defineMereDocsThemeConfig(config: MereDocsThemeUserConfig): MereDocsThemeUserConfig {
   return config
 }
@@ -167,6 +311,7 @@ export function resolveMereDocsThemeConfig(config: MereDocsThemeUserConfig = {})
   return {
     ...defaultMereDocsThemeConfig,
     ...config,
+    keyColor: resolveMereDocsKeyColor(config.keyColor ?? defaultMereDocsThemeConfig.keyColor),
     atlas: {
       ...defaultMereDocsThemeConfig.atlas,
       ...config.atlas,

--- a/docs/.vitepress/theme/mere/index.ts
+++ b/docs/.vitepress/theme/mere/index.ts
@@ -6,7 +6,9 @@ import MereLayout from './MereLayout.vue'
 import {
   defaultMereDocsThemeConfig,
   provideMereDocsThemeConfig,
+  resolveMereProductDocsKeyColor,
   type MereAtlasPlane,
+  type MereDocsKeyColorInput,
   type MereDocsThemeUserConfig,
 } from './config.js'
 import './mere-theme.css'
@@ -18,6 +20,7 @@ export interface MereProductDocsThemeOptions {
   productDomain: string
   docsUrl: string
   productHref?: string
+  keyColor?: MereDocsKeyColorInput
   corePrefix?: string
   coreSuffix?: string
   guideHref?: string
@@ -80,6 +83,7 @@ export function createMereProductDocsTheme(options: MereProductDocsThemeOptions)
   ]
 
   return createMereDocsTheme({
+    keyColor: resolveMereProductDocsKeyColor(options.productName, options.productDomain, options.keyColor),
     atlas: {
       eyebrowLeft: options.docsUrl.replace(/^https?:\/\//, '').replace(/\/$/, ''),
       eyebrowRight: 'docs online',

--- a/docs/.vitepress/theme/mere/mere-theme.css
+++ b/docs/.vitepress/theme/mere/mere-theme.css
@@ -1,50 +1,52 @@
 :root {
-  --mere-canvas: oklch(97.2% 0.013 92);
-  --mere-surface: oklch(99% 0.008 95);
-  --mere-surface-raised: oklch(96.2% 0.016 105);
-  --mere-surface-muted: oklch(93.4% 0.021 118);
-  --mere-ink: oklch(22% 0.025 132);
-  --mere-ink-soft: oklch(38% 0.031 145);
-  --mere-ink-muted: oklch(52% 0.028 145);
-  --mere-line: oklch(84% 0.025 118);
-  --mere-line-strong: oklch(74% 0.04 126);
-  --mere-green: oklch(47% 0.11 155);
-  --mere-green-bright: oklch(68% 0.12 155);
-  --mere-blue: oklch(50% 0.12 230);
-  --mere-plum: oklch(46% 0.11 315);
-  --mere-copper: oklch(56% 0.12 55);
-  --mere-warning: oklch(62% 0.12 76);
-  --mere-danger: oklch(56% 0.15 28);
-  --mere-focus: oklch(62% 0.13 210);
-  --mere-shadow: 0 18px 48px color-mix(in oklch, var(--mere-ink) 11%, transparent);
-  --mere-shadow-soft: 0 10px 32px color-mix(in oklch, var(--mere-ink) 8%, transparent);
+  --mere-canvas: #F4F4F2;
+  --mere-paper: #FCFCFB;
+  --mere-surface: #F8F8F6;
+  --mere-surface-raised: #EFEEEA;
+  --mere-surface-muted: #E7E5E0;
+  --mere-ink: #1A1A17;
+  --mere-ink-soft: #5B5A53;
+  --mere-ink-muted: #8A887E;
+  --mere-line: #DCDBD7;
+  --mere-line-soft: color-mix(in oklch, var(--mere-line) 64%, transparent);
+  --mere-line-strong: #BDBBB4;
+  --mere-accent: #3B4EA0;
+  --mere-accent-soft: color-mix(in oklch, var(--mere-accent) 12%, transparent);
+  --mere-accent-hover: #2F3E82;
+  --mere-accent-contrast: #FCFCFB;
+  --mere-warning: #9C6F1A;
+  --mere-danger: #A84E2C;
+  --mere-focus: #1C7373;
+  --mere-shadow: 0 18px 42px color-mix(in oklch, var(--mere-ink) 8%, transparent);
+  --mere-shadow-soft: 0 10px 26px color-mix(in oklch, var(--mere-ink) 5%, transparent);
 
   --vp-c-bg: var(--mere-canvas);
   --vp-c-bg-alt: var(--mere-surface-raised);
-  --vp-c-bg-elv: var(--mere-surface);
+  --vp-c-bg-elv: var(--mere-paper);
   --vp-c-bg-soft: var(--mere-surface-muted);
   --vp-c-text-1: var(--mere-ink);
   --vp-c-text-2: var(--mere-ink-soft);
   --vp-c-text-3: var(--mere-ink-muted);
   --vp-c-border: var(--mere-line);
-  --vp-c-divider: color-mix(in oklch, var(--mere-line) 72%, transparent);
-  --vp-c-gutter: var(--mere-line);
-  --vp-c-brand-1: var(--mere-green);
-  --vp-c-brand-2: oklch(42% 0.12 155);
-  --vp-c-brand-3: var(--mere-green-bright);
-  --vp-c-brand-soft: color-mix(in oklch, var(--mere-green) 14%, transparent);
-  --vp-c-tip-1: var(--mere-green);
-  --vp-c-tip-soft: color-mix(in oklch, var(--mere-green) 13%, transparent);
+  --vp-c-divider: var(--mere-line-soft);
+  --vp-c-gutter: var(--mere-line-soft);
+  --vp-c-brand-1: var(--mere-accent);
+  --vp-c-brand-2: var(--mere-accent-hover);
+  --vp-c-brand-3: color-mix(in oklch, var(--mere-accent) 78%, var(--mere-paper));
+  --vp-c-brand-soft: var(--mere-accent-soft);
+  --vp-c-tip-1: var(--mere-accent);
+  --vp-c-tip-soft: var(--mere-accent-soft);
   --vp-c-warning-1: var(--mere-warning);
-  --vp-c-warning-soft: color-mix(in oklch, var(--mere-warning) 14%, transparent);
+  --vp-c-warning-soft: color-mix(in oklch, var(--mere-warning) 13%, transparent);
   --vp-c-danger-1: var(--mere-danger);
   --vp-c-danger-soft: color-mix(in oklch, var(--mere-danger) 12%, transparent);
-  --vp-font-family-base: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --vp-font-family-base: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+  --vp-font-family-display: Georgia, "Times New Roman", ui-serif, serif;
   --vp-font-family-mono: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", monospace;
-  --vp-nav-height: 68px;
-  --vp-layout-max-width: 1480px;
-  --vp-code-block-bg: oklch(20% 0.022 148);
-  --vp-code-line-highlight-color: color-mix(in oklch, var(--mere-green) 18%, transparent);
+  --vp-nav-height: 64px;
+  --vp-layout-max-width: 1460px;
+  --vp-code-block-bg: oklch(21% 0.018 165);
+  --vp-code-line-highlight-color: color-mix(in oklch, var(--mere-accent) 18%, transparent);
   --vp-home-hero-name-color: var(--mere-ink);
   --vp-home-hero-name-background: none;
   --vp-home-hero-image-background-image: none;
@@ -52,61 +54,83 @@
 }
 
 .dark {
-  --mere-canvas: oklch(18% 0.018 142);
-  --mere-surface: oklch(22% 0.02 145);
-  --mere-surface-raised: oklch(25% 0.024 148);
-  --mere-surface-muted: oklch(28% 0.026 150);
-  --mere-ink: oklch(92% 0.018 122);
-  --mere-ink-soft: oklch(78% 0.025 135);
-  --mere-ink-muted: oklch(65% 0.027 145);
-  --mere-line: oklch(36% 0.032 148);
-  --mere-line-strong: oklch(46% 0.045 150);
-  --mere-green: oklch(74% 0.11 155);
-  --mere-green-bright: oklch(82% 0.105 155);
-  --mere-blue: oklch(72% 0.1 225);
-  --mere-plum: oklch(72% 0.11 315);
-  --mere-copper: oklch(75% 0.1 62);
-  --mere-warning: oklch(78% 0.11 76);
-  --mere-danger: oklch(71% 0.13 30);
-  --mere-focus: oklch(76% 0.11 210);
-  --mere-shadow: 0 18px 48px color-mix(in oklch, oklch(6% 0.01 145) 46%, transparent);
-  --mere-shadow-soft: 0 10px 32px color-mix(in oklch, oklch(6% 0.01 145) 36%, transparent);
+  --mere-canvas: oklch(17.5% 0.014 165);
+  --mere-paper: oklch(21% 0.014 165);
+  --mere-surface: oklch(23.5% 0.015 165);
+  --mere-surface-raised: oklch(26.5% 0.015 165);
+  --mere-surface-muted: oklch(30% 0.015 165);
+  --mere-ink: oklch(92% 0.011 165);
+  --mere-ink-soft: oklch(77% 0.012 165);
+  --mere-ink-muted: oklch(63% 0.012 165);
+  --mere-line: oklch(36% 0.016 165);
+  --mere-line-soft: color-mix(in oklch, var(--mere-line) 70%, transparent);
+  --mere-line-strong: oklch(47% 0.018 165);
+  --mere-accent: oklch(72% 0.11 268);
+  --mere-accent-soft: color-mix(in oklch, var(--mere-accent) 15%, transparent);
+  --mere-accent-hover: oklch(80% 0.095 268);
+  --mere-accent-contrast: oklch(16% 0.014 170);
+  --mere-warning: oklch(78% 0.1 72);
+  --mere-danger: oklch(72% 0.13 30);
+  --mere-focus: oklch(75% 0.09 190);
+  --mere-shadow: 0 18px 42px color-mix(in oklch, oklch(7% 0.01 165) 42%, transparent);
+  --mere-shadow-soft: 0 10px 26px color-mix(in oklch, oklch(7% 0.01 165) 28%, transparent);
 
   --vp-c-bg: var(--mere-canvas);
   --vp-c-bg-alt: var(--mere-surface-raised);
-  --vp-c-bg-elv: var(--mere-surface);
+  --vp-c-bg-elv: var(--mere-paper);
   --vp-c-bg-soft: var(--mere-surface-muted);
   --vp-c-text-1: var(--mere-ink);
   --vp-c-text-2: var(--mere-ink-soft);
   --vp-c-text-3: var(--mere-ink-muted);
   --vp-c-border: var(--mere-line);
-  --vp-c-divider: color-mix(in oklch, var(--mere-line) 76%, transparent);
-  --vp-c-brand-1: var(--mere-green);
-  --vp-c-brand-2: var(--mere-green-bright);
-  --vp-c-brand-3: oklch(64% 0.1 155);
-  --vp-c-brand-soft: color-mix(in oklch, var(--mere-green) 16%, transparent);
-  --vp-code-block-bg: oklch(14% 0.018 148);
+  --vp-c-divider: var(--mere-line-soft);
+  --vp-c-brand-1: var(--mere-accent);
+  --vp-c-brand-2: var(--mere-accent-hover);
+  --vp-c-brand-3: color-mix(in oklch, var(--mere-accent) 78%, var(--mere-paper));
+  --vp-c-brand-soft: var(--mere-accent-soft);
+  --vp-code-block-bg: oklch(14.5% 0.012 165);
   --vp-home-hero-name-color: var(--mere-ink);
 }
 
 html {
   background: var(--mere-canvas);
+  overflow-x: clip;
   scroll-padding-top: calc(var(--vp-nav-height) + 24px);
 }
 
+.mere-docs-theme {
+  --mere-accent: var(--mere-key, #3B4EA0);
+  --mere-accent-hover: var(--mere-key-hover, #2F3E82);
+  --mere-accent-contrast: var(--mere-key-contrast, #FCFCFB);
+  --mere-accent-soft: color-mix(in oklch, var(--mere-accent) 12%, transparent);
+  --vp-c-brand-1: var(--mere-accent);
+  --vp-c-brand-2: var(--mere-accent-hover);
+  --vp-c-brand-3: color-mix(in oklch, var(--mere-accent) 78%, var(--mere-paper));
+  --vp-c-brand-soft: var(--mere-accent-soft);
+  --vp-c-tip-1: var(--mere-accent);
+  --vp-c-tip-soft: var(--mere-accent-soft);
+  min-height: 100vh;
+}
+
+.dark .mere-docs-theme {
+  --mere-accent: var(--mere-key-dark, #AEBBFF);
+  --mere-accent-hover: var(--mere-key-dark-hover, #CAD2FF);
+  --mere-accent-contrast: var(--mere-key-dark-contrast, #171714);
+  --mere-accent-soft: color-mix(in oklch, var(--mere-accent) 15%, transparent);
+}
+
 body {
+  overflow-x: clip;
   color: var(--mere-ink);
   background:
-    linear-gradient(to right, color-mix(in oklch, var(--mere-line) 28%, transparent) 1px, transparent 1px),
-    linear-gradient(to bottom, color-mix(in oklch, var(--mere-line) 24%, transparent) 1px, transparent 1px),
-    linear-gradient(145deg, var(--mere-canvas), color-mix(in oklch, var(--mere-green) 5%, var(--mere-canvas)) 48%, var(--mere-canvas));
+    linear-gradient(180deg, color-mix(in oklch, var(--mere-paper) 84%, var(--mere-canvas)) 0, var(--mere-canvas) 410px),
+    linear-gradient(180deg, var(--mere-canvas), color-mix(in oklch, var(--mere-canvas) 78%, var(--mere-surface-raised)));
   background-attachment: fixed;
-  background-size: 56px 56px, 56px 56px, auto;
   font-variant-numeric: tabular-nums;
 }
 
 ::selection {
-  background: color-mix(in oklch, var(--mere-green) 30%, transparent);
+  background: color-mix(in oklch, var(--mere-accent) 24%, transparent);
   color: var(--mere-ink);
 }
 
@@ -116,15 +140,15 @@ body {
 }
 
 .VPNav {
-  border-bottom: 1px solid color-mix(in oklch, var(--mere-line) 66%, transparent);
-  background: color-mix(in oklch, var(--mere-canvas) 94%, var(--mere-surface));
+  border-bottom: 1px solid var(--mere-line-soft);
+  background: color-mix(in oklch, var(--mere-canvas) 94%, var(--mere-paper));
 }
 
 .VPNavBar.has-sidebar .content,
 .VPNavBar.has-sidebar .curtain::before,
 .VPNavBar:not(.has-sidebar) .content,
 .VPNavBar:not(.has-sidebar) .curtain::before {
-  background: color-mix(in oklch, var(--mere-canvas) 94%, var(--mere-surface));
+  background: color-mix(in oklch, var(--mere-canvas) 94%, var(--mere-paper));
 }
 
 .VPNavBarTitle .title {
@@ -134,14 +158,7 @@ body {
 }
 
 .mere-nav-mark {
-  display: inline-block;
-  margin-right: 10px;
-  width: 11px;
-  height: 11px;
-  border: 2px solid var(--mere-green);
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--mere-copper) 42%, transparent);
-  box-shadow: 0 0 0 4px color-mix(in oklch, var(--mere-green) 12%, transparent);
+  display: none;
 }
 
 .VPNavBarMenuLink,
@@ -158,66 +175,67 @@ body {
 
 .VPNavBarSearch .DocSearch-Button {
   border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  background: var(--mere-surface);
+  border-radius: 7px;
+  background: var(--mere-paper);
 }
 
 .VPSidebar {
-  border-right: 1px solid color-mix(in oklch, var(--mere-line) 70%, transparent);
-  background: color-mix(in oklch, var(--mere-surface-raised) 72%, var(--mere-canvas));
+  border-right: 1px solid var(--mere-line-soft);
+  background: color-mix(in oklch, var(--mere-surface) 86%, var(--mere-canvas));
 }
 
 .VPSidebarItem.level-0 > .item > .link > .text {
   color: var(--mere-ink);
   font-size: 12px;
   font-weight: 760;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
 .VPSidebarItem .link {
-  border-radius: 7px;
+  border-radius: 6px;
 }
 
 .VPSidebarItem .link:hover,
 .VPSidebarItem.is-active > .item > .link {
-  background: color-mix(in oklch, var(--mere-green) 10%, transparent);
+  background: var(--mere-accent-soft);
   color: var(--mere-ink);
 }
 
 .VPHero {
   margin-top: 0;
-  padding: 48px 24px 12px;
+  padding: 52px 24px 22px;
 }
 
 .VPHero .container {
-  gap: 34px;
+  gap: 46px;
 }
 
 .VPHero .main {
-  max-width: 650px;
+  max-width: 660px;
 }
 
 .VPHero .name {
   max-width: 680px;
   color: var(--mere-ink);
-  font-size: 56px;
-  font-weight: 820;
+  font-family: var(--vp-font-family-display);
+  font-size: 54px;
+  font-weight: 700;
   letter-spacing: 0;
-  line-height: 0.96;
+  line-height: 1.02;
 }
 
 .VPHero .text {
-  max-width: 640px;
+  max-width: 650px;
   color: var(--mere-ink);
-  font-size: 28px;
-  font-weight: 700;
+  font-size: 27px;
+  font-weight: 720;
   letter-spacing: 0;
-  line-height: 1.14;
+  line-height: 1.15;
 }
 
 .VPHero .tagline {
-  max-width: 62ch;
+  max-width: 64ch;
   color: var(--mere-ink-soft);
   font-size: 16px;
   line-height: 1.7;
@@ -225,53 +243,61 @@ body {
 
 .VPHero .actions {
   gap: 10px;
+  max-width: 720px;
+}
+
+.VPHero .action {
+  flex-shrink: 0;
+  padding: 0 !important;
 }
 
 .VPButton {
-  border-radius: 8px !important;
+  border-radius: 7px !important;
   font-weight: 720 !important;
 }
 
 .VPButton.brand {
-  border-color: var(--mere-green) !important;
-  background: var(--mere-green) !important;
-  color: oklch(98% 0.01 118) !important;
-  box-shadow: 0 10px 24px color-mix(in oklch, var(--mere-green) 24%, transparent);
+  border-color: var(--mere-accent) !important;
+  background: var(--mere-accent) !important;
+  color: var(--mere-accent-contrast) !important;
+  box-shadow: 0 8px 18px color-mix(in oklch, var(--mere-accent) 18%, transparent);
 }
 
 .VPButton.brand:hover {
-  border-color: var(--mere-green-bright) !important;
-  background: color-mix(in oklch, var(--mere-green) 86%, var(--mere-green-bright)) !important;
+  border-color: var(--mere-accent-hover) !important;
+  background: var(--mere-accent-hover) !important;
 }
 
 .VPButton.alt {
   border: 1px solid var(--mere-line) !important;
-  background: var(--mere-surface) !important;
+  background: var(--mere-paper) !important;
   color: var(--mere-ink) !important;
 }
 
 .VPButton.alt:hover {
   border-color: var(--mere-line-strong) !important;
-  background: color-mix(in oklch, var(--mere-surface) 76%, var(--mere-green) 8%) !important;
+  background: color-mix(in oklch, var(--mere-paper) 80%, var(--mere-accent) 6%) !important;
 }
 
-.VPFeature {
-  border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  background: var(--mere-surface);
-  box-shadow: var(--mere-shadow-soft);
-  transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1), border-color 180ms cubic-bezier(0.22, 1, 0.36, 1), box-shadow 180ms cubic-bezier(0.22, 1, 0.36, 1);
+.VPFeature,
+.VPLink.VPFeature {
+  border: 0;
+  border-top: 1px solid var(--mere-line-soft);
+  border-radius: 0 !important;
+  padding: 20px 0 4px;
+  background: transparent !important;
+  box-shadow: none !important;
+  transition: border-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.VPFeature:hover {
-  transform: translateY(-2px);
+.VPFeature:hover,
+.VPLink.VPFeature:hover {
   border-color: var(--mere-line-strong);
-  box-shadow: var(--mere-shadow);
 }
 
 .VPFeature .title {
   color: var(--mere-ink);
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 760;
   letter-spacing: 0;
 }
@@ -282,7 +308,7 @@ body {
 }
 
 .VPHomeContent {
-  padding-top: 28px;
+  padding-top: 26px;
 }
 
 .VPDoc {
@@ -300,14 +326,14 @@ body {
 .vp-doc h1 {
   color: var(--mere-ink);
   font-size: 40px;
-  font-weight: 820;
+  font-weight: 830;
   letter-spacing: 0;
-  line-height: 1.05;
+  line-height: 1.06;
 }
 
 .vp-doc h2 {
-  margin-top: 44px;
-  border-top: 1px solid color-mix(in oklch, var(--mere-line) 72%, transparent);
+  margin-top: 46px;
+  border-top: 1px solid var(--mere-line-soft);
   padding-top: 18px;
   color: var(--mere-ink);
   font-size: 25px;
@@ -335,23 +361,23 @@ body {
 }
 
 .vp-doc a {
-  color: var(--mere-green);
-  font-weight: 630;
-  text-decoration-color: color-mix(in oklch, var(--mere-green) 38%, transparent);
+  color: var(--mere-accent);
+  font-weight: 640;
+  text-decoration-color: color-mix(in oklch, var(--mere-accent) 36%, transparent);
   text-decoration-thickness: 0.08em;
   text-underline-offset: 0.22em;
 }
 
 .vp-doc a:hover {
-  color: color-mix(in oklch, var(--mere-green) 82%, var(--mere-blue));
+  color: var(--mere-accent-hover);
   text-decoration-color: currentColor;
 }
 
 .vp-doc blockquote {
-  border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  padding: 16px 18px;
-  background: color-mix(in oklch, var(--mere-surface) 82%, var(--mere-green) 7%);
+  border: 1px solid var(--mere-line-soft);
+  border-radius: 7px;
+  padding: 15px 18px;
+  background: color-mix(in oklch, var(--mere-paper) 84%, var(--mere-accent) 5%);
 }
 
 .vp-doc blockquote > p {
@@ -363,25 +389,25 @@ body {
   max-width: 100%;
   overflow-x: auto;
   border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  background: var(--mere-surface);
-  box-shadow: var(--mere-shadow-soft);
+  border-radius: 7px;
+  background: var(--mere-paper);
+  box-shadow: none;
 }
 
 .vp-doc tr {
-  border-top: 1px solid color-mix(in oklch, var(--mere-line) 70%, transparent);
+  border-top: 1px solid var(--mere-line-soft);
 }
 
 .vp-doc tr:nth-child(2n) {
-  background: color-mix(in oklch, var(--mere-surface-raised) 46%, transparent);
+  background: color-mix(in oklch, var(--mere-surface) 56%, transparent);
 }
 
 .vp-doc tr:hover {
-  background: color-mix(in oklch, var(--mere-green) 8%, transparent);
+  background: color-mix(in oklch, var(--mere-accent) 7%, transparent);
 }
 
 .vp-doc th {
-  background: color-mix(in oklch, var(--mere-surface-muted) 76%, var(--mere-surface));
+  background: color-mix(in oklch, var(--mere-surface-muted) 68%, var(--mere-paper));
   color: var(--mere-ink);
   font-size: 12px;
   font-weight: 760;
@@ -392,7 +418,7 @@ body {
 .vp-doc th,
 .vp-doc td {
   border: 0;
-  border-right: 1px solid color-mix(in oklch, var(--mere-line) 70%, transparent);
+  border-right: 1px solid var(--mere-line-soft);
   padding: 11px 13px;
   vertical-align: top;
 }
@@ -412,23 +438,23 @@ body {
 }
 
 .vp-doc div[class*='language-'] {
-  border: 1px solid color-mix(in oklch, var(--mere-line) 70%, transparent);
-  border-radius: 8px;
-  box-shadow: var(--mere-shadow-soft);
+  border: 1px solid var(--mere-line-soft);
+  border-radius: 7px;
+  box-shadow: none;
 }
 
 .vp-doc :not(pre) > code {
-  border: 1px solid color-mix(in oklch, var(--mere-line) 78%, transparent);
+  border: 1px solid var(--mere-line-soft);
   border-radius: 5px;
-  background: color-mix(in oklch, var(--mere-surface-muted) 64%, var(--mere-surface));
+  background: color-mix(in oklch, var(--mere-surface-muted) 58%, var(--mere-paper));
   color: var(--mere-ink);
   font-size: 0.9em;
 }
 
 .custom-block {
-  border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  background: var(--mere-surface);
+  border: 1px solid var(--mere-line-soft);
+  border-radius: 7px;
+  background: var(--mere-paper);
 }
 
 .custom-block-title {
@@ -437,12 +463,12 @@ body {
 }
 
 .outline-link {
-  border-radius: 7px;
+  border-radius: 6px;
 }
 
 .outline-link:hover,
 .outline-link.active {
-  color: var(--mere-green);
+  color: var(--mere-accent);
 }
 
 .mere-atlas-map {
@@ -454,13 +480,17 @@ body {
   overflow: hidden;
   border: 1px solid var(--mere-line);
   border-radius: 8px;
-  padding: 14px;
-  background:
-    linear-gradient(to right, color-mix(in oklch, var(--mere-line) 28%, transparent) 1px, transparent 1px),
-    linear-gradient(to bottom, color-mix(in oklch, var(--mere-line) 24%, transparent) 1px, transparent 1px),
-    var(--mere-surface);
-  background-size: 24px 24px, 24px 24px, auto;
+  padding: 16px 18px;
+  background: var(--mere-paper);
   box-shadow: var(--mere-shadow);
+}
+
+.mere-atlas-frame::before {
+  content: "";
+  display: block;
+  height: 3px;
+  margin: -16px -18px 12px;
+  background: var(--mere-accent);
 }
 
 .mere-atlas-topline {
@@ -477,69 +507,70 @@ body {
 .mere-atlas-core {
   display: flex;
   align-items: baseline;
-  justify-content: center;
-  margin: 16px auto 14px;
-  min-height: 64px;
-  width: min(330px, 100%);
-  border: 1px solid color-mix(in oklch, var(--mere-line-strong) 78%, transparent);
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--mere-surface) 78%, var(--mere-green) 7%);
+  justify-content: flex-start;
+  margin: 14px 0 12px;
+  min-height: 0;
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--mere-line-soft);
+  border-radius: 0;
+  padding: 0 0 11px;
+  background: transparent;
   color: var(--mere-ink);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--mere-surface) 70%, transparent);
+  box-shadow: none;
 }
 
 .mere-atlas-core-label {
-  font-size: 28px;
+  font-size: 31px;
   font-weight: 820;
   letter-spacing: 0;
 }
 
 .mere-atlas-core-dot {
-  color: var(--mere-green);
-  font-size: 30px;
+  color: var(--mere-accent);
+  font-size: 31px;
   font-weight: 820;
 }
 
 .mere-atlas-planes {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  counter-reset: mere-plane;
+  gap: 0;
 }
 
 .mere-atlas-plane {
-  display: flex;
-  min-height: 126px;
-  flex-direction: column;
-  justify-content: space-between;
-  border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  padding: 12px;
-  background: color-mix(in oklch, var(--mere-surface) 84%, var(--plane-accent) 7%);
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 12px;
+  min-height: 0;
+  border: 0;
+  border-bottom: 1px solid var(--mere-line-soft);
+  border-radius: 0;
+  padding: 11px 0;
+  background: transparent;
   color: var(--mere-ink);
   text-decoration: none;
-  transition: transform 180ms cubic-bezier(0.22, 1, 0.36, 1), border-color 180ms cubic-bezier(0.22, 1, 0.36, 1), background 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: background 180ms cubic-bezier(0.22, 1, 0.36, 1), color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.mere-atlas-plane:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.mere-atlas-plane::before {
+  content: "0" counter(mere-plane);
+  counter-increment: mere-plane;
+  color: var(--mere-ink-muted);
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
 }
 
 .mere-atlas-plane:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in oklch, var(--plane-accent) 80%, var(--mere-line));
-  background: color-mix(in oklch, var(--mere-surface) 74%, var(--plane-accent) 12%);
-}
-
-.mere-atlas-plane.is-green {
-  --plane-accent: var(--mere-green);
-}
-
-.mere-atlas-plane.is-blue {
-  --plane-accent: var(--mere-blue);
-}
-
-.mere-atlas-plane.is-plum {
-  --plane-accent: var(--mere-plum);
-}
-
-.mere-atlas-plane.is-copper {
-  --plane-accent: var(--mere-copper);
+  background: color-mix(in oklch, var(--mere-accent) 5%, transparent);
+  color: var(--mere-ink);
 }
 
 .mere-atlas-plane-name {
@@ -549,7 +580,9 @@ body {
 }
 
 .mere-atlas-plane-signal {
-  margin-top: 6px;
+  display: block;
+  grid-column: 2;
+  margin-top: 5px;
   color: var(--mere-ink-soft);
   font-size: 13px;
   line-height: 1.42;
@@ -558,36 +591,38 @@ body {
 .mere-atlas-plane-items {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 10px;
+  gap: 12px;
+  grid-column: 2;
+  margin-top: 8px;
 }
 
 .mere-atlas-plane-items span {
-  border: 1px solid color-mix(in oklch, var(--plane-accent) 36%, var(--mere-line));
-  border-radius: 999px;
-  padding: 3px 7px;
-  color: color-mix(in oklch, var(--mere-ink) 84%, var(--plane-accent));
-  font-family: var(--vp-font-family-mono);
-  font-size: 10px;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  color: var(--mere-ink-muted);
+  font-size: 11px;
+  font-weight: 560;
+  white-space: nowrap;
 }
 
 .mere-doc-signal {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 18px;
   margin: 0 0 24px;
-  border: 1px solid var(--mere-line);
-  border-radius: 8px;
+  border: 1px solid var(--mere-line-soft);
+  border-radius: 7px;
   padding: 13px 14px;
-  background: color-mix(in oklch, var(--mere-surface) 82%, var(--mere-green) 5%);
-  box-shadow: var(--mere-shadow-soft);
+  background: color-mix(in oklch, var(--mere-paper) 82%, var(--mere-surface));
+  box-shadow: none;
 }
 
 .mere-doc-signal-label {
   display: inline-flex;
   margin-bottom: 4px;
-  color: var(--mere-green);
+  color: var(--mere-accent);
   font-family: var(--vp-font-family-mono);
   font-size: 11px;
   font-weight: 760;
@@ -607,41 +642,47 @@ body {
   flex-shrink: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 10px;
 }
 
 .mere-doc-signal-links a,
 .mere-doc-signal-links span {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
-  border: 1px solid var(--mere-line);
-  border-radius: 999px;
-  padding: 4px 9px;
-  background: var(--mere-surface);
+  min-height: 26px;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
   color: var(--mere-ink-soft);
   font-size: 12px;
   font-weight: 680;
   text-decoration: none;
 }
 
+.mere-doc-signal-links a {
+  color: var(--mere-accent);
+}
+
 .mere-doc-signal-links a:hover {
-  border-color: var(--mere-green);
-  color: var(--mere-ink);
+  color: var(--mere-accent-hover);
+  text-decoration: underline;
+  text-underline-offset: 0.22em;
 }
 
 .mere-docs-network {
   display: grid;
   gap: 7px;
   margin-top: 18px;
-  border: 1px solid var(--mere-line);
-  border-radius: 8px;
-  padding: 12px;
-  background: var(--mere-surface);
+  border: 0;
+  border-top: 1px solid var(--mere-line-soft);
+  border-radius: 0;
+  padding: 12px 0 0;
+  background: transparent;
 }
 
 .mere-docs-network-kicker {
-  color: var(--mere-green);
+  color: var(--mere-accent);
   font-family: var(--vp-font-family-mono);
   font-size: 11px;
   font-weight: 760;
@@ -659,7 +700,7 @@ body {
 }
 
 .mere-docs-network a:hover {
-  background: color-mix(in oklch, var(--mere-green) 10%, transparent);
+  background: var(--mere-accent-soft);
   color: var(--mere-ink);
 }
 
@@ -677,7 +718,6 @@ body {
   }
 
   .mere-doc-signal {
-    align-items: flex-start;
     flex-direction: column;
   }
 
@@ -687,10 +727,6 @@ body {
 }
 
 @media (max-width: 640px) {
-  body {
-    background-size: 40px 40px, 40px 40px, auto;
-  }
-
   .VPHero {
     padding-top: 28px;
     padding-right: 18px;
@@ -699,55 +735,94 @@ body {
 
   .VPHero.has-image .image,
   .VPHero.has-image .image-container {
-    height: auto;
+    height: auto !important;
+    max-width: 100% !important;
+    transform: none !important;
+  }
+
+  .VPHero.has-image .image-container {
+    position: relative !important;
+    inset: auto !important;
+    margin: 0 auto !important;
+    width: min(342px, calc(100vw - 36px)) !important;
   }
 
   .VPHero.has-image .image {
-    margin-bottom: 8px;
+    display: flex;
+    justify-content: center;
+    margin: 0 auto 18px !important;
+    width: 100% !important;
+  }
+
+  .VPHero.has-image .image-bg {
+    display: none;
   }
 
   .VPHero .container {
-    gap: 18px;
+    gap: 20px;
+    max-width: 100%;
+  }
+
+  .VPHero .main {
+    max-width: 100%;
+    min-width: 0;
   }
 
   .VPHero .name {
-    font-size: 32px;
+    max-width: 100%;
+    font-size: 33px;
+    overflow-wrap: break-word;
   }
 
   .VPHero .text {
-    font-size: 20px;
+    max-width: 100%;
+    font-size: 19px;
+    overflow-wrap: break-word;
+  }
+
+  .VPHero .tagline {
+    max-width: 100%;
+    overflow-wrap: break-word;
   }
 
   .VPHero .actions {
-    justify-content: flex-start;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .VPHero .action {
+    min-width: 0;
   }
 
   .VPHero .actions .VPButton {
+    max-width: calc(100vw - 48px);
     min-height: 40px;
     padding: 0 15px;
+    white-space: normal;
   }
 
   .mere-atlas-map {
-    width: min(342px, 100%);
+    width: 100% !important;
+    max-width: calc(100vw - 36px) !important;
   }
 
   .mere-atlas-frame {
-    padding: 10px;
+    box-sizing: border-box;
+    padding: 14px;
+  }
+
+  .mere-atlas-frame::before {
+    margin: -14px -14px 12px;
   }
 
   .mere-atlas-core {
-    margin: 10px auto;
-    min-height: 52px;
+    margin: 12px 0 8px;
+    padding-bottom: 10px;
   }
 
   .mere-atlas-core-label,
   .mere-atlas-core-dot {
     font-size: 24px;
-  }
-
-  .mere-atlas-planes {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 7px;
   }
 
   .mere-atlas-topline {
@@ -758,8 +833,9 @@ body {
   }
 
   .mere-atlas-plane {
-    min-height: 88px;
-    padding: 9px;
+    grid-template-columns: 28px minmax(0, 1fr);
+    gap: 8px;
+    padding: 11px 0;
   }
 
   .mere-atlas-plane-name {


### PR DESCRIPTION
## Summary
- refresh the vendored Mere docs theme from @mere/docs-theme after the refined Pencil/key-color pass
- keeps the public docs self-contained while matching the shared Mere docs look

## Verification
- pnpm install --frozen-lockfile
- pnpm docs:build
- git diff --check
- ./scripts/check.sh