### PR TITLE
Add native Krea 2 Turbo image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added native Krea 2 Turbo text-to-image support through the managed
+  `image-krea2-turbo` model, including component-only Hugging Face pulls,
+  split-transformer validation, Swift MLX MMDiT sampling, docs, and tests.
+
 ## 0.16.0 - 2026-06-16
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -281,6 +281,7 @@ targets.append(contentsOf: [
       "Gemma4/README.md",
       "HiDreamO1/README.md",
       "Ideogram4/README.md",
+      "Krea2/README.md",
       "LFM2/README.md",
       "LightOnOCR/README.md",
       "LTX/README.md",

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ mere.run is a Swift package, CLI, and optional macOS studio for local-first infe
 
 The public OSS repo currently supports:
 
-- local image generation across Klein, ZImage, and HiDream O1 families,
-  including image-to-image, HiDream reference images, LoRA input, and
-  deterministic image validation
+- local image generation across Klein, ZImage, HiDream O1, Krea 2 Turbo, and
+  Ideogram 4 families, including image-to-image, HiDream reference images,
+  LoRA input, and deterministic image validation
 - local text chat, code generation, embeddings, and PII anonymization
 - local speech synthesis, transcription, and voice-profile management
 - local vision captioning, inspection, grounding, segmentation, tracking, live camera tracking, and OCR
@@ -236,6 +236,13 @@ swift run mere.run image generate \
   --prompt "a clean studio product photo of the subject" \
   --ref-image ./subject.png \
   --output ./subject-studio.png
+
+# Krea 2 Turbo runs natively for 8-step text-to-image generation.
+swift run mere.run image generate \
+  --model image-krea2-turbo \
+  --prompt "a cinematic product photo of a translucent portable speaker, crisp reflections" \
+  --steps 8 \
+  --output ./speaker.png
 
 # Run local chat
 swift run mere.run text chat \

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ swift run mere.run sfx video generate \
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
   --variant distilled \
-  --model video-ltx-av \
+  --model video-ltx23-av-mlx \
   --num-frames 65 \
   --output ./clip.mp4
 

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -780,7 +780,7 @@ enum CommandCatalog {
             inputKind: .image,
             outputKind: .file("mp4"),
             defaultPrompt: "a cinematic drone flythrough over snowy mountains",
-            defaultModel: "video-ltx-av"
+            defaultModel: "video-ltx23-av-mlx"
         ),
         CommandTemplate(
             id: .videoExportLatents,

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -2169,11 +2169,11 @@ actor CodeGenServer {
         }
         let resolved = try resolveImageModel(plan.modelID)
         let effectiveSteps = plan.steps
-            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .ideogram)
+            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
                 ? (resolved.manifest.defaults?.steps ?? 4)
                 : 4)
         let effectiveCFG = plan.guidanceScale
-            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .ideogram)
+            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
                 ? (resolved.manifest.defaults?.cfg ?? 1.0)
                 : 1.0)
         let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
@@ -2205,6 +2205,10 @@ actor CodeGenServer {
             _ = try await ZImageTurboGenerator().generate(request, progressHandler: nil)
         case .hidream:
             let generator = HiDreamO1Generator()
+            defer { generator.unload() }
+            _ = try await generator.generate(request, progressHandler: nil)
+        case .krea:
+            let generator = Krea2Generator()
             defer { generator.unload() }
             _ = try await generator.generate(request, progressHandler: nil)
         case .ideogram:

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -173,9 +173,13 @@ struct ImageGenerate: AsyncParsableCommand {
 
         let manifest = try MereRunModelManifest.loadRequired(from: URL(fileURLWithPath: resolvedModel!))
         let effectiveSteps = steps
-            ?? ((manifest.family == .hidream || manifest.family == .ideogram) ? (manifest.defaults?.steps ?? 4) : 4)
+            ?? ((manifest.family == .hidream || manifest.family == .krea || manifest.family == .ideogram)
+                ? (manifest.defaults?.steps ?? 4)
+                : 4)
         let effectiveCFG = cfgScale
-            ?? ((manifest.family == .hidream || manifest.family == .ideogram) ? (manifest.defaults?.cfg ?? 1.0) : 1.0)
+            ?? ((manifest.family == .hidream || manifest.family == .krea || manifest.family == .ideogram)
+                ? (manifest.defaults?.cfg ?? 1.0)
+                : 1.0)
         let effectiveSigmaShift = sigmaShift.map { Float($0) }
             ?? manifest.defaults?.sigmaShift.map { Float($0) }
 
@@ -254,6 +258,10 @@ struct ImageGenerate: AsyncParsableCommand {
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .hidream:
             let generator = HiDreamO1Generator()
+            defer { generator.unload() }
+            result = try await generator.generate(request, progressHandler: progressHandler)
+        case .krea:
+            let generator = Krea2Generator()
             defer { generator.unload() }
             result = try await generator.generate(request, progressHandler: progressHandler)
         case .ideogram:

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -149,7 +149,7 @@ struct VideoGenerate: AsyncParsableCommand {
     var output: String?
 
     @Option(name: [.customShort("m"), .long], help: "Managed model id or local path to the LTX model root.")
-    var model: String = ModelResolver.ModelID.ltxVideoAV.rawValue
+    var model: String = ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
 
     @Option(name: [.customLong("variant")], help: "Native LTX lane: distilled for faster video-only drafts, unified-av for synchronized audio/video.")
     var variant: LTXVideoVariant = .distilled

--- a/Sources/MereRunCLI/Guides/image-generate.md
+++ b/Sources/MereRunCLI/Guides/image-generate.md
@@ -13,6 +13,7 @@ Use one installed image model:
 - `image-bonsai-binary`, `image-bonsai-ternary`
 - `image-ideogram4-sdnq-uint4`
 - `image-hidream-o1`, `image-hidream-o1-dev`
+- `image-krea2-turbo`
 
 ## Install And Check
 
@@ -21,6 +22,7 @@ mere.run model capabilities
 mere.run model pull image-zimage-nano
 mere.run model pull image-bonsai-binary
 mere.run model pull image-bonsai-ternary
+mere.run model pull image-krea2-turbo
 mere.run image generate --help
 mere.run guide image generate --model image-zimage-nano
 ```
@@ -56,6 +58,7 @@ mere.run guide image generate --model image-zimage-nano
 - For FLUX.2 Klein, use explicit visual composition and relationships: foreground, background, lens/framing, color palette, and what must be absent.
 - For Ideogram 4 SDNQ, use `--structured-prompt` when a short prompt needs stronger object, spatial, lighting, camera, or text-render control. The adapter converts the prompt into a long JSON caption and raises the prompt token budget to 2048.
 - For Bonsai binary or ternary, start with four steps at 512 or 1024 square; the manifest applies its native FlowMatch sigma shift.
+- For Krea 2 Turbo, start with the managed default: 1024 square, 8 steps, CFG 0.0, and no reference or input image.
 - Use `--input` plus `--strength 0.25` to preserve layout; use `0.65` or higher for stronger reinterpretation.
 
 ## Examples
@@ -89,6 +92,15 @@ mere.run image generate \
 
 ```bash
 mere.run image generate \
+  --model image-krea2-turbo \
+  --prompt "a cinematic product photo of a translucent portable speaker, crisp reflections" \
+  --width 1024 --height 1024 \
+  --steps 8 \
+  --output ./speaker.png
+```
+
+```bash
+mere.run image generate \
   --model image-ideogram4-sdnq-uint4 \
   --prompt "a knight and a white horse in a meadow, remove the helmet, make it sunny" \
   --structured-prompt \
@@ -108,10 +120,13 @@ mere.run image generate \
 - Missing model: run `mere.run model pull <model-id>` or pass a local model root with `--model`.
 - Negative prompt has no effect: confirm `--cfg` is greater than `1.0`.
 - Input image ignored: lower dimensions may be easier to condition; also reduce or raise `--strength` depending on whether the output is too close or too different.
-- Out of memory: choose a smaller model, reduce width/height, or use a nano tier.
+- Unsupported mode on Krea 2 Turbo: use plain text-to-image; reference images, input images, and LoRA are not wired for that family yet.
+- Out of memory: choose a smaller model, reduce width/height, or use a nano tier. Krea 2 Turbo is a large BF16 component install and is best treated as a 96 GB+ Apple Silicon path.
 
 ## Sources
 
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
 - https://huggingface.co/docs/diffusers/api/pipelines/z_image
 - https://docs.bfl.ai/guides/prompting_guide_flux2_klein
+- https://huggingface.co/krea/Krea-2-Turbo
+- https://github.com/krea-ai/krea-2

--- a/Sources/MereRunCLI/Guides/video-generate.md
+++ b/Sources/MereRunCLI/Guides/video-generate.md
@@ -8,17 +8,16 @@ Generate an MP4 video from text, optionally anchored by a source image, with nat
 
 Managed ids:
 
-- `video-ltx-av`: default LTX root used by the faster distilled lane and the
-  legacy unified AV lane.
-- `video-ltx23-av-mlx`: LTX 2.3 MLX split root for the high-quality
-  synchronized `--variant unified-av` lane.
+- `video-ltx23-av-mlx`: **default.** LTX 2.3 MLX split root — the recommended model
+  for both the distilled and the high-quality synchronized `--variant unified-av` lanes.
+- `video-ltx-av`: legacy merged LTX root. Superseded by LTX 2.3; only still required by
+  `video export-latents`. Not recommended for `video generate`.
 
 You can also pass a local LTX model root with `--model-root`.
 
 ## Install And Check
 
 ```bash
-mere.run model pull video-ltx-av
 mere.run model pull video-ltx23-av-mlx
 mere.run video generate --help
 ```

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
@@ -499,6 +499,13 @@ extension Flux2KleinGenerator {
         let singleFileURL = url.appendingPathComponent("model.safetensors")
 
         let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            // The Qwen3 text encoder used as an embedder only needs hidden states; the
+            // language-model output head (lm_head.*) is not part of the encoder and ships
+            // in some checkpoints (e.g. FLUX.2-klein-9B's 8B Qwen3 embedder). Drop it so
+            // Module.update(verify: .noUnusedKeys) doesn't reject the load.
+            if key == "lm_head" || key.hasPrefix("lm_head.") || key.hasPrefix("model.lm_head") {
+                return []
+            }
             var mappedKey = key
             if key.hasPrefix("model.") {
                 mappedKey = key.replacingOccurrences(of: "model.", with: "encoder.")

--- a/Sources/MereRunCore/Krea2/Krea2Configs.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Configs.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+public struct Krea2ModelIndex: Decodable, Sendable, Hashable {
+    public let className: String?
+    public let diffusersVersion: String?
+    public let isDistilled: Bool?
+    public let patchSize: Int?
+    public let textEncoderSelectLayers: [Int]?
+
+    private enum CodingKeys: String, CodingKey {
+        case className = "_class_name"
+        case diffusersVersion = "_diffusers_version"
+        case isDistilled = "is_distilled"
+        case patchSize = "patch_size"
+        case textEncoderSelectLayers = "text_encoder_select_layers"
+    }
+}
+
+public struct Krea2SchedulerConfig: Decodable, Sendable, Hashable {
+    public let numTrainTimesteps: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case numTrainTimesteps = "num_train_timesteps"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.numTrainTimesteps = try container.decodeIfPresent(Int.self, forKey: .numTrainTimesteps) ?? 1000
+    }
+}
+
+public struct Krea2TransformerConfiguration: Decodable, Sendable, Hashable {
+    public let attentionHeadDim: Int
+    public let axesDimsRope: [Int]
+    public let inChannels: Int
+    public let intermediateSize: Int
+    public let normEps: Float
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let numLayers: Int
+    public let numLayerwiseTextBlocks: Int
+    public let numRefinerTextBlocks: Int
+    public let numTextLayers: Int
+    public let ropeTheta: Float
+    public let textHiddenDim: Int
+    public let textIntermediateSize: Int
+    public let textNumAttentionHeads: Int
+    public let textNumKeyValueHeads: Int
+    public let timestepEmbedDim: Int
+
+    public var hiddenSize: Int {
+        numAttentionHeads * attentionHeadDim
+    }
+
+    public var patchSize: Int {
+        2
+    }
+
+    public var latentChannels: Int {
+        inChannels / (patchSize * patchSize)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case attentionHeadDim = "attention_head_dim"
+        case axesDimsRope = "axes_dims_rope"
+        case inChannels = "in_channels"
+        case intermediateSize = "intermediate_size"
+        case normEps = "norm_eps"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case numLayers = "num_layers"
+        case numLayerwiseTextBlocks = "num_layerwise_text_blocks"
+        case numRefinerTextBlocks = "num_refiner_text_blocks"
+        case numTextLayers = "num_text_layers"
+        case ropeTheta = "rope_theta"
+        case textHiddenDim = "text_hidden_dim"
+        case textIntermediateSize = "text_intermediate_size"
+        case textNumAttentionHeads = "text_num_attention_heads"
+        case textNumKeyValueHeads = "text_num_key_value_heads"
+        case timestepEmbedDim = "timestep_embed_dim"
+    }
+}
+
+public struct Krea2TextEncoderConfiguration: Decodable, Sendable, Hashable {
+    public struct RopeParameters: Decodable, Sendable, Hashable {
+        public let mropeInterleaved: Bool?
+        public let mropeSection: [Int]?
+        public let ropeTheta: Float?
+
+        private enum CodingKeys: String, CodingKey {
+            case mropeInterleaved = "mrope_interleaved"
+            case mropeSection = "mrope_section"
+            case ropeTheta = "rope_theta"
+        }
+    }
+
+    public let headDim: Int
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let maxPositionEmbeddings: Int
+    public let numAttentionHeads: Int
+    public let numHiddenLayers: Int
+    public let numKeyValueHeads: Int
+    public let rmsNormEps: Float
+    public let ropeParameters: RopeParameters?
+    public let ropeTheta: Float
+    public let vocabSize: Int
+
+    private enum RootKeys: String, CodingKey {
+        case textConfig = "text_config"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case headDim = "head_dim"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case numAttentionHeads = "num_attention_heads"
+        case numHiddenLayers = "num_hidden_layers"
+        case numKeyValueHeads = "num_key_value_heads"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeParameters = "rope_parameters"
+        case ropeTheta = "rope_theta"
+        case vocabSize = "vocab_size"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let root = try decoder.container(keyedBy: RootKeys.self)
+        if root.contains(.textConfig) {
+            let nested = try root.nestedContainer(keyedBy: CodingKeys.self, forKey: .textConfig)
+            self.headDim = try nested.decode(Int.self, forKey: .headDim)
+            self.hiddenSize = try nested.decode(Int.self, forKey: .hiddenSize)
+            self.intermediateSize = try nested.decode(Int.self, forKey: .intermediateSize)
+            self.maxPositionEmbeddings = try nested.decode(Int.self, forKey: .maxPositionEmbeddings)
+            self.numAttentionHeads = try nested.decode(Int.self, forKey: .numAttentionHeads)
+            self.numHiddenLayers = try nested.decode(Int.self, forKey: .numHiddenLayers)
+            self.numKeyValueHeads = try nested.decode(Int.self, forKey: .numKeyValueHeads)
+            self.rmsNormEps = try nested.decode(Float.self, forKey: .rmsNormEps)
+            self.ropeParameters = try nested.decodeIfPresent(RopeParameters.self, forKey: .ropeParameters)
+            self.ropeTheta = try nested.decodeIfPresent(Float.self, forKey: .ropeTheta)
+                ?? ropeParameters?.ropeTheta
+                ?? 5_000_000.0
+            self.vocabSize = try nested.decode(Int.self, forKey: .vocabSize)
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.headDim = try container.decode(Int.self, forKey: .headDim)
+        self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        self.intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        self.maxPositionEmbeddings = try container.decode(Int.self, forKey: .maxPositionEmbeddings)
+        self.numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+        self.numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+        self.numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
+        self.rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+        self.ropeParameters = try container.decodeIfPresent(RopeParameters.self, forKey: .ropeParameters)
+        self.ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta)
+            ?? ropeParameters?.ropeTheta
+            ?? 5_000_000.0
+        self.vocabSize = try container.decode(Int.self, forKey: .vocabSize)
+    }
+
+    public var qwenConfiguration: QwenTextEncoderConfiguration {
+        QwenTextEncoderConfiguration(
+            vocabSize: vocabSize,
+            hiddenSize: hiddenSize,
+            numHiddenLayers: numHiddenLayers,
+            numAttentionHeads: numAttentionHeads,
+            numKeyValueHeads: numKeyValueHeads,
+            intermediateSize: intermediateSize,
+            ropeTheta: ropeTheta,
+            maxPositionEmbeddings: maxPositionEmbeddings,
+            rmsNormEps: rmsNormEps,
+            headDim: headDim,
+            mropeSection: ropeParameters?.mropeSection,
+            mropeInterleaved: ropeParameters?.mropeInterleaved ?? false
+        )
+    }
+}
+
+public struct Krea2ModelConfigs: Sendable, Hashable {
+    public let modelIndex: Krea2ModelIndex
+    public let scheduler: Krea2SchedulerConfig
+    public let textEncoder: Krea2TextEncoderConfiguration
+    public let transformer: Krea2TransformerConfiguration
+    public let vae: QwenImageEditVAEConfig
+
+    public var selectedTextLayers: [Int] {
+        modelIndex.textEncoderSelectLayers ?? [2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35]
+    }
+
+    public static func load(
+        from resources: Krea2Resources,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> Krea2ModelConfigs {
+        Krea2ModelConfigs(
+            modelIndex: try decode(Krea2ModelIndex.self, at: resources.modelIndexURL, decoder: decoder),
+            scheduler: try decode(Krea2SchedulerConfig.self, at: resources.schedulerConfigURL, decoder: decoder),
+            textEncoder: try decode(Krea2TextEncoderConfiguration.self, at: resources.textEncoderConfigURL, decoder: decoder),
+            transformer: try decode(Krea2TransformerConfiguration.self, at: resources.transformerConfigURL, decoder: decoder),
+            vae: try decode(QwenImageEditVAEConfig.self, at: resources.vaeConfigURL, decoder: decoder)
+        )
+    }
+
+    private static func decode<T: Decodable>(
+        _ type: T.Type,
+        at url: URL,
+        decoder: JSONDecoder
+    ) throws -> T {
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(type, from: data)
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2Generator.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Generator.swift
@@ -1,0 +1,292 @@
+import Foundation
+import MLX
+import MLXRandom
+
+public enum Krea2GeneratorError: LocalizedError, Sendable {
+    case missingModelFiles([URL])
+    case unsupportedMode(String)
+    case modelsNotLoaded
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingModelFiles(let urls):
+            return "Missing Krea 2 model files: \(urls.map(\.path).joined(separator: ", "))"
+        case .unsupportedMode(let mode):
+            return "Krea 2 Turbo native generation does not support \(mode) yet."
+        case .modelsNotLoaded:
+            return "Krea 2 models were not loaded."
+        }
+    }
+}
+
+public final class Krea2Generator: ImageGenerator {
+    private var loadedModelPath: String?
+    private var configs: Krea2ModelConfigs?
+    private var transformer: Krea2Transformer?
+    private var textEncoder: QwenEncoder?
+    private var tokenizer: QwenTokenizer?
+    private var vae: QwenImageEditVAE?
+
+    public init() {}
+
+    deinit {
+        unload()
+    }
+
+    public func unload() {
+        loadedModelPath = nil
+        configs = nil
+        transformer = nil
+        textEncoder = nil
+        tokenizer = nil
+        vae = nil
+        clearGPUMemory()
+    }
+
+    public func generate(
+        _ request: GenerationRequest,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> GenerationResult {
+        defer {
+            clearGPUMemory()
+        }
+
+        guard request.referenceImages.isEmpty else {
+            throw Krea2GeneratorError.unsupportedMode("reference images")
+        }
+        guard request.inputImage == nil else {
+            throw Krea2GeneratorError.unsupportedMode("image-to-image")
+        }
+        guard request.lora == nil else {
+            throw Krea2GeneratorError.unsupportedMode("LoRA")
+        }
+
+        let rootURL = try resolveModelRoot(request)
+        let resources = Krea2Resources(rootURL: rootURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw Krea2GeneratorError.missingModelFiles(missing)
+        }
+
+        if loadedModelPath != rootURL.path || transformer == nil {
+            do {
+                unload()
+                try loadModels(from: resources, progressHandler: progressHandler)
+            } catch {
+                unload()
+                throw error
+            }
+            loadedModelPath = rootURL.path
+        }
+
+        guard let configs, let transformer, let textEncoder, let tokenizer, let vae else {
+            throw Krea2GeneratorError.modelsNotLoaded
+        }
+
+        progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 0, totalSteps: 1))
+        let text = try encodePrompt(
+            request.prompt,
+            tokenizer: tokenizer,
+            encoder: textEncoder,
+            selectedLayers: configs.selectedTextLayers,
+            maxLength: min(request.maxSequenceLength, 512)
+        )
+        progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 1, totalSteps: 1))
+
+        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let aligned = Krea2SampleBuilder.alignedResolution(width: request.width, height: request.height)
+        var latents = MLXRandom.normal(
+            [
+                1,
+                configs.transformer.latentChannels,
+                aligned.height / Krea2SampleBuilder.vaeCompression,
+                aligned.width / Krea2SampleBuilder.vaeCompression,
+            ],
+            key: MLXRandom.key(seed)
+        ).asType(.bfloat16)
+
+        let prepared = Krea2SampleBuilder.prepare(
+            latents: latents,
+            textLength: text.hiddenStates.dim(1),
+            textMask: text.attentionMask,
+            patch: configs.transformer.patchSize
+        )
+        var imageTokens = prepared.imageTokens.asType(.float32)
+        let mu = request.sigmaShift ?? Krea2SampleBuilder.defaultMu
+        let timesteps = Krea2SampleBuilder.timesteps(
+            imageTokenCount: prepared.imageTokenCount,
+            steps: request.steps,
+            mu: mu
+        )
+
+        for step in 0..<request.steps {
+            try Task.checkCancellation()
+            progressHandler?(GenerationProgress(stage: .denoising, stepIndex: step, totalSteps: request.steps))
+            let tCurrent = timesteps[step]
+            let tPrevious = timesteps[step + 1]
+            let timestep = MLXArray([tCurrent]).asType(.bfloat16)
+            let velocity = transformer(
+                imageTokens: imageTokens.asType(.bfloat16),
+                textContext: text.hiddenStates.asType(.bfloat16),
+                timestep: timestep,
+                positionIds: prepared.positionIds,
+                validMask: prepared.validMask
+            )
+            imageTokens = imageTokens + velocity.asType(.float32) * MLXArray(tPrevious - tCurrent)
+            MLX.eval(imageTokens)
+        }
+        progressHandler?(GenerationProgress(stage: .denoising, stepIndex: request.steps, totalSteps: request.steps))
+
+        progressHandler?(GenerationProgress(stage: .decoding, stepIndex: 0, totalSteps: 1))
+        latents = Krea2SampleBuilder.unpatchify(
+            imageTokens.asType(.bfloat16),
+            tokenHeight: prepared.imageTokenHeight,
+            tokenWidth: prepared.imageTokenWidth,
+            channels: configs.transformer.latentChannels,
+            patch: configs.transformer.patchSize
+        )
+        let decoded = decodeLatents(latents, vae: vae, config: configs.vae, height: request.height, width: request.width)
+        progressHandler?(GenerationProgress(stage: .decoding, stepIndex: 1, totalSteps: 1))
+
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 0, totalSteps: 1))
+        try ensureOutputDirectory(request.outputURL)
+        try QwenImageIO.saveImage(array: decoded, to: request.outputURL)
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 1, totalSteps: 1))
+        return GenerationResult(outputURL: request.outputURL, seed: seed)
+    }
+
+    private func loadModels(
+        from resources: Krea2Resources,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) throws {
+        let loadedConfigs = try Krea2ModelConfigs.load(from: resources)
+        configs = loadedConfigs
+
+        progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 0, totalSteps: 3))
+        transformer = try Krea2ModelLoader.loadTransformer(
+            from: resources,
+            configuration: loadedConfigs.transformer,
+            progressHandler: { shard in
+                progressHandler?(GenerationProgress(
+                    stage: .loadingTransformer,
+                    stepIndex: shard.shardIndex + 1,
+                    totalSteps: max(shard.shardCount, 1)
+                ))
+            }
+        )
+        progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 3, totalSteps: 3))
+
+        progressHandler?(GenerationProgress(stage: .loadingEncoder, stepIndex: 0, totalSteps: 2))
+        tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: 512)
+        textEncoder = try Krea2ModelLoader.loadTextEncoder(
+            from: resources,
+            configuration: loadedConfigs.textEncoder
+        )
+        progressHandler?(GenerationProgress(stage: .loadingEncoder, stepIndex: 2, totalSteps: 2))
+
+        progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 0, totalSteps: 1))
+        vae = try Krea2ModelLoader.loadVAE(from: resources, configuration: loadedConfigs.vae)
+        progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 1, totalSteps: 1))
+    }
+
+    private func encodePrompt(
+        _ prompt: String,
+        tokenizer: QwenTokenizer,
+        encoder: QwenEncoder,
+        selectedLayers: [Int],
+        maxLength: Int
+    ) throws -> (hiddenStates: MLXArray, attentionMask: MLXArray) {
+        let prefix = "<|im_start|>system\nDescribe the image by detailing the color, shape, size, texture, quantity, text, spatial relationships of the objects and background:<|im_end|>\n<|im_start|>user\n"
+        let suffix = "<|im_end|>\n<|im_start|>assistant\n"
+        let prefixDropCount = 34
+        let suffixIds = tokenizer.encodeText(suffix)
+        let inputs = Krea2SampleBuilder.paddedTextTokenInputs(
+            promptTokenIds: tokenizer.encodeText(prefix + prompt),
+            suffixTokenIds: suffixIds,
+            padTokenId: tokenizer.padTokenId,
+            maxLength: maxLength,
+            prefixDropCount: prefixDropCount
+        )
+        let tokenIds = inputs.tokenIds
+        let inputIds = MLXArray(tokenIds.map(Int32.init)).reshaped(1, tokenIds.count)
+        let attentionMask = MLXArray(inputs.attentionMask).reshaped(1, inputs.attentionMask.count)
+        let hiddenStates = encoder.forwardActivationHiddenStates(
+            inputIds: inputIds,
+            attentionMask: attentionMask,
+            activationLayers: Krea2SampleBuilder.qwenActivationLayerIndices(from: selectedLayers)
+        )
+        let stacked = MLX.stacked(hiddenStates, axis: 2).asType(.bfloat16)
+        let croppedStates = stacked[0..., prefixDropCount..., 0..., 0...]
+        let croppedMask = attentionMask[0..., prefixDropCount...]
+        MLX.eval(croppedStates, croppedMask)
+        return (croppedStates, croppedMask)
+    }
+
+    private func decodeLatents(
+        _ latents: MLXArray,
+        vae: QwenImageEditVAE,
+        config: QwenImageEditVAEConfig,
+        height: Int,
+        width: Int
+    ) -> MLXArray {
+        var z = latents
+        if let mean = config.latentsMean, let std = config.latentsStd {
+            let meanTensor = MLXArray(mean).reshaped(1, mean.count, 1, 1).asType(z.dtype)
+            let stdTensor = MLXArray(std).reshaped(1, std.count, 1, 1).asType(z.dtype)
+            z = z * stdTensor + meanTensor
+        }
+        var vaeInput = z
+        if let shift = config.shiftFactor, shift != 0 {
+            vaeInput = vaeInput - MLXArray(shift).asType(vaeInput.dtype)
+        }
+        vaeInput = vaeInput * MLXArray(config.scalingFactor).asType(vaeInput.dtype)
+        var decoded = vae.decode(vaeInput.asType(.bfloat16))
+        decoded = MLX.clip(decoded.asType(.float32), min: -1.0, max: 1.0)
+        var image = QwenImageIO.denormalizeFromDecoder(decoded)
+        if image.dim(2) != height || image.dim(3) != width {
+            image = image[0..., 0..., 0..<height, 0..<width]
+        }
+        return MLX.clip(image, min: 0, max: 1)
+    }
+
+    private func resolveModelRoot(_ request: GenerationRequest) throws -> URL {
+        if let model = request.model {
+            let url = URL(fileURLWithPath: model).standardizedFileURL
+            if FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+        if let resolved = ManagedModelResolver.resolveInstalledModel(id: ModelResolver.ModelID.krea2Turbo.rawValue) {
+            return resolved
+        }
+        throw ModelResolver.ResolverError.modelNotFound(
+            .krea2Turbo,
+            searched: [MereRunModelPaths.modelDir(ModelResolver.ModelID.krea2Turbo.rawValue)],
+            upstreamRepoId: Krea2Resources.upstreamRepoId
+        )
+    }
+
+    private func ensureOutputDirectory(_ outputURL: URL) throws {
+        let directory = outputURL.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
+    private func deterministicSeed(prompt: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in prompt.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x0000_0100_0000_01b3
+        }
+        return hash
+    }
+
+    private func clearGPUMemory(synchronize: Bool = true) {
+        if synchronize {
+            Stream.gpu.synchronize()
+        }
+        MLX.eval(MLXArray([]))
+        Memory.clearCache()
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2Model.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Model.swift
@@ -1,0 +1,449 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+@inline(__always)
+private func krea2RMSNorm(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
+    let dtype = x.dtype
+    let xFloat = x.asType(.float32)
+    let variance = (xFloat * xFloat).mean(axis: -1, keepDims: true)
+    var normalized = xFloat / MLX.sqrt(variance + MLXArray(eps))
+    let scale = (weight.asType(.float32) + MLXArray(1.0)).reshaped(
+        Array(repeating: 1, count: max(0, x.ndim - 1)) + [weight.dim(0)]
+    )
+    normalized = normalized * scale
+    return normalized.asType(dtype)
+}
+
+final class Krea2RMSNorm: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    private let eps: Float
+
+    init(dimensions: Int, eps: Float = 1e-5) {
+        self.eps = eps
+        self._weight.wrappedValue = MLXArray.zeros([dimensions])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        krea2RMSNorm(x, weight: weight, eps: eps)
+    }
+}
+
+final class Krea2SwiGLU: Module {
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ModuleInfo(key: "up") var up: Linear
+    @ModuleInfo(key: "down") var down: Linear
+
+    init(dim: Int, hiddenDim: Int, bias: Bool = false) {
+        self._gate.wrappedValue = Linear(dim, hiddenDim, bias: bias)
+        self._up.wrappedValue = Linear(dim, hiddenDim, bias: bias)
+        self._down.wrappedValue = Linear(hiddenDim, dim, bias: bias)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(MLXNN.silu(gate(x)) * up(x))
+    }
+}
+
+final class Krea2Attention: Module {
+    let heads: Int
+    let kvHeads: Int
+    let headDim: Int
+    let hiddenSize: Int
+    let scale: Float
+
+    @ModuleInfo(key: "to_q") var toQ: Linear
+    @ModuleInfo(key: "to_k") var toK: Linear
+    @ModuleInfo(key: "to_v") var toV: Linear
+    @ModuleInfo(key: "to_gate") var toGate: Linear
+    @ModuleInfo(key: "norm_q") var normQ: Krea2RMSNorm
+    @ModuleInfo(key: "norm_k") var normK: Krea2RMSNorm
+    @ModuleInfo(key: "to_out") var toOut: [Linear]
+
+    init(dim: Int, heads: Int, kvHeads: Int, eps: Float, bias: Bool = false) {
+        self.heads = heads
+        self.kvHeads = kvHeads
+        self.headDim = dim / heads
+        self.hiddenSize = dim
+        self.scale = 1.0 / sqrt(Float(headDim))
+        self._toQ.wrappedValue = Linear(dim, headDim * heads, bias: bias)
+        self._toK.wrappedValue = Linear(dim, headDim * kvHeads, bias: bias)
+        self._toV.wrappedValue = Linear(dim, headDim * kvHeads, bias: bias)
+        self._toGate.wrappedValue = Linear(dim, dim, bias: bias)
+        self._normQ.wrappedValue = Krea2RMSNorm(dimensions: headDim, eps: eps)
+        self._normK.wrappedValue = Krea2RMSNorm(dimensions: headDim, eps: eps)
+        self._toOut.wrappedValue = [Linear(dim, dim, bias: bias)]
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        rotary: (cos: MLXArray, sin: MLXArray)? = nil,
+        mask: MLXArray? = nil
+    ) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+        var q = toQ(x).reshaped(batch, sequence, heads, headDim).transposed(0, 2, 1, 3)
+        var k = toK(x).reshaped(batch, sequence, kvHeads, headDim).transposed(0, 2, 1, 3)
+        var v = toV(x).reshaped(batch, sequence, kvHeads, headDim).transposed(0, 2, 1, 3)
+        let gate = MLX.sigmoid(toGate(x))
+
+        q = normQ(q)
+        k = normK(k)
+        if let rotary {
+            q = Krea2PositionalEncoding.applyRotary(q, rotary: rotary)
+            k = Krea2PositionalEncoding.applyRotary(k, rotary: rotary)
+        }
+        if kvHeads < heads {
+            let repeats = heads / kvHeads
+            k = MLX.repeated(k, count: repeats, axis: 1)
+            v = MLX.repeated(v, count: repeats, axis: 1)
+        }
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: mask
+        )
+        let output = attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, hiddenSize)
+        return toOut[0](output * gate)
+    }
+}
+
+final class Krea2TextFusionBlock: Module {
+    @ModuleInfo(key: "norm1") var norm1: Krea2RMSNorm
+    @ModuleInfo(key: "norm2") var norm2: Krea2RMSNorm
+    @ModuleInfo(key: "attn") var attn: Krea2Attention
+    @ModuleInfo(key: "ff") var ff: Krea2SwiGLU
+
+    init(dim: Int, heads: Int, kvHeads: Int, hiddenDim: Int, eps: Float) {
+        self._norm1.wrappedValue = Krea2RMSNorm(dimensions: dim, eps: eps)
+        self._norm2.wrappedValue = Krea2RMSNorm(dimensions: dim, eps: eps)
+        self._attn.wrappedValue = Krea2Attention(dim: dim, heads: heads, kvHeads: kvHeads, eps: eps)
+        self._ff.wrappedValue = Krea2SwiGLU(dim: dim, hiddenDim: hiddenDim)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        var out = x + attn(norm1(x), mask: mask)
+        out = out + ff(norm2(out))
+        return out
+    }
+}
+
+final class Krea2TextFusionTransformer: Module {
+    @ModuleInfo(key: "layerwise_blocks") var layerwiseBlocks: [Krea2TextFusionBlock]
+    @ModuleInfo(key: "projector") var projector: Linear
+    @ModuleInfo(key: "refiner_blocks") var refinerBlocks: [Krea2TextFusionBlock]
+
+    init(configuration: Krea2TransformerConfiguration) {
+        self._layerwiseBlocks.wrappedValue = (0..<configuration.numLayerwiseTextBlocks).map { _ in
+            Krea2TextFusionBlock(
+                dim: configuration.textHiddenDim,
+                heads: configuration.textNumAttentionHeads,
+                kvHeads: configuration.textNumKeyValueHeads,
+                hiddenDim: configuration.textIntermediateSize,
+                eps: configuration.normEps
+            )
+        }
+        self._projector.wrappedValue = Linear(configuration.numTextLayers, 1, bias: false)
+        self._refinerBlocks.wrappedValue = (0..<configuration.numRefinerTextBlocks).map { _ in
+            Krea2TextFusionBlock(
+                dim: configuration.textHiddenDim,
+                heads: configuration.textNumAttentionHeads,
+                kvHeads: configuration.textNumKeyValueHeads,
+                hiddenDim: configuration.textIntermediateSize,
+                eps: configuration.normEps
+            )
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+        let layerCount = x.dim(2)
+        let dim = x.dim(3)
+        var hidden = x.reshaped(batch * sequence, layerCount, dim)
+        for block in layerwiseBlocks {
+            hidden = block(hidden)
+        }
+        hidden = hidden.reshaped(batch, sequence, layerCount, dim)
+            .transposed(0, 1, 3, 2)
+        hidden = projector(hidden).squeezed(axis: -1)
+        for block in refinerBlocks {
+            hidden = block(hidden, mask: mask)
+        }
+        return hidden
+    }
+}
+
+final class Krea2TextProjection: Module {
+    @ModuleInfo(key: "norm") var norm: Krea2RMSNorm
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+
+    init(textDim: Int, hiddenSize: Int, eps: Float) {
+        self._norm.wrappedValue = Krea2RMSNorm(dimensions: textDim, eps: eps)
+        self._linear1.wrappedValue = Linear(textDim, hiddenSize, bias: true)
+        self._linear2.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(MLXNN.geluApproximate(linear1(norm(x))))
+    }
+}
+
+final class Krea2TimeEmbed: Module {
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+    let embeddingDim: Int
+
+    init(embeddingDim: Int, hiddenSize: Int) {
+        self.embeddingDim = embeddingDim
+        self._linear1.wrappedValue = Linear(embeddingDim, hiddenSize, bias: true)
+        self._linear2.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ timestep: MLXArray, dtype: DType) -> MLXArray {
+        let projected = Self.timestepEmbedding(timestep, dim: embeddingDim).asType(dtype)
+        return linear2(MLXNN.geluApproximate(linear1(projected)))
+    }
+
+    static func timestepEmbedding(_ timestep: MLXArray, dim: Int) -> MLXArray {
+        let half = dim / 2
+        let freqs = MLX.exp(
+            MLXArray(0..<half).asType(.float32) * MLXArray(-Foundation.log(10_000.0) / Float(half))
+        )
+        let args = timestep.asType(.float32).reshaped(timestep.dim(0), 1, 1) * MLXArray(1_000.0) * freqs
+        var embedding = MLX.concatenated([MLX.cos(args), MLX.sin(args)], axis: -1)
+        embedding = embedding.squeezed(axis: 1)
+        if dim % 2 == 1 {
+            embedding = MLX.concatenated([embedding, MLX.zeros([embedding.dim(0), 1], dtype: .float32)], axis: -1)
+        }
+        return embedding
+    }
+}
+
+final class Krea2SingleStreamBlock: Module {
+    @ParameterInfo(key: "scale_shift_table") var scaleShiftTable: MLXArray
+    @ModuleInfo(key: "norm1") var norm1: Krea2RMSNorm
+    @ModuleInfo(key: "norm2") var norm2: Krea2RMSNorm
+    @ModuleInfo(key: "attn") var attn: Krea2Attention
+    @ModuleInfo(key: "ff") var ff: Krea2SwiGLU
+
+    let hiddenSize: Int
+
+    init(configuration: Krea2TransformerConfiguration) {
+        self.hiddenSize = configuration.hiddenSize
+        self._scaleShiftTable.wrappedValue = MLXArray.zeros([6, configuration.hiddenSize])
+        self._norm1.wrappedValue = Krea2RMSNorm(dimensions: configuration.hiddenSize, eps: configuration.normEps)
+        self._norm2.wrappedValue = Krea2RMSNorm(dimensions: configuration.hiddenSize, eps: configuration.normEps)
+        self._attn.wrappedValue = Krea2Attention(
+            dim: configuration.hiddenSize,
+            heads: configuration.numAttentionHeads,
+            kvHeads: configuration.numKeyValueHeads,
+            eps: configuration.normEps
+        )
+        self._ff.wrappedValue = Krea2SwiGLU(
+            dim: configuration.hiddenSize,
+            hiddenDim: configuration.intermediateSize
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        modulation: MLXArray,
+        rotary: (cos: MLXArray, sin: MLXArray),
+        mask: MLXArray
+    ) -> MLXArray {
+        let batch = x.dim(0)
+        let table = scaleShiftTable.reshaped(1, 6, hiddenSize)
+        let values = (modulation.reshaped(batch, 6, hiddenSize) + table).expandedDimensions(axis: 1)
+        let prescale = values[0..., 0..., 0, 0...]
+        let preshift = values[0..., 0..., 1, 0...]
+        let pregate = values[0..., 0..., 2, 0...]
+        let postscale = values[0..., 0..., 3, 0...]
+        let postshift = values[0..., 0..., 4, 0...]
+        let postgate = values[0..., 0..., 5, 0...]
+
+        var out = x + pregate * attn((1 + prescale) * norm1(x) + preshift, rotary: rotary, mask: mask)
+        out = out + postgate * ff((1 + postscale) * norm2(out) + postshift)
+        return out
+    }
+}
+
+final class Krea2FinalLayer: Module {
+    @ModuleInfo(key: "norm") var norm: Krea2RMSNorm
+    @ModuleInfo(key: "linear") var linear: Linear
+    @ParameterInfo(key: "scale_shift_table") var scaleShiftTable: MLXArray
+
+    let hiddenSize: Int
+
+    init(hiddenSize: Int, outChannels: Int, eps: Float) {
+        self.hiddenSize = hiddenSize
+        self._norm.wrappedValue = Krea2RMSNorm(dimensions: hiddenSize, eps: eps)
+        self._linear.wrappedValue = Linear(hiddenSize, outChannels, bias: true)
+        self._scaleShiftTable.wrappedValue = MLXArray.zeros([2, hiddenSize])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, timestepEmbedding: MLXArray) -> MLXArray {
+        let batch = timestepEmbedding.dim(0)
+        let values = timestepEmbedding.reshaped(batch, 1, hiddenSize)
+            + scaleShiftTable.reshaped(1, 2, hiddenSize)
+        let scale = values[0..., 0..<1, 0...]
+        let shift = values[0..., 1..<2, 0...]
+        return linear((1 + scale) * norm(x) + shift)
+    }
+}
+
+final class Krea2PositionalEncoding {
+    let axesDims: [Int]
+    let theta: Float
+
+    init(axesDims: [Int], theta: Float) {
+        self.axesDims = axesDims
+        self.theta = theta
+    }
+
+    func callAsFunction(positionIds: MLXArray) -> (cos: MLXArray, sin: MLXArray) {
+        let pos = positionIds.asType(.float32)
+        var cosParts: [MLXArray] = []
+        var sinParts: [MLXArray] = []
+        for axis in 0..<axesDims.count {
+            let dim = axesDims[axis]
+            let axisPos = pos[0..., 0..., axis]
+            let scale = MLXArray(stride(from: 0, to: dim, by: 2)).asType(.float32) / Float(dim)
+            let omega = 1.0 / MLX.pow(MLXArray(theta), scale)
+            let angles = axisPos.expandedDimensions(axis: -1) * omega
+            cosParts.append(MLX.cos(angles))
+            sinParts.append(MLX.sin(angles))
+        }
+        return (
+            MLX.concatenated(cosParts, axis: -1),
+            MLX.concatenated(sinParts, axis: -1)
+        )
+    }
+
+    static func applyRotary(
+        _ x: MLXArray,
+        rotary: (cos: MLXArray, sin: MLXArray)
+    ) -> MLXArray {
+        let outDtype = x.dtype
+        let xFloat = x.asType(.float32)
+        let shape = xFloat.shape
+        let half = shape[3] / 2
+        let paired = xFloat.reshaped(shape[0], shape[1], shape[2], half, 2)
+        let real = paired[0..., 0..., 0..., 0..., 0]
+        let imaginary = paired[0..., 0..., 0..., 0..., 1]
+        let cosValues = rotary.cos.expandedDimensions(axis: 1)
+        let sinValues = rotary.sin.expandedDimensions(axis: 1)
+        let outReal = real * cosValues - imaginary * sinValues
+        let outImaginary = real * sinValues + imaginary * cosValues
+        return MLX.stacked([outReal, outImaginary], axis: -1).reshaped(shape).asType(outDtype)
+    }
+}
+
+public final class Krea2Transformer: Module {
+    public let configuration: Krea2TransformerConfiguration
+
+    @ModuleInfo(key: "img_in") var imgIn: Linear
+    @ModuleInfo(key: "txt_in") var txtIn: Krea2TextProjection
+    @ModuleInfo(key: "text_fusion") var textFusion: Krea2TextFusionTransformer
+    @ModuleInfo(key: "time_embed") var timeEmbed: Krea2TimeEmbed
+    @ModuleInfo(key: "time_mod_proj") var timeModProj: Linear
+    @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [Krea2SingleStreamBlock]
+    @ModuleInfo(key: "final_layer") var finalLayer: Krea2FinalLayer
+
+    private let positionalEncoding: Krea2PositionalEncoding
+
+    public init(configuration: Krea2TransformerConfiguration) {
+        self.configuration = configuration
+        self._imgIn.wrappedValue = Linear(configuration.inChannels, configuration.hiddenSize, bias: true)
+        self._txtIn.wrappedValue = Krea2TextProjection(
+            textDim: configuration.textHiddenDim,
+            hiddenSize: configuration.hiddenSize,
+            eps: configuration.normEps
+        )
+        self._textFusion.wrappedValue = Krea2TextFusionTransformer(configuration: configuration)
+        self._timeEmbed.wrappedValue = Krea2TimeEmbed(
+            embeddingDim: configuration.timestepEmbedDim,
+            hiddenSize: configuration.hiddenSize
+        )
+        self._timeModProj.wrappedValue = Linear(configuration.hiddenSize, configuration.hiddenSize * 6, bias: true)
+        self._transformerBlocks.wrappedValue = (0..<configuration.numLayers).map { _ in
+            Krea2SingleStreamBlock(configuration: configuration)
+        }
+        self._finalLayer.wrappedValue = Krea2FinalLayer(
+            hiddenSize: configuration.hiddenSize,
+            outChannels: configuration.inChannels,
+            eps: configuration.normEps
+        )
+        self.positionalEncoding = Krea2PositionalEncoding(
+            axesDims: configuration.axesDimsRope,
+            theta: configuration.ropeTheta
+        )
+        super.init()
+    }
+
+    public func callAsFunction(
+        imageTokens: MLXArray,
+        textContext: MLXArray,
+        timestep: MLXArray,
+        positionIds: MLXArray,
+        validMask: MLXArray
+    ) -> MLXArray {
+        let textLength = textContext.dim(1)
+        let imageLength = imageTokens.dim(1)
+        let batch = imageTokens.dim(0)
+        let imageHidden = imgIn(imageTokens)
+        let timeEmbedding = timeEmbed(timestep, dtype: imageHidden.dtype)
+        let timeModulation = timeModProj(MLXNN.geluApproximate(timeEmbedding))
+
+        let textMask = validMask[0..., 0..<textLength]
+        let textAttentionMask = Krea2SampleBuilder.attentionMask(
+            validMask: textMask,
+            dtype: imageHidden.dtype
+        )
+        let textHidden = txtIn(textFusion(textContext, mask: textAttentionMask))
+        var combined = MLX.concatenated([textHidden, imageHidden], axis: 1)
+        var combinedMask = validMask
+        var combinedPositions = positionIds
+        let fullLength = combined.dim(1)
+        let padLength = (256 - (fullLength % 256)) % 256
+        if padLength > 0 {
+            combined = MLX.concatenated([
+                combined,
+                MLX.zeros([batch, padLength, configuration.hiddenSize], dtype: combined.dtype),
+            ], axis: 1)
+            combinedMask = MLX.concatenated([
+                combinedMask,
+                MLX.zeros([batch, padLength], dtype: .int32),
+            ], axis: 1)
+            combinedPositions = MLX.concatenated([
+                combinedPositions,
+                MLX.zeros([batch, padLength, 3], dtype: combinedPositions.dtype),
+            ], axis: 1)
+        }
+
+        let attentionMask = Krea2SampleBuilder.attentionMask(validMask: combinedMask, dtype: combined.dtype)
+        let tokenMask = (combinedMask .== MLXArray(Int32(1))).expandedDimensions(axis: -1)
+        let rotary = positionalEncoding(positionIds: combinedPositions)
+        for block in transformerBlocks {
+            combined = MLX.where(tokenMask, combined, MLX.zeros(combined.shape, dtype: combined.dtype))
+            combined = block(combined, modulation: timeModulation, rotary: rotary, mask: attentionMask)
+        }
+        combined = MLX.where(tokenMask, combined, MLX.zeros(combined.shape, dtype: combined.dtype))
+        let output = finalLayer(combined, timestepEmbedding: timeEmbedding)
+        return output[0..., textLength..<(textLength + imageLength), 0...].asType(.float32)
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2ModelLoader.swift
+++ b/Sources/MereRunCore/Krea2/Krea2ModelLoader.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MLX
+
+public enum Krea2ModelLoader {
+    public static func loadTransformer(
+        from resources: Krea2Resources,
+        configuration: Krea2TransformerConfiguration,
+        dtype: DType? = .bfloat16,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> Krea2Transformer {
+        let transformer = Krea2Transformer(configuration: configuration)
+        try HFSafetensorsWeightsLoader.applyShardedWeights(
+            indexURL: resources.transformerWeightsIndexURL,
+            to: transformer,
+            dtype: dtype,
+            verify: [.shapeMismatch],
+            mapper: mapTransformerWeight,
+            progressHandler: progressHandler
+        )
+        return transformer
+    }
+
+    public static func loadTextEncoder(
+        from resources: Krea2Resources,
+        configuration: Krea2TextEncoderConfiguration,
+        dtype: DType? = .bfloat16
+    ) throws -> QwenEncoder {
+        let encoder = QwenEncoder(configuration: configuration.qwenConfiguration)
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.textEncoderWeightsURL,
+            to: encoder,
+            dtype: dtype,
+            verify: [.shapeMismatch],
+            mapper: mapTextEncoderWeight
+        )
+        return encoder
+    }
+
+    public static func loadVAE(
+        from resources: Krea2Resources,
+        configuration: QwenImageEditVAEConfig,
+        dtype: DType? = .bfloat16
+    ) throws -> QwenImageEditVAE {
+        let vae = QwenImageEditVAE(config: configuration)
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.vaeWeightsURL,
+            to: vae.underlyingVAE,
+            dtype: dtype,
+            verify: [.shapeMismatch],
+            mapper: QwenImageEditVAE.weightMapper
+        )
+        return vae
+    }
+
+    static func mapTransformerWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        [(key, value)]
+    }
+
+    static func mapTextEncoderWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        guard !key.hasPrefix("lm_head."), key != "lm_head" else {
+            return []
+        }
+        if key.hasPrefix("language_model.lm_head") {
+            return []
+        }
+        if key.hasPrefix("language_model.") {
+            return QwenEncoder.mapHFSafetensorWeight(
+                key: String(key.dropFirst("language_model.".count)),
+                value: value
+            )
+        }
+        return QwenEncoder.mapHFSafetensorWeight(key: key, value: value)
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2Resources.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Resources.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+public struct Krea2Resources: Sendable, Hashable {
+    public static let modelId = "image-krea2-turbo"
+    public static let upstreamRepoId = "krea/Krea-2-Turbo"
+    public static let upstreamRevision = "main"
+    public static let estimatedDownloadBytes: Int64 = 36 * 1_073_741_824
+
+    /// Krea publishes both split Diffusers component weights and a root-level
+    /// `turbo.safetensors` copy of the transformer. Pull only the component
+    /// layout so managed installs avoid downloading the same 26 GB twice.
+    public static let snapshotPatterns = [
+        "LICENSE.pdf",
+        "README.md",
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "text_encoder/config.json",
+        "text_encoder/model.safetensors",
+        "tokenizer/chat_template.jinja",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "transformer/config.json",
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "transformer/diffusion_pytorch_model-*.safetensors",
+        "vae/config.json",
+        "vae/diffusion_pytorch_model.safetensors",
+    ]
+
+    public var rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var modelIndexURL: URL { rootURL.appending(path: "model_index.json") }
+    public var schedulerURL: URL { rootURL.appending(path: "scheduler") }
+    public var textEncoderURL: URL { rootURL.appending(path: "text_encoder") }
+    public var tokenizerURL: URL { rootURL.appending(path: "tokenizer") }
+    public var transformerURL: URL { rootURL.appending(path: "transformer") }
+    public var vaeURL: URL { rootURL.appending(path: "vae") }
+    public var schedulerConfigURL: URL { schedulerURL.appending(path: "scheduler_config.json") }
+    public var textEncoderConfigURL: URL { textEncoderURL.appending(path: "config.json") }
+    public var textEncoderWeightsURL: URL { textEncoderURL.appending(path: "model.safetensors") }
+    public var transformerConfigURL: URL { transformerURL.appending(path: "config.json") }
+    public var transformerWeightsIndexURL: URL {
+        transformerURL.appending(path: "diffusion_pytorch_model.safetensors.index.json")
+    }
+    public var vaeConfigURL: URL { vaeURL.appending(path: "config.json") }
+    public var vaeWeightsURL: URL { vaeURL.appending(path: "diffusion_pytorch_model.safetensors") }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing: [URL] = []
+        for file in [
+            modelIndexURL,
+            schedulerConfigURL,
+            textEncoderConfigURL,
+            textEncoderWeightsURL,
+            tokenizerURL.appending(path: "tokenizer.json"),
+            tokenizerURL.appending(path: "tokenizer_config.json"),
+            transformerConfigURL,
+            transformerWeightsIndexURL,
+            vaeConfigURL,
+            vaeWeightsURL,
+        ] where !fileManager.fileExists(atPath: file.path) {
+            missing.append(file)
+        }
+
+        if !hasTransformerShard(fileManager: fileManager) {
+            missing.append(transformerURL.appending(path: "diffusion_pytorch_model-00001-of-00003.safetensors"))
+        }
+
+        return missing
+    }
+
+    private func hasTransformerShard(fileManager: FileManager) -> Bool {
+        let transformerURL = transformerURL.resolvingSymlinksInPath()
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: transformerURL,
+            includingPropertiesForKeys: nil
+        ) else {
+            return false
+        }
+        return children.contains { url in
+            let name = url.lastPathComponent
+            return name.hasPrefix("diffusion_pytorch_model-")
+                && name.hasSuffix(".safetensors")
+        }
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2SampleBuilder.swift
+++ b/Sources/MereRunCore/Krea2/Krea2SampleBuilder.swift
@@ -1,0 +1,157 @@
+import Foundation
+import MLX
+
+public struct Krea2PreparedSample {
+    public let imageTokens: MLXArray
+    public let positionIds: MLXArray
+    public let validMask: MLXArray
+    public let imageTokenHeight: Int
+    public let imageTokenWidth: Int
+    public let textTokenCount: Int
+    public let imageTokenCount: Int
+}
+
+public enum Krea2SampleBuilder {
+    public static let vaeCompression = 8
+    public static let patchSize = 2
+    public static let latentChannels = 16
+    public static let defaultMu: Float = 1.15
+
+    public static func alignedResolution(width: Int, height: Int) -> (width: Int, height: Int) {
+        let align = vaeCompression * patchSize
+        return (roundUp(width, multiple: align), roundUp(height, multiple: align))
+    }
+
+    public static func patchify(_ latents: MLXArray, patch: Int = patchSize) -> MLXArray {
+        let batch = latents.dim(0)
+        let channels = latents.dim(1)
+        let height = latents.dim(2)
+        let width = latents.dim(3)
+        var x = latents.reshaped(batch, channels, height / patch, patch, width / patch, patch)
+        x = x.transposed(0, 2, 4, 1, 3, 5)
+        return x.reshaped(batch, (height / patch) * (width / patch), channels * patch * patch)
+    }
+
+    public static func unpatchify(
+        _ tokens: MLXArray,
+        tokenHeight: Int,
+        tokenWidth: Int,
+        channels: Int = latentChannels,
+        patch: Int = patchSize
+    ) -> MLXArray {
+        let batch = tokens.dim(0)
+        var x = tokens.reshaped(batch, tokenHeight, tokenWidth, channels, patch, patch)
+        x = x.transposed(0, 3, 1, 4, 2, 5)
+        return x.reshaped(batch, channels, tokenHeight * patch, tokenWidth * patch)
+    }
+
+    public static func prepare(
+        latents: MLXArray,
+        textLength: Int,
+        textMask: MLXArray,
+        patch: Int = patchSize
+    ) -> Krea2PreparedSample {
+        let batch = latents.dim(0)
+        let latentHeight = latents.dim(2)
+        let latentWidth = latents.dim(3)
+        let tokenHeight = latentHeight / patch
+        let tokenWidth = latentWidth / patch
+        let imageTokenCount = tokenHeight * tokenWidth
+        let imageTokens = patchify(latents, patch: patch)
+        let imageMask = MLX.ones([batch, imageTokenCount], dtype: .int32)
+        let validMask = MLX.concatenated([textMask.asType(.int32), imageMask], axis: 1)
+
+        var positions = [Float]()
+        positions.reserveCapacity(batch * (textLength + imageTokenCount) * 3)
+        for _ in 0..<batch {
+            for _ in 0..<textLength {
+                positions.append(0)
+                positions.append(0)
+                positions.append(0)
+            }
+            for y in 0..<tokenHeight {
+                for x in 0..<tokenWidth {
+                    positions.append(0)
+                    positions.append(Float(y))
+                    positions.append(Float(x))
+                }
+            }
+        }
+
+        return Krea2PreparedSample(
+            imageTokens: imageTokens,
+            positionIds: MLXArray(positions).reshaped(batch, textLength + imageTokenCount, 3),
+            validMask: validMask,
+            imageTokenHeight: tokenHeight,
+            imageTokenWidth: tokenWidth,
+            textTokenCount: textLength,
+            imageTokenCount: imageTokenCount
+        )
+    }
+
+    public static func timesteps(
+        imageTokenCount: Int,
+        steps: Int,
+        mu: Float? = defaultMu,
+        minResolution: Int = 256,
+        maxResolution: Int = 1280,
+        y1: Float = 0.5,
+        y2: Float = 1.15,
+        sigma: Float = 1.0
+    ) -> [Float] {
+        let x1 = Float((minResolution / (vaeCompression * patchSize)) * (minResolution / (vaeCompression * patchSize)))
+        let x2 = Float((maxResolution / (vaeCompression * patchSize)) * (maxResolution / (vaeCompression * patchSize)))
+        let resolvedMu: Float
+        if let mu {
+            resolvedMu = mu
+        } else {
+            let slope = (y2 - y1) / (x2 - x1)
+            resolvedMu = slope * Float(imageTokenCount) + (y1 - slope * x1)
+        }
+        let expMu = Foundation.exp(resolvedMu)
+        return (0...steps).map { index in
+            let t = 1.0 - Float(index) / Float(steps)
+            guard t > 0 else { return 0 }
+            let shifted = expMu / (expMu + Foundation.pow(1.0 / t - 1.0, sigma))
+            return shifted
+        }
+    }
+
+    public static func paddedTextTokenInputs(
+        promptTokenIds: [Int],
+        suffixTokenIds: [Int],
+        padTokenId: Int,
+        maxLength: Int,
+        prefixDropCount: Int = 34
+    ) -> (tokenIds: [Int], attentionMask: [Int32]) {
+        let promptBlockLength = maxLength + prefixDropCount - suffixTokenIds.count
+        var promptIds = Array(promptTokenIds.prefix(promptBlockLength))
+        var promptMask = Array(repeating: Int32(1), count: promptIds.count)
+        if promptIds.count < promptBlockLength {
+            let paddingCount = promptBlockLength - promptIds.count
+            promptIds.append(contentsOf: Array(repeating: padTokenId, count: paddingCount))
+            promptMask.append(contentsOf: Array(repeating: Int32(0), count: paddingCount))
+        }
+        return (
+            tokenIds: promptIds + suffixTokenIds,
+            attentionMask: promptMask + Array(repeating: Int32(1), count: suffixTokenIds.count)
+        )
+    }
+
+    public static func qwenActivationLayerIndices(from hiddenStateIndices: [Int]) -> [Int] {
+        hiddenStateIndices.map { max(0, $0 - 1) }
+    }
+
+    static func attentionMask(validMask: MLXArray, dtype: DType) -> MLXArray {
+        let batch = validMask.dim(0)
+        let length = validMask.dim(1)
+        let columns = validMask.reshaped(batch, 1, 1, length)
+        let keep = columns .== MLXArray(Int32(1))
+        let zeros = MLX.zeros([batch, 1, length, length], dtype: dtype)
+        return MLX.where(keep, zeros, zeros + MLXArray(-1.0e9).asType(dtype))
+    }
+
+    static func roundUp(_ value: Int, multiple: Int) -> Int {
+        ((value + multiple - 1) / multiple) * multiple
+    }
+}

--- a/Sources/MereRunCore/Krea2/README.md
+++ b/Sources/MereRunCore/Krea2/README.md
@@ -1,0 +1,27 @@
+# Krea2
+
+Native runtime support for Krea 2 Turbo text-to-image generation.
+
+This module owns:
+
+- `Krea2Resources.swift`: managed `image-krea2-turbo` layout and component-only
+  Hugging Face pull patterns.
+- `Krea2Configs.swift`: typed Diffusers, Qwen3-VL text-encoder, transformer,
+  scheduler, and VAE config decoding.
+- `Krea2SampleBuilder.swift`: 16-pixel output alignment, latent patch packing,
+  position ids, attention masks, and shifted 8-step FlowMatch timesteps.
+- `Krea2Model.swift`: native Swift MLX single-stream MMDiT, text fusion, MRoPE,
+  timestep modulation, and final latent projection.
+- `Krea2ModelLoader.swift`: split-transformer, Qwen3-VL text encoder, and Qwen
+  Image VAE weight loading.
+- `Krea2Generator.swift`: prompt conditioning, denoising, VAE decode, and PNG
+  output for `mere.run image generate`.
+
+Krea publishes both split Diffusers component weights and a root-level
+`turbo.safetensors` transformer copy. Managed pulls must keep using the
+component layout so local installs do not fetch the same large transformer
+twice.
+
+The wired public mode is text-to-image with managed defaults of 8 steps, CFG
+0.0, and FlowMatch shift/mu 1.15. Reference images, image-to-image, and LoRA are
+intentionally unsupported until their conditioning paths are implemented.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -28,6 +28,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case bonsaiImage
     case zimageTurbo
     case hidreamO1
+    case krea2
     case ideogram4SDNQ
     case gemma4
     case gemma4Unified
@@ -459,6 +460,22 @@ public enum ManagedModelCatalog {
             upstreamRevision: "main",
             validationKind: .hidreamO1,
             runtimeAutoDownloadAllowed: false,
+            defaultCLICommands: ["image generate"]
+        ),
+        ManagedModelSpec(
+            id: Krea2Resources.modelId,
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Krea2Resources.upstreamRepoId,
+                revision: Krea2Resources.upstreamRevision,
+                patterns: Krea2Resources.snapshotPatterns
+            ),
+            upstreamRepoId: Krea2Resources.upstreamRepoId,
+            upstreamRevision: Krea2Resources.upstreamRevision,
+            validationKind: .krea2,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: Krea2Resources.estimatedDownloadBytes,
             defaultCLICommands: ["image generate"]
         ),
         ManagedModelSpec(
@@ -1289,6 +1306,8 @@ public extension ManagedModelSpec {
             return ZImageTurboResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .hidreamO1:
             return HiDreamO1Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .krea2:
+            return Krea2Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .ideogram4SDNQ:
             return Ideogram4Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .gemma4:

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -277,18 +277,19 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["image generate"]
         ),
         ManagedModelSpec(
-            // FLUX.2 [klein] 9B — gated, non-commercial. 9B flow + 8B Qwen3 text embedder,
-            // step-distilled to 4 steps, native single/multi-reference editing. Raw BFL
-            // diffusers format (same loader path as klein-max). Requires HF_TOKEN with the
-            // gated license accepted at huggingface.co/black-forest-labs/FLUX.2-klein-9B.
+            // FLUX.2 [klein] 9B — 9B flow + 8B Qwen3 text embedder, step-distilled to 4 steps,
+            // native single/multi-reference editing. bf16 diffusers format (same loader path as
+            // klein-max). Pulled from the mlx-community mirror, which is UNGATED (gated:false) —
+            // no HF token required — unlike black-forest-labs/FLUX.2-klein-9B which is gated.
+            // diffusersImageSnapshotPatterns skips the redundant single-file root checkpoint.
             id: "image-klein-9b",
             category: .image,
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
-                repoId: "black-forest-labs/FLUX.2-klein-9B",
+                repoId: "mlx-community/FLUX.2-klein-9B",
                 patterns: diffusersImageSnapshotPatterns
             ),
-            upstreamRepoId: "black-forest-labs/FLUX.2-klein-9B",
+            upstreamRepoId: "mlx-community/FLUX.2-klein-9B",
             validationKind: .flux2Klein,
             runtimeAutoDownloadAllowed: false,
             defaultCLICommands: ["image generate"]

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -266,6 +266,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                Krea2Resources.modelId,
+                "Image, Krea 2 Turbo",
+                "Runs the Krea 2 Turbo 8-step text-to-image model through the native Swift MLX image runtime.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 Ideogram4Resources.modelId,
                 "Image, Ideogram 4 typography",
                 "Installs the SDNQ uint4 Ideogram 4 text-to-image stack with dedicated positive and unconditional transformers.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -20,6 +20,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case zimageTurbo = "zimage-turbo"
         /// HiDream O1 unified pixel transformer family.
         case hidreamO1 = "hidream-o1"
+        /// Krea 2 text-to-image family.
+        case krea2 = "krea-2"
         /// Ideogram 4 text-to-image family.
         case ideogram4 = "ideogram-4"
         /// Gemma 4 family via the native Swift runtime.
@@ -64,6 +66,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case klein
         case zimage
         case hidream
+        case krea
         case ideogram
         case gemma
         case liquid
@@ -934,6 +937,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     scheduler: nil
                 ),
                 upstreamRepoId: "HiDream-ai/HiDream-O1-Image-Dev",
+                createdAt: createdAt
+            )
+        case .krea2Turbo:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .krea2,
+                family: .krea,
+                tier: .turbo,
+                variant: .distilled,
+                precision: .bf16,
+                defaults: Defaults(steps: 8, cfg: 0.0, sigmaShift: Double(Krea2SampleBuilder.defaultMu)),
+                supports: [.txt2img],
+                components: defaultComponents,
+                upstreamRepoId: "\(Krea2Resources.upstreamRepoId)@\(Krea2Resources.upstreamRevision)",
                 createdAt: createdAt
             )
         case .ideogram4SDNQUInt4:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -343,6 +343,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=zimage expects zimage-turbo.")
             case .hidream where engine != .hidreamO1:
                 warnings.append("Manifest engine mismatch: family=hidream expects hidream-o1.")
+            case .krea where engine != .krea2:
+                warnings.append("Manifest engine mismatch: family=krea expects krea-2.")
             case .ideogram where engine != .ideogram4:
                 warnings.append("Manifest engine mismatch: family=ideogram expects ideogram-4.")
             case .gemma where engine != .gemma4:
@@ -490,6 +492,7 @@ public enum MereRunModelValidator {
         if modelId.hasPrefix("image-klein-") { return .klein }
         if modelId.hasPrefix("image-zimage-") { return .zimage }
         if modelId.hasPrefix("image-hidream-") { return .hidream }
+        if modelId.hasPrefix("image-krea2-") { return .krea }
         if modelId.hasPrefix("image-ideogram4-") { return .ideogram }
         if modelId.hasPrefix("vision-segment-") { return .sam }
         if modelId.hasPrefix("vision-ground-") { return .falcon }
@@ -633,6 +636,7 @@ public enum MereRunModelValidator {
     }
 
     private static func hasAnyWeightFiles(in directory: URL, fileManager: FileManager) -> Bool {
+        let directory = directory.resolvingSymlinksInPath()
         guard let children = try? fileManager.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey],
@@ -653,6 +657,7 @@ public enum MereRunModelValidator {
     }
 
     private static func containsIncompleteFiles(in rootURL: URL, fileManager: FileManager) -> Bool {
+        let rootURL = rootURL.resolvingSymlinksInPath()
         guard let e = fileManager.enumerator(
             at: rootURL,
             includingPropertiesForKeys: [.isRegularFileKey],

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -21,6 +21,7 @@ public struct ModelResolver {
         case zetaBase = "image-zimage-base"
         case hidreamO1 = "image-hidream-o1"
         case hidreamO1Dev = "image-hidream-o1-dev"
+        case krea2Turbo = "image-krea2-turbo"
         case ideogram4SDNQUInt4 = "image-ideogram4-sdnq-uint4"
         case mebot = "text-chat-mebot"
         case psiAgent = "text-chat-psi-agent"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -24,6 +24,8 @@ public enum QuantizedModelManifestWriter {
             if id.hasPrefix("image-klein-") { return .klein }
             if id.hasPrefix("image-zimage-") { return .zimage }
             if id.hasPrefix("image-hidream-") { return .hidream }
+            if id.hasPrefix("image-krea2-") { return .krea }
+            if id.hasPrefix("image-ideogram4-") { return .ideogram }
             if id.hasPrefix("vision-segment-") { return .sam }
             if id.hasPrefix("vision-ground-") { return .falcon }
             return nil
@@ -42,6 +44,7 @@ public enum QuantizedModelManifestWriter {
             case .flux2Klein: return .klein
             case .zimageTurbo: return .zimage
             case .hidreamO1: return .hidream
+            case .krea2: return .krea
             case .ideogram4: return .ideogram
             case .gemma4: return .gemma
             case .lfm2: return .liquid
@@ -89,6 +92,8 @@ public enum QuantizedModelManifestWriter {
                     return [.txt2img, .img2img, .loraInference]
                 case .hidreamO1:
                     return [.txt2img, .referenceEdit, .subjectPersonalization]
+                case .krea2:
+                    return [.txt2img]
                 case .ideogram4:
                     return [.txt2img]
                 case .gemma4:
@@ -175,6 +180,12 @@ public enum QuantizedModelManifestWriter {
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 4, cfg: 1.0)
             case .hidreamO1:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 28, cfg: 0.0)
+            case .krea2:
+                manifest.defaults = MereRunModelManifest.Defaults(
+                    steps: 8,
+                    cfg: 0.0,
+                    sigmaShift: Double(Krea2SampleBuilder.defaultMu)
+                )
             case .ideogram4:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 20, cfg: 7.0)
             case .gemma4:

--- a/Sources/MereRunCore/QwenImageEdit/Model/VAE/AutoencoderKL3D.swift
+++ b/Sources/MereRunCore/QwenImageEdit/Model/VAE/AutoencoderKL3D.swift
@@ -10,6 +10,15 @@ private func requireConv2d(_ module: Any, context: String) -> Conv2d {
     return conv
 }
 
+private func qwenAsymmetricDownsamplePad(_ x: MLXArray) -> MLXArray {
+    padded(x, widths: [
+        [0, 0],  // batch
+        [0, 1],  // height: bottom-only zero pad before stride-2 conv
+        [0, 1],  // width: right-only zero pad before stride-2 conv
+        [0, 0]   // channels
+    ])
+}
+
 // MARK: - Configuration
 
 public struct VAE3DConfig {
@@ -53,36 +62,35 @@ public struct VAE3DConfig {
 
 // MARK: - 3D Spatial Norm
 
-/// RMS-style normalization over spatial dimensions [B, C, T, H, W] -> normalizes over T, H, W
+/// Qwen image RMS normalization over channels for [B, C, T, H, W].
 private final class VAE3DSpatialNorm: Module {
     @ModuleInfo(key: "gamma") var gamma: MLXArray
     let eps: Float
 
-    init(channels: Int, eps: Float = 1e-6) {
+    init(channels: Int, eps: Float = 1e-12) {
         self.eps = eps
         self._gamma.wrappedValue = MLXArray.ones([channels, 1, 1, 1])
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        // x: [B, C, T, H, W] in NCTHW format
-        // Normalize over T, H, W (axes 2, 3, 4)
-        let variance = x.square().mean(axes: [2, 3, 4], keepDims: true)
-        let normalized = x * rsqrt(variance + eps)
-        // gamma: [C, 1, 1, 1] broadcasts to [1, C, 1, 1, 1]
-        return normalized * gamma
+        let dtype = x.dtype
+        let xFloat = x.asType(.float32)
+        let variance = xFloat.square().mean(axis: 1, keepDims: true)
+        let normalized = xFloat * rsqrt(variance + eps)
+        return (normalized * gamma.asType(.float32)).asType(dtype)
     }
 }
 
 // MARK: - CausalConv3d
 
-/// 3D convolution with causal (replicate) padding in time dimension
+/// 3D convolution with causal zero padding in the time dimension.
 private final class CausalConv3d: Module {
     @ModuleInfo(key: "weight") var weight: MLXArray
     @ModuleInfo(key: "bias") var bias: MLXArray?
 
     let stride: (Int, Int, Int)
-    let padding: (Int, Int, Int)  // spatial padding only, temporal handled separately
+    let padding: (Int, Int, Int)
     let temporalPadding: Int
     let hasBias: Bool
 
@@ -96,7 +104,7 @@ private final class CausalConv3d: Module {
     ) {
         self.stride = stride
         self.padding = padding
-        self.temporalPadding = kernelSize.0 - 1  // causal: pad (k-1) on left
+        self.temporalPadding = padding.0 * 2
         self.hasBias = bias
 
         // Weight: [out_ch, in_ch, kT, kH, kW]
@@ -110,12 +118,18 @@ private final class CausalConv3d: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
+        if x.dim(2) == 1 && stride.0 == 1 {
+            return callSingleFrame(x)
+        }
+
         var hidden = x  // [B, C, T, H, W]
 
-        // Causal padding: replicate first frame
+        // Qwen's causal conv pads missing history with zeros.
         if temporalPadding > 0 {
-            let firstFrame = hidden[0..., 0..., 0..<1, 0..., 0...]
-            let padFrames = tiled(firstFrame, repetitions: [1, 1, temporalPadding, 1, 1])
+            let padFrames = MLX.zeros(
+                [hidden.dim(0), hidden.dim(1), temporalPadding, hidden.dim(3), hidden.dim(4)],
+                dtype: hidden.dtype
+            )
             hidden = concatenated([padFrames, hidden], axis: 2)
         }
 
@@ -138,6 +152,35 @@ private final class CausalConv3d: Module {
         }
 
         return hidden
+    }
+
+    private func callSingleFrame(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let temporalIndex = weight.dim(2) - 1
+
+        var frame = x[0..., 0..., 0, 0..., 0...].transposed(0, 2, 3, 1)
+        if padding.1 > 0 || padding.2 > 0 {
+            frame = padded(frame, widths: [
+                [0, 0],
+                [padding.1, padding.1],
+                [padding.2, padding.2],
+                [0, 0]
+            ])
+        }
+
+        let kernel = weight[0..., 0..., temporalIndex, 0..., 0...].transposed(0, 2, 3, 1)
+        var hidden = MLX.conv2d(
+            frame,
+            kernel,
+            stride: .init((stride.1, stride.2)),
+            padding: 0
+        )
+        if let b = bias {
+            hidden = hidden + b
+        }
+        let outHeight = hidden.dim(1)
+        let outWidth = hidden.dim(2)
+        return hidden.transposed(0, 3, 1, 2).reshaped(batch, hidden.dim(3), 1, outHeight, outWidth)
     }
 }
 
@@ -262,26 +305,23 @@ private final class VAE3DAttention: Module {
     }
 }
 
-/// 2D spatial norm for attention (channels-last: [B, H, W, C])
+/// Qwen image RMS normalization for attention in channels-last form [B, H, W, C].
 private final class VAE3DSpatialNorm2D: Module {
     @ModuleInfo(key: "gamma") var gamma: MLXArray
     let eps: Float
 
-    init(channels: Int, eps: Float = 1e-6) {
+    init(channels: Int, eps: Float = 1e-12) {
         self.eps = eps
-        // gamma shape [C, 1, 1] for broadcasting over [B, H, W, C] -> need [1, 1, C]
         self._gamma.wrappedValue = MLXArray.ones([channels, 1, 1])
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        // x: [B, H, W, C] (channels-last)
-        // Compute variance over H, W dimensions (axes 1, 2)
-        let variance = x.square().mean(axes: [1, 2], keepDims: true)
-        let normalized = x * rsqrt(variance + eps)
-        // gamma is [C, 1, 1] from weights, needs to broadcast to [1, 1, C] for channels-last
-        // The loaded gamma will be transposed in the weight mapper
-        return normalized * gamma.transposed(2, 1, 0)
+        let dtype = x.dtype
+        let xFloat = x.asType(.float32)
+        let variance = xFloat.square().mean(axis: -1, keepDims: true)
+        let normalized = xFloat * rsqrt(variance + eps)
+        return (normalized * gamma.asType(.float32).transposed(2, 1, 0)).asType(dtype)
     }
 }
 
@@ -508,7 +548,8 @@ private final class VAE3DDecoder: Module {
         for block in upBlocks {
             hidden = block(hidden)
         }
-        hidden = silu(normOut(hidden))
+        let normalized = normOut(hidden)
+        hidden = silu(normalized)
         hidden = convOut(hidden)
         return hidden
     }
@@ -529,7 +570,7 @@ private final class VAE3DDownsampler: Module {
         self.hasTimeConv = temporalDownsample
 
         // resample.1 is the conv (resample.0 is nn.AvgPool in PyTorch, we do stride conv)
-        let conv = Conv2d(inputChannels: inChannels, outputChannels: inChannels, kernelSize: 3, stride: 2, padding: 1)
+        let conv = Conv2d(inputChannels: inChannels, outputChannels: inChannels, kernelSize: 3, stride: 2)
         self._resample.wrappedValue = [conv]
 
         if hasTimeConv {
@@ -539,7 +580,7 @@ private final class VAE3DDownsampler: Module {
                 outputChannels: inChannels,
                 kernelSize: (3, 1, 1),
                 stride: (2, 1, 1),
-                padding: (1, 0, 0)
+                padding: (0, 0, 0)
             )
         }
         super.init()
@@ -561,6 +602,7 @@ private final class VAE3DDownsampler: Module {
 
         // Reshape to [B*T, H, W, C] for channels-last 2D operations
         hidden = hidden.transposed(0, 2, 3, 4, 1).reshaped(b * newT, currentH, currentW, c)
+        hidden = qwenAsymmetricDownsamplePad(hidden)
 
         // Apply conv (resample.1) - Conv2d expects [B, H, W, C]
         let conv = requireConv2d(resample[0], context: "VAE3DDownsampler.resample[0]")
@@ -638,7 +680,7 @@ private final class VAE3DEncoderDownsampleBlock: Module {
         self.channels = channels
         self.hasTimeConv = temporalDownsample
 
-        let conv = Conv2d(inputChannels: channels, outputChannels: channels, kernelSize: 3, stride: 2, padding: 1)
+        let conv = Conv2d(inputChannels: channels, outputChannels: channels, kernelSize: 3, stride: 2)
         self._resample.wrappedValue = [conv]
 
         if temporalDownsample {
@@ -647,7 +689,7 @@ private final class VAE3DEncoderDownsampleBlock: Module {
                 outputChannels: channels,
                 kernelSize: (3, 1, 1),
                 stride: (2, 1, 1),
-                padding: (1, 0, 0)
+                padding: (0, 0, 0)
             )
         }
         super.init()
@@ -668,6 +710,7 @@ private final class VAE3DEncoderDownsampleBlock: Module {
 
         // Reshape to channels-last for Conv2d
         hidden = hidden.transposed(0, 2, 3, 4, 1).reshaped(b * newT, currentH, currentW, c)
+        hidden = qwenAsymmetricDownsamplePad(hidden)
 
         let conv = requireConv2d(resample[0], context: "VAE3DEncoderDownsampleBlock.resample[0]")
         hidden = conv(hidden)
@@ -775,11 +818,25 @@ private final class VAE3DEncoder: Module {
 public final class AutoencoderKL3D: Module {
     public let config: VAE3DConfig
     @ModuleInfo(key: "encoder") private var encoder: VAE3DEncoder
+    @ModuleInfo(key: "quantConv") private var quantConv: CausalConv3d
+    @ModuleInfo(key: "postQuantConv") private var postQuantConv: CausalConv3d
     @ModuleInfo(key: "decoder") private var decoder: VAE3DDecoder
 
     public init(config: VAE3DConfig = .init()) {
         self.config = config
         self._encoder.wrappedValue = VAE3DEncoder(config: config)
+        self._quantConv.wrappedValue = CausalConv3d(
+            inputChannels: config.latentChannels * 2,
+            outputChannels: config.latentChannels * 2,
+            kernelSize: (1, 1, 1),
+            padding: (0, 0, 0)
+        )
+        self._postQuantConv.wrappedValue = CausalConv3d(
+            inputChannels: config.latentChannels,
+            outputChannels: config.latentChannels,
+            kernelSize: (1, 1, 1),
+            padding: (0, 0, 0)
+        )
         self._decoder.wrappedValue = VAE3DDecoder(config: config)
         super.init()
     }
@@ -788,7 +845,7 @@ public final class AutoencoderKL3D: Module {
     /// - Parameter images: [B, C, T, H, W] in [-1, 1] range
     /// - Returns: [B, latent_channels, T/temporalScale, H/spatialScale, W/spatialScale] latent representation
     public func encode(_ images: MLXArray) -> MLXArray {
-        let encoded = encoder(images)
+        let encoded = quantConv(encoder(images))
         // Take first half of channels (mean), ignore logvar
         let mean = encoded[0..., 0..<config.latentChannels, 0..., 0..., 0...]
         // Scale latents
@@ -819,7 +876,8 @@ public final class AutoencoderKL3D: Module {
         if config.shiftFactor != 0 {
             x = x + MLXArray(config.shiftFactor)
         }
-        return decoder(x)
+        let postQuantized = postQuantConv(x)
+        return decoder(postQuantized)
     }
 
     /// Decode single image (convenience)
@@ -854,14 +912,12 @@ private func conv3d(
     // Transpose weight: [O, I, kD, kH, kW] -> [O, kD, kH, kW, I]
     let wT = weight.transposed(0, 2, 3, 4, 1)
 
-    // MLX conv_general - padding is 0 (we handle padding manually in CausalConv3d)
-    let result = convGeneral(
+    // MLX conv3d - padding is 0 (we handle padding manually in CausalConv3d)
+    let result = MLX.conv3d(
         xT,
         wT,
-        strides: .array(stride),
+        stride: .init(stride),
         padding: 0,
-        kernelDilation: 1,
-        inputDilation: 1,
         groups: groups
     )
 

--- a/Sources/MereRunCore/QwenImageEdit/Model/VAE/QwenImageEditVAE.swift
+++ b/Sources/MereRunCore/QwenImageEdit/Model/VAE/QwenImageEditVAE.swift
@@ -143,17 +143,13 @@ extension QwenImageEditVAE {
     public static func weightMapper(key: String, value: MLXArray) -> [(String, MLXArray)] {
         var mappedKey = key
 
-        // Convert snake_case to camelCase for module keys
+        // AutoencoderKL3D keeps the public Qwen module keys in their source
+        // snake_case form. Only the top-level quant conv slots are camelCase
+        // because `quant_conv`/`post_quant_conv` would collide with Swift
+        // naming conventions.
         mappedKey = mappedKey
-            .replacingOccurrences(of: "conv_in", with: "convIn")
-            .replacingOccurrences(of: "conv_out", with: "convOut")
-            .replacingOccurrences(of: "norm_out", with: "normOut")
-            .replacingOccurrences(of: "mid_block", with: "midBlock")
-            .replacingOccurrences(of: "up_blocks", with: "upBlocks")
-            .replacingOccurrences(of: "down_blocks", with: "downBlocks")
-            .replacingOccurrences(of: "conv_shortcut", with: "convShortcut")
-            .replacingOccurrences(of: "time_conv", with: "timeConv")
-            .replacingOccurrences(of: "to_qkv", with: "toQKV")
+            .replacingOccurrences(of: "post_quant_conv", with: "postQuantConv")
+            .replacingOccurrences(of: "quant_conv", with: "quantConv")
 
         // resample.1.* -> resample.0.* (PyTorch has [Upsample, Conv], we only have Conv at index 0)
         if mappedKey.contains(".resample.1.") {
@@ -169,8 +165,8 @@ extension QwenImageEditVAE {
                 // No transpose needed - our CausalConv3d stores in PyTorch format
                 mappedValue = value
             } else if value.ndim == 4 {
-                // 4D conv weight: [O, I, kH, kW] -> [kH, kW, I, O] for MLX Conv2d
-                mappedValue = value.transposed(2, 3, 1, 0)
+                // 4D conv weight: [O, I, kH, kW] -> [O, kH, kW, I] for MLX Conv2d
+                mappedValue = HFSafetensorsWeightsLoader.convWeightOIHWToOHWI(value)
             }
         }
 

--- a/Tests/MereRunCoreTests/Krea2SampleBuilderTests.swift
+++ b/Tests/MereRunCoreTests/Krea2SampleBuilderTests.swift
@@ -1,0 +1,87 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Krea2SampleBuilderTests: XCTestCase {
+    func testAlignedResolutionUsesLatentPatchMultiple() {
+        XCTAssertEqual(Krea2SampleBuilder.alignedResolution(width: 1024, height: 1024).width, 1024)
+        XCTAssertEqual(Krea2SampleBuilder.alignedResolution(width: 1025, height: 1025).width, 1040)
+        XCTAssertEqual(Krea2SampleBuilder.alignedResolution(width: 1025, height: 1025).height, 1040)
+    }
+
+    func testTurboTimestepsUseShiftedOneToZeroGrid() {
+        let timesteps = Krea2SampleBuilder.timesteps(
+            imageTokenCount: 64 * 64,
+            steps: 8,
+            mu: Krea2SampleBuilder.defaultMu
+        )
+
+        XCTAssertEqual(timesteps.count, 9)
+        XCTAssertEqual(timesteps.first, 1.0)
+        XCTAssertEqual(timesteps.last, 0.0)
+        for (current, next) in zip(timesteps, timesteps.dropFirst()) {
+            XCTAssertGreaterThanOrEqual(current, next)
+        }
+    }
+
+    func testTextEncoderWeightMapperStripsKreaLanguageModelPrefix() {
+        let value = MLXArray([Float(1)], [1])
+
+        let mapped = Krea2ModelLoader.mapTextEncoderWeight(
+            key: "language_model.embed_tokens.weight",
+            value: value
+        )
+
+        XCTAssertEqual(mapped.map(\.0), ["embed_tokens.weight"])
+    }
+
+    func testAttentionMaskKeepsPaddedQueryRowsFinite() {
+        let validMask = MLXArray([Int32(1), Int32(1), Int32(0)]).reshaped(1, 3)
+        let mask = Krea2SampleBuilder.attentionMask(validMask: validMask, dtype: .float32)
+
+        XCTAssertEqual(mask[0, 0, 2, 0].item(Float.self), 0)
+        XCTAssertEqual(mask[0, 0, 2, 1].item(Float.self), 0)
+        XCTAssertLessThan(mask[0, 0, 2, 2].item(Float.self), -1_000_000)
+    }
+
+    func testPaddedTextTokenInputsMatchOfficialConditionerShape() {
+        let inputs = Krea2SampleBuilder.paddedTextTokenInputs(
+            promptTokenIds: [10, 11, 12, 13, 14],
+            suffixTokenIds: [20, 21, 22, 23, 24],
+            padTokenId: 0,
+            maxLength: 512,
+            prefixDropCount: 34
+        )
+
+        XCTAssertEqual(inputs.tokenIds.count, 546)
+        XCTAssertEqual(inputs.attentionMask.count, 546)
+        XCTAssertEqual(Array(inputs.tokenIds[0..<5]), [10, 11, 12, 13, 14])
+        XCTAssertEqual(Array(inputs.tokenIds[541..<546]), [20, 21, 22, 23, 24])
+        XCTAssertEqual(Array(inputs.attentionMask[5..<541]).reduce(Int32(0), +), 0)
+        XCTAssertEqual(inputs.tokenIds.count - 34, 512)
+    }
+
+    func testQwenActivationLayerIndicesConvertFromHiddenStateIndices() {
+        XCTAssertEqual(
+            Krea2SampleBuilder.qwenActivationLayerIndices(from: [2, 5, 8, 35]),
+            [1, 4, 7, 34]
+        )
+    }
+
+    func testVAEWeightMapperPreservesQwenPostQuantConv() {
+        let value = MLXArray.zeros([16, 16, 1, 1, 1])
+
+        let mapped = QwenImageEditVAE.weightMapper(key: "post_quant_conv.weight", value: value)
+
+        XCTAssertEqual(mapped.map(\.0), ["postQuantConv.weight"])
+    }
+
+    func testVAEWeightMapperTransposesConv2DWeightsToMLXLayout() {
+        let value = MLXArray.zeros([2, 3, 5, 7])
+
+        let mapped = QwenImageEditVAE.weightMapper(key: "decoder.mid_block.attentions.0.proj.weight", value: value)
+
+        XCTAssertEqual(mapped.map(\.0), ["decoder.mid_block.attentions.0.proj.weight"])
+        XCTAssertEqual(mapped[0].1.shape, [2, 5, 7, 3])
+    }
+}

--- a/Tests/MereRunCoreTests/Krea2VAEReferenceDumpTests.swift
+++ b/Tests/MereRunCoreTests/Krea2VAEReferenceDumpTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Krea2VAEReferenceDumpTests: XCTestCase {
+    func testQwenConv2DReferenceFixtureWhenRequested() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let fixture = env["MERERUN_TEST_KREA2_CONV2D_FIXTURE"], !fixture.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_KREA2_CONV2D_FIXTURE to compare an isolated Qwen conv2d fixture.")
+        }
+
+        let arrays = try MLX.loadArrays(url: URL(fileURLWithPath: fixture))
+        let input = try XCTUnwrap(arrays["input_nchw"])
+        let weight = try XCTUnwrap(arrays["weight_oihw"])
+        let bias = try XCTUnwrap(arrays["bias"])
+        let expected = try XCTUnwrap(arrays["expected_nchw"])
+
+        let paddedInput = padded(input.transposed(0, 2, 3, 1), widths: [[0, 0], [1, 1], [1, 1], [0, 0]])
+        let kernel = weight.transposed(0, 2, 3, 1)
+        let contiguousKernel = kernel.reshaped(-1).reshaped(kernel.shape)
+        let contiguousInput = paddedInput.reshaped(-1).reshaped(paddedInput.shape)
+
+        let direct = MLX.conv2d(paddedInput, kernel, stride: .init((1, 1)), padding: 0) + bias
+        let kernelContiguous = MLX.conv2d(paddedInput, contiguousKernel, stride: .init((1, 1)), padding: 0) + bias
+        let fullyContiguous = MLX.conv2d(contiguousInput, contiguousKernel, stride: .init((1, 1)), padding: 0) + bias
+
+        for (name, channelsLast) in [
+            ("direct", direct),
+            ("kernel_contiguous", kernelContiguous),
+            ("fully_contiguous", fullyContiguous)
+        ] {
+            let actual = channelsLast.transposed(0, 3, 1, 2).asType(.float32)
+            MLX.eval(actual)
+            let maxDiff = MLX.max(MLX.abs(actual - expected.asType(.float32))).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.00001, "\(name) should match the PyTorch fixture.")
+            let stats = Self.statsNCHW(actual)
+            FileHandle.standardError.write(
+                "\(name) max_diff=\(maxDiff) mean=\(stats.mean) std=\(stats.std) min=\(stats.min) max=\(stats.max)\n"
+                    .data(using: .utf8)!
+            )
+        }
+
+        if let root = env["MERERUN_TEST_KREA2_ROOT"], !root.isEmpty {
+            let resources = Krea2Resources(rootURL: URL(fileURLWithPath: root))
+            let configs = try Krea2ModelConfigs.load(from: resources)
+            let vae = try Krea2ModelLoader.loadVAE(from: resources, configuration: configs.vae, dtype: .float32)
+            let params = Dictionary(uniqueKeysWithValues: vae.underlyingVAE.parameters().flattened())
+            let convInWeight = try XCTUnwrap(params["decoder.convIn.weight"] ?? params["decoder.conv_in.weight"])
+            let convInBias = try XCTUnwrap(params["decoder.convIn.bias"] ?? params["decoder.conv_in.bias"])
+            let loadedSlice = convInWeight[0..., 0..., 2, 0..., 0...]
+            let weightDiff = MLX.max(MLX.abs(loadedSlice.asType(.float32) - weight.asType(.float32))).item(Float.self)
+            let biasDiff = MLX.max(MLX.abs(convInBias.asType(.float32) - bias.asType(.float32))).item(Float.self)
+            XCTAssertLessThan(weightDiff, 0.00001, "Loaded conv_in weight should match the PyTorch fixture.")
+            XCTAssertLessThan(biasDiff, 0.00001, "Loaded conv_in bias should match the PyTorch fixture.")
+            let loadedKernel = loadedSlice.transposed(0, 2, 3, 1)
+            let loadedOut = MLX.conv2d(paddedInput, loadedKernel, stride: .init((1, 1)), padding: 0) + convInBias
+            let actual = loadedOut.transposed(0, 3, 1, 2).asType(.float32)
+            MLX.eval(actual)
+            let outputDiff = MLX.max(MLX.abs(actual - expected.asType(.float32))).item(Float.self)
+            XCTAssertLessThan(outputDiff, 0.00001, "Loaded conv_in output should match the PyTorch fixture.")
+            let loadedStats = Self.statsNCHW(actual)
+            FileHandle.standardError.write(
+                "loaded_model weight_diff=\(weightDiff) bias_diff=\(biasDiff) output_diff=\(outputDiff) mean=\(loadedStats.mean) std=\(loadedStats.std) min=\(loadedStats.min) max=\(loadedStats.max)\n"
+                    .data(using: .utf8)!
+            )
+        }
+    }
+
+    func testDumpInstalledKreaQwenVAEDecodeWhenRequested() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let root = env["MERERUN_TEST_KREA2_ROOT"], !root.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_KREA2_ROOT to dump a Krea/Qwen VAE decode.")
+        }
+
+        let output = env["MERERUN_TEST_KREA2_VAE_OUTPUT"] ?? "/tmp/qwen-vae-swift.png"
+        let resources = Krea2Resources(rootURL: URL(fileURLWithPath: root))
+        let configs = try Krea2ModelConfigs.load(from: resources)
+        let dtype: DType = env["MERERUN_TEST_KREA2_VAE_FLOAT32"] == "1" ? .float32 : .bfloat16
+        let vae = try Krea2ModelLoader.loadVAE(from: resources, configuration: configs.vae, dtype: dtype)
+
+        var latents = Self.referenceLatents(channels: configs.vae.latentChannels, height: 16, width: 16)
+        if let mean = configs.vae.latentsMean, let std = configs.vae.latentsStd {
+            let meanTensor = MLXArray(mean).reshaped(1, mean.count, 1, 1).asType(latents.dtype)
+            let stdTensor = MLXArray(std).reshaped(1, std.count, 1, 1).asType(latents.dtype)
+            latents = latents * stdTensor + meanTensor
+        }
+        if let shift = configs.vae.shiftFactor, shift != 0 {
+            latents = latents - MLXArray(shift).asType(latents.dtype)
+        }
+        latents = latents * MLXArray(configs.vae.scalingFactor).asType(latents.dtype)
+
+        var decoded = vae.decode(latents.asType(dtype))
+        decoded = MLX.clip(decoded.asType(.float32), min: -1.0, max: 1.0)
+        let image = MLX.clip(QwenImageIO.denormalizeFromDecoder(decoded), min: 0, max: 1)
+        try QwenImageIO.saveImage(array: image, to: URL(fileURLWithPath: output))
+
+        let stats = Self.stats(image)
+        FileHandle.standardError.write(
+            "swift_vae shape=\(image.shape) mean=\(stats.mean) min=\(stats.min) max=\(stats.max)\n"
+                .data(using: .utf8)!
+        )
+    }
+
+    private static func referenceLatents(channels: Int, height: Int, width: Int) -> MLXArray {
+        var values: [Float] = []
+        values.reserveCapacity(channels * height * width)
+        for c in 0..<channels {
+            for y in 0..<height {
+                for x in 0..<width {
+                    values.append(sinf(Float(c + 1) * 0.13 + Float(y) * 0.07 + Float(x) * 0.11))
+                }
+            }
+        }
+        return MLXArray(values).reshaped(1, channels, height, width)
+    }
+
+    private static func stats(_ image: MLXArray) -> (mean: Float, min: Float, max: Float) {
+        let evaluated = image.asType(.float32)
+        MLX.eval(evaluated)
+        return (
+            mean: MLX.mean(evaluated).item(Float.self),
+            min: MLX.min(evaluated).item(Float.self),
+            max: MLX.max(evaluated).item(Float.self)
+        )
+    }
+
+    private static func statsNCHW(_ image: MLXArray) -> (mean: Float, std: Float, min: Float, max: Float) {
+        let evaluated = image.asType(.float32)
+        MLX.eval(evaluated)
+        return (
+            mean: MLX.mean(evaluated).item(Float.self),
+            std: MLX.std(evaluated).item(Float.self),
+            min: MLX.min(evaluated).item(Float.self),
+            max: MLX.max(evaluated).item(Float.self)
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -65,6 +65,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "image-zimage-nano",
             "image-zimage-base",
             "image-zimage-max",
+            "image-krea2-turbo",
             "image-ideogram4-sdnq-uint4",
         ]
 
@@ -142,6 +143,51 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("unconditional_transformer/diffusion_pytorch_model.safetensors"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("quantization_manifest.json"), true)
+    }
+
+    func testKrea2TurboUsesComponentHubSourceWithoutRootTurboCheckpoint() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Krea2Resources.modelId))
+        let patterns = try XCTUnwrap(spec.hubFallback?.patterns)
+
+        XCTAssertEqual(spec.hubFallback?.repoId, Krea2Resources.upstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Krea2Resources.upstreamRevision)
+        XCTAssertEqual(spec.upstreamRepoId, Krea2Resources.upstreamRepoId)
+        XCTAssertEqual(spec.upstreamRevision, Krea2Resources.upstreamRevision)
+        XCTAssertEqual(spec.validationKind, .krea2)
+        XCTAssertEqual(spec.estimatedDownloadBytes, Krea2Resources.estimatedDownloadBytes)
+        XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
+        XCTAssertTrue(patterns.contains("transformer/diffusion_pytorch_model.safetensors.index.json"))
+        XCTAssertTrue(patterns.contains("transformer/diffusion_pytorch_model-*.safetensors"))
+        XCTAssertTrue(patterns.contains("text_encoder/model.safetensors"))
+        XCTAssertFalse(patterns.contains("turbo.safetensors"))
+        XCTAssertFalse(patterns.contains("*.safetensors"))
+        XCTAssertFalse(patterns.contains("transformer/*"))
+    }
+
+    func testKrea2TurboAcceptsSymlinkedComponentInstallRoot() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Krea2Resources.modelId))
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let snapshot = temp.appendingPathComponent("snapshot", isDirectory: true)
+        try writeMinimalKrea2Root(at: snapshot)
+
+        let root = temp.appendingPathComponent(Krea2Resources.modelId, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: .krea2Turbo, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model_index.json").path,
+            contents: Data("{}".utf8)
+        ))
+        for component in ["tokenizer", "text_encoder", "transformer", "vae", "scheduler"] {
+            try FileManager.default.createSymbolicLink(
+                at: root.appendingPathComponent(component, isDirectory: true),
+                withDestinationURL: snapshot.appendingPathComponent(component, isDirectory: true)
+            )
+        }
+
+        XCTAssertTrue(spec.missingPaths(in: root, fileManager: .default).isEmpty)
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
     }
 
     func testGemma4TurboUsesNVFP4HubSource() throws {
@@ -702,6 +748,40 @@ final class ManagedModelCatalogTests: XCTestCase {
             atPath: scheduler.appendingPathComponent("scheduler_config.json").path,
             contents: Data("{}".utf8)
         ))
+    }
+
+    private func writeMinimalKrea2Root(at root: URL) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: .krea2Turbo, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model_index.json").path,
+            contents: Data("{}".utf8)
+        ))
+
+        let tokenizer = root.appendingPathComponent("tokenizer", isDirectory: true)
+        let textEncoder = root.appendingPathComponent("text_encoder", isDirectory: true)
+        let transformer = root.appendingPathComponent("transformer", isDirectory: true)
+        let vae = root.appendingPathComponent("vae", isDirectory: true)
+        let scheduler = root.appendingPathComponent("scheduler", isDirectory: true)
+        for directory in [tokenizer, textEncoder, transformer, vae, scheduler] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        for file in [
+            tokenizer.appendingPathComponent("tokenizer.json"),
+            tokenizer.appendingPathComponent("tokenizer_config.json"),
+            textEncoder.appendingPathComponent("config.json"),
+            textEncoder.appendingPathComponent("model.safetensors"),
+            transformer.appendingPathComponent("config.json"),
+            transformer.appendingPathComponent("diffusion_pytorch_model.safetensors.index.json"),
+            transformer.appendingPathComponent("diffusion_pytorch_model-00001-of-00003.safetensors"),
+            vae.appendingPathComponent("config.json"),
+            vae.appendingPathComponent("diffusion_pytorch_model.safetensors"),
+            scheduler.appendingPathComponent("scheduler_config.json"),
+        ] {
+            let contents = file.pathExtension == "json" ? Data("{}".utf8) : Data()
+            XCTAssertTrue(FileManager.default.createFile(atPath: file.path, contents: contents))
+        }
     }
 
     private func writeMinimalACEStepRoot(at root: URL, turboSubdirectory: String) throws {

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -132,6 +132,25 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.upstreamRepoId, "HiDream-ai/HiDream-O1-Image")
     }
 
+    func testKrea2TurboTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .krea2Turbo, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, Krea2Resources.modelId)
+        XCTAssertEqual(manifest.engine, .krea2)
+        XCTAssertEqual(manifest.family, .krea)
+        XCTAssertEqual(manifest.tier, .turbo)
+        XCTAssertEqual(manifest.variant, .distilled)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(manifest.defaults?.steps, 8)
+        XCTAssertEqual(manifest.defaults?.cfg, 0.0)
+        XCTAssertEqual(manifest.defaults?.sigmaShift, Double(Krea2SampleBuilder.defaultMu))
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img]))
+        XCTAssertEqual(manifest.components?.transformer, .local(path: "transformer"))
+        XCTAssertEqual(manifest.components?.textEncoder, .local(path: "text_encoder"))
+        XCTAssertEqual(manifest.components?.vae, .local(path: "vae"))
+        XCTAssertEqual(manifest.upstreamRepoId, "\(Krea2Resources.upstreamRepoId)@\(Krea2Resources.upstreamRevision)")
+    }
+
     func testIdeogram4TemplateHasExpectedSDNQMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .ideogram4SDNQUInt4, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -78,6 +78,38 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
     }
 
+    private func writeMinimalValidKrea2Model(at root: URL) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: .krea2Turbo, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try TestFileSystem.writeFile(root.appendingPathComponent("model_index.json"), contents: Data("{}".utf8))
+
+        let tokenizerDir = root.appendingPathComponent("tokenizer", isDirectory: true)
+        let textEncoderDir = root.appendingPathComponent("text_encoder", isDirectory: true)
+        let transformerDir = root.appendingPathComponent("transformer", isDirectory: true)
+        let vaeDir = root.appendingPathComponent("vae", isDirectory: true)
+        let schedulerDir = root.appendingPathComponent("scheduler", isDirectory: true)
+
+        for directory in [tokenizerDir, textEncoderDir, transformerDir, vaeDir, schedulerDir] {
+            try TestFileSystem.createDirectory(directory)
+        }
+        try TestFileSystem.writeFile(tokenizerDir.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(tokenizerDir.appendingPathComponent("tokenizer_config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(textEncoderDir.appendingPathComponent("config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(textEncoderDir.appendingPathComponent("model.safetensors"), contents: Data())
+        try TestFileSystem.writeFile(transformerDir.appendingPathComponent("config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(
+            transformerDir.appendingPathComponent("diffusion_pytorch_model.safetensors.index.json"),
+            contents: Data("{}".utf8)
+        )
+        try TestFileSystem.writeFile(
+            transformerDir.appendingPathComponent("diffusion_pytorch_model-00001-of-00003.safetensors"),
+            contents: Data()
+        )
+        try TestFileSystem.writeFile(vaeDir.appendingPathComponent("config.json"), contents: Data("{}".utf8))
+        try TestFileSystem.writeFile(vaeDir.appendingPathComponent("diffusion_pytorch_model.safetensors"), contents: Data())
+        try TestFileSystem.writeFile(schedulerDir.appendingPathComponent("scheduler_config.json"), contents: Data("{}".utf8))
+    }
+
     private func writeMinimalValidSAM31Model(at root: URL) throws {
         try TestFileSystem.createDirectory(root)
         try MereRunModelManifest.template(for: .visionSegmentSAM31, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
@@ -394,6 +426,47 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(report.manifest?.engine, .hidreamO1)
         XCTAssertEqual(report.manifest?.defaults?.steps, 50)
         XCTAssertEqual(report.manifest?.defaults?.cfg, 5.0)
+    }
+
+    func testKrea2TurboRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(Krea2Resources.modelId, isDirectory: true)
+        try writeMinimalValidKrea2Model(at: root)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: Krea2Resources.modelId)
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.family, .krea)
+        XCTAssertEqual(report.manifest?.engine, .krea2)
+        XCTAssertEqual(report.manifest?.defaults?.steps, 8)
+        XCTAssertEqual(report.manifest?.defaults?.cfg, 0.0)
+        XCTAssertEqual(report.manifest?.defaults?.sigmaShift, Double(Krea2SampleBuilder.defaultMu))
+    }
+
+    func testKrea2TurboSymlinkedComponentLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let snapshot = temp.appendingPathComponent("snapshot", isDirectory: true)
+        try writeMinimalValidKrea2Model(at: snapshot)
+
+        let root = temp.appendingPathComponent(Krea2Resources.modelId, isDirectory: true)
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(for: .krea2Turbo, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try TestFileSystem.writeFile(root.appendingPathComponent("model_index.json"), contents: Data("{}".utf8))
+
+        for component in ["tokenizer", "text_encoder", "transformer", "vae", "scheduler"] {
+            try FileManager.default.createSymbolicLink(
+                at: root.appendingPathComponent(component, isDirectory: true),
+                withDestinationURL: snapshot.appendingPathComponent(component, isDirectory: true)
+            )
+        }
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: Krea2Resources.modelId)
+        XCTAssertTrue(report.isValid, report.errors.joined(separator: "\n"))
+        XCTAssertTrue(report.errors.isEmpty)
     }
 
     func testGemma4MaxChatOnlyRootLayoutPassesValidation() throws {

--- a/demo.sh
+++ b/demo.sh
@@ -166,7 +166,7 @@ log "Saved: $OUT/music_epic.wav"
 step "8/9  VIDEO — Cinematic scene"
 # ═══════════════════════════════════════════════════════════════════════════════
 
-if mere.run model pull video-ltx-av 2>/dev/null; then
+if mere.run model pull video-ltx23-av-mlx 2>/dev/null; then
   mere.run video generate \
     "EXT./INT. 1950s AMERICAN ROADSIDE DINER – NIGHT – CINEMATIC ESTABLISHING SHOT. The camera begins outside on a rain-slicked asphalt street, glowing red neon EAT and OPEN signs reflecting in deep puddles. A slow, steady dolly push moves the camera toward the large plate-glass window of the diner, rain beading and streaking down the glass. Through the window, warm amber tungsten light reveals a long polished chrome counter, red vinyl stools, and a single customer in a wool overcoat hunched over a coffee cup. A waitress in a mint-green uniform with a white apron pours coffee from a glass pot, steam curling into the light. A Wurlitzer jukebox glows softly in the corner with shifting amber and ruby tones. Cigarette smoke drifts in slow lazy curls through the warm light. The camera continues its push, transitioning through the glass into the diner interior, depth of field shifting as the foreground rain blur dissolves and the chrome counter and red booths sharpen into focus. The shot holds a shallow depth of field, anamorphic lens flares pulling soft horizontal streaks from the neon and polished chrome. 35mm Kodak Portra film grain, slightly desaturated palette except for the warm tungsten interior and the saturated reds and ambers of the neon." \
     --variant unified-av \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,16 @@ Qwen image editing:
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+ModelLoading.swift`
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift`
 
+Krea 2 Turbo generation:
+
+- Runtime entrypoint: `Sources/MereRunCore/Krea2/Krea2Generator.swift`
+- Read next:
+  - `Sources/MereRunCore/Krea2/Krea2Resources.swift`
+  - `Sources/MereRunCore/Krea2/Krea2Configs.swift`
+  - `Sources/MereRunCore/Krea2/Krea2Model.swift`
+  - `Sources/MereRunCore/Krea2/Krea2ModelLoader.swift`
+  - `Sources/MereRunCore/Krea2/Krea2SampleBuilder.swift`
+
 Shared text encoder stack used by image models:
 
 - Public entrypoint:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,7 +182,7 @@ swift run mere.run sfx generate \
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
   --variant unified-av \
-  --model-root ~/Library/Application\ Support/MereRun/models/video-ltx-av \
+  --model-root ~/Library/Application\ Support/MereRun/models/video-ltx23-av-mlx \
   --output ./clip.mp4
 ```
 
@@ -881,7 +881,7 @@ Examples:
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
   --variant distilled \
-  --model video-ltx-av \
+  --model video-ltx23-av-mlx \
   --num-frames 65
 
 swift run mere.run video generate \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,7 +67,8 @@ are:
 
 - Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`,
   `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
-  `image-hidream-o1`, `image-hidream-o1-dev`
+  `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-turbo`,
+  `image-ideogram4-sdnq-uint4`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`
 - Text code / agents: `text-agent-qwen35-9b`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
@@ -231,6 +232,7 @@ Examples:
 swift run mere.run image generate --prompt "a black cat on a red sofa"
 swift run mere.run image generate --model image-zimage-nano --prompt "retro robot illustration" --output ./robot.png
 swift run mere.run image generate --model image-bonsai-binary --prompt "sunlit greenhouse bonsai" --output ./bonsai.png
+swift run mere.run image generate --model image-krea2-turbo --prompt "translucent portable speaker product photo" --steps 8 --output ./speaker.png
 swift run mere.run image generate --prompt "turn this into a pencil sketch" --input ./photo.png --strength 0.6
 swift run mere.run image generate --model image-ideogram4-sdnq-uint4 --prompt "a knight and a white horse in a sunny meadow" --structured-prompt --structured-prompt-output ./knight-prompt.json --output ./knight.png
 swift run mere.run image generate \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -231,6 +231,12 @@ swift run mere.run image generate \
   --model image-bonsai-binary \
   --prompt "a tiny bonsai tree in a sunlit greenhouse" \
   --output ./bonsai.png
+
+swift run mere.run image generate \
+  --model image-krea2-turbo \
+  --prompt "a cinematic product photo of a translucent portable speaker, crisp reflections" \
+  --steps 8 \
+  --output ./speaker.png
 ```
 
 ### Text chat

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -22,7 +22,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 
 | Category | Hugging Face pull IDs |
 | --- | --- |
-| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev`, `image-ideogram4-sdnq-uint4` |
+| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-turbo`, `image-ideogram4-sdnq-uint4` |
 | Text chat | `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash` |
 | Vision chat | `vision-chat-gemma4-12b` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
@@ -160,6 +160,42 @@ Runtime defaults come from the managed manifest:
 Both checkpoints are large BF16 unified-transformer roots, about 33 GiB on disk
 each before filesystem compression effects. Expect high unified-memory pressure
 and prefer one-step smokes before full-quality 28/50 step runs.
+
+`image-krea2-turbo` maps to Krea's public Krea 2 Turbo checkpoint:
+
+- `krea/Krea-2-Turbo`
+
+Managed or local roots are expected to contain the component Diffusers layout:
+
+- `model_index.json`
+- `tokenizer/tokenizer_config.json`
+- `tokenizer/tokenizer.json`
+- `text_encoder/config.json`
+- `text_encoder/model.safetensors`
+- `transformer/config.json`
+- `transformer/diffusion_pytorch_model.safetensors.index.json`
+- `transformer/diffusion_pytorch_model-*.safetensors`
+- `vae/config.json`
+- `vae/diffusion_pytorch_model.safetensors`
+- `scheduler/scheduler_config.json`
+
+Krea also publishes a root-level `turbo.safetensors` transformer copy. The
+managed pull intentionally excludes that file and pulls the split transformer
+component instead, so the model store does not download the same 26 GiB payload
+twice.
+
+The native Swift runtime follows the public Krea 2 sampler shape: Qwen3-VL text
+conditioning with the Krea system prefix, layer-selected hidden-state fusion,
+single-stream MMDiT denoising, 16-pixel image-token alignment, FlowMatch Euler
+steps, and Qwen Image VAE decoding. The wired public mode is text-to-image;
+reference images, image-to-image, and LoRA are not supported for this family yet.
+
+Runtime defaults come from the managed manifest:
+
+- `image-krea2-turbo`: 8 steps, CFG 0.0, FlowMatch shift/mu 1.15
+
+The component install is about 36 GiB before filesystem compression effects.
+Expect high unified-memory pressure and prefer 96 GB+ Apple Silicon machines.
 
 `image-ideogram4-sdnq-uint4` maps to WaveCut's public SDNQ uint4 Ideogram 4
 snapshot:

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -71,6 +71,7 @@ Key subdirectories:
 - `Flux2Klein/`: Klein image-family runtime
 - `ZImageTurbo/`: ZImage image-family runtime
 - `HiDreamO1/`: HiDream O1 image-family runtime
+- `Krea2/`: Krea 2 Turbo image-family runtime
 - `QwenImageEdit/`: image editing flow
 - `Gemma4/`, `Q35/`, `LFM2/`, `Psi/`, `MeBot/`: text/chat model families
 - `Embeddings/`: embedding-generation support

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -17,6 +17,7 @@ The public image families are:
 - `image-bonsai-ternary`: PrismML Bonsai ternary FLUX.2 Klein deployment
 - `image-zimage-*`: ZImage image family
 - `image-hidream-o1*`: HiDream O1 unified pixel-transformer family
+- `image-krea2-turbo`: Krea 2 Turbo text-to-image family
 - `image-ideogram4-sdnq-uint4`: Ideogram 4 SDNQ uint4 text-to-image family
 
 Common managed IDs:
@@ -31,6 +32,7 @@ Common managed IDs:
 - `image-zimage-max`
 - `image-hidream-o1-dev`
 - `image-hidream-o1`
+- `image-krea2-turbo`
 - `image-ideogram4-sdnq-uint4`
 
 ## Typical workflows
@@ -112,6 +114,25 @@ MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM=1 ./scripts/check.sh
 MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM_FULL=1 ./scripts/check.sh
 ```
 
+### Krea 2 Turbo
+
+`image-krea2-turbo` maps to `krea/Krea-2-Turbo` and uses the native Swift MLX
+runtime for Krea's distilled 8-step text-to-image model. The managed pull uses
+the split Diffusers component layout and deliberately skips the root
+`turbo.safetensors` duplicate transformer file. Text-to-image generation is
+wired through `image generate`; image-to-image, reference inputs, and LoRA are
+not supported for this family yet.
+
+```bash
+swift run mere.run model pull image-krea2-turbo
+swift run mere.run image generate \
+  --model image-krea2-turbo \
+  --prompt "a cinematic product photo of a translucent portable speaker, crisp reflections" \
+  --width 1024 --height 1024 \
+  --steps 8 \
+  --output ./speaker.png
+```
+
 ### Ideogram 4 SDNQ
 
 `image-ideogram4-sdnq-uint4` maps to `WaveCut/ideogram-4-sdnq-uint4`. The
@@ -170,6 +191,15 @@ swift run mere.run image validate --family klein --test pipeline
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift`
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1TokenizerAndTemplate.swift`
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1Scheduler.swift`
+
+### Krea 2 family
+
+- `Sources/MereRunCore/Krea2/Krea2Generator.swift`
+- `Sources/MereRunCore/Krea2/Krea2Resources.swift`
+- `Sources/MereRunCore/Krea2/Krea2Configs.swift`
+- `Sources/MereRunCore/Krea2/Krea2Model.swift`
+- `Sources/MereRunCore/Krea2/Krea2ModelLoader.swift`
+- `Sources/MereRunCore/Krea2/Krea2SampleBuilder.swift`
 
 ### Image editing support
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -9,10 +9,10 @@ This page covers the native video-generation path exposed through `mere.run vide
 
 ## Model family
 
-- `video-ltx-av`: default LTX root for the faster distilled lane and the legacy
-  unified AV lane.
-- `video-ltx23-av-mlx`: LTX 2.3 MLX split checkpoint for the high-quality
-  `--variant unified-av` lane.
+- `video-ltx23-av-mlx`: **default.** LTX 2.3 MLX split checkpoint — recommended for
+  both the distilled draft lane and the high-quality `--variant unified-av` lane.
+- `video-ltx-av`: legacy merged LTX root, superseded by LTX 2.3. Only still required
+  by `video export-latents`; not recommended for `video generate`.
 
 ## Typical workflows
 
@@ -25,7 +25,7 @@ and is the right first pass for prompt, camera, subject, and composition checks.
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
   --variant distilled \
-  --model video-ltx-av \
+  --model video-ltx23-av-mlx \
   --num-frames 65 \
   --output ./clip.mp4
 ```
@@ -51,9 +51,9 @@ representative unified AV tests. LTX 2.3 expects 24 fps timing; for example,
 15 seconds resolves to 361 frames at 24 fps because LTX frame counts must
 satisfy `8n+1`.
 
-The older `video-ltx-av --variant unified-av` path still exists for compatibility,
-but `video-ltx23-av-mlx --variant unified-av` is the current quality path when
-dialogue, score, and SFX matter.
+`video-ltx23-av-mlx --variant unified-av` is the default and the current quality path
+when dialogue, score, and SFX matter. The older `video-ltx-av` merged root is legacy
+(retained only for `video export-latents`).
 
 ### Export latents
 

--- a/skills/use-mere-run/SKILL.md
+++ b/skills/use-mere-run/SKILL.md
@@ -56,7 +56,7 @@ Use `model capabilities` as the recommendation source before large downloads. Co
 - Speech: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`, `speech-asr-qwen3`, `speech-asr-parakeet`
 - Vision: `vision-ocr-lighton`, `vision-segment-sam31`, `vision-ground-falcon-perception`
 - Music: `music-acestep`
-- Video: `video-ltx-av`
+- Video: `video-ltx23-av-mlx`
 
 Avoid local-path-only IDs for first-time users unless they already have the model files.
 


### PR DESCRIPTION
## Summary
- add native Krea 2 Turbo image generation support, managed model catalog entries, CLI/API routing, and docs
- implement Krea transformer/text/VAE loading and sampling support
- fix Qwen VAE parity issues including Qwen key mapping, causal conv padding, Qwen RMS norm, and post-quant conv handling
- add unit and opt-in installed-model parity tests for Krea/Qwen VAE paths

## Validation
- ./scripts/check.sh
- swift run mere.run image generate -m image-krea2-turbo --prompt "a red ceramic teapot on a wooden table, soft window light, realistic product photo" --seed 12345 --steps 8 --width 512 --height 512 --output /tmp/krea2-turbo-fixed-smoke.png
- additional visual smokes: portrait 512x768, landscape 768x512, still-life 512x512
- opt-in Qwen VAE conv fixture matched PyTorch reference at ~8e-7 max diff

## Note
This branch was created from the existing local klein-9b-support branch, so the PR also contains those already-committed Klein/video commits ahead of main.