### PR TITLE
Add LTX end keyframe conditioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on Keep a Changelog.
 - added native Krea 2 Turbo text-to-image support through the managed
   `image-krea2-turbo` model, including component-only Hugging Face pulls,
   split-transformer validation, Swift MLX MMDiT sampling, docs, and tests.
+- added `mere.run video generate --end-image` and `--end-image-strength` for
+  LTX start-to-end keyframe conditioning.
 
 ## 0.16.0 - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,16 @@ swift run mere.run video generate \
   --num-frames 65 \
   --output ./clip.mp4
 
+# Anchor the first and last keyframes for directed image-to-video
+swift run mere.run video generate \
+  "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
+  --variant distilled \
+  --model video-ltx23-av-mlx \
+  --image ./car-start.png \
+  --end-image ./car-end.png \
+  --num-frames 65 \
+  --output ./clip-directed.mp4
+
 # Generate synchronized LTX 2.3 audio/video
 swift run mere.run model pull video-ltx23-av-mlx
 swift run mere.run video generate \

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -138,6 +138,7 @@ struct VideoGenerate: AsyncParsableCommand {
         Examples:
           swift run mere.run video generate "a cinematic drone flythrough over snowy mountains" --num-frames 65
           swift run mere.run video generate "woman walking in neon rain" --image frame.png
+          swift run mere.run video generate "a car drives from dawn into sunset" --image start.png --end-image end.png
           swift run mere.run video generate "dialogue with clean background music" --variant unified-av --model video-ltx23-av-mlx --duration 15 --fps 24
         """
     )
@@ -181,6 +182,12 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("image-strength")], help: "Image conditioning strength in [0, 1].")
     var imageStrength: Float = 1.0
 
+    @Option(name: [.customLong("end-image")], help: "Optional end keyframe path; conditions the last frame so the clip interpolates a directed start->end motion. Requires --image.")
+    var endImage: String?
+
+    @Option(name: [.customLong("end-image-strength")], help: "End keyframe conditioning strength in [0, 1].")
+    var endImageStrength: Float = 1.0
+
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
@@ -209,6 +216,12 @@ struct VideoGenerate: AsyncParsableCommand {
         }
         guard (0...1).contains(imageStrength) else {
             throw ValidationError("--image-strength must be between 0 and 1")
+        }
+        guard (0...1).contains(endImageStrength) else {
+            throw ValidationError("--end-image-strength must be between 0 and 1")
+        }
+        if endImage != nil, image == nil {
+            throw ValidationError("--end-image requires --image (the start keyframe)")
         }
 
         let resolvedWidth = max(64, (width / 64) * 64)
@@ -248,6 +261,17 @@ struct VideoGenerate: AsyncParsableCommand {
             sourceImageURL = nil
         }
 
+        let endImageURL: URL?
+        if let endImage, !endImage.isEmpty {
+            let url = URL(fileURLWithPath: endImage).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ValidationError("End image file not found: \(url.path)")
+            }
+            endImageURL = url
+        } else {
+            endImageURL = nil
+        }
+
         let resolvedModelRoot = try await resolveVideoModelRoot(
             explicitModelRoot: modelRoot,
             requestedModel: model,
@@ -264,6 +288,8 @@ struct VideoGenerate: AsyncParsableCommand {
             variant: variant,
             sourceImageURL: sourceImageURL,
             imageStrength: imageStrength,
+            endImageURL: endImageURL,
+            endImageStrength: endImageStrength,
             modelRoot: resolvedModelRoot,
             outputURL: outputURL
         )
@@ -279,6 +305,8 @@ struct VideoGenerate: AsyncParsableCommand {
         variant: LTXVideoVariant,
         sourceImageURL: URL?,
         imageStrength: Float,
+        endImageURL: URL?,
+        endImageStrength: Float,
         modelRoot: String,
         outputURL: URL
     ) async throws {
@@ -313,7 +341,9 @@ struct VideoGenerate: AsyncParsableCommand {
                         fps: fps,
                         seed: seed,
                         sourceImageURL: sourceImageURL,
-                        imageStrength: imageStrength
+                        imageStrength: imageStrength,
+                        endImageURL: endImageURL,
+                        endImageStrength: endImageStrength
                     )
                 )
                 await generator.unload()
@@ -356,7 +386,9 @@ struct VideoGenerate: AsyncParsableCommand {
                         fps: fps,
                         seed: seed,
                         sourceImageURL: sourceImageURL,
-                        imageStrength: imageStrength
+                        imageStrength: imageStrength,
+                        endImageURL: endImageURL,
+                        endImageStrength: endImageStrength
                     )
                 )
                 await generator.unload()

--- a/Sources/MereRunCLI/Guides/video-generate.md
+++ b/Sources/MereRunCLI/Guides/video-generate.md
@@ -36,12 +36,16 @@ mere.run video generate --help
 - `--seed`: deterministic generation.
 - `--image`: source image for image-to-video.
 - `--image-strength`: image conditioning strength from `0` to `1`.
+- `--end-image`: optional ending keyframe; requires `--image`.
+- `--end-image-strength`: ending keyframe conditioning strength from `0` to `1`.
 - `--quiet`, `-q`: suppress diagnostics.
 
 ## Prompting Patterns
 
 - Describe subject, motion, camera movement, environment, lighting, and style.
 - For image-to-video, prompt the motion you want, not only what is already visible.
+- For directed image-to-video, pass `--image` and `--end-image` so the first
+  and last latent frames are both anchored.
 - Keep early drafts short: `--num-frames 65` at `24` fps is a fast test.
 - Use `video-ltx23-av-mlx --variant unified-av --fps 24` for representative
   LTX 2.3 dialogue, score, and SFX checks.
@@ -79,6 +83,16 @@ mere.run video generate \
   --output ./product-spin.mp4
 ```
 
+```bash
+mere.run video generate \
+  "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
+  --image ./car-start.png \
+  --image-strength 0.9 \
+  --end-image ./car-end.png \
+  --end-image-strength 0.85 \
+  --output ./car-start-to-end.mp4
+```
+
 ## Iteration Tips
 
 - Lock seed after motion is promising.
@@ -93,6 +107,7 @@ mere.run video generate \
 - Frame count adjusted: expected, LTX uses `8n+1`.
 - Slow motion with normal audio: keep unified AV renders at `--fps 24`.
 - Empty or poor image-to-video: verify `--image` exists and try a higher `--image-strength`.
+- End keyframe rejected: `--end-image` requires a starting `--image`.
 
 ## Sources
 

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -15,6 +15,8 @@ public struct LTXDistilledLatentGenerationOptions: Sendable {
     public let sourceImageURL: URL?
     public let imageStrength: Float
     public let imageFrameIndex: Int
+    public let endImageURL: URL?
+    public let endImageStrength: Float
 
     public init(
         prompt: String,
@@ -26,7 +28,9 @@ public struct LTXDistilledLatentGenerationOptions: Sendable {
         maxTextLength: Int = 1024,
         sourceImageURL: URL? = nil,
         imageStrength: Float = 1.0,
-        imageFrameIndex: Int = 0
+        imageFrameIndex: Int = 0,
+        endImageURL: URL? = nil,
+        endImageStrength: Float = 1.0
     ) {
         self.prompt = prompt
         self.width = width
@@ -38,6 +42,8 @@ public struct LTXDistilledLatentGenerationOptions: Sendable {
         self.sourceImageURL = sourceImageURL
         self.imageStrength = imageStrength
         self.imageFrameIndex = imageFrameIndex
+        self.endImageURL = endImageURL
+        self.endImageStrength = endImageStrength
     }
 }
 
@@ -349,6 +355,7 @@ public actor LTXDistilledLatentGenerator {
         var stage1ConditioningState: LTXLatentConditioningState?
         var stage2ConditioningState: LTXLatentConditioningState?
         var stage2ConditioningLatent: MLXArray?
+        var stage2EndConditioningLatent: MLXArray?
 
         var latents: MLXArray
         if isImageToVideo {
@@ -381,11 +388,34 @@ public actor LTXDistilledLatentGenerator {
             let stage2ImageLatent = encoder.encode(image: stage2Image)
             stage2ConditioningLatent = stage2ImageLatent
 
+            // Optional end keyframe -> conditions the tail latent frame so the clip
+            // interpolates a directed start->end motion.
+            var stage1EndImageLatent: MLXArray?
+            if let endImageURL = options.endImageURL {
+                let stage1EndImage = try loadImageForEncoding(
+                    url: endImageURL,
+                    width: options.width / 2,
+                    height: options.height / 2,
+                    dtype: modelDType
+                )
+                stage1EndImageLatent = encoder.encode(image: stage1EndImage)
+                let stage2EndImage = try loadImageForEncoding(
+                    url: endImageURL,
+                    width: options.width,
+                    height: options.height,
+                    dtype: modelDType
+                )
+                stage2EndConditioningLatent = encoder.encode(image: stage2EndImage)
+            }
+
             var state1 = applyLatentConditioning(
                 baseLatent: MLX.zeros([1, 128, latentFrames, stage1H, stage1W], dtype: modelDType),
                 conditionedLatent: stage1ImageLatent,
                 frameIndex: options.imageFrameIndex,
-                strength: options.imageStrength
+                strength: options.imageStrength,
+                endConditionedLatent: stage1EndImageLatent,
+                endFrameIndex: -1,
+                endStrength: options.endImageStrength
             )
             let stage1Noise = MLXRandom.normal(state1.latent.shape).asType(modelDType)
             let stage1Sigma = MLXArray(STAGE1Sigmas[0]).asType(modelDType)
@@ -474,7 +504,10 @@ public actor LTXDistilledLatentGenerator {
                 baseLatent: latents,
                 conditionedLatent: $0,
                 frameIndex: options.imageFrameIndex,
-                strength: options.imageStrength
+                strength: options.imageStrength,
+                endConditionedLatent: stage2EndConditioningLatent,
+                endFrameIndex: -1,
+                endStrength: options.endImageStrength
             )
         }) {
             let noise = MLXRandom.normal(latents.shape).asType(modelDType)
@@ -1028,7 +1061,10 @@ private func applyLatentConditioning(
     baseLatent: MLXArray,
     conditionedLatent: MLXArray,
     frameIndex: Int,
-    strength: Float
+    strength: Float,
+    endConditionedLatent: MLXArray? = nil,
+    endFrameIndex: Int = -1,
+    endStrength: Float = 1.0
 ) -> LTXLatentConditioningState {
     let b = baseLatent.dim(0)
     let c = baseLatent.dim(1)
@@ -1040,6 +1076,17 @@ private func applyLatentConditioning(
 
     let condEnd = min(frameIndex + condFrames, f)
     let oneMinusStrength = MLXArray(1.0 - strength).asType(dtype)
+
+    // Optional end keyframe: condition a second image at the tail of the clip so
+    // LTX interpolates a directed start->end motion. Defaults to the last latent
+    // frame(s). Start conditioning takes precedence on any overlap.
+    let endCondFrames = endConditionedLatent?.dim(2) ?? 0
+    let endStart = endConditionedLatent != nil
+        ? (endFrameIndex >= 0 ? endFrameIndex : max(0, f - endCondFrames))
+        : f
+    let endStop = min(endStart + endCondFrames, f)
+    let oneMinusEndStrength = MLXArray(1.0 - endStrength).asType(dtype)
+
     var latentFrames: [MLXArray] = []
     var cleanFrames: [MLXArray] = []
     var maskFrames: [MLXArray] = []
@@ -1054,6 +1101,12 @@ private func applyLatentConditioning(
             latentFrames.append(condSlice)
             cleanFrames.append(condSlice)
             maskFrames.append(MLX.full([b, 1, 1, 1, 1], values: oneMinusStrength))
+        } else if let endLatent = endConditionedLatent, frame >= endStart, frame < endStop {
+            let condIdx = frame - endStart
+            let condSlice = endLatent[0..., 0..., condIdx..<condIdx + 1, 0..., 0...]
+            latentFrames.append(condSlice)
+            cleanFrames.append(condSlice)
+            maskFrames.append(MLX.full([b, 1, 1, 1, 1], values: oneMinusEndStrength))
         } else {
             latentFrames.append(baseLatent[0..., 0..., frame..<frame + 1, 0..., 0...])
             cleanFrames.append(MLX.zeros([b, c, 1, h, w], dtype: dtype))
@@ -2760,6 +2813,8 @@ public struct LTXUnifiedAVGenerationOptions: Sendable {
     public let sourceImageURL: URL?
     public let imageStrength: Float
     public let imageFrameIndex: Int
+    public let endImageURL: URL?
+    public let endImageStrength: Float
 
     public init(
         prompt: String,
@@ -2771,7 +2826,9 @@ public struct LTXUnifiedAVGenerationOptions: Sendable {
         maxTextLength: Int = 1024,
         sourceImageURL: URL? = nil,
         imageStrength: Float = 1.0,
-        imageFrameIndex: Int = 0
+        imageFrameIndex: Int = 0,
+        endImageURL: URL? = nil,
+        endImageStrength: Float = 1.0
     ) {
         self.prompt = prompt
         self.width = width
@@ -2783,6 +2840,8 @@ public struct LTXUnifiedAVGenerationOptions: Sendable {
         self.sourceImageURL = sourceImageURL
         self.imageStrength = imageStrength
         self.imageFrameIndex = imageFrameIndex
+        self.endImageURL = endImageURL
+        self.endImageStrength = endImageStrength
     }
 }
 
@@ -3237,6 +3296,7 @@ public actor LTXUnifiedAVGenerator {
         var stage1ConditioningState: LTXLatentConditioningState?
         var stage2ConditioningState: LTXLatentConditioningState?
         var stage2ConditioningLatent: MLXArray?
+        var stage2EndConditioningLatent: MLXArray?
 
         var videoLatents: MLXArray
         if isImageToVideo {
@@ -3269,11 +3329,34 @@ public actor LTXUnifiedAVGenerator {
             let stage2ImageLatent = encoder.encode(image: stage2Image)
             stage2ConditioningLatent = stage2ImageLatent
 
+            // Optional end keyframe -> conditions the tail latent frame so the clip
+            // interpolates a directed start->end motion.
+            var stage1EndImageLatent: MLXArray?
+            if let endImageURL = options.endImageURL {
+                let stage1EndImage = try loadImageForEncoding(
+                    url: endImageURL,
+                    width: options.width / 2,
+                    height: options.height / 2,
+                    dtype: modelDType
+                )
+                stage1EndImageLatent = encoder.encode(image: stage1EndImage)
+                let stage2EndImage = try loadImageForEncoding(
+                    url: endImageURL,
+                    width: options.width,
+                    height: options.height,
+                    dtype: modelDType
+                )
+                stage2EndConditioningLatent = encoder.encode(image: stage2EndImage)
+            }
+
             var state1 = applyLatentConditioning(
                 baseLatent: MLX.zeros([1, 128, latentFrames, stage1H, stage1W], dtype: modelDType),
                 conditionedLatent: stage1ImageLatent,
                 frameIndex: options.imageFrameIndex,
-                strength: options.imageStrength
+                strength: options.imageStrength,
+                endConditionedLatent: stage1EndImageLatent,
+                endFrameIndex: -1,
+                endStrength: options.endImageStrength
             )
             let stage1Noise = MLXRandom.normal(state1.latent.shape).asType(modelDType)
             let stage1Sigma = MLXArray(STAGE1Sigmas[0]).asType(modelDType)
@@ -3353,7 +3436,10 @@ public actor LTXUnifiedAVGenerator {
                 baseLatent: videoLatents,
                 conditionedLatent: $0,
                 frameIndex: options.imageFrameIndex,
-                strength: options.imageStrength
+                strength: options.imageStrength,
+                endConditionedLatent: stage2EndConditioningLatent,
+                endFrameIndex: -1,
+                endStrength: options.endImageStrength
             )
         }) {
             let noise = MLXRandom.normal(videoLatents.shape).asType(modelDType)

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -31,7 +31,39 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertNil(cmd.duration)
         XCTAssertEqual(cmd.fps, 24)
         XCTAssertEqual(cmd.imageStrength, 1.0)
+        XCTAssertNil(cmd.endImage)
+        XCTAssertEqual(cmd.endImageStrength, 1.0)
         XCTAssertNil(cmd.modelRoot)
+    }
+
+    func testVideoGenerateParsesStartAndEndKeyframes() throws {
+        let cmd = try VideoGenerate.parse([
+            "a flower opens from bud to bloom",
+            "--image", "/tmp/start.png",
+            "--image-strength", "0.85",
+            "--end-image", "/tmp/end.png",
+            "--end-image-strength", "0.7",
+        ])
+
+        XCTAssertEqual(cmd.image, "/tmp/start.png")
+        XCTAssertEqual(cmd.imageStrength, 0.85, accuracy: 0.0001)
+        XCTAssertEqual(cmd.endImage, "/tmp/end.png")
+        XCTAssertEqual(cmd.endImageStrength, 0.7, accuracy: 0.0001)
+    }
+
+    func testVideoGenerateRejectsEndImageWithoutStartImage() async throws {
+        let cmd = try VideoGenerate.parse([
+            "a car drives from dawn into sunset",
+            "--end-image", "/tmp/end.png",
+        ])
+
+        do {
+            try await cmd.run()
+            XCTFail("Expected --end-image without --image to fail validation.")
+        } catch {
+            let message = "\(error) \(error.localizedDescription)"
+            XCTAssertTrue(message.contains("--end-image requires --image"))
+        }
     }
 
     func testVideoGenerateParsesDurationOverride() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -861,6 +861,8 @@ Key options:
 - `--seed`
 - `--image`
 - `--image-strength`
+- `--end-image`
+- `--end-image-strength`
 - `--quiet`
 
 Environment:
@@ -893,6 +895,15 @@ swift run mere.run video generate \
   --duration 15 \
   --fps 24 \
   --output ./dialogue-score-sfx.mp4
+
+swift run mere.run video generate \
+  "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
+  --variant distilled \
+  --model video-ltx23-av-mlx \
+  --image ./car-start.png \
+  --end-image ./car-end.png \
+  --num-frames 65 \
+  --output ./car-start-to-end.mp4
 ```
 
 ### `mere.run video export-latents`

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -30,6 +30,27 @@ swift run mere.run video generate \
   --output ./clip.mp4
 ```
 
+### Directed image-to-video
+
+Use `--image` to anchor the first latent frame. Add `--end-image` when the clip
+should move toward a specific final keyframe.
+
+```bash
+swift run mere.run video generate \
+  "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
+  --variant distilled \
+  --model video-ltx23-av-mlx \
+  --image ./car-start.png \
+  --image-strength 0.9 \
+  --end-image ./car-end.png \
+  --end-image-strength 0.85 \
+  --num-frames 65 \
+  --output ./car-start-to-end.mp4
+```
+
+`--end-image` requires `--image`; the start conditioning wins if very short
+clips make the start and end latent conditioning windows overlap.
+
 ### Synchronized AV quality render
 
 For LTX 2.3 audio/video, pull the managed model id and let it install its Gemma


### PR DESCRIPTION
## Summary
- add mere.run video generate --end-image and --end-image-strength for directed start-to-end image-to-video conditioning
- thread optional end keyframe latents through the distilled and unified-AV LTX generation paths
- document the new CLI options and add video command parsing/validation tests

## Validation
- swift test --filter VideoCommandTests
- ./scripts/check.sh

## Stacking
This PR is stacked on #80 (codex/krea2-turbo-native) so the review diff only shows the LTX end-keyframe feature. After #80 merges, this can be retargeted to main if GitHub does not do that automatically.