### PR TITLE
Add Krea 2 Raw LoRA training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added `mere.run image train-lora` for native Krea 2 Raw LoRA training,
+  including managed `image-krea2-raw` pulls, Krea transformer LoRA injection,
+  training manifests/metrics, and Krea 2 Turbo LoRA inference via
+  `image generate --lora`.
 - added native Krea 2 Turbo text-to-image support through the managed
   `image-krea2-turbo` model, including component-only Hugging Face pulls,
   split-transformer validation, Swift MLX MMDiT sampling, docs, and tests.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ mere.run is a Swift package, CLI, and optional macOS studio for local-first infe
 
 The public OSS repo currently supports:
 
-- local image generation across Klein, ZImage, HiDream O1, Krea 2 Turbo, and
+- local image generation across Klein, ZImage, HiDream O1, Krea 2, and
   Ideogram 4 families, including image-to-image, HiDream reference images,
-  LoRA input, and deterministic image validation
+  Krea 2 Raw LoRA training, LoRA input, and deterministic image validation
 - local text chat, code generation, embeddings, and PII anonymization
 - local speech synthesis, transcription, and voice-profile management
 - local vision captioning, inspection, grounding, segmentation, tracking, live camera tracking, and OCR
@@ -243,6 +243,14 @@ swift run mere.run image generate \
   --prompt "a cinematic product photo of a translucent portable speaker, crisp reflections" \
   --steps 8 \
   --output ./speaker.png
+
+# Train Krea 2 LoRAs on Raw, then run them on Turbo.
+swift run mere.run image train-lora \
+  --model image-krea2-raw \
+  --data ./style-dataset \
+  --output ./style-krea2.safetensors \
+  --training-steps 1000 \
+  --lite
 
 # Run local chat
 swift run mere.run text chat \
@@ -480,6 +488,7 @@ The public CLI is modality-first:
 
 - `mere.run guide`
 - `mere.run image generate`
+- `mere.run image train-lora`
 - `mere.run image validate`
 - `mere.run text chat`
 - `mere.run text code`

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -27,6 +27,7 @@ enum CommandTemplateID: String, CaseIterable {
     case modelRemove
     case modelRepairManifests
     case imageGenerate
+    case imageTrainLoRA
     case imageValidate
     case textChat
     case textCode
@@ -54,6 +55,7 @@ enum CommandTemplateID: String, CaseIterable {
 enum CommandInputKind: Equatable {
     case none
     case file([UTType])
+    case directory
     case image
     case audio
     case video
@@ -62,6 +64,7 @@ enum CommandInputKind: Equatable {
         switch self {
         case .none: return "Input"
         case .file: return "File"
+        case .directory: return "Directory"
         case .image: return "Image"
         case .audio: return "Audio"
         case .video: return "Video"
@@ -70,7 +73,7 @@ enum CommandInputKind: Equatable {
 
     var allowedTypes: [UTType] {
         switch self {
-        case .none: return []
+        case .none, .directory: return []
         case .file(let types): return types
         case .image: return [.image]
         case .audio: return [.audio]
@@ -200,6 +203,8 @@ struct CommandTemplate: Identifiable, Equatable {
         case .imageValidate:
             draft.backend = "all"
             draft.variant = "zimage"
+        case .imageTrainLoRA:
+            draft.steps = 1000
         case .videoGenerate:
             draft.width = 768
             draft.height = 512
@@ -343,6 +348,14 @@ struct CommandTemplate: Identifiable, Equatable {
             if !draft.inputPath.isBlank {
                 args += ["--input", draft.inputPath, "--strength", format(draft.strength)]
             }
+            if draft.quiet { args.append("--quiet") }
+
+        case .imageTrainLoRA:
+            args = ["image", "train-lora", "--data", draft.inputPath, "--output", draft.outputPath]
+            args += ["--width", String(draft.width), "--height", String(draft.height)]
+            args += ["--training-steps", String(draft.steps)]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.seed.isBlank { args += ["--seed", draft.seed] }
             if draft.quiet { args.append("--quiet") }
 
         case .imageValidate:
@@ -585,6 +598,16 @@ enum CommandCatalog {
             outputKind: .file("png"),
             defaultPrompt: "a ceramic coffee mug in soft morning light",
             defaultModel: "image-zimage-nano"
+        ),
+        CommandTemplate(
+            id: .imageTrainLoRA,
+            category: .image,
+            title: "Train LoRA",
+            subtitle: "Train Krea 2 Raw adapters",
+            systemImage: "slider.horizontal.3",
+            inputKind: .directory,
+            outputKind: .file("safetensors"),
+            defaultModel: "image-krea2-raw"
         ),
         CommandTemplate(
             id: .imageValidate,

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -234,7 +234,9 @@ private struct CommandEditor: View {
                     PathField(
                         path: $controller.draft.inputPath,
                         placeholder: "Choose \(controller.selectedTemplate.inputKind.title.lowercased())",
-                        mode: .openFile(controller.selectedTemplate.inputKind.allowedTypes)
+                        mode: controller.selectedTemplate.inputKind == .directory
+                            ? .openDirectory
+                            : .openFile(controller.selectedTemplate.inputKind.allowedTypes)
                     )
                 }
             }
@@ -269,6 +271,9 @@ private struct CommandEditor: View {
         case .imageGenerate:
             DimensionsGrid()
             GenerationOptions()
+        case .imageTrainLoRA:
+            DimensionsGrid()
+            LoRATrainingOptions()
         case .imageValidate:
             ImageValidationOptions()
         case .textChat, .textCode, .textEmbed, .textAnonymize, .visionInspect, .visionCaption, .visionOCR:
@@ -632,6 +637,24 @@ private struct GenerationOptions: View {
                     NumberField(title: "CFG", value: $controller.draft.cfgScale)
                     NumberField(title: "Strength", value: $controller.draft.strength)
                 }
+                TextField("Seed", text: $controller.draft.seed)
+                    .textFieldStyle(.plain)
+                    .font(MereRunTheme.bodyFont)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Quiet", isOn: $controller.draft.quiet)
+            }
+        }
+    }
+}
+
+private struct LoRATrainingOptions: View {
+    @EnvironmentObject private var controller: MereRunController
+
+    var body: some View {
+        EditorSection("Training") {
+            VStack(spacing: 10) {
+                NumberStepper(title: "Steps", value: $controller.draft.steps, range: 1...100_000, step: 100)
                 TextField("Seed", text: $controller.draft.seed)
                     .textFieldStyle(.plain)
                     .font(MereRunTheme.bodyFont)

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -188,8 +188,19 @@ enum GuideRegistry {
                 "image-klein-base",
                 "image-bonsai-binary",
                 "image-bonsai-ternary",
+                "image-krea2-turbo",
             ],
             resourceName: "image-generate.md"
+        ),
+        GuideTopic(
+            topic: "image-train-lora",
+            title: "Image Train LoRA",
+            commandPaths: [["image", "train-lora"]],
+            models: [
+                "image-krea2-raw",
+                "image-krea2-turbo",
+            ],
+            resourceName: "image-train-lora.md"
         ),
         GuideTopic(
             topic: "image-validate",

--- a/Sources/MereRunCLI/Commands/ImageCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageCommand.swift
@@ -6,6 +6,7 @@ struct Image: ParsableCommand {
         abstract: "Generate and validate image models.",
         subcommands: [
             ImageGenerate.self,
+            ImageTrainLoRA.self,
             ImageValidate.self,
         ]
     )

--- a/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
@@ -1,0 +1,210 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ImageTrainLoRA: AsyncParsableCommand {
+    static let defaultManagedModelID: ModelResolver.ModelID = .krea2Raw
+
+    static let configuration = CommandConfiguration(
+        commandName: "train-lora",
+        abstract: "Train a local image LoRA adapter.",
+        discussion: """
+        Krea 2 LoRAs are trained on image-krea2-raw and can be used with image-krea2-turbo via image generate --lora.
+        Prints the output LoRA path to stdout. Progress and diagnostics are printed to stderr.
+        """
+    )
+
+    @Option(name: [.customShort("d"), .long], help: "Dataset directory containing image files with matching .txt captions.")
+    var data: String?
+
+    @Option(name: [.customShort("o"), .long], help: "Output .safetensors path.")
+    var output: String
+
+    @Option(name: [.customShort("m"), .long], help: "Raw/base model path or canonical model id (default: image-krea2-raw).")
+    var model: String?
+
+    @Option(name: [.customShort("W"), .long], help: "Training image width in pixels.")
+    var width: Int = 1024
+
+    @Option(name: [.customShort("H"), .long], help: "Training image height in pixels.")
+    var height: Int = 1024
+
+    @Option(name: [.customLong("training-steps"), .customLong("steps")], help: "Number of optimizer steps.")
+    var trainingSteps: Int = 1000
+
+    @Option(name: [.long], help: "Batch size.")
+    var batchSize: Int = 1
+
+    @Option(name: [.customLong("learning-rate"), .customLong("lr")], help: "Learning rate.")
+    var learningRate: Float = 1e-4
+
+    @Option(name: [.customLong("rank")], help: "LoRA rank.")
+    var rank: Int = 16
+
+    @Option(name: [.customLong("alpha")], help: "LoRA alpha. Defaults to rank.")
+    var alpha: Float?
+
+    @Option(name: [.customLong("max-text-length")], help: "Maximum prompt token length.")
+    var maxTextLength: Int = 512
+
+    @Option(name: [.customLong("scheduler-steps")], help: "Number of FlowMatch training timesteps.")
+    var schedulerSteps: Int = 1000
+
+    @Option(name: [.long], help: "Caption dropout probability between 0.0 and 1.0.")
+    var captionDropout: Float = 0.05
+
+    @Option(name: [.long], help: "Random seed. Defaults to wall-clock time when omitted or zero.")
+    var seed: UInt64 = 0
+
+    @Flag(name: [.customLong("lite")], help: "Train only attention Q/V LoRA layers to reduce memory.")
+    var lite: Bool = false
+
+    @Flag(name: [.customLong("exclude-preview-images")], help: "Ignore preview*.png/jpg/webp images in the dataset folder.")
+    var excludePreviewImages: Bool = false
+
+    @Option(name: [.customLong("synthetic-samples")], help: "Use synthetic training samples for runtime smoke tests.")
+    var syntheticSamples: Int?
+
+    @Flag(name: [.short, .long], help: "Print only the output path.")
+    var quiet: Bool = false
+
+    func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+
+        guard width > 0, height > 0, width % 16 == 0, height % 16 == 0 else {
+            throw ValidationError("--width/--height must be > 0 and divisible by 16")
+        }
+        guard trainingSteps >= 1 else {
+            throw ValidationError("--training-steps must be >= 1")
+        }
+        guard batchSize >= 1 else {
+            throw ValidationError("--batch-size must be >= 1")
+        }
+        guard schedulerSteps >= 1 else {
+            throw ValidationError("--scheduler-steps must be >= 1")
+        }
+        guard rank >= 1 else {
+            throw ValidationError("--rank must be >= 1")
+        }
+        guard (0.0...1.0).contains(captionDropout) else {
+            throw ValidationError("--caption-dropout must be between 0.0 and 1.0")
+        }
+        if let syntheticSamples, syntheticSamples < 1 {
+            throw ValidationError("--synthetic-samples must be >= 1")
+        }
+
+        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
+        guard outputURL.pathExtension.lowercased() == "safetensors" else {
+            throw ValidationError("--output must end in .safetensors")
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let modelRoot = try resolveModelRoot()
+        let examples: [Krea2LoRATrainingExample]
+        let datasetRoot: String?
+        if syntheticSamples != nil {
+            examples = []
+            datasetRoot = nil
+        } else {
+            guard let data else {
+                throw ValidationError("--data is required unless --synthetic-samples is set")
+            }
+            let dataURL = URL(fileURLWithPath: data).standardizedFileURL
+            let pairs = try DatasetLoader.loadImageCaptionPairs(
+                from: dataURL,
+                excludePreviewImages: excludePreviewImages
+            )
+            examples = pairs.map { pair in
+                Krea2LoRATrainingExample(imageURL: pair.imageURL, caption: pair.caption)
+            }
+            datasetRoot = dataURL.path
+        }
+
+        var config = Krea2LoRATrainingConfig()
+        config.width = width
+        config.height = height
+        config.maxTextLength = maxTextLength
+        config.schedulerSteps = schedulerSteps
+        config.trainingSteps = trainingSteps
+        config.batchSize = batchSize
+        config.learningRate = learningRate
+        config.seed = seed
+        config.loraRank = rank
+        config.loraAlpha = alpha
+        config.captionDropout = captionDropout
+        config.loraTargetSuffixes = lite ? Krea2LoRAInjector.liteTargetSuffixes : nil
+        config.syntheticSampleCount = syntheticSamples
+        config.datasetRoot = datasetRoot
+
+        let progressHandler = quiet ? nil : Self.makeProgressHandler()
+        if !quiet {
+            CLIStderr.write("[runtime] image training backend: \(NativeMLXRuntime.backendDescription)\n")
+        }
+
+        try await Krea2LoRATrainer.train(
+            modelPath: modelRoot.path,
+            examples: examples,
+            outputURL: outputURL,
+            config: config,
+            progressHandler: progressHandler
+        )
+
+        print(outputURL.path)
+    }
+
+    private func resolveModelRoot() throws -> URL {
+        let resolver = ModelResolver()
+        guard let model else {
+            do {
+                return try resolver.resolve(Self.defaultManagedModelID).rootURL
+            } catch {
+                let modelID = Self.defaultManagedModelID.rawValue
+                throw ValidationError(
+                    "Krea 2 Raw model \(modelID) not found. Pull it with `mere.run model pull \(modelID)` or point --model at a local Raw model path."
+                )
+            }
+        }
+
+        let url = URL(fileURLWithPath: model).standardizedFileURL
+        if FileManager.default.fileExists(atPath: url.path) {
+            return url
+        }
+        if let id = ModelResolver.ModelID(rawValue: model) {
+            do {
+                return try resolver.resolve(id).rootURL
+            } catch {
+                throw ValidationError(
+                    "Model \(id.rawValue) not found. Pull it with `mere.run model pull \(id.rawValue)` or point --model at a local path."
+                )
+            }
+        }
+        throw ValidationError("Model path not found: \(model). Pass a local model path or a known model id.")
+    }
+
+    private static func makeProgressHandler() -> (@Sendable (Krea2LoRATrainingProgress) -> Void) {
+        { progress in
+            switch progress.stage {
+            case .loadingModels:
+                CLIStderr.write("Loading Krea 2 Raw models...\n")
+            case .encodingDataset(let current, let total):
+                CLIStderr.write("\rEncoding dataset (\(current)/\(total))")
+                if current >= total {
+                    CLIStderr.write("\n")
+                }
+            case .injectingLoRA(let layerCount):
+                CLIStderr.write("Injected LoRA into \(layerCount) Krea 2 layers.\n")
+            case .training(let step, let total, let loss):
+                if let loss {
+                    CLIStderr.write(String(format: "\rTraining (%d/%d) loss %.6f\n", step, total, loss))
+                } else {
+                    CLIStderr.write("\rTraining (\(step)/\(total))")
+                }
+            case .saving:
+                CLIStderr.write("Saving LoRA artifacts...\n")
+            }
+        }
+    }
+}

--- a/Sources/MereRunCLI/Guides/image-generate.md
+++ b/Sources/MereRunCLI/Guides/image-generate.md
@@ -58,7 +58,7 @@ mere.run guide image generate --model image-zimage-nano
 - For FLUX.2 Klein, use explicit visual composition and relationships: foreground, background, lens/framing, color palette, and what must be absent.
 - For Ideogram 4 SDNQ, use `--structured-prompt` when a short prompt needs stronger object, spatial, lighting, camera, or text-render control. The adapter converts the prompt into a long JSON caption and raises the prompt token budget to 2048.
 - For Bonsai binary or ternary, start with four steps at 512 or 1024 square; the manifest applies its native FlowMatch sigma shift.
-- For Krea 2 Turbo, start with the managed default: 1024 square, 8 steps, CFG 0.0, and no reference or input image.
+- For Krea 2 Turbo, start with the managed default: 1024 square, 8 steps, CFG 0.0, and no reference or input image. Raw-trained Krea 2 LoRAs can be loaded with `--lora`.
 - Use `--input` plus `--strength 0.25` to preserve layout; use `0.65` or higher for stronger reinterpretation.
 
 ## Examples
@@ -120,7 +120,7 @@ mere.run image generate \
 - Missing model: run `mere.run model pull <model-id>` or pass a local model root with `--model`.
 - Negative prompt has no effect: confirm `--cfg` is greater than `1.0`.
 - Input image ignored: lower dimensions may be easier to condition; also reduce or raise `--strength` depending on whether the output is too close or too different.
-- Unsupported mode on Krea 2 Turbo: use plain text-to-image; reference images, input images, and LoRA are not wired for that family yet.
+- Unsupported mode on Krea 2 Turbo: use text-to-image with optional `--lora`; reference images and input images are not wired for that family yet.
 - Out of memory: choose a smaller model, reduce width/height, or use a nano tier. Krea 2 Turbo is a large BF16 component install and is best treated as a 96 GB+ Apple Silicon path.
 
 ## Sources
@@ -129,4 +129,5 @@ mere.run image generate \
 - https://huggingface.co/docs/diffusers/api/pipelines/z_image
 - https://docs.bfl.ai/guides/prompting_guide_flux2_klein
 - https://huggingface.co/krea/Krea-2-Turbo
+- https://huggingface.co/krea/Krea-2-Raw
 - https://github.com/krea-ai/krea-2

--- a/Sources/MereRunCLI/Guides/image-train-lora.md
+++ b/Sources/MereRunCLI/Guides/image-train-lora.md
@@ -1,0 +1,98 @@
+# Image Train LoRA
+
+## Purpose
+
+Train a local text-to-image LoRA adapter. Use this when you have a small image
+and caption dataset and want an adapter that can be loaded with
+`mere.run image generate --lora`.
+
+## Required Models
+
+- Train on `image-krea2-raw`.
+- Preview and run the adapter on `image-krea2-turbo`.
+
+## Install And Check
+
+```bash
+mere.run model pull image-krea2-raw
+mere.run model pull image-krea2-turbo
+mere.run image train-lora --help
+```
+
+## Dataset Layout
+
+Use image files with matching UTF-8 `.txt` captions:
+
+```text
+dataset/
+  001.png
+  001.txt
+  002.jpg
+  002.txt
+```
+
+Captions should be concrete and visual. For style training, include subject,
+medium, lighting, composition, and any repeatable style tokens you plan to use
+at inference time.
+
+## Parameters
+
+- `--data`, `-d`: dataset directory.
+- `--output`, `-o`: output `.safetensors` adapter path.
+- `--model`, `-m`: Raw/base model id or local model root. Defaults to `image-krea2-raw`.
+- `--width`, `-W`, `--height`, `-H`: fixed training resolution, divisible by 16.
+- `--training-steps`, `--steps`: optimizer steps.
+- `--batch-size`: usually `1` on local Apple Silicon.
+- `--learning-rate`, `--lr`: start around `0.0001`.
+- `--rank`: LoRA rank. Start with `16`; lower for smaller adapters.
+- `--alpha`: LoRA alpha. Defaults to rank.
+- `--max-text-length`: prompt token budget.
+- `--scheduler-steps`: FlowMatch training timestep count.
+- `--caption-dropout`: probability of empty prompt conditioning.
+- `--lite`: train only attention Q/V layers for lower memory use.
+- `--exclude-preview-images`: skip `preview*` images in the dataset folder.
+- `--quiet`, `-q`: print only the final adapter path.
+
+## Train
+
+```bash
+mere.run image train-lora \
+  --data ./dataset \
+  --output ./my-krea2-style.safetensors \
+  --training-steps 1000 \
+  --rank 16 \
+  --lite
+```
+
+The command writes the adapter plus sidecar training artifacts beside it:
+
+- `*.safetensors`: LoRA weights and optimizer state.
+- `*.manifest.json`: training manifest.
+- `*.checkpoint.json`: final checkpoint state.
+- `run.json`: run manifest.
+- `*.loss.csv` and `*.loss.html`: loss history.
+- `*.zip`: portable bundle when archive creation succeeds.
+
+## Preview
+
+```bash
+mere.run image generate \
+  --model image-krea2-turbo \
+  --prompt "a portrait in my trained style" \
+  --lora ./my-krea2-style.safetensors \
+  --lora-scale 1.0 \
+  --output ./preview.png
+```
+
+## Troubleshooting
+
+- Missing Raw model: run `mere.run model pull image-krea2-raw`.
+- LoRA has no visible effect: confirm you are generating with `image-krea2-turbo` and the exact `--lora` path.
+- Out of memory: use `--lite`, lower resolution, lower rank, or fewer concurrent apps.
+- Dataset rejected: check every image has a same-stem `.txt` caption.
+
+## Sources
+
+- https://huggingface.co/krea/Krea-2-Raw
+- https://huggingface.co/krea/Krea-2-Turbo
+- https://www.krea.ai/krea-2-open-source

--- a/Sources/MereRunCore/Krea2/Krea2Generator.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Generator.swift
@@ -26,6 +26,14 @@ public final class Krea2Generator: ImageGenerator {
     private var textEncoder: QwenEncoder?
     private var tokenizer: QwenTokenizer?
     private var vae: QwenImageEditVAE?
+    private var currentLoRA: LoRA?
+    private var transformerLoRALayers: [String: TrainableLoRALayer]?
+    private var transformerLoRARank: Int?
+
+    private static let loraDebugEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_DEBUG"]?.lowercased()
+        return raw == "1" || raw == "true" || raw == "yes"
+    }()
 
     public init() {}
 
@@ -40,6 +48,9 @@ public final class Krea2Generator: ImageGenerator {
         textEncoder = nil
         tokenizer = nil
         vae = nil
+        currentLoRA = nil
+        transformerLoRALayers = nil
+        transformerLoRARank = nil
         clearGPUMemory()
     }
 
@@ -56,9 +67,6 @@ public final class Krea2Generator: ImageGenerator {
         }
         guard request.inputImage == nil else {
             throw Krea2GeneratorError.unsupportedMode("image-to-image")
-        }
-        guard request.lora == nil else {
-            throw Krea2GeneratorError.unsupportedMode("LoRA")
         }
 
         let rootURL = try resolveModelRoot(request)
@@ -78,6 +86,13 @@ public final class Krea2Generator: ImageGenerator {
             }
             loadedModelPath = rootURL.path
         }
+
+        try await applyLoRAIfNeeded(
+            request.lora,
+            resources: resources,
+            configuration: configs?.transformer,
+            progressHandler: progressHandler
+        )
 
         guard let configs, let transformer, let textEncoder, let tokenizer, let vae else {
             throw Krea2GeneratorError.modelsNotLoaded
@@ -187,6 +202,107 @@ public final class Krea2Generator: ImageGenerator {
         progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 0, totalSteps: 1))
         vae = try Krea2ModelLoader.loadVAE(from: resources, configuration: loadedConfigs.vae)
         progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 1, totalSteps: 1))
+    }
+
+    private func applyLoRAIfNeeded(
+        _ lora: LoRA?,
+        resources: Krea2Resources,
+        configuration: Krea2TransformerConfiguration?,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws {
+        guard lora != currentLoRA else { return }
+
+        if lora == nil {
+            if let transformerLoRALayers {
+                for layer in transformerLoRALayers.values {
+                    layer.isActive = false
+                }
+            }
+            currentLoRA = nil
+            return
+        }
+
+        guard let lora else { return }
+        guard let configuration else {
+            throw Krea2GeneratorError.modelsNotLoaded
+        }
+
+        progressHandler?(GenerationProgress(stage: .loadingLoRA, stepIndex: 0, totalSteps: 2))
+        let loraURL = try await LoRAWeightLoader.resolveURL(for: lora)
+        let loraWeights = try LoRAWeightLoader.load(from: loraURL)
+        let targetRank = loraWeights.rank
+
+        if let existingRank = transformerLoRARank, existingRank != targetRank {
+            transformer = try Krea2ModelLoader.loadTransformer(
+                from: resources,
+                configuration: configuration,
+                progressHandler: nil
+            )
+            transformerLoRALayers = nil
+            transformerLoRARank = nil
+            currentLoRA = nil
+        }
+
+        guard let transformer else {
+            throw Krea2GeneratorError.modelsNotLoaded
+        }
+
+        if transformerLoRALayers == nil {
+            if Self.loraDebugEnabled {
+                FileHandle.standardError.write(
+                    Data("[Krea2 LoRA] Injecting with rank=\(targetRank), alpha=\(loraWeights.alpha)\n".utf8)
+                )
+            }
+            transformerLoRALayers = try Krea2LoRAInjector.inject(
+                into: transformer,
+                rank: targetRank,
+                alpha: loraWeights.alpha,
+                targetSuffixes: Krea2LoRAInjector.defaultTargetSuffixes,
+                zeroInitUp: true
+            )
+            transformerLoRARank = targetRank
+            if let transformerLoRALayers {
+                for layer in transformerLoRALayers.values {
+                    layer.isActive = false
+                }
+            }
+        }
+
+        guard let layers = transformerLoRALayers else {
+            throw LoRAError.invalidFormat("Failed to inject Krea 2 LoRA layers.")
+        }
+
+        let updatedCount = Krea2LoRAInjector.applyWeights(
+            loraWeights,
+            to: layers,
+            debug: Self.loraDebugEnabled
+        )
+        for (path, layer) in layers {
+            layer.isActive = loraWeights.weights[path] != nil
+        }
+        guard updatedCount > 0 else {
+            throw LoRAError.invalidFormat("No matching Krea 2 transformer layers found for this LoRA.")
+        }
+
+        let userScale = Self.loraScale(for: lora)
+        if userScale != 1 {
+            let scale = MLXArray(userScale)
+            for layer in layers.values where layer.isActive {
+                layer.loraDown = layer.loraDown * scale
+            }
+        }
+
+        currentLoRA = lora
+        progressHandler?(GenerationProgress(stage: .loadingLoRA, stepIndex: 2, totalSteps: 2))
+    }
+
+    private static func loraScale(for lora: LoRA) -> Float {
+        switch lora {
+        case .local(_, let scale):
+            return Float(scale)
+        case .remote(_, let scale):
+            return Float(scale)
+        }
     }
 
     private func encodePrompt(

--- a/Sources/MereRunCore/Krea2/Krea2LoRAInjector.swift
+++ b/Sources/MereRunCore/Krea2/Krea2LoRAInjector.swift
@@ -1,0 +1,221 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum Krea2LoRAInjectionError: Error, LocalizedError {
+    case invalidRank(Int)
+    case noMatchingLayers
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRank(let rank):
+            return "LoRA rank must be >= 1 (got \(rank))."
+        case .noMatchingLayers:
+            return "No matching Krea 2 transformer Linear layers found for LoRA injection."
+        }
+    }
+}
+
+public enum Krea2LoRAInjector {
+    public static let defaultTargetPrefixes: [String] = [
+        "transformer_blocks.",
+    ]
+
+    public static let defaultTargetSuffixes: [String] = [
+        ".attn.to_q",
+        ".attn.to_k",
+        ".attn.to_v",
+        ".attn.to_out.0",
+        ".ff.gate",
+        ".ff.up",
+        ".ff.down",
+    ]
+
+    public static let liteTargetSuffixes: [String] = [
+        ".attn.to_q",
+        ".attn.to_v",
+    ]
+
+    public static func inject(
+        into transformer: Krea2Transformer,
+        rank: Int,
+        alpha: Float? = nil,
+        targetPrefixes: [String]? = defaultTargetPrefixes,
+        targetSuffixes: [String]? = defaultTargetSuffixes,
+        targetRanks: [String: Int]? = nil,
+        zeroInitUp: Bool = false
+    ) throws -> [String: TrainableLoRALayer] {
+        guard rank >= 1 else {
+            throw Krea2LoRAInjectionError.invalidRank(rank)
+        }
+        if let targetRanks {
+            for configuredRank in targetRanks.values where configuredRank < 1 {
+                throw Krea2LoRAInjectionError.invalidRank(configuredRank)
+            }
+        }
+
+        let shouldTarget: (String) -> Bool = { path in
+            if let targetPrefixes {
+                guard targetPrefixes.contains(where: { path.hasPrefix($0) }) else { return false }
+            }
+            guard let targetSuffixes else { return true }
+            return targetSuffixes.contains { path.hasSuffix($0) }
+        }
+
+        let leafModules = transformer.leafModules().flattened()
+        var replacements: [String: Module] = [:]
+        var loraLayers: [String: TrainableLoRALayer] = [:]
+
+        for (path, module) in leafModules {
+            let resolvedRank: Int = {
+                if let targetRanks {
+                    guard let explicitRank = targetRanks[path] else { return 0 }
+                    return explicitRank
+                }
+                guard shouldTarget(path) else { return 0 }
+                return rank
+            }()
+            guard resolvedRank > 0 else { continue }
+            let alphaValue = alpha ?? Float(resolvedRank)
+
+            if let existingFused = module as? FusedLoRALinear {
+                let newLoRA = LoRALinear(
+                    base: Linear(weight: existingFused.weight, bias: existingFused.bias),
+                    rank: resolvedRank,
+                    alpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                newLoRA.role = .train
+                for lora in existingFused.loras where lora.role == .train {
+                    lora.role = .assistant
+                }
+                existingFused.loras.append(newLoRA)
+                loraLayers[path] = existingFused
+                continue
+            }
+
+            if let loraQuantized = module as? LoRAQuantizedLinear {
+                let fused = FusedLoRALinear(
+                    existingLoRA: loraQuantized,
+                    newRank: resolvedRank,
+                    newAlpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = fused
+                loraLayers[path] = fused
+                continue
+            }
+
+            if let loraLinear = module as? LoRALinear {
+                let fused = FusedLoRALinear(
+                    existingLoRA: loraLinear,
+                    newRank: resolvedRank,
+                    newAlpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = fused
+                loraLayers[path] = fused
+                continue
+            }
+
+            if let quantized = module as? QuantizedLinear {
+                let wrapped = LoRAQuantizedLinear(
+                    base: quantized,
+                    rank: resolvedRank,
+                    alpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = wrapped
+                loraLayers[path] = wrapped
+                continue
+            }
+
+            if let linear = module as? Linear {
+                let wrapped = LoRALinear(
+                    base: linear,
+                    rank: resolvedRank,
+                    alpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = wrapped
+                loraLayers[path] = wrapped
+            }
+        }
+
+        guard !loraLayers.isEmpty else {
+            throw Krea2LoRAInjectionError.noMatchingLayers
+        }
+
+        applyModuleReplacements(replacements, leafModules: leafModules, to: transformer)
+        return loraLayers
+    }
+
+    @discardableResult
+    public static func loadWeights(
+        from url: URL,
+        into loraLayers: [String: TrainableLoRALayer],
+        optimizerStateURL: URL? = nil,
+        debug: Bool = false
+    ) throws -> Int {
+        try ZImageLoRAInjector.loadWeights(
+            from: url,
+            into: loraLayers,
+            optimizerStateURL: optimizerStateURL,
+            debug: debug
+        )
+    }
+
+    @discardableResult
+    public static func applyWeights(
+        _ loraWeights: LoRAWeights,
+        to loraLayers: [String: TrainableLoRALayer],
+        debug: Bool = false
+    ) -> Int {
+        ZImageLoRAInjector.applyWeights(loraWeights, to: loraLayers, debug: debug)
+    }
+
+    private static func applyModuleReplacements(
+        _ replacements: [String: Module],
+        leafModules: [(String, Module)],
+        to model: Module
+    ) {
+        var arrayUpdates: [String: [(Int, Module)]] = [:]
+        var directUpdates: [(String, Module)] = []
+
+        for (path, replacement) in replacements {
+            let components = path.split(separator: ".")
+            if let last = components.last, let index = Int(last) {
+                let parentPath = components.dropLast().joined(separator: ".")
+                arrayUpdates[parentPath, default: []].append((index, replacement))
+            } else {
+                directUpdates.append((path, replacement))
+            }
+        }
+
+        var moduleUpdates: [(String, Module)] = directUpdates
+
+        for (parentPath, indexedReplacements) in arrayUpdates {
+            let currentModules = leafModules.filter { path, _ in
+                let parts = path.split(separator: ".")
+                guard parts.count >= 2 else { return false }
+                guard Int(parts.last!) != nil else { return false }
+                let parent = parts.dropLast().joined(separator: ".")
+                return parent == parentPath
+            }
+
+            var replacementMap: [Int: Module] = [:]
+            for (index, replacement) in indexedReplacements {
+                replacementMap[index] = replacement
+            }
+
+            for (modulePath, originalModule) in currentModules {
+                let index = Int(modulePath.split(separator: ".").last!)!
+                let resolved = replacementMap[index] ?? originalModule
+                moduleUpdates.append((modulePath, resolved))
+            }
+        }
+
+        guard !moduleUpdates.isEmpty else { return }
+        model.update(modules: ModuleChildren.unflattened(moduleUpdates))
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2LoRATrainer.swift
+++ b/Sources/MereRunCore/Krea2/Krea2LoRATrainer.swift
@@ -1,0 +1,718 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+public enum Krea2LoRATrainerError: Error, LocalizedError {
+    case datasetEmpty
+    case invalidDimensions(width: Int, height: Int)
+    case invalidTrainingSteps(Int)
+    case invalidBatchSize(Int)
+    case invalidSchedulerSteps(Int)
+    case outputMustBeSafetensors(URL)
+    case imageNotFound(URL)
+    case captionEmpty(URL)
+    case imageDecodeFailed(URL)
+    case modelPathNotFound(String)
+    case baseModelNotTrainable(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .datasetEmpty:
+            return "Training dataset is empty."
+        case .invalidDimensions(let width, let height):
+            return "Invalid image dimensions (\(width)x\(height)); width/height must be >0 and divisible by 16."
+        case .invalidTrainingSteps(let steps):
+            return "Training steps must be >= 1 (got \(steps))."
+        case .invalidBatchSize(let batchSize):
+            return "Batch size must be >= 1 (got \(batchSize))."
+        case .invalidSchedulerSteps(let steps):
+            return "Scheduler steps must be >= 1 (got \(steps))."
+        case .outputMustBeSafetensors(let url):
+            return "Output must be a .safetensors file: \(url.path)"
+        case .imageNotFound(let url):
+            return "Image not found: \(url.path)"
+        case .captionEmpty(let url):
+            return "Caption is empty for: \(url.path)"
+        case .imageDecodeFailed(let url):
+            return "Failed to decode image: \(url.path)"
+        case .modelPathNotFound(let path):
+            return "Model path not found: \(path)"
+        case .baseModelNotTrainable(let id):
+            return "Krea 2 LoRA training requires the Raw/base checkpoint; got \(id)."
+        }
+    }
+}
+
+public struct Krea2LoRATrainingExample: Hashable, Sendable {
+    public let imageURL: URL
+    public let caption: String
+
+    public init(imageURL: URL, caption: String) {
+        self.imageURL = imageURL
+        self.caption = caption
+    }
+}
+
+public struct Krea2LoRATrainingConfig: Sendable {
+    public var width: Int
+    public var height: Int
+    public var maxTextLength: Int
+    public var schedulerSteps: Int
+    public var trainingSteps: Int
+    public var batchSize: Int
+    public var learningRate: Float
+    public var seed: UInt64
+    public var loraRank: Int
+    public var loraAlpha: Float?
+    public var loraTargetPrefixes: [String]?
+    public var loraTargetSuffixes: [String]?
+    public var captionDropout: Float
+    public var saveDType: DType
+    public var logEvery: Int
+    public var baseModelId: String
+    public var syntheticSampleCount: Int?
+    public var timestepLow: Int
+    public var timestepHigh: Int?
+    public var datasetRoot: String?
+
+    public init(
+        width: Int = 1024,
+        height: Int = 1024,
+        maxTextLength: Int = 512,
+        schedulerSteps: Int = 1000,
+        trainingSteps: Int = 1000,
+        batchSize: Int = 1,
+        learningRate: Float = 1e-4,
+        seed: UInt64 = 0,
+        loraRank: Int = 16,
+        loraAlpha: Float? = nil,
+        loraTargetPrefixes: [String]? = nil,
+        loraTargetSuffixes: [String]? = nil,
+        captionDropout: Float = 0.05,
+        saveDType: DType = .float16,
+        logEvery: Int = 10,
+        baseModelId: String = Krea2RawResources.modelId,
+        syntheticSampleCount: Int? = nil,
+        timestepLow: Int = 0,
+        timestepHigh: Int? = nil,
+        datasetRoot: String? = nil
+    ) {
+        self.width = width
+        self.height = height
+        self.maxTextLength = maxTextLength
+        self.schedulerSteps = schedulerSteps
+        self.trainingSteps = trainingSteps
+        self.batchSize = batchSize
+        self.learningRate = learningRate
+        self.seed = seed
+        self.loraRank = loraRank
+        self.loraAlpha = loraAlpha
+        self.loraTargetPrefixes = loraTargetPrefixes
+        self.loraTargetSuffixes = loraTargetSuffixes
+        self.captionDropout = captionDropout
+        self.saveDType = saveDType
+        self.logEvery = logEvery
+        self.baseModelId = baseModelId
+        self.syntheticSampleCount = syntheticSampleCount
+        self.timestepLow = timestepLow
+        self.timestepHigh = timestepHigh
+        self.datasetRoot = datasetRoot
+    }
+}
+
+public struct Krea2LoRATrainingProgress: Sendable {
+    public enum Stage: Sendable {
+        case loadingModels
+        case encodingDataset(current: Int, total: Int)
+        case injectingLoRA(layerCount: Int)
+        case training(step: Int, total: Int, loss: Float?)
+        case saving
+    }
+
+    public let stage: Stage
+    public let fraction: Float
+
+    public init(stage: Stage, fraction: Float) {
+        self.stage = stage
+        self.fraction = fraction
+    }
+}
+
+public enum Krea2LoRATrainer {
+    public static func train(
+        modelPath: String,
+        examples: [Krea2LoRATrainingExample],
+        outputURL: URL,
+        config: Krea2LoRATrainingConfig = Krea2LoRATrainingConfig(),
+        progressHandler: (@Sendable (Krea2LoRATrainingProgress) -> Void)? = nil
+    ) async throws {
+        guard !examples.isEmpty || (config.syntheticSampleCount ?? 0) > 0 else {
+            throw Krea2LoRATrainerError.datasetEmpty
+        }
+        guard config.width > 0, config.height > 0, config.width % 16 == 0, config.height % 16 == 0 else {
+            throw Krea2LoRATrainerError.invalidDimensions(width: config.width, height: config.height)
+        }
+        guard config.trainingSteps >= 1 else {
+            throw Krea2LoRATrainerError.invalidTrainingSteps(config.trainingSteps)
+        }
+        guard config.batchSize >= 1 else {
+            throw Krea2LoRATrainerError.invalidBatchSize(config.batchSize)
+        }
+        guard config.schedulerSteps >= 1 else {
+            throw Krea2LoRATrainerError.invalidSchedulerSteps(config.schedulerSteps)
+        }
+        guard outputURL.pathExtension.lowercased() == "safetensors" else {
+            throw Krea2LoRATrainerError.outputMustBeSafetensors(outputURL)
+        }
+
+        let modelURL = URL(fileURLWithPath: modelPath).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            throw Krea2LoRATrainerError.modelPathNotFound(modelPath)
+        }
+
+        let modelManifest = try MereRunModelManifest.loadRequired(from: modelURL)
+        guard modelManifest.engine == .krea2, modelManifest.variant == .base else {
+            throw Krea2LoRATrainerError.baseModelNotTrainable(modelManifest.id)
+        }
+
+        progressHandler?(Krea2LoRATrainingProgress(stage: .loadingModels, fraction: 0))
+        let resources = Krea2Resources(rootURL: modelURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw Krea2GeneratorError.missingModelFiles(missing)
+        }
+
+        let configs = try Krea2ModelConfigs.load(from: resources)
+        let maxTextLength = min(config.maxTextLength, 512)
+        let tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: maxTextLength)
+        let textEncoder = try Krea2ModelLoader.loadTextEncoder(
+            from: resources,
+            configuration: configs.textEncoder
+        )
+        let transformer = try Krea2ModelLoader.loadTransformer(
+            from: resources,
+            configuration: configs.transformer
+        )
+        let vae = try Krea2ModelLoader.loadVAE(from: resources, configuration: configs.vae)
+        MLX.eval(textEncoder, transformer, vae)
+        progressHandler?(Krea2LoRATrainingProgress(stage: .loadingModels, fraction: 1))
+
+        struct PreparedExample {
+            let imageTokens: MLXArray
+            let textHiddenStates: MLXArray
+            let textMask: MLXArray
+            let positionIds: MLXArray
+            let validMask: MLXArray
+        }
+
+        let datasetFingerprint = LoRATrainingFingerprint.sha256Hex(
+            examples
+                .map { [$0.imageURL.standardizedFileURL.path, $0.caption].joined(separator: "|") }
+                .joined(separator: "\n")
+        )
+        let runDataFingerprint = makeRunDataFingerprint(examples: examples, dataRootPath: config.datasetRoot)
+        let serializedTargetSuffixes = (config.loraTargetSuffixes ?? Krea2LoRAInjector.defaultTargetSuffixes)
+            .joined(separator: ",")
+        let serializedTargetPrefixes = (config.loraTargetPrefixes ?? Krea2LoRAInjector.defaultTargetPrefixes)
+            .joined(separator: ",")
+        let configFingerprintInput = [
+            "model:\(modelURL.path)",
+            "model_id:\(config.baseModelId)",
+            "size:\(config.width)x\(config.height)",
+            "scheduler_steps:\(config.schedulerSteps)",
+            "training_steps:\(config.trainingSteps)",
+            "batch_size:\(config.batchSize)",
+            "learning_rate:\(config.learningRate)",
+            "rank:\(config.loraRank)",
+            "alpha:\(config.loraAlpha.map { "\($0)" } ?? "")",
+            "max_text_length:\(maxTextLength)",
+            "caption_dropout:\(config.captionDropout)",
+            "timestep_low:\(config.timestepLow)",
+            "timestep_high:\(config.timestepHigh.map { "\($0)" } ?? "")",
+            "synthetic_sample_count:\(config.syntheticSampleCount.map { "\($0)" } ?? "")",
+            "lora_target_prefixes:\(serializedTargetPrefixes)",
+            "lora_target_suffixes:\(serializedTargetSuffixes)",
+        ].joined(separator: "\n")
+        let configFingerprint = LoRATrainingFingerprint.sha256Hex(configFingerprintInput)
+
+        let latentHeight = config.height / Krea2SampleBuilder.vaeCompression
+        let latentWidth = config.width / Krea2SampleBuilder.vaeCompression
+        let imageTokenHeight = latentHeight / configs.transformer.patchSize
+        let imageTokenWidth = latentWidth / configs.transformer.patchSize
+        let imageTokenCount = imageTokenHeight * imageTokenWidth
+        var prepared: [PreparedExample] = []
+        let syntheticCount = config.syntheticSampleCount ?? 0
+
+        if syntheticCount > 0 {
+            prepared.reserveCapacity(syntheticCount)
+            for _ in 0..<syntheticCount {
+                let textLength = max(1, maxTextLength - 34)
+                let cleanLatents = MLXRandom.normal([
+                    1,
+                    configs.transformer.latentChannels,
+                    latentHeight,
+                    latentWidth,
+                ]).asType(.bfloat16)
+                let textHidden = MLXRandom.normal([
+                    1,
+                    textLength,
+                    configs.transformer.numTextLayers,
+                    configs.transformer.textHiddenDim,
+                ]).asType(.bfloat16)
+                let textMask = MLXArray.ones([1, textLength], dtype: .int32)
+                let preparedSample = Krea2SampleBuilder.prepare(
+                    latents: cleanLatents,
+                    textLength: textLength,
+                    textMask: textMask,
+                    patch: configs.transformer.patchSize
+                )
+                let validMask = MLX.concatenated([
+                    textMask,
+                    MLXArray.ones([1, imageTokenCount], dtype: .int32),
+                ], axis: 1)
+                prepared.append(
+                    PreparedExample(
+                        imageTokens: preparedSample.imageTokens.asType(.bfloat16),
+                        textHiddenStates: textHidden,
+                        textMask: textMask,
+                        positionIds: preparedSample.positionIds,
+                        validMask: validMask
+                    )
+                )
+            }
+        } else {
+            prepared.reserveCapacity(examples.count)
+            for (index, example) in examples.enumerated() {
+                try Task.checkCancellation()
+                progressHandler?(Krea2LoRATrainingProgress(
+                    stage: .encodingDataset(current: index, total: examples.count),
+                    fraction: Float(index) / Float(max(examples.count, 1))
+                ))
+                let caption = example.caption.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !caption.isEmpty else {
+                    throw Krea2LoRATrainerError.captionEmpty(example.imageURL)
+                }
+
+                let text = try encodePrompt(
+                    caption,
+                    tokenizer: tokenizer,
+                    encoder: textEncoder,
+                    selectedLayers: configs.selectedTextLayers,
+                    maxLength: maxTextLength
+                )
+                let cleanLatents = try encodeTrainingImage(
+                    example.imageURL,
+                    vae: vae,
+                    config: configs.vae,
+                    width: config.width,
+                    height: config.height
+                )
+                let preparedSample = Krea2SampleBuilder.prepare(
+                    latents: cleanLatents,
+                    textLength: text.hiddenStates.dim(1),
+                    textMask: text.attentionMask,
+                    patch: configs.transformer.patchSize
+                )
+                prepared.append(
+                    PreparedExample(
+                        imageTokens: preparedSample.imageTokens.asType(.bfloat16),
+                        textHiddenStates: text.hiddenStates.asType(.bfloat16),
+                        textMask: text.attentionMask,
+                        positionIds: preparedSample.positionIds,
+                        validMask: preparedSample.validMask
+                    )
+                )
+                MLX.eval(prepared.last!.imageTokens, prepared.last!.textHiddenStates)
+            }
+        }
+
+        progressHandler?(Krea2LoRATrainingProgress(
+            stage: .encodingDataset(current: prepared.count, total: prepared.count),
+            fraction: 1
+        ))
+
+        let emptyPrompt: (hiddenStates: MLXArray, attentionMask: MLXArray)? = try {
+            guard config.captionDropout > 0 else { return nil }
+            if syntheticCount > 0 {
+                let sample = prepared[0]
+                return (
+                    MLXArray.zeros(sample.textHiddenStates.shape, dtype: .bfloat16),
+                    MLXArray.zeros(sample.textMask.shape, dtype: .int32)
+                )
+            }
+            return try encodePrompt(
+                "",
+                tokenizer: tokenizer,
+                encoder: textEncoder,
+                selectedLayers: configs.selectedTextLayers,
+                maxLength: maxTextLength
+            )
+        }()
+
+        let effectiveAlpha = config.loraAlpha ?? Float(config.loraRank)
+        let loraLayers = try Krea2LoRAInjector.inject(
+            into: transformer,
+            rank: config.loraRank,
+            alpha: effectiveAlpha,
+            targetPrefixes: config.loraTargetPrefixes ?? Krea2LoRAInjector.defaultTargetPrefixes,
+            targetSuffixes: config.loraTargetSuffixes ?? Krea2LoRAInjector.defaultTargetSuffixes,
+            zeroInitUp: true
+        )
+        try transformer.freeze(recursive: true, keys: nil, strict: false)
+        for layer in loraLayers.values {
+            guard let module = layer as? Module else { continue }
+            try module.unfreeze(recursive: false, keys: ["loraDown", "loraUp"], strict: true)
+        }
+        ZImageTurboLoRATrainer.initializeAdamStateIfNeeded(for: loraLayers)
+        let loraState = ZImageTurboLoRATrainer.LoRAState(loraLayers: loraLayers)
+        MLX.eval(transformer, loraState)
+        progressHandler?(Krea2LoRATrainingProgress(stage: .injectingLoRA(layerCount: loraLayers.count), fraction: 1))
+
+        let lossAndGrad = valueAndGrad(model: transformer) { model, arrays in
+            let clean = arrays[0]
+            let noise = arrays[1]
+            let textHiddenStates = arrays[2]
+            let timestep = arrays[3].asType(.float32)
+            let positionIds = arrays[4]
+            let validMask = arrays[5]
+            let sigma = timestep.ndim == 0 ? timestep : timestep.expandedDimensions(axis: 1).expandedDimensions(axis: 2)
+
+            let noisy = ((MLXArray(1.0) - sigma) * clean.asType(.float32) + sigma * noise.asType(.float32))
+                .asType(.bfloat16)
+            let pred = model(
+                imageTokens: noisy,
+                textContext: textHiddenStates,
+                timestep: timestep.asType(.bfloat16),
+                positionIds: positionIds,
+                validMask: validMask
+            )
+            let target = noise.asType(.float32) - clean.asType(.float32)
+            return [(pred.asType(.float32) - target).square().mean()]
+        }
+
+        let metricsLogger = try LoRATrainingMetricsLogger(baseOutputURL: outputURL, resumeExisting: false)
+        let effectiveSeed = config.seed == 0 ? UInt64(Date().timeIntervalSince1970) : config.seed
+        var rng = ZImageTurboLoRATrainer.SplitMix64(seed: effectiveSeed)
+        let loraLayerList = loraState.layers
+        let beta1 = MLXArray(Float(0.9))
+        let beta2 = MLXArray(Float(0.999))
+        let oneMinusBeta1 = MLXArray(Float(0.1))
+        let oneMinusBeta2 = MLXArray(Float(0.001))
+        let eps = MLXArray(Float(1e-8))
+        let lr = MLXArray(config.learningRate)
+        let oneMinusLrWd = MLXArray(1.0 - config.learningRate * 0.0001)
+        let timestepHigh = config.timestepHigh ?? config.schedulerSteps
+        let timestepLow = config.timestepLow
+
+        let state: [any Updatable] = [loraState]
+        let trainStep = compile(inputs: state, outputs: state) { inputs -> [MLXArray] in
+            let (values, grads) = lossAndGrad(transformer, inputs)
+            let gradMap = Dictionary(uniqueKeysWithValues: grads.flattened())
+            ZImageTurboLoRATrainer.applyAdamW(
+                loraLayers: loraLayerList,
+                gradMap: gradMap,
+                lr: lr,
+                beta1: beta1,
+                beta2: beta2,
+                oneMinusBeta1: oneMinusBeta1,
+                oneMinusBeta2: oneMinusBeta2,
+                eps: eps,
+                oneMinusLrWd: oneMinusLrWd,
+                useWeightDecay: true
+            )
+            return values
+        }
+
+        for step in 0..<config.trainingSteps {
+            try Task.checkCancellation()
+            let batchSize = min(config.batchSize, prepared.count)
+            var cleanParts: [MLXArray] = []
+            var noiseParts: [MLXArray] = []
+            var textParts: [MLXArray] = []
+            var positionParts: [MLXArray] = []
+            var maskParts: [MLXArray] = []
+            var timestepValues: [Float] = []
+
+            for _ in 0..<batchSize {
+                let index = Int(rng.next() % UInt64(prepared.count))
+                let item = prepared[index]
+                cleanParts.append(item.imageTokens)
+                let useEmptyPrompt = emptyPrompt != nil
+                    && Float(rng.next() % 1000) / 1000.0 < config.captionDropout
+                if useEmptyPrompt, let emptyPrompt {
+                    textParts.append(emptyPrompt.hiddenStates.asType(.bfloat16))
+                    let validMask = MLX.concatenated([
+                        emptyPrompt.attentionMask,
+                        MLXArray.ones([1, imageTokenCount], dtype: .int32),
+                    ], axis: 1)
+                    maskParts.append(validMask)
+                } else {
+                    textParts.append(item.textHiddenStates)
+                    maskParts.append(item.validMask)
+                }
+                positionParts.append(item.positionIds)
+                let noiseSeed = UInt64(UInt32(truncatingIfNeeded: rng.next()))
+                noiseParts.append(
+                    MLXRandom.normal(item.imageTokens.shape, key: MLXRandom.key(noiseSeed))
+                        .asType(.bfloat16)
+                )
+                let rawTimestep = Int(rng.next() % UInt64(max(timestepHigh - timestepLow, 1))) + timestepLow
+                let clamped = min(max(rawTimestep, 0), config.schedulerSteps - 1)
+                timestepValues.append(Float(clamped) / Float(config.schedulerSteps))
+            }
+
+            let cleanBatch = MLX.concatenated(cleanParts, axis: 0)
+            let noiseBatch = MLX.concatenated(noiseParts, axis: 0)
+            let textBatch = MLX.concatenated(textParts, axis: 0)
+            let timestepBatch = MLXArray(timestepValues).asType(.float32)
+            let positionBatch = MLX.concatenated(positionParts, axis: 0)
+            let maskBatch = MLX.concatenated(maskParts, axis: 0)
+            let loss = trainStep([cleanBatch, noiseBatch, textBatch, timestepBatch, positionBatch, maskBatch])[0]
+            MLX.asyncEval(loss, loraState)
+
+            let shouldLog = (step + 1) % max(config.logEvery, 1) == 0 || step == config.trainingSteps - 1
+            let lossValue = shouldLog ? loss.item(Float.self) : nil
+            if let lossValue {
+                try metricsLogger.record(step: step + 1, loss: lossValue)
+            }
+            progressHandler?(Krea2LoRATrainingProgress(
+                stage: .training(step: step + 1, total: config.trainingSteps, loss: lossValue),
+                fraction: Float(step + 1) / Float(config.trainingSteps)
+            ))
+        }
+
+        progressHandler?(Krea2LoRATrainingProgress(stage: .saving, fraction: 0))
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let metadata = [
+            "format": "mererun.krea2.lora",
+            "base_model": config.baseModelId,
+            "recommended_runtime_model": Krea2Resources.modelId,
+            "step": "\(config.trainingSteps)",
+            "total_steps": "\(config.trainingSteps)",
+            "seed": "\(effectiveSeed)",
+            "dataset_fingerprint": datasetFingerprint,
+            "config_fingerprint": configFingerprint,
+        ]
+        try LoRASafetensorsWriter.save(
+            loraLayers: loraLayers,
+            to: outputURL,
+            dtype: config.saveDType,
+            includeOptimizerState: true,
+            metadata: metadata
+        )
+
+        let checkpointState = LoRATrainingCheckpointState(
+            format: "mererun.krea2.lora",
+            baseModel: config.baseModelId,
+            checkpointFile: outputURL.lastPathComponent,
+            step: config.trainingSteps,
+            totalSteps: config.trainingSteps,
+            seed: effectiveSeed,
+            rngState: rng.rawState,
+            datasetFingerprint: datasetFingerprint,
+            configFingerprint: configFingerprint,
+            phaseSchedule: [
+                LoRATrainingCheckpointState.Phase(
+                    width: config.width,
+                    height: config.height,
+                    steps: config.trainingSteps,
+                    sampleCount: prepared.count
+                ),
+            ],
+            phaseCursor: nil,
+            configSnapshot: [
+                "model": modelURL.path,
+                "model_id": config.baseModelId,
+                "size": "\(config.width)x\(config.height)",
+                "scheduler_steps": "\(config.schedulerSteps)",
+                "training_steps": "\(config.trainingSteps)",
+                "batch_size": "\(config.batchSize)",
+                "learning_rate": "\(config.learningRate)",
+                "rank": "\(config.loraRank)",
+                "alpha": config.loraAlpha.map { "\($0)" } ?? "",
+                "max_text_length": "\(maxTextLength)",
+                "caption_dropout": "\(config.captionDropout)",
+                "lora_target_prefixes": serializedTargetPrefixes,
+                "lora_target_suffixes": serializedTargetSuffixes,
+                "config_fingerprint": configFingerprint,
+            ],
+            lossCSVFile: metricsLogger.csvURL.lastPathComponent,
+            lossHTMLFile: metricsLogger.htmlURL.lastPathComponent,
+            manifestFile: LoRATrainingManifest.url(nextTo: outputURL).lastPathComponent
+        )
+        try checkpointState.write(nextTo: outputURL)
+
+        let manifest = LoRATrainingManifest(
+            format: "mererun.krea2.lora",
+            baseModel: config.baseModelId,
+            outputFile: outputURL.lastPathComponent,
+            emaOutputFile: nil,
+            training: LoRATrainingManifest.Training(
+                width: config.width,
+                height: config.height,
+                trainingSteps: config.trainingSteps,
+                batchSize: config.batchSize,
+                learningRate: config.learningRate,
+                seed: effectiveSeed,
+                datasetCount: examples.isEmpty ? prepared.count : examples.count,
+                checkpointInterval: nil,
+                sampleInterval: nil,
+                samplePrompt: nil,
+                emaDecay: 0
+            ),
+            lora: LoRATrainingManifest.LoRA(
+                rank: config.loraRank,
+                alpha: effectiveAlpha,
+                saveDType: String(describing: config.saveDType),
+                includesOptimizerState: true
+            ),
+            extras: [
+                "recommended_runtime_model": Krea2Resources.modelId,
+                "max_text_length": "\(maxTextLength)",
+                "scheduler_steps": "\(config.schedulerSteps)",
+                "caption_dropout": "\(config.captionDropout)",
+                "timestep_low": "\(config.timestepLow)",
+                "timestep_high": config.timestepHigh.map { "\($0)" } ?? "",
+                "synthetic_sample_count": config.syntheticSampleCount.map { "\($0)" } ?? "",
+                "lora_target_prefixes": serializedTargetPrefixes,
+                "lora_target_suffixes": serializedTargetSuffixes,
+                "dataset_root": config.datasetRoot ?? "",
+                "seed": "\(effectiveSeed)",
+                "rng_state": "\(rng.rawState)",
+                "dataset_fingerprint": datasetFingerprint,
+                "config_fingerprint": configFingerprint,
+                "checkpoint_sidecar_file": LoRATrainingCheckpointState.url(nextTo: outputURL).lastPathComponent,
+                "loss_csv_file": metricsLogger.csvURL.lastPathComponent,
+                "loss_html_file": metricsLogger.htmlURL.lastPathComponent,
+            ]
+        )
+        try manifest.write(nextTo: outputURL)
+
+        let runManifest = LoRATrainingRunManifest(
+            format: "mererun.krea2.lora",
+            model: config.baseModelId,
+            isEdit: false,
+            dataRoot: config.datasetRoot,
+            dataRootRelative: LoRATrainingRunManifest.relativePath(
+                from: outputURL.deletingLastPathComponent(),
+                to: config.datasetRoot
+            ),
+            dataFingerprint: runDataFingerprint,
+            checkpointFiles: [
+                "lora_adapter": outputURL.lastPathComponent,
+                "checkpoint_state": LoRATrainingCheckpointState.url(nextTo: outputURL).lastPathComponent,
+                "manifest": LoRATrainingManifest.url(nextTo: outputURL).lastPathComponent,
+                "loss_csv": metricsLogger.csvURL.lastPathComponent,
+                "loss_html": metricsLogger.htmlURL.lastPathComponent,
+                "optimizer": outputURL.lastPathComponent,
+            ],
+            step: config.trainingSteps,
+            totalSteps: config.trainingSteps,
+            seed: effectiveSeed,
+            rngState: rng.rawState,
+            datasetFingerprint: datasetFingerprint,
+            configFingerprint: configFingerprint,
+            phaseSchedule: checkpointState.phaseSchedule,
+            phaseCursor: nil,
+            configSnapshot: checkpointState.configSnapshot
+        )
+        try runManifest.write(nextTo: outputURL)
+        try metricsLogger.writeArtifacts()
+        _ = try? LoRACheckpointArchive.createZipBundle(
+            primaryFile: outputURL,
+            additionalFiles: [
+                LoRATrainingCheckpointState.url(nextTo: outputURL),
+                LoRATrainingManifest.url(nextTo: outputURL),
+                LoRATrainingRunManifest.url(nextTo: outputURL),
+                metricsLogger.csvURL,
+                metricsLogger.htmlURL,
+            ]
+        )
+        progressHandler?(Krea2LoRATrainingProgress(stage: .saving, fraction: 1))
+    }
+
+    static func encodePrompt(
+        _ prompt: String,
+        tokenizer: QwenTokenizer,
+        encoder: QwenEncoder,
+        selectedLayers: [Int],
+        maxLength: Int
+    ) throws -> (hiddenStates: MLXArray, attentionMask: MLXArray) {
+        let prefix = "<|im_start|>system\nDescribe the image by detailing the color, shape, size, texture, quantity, text, spatial relationships of the objects and background:<|im_end|>\n<|im_start|>user\n"
+        let suffix = "<|im_end|>\n<|im_start|>assistant\n"
+        let prefixDropCount = 34
+        let suffixIds = tokenizer.encodeText(suffix)
+        let inputs = Krea2SampleBuilder.paddedTextTokenInputs(
+            promptTokenIds: tokenizer.encodeText(prefix + prompt),
+            suffixTokenIds: suffixIds,
+            padTokenId: tokenizer.padTokenId,
+            maxLength: maxLength,
+            prefixDropCount: prefixDropCount
+        )
+        let tokenIds = inputs.tokenIds
+        let inputIds = MLXArray(tokenIds.map(Int32.init)).reshaped(1, tokenIds.count)
+        let attentionMask = MLXArray(inputs.attentionMask).reshaped(1, inputs.attentionMask.count)
+        let hiddenStates = encoder.forwardActivationHiddenStates(
+            inputIds: inputIds,
+            attentionMask: attentionMask,
+            activationLayers: Krea2SampleBuilder.qwenActivationLayerIndices(from: selectedLayers)
+        )
+        let stacked = MLX.stacked(hiddenStates, axis: 2).asType(.bfloat16)
+        let croppedStates = stacked[0..., prefixDropCount..., 0..., 0...]
+        let croppedMask = attentionMask[0..., prefixDropCount...]
+        MLX.eval(croppedStates, croppedMask)
+        return (croppedStates, croppedMask)
+    }
+
+    static func encodeTrainingImage(
+        _ url: URL,
+        vae: QwenImageEditVAE,
+        config: QwenImageEditVAEConfig,
+        width: Int,
+        height: Int
+    ) throws -> MLXArray {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw Krea2LoRATrainerError.imageNotFound(url)
+        }
+
+        let resized = try QwenImageIO.resizedCenterCropPixelArray(
+            from: url,
+            width: width,
+            height: height,
+            addBatchDimension: true,
+            dtype: .float32
+        )
+        let normalized = QwenImageIO.normalizeForEncoder(resized)
+        let encoded = vae.encode(normalized).asType(.float32)
+
+        var modelLatents = encoded / MLXArray(config.scalingFactor)
+        if let shift = config.shiftFactor, shift != 0 {
+            modelLatents = modelLatents + MLXArray(shift)
+        }
+        if let mean = config.latentsMean, let std = config.latentsStd {
+            let meanTensor = MLXArray(mean).reshaped(1, mean.count, 1, 1)
+            let stdTensor = MLXArray(std).reshaped(1, std.count, 1, 1)
+            modelLatents = (modelLatents - meanTensor) / stdTensor
+        }
+        return modelLatents.asType(.bfloat16)
+    }
+
+    private static func makeRunDataFingerprint(
+        examples: [Krea2LoRATrainingExample],
+        dataRootPath: String?
+    ) -> LoRATrainingRunManifest.DataFingerprint {
+        let imagePaths = examples.map { example in
+            LoRATrainingRunManifest.dataPath(
+                for: example.imageURL,
+                dataRootPath: dataRootPath
+            )
+        }
+        return LoRATrainingRunManifest.DataFingerprint(
+            count: examples.count,
+            images: imagePaths,
+            inputImages: [],
+            isEdit: false
+        )
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2RawResources.swift
+++ b/Sources/MereRunCore/Krea2/Krea2RawResources.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum Krea2RawResources {
+    public static let modelId = "image-krea2-raw"
+    public static let upstreamRepoId = "krea/Krea-2-Raw"
+    public static let upstreamRevision = "main"
+    public static let estimatedDownloadBytes: Int64 = 36 * 1_073_741_824
+
+    /// Raw ships both a root-level `raw.safetensors` file for Krea's official
+    /// codebase and the Diffusers component layout used by mere.run. Pull the
+    /// component layout only so managed installs do not download the transformer
+    /// twice.
+    public static let snapshotPatterns = [
+        "LICENSE.pdf",
+        "README.md",
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "text_encoder/config.json",
+        "text_encoder/model.safetensors",
+        "tokenizer/chat_template.jinja",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "transformer/config.json",
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "transformer/diffusion_pytorch_model-*.safetensors",
+        "vae/config.json",
+        "vae/diffusion_pytorch_model.safetensors",
+    ]
+}

--- a/Sources/MereRunCore/Krea2/README.md
+++ b/Sources/MereRunCore/Krea2/README.md
@@ -1,11 +1,13 @@
 # Krea2
 
-Native runtime support for Krea 2 Turbo text-to-image generation.
+Native runtime support for Krea 2 text-to-image generation and LoRA training.
 
 This module owns:
 
-- `Krea2Resources.swift`: managed `image-krea2-turbo` layout and component-only
-  Hugging Face pull patterns.
+- `Krea2Resources.swift`: managed `image-krea2-turbo` layout and
+  component-only Hugging Face pull patterns.
+- `Krea2RawResources.swift`: managed `image-krea2-raw` layout for LoRA
+  training.
 - `Krea2Configs.swift`: typed Diffusers, Qwen3-VL text-encoder, transformer,
   scheduler, and VAE config decoding.
 - `Krea2SampleBuilder.swift`: 16-pixel output alignment, latent patch packing,
@@ -16,12 +18,17 @@ This module owns:
   Image VAE weight loading.
 - `Krea2Generator.swift`: prompt conditioning, denoising, VAE decode, and PNG
   output for `mere.run image generate`.
+- `Krea2LoRAInjector.swift`: Krea transformer LoRA insertion and weight
+  application.
+- `Krea2LoRATrainer.swift`: Raw-model LoRA training, metrics, manifests, and
+  adapter bundle output.
 
-Krea publishes both split Diffusers component weights and a root-level
-`turbo.safetensors` transformer copy. Managed pulls must keep using the
+Krea publishes split Diffusers component weights and root-level `raw.safetensors`
+or `turbo.safetensors` transformer copies. Managed pulls must keep using the
 component layout so local installs do not fetch the same large transformer
 twice.
 
-The wired public mode is text-to-image with managed defaults of 8 steps, CFG
-0.0, and FlowMatch shift/mu 1.15. Reference images, image-to-image, and LoRA are
-intentionally unsupported until their conditioning paths are implemented.
+The wired public generation mode is text-to-image with optional LoRA adapters.
+Train LoRAs on `image-krea2-raw`, then run them on `image-krea2-turbo`.
+Reference images and image-to-image are intentionally unsupported until their
+conditioning paths are implemented.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -463,6 +463,22 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["image generate"]
         ),
         ManagedModelSpec(
+            id: Krea2RawResources.modelId,
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Krea2RawResources.upstreamRepoId,
+                revision: Krea2RawResources.upstreamRevision,
+                patterns: Krea2RawResources.snapshotPatterns
+            ),
+            upstreamRepoId: Krea2RawResources.upstreamRepoId,
+            upstreamRevision: Krea2RawResources.upstreamRevision,
+            validationKind: .krea2,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: Krea2RawResources.estimatedDownloadBytes,
+            defaultCLICommands: ["image train-lora"]
+        ),
+        ManagedModelSpec(
             id: Krea2Resources.modelId,
             category: .image,
             installShape: .directoryRoot,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -266,9 +266,16 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                Krea2RawResources.modelId,
+                "Image training, Krea 2 Raw",
+                "Installs the Krea 2 Raw base checkpoint for LoRA training and post-training workflows.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 Krea2Resources.modelId,
                 "Image, Krea 2 Turbo",
-                "Runs the Krea 2 Turbo 8-step text-to-image model through the native Swift MLX image runtime.",
+                "Runs the Krea 2 Turbo 8-step text-to-image model and Raw-trained LoRAs through the native Swift MLX image runtime.",
                 minimum: 96,
                 recommended: 128
             ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -939,6 +939,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "HiDream-ai/HiDream-O1-Image-Dev",
                 createdAt: createdAt
             )
+        case .krea2Raw:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .krea2,
+                family: .krea,
+                tier: .max,
+                variant: .base,
+                precision: .bf16,
+                defaults: Defaults(steps: 52, cfg: 3.5, sigmaShift: Double(Krea2SampleBuilder.defaultMu)),
+                supports: [.txt2img, .loraTraining],
+                components: defaultComponents,
+                upstreamRepoId: "\(Krea2RawResources.upstreamRepoId)@\(Krea2RawResources.upstreamRevision)",
+                createdAt: createdAt
+            )
         case .krea2Turbo:
             return MereRunModelManifest(
                 id: modelID.rawValue,
@@ -948,7 +962,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 variant: .distilled,
                 precision: .bf16,
                 defaults: Defaults(steps: 8, cfg: 0.0, sigmaShift: Double(Krea2SampleBuilder.defaultMu)),
-                supports: [.txt2img],
+                supports: [.txt2img, .loraInference],
                 components: defaultComponents,
                 upstreamRepoId: "\(Krea2Resources.upstreamRepoId)@\(Krea2Resources.upstreamRevision)",
                 createdAt: createdAt

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -21,6 +21,7 @@ public struct ModelResolver {
         case zetaBase = "image-zimage-base"
         case hidreamO1 = "image-hidream-o1"
         case hidreamO1Dev = "image-hidream-o1-dev"
+        case krea2Raw = "image-krea2-raw"
         case krea2Turbo = "image-krea2-turbo"
         case ideogram4SDNQUInt4 = "image-ideogram4-sdnq-uint4"
         case mebot = "text-chat-mebot"

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -55,6 +55,33 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertEqual(request.expectedOutputURL?.pathExtension, "png")
     }
 
+    func testImageTrainLoRATemplateBuildsTrainingCommand() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageTrainLoRA))
+        var draft = template.defaultDraft()
+        draft.inputPath = "/tmp/krea-dataset"
+        draft.outputPath = "/tmp/krea-style.safetensors"
+        draft.width = 768
+        draft.height = 768
+        draft.steps = 1200
+        draft.seed = "7"
+
+        XCTAssertEqual(template.inputKind, .directory)
+        XCTAssertEqual(template.defaultModel, "image-krea2-raw")
+        XCTAssertEqual(
+            template.arguments(from: draft),
+            [
+                "image", "train-lora",
+                "--data", "/tmp/krea-dataset",
+                "--output", "/tmp/krea-style.safetensors",
+                "--width", "768",
+                "--height", "768",
+                "--training-steps", "1200",
+                "--model", "image-krea2-raw",
+                "--seed", "7",
+            ]
+        )
+    }
+
     func testReadImageVariantsResolveToDistinctTemplates() throws {
         var draft = StudioDraft()
         draft.reset(for: .readImage)

--- a/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ImageTrainLoRACommandParsingTests: XCTestCase {
+    func testImageCommandExposesTrainLoRA() {
+        let commandNames = Set(Image.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("train-lora"))
+    }
+
+    func testTrainLoRAParsesDefaults() throws {
+        let cmd = try ImageTrainLoRA.parse([
+            "--data", "/tmp/krea-dataset",
+            "--output", "/tmp/krea-style.safetensors",
+        ])
+
+        XCTAssertEqual(cmd.data, "/tmp/krea-dataset")
+        XCTAssertEqual(cmd.output, "/tmp/krea-style.safetensors")
+        XCTAssertNil(cmd.model)
+        XCTAssertEqual(cmd.width, 1024)
+        XCTAssertEqual(cmd.height, 1024)
+        XCTAssertEqual(cmd.trainingSteps, 1000)
+        XCTAssertEqual(cmd.batchSize, 1)
+        XCTAssertEqual(cmd.learningRate, 1e-4)
+        XCTAssertEqual(cmd.rank, 16)
+        XCTAssertNil(cmd.alpha)
+        XCTAssertEqual(cmd.maxTextLength, 512)
+        XCTAssertEqual(cmd.schedulerSteps, 1000)
+        XCTAssertEqual(cmd.captionDropout, 0.05)
+        XCTAssertEqual(cmd.seed, 0)
+        XCTAssertFalse(cmd.lite)
+        XCTAssertFalse(cmd.excludePreviewImages)
+        XCTAssertNil(cmd.syntheticSamples)
+    }
+
+    func testTrainLoRAParsesOverrides() throws {
+        let cmd = try ImageTrainLoRA.parse([
+            "--data", "/tmp/data",
+            "--output", "/tmp/out.safetensors",
+            "--model", "image-krea2-raw",
+            "--width", "768",
+            "--height", "1024",
+            "--steps", "25",
+            "--batch-size", "2",
+            "--learning-rate", "0.0002",
+            "--rank", "8",
+            "--alpha", "4",
+            "--max-text-length", "384",
+            "--scheduler-steps", "500",
+            "--caption-dropout", "0.1",
+            "--seed", "7",
+            "--lite",
+            "--exclude-preview-images",
+        ])
+
+        XCTAssertEqual(cmd.model, "image-krea2-raw")
+        XCTAssertEqual(cmd.width, 768)
+        XCTAssertEqual(cmd.height, 1024)
+        XCTAssertEqual(cmd.trainingSteps, 25)
+        XCTAssertEqual(cmd.batchSize, 2)
+        XCTAssertEqual(cmd.learningRate, 0.0002)
+        XCTAssertEqual(cmd.rank, 8)
+        XCTAssertEqual(cmd.alpha, 4)
+        XCTAssertEqual(cmd.maxTextLength, 384)
+        XCTAssertEqual(cmd.schedulerSteps, 500)
+        XCTAssertEqual(cmd.captionDropout, 0.1)
+        XCTAssertEqual(cmd.seed, 7)
+        XCTAssertTrue(cmd.lite)
+        XCTAssertTrue(cmd.excludePreviewImages)
+    }
+
+    func testTrainLoRAParsesSyntheticSamples() throws {
+        let cmd = try ImageTrainLoRA.parse([
+            "--output", "/tmp/smoke.safetensors",
+            "--synthetic-samples", "2",
+        ])
+
+        XCTAssertNil(cmd.data)
+        XCTAssertEqual(cmd.syntheticSamples, 2)
+    }
+}

--- a/Tests/MereRunCoreTests/Krea2LoRAInjectorTests.swift
+++ b/Tests/MereRunCoreTests/Krea2LoRAInjectorTests.swift
@@ -1,0 +1,81 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Krea2LoRAInjectorTests: XCTestCase {
+    func testDefaultTargetsTransformerBlockAttentionAndFeedForwardLayers() throws {
+        let transformer = Krea2Transformer(configuration: try makeTinyConfig(numLayers: 2))
+
+        let layers = try Krea2LoRAInjector.inject(into: transformer, rank: 4, alpha: 2.0)
+
+        XCTAssertEqual(layers.count, 14)
+        XCTAssertNotNil(layers["transformer_blocks.0.attn.to_q"])
+        XCTAssertNotNil(layers["transformer_blocks.0.attn.to_k"])
+        XCTAssertNotNil(layers["transformer_blocks.0.attn.to_v"])
+        XCTAssertNotNil(layers["transformer_blocks.0.attn.to_out.0"])
+        XCTAssertNotNil(layers["transformer_blocks.0.ff.gate"])
+        XCTAssertNotNil(layers["transformer_blocks.0.ff.up"])
+        XCTAssertNotNil(layers["transformer_blocks.0.ff.down"])
+        XCTAssertNil(layers["text_fusion.refiner_blocks.0.attn.to_q"])
+    }
+
+    func testLiteTargetsOnlyTransformerBlockQAndVLayers() throws {
+        let transformer = Krea2Transformer(configuration: try makeTinyConfig(numLayers: 3))
+
+        let layers = try Krea2LoRAInjector.inject(
+            into: transformer,
+            rank: 2,
+            targetSuffixes: Krea2LoRAInjector.liteTargetSuffixes
+        )
+
+        XCTAssertEqual(layers.count, 6)
+        XCTAssertNotNil(layers["transformer_blocks.0.attn.to_q"])
+        XCTAssertNotNil(layers["transformer_blocks.0.attn.to_v"])
+        XCTAssertNil(layers["transformer_blocks.0.attn.to_k"])
+        XCTAssertNil(layers["transformer_blocks.0.ff.down"])
+    }
+
+    func testTextFusionAcceptsTrainerSyntheticHiddenStateLayout() throws {
+        let config = try makeTinyConfig(numLayers: 1)
+        let textFusion = Krea2TextFusionTransformer(configuration: config)
+        let textLength = 5
+        let hiddenStates = MLXArray.zeros([
+            1,
+            textLength,
+            config.numTextLayers,
+            config.textHiddenDim,
+        ])
+        let validMask = MLXArray.ones([1, textLength], dtype: .int32)
+        let attentionMask = Krea2SampleBuilder.attentionMask(validMask: validMask, dtype: .float32)
+
+        let output = textFusion(hiddenStates, mask: attentionMask)
+        MLX.eval(output)
+
+        XCTAssertEqual(output.shape, [1, textLength, config.textHiddenDim])
+    }
+
+    private func makeTinyConfig(numLayers: Int) throws -> Krea2TransformerConfiguration {
+        let json = """
+        {
+          "attention_head_dim": 8,
+          "axes_dims_rope": [4, 4, 8],
+          "in_channels": 16,
+          "intermediate_size": 32,
+          "norm_eps": 0.00001,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 2,
+          "num_layers": \(numLayers),
+          "num_layerwise_text_blocks": 1,
+          "num_refiner_text_blocks": 1,
+          "num_text_layers": 4,
+          "rope_theta": 10000,
+          "text_hidden_dim": 16,
+          "text_intermediate_size": 32,
+          "text_num_attention_heads": 2,
+          "text_num_key_value_heads": 2,
+          "timestep_embed_dim": 16
+        }
+        """
+        return try JSONDecoder().decode(Krea2TransformerConfiguration.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -65,6 +65,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "image-zimage-nano",
             "image-zimage-base",
             "image-zimage-max",
+            "image-krea2-raw",
             "image-krea2-turbo",
             "image-ideogram4-sdnq-uint4",
         ]
@@ -160,6 +161,26 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(patterns.contains("transformer/diffusion_pytorch_model-*.safetensors"))
         XCTAssertTrue(patterns.contains("text_encoder/model.safetensors"))
         XCTAssertFalse(patterns.contains("turbo.safetensors"))
+        XCTAssertFalse(patterns.contains("*.safetensors"))
+        XCTAssertFalse(patterns.contains("transformer/*"))
+    }
+
+    func testKrea2RawUsesComponentHubSourceWithoutRootRawCheckpoint() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Krea2RawResources.modelId))
+        let patterns = try XCTUnwrap(spec.hubFallback?.patterns)
+
+        XCTAssertEqual(spec.hubFallback?.repoId, Krea2RawResources.upstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Krea2RawResources.upstreamRevision)
+        XCTAssertEqual(spec.upstreamRepoId, Krea2RawResources.upstreamRepoId)
+        XCTAssertEqual(spec.upstreamRevision, Krea2RawResources.upstreamRevision)
+        XCTAssertEqual(spec.validationKind, .krea2)
+        XCTAssertEqual(spec.estimatedDownloadBytes, Krea2RawResources.estimatedDownloadBytes)
+        XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
+        XCTAssertEqual(spec.defaultCLICommands, ["image train-lora"])
+        XCTAssertTrue(patterns.contains("transformer/diffusion_pytorch_model.safetensors.index.json"))
+        XCTAssertTrue(patterns.contains("transformer/diffusion_pytorch_model-*.safetensors"))
+        XCTAssertTrue(patterns.contains("text_encoder/model.safetensors"))
+        XCTAssertFalse(patterns.contains("raw.safetensors"))
         XCTAssertFalse(patterns.contains("*.safetensors"))
         XCTAssertFalse(patterns.contains("transformer/*"))
     }

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -144,11 +144,30 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.defaults?.steps, 8)
         XCTAssertEqual(manifest.defaults?.cfg, 0.0)
         XCTAssertEqual(manifest.defaults?.sigmaShift, Double(Krea2SampleBuilder.defaultMu))
-        XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img]))
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img, .loraInference]))
         XCTAssertEqual(manifest.components?.transformer, .local(path: "transformer"))
         XCTAssertEqual(manifest.components?.textEncoder, .local(path: "text_encoder"))
         XCTAssertEqual(manifest.components?.vae, .local(path: "vae"))
         XCTAssertEqual(manifest.upstreamRepoId, "\(Krea2Resources.upstreamRepoId)@\(Krea2Resources.upstreamRevision)")
+    }
+
+    func testKrea2RawTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .krea2Raw, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, Krea2RawResources.modelId)
+        XCTAssertEqual(manifest.engine, .krea2)
+        XCTAssertEqual(manifest.family, .krea)
+        XCTAssertEqual(manifest.tier, .max)
+        XCTAssertEqual(manifest.variant, .base)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(manifest.defaults?.steps, 52)
+        XCTAssertEqual(manifest.defaults?.cfg, 3.5)
+        XCTAssertEqual(manifest.defaults?.sigmaShift, Double(Krea2SampleBuilder.defaultMu))
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img, .loraTraining]))
+        XCTAssertEqual(manifest.components?.transformer, .local(path: "transformer"))
+        XCTAssertEqual(manifest.components?.textEncoder, .local(path: "text_encoder"))
+        XCTAssertEqual(manifest.components?.vae, .local(path: "vae"))
+        XCTAssertEqual(manifest.upstreamRepoId, "\(Krea2RawResources.upstreamRepoId)@\(Krea2RawResources.upstreamRevision)")
     }
 
     func testIdeogram4TemplateHasExpectedSDNQMetadata() throws {

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -78,9 +78,12 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
     }
 
-    private func writeMinimalValidKrea2Model(at root: URL) throws {
+    private func writeMinimalValidKrea2Model(
+        at root: URL,
+        id: ModelResolver.ModelID = .krea2Turbo
+    ) throws {
         try TestFileSystem.createDirectory(root)
-        try MereRunModelManifest.template(for: .krea2Turbo, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
         try TestFileSystem.writeFile(root.appendingPathComponent("model_index.json"), contents: Data("{}".utf8))
 
         let tokenizerDir = root.appendingPathComponent("tokenizer", isDirectory: true)
@@ -443,6 +446,24 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(report.manifest?.defaults?.steps, 8)
         XCTAssertEqual(report.manifest?.defaults?.cfg, 0.0)
         XCTAssertEqual(report.manifest?.defaults?.sigmaShift, Double(Krea2SampleBuilder.defaultMu))
+    }
+
+    func testKrea2RawRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(Krea2RawResources.modelId, isDirectory: true)
+        try writeMinimalValidKrea2Model(at: root, id: .krea2Raw)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: Krea2RawResources.modelId)
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.family, .krea)
+        XCTAssertEqual(report.manifest?.engine, .krea2)
+        XCTAssertEqual(report.manifest?.variant, .base)
+        XCTAssertEqual(report.manifest?.defaults?.steps, 52)
+        XCTAssertEqual(report.manifest?.defaults?.cfg, 3.5)
+        XCTAssertEqual(Set(report.manifest?.supports ?? []), Set([.txt2img, .loraTraining]))
     }
 
     func testKrea2TurboSymlinkedComponentLayoutPassesValidation() throws {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,11 +44,14 @@ Qwen image editing:
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+ModelLoading.swift`
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift`
 
-Krea 2 Turbo generation:
+Krea 2 generation and LoRA training:
 
 - Runtime entrypoint: `Sources/MereRunCore/Krea2/Krea2Generator.swift`
 - Read next:
+  - `Sources/MereRunCore/Krea2/Krea2RawResources.swift`
   - `Sources/MereRunCore/Krea2/Krea2Resources.swift`
+  - `Sources/MereRunCore/Krea2/Krea2LoRAInjector.swift`
+  - `Sources/MereRunCore/Krea2/Krea2LoRATrainer.swift`
   - `Sources/MereRunCore/Krea2/Krea2Configs.swift`
   - `Sources/MereRunCore/Krea2/Krea2Model.swift`
   - `Sources/MereRunCore/Krea2/Krea2ModelLoader.swift`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,7 @@ Public tree:
 
 - `mere.run guide`
 - `mere.run image generate`
+- `mere.run image train-lora`
 - `mere.run image validate`
 - `mere.run text chat`
 - `mere.run text code`
@@ -67,7 +68,8 @@ are:
 
 - Images: `image-klein-nano`, `image-klein-base`, `image-klein-max`,
   `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
-  `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-turbo`,
+  `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-raw`,
+  `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`
 - Text code / agents: `text-agent-qwen35-9b`, `text-code-qwen3`
@@ -241,6 +243,53 @@ swift run mere.run image generate \
   --ref-image ./subject.png \
   --output ./portrait.png
 ```
+
+### `mere.run image train-lora`
+
+Train a local text-to-image LoRA adapter. Krea 2 LoRAs are trained on
+`image-krea2-raw` and can be used with `image-krea2-turbo` for fast inference.
+
+```bash
+swift run mere.run model pull image-krea2-raw
+swift run mere.run model pull image-krea2-turbo
+swift run mere.run image train-lora \
+  --data ./style-dataset \
+  --output ./style-krea2.safetensors \
+  --training-steps 1000 \
+  --rank 16
+swift run mere.run image generate \
+  --model image-krea2-turbo \
+  --prompt "a studio portrait in the trained style" \
+  --lora ./style-krea2.safetensors \
+  --output ./style-preview.png
+```
+
+Dataset folders use image files with matching `.txt` captions:
+
+```text
+style-dataset/
+  001.png
+  001.txt
+  002.jpg
+  002.txt
+```
+
+Key options:
+
+- `--data`: dataset directory with image + caption pairs
+- `--output`: output `.safetensors` adapter path
+- `--model`: Raw/base model id or local model path; defaults to `image-krea2-raw`
+- `--width`, `--height`: fixed training resolution; must be divisible by 16
+- `--training-steps`, `--steps`
+- `--batch-size`
+- `--learning-rate`, `--lr`
+- `--rank`, `--alpha`
+- `--max-text-length`
+- `--scheduler-steps`
+- `--caption-dropout`
+- `--lite`: train only attention Q/V layers to reduce memory
+- `--exclude-preview-images`
+- `--quiet`
 
 ### `mere.run image validate`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -22,7 +22,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 
 | Category | Hugging Face pull IDs |
 | --- | --- |
-| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-turbo`, `image-ideogram4-sdnq-uint4` |
+| Image | `image-klein-nano`, `image-klein-base`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-raw`, `image-krea2-turbo`, `image-ideogram4-sdnq-uint4` |
 | Text chat | `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash` |
 | Vision chat | `vision-chat-gemma4-12b` |
 | Text code / agents | `text-agent-qwen35-9b`, `text-code-qwen3` |
@@ -161,8 +161,10 @@ Both checkpoints are large BF16 unified-transformer roots, about 33 GiB on disk
 each before filesystem compression effects. Expect high unified-memory pressure
 and prefer one-step smokes before full-quality 28/50 step runs.
 
-`image-krea2-turbo` maps to Krea's public Krea 2 Turbo checkpoint:
+`image-krea2-raw` and `image-krea2-turbo` map to Krea's public Krea 2
+checkpoints:
 
+- `krea/Krea-2-Raw`
 - `krea/Krea-2-Turbo`
 
 Managed or local roots are expected to contain the component Diffusers layout:
@@ -179,19 +181,22 @@ Managed or local roots are expected to contain the component Diffusers layout:
 - `vae/diffusion_pytorch_model.safetensors`
 - `scheduler/scheduler_config.json`
 
-Krea also publishes a root-level `turbo.safetensors` transformer copy. The
-managed pull intentionally excludes that file and pulls the split transformer
-component instead, so the model store does not download the same 26 GiB payload
-twice.
+Krea also publishes root-level `raw.safetensors` and `turbo.safetensors`
+transformer copies for the official codebase. Managed pulls intentionally
+exclude those files and pull the split transformer component instead, so the
+model store does not download the same large transformer payload twice.
 
 The native Swift runtime follows the public Krea 2 sampler shape: Qwen3-VL text
 conditioning with the Krea system prefix, layer-selected hidden-state fusion,
 single-stream MMDiT denoising, 16-pixel image-token alignment, FlowMatch Euler
-steps, and Qwen Image VAE decoding. The wired public mode is text-to-image;
-reference images, image-to-image, and LoRA are not supported for this family yet.
+steps, and Qwen Image VAE decoding. The wired public generation mode is
+text-to-image with optional LoRA adapters; reference images and image-to-image
+are not supported for this family yet. LoRA training uses `image-krea2-raw`;
+inference uses `image-krea2-turbo`.
 
 Runtime defaults come from the managed manifest:
 
+- `image-krea2-raw`: 52 steps, CFG 3.5, FlowMatch shift/mu 1.15
 - `image-krea2-turbo`: 8 steps, CFG 0.0, FlowMatch shift/mu 1.15
 
 The component install is about 36 GiB before filesystem compression effects.

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -71,7 +71,7 @@ Key subdirectories:
 - `Flux2Klein/`: Klein image-family runtime
 - `ZImageTurbo/`: ZImage image-family runtime
 - `HiDreamO1/`: HiDream O1 image-family runtime
-- `Krea2/`: Krea 2 Turbo image-family runtime
+- `Krea2/`: Krea 2 image-family runtime and Raw LoRA training
 - `QwenImageEdit/`: image editing flow
 - `Gemma4/`, `Q35/`, `LFM2/`, `Psi/`, `MeBot/`: text/chat model families
 - `Embeddings/`: embedding-generation support

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -6,6 +6,7 @@ model families are supported, and how the code is organized.
 ## Public surface
 
 - `mere.run image generate`
+- `mere.run image train-lora`
 - `mere.run image validate`
 
 ## Model families
@@ -17,7 +18,8 @@ The public image families are:
 - `image-bonsai-ternary`: PrismML Bonsai ternary FLUX.2 Klein deployment
 - `image-zimage-*`: ZImage image family
 - `image-hidream-o1*`: HiDream O1 unified pixel-transformer family
-- `image-krea2-turbo`: Krea 2 Turbo text-to-image family
+- `image-krea2-raw`: Krea 2 Raw base checkpoint for LoRA training
+- `image-krea2-turbo`: Krea 2 Turbo text-to-image and LoRA inference family
 - `image-ideogram4-sdnq-uint4`: Ideogram 4 SDNQ uint4 text-to-image family
 
 Common managed IDs:
@@ -32,6 +34,7 @@ Common managed IDs:
 - `image-zimage-max`
 - `image-hidream-o1-dev`
 - `image-hidream-o1`
+- `image-krea2-raw`
 - `image-krea2-turbo`
 - `image-ideogram4-sdnq-uint4`
 
@@ -114,24 +117,36 @@ MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM=1 ./scripts/check.sh
 MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM_FULL=1 ./scripts/check.sh
 ```
 
-### Krea 2 Turbo
+### Krea 2 Raw and Turbo
 
-`image-krea2-turbo` maps to `krea/Krea-2-Turbo` and uses the native Swift MLX
-runtime for Krea's distilled 8-step text-to-image model. The managed pull uses
-the split Diffusers component layout and deliberately skips the root
-`turbo.safetensors` duplicate transformer file. Text-to-image generation is
-wired through `image generate`; image-to-image, reference inputs, and LoRA are
-not supported for this family yet.
+`image-krea2-raw` maps to `krea/Krea-2-Raw` and installs Krea's base
+checkpoint for LoRA training. `image-krea2-turbo` maps to `krea/Krea-2-Turbo`
+and uses the native Swift MLX runtime for Krea's distilled 8-step text-to-image
+model. Both managed pulls use the split Diffusers component layout and
+deliberately skip the root `raw.safetensors` / `turbo.safetensors` duplicate
+transformer files.
+
+Train adapters on Raw, then preview or run them on Turbo:
 
 ```bash
+swift run mere.run model pull image-krea2-raw
 swift run mere.run model pull image-krea2-turbo
+swift run mere.run image train-lora \
+  --data ./style-dataset \
+  --output ./style-krea2.safetensors \
+  --training-steps 1000 \
+  --rank 16
 swift run mere.run image generate \
   --model image-krea2-turbo \
-  --prompt "a cinematic product photo of a translucent portable speaker, crisp reflections" \
+  --prompt "a cinematic product photo in the trained style" \
+  --lora ./style-krea2.safetensors \
   --width 1024 --height 1024 \
   --steps 8 \
   --output ./speaker.png
 ```
+
+The wired Krea generation mode is text-to-image with optional LoRA adapters;
+image-to-image and reference inputs are not wired for this family yet.
 
 ### Ideogram 4 SDNQ
 
@@ -195,6 +210,9 @@ swift run mere.run image validate --family klein --test pipeline
 ### Krea 2 family
 
 - `Sources/MereRunCore/Krea2/Krea2Generator.swift`
+- `Sources/MereRunCore/Krea2/Krea2LoRAInjector.swift`
+- `Sources/MereRunCore/Krea2/Krea2LoRATrainer.swift`
+- `Sources/MereRunCore/Krea2/Krea2RawResources.swift`
 - `Sources/MereRunCore/Krea2/Krea2Resources.swift`
 - `Sources/MereRunCore/Krea2/Krea2Configs.swift`
 - `Sources/MereRunCore/Krea2/Krea2Model.swift`


### PR DESCRIPTION
## Summary
- add managed `image-krea2-raw` metadata, manifest support, validation coverage, and component-only Hub pull patterns for Krea Raw
- add `mere.run image train-lora` with Krea 2 Raw training, Krea transformer LoRA injection, final training artifacts/metrics/manifests, and Krea Turbo LoRA inference support
- wire the optional macOS app command catalog, CLI guide, README, runtime docs, architecture docs, and changelog for the Raw-train/Turbo-run workflow

## Validation
- `swift test --filter Krea2LoRAInjectorTests && swift test --filter ImageTrainLoRACommandParsingTests && swift test --filter ManagedModelCatalogTests && swift test --filter MereRunModelManifestTests && swift test --filter MereRunModelValidatorTests`
- `swift test --filter StudioTypesTests/testImageTrainLoRATemplateBuildsTrainingCommand`
- `swift test --filter GuideCommandTests`
- `swift run mere.run image train-lora --help`
- `swift run mere.run guide image train-lora`
- `swift run mere.run model pull image-krea2-raw`
- Synthetic runtime smoke: `swift run mere.run image train-lora --model image-krea2-raw --synthetic-samples 1 --training-steps 1 --width 256 --height 256 --lite --output /tmp/krea2-raw-lora-smoke.safetensors`
- Real dataset runtime smoke: `swift run mere.run image train-lora --model image-krea2-raw --data /tmp/krea2-real-dataset --training-steps 1 --width 256 --height 256 --lite --output /tmp/krea2-real-lora-smoke.safetensors`
- Real-data Turbo LoRA smoke: `swift run mere.run image generate --model image-krea2-turbo --prompt "a bright beach landscape with ocean water and pale sand" --steps 1 --width 256 --height 256 --lora /tmp/krea2-real-lora-smoke.safetensors --output /tmp/krea2-real-turbo-lora-smoke.png`
- `./scripts/check.sh`

## Smoke artifacts
- Synthetic Raw trainer output: `/tmp/krea2-raw-lora-smoke.safetensors` (51 MB) plus checkpoint, manifest, loss CSV/HTML, and zip bundle
- Synthetic Turbo LoRA image output: `/tmp/krea2-turbo-lora-smoke.png` (256x256 PNG)
- Real dataset: `/tmp/krea2-real-dataset/001.png` plus `/tmp/krea2-real-dataset/001.txt`, converted from macOS `The Beach.heic` wallpaper thumbnail
- Real Raw trainer output: `/tmp/krea2-real-lora-smoke.safetensors` (51 MB) plus checkpoint, manifest, loss CSV/HTML, and zip bundle; loss CSV recorded `1,0.20518516`
- Real-data Turbo LoRA image output: `/tmp/krea2-real-turbo-lora-smoke.png` (256x256 PNG)

## Notes
- The image smokes are intentionally 1-step 256px runtime proofs, not quality benchmarks.
- The first real-checkpoint smoke caught a synthetic hidden-state axis bug; this PR includes the fix and a regression test.

## Sources
- https://huggingface.co/krea/Krea-2-Raw
- https://www.krea.ai/krea-2-open-source
