### PR TITLE
Add official plugin catalog commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added `mere.run plugin { list, info, install, doctor }` for live official
+  companion-plugin catalog discovery, `pipx` install previews, opt-in
+  execution, and post-install manifest verification.
+
 ## 0.17.0 - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ The public CLI is modality-first:
 - `mere.run model { list, capabilities, info, pull, remove, runtime, repair-manifests }`
 - `mere.run status`
 - `mere.run api serve`
+- `mere.run plugin { list, info, install, doctor }`
 - `mere.run setup`
 - `mere.run agent { onboard, install-pi, start }`
 

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -416,6 +416,19 @@ enum GuideRegistry {
             resourceName: "open-webui.md"
         ),
         GuideTopic(
+            topic: "plugin",
+            title: "Plugin",
+            commandPaths: [
+                ["plugin"],
+                ["plugin", "list"],
+                ["plugin", "info"],
+                ["plugin", "install"],
+                ["plugin", "doctor"],
+            ],
+            models: [],
+            resourceName: "plugin.md"
+        ),
+        GuideTopic(
             topic: "status",
             title: "Status",
             commandPaths: [["status"]],

--- a/Sources/MereRunCLI/Commands/PluginCommand.swift
+++ b/Sources/MereRunCLI/Commands/PluginCommand.swift
@@ -276,26 +276,26 @@ enum PluginCatalogClient {
         request.cachePolicy = .reloadIgnoringLocalCacheData
 
         let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<(Data, URLResponse), Error>?
+        let result = PluginCatalogRequestResult()
         let task = URLSession.shared.dataTask(with: request) { data, response, error in
             defer { semaphore.signal() }
             if let error {
-                result = .failure(error)
+                result.store(.failure(error))
                 return
             }
             guard let data, let response else {
-                result = .failure(ValidationError("Plugin catalog request returned no response."))
+                result.store(.failure(ValidationError("Plugin catalog request returned no response.")))
                 return
             }
-            result = .success((data, response))
+            result.store(.success((data, response)))
         }
         task.resume()
         semaphore.wait()
 
-        guard let result else {
+        guard let storedResult = result.load() else {
             throw ValidationError("Plugin catalog request did not complete.")
         }
-        let (data, response) = try result.get()
+        let (data, response) = try storedResult.get()
         if let httpResponse = response as? HTTPURLResponse,
            !(200..<300).contains(httpResponse.statusCode) {
             throw ValidationError("Plugin catalog request failed with HTTP \(httpResponse.statusCode): \(url.absoluteString)")
@@ -304,6 +304,23 @@ enum PluginCatalogClient {
             throw ValidationError("Plugin catalog response was empty: \(url.absoluteString)")
         }
         return data
+    }
+}
+
+final class PluginCatalogRequestResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<(Data, URLResponse), Error>?
+
+    func store(_ newResult: Result<(Data, URLResponse), Error>) {
+        lock.lock()
+        result = newResult
+        lock.unlock()
+    }
+
+    func load() -> Result<(Data, URLResponse), Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return result
     }
 }
 

--- a/Sources/MereRunCLI/Commands/PluginCommand.swift
+++ b/Sources/MereRunCLI/Commands/PluginCommand.swift
@@ -1,0 +1,435 @@
+import ArgumentParser
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct Plugin: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "plugin",
+        abstract: "Discover and install official mere.run companion plugins.",
+        subcommands: [
+            PluginList.self,
+            PluginInfo.self,
+            PluginInstall.self,
+            PluginDoctor.self,
+        ]
+    )
+}
+
+struct PluginList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List official plugins from the live catalog."
+    )
+
+    @Option(name: [.long], help: "Plugin catalog URL or local JSON path.")
+    var catalogURL: String?
+
+    @Flag(name: [.long], help: "Print the catalog JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        let catalog = try PluginCatalogClient.load(catalogURL: catalogURL)
+        if json {
+            print(try PluginCatalogClient.renderJSON(catalog))
+            return
+        }
+
+        print("Catalog: \(catalog.source)")
+        print("Default channel: \(catalog.defaultChannel)")
+        print("")
+        for plugin in catalog.plugins {
+            let install = try plugin.install(channel: catalog.defaultChannel)
+            print("\(plugin.id)")
+            print("  \(plugin.description)")
+            print("  command: \(plugin.entrypoint)")
+            print("  install: \(PluginInstallCommand.render(install: install))")
+            print("")
+        }
+    }
+}
+
+struct PluginInfo: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "info",
+        abstract: "Show one plugin's catalog entry and install command."
+    )
+
+    @Argument(help: "Plugin id, for example mere-runpod.")
+    var id: String
+
+    @Option(name: [.long], help: "Plugin catalog URL or local JSON path.")
+    var catalogURL: String?
+
+    @Option(name: [.long], help: "Install channel. Defaults to the catalog default channel.")
+    var channel: String?
+
+    @Flag(name: [.long], help: "Print the plugin catalog entry as JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        let catalog = try PluginCatalogClient.load(catalogURL: catalogURL)
+        let plugin = try catalog.requirePlugin(id)
+        let resolvedChannel = channel ?? catalog.defaultChannel
+        let install = try plugin.install(channel: resolvedChannel)
+        if json {
+            print(try PluginCatalogClient.renderJSON(plugin))
+            return
+        }
+
+        print("\(plugin.id): \(plugin.name)")
+        print(plugin.description)
+        print("")
+        print("Repository: \(plugin.repo)")
+        print("Package: \(plugin.package)")
+        print("Entrypoint: \(plugin.entrypoint)")
+        print("Capabilities: \(plugin.capabilities.joined(separator: ", "))")
+        print("Channel: \(resolvedChannel)")
+        print("")
+        print("Install command:")
+        print("  \(PluginInstallCommand.render(install: install))")
+    }
+}
+
+struct PluginInstall: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install one official plugin using its catalog install command."
+    )
+
+    @Argument(help: "Plugin id, for example mere-runpod.")
+    var id: String
+
+    @Option(name: [.long], help: "Plugin catalog URL or local JSON path.")
+    var catalogURL: String?
+
+    @Option(name: [.long], help: "Install channel. Defaults to the catalog default channel.")
+    var channel: String?
+
+    @Flag(name: [.long], help: "Run the install command. Without --yes, print the exact command only.")
+    var yes: Bool = false
+
+    @Flag(name: [.long], help: "Pass --force to pipx install.")
+    var force: Bool = false
+
+    func run() throws {
+        let catalog = try PluginCatalogClient.load(catalogURL: catalogURL)
+        let plugin = try catalog.requirePlugin(id)
+        let resolvedChannel = channel ?? catalog.defaultChannel
+        let install = try plugin.install(channel: resolvedChannel)
+        let command = PluginInstallCommand(install: install, force: force)
+
+        if !yes {
+            print("Install command:")
+            print("  \(command.render())")
+            print("")
+            print("Run with --yes to execute it:")
+            print("  \(CLICommandDisplay.command("plugin install \(ShellCommand.quote(id)) --channel \(ShellCommand.quote(resolvedChannel)) --yes"))")
+            return
+        }
+
+        try command.run()
+        let manifest = try PluginVerifier.verify(entrypoint: plugin.entrypoint)
+        guard manifest.name == plugin.id else {
+            throw ValidationError(
+                "Installed plugin manifest name mismatch: expected \(plugin.id), got \(manifest.name)"
+            )
+        }
+        print("Installed \(plugin.id) with \(install.manager).")
+        print("Verified \(plugin.entrypoint) manifest version \(manifest.version).")
+    }
+}
+
+struct PluginDoctor: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "doctor",
+        abstract: "Run an installed plugin's doctor command."
+    )
+
+    @Argument(help: "Plugin id, for example mere-runpod.")
+    var id: String
+
+    @Option(name: [.long], help: "Plugin catalog URL or local JSON path.")
+    var catalogURL: String?
+
+    func run() throws {
+        let catalog = try PluginCatalogClient.load(catalogURL: catalogURL)
+        let plugin = try catalog.requirePlugin(id)
+        guard PluginProcess.which(plugin.entrypoint) != nil else {
+            let install = try plugin.install(channel: catalog.defaultChannel)
+            throw ValidationError(
+                """
+                Plugin \(plugin.id) is not installed on PATH.
+                Install it with: \(PluginInstallCommand.render(install: install))
+                """
+            )
+        }
+        try PluginProcess.runExecutable(plugin.entrypoint, arguments: ["doctor"])
+    }
+}
+
+struct PluginCatalog: Codable {
+    let contractVersion: String
+    let updatedAt: String
+    let defaultChannel: String
+    let plugins: [PluginCatalogEntry]
+    var source: String = PluginCatalogClient.defaultCatalogURL
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion
+        case updatedAt
+        case defaultChannel
+        case plugins
+    }
+
+    func requirePlugin(_ id: String) throws -> PluginCatalogEntry {
+        if let plugin = plugins.first(where: { $0.id == id }) {
+            return plugin
+        }
+        let known = plugins.map(\.id).sorted().joined(separator: ", ")
+        throw ValidationError("Unknown plugin: \(id). Known plugins: \(known)")
+    }
+}
+
+struct PluginCatalogEntry: Codable {
+    let id: String
+    let name: String
+    let description: String
+    let repo: String
+    let package: String
+    let subdirectory: String
+    let entrypoint: String
+    let capabilities: [String]
+    let channels: [String: PluginCatalogInstall]
+
+    func install(channel: String) throws -> PluginCatalogInstall {
+        guard let install = channels[channel] else {
+            let known = channels.keys.sorted().joined(separator: ", ")
+            throw ValidationError("Plugin \(id) has no channel '\(channel)'. Available channels: \(known)")
+        }
+        return install
+    }
+}
+
+struct PluginCatalogInstall: Codable {
+    let manager: String
+    let spec: String
+    let ref: String?
+}
+
+struct PluginManifest: Decodable {
+    let contractVersion: String
+    let name: String
+    let version: String
+}
+
+enum PluginCatalogClient {
+    static let defaultCatalogURL = "https://raw.githubusercontent.com/sawfwair/mere-plugins/main/catalog/plugins.v1.json"
+
+    static func load(catalogURL: String?) throws -> PluginCatalog {
+        let source = catalogURL?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = try resolveCatalogURL(source)
+        let data = try loadCatalogData(from: resolved)
+        let decoder = JSONDecoder()
+        var catalog = try decoder.decode(PluginCatalog.self, from: data)
+        catalog.source = source?.isEmpty == false ? source! : defaultCatalogURL
+        guard catalog.contractVersion == "mere.run/plugin-catalog.v1" else {
+            throw ValidationError("Unsupported plugin catalog contract: \(catalog.contractVersion)")
+        }
+        return catalog
+    }
+
+    static func renderJSON<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(value)
+        guard let output = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Could not render JSON as UTF-8.")
+        }
+        return output
+    }
+
+    private static func resolveCatalogURL(_ raw: String?) throws -> URL {
+        guard let raw, !raw.isEmpty else {
+            return URL(string: defaultCatalogURL)!
+        }
+        if raw.hasPrefix("http://") || raw.hasPrefix("https://") || raw.hasPrefix("file://") {
+            guard let url = URL(string: raw) else {
+                throw ValidationError("Invalid catalog URL: \(raw)")
+            }
+            return url
+        }
+        return URL(fileURLWithPath: NSString(string: raw).expandingTildeInPath)
+    }
+
+    private static func loadCatalogData(from url: URL) throws -> Data {
+        if url.scheme == "http" || url.scheme == "https" {
+            return try loadRemoteCatalogData(from: url)
+        }
+        return try Data(contentsOf: url)
+    }
+
+    private static func loadRemoteCatalogData(from url: URL) throws -> Data {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<(Data, URLResponse), Error>?
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { semaphore.signal() }
+            if let error {
+                result = .failure(error)
+                return
+            }
+            guard let data, let response else {
+                result = .failure(ValidationError("Plugin catalog request returned no response."))
+                return
+            }
+            result = .success((data, response))
+        }
+        task.resume()
+        semaphore.wait()
+
+        guard let result else {
+            throw ValidationError("Plugin catalog request did not complete.")
+        }
+        let (data, response) = try result.get()
+        if let httpResponse = response as? HTTPURLResponse,
+           !(200..<300).contains(httpResponse.statusCode) {
+            throw ValidationError("Plugin catalog request failed with HTTP \(httpResponse.statusCode): \(url.absoluteString)")
+        }
+        guard !data.isEmpty else {
+            throw ValidationError("Plugin catalog response was empty: \(url.absoluteString)")
+        }
+        return data
+    }
+}
+
+struct PluginInstallCommand {
+    let install: PluginCatalogInstall
+    let force: Bool
+
+    init(install: PluginCatalogInstall, force: Bool = false) {
+        self.install = install
+        self.force = force
+    }
+
+    static func render(install: PluginCatalogInstall) -> String {
+        PluginInstallCommand(install: install).render()
+    }
+
+    func render() -> String {
+        switch install.manager {
+        case "pipx":
+            var parts = ["pipx", "install"]
+            if force {
+                parts.append("--force")
+            }
+            parts.append(install.spec)
+            return parts.map(ShellCommand.quote).joined(separator: " ")
+        default:
+            return "\(install.manager) \(ShellCommand.quote(install.spec))"
+        }
+    }
+
+    func run() throws {
+        guard install.manager == "pipx" else {
+            throw ValidationError("Unsupported plugin install manager: \(install.manager)")
+        }
+        guard PluginProcess.which("pipx") != nil else {
+            throw ValidationError(
+                """
+                pipx is required to install this plugin.
+                Install pipx first, then retry: brew install pipx
+                """
+            )
+        }
+        var args = ["install"]
+        if force {
+            args.append("--force")
+        }
+        args.append(install.spec)
+        try PluginProcess.runExecutable("pipx", arguments: args)
+    }
+}
+
+enum PluginVerifier {
+    static func verify(entrypoint: String) throws -> PluginManifest {
+        let data = try PluginProcess.captureExecutable(entrypoint, arguments: ["manifest", "--json"])
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+        guard manifest.contractVersion == "mere.run/plugin.v1" else {
+            throw ValidationError("Unsupported plugin manifest contract: \(manifest.contractVersion)")
+        }
+        return manifest
+    }
+}
+
+enum PluginProcess {
+    static func which(_ name: String) -> URL? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = [name]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+        try? process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        guard let raw = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty else { return nil }
+        return URL(fileURLWithPath: raw)
+    }
+
+    static func runExecutable(_ executable: String, arguments: [String]) throws {
+        guard let url = which(executable) else {
+            throw ValidationError("Executable not found on PATH: \(executable)")
+        }
+        let process = Process()
+        process.executableURL = url
+        process.arguments = arguments
+        process.standardInput = FileHandle.standardInput
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw ValidationError("\(executable) exited with status \(process.terminationStatus)")
+        }
+    }
+
+    static func captureExecutable(_ executable: String, arguments: [String]) throws -> Data {
+        guard let url = which(executable) else {
+            throw ValidationError("Executable not found on PATH: \(executable)")
+        }
+        let process = Process()
+        process.executableURL = url
+        process.arguments = arguments
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.standardError
+        try process.run()
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            throw ValidationError("\(executable) exited with status \(process.terminationStatus)")
+        }
+        return data
+    }
+}
+
+enum ShellCommand {
+    static func quote(_ value: String) -> String {
+        if value.isEmpty {
+            return "''"
+        }
+        let safe = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_+-./:=@#")
+        if value.unicodeScalars.allSatisfy({ safe.contains($0) }) {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/MereRunCLI/Guides/plugin.md
+++ b/Sources/MereRunCLI/Guides/plugin.md
@@ -1,0 +1,95 @@
+# Plugin
+
+## Purpose
+
+Discover and install official companion plugins without putting provider-specific
+runtime code into the core `mere.run` CLI. Plugins are separate executables that
+use the user's own accounts and credentials for workflows such as remote GPU
+training.
+
+## Required Models
+
+No model is required to list or install plugins. Individual plugin recipes may
+require models, datasets, credentials, or external compute.
+
+## Install And Check
+
+```bash
+mere.run plugin list
+mere.run plugin info mere-runpod
+mere.run plugin install mere-runpod
+mere.run plugin install mere-runpod --yes
+mere.run plugin doctor mere-runpod
+mere.run guide plugin
+```
+
+## Parameters
+
+- `--catalog-url`: plugin catalog URL or local JSON path. Defaults to the live
+  official catalog in `sawfwair/mere-plugins`.
+- `--json`: print the catalog or plugin entry as JSON for scripts.
+- `--channel`: install channel, defaulting to the catalog's default channel.
+- `--yes`: execute the install command. Without it, `install` prints the exact
+  command only.
+- `--force`: pass `--force` to `pipx install`.
+
+## Usage Patterns
+
+- Use `plugin list` to see the current official catalog and the install command
+  each plugin declares.
+- Use `plugin info <id>` before installing to inspect repository, package,
+  entrypoint, capabilities, and channel-specific install spec.
+- Use `plugin install <id>` first when you want a dry-run command preview.
+- Add `--yes` when you want `mere.run` to run the catalog's `pipx install`
+  command and verify `<plugin> manifest --json`.
+- Use `plugin doctor <id>` after install to run the plugin's own environment
+  checks.
+- Use `--catalog-url ./plugins.v1.json` while developing or testing a catalog
+  before it is published.
+
+## Examples
+
+```bash
+mere.run plugin list
+```
+
+```bash
+mere.run plugin info mere-runpod
+```
+
+```bash
+mere.run plugin install mere-runpod --yes
+mere.run plugin doctor mere-runpod
+```
+
+```bash
+mere.run plugin list \
+  --catalog-url https://raw.githubusercontent.com/sawfwair/mere-plugins/main/catalog/plugins.v1.json \
+  --json
+```
+
+## Iteration Tips
+
+- The catalog is data, not dynamic code. `plugin list` and `plugin info` only
+  fetch and decode JSON.
+- `plugin install` uses `pipx`, so installed plugin CLIs live outside the
+  `mere.run` Swift package and can be updated independently.
+- A plugin must report the `mere.run/plugin.v1` manifest contract before
+  `plugin install --yes` is considered verified.
+- Provider credentials stay with the plugin and the user's environment; the core
+  CLI only resolves catalog metadata and launches the companion executable.
+
+## Troubleshooting
+
+- `pipx is required`: install it with `brew install pipx`, then retry.
+- `Unknown plugin`: rerun `mere.run plugin list` or check the selected
+  `--catalog-url`.
+- `Executable not found on PATH`: ensure `pipx ensurepath` has been run and
+  your shell sees the plugin entrypoint.
+- Manifest mismatch: the installed command is not the cataloged plugin. Reinstall
+  with `--force` or inspect your PATH ordering.
+
+## Sources
+
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/PluginCommand.swift
+- https://github.com/sawfwair/mere-plugins/blob/main/catalog/plugins.v1.json

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -30,6 +30,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Config.self,
             API.self,
             OpenWebUI.self,
+            Plugin.self,
             Setup.self,
             Agent.self,
         ]

--- a/Tests/MereRunCLITests/PluginCommandTests.swift
+++ b/Tests/MereRunCLITests/PluginCommandTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+final class PluginCommandTests: XCTestCase {
+    func testMereRunCLIExposesPluginCommand() {
+        let commandNames = Set(MereRunCLI.configuration.subcommands.map { $0.configuration.commandName })
+
+        XCTAssertTrue(commandNames.contains("plugin"))
+    }
+
+    func testPluginCommandExposesCatalogSubcommands() {
+        let commandNames = Set(Plugin.configuration.subcommands.map { $0.configuration.commandName })
+
+        XCTAssertEqual(commandNames, Set(["list", "info", "install", "doctor"]))
+    }
+
+    func testCatalogLoadsFromLocalPath() throws {
+        let catalogURL = try writeCatalog()
+
+        let catalog = try PluginCatalogClient.load(catalogURL: catalogURL.path)
+        let plugin = try catalog.requirePlugin("mere-runpod")
+        let install = try plugin.install(channel: "main")
+
+        XCTAssertEqual(catalog.contractVersion, "mere.run/plugin-catalog.v1")
+        XCTAssertEqual(catalog.defaultChannel, "main")
+        XCTAssertEqual(plugin.name, "RunPod Runner")
+        XCTAssertEqual(plugin.package, "mere-runpod")
+        XCTAssertEqual(plugin.entrypoint, "mere-runpod")
+        XCTAssertEqual(install.manager, "pipx")
+        XCTAssertEqual(
+            install.spec,
+            "git+https://github.com/sawfwair/mere-plugins.git@main#subdirectory=packages/mere-runpod"
+        )
+    }
+
+    func testPluginInfoParsesCatalogAndChannelOptions() throws {
+        let command = try PluginInfo.parse([
+            "mere-runpod",
+            "--catalog-url", "/tmp/catalog.json",
+            "--channel", "main",
+            "--json",
+        ])
+
+        XCTAssertEqual(command.id, "mere-runpod")
+        XCTAssertEqual(command.catalogURL, "/tmp/catalog.json")
+        XCTAssertEqual(command.channel, "main")
+        XCTAssertTrue(command.json)
+    }
+
+    func testPluginInstallDefaultsToDryRun() throws {
+        let command = try PluginInstall.parse([
+            "mere-runpod",
+            "--catalog-url", "/tmp/catalog.json",
+        ])
+
+        XCTAssertEqual(command.id, "mere-runpod")
+        XCTAssertEqual(command.catalogURL, "/tmp/catalog.json")
+        XCTAssertNil(command.channel)
+        XCTAssertFalse(command.yes)
+        XCTAssertFalse(command.force)
+    }
+
+    func testPluginInstallCommandRendersPipxForceCommand() {
+        let install = PluginCatalogInstall(
+            manager: "pipx",
+            spec: "git+https://github.com/sawfwair/mere-plugins.git@main#subdirectory=packages/mere-runpod",
+            ref: "main"
+        )
+
+        let command = PluginInstallCommand(install: install, force: true).render()
+
+        XCTAssertEqual(
+            command,
+            "pipx install --force git+https://github.com/sawfwair/mere-plugins.git@main#subdirectory=packages/mere-runpod"
+        )
+    }
+
+    func testUnknownPluginErrorListsKnownPlugins() throws {
+        let catalogURL = try writeCatalog()
+        let catalog = try PluginCatalogClient.load(catalogURL: catalogURL.path)
+
+        XCTAssertThrowsError(try catalog.requirePlugin("mere-unknown")) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("Unknown plugin: mere-unknown"))
+            XCTAssertTrue(message.contains("mere-runpod"))
+        }
+    }
+
+    private func writeCatalog() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PluginCommandTests.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let catalogURL = directory.appendingPathComponent("plugins.v1.json")
+        try catalogJSON.write(to: catalogURL, atomically: true, encoding: .utf8)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return catalogURL
+    }
+}
+
+private let catalogJSON = """
+{
+  "contractVersion": "mere.run/plugin-catalog.v1",
+  "updatedAt": "2026-06-26T11:45:00Z",
+  "defaultChannel": "main",
+  "plugins": [
+    {
+      "id": "mere-runpod",
+      "name": "RunPod Runner",
+      "description": "Run canonical mere.run recipes on user-owned ephemeral RunPod pods.",
+      "repo": "https://github.com/sawfwair/mere-plugins",
+      "package": "mere-runpod",
+      "subdirectory": "packages/mere-runpod",
+      "entrypoint": "mere-runpod",
+      "capabilities": ["remote-runner", "runpod", "train-lora"],
+      "channels": {
+        "main": {
+          "manager": "pipx",
+          "ref": "main",
+          "spec": "git+https://github.com/sawfwair/mere-plugins.git@main#subdirectory=packages/mere-runpod"
+        }
+      }
+    }
+  ]
+}
+"""

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -75,6 +75,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "api",
             "config",
             "open-webui",
+            "plugin",
             "setup",
             "agent",
         ]))

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,7 @@ Public tree:
 - `mere.run status`
 - `mere.run api serve`
 - `mere.run open-webui quickstart`
+- `mere.run plugin { list, info, install, doctor }`
 - `mere.run setup`
 - `mere.run agent { onboard, install-pi, start }`
 
@@ -195,9 +196,43 @@ swift run mere.run video generate \
 swift run mere.run api serve --engine text-chat-gemma4
 ```
 
+### Install a companion plugin
+
+Official companion plugins are distributed outside the Swift package. The CLI
+reads the live catalog from `sawfwair/mere-plugins`, prints the exact install
+command by default, and only executes it when `--yes` is present.
+
+```bash
+swift run mere.run plugin list
+swift run mere.run plugin info mere-runpod
+swift run mere.run plugin install mere-runpod
+swift run mere.run plugin install mere-runpod --yes
+swift run mere.run plugin doctor mere-runpod
+```
+
 ## Command reference
 
 Model installation in the OSS repo is explicit. `mere.run model pull` uses cataloged Hugging Face snapshots only; local-path-only models must be supplied with command-specific `--model` or `--model-root` options. See [`configuration.md`](./configuration.md) and [`model-sources.md`](./model-sources.md).
+
+### `mere.run plugin`
+
+Discover and install official companion plugins from the live plugin catalog.
+Plugins are separate executables, not code loaded into the `mere.run` process.
+
+```bash
+swift run mere.run plugin list
+swift run mere.run plugin info mere-runpod
+swift run mere.run plugin install mere-runpod --yes
+swift run mere.run plugin doctor mere-runpod
+```
+
+Key options:
+
+- `--catalog-url`: plugin catalog URL or local JSON path
+- `--json`: emit catalog or plugin metadata as JSON
+- `--channel`: install channel, defaulting to the catalog default
+- `--yes`: execute the install command; omitted means dry-run preview
+- `--force`: pass `--force` to `pipx install`
 
 ### `mere.run image generate`
 


### PR DESCRIPTION
## Summary
- add `mere.run plugin { list, info, install, doctor }` backed by the live official plugin catalog
- keep installs dry-run by default, with `--yes` executing cataloged `pipx install` specs and verifying `manifest --json`
- add plugin guide/docs/changelog coverage and focused command/catalog tests

## Validation
- `./scripts/check.sh`
- `.build/debug/mere.run plugin list` against the live GitHub catalog
- isolated `pipx` smoke installed `mere-runpod 0.1.0` from the live catalog and `mere.run plugin doctor mere-runpod` passed

## Companion catalog
- pushed `sawfwair/mere-plugins@1e80d85` with `catalog/plugins.v1.json` and `contracts/catalog.v1.schema.json`