### PR TITLE
Add native Ornith OptiQ model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on Keep a Changelog.
 - added `vision-ocr-infinity-pro-int8` as an explicit-pull native Infinity
   Pro OCR option for quality-focused evals while keeping LightOnOCR as the
   default `vision ocr` backend.
+- added `text-agent-ornith-9b` as an experimental native Qwen-family MLX/OptiQ
+  coding-agent target backed by the pinned public Ornith 1.0 9B snapshot.
 
 ### Fixed
 

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -20,6 +20,7 @@ struct TextChat: AsyncParsableCommand {
         Known model IDs:
           - text-chat-q36-nano (Qwen3.6-35B-A3B OptiQ 4-bit, default on Apple Silicon)
           - text-chat-q36-nano-gguf (Qwen3.6-35B-A3B GGUF, default on Linux CUDA)
+          - text-agent-ornith-9b (Ornith 1.0 9B OptiQ, experimental coding-agent target)
           - text-chat-gemma4-12b (Gemma 4 12B dense native Swift runtime)
           - text-chat-gemma4-12b-4bit (Gemma 4 12B MLX 4-bit native Swift runtime)
           - text-chat-gemma4-turbo (Gemma 4 26B-A4B NVFP4 native Swift runtime)
@@ -105,7 +106,7 @@ struct TextChat: AsyncParsableCommand {
         return NativeMLXRuntime.backendDescription
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")

--- a/Sources/MereRunCLI/Guides/agent-onboard.md
+++ b/Sources/MereRunCLI/Guides/agent-onboard.md
@@ -10,7 +10,8 @@ No model is required to print readiness. Optional model pulls/configuration
 should use the recommended setup-agent tier; on 96 GB+ Apple Silicon Macs that
 is `text-agent-deepseek-v4-flash`. Smaller Qwen agent models are lower-memory
 or comparison alternatives. `text-code-north-mini` is available for native
-GGUF coding-agent experiments.
+GGUF coding-agent experiments, and `text-agent-ornith-9b` is available for
+native Qwen-family MLX/OptiQ coding-agent experiments.
 
 ## Install And Check
 
@@ -36,6 +37,8 @@ mere.run agent onboard --help
 - Use `--configure-pi --model <id>` when Pi should call a local mere.run API provider.
 - For North Mini Code, pull `text-code-north-mini`, start `api serve --engine text-code`,
   then use `--configure-pi --model text-code-north-mini --host <host> --port <port>`.
+- For Ornith, pull `text-agent-ornith-9b`, start `api serve --engine text-chat-q36 --model text-agent-ornith-9b`,
+  then use `--configure-pi --model text-agent-ornith-9b --host <host> --port <port>`.
 
 ## Examples
 
@@ -50,6 +53,11 @@ mere.run agent onboard --install-pi --configure-pi --model text-agent-deepseek-v
 ```bash
 mere.run model pull text-code-north-mini
 mere.run agent onboard --configure-pi --model text-code-north-mini --port 8080
+```
+
+```bash
+mere.run model pull text-agent-ornith-9b
+mere.run agent onboard --configure-pi --model text-agent-ornith-9b --port 8080
 ```
 
 ## Iteration Tips

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -13,7 +13,8 @@ Supported engines:
 - `text-code`: GGUF code models such as `text-code-qwen3` and `text-code-north-mini`.
 - `text-chat-gemma4`: Gemma text chat models, including `text-chat-gemma4-12b`.
 - `vision-chat-gemma4-12b`: Gemma 4 12B vision chat over the Gemma4 API serving engine.
-- `text-chat-q36`: Qwen-family serving engine; defaults to `text-chat-q36-nano`.
+- `text-chat-q36`: Qwen-family serving engine; defaults to `text-chat-q36-nano`
+  and also serves Qwen-family agent experiments such as `text-agent-ornith-9b`.
 - `text-chat-lfm2`: LFM2 serving engine; defaults to `text-chat-lfm25-a1b-8bit`.
 - `text-chat-deepseek-v4-flash`: DeepSeek V4 Flash via the bundled DS4 server.
 - `text-chat-klein`: local Klein/MeBot chat path when installed.
@@ -158,6 +159,11 @@ mere.run api serve --engine text-chat-gemma4 --model vision-chat-gemma4-12b --po
 ```bash
 mere.run model pull text-chat-lfm25-a1b-8bit
 mere.run api serve --engine text-chat-lfm2 --port 11434
+```
+
+```bash
+mere.run model pull text-agent-ornith-9b
+mere.run api serve --engine text-chat-q36 --model text-agent-ornith-9b --port 11434
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,11 +6,12 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-12b-4bit`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-12b-4bit`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-agent-ornith-9b`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
 `text-chat-gemma4-12b` is the managed dense Google Gemma 4 12B-it checkpoint, routed through the native Swift Gemma 4 runtime for text chat.
 Pulling `text-chat-gemma4-12b` or `vision-chat-gemma4-12b` also installs the managed `text-chat-gemma4-12b-mtp` assistant; greedy serial Gemma 12B decode uses it for verified decode-tail MTP when the prompt is above the configured threshold.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
 `text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head that is used only by the adaptive long-context speculative decode path.
+`text-agent-ornith-9b` is the managed Ornith 1.0 9B OptiQ MLX coding-agent experiment; it uses the native Qwen-family runtime rather than the GGUF `text code` command.
 `text-chat-lfm25-a1b-8bit` is the managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot and runs through the native Swift LFM2 runtime.
 
 ## Chat Winners By RAM Band
@@ -82,6 +83,13 @@ mere.run text chat \
 
 ```bash
 mere.run text chat \
+  --model text-agent-ornith-9b \
+  --temperature 0.2 \
+  --prompt "Write a compact Swift function with one XCTest for slugifying a model id."
+```
+
+```bash
+mere.run text chat \
   --model text-chat-lfm25-a1b-8bit \
   --prompt "Summarize the tradeoffs of mixture-of-experts chat models."
 ```
@@ -103,5 +111,6 @@ mere.run text chat \
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/TextChatCommand.swift
 - https://ai.google.dev/gemma/docs/core/prompt-structure
 - https://huggingface.co/mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit
+- https://huggingface.co/sahilchachra/ornith-1.0-9b-optiq-5bpw-mlx
 - https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-MLX-8bit
 - https://huggingface.co/google/gemma-4-31B

--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -158,6 +158,7 @@ public enum MereRunAgentModelCatalog {
         [
             qwen35NineB(),
             northMiniCode(),
+            ornith9B(),
             q36Nano(),
             qwen3CoderNext(),
             deepseekV4Flash(),
@@ -197,6 +198,18 @@ public enum MereRunAgentModelCatalog {
             recommendedUnifiedMemoryGB: 32,
             servingEngine: .textCode,
             managedModelID: NorthMiniCodeResources.modelId
+        )
+    }
+
+    private static func ornith9B() -> MereRunAgentModelRecommendation {
+        MereRunAgentModelRecommendation(
+            id: Q35Resources.ornith9BModelId,
+            displayName: "Ornith 1.0 9B OptiQ",
+            summary: "Experimental 9B OptiQ MLX coding-agent model for native Qwen-family smoke tests.",
+            minimumUnifiedMemoryGB: 16,
+            recommendedUnifiedMemoryGB: 24,
+            servingEngine: .textChatQ35,
+            managedModelID: Q35Resources.ornith9BModelId
         )
     }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -683,6 +683,17 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["chat", "api serve"]
         ),
         ManagedModelSpec(
+            id: Q35Resources.ornith9BModelId,
+            category: .textCode,
+            installShape: .directoryRoot,
+            hubFallback: Q35Resources.profile(for: Q35Resources.ornith9BModelId)?.hubFallbackConfig,
+            upstreamRepoId: Q35Resources.ornith9BUpstreamRepoId,
+            upstreamRevision: Q35Resources.ornith9BUpstreamRevision,
+            validationKind: .q35,
+            estimatedDownloadBytes: Q35Resources.ornith9BEstimatedDownloadBytes,
+            defaultCLICommands: ["chat", "api serve", "agent start"]
+        ),
+        ManagedModelSpec(
             id: AgentModelResources.qwen35NineBModelId,
             category: .textCode,
             installShape: .singleFile(relativePath: AgentModelResources.qwen35NineBRelativePath),

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -375,6 +375,13 @@ public enum ManagedModelCapabilityCatalog {
                 setup: true
             ),
             descriptor(
+                Q35Resources.ornith9BModelId,
+                "Ornith 1.0 9B OptiQ",
+                "Runs DeepReinforce's Ornith 1.0 9B agentic coding model through the native Qwen-family MLX runtime.",
+                minimum: 16,
+                recommended: 24
+            ),
+            descriptor(
                 LFM2Resources.defaultModelId,
                 "LFM2.5 A1B 8-bit",
                 "Runs the LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot through the native Swift LFM2 runtime.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -805,6 +805,22 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "\(AgentModelResources.qwen35NineBRepoId)@\(AgentModelResources.qwen35NineBRevision)",
                 createdAt: createdAt
             )
+        case .ornith9B:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .qwen35HybridMoE,
+                family: .code,
+                tier: .nano,
+                variant: .standard,
+                precision: .int4,
+                quantization: Quantization(bits: 4, groupSize: 64, scheme: "mlx-optiq-mixed-affine"),
+                defaults: nil,
+                supports: [.chat, .codeGeneration],
+                components: q35TextComponents,
+                upstreamRepoId: "\(Q35Resources.ornith9BUpstreamRepoId)"
+                    + "@\(Q35Resources.ornith9BUpstreamRevision)",
+                createdAt: createdAt
+            )
         case .northMiniCode:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -365,8 +365,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=embed expects qwen3-embedding.")
             case .privacy where engine != .openAIPrivacyFilter:
                 warnings.append("Manifest engine mismatch: family=privacy expects openai-privacy-filter.")
-            case .code where engine != .qwen3Coder && engine != .northMiniCode:
-                warnings.append("Manifest engine mismatch: family=code expects qwen3-coder or north-mini-code.")
+            case .code where engine != .qwen3Coder && engine != .northMiniCode && engine != .qwen35HybridMoE:
+                warnings.append("Manifest engine mismatch: family=code expects qwen3-coder, north-mini-code, or qwen3.5-hybrid-moe.")
             case .ocr where engine != .lightOnOCR && engine != .qwen35HybridMoE:
                 warnings.append("Manifest engine mismatch: family=ocr expects lighton-ocr or qwen3.5-hybrid-moe.")
             case .music where engine != .aceStep && engine != .magentaRT2:

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -39,6 +39,7 @@ public struct ModelResolver {
         case q36Nano = "text-chat-q36-nano"
         case lfm25A1B8Bit = "text-chat-lfm25-a1b-8bit"
         case qwen35Agent9B = "text-agent-qwen35-9b"
+        case ornith9B = "text-agent-ornith-9b"
         case northMiniCode = "text-code-north-mini"
         case q36NanoGGUF = "text-chat-q36-nano-gguf"
         case deepseekV4Flash = "text-agent-deepseek-v4-flash"

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -1436,8 +1436,10 @@ public actor Q35Generator: ChatGenerator {
             }
             let normalizedMapped = Self.normalizeMappedExpertWeightKey(mapped)
             if normalizedMapped.hasSuffix(".linear_attn.conv1d.weight"), value.ndim == 3 {
-                let transposed = value.transposed(0, 2, 1)
-                return [(normalizedMapped, transposed.reshaped(-1).reshaped(transposed.shape))]
+                return [(normalizedMapped, Self.normalizedLinearAttentionConv1DWeight(value))]
+            }
+            if Self.isOffsetRMSNormWeight(normalizedMapped) {
+                return [(normalizedMapped, value - MLXArray(1.0).asType(value.dtype))]
             }
             return [(normalizedMapped, value)]
         }
@@ -1451,8 +1453,10 @@ public actor Q35Generator: ChatGenerator {
         let quantizedMapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
             guard !key.hasPrefix("__unused__.") else { return [] }
             if key.hasSuffix(".linear_attn.conv1d.weight"), value.ndim == 3 {
-                let transposed = value.transposed(0, 2, 1)
-                return [(key, transposed.reshaped(-1).reshaped(transposed.shape))]
+                return [(key, Self.normalizedLinearAttentionConv1DWeight(value))]
+            }
+            if Self.isOffsetRMSNormWeight(key) {
+                return [(key, value - MLXArray(1.0).asType(value.dtype))]
             }
             return [(key, value)]
         }
@@ -1528,6 +1532,22 @@ public actor Q35Generator: ChatGenerator {
             return String(key.dropLast(expertDownSuffix.count)) + ".mlp.switch_mlp.down_proj.weight"
         }
         return key
+    }
+
+    static func normalizedLinearAttentionConv1DWeight(_ value: MLXArray) -> MLXArray {
+        guard value.ndim == 3, value.dim(1) == 1, value.dim(2) > 1 else {
+            return value
+        }
+        let transposed = value.transposed(0, 2, 1)
+        return transposed.reshaped(-1).reshaped(transposed.shape)
+    }
+
+    static func isOffsetRMSNormWeight(_ key: String) -> Bool {
+        key.hasSuffix(".input_layernorm.weight")
+            || key.hasSuffix(".post_attention_layernorm.weight")
+            || key.hasSuffix(".self_attn.q_norm.weight")
+            || key.hasSuffix(".self_attn.k_norm.weight")
+            || key == "model.norm.weight"
     }
 
     private static func splitMappedExpertGateUpWeight(_ key: String, _ value: MLXArray) -> [(String, MLXArray)]? {

--- a/Sources/MereRunCore/Q35/Q35LinearAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35LinearAttention.swift
@@ -33,8 +33,8 @@ private func q35Swiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
 
 @inline(__always)
 private func q35RmsNormNoWeight(_ x: MLXArray, eps: Float = 1e-6) -> MLXArray {
-    let squaredSum = (x * x).sum(axis: -1, keepDims: true)
-    return x * rsqrt(squaredSum + MLXArray(eps).asType(x.dtype))
+    let squaredMean = (x * x).mean(axis: -1, keepDims: true)
+    return x * rsqrt(squaredMean + MLXArray(eps).asType(x.dtype))
 }
 
 @inline(__always)
@@ -65,8 +65,7 @@ private func q35GatedDeltaUpdate(
     let beta = MLX.sigmoid(b).asType(.float32)
     let g = q35ComputeG(aLog: aLog, a: a, dtBias: dtBias)
 
-    let invScale = 1.0 / sqrt(Float(max(1, keyHeadDim)))
-    var qExpanded = q.asType(.float32) * MLXArray(invScale)
+    var qExpanded = q.asType(.float32)
     var kExpanded = k.asType(.float32)
     let v32 = v.asType(.float32)
     let repeatFactor = max(1, numValueHeads / max(1, numKeyHeads))
@@ -290,8 +289,9 @@ final class Q35LinearAttention: Module {
         var k = kConv.reshaped(batch, sequence, numKeyHeads, keyHeadDim)
         let v = vConv.reshaped(batch, sequence, numValueHeads, valueHeadDim)
 
-        q = q35RmsNormNoWeight(q)
-        k = q35RmsNormNoWeight(k)
+        let invScale = 1.0 / sqrt(Float(max(1, keyHeadDim)))
+        q = q35RmsNormNoWeight(q) * MLXArray(invScale * invScale).asType(q.dtype)
+        k = q35RmsNormNoWeight(k) * MLXArray(invScale).asType(k.dtype)
 
         let (updated, state) = q35GatedDeltaUpdate(
             q: q,

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -26,6 +26,7 @@ public struct Q35Resources: Sendable, Hashable {
     }
 
     public static let q36NanoModelId = "text-chat-q36-nano"
+    public static let ornith9BModelId = "text-agent-ornith-9b"
     public static let infinityParser2FlashModelId = "vision-ocr-infinity-flash"
     public static let infinityParser2ProModelId = "vision-ocr-infinity-pro"
     public static let infinityParser2ProInt8ModelId = "vision-ocr-infinity-pro-int8"
@@ -33,6 +34,9 @@ public struct Q35Resources: Sendable, Hashable {
 
     public static let q36NanoUpstreamRepoId = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit"
     public static let q36NanoUpstreamRevision = "63d520640ca7461f31ba66104612135770090340"
+    public static let ornith9BUpstreamRepoId = "sahilchachra/ornith-1.0-9b-optiq-5bpw-mlx"
+    public static let ornith9BUpstreamRevision = "4f9f4fc2c10ec17cbeb9dae086a7f1272c904e86"
+    public static let ornith9BEstimatedDownloadBytes: Int64 = 7 * 1_073_741_824
     public static let infinityParser2FlashUpstreamRepoId = "infly/Infinity-Parser2-Flash"
     public static let infinityParser2FlashUpstreamRevision = "30f02aca5ee7c32d22a962cbece5c19611147c9e"
     public static let infinityParser2ProUpstreamRepoId = "infly/Infinity-Parser2-Pro"
@@ -45,6 +49,11 @@ public struct Q35Resources: Sendable, Hashable {
             modelId: q36NanoModelId,
             upstreamRepoId: q36NanoUpstreamRepoId,
             upstreamRevision: q36NanoUpstreamRevision
+        ),
+        ornith9BModelId: Profile(
+            modelId: ornith9BModelId,
+            upstreamRepoId: ornith9BUpstreamRepoId,
+            upstreamRevision: ornith9BUpstreamRevision
         ),
         infinityParser2FlashModelId: Profile(
             modelId: infinityParser2FlashModelId,
@@ -79,6 +88,7 @@ public struct Q35Resources: Sendable, Hashable {
         "tokenizer.json",
         "tokenizer_config.json",
         "chat_template.jinja",
+        "optiq_metadata.json",
         "model.safetensors",
         "model.safetensors.index.json",
         "*.safetensors",

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -99,6 +99,29 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textCode)
     }
 
+    func testOrnithProviderUsesNativeQ35ManagedModelID() throws {
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog
+                .allTierRecommendations(
+                    on: MereRunMachineProfile(
+                        physicalMemoryBytes: 24 * 1_073_741_824,
+                        processorName: "M4 Pro",
+                        isAppleSiliconMac: true
+                    )
+                )
+                .first { $0.id == Q35Resources.ornith9BModelId }
+        )
+
+        let runtime = try SetupAgentRuntime.runtime(for: recommendation)
+        let providerModel = SetupAgentRuntime.providerModel(for: recommendation)
+
+        XCTAssertEqual(runtime.engine, .textChatQ36)
+        XCTAssertEqual(providerModel.id, Q35Resources.ornith9BModelId)
+        XCTAssertEqual(providerModel.contextWindow, Q35Resources.defaultContextLength)
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textChatQ35)
+    }
+
     func testPiProviderCanBeWrittenToIsolatedHome() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-pi-home-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -291,6 +291,19 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("*.safetensors"), true)
     }
 
+    func testOrnith9BUsesNativeQ35OptiQHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.ornith9BModelId))
+
+        XCTAssertEqual(spec.category, .textCode)
+        XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.ornith9BUpstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.ornith9BUpstreamRevision)
+        XCTAssertEqual(spec.upstreamRepoId, Q35Resources.ornith9BUpstreamRepoId)
+        XCTAssertEqual(spec.validationKind, .q35)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
+        XCTAssertEqual(spec.estimatedDownloadBytes, Q35Resources.ornith9BEstimatedDownloadBytes)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("optiq_metadata.json"), true)
+    }
+
     func testInfinityParser2FlashUsesNativeQ35VisionOCRSpec() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.infinityParser2FlashModelId))
 

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -101,6 +101,26 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textCode)
     }
 
+    func testOrnith9BIsSupportedOnTwentyFourGBAndStartableThroughQ35() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.ornith9BModelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 24 * 1_073_741_824,
+            processorName: "M4 Pro",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog
+                .allTierRecommendations(on: machine)
+                .first { $0.id == Q35Resources.ornith9BModelId }
+        )
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textChatQ35)
+    }
+
     func testUnsupportedRuntimeIsRejected() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -169,6 +169,25 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
+    func testOrnith9BTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .ornith9B, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, Q35Resources.ornith9BModelId)
+        XCTAssertEqual(manifest.engine, .qwen35HybridMoE)
+        XCTAssertEqual(manifest.family, .code)
+        XCTAssertEqual(manifest.tier, .nano)
+        XCTAssertEqual(manifest.variant, .standard)
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-optiq-mixed-affine")
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration]))
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(Q35Resources.ornith9BUpstreamRepoId)@\(Q35Resources.ornith9BUpstreamRevision)"
+        )
+    }
+
     func testHiDreamO1DevTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .hidreamO1Dev, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -371,6 +371,20 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(report.manifest?.upstreamRepoId, "\(Q35Resources.q36NanoUpstreamRepoId)@\(Q35Resources.q36NanoUpstreamRevision)")
     }
 
+    func testOrnithQ35CodeRootLayoutPassesValidationWithoutEngineWarning() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(Q35Resources.ornith9BModelId, isDirectory: true)
+        try writeMinimalValidQ35FamilyModel(at: root, id: .ornith9B)
+
+        let report = MereRunModelValidator.validate(modelRoot: root, expectedModelID: Q35Resources.ornith9BModelId)
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.family, .code)
+        XCTAssertFalse(report.warnings.contains { $0.contains("family=code expects") })
+    }
+
     func testLFM2ChatOnlyRootLayoutPassesValidation() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -40,6 +40,24 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual((target.width / 16) * (target.height / 16) / 4, 2_244)
     }
 
+    func testQ35LinearAttentionConvWeightsKeepMLXLayout() {
+        let mlxLayout = MLXArray.zeros([8, 4, 1])
+        let normalizedMLX = Q35Generator.normalizedLinearAttentionConv1DWeight(mlxLayout)
+        XCTAssertEqual(normalizedMLX.shape, [8, 4, 1])
+
+        let pytorchDepthwiseLayout = MLXArray.zeros([8, 1, 4])
+        let normalizedPyTorch = Q35Generator.normalizedLinearAttentionConv1DWeight(pytorchDepthwiseLayout)
+        XCTAssertEqual(normalizedPyTorch.shape, [8, 4, 1])
+    }
+
+    func testQ35RMSNormOffsetConversionSkipsLinearAttentionGateNorm() {
+        XCTAssertTrue(Q35Generator.isOffsetRMSNormWeight("model.layers.0.input_layernorm.weight"))
+        XCTAssertTrue(Q35Generator.isOffsetRMSNormWeight("model.layers.0.post_attention_layernorm.weight"))
+        XCTAssertTrue(Q35Generator.isOffsetRMSNormWeight("model.layers.3.self_attn.q_norm.weight"))
+        XCTAssertTrue(Q35Generator.isOffsetRMSNormWeight("model.norm.weight"))
+        XCTAssertFalse(Q35Generator.isOffsetRMSNormWeight("model.layers.0.linear_attn.norm.weight"))
+    }
+
     func testQ35TemplateLeavesThinkingOpenWhenRequested() {
         let rendered = Q35TokenizerAndTemplate.renderPrompt(
             messages: [ChatMessage(role: .user, content: "Explain.")],
@@ -318,6 +336,44 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(config.textConfig.numExpertsPerTok, 0)
         XCTAssertEqual(config.visionConfig?.patchSize, 16)
         XCTAssertEqual(config.visionConfig?.spatialMergeSize, 2)
+    }
+
+    func testQ35ConfigAllowsOrnithOptiQQuantizationMetadata() throws {
+        var configObject = makeBaseConfig()
+        configObject["model_type"] = "qwen3_5"
+        configObject["architectures"] = ["Qwen3_5ForConditionalGeneration"]
+        configObject["quantization"] = [
+            "group_size": 64,
+            "bits": 4,
+            "mode": "affine",
+            "language_model.model.layers.0.linear_attn.in_proj_qkv": [
+                "bits": 8,
+                "group_size": 64,
+            ],
+        ]
+        if var textConfig = configObject["text_config"] as? [String: Any] {
+            textConfig["model_type"] = "qwen3_5_text"
+            textConfig["hidden_size"] = 4096
+            textConfig["num_hidden_layers"] = 32
+            textConfig["intermediate_size"] = 12288
+            textConfig["num_attention_heads"] = 16
+            textConfig["num_key_value_heads"] = 4
+            textConfig["head_dim"] = 256
+            textConfig.removeValue(forKey: "num_experts")
+            textConfig.removeValue(forKey: "num_experts_per_tok")
+            textConfig.removeValue(forKey: "moe_intermediate_size")
+            textConfig.removeValue(forKey: "shared_expert_intermediate_size")
+            configObject["text_config"] = textConfig
+        }
+
+        let config = try decodeConfig(configObject)
+
+        XCTAssertEqual(config.modelType, "qwen3_5")
+        XCTAssertEqual(config.quantization?.bits, 4)
+        XCTAssertEqual(config.quantization?.groupSize, 64)
+        XCTAssertEqual(config.quantization?.mode, "affine")
+        XCTAssertFalse(config.textConfig.usesMoE)
+        XCTAssertEqual(config.textConfig.hiddenSize, 4096)
     }
 
     func testQ35DenseFeedForwardRuntimeProducesLogits() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ are:
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`
-- Text code / agents: `text-agent-qwen35-9b`, `text-code-north-mini`, `text-code-qwen3`
+- Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-code-north-mini`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Text anonymize: `text-anonymize-privacy-filter`
 - Speech TTS: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`
@@ -406,6 +406,7 @@ Examples:
 ```bash
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
 swift run mere.run text chat --model text-chat-q36-nano --prompt "Explain speculative decoding."
+swift run mere.run text chat --model text-agent-ornith-9b --prompt "Write a compact Swift slugify helper."
 swift run mere.run text chat --model text-chat-lfm25-a1b-8bit --prompt "Summarize LFM2 in one paragraph."
 swift run mere.run text chat --stream --prompt "Write a short welcome message."
 swift run mere.run text chat --thinking --stats --prompt "How would you design a tokenizer?"
@@ -1489,6 +1490,10 @@ coding model. It is pullable through `model pull`, can be served with
 through the Pi-backed `agent start` path like other `text-code` models once the
 installed llama.cpp runtime supports the `cohere2moe` architecture.
 
+Ornith (`text-agent-ornith-9b`) is available as an experimental native
+MLX/OptiQ coding-agent model. It uses the Qwen-family runtime, so serve it with
+`api serve --engine text-chat-q36 --model text-agent-ornith-9b`.
+
 BYOA prints a ready-to-paste Claude/Codex prompt. Manual mode prints the
 commands for capabilities, model pulls, serving, and optional Pi installation.
 Pi auto-install uses the published macOS release assets; on Linux, put a `pi`
@@ -1507,6 +1512,7 @@ swift run mere.run agent onboard --pull-recommended
 swift run mere.run agent onboard --install-pi --configure-pi
 swift run mere.run agent onboard --configure-pi --model text-agent-deepseek-v4-flash
 swift run mere.run agent onboard --configure-pi --model text-code-north-mini --port 8080
+swift run mere.run agent onboard --configure-pi --model text-agent-ornith-9b --port 8080
 ```
 
 ### `mere.run agent install-pi`

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -25,7 +25,7 @@ Override that with `MERERUN_MODELS_DIR` or `--models-root`.
 | Image | `image-klein-nano`, `image-klein-base`, `image-klein-base-9b`, `image-klein-max`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`, `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-raw`, `image-krea2-turbo`, `image-ideogram4-sdnq-uint4` |
 | Text chat | `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash` |
 | Vision chat | `vision-chat-gemma4-12b` |
-| Text code / agents | `text-agent-qwen35-9b`, `text-code-north-mini`, `text-code-qwen3` |
+| Text code / agents | `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-code-north-mini`, `text-code-qwen3` |
 | Text embed | `text-embed-qwen3-0.6b` |
 | Text anonymize | `text-anonymize-privacy-filter` |
 | Speech TTS | `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice` |
@@ -58,6 +58,12 @@ Mini Code 1.0 at the pinned catalog revision. North Mini Code is a 30B total /
 `North-Mini-Code-1.0-UD-Q4_K_M.gguf` file so the model runs through the same
 native Swift/llama.cpp `text code` path as the existing Qwen coder. It requires
 a llama.cpp runtime with `cohere2moe` architecture support.
+
+`text-agent-ornith-9b` installs the public
+`sahilchachra/ornith-1.0-9b-optiq-5bpw-mlx` snapshot at the pinned catalog
+revision. Ornith is a DeepReinforce agentic coding model with Qwen3.5 text
+architecture metadata; mere.run treats this MLX OptiQ quant as a native
+Qwen-family runtime target for `chat`, `api serve`, and setup-agent experiments.
 
 `text-agent-deepseek-v4-flash` is the preferred managed setup-agent tier on
 96 GB+ Apple Silicon Macs. Smaller Qwen setup agents are lower-memory

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -295,6 +295,9 @@ Engine compatibility:
 - `text-chat-q36-nano`: uses the Qwen-family serving engine with Qwen3.6
   35B-A3B OptiQ chat weights, accepts function tools, and accepts one image
   content part per message.
+- `text-agent-ornith-9b`: uses the same Qwen-family serving engine for the
+  Ornith 1.0 9B OptiQ coding-agent experiment; start it with
+  `api serve --engine text-chat-q36 --model text-agent-ornith-9b`.
 - `text-chat-lfm25-a1b-8bit`: uses the LFM2 serving engine with the
   LiquidAI LFM2.5 8B-A1B MLX 8-bit weights, accepts function tools, and rejects
   image content parts.

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -39,7 +39,7 @@ swift run mere.run --models-root /path/to/models model list
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
@@ -95,6 +95,8 @@ Apple Silicon Macs, `text-agent-deepseek-v4-flash` is the preferred managed
 setup-agent tier; smaller Qwen agent models are alternatives, not upgrades.
 `text-code-north-mini` can be pulled, inspected, and run through the native
 GGUF code runtime for coding-agent comparisons against `text-code-qwen3`.
+`text-agent-ornith-9b` can be pulled, inspected, and run through the native
+Qwen-family MLX/OptiQ runtime for coding-agent comparisons.
 
 ### `mere.run model remove`
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -20,6 +20,7 @@ embeddings, and PII anonymization.
 - `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
 - `text-chat-q36-nano`
 - `text-chat-lfm25-a1b-8bit` (managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot)
+- `text-agent-ornith-9b` (experimental native MLX/OptiQ coding-agent snapshot)
 - `text-agent-deepseek-v4-flash` (API/agent serving)
 - `text-chat-mebot`
 - `text-chat-psi-agent`
@@ -68,6 +69,11 @@ equally recommended:
 `text-chat-lfm25-a1b-8bit` installs `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
 and runs through the native Swift LFM2 runtime. It is text-only; use
 `--model text-chat-lfm25-a1b-8bit` for CLI chat or `api serve --engine text-chat-lfm2`.
+
+`text-agent-ornith-9b` installs an Ornith 1.0 9B OptiQ MLX snapshot and runs
+through the native Qwen-family runtime. Use `text chat --model text-agent-ornith-9b`
+or `api serve --engine text-chat-q36 --model text-agent-ornith-9b` for coding-agent
+smoke tests.
 
 ### Local code generation
 


### PR DESCRIPTION
## Summary
- add managed `text-agent-ornith-9b` support pinned to `sahilchachra/ornith-1.0-9b-optiq-5bpw-mlx`
- wire Ornith through model resolution, manifests, support tiers, agent recommendations, CLI help, docs, and changelog
- fix the native Q35 path for current Qwen3.5/OptiQ artifacts: MLX conv1d layout, RMSNorm offset conversion, and gated-delta q/k scaling

## Validation
- `./scripts/check.sh` from a clean detached worktree at commit `778996b`
- `mere.run model pull text-agent-ornith-9b`
- `mere.run model info text-agent-ornith-9b` reported a valid manifest and 6.95 GB installed model
- `mere.run text chat --model text-agent-ornith-9b --max-tokens 96 --temperature 0 --stats ...` generated a coherent Swift `slugifyModelID(_:)` function at 22.43 decode tok/s
- `mere.run api serve --engine text-chat-q36 --model text-agent-ornith-9b --host 127.0.0.1 --port 18080 --memory-guard off`, then `/health`, `/v1/models`, and `/v1/chat/completions` returned `READY`

## Notes
- This PR builds on the native North Mini Code branch commit and adds the Ornith native Q35 lane on top.
- The product runtime path is Swift-native MLX; Python tooling was not added to the runtime surface.