### PR TITLE
macOS Studio engine refactor (Phase 1) — complete: all of WS-1

### DIFF
--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -268,6 +268,14 @@ protocol MereRunProcessRunning: AnyObject {
     ) throws -> MereRunRunningProcess
 }
 
+/// A seam over filesystem existence checks so run-output detection can be unit-tested without
+/// touching the real disk. `FileManager` is the production implementation.
+protocol MereRunFileProbing {
+    func fileExists(atPath path: String) -> Bool
+}
+
+extension FileManager: MereRunFileProbing {}
+
 private final class FoundationRunningProcess: MereRunRunningProcess, @unchecked Sendable {
     private let process: Process
     private let stdoutPipe: Pipe
@@ -472,6 +480,8 @@ final class MereRunController: ObservableObject {
     }
 
     private let processRunner: MereRunProcessRunning
+    private let fileSystem: MereRunFileProbing
+    private let cliResolve: (String) -> MereRunLaunch
     private var currentProcess: MereRunRunningProcess?
     private var utilityProcesses: [UUID: MereRunRunningProcess] = [:]
     private var readinessProcesses: [StudioMode: MereRunRunningProcess] = [:]
@@ -511,9 +521,13 @@ final class MereRunController: ObservableObject {
 
     init(
         processRunner: MereRunProcessRunning = FoundationMereRunProcessRunner(),
+        fileSystem: MereRunFileProbing = FileManager.default,
+        cliResolver: @escaping (String) -> MereRunLaunch = { CLIResolver.resolve(customPath: $0) },
         resolvesCLIOnInit: Bool = true
     ) {
         self.processRunner = processRunner
+        self.fileSystem = fileSystem
+        self.cliResolve = cliResolver
         let initial = CommandCatalog.templates.first!
         selectedTemplate = initial
         draft = initial.defaultDraft()
@@ -558,7 +572,7 @@ final class MereRunController: ObservableObject {
     }
 
     func refreshResolvedCLI() {
-        let launch = CLIResolver.resolve(customPath: cliPath)
+        let launch = cliResolve(cliPath)
         resolvedCLI = displayDescription(for: launch)
     }
 
@@ -595,13 +609,13 @@ final class MereRunController: ObservableObject {
     }
 
     func commandPreview(template: CommandTemplate, draft: CommandDraft, masksSecrets: Bool) -> String {
-        let launch = CLIResolver.resolve(customPath: cliPath)
+        let launch = cliResolve(cliPath)
         let args = commandArguments(template: template, draft: draft)
         return launch.displayCommand(for: masksSecrets ? args.maskingSecrets() : args)
     }
 
     func utilityCommandResult(args: [String], masksSecrets: Bool = true) async -> MereRunUtilityCommandResult {
-        let launch = CLIResolver.resolve(customPath: cliPath)
+        let launch = cliResolve(cliPath)
         let cliArgs: [String]
         if !modelsRoot.isBlank {
             cliArgs = ["--models-root", NSString(string: modelsRoot).expandingTildeInPath] + args
@@ -722,7 +736,7 @@ final class MereRunController: ObservableObject {
         modelID: String,
         request: ReadinessRequest
     ) {
-        let launch = CLIResolver.resolve(customPath: cliPath)
+        let launch = cliResolve(cliPath)
         let capabilityTemplate = CommandCatalog.template(id: .modelCapabilities) ?? selectedTemplate
         var capabilityDraft = capabilityTemplate.defaultDraft()
         capabilityDraft.all = true
@@ -783,7 +797,7 @@ final class MereRunController: ObservableObject {
         modelID: String,
         request: ReadinessRequest
     ) {
-        let launch = CLIResolver.resolve(customPath: cliPath)
+        let launch = cliResolve(cliPath)
         let modelListTemplate = CommandCatalog.template(id: .modelList) ?? selectedTemplate
         let modelListDraft = modelListTemplate.defaultDraft()
         let args = commandArguments(
@@ -837,7 +851,7 @@ final class MereRunController: ObservableObject {
         }
         refreshResolvedCLI()
 
-        let launch = CLIResolver.resolve(customPath: cliPath)
+        let launch = cliResolve(cliPath)
         let args = commandArguments(template: spec.template, draft: spec.draft)
         let display = launch.displayCommand(for: args)
         let expectedOutput = expectedOutputURL(template: spec.template, draft: spec.draft)
@@ -1270,8 +1284,8 @@ final class MereRunController: ObservableObject {
         }
     }
 
-    private func detectOutputURL(expected: URL?, stdout: String) -> URL? {
-        let fm = FileManager.default
+    func detectOutputURL(expected: URL?, stdout: String) -> URL? {
+        let fm = fileSystem
 
         // 1. The explicit `--output` path the request asked for, once it has landed.
         if let expected, fm.fileExists(atPath: expected.path) {

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -482,23 +482,29 @@ final class MereRunController: ObservableObject {
     private let processRunner: MereRunProcessRunning
     private let fileSystem: MereRunFileProbing
     private let cliResolve: (String) -> MereRunLaunch
-    private var currentProcess: MereRunRunningProcess?
     private var utilityProcesses: [UUID: MereRunRunningProcess] = [:]
     private var readinessProcesses: [StudioMode: MereRunRunningProcess] = [:]
     private var readinessRequests: [StudioMode: ReadinessRequest] = [:]
-    private var stdoutBuffer = ""
-    private var stderrBuffer = ""
-    private var activeRunTemplateID: CommandTemplateID?
-    private var activeRunPreview = ""
-    /// The expected `--output` location of the run currently in flight. Captured from the run's
-    /// snapshot so live output detection never reads the editing state, which may have moved on.
-    private var activeExpectedOutput: URL?
-    private var outputWatchTask: Task<Void, Never>?
+    /// Runs currently in flight, each with its own isolated process, buffers, logs, progress
+    /// and output. Up to `maxConcurrentRuns` run at once; the rest wait in `queuedRuns`.
+    private var sessions: [RunSession] = []
+    /// The session whose live state mirrors into the published console fields (the run the
+    /// single-pane console/canvas currently shows). Background sessions still complete into the
+    /// library by request id. Persists past completion so the last run's result stays visible.
+    private var foregroundSessionID: UUID?
     private var queuedRuns: [StudioRunRequest] = []
+
+    private var foregroundSession: RunSession? {
+        sessions.first { $0.id == foregroundSessionID }
+    }
 
     private static let stdoutBufferByteLimit = 32 * 1024
     private static let stderrBufferByteLimit = 32 * 1024
     private static let outputDetectionLineLimit = 40
+    private static let logLineLimit = 1200
+    /// Conservative cap on simultaneous runs. ML inference is memory-heavy, so this stays small;
+    /// it is the single knob for how many runs may execute at once before further ones queue.
+    static let maxConcurrentRuns = 2
 
     private struct ReadinessRequest: Equatable {
         let modelID: String
@@ -674,9 +680,37 @@ final class MereRunController: ObservableObject {
         let requestID: UUID?
     }
 
+    /// All mutable state for a single in-flight run, isolated so concurrent runs never clobber
+    /// each other's process, buffers, logs, progress or output. `@MainActor` (so it is Sendable
+    /// and can be captured by the process callbacks); every field is touched only on the main actor.
+    @MainActor
+    private final class RunSession: Identifiable {
+        let id = UUID()
+        let spec: RunSpec
+        let preview: String
+        let expectedOutput: URL?
+        var process: MereRunRunningProcess?
+        var stdoutBuffer = ""
+        var stderrBuffer = ""
+        var logs: [LogLine] = []
+        var liveOutputText = ""
+        var currentProgress: StudioRunProgress?
+        var lastOutputURL: URL?
+        var exitCode: Int32?
+        var status: String
+        var outputWatchTask: Task<Void, Never>?
+
+        init(spec: RunSpec, preview: String, expectedOutput: URL?, status: String) {
+            self.spec = spec
+            self.preview = preview
+            self.expectedOutput = expectedOutput
+            self.status = status
+        }
+    }
+
     @discardableResult
     func run(studio request: StudioRunRequest) -> Bool {
-        if isRunning || !queuedRuns.isEmpty {
+        guard sessions.count < Self.maxConcurrentRuns, queuedRuns.isEmpty else {
             enqueue(request)
             return true
         }
@@ -840,12 +874,13 @@ final class MereRunController: ObservableObject {
 
     @discardableResult
     func run() -> Bool {
-        startRun(RunSpec(template: selectedTemplate, draft: draft, requestID: nil))
+        guard sessions.count < Self.maxConcurrentRuns else { return false }
+        return startRun(RunSpec(template: selectedTemplate, draft: draft, requestID: nil))
     }
 
     @discardableResult
     private func startRun(_ spec: RunSpec) -> Bool {
-        guard !isRunning else { return false }
+        guard sessions.count < Self.maxConcurrentRuns else { return false }
         if let shortCircuit = ensureCameraAccess(spec: spec) {
             return shortCircuit
         }
@@ -855,99 +890,100 @@ final class MereRunController: ObservableObject {
         let args = commandArguments(template: spec.template, draft: spec.draft)
         let display = launch.displayCommand(for: args)
         let expectedOutput = expectedOutputURL(template: spec.template, draft: spec.draft)
-        activeRunTemplateID = spec.template.id
-        activeRunPreview = display
-        activeRunRequestID = spec.requestID
-        activeExpectedOutput = expectedOutput
+        let initialStatus = spec.template.id == .modelPull ? "Downloading model" : "Running"
+        let session = RunSession(spec: spec, preview: display, expectedOutput: expectedOutput, status: initialStatus)
 
         if let message = spec.template.validationMessage(for: spec.draft) {
             append(message, stream: .system)
             status = message
-            lastExitCode = 64
-            finishPreflightFailure(exitCode: 64, outputText: message)
+            finishPreflightFailure(session: session, exitCode: 64, outputText: message)
             return false
         }
 
-        logs.removeAll()
-        stdoutBuffer.removeAll(keepingCapacity: true)
-        stderrBuffer.removeAll(keepingCapacity: true)
-        liveOutputText = ""
-        currentProgress = nil
-        lastOutputURL = nil
-        lastExitCode = nil
-
-        guard prepareOutputLocation(template: spec.template, draft: spec.draft) else {
-            lastExitCode = -1
-            finishPreflightFailure(exitCode: -1, outputText: capturedResultText(exitCode: -1) ?? status)
+        if let prepError = prepareOutputLocation(template: spec.template, draft: spec.draft) {
+            append(prepError, stream: .stderr)
+            status = "Output path unavailable"
+            finishPreflightFailure(session: session, exitCode: -1, outputText: prepError)
             return false
         }
 
-        status = spec.template.id == .modelPull ? "Downloading model" : "Running"
-        isRunning = true
-
-        append(display, stream: .system)
-        startOutputWatch(expectedOutput: expectedOutput)
+        sessions.append(session)
+        setForeground(session)
+        append(display, stream: .system, to: session)
+        startOutputWatch(for: session)
 
         do {
-            currentProcess = try processRunner.start(
+            session.process = try processRunner.start(
                 configuration: processConfiguration(
                     launch: launch,
                     args: args,
                     environmentTemplateID: spec.template.id,
                     environmentDraft: spec.draft
                 ),
-                stdout: { [weak self] text in
+                stdout: { [weak self, weak session] text in
                     Task { @MainActor in
-                        self?.append(text, stream: .stdout)
+                        guard let self, let session else { return }
+                        self.append(text, stream: .stdout, to: session)
                     }
                 },
-                stderr: { [weak self] text in
+                stderr: { [weak self, weak session] text in
                     Task { @MainActor in
-                        self?.append(text, stream: .stderr)
+                        guard let self, let session else { return }
+                        self.append(text, stream: .stderr, to: session)
                     }
                 },
-                termination: { [weak self] code in
+                termination: { [weak self, weak session] code in
                     Task { @MainActor in
-                        self?.finishRun(exitCode: code, expectedOutput: expectedOutput)
+                        guard let self, let session else { return }
+                        self.finishRun(session: session, exitCode: code)
                     }
                 }
             )
         } catch {
-            isRunning = false
-            status = "Failed to start"
-            append(error.localizedDescription, stream: .stderr)
-            if let activeRunTemplateID {
-                lastRunResult = MereRunRunResult(
-                    requestID: activeRunRequestID,
-                    templateID: activeRunTemplateID,
-                    commandPreview: activeRunPreview,
-                    exitCode: -1,
-                    outputURL: nil,
-                    outputText: capturedResultText(exitCode: -1)
-                )
-            }
-            activeRunTemplateID = nil
-            activeRunPreview = ""
-            activeRunRequestID = nil
-            activeExpectedOutput = nil
-            stopOutputWatch()
-            startNextQueuedRun()
+            append(error.localizedDescription, stream: .stderr, to: session)
+            finishRun(session: session, exitCode: -1)
             return false
         }
         return true
     }
 
     func cancel() {
-        guard isRunning else { return }
-        currentProcess?.terminate()
-        append("Termination requested.", stream: .system)
+        guard let session = foregroundSession, session.process != nil else { return }
+        session.process?.terminate()
+        append("Termination requested.", stream: .system, to: session)
+    }
+
+    /// Resets the published console fields to reflect `session` as the run the single-pane
+    /// console/canvas shows. Background sessions keep their own state and complete into the library.
+    private func setForeground(_ session: RunSession) {
+        foregroundSessionID = session.id
+        logs = session.logs
+        liveOutputText = session.liveOutputText
+        currentProgress = session.currentProgress
+        status = session.status
+        activeRunRequestID = session.spec.requestID
+        lastOutputURL = session.lastOutputURL
+        lastExitCode = session.exitCode
+        isRunning = session.exitCode == nil
+    }
+
+    /// Mirrors `session`'s live state into the published console fields while it is the foreground.
+    private func mirrorForeground(_ session: RunSession) {
+        guard session.id == foregroundSessionID else { return }
+        logs = session.logs
+        liveOutputText = session.liveOutputText
+        currentProgress = session.currentProgress
+        status = session.status
+        if let url = session.lastOutputURL { lastOutputURL = url }
     }
 
     /// Terminates every child process the app launched (active run, queued utility, and
     /// readiness probes, including a long-lived `api serve`). Called on app termination so
     /// child CLIs are never orphaned.
     func terminateAllProcesses() {
-        currentProcess?.terminate()
+        for session in sessions {
+            session.process?.terminate()
+        }
         for process in utilityProcesses.values {
             process.terminate()
         }
@@ -1033,23 +1069,23 @@ final class MereRunController: ObservableObject {
         NSWorkspace.shared.activateFileViewerSelecting([lastOutputURL])
     }
 
-    private func finishRun(exitCode: Int32, expectedOutput: URL?) {
-        currentProcess = nil
-        isRunning = false
-        stopOutputWatch()
-        currentProgress = nil
-        lastExitCode = exitCode
+    private func finishRun(session: RunSession, exitCode: Int32) {
+        session.outputWatchTask?.cancel()
+        session.outputWatchTask = nil
+        session.process = nil
+        session.exitCode = exitCode
+        session.currentProgress = nil
 
-        let detectedOutput = detectOutputURL(expected: expectedOutput, stdout: stdoutBuffer)
-        let outputText = capturedResultText(exitCode: exitCode)
-        lastOutputURL = detectedOutput
+        let detectedOutput = detectOutputURL(expected: session.expectedOutput, stdout: session.stdoutBuffer)
+        let outputText = capturedResultText(for: session, exitCode: exitCode)
+        if let detectedOutput { session.lastOutputURL = detectedOutput }
 
         if exitCode == 0 {
-            status = detectedOutput == nil ? "Completed" : "Completed: \(detectedOutput!.lastPathComponent)"
-            append("Completed with exit code 0.", stream: .system)
+            session.status = detectedOutput == nil ? "Completed" : "Completed: \(detectedOutput!.lastPathComponent)"
+            session.logs.append(LogLine(stream: .system, text: "Completed with exit code 0."))
         } else {
-            status = "Exited \(exitCode)"
-            append("Exited with code \(exitCode).", stream: .system)
+            session.status = "Exited \(exitCode)"
+            session.logs.append(LogLine(stream: .system, text: "Exited with code \(exitCode)."))
         }
 
         notifyCompletionIfNeeded(
@@ -1059,38 +1095,42 @@ final class MereRunController: ObservableObject {
                 : "Exited with code \(exitCode)"
         )
 
-        if let activeRunTemplateID {
-            lastRunResult = MereRunRunResult(
-                requestID: activeRunRequestID,
-                templateID: activeRunTemplateID,
-                commandPreview: activeRunPreview,
-                exitCode: exitCode,
-                outputURL: detectedOutput,
-                outputText: outputText
-            )
+        // Every run — foreground or background — publishes its result so the library (keyed by
+        // request id) records it. Only the foreground updates the shared console fields.
+        if session.id == foregroundSessionID {
+            logs = session.logs
+            liveOutputText = session.liveOutputText
+            currentProgress = nil
+            status = session.status
+            lastExitCode = exitCode
+            if let detectedOutput { lastOutputURL = detectedOutput }
+            isRunning = false
+            activeRunRequestID = nil
         }
-        activeRunTemplateID = nil
-        activeRunPreview = ""
-        activeRunRequestID = nil
-        activeExpectedOutput = nil
+
+        lastRunResult = MereRunRunResult(
+            requestID: session.spec.requestID,
+            templateID: session.spec.template.id,
+            commandPreview: session.preview,
+            exitCode: exitCode,
+            outputURL: detectedOutput,
+            outputText: outputText
+        )
+
+        sessions.removeAll { $0.id == session.id }
         startNextQueuedRun()
     }
 
-    private func finishPreflightFailure(exitCode: Int32, outputText: String?) {
-        guard let templateID = activeRunTemplateID else { return }
+    private func finishPreflightFailure(session: RunSession, exitCode: Int32, outputText: String?) {
+        lastExitCode = exitCode
         lastRunResult = MereRunRunResult(
-            requestID: activeRunRequestID,
-            templateID: templateID,
-            commandPreview: activeRunPreview,
+            requestID: session.spec.requestID,
+            templateID: session.spec.template.id,
+            commandPreview: session.preview,
             exitCode: exitCode,
             outputURL: nil,
             outputText: outputText
         )
-        activeRunTemplateID = nil
-        activeRunPreview = ""
-        activeRunRequestID = nil
-        activeExpectedOutput = nil
-        stopOutputWatch()
         startNextQueuedRun()
     }
 
@@ -1101,35 +1141,34 @@ final class MereRunController: ObservableObject {
     }
 
     private func startNextQueuedRun() {
-        guard !isRunning, currentProcess == nil, !queuedRuns.isEmpty else { return }
+        guard sessions.count < Self.maxConcurrentRuns, !queuedRuns.isEmpty else { return }
         let next = queuedRuns.removeFirst()
         queuedRunCount = queuedRuns.count
         _ = startRun(RunSpec(template: next.template, draft: next.draft, requestID: next.id))
     }
 
-    private func startOutputWatch(expectedOutput: URL?) {
-        stopOutputWatch()
-        outputWatchTask = Task { [weak self] in
+    private func startOutputWatch(for session: RunSession) {
+        session.outputWatchTask = Task { [weak self, weak session] in
             while !Task.isCancelled {
                 await MainActor.run {
-                    self?.publishDetectedOutputIfNeeded(expectedOutput: expectedOutput)
+                    guard let self, let session else { return }
+                    self.publishDetectedOutputIfNeeded(for: session)
                 }
                 try? await Task.sleep(for: .milliseconds(350))
             }
         }
     }
 
-    private func stopOutputWatch() {
-        outputWatchTask?.cancel()
-        outputWatchTask = nil
-    }
-
-    private func publishDetectedOutputIfNeeded(expectedOutput: URL?) {
-        guard isRunning else { return }
-        let detectedOutput = detectOutputURL(expected: expectedOutput, stdout: stdoutBuffer)
-        guard let detectedOutput, detectedOutput != lastOutputURL else { return }
-        lastOutputURL = detectedOutput
-        status = "Generated: \(detectedOutput.lastPathComponent)"
+    private func publishDetectedOutputIfNeeded(for session: RunSession) {
+        guard session.exitCode == nil else { return }
+        let detectedOutput = detectOutputURL(expected: session.expectedOutput, stdout: session.stdoutBuffer)
+        guard let detectedOutput, detectedOutput != session.lastOutputURL else { return }
+        session.lastOutputURL = detectedOutput
+        session.status = "Generated: \(detectedOutput.lastPathComponent)"
+        if session.id == foregroundSessionID {
+            lastOutputURL = detectedOutput
+            status = session.status
+        }
     }
 
     private func handleCLIInstall(_ outcome: CLIBootstrapInstallOutcome) {
@@ -1183,15 +1222,17 @@ final class MereRunController: ObservableObject {
         readinessProcesses[mode] = nil
     }
 
-    private func append(_ text: String, stream: LogStream) {
+    /// Appends a run's output to its session, mirroring into the published console fields when
+    /// that session is the foreground one.
+    private func append(_ text: String, stream: LogStream, to session: RunSession) {
         if stream == .stdout {
-            stdoutBuffer += text
-            trimStdoutBuffer()
-            liveOutputText = stdoutBuffer.replacingOccurrences(of: "\0", with: "")
-            publishDetectedOutputIfNeeded(expectedOutput: activeExpectedOutput)
+            session.stdoutBuffer += text
+            session.stdoutBuffer = Self.trimmed(session.stdoutBuffer, toByteLimit: Self.stdoutBufferByteLimit)
+            session.liveOutputText = session.stdoutBuffer.replacingOccurrences(of: "\0", with: "")
+            publishDetectedOutputIfNeeded(for: session)
         } else if stream == .stderr {
-            stderrBuffer += text
-            trimStderrBuffer()
+            session.stderrBuffer += text
+            session.stderrBuffer = Self.trimmed(session.stderrBuffer, toByteLimit: Self.stderrBufferByteLimit)
         }
 
         let normalized = text
@@ -1204,44 +1245,46 @@ final class MereRunController: ObservableObject {
             // Collapse repeated carriage-return progress updates into one structured value
             // instead of flooding the log with hundreds of lines.
             if let progress = StudioProgressParser.parse(trimmed) {
-                currentProgress = progress
+                session.currentProgress = progress
                 continue
             }
+            session.logs.append(LogLine(stream: stream, text: trimmed))
+        }
+
+        if session.logs.count > Self.logLineLimit {
+            session.logs.removeFirst(session.logs.count - Self.logLineLimit)
+        }
+        mirrorForeground(session)
+    }
+
+    /// Appends a controller-level message (install, camera, queue notices) directly to the
+    /// foreground console; these are not tied to any one run's session.
+    private func append(_ text: String, stream: LogStream) {
+        for line in text.replacingOccurrences(of: "\r", with: "\n").components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
             logs.append(LogLine(stream: stream, text: trimmed))
         }
-
-        if logs.count > 1200 {
-            logs.removeFirst(logs.count - 1200)
+        if logs.count > Self.logLineLimit {
+            logs.removeFirst(logs.count - Self.logLineLimit)
         }
     }
 
-    private func trimStdoutBuffer() {
-        guard stdoutBuffer.utf8.count > Self.stdoutBufferByteLimit else { return }
-        stdoutBuffer = String(decoding: stdoutBuffer.utf8.suffix(Self.stdoutBufferByteLimit), as: UTF8.self)
+    private static func trimmed(_ buffer: String, toByteLimit limit: Int) -> String {
+        guard buffer.utf8.count > limit else { return buffer }
+        return String(decoding: buffer.utf8.suffix(limit), as: UTF8.self)
     }
 
-    private func trimStderrBuffer() {
-        guard stderrBuffer.utf8.count > Self.stderrBufferByteLimit else { return }
-        stderrBuffer = String(decoding: stderrBuffer.utf8.suffix(Self.stderrBufferByteLimit), as: UTF8.self)
-    }
-
-    private func capturedStdoutText() -> String? {
-        let trimmed = stdoutBuffer
+    private func nonEmptyTrimmed(_ buffer: String) -> String? {
+        let trimmed = buffer
             .replacingOccurrences(of: "\0", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func capturedStderrText() -> String? {
-        let trimmed = stderrBuffer
-            .replacingOccurrences(of: "\0", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private func capturedResultText(exitCode: Int32) -> String? {
-        let stdout = capturedStdoutText()
-        guard exitCode != 0, let stderr = capturedStderrText() else {
+    private func capturedResultText(for session: RunSession, exitCode: Int32) -> String? {
+        let stdout = nonEmptyTrimmed(session.stdoutBuffer)
+        guard exitCode != 0, let stderr = nonEmptyTrimmed(session.stderrBuffer) else {
             return stdout
         }
 
@@ -1258,9 +1301,11 @@ final class MereRunController: ObservableObject {
         return URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
     }
 
-    private func prepareOutputLocation(template: CommandTemplate, draft: CommandDraft) -> Bool {
+    /// Ensures the run's output directory exists. Returns `nil` on success, or a diagnostic
+    /// message when the directory could not be created (so the caller can surface it per run).
+    private func prepareOutputLocation(template: CommandTemplate, draft: CommandDraft) -> String? {
         guard !draft.outputPath.isBlank else {
-            return true
+            return nil
         }
 
         let outputURL = URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
@@ -1271,16 +1316,14 @@ final class MereRunController: ObservableObject {
         case .directory:
             directoryURL = outputURL
         case .none:
-            return true
+            return nil
         }
 
         do {
             try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-            return true
+            return nil
         } catch {
-            status = "Output path unavailable"
-            append("Could not create output directory \(directoryURL.path): \(error.localizedDescription)", stream: .stderr)
-            return false
+            return "Could not create output directory \(directoryURL.path): \(error.localizedDescription)"
         }
     }
 

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -466,6 +466,9 @@ final class MereRunController: ObservableObject {
     private var stderrBuffer = ""
     private var activeRunTemplateID: CommandTemplateID?
     private var activeRunPreview = ""
+    /// The expected `--output` location of the run currently in flight. Captured from the run's
+    /// snapshot so live output detection never reads the editing state, which may have moved on.
+    private var activeExpectedOutput: URL?
     private var outputWatchTask: Task<Void, Never>?
     private var queuedRuns: [StudioRunRequest] = []
 
@@ -612,6 +615,15 @@ final class MereRunController: ObservableObject {
         }
     }
 
+    /// A captured snapshot of what to run, decoupled from the live editing state
+    /// (`selectedTemplate`/`draft`). A queued or Studio-initiated run executes from its own
+    /// snapshot, so it never overwrites whatever the user is currently editing in either surface.
+    private struct RunSpec {
+        let template: CommandTemplate
+        let draft: CommandDraft
+        let requestID: UUID?
+    }
+
     @discardableResult
     func run(studio request: StudioRunRequest) -> Bool {
         if isRunning || !queuedRuns.isEmpty {
@@ -619,9 +631,7 @@ final class MereRunController: ObservableObject {
             return true
         }
 
-        selectedTemplate = request.template
-        draft = request.draft
-        return startRun(requestID: request.id)
+        return startRun(RunSpec(template: request.template, draft: request.draft, requestID: request.id))
     }
 
     func checkReadiness(for mode: StudioMode, draft studioDraft: StudioDraft) {
@@ -780,26 +790,27 @@ final class MereRunController: ObservableObject {
 
     @discardableResult
     func run() -> Bool {
-        startRun(requestID: nil)
+        startRun(RunSpec(template: selectedTemplate, draft: draft, requestID: nil))
     }
 
     @discardableResult
-    private func startRun(requestID: UUID?) -> Bool {
+    private func startRun(_ spec: RunSpec) -> Bool {
         guard !isRunning else { return false }
-        if let shortCircuit = ensureCameraAccess(requestID: requestID) {
+        if let shortCircuit = ensureCameraAccess(spec: spec) {
             return shortCircuit
         }
         refreshResolvedCLI()
 
         let launch = CLIResolver.resolve(customPath: cliPath)
-        let args = commandArguments
+        let args = commandArguments(template: spec.template, draft: spec.draft)
         let display = launch.displayCommand(for: args)
-        let expectedOutput = expectedOutputURL()
-        activeRunTemplateID = selectedTemplate.id
+        let expectedOutput = expectedOutputURL(template: spec.template, draft: spec.draft)
+        activeRunTemplateID = spec.template.id
         activeRunPreview = display
-        activeRunRequestID = requestID
+        activeRunRequestID = spec.requestID
+        activeExpectedOutput = expectedOutput
 
-        if let message = selectedTemplate.validationMessage(for: draft) {
+        if let message = spec.template.validationMessage(for: spec.draft) {
             append(message, stream: .system)
             status = message
             lastExitCode = 64
@@ -815,13 +826,13 @@ final class MereRunController: ObservableObject {
         lastOutputURL = nil
         lastExitCode = nil
 
-        guard prepareOutputLocation() else {
+        guard prepareOutputLocation(template: spec.template, draft: spec.draft) else {
             lastExitCode = -1
             finishPreflightFailure(exitCode: -1, outputText: capturedResultText(exitCode: -1) ?? status)
             return false
         }
 
-        status = selectedTemplate.id == .modelPull ? "Downloading model" : "Running"
+        status = spec.template.id == .modelPull ? "Downloading model" : "Running"
         isRunning = true
 
         append(display, stream: .system)
@@ -829,7 +840,12 @@ final class MereRunController: ObservableObject {
 
         do {
             currentProcess = try processRunner.start(
-                configuration: processConfiguration(launch: launch, args: args),
+                configuration: processConfiguration(
+                    launch: launch,
+                    args: args,
+                    environmentTemplateID: spec.template.id,
+                    environmentDraft: spec.draft
+                ),
                 stdout: { [weak self] text in
                     Task { @MainActor in
                         self?.append(text, stream: .stdout)
@@ -863,6 +879,7 @@ final class MereRunController: ObservableObject {
             activeRunTemplateID = nil
             activeRunPreview = ""
             activeRunRequestID = nil
+            activeExpectedOutput = nil
             stopOutputWatch()
             startNextQueuedRun()
             return false
@@ -897,8 +914,8 @@ final class MereRunController: ObservableObject {
     /// Returns a `Bool` to short-circuit `startRun` when access is pending (async request
     /// will retry) or denied. The CLI captures the camera as a child of this app bundle,
     /// so TCC attributes access here and the usage string lives in the app's Info.plist.
-    private func ensureCameraAccess(requestID: UUID?) -> Bool? {
-        guard requiresCameraAccess(selectedTemplate.id) else { return nil }
+    private func ensureCameraAccess(spec: RunSpec) -> Bool? {
+        guard requiresCameraAccess(spec.template.id) else { return nil }
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .authorized:
             return nil
@@ -907,7 +924,7 @@ final class MereRunController: ObservableObject {
                 Task { @MainActor in
                     guard let self else { return }
                     if granted {
-                        _ = self.startRun(requestID: requestID)
+                        _ = self.startRun(spec)
                     } else {
                         self.reportCameraDenied()
                     }
@@ -1005,6 +1022,7 @@ final class MereRunController: ObservableObject {
         activeRunTemplateID = nil
         activeRunPreview = ""
         activeRunRequestID = nil
+        activeExpectedOutput = nil
         startNextQueuedRun()
     }
 
@@ -1021,6 +1039,7 @@ final class MereRunController: ObservableObject {
         activeRunTemplateID = nil
         activeRunPreview = ""
         activeRunRequestID = nil
+        activeExpectedOutput = nil
         stopOutputWatch()
         startNextQueuedRun()
     }
@@ -1035,9 +1054,7 @@ final class MereRunController: ObservableObject {
         guard !isRunning, currentProcess == nil, !queuedRuns.isEmpty else { return }
         let next = queuedRuns.removeFirst()
         queuedRunCount = queuedRuns.count
-        selectedTemplate = next.template
-        draft = next.draft
-        _ = startRun(requestID: next.id)
+        _ = startRun(RunSpec(template: next.template, draft: next.draft, requestID: next.id))
     }
 
     private func startOutputWatch(expectedOutput: URL?) {
@@ -1121,7 +1138,7 @@ final class MereRunController: ObservableObject {
             stdoutBuffer += text
             trimStdoutBuffer()
             liveOutputText = stdoutBuffer.replacingOccurrences(of: "\0", with: "")
-            publishDetectedOutputIfNeeded(expectedOutput: expectedOutputURL())
+            publishDetectedOutputIfNeeded(expectedOutput: activeExpectedOutput)
         } else if stream == .stderr {
             stderrBuffer += text
             trimStderrBuffer()
@@ -1184,21 +1201,21 @@ final class MereRunController: ObservableObject {
         return stderr
     }
 
-    private func expectedOutputURL() -> URL? {
-        guard selectedTemplate.outputKind != .none, !draft.outputPath.isBlank else {
+    private func expectedOutputURL(template: CommandTemplate, draft: CommandDraft) -> URL? {
+        guard template.outputKind != .none, !draft.outputPath.isBlank else {
             return nil
         }
         return URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
     }
 
-    private func prepareOutputLocation() -> Bool {
+    private func prepareOutputLocation(template: CommandTemplate, draft: CommandDraft) -> Bool {
         guard !draft.outputPath.isBlank else {
             return true
         }
 
         let outputURL = URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
         let directoryURL: URL
-        switch selectedTemplate.outputKind {
+        switch template.outputKind {
         case .file:
             directoryURL = outputURL.deletingLastPathComponent()
         case .directory:

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -440,6 +440,17 @@ final class MereRunController: ObservableObject {
     @Published var workingDirectory: String {
         didSet { UserDefaults.standard.set(workingDirectory, forKey: Keys.workingDirectory) }
     }
+    // The runtime server the Studio talks to for model load/unload. Owned here — and persisted —
+    // rather than derived from a transient command draft, so requests target the actual runtime.
+    @Published var runtimeHost: String {
+        didSet { UserDefaults.standard.set(runtimeHost, forKey: Keys.runtimeHost) }
+    }
+    @Published var runtimePort: Int {
+        didSet { UserDefaults.standard.set(runtimePort, forKey: Keys.runtimePort) }
+    }
+    @Published var runtimeAPIKey: String {
+        didSet { UserDefaults.standard.set(runtimeAPIKey, forKey: Keys.runtimeAPIKey) }
+    }
     @Published private(set) var liveOutputText = ""
     @Published private(set) var currentProgress: StudioRunProgress?
     @Published private(set) var cliVersion: String?
@@ -455,6 +466,9 @@ final class MereRunController: ObservableObject {
         static let modelsRoot = "mererun.app.modelsRoot"
         static let hubCache = "mererun.app.hubCache"
         static let workingDirectory = "mererun.app.workingDirectory"
+        static let runtimeHost = "mererun.app.runtimeHost"
+        static let runtimePort = "mererun.app.runtimePort"
+        static let runtimeAPIKey = "mererun.app.runtimeAPIKey"
     }
 
     private let processRunner: MereRunProcessRunning
@@ -508,6 +522,9 @@ final class MereRunController: ObservableObject {
         hubCache = UserDefaults.standard.string(forKey: Keys.hubCache) ?? ""
         workingDirectory = UserDefaults.standard.string(forKey: Keys.workingDirectory)
             ?? FileManager.default.homeDirectoryForCurrentUser.path
+        runtimeHost = UserDefaults.standard.string(forKey: Keys.runtimeHost) ?? "127.0.0.1"
+        runtimePort = (UserDefaults.standard.object(forKey: Keys.runtimePort) as? Int) ?? 8080
+        runtimeAPIKey = UserDefaults.standard.string(forKey: Keys.runtimeAPIKey) ?? ""
         if resolvesCLIOnInit {
             refreshResolvedCLI()
         }
@@ -519,6 +536,25 @@ final class MereRunController: ObservableObject {
         lastOutputURL = nil
         lastExitCode = nil
         status = "Idle"
+    }
+
+    /// URL on the runtime server (model load/unload) for `path`, built from the owned
+    /// host/port rather than a transient command draft.
+    func runtimeURL(path: String) -> URL {
+        let host = runtimeHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let safeHost = host.isEmpty ? "127.0.0.1" : host
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = safeHost
+        components.port = runtimePort
+        components.path = path
+        return components.url ?? URL(string: "http://127.0.0.1:8080\(path)")!
+    }
+
+    /// The `Authorization` header value for runtime-server requests, or nil when no key is set.
+    var runtimeAuthorizationHeader: String? {
+        let key = runtimeAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return key.isEmpty ? nil : "Bearer \(key)"
     }
 
     func refreshResolvedCLI() {

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -1219,10 +1219,25 @@ final class MereRunController: ObservableObject {
 
     private func detectOutputURL(expected: URL?, stdout: String) -> URL? {
         let fm = FileManager.default
+
+        // 1. The explicit `--output` path the request asked for, once it has landed.
         if let expected, fm.fileExists(atPath: expected.path) {
             return expected
         }
 
+        // 2. Honor the CLI's stdout contract: media commands print the artifact path as a bare
+        //    line and directory/OCR commands as `input -> output` pairs, most-recent first.
+        //    This is the only path that detects `input -> output` outputs at all (a whole pair
+        //    line never resolves as a file), and it targets the result line rather than guessing.
+        for candidate in StudioResultParser.outputPaths(fromStdout: stdout) {
+            let expanded = NSString(string: candidate).expandingTildeInPath
+            if fm.fileExists(atPath: expanded) {
+                return URL(fileURLWithPath: expanded)
+            }
+        }
+
+        // 3. Fallback for commands without a clean path contract: the last trailing stdout
+        //    line that happens to resolve to an existing file (e.g. a relative path).
         let candidates = stdout
             .components(separatedBy: .newlines)
             .compactMap { line -> String? in

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -1174,6 +1174,29 @@ struct MereRunSettingsView: View {
                         .foregroundStyle(MereRunTheme.textMuted)
                 }
             }
+            EditorSection("Runtime server") {
+                HStack(spacing: 10) {
+                    TextField("Host", text: $controller.runtimeHost)
+                        .textFieldStyle(.plain)
+                        .font(MereRunTheme.bodyFont)
+                        .padding(10)
+                        .merePanel()
+                    TextField("Port", value: $controller.runtimePort, format: .number.grouping(.never))
+                        .textFieldStyle(.plain)
+                        .font(MereRunTheme.bodyFont)
+                        .frame(width: 90)
+                        .padding(10)
+                        .merePanel()
+                    SecureField("API key (optional)", text: $controller.runtimeAPIKey)
+                        .textFieldStyle(.plain)
+                        .font(MereRunTheme.bodyFont)
+                        .padding(10)
+                        .merePanel()
+                }
+                Text("Where the Models panel sends load/unload requests for the running runtime (`mere.run api serve`).")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
             EditorSection("Install") {
                 HStack(spacing: 10) {
                     Button {

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -595,10 +595,10 @@ struct StudioModelsSheet: View {
         loadingRuntimeID = row.id
         statusMessage = "\(action.capitalized)ing \(row.id)..."
         do {
-            var request = URLRequest(url: runtimeURL(for: row, action: action))
+            var request = URLRequest(url: controller.runtimeURL(path: "/runtime/models/\(row.id)/\(action)"))
             request.httpMethod = "POST"
-            if !controller.draft.apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                request.setValue("Bearer \(controller.draft.apiKey)", forHTTPHeaderField: "Authorization")
+            if let authorization = controller.runtimeAuthorizationHeader {
+                request.setValue(authorization, forHTTPHeaderField: "Authorization")
             }
             let (_, response) = try await URLSession.shared.data(for: request)
             let http = response as? HTTPURLResponse
@@ -611,17 +611,6 @@ struct StudioModelsSheet: View {
             statusMessage = "Runtime server is not reachable"
         }
         loadingRuntimeID = nil
-    }
-
-    private func runtimeURL(for row: StudioModelInventoryRow, action: String) -> URL {
-        let host = controller.draft.host.trimmingCharacters(in: .whitespacesAndNewlines)
-        let safeHost = host.isEmpty ? "127.0.0.1" : host
-        var components = URLComponents()
-        components.scheme = "http"
-        components.host = safeHost
-        components.port = controller.draft.port
-        components.path = "/runtime/models/\(row.id)/\(action)"
-        return components.url ?? URL(string: "http://127.0.0.1:8080/runtime/models/\(row.id)/\(action)")!
     }
 
     @MainActor

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -685,6 +685,39 @@ enum StudioProgressParser {
     }
 }
 
+/// Extracts the output-artifact path a `mere.run` command reports on stdout.
+///
+/// The CLI's contract (AGENTS.md: stdout is machine-readable, stderr is diagnostic) is that
+/// media commands print the artifact path as a bare line, e.g. `/Users/me/out.png`, while the
+/// directory/OCR commands print `input -> output` pairs. Progress and logs go to stderr, so a
+/// media command's stdout is effectively just its result path(s). Transcription prints
+/// transcript text and reports no path here — the explicit `--output` location covers it.
+enum StudioResultParser {
+    /// Output-artifact paths parsed from `stdout`, most-recently-emitted first.
+    static func outputPaths(fromStdout stdout: String) -> [String] {
+        var paths: [String] = []
+        let lines = stdout
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        for line in lines.reversed() {
+            if let separator = line.range(of: " -> ") ?? line.range(of: " → ") {
+                // `input -> output` pair (vision ocr/caption): the artifact is the right side.
+                let rhs = String(line[separator.upperBound...]).trimmingCharacters(in: .whitespaces)
+                if isPathLike(rhs) { paths.append(rhs) }
+            } else if isPathLike(line) {
+                paths.append(line)
+            }
+        }
+        return paths
+    }
+
+    /// True when a line is an absolute or tilde-rooted filesystem path rather than prose.
+    static func isPathLike(_ candidate: String) -> Bool {
+        candidate.hasPrefix("/") || candidate.hasPrefix("~/")
+    }
+}
+
 enum ModelReadinessParser {
     static func state(for modelID: String, modelListOutput: String) -> ModelReadinessState {
         guard !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/StudioCompletion.md
+++ b/StudioCompletion.md
@@ -39,6 +39,14 @@ Effort key: **S** ≈ 1–2 days · **M** ≈ 3–5 days · **L** ≈ 1–2 week
 
 ### WS-1 — Run engine & CLI contract (Phase 1) · XL
 
+> **✅ Complete** (PR #93). All six items landed: contract-driven output detection
+> (`StudioResultParser`, 1.1), per-run `RunSession` engine with up to `maxConcurrentRuns`
+> concurrent runs and isolated logs (1.2 + 1.4), editing/running decoupled via an immutable
+> `RunSpec` snapshot (1.3), owned runtime-server endpoint (1.5), and injected
+> filesystem/CLI-locator test seams (1.6). The structured `RunResult.swift`/`RunCoordinator.swift`
+> split below was folded into `MereRunController`; a multi-pane UI to *view* background runs
+> (vs. the foreground console) remains a Phase-4 polish item.
+
 The single-run, heuristic-output controller is the structural ceiling. This must precede
 deep feature work that assumes concurrency and reliable results.
 

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -294,6 +294,50 @@ final class MereRunControllerTests: XCTestCase {
         XCTAssertNil(controller.runtimeAuthorizationHeader)
     }
 
+    func testDetectOutputURLPrefersStdoutContractPath() {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/out/render.png"]
+        let controller = MereRunController(
+            processRunner: RecordingProcessRunner(), fileSystem: probe, resolvesCLIOnInit: false
+        )
+        let detected = controller.detectOutputURL(expected: nil, stdout: "loading model\n/out/render.png\n")
+        XCTAssertEqual(detected?.path, "/out/render.png")
+    }
+
+    func testDetectOutputURLResolvesArrowPairRightSide() {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/out/page.txt"]
+        let controller = MereRunController(
+            processRunner: RecordingProcessRunner(), fileSystem: probe, resolvesCLIOnInit: false
+        )
+        // A whole "in -> out" line is never a path; only the contract parser resolves this.
+        let detected = controller.detectOutputURL(expected: nil, stdout: "/in/page.png -> /out/page.txt\n")
+        XCTAssertEqual(detected?.path, "/out/page.txt")
+    }
+
+    func testDetectOutputURLPrefersExpectedOutputWhenPresent() {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/want/out.wav", "/other/x.wav"]
+        let controller = MereRunController(
+            processRunner: RecordingProcessRunner(), fileSystem: probe, resolvesCLIOnInit: false
+        )
+        let detected = controller.detectOutputURL(
+            expected: URL(fileURLWithPath: "/want/out.wav"), stdout: "/other/x.wav\n"
+        )
+        XCTAssertEqual(detected?.path, "/want/out.wav")
+    }
+
+    func testCLIResolverInjectionIsUsedForResolution() {
+        let stubLaunch = MereRunLaunch.executable(URL(fileURLWithPath: "/stub/mere.run"))
+        let controller = MereRunController(
+            processRunner: RecordingProcessRunner(),
+            cliResolver: { _ in stubLaunch },
+            resolvesCLIOnInit: false
+        )
+        controller.refreshResolvedCLI()
+        XCTAssertEqual(controller.resolvedCLI, "/stub/mere.run")
+    }
+
     func testRunningStudioRunPublishesOutputBeforeProcessExits() async throws {
         let runner = RecordingProcessRunner()
         let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
@@ -392,4 +436,9 @@ private final class RecordingProcess: MereRunRunningProcess {
     func terminate() {
         terminateCallCount += 1
     }
+}
+
+private final class StubFileProbe: MereRunFileProbing {
+    var existingPaths: Set<String> = []
+    func fileExists(atPath path: String) -> Bool { existingPaths.contains(path) }
 }

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -271,6 +271,29 @@ final class MereRunControllerTests: XCTestCase {
         XCTAssertEqual(controller.draft.extraArguments, "user-is-editing-this")
     }
 
+    func testRuntimeEndpointIsOwnedNotDerivedFromDraft() {
+        let controller = MereRunController(processRunner: RecordingProcessRunner(), resolvesCLIOnInit: false)
+        controller.runtimeHost = "example.local"
+        controller.runtimePort = 9000
+        controller.runtimeAPIKey = "secret"
+        // The transient command draft must not influence the runtime endpoint.
+        controller.draft.host = "10.0.0.1"
+        controller.draft.port = 1234
+        controller.draft.apiKey = "draft-key"
+
+        let url = controller.runtimeURL(path: "/runtime/models/foo/load")
+        XCTAssertEqual(url.absoluteString, "http://example.local:9000/runtime/models/foo/load")
+        XCTAssertEqual(controller.runtimeAuthorizationHeader, "Bearer secret")
+    }
+
+    func testRuntimeEndpointFallsBackAndOmitsEmptyAuth() {
+        let controller = MereRunController(processRunner: RecordingProcessRunner(), resolvesCLIOnInit: false)
+        controller.runtimeHost = "   "
+        controller.runtimeAPIKey = "  "
+        XCTAssertEqual(controller.runtimeURL(path: "/x").host, "127.0.0.1")
+        XCTAssertNil(controller.runtimeAuthorizationHeader)
+    }
+
     func testRunningStudioRunPublishesOutputBeforeProcessExits() async throws {
         let runner = RecordingProcessRunner()
         let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -207,44 +207,76 @@ final class MereRunControllerTests: XCTestCase {
         )
     }
 
-    func testStudioRunsQueueBehindActiveProcess() async throws {
+    func testStudioRunsExecuteConcurrentlyUpToCapThenQueue() async throws {
         let runner = RecordingProcessRunner()
         let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
         controller.cliPath = "/usr/bin/true"
         let template = try XCTUnwrap(CommandCatalog.template(id: .custom))
-        var firstDraft = template.defaultDraft()
-        firstDraft.extraArguments = "first"
-        var secondDraft = template.defaultDraft()
-        secondDraft.extraArguments = "second"
-        let first = StudioRunRequest(mode: .chat, templateID: .custom, template: template, draft: firstDraft)
-        let second = StudioRunRequest(mode: .code, templateID: .custom, template: template, draft: secondDraft)
+        func request(_ arg: String, mode: StudioMode) -> StudioRunRequest {
+            var draft = template.defaultDraft()
+            draft.extraArguments = arg
+            return StudioRunRequest(mode: mode, templateID: .custom, template: template, draft: draft)
+        }
+        XCTAssertEqual(MereRunController.maxConcurrentRuns, 2)
+        let first = request("first", mode: .chat)
+        let second = request("second", mode: .code)
+        let third = request("third", mode: .chat)
 
+        // Up to maxConcurrentRuns run at once; the foreground follows the latest started.
         XCTAssertTrue(controller.run(studio: first))
-        XCTAssertTrue(controller.isRunning)
-        XCTAssertEqual(controller.activeRunRequestID, first.id)
-        XCTAssertEqual(runner.starts.count, 1)
-
         XCTAssertTrue(controller.run(studio: second))
-        XCTAssertEqual(controller.queuedRunCount, 1)
-        XCTAssertEqual(runner.starts.count, 1)
+        XCTAssertEqual(runner.starts.count, 2)
+        XCTAssertEqual(controller.queuedRunCount, 0)
+        XCTAssertTrue(controller.isRunning)
+        XCTAssertEqual(controller.activeRunRequestID, second.id)
 
+        // A run beyond the cap queues.
+        XCTAssertTrue(controller.run(studio: third))
+        XCTAssertEqual(runner.starts.count, 2)
+        XCTAssertEqual(controller.queuedRunCount, 1)
+
+        // A background run completing still publishes its result (the library keys by request id)
+        // and frees a slot, so the queued run starts.
         runner.starts[0].termination(0)
         await Task.yield()
         await Task.yield()
 
         XCTAssertEqual(controller.lastRunResult?.requestID, first.id)
-        XCTAssertEqual(controller.activeRunRequestID, second.id)
         XCTAssertEqual(controller.queuedRunCount, 0)
+        XCTAssertEqual(runner.starts.count, 3)
+        XCTAssertEqual(runner.starts[2].configuration.arguments, ["third"])
+    }
+
+    func testConcurrentRunsKeepIsolatedOutputAndResults() async throws {
+        let runner = RecordingProcessRunner()
+        let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
+        controller.cliPath = "/usr/bin/true"
+        let template = try XCTUnwrap(CommandCatalog.template(id: .custom))
+        func request(_ arg: String) -> StudioRunRequest {
+            var draft = template.defaultDraft()
+            draft.extraArguments = arg
+            return StudioRunRequest(mode: .chat, templateID: .custom, template: template, draft: draft)
+        }
+        let background = request("background")
+        let foreground = request("foreground")
+
+        XCTAssertTrue(controller.run(studio: background))   // starts[0]
+        XCTAssertTrue(controller.run(studio: foreground))   // starts[1], now the foreground
         XCTAssertEqual(runner.starts.count, 2)
-        XCTAssertEqual(runner.starts[1].configuration.arguments, ["second"])
 
-        runner.starts[1].termination(0)
+        runner.starts[0].stdout("background-only-line\n")
+        runner.starts[1].stdout("foreground-line\n")
+        await Task.yield()
+
+        // The console shows only the foreground run's output; the background run's is isolated.
+        XCTAssertTrue(controller.logs.contains { $0.text == "foreground-line" })
+        XCTAssertFalse(controller.logs.contains { $0.text == "background-only-line" })
+
+        // The background run still publishes its own result, keyed by its request id.
+        runner.starts[0].termination(0)
         await Task.yield()
         await Task.yield()
-
-        XCTAssertFalse(controller.isRunning)
-        XCTAssertNil(controller.activeRunRequestID)
-        XCTAssertEqual(controller.lastRunResult?.requestID, second.id)
+        XCTAssertEqual(controller.lastRunResult?.requestID, background.id)
     }
 
     func testStudioRunDoesNotClobberEditingState() throws {

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -247,6 +247,30 @@ final class MereRunControllerTests: XCTestCase {
         XCTAssertEqual(controller.lastRunResult?.requestID, second.id)
     }
 
+    func testStudioRunDoesNotClobberEditingState() throws {
+        let runner = RecordingProcessRunner()
+        let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
+        controller.cliPath = "/usr/bin/true"
+
+        // The user is editing a template/draft in the Advanced surface.
+        let editing = try XCTUnwrap(CommandCatalog.template(id: .custom))
+        var editingDraft = editing.defaultDraft()
+        editingDraft.extraArguments = "user-is-editing-this"
+        controller.selectedTemplate = editing
+        controller.draft = editingDraft
+
+        // A Studio run of a different draft starts from its own snapshot.
+        var runDraft = editing.defaultDraft()
+        runDraft.extraArguments = "studio-run"
+        let request = StudioRunRequest(mode: .chat, templateID: .custom, template: editing, draft: runDraft)
+        XCTAssertTrue(controller.run(studio: request))
+
+        // It runs with the request's arguments...
+        XCTAssertEqual(runner.starts.first?.configuration.arguments, ["studio-run"])
+        // ...while the user's editing state is left untouched.
+        XCTAssertEqual(controller.draft.extraArguments, "user-is-editing-this")
+    }
+
     func testRunningStudioRunPublishesOutputBeforeProcessExits() async throws {
         let runner = RecordingProcessRunner()
         let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -174,6 +174,34 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertNil(StudioProgressParser.parse("[info] starting up"))
     }
 
+    func testStudioResultParserExtractsBarePathFromStdout() {
+        // Media commands print only the artifact path on stdout (diagnostics go to stderr).
+        let stdout = "/Users/me/Documents/render.png\n"
+        XCTAssertEqual(StudioResultParser.outputPaths(fromStdout: stdout), ["/Users/me/Documents/render.png"])
+    }
+
+    func testStudioResultParserReturnsMostRecentPathFirst() {
+        let stdout = "/tmp/first.wav\n/tmp/second.wav\n"
+        XCTAssertEqual(
+            StudioResultParser.outputPaths(fromStdout: stdout),
+            ["/tmp/second.wav", "/tmp/first.wav"]
+        )
+    }
+
+    func testStudioResultParserExtractsRightSideOfArrowPair() {
+        // vision ocr/caption print `input -> output`; the artifact is the right-hand side.
+        let stdout = "/in/page.png -> /out/page.txt\n"
+        XCTAssertEqual(StudioResultParser.outputPaths(fromStdout: stdout), ["/out/page.txt"])
+        let unicodeArrow = "/in/page.png → /out/page.md\n"
+        XCTAssertEqual(StudioResultParser.outputPaths(fromStdout: unicodeArrow), ["/out/page.md"])
+    }
+
+    func testStudioResultParserIgnoresNonPathLines() {
+        // Transcription emits prose on stdout, not a path — nothing should be parsed.
+        let stdout = "This is the transcript of the audio file.\nSecond sentence here.\n"
+        XCTAssertTrue(StudioResultParser.outputPaths(fromStdout: stdout).isEmpty)
+    }
+
     func testSfxStudioModeBuildsGenerateCommand() throws {
         var draft = StudioDraft()
         draft.reset(for: .sfx)


### PR DESCRIPTION
## Summary

**Phase 1 — the macOS Studio engine refactor — complete.** All six WS-1 items from
`StudioCompletion.md`, landed as green, independently reviewable commits.

## Commits

- **WS-1.1 — contract-driven output detection.** `StudioResultParser` honors the CLI's stdout
  contract (bare artifact path; `input -> output` pairs) before falling back to the old scan.
  Fixes vision ocr/caption detection, which never worked (a whole pair line is never a path).
- **WS-1.3 — decouple editing from running.** Runs execute from an immutable `RunSpec` snapshot,
  so a queued or Studio-initiated run never clobbers the draft you're editing.
- **WS-1.5 — runtime-server endpoint ownership.** The controller owns persisted
  runtimeHost/port/apiKey (+ a Settings section); the Models panel no longer derives the endpoint
  from a transient command draft.
- **WS-1.6 — test seams.** Injected `MereRunFileProbing` + CLI-locator closure; output detection
  and resolution are unit-testable without touching disk or environment.
- **WS-1.2 + WS-1.4 — concurrent per-run session engine.** `RunSession` objects own isolated
  process / stdout+stderr buffers / logs / progress / output. Up to `maxConcurrentRuns` (2) run at
  once; the rest queue. The foreground session mirrors into the published console (single-pane UI
  unchanged) while background runs stay isolated and still publish their results — the Studio
  library already keys by request id, so each lands in the right item.

## Verification

- `swiftlint --strict` clean · full build · **879 tests / 41 skipped / 0 failures** (`check.sh` exit 0)
- +15 tests across the five increments: result parser, editing/running decouple, runtime endpoint
  ownership, detection/resolution seams, and concurrency + per-run isolation.

## Scope note

True concurrency lands in the **engine** (exercised via the process-runner test harness). A
multi-pane UI to actively *view* a background run's live console (vs. the foreground one) is a
Phase-4 polish item; today background runs complete into the library by request id. The cap is a
single conservative constant (`maxConcurrentRuns = 2`) since ML inference is memory-heavy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QA5hhtDTCaSAHgfYgh56kM
