### PR TITLE
Phase 3 — Conversational depth & CLI feature parity (WS-2 + WS-3)

### DIFF
--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -47,10 +47,21 @@ enum CommandTemplateID: String, CaseIterable {
     case visionTrack
     case visionTrackLive
     case musicGenerate
+    case musicAnalyze
+    case musicRealtime
     case videoGenerate
     case videoExportLatents
     case sfxGenerate
     case sfxVideo
+    case sfxAEEncode
+    case sfxAEDecode
+    case sfxClapScore
+    case sfxConditionText
+    case modelBenchmark
+    case pluginList
+    case pluginInstall
+    case pluginDoctor
+    case openWebui
     case apiServe
     case custom
 }
@@ -128,6 +139,12 @@ struct CommandDraft: Equatable {
     var refAudioPath = ""
     var refText = ""
     var saveProfileName = ""
+    // Vision chat (vision-capable chat models) and the agentic tool loop for `text chat`.
+    var imagePath = ""
+    var tools = ""
+    var toolLoop = false
+    var allowShellExec = false
+    var sandboxDir = ""
     var setupMode = "agent"
     var agentModel = "tier"
     var quiet = false
@@ -378,8 +395,13 @@ struct CommandTemplate: Identifiable, Equatable {
         case .textChat:
             args = ["text", "chat", "--prompt", draft.prompt]
             if !draft.secondaryText.isBlank { args += ["--system", draft.secondaryText] }
+            if !draft.imagePath.isBlank { args += ["--image", draft.imagePath] }
             args += ["--max-tokens", String(draft.maxTokens), "--temperature", format(draft.temperature), "--top-p", format(draft.topP)]
             if !draft.model.isBlank { args += ["--model", draft.model] }
+            if !draft.tools.isBlank { args += ["--tools", draft.tools] }
+            if draft.toolLoop { args.append("--tool-loop") }
+            if draft.allowShellExec { args.append("--allow-shell-exec") }
+            if !draft.sandboxDir.isBlank { args += ["--sandbox-dir", draft.sandboxDir] }
             if draft.stream { args.append("--stream") }
             if draft.all { args.append("--thinking") }
             if draft.force { args.append("--stats") }
@@ -532,6 +554,66 @@ struct CommandTemplate: Identifiable, Equatable {
             args += ["--duration", format(draft.durationSeconds), "--steps", String(draft.steps)]
             if !draft.seed.isBlank { args += ["--seed", draft.seed] }
             if draft.quiet { args.append("--quiet") }
+
+        case .musicAnalyze:
+            args = ["music", "analyze", draft.inputPath]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.all { args.append("--include-raw-lm") }
+            if draft.quiet { args.append("--quiet") }
+
+        case .musicRealtime:
+            args = ["music", "realtime", draft.prompt]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            args += ["--duration", format(draft.durationSeconds)]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            // GUI subprocesses have no audio device contract or stdin TTY, so capture to the
+            // output WAV without live playback; interactive steering stays CLI-only.
+            args.append("--no-play")
+            if draft.quiet { args.append("--quiet") }
+
+        case .sfxAEEncode:
+            args = ["sfx", "ae", "encode", draft.inputPath]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .sfxAEDecode:
+            args = ["sfx", "ae", "decode", draft.inputPath]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .sfxClapScore:
+            args = ["sfx", "clap", "score", draft.prompt, draft.inputPath]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .sfxConditionText:
+            args = ["sfx", "condition", "text", draft.prompt]
+            if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.quiet { args.append("--quiet") }
+
+        case .modelBenchmark:
+            args = ["model", "benchmark", "q36-mtp"]
+            if !draft.model.isBlank { args += ["--model", draft.model] }
+            if draft.all { args.append("--json") }
+
+        case .pluginList:
+            args = ["plugin", "list"]
+            if draft.all { args.append("--json") }
+
+        case .pluginInstall:
+            args = ["plugin", "install", draft.prompt]
+            if draft.force { args.append("--yes") }
+
+        case .pluginDoctor:
+            args = ["plugin", "doctor", draft.prompt]
+
+        case .openWebui:
+            args = ["open-webui", "quickstart", "--host", draft.host, "--port", String(draft.port)]
+            if !draft.model.isBlank { args += ["--text-model", draft.model] }
+            if !draft.apiKey.isBlank { args += ["--api-key", draft.apiKey] }
 
         case .apiServe:
             args = ["api", "serve", "--host", draft.host, "--port", String(draft.port), "--engine", draft.engine]
@@ -870,6 +952,104 @@ enum CommandCatalog {
             inputKind: .video,
             outputKind: .file("wav"),
             defaultPrompt: "footsteps on gravel"
+        ),
+        CommandTemplate(
+            id: .musicAnalyze,
+            category: .media,
+            title: "Analyze music",
+            subtitle: "ACE-Step audio understanding (JSON)",
+            systemImage: "waveform.badge.magnifyingglass",
+            inputKind: .audio,
+            defaultModel: "music-acestep"
+        ),
+        CommandTemplate(
+            id: .musicRealtime,
+            category: .media,
+            title: "Realtime music",
+            subtitle: "Magenta RT2 capture to WAV",
+            systemImage: "dot.radiowaves.left.and.right",
+            promptLabel: "Prompt",
+            outputKind: .file("wav"),
+            defaultPrompt: "warm ambient pads with a slow build"
+        ),
+        CommandTemplate(
+            id: .sfxAEEncode,
+            category: .sfx,
+            title: "Autoencoder · encode",
+            subtitle: "Audio → Woosh latents (.npy)",
+            systemImage: "arrow.down.doc",
+            inputKind: .audio,
+            outputKind: .file("npy")
+        ),
+        CommandTemplate(
+            id: .sfxAEDecode,
+            category: .sfx,
+            title: "Autoencoder · decode",
+            subtitle: "Woosh latents (.npy) → audio",
+            systemImage: "arrow.up.doc",
+            inputKind: .file([.data]),
+            outputKind: .file("wav")
+        ),
+        CommandTemplate(
+            id: .sfxClapScore,
+            category: .sfx,
+            title: "CLAP score",
+            subtitle: "Score audio against a prompt (JSON)",
+            systemImage: "checkmark.seal",
+            promptLabel: "Prompt",
+            inputKind: .audio,
+            defaultPrompt: "a heavy wooden door creaking open"
+        ),
+        CommandTemplate(
+            id: .sfxConditionText,
+            category: .sfx,
+            title: "Conditioning · text",
+            subtitle: "Export Woosh conditioning tensors",
+            systemImage: "function",
+            promptLabel: "Prompt",
+            outputKind: .file("safetensors"),
+            defaultPrompt: "a heavy wooden door creaking open"
+        ),
+        CommandTemplate(
+            id: .modelBenchmark,
+            category: .models,
+            title: "Benchmark",
+            subtitle: "Focused Qwen3.6 MTP benchmark",
+            systemImage: "speedometer",
+            defaultModel: "text-chat-q36-nano"
+        ),
+        CommandTemplate(
+            id: .pluginList,
+            category: .server,
+            title: "Plugins",
+            subtitle: "List official companion plugins",
+            systemImage: "puzzlepiece.extension"
+        ),
+        CommandTemplate(
+            id: .pluginInstall,
+            category: .server,
+            title: "Install plugin",
+            subtitle: "Install an official plugin by id",
+            systemImage: "square.and.arrow.down",
+            promptLabel: "Plugin id",
+            defaultPrompt: "mere-runpod"
+        ),
+        CommandTemplate(
+            id: .pluginDoctor,
+            category: .server,
+            title: "Plugin doctor",
+            subtitle: "Run an installed plugin's doctor",
+            systemImage: "stethoscope",
+            promptLabel: "Plugin id",
+            defaultPrompt: "mere-runpod"
+        ),
+        CommandTemplate(
+            id: .openWebui,
+            category: .server,
+            title: "Open WebUI",
+            subtitle: "Start the Open WebUI companion",
+            systemImage: "globe",
+            defaultModel: "text-chat-gemma4-12b"
         ),
         CommandTemplate(
             id: .apiServe,

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -450,6 +450,8 @@ final class MereRunController: ObservableObject {
     /// Live, think-stripped assistant text per in-flight conversation, so a streaming bubble can
     /// render even for a background conversation (the foreground-only liveOutputText cannot).
     @Published private(set) var conversationLiveText: [UUID: String] = [:]
+    /// Latest parsed `status --json` snapshot for the Studio status pill (nil until first probe).
+    @Published private(set) var serverStatus: StudioServerStatus?
     @Published private(set) var queuedRunCount = 0
     @Published var readinessByMode: [StudioMode: ModelReadinessState] = [:]
     @Published var modelCapabilitiesByID: [String: StudioModelCapability] = [:]
@@ -623,6 +625,55 @@ final class MereRunController: ObservableObject {
             : ["config", "set", "hf-token", trimmed]
         let result = await utilityCommandResult(args: args)
         return result.exitCode == 0
+    }
+
+    /// Probes the configured local API server and publishes the parsed snapshot for the status pill.
+    func refreshServerStatus() async {
+        var args = ["status", "--json", "--host", runtimeHost, "--port", String(runtimePort)]
+        if !runtimeAPIKey.isBlank { args += ["--api-key", runtimeAPIKey] }
+        let result = await utilityCommandResult(args: args)
+        serverStatus = StudioServerStatus.parse(jsonStdout: result.stdout)
+    }
+
+    /// The persisted Hugging Face endpoint (config key hf-endpoint), or "" if unset.
+    func loadHuggingFaceEndpoint() async -> String {
+        let result = await utilityCommandResult(args: ["config", "get", "hf-endpoint", "--reveal"], masksSecrets: false)
+        guard result.exitCode == 0 else { return "" }
+        let value = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        // `config get` prints "(unset)" style text when missing; treat any non-URL as empty.
+        return value.hasPrefix("http") ? value : ""
+    }
+
+    func saveHuggingFaceEndpoint(_ endpoint: String) async -> Bool {
+        let trimmed = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        let args = trimmed.isEmpty
+            ? ["config", "unset", "hf-endpoint"]
+            : ["config", "set", "hf-endpoint", trimmed]
+        let result = await utilityCommandResult(args: args)
+        return result.exitCode == 0
+    }
+
+    /// Lists saved voice-clone profiles via `speech profile list` (tab-separated id/name/updated).
+    func loadVoiceProfiles() async -> [StudioVoiceProfile] {
+        let result = await utilityCommandResult(args: ["speech", "profile", "list"])
+        guard result.exitCode == 0 else { return [] }
+        return StudioVoiceProfile.parse(listOutput: result.stdout)
+    }
+
+    /// Offline guide topics for the in-app help panel (`guide --list --json`).
+    func loadGuideTopics() async -> [StudioGuideTopic] {
+        let result = await utilityCommandResult(args: ["guide", "--list", "--json"])
+        guard result.exitCode == 0 else { return [] }
+        return StudioGuideTopic.parse(listJSON: result.stdout)
+    }
+
+    /// Markdown content for one guide topic (`guide <command-path> --json`).
+    func loadGuideContent(commandPath: [String]) async -> String {
+        let result = await utilityCommandResult(args: ["guide"] + commandPath + ["--json"])
+        guard result.exitCode == 0 else {
+            return result.stderr.isBlank ? "No guide is available for this topic." : result.stderr
+        }
+        return StudioGuideTopic.parseContent(payloadJSON: result.stdout) ?? result.stdout
     }
 
     func commandArguments(template: CommandTemplate, draft: CommandDraft) -> [String] {

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -1154,6 +1154,8 @@ struct MereRunSettingsView: View {
     @EnvironmentObject private var controller: MereRunController
     @State private var hfToken = ""
     @State private var hfStatus: String?
+    @State private var hfEndpoint = ""
+    @State private var hfEndpointStatus: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -1196,6 +1198,31 @@ struct MereRunSettingsView: View {
                         .font(MereRunTheme.captionFont)
                         .foregroundStyle(MereRunTheme.textMuted)
                 }
+            }
+            EditorSection("Hugging Face endpoint") {
+                HStack(spacing: 10) {
+                    TextField("https://huggingface.co (override mirror)", text: $hfEndpoint)
+                        .textFieldStyle(.plain)
+                        .font(MereRunTheme.bodyFont)
+                        .padding(10)
+                        .merePanel()
+                    Button("Save") {
+                        Task {
+                            let ok = await controller.saveHuggingFaceEndpoint(hfEndpoint)
+                            hfEndpointStatus = ok ? "Saved" : "Could not save endpoint"
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(MereRunTheme.accent)
+                }
+                if let hfEndpointStatus {
+                    Text(hfEndpointStatus)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+            }
+            .task {
+                hfEndpoint = await controller.loadHuggingFaceEndpoint()
             }
             EditorSection("Runtime server") {
                 HStack(spacing: 10) {

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -17,7 +17,24 @@ struct MereRunRootView: View {
 }
 
 struct AdvancedControlSurface: View {
+    /// Docked beside the Studio canvas shows a single resizable column (template picker + editor);
+    /// detached shows the full three-pane (sidebar · editor · console).
+    var docked = false
+    var onDetach: (() -> Void)?
+
     var body: some View {
+        Group {
+            if docked {
+                DockedAdvancedEditor(onDetach: onDetach)
+            } else {
+                fullSurface
+            }
+        }
+        .background(MereRunTheme.background.ignoresSafeArea())
+        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+
+    private var fullSurface: some View {
         ScrollView(.horizontal) {
             HStack(spacing: 0) {
                 CommandSidebar()
@@ -37,8 +54,65 @@ struct AdvancedControlSurface: View {
             }
             .frame(width: 1_210)
         }
-        .background(MereRunTheme.background.ignoresSafeArea())
-        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+}
+
+/// The docked Advanced column: a compact template picker (the sidebar's job, condensed) above the
+/// scrollable editor, so the 560-ish rail never scrolls horizontally. A detach button promotes it
+/// to the full three-pane.
+private struct DockedAdvancedEditor: View {
+    @EnvironmentObject private var controller: MereRunController
+    var onDetach: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().overlay(MereRunTheme.border.opacity(0.5))
+            ScrollView {
+                CommandEditor()
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Menu {
+                ForEach(CommandCategory.allCases) { category in
+                    let templates = CommandCatalog.templates(in: category)
+                    if !templates.isEmpty {
+                        Section(category.rawValue) {
+                            ForEach(templates) { template in
+                                Button(template.title) { controller.select(template) }
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: controller.selectedTemplate.systemImage)
+                    Text(controller.selectedTemplate.title)
+                        .font(MereRunTheme.sectionFont)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+
+            Spacer(minLength: 0)
+
+            if let onDetach {
+                Button(action: onDetach) {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                }
+                .buttonStyle(.plain)
+                .help("Detach to the full control surface")
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
     }
 }
 

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -728,6 +728,29 @@ private struct TextGenerationOptions: View {
                     Spacer()
                     Toggle("Quiet", isOn: $controller.draft.quiet)
                 }
+
+                if controller.selectedTemplate.id == .textChat {
+                    Divider().overlay(MereRunTheme.border.opacity(0.4))
+                    TextField("Tools (comma-separated: write_file, shell_exec)", text: $controller.draft.tools)
+                        .textFieldStyle(.plain)
+                        .padding(10)
+                        .merePanel()
+                    HStack {
+                        Toggle("Tool loop", isOn: $controller.draft.toolLoop)
+                        Toggle("Allow shell exec", isOn: $controller.draft.allowShellExec)
+                        Spacer()
+                    }
+                    PathField(
+                        path: $controller.draft.sandboxDir,
+                        placeholder: "Tool sandbox directory (optional)",
+                        mode: .openDirectory
+                    )
+                    PathField(
+                        path: $controller.draft.imagePath,
+                        placeholder: "Image for vision chat (optional)",
+                        mode: .openFile([.image])
+                    )
+                }
             }
         }
     }

--- a/Sources/MereRunApp/StudioConversationView.swift
+++ b/Sources/MereRunApp/StudioConversationView.swift
@@ -11,6 +11,7 @@ struct StudioConversationView: View {
     let onNewChat: () -> Void
     let onCopy: (String) -> Void
     let onRetry: () -> Void
+    let onEdit: (UUID) -> Void
 
     private static let streamingBubbleID = "studio.conversation.streaming"
 
@@ -83,7 +84,8 @@ struct StudioConversationView: View {
                                 failed: message.failed,
                                 monospaced: mode == .code && message.role == .assistant,
                                 onCopy: message.content.isEmpty ? nil : { onCopy(message.content) },
-                                onRetry: retryAction(for: message)
+                                onRetry: retryAction(for: message),
+                                onEdit: editAction(for: message)
                             )
                             .id(message.id)
                         }
@@ -116,6 +118,12 @@ struct StudioConversationView: View {
         return onRetry
     }
 
+    /// Edit is offered on user turns when idle (truncates the thread back to that turn).
+    private func editAction(for message: StudioMessage) -> (() -> Void)? {
+        guard !isRunning, message.role == .user else { return nil }
+        return { onEdit(message.id) }
+    }
+
     private func scrollToEnd(_ proxy: ScrollViewProxy) {
         withAnimation(.easeOut(duration: 0.15)) {
             if isRunning {
@@ -135,6 +143,7 @@ private struct StudioMessageBubble: View {
     var monospaced: Bool = false
     var onCopy: (() -> Void)?
     var onRetry: (() -> Void)?
+    var onEdit: (() -> Void)?
 
     private var isUser: Bool { role == .user }
 
@@ -151,12 +160,17 @@ private struct StudioMessageBubble: View {
                         .font(MereRunTheme.captionFont)
                         .foregroundStyle(MereRunTheme.red)
                 }
-                if !isStreaming, onCopy != nil || onRetry != nil {
+                if !isStreaming, onCopy != nil || onRetry != nil || onEdit != nil {
                     HStack(spacing: 14) {
                         if let onCopy {
                             Button(action: onCopy) { Label("Copy", systemImage: "doc.on.doc") }
                                 .buttonStyle(.plain)
                                 .help("Copy message")
+                        }
+                        if let onEdit {
+                            Button(action: onEdit) { Label("Edit", systemImage: "pencil") }
+                                .buttonStyle(.plain)
+                                .help("Edit and re-run from this turn")
                         }
                         if let onRetry {
                             Button(action: onRetry) { Label("Retry", systemImage: "arrow.clockwise") }

--- a/Sources/MereRunApp/StudioHelpSheet.swift
+++ b/Sources/MereRunApp/StudioHelpSheet.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// In-app help powered by the offline `guide` command: a topic list on the left and the selected
+/// topic's Markdown rendered on the right.
+struct StudioHelpSheet: View {
+    @EnvironmentObject private var controller: MereRunController
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var topics: [StudioGuideTopic] = []
+    @State private var selected: StudioGuideTopic?
+    @State private var content = ""
+    @State private var isLoading = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(MereRunTheme.border.opacity(0.4))
+            HStack(spacing: 0) {
+                sidebar
+                    .frame(width: 220)
+                Divider().overlay(MereRunTheme.border.opacity(0.4))
+                detail
+            }
+        }
+        .background(MereRunTheme.background)
+        .task { await loadTopics() }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Guide")
+                .font(MereRunTheme.titleFont)
+            Spacer()
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(20)
+    }
+
+    private var sidebar: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 2) {
+                ForEach(topics) { topic in
+                    Button { select(topic) } label: {
+                        Text(topic.title)
+                            .font(MereRunTheme.bodyFont)
+                            .foregroundStyle(selected?.id == topic.id ? MereRunTheme.accent : MereRunTheme.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 14)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var detail: some View {
+        ScrollView {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(40)
+            } else if content.isEmpty {
+                Text("Select a topic to read its guide.")
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(24)
+            } else {
+                Text(renderedMarkdown)
+                    .font(MereRunTheme.bodyFont)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(24)
+            }
+        }
+    }
+
+    private var renderedMarkdown: AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        return (try? AttributedString(markdown: content, options: options)) ?? AttributedString(content)
+    }
+
+    private func loadTopics() async {
+        topics = await controller.loadGuideTopics()
+        if selected == nil, let first = topics.first {
+            select(first)
+        }
+    }
+
+    private func select(_ topic: StudioGuideTopic) {
+        selected = topic
+        isLoading = true
+        Task {
+            let text = await controller.loadGuideContent(commandPath: topic.commandPath)
+            content = text
+            isLoading = false
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioLibraryStore.swift
+++ b/Sources/MereRunApp/StudioLibraryStore.swift
@@ -121,11 +121,12 @@ final class StudioLibraryStore: ObservableObject {
         mode: StudioMode,
         model: String?,
         systemPrompt: String?,
-        content: String
+        content: String,
+        imagePath: String? = nil
     ) -> StudioLibraryItem {
         if let index = items.firstIndex(where: { $0.id == conversationID }) {
             var item = items[index]
-            item.messages = (item.messages ?? []) + [StudioMessage(role: .user, content: content)]
+            item.messages = (item.messages ?? []) + [StudioMessage(role: .user, content: content, imagePath: imagePath)]
             item.status = .running
             item.updatedAt = Date()
             items[index] = item
@@ -145,7 +146,7 @@ final class StudioLibraryStore: ObservableObject {
             exitCode: nil,
             commandPreview: mode == .code ? "mere.run text code" : "mere.run text chat",
             outputText: nil,
-            messages: [StudioMessage(role: .user, content: content)],
+            messages: [StudioMessage(role: .user, content: content, imagePath: imagePath)],
             systemPrompt: systemPrompt,
             model: model
         )
@@ -170,9 +171,9 @@ final class StudioLibraryStore: ObservableObject {
     }
 
     /// Truncates a thread at `messageID` (removing it and everything after). Returns the removed
-    /// message's content when it was a user turn, so the composer can be repopulated for editing.
+    /// message when it was a user turn, so the composer can be repopulated (text + image) for editing.
     @discardableResult
-    func truncate(conversationID: UUID, removingFrom messageID: UUID) -> String? {
+    func truncate(conversationID: UUID, removingFrom messageID: UUID) -> StudioMessage? {
         guard let index = items.firstIndex(where: { $0.id == conversationID }),
               var messages = items[index].messages,
               let messageIndex = messages.firstIndex(where: { $0.id == messageID }) else { return nil }
@@ -183,7 +184,7 @@ final class StudioLibraryStore: ObservableObject {
         item.updatedAt = Date()
         items[index] = item
         save()
-        return removed.role == .user ? removed.content : nil
+        return removed.role == .user ? removed : nil
     }
 
     /// Drops the last assistant message of a thread (used by retry before re-running the turn).

--- a/Sources/MereRunApp/StudioLibraryStore.swift
+++ b/Sources/MereRunApp/StudioLibraryStore.swift
@@ -169,6 +169,23 @@ final class StudioLibraryStore: ObservableObject {
         save()
     }
 
+    /// Truncates a thread at `messageID` (removing it and everything after). Returns the removed
+    /// message's content when it was a user turn, so the composer can be repopulated for editing.
+    @discardableResult
+    func truncate(conversationID: UUID, removingFrom messageID: UUID) -> String? {
+        guard let index = items.firstIndex(where: { $0.id == conversationID }),
+              var messages = items[index].messages,
+              let messageIndex = messages.firstIndex(where: { $0.id == messageID }) else { return nil }
+        let removed = messages[messageIndex]
+        messages.removeSubrange(messageIndex...)
+        var item = items[index]
+        item.messages = messages
+        item.updatedAt = Date()
+        items[index] = item
+        save()
+        return removed.role == .user ? removed.content : nil
+    }
+
     /// Drops the last assistant message of a thread (used by retry before re-running the turn).
     func dropLastAssistant(conversationID: UUID) {
         guard let index = items.firstIndex(where: { $0.id == conversationID }) else { return }

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -1474,6 +1474,7 @@ private struct StudioOptionsSheet: View {
     @Binding var draft: StudioDraft
     @EnvironmentObject private var controller: MereRunController
     @Environment(\.dismiss) private var dismiss
+    @State private var voiceProfiles: [StudioVoiceProfile] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -1514,6 +1515,37 @@ private struct StudioOptionsSheet: View {
                 .padding(10)
                 .merePanel()
 
+            if mode == .speak {
+                Picker("Voice", selection: $draft.voiceMode) {
+                    Text("Style").tag("style")
+                    Text("Clone").tag("clone")
+                }
+                .pickerStyle(.segmented)
+
+                if draft.voiceMode == "clone" {
+                    Picker("Profile", selection: $draft.voiceProfile) {
+                        Text("None").tag("")
+                        ForEach(voiceProfiles) { profile in
+                            Text(profile.name).tag(profile.id)
+                        }
+                    }
+                    HStack(spacing: 10) {
+                        Text(draft.refAudioPath.isEmpty
+                            ? "No reference audio"
+                            : URL(fileURLWithPath: draft.refAudioPath).lastPathComponent)
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                            .lineLimit(1)
+                        Spacer()
+                        Button("Reference audio…") { chooseReferenceAudio() }
+                    }
+                    TextField("Save as profile (optional)", text: $draft.saveProfileName)
+                        .textFieldStyle(.plain)
+                        .padding(10)
+                        .merePanel()
+                }
+            }
+
             if [.createImage, .video].contains(mode) {
                 HStack(spacing: 10) {
                     Stepper("Width \(draft.width)", value: $draft.width, in: 64...4096, step: 64)
@@ -1544,6 +1576,19 @@ private struct StudioOptionsSheet: View {
         .padding(22)
         .background(MereRunTheme.background)
         .foregroundStyle(MereRunTheme.textPrimary)
+        .task {
+            if mode == .speak { voiceProfiles = await controller.loadVoiceProfiles() }
+        }
+    }
+
+    private func chooseReferenceAudio() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.audio]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        if panel.runModal() == .OK, let url = panel.url {
+            draft.refAudioPath = url.path
+        }
     }
 
     private func readImageActionUnavailableMessage(_ action: StudioReadImageAction) -> String? {

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -425,6 +425,8 @@ struct StudioRootView: View {
             activeConversationID = conversationID
             selectedLibraryID = conversationID
             draft.prompt = ""
+            // The image rode with this turn; clear it so the next turn doesn't resend it.
+            draft.inputPath = ""
         } catch {
             studioError = error.localizedDescription
         }

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -160,7 +160,8 @@ struct StudioRootView: View {
                     onShowDetails: { showAdvanced = true },
                     onNewChat: startNewConversation,
                     onCopy: copyToClipboard,
-                    onRetry: retryLastTurn
+                    onRetry: retryLastTurn,
+                    onEdit: editMessage
                 )
 
                 StudioPromptBar(
@@ -479,6 +480,16 @@ struct StudioRootView: View {
             controller.run(studio: request)
         } catch {
             studioError = error.localizedDescription
+        }
+    }
+
+    /// Edits a prior user turn: truncates the thread at that message and loads its text back into
+    /// the composer, so sending re-runs the conversation from that point.
+    private func editMessage(_ messageID: UUID) {
+        guard let conversationID = activeConversationID,
+              !controller.runningConversationIDs.contains(conversationID) else { return }
+        if let content = library.truncate(conversationID: conversationID, removingFrom: messageID) {
+            draft.prompt = content
         }
     }
 
@@ -832,6 +843,7 @@ private struct StudioCanvas: View {
     let onNewChat: () -> Void
     let onCopy: (String) -> Void
     let onRetry: () -> Void
+    let onEdit: (UUID) -> Void
 
     private var visibleLiveOutputText: String? {
         guard isRunning else { return nil }
@@ -859,7 +871,8 @@ private struct StudioCanvas: View {
                     mode: mode,
                     onNewChat: onNewChat,
                     onCopy: onCopy,
-                    onRetry: onRetry
+                    onRetry: onRetry,
+                    onEdit: onEdit
                 )
                 .transition(.opacity)
             } else if let item {

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -11,6 +11,7 @@ struct StudioRootView: View {
     @State private var showAdvanced = false
     @State private var showOptions = false
     @State private var showModels = false
+    @State private var showHelp = false
     @State private var selectedLibraryID: UUID?
     /// The conversation the canvas/composer targets in chat/code modes. nil means a fresh,
     /// not-yet-sent conversation (so the library has no empty row until the first message).
@@ -122,7 +123,9 @@ struct StudioRootView: View {
                     readiness: readiness,
                     modeCapabilities: modeCapabilities,
                     resolvedCLI: controller.resolvedCLI,
-                    onShowModels: { showModels = true }
+                    serverStatus: controller.serverStatus,
+                    onShowModels: { showModels = true },
+                    onShowHelp: { showHelp = true }
                 )
 
                 Divider()
@@ -228,6 +231,19 @@ struct StudioRootView: View {
                     showWelcome = false
                 }
             )
+        }
+        .sheet(isPresented: $showHelp) {
+            StudioHelpSheet()
+                .environmentObject(controller)
+                .frame(width: 720, height: 560)
+        }
+        .task {
+            // Poll the local server status for the top-bar pill. status has a 1s probe timeout,
+            // so a modest cadence keeps the pill live without hammering the CLI.
+            while !Task.isCancelled {
+                await controller.refreshServerStatus()
+                try? await Task.sleep(nanoseconds: 20 * 1_000_000_000)
+            }
         }
         .onAppear {
             draft.reset(for: mode)
@@ -562,7 +578,9 @@ private struct StudioTopBar: View {
     let readiness: ModelReadinessState
     let modeCapabilities: [StudioMode: StudioModelCapability]
     let resolvedCLI: String
+    let serverStatus: StudioServerStatus?
     let onShowModels: () -> Void
+    let onShowHelp: () -> Void
 
     var body: some View {
         VStack(spacing: 14) {
@@ -589,6 +607,13 @@ private struct StudioTopBar: View {
                 Spacer()
 
                 StudioStatusPill(
+                    title: "Server",
+                    detail: serverStatusDetail,
+                    systemImage: serverStatus?.isReachable == true ? "bolt.horizontal.circle" : "circle.dashed",
+                    color: serverStatusColor
+                )
+
+                StudioStatusPill(
                     title: readiness.title,
                     detail: readiness.message,
                     systemImage: readinessStatusImage,
@@ -606,6 +631,13 @@ private struct StudioTopBar: View {
                     onShowModels()
                 } label: {
                     Label("Models", systemImage: "shippingbox")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    onShowHelp()
+                } label: {
+                    Label("Help", systemImage: "questionmark.circle")
                 }
                 .buttonStyle(.bordered)
 
@@ -639,6 +671,20 @@ private struct StudioTopBar: View {
         .padding(.horizontal, 22)
         .padding(.top, 16)
         .padding(.bottom, 14)
+    }
+
+    private var serverStatusDetail: String {
+        guard let serverStatus else { return "checking…" }
+        if serverStatus.isReachable {
+            let model = serverStatus.loadedModelSummary.map { " · \($0)" } ?? ""
+            return "up\(model) · \(serverStatus.installedCount) installed"
+        }
+        return "offline · \(serverStatus.installedCount) installed"
+    }
+
+    private var serverStatusColor: Color {
+        guard let serverStatus else { return MereRunTheme.textMuted }
+        return serverStatus.isReachable ? MereRunTheme.green : MereRunTheme.textMuted
     }
 
     private var readinessStatusImage: String {

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -12,6 +12,9 @@ struct StudioRootView: View {
     @State private var showOptions = false
     @State private var showModels = false
     @State private var showHelp = false
+    @State private var advancedWidth: CGFloat = 560
+    @State private var advancedDragStartWidth: CGFloat?
+    @State private var advancedDetached = false
     @State private var selectedLibraryID: UUID?
     /// The conversation the canvas/composer targets in chat/code modes. nil means a fresh,
     /// not-yet-sent conversation (so the library has no empty row until the first message).
@@ -190,10 +193,9 @@ struct StudioRootView: View {
             }
 
             if showAdvanced {
-                Divider()
-                    .overlay(MereRunTheme.border.opacity(0.55))
-                AdvancedControlSurface()
-                    .frame(width: 560)
+                advancedResizeHandle
+                AdvancedControlSurface(docked: true, onDetach: { advancedDetached = true })
+                    .frame(width: advancedWidth)
             }
         }
         .background {
@@ -238,6 +240,22 @@ struct StudioRootView: View {
                 .environmentObject(controller)
                 .frame(width: 720, height: 560)
         }
+        .sheet(isPresented: $advancedDetached) {
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Advanced — full control surface")
+                        .font(MereRunTheme.sectionFont)
+                    Spacer()
+                    Button("Dock") { advancedDetached = false }
+                        .keyboardShortcut(.defaultAction)
+                }
+                .padding(16)
+                Divider().overlay(MereRunTheme.border.opacity(0.5))
+                AdvancedControlSurface(docked: false)
+            }
+            .frame(width: 1_260, height: 780)
+            .environmentObject(controller)
+        }
         .task {
             // Poll the local server status for the top-bar pill. status has a 1s probe timeout,
             // so a modest cadence keeps the pill live without hammering the CLI.
@@ -252,6 +270,9 @@ struct StudioRootView: View {
             if !hasCompletedWelcome {
                 showWelcome = true
             }
+        }
+        .onChange(of: showAdvanced) { _, isShown in
+            if isShown { syncAdvancedToStudio() }
         }
         .onChange(of: mode) { _, newMode in
             var nextDraft = StudioDraft()
@@ -481,6 +502,38 @@ struct StudioRootView: View {
         } catch {
             studioError = error.localizedDescription
         }
+    }
+
+    /// A draggable divider that resizes the docked Advanced column. The panel is on the right, so
+    /// dragging left widens it; width is clamped to a usable range.
+    private var advancedResizeHandle: some View {
+        Rectangle()
+            .fill(MereRunTheme.border.opacity(0.55))
+            .frame(width: 5)
+            .contentShape(Rectangle())
+            .onHover { inside in
+                if inside { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+            }
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        let base = advancedDragStartWidth ?? advancedWidth
+                        if advancedDragStartWidth == nil { advancedDragStartWidth = base }
+                        advancedWidth = min(max(base - value.translation.width, 360), 860)
+                    }
+                    .onEnded { _ in advancedDragStartWidth = nil }
+            )
+    }
+
+    /// When Advanced opens, pre-select the template for the active Studio mode and carry over what
+    /// the composer already holds, so Advanced deepens the current task instead of resetting it.
+    private func syncAdvancedToStudio() {
+        if let template = CommandCatalog.template(id: mode.defaultTemplateID) {
+            controller.select(template)
+        }
+        controller.draft.prompt = draft.prompt
+        if !draft.model.isBlank { controller.draft.model = draft.model }
+        if !draft.inputPath.isBlank { controller.draft.inputPath = draft.inputPath }
     }
 
     /// Edits a prior user turn: truncates the thread at that message and loads its text back into

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -440,12 +440,15 @@ struct StudioRootView: View {
 
         let systemPrompt = draft.secondaryText.trimmingCharacters(in: .whitespacesAndNewlines)
         let model = draft.model.isBlank ? nil : draft.model
+        // Vision chat attaches an image to this turn (chat only); persist it so edit/retry resend it.
+        let turnImage = (mode == .chat && !draft.inputPath.isBlank) ? draft.inputPath : nil
         let item = library.appendUser(
             conversationID: conversationID,
             mode: mode,
             model: model,
             systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
-            content: content
+            content: content,
+            imagePath: turnImage
         )
 
         let rendered = ConversationTranscript.render(
@@ -494,6 +497,8 @@ struct StudioRootView: View {
             var runDraft = draft
             runDraft.prompt = rendered.prompt
             runDraft.secondaryText = systemPrompt ?? ""
+            // Re-attach the image the last user turn carried (or none), not the cleared composer's.
+            runDraft.inputPath = item.messages?.last?.imagePath ?? ""
             if let model = item.model, !model.isBlank { runDraft.model = model }
             let request = try StudioCommandAdapter.makeRequest(
                 mode: item.mode, draft: runDraft, conversationID: conversationID
@@ -526,7 +531,8 @@ struct StudioRootView: View {
     }
 
     /// When Advanced opens, pre-select the template for the active Studio mode and carry over what
-    /// the composer already holds, so Advanced deepens the current task instead of resetting it.
+    /// the composer already holds — including the shared depth fields — so Advanced deepens the
+    /// current task without silently reverting edits.
     private func syncAdvancedToStudio() {
         if let template = CommandCatalog.template(id: mode.defaultTemplateID) {
             controller.select(template)
@@ -534,6 +540,18 @@ struct StudioRootView: View {
         controller.draft.prompt = draft.prompt
         if !draft.model.isBlank { controller.draft.model = draft.model }
         if !draft.inputPath.isBlank { controller.draft.inputPath = draft.inputPath }
+        // Shared schema depth (WS-3.5): keep the two surfaces aligned after live edits, not only
+        // at defaults.
+        controller.draft.temperature = draft.temperature
+        controller.draft.maxTokens = draft.maxTokens
+        controller.draft.cfgScale = draft.cfgScale
+        controller.draft.strength = draft.strength
+        controller.draft.language = draft.language
+        controller.draft.backend = draft.backend
+        controller.draft.timestamps = draft.timestamps
+        controller.draft.fps = draft.fps
+        controller.draft.numFrames = draft.numFrames
+        controller.draft.variant = draft.variant
     }
 
     /// Edits a prior user turn: truncates the thread at that message and loads its text back into
@@ -541,8 +559,17 @@ struct StudioRootView: View {
     private func editMessage(_ messageID: UUID) {
         guard let conversationID = activeConversationID,
               !controller.runningConversationIDs.contains(conversationID) else { return }
-        if let content = library.truncate(conversationID: conversationID, removingFrom: messageID) {
-            draft.prompt = content
+        if let removed = library.truncate(conversationID: conversationID, removingFrom: messageID) {
+            draft.prompt = removed.content
+            // Restore the turn's attached image so re-sending re-runs vision chat as before.
+            if mode == .chat { draft.inputPath = removed.imagePath ?? "" }
+        }
+        // Editing the first turn empties the thread — drop the now-empty row and act like a new chat.
+        if let item = library.items.first(where: { $0.id == conversationID }),
+           item.messages?.isEmpty ?? true {
+            library.delete(id: conversationID)
+            activeConversationID = nil
+            selectedLibraryID = nil
         }
     }
 

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -1637,6 +1637,13 @@ private struct StudioOptionsSheet: View {
                     .merePanel()
             }
 
+            if !StudioOptionSchema.fields(for: mode).isEmpty {
+                Divider().overlay(MereRunTheme.border.opacity(0.4))
+                ForEach(StudioOptionSchema.fields(for: mode)) { field in
+                    optionRow(field)
+                }
+            }
+
             Spacer()
         }
         .padding(22)
@@ -1645,6 +1652,41 @@ private struct StudioOptionsSheet: View {
         .task {
             if mode == .speak { voiceProfiles = await controller.loadVoiceProfiles() }
         }
+    }
+
+    /// Renders one schema field as the appropriate control, bound through the draft key path.
+    @ViewBuilder
+    private func optionRow(_ field: StudioOptionField) -> some View {
+        switch field.control {
+        case let .int(keyPath, range, step):
+            Stepper("\(field.label): \(draft[keyPath: keyPath])", value: binding(keyPath), in: range, step: step)
+        case let .double(keyPath):
+            HStack {
+                Text(field.label)
+                Spacer()
+                TextField(field.label, value: binding(keyPath), format: .number)
+                    .textFieldStyle(.plain)
+                    .frame(width: 90)
+                    .padding(8)
+                    .merePanel()
+            }
+        case let .bool(keyPath):
+            Toggle(field.label, isOn: binding(keyPath))
+        case let .text(keyPath, placeholder):
+            HStack {
+                Text(field.label)
+                Spacer()
+                TextField(placeholder, text: binding(keyPath))
+                    .textFieldStyle(.plain)
+                    .frame(width: 170)
+                    .padding(8)
+                    .merePanel()
+            }
+        }
+    }
+
+    private func binding<Value>(_ keyPath: WritableKeyPath<StudioDraft, Value>) -> Binding<Value> {
+        Binding(get: { draft[keyPath: keyPath] }, set: { draft[keyPath: keyPath] = $0 })
     }
 
     private func chooseReferenceAudio() {

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -811,3 +811,102 @@ enum ModelReadinessParser {
         return .unknown("Run model capabilities or configure model sources to check \(modelID).")
     }
 }
+
+/// A parsed snapshot of `mere.run status --json` for the Studio status pill.
+struct StudioServerStatus: Equatable {
+    let health: String
+    let loadedModels: [String]
+    let installedCount: Int
+
+    var isReachable: Bool {
+        let normalized = health.lowercased()
+        return normalized == "ok" || normalized == "up" || normalized == "healthy"
+            || normalized == "reachable" || !loadedModels.isEmpty
+    }
+
+    var loadedModelSummary: String? {
+        loadedModels.first
+    }
+
+    static func parse(jsonStdout: String) -> StudioServerStatus? {
+        guard let data = jsonObjectData(in: jsonStdout) else { return nil }
+        struct Snapshot: Decodable {
+            struct Server: Decodable {
+                let health: String?
+                let loadedModels: [String]?
+            }
+            struct InstalledModel: Decodable { let id: String }
+            let server: Server?
+            let installedModels: [InstalledModel]?
+        }
+        guard let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) else { return nil }
+        return StudioServerStatus(
+            health: snapshot.server?.health ?? "unknown",
+            loadedModels: snapshot.server?.loadedModels ?? [],
+            installedCount: snapshot.installedModels?.count ?? 0
+        )
+    }
+
+    /// The CLI may emit diagnostics around the JSON; isolate the top-level object.
+    private static func jsonObjectData(in text: String) -> Data? {
+        guard let start = text.firstIndex(of: "{"),
+              let end = text.lastIndex(of: "}"),
+              start < end else { return nil }
+        return String(text[start...end]).data(using: .utf8)
+    }
+}
+
+/// One offline `guide` topic from `guide --list --json`, with the command path used to fetch it.
+struct StudioGuideTopic: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let commandPath: [String]
+
+    static func parse(listJSON: String) -> [StudioGuideTopic] {
+        guard let data = jsonArrayData(in: listJSON) else { return [] }
+        struct Item: Decodable { let topic: String; let title: String; let commands: [String] }
+        guard let items = try? JSONDecoder().decode([Item].self, from: data) else { return [] }
+        return items.map { item in
+            let path = (item.commands.first ?? item.topic).split(separator: " ").map(String.init)
+            return StudioGuideTopic(id: item.topic, title: item.title, commandPath: path)
+        }
+    }
+
+    static func parseContent(payloadJSON: String) -> String? {
+        guard let data = jsonObjectData(in: payloadJSON) else { return nil }
+        struct Payload: Decodable { let content: String }
+        return (try? JSONDecoder().decode(Payload.self, from: data))?.content
+    }
+
+    private static func jsonArrayData(in text: String) -> Data? {
+        guard let start = text.firstIndex(of: "["),
+              let end = text.lastIndex(of: "]"),
+              start < end else { return nil }
+        return String(text[start...end]).data(using: .utf8)
+    }
+
+    private static func jsonObjectData(in text: String) -> Data? {
+        guard let start = text.firstIndex(of: "{"),
+              let end = text.lastIndex(of: "}"),
+              start < end else { return nil }
+        return String(text[start...end]).data(using: .utf8)
+    }
+}
+
+/// A saved voice-clone profile from `speech profile list` (tab-separated id/name/updatedAt).
+struct StudioVoiceProfile: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let updatedAt: String
+
+    static func parse(listOutput: String) -> [StudioVoiceProfile] {
+        listOutput.components(separatedBy: .newlines).compactMap { line in
+            let parts = line.components(separatedBy: "\t")
+            guard parts.count >= 2 else { return nil }
+            let id = parts[0].trimmingCharacters(in: .whitespaces)
+            let name = parts[1].trimmingCharacters(in: .whitespaces)
+            guard !id.isEmpty, !name.isEmpty else { return nil }
+            return StudioVoiceProfile(id: id, name: name, updatedAt: parts.count > 2 ? parts[2] : "")
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -535,6 +535,13 @@ enum StudioCommandAdapter {
             throw StudioCommandError.missingInput(mode.acceptedTypes.first == .audio ? "audio" : mode.acceptedTypes.first == .movie ? "video" : "image")
         }
 
+        // Clone voice needs a source the CLI accepts; otherwise `speech synthesize` hard-fails with
+        // "Clone mode requires --profile or --ref-audio." Validate it up front instead.
+        if mode == .speak, draft.voiceMode == "clone",
+           draft.voiceProfile.isBlank, draft.refAudioPath.isBlank {
+            throw StudioCommandError.missingPrompt("A saved voice profile or reference audio")
+        }
+
         let promptRequired: Bool
         switch mode {
         case .listen:
@@ -572,19 +579,24 @@ struct StudioMessage: Codable, Identifiable, Equatable {
     var createdAt: Date
     /// True for an assistant turn whose run exited non-zero; the thread is kept either way.
     var failed: Bool
+    /// The image attached to this user turn (vision chat), so edit/retry resend it. Optional so
+    /// older persisted threads decode unchanged.
+    var imagePath: String?
 
     init(
         id: UUID = UUID(),
         role: StudioMessageRole,
         content: String,
         createdAt: Date = Date(),
-        failed: Bool = false
+        failed: Bool = false,
+        imagePath: String? = nil
     ) {
         self.id = id
         self.role = role
         self.content = content
         self.createdAt = createdAt
         self.failed = failed
+        self.imagePath = imagePath
     }
 }
 

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -92,7 +92,7 @@ enum StudioMode: String, CaseIterable, Codable, Identifiable {
 
     var acceptedTypes: [UTType] {
         switch self {
-        case .createImage, .readImage, .findObjects, .segment:
+        case .createImage, .readImage, .findObjects, .segment, .chat:
             return [.image]
         case .listen:
             return [.audio]
@@ -321,6 +321,8 @@ enum StudioCommandAdapter {
             // Conversation turns stream so the canvas renders tokens live; the reply is
             // accumulated and think-stripped app-side.
             if conversationID != nil { draft.stream = true }
+            // Vision chat: a single attached image rides with this turn (chat only, not code).
+            if mode == .chat, !studioDraft.inputPath.isBlank { draft.imagePath = studioDraft.inputPath }
 
         case .speak:
             draft.prompt = prompt

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -207,8 +207,21 @@ struct StudioDraft: Codable, Equatable {
     var voiceProfile = ""
     var refAudioPath = ""
     var saveProfileName = ""
+    // Advanced depth shared with the Advanced surface (see StudioOptionSchema). Defaults are
+    // seeded from the matching template's CommandDraft so the two surfaces never drift.
+    var temperature = 0.7
+    var maxTokens = 2048
+    var cfgScale = 1.0
+    var strength = 0.75
+    var language = "auto"
+    var timestamps = true
+    var backend = "auto"
+    var fps = 24
+    var numFrames = 65
+    var variant = "distilled"
 
     mutating func reset(for mode: StudioMode) {
+        let base = CommandCatalog.template(id: mode.defaultTemplateID)?.defaultDraft()
         prompt = modeDefaultPrompt(mode)
         secondaryText = modeDefaultSecondaryText(mode)
         inputPath = ""
@@ -223,6 +236,16 @@ struct StudioDraft: Codable, Equatable {
         voiceProfile = ""
         refAudioPath = ""
         saveProfileName = ""
+        temperature = base?.temperature ?? 0.7
+        maxTokens = base?.maxTokens ?? 2048
+        cfgScale = base?.cfgScale ?? 1.0
+        strength = base?.strength ?? 0.75
+        language = base?.language ?? "auto"
+        timestamps = base?.timestamps ?? true
+        backend = base?.backend ?? "auto"
+        fps = base?.fps ?? 24
+        numFrames = base?.numFrames ?? 65
+        variant = base?.variant ?? "distilled"
     }
 
     private func modeDefaultPrompt(_ mode: StudioMode) -> String {
@@ -236,6 +259,54 @@ struct StudioDraft: Codable, Equatable {
 
     private func modeDefaultSecondaryText(_ mode: StudioMode) -> String {
         CommandCatalog.template(id: mode.defaultTemplateID)?.defaultSecondaryText ?? ""
+    }
+}
+
+/// One advanced option for a Studio mode: a label plus a typed control bound to a `StudioDraft`
+/// key path. This is the single source of truth for the depth controls — the Studio sheet renders
+/// it, and the adapter maps the same fields to the identical CLI flags the Advanced surface emits.
+struct StudioOptionField: Identifiable {
+    let id: String
+    let label: String
+    let control: Control
+
+    enum Control {
+        case int(WritableKeyPath<StudioDraft, Int>, range: ClosedRange<Int>, step: Int)
+        case double(WritableKeyPath<StudioDraft, Double>)
+        case bool(WritableKeyPath<StudioDraft, Bool>)
+        case text(WritableKeyPath<StudioDraft, String>, placeholder: String)
+    }
+}
+
+enum StudioOptionSchema {
+    static func fields(for mode: StudioMode) -> [StudioOptionField] {
+        switch mode {
+        case .chat, .code:
+            return [
+                StudioOptionField(id: "temperature", label: "Temperature", control: .double(\.temperature)),
+                StudioOptionField(id: "maxTokens", label: "Max tokens", control: .int(\.maxTokens, range: 1...32_768, step: 64)),
+            ]
+        case .createImage:
+            return [
+                StudioOptionField(id: "cfg", label: "CFG scale", control: .double(\.cfgScale)),
+                StudioOptionField(id: "strength", label: "Img2img strength", control: .double(\.strength)),
+            ]
+        case .listen:
+            return [
+                StudioOptionField(id: "language", label: "Language", control: .text(\.language, placeholder: "auto")),
+                StudioOptionField(id: "backend", label: "Backend", control: .text(\.backend, placeholder: "auto")),
+                StudioOptionField(id: "timestamps", label: "Timestamps", control: .bool(\.timestamps)),
+            ]
+        case .video:
+            return [
+                StudioOptionField(id: "variant", label: "Variant", control: .text(\.variant, placeholder: "distilled")),
+                StudioOptionField(id: "fps", label: "Frames per second", control: .int(\.fps, range: 1...60, step: 1)),
+                StudioOptionField(id: "numFrames", label: "Frames", control: .int(\.numFrames, range: 1...600, step: 1)),
+                StudioOptionField(id: "strength", label: "Image strength", control: .double(\.strength)),
+            ]
+        default:
+            return []
+        }
     }
 }
 
@@ -323,11 +394,15 @@ enum StudioCommandAdapter {
             draft.height = studioDraft.height
             draft.steps = studioDraft.steps
             draft.seed = studioDraft.seed
+            draft.cfgScale = studioDraft.cfgScale
+            draft.strength = studioDraft.strength
 
         case .chat, .code:
             draft.prompt = prompt
             draft.secondaryText = secondary
             draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.temperature = studioDraft.temperature
+            draft.maxTokens = studioDraft.maxTokens
             // Conversation turns stream so the canvas renders tokens live; the reply is
             // accumulated and think-stripped app-side.
             if conversationID != nil { draft.stream = true }
@@ -348,6 +423,9 @@ enum StudioCommandAdapter {
         case .listen:
             draft.inputPath = studioDraft.inputPath
             draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.language = studioDraft.language
+            draft.backend = studioDraft.backend
+            draft.timestamps = studioDraft.timestamps
 
         case .readImage:
             draft.inputPath = studioDraft.inputPath
@@ -374,6 +452,10 @@ enum StudioCommandAdapter {
             draft.width = studioDraft.width
             draft.height = studioDraft.height
             draft.seed = studioDraft.seed
+            draft.variant = studioDraft.variant
+            draft.fps = studioDraft.fps
+            draft.numFrames = studioDraft.numFrames
+            draft.strength = studioDraft.strength
 
         case .sfx:
             draft.prompt = prompt

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -201,6 +201,12 @@ struct StudioDraft: Codable, Equatable {
     var seed = ""
     var durationSeconds = 10.0
     var readImageAction: StudioReadImageAction = .inspect
+    // Speak voice cloning (Studio surface). "style" uses the voice description; "clone" uses a
+    // saved profile or reference audio.
+    var voiceMode = "style"
+    var voiceProfile = ""
+    var refAudioPath = ""
+    var saveProfileName = ""
 
     mutating func reset(for mode: StudioMode) {
         prompt = modeDefaultPrompt(mode)
@@ -213,6 +219,10 @@ struct StudioDraft: Codable, Equatable {
         seed = ""
         durationSeconds = 10
         readImageAction = .inspect
+        voiceMode = "style"
+        voiceProfile = ""
+        refAudioPath = ""
+        saveProfileName = ""
     }
 
     private func modeDefaultPrompt(_ mode: StudioMode) -> String {
@@ -328,6 +338,12 @@ enum StudioCommandAdapter {
             draft.prompt = prompt
             draft.secondaryText = secondary.isEmpty ? draft.secondaryText : secondary
             draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.voiceMode = studioDraft.voiceMode
+            if studioDraft.voiceMode == "clone" {
+                draft.voiceProfile = studioDraft.voiceProfile
+                draft.refAudioPath = studioDraft.refAudioPath
+                draft.saveProfileName = studioDraft.saveProfileName
+            }
 
         case .listen:
             draft.inputPath = studioDraft.inputPath

--- a/Sources/MereRunCLI/Commands/ModelCapabilitiesCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCapabilitiesCommand.swift
@@ -14,6 +14,9 @@ struct ModelCapabilities: ParsableCommand {
     @Flag(name: [.long], help: "Show only models recommended for first setup.")
     var recommended: Bool = false
 
+    @Flag(name: [.long], help: "Emit a machine-readable capability report.")
+    var json: Bool = false
+
     func run() throws {
         let machine = MereRunMachineProfile.current
         let reports = ManagedModelCapabilityCatalog.supportReports(on: machine)
@@ -25,13 +28,39 @@ struct ModelCapabilities: ParsableCommand {
             }
             return all || report.isSupported
         }
+        let chatBands = ManagedModelCapabilityCatalog.recommendedChatBandReports(on: machine)
+        let recommendedReports = ManagedModelCapabilityCatalog.recommendedSetupReports(on: machine)
+        let unavailableRecommended = reports.filter {
+            $0.isSupported
+                && $0.descriptor.isRecommendedForSetup
+                && !$0.spec.hasAnyManagedDownloadSource()
+        }
+
+        if json {
+            let payload = ModelCapabilitiesOutput(
+                machine: .init(machine),
+                chatBands: chatBands.map { .init($0, machine: machine) },
+                recommendedChatModel: chatBands
+                    .first { $0.contains(unifiedMemoryGB: machine.unifiedMemoryGB) }
+                    .map { .init($0, machine: machine) },
+                setupAgent: MereRunAgentModelCatalog
+                    .recommendation(for: .tier, on: machine)
+                    .map(ModelCapabilitiesSetupAgent.init),
+                recommendedSetupModels: recommendedReports.map(ModelCapabilitiesModel.init),
+                unavailableRecommendedModelIDs: unavailableRecommended.map { $0.spec.id },
+                models: visibleReports.map(ModelCapabilitiesModel.init)
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            print(String(decoding: try encoder.encode(payload), as: UTF8.self))
+            return
+        }
 
         print("Machine")
         print("  processor: \(machine.processorName)")
         print("  unifiedMemory: \(machine.unifiedMemoryGB) GB")
         print("  appleSiliconMac: \(machine.isAppleSiliconMac)")
 
-        let chatBands = ManagedModelCapabilityCatalog.recommendedChatBandReports(on: machine)
         if !chatBands.isEmpty {
             print("\nRecommended chat winners by RAM band")
             for band in chatBands {
@@ -53,18 +82,12 @@ struct ModelCapabilities: ParsableCommand {
             }
         }
 
-        let recommendedReports = ManagedModelCapabilityCatalog.recommendedSetupReports(on: machine)
         if !recommendedReports.isEmpty {
             print("\nRecommended setup coverage (downloadable from Hugging Face)")
             print("  note: cross-modality starter set; lower-memory agent alternatives are not ranked upgrades.")
             for report in recommendedReports {
                 print("  mere.run model pull \(report.spec.id)")
             }
-        }
-        let unavailableRecommended = reports.filter {
-            $0.isSupported
-                && $0.descriptor.isRecommendedForSetup
-                && !$0.spec.hasAnyManagedDownloadSource()
         }
         if !unavailableRecommended.isEmpty {
             let ids = unavailableRecommended.map(\.spec.id).joined(separator: ", ")
@@ -99,5 +122,105 @@ struct ModelCapabilities: ParsableCommand {
 
     private func downloadLabel(for spec: ManagedModelSpec) -> String {
         spec.hubFallback == nil ? "local path only" : "Hugging Face snapshot"
+    }
+}
+
+struct ModelCapabilitiesOutput: Codable, Equatable {
+    let machine: ModelCapabilitiesMachine
+    let chatBands: [ModelCapabilitiesChatBand]
+    let recommendedChatModel: ModelCapabilitiesChatBand?
+    let setupAgent: ModelCapabilitiesSetupAgent?
+    let recommendedSetupModels: [ModelCapabilitiesModel]
+    let unavailableRecommendedModelIDs: [String]
+    let models: [ModelCapabilitiesModel]
+}
+
+struct ModelCapabilitiesMachine: Codable, Equatable {
+    let processor: String
+    let unifiedMemoryGB: Int
+    let appleSiliconMac: Bool
+    let linux: Bool
+
+    init(_ machine: MereRunMachineProfile) {
+        processor = machine.processorName
+        unifiedMemoryGB = machine.unifiedMemoryGB
+        appleSiliconMac = machine.isAppleSiliconMac
+        linux = machine.isLinux
+    }
+}
+
+struct ModelCapabilitiesChatBand: Codable, Equatable {
+    let bandLabel: String
+    let minimumUnifiedMemoryGB: Int
+    let maximumUnifiedMemoryGB: Int?
+    let modelID: String
+    let title: String
+    let summary: String
+    let alternateModelIDs: [String]
+    let currentMachine: Bool
+
+    init(_ band: ManagedChatModelBandRecommendation, machine: MereRunMachineProfile) {
+        bandLabel = band.bandLabel
+        minimumUnifiedMemoryGB = band.minimumUnifiedMemoryGB
+        maximumUnifiedMemoryGB = band.maximumUnifiedMemoryGB
+        modelID = band.modelID
+        title = band.title
+        summary = band.summary
+        alternateModelIDs = band.alternateModelIDs
+        currentMachine = band.contains(unifiedMemoryGB: machine.unifiedMemoryGB)
+    }
+}
+
+struct ModelCapabilitiesSetupAgent: Codable, Equatable {
+    let id: String
+    let displayName: String
+    let summary: String
+    let minimumUnifiedMemoryGB: Int
+    let recommendedUnifiedMemoryGB: Int
+    let servingEngine: String
+    let startableByMereRun: Bool
+    let sourceConfigurationRequired: Bool
+    let reason: String?
+
+    init(_ recommendation: MereRunAgentModelRecommendation) {
+        id = recommendation.id
+        displayName = recommendation.displayName
+        summary = recommendation.summary
+        minimumUnifiedMemoryGB = recommendation.minimumUnifiedMemoryGB
+        recommendedUnifiedMemoryGB = recommendation.recommendedUnifiedMemoryGB
+        servingEngine = recommendation.servingEngine.rawValue
+        startableByMereRun = recommendation.isStartableByMereRun
+        sourceConfigurationRequired = recommendation.sourceConfigurationRequired
+        reason = recommendation.reason
+    }
+}
+
+struct ModelCapabilitiesModel: Codable, Equatable {
+    let id: String
+    let title: String
+    let category: String
+    let summary: String
+    let minimumUnifiedMemoryGB: Int
+    let recommendedUnifiedMemoryGB: Int
+    let supported: Bool
+    let reasons: [String]
+    let recommendedForSetup: Bool
+    let managedDownloadAvailable: Bool
+    let download: String
+    let commands: [String]
+
+    init(_ report: ManagedModelSupportReport) {
+        id = report.spec.id
+        title = report.descriptor.title
+        category = report.spec.category.rawValue
+        summary = report.descriptor.summary
+        minimumUnifiedMemoryGB = report.descriptor.minimumUnifiedMemoryGB
+        recommendedUnifiedMemoryGB = report.descriptor.recommendedUnifiedMemoryGB
+        supported = report.isSupported
+        reasons = report.reasons
+        recommendedForSetup = report.descriptor.isRecommendedForSetup
+        managedDownloadAvailable = report.spec.hasAnyManagedDownloadSource()
+        download = report.spec.hubFallback == nil ? "local-path" : "hugging-face"
+        commands = report.spec.defaultCLICommands
     }
 }

--- a/StudioCompletion.md
+++ b/StudioCompletion.md
@@ -24,8 +24,12 @@ Already landed in this branch (do **not** re-plan these — they are done and va
 - **Phase 2 — Media & progress (complete).** Inline AVKit video + AVAudioPlayer audio,
   determinate progress (bytes/speed/%), drag-and-drop, library search/delete/rename,
   mode-scoped canvas selection.
-- **Phase 3 — partial.** `sfx` Studio mode + Advanced sfx templates; voice-cloning flags on
-  `speech synthesize` (Advanced).
+- **Phase 3 — Conversational depth & CLI parity (complete).** WS-2: multi-turn chat/code with
+  edit-and-rerun, vision-chat image attach, agentic tool-loop flags, Studio voice-clone UI.
+  WS-3: music analyze/realtime + full sfx family + plugin/open-webui/benchmark Advanced templates,
+  `config` HF-endpoint in Settings, live `status --json` pill, guide-powered help panel,
+  schema-driven Studio option depth (no drift with Advanced), responsive resizable/detachable
+  Advanced panel.
 - **Phase 4 — partial.** Completion notifications, app↔CLI version handshake, HF-token
   setting, library-error banner, accessibility labels, Run/Help menu, first-run welcome.
 
@@ -63,21 +67,21 @@ deep feature work that assumes concurrency and reliable results.
 
 | ID | Task | Effort | Acceptance |
 |----|------|--------|------------|
-| 2.1 | ✅ **Multi-turn chat/code (done)** — app-side conversation model (ordered turns per thread; the CLI is stateless), user/assistant bubbles in the canvas, persistent composer, "New chat", per-message copy + last-turn retry; re-send accumulated system+turns each run with context-window budgeting surfaced via a trim banner. Adversarially reviewed (lossless concurrent completion delivery, queued-turn tracking, think-tag stripping, failed-turn isolation, lenient library decode). _Edit-message is the remaining sub-item, deferred._ | L | Chat/code keep context across turns with a message-history UI; long conversations truncate visibly, not silently. |
-| 2.2 | **Vision chat** — image attachment for vision-capable chat models (CLI `--image`) in Studio. | M | An image can be attached to a chat turn and is sent via `--image`. |
-| 2.3 | **Agentic tool loop (Advanced)** — surface `--tools`/`--tool-loop`/`--allow-shell-exec`/`--sandbox-dir`/`--thinking` for `text chat`. | M | Tool-loop flags are reachable and correctly built in the Advanced editor. |
-| 2.4 | **Studio voice-clone UI** — a profile picker listing saved profiles (`speech profile list`), style/clone toggle, reference-audio attach with save-as-profile, wired into the Speak mode (the Advanced flags already exist). | M | Voice cloning is reachable end-to-end from the Speak mode. |
+| 2.1 | ✅ **Multi-turn chat/code + edit (done)** — app-side conversation model (ordered turns per thread; the CLI is stateless), user/assistant bubbles in the canvas, persistent composer, "New chat", per-message copy + last-turn retry; **edit a prior user turn** (truncates the thread back to that turn via `store.truncate` and reloads its text into the composer to re-run); re-send accumulated system+turns each run with context-window budgeting surfaced via a trim banner. Adversarially reviewed. | L | Chat/code keep context across turns with a message-history UI; long conversations truncate visibly, not silently. |
+| 2.2 | ✅ **Vision chat (done)** — image attachment for vision-capable chat models (CLI `--image`) in Studio chat; the image rides with one turn and is cleared after sending. | M | An image can be attached to a chat turn and is sent via `--image`. |
+| 2.3 | ✅ **Agentic tool loop (done, Advanced)** — `--tools`/`--tool-loop`/`--allow-shell-exec`/`--sandbox-dir`/`--thinking` surfaced for `text chat` in the Advanced editor. | M | Tool-loop flags are reachable and correctly built in the Advanced editor. |
+| 2.4 | ✅ **Studio voice-clone UI (done)** — Speak mode gains a Style/Clone picker; Clone mode shows a profile picker from `speech profile list`, a reference-audio chooser, and a save-as-profile field, mapped to `--mode/--profile/--ref-audio/--save-profile`. | M | Voice cloning is reachable end-to-end from the Speak mode. |
 
 ### WS-3 — CLI feature parity (Phase 3) · L
 
 | ID | Task | Effort | Acceptance |
 |----|------|--------|------------|
-| 3.1 | **`music analyze`** (Advanced, audio→JSON) and **`music realtime`** scoped as a dedicated interactive experience (live audio + control panel). | L | `music analyze` runs from Advanced; `music realtime` has a documented interactive surface. |
-| 3.2 | **`sfx ae` / `sfx clap` / `sfx condition`** as Advanced templates. | M | The full sfx family is reachable from Advanced. |
-| 3.3 | **`config`** (HF endpoint, other keys) surfaced in Settings (HF token already done); **`status --json`** as a live status pill in the Studio top bar (server up?, loaded model, installed count). | M | Status pill reflects `status --json`; config values are editable in Settings with masking. |
-| 3.4 | **`plugin`** (list/install/doctor), **`open-webui` quickstart**, **`model benchmark`** as Advanced templates; wire **`guide`** into a help panel. | M | Each command is invokable from the GUI; guide powers in-app help. |
-| 3.5 | **Shared per-mode option schema** rendered in both Studio and Advanced (single source of truth) — chat temperature/max-tokens, image CFG/strength, transcription language/timestamps/backend, video duration/fps/frames/variant/end-image. | L | Studio options expose real depth; no drift between surfaces (schema-driven). |
-| 3.6 | **Responsive Advanced panel** — single resizable column when docked vs full 3-pane detached; pre-select the template matching the active Studio mode and share draft state. | L | The 1210px panel no longer scrolls inside the rail; "Advanced" deepens the current task. |
+| 3.1 | ✅ **`music analyze` + `music realtime` (done)** — Advanced templates (realtime runs `--no-play` since the GUI has no audio device/stdin TTY; interactive playback stays CLI-only). | L | `music analyze` runs from Advanced; `music realtime` has a documented surface. |
+| 3.2 | ✅ **`sfx ae` / `sfx clap` / `sfx condition` (done)** — Advanced templates (ae encode/decode, clap score, condition text). | M | The full sfx family is reachable from Advanced. |
+| 3.3 | ✅ **`config` + status pill (done)** — Settings gains a Hugging Face endpoint field (`config get/set hf-endpoint`) beside the masked token; a Studio top-bar pill polls `status --json` every 20s and shows reachability, loaded model, and installed count. | M | Status pill reflects `status --json`; config values are editable in Settings with masking. |
+| 3.4 | ✅ **`plugin`/`open-webui`/`benchmark` + guide help (done)** — plugin list/install/doctor, open-webui quickstart, and model benchmark as Advanced templates; a "Help" button opens a guide-powered panel (`guide --list --json` + per-topic Markdown). | M | Each command is invokable from the GUI; guide powers in-app help. |
+| 3.5 | ✅ **Shared per-mode option schema (done)** — `StudioOptionSchema` is the single source of truth (chat temperature/max-tokens, image CFG/strength, transcription language/backend/timestamps, video variant/fps/frames/strength); the Studio sheet renders it generically and the adapter maps every field to the same CLI flag the Advanced surface emits. Defaults are seeded from the template's `CommandDraft` to avoid drift. (Video "duration"/"end-image" omitted — no such CLI flags; frames+fps define duration.) | L | Studio options expose real depth; no drift between surfaces (schema-driven). |
+| 3.6 | ✅ **Responsive Advanced panel (done)** — docked shows a single resizable column (compact template Menu + scrollable editor; drag handle 360–860pt) instead of a horizontally-scrolling 1210px three-pane; a detach button opens the full three-pane in a large sheet; opening Advanced pre-selects the active Studio mode's template and carries over the composer's prompt/model/input. | L | The 1210px panel no longer scrolls inside the rail; "Advanced" deepens the current task. |
 
 ### WS-4 — Native polish & accessibility (Phase 4) · L
 

--- a/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
+++ b/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
@@ -187,6 +187,23 @@ final class StudioLibraryStoreTests: XCTestCase {
         XCTAssertEqual(store.items.first?.messages?.map(\.role), [.user])
     }
 
+    func testTruncateRemovesFromMessageAndReturnsUserContent() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let conversationID = UUID()
+        store.appendUser(conversationID: conversationID, mode: .chat, model: nil, systemPrompt: nil, content: "one")
+        store.appendAssistant(conversationID: conversationID, content: "a1", exitCode: 0)
+        store.appendUser(conversationID: conversationID, mode: .chat, model: nil, systemPrompt: nil, content: "two")
+        store.appendAssistant(conversationID: conversationID, content: "a2", exitCode: 0)
+
+        let messages = try XCTUnwrap(store.items.first?.messages)
+        let secondTurnID = try XCTUnwrap(messages.first { $0.content == "two" }?.id)
+        let removed = store.truncate(conversationID: conversationID, removingFrom: secondTurnID)
+
+        XCTAssertEqual(removed, "two")
+        XCTAssertEqual(store.items.first?.messages?.map(\.content), ["one", "a1"])
+    }
+
     func testLoadKeepsValidRowsWhenOneIsCorrupt() throws {
         let url = try temporaryLibraryURL()
         let good = """

--- a/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
+++ b/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
@@ -200,8 +200,22 @@ final class StudioLibraryStoreTests: XCTestCase {
         let secondTurnID = try XCTUnwrap(messages.first { $0.content == "two" }?.id)
         let removed = store.truncate(conversationID: conversationID, removingFrom: secondTurnID)
 
-        XCTAssertEqual(removed, "two")
+        XCTAssertEqual(removed?.content, "two")
         XCTAssertEqual(store.items.first?.messages?.map(\.content), ["one", "a1"])
+    }
+
+    func testAppendUserStoresImageForVisionTurnAndTruncateReturnsIt() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let conversationID = UUID()
+        store.appendUser(
+            conversationID: conversationID, mode: .chat, model: nil, systemPrompt: nil,
+            content: "what is this?", imagePath: "/tmp/photo.png"
+        )
+        let messageID = try XCTUnwrap(store.items.first?.messages?.first?.id)
+        let removed = store.truncate(conversationID: conversationID, removingFrom: messageID)
+        XCTAssertEqual(removed?.imagePath, "/tmp/photo.png")
+        XCTAssertEqual(store.items.first?.messages?.isEmpty, true)
     }
 
     func testLoadKeepsValidRowsWhenOneIsCorrupt() throws {

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -34,6 +34,61 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertTrue(chatTemplate.arguments(from: draft).contains("--stream"))
     }
 
+    func testChatBuildsVisionAndToolLoopFlags() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .textChat))
+        var draft = template.defaultDraft()
+        draft.imagePath = "/tmp/in.png"
+        draft.tools = "write_file,shell_exec"
+        draft.toolLoop = true
+        draft.allowShellExec = true
+        draft.sandboxDir = "/tmp/box"
+        let args = template.arguments(from: draft)
+        assertPair(args, "--image", "/tmp/in.png")
+        assertPair(args, "--tools", "write_file,shell_exec")
+        assertPair(args, "--sandbox-dir", "/tmp/box")
+        XCTAssertTrue(args.contains("--tool-loop"))
+        XCTAssertTrue(args.contains("--allow-shell-exec"))
+    }
+
+    func testChatOmitsVisionAndToolFlagsByDefault() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .textChat))
+        let args = template.arguments(from: template.defaultDraft())
+        XCTAssertFalse(args.contains("--image"))
+        XCTAssertFalse(args.contains("--tools"))
+        XCTAssertFalse(args.contains("--tool-loop"))
+        XCTAssertFalse(args.contains("--allow-shell-exec"))
+    }
+
+    func testNewAdvancedTemplatesBuildExpectedCommands() throws {
+        func args(_ id: CommandTemplateID, _ mutate: (inout CommandDraft) -> Void = { _ in }) throws -> [String] {
+            let template = try XCTUnwrap(CommandCatalog.template(id: id))
+            var draft = template.defaultDraft()
+            mutate(&draft)
+            return template.arguments(from: draft)
+        }
+        XCTAssertEqual(try args(.musicAnalyze) { $0.inputPath = "/a.wav" }.prefix(3).map { $0 }, ["music", "analyze", "/a.wav"])
+        XCTAssertEqual(try args(.musicRealtime).prefix(2).map { $0 }, ["music", "realtime"])
+        XCTAssertTrue(try args(.musicRealtime).contains("--no-play"))
+        XCTAssertEqual(try args(.sfxAEEncode) { $0.inputPath = "/a.wav" }.prefix(3).map { $0 }, ["sfx", "ae", "encode"])
+        XCTAssertEqual(try args(.sfxAEDecode) { $0.inputPath = "/a.npy" }.prefix(3).map { $0 }, ["sfx", "ae", "decode"])
+        XCTAssertEqual(try args(.sfxClapScore) { $0.prompt = "door"; $0.inputPath = "/a.wav" }.prefix(3).map { $0 }, ["sfx", "clap", "score"])
+        XCTAssertEqual(try args(.sfxConditionText) { $0.prompt = "door" }.prefix(3).map { $0 }, ["sfx", "condition", "text"])
+        XCTAssertEqual(try args(.modelBenchmark).prefix(3).map { $0 }, ["model", "benchmark", "q36-mtp"])
+        XCTAssertEqual(try args(.pluginList).prefix(2).map { $0 }, ["plugin", "list"])
+        XCTAssertEqual(try args(.pluginInstall) { $0.prompt = "mere-runpod"; $0.force = true }, ["plugin", "install", "mere-runpod", "--yes"])
+        XCTAssertEqual(try args(.pluginDoctor) { $0.prompt = "mere-runpod" }, ["plugin", "doctor", "mere-runpod"])
+        XCTAssertEqual(try args(.openWebui).prefix(2).map { $0 }, ["open-webui", "quickstart"])
+    }
+
+    private func assertPair(_ args: [String], _ flag: String, _ value: String,
+                            file: StaticString = #filePath, line: UInt = #line) {
+        guard let index = args.firstIndex(of: flag), index + 1 < args.count else {
+            XCTFail("flag \(flag) not found in \(args)", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(args[index + 1], value, file: file, line: line)
+    }
+
     func testStudioRunRequestBuildsImageCommandWithDefaultOutput() throws {
         var draft = StudioDraft()
         draft.reset(for: .createImage)

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -325,6 +325,32 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertTrue(request.draft.imagePath.isEmpty)
     }
 
+    func testSpeakCloneRequestMapsProfileAndReferenceAudio() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .speak)
+        draft.prompt = "hello world"
+        draft.voiceMode = "clone"
+        draft.voiceProfile = "narrator-id"
+        draft.refAudioPath = "/tmp/ref.wav"
+        draft.saveProfileName = "Narrator"
+        let request = try StudioCommandAdapter.makeRequest(mode: .speak, draft: draft)
+        let args = request.template.arguments(from: request.draft)
+        assertPair(args, "--mode", "clone")
+        assertPair(args, "--profile", "narrator-id")
+        assertPair(args, "--ref-audio", "/tmp/ref.wav")
+        assertPair(args, "--save-profile", "Narrator")
+    }
+
+    func testSpeakStyleRequestOmitsCloneFlags() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .speak)
+        draft.prompt = "hello world"
+        let request = try StudioCommandAdapter.makeRequest(mode: .speak, draft: draft)
+        let args = request.template.arguments(from: request.draft)
+        XCTAssertFalse(args.contains("--profile"))
+        XCTAssertFalse(args.contains("--ref-audio"))
+    }
+
     func testLegacyLibraryItemDecodesWithoutConversationFields() throws {
         let legacy = StudioLibraryItem(
             id: UUID(), mode: .chat, prompt: "hello there",

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -351,6 +351,67 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertFalse(args.contains("--ref-audio"))
     }
 
+    func testChatSchemaExposesTemperatureAndMaxTokens() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .chat)
+        draft.prompt = "hi"
+        draft.temperature = 0.3
+        draft.maxTokens = 1234
+        let request = try StudioCommandAdapter.makeRequest(mode: .chat, draft: draft)
+        let args = request.template.arguments(from: request.draft)
+        assertPair(args, "--temperature", "0.3")
+        assertPair(args, "--max-tokens", "1234")
+    }
+
+    func testImageSchemaExposesCfgAndStrength() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        draft.prompt = "a cat"
+        draft.inputPath = "/tmp/base.png"
+        draft.cfgScale = 6.5
+        draft.strength = 0.4
+        let request = try StudioCommandAdapter.makeRequest(mode: .createImage, draft: draft)
+        let args = request.template.arguments(from: request.draft)
+        assertPair(args, "--cfg", "6.5")
+        assertPair(args, "--strength", "0.4")
+    }
+
+    func testListenSchemaExposesLanguageBackendTimestamps() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .listen)
+        draft.inputPath = "/tmp/a.wav"
+        draft.language = "es"
+        draft.backend = "mlx"
+        draft.timestamps = false
+        let request = try StudioCommandAdapter.makeRequest(mode: .listen, draft: draft)
+        let args = request.template.arguments(from: request.draft)
+        assertPair(args, "--language", "es")
+        assertPair(args, "--backend", "mlx")
+        XCTAssertTrue(args.contains("--no-timestamps"))
+    }
+
+    func testVideoSchemaExposesVariantFpsFrames() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .video)
+        draft.prompt = "a wave"
+        draft.variant = "full"
+        draft.fps = 30
+        draft.numFrames = 120
+        let request = try StudioCommandAdapter.makeRequest(mode: .video, draft: draft)
+        let args = request.template.arguments(from: request.draft)
+        assertPair(args, "--variant", "full")
+        assertPair(args, "--fps", "30")
+        assertPair(args, "--num-frames", "120")
+    }
+
+    func testSchemaDefaultsMatchTemplateDraftSoSurfacesDoNotDrift() {
+        var draft = StudioDraft()
+        draft.reset(for: .chat)
+        let base = CommandCatalog.template(id: StudioMode.chat.defaultTemplateID)?.defaultDraft()
+        XCTAssertEqual(draft.temperature, base?.temperature)
+        XCTAssertEqual(draft.maxTokens, base?.maxTokens)
+    }
+
     func testLegacyLibraryItemDecodesWithoutConversationFields() throws {
         let legacy = StudioLibraryItem(
             id: UUID(), mode: .chat, prompt: "hello there",

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -351,6 +351,23 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertFalse(args.contains("--ref-audio"))
     }
 
+    func testSpeakCloneWithoutSourceFailsValidation() {
+        var draft = StudioDraft()
+        draft.reset(for: .speak)
+        draft.prompt = "hello world"
+        draft.voiceMode = "clone"
+        XCTAssertThrowsError(try StudioCommandAdapter.makeRequest(mode: .speak, draft: draft))
+    }
+
+    func testSpeakCloneWithProfilePassesValidation() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .speak)
+        draft.prompt = "hello world"
+        draft.voiceMode = "clone"
+        draft.voiceProfile = "narrator-id"
+        XCTAssertNoThrow(try StudioCommandAdapter.makeRequest(mode: .speak, draft: draft))
+    }
+
     func testChatSchemaExposesTemperatureAndMaxTokens() throws {
         var draft = StudioDraft()
         draft.reset(for: .chat)

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -280,6 +280,25 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertNil(request.conversationID)
     }
 
+    func testChatConversationRequestAttachesImage() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .chat)
+        draft.prompt = "what is this?"
+        draft.inputPath = "/tmp/pic.png"
+        let request = try StudioCommandAdapter.makeRequest(mode: .chat, draft: draft, conversationID: UUID())
+        XCTAssertEqual(request.draft.imagePath, "/tmp/pic.png")
+        assertPair(request.template.arguments(from: request.draft), "--image", "/tmp/pic.png")
+    }
+
+    func testCodeConversationRequestIgnoresImage() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .code)
+        draft.prompt = "hi"
+        draft.inputPath = "/tmp/pic.png"
+        let request = try StudioCommandAdapter.makeRequest(mode: .code, draft: draft, conversationID: UUID())
+        XCTAssertTrue(request.draft.imagePath.isEmpty)
+    }
+
     func testLegacyLibraryItemDecodesWithoutConversationFields() throws {
         let legacy = StudioLibraryItem(
             id: UUID(), mode: .chat, prompt: "hello there",

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -80,6 +80,32 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertEqual(try args(.openWebui).prefix(2).map { $0 }, ["open-webui", "quickstart"])
     }
 
+    func testStudioServerStatusParsesSnapshot() {
+        let json = """
+        {"server":{"url":"http://127.0.0.1:8080","health":"ok","loadedModels":["text-chat-gemma4"]},\
+        "knownModelCount":40,\
+        "installedModels":[{"id":"a","category":"text","size":"1 GB"},{"id":"b","category":"image","size":"2 GB"}]}
+        """
+        let status = StudioServerStatus.parse(jsonStdout: "probing...\n" + json + "\n")
+        XCTAssertEqual(status?.health, "ok")
+        XCTAssertEqual(status?.loadedModels, ["text-chat-gemma4"])
+        XCTAssertEqual(status?.installedCount, 2)
+        XCTAssertEqual(status?.isReachable, true)
+    }
+
+    func testStudioServerStatusReturnsNilForNonJSON() {
+        XCTAssertNil(StudioServerStatus.parse(jsonStdout: "connection refused"))
+    }
+
+    func testStudioVoiceProfileParsesTabSeparatedList() {
+        let out = "11111111-1111-1111-1111-111111111111\tNarrator\t2026-06-01\n"
+            + "22222222-2222-2222-2222-222222222222\tHero\t2026-06-02\n"
+        let profiles = StudioVoiceProfile.parse(listOutput: out)
+        XCTAssertEqual(profiles.count, 2)
+        XCTAssertEqual(profiles.first?.name, "Narrator")
+        XCTAssertEqual(profiles.last?.id, "22222222-2222-2222-2222-222222222222")
+    }
+
     private func assertPair(_ args: [String], _ flag: String, _ value: String,
                             file: StaticString = #filePath, line: UInt = #line) {
         guard let index = args.firstIndex(of: flag), index + 1 < args.count else {

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MereRunCore
 @testable import MereRunCLI
 
 final class ModelPullCommandParsingTests: XCTestCase {
@@ -15,6 +16,49 @@ final class ModelPullCommandParsingTests: XCTestCase {
     func testModelCommandExposesCapabilities() {
         let commandNames = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertTrue(commandNames.contains("capabilities"))
+    }
+
+    func testModelCapabilitiesParsesJsonRecommendationFlags() throws {
+        let cmd = try ModelCapabilities.parse(["--recommended", "--json"])
+
+        XCTAssertTrue(cmd.recommended)
+        XCTAssertTrue(cmd.json)
+    }
+
+    func testModelCapabilitiesJsonIncludesMachineChatRecommendation() throws {
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M1 Max",
+            isAppleSiliconMac: true
+        )
+        let bands = ManagedModelCapabilityCatalog.recommendedChatBandReports(on: machine)
+        let payload = ModelCapabilitiesOutput(
+            machine: .init(machine),
+            chatBands: bands.map { .init($0, machine: machine) },
+            recommendedChatModel: bands
+                .first { $0.contains(unifiedMemoryGB: machine.unifiedMemoryGB) }
+                .map { .init($0, machine: machine) },
+            setupAgent: MereRunAgentModelCatalog
+                .recommendation(for: .tier, on: machine)
+                .map(ModelCapabilitiesSetupAgent.init),
+            recommendedSetupModels: ManagedModelCapabilityCatalog
+                .recommendedSetupReports(on: machine)
+                .map(ModelCapabilitiesModel.init),
+            unavailableRecommendedModelIDs: [],
+            models: []
+        )
+
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(ModelCapabilitiesOutput.self, from: data)
+
+        XCTAssertEqual(decoded.machine.unifiedMemoryGB, 32)
+        XCTAssertEqual(decoded.recommendedChatModel?.modelID, "text-chat-q36-nano")
+        XCTAssertEqual(decoded.recommendedChatModel?.alternateModelIDs, [
+            "text-chat-gemma4-turbo",
+            "text-chat-gemma4-12b-4bit",
+        ])
+        XCTAssertTrue(decoded.recommendedChatModel?.currentMachine == true)
+        XCTAssertEqual(decoded.setupAgent?.id, "text-chat-q36-nano")
     }
 
     func testInstallValidationErrorIncludesRetryWithoutUsage() {


### PR DESCRIPTION
## Phase 3 — Conversational depth & CLI feature parity

Completes Phase 3 of the macOS Studio roadmap (WS-2 + WS-3) on top of the merged multi-turn chat (#94). The app remains a thin GUI over the stateless `mere.run` CLI; every new control maps to a verified public flag.

### WS-2 — Conversational depth
- **2.1 Edit a prior turn** — user message bubbles get an Edit action (idle only); `StudioLibraryStore.truncate` drops that turn and everything after it and reloads its text into the composer to re-run from that point.
- **2.2 Vision chat** — chat-only `--image` attach; the image rides one turn and is cleared after sending.
- **2.3 Agentic tool loop (Advanced)** — `--tools` / `--tool-loop` / `--allow-shell-exec` / `--sandbox-dir` / `--thinking` for `text chat`.
- **2.4 Studio voice-clone UI** — Speak gains a Style/Clone picker; Clone shows a profile picker from `speech profile list`, a reference-audio chooser, and a save-as-profile field → `--mode/--profile/--ref-audio/--save-profile`.

### WS-3 — CLI feature parity
- **3.1/3.2 templates** — music analyze + realtime (realtime forced `--no-play`; the GUI has no audio device/stdin TTY), and the full sfx family (ae encode/decode, clap score, condition text).
- **3.3 status + config** — a top-bar pill polls `status --json` every 20s (reachability, loaded model, installed count); Settings gains a Hugging Face endpoint field (`config get/set hf-endpoint`) beside the masked token.
- **3.4 templates + help** — plugin list/install/doctor, open-webui quickstart, model benchmark; a "Help" button opens a guide-powered panel (`guide --list --json` + per-topic Markdown).
- **3.5 shared option schema** — `StudioOptionSchema` is the single source of truth for each mode's advanced depth (chat temperature/max-tokens, image CFG/strength, transcription language/backend/timestamps, video variant/fps/frames/strength). The Studio sheet renders it generically; the adapter maps every field to the same CLI flag the Advanced surface emits; defaults are seeded from the template's `CommandDraft` so the two surfaces never drift.
- **3.6 responsive Advanced panel** — docked is now a single resizable column (compact template picker + scrollable editor; drag handle 360–860pt) instead of a horizontally-scrolling 1210px three-pane; a detach button opens the full three-pane in a sheet; opening Advanced pre-selects the active mode's template and carries over the composer's prompt/model/input.

### Verification
- `./scripts/check.sh` green: **925 tests, 0 failures**, swiftlint --strict clean.
- New unit tests cover the adapter flag mapping for every schema field and voice-clone mode, the status/guide/voice-profile parsers, and `truncate`.
- Adversarially reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QA5hhtDTCaSAHgfYgh56kM
