### PR TITLE
WS-5: harden app signing — inside-out + split app/CLI entitlements

### DIFF
--- a/StudioCompletion.md
+++ b/StudioCompletion.md
@@ -103,9 +103,21 @@ deep feature work that assumes concurrency and reliable results.
 
 ### WS-5 — Distribution hardening (Phase 4) · M (+ credential-gated)
 
+> **Signing hardened (code complete).** `build_mere_run_app.sh` now signs inside-out with
+> per-binary entitlements instead of a fragile `codesign --deep` pass: the app exe gets only
+> `device.camera`; the bundled CLI + vendored ds4 inference binaries get
+> `allow-jit`/`allow-unsigned-executable-memory`/`disable-library-validation`/`device.camera` via
+> the new `scripts/MereRunCLI.entitlements`. Dropped the unused `device.audio-input` entitlement +
+> `NSMicrophoneUsageDescription` (nothing records the mic yet) and added Developer-ID Info.plist
+> keys (`LSApplicationCategoryType`, `NSHumanReadableCopyright`, `CFBundleInfoDictionaryVersion`).
+> The private `mere-run-release-tools` (`build_release.sh`/`make_dmg.sh`) was fixed to stop
+> double-signing / stripping the app exe's entitlements (it now defers signing to the public
+> script). Verified locally with an ad-hoc identity (`codesign --verify` valid, correct per-binary
+> entitlements). **Remaining = credential-gated:** an actual Developer-ID signed + notarized run.
+
 | ID | Task | Effort | Acceptance |
 |----|------|--------|------------|
-| 5.1 | **Developer ID signing run** — set `MERERUN_CODESIGN_IDENTITY` in CI; the scripts already sign with `--options runtime` + entitlements. *(Credential-gated.)* | S | `spctl --assess` passes on a downloaded DMG from a clean machine. |
+| 5.1 | **Developer ID signing run** — set `MERERUN_CODESIGN_IDENTITY`; the scripts now sign inside-out with `--options runtime` + correct per-binary entitlements. *(Credential-gated: needs the Developer ID cert.)* | S | `spctl --assess` passes on a downloaded DMG from a clean machine. |
 | 5.2 | **Notarization** — `MACOS_*`/`MERERUN_NOTARY_*` GitHub secrets; `package-macos.sh` already submits + staples. *(Credential-gated.)* | S | `notarytool` accepts the bundle; stapled DMG opens with no Gatekeeper prompt. |
 | 5.3 | **Auto-update** — Sparkle is **out of scope for this OSS repo** (AGENTS.md forbids hosted-service surfaces). Ship the app↔CLI version handshake (done) and document the maintainer-side update channel; if auto-update is wanted, it lives in the distribution layer. | S | Version mismatch is surfaced in-app; update channel documented. |
 | 5.4 | **MetricKit diagnostics** — opt-in `MXCrashDiagnostic` capture + an "Export diagnostics" action bundling logs + app/CLI versions (no remote upload). | M | Users can export a diagnostics bundle for bug reports. |

--- a/scripts/MereRun.entitlements
+++ b/scripts/MereRun.entitlements
@@ -3,26 +3,21 @@
 <plist version="1.0">
 <dict>
 	<!--
-	  Hardened-runtime entitlements for the notarized (non-sandboxed) Developer ID build.
-	  Mac App Store / App Sandbox is intentionally out of scope for this OSS distribution.
+	  Hardened-runtime entitlements for the SwiftUI app executable (Contents/MacOS/mere.run.app)
+	  of the notarized (non-sandboxed) Developer ID build. Mac App Store / App Sandbox is
+	  intentionally out of scope for this OSS distribution.
 
-	  - allow-jit / allow-unsigned-executable-memory: the bundled CLI runs MLX/Metal and
-	    llama.cpp inference which JIT-compile and use executable memory.
-	  - disable-library-validation: the app spawns the bundled CLI (separate Mach-O) which
-	    loads its co-located llama.framework, mlx bundle, and the vendored ds4-server.
-	  - device.camera / device.audio-input: required under the hardened runtime for the
-	    `vision track-live` (camera) and future `music realtime` (microphone) capture paths,
-	    in addition to the NSCameraUsageDescription / NSMicrophoneUsageDescription strings.
+	  The app target links only system frameworks (Package.swift: MereRunApp dependencies = [])
+	  and does no JIT, executable-memory, or unsigned-library loading itself — all inference and
+	  the AVCaptureSession capture run in the bundled `mere.run` CLI child, which carries those
+	  entitlements on its own signature (see scripts/MereRunCLI.entitlements). So the app needs
+	  only the camera entitlement:
+
+	  - device.camera: the app calls AVCaptureDevice.requestAccess(for: .video) to grant the
+	    camera before launching `vision track-live`; pairs with NSCameraUsageDescription.
+	    (No audio-input: nothing records the microphone in-app — add it when that ships.)
 	-->
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.device.camera</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
 	<true/>
 </dict>
 </plist>

--- a/scripts/MereRunCLI.entitlements
+++ b/scripts/MereRunCLI.entitlements
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Hardened-runtime entitlements for the bundled `mere.run` CLI (and the vendored ds4
+	  inference binaries) inside MereRun.app. The CLI — not the SwiftUI app — is the process
+	  that JIT-compiles, allocates executable memory, loads co-located unsigned frameworks, and
+	  opens the camera, so these entitlements belong on the CLI's own signature. The app bundle
+	  is signed inside-out (see build_mere_run_app.sh), so the CLI carries this set explicitly
+	  rather than relying on a deep codesign pass to propagate the app's entitlements.
+
+	  - allow-jit / allow-unsigned-executable-memory: MLX/Metal and llama.cpp JIT-compile and
+	    use executable memory during inference.
+	  - disable-library-validation: the CLI loads its co-located llama.framework, the mlx bundle,
+	    and the vendored ds4-server (third-party signatures, not the app's Team ID).
+	  - device.camera: `vision track-live` opens an AVCaptureSession in this process.
+	    (No audio-input: nothing captures the microphone yet — add it when that ships.)
+	-->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -105,29 +105,63 @@ plutil -insert CFBundleShortVersionString -string "$app_version" "${contents}/In
 plutil -insert LSMinimumSystemVersion -string "15.0" "${contents}/Info.plist"
 plutil -insert NSPrincipalClass -string "NSApplication" "${contents}/Info.plist"
 plutil -insert NSHighResolutionCapable -bool true "${contents}/Info.plist"
-# TCC usage strings. The CLI captures the camera/mic as a child of this bundle, so TCC
-# attributes access to the app and the strings must live here.
+plutil -insert CFBundleInfoDictionaryVersion -string "6.0" "${contents}/Info.plist"
+plutil -insert LSApplicationCategoryType -string "public.app-category.developer-tools" "${contents}/Info.plist"
+plutil -insert NSHumanReadableCopyright -string "© mere.run" "${contents}/Info.plist"
+# TCC usage string. The CLI opens the camera as a child of this bundle, so TCC attributes
+# access to the app and the string must live here. (No microphone string: nothing records the
+# mic yet — add NSMicrophoneUsageDescription when `music realtime` mic capture ships.)
 plutil -insert NSCameraUsageDescription -string \
   "MereRun uses the camera for live object tracking (vision track-live)." "${contents}/Info.plist"
-plutil -insert NSMicrophoneUsageDescription -string \
-  "MereRun uses the microphone for realtime music input." "${contents}/Info.plist"
 
 if [[ -f "$app_icon" ]]; then
   cp "$app_icon" "${resources}/AppIcon.icns"
   plutil -insert CFBundleIconFile -string "AppIcon" "${contents}/Info.plist"
 fi
 
-# Codesign the whole bundle in a single deep pass so nested code (llama.framework, the mlx
-# bundle, the CLI, and the vendored ds4-server) is signed consistently. With a Developer ID
-# identity this produces a hardened-runtime, notarizable bundle; otherwise it ad-hoc signs
-# for local development. Manual inside-out signing of the mixed vendored tree is brittle, so
-# --deep is used deliberately here.
-if [[ "$identity" == "-" ]]; then
-  codesign --force --deep --sign - "$bundle"
-else
-  codesign --force --deep --timestamp --options runtime \
-    --entitlements "$entitlements" --sign "$identity" "$bundle"
-  codesign --verify --deep --strict --verbose=2 "$bundle"
-fi
+# Codesign inside-out so each Mach-O carries the entitlements it actually needs on its OWN
+# signature. We deliberately do not lean on `codesign --deep --force` for entitlements: a forced
+# deep pass applies the *same* entitlements to every nested binary (unreliable across toolchains
+# and wrong here — the app and CLI need different sets). The app executable links only system
+# frameworks and just opens the camera, so it gets the minimal app set; the bundled CLI and the
+# vendored ds4 inference binaries JIT, load co-located unsigned frameworks, and capture the
+# camera, so they get the broader CLI set. With a Developer ID identity this yields a
+# hardened-runtime, notarizable bundle; with the default "-" it ad-hoc signs for local dev.
+cli_entitlements="${repo_root}/scripts/MereRunCLI.entitlements"
+
+sign() {
+  # sign <entitlements-or-empty> <path...>
+  local ents="$1"; shift
+  local args=(--force --options runtime --sign "$identity")
+  [[ "$identity" != "-" ]] && args+=(--timestamp)
+  [[ -n "$ents" ]] && args+=(--entitlements "$ents")
+  codesign "${args[@]}" "$@"
+}
+
+# 1. Co-located frameworks/bundles — no entitlements.
+while IFS= read -r -d '' asset; do
+  sign "" "$asset"
+done < <(find "$helpers" \( -name '*.framework' -o -name '*.bundle' \) -prune -print0)
+
+# 2. The bundled CLI and every vendored Mach-O under Helpers — CLI entitlements. (The .metal
+#    shader sources sit beside the ds4 executables; the file-type test skips them.)
+sign "$cli_entitlements" "${helpers}/mere.run"
+while IFS= read -r -d '' candidate; do
+  if file -b "$candidate" | grep -q 'Mach-O'; then
+    sign "$cli_entitlements" "$candidate"
+  fi
+done < <(find "${helpers}/vendor" -type f -print0 2>/dev/null)
+
+# 3. Seal the bundle. The app executable arrives ad-hoc-signed by the Swift toolchain, so strip
+#    that first — then a `--deep` pass WITHOUT `--force` signs only the now-unsigned app exe
+#    (with the app entitlements) and seals CodeResources, while skipping — never re-stamping —
+#    the already-signed nested code, so each nested binary keeps its own entitlement set. --deep
+#    (vs a plain seal) is needed so codesign walks the loose vendored ds4 tree correctly instead
+#    of mistaking its sibling .metal shaders for unsigned nested code.
+codesign --remove-signature "${macos}/mere.run.app" 2>/dev/null || true
+seal_args=(--deep --options runtime --entitlements "$entitlements" --sign "$identity")
+[[ "$identity" != "-" ]] && seal_args+=(--timestamp)
+codesign "${seal_args[@]}" "$bundle"
+codesign --verify --verbose=2 "$bundle"
 
 echo "$bundle"


### PR DESCRIPTION
Distribution-hardening half of WS-5 (the credential-free, code part). The actual Developer-ID-signed + notarized **run** stays yours to execute from `mere-run-release-tools`.

### Audit that drove this
Three parallel read-only agents + an empirical `codesign` test on this host found: the bundle was signed in a single `codesign --deep` pass that relied on **undocumented, toolchain-dependent** behavior to push the app's entitlements onto the bundled CLI. It happens to work on the current host, but is fragile — and the private re-seal made it worse (see the companion PR).

Concrete camera/mic finding: `vision track-live` opens its `AVCaptureSession` in the **bundled CLI child** (the app only fires the TCC prompt), so the CLI binary — not just the app — needs `device.camera` on its own signature. The mic is **not captured anywhere** yet.

### Changes
- **New `scripts/MereRunCLI.entitlements`** for the bundled `mere.run` CLI + vendored ds4 binaries: `allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, `device.camera`.
- **`scripts/MereRun.entitlements` trimmed** to the app's real needs — `device.camera` only. (`MereRunApp` has `dependencies: []`; it links only system frameworks and does no JIT/library loading itself.)
- **Dropped the unused `device.audio-input` + `NSMicrophoneUsageDescription`** (least privilege; re-add when `music realtime` mic capture ships).
- **`build_mere_run_app.sh` now signs inside-out**: frameworks (no entitlements) → CLI + ds4 (CLI entitlements) → strip the toolchain's ad-hoc sig off the app exe → seal with a `--deep` pass *without* `--force` (signs only the now-unsigned app exe with the app entitlements, records nested signatures without re-stamping them). `--deep` is kept for the seal only so codesign walks the loose vendored ds4 tree (its sibling `.metal` shaders otherwise trip a plain seal).
- **Info.plist**: added `LSApplicationCategoryType` (developer-tools), `NSHumanReadableCopyright`, `CFBundleInfoDictionaryVersion`.

### Verification (local, ad-hoc identity)
```
app exe : device.camera
mere.run: allow-jit, allow-unsigned-executable-memory, disable-library-validation, device.camera
codesign --verify --verbose=2 → valid on disk, satisfies its Designated Requirement
Info.plist: LSApplicationCategoryType present; mic usage string absent
```
⚠️ A real **Developer-ID signed + notarized** build still needs the cert in the keychain — that's the credential-gated WS-5.1/5.2 run.

### Companion
Requires **sawfwair/mere-run-release-tools#1** (stops the private pipeline from double-signing / stripping the app exe's entitlements). Land both together.

Only `scripts/` + `StudioCompletion.md` touched; unrelated in-flight CLI/Core work left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QA5hhtDTCaSAHgfYgh56kM