### PR TITLE
Add code benchmark slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ swift run mere.run model benchmark q36-mtp \
   --decode-tokens 32 \
   --json
 
+# Small real coding-eval slice: Ornith vs North Mini vs Qwen3-Coder
+swift run mere.run model benchmark code \
+  --allow-code-execution \
+  --json
+
 # Tiny synthetic VLM eval: Gemma4 12B vision chat vs existing Qwen3-VL inspect backend
 swift run mere.run model benchmark vlm --json
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -32,6 +32,9 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     @Option(name: [.long], help: "Python executable used to run HumanEval slice tests.")
     var python: String = "python3"
 
+    @Option(name: [.long], help: "Sandbox backend for generated-code execution.")
+    var sandbox: CodeExecutionSandboxMode = .auto
+
     @Flag(name: [.long], help: "Print the benchmark plan without loading models or executing generated code.")
     var dryRun: Bool = false
 
@@ -60,6 +63,9 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
         guard executionTimeout > 0, executionTimeout.isFinite else {
             throw ValidationError("--execution-timeout must be a positive finite number.")
         }
+        if !dryRun {
+            try CodeExecutionSandbox.preflight(mode: sandbox)
+        }
         if !dryRun && !allowCodeExecution {
             throw ValidationError(
                 "model benchmark code executes generated Python. Re-run with --allow-code-execution."
@@ -79,7 +85,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
             maxTokens: maxTokens,
             temperature: temperature,
             topP: topP,
-            executionTimeout: executionTimeout
+            executionTimeout: executionTimeout,
+            sandbox: sandbox.rawValue
         )
 
         if dryRun {
@@ -225,9 +232,10 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                 let response = try await generate(request)
                 let generationSeconds = Date().timeIntervalSince(generationStart)
                 let candidate = task.candidateProgram(from: response.response)
-                let execution = try CodeBenchmarkPythonRunner.run(
+                let execution = try CodeExecutionSandbox.runPython(
                     program: task.testProgram(candidateProgram: candidate),
                     python: python,
+                    mode: sandbox,
                     timeout: executionTimeout
                 )
                 caseResults.append(
@@ -237,6 +245,7 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         passed: execution.passed,
                         generationSeconds: generationSeconds,
                         executionSeconds: execution.seconds,
+                        sandboxBackend: execution.backend.rawValue,
                         tokensGenerated: response.tokensGenerated,
                         decodeTokensPerSecond: response.decodeTokensPerSecond(elapsed: generationSeconds),
                         error: execution.errorSummary
@@ -250,6 +259,7 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         passed: false,
                         generationSeconds: Date().timeIntervalSince(generationStart),
                         executionSeconds: nil,
+                        sandboxBackend: nil,
                         tokensGenerated: 0,
                         decodeTokensPerSecond: nil,
                         error: String(describing: error)
@@ -455,95 +465,6 @@ private struct CodeBenchmarkTask: Encodable {
     ]
 }
 
-private struct CodeBenchmarkPythonRunner {
-    struct Result {
-        let passed: Bool
-        let seconds: Double
-        let timedOut: Bool
-        let status: Int32
-        let stdout: String
-        let stderr: String
-
-        var errorSummary: String? {
-            guard !passed else {
-                return nil
-            }
-            if timedOut {
-                return "Timed out after \(String(format: "%.2f", seconds))s."
-            }
-            let detail = [stderr, stdout]
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .first { !$0.isEmpty } ?? "Python exited with status \(status)."
-            return Self.tail(detail)
-        }
-
-        private static func tail(_ text: String, maxCharacters: Int = 800) -> String {
-            guard text.count > maxCharacters else {
-                return text
-            }
-            return String(text.suffix(maxCharacters))
-        }
-    }
-
-    static func run(program: String, python: String, timeout: Double) throws -> Result {
-        let fileManager = FileManager.default
-        let workDir = fileManager.temporaryDirectory
-            .appendingPathComponent("mererun-code-benchmark-\(UUID().uuidString)", isDirectory: true)
-        try fileManager.createDirectory(at: workDir, withIntermediateDirectories: true)
-        defer {
-            try? fileManager.removeItem(at: workDir)
-        }
-
-        let scriptURL = workDir.appendingPathComponent("candidate.py")
-        try program.write(to: scriptURL, atomically: true, encoding: .utf8)
-
-        let process = Process()
-        if python.contains("/") {
-            process.executableURL = URL(fileURLWithPath: python)
-            process.arguments = [scriptURL.path]
-        } else {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [python, scriptURL.path]
-        }
-        process.currentDirectoryURL = workDir
-        process.environment = [
-            "PATH": ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin",
-            "PYTHONIOENCODING": "utf-8",
-            "PYTHONNOUSERSITE": "1",
-        ]
-
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        let start = Date()
-        try process.run()
-        var timedOut = false
-        while process.isRunning {
-            if Date().timeIntervalSince(start) > timeout {
-                timedOut = true
-                process.terminate()
-                break
-            }
-            Thread.sleep(forTimeInterval: 0.05)
-        }
-        process.waitUntilExit()
-        let seconds = Date().timeIntervalSince(start)
-        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-
-        return Result(
-            passed: !timedOut && process.terminationStatus == 0,
-            seconds: seconds,
-            timedOut: timedOut,
-            status: process.terminationStatus,
-            stdout: stdout,
-            stderr: stderr
-        )
-    }
-}
-
 private struct CodeBenchmarkPlan: Encodable {
     let suite: String
     let models: [String]
@@ -552,6 +473,7 @@ private struct CodeBenchmarkPlan: Encodable {
     let temperature: Double
     let topP: Double
     let executionTimeout: Double
+    let sandbox: String
 }
 
 private struct CodeBenchmarkReport: Encodable {
@@ -572,6 +494,7 @@ private struct CodeBenchmarkReport: Encodable {
             "tasks: \(plan.tasks.joined(separator: ", "))",
             "models: \(plan.models.joined(separator: ", "))",
             "sampling: temperature=\(plan.temperature) top_p=\(plan.topP) max_tokens=\(plan.maxTokens)",
+            "sandbox: \(plan.sandbox)",
             "",
         ]
         guard !models.isEmpty else {
@@ -639,6 +562,7 @@ private struct CodeBenchmarkModelResult: Encodable {
             let timing = [
                 "gen=\(Self.format(result.generationSeconds))s",
                 result.executionSeconds.map { "exec=\(Self.format($0))s" },
+                result.sandboxBackend.map { "sandbox=\($0)" },
                 result.decodeTokensPerSecond.map { "tps=\(Self.format($0))" },
             ]
                 .compactMap { $0 }
@@ -681,6 +605,7 @@ private struct CodeBenchmarkCaseResult: Encodable {
     let passed: Bool
     let generationSeconds: Double
     let executionSeconds: Double?
+    let sandboxBackend: String?
     let tokensGenerated: Int
     let decodeTokensPerSecond: Double?
     let error: String?

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -1,0 +1,699 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ModelBenchmarkCode: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "code",
+        abstract: "Run a small real coding-eval slice against local coding models."
+    )
+
+    @Option(name: [.long], help: "Comma-separated model ids. Defaults to the installed coding comparison lane.")
+    var models: String?
+
+    @Option(name: [.long], help: "Benchmark suite.")
+    var suite: CodeBenchmarkSuite = .humanEvalSlice
+
+    @Option(name: [.long], help: "Comma-separated task ids from the selected suite.")
+    var tasks: String?
+
+    @Option(name: [.long], help: "Maximum generated tokens per task.")
+    var maxTokens: Int = 512
+
+    @Option(name: [.long], help: "Temperature for generation.")
+    var temperature: Double = 0
+
+    @Option(name: [.long], help: "Top-p for generation.")
+    var topP: Double = 1
+
+    @Option(name: [.long], help: "Generated-code execution timeout in seconds.")
+    var executionTimeout: Double = 5
+
+    @Option(name: [.long], help: "Python executable used to run HumanEval slice tests.")
+    var python: String = "python3"
+
+    @Flag(name: [.long], help: "Print the benchmark plan without loading models or executing generated code.")
+    var dryRun: Bool = false
+
+    @Flag(name: [.long], help: "Acknowledge that benchmark scoring executes generated Python code locally.")
+    var allowCodeExecution: Bool = false
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    private static let defaultModelIDs = [
+        Q35Resources.ornith9BModelId,
+        NorthMiniCodeResources.modelId,
+        CodeGenResources.defaultModelId,
+    ]
+
+    func validate() throws {
+        guard maxTokens > 0 else {
+            throw ValidationError("--max-tokens must be greater than zero.")
+        }
+        guard (0...2).contains(temperature), temperature.isFinite else {
+            throw ValidationError("--temperature must be finite and between 0 and 2.")
+        }
+        guard (0...1).contains(topP), topP.isFinite else {
+            throw ValidationError("--top-p must be finite and between 0 and 1.")
+        }
+        guard executionTimeout > 0, executionTimeout.isFinite else {
+            throw ValidationError("--execution-timeout must be a positive finite number.")
+        }
+        if !dryRun && !allowCodeExecution {
+            throw ValidationError(
+                "model benchmark code executes generated Python. Re-run with --allow-code-execution."
+            )
+        }
+        _ = try selectedModelIDs()
+        _ = try selectedTasks()
+    }
+
+    func run() async throws {
+        let modelIDs = try selectedModelIDs()
+        let benchmarkTasks = try selectedTasks()
+        let reportPlan = CodeBenchmarkPlan(
+            suite: suite.rawValue,
+            models: modelIDs,
+            tasks: benchmarkTasks.map(\.taskID),
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            executionTimeout: executionTimeout
+        )
+
+        if dryRun {
+            let report = CodeBenchmarkReport(plan: reportPlan, models: [])
+            try printReport(report)
+            return
+        }
+        if modelIDs.contains(where: Self.requiresMLXBundle) {
+            try MLXBundleSupport.ensureAvailable(quiet: json)
+        }
+
+        var modelResults: [CodeBenchmarkModelResult] = []
+        modelResults.reserveCapacity(modelIDs.count)
+        for modelID in modelIDs {
+            if !json {
+                CLIStderr.write("Benchmarking \(modelID)...\n")
+            }
+            modelResults.append(try await runModel(modelID, tasks: benchmarkTasks))
+        }
+
+        let report = CodeBenchmarkReport(plan: reportPlan, models: modelResults)
+        try printReport(report)
+    }
+
+    private func selectedModelIDs() throws -> [String] {
+        let rawModels = models?.split(separator: ",").map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        } ?? Self.defaultModelIDs
+        let modelIDs = rawModels.filter { !$0.isEmpty }
+        guard !modelIDs.isEmpty else {
+            throw ValidationError("--models must include at least one model id.")
+        }
+        return modelIDs
+    }
+
+    private func selectedTasks() throws -> [CodeBenchmarkTask] {
+        let suiteTasks = suite.tasks
+        guard let tasks else {
+            return suiteTasks
+        }
+        let requestedIDs = tasks
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !requestedIDs.isEmpty else {
+            throw ValidationError("--tasks must include at least one task id.")
+        }
+        var selected: [CodeBenchmarkTask] = []
+        selected.reserveCapacity(requestedIDs.count)
+        for taskID in requestedIDs {
+            guard let task = suiteTasks.first(where: { $0.taskID == taskID }) else {
+                throw ValidationError("Unknown task id for \(suite.rawValue): \(taskID).")
+            }
+            selected.append(task)
+        }
+        return selected
+    }
+
+    private func runModel(_ modelID: String, tasks: [CodeBenchmarkTask]) async throws -> CodeBenchmarkModelResult {
+        guard let spec = ManagedModelCatalog.spec(for: modelID) else {
+            return CodeBenchmarkModelResult.missing(model: modelID, reason: "Unknown model id.")
+        }
+        guard spec.category == .textCode else {
+            return CodeBenchmarkModelResult.missing(model: modelID, reason: "Model is not a text-code model.")
+        }
+        guard let installedURL = ManagedModelResolver.resolveInstalledModel(id: modelID) else {
+            return CodeBenchmarkModelResult.missing(
+                model: modelID,
+                reason: "Model is not installed. Run `mere.run model pull \(modelID)` first."
+            )
+        }
+
+        switch spec.validationKind {
+        case .codegenGGUF:
+            let generator = CodeGenGenerator(modelId: modelID)
+            do {
+                let result = try await runTasks(
+                    modelID,
+                    engine: "codegen-gguf",
+                    modelPath: installedURL.path,
+                    tasks: tasks,
+                    generate: { request in
+                        try await generator.chat(request, modelPath: installedURL.path, progressHandler: nil)
+                    }
+                )
+                await generator.unload()
+                return result
+            } catch {
+                await generator.unload()
+                throw error
+            }
+
+        case .q35:
+            let generator = Q35Generator(modelId: modelID)
+            do {
+                let result = try await runTasks(
+                    modelID,
+                    engine: "q35-mlx",
+                    modelPath: installedURL.path,
+                    tasks: tasks,
+                    generate: { request in
+                        try await generator.chat(request, modelPath: installedURL.path, progressHandler: nil)
+                    }
+                )
+                await generator.unload()
+                return result
+            } catch {
+                await generator.unload()
+                throw error
+            }
+
+        default:
+            return CodeBenchmarkModelResult.missing(
+                model: modelID,
+                reason: "Unsupported coding benchmark runtime: \(spec.validationKind.rawValue)."
+            )
+        }
+    }
+
+    private func runTasks(
+        _ modelID: String,
+        engine: String,
+        modelPath: String,
+        tasks: [CodeBenchmarkTask],
+        generate: (ChatRequest) async throws -> ChatResponse
+    ) async throws -> CodeBenchmarkModelResult {
+        var caseResults: [CodeBenchmarkCaseResult] = []
+        caseResults.reserveCapacity(tasks.count)
+        for task in tasks {
+            let request = ChatRequest(
+                messages: [
+                    ChatMessage(role: .system, content: Self.systemPrompt),
+                    ChatMessage(role: .user, content: task.promptText),
+                ],
+                maxTokens: maxTokens,
+                temperature: temperature,
+                topP: topP,
+                showThinking: false,
+                stopOnEOS: true
+            )
+            let generationStart = Date()
+            do {
+                let response = try await generate(request)
+                let generationSeconds = Date().timeIntervalSince(generationStart)
+                let candidate = task.candidateProgram(from: response.response)
+                let execution = try CodeBenchmarkPythonRunner.run(
+                    program: task.testProgram(candidateProgram: candidate),
+                    python: python,
+                    timeout: executionTimeout
+                )
+                caseResults.append(
+                    CodeBenchmarkCaseResult(
+                        taskID: task.taskID,
+                        entryPoint: task.entryPoint,
+                        passed: execution.passed,
+                        generationSeconds: generationSeconds,
+                        executionSeconds: execution.seconds,
+                        tokensGenerated: response.tokensGenerated,
+                        decodeTokensPerSecond: response.decodeTokensPerSecond(elapsed: generationSeconds),
+                        error: execution.errorSummary
+                    )
+                )
+            } catch {
+                caseResults.append(
+                    CodeBenchmarkCaseResult(
+                        taskID: task.taskID,
+                        entryPoint: task.entryPoint,
+                        passed: false,
+                        generationSeconds: Date().timeIntervalSince(generationStart),
+                        executionSeconds: nil,
+                        tokensGenerated: 0,
+                        decodeTokensPerSecond: nil,
+                        error: String(describing: error)
+                    )
+                )
+            }
+        }
+        return CodeBenchmarkModelResult(
+            model: modelID,
+            engine: engine,
+            modelPath: modelPath,
+            status: "completed",
+            error: nil,
+            cases: caseResults
+        )
+    }
+
+    private func printReport(_ report: CodeBenchmarkReport) throws {
+        if json {
+            print(try report.jsonString())
+        } else {
+            print(report.renderText())
+        }
+    }
+
+    private static func requiresMLXBundle(modelID: String) -> Bool {
+        ManagedModelCatalog.spec(for: modelID)?.validationKind == .q35
+    }
+
+    private static let systemPrompt = """
+    You are completing Python programming benchmark tasks. Return only valid Python code.
+    Do not include Markdown fences, prose, comments about your approach, or test code.
+    """
+}
+
+enum CodeBenchmarkSuite: String, CaseIterable, ExpressibleByArgument {
+    case humanEvalSlice = "humaneval-slice"
+
+    fileprivate var tasks: [CodeBenchmarkTask] {
+        switch self {
+        case .humanEvalSlice:
+            return CodeBenchmarkTask.humanEvalSlice
+        }
+    }
+}
+
+private struct CodeBenchmarkTask: Encodable {
+    let taskID: String
+    let entryPoint: String
+    let prompt: String
+    let tests: String
+
+    var promptText: String {
+        """
+        Complete the following HumanEval task. Return only the Python implementation.
+
+        \(prompt)
+        """
+    }
+
+    func candidateProgram(from response: String) -> String {
+        let code = Self.extractCode(from: response, entryPoint: entryPoint)
+        if code.contains("def \(entryPoint)") {
+            return Self.withPromptImports(prompt: prompt, candidate: code)
+        }
+        return prompt + "\n" + code
+    }
+
+    func testProgram(candidateProgram: String) -> String {
+        """
+        \(candidateProgram)
+
+        \(tests)
+
+        check(\(entryPoint))
+        """
+    }
+
+    private static func extractCode(from response: String, entryPoint: String) -> String {
+        var text = fencedCodeBlock(in: response) ?? response
+        text = text.replacingOccurrences(of: "\r\n", with: "\n")
+        if let range = text.range(of: "from typing") {
+            text = String(text[range.lowerBound...])
+        } else if let range = text.range(of: "def \(entryPoint)") {
+            text = String(text[range.lowerBound...])
+        }
+        if let fence = text.range(of: "```") {
+            text = String(text[..<fence.lowerBound])
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func fencedCodeBlock(in response: String) -> String? {
+        guard let opening = response.range(of: "```") else {
+            return nil
+        }
+        var bodyStart = opening.upperBound
+        if let newline = response[bodyStart...].firstIndex(of: "\n") {
+            bodyStart = response.index(after: newline)
+        }
+        guard let closing = response[bodyStart...].range(of: "```") else {
+            return String(response[bodyStart...])
+        }
+        return String(response[bodyStart..<closing.lowerBound])
+    }
+
+    private static func withPromptImports(prompt: String, candidate: String) -> String {
+        let imports = prompt
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+            .filter { line in
+                line.hasPrefix("import ") || line.hasPrefix("from ")
+            }
+        let missingImports = imports.filter { !candidate.contains($0) }
+        guard !missingImports.isEmpty else {
+            return candidate
+        }
+        return (missingImports + ["", candidate]).joined(separator: "\n")
+    }
+
+    // Three public OpenAI HumanEval tasks, kept as a tiny slice rather than a
+    // leaderboard substitute. HumanEval is MIT licensed.
+    static let humanEvalSlice = [
+        CodeBenchmarkTask(
+            taskID: "HumanEval/0",
+            entryPoint: "has_close_elements",
+            prompt: """
+            from typing import List
+
+
+            def has_close_elements(numbers: List[float], threshold: float) -> bool:
+                \"\"\" Check if in given list of numbers, are any two numbers closer to each other than
+                given threshold.
+                >>> has_close_elements([1.0, 2.0, 3.0], 0.5)
+                False
+                >>> has_close_elements([1.0, 2.8, 3.0, 4.0, 5.0, 2.0], 0.3)
+                True
+                \"\"\"
+            """,
+            tests: """
+            def check(candidate):
+                assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True
+                assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False
+                assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True
+                assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False
+                assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True
+                assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True
+                assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False
+            """
+        ),
+        CodeBenchmarkTask(
+            taskID: "HumanEval/3",
+            entryPoint: "below_zero",
+            prompt: """
+            from typing import List
+
+
+            def below_zero(operations: List[int]) -> bool:
+                \"\"\" You're given a list of deposit and withdrawal operations on a bank account that starts with
+                zero balance. Your task is to detect if at any point the balance of account fallls below zero, and
+                at that point function should return True. Otherwise it should return False.
+                >>> below_zero([1, 2, 3])
+                False
+                >>> below_zero([1, 2, -4, 5])
+                True
+                \"\"\"
+            """,
+            tests: """
+            def check(candidate):
+                assert candidate([]) == False
+                assert candidate([1, 2, -3, 1, 2, -3]) == False
+                assert candidate([1, 2, -4, 5, 6]) == True
+                assert candidate([1, -1, 2, -2, 5, -5, 4, -4]) == False
+                assert candidate([1, -1, 2, -2, 5, -5, 4, -5]) == True
+                assert candidate([1, -2, 2, -2, 5, -5, 4, -4]) == True
+            """
+        ),
+        CodeBenchmarkTask(
+            taskID: "HumanEval/8",
+            entryPoint: "sum_product",
+            prompt: """
+            from typing import List, Tuple
+
+
+            def sum_product(numbers: List[int]) -> Tuple[int, int]:
+                \"\"\" For a given list of integers, return a tuple consisting of a sum and a product of all the integers in a list.
+                Empty sum should be equal to 0 and empty product should be equal to 1.
+                >>> sum_product([])
+                (0, 1)
+                >>> sum_product([1, 2, 3, 4])
+                (10, 24)
+                \"\"\"
+            """,
+            tests: """
+            def check(candidate):
+                assert candidate([]) == (0, 1)
+                assert candidate([1, 1, 1]) == (3, 1)
+                assert candidate([100, 0]) == (100, 0)
+                assert candidate([3, 5, 7]) == (3 + 5 + 7, 3 * 5 * 7)
+                assert candidate([10]) == (10, 10)
+            """
+        ),
+    ]
+}
+
+private struct CodeBenchmarkPythonRunner {
+    struct Result {
+        let passed: Bool
+        let seconds: Double
+        let timedOut: Bool
+        let status: Int32
+        let stdout: String
+        let stderr: String
+
+        var errorSummary: String? {
+            guard !passed else {
+                return nil
+            }
+            if timedOut {
+                return "Timed out after \(String(format: "%.2f", seconds))s."
+            }
+            let detail = [stderr, stdout]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { !$0.isEmpty } ?? "Python exited with status \(status)."
+            return Self.tail(detail)
+        }
+
+        private static func tail(_ text: String, maxCharacters: Int = 800) -> String {
+            guard text.count > maxCharacters else {
+                return text
+            }
+            return String(text.suffix(maxCharacters))
+        }
+    }
+
+    static func run(program: String, python: String, timeout: Double) throws -> Result {
+        let fileManager = FileManager.default
+        let workDir = fileManager.temporaryDirectory
+            .appendingPathComponent("mererun-code-benchmark-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: workDir, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: workDir)
+        }
+
+        let scriptURL = workDir.appendingPathComponent("candidate.py")
+        try program.write(to: scriptURL, atomically: true, encoding: .utf8)
+
+        let process = Process()
+        if python.contains("/") {
+            process.executableURL = URL(fileURLWithPath: python)
+            process.arguments = [scriptURL.path]
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [python, scriptURL.path]
+        }
+        process.currentDirectoryURL = workDir
+        process.environment = [
+            "PATH": ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONNOUSERSITE": "1",
+        ]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let start = Date()
+        try process.run()
+        var timedOut = false
+        while process.isRunning {
+            if Date().timeIntervalSince(start) > timeout {
+                timedOut = true
+                process.terminate()
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        process.waitUntilExit()
+        let seconds = Date().timeIntervalSince(start)
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        return Result(
+            passed: !timedOut && process.terminationStatus == 0,
+            seconds: seconds,
+            timedOut: timedOut,
+            status: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}
+
+private struct CodeBenchmarkPlan: Encodable {
+    let suite: String
+    let models: [String]
+    let tasks: [String]
+    let maxTokens: Int
+    let temperature: Double
+    let topP: Double
+    let executionTimeout: Double
+}
+
+private struct CodeBenchmarkReport: Encodable {
+    let plan: CodeBenchmarkPlan
+    let models: [CodeBenchmarkModelResult]
+
+    func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func renderText() -> String {
+        var lines = [
+            "Code benchmark",
+            "suite: \(plan.suite)",
+            "tasks: \(plan.tasks.joined(separator: ", "))",
+            "models: \(plan.models.joined(separator: ", "))",
+            "sampling: temperature=\(plan.temperature) top_p=\(plan.topP) max_tokens=\(plan.maxTokens)",
+            "",
+        ]
+        guard !models.isEmpty else {
+            lines.append("dry run: no models loaded and no generated code executed")
+            return lines.joined(separator: "\n")
+        }
+        lines.append("model                         engine       pass  avg_gen_s  avg_exec_s  avg_tps")
+        for result in models {
+            lines.append(result.summaryLine())
+        }
+        lines.append("")
+        for result in models {
+            lines.append(result.renderDetails())
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct CodeBenchmarkModelResult: Encodable {
+    let model: String
+    let engine: String?
+    let modelPath: String?
+    let status: String
+    let error: String?
+    let cases: [CodeBenchmarkCaseResult]
+
+    static func missing(model: String, reason: String) -> CodeBenchmarkModelResult {
+        CodeBenchmarkModelResult(
+            model: model,
+            engine: nil,
+            modelPath: nil,
+            status: "skipped",
+            error: reason,
+            cases: []
+        )
+    }
+
+    var passCount: Int {
+        cases.filter(\.passed).count
+    }
+
+    func summaryLine() -> String {
+        let passText = "\(passCount)/\(cases.count)"
+        let avgGeneration = average(cases.compactMap(\.generationSeconds))
+        let avgExecution = average(cases.compactMap(\.executionSeconds))
+        let avgTPS = average(cases.compactMap(\.decodeTokensPerSecond))
+        return [
+            Self.padded(model, width: 29),
+            Self.padded(engine ?? status, width: 12),
+            Self.padded(passText, width: 5),
+            Self.padded(Self.format(avgGeneration), width: 10),
+            Self.padded(Self.format(avgExecution), width: 11),
+            Self.padded(Self.format(avgTPS), width: 7),
+        ].joined(separator: " ")
+    }
+
+    func renderDetails() -> String {
+        var lines = ["\(model): \(status)"]
+        if let error {
+            lines.append("  \(error)")
+        }
+        for result in cases {
+            let mark = result.passed ? "pass" : "fail"
+            let timing = [
+                "gen=\(Self.format(result.generationSeconds))s",
+                result.executionSeconds.map { "exec=\(Self.format($0))s" },
+                result.decodeTokensPerSecond.map { "tps=\(Self.format($0))" },
+            ]
+                .compactMap { $0 }
+                .joined(separator: " ")
+            lines.append("  \(mark) \(result.taskID) \(result.entryPoint) \(timing)")
+            if let error = result.error {
+                lines.append("    \(error.replacingOccurrences(of: "\n", with: "\n    "))")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func average(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else {
+            return nil
+        }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    private func average(_ values: [Double]) -> Double? {
+        Self.average(values)
+    }
+
+    private static func format(_ value: Double?) -> String {
+        guard let value else {
+            return "-"
+        }
+        return String(format: "%.2f", value)
+    }
+
+    private static func padded(_ value: String, width: Int) -> String {
+        let padding = max(0, width - value.count)
+        return value + String(repeating: " ", count: padding)
+    }
+}
+
+private struct CodeBenchmarkCaseResult: Encodable {
+    let taskID: String
+    let entryPoint: String
+    let passed: Bool
+    let generationSeconds: Double
+    let executionSeconds: Double?
+    let tokensGenerated: Int
+    let decodeTokensPerSecond: Double?
+    let error: String?
+}
+
+private extension ChatResponse {
+    func decodeTokensPerSecond(elapsed: Double) -> Double? {
+        if let timing, let decodeTokensPerSecond = timing.decodeTokensPerSecond {
+            return decodeTokensPerSecond
+        }
+        guard elapsed > 0, tokensGenerated > 0 else {
+            return nil
+        }
+        return Double(tokensGenerated) / elapsed
+    }
+}

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -12,6 +12,7 @@ struct ModelBenchmark: ParsableCommand {
         commandName: "benchmark",
         abstract: "Run focused local model benchmarks.",
         subcommands: [
+            ModelBenchmarkCode.self,
             ModelBenchmarkGemma4KV.self,
             ModelBenchmarkGemma4MTP.self,
             ModelBenchmarkQ36MTP.self,

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -41,6 +41,14 @@ mere.run model benchmark q36-mtp \
   --json
 ```
 
+Compare the installed coding models on a small HumanEval slice:
+
+```bash
+mere.run model benchmark code \
+  --allow-code-execution \
+  --json
+```
+
 Compare Gemma4 12B vision chat against the existing Qwen3-VL inspect backend:
 
 ```bash
@@ -131,6 +139,41 @@ Use one of:
 
 The fixture prompt is for runtime comparison only; it is not a quality eval.
 
+## Code Benchmark
+
+`model benchmark code` runs a tiny, fixed HumanEval slice against local coding
+models. It is a real functional-code eval slice, not a full pass@k benchmark or
+leaderboard substitute. The default comparison is:
+
+- `text-agent-ornith-9b`: native Q35/MLX OptiQ coding-agent target.
+- `text-code-north-mini`: native llama.cpp/GGUF North Mini Code target.
+- `text-code-qwen3`: native llama.cpp/GGUF Qwen3-Coder baseline.
+
+The default suite is `humaneval-slice`, currently three public HumanEval tasks:
+
+- `HumanEval/0`
+- `HumanEval/3`
+- `HumanEval/8`
+
+Each task is prompted once with deterministic sampling by default
+(`--temperature 0 --top-p 1`), the generated Python is combined with the task's
+tests, and the candidate is executed with `python3` in a short-lived temporary
+directory. Because this runs generated code locally, the command requires
+`--allow-code-execution` unless you are using `--dry-run`.
+
+Narrow the run while iterating:
+
+```bash
+mere.run model benchmark code \
+  --models text-agent-ornith-9b,text-code-north-mini \
+  --tasks HumanEval/0 \
+  --allow-code-execution
+```
+
+Use `--python` to select a Python interpreter and `--execution-timeout` to
+control the per-candidate subprocess timeout. The command never auto-pulls
+models during scoring; install missing models with `mere.run model pull` first.
+
 ## VLM Benchmark
 
 `model benchmark vlm` writes a tiny deterministic image-question suite to a
@@ -211,6 +254,8 @@ mere.run model benchmark vlm \
 ## Notes
 
 - Pull `text-chat-gemma4-turbo` before running the benchmark.
+- Pull `text-agent-ornith-9b`, `text-code-north-mini`, and `text-code-qwen3`
+  before running the default code benchmark comparison.
 - Pull `vision-chat-gemma4-12b` before using it in the VLM benchmark.
 - Install `lmms-eval` dependencies in the selected Python environment before
   running external datasets; dataset downloads and licenses are handled by the
@@ -221,6 +266,7 @@ mere.run model benchmark vlm \
 ## Sources
 
 - `Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift`
+- `Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift`
 - `Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift`
 - `Sources/MereRunCore/Gemma4/Gemma4Generator.swift`
 - `Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift`

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -157,9 +157,12 @@ The default suite is `humaneval-slice`, currently three public HumanEval tasks:
 
 Each task is prompted once with deterministic sampling by default
 (`--temperature 0 --top-p 1`), the generated Python is combined with the task's
-tests, and the candidate is executed with `python3` in a short-lived temporary
-directory. Because this runs generated code locally, the command requires
-`--allow-code-execution` unless you are using `--dry-run`.
+tests, and the candidate is executed with `python3` inside the selected sandbox
+backend. Because this runs generated code locally, the command requires
+`--allow-code-execution` unless you are using `--dry-run`. The default
+`--sandbox auto` uses `sandbox-exec` on macOS and `bubblewrap` on Linux when
+available. Use `--sandbox none` only for a trusted local smoke where timeout and
+temporary-directory hygiene are enough.
 
 Narrow the run while iterating:
 

--- a/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
+++ b/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
@@ -1,0 +1,333 @@
+import ArgumentParser
+import Foundation
+
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+enum CodeExecutionSandboxMode: String, CaseIterable, ExpressibleByArgument, Codable {
+    case auto
+    case macOSSandboxExec = "macos-sandbox-exec"
+    case bubblewrap
+    case none
+}
+
+enum CodeExecutionSandboxBackend: String, Codable {
+    case macOSSandboxExec = "macos-sandbox-exec"
+    case bubblewrap
+    case none
+}
+
+struct CodeExecutionSandboxResult {
+    let backend: CodeExecutionSandboxBackend
+    let passed: Bool
+    let seconds: Double
+    let timedOut: Bool
+    let status: Int32
+    let stdout: String
+    let stderr: String
+    let stdoutTruncated: Bool
+    let stderrTruncated: Bool
+
+    var errorSummary: String? {
+        guard !passed else {
+            return nil
+        }
+        if timedOut {
+            return "Timed out after \(String(format: "%.2f", seconds))s."
+        }
+        let detail = [stderr, stdout]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty } ?? "Process exited with status \(status)."
+        return Self.tail(detail)
+    }
+
+    private static func tail(_ text: String, maxCharacters: Int = 800) -> String {
+        guard text.count > maxCharacters else {
+            return text
+        }
+        return String(text.suffix(maxCharacters))
+    }
+}
+
+enum CodeExecutionSandbox {
+    static let defaultOutputLimitBytes = 256 * 1024
+
+    static func preflight(mode: CodeExecutionSandboxMode) throws {
+        _ = try resolveBackend(mode: mode)
+    }
+
+    static func runPython(
+        program: String,
+        python: String,
+        mode: CodeExecutionSandboxMode,
+        timeout: Double,
+        outputLimitBytes: Int = defaultOutputLimitBytes
+    ) throws -> CodeExecutionSandboxResult {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("mererun-code-benchmark-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        let workDir = root.resolvingSymlinksInPath()
+        defer {
+            try? fileManager.removeItem(at: root)
+            if workDir != root {
+                try? fileManager.removeItem(at: workDir)
+            }
+        }
+
+        let scriptURL = workDir.appendingPathComponent("candidate.py")
+        try program.write(to: scriptURL, atomically: true, encoding: .utf8)
+
+        let backend = try resolveBackend(mode: mode)
+        let process = Process()
+        process.currentDirectoryURL = workDir
+        process.environment = sandboxEnvironment(workDir: workDir)
+
+        switch backend {
+        case .macOSSandboxExec:
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")
+            process.arguments = [
+                "-p",
+                macOSSandboxProfile(workDir: workDir),
+            ] + pythonInvocation(python: python, scriptPath: "candidate.py")
+
+        case .bubblewrap:
+            let bubblewrap = try requireExecutable(named: "bwrap")
+            process.executableURL = URL(fileURLWithPath: bubblewrap)
+            process.arguments = bubblewrapArguments(
+                workDir: workDir,
+                pythonArguments: pythonInvocation(python: python, scriptPath: "candidate.py")
+            )
+
+        case .none:
+            let invocation = pythonInvocation(python: python, scriptPath: "candidate.py")
+            process.executableURL = URL(fileURLWithPath: invocation[0])
+            process.arguments = Array(invocation.dropFirst())
+        }
+
+        let stdout = LimitedOutputPipe(limitBytes: outputLimitBytes)
+        let stderr = LimitedOutputPipe(limitBytes: outputLimitBytes)
+        process.standardOutput = stdout.pipe
+        process.standardError = stderr.pipe
+
+        let start = Date()
+        try process.run()
+        var timedOut = false
+        while process.isRunning {
+            if Date().timeIntervalSince(start) > timeout {
+                timedOut = true
+                terminate(process)
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        process.waitUntilExit()
+        let seconds = Date().timeIntervalSince(start)
+        let stdoutCapture = stdout.finish()
+        let stderrCapture = stderr.finish()
+
+        return CodeExecutionSandboxResult(
+            backend: backend,
+            passed: !timedOut && process.terminationStatus == 0,
+            seconds: seconds,
+            timedOut: timedOut,
+            status: process.terminationStatus,
+            stdout: stdoutCapture.text,
+            stderr: stderrCapture.text,
+            stdoutTruncated: stdoutCapture.truncated,
+            stderrTruncated: stderrCapture.truncated
+        )
+    }
+
+    private static func resolveBackend(mode: CodeExecutionSandboxMode) throws -> CodeExecutionSandboxBackend {
+        switch mode {
+        case .auto:
+            #if os(macOS)
+            if executableExists(at: "/usr/bin/sandbox-exec") {
+                return .macOSSandboxExec
+            }
+            #elseif os(Linux)
+            if findExecutable(named: "bwrap") != nil {
+                return .bubblewrap
+            }
+            #endif
+            throw ValidationError(
+                "No supported code sandbox backend is available. Install bubblewrap on Linux or pass --sandbox none."
+            )
+
+        case .macOSSandboxExec:
+            guard executableExists(at: "/usr/bin/sandbox-exec") else {
+                throw ValidationError("macOS sandbox-exec is not available on this host.")
+            }
+            return .macOSSandboxExec
+
+        case .bubblewrap:
+            guard findExecutable(named: "bwrap") != nil else {
+                throw ValidationError("bubblewrap sandbox is not available on this host.")
+            }
+            return .bubblewrap
+
+        case .none:
+            return .none
+        }
+    }
+
+    private static func sandboxEnvironment(workDir: URL) -> [String: String] {
+        [
+            "PATH": ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": workDir.path,
+            "TMPDIR": workDir.path,
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+        ]
+    }
+
+    private static func pythonInvocation(python: String, scriptPath: String) -> [String] {
+        if python.contains("/") {
+            return [python, scriptPath]
+        }
+        return ["/usr/bin/env", python, scriptPath]
+    }
+
+    private static func macOSSandboxProfile(workDir: URL) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .resolvingSymlinksInPath()
+            .path
+        let escapedHome = sandboxEscaped(home)
+        let escapedWorkDir = sandboxEscaped(workDir.path)
+        return """
+        (version 1)
+        (deny default)
+        (allow process*)
+        (allow sysctl-read)
+        (allow mach-lookup)
+        (allow file-read*)
+        (deny file-read* (subpath "\(escapedHome)"))
+        (allow file-read* (subpath "\(escapedWorkDir)"))
+        (allow file-write* (subpath "\(escapedWorkDir)"))
+        (deny network*)
+        """
+    }
+
+    private static func bubblewrapArguments(workDir: URL, pythonArguments: [String]) -> [String] {
+        [
+            "--die-with-parent",
+            "--new-session",
+            "--unshare-all",
+            "--proc", "/proc",
+            "--dev", "/dev",
+            "--ro-bind", "/", "/",
+            "--bind", workDir.path, workDir.path,
+            "--chdir", workDir.path,
+            "--setenv", "PATH", ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin",
+            "--setenv", "HOME", workDir.path,
+            "--setenv", "TMPDIR", workDir.path,
+            "--setenv", "PYTHONIOENCODING", "utf-8",
+            "--setenv", "PYTHONDONTWRITEBYTECODE", "1",
+            "--setenv", "PYTHONNOUSERSITE", "1",
+        ] + pythonArguments
+    }
+
+    private static func sandboxEscaped(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func requireExecutable(named name: String) throws -> String {
+        guard let path = findExecutable(named: name) else {
+            throw ValidationError("Required executable not found: \(name).")
+        }
+        return path
+    }
+
+    private static func findExecutable(named name: String) -> String? {
+        if name.contains("/") {
+            return executableExists(at: name) ? name : nil
+        }
+        let path = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        for directory in path.split(separator: ":").map(String.init) {
+            let candidate = URL(fileURLWithPath: directory).appendingPathComponent(name).path
+            if executableExists(at: candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func executableExists(at path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+            && FileManager.default.isExecutableFile(atPath: path)
+    }
+
+    private static func terminate(_ process: Process) {
+        process.terminate()
+        Thread.sleep(forTimeInterval: 0.2)
+        guard process.isRunning else {
+            return
+        }
+        #if os(macOS) || os(Linux)
+        kill(pid_t(process.processIdentifier), SIGKILL)
+        #else
+        process.terminate()
+        #endif
+    }
+}
+
+private final class LimitedOutputPipe: @unchecked Sendable {
+    struct Capture {
+        let text: String
+        let truncated: Bool
+    }
+
+    let pipe = Pipe()
+
+    private let limitBytes: Int
+    private let lock = NSLock()
+    private var data = Data()
+    private var truncated = false
+
+    init(limitBytes: Int) {
+        self.limitBytes = limitBytes
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else {
+                return
+            }
+            self?.append(chunk)
+        }
+    }
+
+    func finish() -> Capture {
+        pipe.fileHandleForReading.readabilityHandler = nil
+        append(pipe.fileHandleForReading.readDataToEndOfFile())
+        let text = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+        return Capture(
+            text: truncated ? text + "\n[output truncated]" : text,
+            truncated: truncated
+        )
+    }
+
+    private func append(_ chunk: Data) {
+        guard !chunk.isEmpty else {
+            return
+        }
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        let remaining = max(0, limitBytes - data.count)
+        if remaining > 0 {
+            data.append(chunk.prefix(remaining))
+        }
+        if chunk.count > remaining {
+            truncated = true
+        }
+    }
+}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,8 +4,43 @@ This repository ships a small number of vendored third-party runtime artifacts
 so a clean checkout can build and run the public `mere.run` package without an
 extra bootstrap step.
 
+It also includes small third-party evaluation fixtures where noted below.
+
 When any vendored artifact changes, update this file in the same pull request
 with the new upstream source, version or commit when known, and license data.
+
+## Evaluation fixtures
+
+### HumanEval slice
+
+- purpose: three public HumanEval tasks embedded in `model benchmark code`
+- upstream project: [`openai/human-eval`](https://github.com/openai/human-eval)
+- included tasks: `HumanEval/0`, `HumanEval/3`, `HumanEval/8`
+- license: MIT
+
+```
+The MIT License
+
+Copyright (c) OpenAI (https://openai.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
 
 ## Vendored artifacts
 

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -13,6 +13,59 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertTrue(commandNames.contains("vlm"))
     }
 
+    func testBenchmarkCommandExposesCodeSubcommand() {
+        let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("code"))
+    }
+
+    func testCodeBenchmarkRequiresExecutionOptIn() {
+        XCTAssertThrowsError(try ModelBenchmarkCode.parse([]))
+    }
+
+    func testCodeBenchmarkParsesDryRunDefaults() throws {
+        let cmd = try ModelBenchmarkCode.parse(["--dry-run"])
+
+        XCTAssertNil(cmd.models)
+        XCTAssertEqual(cmd.suite, .humanEvalSlice)
+        XCTAssertNil(cmd.tasks)
+        XCTAssertEqual(cmd.maxTokens, 512)
+        XCTAssertEqual(cmd.temperature, 0)
+        XCTAssertEqual(cmd.topP, 1)
+        XCTAssertEqual(cmd.executionTimeout, 5)
+        XCTAssertEqual(cmd.python, "python3")
+        XCTAssertTrue(cmd.dryRun)
+        XCTAssertFalse(cmd.allowCodeExecution)
+        XCTAssertFalse(cmd.json)
+    }
+
+    func testCodeBenchmarkParsesOverrides() throws {
+        let cmd = try ModelBenchmarkCode.parse([
+            "--models", "text-agent-ornith-9b,text-code-north-mini",
+            "--suite", "humaneval-slice",
+            "--tasks", "HumanEval/0,HumanEval/8",
+            "--max-tokens", "256",
+            "--temperature", "0.2",
+            "--top-p", "0.8",
+            "--execution-timeout", "3.5",
+            "--python", "/tmp/venv/bin/python",
+            "--dry-run",
+            "--allow-code-execution",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.models, "text-agent-ornith-9b,text-code-north-mini")
+        XCTAssertEqual(cmd.suite, .humanEvalSlice)
+        XCTAssertEqual(cmd.tasks, "HumanEval/0,HumanEval/8")
+        XCTAssertEqual(cmd.maxTokens, 256)
+        XCTAssertEqual(cmd.temperature, 0.2)
+        XCTAssertEqual(cmd.topP, 0.8)
+        XCTAssertEqual(cmd.executionTimeout, 3.5)
+        XCTAssertEqual(cmd.python, "/tmp/venv/bin/python")
+        XCTAssertTrue(cmd.dryRun)
+        XCTAssertTrue(cmd.allowCodeExecution)
+        XCTAssertTrue(cmd.json)
+    }
+
     func testBenchmarkCommandExposesGemma4MTPSubcommand() {
         let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertTrue(commandNames.contains("gemma4-mtp"))

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -33,6 +33,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertEqual(cmd.topP, 1)
         XCTAssertEqual(cmd.executionTimeout, 5)
         XCTAssertEqual(cmd.python, "python3")
+        XCTAssertEqual(cmd.sandbox, .auto)
         XCTAssertTrue(cmd.dryRun)
         XCTAssertFalse(cmd.allowCodeExecution)
         XCTAssertFalse(cmd.json)
@@ -48,6 +49,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
             "--top-p", "0.8",
             "--execution-timeout", "3.5",
             "--python", "/tmp/venv/bin/python",
+            "--sandbox", "none",
             "--dry-run",
             "--allow-code-execution",
             "--json",
@@ -61,10 +63,52 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertEqual(cmd.topP, 0.8)
         XCTAssertEqual(cmd.executionTimeout, 3.5)
         XCTAssertEqual(cmd.python, "/tmp/venv/bin/python")
+        XCTAssertEqual(cmd.sandbox, .none)
         XCTAssertTrue(cmd.dryRun)
         XCTAssertTrue(cmd.allowCodeExecution)
         XCTAssertTrue(cmd.json)
     }
+
+    func testCodeExecutionSandboxNoneRunsPython() throws {
+        let result = try CodeExecutionSandbox.runPython(
+            program: "print('ok')",
+            python: "python3",
+            mode: .none,
+            timeout: 2
+        )
+
+        XCTAssertTrue(result.passed)
+        XCTAssertEqual(result.backend, .none)
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "ok")
+    }
+
+    #if os(macOS)
+    func testCodeExecutionSandboxExecDeniesHomeReads() throws {
+        try CodeExecutionSandbox.preflight(mode: .macOSSandboxExec)
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .resolvingSymlinksInPath()
+            .path
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+        let result = try CodeExecutionSandbox.runPython(
+            program: """
+            import os
+            try:
+                os.listdir('\(home)')
+                raise SystemExit(7)
+            except PermissionError:
+                print('denied')
+            """,
+            python: "python3",
+            mode: .macOSSandboxExec,
+            timeout: 2
+        )
+
+        XCTAssertTrue(result.passed, result.errorSummary ?? "")
+        XCTAssertEqual(result.backend, .macOSSandboxExec)
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "denied")
+    }
+    #endif
 
     func testBenchmarkCommandExposesGemma4MTPSubcommand() {
         let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1232,6 +1232,25 @@ block verifier; non-greedy forced MTP stays on the exact probabilistic
 speculative path. Use `--mtp-block-size` to test a different greedy draft block
 cap and `--forced-mtp-min-prompt-tokens` to adjust the forced policy threshold.
 
+### `mere.run model benchmark code`
+
+Run a small real coding-eval slice against installed local coding models. The
+default suite is `humaneval-slice`, a three-task HumanEval subset covering
+`HumanEval/0`, `HumanEval/3`, and `HumanEval/8`. The default model comparison is
+`text-agent-ornith-9b`, `text-code-north-mini`, and `text-code-qwen3`.
+
+```bash
+swift run mere.run model benchmark code \
+  --allow-code-execution \
+  --json
+```
+
+The command prompts each model once per task, combines the generated Python with
+the task tests, and runs that candidate in a temporary `python3` subprocess with
+a per-candidate timeout. Because scoring executes generated code locally, pass
+`--allow-code-execution` for real runs or `--dry-run` to inspect the plan.
+Use `--models` and `--tasks` to narrow the slice while iterating.
+
 ### `mere.run model benchmark vlm`
 
 Run a tiny synthetic VLM smoke, or use `lmms-eval` to compare an installed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1246,10 +1246,13 @@ swift run mere.run model benchmark code \
 ```
 
 The command prompts each model once per task, combines the generated Python with
-the task tests, and runs that candidate in a temporary `python3` subprocess with
+the task tests, and runs that candidate in a sandboxed `python3` subprocess with
 a per-candidate timeout. Because scoring executes generated code locally, pass
 `--allow-code-execution` for real runs or `--dry-run` to inspect the plan.
-Use `--models` and `--tasks` to narrow the slice while iterating.
+The default `--sandbox auto` uses `sandbox-exec` on macOS and `bubblewrap` on
+Linux when available. Use `--sandbox none` only for a trusted local smoke where
+timeout and temporary-directory hygiene are enough. Use `--models` and `--tasks`
+to narrow the slice while iterating.
 
 ### `mere.run model benchmark vlm`
 


### PR DESCRIPTION
## Summary
- add `mere.run model benchmark code` with a tiny HumanEval slice for local coding-model comparison
- default the slice to Ornith Q35/MLX, North Mini Code GGUF, and Qwen3-Coder GGUF
- execute generated Python through a shared Swift sandbox runner by default (`sandbox-exec` on macOS, `bubblewrap` on Linux when available)
- require `--allow-code-execution` for real scoring, with `--sandbox none` available only as an explicit trusted-local fallback
- document the command and add the HumanEval MIT notice

## Validation
- `./scripts/check.sh`
- `swift test --filter ModelBenchmarkCommandTests`
- `.build/debug/mere.run model benchmark code --dry-run`
- `.build/debug/mere.run model benchmark code --dry-run --json`
- `.build/debug/mere.run model benchmark code --models text-agent-ornith-9b --tasks HumanEval/8 --max-tokens 256 --execution-timeout 5 --allow-code-execution`
- `.build/debug/mere.run model benchmark code --models text-code-north-mini --tasks HumanEval/8 --max-tokens 256 --execution-timeout 5 --allow-code-execution`
- `.build/debug/mere.run model benchmark code --models text-code-qwen3 --tasks HumanEval/8 --max-tokens 256 --execution-timeout 5 --allow-code-execution`

## Sandbox smoke
- macOS unit test verifies `sandbox-exec` denies generated code reads of the real user home directory
- real North Mini one-task smoke reported `sandbox=macos-sandbox-exec` and passed `HumanEval/8`

## Notes
This is a slice for local platform comparison, not a full HumanEval/pass@k benchmark. The command never auto-pulls models during scoring; missing models are reported as skipped.