### PR TITLE
Fix code benchmark stop handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ The format is based on Keep a Changelog.
 - fixed mflux-format FLUX.2 Klein transformer loading by mapping
   `time_guidance_embed.linear_*` weights into the native Swift transformer's
   nested timestep embedder path.
+- split `<think>...</think>` model output into preserved reasoning metadata and
+  visible response text across native chat responses, API non-streaming output,
+  and code benchmark reports.
+- fixed MLX CUDA BF16 sigmoid JIT smoke failures by patching the upstream CUDA
+  unary kernel path during `scripts/prepare-linux-native.sh`.
 
 ## 0.17.0 - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@ The format is based on Keep a Changelog.
   nested timestep embedder path.
 - split `<think>...</think>` model output into preserved reasoning metadata and
   visible response text across native chat responses, API non-streaming output,
-  and code benchmark reports.
+  and code benchmark reports, including reopened-reasoning diagnostics for
+  loop-like model output.
 - fixed MLX CUDA BF16 sigmoid JIT smoke failures by patching the upstream CUDA
   unary kernel path during `scripts/prepare-linux-native.sh`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ The format is based on Keep a Changelog.
   default `vision ocr` backend.
 - added `text-agent-ornith-9b` as an experimental native Qwen-family MLX/OptiQ
   coding-agent target backed by the pinned public Ornith 1.0 9B snapshot.
+- added `text-agent-ornith-35b` as a managed native GGUF coding-agent target
+  for larger Ornith evals through the existing `text-code` runtime.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ The format is based on Keep a Changelog.
   default `vision ocr` backend.
 - added `text-agent-ornith-9b` as an experimental native Qwen-family MLX/OptiQ
   coding-agent target backed by the pinned public Ornith 1.0 9B snapshot.
+- added `text-agent-ornith-35b-mlx` as a local native Qwen-family MLX Q4
+  coding-agent target for testing converted Ornith 1.0 35B snapshots.
 - added `text-agent-ornith-35b` as a managed native GGUF coding-agent target
   for larger Ornith evals through the existing `text-code` runtime.
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ swift run mere.run model capabilities --recommended
 # 16-23 GB: text-chat-gemma4-12b-4bit
 # 24-95 GB: text-chat-q36-nano
 # 96+ GB: text-agent-deepseek-v4-flash for agent/API chat; Q36 for lower-latency CLI chat
-# Coding-agent comparison: text-code-north-mini and text-agent-ornith-35b via native llama.cpp/GGUF
+# Coding-agent comparison: text-code-north-mini, text-agent-ornith-35b-mlx, and text-agent-ornith-35b
 
 # Choose guided, bring-your-own-agent, or manual setup
 swift run mere.run setup
@@ -239,6 +239,7 @@ swift run mere.run model pull image-zimage-nano
 swift run mere.run model pull text-chat-lfm25-a1b-8bit
 swift run mere.run model pull text-code-north-mini
 swift run mere.run model pull text-agent-ornith-35b
+# text-agent-ornith-35b-mlx is local-only until a converted MLX snapshot is published
 
 # Generate an image
 swift run mere.run image generate \

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ swift run mere.run model capabilities --recommended
 # 16-23 GB: text-chat-gemma4-12b-4bit
 # 24-95 GB: text-chat-q36-nano
 # 96+ GB: text-agent-deepseek-v4-flash for agent/API chat; Q36 for lower-latency CLI chat
-# Coding-agent comparison: text-code-north-mini via native llama.cpp/GGUF
+# Coding-agent comparison: text-code-north-mini and text-agent-ornith-35b via native llama.cpp/GGUF
 
 # Choose guided, bring-your-own-agent, or manual setup
 swift run mere.run setup
@@ -238,6 +238,7 @@ swift run mere.run setup
 swift run mere.run model pull image-zimage-nano
 swift run mere.run model pull text-chat-lfm25-a1b-8bit
 swift run mere.run model pull text-code-north-mini
+swift run mere.run model pull text-agent-ornith-35b
 
 # Generate an image
 swift run mere.run image generate \

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -2115,6 +2115,7 @@ actor CodeGenServer {
                     message: OpenAIChatMessage(
                         role: "assistant",
                         content: result.response,
+                        reasoning_content: result.reasoningContent,
                         tool_calls: openAIToolCalls(from: result.toolCalls)
                     ),
                     finish_reason: openAIFinishReason(for: result)
@@ -2679,7 +2680,10 @@ actor CodeGenServer {
                         choices: [
                             OpenAIChatChoice(
                                 index: 0,
-                                delta: OpenAIChatDelta(content: result.response),
+                                delta: OpenAIChatDelta(
+                                    content: result.response,
+                                    reasoning_content: result.reasoningContent
+                                ),
                                 finish_reason: nil
                             )
                         ]

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -376,6 +376,10 @@ struct APIEngineCapabilities: Equatable, Sendable {
 
     static let localText = APIEngineCapabilities()
 
+    static let localTextWithStopSequences = APIEngineCapabilities(
+        supportsStopSequences: true
+    )
+
     static let localTextWithStructuredJSON = APIEngineCapabilities(
         supportsStructuredOutputs: true
     )
@@ -805,6 +809,7 @@ enum APIServerContract {
             lora: lora,
             requiresJSON: requiresJSON,
             tools: tools,
+            stopSequences: openaiRequest.stop?.values ?? [],
             maxContextTokens: contextSize
         )
     }
@@ -2112,7 +2117,7 @@ actor CodeGenServer {
                         content: result.response,
                         tool_calls: openAIToolCalls(from: result.toolCalls)
                     ),
-                    finish_reason: result.toolCalls?.isEmpty == false ? "tool_calls" : "stop"
+                    finish_reason: openAIFinishReason(for: result)
                 )
             ],
             usage: OpenAIUsage(
@@ -2695,7 +2700,7 @@ actor CodeGenServer {
                         OpenAIChatChoice(
                             index: 0,
                             delta: OpenAIChatDelta(),
-                            finish_reason: result.toolCalls?.isEmpty == false ? "tool_calls" : "stop"
+                            finish_reason: openAIFinishReason(for: result)
                         )
                     ]
                 )
@@ -2764,6 +2769,13 @@ actor CodeGenServer {
                 )
             )
         }
+    }
+
+    private nonisolated func openAIFinishReason(for result: ChatResponse) -> String {
+        if result.toolCalls?.isEmpty == false {
+            return "tool_calls"
+        }
+        return result.finishReason == .length ? "length" : "stop"
     }
 
     private nonisolated func jsonString(from arguments: [String: String]) -> String {

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -235,6 +235,7 @@ enum GuideRegistry {
             models: [
                 "text-code-qwen3",
                 "text-code-north-mini",
+                "text-agent-ornith-35b",
             ],
             resourceName: "text-code.md"
         ),
@@ -393,6 +394,8 @@ enum GuideRegistry {
             commandPaths: [["api", "serve"]],
             models: [
                 "text-code-qwen3",
+                "text-code-north-mini",
+                "text-agent-ornith-35b",
                 "text-chat-gemma4",
                 "text-chat-gemma4-12b",
                 "vision-chat-gemma4-12b",
@@ -521,6 +524,7 @@ enum GuideRegistry {
                 "text-code-qwen3",
                 "text-agent-qwen35-9b",
                 "text-code-north-mini",
+                "text-agent-ornith-35b",
             ],
             resourceName: "setup.md"
         ),
@@ -532,6 +536,7 @@ enum GuideRegistry {
                 "text-code-qwen3",
                 "text-agent-qwen35-9b",
                 "text-code-north-mini",
+                "text-agent-ornith-35b",
             ],
             resourceName: "agent-onboard.md"
         ),
@@ -550,6 +555,7 @@ enum GuideRegistry {
                 "text-code-qwen3",
                 "text-agent-qwen35-9b",
                 "text-code-north-mini",
+                "text-agent-ornith-35b",
             ],
             resourceName: "agent-start.md"
         ),

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkAPIWorkloadCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkAPIWorkloadCommand.swift
@@ -265,28 +265,24 @@ struct ModelBenchmarkAPIWorkload: AsyncParsableCommand {
         }
         request.httpBody = body
 
-        let start = Date()
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
-        guard let http = response as? HTTPURLResponse else {
-            throw ValidationError("Chat completion returned a non-HTTP response.")
-        }
-
         var firstTokenSeconds: Double?
         var completion = ""
         var streamedChunks = 0
         var completionTokens: Int?
         var errorBody = ""
-        for try await line in bytes.lines {
-            if http.statusCode != 200 {
+
+        let start = Date()
+        func consumeLine(_ line: String, statusCode: Int) {
+            if statusCode != 200 {
                 errorBody += line
-                continue
+                return
             }
-            guard line.hasPrefix("data: ") else { continue }
+            guard line.hasPrefix("data: ") else { return }
             let payload = String(line.dropFirst("data: ".count))
-            guard payload != "[DONE]" else { break }
-            guard let data = payload.data(using: .utf8),
+            guard payload != "[DONE]" else { return }
+            guard let data = payload.data(using: String.Encoding.utf8),
                   let chunk = try? JSONDecoder().decode(OpenAIChatResponse.self, from: data) else {
-                continue
+                return
             }
             if let usage = chunk.usage {
                 completionTokens = usage.completion_tokens
@@ -301,6 +297,29 @@ struct ModelBenchmarkAPIWorkload: AsyncParsableCommand {
                 }
             }
         }
+
+        let http: HTTPURLResponse
+        #if os(Linux)
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        guard let resolvedHTTP = response as? HTTPURLResponse else {
+            throw ValidationError("Chat completion returned a non-HTTP response.")
+        }
+        http = resolvedHTTP
+        let responseText = String(data: responseData, encoding: .utf8)
+            ?? String(decoding: responseData, as: UTF8.self)
+        for line in responseText.split(separator: "\n", omittingEmptySubsequences: false) {
+            consumeLine(String(line), statusCode: http.statusCode)
+        }
+        #else
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        guard let resolvedHTTP = response as? HTTPURLResponse else {
+            throw ValidationError("Chat completion returned a non-HTTP response.")
+        }
+        http = resolvedHTTP
+        for try await line in bytes.lines {
+            consumeLine(line, statusCode: http.statusCode)
+        }
+        #endif
 
         let totalSeconds = Date().timeIntervalSince(start)
         guard http.statusCode == 200 else {

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -18,7 +18,7 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     var tasks: String?
 
     @Option(name: [.long], help: "Maximum generated tokens per task.")
-    var maxTokens: Int = 512
+    var maxTokens: Int = 1024
 
     @Option(name: [.long], help: "Temperature for generation.")
     var temperature: Double = 0
@@ -225,7 +225,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                 temperature: temperature,
                 topP: topP,
                 showThinking: false,
-                stopOnEOS: true
+                stopOnEOS: true,
+                stopSequences: Self.codeBenchmarkStopSequences
             )
             let generationStart = Date()
             do {
@@ -248,6 +249,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         sandboxBackend: execution.backend.rawValue,
                         tokensGenerated: response.tokensGenerated,
                         decodeTokensPerSecond: response.decodeTokensPerSecond(elapsed: generationSeconds),
+                        finishReason: response.finishReason?.rawValue,
+                        reachedMaxTokens: response.reachedMaxTokens(limit: maxTokens),
                         error: execution.errorSummary
                     )
                 )
@@ -262,6 +265,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         sandboxBackend: nil,
                         tokensGenerated: 0,
                         decodeTokensPerSecond: nil,
+                        finishReason: nil,
+                        reachedMaxTokens: false,
                         error: String(describing: error)
                     )
                 )
@@ -292,7 +297,14 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     private static let systemPrompt = """
     You are completing Python programming benchmark tasks. Return only valid Python code.
     Do not include Markdown fences, prose, comments about your approach, or test code.
+    Stop immediately after the requested function implementation.
     """
+
+    private static let codeBenchmarkStopSequences = TextGenerationStopSequences.defaultRenderedChatStops + [
+        "\n# The following code is for testing",
+        "\nif __name__",
+        "\ndef check(",
+    ]
 }
 
 enum CodeBenchmarkSuite: String, CaseIterable, ExpressibleByArgument {
@@ -564,6 +576,9 @@ private struct CodeBenchmarkModelResult: Encodable {
                 result.executionSeconds.map { "exec=\(Self.format($0))s" },
                 result.sandboxBackend.map { "sandbox=\($0)" },
                 result.decodeTokensPerSecond.map { "tps=\(Self.format($0))" },
+                "tokens=\(result.tokensGenerated)",
+                result.finishReason.map { "finish=\($0)" },
+                result.reachedMaxTokens ? "capped=true" : nil,
             ]
                 .compactMap { $0 }
                 .joined(separator: " ")
@@ -608,10 +623,22 @@ private struct CodeBenchmarkCaseResult: Encodable {
     let sandboxBackend: String?
     let tokensGenerated: Int
     let decodeTokensPerSecond: Double?
+    let finishReason: String?
+    let reachedMaxTokens: Bool
     let error: String?
 }
 
 private extension ChatResponse {
+    func reachedMaxTokens(limit: Int) -> Bool {
+        if finishReason == .length {
+            return true
+        }
+        guard finishReason == nil else {
+            return false
+        }
+        return tokensGenerated >= limit
+    }
+
     func decodeTokensPerSecond(elapsed: Double) -> Double? {
         if let timing, let decodeTokensPerSecond = timing.decodeTokensPerSecond {
             return decodeTokensPerSecond

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -267,6 +267,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         reachedMaxTokens: response.reachedMaxTokens(limit: maxTokens),
                         reasoningCharacters: response.reasoningContent?.count,
                         incompleteReasoning: response.hasIncompleteReasoning,
+                        reasoningBlockCount: response.reasoningBlockCount,
+                        reopenedReasoning: response.hasReopenedReasoning,
                         error: execution.errorSummary
                     )
                 )
@@ -285,6 +287,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         reachedMaxTokens: false,
                         reasoningCharacters: nil,
                         incompleteReasoning: false,
+                        reasoningBlockCount: 0,
+                        reopenedReasoning: false,
                         error: String(describing: error)
                     )
                 )
@@ -651,7 +655,9 @@ private struct CodeBenchmarkModelResult: Encodable {
                 result.finishReason.map { "finish=\($0)" },
                 result.reachedMaxTokens ? "capped=true" : nil,
                 result.reasoningCharacters.map { "reasoning_chars=\($0)" },
+                result.reasoningBlockCount > 0 ? "reasoning_blocks=\(result.reasoningBlockCount)" : nil,
                 result.incompleteReasoning ? "reasoning_incomplete=true" : nil,
+                result.reopenedReasoning ? "reasoning_reopened=true" : nil,
             ]
                 .compactMap { $0 }
                 .joined(separator: " ")
@@ -700,6 +706,8 @@ private struct CodeBenchmarkCaseResult: Encodable {
     let reachedMaxTokens: Bool
     let reasoningCharacters: Int?
     let incompleteReasoning: Bool
+    let reasoningBlockCount: Int
+    let reopenedReasoning: Bool
     let error: String?
 }
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -265,6 +265,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         decodeTokensPerSecond: response.decodeTokensPerSecond(elapsed: generationSeconds),
                         finishReason: response.finishReason?.rawValue,
                         reachedMaxTokens: response.reachedMaxTokens(limit: maxTokens),
+                        reasoningCharacters: response.reasoningContent?.count,
+                        incompleteReasoning: response.hasIncompleteReasoning,
                         error: execution.errorSummary
                     )
                 )
@@ -281,6 +283,8 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                         decodeTokensPerSecond: nil,
                         finishReason: nil,
                         reachedMaxTokens: false,
+                        reasoningCharacters: nil,
+                        incompleteReasoning: false,
                         error: String(describing: error)
                     )
                 )
@@ -646,6 +650,8 @@ private struct CodeBenchmarkModelResult: Encodable {
                 "tokens=\(result.tokensGenerated)",
                 result.finishReason.map { "finish=\($0)" },
                 result.reachedMaxTokens ? "capped=true" : nil,
+                result.reasoningCharacters.map { "reasoning_chars=\($0)" },
+                result.incompleteReasoning ? "reasoning_incomplete=true" : nil,
             ]
                 .compactMap { $0 }
                 .joined(separator: " ")
@@ -692,6 +698,8 @@ private struct CodeBenchmarkCaseResult: Encodable {
     let decodeTokensPerSecond: Double?
     let finishReason: String?
     let reachedMaxTokens: Bool
+    let reasoningCharacters: Int?
+    let incompleteReasoning: Bool
     let error: String?
 }
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -5,7 +5,7 @@ import MereRunCore
 struct ModelBenchmarkCode: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "code",
-        abstract: "Run a small real coding-eval slice against local coding models."
+        abstract: "Run a real coding-eval slice against local coding models."
     )
 
     @Option(name: [.long], help: "Comma-separated model ids. Defaults to the installed coding comparison lane.")
@@ -16,6 +16,12 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
 
     @Option(name: [.long], help: "Comma-separated task ids from the selected suite.")
     var tasks: String?
+
+    @Option(
+        name: [.long],
+        help: "Optional official HumanEval JSONL file for running a larger task slice."
+    )
+    var humanevalFile: String?
 
     @Option(name: [.long], help: "Maximum generated tokens per task.")
     var maxTokens: Int = 1024
@@ -123,7 +129,7 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     }
 
     private func selectedTasks() throws -> [CodeBenchmarkTask] {
-        let suiteTasks = suite.tasks
+        let suiteTasks = try availableTasks()
         guard let tasks else {
             return suiteTasks
         }
@@ -143,6 +149,14 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
             selected.append(task)
         }
         return selected
+    }
+
+    private func availableTasks() throws -> [CodeBenchmarkTask] {
+        guard let humanevalFile else {
+            return suite.tasks
+        }
+        let url = URL(fileURLWithPath: humanevalFile)
+        return try HumanEvalJSONLLoader.load(from: url)
     }
 
     private func runModel(_ modelID: String, tasks: [CodeBenchmarkTask]) async throws -> CodeBenchmarkModelResult {
@@ -318,7 +332,7 @@ enum CodeBenchmarkSuite: String, CaseIterable, ExpressibleByArgument {
     }
 }
 
-private struct CodeBenchmarkTask: Encodable {
+struct CodeBenchmarkTask: Encodable {
     let taskID: String
     let entryPoint: String
     let prompt: String
@@ -475,6 +489,59 @@ private struct CodeBenchmarkTask: Encodable {
             """
         ),
     ]
+}
+
+enum HumanEvalJSONLLoader {
+    static func load(from url: URL) throws -> [CodeBenchmarkTask] {
+        guard url.pathExtension != "gz" else {
+            throw ValidationError("Decompress HumanEval.jsonl.gz first, then pass the .jsonl path to --humaneval-file.")
+        }
+        let data = try Data(contentsOf: url)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw ValidationError("HumanEval JSONL must be UTF-8 text.")
+        }
+
+        var tasks: [CodeBenchmarkTask] = []
+        tasks.reserveCapacity(164)
+        for (lineNumber, rawLine) in text.split(separator: "\n", omittingEmptySubsequences: true).enumerated() {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            do {
+                let record = try JSONDecoder().decode(HumanEvalJSONLRecord.self, from: Data(line.utf8))
+                tasks.append(record.task)
+            } catch {
+                throw ValidationError("Invalid HumanEval JSONL at line \(lineNumber + 1): \(error)")
+            }
+        }
+
+        guard !tasks.isEmpty else {
+            throw ValidationError("HumanEval JSONL did not contain any tasks.")
+        }
+        return tasks
+    }
+}
+
+private struct HumanEvalJSONLRecord: Decodable {
+    let taskID: String
+    let prompt: String
+    let tests: String
+    let entryPoint: String
+
+    private enum CodingKeys: String, CodingKey {
+        case taskID = "task_id"
+        case prompt
+        case tests = "test"
+        case entryPoint = "entry_point"
+    }
+
+    var task: CodeBenchmarkTask {
+        CodeBenchmarkTask(
+            taskID: taskID,
+            entryPoint: entryPoint,
+            prompt: prompt,
+            tests: tests
+        )
+    }
 }
 
 private struct CodeBenchmarkPlan: Encodable {

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -360,22 +360,7 @@ struct TextChat: AsyncParsableCommand {
 
     func cleanResponse(_ response: String, showThinking: Bool) -> String {
         guard !showThinking else { return response }
-        var cleaned = response.replacingOccurrences(
-            of: "(?is)<think>.*?</think>",
-            with: "",
-            options: .regularExpression
-        )
-        cleaned = cleaned.replacingOccurrences(
-            of: "(?is)<think>.*\\z",
-            with: "",
-            options: .regularExpression
-        )
-        cleaned = cleaned.replacingOccurrences(
-            of: "(?i)</think>",
-            with: "",
-            options: .regularExpression
-        )
-        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ChatReasoningMarkup.splitThinkBlocks(in: response).visibleContent
     }
 
     func resolveGemma4KVCacheQuantization(for modelId: String) throws -> Gemma4KVCacheQuantization {

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -21,6 +21,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-q36-nano (Qwen3.6-35B-A3B OptiQ 4-bit, default on Apple Silicon)
           - text-chat-q36-nano-gguf (Qwen3.6-35B-A3B GGUF, default on Linux CUDA)
           - text-agent-ornith-9b (Ornith 1.0 9B OptiQ, experimental coding-agent target)
+          - text-agent-ornith-35b-mlx (Ornith 1.0 35B MLX Q4, local converted coding-agent target)
           - text-chat-gemma4-12b (Gemma 4 12B dense native Swift runtime)
           - text-chat-gemma4-12b-4bit (Gemma 4 12B MLX 4-bit native Swift runtime)
           - text-chat-gemma4-turbo (Gemma 4 26B-A4B NVFP4 native Swift runtime)
@@ -106,7 +107,7 @@ struct TextChat: AsyncParsableCommand {
         return NativeMLXRuntime.backendDescription
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-q36-nano (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-agent-ornith-9b, text-agent-ornith-35b-mlx, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")

--- a/Sources/MereRunCLI/Guides/agent-onboard.md
+++ b/Sources/MereRunCLI/Guides/agent-onboard.md
@@ -12,7 +12,8 @@ is `text-agent-deepseek-v4-flash`. Smaller Qwen agent models are lower-memory
 or comparison alternatives. `text-code-north-mini` is available for native
 GGUF coding-agent experiments, `text-agent-ornith-35b` is available for larger
 native GGUF Ornith evals, and `text-agent-ornith-9b` is available for native
-Qwen-family MLX/OptiQ coding-agent experiments.
+Qwen-family MLX/OptiQ coding-agent experiments. `text-agent-ornith-35b-mlx`
+is the local converted native MLX Q4 lane for larger Ornith evals.
 
 ## Install And Check
 
@@ -40,6 +41,8 @@ mere.run agent onboard --help
   then use `--configure-pi --model text-code-north-mini --host <host> --port <port>`.
 - For Ornith 35B, pull `text-agent-ornith-35b`, start `api serve --engine text-code --model text-agent-ornith-35b`,
   then use `--configure-pi --model text-agent-ornith-35b --host <host> --port <port>`.
+- For Ornith 35B MLX, install `text-agent-ornith-35b-mlx`, start `api serve --engine text-chat-q36 --model text-agent-ornith-35b-mlx`,
+  then use `--configure-pi --model text-agent-ornith-35b-mlx --host <host> --port <port>`.
 - For Ornith, pull `text-agent-ornith-9b`, start `api serve --engine text-chat-q36 --model text-agent-ornith-9b`,
   then use `--configure-pi --model text-agent-ornith-9b --host <host> --port <port>`.
 

--- a/Sources/MereRunCLI/Guides/agent-onboard.md
+++ b/Sources/MereRunCLI/Guides/agent-onboard.md
@@ -10,8 +10,9 @@ No model is required to print readiness. Optional model pulls/configuration
 should use the recommended setup-agent tier; on 96 GB+ Apple Silicon Macs that
 is `text-agent-deepseek-v4-flash`. Smaller Qwen agent models are lower-memory
 or comparison alternatives. `text-code-north-mini` is available for native
-GGUF coding-agent experiments, and `text-agent-ornith-9b` is available for
-native Qwen-family MLX/OptiQ coding-agent experiments.
+GGUF coding-agent experiments, `text-agent-ornith-35b` is available for larger
+native GGUF Ornith evals, and `text-agent-ornith-9b` is available for native
+Qwen-family MLX/OptiQ coding-agent experiments.
 
 ## Install And Check
 
@@ -37,6 +38,8 @@ mere.run agent onboard --help
 - Use `--configure-pi --model <id>` when Pi should call a local mere.run API provider.
 - For North Mini Code, pull `text-code-north-mini`, start `api serve --engine text-code`,
   then use `--configure-pi --model text-code-north-mini --host <host> --port <port>`.
+- For Ornith 35B, pull `text-agent-ornith-35b`, start `api serve --engine text-code --model text-agent-ornith-35b`,
+  then use `--configure-pi --model text-agent-ornith-35b --host <host> --port <port>`.
 - For Ornith, pull `text-agent-ornith-9b`, start `api serve --engine text-chat-q36 --model text-agent-ornith-9b`,
   then use `--configure-pi --model text-agent-ornith-9b --host <host> --port <port>`.
 
@@ -53,6 +56,11 @@ mere.run agent onboard --install-pi --configure-pi --model text-agent-deepseek-v
 ```bash
 mere.run model pull text-code-north-mini
 mere.run agent onboard --configure-pi --model text-code-north-mini --port 8080
+```
+
+```bash
+mere.run model pull text-agent-ornith-35b
+mere.run agent onboard --configure-pi --model text-agent-ornith-35b --port 8080
 ```
 
 ```bash

--- a/Sources/MereRunCLI/Guides/agent-start.md
+++ b/Sources/MereRunCLI/Guides/agent-start.md
@@ -37,6 +37,8 @@ mere.run status
   through the native GGUF code runtime.
 - Use `agent start --model text-agent-ornith-35b` to compare the larger Ornith
   GGUF coding-agent target through the same native `text-code` runtime.
+- Use `agent start --model text-agent-ornith-35b-mlx` to compare the locally
+  converted Ornith 35B MLX target through the native Qwen-family runtime.
 - On Linux, provide an existing Pi binary with `--pi-path` or PATH before starting.
 - Run `status` when you need to confirm the local server and served model.
 - Keep the default prompt unless the user has a specific setup goal.

--- a/Sources/MereRunCLI/Guides/agent-start.md
+++ b/Sources/MereRunCLI/Guides/agent-start.md
@@ -6,7 +6,7 @@ Start Pi against a local mere.run setup-agent API server. This is the guided "he
 
 ## Required Models
 
-Use this machine's supported setup-agent tier. On 96 GB+ Apple Silicon Macs, `text-agent-deepseek-v4-flash` is the preferred managed setup agent. Smaller Qwen and North Mini Code models are lower-memory or comparison alternatives, not upgrades from DeepSeek V4 Flash. On Linux, provide Pi with `--pi-path` or PATH; auto-install uses macOS release assets.
+Use this machine's supported setup-agent tier. On 96 GB+ Apple Silicon Macs, `text-agent-deepseek-v4-flash` is the preferred managed setup agent. Smaller Qwen, North Mini Code, and Ornith 35B models are lower-memory or comparison alternatives, not upgrades from DeepSeek V4 Flash. On Linux, provide Pi with `--pi-path` or PATH; auto-install uses macOS release assets.
 
 ## Install And Check
 
@@ -35,6 +35,8 @@ mere.run status
 - Use `--skip-server` only when you already started a compatible local API server.
 - Use `agent start --model text-code-north-mini` to compare North Mini Code
   through the native GGUF code runtime.
+- Use `agent start --model text-agent-ornith-35b` to compare the larger Ornith
+  GGUF coding-agent target through the same native `text-code` runtime.
 - On Linux, provide an existing Pi binary with `--pi-path` or PATH before starting.
 - Run `status` when you need to confirm the local server and served model.
 - Keep the default prompt unless the user has a specific setup goal.

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -15,7 +15,8 @@ Supported engines:
 - `text-chat-gemma4`: Gemma text chat models, including `text-chat-gemma4-12b`.
 - `vision-chat-gemma4-12b`: Gemma 4 12B vision chat over the Gemma4 API serving engine.
 - `text-chat-q36`: Qwen-family serving engine; defaults to `text-chat-q36-nano`
-  and also serves Qwen-family agent experiments such as `text-agent-ornith-9b`.
+  and also serves Qwen-family agent experiments such as `text-agent-ornith-9b`
+  and `text-agent-ornith-35b-mlx`.
 - `text-chat-lfm2`: LFM2 serving engine; defaults to `text-chat-lfm25-a1b-8bit`.
 - `text-chat-deepseek-v4-flash`: DeepSeek V4 Flash via the bundled DS4 server.
 - `text-chat-klein`: local Klein/MeBot chat path when installed.

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -10,7 +10,8 @@ this when another tool, editor, UI, or agent needs to call mere.run over HTTP.
 
 Supported engines:
 
-- `text-code`: GGUF code models such as `text-code-qwen3` and `text-code-north-mini`.
+- `text-code`: GGUF code models such as `text-code-qwen3`,
+  `text-code-north-mini`, and `text-agent-ornith-35b`.
 - `text-chat-gemma4`: Gemma text chat models, including `text-chat-gemma4-12b`.
 - `vision-chat-gemma4-12b`: Gemma 4 12B vision chat over the Gemma4 API serving engine.
 - `text-chat-q36`: Qwen-family serving engine; defaults to `text-chat-q36-nano`

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -115,6 +115,7 @@ mere.run status
   `benchmarkStats` so these experiments stay measured.
 - DS4 raw-proxies the complete OpenAI chat request to `ds4-server`.
 - Native engines reject unsupported OpenAI fields explicitly instead of silently dropping them.
+- `text-code` maps OpenAI `stop` sequences into native generation stops.
 - Function `tool_choice` values are accepted for native tool-capable engines;
   specific function choices narrow the advertised tools to the named function.
 - `/v1/embeddings` accepts OpenAI-compatible string or string-array `input`

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -162,7 +162,9 @@ backend. Because this runs generated code locally, the command requires
 `--allow-code-execution` unless you are using `--dry-run`. The default
 `--sandbox auto` uses `sandbox-exec` on macOS and `bubblewrap` on Linux when
 available. Use `--sandbox none` only for a trusted local smoke where timeout and
-temporary-directory hygiene are enough.
+temporary-directory hygiene are enough. The default generation cap is
+`--max-tokens 1024`; JSON and text output flag cases that still reach the cap
+with `reachedMaxTokens`/`capped=true`.
 
 Narrow the run while iterating:
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -149,6 +149,9 @@ leaderboard substitute. The default comparison is:
 - `text-code-north-mini`: native llama.cpp/GGUF North Mini Code target.
 - `text-code-qwen3`: native llama.cpp/GGUF Qwen3-Coder baseline.
 
+For larger explicit Ornith runs, pass `--models text-agent-ornith-35b`; it is
+not part of the default comparison because it is a larger GGUF download/load.
+
 The default suite is `humaneval-slice`, currently three public HumanEval tasks:
 
 - `HumanEval/0`
@@ -170,7 +173,7 @@ Narrow the run while iterating:
 
 ```bash
 mere.run model benchmark code \
-  --models text-agent-ornith-9b,text-code-north-mini \
+  --models text-agent-ornith-35b \
   --tasks HumanEval/0 \
   --allow-code-execution
 ```
@@ -189,6 +192,7 @@ gunzip -c /tmp/HumanEval.jsonl.gz > /tmp/HumanEval.jsonl
 mere.run model benchmark code \
   --humaneval-file /tmp/HumanEval.jsonl \
   --tasks HumanEval/0,HumanEval/1,HumanEval/2,HumanEval/3,HumanEval/4 \
+  --models text-agent-ornith-35b \
   --allow-code-execution
 ```
 
@@ -274,6 +278,7 @@ mere.run model benchmark vlm \
 - Pull `text-chat-gemma4-turbo` before running the benchmark.
 - Pull `text-agent-ornith-9b`, `text-code-north-mini`, and `text-code-qwen3`
   before running the default code benchmark comparison.
+- Pull `text-agent-ornith-35b` before running larger explicit Ornith code evals.
 - Pull `vision-chat-gemma4-12b` before using it in the VLM benchmark.
 - Install `lmms-eval` dependencies in the selected Python environment before
   running external datasets; dataset downloads and licenses are handled by the

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -167,7 +167,10 @@ backend. Because this runs generated code locally, the command requires
 available. Use `--sandbox none` only for a trusted local smoke where timeout and
 temporary-directory hygiene are enough. The default generation cap is
 `--max-tokens 1024`; JSON and text output flag cases that still reach the cap
-with `reachedMaxTokens`/`capped=true`.
+with `reachedMaxTokens`/`capped=true`. Reasoning-model output is split before
+scoring: visible code is executed, while captured `<think>...</think>` content
+is reported as `reasoningCharacters`/`reasoning_chars` and
+`incompleteReasoning`/`reasoning_incomplete`.
 
 Narrow the run while iterating:
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -179,6 +179,19 @@ Use `--python` to select a Python interpreter and `--execution-timeout` to
 control the per-candidate subprocess timeout. The command never auto-pulls
 models during scoring; install missing models with `mere.run model pull` first.
 
+For a larger slice, download the official HumanEval JSONL, decompress it, and
+pass it with `--humaneval-file`:
+
+```bash
+curl -L https://raw.githubusercontent.com/openai/human-eval/master/data/HumanEval.jsonl.gz \
+  -o /tmp/HumanEval.jsonl.gz
+gunzip -c /tmp/HumanEval.jsonl.gz > /tmp/HumanEval.jsonl
+mere.run model benchmark code \
+  --humaneval-file /tmp/HumanEval.jsonl \
+  --tasks HumanEval/0,HumanEval/1,HumanEval/2,HumanEval/3,HumanEval/4 \
+  --allow-code-execution
+```
+
 ## VLM Benchmark
 
 `model benchmark vlm` writes a tiny deterministic image-question suite to a

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -170,7 +170,9 @@ temporary-directory hygiene are enough. The default generation cap is
 with `reachedMaxTokens`/`capped=true`. Reasoning-model output is split before
 scoring: visible code is executed, while captured `<think>...</think>` content
 is reported as `reasoningCharacters`/`reasoning_chars` and
-`incompleteReasoning`/`reasoning_incomplete`.
+`incompleteReasoning`/`reasoning_incomplete`. A second generated reasoning
+block is reported as `reasoning_reopened=true`; treat it as a loop or
+phase-restart warning, not a correctness failure by itself.
 
 Narrow the run while iterating:
 

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -149,8 +149,10 @@ leaderboard substitute. The default comparison is:
 - `text-code-north-mini`: native llama.cpp/GGUF North Mini Code target.
 - `text-code-qwen3`: native llama.cpp/GGUF Qwen3-Coder baseline.
 
-For larger explicit Ornith runs, pass `--models text-agent-ornith-35b`; it is
-not part of the default comparison because it is a larger GGUF download/load.
+For larger explicit Ornith runs, pass `--models text-agent-ornith-35b-mlx` for
+the local native MLX Q4 conversion or `--models text-agent-ornith-35b` for the
+GGUF target. They are not part of the default comparison because they are larger
+installs/loads.
 
 The default suite is `humaneval-slice`, currently three public HumanEval tasks:
 

--- a/Sources/MereRunCLI/Guides/setup.md
+++ b/Sources/MereRunCLI/Guides/setup.md
@@ -10,7 +10,8 @@ No model is required to view the plan. Agent setup selects this machine's
 supported tier; on 96 GB+ machines that is `text-agent-deepseek-v4-flash`.
 Smaller Qwen agent models are lower-memory or comparison alternatives, not
 upgrades from DeepSeek V4 Flash. `text-code-north-mini` can be pulled for
-native GGUF coding-agent experiments through the same `text-code` runtime.
+native GGUF coding-agent experiments through the same `text-code` runtime;
+`text-agent-ornith-35b` is the larger explicit Ornith GGUF eval target.
 
 ## Install And Check
 
@@ -39,7 +40,8 @@ mere.run model capabilities --recommended
 - Use agent mode only with a supported local runtime and model. Prefer `--agent-model tier` unless the user asks for a smaller comparison model.
 - On Linux, provide Pi with `--pi-path` or put `pi` on PATH; auto-install uses macOS release assets.
 - Use `--agent-model small` for the smallest setup model, or pull
-  `text-code-north-mini` manually when comparing North Mini Code against Qwen.
+  `text-code-north-mini` or `text-agent-ornith-35b` manually when comparing
+  coding models against Qwen.
 
 ## Examples
 

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,12 +6,13 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-12b-4bit`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-agent-ornith-9b`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-12b-4bit`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
 `text-chat-gemma4-12b` is the managed dense Google Gemma 4 12B-it checkpoint, routed through the native Swift Gemma 4 runtime for text chat.
 Pulling `text-chat-gemma4-12b` or `vision-chat-gemma4-12b` also installs the managed `text-chat-gemma4-12b-mtp` assistant; greedy serial Gemma 12B decode uses it for verified decode-tail MTP when the prompt is above the configured threshold.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
 `text-chat-q36-nano` is the managed Qwen3.6 35B-A3B OptiQ 4-bit MLX snapshot; its upstream repo includes an MTP head that is used only by the adaptive long-context speculative decode path.
 `text-agent-ornith-9b` is the managed Ornith 1.0 9B OptiQ MLX coding-agent experiment; it uses the native Qwen-family runtime rather than the GGUF `text code` command.
+`text-agent-ornith-35b-mlx` is the local converted Ornith 1.0 35B Q4 MLX coding-agent target; it also uses the native Qwen-family runtime.
 `text-chat-lfm25-a1b-8bit` is the managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot and runs through the native Swift LFM2 runtime.
 
 ## Chat Winners By RAM Band

--- a/Sources/MereRunCLI/Guides/text-code.md
+++ b/Sources/MereRunCLI/Guides/text-code.md
@@ -16,6 +16,8 @@ architecture support.
 For larger Ornith coding-agent evals, `text-agent-ornith-35b` installs
 DeepReinforce's Q4_K_M GGUF quant and runs through the same native `text-code`
 path with a 32K runtime context.
+Use `text-agent-ornith-35b-mlx` through `text chat`, `api serve`, or
+`model benchmark code` when testing a locally converted native MLX Q4 snapshot.
 
 ## Install And Check
 

--- a/Sources/MereRunCLI/Guides/text-code.md
+++ b/Sources/MereRunCLI/Guides/text-code.md
@@ -13,12 +13,16 @@ For lower-memory coding experiments, `text-code-north-mini` installs the
 Unsloth GGUF quant of Cohere Labs' North Mini Code. It runs through the native
 Swift/llama.cpp code path and requires a llama.cpp runtime with `cohere2moe`
 architecture support.
+For larger Ornith coding-agent evals, `text-agent-ornith-35b` installs
+DeepReinforce's Q4_K_M GGUF quant and runs through the same native `text-code`
+path with a 32K runtime context.
 
 ## Install And Check
 
 ```bash
 mere.run model pull text-code-qwen3
 mere.run model pull text-code-north-mini
+mere.run model pull text-agent-ornith-35b
 mere.run text code --help
 ```
 
@@ -61,6 +65,12 @@ mere.run text code \
   --prompt "Write a small Swift Result extension with tests."
 ```
 
+```bash
+mere.run text code \
+  --model text-agent-ornith-35b \
+  --prompt "Write a small Swift Result extension with tests."
+```
+
 ## Iteration Tips
 
 - Lower temperature for compiler-sensitive work.
@@ -72,6 +82,8 @@ mere.run text code \
 - No model found: run `mere.run model pull text-code-qwen3` or pass a GGUF path with `--model`.
 - North Mini Code fails to load: rebuild or update the bundled llama.cpp runtime
   so it includes `cohere2moe` support.
+- Ornith 35B answers with long reasoning: reduce `--max-tokens` or ask for code
+  only when doing interactive generation.
 - Output rambles: reduce `--max-tokens` and ask for a specific format.
 - Code is stale: paste current symbols and file names instead of relying on model memory.
 

--- a/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
+++ b/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
@@ -295,13 +295,14 @@ private final class LimitedOutputPipe: @unchecked Sendable {
 
     init(limitBytes: Int) {
         self.limitBytes = limitBytes
-        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+        let handler: @Sendable (FileHandle) -> Void = { [weak self] handle in
             let chunk = handle.availableData
             guard !chunk.isEmpty else {
                 return
             }
             self?.append(chunk)
         }
+        pipe.fileHandleForReading.readabilityHandler = handler
     }
 
     func finish() -> Capture {

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1727,7 +1727,7 @@ extension RuntimeServingEngine {
     var openAICompatibility: APIEngineCapabilities {
         switch self {
         case .textCode:
-            return .localText
+            return .localTextWithStopSequences
         case .textChatKlein:
             return .localTextWithStructuredJSON
         case .textChatGemma4:

--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -34,6 +34,25 @@ public struct NorthMiniCodeResources: Sendable, Hashable {
     )
 }
 
+public struct Ornith35BCodeResources: Sendable, Hashable {
+    public static let modelId = "text-agent-ornith-35b"
+    public static let upstreamRepoId = "deepreinforce-ai/Ornith-1.0-35B-GGUF"
+    public static let upstreamRevision = "c2e1703039380de4ce6820e97afd185682d3c16c"
+    public static let ggufFile = "ornith-1.0-35b-Q4_K_M.gguf"
+    public static let managedRelativePath = "\(modelId).gguf"
+    public static let contextLength = 262_144
+    public static let runtimeContextLength = 32_768
+    public static let maxOutputTokens = 4_096
+    public static let estimatedDownloadBytes: Int64 = 21_166_757_760
+
+    public static let hubFallbackConfig = HubFallbackConfig(
+        repoId: upstreamRepoId,
+        revision: upstreamRevision,
+        patterns: [ggufFile],
+        filePath: ggufFile
+    )
+}
+
 public enum MereRunAgentServingEngine: String, Hashable, Sendable {
     case textCode = "text-code"
     case textChatQ36 = "text-chat-q36"
@@ -159,6 +178,7 @@ public enum MereRunAgentModelCatalog {
             qwen35NineB(),
             northMiniCode(),
             ornith9B(),
+            ornith35B(),
             q36Nano(),
             qwen3CoderNext(),
             deepseekV4Flash(),
@@ -210,6 +230,18 @@ public enum MereRunAgentModelCatalog {
             recommendedUnifiedMemoryGB: 24,
             servingEngine: .textChatQ35,
             managedModelID: Q35Resources.ornith9BModelId
+        )
+    }
+
+    private static func ornith35B() -> MereRunAgentModelRecommendation {
+        MereRunAgentModelRecommendation(
+            id: Ornith35BCodeResources.modelId,
+            displayName: "Ornith 1.0 35B Q4",
+            summary: "Larger Ornith GGUF coding-agent model for native llama.cpp-backed eval comparisons.",
+            minimumUnifiedMemoryGB: 32,
+            recommendedUnifiedMemoryGB: 64,
+            servingEngine: .textCode,
+            managedModelID: Ornith35BCodeResources.modelId
         )
     }
 

--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -179,6 +179,7 @@ public enum MereRunAgentModelCatalog {
             northMiniCode(),
             ornith9B(),
             ornith35B(),
+            ornith35BMLX(),
             q36Nano(),
             qwen3CoderNext(),
             deepseekV4Flash(),
@@ -242,6 +243,18 @@ public enum MereRunAgentModelCatalog {
             recommendedUnifiedMemoryGB: 64,
             servingEngine: .textCode,
             managedModelID: Ornith35BCodeResources.modelId
+        )
+    }
+
+    private static func ornith35BMLX() -> MereRunAgentModelRecommendation {
+        MereRunAgentModelRecommendation(
+            id: Q35Resources.ornith35BMLXModelId,
+            displayName: "Ornith 1.0 35B MLX Q4",
+            summary: "Converted MLX Q4 Ornith 35B MoE for native Swift Qwen-family eval comparisons.",
+            minimumUnifiedMemoryGB: 24,
+            recommendedUnifiedMemoryGB: 32,
+            servingEngine: .textChatQ35,
+            managedModelID: Q35Resources.ornith35BMLXModelId
         )
     }
 

--- a/Sources/MereRunCore/CodeGen/CodeGenGenerator.swift
+++ b/Sources/MereRunCore/CodeGen/CodeGenGenerator.swift
@@ -61,20 +61,11 @@ public actor CodeGenGenerator: ChatGenerator {
 
         let prompt = ctx.chatPrompt(for: request.messages)
 
-        progressHandler?(ChatProgress(stage: .generating, message: "Generating..."))
-        try ctx.completionInit(text: prompt)
-
-        var response = ""
-        while !ctx.isDone {
-            let token = try ctx.completionLoop()
-            response += token
-            progressHandler?(ChatProgress(stage: .generating, message: token))
-        }
-
-        let tokensDecoded = ctx.getTokensDecoded()
-        return ChatResponse(
-            response: Self.trimmingRenderedStopSequences(from: response),
-            tokensGenerated: tokensDecoded
+        return try Self.generateResponse(
+            request: request,
+            context: ctx,
+            prompt: prompt,
+            progressHandler: progressHandler
         )
     }
 
@@ -124,20 +115,48 @@ public actor CodeGenGenerator: ChatGenerator {
 
         let prompt = ctx.chatPrompt(for: request.messages)
 
+        return try Self.generateResponse(
+            request: request,
+            context: ctx,
+            prompt: prompt,
+            progressHandler: progressHandler
+        )
+    }
+
+    private static func generateResponse(
+        request: ChatRequest,
+        context ctx: LlamaContext,
+        prompt: String,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> ChatResponse {
+        let stopSequences = TextGenerationStopSequences.merged(
+            TextGenerationStopSequences.defaultRenderedChatStops + request.stopSequences
+        )
         progressHandler?(ChatProgress(stage: .generating, message: "Generating..."))
         try ctx.completionInit(text: prompt)
 
         var response = ""
+        var finishReason: ChatFinishReason?
         while !ctx.isDone {
             let token = try ctx.completionLoop()
             response += token
+            let trimmed = TextGenerationStopSequences.trimming(response, sequences: stopSequences)
+            if trimmed.matchedSequence != nil {
+                response = trimmed.text
+                finishReason = .stopSequence
+                break
+            }
             progressHandler?(ChatProgress(stage: .generating, message: token))
         }
 
         let tokensDecoded = ctx.getTokensDecoded()
+        if finishReason == nil {
+            finishReason = tokensDecoded >= request.maxTokens ? .length : .stop
+        }
         return ChatResponse(
-            response: Self.trimmingRenderedStopSequences(from: response),
-            tokensGenerated: tokensDecoded
+            response: TextGenerationStopSequences.trimming(response, sequences: stopSequences).text,
+            tokensGenerated: tokensDecoded,
+            finishReason: finishReason
         )
     }
 
@@ -211,28 +230,6 @@ public actor CodeGenGenerator: ChatGenerator {
         case .downloadFailed(let message):
             return .downloadFailed(message)
         }
-    }
-
-    private static func trimmingRenderedStopSequences(from response: String) -> String {
-        let stopSequences = [
-            "<|END_OF_TURN_TOKEN|>",
-            "<|im_end|>",
-            "</s>",
-            "<|endoftext|>"
-        ]
-        var firstStopRange: Range<String.Index>?
-        for stopSequence in stopSequences {
-            guard let range = response.range(of: stopSequence) else {
-                continue
-            }
-            if let current = firstStopRange, current.lowerBound <= range.lowerBound {
-                continue
-            }
-            firstStopRange = range
-        }
-
-        let trimmed = firstStopRange.map { String(response[..<$0.lowerBound]) } ?? response
-        return trimmed.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
 }

--- a/Sources/MereRunCore/CodeGen/CodeGenGenerator.swift
+++ b/Sources/MereRunCore/CodeGen/CodeGenGenerator.swift
@@ -154,8 +154,9 @@ public actor CodeGenGenerator: ChatGenerator {
             finishReason = tokensDecoded >= request.maxTokens ? .length : .stop
         }
         return ChatResponse(
-            response: TextGenerationStopSequences.trimming(response, sequences: stopSequences).text,
+            generatedText: TextGenerationStopSequences.trimming(response, sequences: stopSequences).text,
             tokensGenerated: tokensDecoded,
+            showThinking: request.showThinking,
             finishReason: finishReason
         )
     }

--- a/Sources/MereRunCore/CodeGen/CodeGenResources.swift
+++ b/Sources/MereRunCore/CodeGen/CodeGenResources.swift
@@ -20,6 +20,8 @@ public struct CodeGenResources: Sendable, Hashable {
         switch modelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case NorthMiniCodeResources.modelId:
             return "North Mini Code"
+        case Ornith35BCodeResources.modelId:
+            return "Ornith 1.0 35B"
         default:
             return "Qwen3-Coder"
         }
@@ -29,6 +31,8 @@ public struct CodeGenResources: Sendable, Hashable {
         switch modelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case NorthMiniCodeResources.modelId:
             return UInt32(NorthMiniCodeResources.runtimeContextLength)
+        case Ornith35BCodeResources.modelId:
+            return UInt32(Ornith35BCodeResources.runtimeContextLength)
         default:
             return 32_768
         }

--- a/Sources/MereRunCore/CodeGen/LlamaCLIProcess.swift
+++ b/Sources/MereRunCore/CodeGen/LlamaCLIProcess.swift
@@ -77,16 +77,21 @@ struct LlamaCLIProcess {
             let invocation = Self.invocation(for: request, modelPath: modelPath)
             progressHandler?(ChatProgress(stage: .generating, message: "Generating..."))
             let result = try run(arguments: invocation.arguments)
-            let response = Self.extractResponse(from: result.stdout)
+            let rawResponse = Self.extractResponse(from: result.stdout)
+            let trimmed = TextGenerationStopSequences.trimming(
+                rawResponse,
+                sequences: TextGenerationStopSequences.defaultRenderedChatStops + request.stopSequences
+            )
             let performance = Self.extractPerformance(from: result.stdout)
-            guard !response.isEmpty else {
+            guard !trimmed.text.isEmpty else {
                 throw LlamaCLIProcessError.emptyResponse(stderr: Self.tail(result.stderr))
             }
-            progressHandler?(ChatProgress(stage: .generating, message: response))
+            progressHandler?(ChatProgress(stage: .generating, message: trimmed.text))
             return ChatResponse(
-                response: response,
-                tokensGenerated: max(1, response.split(whereSeparator: { $0.isWhitespace }).count),
-                timing: performance.chatTiming
+                response: trimmed.text,
+                tokensGenerated: max(1, rawResponse.split(whereSeparator: { $0.isWhitespace }).count),
+                timing: performance.chatTiming,
+                finishReason: trimmed.matchedSequence == nil ? nil : .stopSequence
             )
         }.value
     }

--- a/Sources/MereRunCore/CodeGen/LlamaCLIProcess.swift
+++ b/Sources/MereRunCore/CodeGen/LlamaCLIProcess.swift
@@ -86,13 +86,15 @@ struct LlamaCLIProcess {
             guard !trimmed.text.isEmpty else {
                 throw LlamaCLIProcessError.emptyResponse(stderr: Self.tail(result.stderr))
             }
-            progressHandler?(ChatProgress(stage: .generating, message: trimmed.text))
-            return ChatResponse(
-                response: trimmed.text,
+            let response = ChatResponse(
+                generatedText: trimmed.text,
                 tokensGenerated: max(1, rawResponse.split(whereSeparator: { $0.isWhitespace }).count),
+                showThinking: request.showThinking,
                 timing: performance.chatTiming,
                 finishReason: trimmed.matchedSequence == nil ? nil : .stopSequence
             )
+            progressHandler?(ChatProgress(stage: .generating, message: response.response))
+            return response
         }.value
     }
 

--- a/Sources/MereRunCore/CodeGen/LlamaContext.swift
+++ b/Sources/MereRunCore/CodeGen/LlamaContext.swift
@@ -330,12 +330,9 @@ public final class LlamaContext: @unchecked Sendable {
     }
 
     private static func isRenderedStopToken(_ token: String) -> Bool {
-        switch token.trimmingCharacters(in: .whitespacesAndNewlines) {
-        case "<|END_OF_TURN_TOKEN|>", "<|im_end|>", "</s>", "<|endoftext|>":
-            return true
-        default:
-            return false
-        }
+        TextGenerationStopSequences.defaultRenderedChatStops.contains(
+            token.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
     }
 
     private func applyModelChatTemplate(_ messages: [ChatMessage]) -> String? {

--- a/Sources/MereRunCore/CodeGen/OpenAITypes.swift
+++ b/Sources/MereRunCore/CodeGen/OpenAITypes.swift
@@ -395,6 +395,7 @@ public struct OpenAIEmbeddingRequest: Codable, Sendable {
 public struct OpenAIChatMessage: Codable, Sendable {
     public var role: String
     public var content: String
+    public var reasoning_content: String?
     public var name: String?
     public var tool_call_id: String?
     public var tool_calls: [OpenAIChatToolCall]?
@@ -403,6 +404,7 @@ public struct OpenAIChatMessage: Codable, Sendable {
     public init(
         role: String,
         content: String = "",
+        reasoning_content: String? = nil,
         name: String? = nil,
         tool_call_id: String? = nil,
         tool_calls: [OpenAIChatToolCall]? = nil,
@@ -410,6 +412,7 @@ public struct OpenAIChatMessage: Codable, Sendable {
     ) {
         self.role = role
         self.content = content
+        self.reasoning_content = reasoning_content
         self.name = name
         self.tool_call_id = tool_call_id
         self.tool_calls = tool_calls
@@ -419,6 +422,7 @@ public struct OpenAIChatMessage: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case role
         case content
+        case reasoning_content
         case name
         case tool_call_id
         case tool_calls
@@ -430,6 +434,7 @@ public struct OpenAIChatMessage: Codable, Sendable {
         let decoded = try container.decodeFlexibleContentIfPresent(forKey: .content)
         content = decoded.text
         imageURLs = decoded.imageURLs
+        reasoning_content = try container.decodeIfPresent(String.self, forKey: .reasoning_content)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         tool_call_id = try container.decodeIfPresent(String.self, forKey: .tool_call_id)
         tool_calls = try container.decodeIfPresent([OpenAIChatToolCall].self, forKey: .tool_calls)
@@ -439,6 +444,7 @@ public struct OpenAIChatMessage: Codable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(role, forKey: .role)
         try container.encode(content, forKey: .content)
+        try container.encodeIfPresent(reasoning_content, forKey: .reasoning_content)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(tool_call_id, forKey: .tool_call_id)
         try container.encodeIfPresent(tool_calls, forKey: .tool_calls)
@@ -712,11 +718,18 @@ public struct OpenAIChatChoice: Codable, Sendable {
 public struct OpenAIChatDelta: Codable, Sendable {
     public var role: String?
     public var content: String?
+    public var reasoning_content: String?
     public var tool_calls: [OpenAIChatToolCallDelta]?
 
-    public init(role: String? = nil, content: String? = nil, tool_calls: [OpenAIChatToolCallDelta]? = nil) {
+    public init(
+        role: String? = nil,
+        content: String? = nil,
+        reasoning_content: String? = nil,
+        tool_calls: [OpenAIChatToolCallDelta]? = nil
+    ) {
         self.role = role
         self.content = content
+        self.reasoning_content = reasoning_content
         self.tool_calls = tool_calls
     }
 }

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
@@ -92,7 +92,8 @@ public actor DeepseekV4FlashGenerator: ChatGenerator {
                 loadSeconds: loadSeconds,
                 prefillSeconds: 0,
                 decodeSeconds: elapsed
-            )
+            ),
+            reasoningContent: choice.message?.reasoning_content ?? choice.delta?.reasoning_content
         )
     }
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Chat.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Chat.swift
@@ -112,8 +112,9 @@ extension Flux2KleinGenerator {
                 if isValidJSON(lastResponse) {
                     debugLog?("chat: JSON validation passed")
                     return ChatResponse(
-                        response: lastResponse,
-                        tokensGenerated: generatedTokens.count
+                        generatedText: lastResponse,
+                        tokensGenerated: generatedTokens.count,
+                        showThinking: request.showThinking
                     )
                 } else {
                     debugLog?("chat: JSON validation failed, attempt \(attempt)/\(maxRetries)")
@@ -123,8 +124,9 @@ extension Flux2KleinGenerator {
                 }
             } else {
                 return ChatResponse(
-                    response: lastResponse,
-                    tokensGenerated: generatedTokens.count
+                    generatedText: lastResponse,
+                    tokensGenerated: generatedTokens.count,
+                    showThinking: request.showThinking
                 )
             }
         }
@@ -132,8 +134,9 @@ extension Flux2KleinGenerator {
         // All retries exhausted - return last response anyway
         debugLog?("chat: JSON validation failed after \(maxRetries) attempts, returning last response")
         return ChatResponse(
-            response: lastResponse,
-            tokensGenerated: 0
+            generatedText: lastResponse,
+            tokensGenerated: 0,
+            showThinking: request.showThinking
         )
     }
 
@@ -210,23 +213,26 @@ extension Flux2KleinGenerator {
             if request.requiresJSON {
                 if isValidJSON(lastResponse) {
                     return ChatResponse(
-                        response: lastResponse,
-                        tokensGenerated: generatedTokens.count
+                        generatedText: lastResponse,
+                        tokensGenerated: generatedTokens.count,
+                        showThinking: request.showThinking
                     )
                 } else if attempt < maxRetries {
                     progressHandler?(ChatProgress(stage: .generating, message: "Retrying generation"))
                 }
             } else {
                 return ChatResponse(
-                    response: lastResponse,
-                    tokensGenerated: generatedTokens.count
+                    generatedText: lastResponse,
+                    tokensGenerated: generatedTokens.count,
+                    showThinking: request.showThinking
                 )
             }
         }
 
         return ChatResponse(
-            response: lastResponse,
-            tokensGenerated: 0
+            generatedText: lastResponse,
+            tokensGenerated: 0,
+            showThinking: request.showThinking
         )
     }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -726,6 +726,25 @@ public actor Gemma4Generator: ChatGenerator {
         jsonConstrained: Bool = false,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Gemma4BatchedDecodeResult {
+        if canUsePipelinedGreedyDecode(
+            generationConfig,
+            mtpModel: mtpModel,
+            jsonConstrained: jsonConstrained
+        ) {
+            return try await decodeTokensGreedyPipelined(
+                model: model,
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                initialLogits: initialLogits,
+                layerCaches: layerCaches,
+                eosSet: eosSet,
+                generationConfig: generationConfig,
+                tokenBudget: tokenBudget,
+                promptTokens: promptTokens,
+                mtpStatsTemplate: mtpStatsTemplate,
+                progressHandler: progressHandler
+            )
+        }
+
         var logits = initialLogits
         var layerCaches = layerCaches
         var generated: [Int] = []
@@ -776,9 +795,11 @@ public actor Gemma4Generator: ChatGenerator {
                 firstTokenSeconds = Date().timeIntervalSince(decodeStart)
             }
             repetitionHistory.append(next)
-            let piece = tokenizerAndTemplate.decode(token: next)
-            if !piece.isEmpty {
-                progressHandler?(ChatProgress(stage: .generating, message: piece))
+            if let progressHandler {
+                let piece = tokenizerAndTemplate.decode(token: next)
+                if !piece.isEmpty {
+                    progressHandler(ChatProgress(stage: .generating, message: piece))
+                }
             }
 
             if jsonConstrained, jsonScanner.isComplete {
@@ -814,7 +835,7 @@ public actor Gemma4Generator: ChatGenerator {
                         .reshaped(1, draft.tokens.count + 1)
                     let candidate = model.forwardForSpeculation(
                         inputIds: candidateInput,
-                        cache: candidateCaches as [AnyObject]
+                        cache: candidateCaches
                     )
                     MLX.eval(candidate.logits, candidate.hidden)
 
@@ -846,9 +867,11 @@ public actor Gemma4Generator: ChatGenerator {
                             generated.append(token)
                             repetitionHistory.append(token)
                             mtpStats.acceptedTokens += 1
-                            let tokenPiece = tokenizerAndTemplate.decode(token: token)
-                            if !tokenPiece.isEmpty {
-                                progressHandler?(ChatProgress(stage: .generating, message: tokenPiece))
+                            if let progressHandler {
+                                let tokenPiece = tokenizerAndTemplate.decode(token: token)
+                                if !tokenPiece.isEmpty {
+                                    progressHandler(ChatProgress(stage: .generating, message: tokenPiece))
+                                }
                             }
                         }
                         layerCaches = candidateCaches
@@ -879,9 +902,11 @@ public actor Gemma4Generator: ChatGenerator {
                         generated.append(token)
                         repetitionHistory.append(token)
                         mtpStats.acceptedTokens += 1
-                        let tokenPiece = tokenizerAndTemplate.decode(token: token)
-                        if !tokenPiece.isEmpty {
-                            progressHandler?(ChatProgress(stage: .generating, message: tokenPiece))
+                        if let progressHandler {
+                            let tokenPiece = tokenizerAndTemplate.decode(token: token)
+                            if !tokenPiece.isEmpty {
+                                progressHandler(ChatProgress(stage: .generating, message: tokenPiece))
+                            }
                         }
                     }
                     if hitEOS || generated.count >= tokenBudget {
@@ -896,9 +921,11 @@ public actor Gemma4Generator: ChatGenerator {
                     }
                     generated.append(replacement)
                     repetitionHistory.append(replacement)
-                    let replacementPiece = tokenizerAndTemplate.decode(token: replacement)
-                    if !replacementPiece.isEmpty {
-                        progressHandler?(ChatProgress(stage: .generating, message: replacementPiece))
+                    if let progressHandler {
+                        let replacementPiece = tokenizerAndTemplate.decode(token: replacement)
+                        if !replacementPiece.isEmpty {
+                            progressHandler(ChatProgress(stage: .generating, message: replacementPiece))
+                        }
                     }
 
                     let replacementCaches = forkLayerCaches(baseCaches)
@@ -906,7 +933,7 @@ public actor Gemma4Generator: ChatGenerator {
                         .reshaped(1, acceptedPrefix.count + 2)
                     let replacementForward = model.forwardForSpeculation(
                         inputIds: replacementInput,
-                        cache: replacementCaches as [AnyObject]
+                        cache: replacementCaches
                     )
                     MLX.eval(replacementForward.logits, replacementForward.hidden)
                     layerCaches = replacementCaches
@@ -922,13 +949,13 @@ public actor Gemma4Generator: ChatGenerator {
 
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
             if mtpModel != nil {
-                let output = model.forwardForSpeculation(inputIds: nextInput, cache: layerCaches as [AnyObject])
+                let output = model.forwardForSpeculation(inputIds: nextInput, cache: layerCaches)
                 logits = output.logits
                 previousHidden = model.speculativeDraftHidden(lastTokenHidden(output.hidden))
                 currentSharedKVStates = output.sharedKVStates
                 MLX.eval(logits, previousHidden!)
             } else {
-                logits = model.forward(inputIds: nextInput, cache: layerCaches as [AnyObject])
+                logits = model.forward(inputIds: nextInput, cache: layerCaches)
                 MLX.eval(logits)
             }
         }
@@ -939,6 +966,130 @@ public actor Gemma4Generator: ChatGenerator {
             firstTokenSeconds: firstTokenSeconds,
             mtpStats: mtpStats
         )
+    }
+
+    private func canUsePipelinedGreedyDecode(
+        _ config: GenerationConfig,
+        mtpModel: Gemma4AssistantDraftModel?,
+        jsonConstrained: Bool
+    ) -> Bool {
+        mtpModel == nil && !jsonConstrained && config.temperature == 0
+    }
+
+    private func decodeTokensGreedyPipelined(
+        model: any Gemma4CausalModel,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [Gemma4AttentionCache],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int],
+        mtpStatsTemplate: Gemma4MTPStats,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> Gemma4BatchedDecodeResult {
+        let layerCaches = layerCaches
+        var generated: [Int] = []
+        generated.reserveCapacity(tokenBudget)
+        var repetitionHistory = greedyRepetitionHistoryArray(
+            promptTokens: promptTokens,
+            config: generationConfig
+        )
+        var firstTokenSeconds: Double?
+        var pendingToken = greedySampleTokenArray(
+            logits: initialLogits[0, -1, 0...],
+            config: generationConfig,
+            previousTokenIndices: repetitionHistory
+        )
+        MLX.asyncEval(pendingToken)
+        let decodeStart = Date()
+
+        while generated.count < tokenBudget {
+            try Task.checkCancellation()
+
+            let scheduled: (token: MLXArray, history: MLXArray?)?
+            if generated.count + 1 < tokenBudget {
+                let nextInput = pendingToken.asType(.int32).reshaped(1, 1)
+                let nextLogits = model.forward(inputIds: nextInput, cache: layerCaches)
+                let nextHistory = appendingGreedyRepetitionHistory(
+                    repetitionHistory,
+                    token: pendingToken,
+                    config: generationConfig
+                )
+                let nextToken = greedySampleTokenArray(
+                    logits: nextLogits[0, -1, 0...],
+                    config: generationConfig,
+                    previousTokenIndices: nextHistory
+                )
+                MLX.asyncEval(nextToken, nextLogits)
+                scheduled = (nextToken, nextHistory)
+            } else {
+                scheduled = nil
+            }
+
+            let next = pendingToken.item(Int.self)
+            if eosSet.contains(next) {
+                break
+            }
+
+            generated.append(next)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(decodeStart)
+            }
+            if let progressHandler {
+                let piece = tokenizerAndTemplate.decode(token: next)
+                if !piece.isEmpty {
+                    progressHandler(ChatProgress(stage: .generating, message: piece))
+                }
+            }
+
+            guard let scheduled, generated.count < tokenBudget else {
+                break
+            }
+            pendingToken = scheduled.token
+            repetitionHistory = scheduled.history
+        }
+
+        return Gemma4BatchedDecodeResult(
+            generatedTokens: generated,
+            decodeSeconds: Date().timeIntervalSince(decodeStart),
+            firstTokenSeconds: firstTokenSeconds,
+            mtpStats: mtpStatsTemplate
+        )
+    }
+
+    private func greedyRepetitionHistoryArray(
+        promptTokens: [Int],
+        config: GenerationConfig
+    ) -> MLXArray? {
+        guard config.repetitionPenalty != nil,
+              config.repetitionContextSize > 0,
+              !promptTokens.isEmpty else {
+            return nil
+        }
+        return MLXArray(promptTokens.suffix(config.repetitionContextSize).map { Int32($0) })
+    }
+
+    private func appendingGreedyRepetitionHistory(
+        _ history: MLXArray?,
+        token: MLXArray,
+        config: GenerationConfig
+    ) -> MLXArray? {
+        guard config.repetitionPenalty != nil, config.repetitionContextSize > 0 else {
+            return nil
+        }
+
+        let nextToken = token.asType(.int32).reshaped(1)
+        guard let history else {
+            return nextToken
+        }
+
+        let combined = concatenated([history, nextToken], axis: 0)
+        let overflow = combined.dim(0) - config.repetitionContextSize
+        guard overflow > 0 else {
+            return combined
+        }
+        return combined[overflow..<combined.dim(0)]
     }
 
     private func enqueueDecodeRow(
@@ -1061,9 +1212,11 @@ public actor Gemma4Generator: ChatGenerator {
                 row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
             }
             row.repetitionHistory.append(next)
-            let piece = tokenizerAndTemplate.decode(token: next)
-            if !piece.isEmpty {
-                row.progressHandler?(ChatProgress(stage: .generating, message: piece))
+            if let progressHandler = row.progressHandler {
+                let piece = tokenizerAndTemplate.decode(token: next)
+                if !piece.isEmpty {
+                    progressHandler(ChatProgress(stage: .generating, message: piece))
+                }
             }
         }
 
@@ -1074,7 +1227,7 @@ public actor Gemma4Generator: ChatGenerator {
            let batchedCaches = makeBatchedLayerCaches(continuingRows.map(\.layerCaches)) {
             let nextInput = MLXArray(continuingRows.compactMap { $0.generatedTokens.last }.map(Int32.init))
                 .reshaped(continuingRows.count, 1)
-            let batchedLogits = model.forward(inputIds: nextInput, cache: batchedCaches as [AnyObject])
+            let batchedLogits = model.forward(inputIds: nextInput, cache: batchedCaches)
             MLX.eval(batchedLogits)
             guard let splitCaches = splitBatchedLayerCaches(batchedCaches, rowCount: continuingRows.count) else {
                 throw Gemma4Error.unsupportedConfiguration("Gemma4 batched decode could not split merged KV cache rows.")
@@ -1097,7 +1250,7 @@ public actor Gemma4Generator: ChatGenerator {
         for row in continuingRows {
             guard let next = row.generatedTokens.last else { continue }
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
-            row.logits = model.forward(inputIds: nextInput, cache: row.layerCaches as [AnyObject])
+            row.logits = model.forward(inputIds: nextInput, cache: row.layerCaches)
             MLX.eval(row.logits)
             singleDecodeSteps += 1
         }
@@ -1219,13 +1372,13 @@ public actor Gemma4Generator: ChatGenerator {
                 .reshaped(1, end - processed)
             let chunkLogits: MLXArray
             if captureSpeculation, end == promptTokens.count {
-                let output = model.forwardForSpeculation(inputIds: chunk, cache: cache as [AnyObject])
+                let output = model.forwardForSpeculation(inputIds: chunk, cache: cache)
                 chunkLogits = output.logits
                 hidden = output.hidden
                 sharedKVStates = output.sharedKVStates
                 MLX.eval(chunkLogits, output.hidden)
             } else {
-                chunkLogits = model.forward(inputIds: chunk, cache: cache as [AnyObject])
+                chunkLogits = model.forward(inputIds: chunk, cache: cache)
                 MLX.eval(chunkLogits)
             }
             logits = chunkLogits
@@ -1278,7 +1431,7 @@ public actor Gemma4Generator: ChatGenerator {
                 pixelValues: imageBatch.pixelValues,
                 imagePositionIds: imageBatch.imagePositionIds,
                 mmTokenTypeIds: mmTokenTypeIds,
-                cache: cache as [AnyObject]
+                cache: cache
             )
             MLX.eval(output.logits, output.hidden)
             result = Gemma4PrefillResult(
@@ -1292,7 +1445,7 @@ public actor Gemma4Generator: ChatGenerator {
                 pixelValues: imageBatch.pixelValues,
                 imagePositionIds: imageBatch.imagePositionIds,
                 mmTokenTypeIds: mmTokenTypeIds,
-                cache: cache as [AnyObject]
+                cache: cache
             )
             MLX.eval(logits)
             result = Gemma4PrefillResult(logits: logits, hidden: nil, sharedKVStates: [:])
@@ -1305,10 +1458,7 @@ public actor Gemma4Generator: ChatGenerator {
         model: any Gemma4CausalModel,
         quantization: Gemma4KVCacheQuantization
     ) throws -> [Gemma4AttentionCache] {
-        guard let caches = model.makeCache(quantization: quantization) as? [Gemma4AttentionCache] else {
-            throw Gemma4Error.unsupportedConfiguration("Gemma4 cache construction returned an incompatible cache type.")
-        }
-        return caches
+        model.makeAttentionCache(quantization: quantization)
     }
 
     private func collectSharedKVStatesForMTP(

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -476,11 +476,14 @@ public actor Gemma4Generator: ChatGenerator {
         )
         lastMTPStats = decodeResult.mtpStats ?? mtpTemplate
         let generated = decodeResult.generatedTokens
+        let decodedRaw = tokenizerAndTemplate.decode(tokens: generated)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let decoded = Self.cleanedResponse(
-            tokenizerAndTemplate.decode(tokens: generated),
+            decodedRaw,
             showThinking: request.showThinking
         )
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let reasoningSplit = ChatReasoningMarkup.splitThinkBlocks(in: decodedRaw)
 
         let toolCalls: [ToolCall]? = hasTools ? {
             let parsed = Gemma4ToolParser.parseToolCalls(decoded)
@@ -501,7 +504,9 @@ public actor Gemma4Generator: ChatGenerator {
                 decodeKVCache: kvCacheQuantization.statusDescription
             ),
             toolCalls: toolCalls,
-            promptTokens: promptTokens.count
+            promptTokens: promptTokens.count,
+            reasoningContent: reasoningSplit.reasoningContent,
+            hasIncompleteReasoning: reasoningSplit.hasIncompleteReasoning
         )
     }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -5,17 +5,8 @@ import MLXNN
 import MLXRandom
 
 @inline(__always)
-private func gemma4RepeatAlongHeads(_ x: MLXArray, heads: Int) -> MLXArray {
-    MLX.repeated(x, count: heads, axis: 1)
-}
-
-@inline(__always)
-private func gemma4RMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
-    let dtype = x.dtype
-    let x32 = x.asType(.float32)
-    let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)
-    let normalized = x32 * rsqrt(variance + MLXArray(eps))
-    return normalized.asType(dtype)
+private func gemma4RMSNormNoScale(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
+    MLXFast.rmsNorm(x, weight: weight, eps: eps)
 }
 
 struct Gemma4SharedKVState {
@@ -592,6 +583,7 @@ final class Gemma4Attention: Module {
     private let rmsNormEps: Float
     private let isKVSharedLayer: Bool
     private let useKeyEqualsValue: Bool
+    private let valueNormWeight: MLXArray
 
     init(config: Gemma4TextConfig, layerIndex: Int, forceKVShared: Bool = false) {
         self.layerType = config.layerTypes[layerIndex]
@@ -604,6 +596,7 @@ final class Gemma4Attention: Module {
         self.numKVHeads = isFullAttention ? (config.numGlobalKeyValueHeads ?? config.numKeyValueHeads) : config.numKeyValueHeads
         self.isKVSharedLayer = forceKVShared || (config.numKVSharedLayers > 0 && layerIndex >= (config.numHiddenLayers - config.numKVSharedLayers))
         self.useKeyEqualsValue = config.attentionKEqV && isFullAttention
+        self.valueNormWeight = MLXArray.ones([headDim])
 
         let ropeConfig = config.ropeParameters[layerType] ?? config.ropeParameters["sliding_attention"]
         let ropeBase = ropeConfig?.ropeTheta ?? 10_000
@@ -671,7 +664,7 @@ final class Gemma4Attention: Module {
                     : vProj!(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
 
                 rawKeys = kNorm(rawKeys)
-                rawValues = gemma4RMSNormNoScale(rawValues, eps: rmsNormEps)
+                rawValues = gemma4RMSNormNoScale(rawValues, weight: valueNormWeight, eps: rmsNormEps)
 
                 var computedKeys = rawKeys.transposed(0, 2, 1, 3)
                 let computedValues = rawValues.transposed(0, 2, 1, 3)
@@ -689,7 +682,7 @@ final class Gemma4Attention: Module {
                 : vProj!(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
 
             rawKeys = kNorm(rawKeys)
-            rawValues = gemma4RMSNormNoScale(rawValues, eps: rmsNormEps)
+            rawValues = gemma4RMSNormNoScale(rawValues, weight: valueNormWeight, eps: rmsNormEps)
 
             var computedKeys = rawKeys.transposed(0, 2, 1, 3)
             let computedValues = rawValues.transposed(0, 2, 1, 3)
@@ -711,17 +704,10 @@ final class Gemma4Attention: Module {
             }
         }
 
-        var broadcastKeys = keys
-        var broadcastValues = values
-        if repeats > 1 {
-            broadcastKeys = gemma4RepeatAlongHeads(broadcastKeys, heads: repeats)
-            broadcastValues = gemma4RepeatAlongHeads(broadcastValues, heads: repeats)
-        }
-
         let mask = makeAttentionMask(
             queryLength: sequenceLength,
             queryOffset: offset,
-            keyLength: broadcastKeys.dim(2),
+            keyLength: keys.dim(2),
             windowSize: layerType == "sliding_attention" ? windowSize : nil,
             dtype: x.dtype,
             visionBlockIDs: visionBlockIDs
@@ -729,8 +715,8 @@ final class Gemma4Attention: Module {
 
         let attended = MLXFast.scaledDotProductAttention(
             queries: queries,
-            keys: broadcastKeys,
-            values: broadcastValues,
+            keys: keys,
+            values: values,
             scale: scale,
             mask: mask
         )
@@ -1263,15 +1249,17 @@ final class Gemma4UnifiedMultimodalEmbedder: Module {
     @ModuleInfo(key: "embedding_projection") var embeddingProjection: Linear
 
     private let eps: Float
+    private let normWeight: MLXArray
 
     init(embeddingDim: Int, textHiddenSize: Int, eps: Float) {
         self.eps = eps
+        self.normWeight = MLXArray.ones([embeddingDim])
         self._embeddingProjection.wrappedValue = Linear(embeddingDim, textHiddenSize, bias: false)
         super.init()
     }
 
     func callAsFunction(_ inputsEmbeds: MLXArray) -> MLXArray {
-        embeddingProjection(gemma4RMSNormNoScale(inputsEmbeds, eps: eps))
+        embeddingProjection(gemma4RMSNormNoScale(inputsEmbeds, weight: normWeight, eps: eps))
     }
 }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -3,6 +3,17 @@ import MLX
 import MLXFast
 import MLXNN
 import MLXRandom
+import Cmlx
+
+@inline(__always)
+private func gemma4RMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
+    let noWeight = MLXArray.mlxNone
+    var result = mlx_array_new()
+    _ = withExtendedLifetime(noWeight) {
+        mlx_fast_rms_norm(&result, x.ctx, noWeight.ctx, eps, StreamOrDevice.default.ctx)
+    }
+    return MLXArray(result)
+}
 
 @inline(__always)
 private func gemma4RMSNormNoScale(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
@@ -29,12 +40,12 @@ struct Gemma4ForwardOutput {
 }
 
 protocol Gemma4CausalModel: AnyObject, Sendable {
-    func forward(inputIds: MLXArray, cache: [AnyObject]?) -> MLXArray
-    func forwardForSpeculation(inputIds: MLXArray, cache: [AnyObject]?) -> Gemma4ForwardOutput
+    func forward(inputIds: MLXArray, cache: [Gemma4AttentionCache]?) -> MLXArray
+    func forwardForSpeculation(inputIds: MLXArray, cache: [Gemma4AttentionCache]?) -> Gemma4ForwardOutput
     func inputEmbeddings(for inputIds: MLXArray) -> MLXArray
     func speculativeLogits(fromHidden hidden: MLXArray) -> MLXArray
     func speculativeDraftHidden(_ hidden: MLXArray) -> MLXArray
-    func makeCache(quantization: Gemma4KVCacheQuantization?) -> [AnyObject]
+    func makeAttentionCache(quantization: Gemma4KVCacheQuantization?) -> [Gemma4AttentionCache]
 }
 
 /// Proportional RoPE for Gemma 4 full-attention layers.
@@ -138,24 +149,55 @@ extension Gemma4AttentionCache {
 }
 
 final class Gemma4FullKVCache: Gemma4AttentionCache {
+    private static let allocationStep = 256
+
     private var keys: MLXArray?
     private var values: MLXArray?
     private(set) var offset: Int = 0
 
     func currentState() -> (MLXArray, MLXArray)? {
         guard let keys, let values else { return nil }
-        return (keys, values)
+        guard offset < keys.dim(2) else {
+            return (keys, values)
+        }
+        return (keys[0..., 0..., 0..<offset, 0...], values[0..., 0..., 0..<offset, 0...])
     }
 
     func append(keys: MLXArray, values: MLXArray) {
-        if let existingKeys = self.keys, let existingValues = self.values {
-            self.keys = concatenated([existingKeys, keys], axis: 2)
-            self.values = concatenated([existingValues, values], axis: 2)
-        } else {
-            self.keys = keys
-            self.values = values
+        let previousOffset = offset
+        let newOffset = previousOffset + keys.dim(2)
+
+        if self.keys == nil || newOffset > (self.keys?.dim(2) ?? 0) {
+            let batch = keys.dim(0)
+            let heads = keys.dim(1)
+            let keyDim = keys.dim(3)
+            let valueDim = values.dim(3)
+            let missing = max(0, newOffset - (self.keys?.dim(2) ?? 0))
+            let steps = max(1, (missing + Self.allocationStep - 1) / Self.allocationStep)
+            let growth = steps * Self.allocationStep
+            let newKeys = MLXArray.zeros([batch, heads, growth, keyDim], dtype: keys.dtype)
+            let newValues = MLXArray.zeros([batch, heads, growth, valueDim], dtype: values.dtype)
+            if let existingKeys = self.keys, let existingValues = self.values {
+                let trimmedKeys = previousOffset < existingKeys.dim(2)
+                    ? existingKeys[0..., 0..., 0..<previousOffset, 0...]
+                    : existingKeys
+                let trimmedValues = previousOffset < existingValues.dim(2)
+                    ? existingValues[0..., 0..., 0..<previousOffset, 0...]
+                    : existingValues
+                self.keys = concatenated([trimmedKeys, newKeys], axis: 2)
+                self.values = concatenated([trimmedValues, newValues], axis: 2)
+            } else {
+                self.keys = newKeys
+                self.values = newValues
+            }
         }
-        self.offset += keys.dim(2)
+
+        guard let storedKeys = self.keys, let storedValues = self.values else {
+            preconditionFailure("Gemma4FullKVCache should allocate before writing.")
+        }
+        storedKeys[0..., 0..., previousOffset..<newOffset, 0...] = keys
+        storedValues[0..., 0..., previousOffset..<newOffset, 0...] = values
+        self.offset = newOffset
     }
 
     func fork() -> Gemma4AttentionCache {
@@ -225,10 +267,13 @@ final class Gemma4FullKVCache: Gemma4AttentionCache {
 }
 
 final class Gemma4SlidingKVCache: Gemma4AttentionCache {
+    private static let allocationStep = 256
+
     private let maxSize: Int
     private var keys: MLXArray?
     private var values: MLXArray?
     private(set) var offset: Int = 0
+    private var writeIndex: Int = 0
 
     init(maxSize: Int) {
         self.maxSize = max(1, maxSize)
@@ -240,30 +285,108 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
 
     func currentState() -> (MLXArray, MLXArray)? {
         guard let keys, let values else { return nil }
-        return (keys, values)
+        return (temporalOrder(keys), temporalOrder(values))
     }
 
     func append(keys: MLXArray, values: MLXArray) {
-        let combinedKeys: MLXArray
-        let combinedValues: MLXArray
-        if let existingKeys = self.keys, let existingValues = self.values {
-            combinedKeys = concatenated([existingKeys, keys], axis: 2)
-            combinedValues = concatenated([existingValues, values], axis: 2)
+        if keys.dim(2) == 1 {
+            updateInPlace(keys: keys, values: values)
         } else {
-            combinedKeys = keys
-            combinedValues = values
+            updateByConcatenating(keys: keys, values: values)
+        }
+    }
+
+    private func updateByConcatenating(keys: MLXArray, values: MLXArray) {
+        if let existingKeys = self.keys, let existingValues = self.values {
+            let orderedKeys = temporalOrder(existingKeys)
+            let orderedValues = temporalOrder(existingValues)
+            writeIndex = orderedKeys.dim(2)
+            let trimSize = writeIndex - maxSize + keys.dim(2)
+            self.keys = trim(orderedKeys, trimSize: trimSize, appending: keys)
+            self.values = trim(orderedValues, trimSize: trimSize, appending: values)
+        } else {
+            self.keys = keys
+            self.values = values
+        }
+        offset += keys.dim(2)
+        writeIndex = self.keys?.dim(2) ?? 0
+    }
+
+    private func updateInPlace(keys: MLXArray, values: MLXArray) {
+        let previousOffset = offset
+        if self.keys == nil || (previousOffset >= (self.keys?.dim(2) ?? 0) && (self.keys?.dim(2) ?? 0) < maxSize) {
+            let batch = keys.dim(0)
+            let heads = keys.dim(1)
+            let keyDim = keys.dim(3)
+            let valueDim = values.dim(3)
+            let existingSize = self.keys?.dim(2) ?? 0
+            let growth = min(Self.allocationStep, maxSize - existingSize)
+            if growth > 0 {
+                let newKeys = MLXArray.zeros([batch, heads, growth, keyDim], dtype: keys.dtype)
+                let newValues = MLXArray.zeros([batch, heads, growth, valueDim], dtype: values.dtype)
+                if let existingKeys = self.keys, let existingValues = self.values {
+                    let trimmedKeys = previousOffset < existingKeys.dim(2)
+                        ? existingKeys[0..., 0..., 0..<previousOffset, 0...]
+                        : existingKeys
+                    let trimmedValues = previousOffset < existingValues.dim(2)
+                        ? existingValues[0..., 0..., 0..<previousOffset, 0...]
+                        : existingValues
+                    self.keys = concatenated([trimmedKeys, newKeys], axis: 2)
+                    self.values = concatenated([trimmedValues, newValues], axis: 2)
+                } else {
+                    self.keys = newKeys
+                    self.values = newValues
+                }
+                writeIndex = min(previousOffset, self.keys?.dim(2) ?? previousOffset)
+            }
         }
 
-        let totalLength = combinedKeys.dim(2)
-        if totalLength > maxSize {
-            let start = totalLength - maxSize
-            self.keys = combinedKeys[0..., 0..., start..., 0...]
-            self.values = combinedValues[0..., 0..., start..., 0...]
-        } else {
-            self.keys = combinedKeys
-            self.values = combinedValues
+        if let existingKeys = self.keys, existingKeys.dim(2) > maxSize {
+            self.keys = trim(existingKeys, trimSize: existingKeys.dim(2) - maxSize)
+            writeIndex = maxSize
         }
-        self.offset += keys.dim(2)
+        if let existingValues = self.values, existingValues.dim(2) > maxSize {
+            self.values = trim(existingValues, trimSize: existingValues.dim(2) - maxSize)
+        }
+        if writeIndex >= maxSize {
+            writeIndex = 0
+        }
+
+        let newWriteIndex = writeIndex + keys.dim(2)
+        guard let storedKeys = self.keys, let storedValues = self.values else {
+            preconditionFailure("Gemma4SlidingKVCache should allocate before writing.")
+        }
+        storedKeys[0..., 0..., writeIndex..<newWriteIndex, 0...] = keys
+        storedValues[0..., 0..., writeIndex..<newWriteIndex, 0...] = values
+        offset += keys.dim(2)
+        writeIndex = newWriteIndex
+    }
+
+    private func temporalOrder(_ array: MLXArray) -> MLXArray {
+        let length = array.dim(2)
+        if offset < length {
+            return array[0..., 0..., 0..<offset, 0...]
+        }
+        guard writeIndex < length, writeIndex < offset else {
+            return array
+        }
+        return concatenated([
+            array[0..., 0..., writeIndex..., 0...],
+            array[0..., 0..., 0..<writeIndex, 0...],
+        ], axis: 2)
+    }
+
+    private func trim(_ array: MLXArray, trimSize: Int, appending append: MLXArray? = nil) -> MLXArray {
+        var parts: [MLXArray]
+        if trimSize > 0 {
+            parts = [array[0..., 0..., trimSize..., 0...]]
+        } else {
+            parts = [array]
+        }
+        if let append {
+            parts.append(append)
+        }
+        return concatenated(parts, axis: 2)
     }
 
     func fork() -> Gemma4AttentionCache {
@@ -271,6 +394,7 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
         copy.keys = keys
         copy.values = values
         copy.offset = offset
+        copy.writeIndex = writeIndex
         return copy
     }
 
@@ -291,6 +415,7 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
             cache.values = values
         }
         cache.offset = offset
+        cache.writeIndex = cache.keys?.dim(2) ?? 0
         return cache
     }
 
@@ -327,6 +452,7 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
         copy.keys = concatenated(states.map(\.0), axis: 0)
         copy.values = concatenated(states.map(\.1), axis: 0)
         copy.offset = offset
+        copy.writeIndex = copy.keys?.dim(2) ?? 0
         return copy
     }
 
@@ -339,6 +465,7 @@ final class Gemma4SlidingKVCache: Gemma4AttentionCache {
             copy.keys = keys[index..<(index + 1), 0..., 0..., 0...]
             copy.values = values[index..<(index + 1), 0..., 0..., 0...]
             copy.offset = offset
+            copy.writeIndex = writeIndex
             return copy
         }
     }
@@ -583,7 +710,6 @@ final class Gemma4Attention: Module {
     private let rmsNormEps: Float
     private let isKVSharedLayer: Bool
     private let useKeyEqualsValue: Bool
-    private let valueNormWeight: MLXArray
 
     init(config: Gemma4TextConfig, layerIndex: Int, forceKVShared: Bool = false) {
         self.layerType = config.layerTypes[layerIndex]
@@ -596,7 +722,6 @@ final class Gemma4Attention: Module {
         self.numKVHeads = isFullAttention ? (config.numGlobalKeyValueHeads ?? config.numKeyValueHeads) : config.numKeyValueHeads
         self.isKVSharedLayer = forceKVShared || (config.numKVSharedLayers > 0 && layerIndex >= (config.numHiddenLayers - config.numKVSharedLayers))
         self.useKeyEqualsValue = config.attentionKEqV && isFullAttention
-        self.valueNormWeight = MLXArray.ones([headDim])
 
         let ropeConfig = config.ropeParameters[layerType] ?? config.ropeParameters["sliding_attention"]
         let ropeBase = ropeConfig?.ropeTheta ?? 10_000
@@ -664,7 +789,7 @@ final class Gemma4Attention: Module {
                     : vProj!(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
 
                 rawKeys = kNorm(rawKeys)
-                rawValues = gemma4RMSNormNoScale(rawValues, weight: valueNormWeight, eps: rmsNormEps)
+                rawValues = gemma4RMSNormNoScale(rawValues, eps: rmsNormEps)
 
                 var computedKeys = rawKeys.transposed(0, 2, 1, 3)
                 let computedValues = rawValues.transposed(0, 2, 1, 3)
@@ -682,7 +807,7 @@ final class Gemma4Attention: Module {
                 : vProj!(x).reshaped(batchSize, sequenceLength, numKVHeads, headDim)
 
             rawKeys = kNorm(rawKeys)
-            rawValues = gemma4RMSNormNoScale(rawValues, weight: valueNormWeight, eps: rmsNormEps)
+            rawValues = gemma4RMSNormNoScale(rawValues, eps: rmsNormEps)
 
             var computedKeys = rawKeys.transposed(0, 2, 1, 3)
             let computedValues = rawValues.transposed(0, 2, 1, 3)
@@ -1135,8 +1260,11 @@ public final class Gemma4TextCausalLM: Module, Gemma4CausalModel, @unchecked Sen
         _ inputIds: MLXArray,
         cache: [AnyObject]? = nil
     ) -> MLXArray {
-        let typedCache = cache as? [Gemma4AttentionCache]
-        var logits = languageModel.logits(inputIds, cache: typedCache)
+        forward(inputIds: inputIds, cache: cache as? [Gemma4AttentionCache])
+    }
+
+    func forward(inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> MLXArray {
+        var logits = languageModel.logits(inputIds, cache: cache)
         if let finalLogitSoftcapping {
             let softcap = MLXArray(finalLogitSoftcapping).asType(logits.dtype)
             logits = tanh(logits / softcap) * softcap
@@ -1144,12 +1272,7 @@ public final class Gemma4TextCausalLM: Module, Gemma4CausalModel, @unchecked Sen
         return logits
     }
 
-    func forward(inputIds: MLXArray, cache: [AnyObject]? = nil) -> MLXArray {
-        self(inputIds, cache: cache)
-    }
-
-    func forwardForSpeculation(inputIds: MLXArray, cache: [AnyObject]? = nil) -> Gemma4ForwardOutput {
-        let typedCache = cache as? [Gemma4AttentionCache]
+    func forwardForSpeculation(inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> Gemma4ForwardOutput {
         var tokenIds = inputIds
         if tokenIds.dtype != .int32 {
             tokenIds = tokenIds.asType(.int32)
@@ -1157,7 +1280,7 @@ public final class Gemma4TextCausalLM: Module, Gemma4CausalModel, @unchecked Sen
         let output = languageModel.detailedLogits(
             embeddings: languageModel.embeddings(inputIds: tokenIds),
             inputIds: tokenIds,
-            cache: typedCache
+            cache: cache
         )
         let logits = applyFinalSoftcap(output.logits)
         return Gemma4ForwardOutput(
@@ -1183,8 +1306,12 @@ public final class Gemma4TextCausalLM: Module, Gemma4CausalModel, @unchecked Sen
         languageModel.norm(hidden)
     }
 
-    public func makeCache(quantization: Gemma4KVCacheQuantization? = nil) -> [AnyObject] {
+    func makeAttentionCache(quantization: Gemma4KVCacheQuantization? = nil) -> [Gemma4AttentionCache] {
         languageModel.makeCache(quantization: quantization)
+    }
+
+    public func makeCache(quantization: Gemma4KVCacheQuantization? = nil) -> [AnyObject] {
+        makeAttentionCache(quantization: quantization)
     }
 
     private func applyFinalSoftcap(_ logits: MLXArray) -> MLXArray {
@@ -1292,9 +1419,8 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         super.init()
     }
 
-    func forward(inputIds: MLXArray, cache: [AnyObject]? = nil) -> MLXArray {
-        let typedCache = cache as? [Gemma4AttentionCache]
-        var logits = languageModel.logits(inputIds, cache: typedCache)
+    func forward(inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> MLXArray {
+        var logits = languageModel.logits(inputIds, cache: cache)
         if let finalLogitSoftcapping {
             let softcap = MLXArray(finalLogitSoftcapping).asType(logits.dtype)
             logits = tanh(logits / softcap) * softcap
@@ -1302,8 +1428,7 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         return logits
     }
 
-    func forwardForSpeculation(inputIds: MLXArray, cache: [AnyObject]? = nil) -> Gemma4ForwardOutput {
-        let typedCache = cache as? [Gemma4AttentionCache]
+    func forwardForSpeculation(inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> Gemma4ForwardOutput {
         var tokenIds = inputIds
         if tokenIds.dtype != .int32 {
             tokenIds = tokenIds.asType(.int32)
@@ -1311,7 +1436,7 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         let output = languageModel.detailedLogits(
             embeddings: languageModel.embeddings(inputIds: tokenIds),
             inputIds: tokenIds,
-            cache: typedCache
+            cache: cache
         )
         let logits = applyFinalSoftcap(output.logits)
         return Gemma4ForwardOutput(
@@ -1326,9 +1451,8 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         pixelValues: MLXArray,
         imagePositionIds: MLXArray,
         mmTokenTypeIds: MLXArray,
-        cache: [AnyObject]? = nil
+        cache: [Gemma4AttentionCache]? = nil
     ) throws -> MLXArray {
-        let typedCache = cache as? [Gemma4AttentionCache]
         var tokenIds = inputIds
         if tokenIds.dtype != .int32 {
             tokenIds = tokenIds.asType(.int32)
@@ -1347,7 +1471,7 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         var logits = languageModel.logits(
             embeddings: embeddings,
             inputIds: tokenIds,
-            cache: typedCache,
+            cache: cache,
             mmTokenTypeIds: mmTokenTypeIds
         )
         if let finalLogitSoftcapping {
@@ -1362,9 +1486,8 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         pixelValues: MLXArray,
         imagePositionIds: MLXArray,
         mmTokenTypeIds: MLXArray,
-        cache: [AnyObject]? = nil
+        cache: [Gemma4AttentionCache]? = nil
     ) throws -> Gemma4ForwardOutput {
-        let typedCache = cache as? [Gemma4AttentionCache]
         var tokenIds = inputIds
         if tokenIds.dtype != .int32 {
             tokenIds = tokenIds.asType(.int32)
@@ -1383,7 +1506,7 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         let output = languageModel.detailedLogits(
             embeddings: embeddings,
             inputIds: tokenIds,
-            cache: typedCache,
+            cache: cache,
             mmTokenTypeIds: mmTokenTypeIds
         )
         return Gemma4ForwardOutput(
@@ -1409,8 +1532,12 @@ public final class Gemma4UnifiedCausalLM: Module, Gemma4CausalModel, @unchecked 
         languageModel.norm(hidden)
     }
 
-    public func makeCache(quantization: Gemma4KVCacheQuantization? = nil) -> [AnyObject] {
+    func makeAttentionCache(quantization: Gemma4KVCacheQuantization? = nil) -> [Gemma4AttentionCache] {
         languageModel.makeCache(quantization: quantization)
+    }
+
+    public func makeCache(quantization: Gemma4KVCacheQuantization? = nil) -> [AnyObject] {
+        makeAttentionCache(quantization: quantization)
     }
 
     private func applyFinalSoftcap(_ logits: MLXArray) -> MLXArray {

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -328,6 +328,8 @@ public struct ChatResponse: Sendable, Hashable {
     public var finishReason: ChatFinishReason?
     public var reasoningContent: String?
     public var hasIncompleteReasoning: Bool
+    public var reasoningBlockCount: Int
+    public var hasReopenedReasoning: Bool
 
     public init(
         response: String,
@@ -337,7 +339,9 @@ public struct ChatResponse: Sendable, Hashable {
         promptTokens: Int? = nil,
         finishReason: ChatFinishReason? = nil,
         reasoningContent: String? = nil,
-        hasIncompleteReasoning: Bool = false
+        hasIncompleteReasoning: Bool = false,
+        reasoningBlockCount: Int = 0,
+        hasReopenedReasoning: Bool = false
     ) {
         self.response = response
         self.tokensGenerated = tokensGenerated
@@ -348,6 +352,8 @@ public struct ChatResponse: Sendable, Hashable {
         let trimmedReasoning = reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.reasoningContent = trimmedReasoning?.nilIfEmpty
         self.hasIncompleteReasoning = hasIncompleteReasoning
+        self.reasoningBlockCount = reasoningBlockCount
+        self.hasReopenedReasoning = hasReopenedReasoning
     }
 
     public init(
@@ -371,7 +377,9 @@ public struct ChatResponse: Sendable, Hashable {
             promptTokens: promptTokens,
             finishReason: finishReason,
             reasoningContent: split.reasoningContent,
-            hasIncompleteReasoning: split.hasIncompleteReasoning
+            hasIncompleteReasoning: split.hasIncompleteReasoning,
+            reasoningBlockCount: split.reasoningBlockCount,
+            hasReopenedReasoning: split.hasReopenedReasoning
         )
     }
 }
@@ -444,16 +452,22 @@ public struct ChatReasoningSplit: Sendable, Hashable {
     public var visibleContent: String
     public var reasoningContent: String?
     public var hasIncompleteReasoning: Bool
+    public var reasoningBlockCount: Int
+    public var hasReopenedReasoning: Bool
 
     public init(
         visibleContent: String,
         reasoningContent: String? = nil,
-        hasIncompleteReasoning: Bool = false
+        hasIncompleteReasoning: Bool = false,
+        reasoningBlockCount: Int = 0,
+        hasReopenedReasoning: Bool = false
     ) {
         self.visibleContent = visibleContent
         let trimmedReasoning = reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.reasoningContent = trimmedReasoning?.nilIfEmpty
         self.hasIncompleteReasoning = hasIncompleteReasoning
+        self.reasoningBlockCount = reasoningBlockCount
+        self.hasReopenedReasoning = hasReopenedReasoning
     }
 }
 
@@ -466,6 +480,7 @@ public enum ChatReasoningMarkup {
         var reasoningParts: [String] = []
         var index = text.startIndex
         var hasIncompleteReasoning = false
+        var reasoningBlockCount = 0
 
         func appendReasoning(_ slice: Substring) {
             let part = String(slice).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -487,6 +502,7 @@ public enum ChatReasoningMarkup {
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                         .isEmpty && reasoningParts.isEmpty
                     if prefixIsOnlyReasoning {
+                        reasoningBlockCount += 1
                         appendReasoning(prefix)
                     } else {
                         visible += prefix
@@ -502,6 +518,7 @@ public enum ChatReasoningMarkup {
             }
 
             visible += text[index..<openRange.lowerBound]
+            reasoningBlockCount += 1
             let reasoningStart = openRange.upperBound
             if let closeRange = text.range(
                 of: closeThinkTag,
@@ -520,7 +537,9 @@ public enum ChatReasoningMarkup {
         return ChatReasoningSplit(
             visibleContent: visible.trimmingCharacters(in: .whitespacesAndNewlines),
             reasoningContent: reasoningParts.joined(separator: "\n\n"),
-            hasIncompleteReasoning: hasIncompleteReasoning
+            hasIncompleteReasoning: hasIncompleteReasoning,
+            reasoningBlockCount: reasoningBlockCount,
+            hasReopenedReasoning: reasoningBlockCount > 1
         )
     }
 }

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -326,6 +326,8 @@ public struct ChatResponse: Sendable, Hashable {
     public var toolCalls: [ToolCall]?
     public var promptTokens: Int?
     public var finishReason: ChatFinishReason?
+    public var reasoningContent: String?
+    public var hasIncompleteReasoning: Bool
 
     public init(
         response: String,
@@ -333,7 +335,9 @@ public struct ChatResponse: Sendable, Hashable {
         timing: ChatTiming? = nil,
         toolCalls: [ToolCall]? = nil,
         promptTokens: Int? = nil,
-        finishReason: ChatFinishReason? = nil
+        finishReason: ChatFinishReason? = nil,
+        reasoningContent: String? = nil,
+        hasIncompleteReasoning: Bool = false
     ) {
         self.response = response
         self.tokensGenerated = tokensGenerated
@@ -341,6 +345,34 @@ public struct ChatResponse: Sendable, Hashable {
         self.toolCalls = toolCalls
         self.promptTokens = promptTokens
         self.finishReason = finishReason
+        let trimmedReasoning = reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.reasoningContent = trimmedReasoning?.nilIfEmpty
+        self.hasIncompleteReasoning = hasIncompleteReasoning
+    }
+
+    public init(
+        generatedText: String,
+        tokensGenerated: Int,
+        showThinking: Bool,
+        timing: ChatTiming? = nil,
+        toolCalls: [ToolCall]? = nil,
+        promptTokens: Int? = nil,
+        finishReason: ChatFinishReason? = nil
+    ) {
+        let split = ChatReasoningMarkup.splitThinkBlocks(in: generatedText)
+        let visibleResponse = showThinking
+            ? generatedText.trimmingCharacters(in: .whitespacesAndNewlines)
+            : split.visibleContent
+        self.init(
+            response: visibleResponse,
+            tokensGenerated: tokensGenerated,
+            timing: timing,
+            toolCalls: toolCalls,
+            promptTokens: promptTokens,
+            finishReason: finishReason,
+            reasoningContent: split.reasoningContent,
+            hasIncompleteReasoning: split.hasIncompleteReasoning
+        )
     }
 }
 
@@ -408,6 +440,91 @@ public enum TextGenerationStopSequences {
     }
 }
 
+public struct ChatReasoningSplit: Sendable, Hashable {
+    public var visibleContent: String
+    public var reasoningContent: String?
+    public var hasIncompleteReasoning: Bool
+
+    public init(
+        visibleContent: String,
+        reasoningContent: String? = nil,
+        hasIncompleteReasoning: Bool = false
+    ) {
+        self.visibleContent = visibleContent
+        let trimmedReasoning = reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.reasoningContent = trimmedReasoning?.nilIfEmpty
+        self.hasIncompleteReasoning = hasIncompleteReasoning
+    }
+}
+
+public enum ChatReasoningMarkup {
+    private static let openThinkTag = "<think>"
+    private static let closeThinkTag = "</think>"
+
+    public static func splitThinkBlocks(in text: String) -> ChatReasoningSplit {
+        var visible = ""
+        var reasoningParts: [String] = []
+        var index = text.startIndex
+        var hasIncompleteReasoning = false
+
+        func appendReasoning(_ slice: Substring) {
+            let part = String(slice).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !part.isEmpty {
+                reasoningParts.append(part)
+            }
+        }
+
+        while index < text.endIndex {
+            let remaining = index..<text.endIndex
+            let openRange = text.range(of: openThinkTag, options: .caseInsensitive, range: remaining)
+            let closeRange = text.range(of: closeThinkTag, options: .caseInsensitive, range: remaining)
+
+            if let closeRange {
+                let closeBeforeOpen = openRange.map { closeRange.lowerBound < $0.lowerBound } ?? true
+                if closeBeforeOpen {
+                    let prefix = text[index..<closeRange.lowerBound]
+                    let prefixIsOnlyReasoning = visible
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty && reasoningParts.isEmpty
+                    if prefixIsOnlyReasoning {
+                        appendReasoning(prefix)
+                    } else {
+                        visible += prefix
+                    }
+                    index = closeRange.upperBound
+                    continue
+                }
+            }
+
+            guard let openRange else {
+                visible += text[index...]
+                break
+            }
+
+            visible += text[index..<openRange.lowerBound]
+            let reasoningStart = openRange.upperBound
+            if let closeRange = text.range(
+                of: closeThinkTag,
+                options: .caseInsensitive,
+                range: reasoningStart..<text.endIndex
+            ) {
+                appendReasoning(text[reasoningStart..<closeRange.lowerBound])
+                index = closeRange.upperBound
+            } else {
+                appendReasoning(text[reasoningStart..<text.endIndex])
+                hasIncompleteReasoning = true
+                break
+            }
+        }
+
+        return ChatReasoningSplit(
+            visibleContent: visible.trimmingCharacters(in: .whitespacesAndNewlines),
+            reasoningContent: reasoningParts.joined(separator: "\n\n"),
+            hasIncompleteReasoning: hasIncompleteReasoning
+        )
+    }
+}
+
 public enum ChatStage: String, Sendable, Hashable {
     case loadingModel
     case encoding
@@ -429,4 +546,10 @@ public protocol ChatGenerator {
         _ request: ChatRequest,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> ChatResponse
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
 }

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -249,6 +249,7 @@ public struct ChatRequest: Sendable, Hashable {
     public var requiresJSON: Bool
     public var tools: [ToolDefinition]?
     public var stopOnEOS: Bool
+    public var stopSequences: [String]
     public var kvCacheMode: RuntimeKVCacheMode?
     public var maxContextTokens: Int?
 
@@ -262,6 +263,7 @@ public struct ChatRequest: Sendable, Hashable {
         requiresJSON: Bool = false,
         tools: [ToolDefinition]? = nil,
         stopOnEOS: Bool = true,
+        stopSequences: [String] = [],
         kvCacheMode: RuntimeKVCacheMode? = nil,
         maxContextTokens: Int? = nil
     ) {
@@ -274,6 +276,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.requiresJSON = requiresJSON
         self.tools = tools
         self.stopOnEOS = stopOnEOS
+        self.stopSequences = stopSequences
         self.kvCacheMode = kvCacheMode
         self.maxContextTokens = maxContextTokens
     }
@@ -322,19 +325,86 @@ public struct ChatResponse: Sendable, Hashable {
     public var timing: ChatTiming?
     public var toolCalls: [ToolCall]?
     public var promptTokens: Int?
+    public var finishReason: ChatFinishReason?
 
     public init(
         response: String,
         tokensGenerated: Int,
         timing: ChatTiming? = nil,
         toolCalls: [ToolCall]? = nil,
-        promptTokens: Int? = nil
+        promptTokens: Int? = nil,
+        finishReason: ChatFinishReason? = nil
     ) {
         self.response = response
         self.tokensGenerated = tokensGenerated
         self.timing = timing
         self.toolCalls = toolCalls
         self.promptTokens = promptTokens
+        self.finishReason = finishReason
+    }
+}
+
+public enum ChatFinishReason: String, Sendable, Hashable {
+    case stop
+    case stopSequence = "stop_sequence"
+    case length
+}
+
+public enum TextGenerationStopSequences {
+    public static let defaultRenderedChatStops = [
+        "<|END_OF_TURN_TOKEN|>",
+        "<|END_OFTURN_TOKEN|>",
+        "<|CHANNEL_END|>",
+        "<|im_end|>",
+        "</s>",
+        "<|endoftext|>",
+    ]
+
+    public static func merged(_ sequences: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        result.reserveCapacity(sequences.count)
+        for sequence in sequences {
+            guard !sequence.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  seen.insert(sequence).inserted else {
+                continue
+            }
+            result.append(sequence)
+        }
+        return result
+    }
+
+    public static func firstMatch(
+        in text: String,
+        sequences: [String]
+    ) -> (sequence: String, range: Range<String.Index>)? {
+        var first: (sequence: String, range: Range<String.Index>)?
+        for sequence in merged(sequences) {
+            guard let range = text.range(of: sequence) else {
+                continue
+            }
+            if let current = first {
+                if range.lowerBound < current.range.lowerBound
+                    || (range.lowerBound == current.range.lowerBound && range.upperBound > current.range.upperBound) {
+                    first = (sequence, range)
+                }
+            } else {
+                first = (sequence, range)
+            }
+        }
+        return first
+    }
+
+    public static func trimming(
+        _ text: String,
+        sequences: [String]
+    ) -> (text: String, matchedSequence: String?) {
+        guard let match = firstMatch(in: text, sequences: sequences) else {
+            return (text.trimmingCharacters(in: .whitespacesAndNewlines), nil)
+        }
+        let trimmed = String(text[..<match.range.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed, match.sequence)
     }
 }
 

--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -199,8 +199,9 @@ public actor LFM2Generator: ChatGenerator {
         }() : nil
 
         return ChatResponse(
-            response: decoded,
+            generatedText: decoded,
             tokensGenerated: decodeResult.generatedTokens.count,
+            showThinking: request.showThinking,
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -694,6 +694,17 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["chat", "api serve", "agent start"]
         ),
         ManagedModelSpec(
+            id: Q35Resources.ornith35BMLXModelId,
+            category: .textCode,
+            installShape: .directoryRoot,
+            upstreamRepoId: Q35Resources.ornith35BMLXUpstreamRepoId,
+            upstreamRevision: Q35Resources.ornith35BMLXUpstreamRevision,
+            validationKind: .q35,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: Q35Resources.ornith35BMLXEstimatedDownloadBytes,
+            defaultCLICommands: ["chat", "api serve", "agent start", "model benchmark code"]
+        ),
+        ManagedModelSpec(
             id: AgentModelResources.qwen35NineBModelId,
             category: .textCode,
             installShape: .singleFile(relativePath: AgentModelResources.qwen35NineBRelativePath),

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -715,6 +715,17 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["text code", "api serve", "agent start"]
         ),
         ManagedModelSpec(
+            id: Ornith35BCodeResources.modelId,
+            category: .textCode,
+            installShape: .singleFile(relativePath: Ornith35BCodeResources.managedRelativePath),
+            hubFallback: Ornith35BCodeResources.hubFallbackConfig,
+            upstreamRepoId: Ornith35BCodeResources.upstreamRepoId,
+            upstreamRevision: Ornith35BCodeResources.upstreamRevision,
+            validationKind: .codegenGGUF,
+            estimatedDownloadBytes: Ornith35BCodeResources.estimatedDownloadBytes,
+            defaultCLICommands: ["text code", "api serve", "agent start"]
+        ),
+        ManagedModelSpec(
             // GGUF Qwen3.6-35B-A3B: the CUDA default chat model. Routes through
             // llama.cpp (.codegenGGUF) for the GB10-optimized quantized-MoE
             // kernels (~68 tok/s on GB10 vs ~13 for the MLX path). Same model

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -414,6 +414,14 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 32
             ),
             descriptor(
+                Ornith35BCodeResources.modelId,
+                "Ornith 1.0 35B Q4",
+                "Runs DeepReinforce's larger Ornith coding-agent GGUF through the native "
+                + "llama.cpp/GGUF code runtime.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
                 "speech-tts-qwen3-nano",
                 "Text to speech",
                 "Synthesizes speech with Qwen3 TTS, including style prompts and voice-design workflows.",

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -382,6 +382,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 24
             ),
             descriptor(
+                Q35Resources.ornith35BMLXModelId,
+                "Ornith 1.0 35B MLX Q4",
+                "Runs a converted Ornith 1.0 35B Q4 MLX MoE through the native Qwen-family runtime.",
+                minimum: 24,
+                recommended: 32
+            ),
+            descriptor(
                 LFM2Resources.defaultModelId,
                 "LFM2.5 A1B 8-bit",
                 "Runs the LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot through the native Swift LFM2 runtime.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -821,6 +821,22 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     + "@\(Q35Resources.ornith9BUpstreamRevision)",
                 createdAt: createdAt
             )
+        case .ornith35BMLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .qwen35HybridMoE,
+                family: .code,
+                tier: .small,
+                variant: .standard,
+                precision: .int4,
+                quantization: Quantization(bits: 4, groupSize: 64, scheme: "mlx-affine-moe"),
+                defaults: nil,
+                supports: [.chat, .codeGeneration],
+                components: q35TextComponents,
+                upstreamRepoId: "\(Q35Resources.ornith35BMLXUpstreamRepoId)"
+                    + "@\(Q35Resources.ornith35BMLXUpstreamRevision)",
+                createdAt: createdAt
+            )
         case .ornith35B:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -821,6 +821,22 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     + "@\(Q35Resources.ornith9BUpstreamRevision)",
                 createdAt: createdAt
             )
+        case .ornith35B:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .qwen3Coder,
+                family: .code,
+                tier: .small,
+                variant: .standard,
+                precision: .int4,
+                quantization: Quantization(bits: 4, groupSize: 64, scheme: "gguf-q4-k-m"),
+                defaults: nil,
+                supports: [.chat, .codeGeneration],
+                components: nil,
+                upstreamRepoId: "\(Ornith35BCodeResources.upstreamRepoId)"
+                    + "@\(Ornith35BCodeResources.upstreamRevision)",
+                createdAt: createdAt
+            )
         case .northMiniCode:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -41,6 +41,7 @@ public struct ModelResolver {
         case qwen35Agent9B = "text-agent-qwen35-9b"
         case ornith9B = "text-agent-ornith-9b"
         case ornith35B = "text-agent-ornith-35b"
+        case ornith35BMLX = "text-agent-ornith-35b-mlx"
         case northMiniCode = "text-code-north-mini"
         case q36NanoGGUF = "text-chat-q36-nano-gguf"
         case deepseekV4Flash = "text-agent-deepseek-v4-flash"

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -40,6 +40,7 @@ public struct ModelResolver {
         case lfm25A1B8Bit = "text-chat-lfm25-a1b-8bit"
         case qwen35Agent9B = "text-agent-qwen35-9b"
         case ornith9B = "text-agent-ornith-9b"
+        case ornith35B = "text-agent-ornith-35b"
         case northMiniCode = "text-code-north-mini"
         case q36NanoGGUF = "text-chat-q36-nano-gguf"
         case deepseekV4Flash = "text-agent-deepseek-v4-flash"

--- a/Sources/MereRunCore/Psi/Psi3ChatGenerator.swift
+++ b/Sources/MereRunCore/Psi/Psi3ChatGenerator.swift
@@ -44,8 +44,9 @@ public actor Psi3ChatGenerator: ChatGenerator {
         )
 
         return ChatResponse(
-            response: result.response,
-            tokensGenerated: result.tokensGenerated
+            generatedText: result.response,
+            tokensGenerated: result.tokensGenerated,
+            showThinking: request.showThinking
         )
     }
 
@@ -76,8 +77,9 @@ public actor Psi3ChatGenerator: ChatGenerator {
         )
 
         return ChatResponse(
-            response: result.response,
-            tokensGenerated: result.tokensGenerated
+            generatedText: result.response,
+            tokensGenerated: result.tokensGenerated,
+            showThinking: request.showThinking
         )
     }
 

--- a/Sources/MereRunCore/Q35/Q35Config.swift
+++ b/Sources/MereRunCore/Q35/Q35Config.swift
@@ -40,6 +40,7 @@ public struct Q35TextConfig: Codable, Sendable, Hashable {
     public let headDim: Int
     public let numExperts: Int
     public let numExpertsPerTok: Int
+    public let normTopKProb: Bool
     public let layerTypes: [String]
     public let mlpOnlyLayers: [Int]
     public let linearNumValueHeads: Int
@@ -69,6 +70,7 @@ public struct Q35TextConfig: Codable, Sendable, Hashable {
         case headDim = "head_dim"
         case numExperts = "num_experts"
         case numExpertsPerTok = "num_experts_per_tok"
+        case normTopKProb = "norm_topk_prob"
         case layerTypes = "layer_types"
         case mlpOnlyLayers = "mlp_only_layers"
         case linearNumValueHeads = "linear_num_value_heads"
@@ -115,6 +117,7 @@ public struct Q35TextConfig: Codable, Sendable, Hashable {
         self.headDim = try container.decode(Int.self, forKey: .headDim)
         self.numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts) ?? 0
         self.numExpertsPerTok = try container.decodeIfPresent(Int.self, forKey: .numExpertsPerTok) ?? 0
+        self.normTopKProb = try container.decodeIfPresent(Bool.self, forKey: .normTopKProb) ?? false
         self.layerTypes = try container.decode([String].self, forKey: .layerTypes)
         self.mlpOnlyLayers = try container.decodeIfPresent([Int].self, forKey: .mlpOnlyLayers) ?? []
         self.linearNumValueHeads = try container.decode(Int.self, forKey: .linearNumValueHeads)
@@ -146,6 +149,7 @@ public struct Q35TextConfig: Codable, Sendable, Hashable {
         try container.encode(headDim, forKey: .headDim)
         try container.encode(numExperts, forKey: .numExperts)
         try container.encode(numExpertsPerTok, forKey: .numExpertsPerTok)
+        try container.encode(normTopKProb, forKey: .normTopKProb)
         try container.encode(layerTypes, forKey: .layerTypes)
         try container.encode(mlpOnlyLayers, forKey: .mlpOnlyLayers)
         try container.encode(linearNumValueHeads, forKey: .linearNumValueHeads)

--- a/Sources/MereRunCore/Q35/Q35FullAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35FullAttention.swift
@@ -116,24 +116,13 @@ final class Q35FullAttention: Module {
             v = q35RepeatAlongHeads(v, heads: repeats)
         }
 
-        let useEagerDecode = s == 1
-        let attn: MLXArray
-        if useEagerDecode {
-            var scores = MLX.matmul(q, k.transposed(0, 1, 3, 2)) * MLXArray(scale).asType(q.dtype)
-            if case .array(let maskArray) = mask {
-                scores = scores + maskArray.asType(scores.dtype)
-            }
-            let weights = softmax(scores.asType(.float32), axis: -1).asType(q.dtype)
-            attn = MLX.matmul(weights, v)
-        } else {
-            attn = MLXFast.scaledDotProductAttention(
-                queries: q,
-                keys: k,
-                values: v,
-                scale: scale,
-                mask: mask
-            )
-        }
+        let attn = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: mask
+        )
 
         var out = attn.transposed(0, 2, 1, 3).reshaped(b, s, numHeads * headDim)
         if let gate {

--- a/Sources/MereRunCore/Q35/Q35FullAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35FullAttention.swift
@@ -3,11 +3,6 @@ import MLX
 import MLXFast
 import MLXNN
 
-@inline(__always)
-private func q35RepeatAlongHeads(_ x: MLXArray, heads: Int) -> MLXArray {
-    MLX.repeated(x, count: heads, axis: 1)
-}
-
 final class Q35FullAttention: Module {
     @ModuleInfo(key: "q_proj") var qProj: Linear
     @ModuleInfo(key: "k_proj") var kProj: Linear
@@ -108,12 +103,6 @@ final class Q35FullAttention: Module {
             let cached = cache.update(keys: k, values: v)
             k = cached.0
             v = cached.1
-        }
-
-        let repeats = max(1, numHeads / max(1, numKVHeads))
-        if repeats > 1 {
-            k = q35RepeatAlongHeads(k, heads: repeats)
-            v = q35RepeatAlongHeads(v, heads: repeats)
         }
 
         let attn = MLXFast.scaledDotProductAttention(

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -417,6 +417,10 @@ public actor Q35Generator: ChatGenerator {
             repetitionPenalty: nil,
             repetitionContextSize: 64
         )
+        let retainPrefillHidden =
+            prefixKVCacheEnabled
+            || (Self.shouldSpeculate(promptTokenCount: promptTokens.count, maxContextTokens: effectiveContext)
+                && mtpModel != nil)
 
         var layerCaches = makeLayerCaches(config: loadedConfig)
         let promptInput = MLXArray(promptTokens.map { Int32($0) }).reshaped(1, promptTokens.count)
@@ -450,6 +454,7 @@ public actor Q35Generator: ChatGenerator {
                 existingHidden: prefixSeed?.hidden,
                 modelPath: loadedModelPath ?? "",
                 checkpointTokenCounts: prefixCheckpoints,
+                retainHidden: retainPrefillHidden,
                 progressHandler: progressHandler
             )
         } else {
@@ -459,6 +464,7 @@ public actor Q35Generator: ChatGenerator {
                         model: model,
                         promptTokens: promptTokens,
                         cache: layerCaches,
+                        retainHidden: retainPrefillHidden,
                         progressHandler: progressHandler
                     )
                 } else {
@@ -490,6 +496,7 @@ public actor Q35Generator: ChatGenerator {
                         inputEmbeddings: promptEmbeddings,
                         cache: layerCaches,
                         positionIds: positionIds,
+                        retainHidden: retainPrefillHidden,
                         progressHandler: progressHandler
                     )
                 }
@@ -498,6 +505,7 @@ public actor Q35Generator: ChatGenerator {
                     model: model,
                     promptTokens: promptTokens,
                     cache: layerCaches,
+                    retainHidden: retainPrefillHidden,
                     progressHandler: progressHandler
                 )
             }
@@ -685,7 +693,8 @@ public actor Q35Generator: ChatGenerator {
     ) async throws -> Q35BatchedDecodeResult {
         var logits = initialLogits
         var layerCaches = layerCaches
-        var previousHidden = initialHidden.map(lastTokenHidden)
+        let retainHidden = mtpModel != nil
+        var previousHidden = retainHidden ? initialHidden.map(lastTokenHidden) : nil
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
@@ -886,15 +895,25 @@ public actor Q35Generator: ChatGenerator {
             }
 
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
-            let output = model.forward(
-                nextInput,
-                cache: layerCaches,
-                positionIds: decodePositionIds(layerCaches: layerCaches, tokenCount: 1, ropeDelta: mropeRopeDelta)
-            )
-            logits = output.logits
-            previousHidden = lastTokenHidden(output.hidden)
-            MLX.eval(logits)
-            MLX.eval(previousHidden!)
+            let positionIds = decodePositionIds(layerCaches: layerCaches, tokenCount: 1, ropeDelta: mropeRopeDelta)
+            if retainHidden {
+                let output = model.forward(
+                    nextInput,
+                    cache: layerCaches,
+                    positionIds: positionIds
+                )
+                logits = output.logits
+                previousHidden = lastTokenHidden(output.hidden)
+                MLX.eval(logits)
+                MLX.eval(previousHidden!)
+            } else {
+                logits = model(
+                    nextInput,
+                    cache: layerCaches,
+                    positionIds: positionIds
+                )
+                MLX.eval(logits)
+            }
         }
 
         return Q35BatchedDecodeResult(
@@ -1223,6 +1242,7 @@ public actor Q35Generator: ChatGenerator {
         existingHidden: MLXArray? = nil,
         modelPath: String? = nil,
         checkpointTokenCounts: Set<Int> = [],
+        retainHidden: Bool = true,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Q35PrefillOutput {
         guard !promptTokens.isEmpty else {
@@ -1248,23 +1268,30 @@ public actor Q35Generator: ChatGenerator {
             }
             let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
                 .reshaped(1, end - processed)
-            let output = model.forward(chunk, cache: cache)
-            MLX.eval(output.logits)
-            MLX.eval(output.hidden)
-            logits = output.logits
-            hidden = output.hidden
-            processed = end
-            if let modelPath {
-                storePrefixKVCache(
-                    modelPath: modelPath,
-                    promptTokens: promptTokens,
-                    tokenCount: processed,
-                    cache: cache,
-                    logits: output.logits,
-                    hidden: output.hidden,
-                    priority: checkpointTokenCounts.contains(processed) ? .semantic : .chunk
-                )
+            if retainHidden {
+                let output = model.forward(chunk, cache: cache)
+                MLX.eval(output.logits)
+                MLX.eval(output.hidden)
+                logits = output.logits
+                hidden = output.hidden
+                if let modelPath {
+                    storePrefixKVCache(
+                        modelPath: modelPath,
+                        promptTokens: promptTokens,
+                        tokenCount: end,
+                        cache: cache,
+                        logits: output.logits,
+                        hidden: output.hidden,
+                        priority: checkpointTokenCounts.contains(end) ? .semantic : .chunk
+                    )
+                }
+            } else {
+                let output = model(chunk, cache: cache)
+                MLX.eval(output)
+                logits = output
+                hidden = nil
             }
+            processed = end
             await Task.yield()
         }
 
@@ -1279,6 +1306,7 @@ public actor Q35Generator: ChatGenerator {
         inputEmbeddings: MLXArray,
         cache: [Q35LayerCache?],
         positionIds: MLXArray? = nil,
+        retainHidden: Bool = true,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Q35PrefillOutput {
         let tokenCount = inputEmbeddings.dim(1)
@@ -1298,16 +1326,28 @@ public actor Q35Generator: ChatGenerator {
             let chunkEmbeddings = inputEmbeddings[0..., processed..<end, 0...]
             let chunkInput = MLXArray.zeros([1, end - processed], dtype: .int32)
             let chunkPositionIds = positionIds?[0..., 0..., processed..<end]
-            let output = model.forward(
-                chunkInput,
-                cache: cache,
-                inputEmbeddings: chunkEmbeddings,
-                positionIds: chunkPositionIds
-            )
-            MLX.eval(output.logits)
-            MLX.eval(output.hidden)
-            logits = output.logits
-            hidden = output.hidden
+            if retainHidden {
+                let output = model.forward(
+                    chunkInput,
+                    cache: cache,
+                    inputEmbeddings: chunkEmbeddings,
+                    positionIds: chunkPositionIds
+                )
+                MLX.eval(output.logits)
+                MLX.eval(output.hidden)
+                logits = output.logits
+                hidden = output.hidden
+            } else {
+                let output = model(
+                    chunkInput,
+                    cache: cache,
+                    inputEmbeddings: chunkEmbeddings,
+                    positionIds: chunkPositionIds
+                )
+                MLX.eval(output)
+                logits = output
+                hidden = nil
+            }
             processed = end
             await Task.yield()
         }

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -524,8 +524,16 @@ public actor Q35Generator: ChatGenerator {
             progressHandler: progressHandler
         )
 
-        let decoded = tokenizerAndTemplate.decode(tokens: decodeResult.generatedTokens)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let stopSequences = TextGenerationStopSequences.merged(request.stopSequences)
+        let decodedRaw = tokenizerAndTemplate.decode(tokens: decodeResult.generatedTokens)
+        let trimmed = TextGenerationStopSequences.trimming(decodedRaw, sequences: stopSequences)
+        let decoded = trimmed.text
+        let finishReason: ChatFinishReason = {
+            if trimmed.matchedSequence != nil {
+                return .stopSequence
+            }
+            return decodeResult.generatedTokens.count >= tokenBudget ? .length : .stop
+        }()
         let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
             let parsed = Gemma4ToolParser.parseToolCalls(decoded)
             return parsed.isEmpty ? nil : parsed
@@ -540,7 +548,8 @@ public actor Q35Generator: ChatGenerator {
                 decodeSeconds: decodeResult.decodeSeconds
             ),
             toolCalls: toolCalls,
-            promptTokens: promptTokens.count
+            promptTokens: promptTokens.count,
+            finishReason: finishReason
         )
     }
 

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -540,8 +540,9 @@ public actor Q35Generator: ChatGenerator {
         }() : nil
 
         return ChatResponse(
-            response: decoded,
+            generatedText: decoded,
             tokensGenerated: decodeResult.generatedTokens.count,
+            showThinking: request.showThinking,
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -691,6 +691,19 @@ public actor Q35Generator: ChatGenerator {
         promptTokens: [Int],
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Q35BatchedDecodeResult {
+        if mtpModel == nil, canUsePipelinedGreedyDecode(generationConfig) {
+            return try await decodeTokensGreedyPipelined(
+                model: model,
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                initialLogits: initialLogits,
+                layerCaches: layerCaches,
+                eosSet: eosSet,
+                tokenBudget: tokenBudget,
+                mropeRopeDelta: mropeRopeDelta,
+                progressHandler: progressHandler
+            )
+        }
+
         var logits = initialLogits
         var layerCaches = layerCaches
         let retainHidden = mtpModel != nil
@@ -704,6 +717,7 @@ public actor Q35Generator: ChatGenerator {
         func emit(_ token: Int) {
             generated.append(token)
             repetitionHistory.append(token)
+            guard let progressHandler else { return }
             let piece = tokenizerAndTemplate.decode(token: token)
             guard !piece.isEmpty else { return }
             if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -718,7 +732,7 @@ public actor Q35Generator: ChatGenerator {
                 visiblePiece = pendingProgressWhitespace + piece
                 pendingProgressWhitespace = ""
             }
-            progressHandler?(ChatProgress(stage: .generating, message: visiblePiece))
+            progressHandler(ChatProgress(stage: .generating, message: visiblePiece))
         }
 
         while generated.count < tokenBudget {
@@ -922,6 +936,88 @@ public actor Q35Generator: ChatGenerator {
         )
     }
 
+    private func canUsePipelinedGreedyDecode(_ config: GenerationConfig) -> Bool {
+        config.temperature == 0
+            && config.repetitionPenalty == nil
+            && config.bannedTokens.isEmpty
+    }
+
+    private func decodeTokensGreedyPipelined(
+        model: Q35Model,
+        tokenizerAndTemplate: Q35TokenizerAndTemplate,
+        initialLogits: MLXArray,
+        layerCaches: [Q35LayerCache?],
+        eosSet: Set<Int>,
+        tokenBudget: Int,
+        mropeRopeDelta: Int?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> Q35BatchedDecodeResult {
+        let layerCaches = layerCaches
+        var pendingToken = greedyTokenArray(from: initialLogits)
+        asyncEval(pendingToken)
+
+        var generated: [Int] = []
+        generated.reserveCapacity(tokenBudget)
+        var pendingProgressWhitespace = ""
+        let decodeStart = Date()
+
+        func emit(_ token: Int) {
+            generated.append(token)
+            guard let progressHandler else { return }
+            let piece = tokenizerAndTemplate.decode(token: token)
+            guard !piece.isEmpty else { return }
+            if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                pendingProgressWhitespace += piece
+                return
+            }
+
+            let visiblePiece: String
+            if pendingProgressWhitespace.isEmpty {
+                visiblePiece = piece
+            } else {
+                visiblePiece = pendingProgressWhitespace + piece
+                pendingProgressWhitespace = ""
+            }
+            progressHandler(ChatProgress(stage: .generating, message: visiblePiece))
+        }
+
+        while generated.count < tokenBudget {
+            try Task.checkCancellation()
+
+            let scheduled: MLXArray?
+            if generated.count + 1 < tokenBudget {
+                let nextInput = pendingToken.asType(.int32).reshaped(1, 1)
+                let nextLogits = model(
+                    nextInput,
+                    cache: layerCaches,
+                    positionIds: decodePositionIds(layerCaches: layerCaches, tokenCount: 1, ropeDelta: mropeRopeDelta)
+                )
+                let nextToken = greedyTokenArray(from: nextLogits)
+                asyncEval(nextToken, nextLogits)
+                scheduled = nextToken
+            } else {
+                scheduled = nil
+            }
+
+            let token = pendingToken.item(Int.self)
+            if eosSet.contains(token) {
+                break
+            }
+
+            emit(token)
+
+            guard let scheduled else {
+                break
+            }
+            pendingToken = scheduled
+        }
+
+        return Q35BatchedDecodeResult(
+            generatedTokens: generated,
+            decodeSeconds: Date().timeIntervalSince(decodeStart)
+        )
+    }
+
     private func enqueueDecodeRow(
         _ row: Q35BatchedDecodeRow,
         model: Q35Model,
@@ -1091,9 +1187,11 @@ public actor Q35Generator: ChatGenerator {
             }
             row.generatedTokens.append(next)
             row.repetitionHistory.append(next)
-            let piece = tokenizerAndTemplate.decode(token: next)
-            if !piece.isEmpty {
-                row.progressHandler?(ChatProgress(stage: .generating, message: piece))
+            if let progressHandler = row.progressHandler {
+                let piece = tokenizerAndTemplate.decode(token: next)
+                if !piece.isEmpty {
+                    progressHandler(ChatProgress(stage: .generating, message: piece))
+                }
             }
         }
 
@@ -1231,6 +1329,10 @@ public actor Q35Generator: ChatGenerator {
     private func lastTokenLogits(_ logits: MLXArray) -> MLXArray {
         let start = max(0, logits.dim(1) - 1)
         return logits[0..., start..<(start + 1), 0...]
+    }
+
+    private func greedyTokenArray(from logits: MLXArray) -> MLXArray {
+        argMax(logits[0, -1, 0...], axis: -1).asType(.int32)
     }
 
     private func chunkedPrefill(

--- a/Sources/MereRunCore/Q35/Q35LinearAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35LinearAttention.swift
@@ -3,16 +3,9 @@ import MLX
 import MLXFast
 import MLXNN
 
-private let q35RMSNormGatedCompiled = compile(shapeless: true) { hiddenStates, gate, weight in
-    let dtype = hiddenStates.dtype
-    let hidden32 = hiddenStates.asType(.float32)
-    let variance = (hidden32 * hidden32).mean(axis: -1, keepDims: true)
-    let scale = weight.asType(.float32).reshaped(
-        Array(repeating: 1, count: hiddenStates.ndim - 1) + [weight.dim(0)]
-    )
-    let normalized = hidden32 * rsqrt(variance + MLXArray(1e-6))
-    let gated = normalized * scale * MLXNN.silu(gate.asType(.float32))
-    return gated.asType(dtype)
+private let q35PreciseSwigluCompiled = compile(shapeless: true) { hiddenStates, gate, x in
+    let gate = MLXNN.silu(gate.asType(.float32))
+    return (gate * x.asType(.float32)).asType(hiddenStates.dtype)
 }
 
 final class Q35RMSNormGated: Module {
@@ -26,23 +19,11 @@ final class Q35RMSNormGated: Module {
     }
 
     func callAsFunction(_ hiddenStates: MLXArray, gate: MLXArray?) -> MLXArray {
-        guard eps == 1e-6, let gate else {
-            return callUncompiled(hiddenStates, gate: gate)
+        let normalized = MLXFast.rmsNorm(hiddenStates, weight: weight, eps: eps)
+        guard let gate else {
+            return normalized.asType(hiddenStates.dtype)
         }
-        return q35RMSNormGatedCompiled(hiddenStates, gate, weight)
-    }
-
-    private func callUncompiled(_ hiddenStates: MLXArray, gate: MLXArray?) -> MLXArray {
-        let dtype = hiddenStates.dtype
-        let hidden32 = hiddenStates.asType(.float32)
-        let variance = (hidden32 * hidden32).mean(axis: -1, keepDims: true)
-        let scale = weight.reshaped([1, 1, 1, hiddenStates.dim(hiddenStates.ndim - 1)])
-        var normalized = (hidden32 * rsqrt(variance + MLXArray(eps))).asType(dtype)
-        normalized = normalized * scale
-        if let gate {
-            normalized = normalized * MLXNN.silu(gate.asType(.float32))
-        }
-        return normalized.asType(dtype)
+        return q35PreciseSwigluCompiled(hiddenStates, gate, normalized)
     }
 }
 
@@ -62,6 +43,46 @@ private func q35RmsNormNoWeight(_ x: MLXArray, eps: Float = 1e-6) -> MLXArray {
         return x * rsqrt(squaredMean + MLXArray(eps).asType(x.dtype))
     }
     return q35RmsNormNoWeightCompiled(x)
+}
+
+private func q35ConcatenatedOptional(_ lhs: MLXArray?, _ rhs: MLXArray?) -> MLXArray?? {
+    switch (lhs, rhs) {
+    case (nil, nil):
+        return .some(nil)
+    case let (lhs?, rhs?):
+        return .some(MLX.concatenated([lhs, rhs], axis: 0))
+    default:
+        return nil
+    }
+}
+
+func q35FusedPortableQuantizedLinear(_ lhs: Linear, _ rhs: Linear) -> PortableQuantizedLinear? {
+    guard let lhs = lhs as? PortableQuantizedLinear,
+          let rhs = rhs as? PortableQuantizedLinear,
+          lhs.shape.1 == rhs.shape.1,
+          lhs.groupSize == rhs.groupSize,
+          lhs.bits == rhs.bits,
+          lhs.mode == rhs.mode,
+          let bias = q35ConcatenatedOptional(lhs.bias, rhs.bias),
+          let biases = q35ConcatenatedOptional(lhs.biases, rhs.biases) else {
+        return nil
+    }
+
+    let weight = MLX.concatenated([lhs.weight, rhs.weight], axis: 0)
+    let scales = MLX.concatenated([lhs.scales, rhs.scales], axis: 0)
+    MLX.eval(weight, scales)
+    if let bias { MLX.eval(bias) }
+    if let biases { MLX.eval(biases) }
+
+    return PortableQuantizedLinear(
+        weight: weight,
+        bias: bias,
+        scales: scales,
+        biases: biases,
+        groupSize: lhs.groupSize,
+        bits: lhs.bits,
+        mode: lhs.mode
+    )
 }
 
 private let q35ComputeGCompiled = compile(shapeless: true) { aLog, a, dtBias in
@@ -420,6 +441,8 @@ final class Q35LinearAttention: Module {
     private let valueDim: Int
     private let convDim: Int
     private let convKernelSize: Int
+    private var fusedInProjQKVZ: Linear?
+    private var fusedInProjBA: Linear?
 
     init(config: Q35Config) {
         let text = config.textConfig
@@ -468,10 +491,33 @@ final class Q35LinearAttention: Module {
         let sequence = x.dim(1)
         let keep = max(0, convKernelSize - 1)
 
-        let qkv = inProjQKV(x)
-        let z = inProjZ(x).reshaped(batch, sequence, numValueHeads, valueHeadDim)
-        let b = inProjB(x)
-        let a = inProjA(x)
+        let qkv: MLXArray
+        let z: MLXArray
+        if fusedInProjQKVZ == nil {
+            fusedInProjQKVZ = q35FusedPortableQuantizedLinear(inProjQKV, inProjZ)
+        }
+        if let fusedInProjQKVZ {
+            let qkvz = fusedInProjQKVZ(x)
+            qkv = qkvz[.ellipsis, 0..<convDim]
+            z = qkvz[.ellipsis, convDim...].reshaped(batch, sequence, numValueHeads, valueHeadDim)
+        } else {
+            qkv = inProjQKV(x)
+            z = inProjZ(x).reshaped(batch, sequence, numValueHeads, valueHeadDim)
+        }
+
+        let b: MLXArray
+        let a: MLXArray
+        if fusedInProjBA == nil {
+            fusedInProjBA = q35FusedPortableQuantizedLinear(inProjB, inProjA)
+        }
+        if let fusedInProjBA {
+            let ba = fusedInProjBA(x)
+            b = ba[.ellipsis, 0..<numValueHeads]
+            a = ba[.ellipsis, numValueHeads...]
+        } else {
+            b = inProjB(x)
+            a = inProjA(x)
+        }
 
         let convState = cache?.convState
             ?? MLXArray.zeros([batch, keep, convDim], dtype: x.dtype)

--- a/Sources/MereRunCore/Q35/Q35LinearAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35LinearAttention.swift
@@ -1,6 +1,19 @@
 import Foundation
 import MLX
+import MLXFast
 import MLXNN
+
+private let q35RMSNormGatedCompiled = compile(shapeless: true) { hiddenStates, gate, weight in
+    let dtype = hiddenStates.dtype
+    let hidden32 = hiddenStates.asType(.float32)
+    let variance = (hidden32 * hidden32).mean(axis: -1, keepDims: true)
+    let scale = weight.asType(.float32).reshaped(
+        Array(repeating: 1, count: hiddenStates.ndim - 1) + [weight.dim(0)]
+    )
+    let normalized = hidden32 * rsqrt(variance + MLXArray(1e-6))
+    let gated = normalized * scale * MLXNN.silu(gate.asType(.float32))
+    return gated.asType(dtype)
+}
 
 final class Q35RMSNormGated: Module {
     @ModuleInfo(key: "weight") var weight: MLXArray
@@ -13,6 +26,13 @@ final class Q35RMSNormGated: Module {
     }
 
     func callAsFunction(_ hiddenStates: MLXArray, gate: MLXArray?) -> MLXArray {
+        guard eps == 1e-6, let gate else {
+            return callUncompiled(hiddenStates, gate: gate)
+        }
+        return q35RMSNormGatedCompiled(hiddenStates, gate, weight)
+    }
+
+    private func callUncompiled(_ hiddenStates: MLXArray, gate: MLXArray?) -> MLXArray {
         let dtype = hiddenStates.dtype
         let hidden32 = hiddenStates.asType(.float32)
         let variance = (hidden32 * hidden32).mean(axis: -1, keepDims: true)
@@ -31,20 +51,103 @@ private func q35Swiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
     MLXNN.silu(gate) * up
 }
 
-@inline(__always)
-private func q35RmsNormNoWeight(_ x: MLXArray, eps: Float = 1e-6) -> MLXArray {
+private let q35RmsNormNoWeightCompiled = compile(shapeless: true) { x in
     let squaredMean = (x * x).mean(axis: -1, keepDims: true)
-    return x * rsqrt(squaredMean + MLXArray(eps).asType(x.dtype))
+    return x * rsqrt(squaredMean + MLXArray(1e-6).asType(x.dtype))
 }
 
-@inline(__always)
-private func q35ComputeG(aLog: MLXArray, a: MLXArray, dtBias: MLXArray) -> MLXArray {
+private func q35RmsNormNoWeight(_ x: MLXArray, eps: Float = 1e-6) -> MLXArray {
+    guard eps == 1e-6 else {
+        let squaredMean = (x * x).mean(axis: -1, keepDims: true)
+        return x * rsqrt(squaredMean + MLXArray(eps).asType(x.dtype))
+    }
+    return q35RmsNormNoWeightCompiled(x)
+}
+
+private let q35ComputeGCompiled = compile(shapeless: true) { aLog, a, dtBias in
     let dt = softplus(a.asType(.float32) + dtBias.asType(.float32).reshaped(1, 1, dtBias.dim(0)))
     let decayBase = MLX.exp(aLog.asType(.float32)).reshaped(1, 1, dtBias.dim(0))
     return MLX.exp(-decayBase * dt)
 }
 
-private func q35GatedDeltaUpdate(
+@inline(__always)
+private func q35ComputeG(aLog: MLXArray, a: MLXArray, dtBias: MLXArray) -> MLXArray {
+    q35ComputeGCompiled(aLog, a, dtBias)
+}
+
+#if os(macOS)
+private enum Q35GatedDeltaMetalKernel {
+    static let kernel = MLXFast.metalKernel(
+        name: "q35_gated_delta_step",
+        inputNames: ["q", "k", "v", "g", "beta", "state_in", "T"],
+        outputNames: ["y", "state_out"],
+        source: """
+            auto n = thread_position_in_grid.z;
+            auto b_idx = n / Hv;
+            auto hv_idx = n % Hv;
+            auto hk_idx = hv_idx / (Hv / Hk);
+            constexpr int n_per_t = Dk / 32;
+
+            auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+            auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+            auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+            y += b_idx * T * Hv * Dv + hv_idx * Dv;
+
+            auto dk_idx = thread_position_in_threadgroup.x;
+            auto dv_idx = thread_position_in_grid.y;
+
+            auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+            auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+
+            float state[n_per_t];
+            for (int i = 0; i < n_per_t; ++i) {
+              auto s_idx = n_per_t * dk_idx + i;
+              state[i] = static_cast<float>(i_state[s_idx]);
+            }
+
+            auto g_ = g + b_idx * T * Hv;
+            auto beta_ = beta + b_idx * T * Hv;
+
+            for (int t = 0; t < T; ++t) {
+              float kv_mem = 0.0f;
+              for (int i = 0; i < n_per_t; ++i) {
+                auto s_idx = n_per_t * dk_idx + i;
+                state[i] = state[i] * g_[hv_idx];
+                kv_mem += state[i] * k_[s_idx];
+              }
+              kv_mem = simd_sum(kv_mem);
+
+              auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+
+              float out = 0.0f;
+              for (int i = 0; i < n_per_t; ++i) {
+                auto s_idx = n_per_t * dk_idx + i;
+                state[i] = state[i] + k_[s_idx] * delta;
+                out += state[i] * q_[s_idx];
+              }
+              out = simd_sum(out);
+              if (thread_index_in_simdgroup == 0) {
+                y[dv_idx] = static_cast<InT>(out);
+              }
+
+              q_ += Hk * Dk;
+              k_ += Hk * Dk;
+              v_ += Hv * Dv;
+              y += Hv * Dv;
+              g_ += Hv;
+              beta_ += Hv;
+            }
+            for (int i = 0; i < n_per_t; ++i) {
+              auto s_idx = n_per_t * dk_idx + i;
+              o_state[s_idx] = static_cast<StT>(state[i]);
+            }
+            """
+    )
+}
+#endif
+
+func q35GatedDeltaUpdateOps(
     q: MLXArray,
     k: MLXArray,
     v: MLXArray,
@@ -109,6 +212,109 @@ private func q35GatedDeltaUpdate(
 
     return (y.asType(outputDType), recurrent)
 }
+
+func q35GatedDeltaUpdate(
+    q: MLXArray,
+    k: MLXArray,
+    v: MLXArray,
+    a: MLXArray,
+    b: MLXArray,
+    aLog: MLXArray,
+    dtBias: MLXArray,
+    state: MLXArray?,
+    numKeyHeads: Int,
+    numValueHeads: Int,
+    valueHeadDim: Int
+) -> (MLXArray, MLXArray) {
+    #if os(macOS)
+    if let fast = q35GatedDeltaUpdateMetal(
+        q: q,
+        k: k,
+        v: v,
+        a: a,
+        b: b,
+        aLog: aLog,
+        dtBias: dtBias,
+        state: state,
+        numKeyHeads: numKeyHeads,
+        numValueHeads: numValueHeads,
+        valueHeadDim: valueHeadDim
+    ) {
+        return fast
+    }
+    #endif
+
+    return q35GatedDeltaUpdateOps(
+        q: q,
+        k: k,
+        v: v,
+        a: a,
+        b: b,
+        aLog: aLog,
+        dtBias: dtBias,
+        state: state,
+        numKeyHeads: numKeyHeads,
+        numValueHeads: numValueHeads,
+        valueHeadDim: valueHeadDim
+    )
+}
+
+#if os(macOS)
+func q35GatedDeltaUpdateMetal(
+    q: MLXArray,
+    k: MLXArray,
+    v: MLXArray,
+    a: MLXArray,
+    b: MLXArray,
+    aLog: MLXArray,
+    dtBias: MLXArray,
+    state: MLXArray?,
+    numKeyHeads: Int,
+    numValueHeads: Int,
+    valueHeadDim: Int
+) -> (MLXArray, MLXArray)? {
+    guard Device.defaultDevice().deviceType == .gpu else {
+        return nil
+    }
+
+    let batch = q.dim(0)
+    let sequence = q.dim(1)
+    let keyHeadDim = q.dim(3)
+    guard keyHeadDim % 32 == 0,
+          numKeyHeads > 0,
+          numValueHeads > 0,
+          numValueHeads % numKeyHeads == 0 else {
+        return nil
+    }
+
+    let beta = MLX.sigmoid(b).asType(.float32)
+    let g = q35ComputeG(aLog: aLog, a: a, dtBias: dtBias)
+    let recurrent = state
+        .map { $0.asType(.float32) }
+        ?? MLXArray.zeros([batch, numValueHeads, valueHeadDim, keyHeadDim], dtype: .float32)
+
+    let outputs = Q35GatedDeltaMetalKernel.kernel(
+        [q, k, v, g, beta, recurrent, sequence],
+        template: [
+            ("InT", q.dtype),
+            ("StT", recurrent.dtype),
+            ("Dk", keyHeadDim),
+            ("Dv", valueHeadDim),
+            ("Hk", numKeyHeads),
+            ("Hv", numValueHeads),
+        ],
+        grid: (32, valueHeadDim, batch * numValueHeads),
+        threadGroup: (32, 4, 1),
+        outputShapes: [
+            [batch, sequence, numValueHeads, valueHeadDim],
+            recurrent.shape,
+        ],
+        outputDTypes: [q.dtype, recurrent.dtype]
+    )
+
+    return (outputs[0], outputs[1])
+}
+#endif
 
 public final class Q35LinearCache: @unchecked Sendable {
     var convState: MLXArray?

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -65,39 +65,44 @@ final class Q35SwitchLinear: Module {
         }
 
         let flatIndices = indices.reshaped([batchTokens * topK])
-
-        let output: MLXArray
-        if let scales {
-            let resolved = resolvedQuantization(inputDim: inputDim, scales: scales)
-            output = portableGatherQuantizedMM(
-                flatX,
-                weight,
-                scales: scales,
-                biases: biases,
-                rhsIndices: flatIndices,
-                transpose: true,
-                groupSize: resolved.groupSize,
-                bits: resolved.bits,
-                mode: .affine,
-                sortedIndices: false
-            )
-        } else {
-            output = gatherMM(
-                flatX,
-                weight.swappedAxes(-1, -2),
-                rhsIndices: flatIndices,
-                sortedIndices: false
-            )
-        }
-
+        let output = applyFlat(flatX, indices: flatIndices, sortedIndices: false)
         let outDim = output.dim(2)
         var reshaped = output.reshaped([batchTokens, topK, outDim])
         reshaped = reshaped.reshaped([x.dim(0), x.dim(1), topK, outDim])
 
-        if let bias {
-            return reshaped + bias.reshaped([1, 1, 1, outDim])
-        }
         return reshaped
+    }
+
+    func applyFlat(_ x: MLXArray, indices: MLXArray, sortedIndices: Bool) -> MLXArray {
+        let inputDim = x.dim(x.ndim - 1)
+        let output: MLXArray
+        if let scales {
+            let resolved = resolvedQuantization(inputDim: inputDim, scales: scales)
+            output = portableGatherQuantizedMM(
+                x,
+                weight,
+                scales: scales,
+                biases: biases,
+                rhsIndices: indices,
+                transpose: true,
+                groupSize: resolved.groupSize,
+                bits: resolved.bits,
+                mode: .affine,
+                sortedIndices: sortedIndices
+            )
+        } else {
+            output = gatherMM(
+                x,
+                weight.swappedAxes(-1, -2),
+                rhsIndices: indices,
+                sortedIndices: sortedIndices
+            )
+        }
+
+        if let bias {
+            return output + bias.take(indices, axis: 0).expandedDimensions(axis: 1)
+        }
+        return output
     }
 
     private func resolvedQuantization(inputDim: Int, scales: MLXArray) -> (groupSize: Int, bits: Int) {
@@ -164,6 +169,33 @@ final class Q35SwitchGLU: Module {
     }
 
     func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let batchTokens = x.dim(0) * x.dim(1)
+        let topK = indices.dim(2)
+        let routeCount = batchTokens * topK
+        guard routeCount >= 64 else {
+            return unsorted(x, indices: indices)
+        }
+
+        let inputDim = x.dim(x.ndim - 1)
+        let flatIndices = indices.reshaped([routeCount])
+        let order = argSort(flatIndices, axis: 0)
+        let inverseOrder = argSort(order, axis: 0)
+        let sortedIndices = flatIndices.take(order, axis: 0)
+        let tokenOrder = order.floorDivide(topK)
+        let flatInput = x.reshaped([batchTokens, inputDim])
+            .take(tokenOrder, axis: 0)
+            .reshaped([routeCount, 1, inputDim])
+
+        let up = upProj.applyFlat(flatInput, indices: sortedIndices, sortedIndices: true)
+        let gate = gateProj.applyFlat(flatInput, indices: sortedIndices, sortedIndices: true)
+        let activated = q35Swiglu(gate, up)
+        let output = downProj.applyFlat(activated, indices: sortedIndices, sortedIndices: true)
+            .take(inverseOrder, axis: 0)
+
+        return output.reshaped([x.dim(0), x.dim(1), topK, output.dim(2)])
+    }
+
+    func unsorted(_ x: MLXArray, indices: MLXArray) -> MLXArray {
         let up = upProj(x, indices: indices)
         let gate = gateProj(x, indices: indices)
         let activated = q35Swiglu(gate, up)
@@ -237,10 +269,9 @@ final class Q35FeedForward: Module {
            let switchMLP,
            let sharedExpert,
            let sharedExpertGate {
-            var scores = softmax(gate(x), axis: -1)
+            var scores = softmax(gate(x), axis: -1, precise: true)
 
-            let kth = topK - 1
-            let indices = argPartition(-scores, kth: kth, axis: -1)[.ellipsis, 0..<topK]
+            let indices = argPartition(scores, kth: -topK, axis: -1)[.ellipsis, (-topK)...]
             scores = takeAlong(scores, indices, axis: -1)
 
             if normTopKProb, topK > 1 {
@@ -289,10 +320,9 @@ final class Q35MoE: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var scores = softmax(gate(x), axis: -1)
+        var scores = softmax(gate(x), axis: -1, precise: true)
 
-        let kth = topK - 1
-        let indices = argPartition(-scores, kth: kth, axis: -1)[.ellipsis, 0..<topK]
+        let indices = argPartition(scores, kth: -topK, axis: -1)[.ellipsis, (-topK)...]
         scores = takeAlong(scores, indices, axis: -1)
 
         if normTopKProb, topK > 1 {

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -4,9 +4,13 @@ import MLXFast
 import MLXNN
 import MLXRandom
 
+private let q35SwigluCompiled = compile(shapeless: true) { gate, up in
+    MLXNN.silu(gate) * up
+}
+
 @inline(__always)
 private func q35Swiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
-    MLXNN.silu(gate) * up
+    q35SwigluCompiled(gate, up)
 }
 
 final class Q35SwitchLinear: Module {

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -62,10 +62,8 @@ final class Q35SwitchLinear: Module {
         if x.ndim == 4 && x.dim(2) == topK {
             flatX = x.reshaped([batchTokens * topK, 1, inputDim])
         } else {
-            var expanded = x.reshaped([batchTokens, 1, inputDim])
-            expanded = MLX.expandedDimensions(expanded, axis: 1)
-            expanded = MLX.repeated(expanded, count: topK, axis: 1)
-            flatX = expanded.reshaped([batchTokens * topK, 1, inputDim])
+            let expanded = MLX.expandedDimensions(x, axes: [-2, -3])
+            return applyGather(expanded, indices: indices, sortedIndices: false).squeezed(axis: -2)
         }
 
         let flatIndices = indices.reshaped([batchTokens * topK])
@@ -78,6 +76,10 @@ final class Q35SwitchLinear: Module {
     }
 
     func applyFlat(_ x: MLXArray, indices: MLXArray, sortedIndices: Bool) -> MLXArray {
+        applyGather(x, indices: indices, sortedIndices: sortedIndices)
+    }
+
+    private func applyGather(_ x: MLXArray, indices: MLXArray, sortedIndices: Bool) -> MLXArray {
         let inputDim = x.dim(x.ndim - 1)
         let output: MLXArray
         if let scales {
@@ -104,7 +106,7 @@ final class Q35SwitchLinear: Module {
         }
 
         if let bias {
-            return output + bias.take(indices, axis: 0).expandedDimensions(axis: 1)
+            return output + bias.take(indices, axis: 0).expandedDimensions(axis: -2)
         }
         return output
     }
@@ -241,7 +243,7 @@ final class Q35FeedForward: Module {
         let text = config.textConfig
         self.usesMoE = text.usesMoE
         self.topK = max(1, text.numExpertsPerTok)
-        self.normTopKProb = true
+        self.normTopKProb = text.normTopKProb
 
         if text.usesMoE {
             self._gate.wrappedValue = Linear(text.hiddenSize, text.numExperts, bias: false)
@@ -310,7 +312,7 @@ final class Q35MoE: Module {
     init(config: Q35Config) {
         let text = config.textConfig
         self.topK = max(1, text.numExpertsPerTok)
-        self.normTopKProb = true
+        self.normTopKProb = text.normTopKProb
 
         self._gate.wrappedValue = Linear(text.hiddenSize, text.numExperts, bias: false)
         self._switchMLP.wrappedValue = Q35SwitchGLU(config: config)

--- a/Sources/MereRunCore/Q35/Q35RMSNorm.swift
+++ b/Sources/MereRunCore/Q35/Q35RMSNorm.swift
@@ -2,6 +2,16 @@ import Foundation
 import MLX
 import MLXNN
 
+private let q35RMSNormCompiled = compile(shapeless: true) { x, weight in
+    let dtype = x.dtype
+    let x32 = x.asType(.float32)
+    let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)
+    let normalized = x32 * rsqrt(variance + MLXArray(1e-6))
+    let scale = weight.asType(.float32) + MLXArray(1.0)
+    let output = normalized * scale.reshaped(Array(repeating: 1, count: x.ndim - 1) + [scale.dim(0)])
+    return output.asType(dtype)
+}
+
 final class Q35RMSNorm: Module {
     @ModuleInfo(key: "weight") var weight: MLXArray
 
@@ -14,6 +24,13 @@ final class Q35RMSNorm: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
+        guard eps == 1e-6 else {
+            return callUncompiled(x)
+        }
+        return q35RMSNormCompiled(x, weight)
+    }
+
+    private func callUncompiled(_ x: MLXArray) -> MLXArray {
         let dtype = x.dtype
         let x32 = x.asType(.float32)
         let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)

--- a/Sources/MereRunCore/Q35/Q35RMSNorm.swift
+++ b/Sources/MereRunCore/Q35/Q35RMSNorm.swift
@@ -1,21 +1,13 @@
 import Foundation
 import MLX
+import MLXFast
 import MLXNN
-
-private let q35RMSNormCompiled = compile(shapeless: true) { x, weight in
-    let dtype = x.dtype
-    let x32 = x.asType(.float32)
-    let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)
-    let normalized = x32 * rsqrt(variance + MLXArray(1e-6))
-    let scale = weight.asType(.float32) + MLXArray(1.0)
-    let output = normalized * scale.reshaped(Array(repeating: 1, count: x.ndim - 1) + [scale.dim(0)])
-    return output.asType(dtype)
-}
 
 final class Q35RMSNorm: Module {
     @ModuleInfo(key: "weight") var weight: MLXArray
 
     private let eps: Float
+    private var effectiveWeight: MLXArray?
 
     init(dimensions: Int, eps: Float) {
         self._weight.wrappedValue = MLXArray.zeros([dimensions])
@@ -24,19 +16,11 @@ final class Q35RMSNorm: Module {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        guard eps == 1e-6 else {
-            return callUncompiled(x)
+        if effectiveWeight == nil {
+            let scale = weight + MLXArray(1.0).asType(weight.dtype)
+            MLX.eval(scale)
+            effectiveWeight = scale
         }
-        return q35RMSNormCompiled(x, weight)
-    }
-
-    private func callUncompiled(_ x: MLXArray) -> MLXArray {
-        let dtype = x.dtype
-        let x32 = x.asType(.float32)
-        let variance = MLX.mean(x32 * x32, axis: -1, keepDims: true)
-        let normalized = x32 * rsqrt(variance + MLXArray(eps))
-        let scale = weight.asType(.float32) + MLXArray(1.0)
-        let output = normalized * scale.reshaped(Array(repeating: 1, count: x.ndim - 1) + [scale.dim(0)])
-        return output.asType(dtype)
+        return MLXFast.rmsNorm(x, weight: effectiveWeight ?? weight, eps: eps)
     }
 }

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -27,6 +27,7 @@ public struct Q35Resources: Sendable, Hashable {
 
     public static let q36NanoModelId = "text-chat-q36-nano"
     public static let ornith9BModelId = "text-agent-ornith-9b"
+    public static let ornith35BMLXModelId = "text-agent-ornith-35b-mlx"
     public static let infinityParser2FlashModelId = "vision-ocr-infinity-flash"
     public static let infinityParser2ProModelId = "vision-ocr-infinity-pro"
     public static let infinityParser2ProInt8ModelId = "vision-ocr-infinity-pro-int8"
@@ -37,6 +38,9 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith9BUpstreamRepoId = "sahilchachra/ornith-1.0-9b-optiq-5bpw-mlx"
     public static let ornith9BUpstreamRevision = "4f9f4fc2c10ec17cbeb9dae086a7f1272c904e86"
     public static let ornith9BEstimatedDownloadBytes: Int64 = 7 * 1_073_741_824
+    public static let ornith35BMLXUpstreamRepoId = "deepreinforce-ai/Ornith-1.0-35B"
+    public static let ornith35BMLXUpstreamRevision = "5df2ed3f675c7beaa490328cc70bb573b65fb660"
+    public static let ornith35BMLXEstimatedDownloadBytes: Int64 = 18 * 1_073_741_824
     public static let infinityParser2FlashUpstreamRepoId = "infly/Infinity-Parser2-Flash"
     public static let infinityParser2FlashUpstreamRevision = "30f02aca5ee7c32d22a962cbece5c19611147c9e"
     public static let infinityParser2ProUpstreamRepoId = "infly/Infinity-Parser2-Pro"
@@ -54,6 +58,11 @@ public struct Q35Resources: Sendable, Hashable {
             modelId: ornith9BModelId,
             upstreamRepoId: ornith9BUpstreamRepoId,
             upstreamRevision: ornith9BUpstreamRevision
+        ),
+        ornith35BMLXModelId: Profile(
+            modelId: ornith35BMLXModelId,
+            upstreamRepoId: ornith35BMLXUpstreamRepoId,
+            upstreamRevision: ornith35BMLXUpstreamRevision
         ),
         infinityParser2FlashModelId: Profile(
             modelId: infinityParser2FlashModelId,

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
@@ -50,6 +50,43 @@ public func argMaxSample(logits: MLXArray) -> Int {
     argMax(logits, axis: -1).item(Int.self)
 }
 
+public func greedySampleTokenArray(
+    logits: MLXArray,
+    config: GenerationConfig,
+    previousTokens: [Int]
+) -> MLXArray {
+    let contextTokens = previousTokens.isEmpty || config.repetitionPenalty == nil
+        ? nil
+        : MLXArray(previousTokens.suffix(config.repetitionContextSize).map { Int32($0) })
+    return greedySampleTokenArray(
+        logits: logits,
+        config: config,
+        previousTokenIndices: contextTokens
+    )
+}
+
+public func greedySampleTokenArray(
+    logits: MLXArray,
+    config: GenerationConfig,
+    previousTokenIndices: MLXArray?
+) -> MLXArray {
+    var logits = logits
+
+    logits = applyTokenBan(logits: logits, tokens: config.bannedTokens)
+
+    if let penalty = config.repetitionPenalty,
+       let previousTokenIndices,
+       previousTokenIndices.dim(0) > 0 {
+        logits = applyRepetitionPenalty(
+            logits: logits,
+            tokenIndices: previousTokenIndices,
+            penalty: penalty
+        )
+    }
+
+    return argMax(logits, axis: -1).asType(.int32)
+}
+
 public func topPSample(logits: MLXArray, temperature: Float, topP: Float) -> Int {
     var logits = logits
     if logits.dtype == .bfloat16 {
@@ -110,6 +147,26 @@ public func applyRepetitionPenalty(
 
     let result = logits
     result[indices] = penalized
+    return result
+}
+
+public func applyRepetitionPenalty(
+    logits: MLXArray,
+    tokenIndices: MLXArray,
+    penalty: Float
+) -> MLXArray {
+    guard tokenIndices.dim(0) > 0, penalty != 1.0 else { return logits }
+
+    let selectedLogits = logits[tokenIndices]
+
+    let penalized = MLX.where(
+        selectedLogits .< 0,
+        selectedLogits * penalty,
+        selectedLogits / penalty
+    )
+
+    let result = logits
+    result[tokenIndices] = penalized
     return result
 }
 

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -140,28 +140,27 @@ public final class QwenAttention: Module {
       values = cachedValues
     }
 
-    if numKeyValueHeads != numAttentionHeads {
-      keys = expandKeyValue(keys, repeats: numKeyValueGroups)
-      values = expandKeyValue(values, repeats: numKeyValueGroups)
-    }
-
     let queriesF32 = queries.asType(.float32)
-    let keysF32 = keys.asType(.float32)
-    let valuesF32 = values.asType(.float32)
 
     let output: MLXArray
     if cache != nil && L == 1 {
       // Qwen3-VL decode diverges after prefill on the fast single-token path.
       // Fall back to explicit attention for cached 1-token decode, which matches
       // the upstream reference more closely while keeping prefill on the fast kernel.
+      if numKeyValueHeads != numAttentionHeads {
+        keys = expandKeyValue(keys, repeats: numKeyValueGroups)
+        values = expandKeyValue(values, repeats: numKeyValueGroups)
+      }
+      let keysF32 = keys.asType(.float32)
+      let valuesF32 = values.asType(.float32)
       let scores = MLX.matmul(queriesF32, keysF32.transposed(0, 1, 3, 2)) * MLXArray(scale)
       let probs = softmax(scores, axis: -1)
       output = MLX.matmul(probs, valuesF32)
     } else {
       output = MLXFast.scaledDotProductAttention(
         queries: queriesF32,
-        keys: keysF32,
-        values: valuesF32,
+        keys: keys.asType(.float32),
+        values: values.asType(.float32),
         scale: scale,
         mask: mask
       )

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift
@@ -267,8 +267,9 @@ public actor ZImageTurboGenerator: ImageGenerator, ChatGenerator {
                 debugLog?("chat: decoded response length=\(cleanedResponse.count)")
 
                 return ChatResponse(
-                    response: cleanedResponse,
-                    tokensGenerated: generatedTokens.count
+                    generatedText: cleanedResponse,
+                    tokensGenerated: generatedTokens.count,
+                    showThinking: request.showThinking
                 )
             }()
 

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -642,6 +642,34 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.messages[0].content, "Follow repo rules.")
     }
 
+    func testChatRequestMapsSupportedStopSequences() throws {
+        let single = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            stop: .string("END")
+        )
+        let singleRequest = try APIServerContract.chatRequest(
+            from: single,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: RuntimeServingEngine.textCode.openAICompatibility
+        )
+        XCTAssertEqual(singleRequest.stopSequences, ["END"])
+
+        let multiple = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            stop: .array(["END", "", "\nif __name__"])
+        )
+        let multipleRequest = try APIServerContract.chatRequest(
+            from: multiple,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: RuntimeServingEngine.textCode.openAICompatibility
+        )
+        XCTAssertEqual(multipleRequest.stopSequences, ["END", "\nif __name__"])
+    }
+
     func testChatRequestValidatesImageContentPartsAgainstEngineCapability() throws {
         let data = """
         {

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -28,6 +28,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertNil(cmd.models)
         XCTAssertEqual(cmd.suite, .humanEvalSlice)
         XCTAssertNil(cmd.tasks)
+        XCTAssertNil(cmd.humanevalFile)
         XCTAssertEqual(cmd.maxTokens, 1024)
         XCTAssertEqual(cmd.temperature, 0)
         XCTAssertEqual(cmd.topP, 1)
@@ -67,6 +68,45 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertTrue(cmd.dryRun)
         XCTAssertTrue(cmd.allowCodeExecution)
         XCTAssertTrue(cmd.json)
+    }
+
+    func testCodeBenchmarkParsesHumanEvalFile() throws {
+        let url = try makeHumanEvalJSONLFixture()
+        let cmd = try ModelBenchmarkCode.parse([
+            "--tasks", "HumanEval/42",
+            "--humaneval-file", url.path,
+            "--dry-run",
+        ])
+
+        XCTAssertEqual(cmd.humanevalFile, url.path)
+        XCTAssertEqual(cmd.tasks, "HumanEval/42")
+    }
+
+    func testHumanEvalJSONLLoaderDecodesOfficialShape() throws {
+        let url = try makeHumanEvalJSONLFixture()
+
+        let tasks = try HumanEvalJSONLLoader.load(from: url)
+
+        XCTAssertEqual(tasks.count, 1)
+        XCTAssertEqual(tasks[0].taskID, "HumanEval/42")
+        XCTAssertEqual(tasks[0].entryPoint, "answer")
+        XCTAssertTrue(tasks[0].prompt.contains("def answer()"))
+        XCTAssertTrue(tasks[0].tests.contains("assert candidate() == 42"))
+    }
+
+    private func makeHumanEvalJSONLFixture() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-humaneval-loader-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        let url = directory.appendingPathComponent("HumanEval.jsonl")
+        let line = """
+        {"task_id":"HumanEval/42","prompt":"def answer():\\n    pass\\n","entry_point":"answer","canonical_solution":"    return 42\\n","test":"def check(candidate):\\n    assert candidate() == 42\\n"}
+        """
+        try Data((line + "\n").utf8).write(to: url)
+        return url
     }
 
     func testCodeExecutionSandboxNoneRunsPython() throws {

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -42,7 +42,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
 
     func testCodeBenchmarkParsesOverrides() throws {
         let cmd = try ModelBenchmarkCode.parse([
-            "--models", "text-agent-ornith-9b,text-code-north-mini",
+            "--models", "text-agent-ornith-35b-mlx,text-code-north-mini",
             "--suite", "humaneval-slice",
             "--tasks", "HumanEval/0,HumanEval/8",
             "--max-tokens", "256",
@@ -56,7 +56,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
             "--json",
         ])
 
-        XCTAssertEqual(cmd.models, "text-agent-ornith-9b,text-code-north-mini")
+        XCTAssertEqual(cmd.models, "text-agent-ornith-35b-mlx,text-code-north-mini")
         XCTAssertEqual(cmd.suite, .humanEvalSlice)
         XCTAssertEqual(cmd.tasks, "HumanEval/0,HumanEval/8")
         XCTAssertEqual(cmd.maxTokens, 256)

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -28,7 +28,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertNil(cmd.models)
         XCTAssertEqual(cmd.suite, .humanEvalSlice)
         XCTAssertNil(cmd.tasks)
-        XCTAssertEqual(cmd.maxTokens, 512)
+        XCTAssertEqual(cmd.maxTokens, 1024)
         XCTAssertEqual(cmd.temperature, 0)
         XCTAssertEqual(cmd.topP, 1)
         XCTAssertEqual(cmd.executionTimeout, 5)

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -99,6 +99,29 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textCode)
     }
 
+    func testOrnith35BProviderUsesNativeManagedModelID() throws {
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog
+                .allTierRecommendations(
+                    on: MereRunMachineProfile(
+                        physicalMemoryBytes: 64 * 1_073_741_824,
+                        processorName: "M4 Max",
+                        isAppleSiliconMac: true
+                    )
+                )
+                .first { $0.id == Ornith35BCodeResources.modelId }
+        )
+
+        let providerModel = SetupAgentRuntime.providerModel(for: recommendation)
+
+        XCTAssertEqual(providerModel.id, Ornith35BCodeResources.modelId)
+        XCTAssertEqual(providerModel.contextWindow, Ornith35BCodeResources.runtimeContextLength)
+        XCTAssertEqual(providerModel.maxTokens, Ornith35BCodeResources.maxOutputTokens)
+        XCTAssertFalse(providerModel.reasoning)
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textCode)
+    }
+
     func testOrnithProviderUsesNativeQ35ManagedModelID() throws {
         let recommendation = try XCTUnwrap(
             MereRunAgentModelCatalog

--- a/Tests/MereRunCoreTests/Gemma4JSONConstrainedDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4JSONConstrainedDecodingTests.swift
@@ -107,6 +107,26 @@ final class Gemma4JSONConstrainedDecodingTests: XCTestCase {
         XCTAssertNotEqual(token, 1)
     }
 
+    func testGenerationConfigBannedTokensFlowThroughGreedyTokenArray() {
+        let logits = MLXArray([Float]([0.0, 8.0, 0.0, 0.0]))
+        var config = GenerationConfig(temperature: 0)
+        config.bannedTokens = [1]
+        let token = greedySampleTokenArray(logits: logits, config: config, previousTokens: [])
+        XCTAssertNotEqual(token.item(Int.self), 1)
+    }
+
+    func testGreedyTokenArrayHonorsTensorRepetitionPenalty() {
+        let logits = MLXArray([Float]([0.0, 5.0, 4.0]))
+        let config = GenerationConfig(temperature: 0, repetitionPenalty: 2.0)
+        let previous = MLXArray([Int32(1)])
+        let token = greedySampleTokenArray(
+            logits: logits,
+            config: config,
+            previousTokenIndices: previous
+        )
+        XCTAssertEqual(token.item(Int.self), 2)
+    }
+
     func testGemma4MultimodalDecodeBanIncludesVisionPromptTokens() {
         let banned = Gemma4Generator.multimodalDecodeBannedTokens(
             imageTokenId: 10,

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -201,10 +201,10 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         configObject["hidden_size_per_layer_input"] = 0
         let config = try decodeTextConfig(configObject)
         let model = Gemma4TextCausalLM(config: config)
-        let caches = try XCTUnwrap(model.makeCache(quantization: nil) as? [Gemma4AttentionCache])
+        let caches = model.makeAttentionCache(quantization: nil)
         let inputIds = MLXArray([Int32(3), Int32(4)]).reshaped(1, 2)
 
-        let output = model.forwardForSpeculation(inputIds: inputIds, cache: caches as [AnyObject])
+        let output = model.forwardForSpeculation(inputIds: inputIds, cache: caches)
 
         MLX.eval(output.logits, output.hidden)
         XCTAssertEqual(output.logits.shape, [1, 2, config.vocabSize])

--- a/Tests/MereRunCoreTests/Ideogram4RuntimeTests.swift
+++ b/Tests/MereRunCoreTests/Ideogram4RuntimeTests.swift
@@ -152,6 +152,32 @@ final class Ideogram4RuntimeTests: XCTestCase {
         XCTAssertTrue(MLX.max(MLX.abs(features.asType(.float32))).item(Float.self).isFinite)
     }
 
+    func testQwenTextEncoderGroupedQueryAttentionRunsOnFastPrefillPath() {
+        let encoder = QwenEncoder(configuration: QwenTextEncoderConfiguration(
+            vocabSize: 32,
+            hiddenSize: 8,
+            numHiddenLayers: 1,
+            numAttentionHeads: 4,
+            numKeyValueHeads: 2,
+            intermediateSize: 16,
+            ropeTheta: 10_000,
+            maxPositionEmbeddings: 32,
+            rmsNormEps: 1e-6,
+            headDim: 2
+        ))
+        let inputIds = MLXArray([Int32(1), Int32(2), Int32(3), Int32(4)]).reshaped(1, 4)
+        let attentionMask = MLXArray([Int32(1), Int32(1), Int32(1), Int32(1)]).reshaped(1, 4)
+
+        let output = encoder.forward(
+            inputIds: inputIds,
+            attentionMask: attentionMask
+        ).lastHiddenState
+        eval(output)
+
+        XCTAssertEqual(output.shape, [1, 4, 8])
+        XCTAssertTrue(MLX.max(MLX.abs(output.asType(.float32))).item(Float.self).isFinite)
+    }
+
     func testTextFeatureConcatenationInterleavesActivationLayersPerHiddenChannel() {
         let layer0 = MLXArray([1, 2, 3, 4], [1, 2, 2])
         let layer1 = MLXArray([10, 20, 30, 40], [1, 2, 2])

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -317,6 +317,20 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("optiq_metadata.json"), true)
     }
 
+    func testOrnith35BMLXUsesLocalNativeQ35Source() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.ornith35BMLXModelId))
+
+        XCTAssertEqual(spec.category, .textCode)
+        XCTAssertEqual(spec.installShape, .directoryRoot)
+        XCTAssertNil(spec.hubFallback)
+        XCTAssertEqual(spec.upstreamRepoId, Q35Resources.ornith35BMLXUpstreamRepoId)
+        XCTAssertEqual(spec.upstreamRevision, Q35Resources.ornith35BMLXUpstreamRevision)
+        XCTAssertEqual(spec.validationKind, .q35)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.estimatedDownloadBytes, Q35Resources.ornith35BMLXEstimatedDownloadBytes)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
+    }
+
     func testInfinityParser2FlashUsesNativeQ35VisionOCRSpec() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.infinityParser2FlashModelId))
 

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -378,6 +378,23 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textCode)
     }
 
+    func testOrnith35BUsesPinnedGGUFHubSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Ornith35BCodeResources.modelId))
+
+        XCTAssertEqual(spec.category, .textCode)
+        XCTAssertEqual(spec.installShape, .singleFile(relativePath: Ornith35BCodeResources.managedRelativePath))
+        XCTAssertEqual(spec.hubFallback?.repoId, Ornith35BCodeResources.upstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Ornith35BCodeResources.upstreamRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, [Ornith35BCodeResources.ggufFile])
+        XCTAssertEqual(spec.hubFallback?.filePath, Ornith35BCodeResources.ggufFile)
+        XCTAssertEqual(spec.upstreamRepoId, Ornith35BCodeResources.upstreamRepoId)
+        XCTAssertEqual(spec.upstreamRevision, Ornith35BCodeResources.upstreamRevision)
+        XCTAssertEqual(spec.validationKind, .codegenGGUF)
+        XCTAssertTrue(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.estimatedDownloadBytes, Ornith35BCodeResources.estimatedDownloadBytes)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textCode)
+    }
+
     func testLFM2UsesLiquidAIHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: LFM2Resources.defaultModelId))
 

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -121,6 +121,26 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textChatQ35)
     }
 
+    func testOrnith35BIsSupportedOnSixtyFourGBAndStartableThroughTextCode() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Ornith35BCodeResources.modelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog
+                .allTierRecommendations(on: machine)
+                .first { $0.id == Ornith35BCodeResources.modelId }
+        )
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textCode)
+    }
+
     func testUnsupportedRuntimeIsRejected() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -141,6 +141,26 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textCode)
     }
 
+    func testOrnith35BMLXIsSupportedOnThirtyTwoGBAndStartableThroughQ35() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.ornith35BMLXModelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog
+                .allTierRecommendations(on: machine)
+                .first { $0.id == Q35Resources.ornith35BMLXModelId }
+        )
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textChatQ35)
+    }
+
     func testUnsupportedRuntimeIsRejected() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-klein-nano"))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -188,6 +188,25 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
+    func testOrnith35BMLXTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .ornith35BMLX, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, Q35Resources.ornith35BMLXModelId)
+        XCTAssertEqual(manifest.engine, .qwen35HybridMoE)
+        XCTAssertEqual(manifest.family, .code)
+        XCTAssertEqual(manifest.tier, .small)
+        XCTAssertEqual(manifest.variant, .standard)
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine-moe")
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration]))
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(Q35Resources.ornith35BMLXUpstreamRepoId)@\(Q35Resources.ornith35BMLXUpstreamRevision)"
+        )
+    }
+
     func testOrnith35BTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .ornith35B, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -188,6 +188,25 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
+    func testOrnith35BTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(for: .ornith35B, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.id, Ornith35BCodeResources.modelId)
+        XCTAssertEqual(manifest.engine, .qwen3Coder)
+        XCTAssertEqual(manifest.family, .code)
+        XCTAssertEqual(manifest.tier, .small)
+        XCTAssertEqual(manifest.variant, .standard)
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "gguf-q4-k-m")
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration]))
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(Ornith35BCodeResources.upstreamRepoId)@\(Ornith35BCodeResources.upstreamRevision)"
+        )
+    }
+
     func testHiDreamO1DevTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .hidreamO1Dev, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -385,6 +385,24 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertFalse(report.warnings.contains { $0.contains("family=code expects") })
     }
 
+    func testOrnith35BMLXQ35RootLayoutPassesValidationWithoutEngineWarning() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(Q35Resources.ornith35BMLXModelId, isDirectory: true)
+        try writeMinimalValidQ35FamilyModel(at: root, id: .ornith35BMLX)
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: Q35Resources.ornith35BMLXModelId
+        )
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.family, .code)
+        XCTAssertEqual(report.manifest?.tier, .small)
+        XCTAssertFalse(report.warnings.contains { $0.contains("family=code expects") })
+    }
+
     func testLFM2ChatOnlyRootLayoutPassesValidation() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
+++ b/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
@@ -92,6 +92,51 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
         XCTAssertLessThan(maxDiff, 0.001)
     }
 
+    func testQ35SwitchLinearSortedRouteMatchesUnsortedRoute() throws {
+        let routeCount = 64
+        let inputDims = 4
+        let outputDims = 3
+        let numExperts = 5
+        let weightValues = (0..<(numExperts * outputDims * inputDims)).map {
+            Float(($0 % 23) - 11) / 13.0
+        }
+        let inputValues = (0..<(routeCount * inputDims)).map {
+            Float(($0 % 17) - 8) / 9.0
+        }
+        let expertIndices = (0..<routeCount).map { Int32(($0 * 3 + 2) % numExperts) }
+        let flatX = MLXArray(inputValues, [routeCount, 1, inputDims])
+        let indices = MLXArray(expertIndices, [routeCount])
+
+        let layer = Q35SwitchLinear(
+            inputDims: inputDims,
+            outputDims: outputDims,
+            numExperts: numExperts,
+            groupSize: 64,
+            bits: 4,
+            quantized: false,
+            bias: false
+        )
+        try layer.update(
+            parameters: ModuleParameters.unflattened([
+                ("weight", MLXArray(weightValues, [numExperts, outputDims, inputDims])),
+            ]),
+            verify: .none
+        )
+
+        let expected = layer.applyFlat(flatX, indices: indices, sortedIndices: false)
+        let order = argSort(indices, axis: 0)
+        let inverseOrder = argSort(order, axis: 0)
+        let actual = layer.applyFlat(
+            flatX.take(order, axis: 0),
+            indices: indices.take(order, axis: 0),
+            sortedIndices: true
+        )
+        .take(inverseOrder, axis: 0)
+
+        let maxDiff = MLX.max(MLX.abs(expected.asType(.float32) - actual.asType(.float32))).item(Float.self)
+        XCTAssertLessThan(maxDiff, 0.0001)
+    }
+
     func testDequantizedGatherFallbackMatchesGatherQMM() {
         let weightValues = (0..<384).map { Float($0 % 17) / 16.0 - 0.5 }
         let denseWeight = MLXArray(weightValues, [3, 4, 32])

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -50,6 +50,61 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(normalizedPyTorch.shape, [8, 4, 1])
     }
 
+    func testQ35GatedDeltaMetalMatchesOpsReference() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Q35 gated-delta Metal parity requires MERERUN_TEST_MLX_DEVICE=gpu.")
+        }
+
+        let batch = 1
+        let sequence = 3
+        let numKeyHeads = 2
+        let numValueHeads = 4
+        let keyHeadDim = 32
+        let valueHeadDim = 4
+
+        MLXRandom.seed(11)
+        let q = MLXRandom.uniform(-0.3 ..< 0.3, [batch, sequence, numKeyHeads, keyHeadDim])
+        let k = MLXRandom.uniform(-0.3 ..< 0.3, [batch, sequence, numKeyHeads, keyHeadDim])
+        let v = MLXRandom.uniform(-0.3 ..< 0.3, [batch, sequence, numValueHeads, valueHeadDim])
+        let a = MLXRandom.uniform(-0.1 ..< 0.1, [batch, sequence, numValueHeads])
+        let b = MLXRandom.uniform(-0.1 ..< 0.1, [batch, sequence, numValueHeads])
+        let aLog = MLXRandom.uniform(-0.2 ..< 0.2, [numValueHeads])
+        let dtBias = MLXRandom.uniform(-0.2 ..< 0.2, [numValueHeads])
+        let state = MLXRandom.uniform(-0.1 ..< 0.1, [batch, numValueHeads, valueHeadDim, keyHeadDim])
+
+        let reference = q35GatedDeltaUpdateOps(
+            q: q,
+            k: k,
+            v: v,
+            a: a,
+            b: b,
+            aLog: aLog,
+            dtBias: dtBias,
+            state: state,
+            numKeyHeads: numKeyHeads,
+            numValueHeads: numValueHeads,
+            valueHeadDim: valueHeadDim
+        )
+        let fast = try XCTUnwrap(q35GatedDeltaUpdateMetal(
+            q: q,
+            k: k,
+            v: v,
+            a: a,
+            b: b,
+            aLog: aLog,
+            dtBias: dtBias,
+            state: state,
+            numKeyHeads: numKeyHeads,
+            numValueHeads: numValueHeads,
+            valueHeadDim: valueHeadDim
+        ))
+
+        let outputMaxDiff = MLX.max(MLX.abs(reference.0.asType(.float32) - fast.0.asType(.float32))).item(Float.self)
+        let stateMaxDiff = MLX.max(MLX.abs(reference.1.asType(.float32) - fast.1.asType(.float32))).item(Float.self)
+        XCTAssertEqual(outputMaxDiff, 0, accuracy: 1e-5)
+        XCTAssertEqual(stateMaxDiff, 0, accuracy: 1e-5)
+    }
+
     func testQ35RMSNormOffsetConversionSkipsLinearAttentionGateNorm() {
         XCTAssertTrue(Q35Generator.isOffsetRMSNormWeight("model.layers.0.input_layernorm.weight"))
         XCTAssertTrue(Q35Generator.isOffsetRMSNormWeight("model.layers.0.post_attention_layernorm.weight"))

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -50,6 +50,37 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(normalizedPyTorch.shape, [8, 4, 1])
     }
 
+    func testQ35FusedPortableQuantizedLinearMatchesSeparateOutputs() {
+        MLXRandom.seed(42)
+        let lhs = PortableQuantizedLinear(
+            weight: MLXRandom.uniform(-1.0 ..< 1.0, [4, 32]),
+            bias: nil,
+            groupSize: 32,
+            bits: 4,
+            mode: .affine
+        )
+        let rhs = PortableQuantizedLinear(
+            weight: MLXRandom.uniform(-1.0 ..< 1.0, [6, 32]),
+            bias: nil,
+            groupSize: 32,
+            bits: 4,
+            mode: .affine
+        )
+        guard let fused = q35FusedPortableQuantizedLinear(lhs, rhs) else {
+            XCTFail("Expected compatible quantized projections to fuse")
+            return
+        }
+
+        let input = MLXRandom.uniform(-1.0 ..< 1.0, [2, 3, 32])
+        let separate = MLX.concatenated([lhs(input), rhs(input)], axis: -1)
+        let together = fused(input)
+        MLX.eval(separate, together)
+
+        XCTAssertEqual(together.shape, separate.shape)
+        let maxDiff = MLX.max(MLX.abs((together - separate).asType(.float32))).item(Float.self)
+        XCTAssertLessThan(maxDiff, 1e-4)
+    }
+
     func testQ35GatedDeltaMetalMatchesOpsReference() throws {
         guard Device.defaultDevice().deviceType == .gpu else {
             throw XCTSkip("Q35 gated-delta Metal parity requires MERERUN_TEST_MLX_DEVICE=gpu.")
@@ -429,6 +460,22 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(config.quantization?.mode, "affine")
         XCTAssertFalse(config.textConfig.usesMoE)
         XCTAssertEqual(config.textConfig.hiddenSize, 4096)
+    }
+
+    func testQ35ConfigUsesMLXLMNormTopKDefault() throws {
+        var configObject = makeBaseConfig()
+        var textConfig = configObject["text_config"] as? [String: Any] ?? [:]
+        textConfig.removeValue(forKey: "norm_topk_prob")
+        configObject["text_config"] = textConfig
+
+        let defaulted = try decodeConfig(configObject)
+        XCTAssertFalse(defaulted.textConfig.normTopKProb)
+
+        textConfig["norm_topk_prob"] = true
+        configObject["text_config"] = textConfig
+
+        let explicit = try decodeConfig(configObject)
+        XCTAssertTrue(explicit.textConfig.normTopKProb)
     }
 
     func testQ35DenseFeedForwardRuntimeProducesLogits() throws {

--- a/Tests/MereRunCoreTests/TextGenerationStopSequencesTests.swift
+++ b/Tests/MereRunCoreTests/TextGenerationStopSequencesTests.swift
@@ -62,4 +62,51 @@ final class TextGenerationStopSequencesTests: XCTestCase {
         XCTAssertEqual(request.stopSequences, ["END"])
         XCTAssertEqual(response.finishReason, .stopSequence)
     }
+
+    func testReasoningMarkupSplitsThinkBlocks() {
+        let split = ChatReasoningMarkup.splitThinkBlocks(
+            in: "<think>first thought</think>Final <think>second thought</think>answer"
+        )
+
+        XCTAssertEqual(split.visibleContent, "Final answer")
+        XCTAssertEqual(split.reasoningContent, "first thought\n\nsecond thought")
+        XCTAssertFalse(split.hasIncompleteReasoning)
+    }
+
+    func testReasoningMarkupCapturesIncompleteThinkBlock() {
+        let split = ChatReasoningMarkup.splitThinkBlocks(in: "before <think>still working")
+
+        XCTAssertEqual(split.visibleContent, "before")
+        XCTAssertEqual(split.reasoningContent, "still working")
+        XCTAssertTrue(split.hasIncompleteReasoning)
+    }
+
+    func testReasoningMarkupHandlesLeadingOrphanClose() {
+        let split = ChatReasoningMarkup.splitThinkBlocks(
+            in: "hidden reasoning</think>The visible answer."
+        )
+
+        XCTAssertEqual(split.visibleContent, "The visible answer.")
+        XCTAssertEqual(split.reasoningContent, "hidden reasoning")
+    }
+
+    func testReasoningMarkupKeepsVisibleTextBeforeLateOrphanClose() {
+        let split = ChatReasoningMarkup.splitThinkBlocks(
+            in: "<think>draft</think>Final answer.</think>"
+        )
+
+        XCTAssertEqual(split.visibleContent, "Final answer.")
+        XCTAssertEqual(split.reasoningContent, "draft")
+    }
+
+    func testChatResponseSeparatesReasoningWhenThinkingHidden() {
+        let response = ChatResponse(
+            generatedText: "<think>work</think>Answer",
+            tokensGenerated: 4,
+            showThinking: false
+        )
+
+        XCTAssertEqual(response.response, "Answer")
+        XCTAssertEqual(response.reasoningContent, "work")
+    }
 }

--- a/Tests/MereRunCoreTests/TextGenerationStopSequencesTests.swift
+++ b/Tests/MereRunCoreTests/TextGenerationStopSequencesTests.swift
@@ -71,6 +71,8 @@ final class TextGenerationStopSequencesTests: XCTestCase {
         XCTAssertEqual(split.visibleContent, "Final answer")
         XCTAssertEqual(split.reasoningContent, "first thought\n\nsecond thought")
         XCTAssertFalse(split.hasIncompleteReasoning)
+        XCTAssertEqual(split.reasoningBlockCount, 2)
+        XCTAssertTrue(split.hasReopenedReasoning)
     }
 
     func testReasoningMarkupCapturesIncompleteThinkBlock() {
@@ -79,6 +81,8 @@ final class TextGenerationStopSequencesTests: XCTestCase {
         XCTAssertEqual(split.visibleContent, "before")
         XCTAssertEqual(split.reasoningContent, "still working")
         XCTAssertTrue(split.hasIncompleteReasoning)
+        XCTAssertEqual(split.reasoningBlockCount, 1)
+        XCTAssertFalse(split.hasReopenedReasoning)
     }
 
     func testReasoningMarkupHandlesLeadingOrphanClose() {
@@ -88,6 +92,8 @@ final class TextGenerationStopSequencesTests: XCTestCase {
 
         XCTAssertEqual(split.visibleContent, "The visible answer.")
         XCTAssertEqual(split.reasoningContent, "hidden reasoning")
+        XCTAssertEqual(split.reasoningBlockCount, 1)
+        XCTAssertFalse(split.hasReopenedReasoning)
     }
 
     func testReasoningMarkupKeepsVisibleTextBeforeLateOrphanClose() {
@@ -97,6 +103,19 @@ final class TextGenerationStopSequencesTests: XCTestCase {
 
         XCTAssertEqual(split.visibleContent, "Final answer.")
         XCTAssertEqual(split.reasoningContent, "draft")
+        XCTAssertEqual(split.reasoningBlockCount, 1)
+        XCTAssertFalse(split.hasReopenedReasoning)
+    }
+
+    func testReasoningMarkupFlagsThinkBlockReopenedAfterFinalText() {
+        let split = ChatReasoningMarkup.splitThinkBlocks(
+            in: "<think>draft</think>Final answer.<think>looping again</think>Duplicate answer."
+        )
+
+        XCTAssertEqual(split.visibleContent, "Final answer.Duplicate answer.")
+        XCTAssertEqual(split.reasoningContent, "draft\n\nlooping again")
+        XCTAssertEqual(split.reasoningBlockCount, 2)
+        XCTAssertTrue(split.hasReopenedReasoning)
     }
 
     func testChatResponseSeparatesReasoningWhenThinkingHidden() {
@@ -108,5 +127,7 @@ final class TextGenerationStopSequencesTests: XCTestCase {
 
         XCTAssertEqual(response.response, "Answer")
         XCTAssertEqual(response.reasoningContent, "work")
+        XCTAssertEqual(response.reasoningBlockCount, 1)
+        XCTAssertFalse(response.hasReopenedReasoning)
     }
 }

--- a/Tests/MereRunCoreTests/TextGenerationStopSequencesTests.swift
+++ b/Tests/MereRunCoreTests/TextGenerationStopSequencesTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import MereRunCore
+
+final class TextGenerationStopSequencesTests: XCTestCase {
+    func testTrimmingStopsAtNorthRenderedChannelMarker() {
+        let response = """
+        def has_close_elements(numbers, threshold):
+            return False
+        <|CHANNEL_END|><|END_OFTURN_TOKEN|>|
+
+        def has_close_elements(numbers, threshold):
+            return True
+        """
+
+        let trimmed = TextGenerationStopSequences.trimming(
+            response,
+            sequences: TextGenerationStopSequences.defaultRenderedChatStops
+        )
+
+        XCTAssertEqual(trimmed.matchedSequence, "<|CHANNEL_END|>")
+        XCTAssertEqual(
+            trimmed.text,
+            """
+            def has_close_elements(numbers, threshold):
+                return False
+            """
+        )
+    }
+
+    func testFirstMatchPrefersEarliestStopSequence() {
+        let response = "answer<|im_end|> trailing <|CHANNEL_END|>"
+
+        let match = TextGenerationStopSequences.firstMatch(
+            in: response,
+            sequences: TextGenerationStopSequences.defaultRenderedChatStops
+        )
+
+        XCTAssertEqual(match?.sequence, "<|im_end|>")
+    }
+
+    func testMergedPreservesLeadingNewlineStopSequences() {
+        let sequences = TextGenerationStopSequences.merged([
+            "\nif __name__",
+            "\nif __name__",
+            "   ",
+        ])
+
+        XCTAssertEqual(sequences, ["\nif __name__"])
+    }
+
+    func testChatRequestAndResponseCarryStopMetadata() {
+        let request = ChatRequest(
+            messages: [ChatMessage(role: .user, content: "hi")],
+            stopSequences: ["END"]
+        )
+        let response = ChatResponse(
+            response: "ok",
+            tokensGenerated: 1,
+            finishReason: .stopSequence
+        )
+
+        XCTAssertEqual(request.stopSequences, ["END"])
+        XCTAssertEqual(response.finishReason, .stopSequence)
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1268,8 +1268,10 @@ timeout and temporary-directory hygiene are enough. The default generation cap i
 or `capped=true` in text output. Reasoning blocks are preserved separately as
 `reasoningCharacters`/`reasoning_chars` and
 `incompleteReasoning`/`reasoning_incomplete`, while only visible code is
-executed. Use `--models` and `--tasks` to narrow the slice while iterating. Use
-`--models text-agent-ornith-35b` for the larger Ornith GGUF eval target.
+executed. `reasoning_reopened=true` flags a second generated reasoning block,
+which usually indicates a loop or phase restart. Use `--models` and `--tasks`
+to narrow the slice while iterating. Use `--models text-agent-ornith-35b` for
+the larger Ornith GGUF eval target.
 
 For a larger slice from the official HumanEval data, download and decompress
 `HumanEval.jsonl.gz`, then pass the JSONL file with `--humaneval-file`:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1254,8 +1254,10 @@ a per-candidate timeout. Because scoring executes generated code locally, pass
 `--allow-code-execution` for real runs or `--dry-run` to inspect the plan.
 The default `--sandbox auto` uses `sandbox-exec` on macOS and `bubblewrap` on
 Linux when available. Use `--sandbox none` only for a trusted local smoke where
-timeout and temporary-directory hygiene are enough. Use `--models` and `--tasks`
-to narrow the slice while iterating.
+timeout and temporary-directory hygiene are enough. The default generation cap is
+`--max-tokens 1024`, and capped cases are reported as `reachedMaxTokens` in JSON
+or `capped=true` in text output. Use `--models` and `--tasks` to narrow the
+slice while iterating.
 
 ### `mere.run model benchmark vlm`
 
@@ -1430,8 +1432,8 @@ OpenAI chat compatibility:
 - Native engines decode the common OpenAI Chat request shape and reject
   unsupported high-impact fields with `invalid_request_error`.
 - `max_completion_tokens`, `developer` messages, function tools, image content
-  parts, structured JSON mode, and streaming usage are capability-gated by
-  engine.
+  parts, structured JSON mode, `stop` sequences, and streaming usage are
+  capability-gated by engine.
 - `tool_choice` accepts `none`, `auto`, `required`, and specific function
   choices by narrowing the advertised tool list to the named function.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1259,6 +1259,19 @@ timeout and temporary-directory hygiene are enough. The default generation cap i
 or `capped=true` in text output. Use `--models` and `--tasks` to narrow the
 slice while iterating.
 
+For a larger slice from the official HumanEval data, download and decompress
+`HumanEval.jsonl.gz`, then pass the JSONL file with `--humaneval-file`:
+
+```bash
+curl -L https://raw.githubusercontent.com/openai/human-eval/master/data/HumanEval.jsonl.gz \
+  -o /tmp/HumanEval.jsonl.gz
+gunzip -c /tmp/HumanEval.jsonl.gz > /tmp/HumanEval.jsonl
+swift run mere.run model benchmark code \
+  --humaneval-file /tmp/HumanEval.jsonl \
+  --tasks HumanEval/0,HumanEval/1,HumanEval/2,HumanEval/3,HumanEval/4 \
+  --allow-code-execution
+```
+
 ### `mere.run model benchmark vlm`
 
 Run a tiny synthetic VLM smoke, or use `lmms-eval` to compare an installed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ are:
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`
-- Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`
+- Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Text anonymize: `text-anonymize-privacy-filter`
 - Speech TTS: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`
@@ -456,6 +456,14 @@ same native Swift/llama.cpp code path:
 ```bash
 swift run mere.run model pull text-agent-ornith-35b
 swift run mere.run text code --model text-agent-ornith-35b --prompt "Sketch a small Swift Result helper."
+```
+
+`text-agent-ornith-35b-mlx` is the native Swift/MLX lane for a locally converted
+Ornith 1.0 35B Q4 directory. It is intentionally local-only until a converted
+MLX snapshot is published:
+
+```bash
+swift run mere.run text chat --model text-agent-ornith-35b-mlx --prompt "Sketch a small Swift Result helper."
 ```
 
 ### `mere.run text embed`
@@ -1547,10 +1555,13 @@ installed llama.cpp runtime supports the `cohere2moe` architecture.
 Ornith (`text-agent-ornith-9b`) is available as an experimental native
 MLX/OptiQ coding-agent model. It uses the Qwen-family runtime, so serve it with
 `api serve --engine text-chat-q36 --model text-agent-ornith-9b`.
+The local converted Ornith 35B MLX target (`text-agent-ornith-35b-mlx`) uses
+the same native Qwen-family serving engine when installed.
 The larger Ornith 35B GGUF target (`text-agent-ornith-35b`) is also available
 for explicit evals and runs through:
 
 ```bash
+swift run mere.run api serve --engine text-chat-q36 --model text-agent-ornith-35b-mlx
 swift run mere.run api serve --engine text-code --model text-agent-ornith-35b
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ are:
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`
-- Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-code-north-mini`, `text-code-qwen3`
+- Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Text anonymize: `text-anonymize-privacy-filter`
 - Speech TTS: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`
@@ -447,6 +447,15 @@ Swift/llama.cpp code path as Qwen:
 ```bash
 swift run mere.run model pull text-code-north-mini
 swift run mere.run text code --model text-code-north-mini --prompt "Sketch a small Swift Result helper."
+```
+
+Ornith 35B is managed as `text-agent-ornith-35b` for larger local coding-agent
+comparisons. It pulls DeepReinforce's Q4_K_M GGUF quant and runs through the
+same native Swift/llama.cpp code path:
+
+```bash
+swift run mere.run model pull text-agent-ornith-35b
+swift run mere.run text code --model text-agent-ornith-35b --prompt "Sketch a small Swift Result helper."
 ```
 
 ### `mere.run text embed`
@@ -1257,7 +1266,8 @@ Linux when available. Use `--sandbox none` only for a trusted local smoke where
 timeout and temporary-directory hygiene are enough. The default generation cap is
 `--max-tokens 1024`, and capped cases are reported as `reachedMaxTokens` in JSON
 or `capped=true` in text output. Use `--models` and `--tasks` to narrow the
-slice while iterating.
+slice while iterating. Use `--models text-agent-ornith-35b` for the larger
+Ornith GGUF eval target.
 
 For a larger slice from the official HumanEval data, download and decompress
 `HumanEval.jsonl.gz`, then pass the JSONL file with `--humaneval-file`:
@@ -1533,6 +1543,12 @@ installed llama.cpp runtime supports the `cohere2moe` architecture.
 Ornith (`text-agent-ornith-9b`) is available as an experimental native
 MLX/OptiQ coding-agent model. It uses the Qwen-family runtime, so serve it with
 `api serve --engine text-chat-q36 --model text-agent-ornith-9b`.
+The larger Ornith 35B GGUF target (`text-agent-ornith-35b`) is also available
+for explicit evals and runs through:
+
+```bash
+swift run mere.run api serve --engine text-code --model text-agent-ornith-35b
+```
 
 BYOA prints a ready-to-paste Claude/Codex prompt. Manual mode prints the
 commands for capabilities, model pulls, serving, and optional Pi installation.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1265,9 +1265,11 @@ The default `--sandbox auto` uses `sandbox-exec` on macOS and `bubblewrap` on
 Linux when available. Use `--sandbox none` only for a trusted local smoke where
 timeout and temporary-directory hygiene are enough. The default generation cap is
 `--max-tokens 1024`, and capped cases are reported as `reachedMaxTokens` in JSON
-or `capped=true` in text output. Use `--models` and `--tasks` to narrow the
-slice while iterating. Use `--models text-agent-ornith-35b` for the larger
-Ornith GGUF eval target.
+or `capped=true` in text output. Reasoning blocks are preserved separately as
+`reasoningCharacters`/`reasoning_chars` and
+`incompleteReasoning`/`reasoning_incomplete`, while only visible code is
+executed. Use `--models` and `--tasks` to narrow the slice while iterating. Use
+`--models text-agent-ornith-35b` for the larger Ornith GGUF eval target.
 
 For a larger slice from the official HumanEval data, download and decompress
 `HumanEval.jsonl.gz`, then pass the JSONL file with `--humaneval-file`:

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -53,6 +53,7 @@ from the runtime catalog used by `mere.run model list`,
 | `text-chat` | `text-chat-gemma4-max` |
 | `text-chat` | `text-chat-q36-nano` |
 | `text-code` | `text-agent-ornith-9b` |
+| `text-code` | `text-agent-ornith-35b-mlx` |
 | `text-code` | `text-agent-qwen35-9b` |
 | `text-code` | `text-code-north-mini` |
 | `text-code` | `text-agent-ornith-35b` |
@@ -115,6 +116,11 @@ a llama.cpp runtime with `cohere2moe` architecture support.
 revision. Ornith is a DeepReinforce agentic coding model with Qwen3.5 text
 architecture metadata; mere.run treats this MLX OptiQ quant as a native
 Qwen-family runtime target for `chat`, `api serve`, and setup-agent experiments.
+
+`text-agent-ornith-35b-mlx` is reserved for a locally converted Q4 MLX snapshot
+of `deepreinforce-ai/Ornith-1.0-35B` at the pinned catalog revision. It runs
+through the native Qwen-family runtime, but has no Hugging Face pull source yet;
+install a converted directory under the local model store before using it.
 
 `text-agent-ornith-35b` installs DeepReinforce's public
 `deepreinforce-ai/Ornith-1.0-35B-GGUF` Q4_K_M file at the pinned catalog

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -55,6 +55,7 @@ from the runtime catalog used by `mere.run model list`,
 | `text-code` | `text-agent-ornith-9b` |
 | `text-code` | `text-agent-qwen35-9b` |
 | `text-code` | `text-code-north-mini` |
+| `text-code` | `text-agent-ornith-35b` |
 | `text-chat` | `text-chat-q36-nano-gguf` |
 | `text-chat` | `text-agent-deepseek-v4-flash` |
 | `text-chat` | `text-chat-lfm25-a1b-8bit` |
@@ -114,6 +115,12 @@ a llama.cpp runtime with `cohere2moe` architecture support.
 revision. Ornith is a DeepReinforce agentic coding model with Qwen3.5 text
 architecture metadata; mere.run treats this MLX OptiQ quant as a native
 Qwen-family runtime target for `chat`, `api serve`, and setup-agent experiments.
+
+`text-agent-ornith-35b` installs DeepReinforce's public
+`deepreinforce-ai/Ornith-1.0-35B-GGUF` Q4_K_M file at the pinned catalog
+revision. It runs through the native Swift/llama.cpp `text code` path for
+larger Ornith coding-agent comparisons and uses a 32K runtime context by
+default to keep local evals predictable.
 
 `text-agent-deepseek-v4-flash` is the preferred managed setup-agent tier on
 96 GB+ Apple Silicon Macs. Smaller Qwen setup agents are lower-memory

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -303,9 +303,9 @@ Engine compatibility:
   image content parts.
 - `text-chat-klein`: supports `response_format: {"type":"json_object"}` with
   local JSON retry behavior.
-- `text-code`: accepts plain text chat requests and rejects tools, images,
-  reasoning controls, logprobs, seed, stop sequences, and structured outputs
-  with explicit errors.
+- `text-code`: accepts plain text chat requests and OpenAI `stop` sequences;
+  rejects tools, images, reasoning controls, logprobs, seed, and structured
+  outputs with explicit errors.
 
 Streaming responses only emit assistant content tokens. Local progress labels
 stay in logs/stderr, and `stream_options.include_usage` adds the final usage

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -303,6 +303,9 @@ Engine compatibility:
 - `text-agent-ornith-9b`: uses the same Qwen-family serving engine for the
   Ornith 1.0 9B OptiQ coding-agent experiment; start it with
   `api serve --engine text-chat-q36 --model text-agent-ornith-9b`.
+- `text-agent-ornith-35b-mlx`: uses the Qwen-family serving engine for a local
+  converted Ornith 1.0 35B Q4 MLX snapshot; start it with
+  `api serve --engine text-chat-q36 --model text-agent-ornith-35b-mlx`.
 - `text-chat-lfm25-a1b-8bit`: uses the LFM2 serving engine with the
   LiquidAI LFM2.5 8B-A1B MLX 8-bit weights, accepts function tools, and rejects
   image content parts.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -283,6 +283,11 @@ supported fields into `ChatRequest` or return an OpenAI-style
 `metadata`, `user`, and `service_tier` are accepted as request context but do
 not change local generation.
 
+For non-streaming chat responses, native runtimes split `<think>...</think>`
+blocks out of `message.content` and expose them as OpenAI-compatible
+`message.reasoning_content` when present. Streaming responses still emit token
+chunks as they are produced.
+
 Engine compatibility:
 
 - `text-chat-deepseek-v4-flash`: raw-proxies the original request body to

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -304,8 +304,10 @@ Engine compatibility:
 - `text-chat-klein`: supports `response_format: {"type":"json_object"}` with
   local JSON retry behavior.
 - `text-code`: accepts plain text chat requests and OpenAI `stop` sequences;
-  rejects tools, images, reasoning controls, logprobs, seed, and structured
-  outputs with explicit errors.
+  use it for GGUF code models such as `text-code-qwen3`,
+  `text-code-north-mini`, and `text-agent-ornith-35b`. It rejects tools,
+  images, reasoning controls, logprobs, seed, and structured outputs with
+  explicit errors.
 
 Streaming responses only emit assistant content tokens. Local progress labels
 stay in logs/stderr, and `stream_options.include_usage` adds the final usage

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -39,7 +39,7 @@ swift run mere.run --models-root /path/to/models model list
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
@@ -97,6 +97,8 @@ setup-agent tier; smaller Qwen agent models are alternatives, not upgrades.
 GGUF code runtime for coding-agent comparisons against `text-code-qwen3`.
 `text-agent-ornith-9b` can be pulled, inspected, and run through the native
 Qwen-family MLX/OptiQ runtime for coding-agent comparisons.
+`text-agent-ornith-35b` is the larger GGUF Ornith eval target and runs through
+the native `text-code`/llama.cpp path.
 
 ### `mere.run model remove`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -39,7 +39,7 @@ swift run mere.run --models-root /path/to/models model list
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
@@ -97,6 +97,9 @@ setup-agent tier; smaller Qwen agent models are alternatives, not upgrades.
 GGUF code runtime for coding-agent comparisons against `text-code-qwen3`.
 `text-agent-ornith-9b` can be pulled, inspected, and run through the native
 Qwen-family MLX/OptiQ runtime for coding-agent comparisons.
+`text-agent-ornith-35b-mlx` is a local-only converted MLX Q4 Ornith target; it
+can be inspected and served once its converted directory exists in the model
+store, but `model pull` is disabled until a converted public snapshot exists.
 `text-agent-ornith-35b` is the larger GGUF Ornith eval target and runs through
 the native `text-code`/llama.cpp path.
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -27,6 +27,7 @@ embeddings, and PII anonymization.
 
 ### Code
 
+- `text-agent-ornith-35b`
 - `text-code-north-mini`
 - `text-code-qwen3`
 
@@ -82,16 +83,23 @@ swift run mere.run text code \
   --prompt "Write a Swift function that reverses a string."
 ```
 
-`text-code-qwen3` and `text-code-north-mini` are native `text code` models and
-run GGUF weights through llama.cpp. North Mini Code uses the Unsloth
-`North-Mini-Code-1.0-UD-Q4_K_M.gguf` quant, so it requires a llama.cpp runtime
-with `cohere2moe` architecture support.
+`text-code-qwen3`, `text-code-north-mini`, and `text-agent-ornith-35b` are
+native `text code` models and run GGUF weights through llama.cpp. North Mini
+Code uses the Unsloth `North-Mini-Code-1.0-UD-Q4_K_M.gguf` quant, so it
+requires a llama.cpp runtime with `cohere2moe` architecture support. Ornith 35B
+uses DeepReinforce's `ornith-1.0-35b-Q4_K_M.gguf` quant for larger coding-agent
+evals.
 
 ```bash
 swift run mere.run model pull text-code-north-mini
 swift run mere.run text code \
   --model text-code-north-mini \
   --prompt "Write a Swift function that reverses a string."
+
+swift run mere.run model pull text-agent-ornith-35b
+swift run mere.run text code \
+  --model text-agent-ornith-35b \
+  --prompt "Write a compact Swift Result helper."
 ```
 
 ### Embeddings

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -21,6 +21,7 @@ embeddings, and PII anonymization.
 - `text-chat-q36-nano`
 - `text-chat-lfm25-a1b-8bit` (managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot)
 - `text-agent-ornith-9b` (experimental native MLX/OptiQ coding-agent snapshot)
+- `text-agent-ornith-35b-mlx` (local native MLX Q4 coding-agent snapshot)
 - `text-agent-deepseek-v4-flash` (API/agent serving)
 - `text-chat-mebot`
 - `text-chat-psi-agent`
@@ -75,6 +76,10 @@ and runs through the native Swift LFM2 runtime. It is text-only; use
 through the native Qwen-family runtime. Use `text chat --model text-agent-ornith-9b`
 or `api serve --engine text-chat-q36 --model text-agent-ornith-9b` for coding-agent
 smoke tests.
+
+`text-agent-ornith-35b-mlx` is the same native Qwen-family runtime lane for a
+locally converted Ornith 1.0 35B Q4 MLX directory. It does not auto-download
+from Hugging Face until a converted snapshot is published.
 
 ### Local code generation
 

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -285,6 +285,42 @@ patch_mlx_cuda_jit_include_path() {
   echo "[prepare-linux-native] patched mlx-swift CUDA JIT include path in ${mlx_jit_module#$repo_root/}."
 }
 
+patch_mlx_cuda_bf16_sigmoid() {
+  local mlx_unary_ops="$1"
+  if [[ ! -f "$mlx_unary_ops" ]]; then
+    return
+  fi
+  if grep -Fq "MERERUN_CUDA_BF16_SIGMOID_ABS" "$mlx_unary_ops"; then
+    return
+  fi
+
+  local mlx_unary_tmp
+  mlx_unary_tmp="$(mktemp "${TMPDIR:-/tmp}/mererun-mlx-unary.XXXXXX")"
+  if ! awk '
+    /T y = 1 \/ \(1 \+ cuda::std::exp\(cuda::std::abs\(x\)\)\);/ && !patched {
+      print "    T y;"
+      print "    if constexpr (cuda::std::is_same_v<T, __nv_bfloat16>) {"
+      print "      // MERERUN_CUDA_BF16_SIGMOID_ABS: CUDA 12.x cannot resolve"
+      print "      // cuda::std::abs(__nv_bfloat16) in NVRTC JIT kernels."
+      print "      float abs_x = cuda::std::abs(static_cast<float>(x));"
+      print "      y = static_cast<T>(1.0f / (1.0f + cuda::std::exp(abs_x)));"
+      print "    } else {"
+      print "      y = 1 / (1 + cuda::std::exp(cuda::std::abs(x)));"
+      print "    }"
+      patched=1
+      next
+    }
+    { print }
+    END { if (!patched) exit 42 }
+  ' "$mlx_unary_ops" >"$mlx_unary_tmp"; then
+    rm -f "$mlx_unary_tmp"
+    echo "[prepare-linux-native] error: could not patch MLX CUDA bf16 sigmoid in ${mlx_unary_ops#$repo_root/}." >&2
+    exit 69
+  fi
+  mv "$mlx_unary_tmp" "$mlx_unary_ops"
+  echo "[prepare-linux-native] patched mlx-swift CUDA bf16 sigmoid in ${mlx_unary_ops#$repo_root/}."
+}
+
 detect_cuda_dependency_defaults() {
   if [[ "$linux_accel" != "cuda" ]]; then
     return
@@ -534,6 +570,8 @@ smoke_mlx_swift_cuda() {
 
   patch_mlx_cuda_jit_include_path "$mlx_cmake_src/Source/Cmlx/mlx/mlx/backend/cuda/jit_module.cpp"
   patch_mlx_cuda_jit_include_path "$mlx_cmake_build/_deps/mlx-src/mlx/backend/cuda/jit_module.cpp"
+  patch_mlx_cuda_bf16_sigmoid "$mlx_cmake_src/Source/Cmlx/mlx/mlx/backend/cuda/device/unary_ops.cuh"
+  patch_mlx_cuda_bf16_sigmoid "$mlx_cmake_build/_deps/mlx-src/mlx/backend/cuda/device/unary_ops.cuh"
 
   local local_openblas_root="$native_root/deps/apt-root"
   local local_openblas_lib="$local_openblas_root/usr/lib/$deb_multiarch/openblas-pthread/libopenblas.so"
@@ -632,6 +670,7 @@ smoke_mlx_swift_cuda() {
   echo "[prepare-linux-native] configuring mlx-swift CUDA smoke via CMake"
   cmake -S "$mlx_cmake_src" -B "$mlx_cmake_build" -G Ninja "${mlx_cmake_args[@]}"
   patch_mlx_cuda_jit_include_path "$mlx_cmake_build/_deps/mlx-src/mlx/backend/cuda/jit_module.cpp"
+  patch_mlx_cuda_bf16_sigmoid "$mlx_cmake_build/_deps/mlx-src/mlx/backend/cuda/device/unary_ops.cuh"
 
   echo "[prepare-linux-native] building mlx-swift CUDA smoke"
   local build_jobs


### PR DESCRIPTION
## Summary
- Add shared text stop-sequence trimming/finish metadata for native chat responses, including North/Cohere rendered markers.
- Wire code benchmarks to pass benchmark-specific stops, raise the default cap to 1024, and report finish/cap metadata.
- Expose supported OpenAI stop sequences for the native text-code API path and document the capability boundary.

## Validation
- ./scripts/check.sh
- pnpm docs:build
- swift test --filter APIServeCommandTests
- swift test --filter ModelBenchmarkCommandTests
- swift test --filter TextGenerationStopSequencesTests
- ./.build/debug/mere.run model benchmark code --models text-code-north-mini --tasks HumanEval/0 --allow-code-execution --json

## Live smoke
North Mini Code HumanEval/0 passed with finishReason=stop_sequence, reachedMaxTokens=false, tokensGenerated=65.