### PR TITLE
Add API workload benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,11 +322,11 @@ swift run mere.run guide open-webui
 scripts/smoke-open-webui.sh print-env
 scripts/smoke-open-webui.sh live-smoke
 
-# Optional Gemma4 prefix KV reuse prototype; status reports cache and timing stats
-MERERUN_GEMMA4_PREFIX_KV_CACHE=1 swift run mere.run api serve --engine text-chat-gemma4
+# Gemma4 prefix KV reuse is on by default for api serve; set 0 for a baseline
+MERERUN_GEMMA4_PREFIX_KV_CACHE=0 swift run mere.run api serve --engine text-chat-gemma4
 
-# Optional Qwen3.6 text-only prefix KV reuse prototype; vision prompts are excluded
-MERERUN_Q35_PREFIX_KV_CACHE=1 swift run mere.run api serve
+# Qwen3.6 text-only prefix KV reuse is also on by default; set 0 for a baseline
+MERERUN_Q35_PREFIX_KV_CACHE=0 swift run mere.run api serve
 
 # Optional decode batching; overlap requires max-active > 1
 MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
@@ -364,6 +364,15 @@ swift run mere.run model benchmark q36-mtp \
   --prompt-repeat-values 8,80,150 \
   --temperature-values 0,0.7 \
   --decode-tokens 32 \
+  --json
+
+# Real serving-path workload: streaming chat TTFT, throughput, cache, and batching counters
+swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-turbo \
+  --max-active-requests 1
+swift run mere.run model benchmark api-workload \
+  --model text-chat-gemma4-turbo \
   --json
 
 # Small real coding-eval slice: Ornith vs North Mini vs Qwen3-Coder

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -470,6 +470,7 @@ enum GuideRegistry {
                 ["model", "benchmark", "gemma4-kv"],
                 ["model", "benchmark", "gemma4-mtp"],
                 ["model", "benchmark", "q36-mtp"],
+                ["model", "benchmark", "api-workload"],
             ],
             models: [
                 "text-chat-gemma4-turbo",

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkAPIWorkloadCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkAPIWorkloadCommand.swift
@@ -1,0 +1,603 @@
+import ArgumentParser
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import MereRunCore
+
+struct ModelBenchmarkAPIWorkload: AsyncParsableCommand {
+    private static let apiKeyEnvironmentKey = "MERERUN_API_KEY"
+
+    static let configuration = CommandConfiguration(
+        commandName: "api-workload",
+        abstract: "Replay a chat workload against a running API server and measure runtime cache counters."
+    )
+
+    @Option(name: [.long], help: "Local API host to benchmark.")
+    var host: String = "127.0.0.1"
+
+    @Option(name: [.long], help: "Local API port to benchmark.")
+    var port: Int = 8080
+
+    @Option(name: [.long], help: "Bearer token for API endpoints. Also read from MERERUN_API_KEY.")
+    var apiKey: String?
+
+    @Option(name: [.long], help: "OpenAI chat model id or runtime alias.")
+    var model: String = Gemma4Resources.turboModelId
+
+    @Option(name: [.long], help: "JSONL workload file. Each line may contain {id,user} or {id,messages}.")
+    var workloadFile: String?
+
+    @Option(name: [.long], help: "Number of built-in workload turns when --workload-file is omitted.")
+    var turns: Int = 8
+
+    @Option(name: [.long], help: "Repeated shared-context rows in the built-in stable prefix.")
+    var sharedPrefixRepeat: Int = 32
+
+    @Option(name: [.long], help: "Maximum completion tokens per request.")
+    var maxTokens: Int = 64
+
+    @Option(name: [.long], help: "Temperature for each chat request.")
+    var temperature: Double = 0
+
+    @Option(name: [.long], help: "Top-p for each chat request.")
+    var topP: Double = 1
+
+    @Option(name: [.long], help: "Requests to issue concurrently. Use >1 with api serve --max-active-requests >1.")
+    var concurrency: Int = 1
+
+    @Option(name: [.long], help: "HTTP request timeout in seconds.")
+    var timeoutSeconds: Double = 300
+
+    @Flag(name: [.long], help: "Print the workload plan without contacting the server.")
+    var dryRun: Bool = false
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    func validate() throws {
+        guard port > 0 else {
+            throw ValidationError("--port must be greater than zero.")
+        }
+        guard !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError("--model must not be empty.")
+        }
+        guard turns > 0 else {
+            throw ValidationError("--turns must be greater than zero.")
+        }
+        guard sharedPrefixRepeat > 0 else {
+            throw ValidationError("--shared-prefix-repeat must be greater than zero.")
+        }
+        guard maxTokens > 0 else {
+            throw ValidationError("--max-tokens must be greater than zero.")
+        }
+        guard (0...2).contains(temperature), temperature.isFinite else {
+            throw ValidationError("--temperature must be finite and between 0 and 2.")
+        }
+        guard (0...1).contains(topP), topP.isFinite else {
+            throw ValidationError("--top-p must be finite and between 0 and 1.")
+        }
+        guard concurrency > 0 else {
+            throw ValidationError("--concurrency must be greater than zero.")
+        }
+        guard timeoutSeconds > 0, timeoutSeconds.isFinite else {
+            throw ValidationError("--timeout-seconds must be a positive finite number.")
+        }
+    }
+
+    func run() async throws {
+        let cases = try workloadCases()
+        let plan = APIWorkloadBenchmarkPlan(
+            baseURL: baseURLString,
+            model: model,
+            workloadFile: workloadFile,
+            requestCount: cases.count,
+            concurrency: concurrency,
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            streaming: true,
+            sharedPrefixRepeat: workloadFile == nil ? sharedPrefixRepeat : nil
+        )
+        if dryRun {
+            try printReport(APIWorkloadBenchmarkReport(
+                plan: plan,
+                statusBefore: nil,
+                statusBeforeDetail: "dry run",
+                statusAfter: nil,
+                statusAfterDetail: "dry run",
+                statusDelta: nil,
+                requests: [],
+                summary: APIWorkloadBenchmarkSummary(results: [], statusDelta: nil)
+            ))
+            return
+        }
+
+        let statusBefore = await runtimeStatus()
+        let workloadStart = Date()
+        let results = try await runCases(cases)
+        let wallSeconds = Date().timeIntervalSince(workloadStart)
+        let statusAfter = await runtimeStatus()
+        let delta = APIWorkloadStatusDelta(before: statusBefore.snapshot, after: statusAfter.snapshot)
+        let report = APIWorkloadBenchmarkReport(
+            plan: plan,
+            statusBefore: statusBefore.snapshot,
+            statusBeforeDetail: statusBefore.detail,
+            statusAfter: statusAfter.snapshot,
+            statusAfterDetail: statusAfter.detail,
+            statusDelta: delta,
+            requests: results.sorted { $0.sequence < $1.sequence },
+            summary: APIWorkloadBenchmarkSummary(results: results, wallSeconds: wallSeconds, statusDelta: delta)
+        )
+        try printReport(report)
+    }
+
+    private var baseURLString: String {
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlHost: String
+        if trimmedHost.contains(":") && !trimmedHost.hasPrefix("[") {
+            urlHost = "[\(trimmedHost)]"
+        } else {
+            urlHost = trimmedHost.isEmpty ? "127.0.0.1" : trimmedHost
+        }
+        return "http://\(urlHost):\(port)"
+    }
+
+    private func resolvedAPIKey() -> String? {
+        if let apiKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines), !apiKey.isEmpty {
+            return apiKey
+        }
+        if let apiKey = ProcessInfo.processInfo.environment[Self.apiKeyEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !apiKey.isEmpty {
+            return apiKey
+        }
+        return nil
+    }
+
+    private func workloadCases() throws -> [APIWorkloadCase] {
+        if let workloadFile {
+            return try loadJSONLWorkload(path: workloadFile)
+        }
+        return Self.builtInStablePrefixWorkload(turns: turns, sharedPrefixRepeat: sharedPrefixRepeat)
+    }
+
+    private func loadJSONLWorkload(path: String) throws -> [APIWorkloadCase] {
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        let raw = try String(contentsOf: url, encoding: .utf8)
+        let decoder = JSONDecoder()
+        let cases = try raw
+            .split(whereSeparator: \.isNewline)
+            .enumerated()
+            .compactMap { index, line -> APIWorkloadCase? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return nil }
+                let input = try decoder.decode(APIWorkloadInputCase.self, from: Data(trimmed.utf8))
+                return try input.workloadCase(sequence: index)
+            }
+        guard !cases.isEmpty else {
+            throw ValidationError("--workload-file must contain at least one JSONL request.")
+        }
+        return cases
+    }
+
+    static func builtInStablePrefixWorkload(turns: Int, sharedPrefixRepeat: Int) -> [APIWorkloadCase] {
+        let sharedContext = (1...sharedPrefixRepeat)
+            .map { index in
+                "Cache note \(index): local runtime work needs stable prefixes, visible queueing, " +
+                    "bounded memory, and measured latency before SSD persistence."
+            }
+            .joined(separator: "\n")
+        let system = """
+        You are measuring a local inference runtime. Use the shared context faithfully and answer
+        in one concise sentence.
+
+        Shared context:
+        \(sharedContext)
+        """
+        let questions = [
+            "Name the runtime feature that should stay in memory before SSD persistence is considered.",
+            "What metric should improve before promoting prefix KV reuse?",
+            "Why should request admission remain fair and visible?",
+            "What does chunked prefill improve for long prompts?",
+            "Which cache signal tells us repeated prefixes are actually reused?",
+            "Why is continuous batching kept behind an opt-in switch?",
+            "What should happen before enabling SSD-backed KV persistence?",
+            "Summarize the benchmark decision rule in one sentence.",
+        ]
+
+        return (0..<turns).map { index in
+            APIWorkloadCase(
+                id: "stable-prefix-\(index + 1)",
+                sequence: index,
+                messages: [
+                    OpenAIChatMessage(role: "system", content: system),
+                    OpenAIChatMessage(role: "user", content: questions[index % questions.count]),
+                ]
+            )
+        }
+    }
+
+    private func runCases(_ cases: [APIWorkloadCase]) async throws -> [APIWorkloadRequestResult] {
+        var results: [APIWorkloadRequestResult] = []
+        results.reserveCapacity(cases.count)
+        var index = 0
+        while index < cases.count {
+            let batch = Array(cases[index..<min(index + concurrency, cases.count)])
+            let batchResults = try await withThrowingTaskGroup(of: APIWorkloadRequestResult.self) { group in
+                for benchmarkCase in batch {
+                    group.addTask {
+                        try await runCase(benchmarkCase)
+                    }
+                }
+                var collected: [APIWorkloadRequestResult] = []
+                collected.reserveCapacity(batch.count)
+                for try await result in group {
+                    collected.append(result)
+                }
+                return collected
+            }
+            results.append(contentsOf: batchResults)
+            index += batch.count
+        }
+        return results
+    }
+
+    private func runCase(_ benchmarkCase: APIWorkloadCase) async throws -> APIWorkloadRequestResult {
+        var chatRequest = OpenAIChatRequest(
+            model: model,
+            messages: benchmarkCase.messages,
+            temperature: temperature,
+            top_p: topP,
+            max_tokens: maxTokens,
+            stream: true
+        )
+        chatRequest.stream_options = nil
+        let body = try JSONEncoder().encode(chatRequest)
+        guard let url = URL(string: "\(baseURLString)/v1/chat/completions") else {
+            throw ValidationError("Invalid API server URL.")
+        }
+        var request = URLRequest(url: url, timeoutInterval: timeoutSeconds)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey = resolvedAPIKey() {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = body
+
+        let start = Date()
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ValidationError("Chat completion returned a non-HTTP response.")
+        }
+
+        var firstTokenSeconds: Double?
+        var completion = ""
+        var streamedChunks = 0
+        var completionTokens: Int?
+        var errorBody = ""
+        for try await line in bytes.lines {
+            if http.statusCode != 200 {
+                errorBody += line
+                continue
+            }
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst("data: ".count))
+            guard payload != "[DONE]" else { break }
+            guard let data = payload.data(using: .utf8),
+                  let chunk = try? JSONDecoder().decode(OpenAIChatResponse.self, from: data) else {
+                continue
+            }
+            if let usage = chunk.usage {
+                completionTokens = usage.completion_tokens
+            }
+            for choice in chunk.choices {
+                if let token = choice.delta?.content, !token.isEmpty {
+                    if firstTokenSeconds == nil {
+                        firstTokenSeconds = Date().timeIntervalSince(start)
+                    }
+                    streamedChunks += 1
+                    completion += token
+                }
+            }
+        }
+
+        let totalSeconds = Date().timeIntervalSince(start)
+        guard http.statusCode == 200 else {
+            return APIWorkloadRequestResult(
+                id: benchmarkCase.id,
+                sequence: benchmarkCase.sequence,
+                promptCharacters: benchmarkCase.promptCharacters,
+                statusCode: http.statusCode,
+                ttftSeconds: firstTokenSeconds,
+                totalSeconds: totalSeconds,
+                streamedChunks: streamedChunks,
+                completionCharacters: completion.count,
+                completionTokens: completionTokens,
+                error: errorBody.isEmpty ? "HTTP \(http.statusCode)" : errorBody
+            )
+        }
+
+        return APIWorkloadRequestResult(
+            id: benchmarkCase.id,
+            sequence: benchmarkCase.sequence,
+            promptCharacters: benchmarkCase.promptCharacters,
+            statusCode: http.statusCode,
+            ttftSeconds: firstTokenSeconds,
+            totalSeconds: totalSeconds,
+            streamedChunks: streamedChunks,
+            completionCharacters: completion.count,
+            completionTokens: completionTokens,
+            error: nil
+        )
+    }
+
+    private func runtimeStatus() async -> (snapshot: RuntimeModelPoolStatus?, detail: String?) {
+        guard let url = URL(string: "\(baseURLString)/runtime/status") else {
+            return (nil, "invalid runtime status URL")
+        }
+        var request = URLRequest(url: url, timeoutInterval: max(0.1, timeoutSeconds))
+        if let apiKey = resolvedAPIKey() {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return (nil, "runtime status returned a non-HTTP response")
+            }
+            guard http.statusCode == 200 else {
+                return (nil, "runtime status returned HTTP \(http.statusCode)")
+            }
+            return (try JSONDecoder().decode(RuntimeModelPoolStatus.self, from: data), nil)
+        } catch {
+            return (nil, Self.shortNetworkError(error))
+        }
+    }
+
+    private func printReport(_ report: APIWorkloadBenchmarkReport) throws {
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(report)
+            print(String(decoding: data, as: UTF8.self))
+        } else {
+            print(report.renderText())
+        }
+    }
+
+    private static func shortNetworkError(_ error: Error) -> String {
+        if let urlError = error as? URLError {
+            return "\(urlError.code)"
+        }
+        return error.localizedDescription
+    }
+}
+
+struct APIWorkloadInputCase: Codable {
+    let id: String?
+    let user: String?
+    let messages: [OpenAIChatMessage]?
+
+    func workloadCase(sequence: Int) throws -> APIWorkloadCase {
+        if let messages, !messages.isEmpty {
+            return APIWorkloadCase(
+                id: id ?? "request-\(sequence + 1)",
+                sequence: sequence,
+                messages: messages
+            )
+        }
+        if let user = user?.trimmingCharacters(in: .whitespacesAndNewlines), !user.isEmpty {
+            return APIWorkloadCase(
+                id: id ?? "request-\(sequence + 1)",
+                sequence: sequence,
+                messages: [OpenAIChatMessage(role: "user", content: user)]
+            )
+        }
+        throw ValidationError("JSONL workload case \(id ?? "#\(sequence + 1)") must include messages or user.")
+    }
+}
+
+struct APIWorkloadCase {
+    let id: String
+    let sequence: Int
+    let messages: [OpenAIChatMessage]
+
+    var promptCharacters: Int {
+        messages.reduce(0) { $0 + $1.content.count }
+    }
+}
+
+struct APIWorkloadBenchmarkPlan: Codable, Equatable {
+    let baseURL: String
+    let model: String
+    let workloadFile: String?
+    let requestCount: Int
+    let concurrency: Int
+    let maxTokens: Int
+    let temperature: Double
+    let topP: Double
+    let streaming: Bool
+    let sharedPrefixRepeat: Int?
+}
+
+struct APIWorkloadRequestResult: Codable, Equatable {
+    let id: String
+    let sequence: Int
+    let promptCharacters: Int
+    let statusCode: Int
+    let ttftSeconds: Double?
+    let totalSeconds: Double
+    let streamedChunks: Int
+    let completionCharacters: Int
+    let completionTokens: Int?
+    let error: String?
+}
+
+struct APIWorkloadStatusDelta: Codable, Equatable {
+    let prefixKVHits: Int
+    let prefixKVMisses: Int
+    let prefixKVStoredPrefixes: Int
+    let prefixKVReusedTokens: Int
+    let decodeBatchedSteps: Int
+    let decodeSingleSteps: Int
+    let decodeSamePositionBatchedSteps: Int
+    let decodeVariablePositionBatchedSteps: Int
+    let completedRequests: Int
+    let failedRequests: Int
+    let generatedTokens: Int
+    let ssdKVCacheAvailable: Bool
+
+    init?(before: RuntimeModelPoolStatus?, after: RuntimeModelPoolStatus?) {
+        guard let before, let after else { return nil }
+        let beforePrefix = before.cacheStats.prefixKVReuse
+        let afterPrefix = after.cacheStats.prefixKVReuse
+        let beforeBatching = before.cacheStats.decodeBatching
+        let afterBatching = after.cacheStats.decodeBatching
+        let beforeBenchmark = before.benchmarkStats
+        let afterBenchmark = after.benchmarkStats
+        prefixKVHits = afterPrefix.hits - beforePrefix.hits
+        prefixKVMisses = afterPrefix.misses - beforePrefix.misses
+        prefixKVStoredPrefixes = afterPrefix.storedPrefixes - beforePrefix.storedPrefixes
+        prefixKVReusedTokens = afterPrefix.reusedTokens - beforePrefix.reusedTokens
+        decodeBatchedSteps = afterBatching.batchedDecodeSteps - beforeBatching.batchedDecodeSteps
+        decodeSingleSteps = afterBatching.singleDecodeSteps - beforeBatching.singleDecodeSteps
+        decodeSamePositionBatchedSteps =
+            afterBatching.samePositionBatchedSteps - beforeBatching.samePositionBatchedSteps
+        decodeVariablePositionBatchedSteps =
+            afterBatching.variablePositionBatchedSteps - beforeBatching.variablePositionBatchedSteps
+        completedRequests = (afterBenchmark?.completedRequests ?? 0) - (beforeBenchmark?.completedRequests ?? 0)
+        failedRequests = (afterBenchmark?.failedRequests ?? 0) - (beforeBenchmark?.failedRequests ?? 0)
+        generatedTokens = (afterBenchmark?.generatedTokens ?? 0) - (beforeBenchmark?.generatedTokens ?? 0)
+        ssdKVCacheAvailable = after.cacheStats.ssdKVCache.available
+    }
+}
+
+struct APIWorkloadBenchmarkSummary: Codable, Equatable {
+    let completedRequests: Int
+    let failedRequests: Int
+    let wallSeconds: Double?
+    let averageTTFTSeconds: Double?
+    let p50TTFTSeconds: Double?
+    let p95TTFTSeconds: Double?
+    let averageTotalSeconds: Double?
+    let p50TotalSeconds: Double?
+    let p95TotalSeconds: Double?
+    let requestsPerSecond: Double?
+    let prefixKVHits: Int?
+    let prefixKVMisses: Int?
+    let prefixKVReusedTokens: Int?
+    let decodeBatchedSteps: Int?
+    let decodeSingleSteps: Int?
+    let ssdKVCacheAvailable: Bool?
+
+    init(results: [APIWorkloadRequestResult], wallSeconds: Double? = nil, statusDelta: APIWorkloadStatusDelta?) {
+        completedRequests = results.filter { $0.error == nil && $0.statusCode == 200 }.count
+        failedRequests = results.count - completedRequests
+        self.wallSeconds = wallSeconds
+        let ttfts = results.compactMap(\.ttftSeconds).sorted()
+        let totals = results.map(\.totalSeconds).sorted()
+        averageTTFTSeconds = Self.average(ttfts)
+        p50TTFTSeconds = Self.percentile(ttfts, percentile: 0.50)
+        p95TTFTSeconds = Self.percentile(ttfts, percentile: 0.95)
+        averageTotalSeconds = Self.average(totals)
+        p50TotalSeconds = Self.percentile(totals, percentile: 0.50)
+        p95TotalSeconds = Self.percentile(totals, percentile: 0.95)
+        if let wallSeconds, wallSeconds > 0 {
+            requestsPerSecond = Double(completedRequests) / wallSeconds
+        } else {
+            let serialSeconds = totals.reduce(0, +)
+            requestsPerSecond = serialSeconds > 0 ? Double(completedRequests) / serialSeconds : nil
+        }
+        prefixKVHits = statusDelta?.prefixKVHits
+        prefixKVMisses = statusDelta?.prefixKVMisses
+        prefixKVReusedTokens = statusDelta?.prefixKVReusedTokens
+        decodeBatchedSteps = statusDelta?.decodeBatchedSteps
+        decodeSingleSteps = statusDelta?.decodeSingleSteps
+        ssdKVCacheAvailable = statusDelta?.ssdKVCacheAvailable
+    }
+
+    private static func average(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    private static func percentile(_ sortedValues: [Double], percentile: Double) -> Double? {
+        guard !sortedValues.isEmpty else { return nil }
+        let index = min(
+            sortedValues.count - 1,
+            max(0, Int((Double(sortedValues.count - 1) * percentile).rounded(.toNearestOrAwayFromZero)))
+        )
+        return sortedValues[index]
+    }
+}
+
+struct APIWorkloadBenchmarkReport: Codable, Equatable {
+    let plan: APIWorkloadBenchmarkPlan
+    let statusBefore: RuntimeModelPoolStatus?
+    let statusBeforeDetail: String?
+    let statusAfter: RuntimeModelPoolStatus?
+    let statusAfterDetail: String?
+    let statusDelta: APIWorkloadStatusDelta?
+    let requests: [APIWorkloadRequestResult]
+    let summary: APIWorkloadBenchmarkSummary
+
+    func renderText() -> String {
+        var lines = [
+            "API workload benchmark",
+            "server: \(plan.baseURL)",
+            "model: \(plan.model)",
+            "requests: \(plan.requestCount) concurrency=\(plan.concurrency) max_tokens=\(plan.maxTokens)",
+            "",
+            "summary:",
+            "  completed=\(summary.completedRequests) failed=\(summary.failedRequests)",
+            "  wall=\(formatSeconds(summary.wallSeconds)) rps=\(format(summary.requestsPerSecond))",
+            "  ttft avg=\(formatSeconds(summary.averageTTFTSeconds)) " +
+                "p50=\(formatSeconds(summary.p50TTFTSeconds)) " +
+                "p95=\(formatSeconds(summary.p95TTFTSeconds))",
+            "  total avg=\(formatSeconds(summary.averageTotalSeconds)) " +
+                "p50=\(formatSeconds(summary.p50TotalSeconds)) " +
+                "p95=\(formatSeconds(summary.p95TotalSeconds))",
+        ]
+        if let statusDelta {
+            lines += [
+                "  prefix KV hits=\(statusDelta.prefixKVHits) " +
+                    "misses=\(statusDelta.prefixKVMisses) " +
+                    "reused_tokens=\(statusDelta.prefixKVReusedTokens)",
+                "  decode batched_steps=\(statusDelta.decodeBatchedSteps) " +
+                    "single_steps=\(statusDelta.decodeSingleSteps)",
+                "  SSD KV cache available=\(statusDelta.ssdKVCacheAvailable)",
+            ]
+        } else {
+            lines.append("  runtime status delta: unavailable")
+            if let statusBeforeDetail {
+                lines.append("  before status: \(statusBeforeDetail)")
+            }
+            if let statusAfterDetail {
+                lines.append("  after status: \(statusAfterDetail)")
+            }
+        }
+        lines.append("")
+        for result in requests.sorted(by: { $0.sequence < $1.sequence }) {
+            lines.append(
+                "  \(result.id): status=\(result.statusCode) " +
+                    "ttft=\(formatSeconds(result.ttftSeconds)) " +
+                    "total=\(formatSeconds(result.totalSeconds)) " +
+                    "chunks=\(result.streamedChunks)"
+            )
+            if let error = result.error {
+                lines.append("    error: \(error)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func format(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return String(format: "%.3f", value)
+    }
+
+    private func formatSeconds(_ value: Double?) -> String {
+        guard let value else { return "n/a" }
+        return "\(format(value))s"
+    }
+}

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -16,6 +16,7 @@ struct ModelBenchmark: ParsableCommand {
             ModelBenchmarkGemma4KV.self,
             ModelBenchmarkGemma4MTP.self,
             ModelBenchmarkQ36MTP.self,
+            ModelBenchmarkAPIWorkload.self,
             ModelBenchmarkVLM.self,
         ]
     )

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -91,14 +91,15 @@ mere.run status
   removed from the FIFO instead of running later.
 - Gemma4 and Qwen-family chat use chunked prefill with cancellation/progress checkpoints.
   This improves long-prompt observability without arbitrary batching.
-- Gemma4 can opt into in-memory prefix KV reuse with
-  `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; `/runtime/status` reports entries, hits,
-  and reused tokens when a Gemma4 model is loaded. The cache records chunk
-  boundaries plus the stable chat prefix before the final message when token
-  prefixes match exactly.
-- Qwen-family chat can opt into text-only in-memory prefix KV reuse with
-  `MERERUN_Q35_PREFIX_KV_CACHE=1`; vision prompts are excluded from reuse, and
-  text-only requests use the same stable chat-prefix checkpoint rule as Gemma4.
+- Gemma4 uses in-memory prefix KV reuse by default; set
+  `MERERUN_GEMMA4_PREFIX_KV_CACHE=0` for a baseline. `/runtime/status` reports
+  entries, hits, and reused tokens when a Gemma4 model is loaded. The cache
+  records chunk boundaries plus the stable chat prefix before the final message
+  when token prefixes match exactly.
+- Qwen-family chat uses text-only in-memory prefix KV reuse by default; set
+  `MERERUN_Q35_PREFIX_KV_CACHE=0` for a baseline. Vision prompts are excluded
+  from reuse, and text-only requests use the same stable chat-prefix checkpoint
+  rule as Gemma4.
 - Gemma4 and Qwen-family chat can opt into decode batching with
   `MERERUN_GEMMA4_CONTINUOUS_BATCHING=1` or
   `MERERUN_Q35_CONTINUOUS_BATCHING=1`; use `--max-active-requests` above `1` to

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -41,6 +41,20 @@ mere.run model benchmark q36-mtp \
   --json
 ```
 
+Replay a real OpenAI-compatible chat workload against a running API server:
+
+```bash
+MERERUN_GEMMA4_PREFIX_KV_CACHE=0 \
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-turbo \
+  --max-active-requests 1
+
+mere.run model benchmark api-workload \
+  --model text-chat-gemma4-turbo \
+  --json
+```
+
 Compare the installed coding models on a small HumanEval slice:
 
 ```bash
@@ -124,6 +138,55 @@ against baseline. Use `--temperature-values 0,0.7` to compare deterministic
 greedy decode against the default chat sampling temperature. Greedy forced MTP
 uses the native block verifier; non-greedy forced MTP stays on the exact
 probabilistic speculative path.
+
+## API Workload Benchmark
+
+`model benchmark api-workload` replays streaming `/v1/chat/completions`
+requests against an already-running `mere.run api serve` process. It is the
+serving-path benchmark for prefix reuse, request admission, and opt-in decode
+batching. The built-in workload uses a deterministic stable system prefix with
+different final user turns so prefix-cache hits, TTFT, and active-request
+behavior are visible in `/runtime/status`.
+
+Run the same workload twice, with prefix reuse disabled for the baseline and
+then default prefix reuse plus opt-in batching enabled, before promoting cache
+or batching changes:
+
+```bash
+MERERUN_GEMMA4_PREFIX_KV_CACHE=0 \
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-turbo \
+  --max-active-requests 1
+
+mere.run model benchmark api-workload \
+  --model text-chat-gemma4-turbo \
+  --json
+
+MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 \
+mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-turbo \
+  --max-active-requests 4
+
+mere.run model benchmark api-workload \
+  --model text-chat-gemma4-turbo \
+  --concurrency 4 \
+  --json
+```
+
+Output includes per-request status, TTFT, total latency, streamed chunk count,
+and runtime-status deltas for prefix KV hits/misses, reused tokens, decode
+batched steps, single decode steps, completed requests, failed requests, and
+whether SSD KV cache is available. SSD cache promotion should require repeatable
+TTFT or throughput wins from in-memory prefix reuse first.
+
+Use `--workload-file` to replay JSONL:
+
+```json
+{"id":"case-1","user":"Summarize the runtime benchmark rule."}
+{"id":"case-2","messages":[{"role":"system","content":"Shared product context..."},{"role":"user","content":"Answer from that context."}]}
+```
 
 ## Prompt Control
 

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -4,6 +4,14 @@ import MereRunCore
 import Darwin
 #endif
 
+private func runtimeDefaultOnEnvironmentFlag(_ key: String) -> Bool {
+    guard let rawValue = ProcessInfo.processInfo.environment[key] else {
+        return true
+    }
+    let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return !["0", "false", "no", "off"].contains(normalized)
+}
+
 struct RuntimeModelPoolStatus: Codable, Equatable, Sendable {
     let object: String
     let defaultModel: String
@@ -55,7 +63,8 @@ struct RuntimeControlPlaneCapabilities: Codable, Equatable, Sendable {
                 enabled: prefixKVCacheEnabled,
                 detail: prefixKVCacheEnabled
                     ? "In-memory prefix KV reuse is enabled for matching Gemma4 or Qwen-family text token prefixes."
-                    : "In-memory prefix KV reuse is available behind MERERUN_GEMMA4_PREFIX_KV_CACHE=1 and MERERUN_Q35_PREFIX_KV_CACHE=1."
+                    : "In-memory prefix KV reuse is disabled by " +
+                        "MERERUN_GEMMA4_PREFIX_KV_CACHE=0 or MERERUN_Q35_PREFIX_KV_CACHE=0."
             ),
             ssdKVCache: RuntimeCapabilityStatus(
                 available: false,
@@ -744,9 +753,9 @@ actor RuntimeModelPool {
         startupModelPath: String?,
         settingsStore: RuntimeModelSettingsStore = RuntimeModelSettingsStore(),
         gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
-        gemma4PrefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PREFIX_KV_CACHE"] == "1",
+        gemma4PrefixKVCacheEnabled: Bool = runtimeDefaultOnEnvironmentFlag("MERERUN_GEMMA4_PREFIX_KV_CACHE"),
         gemma4ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_CONTINUOUS_BATCHING"] == "1",
-        q35PrefixKVCacheEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_PREFIX_KV_CACHE"] == "1",
+        q35PrefixKVCacheEnabled: Bool = runtimeDefaultOnEnvironmentFlag("MERERUN_Q35_PREFIX_KV_CACHE"),
         q35ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_CONTINUOUS_BATCHING"] == "1",
         currentDate: @escaping @Sendable () -> Date = { Date() },
         currentMemorySample: @escaping @Sendable () -> RuntimeMemorySample = { RuntimeMemorySample.current() },
@@ -1064,6 +1073,7 @@ actor RuntimeModelPool {
             return loaded
         }
 
+        try MLXBundleSupport.ensureAvailable(quiet: true)
         let loaded = makeLoadedModel(for: resolved)
         loadedModels[resolved.id] = loaded
         do {

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -120,6 +120,77 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertTrue(commandNames.contains("q36-mtp"))
     }
 
+    func testBenchmarkCommandExposesAPIWorkloadSubcommand() {
+        let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("api-workload"))
+    }
+
+    func testAPIWorkloadBenchmarkParsesDefaults() throws {
+        let cmd = try ModelBenchmarkAPIWorkload.parse(["--dry-run"])
+
+        XCTAssertEqual(cmd.host, "127.0.0.1")
+        XCTAssertEqual(cmd.port, 8080)
+        XCTAssertNil(cmd.apiKey)
+        XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
+        XCTAssertNil(cmd.workloadFile)
+        XCTAssertEqual(cmd.turns, 8)
+        XCTAssertEqual(cmd.sharedPrefixRepeat, 32)
+        XCTAssertEqual(cmd.maxTokens, 64)
+        XCTAssertEqual(cmd.temperature, 0)
+        XCTAssertEqual(cmd.topP, 1)
+        XCTAssertEqual(cmd.concurrency, 1)
+        XCTAssertEqual(cmd.timeoutSeconds, 300)
+        XCTAssertTrue(cmd.dryRun)
+        XCTAssertFalse(cmd.json)
+    }
+
+    func testAPIWorkloadBenchmarkParsesOverrides() throws {
+        let cmd = try ModelBenchmarkAPIWorkload.parse([
+            "--host", "localhost",
+            "--port", "11434",
+            "--api-key", "secret",
+            "--model", Q35Resources.q36NanoModelId,
+            "--workload-file", "/tmp/workload.jsonl",
+            "--turns", "3",
+            "--shared-prefix-repeat", "4",
+            "--max-tokens", "16",
+            "--temperature", "0.2",
+            "--top-p", "0.8",
+            "--concurrency", "2",
+            "--timeout-seconds", "30",
+            "--dry-run",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.host, "localhost")
+        XCTAssertEqual(cmd.port, 11434)
+        XCTAssertEqual(cmd.apiKey, "secret")
+        XCTAssertEqual(cmd.model, Q35Resources.q36NanoModelId)
+        XCTAssertEqual(cmd.workloadFile, "/tmp/workload.jsonl")
+        XCTAssertEqual(cmd.turns, 3)
+        XCTAssertEqual(cmd.sharedPrefixRepeat, 4)
+        XCTAssertEqual(cmd.maxTokens, 16)
+        XCTAssertEqual(cmd.temperature, 0.2)
+        XCTAssertEqual(cmd.topP, 0.8)
+        XCTAssertEqual(cmd.concurrency, 2)
+        XCTAssertEqual(cmd.timeoutSeconds, 30)
+        XCTAssertTrue(cmd.dryRun)
+        XCTAssertTrue(cmd.json)
+    }
+
+    func testAPIWorkloadBuiltInFixtureUsesStablePrefix() {
+        let cases = ModelBenchmarkAPIWorkload.builtInStablePrefixWorkload(turns: 2, sharedPrefixRepeat: 3)
+
+        XCTAssertEqual(cases.count, 2)
+        XCTAssertEqual(cases[0].messages.count, 2)
+        XCTAssertEqual(cases[1].messages.count, 2)
+        XCTAssertEqual(cases[0].messages[0].role, "system")
+        XCTAssertEqual(cases[1].messages[0].role, "system")
+        XCTAssertEqual(cases[0].messages[0].content, cases[1].messages[0].content)
+        XCTAssertNotEqual(cases[0].messages[1].content, cases[1].messages[1].content)
+        XCTAssertTrue(cases[0].messages[0].content.contains("Cache note 3"))
+    }
+
     func testQ36MTPBenchmarkParsesDefaults() throws {
         let cmd = try ModelBenchmarkQ36MTP.parse([])
 

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -26,7 +26,7 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertTrue(status.capabilities.chunkedPrefill.enabled)
         XCTAssertTrue(status.capabilities.continuousBatching.available)
         XCTAssertFalse(status.capabilities.continuousBatching.enabled)
-        XCTAssertFalse(status.capabilities.prefixKVReuse.enabled)
+        XCTAssertTrue(status.capabilities.prefixKVReuse.enabled)
     }
 
     func testModelsResponseIncludesStartupDefault() async throws {
@@ -60,6 +60,25 @@ final class RuntimeModelPoolTests: XCTestCase {
 
         XCTAssertTrue(status.capabilities.prefixKVReuse.available)
         XCTAssertTrue(status.capabilities.prefixKVReuse.enabled)
+    }
+
+    func testStatusReportsPrefixKVCacheCapabilityWhenExplicitlyDisabled() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            gemma4PrefixKVCacheEnabled: false,
+            q35PrefixKVCacheEnabled: false
+        )
+
+        let status = await pool.status()
+
+        XCTAssertTrue(status.capabilities.prefixKVReuse.available)
+        XCTAssertFalse(status.capabilities.prefixKVReuse.enabled)
+        XCTAssertTrue(status.capabilities.prefixKVReuse.detail.contains("disabled"))
     }
 
     func testStatusReportsQ35PrefixKVCacheCapabilityWhenEnabled() async throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1235,6 +1235,49 @@ block verifier; non-greedy forced MTP stays on the exact probabilistic
 speculative path. Use `--mtp-block-size` to test a different greedy draft block
 cap and `--forced-mtp-min-prompt-tokens` to adjust the forced policy threshold.
 
+### `mere.run model benchmark api-workload`
+
+Replay streaming OpenAI-compatible chat requests against an already-running
+`mere.run api serve` process. This is the serving-path benchmark for request
+admission, prefix KV reuse, opt-in decode batching, and the eventual SSD KV
+decision.
+
+```bash
+MERERUN_GEMMA4_PREFIX_KV_CACHE=0 \
+swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-turbo \
+  --max-active-requests 1
+
+swift run mere.run model benchmark api-workload \
+  --model text-chat-gemma4-turbo \
+  --json
+```
+
+To test the measured-work path, rerun the same workload with default prefix
+reuse and opt-in batching enabled, then compare TTFT, wall-clock throughput, and
+runtime status deltas:
+
+```bash
+MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 \
+swift run mere.run api serve \
+  --engine text-chat-gemma4 \
+  --model text-chat-gemma4-turbo \
+  --max-active-requests 4
+
+swift run mere.run model benchmark api-workload \
+  --model text-chat-gemma4-turbo \
+  --concurrency 4 \
+  --json
+```
+
+The built-in workload uses one stable system prefix and varied final user turns.
+Output reports per-request TTFT, total latency, streamed chunk count, wall-clock
+requests/sec, prefix KV hits/misses, reused prefix tokens, decode batched steps,
+single decode steps, and whether SSD KV cache is available. Use
+`--workload-file` to replay JSONL rows with either `{ "id", "user" }` or
+`{ "id", "messages" }`.
+
 ### `mere.run model benchmark code`
 
 Run a small real coding-eval slice against installed local coding models. The
@@ -1378,13 +1421,15 @@ Security defaults:
 - elevated or critical memory pressure pauses extra concurrent admissions while
   letting one request run so the server can make progress
 - Gemma4 and Qwen-family chat use chunked prefill checkpoints for long prompts.
-- Gemma4 can opt into an in-memory prefix KV reuse prototype with
-  `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; runtime status reports entries, hits, and
-  reused tokens when a Gemma4 model is loaded, including semantic chat-prefix
-  checkpoints before the final message when token prefixes match exactly
-- Qwen-family chat can opt into text-only in-memory prefix KV reuse with
-  `MERERUN_Q35_PREFIX_KV_CACHE=1`; vision prompts are excluded from reuse, and
-  text-only requests use the same semantic chat-prefix checkpoints as Gemma4
+- Gemma4 uses in-memory prefix KV reuse by default in `api serve`; set
+  `MERERUN_GEMMA4_PREFIX_KV_CACHE=0` for a baseline. Runtime status reports
+  entries, hits, and reused tokens when a Gemma4 model is loaded, including
+  semantic chat-prefix checkpoints before the final message when token prefixes
+  match exactly.
+- Qwen-family chat uses text-only in-memory prefix KV reuse by default in
+  `api serve`; set `MERERUN_Q35_PREFIX_KV_CACHE=0` for a baseline. Vision
+  prompts are excluded from reuse, and text-only requests use the same semantic
+  chat-prefix checkpoints as Gemma4.
 - Managed Gemma4 12B text and vision pulls install a companion MTP assistant.
   When `MERERUN_GEMMA4_MTP` is not disabled, greedy serial decode can use that
   assistant on the decode tail after prefill; sampled requests, continuous

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,10 +60,11 @@ This is optional for loopback-only usage and required for non-loopback binds.
 
 ### `MERERUN_GEMMA4_PREFIX_KV_CACHE`
 
-Set to `1` to enable the in-memory Gemma4 prefix KV reuse prototype in
-`mere.run api serve`. This stores bounded, forked Gemma4 prompt-prefix cache
-state for matching token prefixes and reports entries, hits, and reused tokens
-through `/runtime/status`. When the final chat message changes but the earlier
+Gemma4 in-memory prefix KV reuse is enabled by default in `mere.run api serve`.
+Set this to `0`, `false`, `no`, or `off` to disable it for a baseline run. The
+runtime stores bounded, forked Gemma4 prompt-prefix cache state for matching
+token prefixes and reports entries, hits, and reused tokens through
+`/runtime/status`. When the final chat message changes but the earlier
 system/tool/chat prefix is identical, Gemma4 stores that semantic prefix as an
 extra checkpoint before continuing normal prefill chunks. The bounded cache
 keeps semantic checkpoints ahead of ordinary chunk checkpoints when pruning.
@@ -112,10 +113,11 @@ clamped to the native runtime's supported range.
 
 ### `MERERUN_Q35_PREFIX_KV_CACHE`
 
-Set to `1` to enable the in-memory Qwen-family text-only prefix KV reuse prototype in
-`mere.run api serve`. Vision prompts are excluded because image embeddings
-change the effective prefix even when the token ids match. Runtime status uses
-the same prefix KV counters as Gemma4. Text-only Qwen-family requests also store the
+Qwen-family text-only prefix KV reuse is enabled by default in
+`mere.run api serve`. Set this to `0`, `false`, `no`, or `off` to disable it for
+a baseline run. Vision prompts are excluded because image embeddings change the
+effective prefix even when the token ids match. Runtime status uses the same
+prefix KV counters as Gemma4. Text-only Qwen-family requests also store the
 stable chat prefix before the final message as an extra checkpoint when it is an
 exact token prefix of the full prompt, and the bounded cache gives those
 semantic checkpoints the same pruning priority as Gemma4.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -171,16 +171,16 @@ swift run mere.run api serve \
 - Gemma4 and Qwen-family prefills are chunked with cancellation and progress checkpoints
   before decode; this is cooperative single-request prefill, not continuous
   batching
-- Gemma4 has an opt-in in-memory prefix KV reuse prototype behind
-  `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`; `/runtime/status` reports cache entries,
-  hits, and reused tokens when the Gemma4 model is loaded; the cache stores
-  chunk boundaries plus the stable chat prefix before the final message when it
-  is an exact token prefix, and pruning keeps that stable prefix ahead of
-  ordinary chunk boundaries
-- Qwen-family chat has an opt-in text-only prefix KV reuse prototype behind
-  `MERERUN_Q35_PREFIX_KV_CACHE=1`; vision prompts are excluded because image
-  embeddings alter the effective prefix; text-only requests use the same stable
-  chat-prefix checkpoint and pruning rule as Gemma4
+- Gemma4 uses in-memory prefix KV reuse by default in `api serve`; set
+  `MERERUN_GEMMA4_PREFIX_KV_CACHE=0` for a baseline. `/runtime/status` reports
+  cache entries, hits, and reused tokens when the Gemma4 model is loaded; the
+  cache stores chunk boundaries plus the stable chat prefix before the final
+  message when it is an exact token prefix, and pruning keeps that stable prefix
+  ahead of ordinary chunk boundaries.
+- Qwen-family chat uses text-only prefix KV reuse by default in `api serve`; set
+  `MERERUN_Q35_PREFIX_KV_CACHE=0` for a baseline. Vision prompts are excluded
+  because image embeddings alter the effective prefix; text-only requests use
+  the same stable chat-prefix checkpoint and pruning rule as Gemma4.
 - Managed Gemma4 12B text and vision installs include the
   `text-chat-gemma4-12b-mtp` assistant companion. The API server uses it only
   for greedy serial decode-tail speculation after prefill; sampled requests,


### PR DESCRIPTION
## Summary
- add `mere.run model benchmark api-workload` for replaying streaming chat requests against a running API server
- capture serving-path TTFT, total latency, wall-clock throughput, streamed chunks, prefix KV deltas, decode batching counters, and SSD KV availability from `/runtime/status`
- document the measured-work flow and fix RuntimeModelPool text preloads to install MLX metallib compatibility files before loading native text engines

## Known eval framing
- keep `model benchmark code` as the small functional HumanEval slice
- keep `model benchmark vlm` / lmms-eval support for multimodal quality checks
- use `api-workload` for ShareGPT-style serving replay: repeated prefixes, concurrency, TTFT, cache-hit counters, and batching throughput

## Validation
- `swift test --filter ModelBenchmarkCommandTests`
- `swift test --filter RuntimeModelPoolTests`
- `swift test --filter GuideCommandTests`
- `swift test --filter StatusCommandTests`
- `swift run mere.run model benchmark api-workload --dry-run`
- `swift run mere.run model benchmark api-workload --dry-run --json`
- live Gemma4 Turbo API smoke, cache off: 2/2 completed; prefix KV hits=0 misses=0 reused_tokens=0; SSD KV available=false
- live Gemma4 Turbo API smoke, `MERERUN_GEMMA4_PREFIX_KV_CACHE=1`: 2/2 completed; prefix KV hits=1 misses=1 reused_tokens=139; second request TTFT=0.084s
- `./scripts/check.sh` (948 tests, 41 skipped, 0 failures)
