### PR TITLE
Fix Qwen3 GGUF pull validation

### DIFF
--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1486,7 +1486,11 @@ public extension ManagedModelSpec {
         case .privacyFilter:
             return OpenAIPrivacyFilterResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .codegenGGUF:
-            return Self.missingCodeGenPaths(in: rootURL, fileManager: fileManager)
+            return Self.missingCodeGenPaths(
+                preferredRelativePath: hubFallback?.filePath,
+                in: rootURL,
+                fileManager: fileManager
+            )
         case .deepseekV4FlashIMatrixGGUF:
             return Self.missingDeepseekV4FlashIMatrixPaths(in: rootURL, fileManager: fileManager)
         case .lightOnOCR:
@@ -1719,8 +1723,20 @@ public extension ManagedModelSpec {
             .filter { !fileManager.fileExists(atPath: $0.path) }
     }
 
-    private static func missingCodeGenPaths(in rootURL: URL, fileManager: FileManager) -> [URL] {
-        findFirstGGUFFile(in: rootURL, fileManager: fileManager) == nil ? [rootURL.appendingPathComponent("*.gguf")] : []
+    private static func missingCodeGenPaths(
+        preferredRelativePath: String?,
+        in rootURL: URL,
+        fileManager: FileManager
+    ) -> [URL] {
+        if let preferredRelativePath {
+            let preferredURL = rootURL.appendingPathComponent(preferredRelativePath, isDirectory: false)
+            if isRegularFileOrSymlinkTarget(preferredURL, fileManager: fileManager) {
+                return []
+            }
+        }
+        return findFirstGGUFFile(in: rootURL, fileManager: fileManager) == nil
+            ? [rootURL.appendingPathComponent("*.gguf")]
+            : []
     }
 
     /// DeepSeek V4 Flash explicitly prefers the imatrix-tuned GGUF (per the

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -409,6 +409,33 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textCode)
     }
 
+    func testQwen3CodeAcceptsSymlinkedNestedHubGGUFInstallRoot() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: CodeGenResources.defaultModelId))
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        XCTAssertEqual(spec.hubFallback?.filePath, CodeGenResources.hubGGUFPath)
+
+        let snapshot = temp.appendingPathComponent("snapshot", isDirectory: true)
+        let snapshotFile = snapshot.appendingPathComponent(CodeGenResources.hubGGUFPath, isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: snapshotFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: snapshotFile.path, contents: Data()))
+
+        let root = temp.appendingPathComponent(CodeGenResources.defaultModelId, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: .qwen3Code, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("Qwen3-Coder-Next-Q4_K_M", isDirectory: true),
+            withDestinationURL: snapshot.appendingPathComponent("Qwen3-Coder-Next-Q4_K_M", isDirectory: true)
+        )
+
+        XCTAssertTrue(spec.missingPaths(in: root, fileManager: .default).isEmpty)
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+    }
+
     func testLFM2UsesLiquidAIHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: LFM2Resources.defaultModelId))
 


### PR DESCRIPTION
## Summary
- accept the catalog's explicit GGUF hub file path when validating codegen GGUF installs
- add a regression for the symlinked nested Qwen3-Coder snapshot layout seen on Linux installs

## Test plan
- swift test --filter ManagedModelCatalogTests
- ./scripts/check.sh