### PR TITLE
Add LoRA run viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .build/
 .swiftpm/
 .DS_Store
+.tmp/
 DerivedData/
 *.xcuserstate
 node_modules/

--- a/README.md
+++ b/README.md
@@ -280,7 +280,11 @@ swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-klein.safetensors \
   --recipe klein-fast-style \
+  --visualize \
   --quiet
+
+# Reopen the local run dashboard later from the run directory.
+swift run mere.run image visualize-run .
 
 # Run local chat
 swift run mere.run text chat \

--- a/Sources/MereRunCLI/Commands/ImageCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageCommand.swift
@@ -7,6 +7,7 @@ struct Image: ParsableCommand {
         subcommands: [
             ImageGenerate.self,
             ImageTrainLoRA.self,
+            ImageVisualizeRun.self,
             ImageValidate.self,
         ]
     )

--- a/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
@@ -151,6 +151,12 @@ struct ImageTrainLoRA: AsyncParsableCommand {
     @Option(name: [.customLong("sample-seed")], help: "Klein preview seed.")
     var sampleSeed: UInt64?
 
+    @Flag(name: [.customLong("visualize")], help: "Start a loopback LoRA training dashboard for this run.")
+    var visualize: Bool = false
+
+    @Option(name: [.customLong("visualize-port")], help: "Loopback port for --visualize.")
+    var visualizePort: Int = 8787
+
     @Option(name: [.customLong("lora-target-ranks")], help: "Klein suffix rank map, e.g. .attn.to_q=128,.ff.linear_in=64.")
     var loraTargetRanks: String?
 
@@ -251,6 +257,9 @@ struct ImageTrainLoRA: AsyncParsableCommand {
         guard sampleLoRAScale >= 0 else {
             throw ValidationError("--sample-lora-scale must be >= 0")
         }
+        if visualize, !(1...65535).contains(visualizePort) {
+            throw ValidationError("--visualize-port must be between 1 and 65535")
+        }
         if loraTargetRanks != nil, loraRankPreset != nil {
             throw ValidationError("--lora-target-ranks cannot be combined with --lora-rank-preset")
         }
@@ -305,15 +314,50 @@ struct ImageTrainLoRA: AsyncParsableCommand {
 
         let modelRoot = try resolveModelRoot(model: resolvedOptions.model)
         let modelManifest = try MereRunModelManifest.loadRequired(from: modelRoot)
+        let visualization = try startVisualizationIfNeeded(
+            outputURL: outputURL,
+            modelRoot: modelRoot,
+            modelManifest: modelManifest,
+            options: resolvedOptions
+        )
+        defer { visualization?.stop() }
 
-        switch modelManifest.family {
-        case .krea:
-            try await runKreaTraining(modelRoot: modelRoot, outputURL: outputURL, options: resolvedOptions)
-        case .klein:
-            try await runKleinTraining(modelRoot: modelRoot, outputURL: outputURL, options: resolvedOptions)
-        default:
-            let family = modelManifest.family?.rawValue ?? "unknown"
-            throw ValidationError("Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.")
+        do {
+            switch modelManifest.family {
+            case .krea:
+                try await runKreaTraining(
+                    modelRoot: modelRoot,
+                    outputURL: outputURL,
+                    options: resolvedOptions,
+                    eventLogger: visualization?.logger
+                )
+            case .klein:
+                try await runKleinTraining(
+                    modelRoot: modelRoot,
+                    outputURL: outputURL,
+                    options: resolvedOptions,
+                    eventLogger: visualization?.logger
+                )
+            default:
+                let family = modelManifest.family?.rawValue ?? "unknown"
+                throw ValidationError("Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.")
+            }
+            try visualization?.logger.record(
+                type: "run_finished",
+                stage: "finished",
+                step: resolvedOptions.trainingSteps,
+                totalSteps: resolvedOptions.trainingSteps,
+                fraction: 1,
+                path: outputURL.path
+            )
+        } catch {
+            try? visualization?.logger.record(
+                type: "run_failed",
+                stage: "failed",
+                message: error.localizedDescription,
+                path: outputURL.path
+            )
+            throw error
         }
 
         if benchmarkSteps == nil {
@@ -324,7 +368,8 @@ struct ImageTrainLoRA: AsyncParsableCommand {
     private func runKreaTraining(
         modelRoot: URL,
         outputURL: URL,
-        options: ResolvedLoRATrainingOptions
+        options: ResolvedLoRATrainingOptions,
+        eventLogger: LoRATrainingEventLogger?
     ) async throws {
         if options.checkpointInterval != nil {
             throw ValidationError("--checkpoint-interval is only supported for FLUX.2 Klein LoRA training")
@@ -379,7 +424,11 @@ struct ImageTrainLoRA: AsyncParsableCommand {
             config.lrMinFactor = lrMinFactor
         }
 
-        let progressHandler = quiet ? nil : Self.makeProgressHandler()
+        let stderrProgressHandler = quiet ? nil : Self.makeProgressHandler()
+        let progressHandler = Self.makeKreaProgressHandler(
+            stderrProgressHandler: stderrProgressHandler,
+            eventLogger: eventLogger
+        )
         if !quiet {
             CLIStderr.write("[runtime] image training backend: \(NativeMLXRuntime.backendDescription)\n")
         }
@@ -396,7 +445,8 @@ struct ImageTrainLoRA: AsyncParsableCommand {
     private func runKleinTraining(
         modelRoot: URL,
         outputURL: URL,
-        options: ResolvedLoRATrainingOptions
+        options: ResolvedLoRATrainingOptions,
+        eventLogger: LoRATrainingEventLogger?
     ) async throws {
         if syntheticSamples != nil {
             throw ValidationError("--synthetic-samples is only supported for Krea 2 LoRA smoke tests")
@@ -484,12 +534,17 @@ struct ImageTrainLoRA: AsyncParsableCommand {
             config.adamWeightDecay = adamWeightDecay
         }
 
-        let progressHandler = quiet ? nil : Self.makeKleinProgressHandler()
+        let stderrProgressHandler = quiet ? nil : Self.makeKleinProgressHandler()
+        let progressHandler = Self.makeKleinProgressHandler(
+            stderrProgressHandler: stderrProgressHandler,
+            eventLogger: eventLogger
+        )
         let sampleHandler = try makeKleinSampleHandler(
             outputURL: outputURL,
             fallbackPrompt: examples.first?.caption ?? "",
             width: options.width,
-            height: options.height
+            height: options.height,
+            eventLogger: eventLogger
         )
         if !quiet {
             CLIStderr.write("[runtime] image training backend: \(NativeMLXRuntime.backendDescription)\n")
@@ -741,7 +796,8 @@ struct ImageTrainLoRA: AsyncParsableCommand {
         outputURL: URL,
         fallbackPrompt: String,
         width: Int,
-        height: Int
+        height: Int,
+        eventLogger: LoRATrainingEventLogger?
     ) throws -> (@Sendable (Int, URL) async -> Void)? {
         guard sampleInterval != nil else { return nil }
 
@@ -778,13 +834,68 @@ struct ImageTrainLoRA: AsyncParsableCommand {
                     lora: .local(path: checkpointURL.path, scale: loraScale)
                 )
                 _ = try await generator.generate(request, progressHandler: nil)
+                try? eventLogger?.record(
+                    type: "sample_saved",
+                    stage: "sampling",
+                    step: step,
+                    path: sampleURL.path,
+                    metadata: ["checkpoint": checkpointURL.path]
+                )
                 if !quietMode {
                     CLIStderr.write("[sample] \(sampleURL.path)\n")
                 }
             } catch {
+                try? eventLogger?.record(
+                    type: "sample_failed",
+                    stage: "sampling",
+                    message: error.localizedDescription,
+                    step: step,
+                    metadata: ["checkpoint": checkpointURL.path]
+                )
                 CLIStderr.write("[sample] step \(step) failed: \(error.localizedDescription)\n")
             }
         }
+    }
+
+    private func startVisualizationIfNeeded(
+        outputURL: URL,
+        modelRoot: URL,
+        modelManifest: MereRunModelManifest,
+        options: ResolvedLoRATrainingOptions
+    ) throws -> LoRATrainingVisualization? {
+        guard visualize else { return nil }
+        let logger = try LoRATrainingEventLogger(baseOutputURL: outputURL)
+        let viewer = LoRATrainingRunViewer(runDirectoryURL: outputURL.deletingLastPathComponent())
+        let host = "127.0.0.1"
+        let port = visualizePort
+        let task = Task {
+            do {
+                try await viewer.run(host: host, port: port)
+            } catch is CancellationError {
+                // The training command owns this helper server and cancels it when the run exits.
+            } catch {
+                CLIStderr.write("[visualize] server stopped: \(error.localizedDescription)\n")
+            }
+        }
+        try logger.record(
+            type: "run_started",
+            stage: "starting",
+            message: "LoRA training started.",
+            step: 0,
+            totalSteps: options.trainingSteps,
+            fraction: 0,
+            path: outputURL.path,
+            metadata: [
+                "viewer_url": "http://\(host):\(port)",
+                "model_root": modelRoot.path,
+                "model_id": modelManifest.id,
+                "model_family": modelManifest.family?.rawValue ?? "unknown",
+                "recipe": recipe ?? "",
+                "data": data ?? "",
+                "output": outputURL.path,
+            ]
+        )
+        return LoRATrainingVisualization(logger: logger, serverTask: task)
     }
 
     private func resolveKleinSampleModelPath() throws -> String {
@@ -917,5 +1028,144 @@ struct ImageTrainLoRA: AsyncParsableCommand {
                 CLIStderr.write("Saving LoRA artifacts...\n")
             }
         }
+    }
+
+    private static func makeKreaProgressHandler(
+        stderrProgressHandler: (@Sendable (Krea2LoRATrainingProgress) -> Void)?,
+        eventLogger: LoRATrainingEventLogger?
+    ) -> (@Sendable (Krea2LoRATrainingProgress) -> Void)? {
+        guard stderrProgressHandler != nil || eventLogger != nil else { return nil }
+        return { progress in
+            stderrProgressHandler?(progress)
+            recordKreaProgress(progress, to: eventLogger)
+        }
+    }
+
+    private static func makeKleinProgressHandler(
+        stderrProgressHandler: (@Sendable (Flux2KleinLoRATrainingProgress) -> Void)?,
+        eventLogger: LoRATrainingEventLogger?
+    ) -> (@Sendable (Flux2KleinLoRATrainingProgress) -> Void)? {
+        guard stderrProgressHandler != nil || eventLogger != nil else { return nil }
+        return { progress in
+            stderrProgressHandler?(progress)
+            recordKleinProgress(progress, to: eventLogger)
+        }
+    }
+
+    private static func recordKreaProgress(
+        _ progress: Krea2LoRATrainingProgress,
+        to eventLogger: LoRATrainingEventLogger?
+    ) {
+        guard let eventLogger else { return }
+        switch progress.stage {
+        case .loadingModels:
+            try? eventLogger.record(
+                type: "progress",
+                stage: "loading_models",
+                message: "Loading Krea 2 Raw models.",
+                fraction: progress.fraction
+            )
+        case .encodingDataset(let current, let total):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "encoding_dataset",
+                message: "Encoding dataset.",
+                step: current,
+                totalSteps: total,
+                fraction: progress.fraction
+            )
+        case .injectingLoRA(let layerCount):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "injecting_lora",
+                message: "Injected LoRA layers.",
+                fraction: progress.fraction,
+                metadata: ["layer_count": "\(layerCount)"]
+            )
+        case .training(let step, let total, let loss):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "training",
+                message: "Training.",
+                step: step,
+                totalSteps: total,
+                loss: loss,
+                fraction: progress.fraction
+            )
+        case .saving:
+            try? eventLogger.record(
+                type: "progress",
+                stage: "saving",
+                message: "Saving LoRA artifacts.",
+                fraction: progress.fraction
+            )
+        }
+    }
+
+    private static func recordKleinProgress(
+        _ progress: Flux2KleinLoRATrainingProgress,
+        to eventLogger: LoRATrainingEventLogger?
+    ) {
+        guard let eventLogger else { return }
+        switch progress.stage {
+        case .loadingModels:
+            try? eventLogger.record(
+                type: "progress",
+                stage: "loading_models",
+                message: "Loading FLUX.2 Klein models.",
+                fraction: progress.fraction
+            )
+        case .encodingDataset(let current, let total):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "encoding_dataset",
+                message: "Encoding dataset.",
+                step: current,
+                totalSteps: total,
+                fraction: progress.fraction
+            )
+        case .injectingLoRA(let layerCount):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "injecting_lora",
+                message: "Injected LoRA layers.",
+                fraction: progress.fraction,
+                metadata: ["layer_count": "\(layerCount)"]
+            )
+        case .training(let step, let total, let loss):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "training",
+                message: "Training.",
+                step: step,
+                totalSteps: total,
+                loss: loss,
+                fraction: progress.fraction
+            )
+        case .sampling(let step):
+            try? eventLogger.record(
+                type: "progress",
+                stage: "sampling",
+                message: "Sampling preview.",
+                step: step,
+                fraction: progress.fraction
+            )
+        case .saving:
+            try? eventLogger.record(
+                type: "progress",
+                stage: "saving",
+                message: "Saving LoRA artifacts.",
+                fraction: progress.fraction
+            )
+        }
+    }
+}
+
+private struct LoRATrainingVisualization {
+    let logger: LoRATrainingEventLogger
+    let serverTask: Task<Void, Never>
+
+    func stop() {
+        serverTask.cancel()
     }
 }

--- a/Sources/MereRunCLI/Commands/ImageVisualizeRunCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageVisualizeRunCommand.swift
@@ -1,0 +1,34 @@
+import ArgumentParser
+import Foundation
+
+struct ImageVisualizeRun: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "visualize-run",
+        abstract: "Open a local LoRA training run viewer.",
+        discussion: """
+        Serves a loopback-only web UI for an existing LoRA run directory. The viewer reads run.json,
+        loss CSV files, training events, samples, checkpoints, and adapter artifacts from disk.
+        """
+    )
+
+    @Argument(help: "LoRA run directory containing run.json, loss CSV, events, samples, or checkpoints.")
+    var runDirectory: String
+
+    @Option(name: [.long], help: "Loopback port for the viewer.")
+    var port: Int = 8787
+
+    func run() async throws {
+        guard (1...65535).contains(port) else {
+            throw ValidationError("--port must be between 1 and 65535")
+        }
+
+        let url = URL(fileURLWithPath: runDirectory).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw ValidationError("Run directory not found: \(url.path)")
+        }
+
+        let viewer = LoRATrainingRunViewer(runDirectoryURL: url)
+        try await viewer.run(host: "127.0.0.1", port: port)
+    }
+}

--- a/Sources/MereRunCLI/Support/LoRATrainingRunViewer.swift
+++ b/Sources/MereRunCLI/Support/LoRATrainingRunViewer.swift
@@ -1,0 +1,659 @@
+import Foundation
+import Hummingbird
+import MereRunCore
+import NIOCore
+
+struct LoRATrainingRunViewer {
+    let runDirectoryURL: URL
+
+    init(runDirectoryURL: URL) {
+        self.runDirectoryURL = runDirectoryURL.standardizedFileURL
+    }
+
+    func run(host: String, port: Int) async throws {
+        let router = buildRouter()
+        let app = Application(
+            router: router,
+            configuration: .init(address: .hostname(host, port: port))
+        )
+
+        CLIStderr.write("[visualize] LoRA training viewer: http://\(host):\(port)\n")
+        CLIStderr.write("[visualize] Run directory: \(runDirectoryURL.path)\n")
+        CLIStderr.write("[visualize] Press Ctrl+C to stop.\n")
+        try await app.runService()
+    }
+
+    nonisolated func buildRouter() -> Router<BasicRequestContext> {
+        let router = Router()
+
+        router.get("/") { _, _ in
+            htmlResponse(Self.dashboardHTML)
+        }
+
+        router.get("/health") { _, _ in
+            try jsonResponse(["status": "ok"])
+        }
+
+        router.get("/api/run") { [self] _, _ in
+            do {
+                return try jsonResponse(snapshot())
+            } catch {
+                return errorResponse(message: error.localizedDescription)
+            }
+        }
+
+        router.get("/api/events") { [self] _, _ in
+            do {
+                return try jsonResponse(loadEvents())
+            } catch {
+                return errorResponse(message: error.localizedDescription)
+            }
+        }
+
+        router.get("/api/loss.csv") { [self] _, _ in
+            do {
+                guard let url = firstLossCSVURL() else {
+                    return Response(status: .notFound)
+                }
+                let data = try Data(contentsOf: url)
+                return binaryResponse(data, contentType: "text/csv; charset=utf-8")
+            } catch {
+                return errorResponse(message: error.localizedDescription)
+            }
+        }
+
+        router.get("/api/artifacts/:kind/:name") { [self] _, context in
+            do {
+                guard let kind = context.parameters.get("kind", as: String.self),
+                      let rawName = context.parameters.get("name", as: String.self),
+                      let url = artifactURL(kind: kind, name: rawName) else {
+                    return Response(status: .notFound)
+                }
+                let data = try Data(contentsOf: url)
+                return binaryResponse(data, contentType: contentType(for: url))
+            } catch {
+                return errorResponse(message: error.localizedDescription)
+            }
+        }
+
+        return router
+    }
+
+    func snapshot() throws -> LoRATrainingRunViewerSnapshot {
+        let runManifest = try loadRunManifest()
+        let events = try loadEvents()
+        let lossPoints = try loadLossPoints()
+        let artifacts = try listArtifacts()
+        let latestEvent = events.last
+        let status: String = {
+            if latestEvent?.type == "run_failed" { return "failed" }
+            if latestEvent?.type == "run_finished" { return "finished" }
+            if let runManifest, runManifest.step >= runManifest.totalSteps { return "finished" }
+            if !events.isEmpty { return "running" }
+            return "idle"
+        }()
+
+        return LoRATrainingRunViewerSnapshot(
+            runDirectory: runDirectoryURL.path,
+            status: status,
+            runManifest: runManifest,
+            lossPoints: lossPoints,
+            events: events,
+            artifacts: artifacts
+        )
+    }
+
+    private func loadRunManifest() throws -> LoRATrainingRunManifest? {
+        let url = runDirectoryURL.appendingPathComponent(LoRATrainingRunManifest.filename)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        let data = try Data(contentsOf: url)
+        return try LoRATrainingRunManifest.decode(from: data)
+    }
+
+    private func loadEvents() throws -> [LoRATrainingRunEvent] {
+        let urls = try files(in: runDirectoryURL)
+            .filter { $0.lastPathComponent.hasSuffix(LoRATrainingRunEvent.filenameSuffix) }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        var events: [LoRATrainingRunEvent] = []
+        for url in urls {
+            events.append(contentsOf: try LoRATrainingRunEvent.load(from: url))
+        }
+        return events.sorted { lhs, rhs in
+            if lhs.createdAt == rhs.createdAt {
+                return lhs.sequence < rhs.sequence
+            }
+            return lhs.createdAt < rhs.createdAt
+        }
+    }
+
+    private func loadLossPoints() throws -> [LoRALossPoint] {
+        guard let url = firstLossCSVURL() else {
+            return []
+        }
+        return try LoRATrainingMetricsLogger.loadPoints(from: url)
+    }
+
+    private func firstLossCSVURL() -> URL? {
+        (try? files(in: runDirectoryURL))
+            .flatMap { urls in
+                urls
+                    .filter { $0.lastPathComponent.hasSuffix(".loss.csv") }
+                    .sorted { $0.lastPathComponent < $1.lastPathComponent }
+                    .first
+            }
+    }
+
+    private func listArtifacts() throws -> [LoRATrainingRunArtifact] {
+        var artifacts: [LoRATrainingRunArtifact] = []
+        artifacts.append(contentsOf: try listArtifacts(in: runDirectoryURL, kind: "root"))
+
+        let sampleDirectory = runDirectoryURL.appendingPathComponent("samples", isDirectory: true)
+        if isDirectory(sampleDirectory) {
+            artifacts.append(contentsOf: try listArtifacts(in: sampleDirectory, kind: "samples"))
+        }
+
+        let checkpointDirectory = runDirectoryURL.appendingPathComponent("checkpoints", isDirectory: true)
+        if isDirectory(checkpointDirectory) {
+            artifacts.append(contentsOf: try listArtifacts(in: checkpointDirectory, kind: "checkpoints"))
+        }
+
+        return artifacts.sorted {
+            if $0.kind == $1.kind {
+                return $0.name < $1.name
+            }
+            return $0.kind < $1.kind
+        }
+    }
+
+    private func listArtifacts(in directory: URL, kind: String) throws -> [LoRATrainingRunArtifact] {
+        try files(in: directory).compactMap { url in
+            let name = url.lastPathComponent
+            guard isAllowedArtifact(url),
+                  let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+                return nil
+            }
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            let size = (attributes?[.size] as? NSNumber)?.int64Value
+            return LoRATrainingRunArtifact(
+                kind: kind,
+                name: name,
+                path: url.path,
+                sizeBytes: size,
+                contentType: contentType(for: url),
+                url: "/api/artifacts/\(kind)/\(encodedName)",
+                isImage: isImageArtifact(url)
+            )
+        }
+    }
+
+    private func artifactURL(kind: String, name rawName: String) -> URL? {
+        guard ["root", "samples", "checkpoints"].contains(kind) else { return nil }
+        let name = rawName.removingPercentEncoding ?? rawName
+        guard !name.isEmpty,
+              !name.contains("/"),
+              !name.contains("\\"),
+              name != ".",
+              name != "..",
+              !name.contains("..") else {
+            return nil
+        }
+
+        let directory: URL = switch kind {
+        case "samples":
+            runDirectoryURL.appendingPathComponent("samples", isDirectory: true)
+        case "checkpoints":
+            runDirectoryURL.appendingPathComponent("checkpoints", isDirectory: true)
+        default:
+            runDirectoryURL
+        }
+        let candidate = directory.appendingPathComponent(name, isDirectory: false).standardizedFileURL
+        guard candidate.deletingLastPathComponent().path == directory.standardizedFileURL.path,
+              FileManager.default.fileExists(atPath: candidate.path),
+              isAllowedArtifact(candidate) else {
+            return nil
+        }
+        return candidate
+    }
+
+    private func files(in directory: URL) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ).filter { url in
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            return values?.isRegularFile == true
+        }
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    private func isAllowedArtifact(_ url: URL) -> Bool {
+        [
+            "csv",
+            "html",
+            "json",
+            "jsonl",
+            "png",
+            "jpg",
+            "jpeg",
+            "webp",
+            "safetensors",
+            "zip",
+        ].contains(url.pathExtension.lowercased())
+    }
+
+    private func isImageArtifact(_ url: URL) -> Bool {
+        ["png", "jpg", "jpeg", "webp"].contains(url.pathExtension.lowercased())
+    }
+
+    private func contentType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "csv":
+            return "text/csv; charset=utf-8"
+        case "html":
+            return "text/html; charset=utf-8"
+        case "json", "jsonl":
+            return "application/json"
+        case "png":
+            return "image/png"
+        case "jpg", "jpeg":
+            return "image/jpeg"
+        case "webp":
+            return "image/webp"
+        case "zip":
+            return "application/zip"
+        default:
+            return "application/octet-stream"
+        }
+    }
+
+    private static let dashboardHTML = #"""
+    <!doctype html>
+    <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <title>mere.run LoRA Training</title>
+      <style>
+        :root {
+          color-scheme: light;
+          --bg: #f6f7f8;
+          --panel: #ffffff;
+          --text: #121417;
+          --muted: #626b77;
+          --line: #d9dee5;
+          --green: #1c7c54;
+          --red: #bf3b3b;
+          --blue: #2f6fbd;
+          --gold: #9a6a16;
+        }
+        * { box-sizing: border-box; }
+        body {
+          margin: 0;
+          background: var(--bg);
+          color: var(--text);
+          font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+        }
+        header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 16px;
+          padding: 18px 24px;
+          border-bottom: 1px solid var(--line);
+          background: rgba(255, 255, 255, 0.92);
+          position: sticky;
+          top: 0;
+          z-index: 2;
+        }
+        h1 { font-size: 18px; line-height: 1.2; margin: 0; font-weight: 650; }
+        .status {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          font-size: 13px;
+          color: var(--muted);
+        }
+        .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--gold); }
+        .dot.finished { background: var(--green); }
+        .dot.failed { background: var(--red); }
+        .dot.running { background: var(--blue); }
+        main {
+          display: grid;
+          grid-template-columns: minmax(0, 1.7fr) minmax(320px, 0.85fr);
+          gap: 16px;
+          padding: 16px 24px 28px;
+        }
+        section {
+          background: var(--panel);
+          border: 1px solid var(--line);
+          border-radius: 8px;
+          overflow: hidden;
+        }
+        .section-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          padding: 12px 14px;
+          border-bottom: 1px solid var(--line);
+        }
+        h2 { margin: 0; font-size: 13px; font-weight: 650; color: #20242a; }
+        .small { font-size: 12px; color: var(--muted); }
+        .metrics {
+          display: grid;
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+          gap: 10px;
+          padding: 14px;
+        }
+        .metric {
+          border: 1px solid var(--line);
+          border-radius: 7px;
+          padding: 10px;
+          min-width: 0;
+          background: #fbfcfd;
+        }
+        .label { display: block; font-size: 11px; color: var(--muted); margin-bottom: 4px; }
+        .value { font-size: 17px; font-weight: 650; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        canvas { display: block; width: 100%; height: 360px; padding: 10px 14px 14px; }
+        .samples {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+          gap: 10px;
+          padding: 14px;
+        }
+        figure { margin: 0; border: 1px solid var(--line); border-radius: 7px; overflow: hidden; background: #f0f2f4; }
+        figure img { display: block; width: 100%; aspect-ratio: 4 / 3; object-fit: cover; }
+        figcaption { padding: 7px 8px; font-size: 12px; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .list { padding: 8px 14px 14px; }
+        .row {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) auto;
+          gap: 10px;
+          align-items: center;
+          padding: 8px 0;
+          border-bottom: 1px solid #edf0f3;
+          font-size: 13px;
+        }
+        .row:last-child { border-bottom: 0; }
+        a { color: #1f5f99; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        .event { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: #2b3139; }
+        .muted { color: var(--muted); }
+        @media (max-width: 980px) {
+          main { grid-template-columns: 1fr; padding: 12px; }
+          header { padding: 14px 12px; }
+          .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
+      </style>
+    </head>
+    <body>
+      <header>
+        <h1>mere.run LoRA Training</h1>
+        <div class="status"><span id="status-dot" class="dot"></span><span id="status-text">loading</span></div>
+      </header>
+      <main>
+        <div>
+          <section>
+            <div class="section-head">
+              <h2>Run</h2>
+              <span id="run-path" class="small"></span>
+            </div>
+            <div class="metrics">
+              <div class="metric"><span class="label">step</span><span id="metric-step" class="value">-</span></div>
+              <div class="metric"><span class="label">loss</span><span id="metric-loss" class="value">-</span></div>
+              <div class="metric"><span class="label">progress</span><span id="metric-progress" class="value">-</span></div>
+              <div class="metric"><span class="label">samples</span><span id="metric-samples" class="value">-</span></div>
+            </div>
+          </section>
+          <section style="margin-top:16px">
+            <div class="section-head">
+              <h2>Loss</h2>
+              <a class="small" href="/api/loss.csv">loss.csv</a>
+            </div>
+            <canvas id="loss-chart" width="1100" height="420"></canvas>
+          </section>
+          <section style="margin-top:16px">
+            <div class="section-head">
+              <h2>Samples</h2>
+              <span id="sample-count" class="small"></span>
+            </div>
+            <div id="samples" class="samples"></div>
+          </section>
+        </div>
+        <div>
+          <section>
+            <div class="section-head">
+              <h2>Artifacts</h2>
+              <span id="artifact-count" class="small"></span>
+            </div>
+            <div id="artifacts" class="list"></div>
+          </section>
+          <section style="margin-top:16px">
+            <div class="section-head">
+              <h2>Events</h2>
+              <span id="event-count" class="small"></span>
+            </div>
+            <div id="events" class="list"></div>
+          </section>
+        </div>
+      </main>
+      <script>
+        const els = {
+          dot: document.getElementById('status-dot'),
+          status: document.getElementById('status-text'),
+          path: document.getElementById('run-path'),
+          step: document.getElementById('metric-step'),
+          loss: document.getElementById('metric-loss'),
+          progress: document.getElementById('metric-progress'),
+          samplesMetric: document.getElementById('metric-samples'),
+          sampleCount: document.getElementById('sample-count'),
+          samples: document.getElementById('samples'),
+          artifactCount: document.getElementById('artifact-count'),
+          artifacts: document.getElementById('artifacts'),
+          eventCount: document.getElementById('event-count'),
+          events: document.getElementById('events'),
+          chart: document.getElementById('loss-chart')
+        };
+
+        function fmtBytes(n) {
+          if (!n && n !== 0) return '';
+          const units = ['B', 'KB', 'MB', 'GB'];
+          let size = n, i = 0;
+          while (size >= 1024 && i < units.length - 1) { size /= 1024; i++; }
+          return `${size.toFixed(i ? 1 : 0)} ${units[i]}`;
+        }
+
+        function latestTraining(events) {
+          for (let i = events.length - 1; i >= 0; i--) {
+            if (events[i].type === 'progress' && events[i].stage === 'training') return events[i];
+          }
+          return null;
+        }
+
+        function drawLoss(points) {
+          const canvas = els.chart;
+          const ctx = canvas.getContext('2d');
+          const w = canvas.width, h = canvas.height;
+          ctx.clearRect(0, 0, w, h);
+          ctx.fillStyle = '#ffffff';
+          ctx.fillRect(0, 0, w, h);
+          ctx.strokeStyle = '#d9dee5';
+          ctx.lineWidth = 1;
+          const m = { l: 62, r: 20, t: 22, b: 46 };
+          ctx.beginPath();
+          ctx.moveTo(m.l, m.t);
+          ctx.lineTo(m.l, h - m.b);
+          ctx.lineTo(w - m.r, h - m.b);
+          ctx.stroke();
+          if (!points.length) {
+            ctx.fillStyle = '#626b77';
+            ctx.font = '18px -apple-system, BlinkMacSystemFont, sans-serif';
+            ctx.fillText('Waiting for loss points', m.l + 16, m.t + 42);
+            return;
+          }
+          const xs = points.map(p => p.step);
+          const ys = points.map(p => p.loss);
+          const minX = Math.min(...xs), maxX = Math.max(...xs);
+          const minY = Math.min(...ys), maxY = Math.max(...ys);
+          const x = v => m.l + ((v - minX) / Math.max(maxX - minX, 1)) * (w - m.l - m.r);
+          const y = v => m.t + (1 - ((v - minY) / Math.max(maxY - minY, 1e-9))) * (h - m.t - m.b);
+          ctx.strokeStyle = '#1c7c54';
+          ctx.lineWidth = 3;
+          ctx.beginPath();
+          points.forEach((p, i) => {
+            const px = x(p.step), py = y(p.loss);
+            if (i) ctx.lineTo(px, py); else ctx.moveTo(px, py);
+          });
+          ctx.stroke();
+          ctx.fillStyle = '#121417';
+          ctx.font = '13px ui-monospace, SFMono-Regular, Menlo, monospace';
+          ctx.fillText(`loss ${minY.toFixed(4)} - ${maxY.toFixed(4)}`, m.l, 18);
+          ctx.fillText(`step ${minX} - ${maxX}`, m.l, h - 14);
+        }
+
+        function render(snapshot) {
+          const events = snapshot.events || [];
+          const loss = snapshot.loss_points || [];
+          const artifacts = snapshot.artifacts || [];
+          const images = artifacts.filter(a => a.kind === 'samples' && a.is_image).slice(-12).reverse();
+          const latest = latestTraining(events);
+          const manifest = snapshot.run_manifest;
+          const total = latest?.total_steps || manifest?.total_steps || 0;
+          const step = latest?.step || manifest?.step || 0;
+          const lastLoss = loss.length ? loss[loss.length - 1].loss : latest?.loss;
+
+          els.dot.className = `dot ${snapshot.status}`;
+          els.status.textContent = snapshot.status;
+          els.path.textContent = snapshot.run_directory || '';
+          els.step.textContent = total ? `${step} / ${total}` : (step || '-');
+          els.loss.textContent = Number.isFinite(lastLoss) ? lastLoss.toFixed(6) : '-';
+          els.progress.textContent = total ? `${Math.round((step / total) * 100)}%` : '-';
+          els.samplesMetric.textContent = String(images.length);
+          els.sampleCount.textContent = `${images.length} shown`;
+          els.artifactCount.textContent = `${artifacts.length} files`;
+          els.eventCount.textContent = `${events.length} events`;
+
+          drawLoss(loss);
+
+          els.samples.innerHTML = images.map(a => `
+            <figure>
+              <a href="${a.url}" target="_blank" rel="noreferrer"><img src="${a.url}" alt="${a.name}"></a>
+              <figcaption>${a.name}</figcaption>
+            </figure>
+          `).join('') || '<div class="small">No sample images yet.</div>';
+
+          els.artifacts.innerHTML = artifacts.map(a => `
+            <div class="row">
+              <a href="${a.url}" target="_blank" rel="noreferrer">${a.kind}/${a.name}</a>
+              <span class="small">${fmtBytes(a.size_bytes)}</span>
+            </div>
+          `).join('') || '<div class="small">No artifacts yet.</div>';
+
+          els.events.innerHTML = events.slice(-30).reverse().map(e => `
+            <div class="row event">
+              <span><span class="muted">#${e.sequence}</span> ${e.type}${e.stage ? `:${e.stage}` : ''}${e.step ? ` step ${e.step}` : ''}${e.loss ? ` loss ${Number(e.loss).toFixed(6)}` : ''}</span>
+              <span class="muted">${new Date(e.created_at).toLocaleTimeString()}</span>
+            </div>
+          `).join('') || '<div class="small">No events yet.</div>';
+        }
+
+        async function refresh() {
+          try {
+            const response = await fetch('/api/run', { cache: 'no-store' });
+            render(await response.json());
+          } catch (error) {
+            els.status.textContent = 'viewer error';
+            els.dot.className = 'dot failed';
+          }
+        }
+
+        refresh();
+        setInterval(refresh, 2000);
+      </script>
+    </body>
+    </html>
+    """#
+}
+
+struct LoRATrainingRunViewerSnapshot: Encodable {
+    let runDirectory: String
+    let status: String
+    let runManifest: LoRATrainingRunManifest?
+    let lossPoints: [LoRALossPoint]
+    let events: [LoRATrainingRunEvent]
+    let artifacts: [LoRATrainingRunArtifact]
+
+    enum CodingKeys: String, CodingKey {
+        case runDirectory = "run_directory"
+        case status
+        case runManifest = "run_manifest"
+        case lossPoints = "loss_points"
+        case events
+        case artifacts
+    }
+}
+
+struct LoRATrainingRunArtifact: Encodable, Equatable {
+    let kind: String
+    let name: String
+    let path: String
+    let sizeBytes: Int64?
+    let contentType: String
+    let url: String
+    let isImage: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case name
+        case path
+        case sizeBytes = "size_bytes"
+        case contentType = "content_type"
+        case url
+        case isImage = "is_image"
+    }
+}
+
+private func jsonResponse<T: Encodable>(_ payload: T, status: HTTPResponse.Status = .ok) throws -> Response {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(payload)
+    return Response(
+        status: status,
+        headers: [.contentType: "application/json"],
+        body: .init(byteBuffer: ByteBuffer(bytes: data))
+    )
+}
+
+private func htmlResponse(_ html: String) -> Response {
+    Response(
+        status: .ok,
+        headers: [.contentType: "text/html; charset=utf-8"],
+        body: .init(byteBuffer: ByteBuffer(string: html))
+    )
+}
+
+private func binaryResponse(_ data: Data, contentType: String) -> Response {
+    Response(
+        status: .ok,
+        headers: [.contentType: contentType],
+        body: .init(byteBuffer: ByteBuffer(bytes: data))
+    )
+}
+
+private func errorResponse(message: String) -> Response {
+    let payload = ["error": message]
+    let data = (try? JSONEncoder().encode(payload)) ?? Data("{\"error\":\"viewer error\"}".utf8)
+    return Response(
+        status: .internalServerError,
+        headers: [.contentType: "application/json"],
+        body: .init(byteBuffer: ByteBuffer(bytes: data))
+    )
+}

--- a/Sources/MereRunCore/LoRA/LoRATrainingEvents.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingEvents.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+public struct LoRATrainingRunEvent: Codable, Hashable, Sendable {
+    public static let filenameSuffix = ".events.jsonl"
+
+    public let sequence: Int
+    public let createdAt: Date
+    public let type: String
+    public let stage: String?
+    public let message: String?
+    public let step: Int?
+    public let totalSteps: Int?
+    public let loss: Float?
+    public let fraction: Float?
+    public let path: String?
+    public let metadata: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case sequence
+        case createdAt = "created_at"
+        case type
+        case stage
+        case message
+        case step
+        case totalSteps = "total_steps"
+        case loss
+        case fraction
+        case path
+        case metadata
+    }
+
+    public init(
+        sequence: Int,
+        createdAt: Date = Date(),
+        type: String,
+        stage: String? = nil,
+        message: String? = nil,
+        step: Int? = nil,
+        totalSteps: Int? = nil,
+        loss: Float? = nil,
+        fraction: Float? = nil,
+        path: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.sequence = sequence
+        self.createdAt = createdAt
+        self.type = type
+        self.stage = stage
+        self.message = message
+        self.step = step
+        self.totalSteps = totalSteps
+        self.loss = loss
+        self.fraction = fraction
+        self.path = path
+        self.metadata = metadata
+    }
+
+    public static func url(nextTo outputURL: URL) -> URL {
+        let base = outputURL.deletingPathExtension().lastPathComponent
+        return outputURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(base)\(filenameSuffix)", isDirectory: false)
+    }
+
+    public static func load(from eventURL: URL) throws -> [LoRATrainingRunEvent] {
+        guard FileManager.default.fileExists(atPath: eventURL.path) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let text = try String(contentsOf: eventURL, encoding: .utf8)
+        var events: [LoRATrainingRunEvent] = []
+        for line in text.split(whereSeparator: \.isNewline) {
+            let row = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !row.isEmpty, let data = row.data(using: .utf8) else { continue }
+            if let event = try? decoder.decode(LoRATrainingRunEvent.self, from: data) {
+                events.append(event)
+            }
+        }
+        return events.sorted { lhs, rhs in
+            if lhs.sequence == rhs.sequence {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.sequence < rhs.sequence
+        }
+    }
+}
+
+public final class LoRATrainingEventLogger: @unchecked Sendable {
+    public let eventURL: URL
+
+    private let lock = NSLock()
+    private var nextSequence: Int
+
+    public init(baseOutputURL: URL, resumeExisting: Bool = false) throws {
+        self.eventURL = LoRATrainingRunEvent.url(nextTo: baseOutputURL)
+        try FileManager.default.createDirectory(
+            at: eventURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        if resumeExisting {
+            let existing = try LoRATrainingRunEvent.load(from: eventURL)
+            self.nextSequence = (existing.map(\.sequence).max() ?? -1) + 1
+        } else {
+            self.nextSequence = 0
+            try Data().write(to: eventURL, options: [.atomic])
+        }
+    }
+
+    public func record(
+        type: String,
+        stage: String? = nil,
+        message: String? = nil,
+        step: Int? = nil,
+        totalSteps: Int? = nil,
+        loss: Float? = nil,
+        fraction: Float? = nil,
+        path: String? = nil,
+        metadata: [String: String] = [:]
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let event = LoRATrainingRunEvent(
+            sequence: nextSequence,
+            type: type,
+            stage: stage,
+            message: message,
+            step: step,
+            totalSteps: totalSteps,
+            loss: loss,
+            fraction: fraction,
+            path: path,
+            metadata: metadata
+        )
+        nextSequence += 1
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        var data = try encoder.encode(event)
+        data.append(contentsOf: "\n".utf8)
+
+        if let handle = try? FileHandle(forWritingTo: eventURL) {
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            try handle.close()
+        } else {
+            try data.write(to: eventURL, options: [.atomic])
+        }
+    }
+}

--- a/Sources/MereRunCore/LoRA/LoRATrainingMetrics.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingMetrics.swift
@@ -169,7 +169,7 @@ public final class LoRATrainingMetricsLogger: @unchecked Sendable {
         try html.write(to: htmlURL, atomically: true, encoding: .utf8)
     }
 
-    private static func loadPoints(from csvURL: URL) throws -> [LoRALossPoint] {
+    public static func loadPoints(from csvURL: URL) throws -> [LoRALossPoint] {
         guard FileManager.default.fileExists(atPath: csvURL.path) else {
             return []
         }

--- a/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
@@ -6,6 +6,7 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
     func testImageCommandExposesTrainLoRA() {
         let commandNames = Set(Image.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertTrue(commandNames.contains("train-lora"))
+        XCTAssertTrue(commandNames.contains("visualize-run"))
     }
 
     func testTrainLoRAParsesDefaults() throws {
@@ -46,6 +47,8 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.sampleGuidanceScale, 1.0)
         XCTAssertEqual(cmd.sampleLoRAScale, 1.0)
         XCTAssertNil(cmd.sampleSeed)
+        XCTAssertFalse(cmd.visualize)
+        XCTAssertEqual(cmd.visualizePort, 8787)
         XCTAssertNil(cmd.loraTargetRanks)
         XCTAssertNil(cmd.loraRankPreset)
         XCTAssertNil(cmd.loraTargetPreset)
@@ -94,6 +97,8 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
             "--sample-cfg", "1.2",
             "--sample-lora-scale", "0.75",
             "--sample-seed", "99",
+            "--visualize",
+            "--visualize-port", "8899",
             "--lora-target-ranks", ".attn.to_q=128,.ff.linear_in=64",
             "--timestep-sampling", "shift",
             "--timestep-loss-weighting", "weighted",
@@ -136,6 +141,8 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.sampleGuidanceScale, 1.2)
         XCTAssertEqual(cmd.sampleLoRAScale, 0.75)
         XCTAssertEqual(cmd.sampleSeed, 99)
+        XCTAssertTrue(cmd.visualize)
+        XCTAssertEqual(cmd.visualizePort, 8899)
         XCTAssertEqual(cmd.loraTargetRanks, ".attn.to_q=128,.ff.linear_in=64")
         XCTAssertNil(cmd.loraRankPreset)
         XCTAssertNil(cmd.loraTargetPreset)
@@ -159,6 +166,54 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
 
         XCTAssertNil(cmd.data)
         XCTAssertEqual(cmd.syntheticSamples, 2)
+    }
+
+    func testImageVisualizeRunParsesDefaults() throws {
+        let cmd = try ImageVisualizeRun.parse(["/tmp/lora-run"])
+
+        XCTAssertEqual(cmd.runDirectory, "/tmp/lora-run")
+        XCTAssertEqual(cmd.port, 8787)
+    }
+
+    func testImageVisualizeRunParsesPort() throws {
+        let cmd = try ImageVisualizeRun.parse([
+            "/tmp/lora-run",
+            "--port", "8899",
+        ])
+
+        XCTAssertEqual(cmd.runDirectory, "/tmp/lora-run")
+        XCTAssertEqual(cmd.port, 8899)
+    }
+
+    func testLoRATrainingRunViewerSnapshotReadsRunArtifacts() throws {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-viewer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let outputURL = temp.appendingPathComponent("demo.safetensors")
+        try Data("adapter".utf8).write(to: outputURL)
+
+        let metrics = try LoRATrainingMetricsLogger(baseOutputURL: outputURL, resumeExisting: false)
+        try metrics.record(step: 10, loss: 0.75)
+        try metrics.record(step: 20, loss: 0.5)
+
+        let logger = try LoRATrainingEventLogger(baseOutputURL: outputURL)
+        try logger.record(type: "run_started", stage: "starting", step: 0, totalSteps: 20)
+        try logger.record(type: "progress", stage: "training", step: 20, totalSteps: 20, loss: 0.5, fraction: 1)
+
+        let sampleDir = temp.appendingPathComponent("samples", isDirectory: true)
+        try FileManager.default.createDirectory(at: sampleDir, withIntermediateDirectories: true)
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: sampleDir.appendingPathComponent("demo-step20-sample.png"))
+
+        let viewer = LoRATrainingRunViewer(runDirectoryURL: temp)
+        let snapshot = try viewer.snapshot()
+
+        XCTAssertEqual(snapshot.status, "running")
+        XCTAssertEqual(snapshot.lossPoints.map(\.step), [10, 20])
+        XCTAssertEqual(snapshot.events.map(\.type), ["run_started", "progress"])
+        XCTAssertTrue(snapshot.artifacts.contains { $0.kind == "root" && $0.name == "demo.safetensors" })
+        XCTAssertTrue(snapshot.artifacts.contains { $0.kind == "samples" && $0.isImage })
     }
 
     func testTrainLoRAParsesKleinModelPath() throws {

--- a/Tests/MereRunCoreTests/LoRATrainingArtifactsTests.swift
+++ b/Tests/MereRunCoreTests/LoRATrainingArtifactsTests.swift
@@ -97,6 +97,40 @@ final class LoRATrainingArtifactsTests: MereRunCoreTestCase {
         XCTAssertTrue(csv.contains("3,0.5"))
     }
 
+    func testTrainingEventLoggerPersistsJSONLinesAndResumesSequence() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let outputURL = temp.appendingPathComponent("train-output.safetensors")
+        let logger = try LoRATrainingEventLogger(baseOutputURL: outputURL)
+        try logger.record(
+            type: "run_started",
+            stage: "starting",
+            step: 0,
+            totalSteps: 20,
+            metadata: ["model": "image-klein-base-9b"]
+        )
+        try logger.record(
+            type: "progress",
+            stage: "training",
+            step: 10,
+            totalSteps: 20,
+            loss: 0.42,
+            fraction: 0.5
+        )
+
+        let resumed = try LoRATrainingEventLogger(baseOutputURL: outputURL, resumeExisting: true)
+        try resumed.record(type: "run_finished", stage: "finished", step: 20, totalSteps: 20, fraction: 1)
+
+        let events = try LoRATrainingRunEvent.load(from: logger.eventURL)
+        XCTAssertEqual(events.count, 3)
+        XCTAssertEqual(events.map(\.sequence), [0, 1, 2])
+        XCTAssertEqual(events[0].type, "run_started")
+        XCTAssertEqual(events[1].stage, "training")
+        XCTAssertEqual(events[1].loss, 0.42)
+        XCTAssertEqual(events[2].type, "run_finished")
+    }
+
     func testCheckpointArchiveCreation() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,7 @@ Public tree:
 - `mere.run guide`
 - `mere.run image generate`
 - `mere.run image train-lora`
+- `mere.run image visualize-run`
 - `mere.run image validate`
 - `mere.run text chat`
 - `mere.run text code`
@@ -328,6 +329,7 @@ swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-klein.safetensors \
   --recipe klein-fast-style \
+  --visualize \
   --quiet
 swift run mere.run image generate \
   --model image-klein-9b \
@@ -372,7 +374,19 @@ Key options:
 - `--no-compile`: disable compiled train-step graphs
 - `--lora-target-preset`: exact Klein target preset, including `fal-klein-fast`
 - `--lora-target-mode`: for FLUX.2 Klein, `suffix` or `transformer-linear-walk`
+- `--visualize`: start a loopback LoRA training dashboard for the run
+- `--visualize-port`: port for the local dashboard; defaults to `8787`
 - `--quiet`
+
+### `mere.run image visualize-run`
+
+Open the same local LoRA training dashboard for an existing run directory.
+The viewer reads `run.json`, `*.loss.csv`, `*.events.jsonl`, samples,
+checkpoints, and adapter artifacts from disk.
+
+```bash
+swift run mere.run image visualize-run ./runs/my-style --port 8787
+```
 
 ### `mere.run image validate`
 

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -74,6 +74,7 @@ swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-klein.safetensors \
   --recipe klein-fast-style \
+  --visualize \
   --quiet
 swift run mere.run image generate \
   --model image-klein-9b \
@@ -81,6 +82,14 @@ swift run mere.run image generate \
   --lora ./style-klein.safetensors \
   --lora-scale 2.0 \
   --output ./style-klein.png
+```
+
+Add `--visualize` during training to start a loopback dashboard with the live
+loss curve, progress events, samples, checkpoints, and run artifacts. Reopen a
+completed or copied run directory later with:
+
+```bash
+swift run mere.run image visualize-run ./runs/my-style
 ```
 
 ### Bonsai binary and ternary


### PR DESCRIPTION
## Summary
- add `mere.run image visualize-run` plus `image train-lora --visualize` for a loopback LoRA run dashboard
- persist typed LoRA training events alongside existing metrics and samples
- accept preferred nested Qwen3 Code GGUF paths through symlinked install roots
- ignore local `.tmp/` scratch artifacts

## Validation
- `swift test --filter ImageTrainLoRACommandParsingTests`
- `swift test --filter LoRATrainingArtifactsTests`
- `swift test --filter ManagedModelCatalogTests`
- `./scripts/check.sh`