### PR TITLE
Prepare 0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.18.0 - 2026-07-01
+
 ### Added
 
+- added `image train-lora --visualize` and `image visualize-run` for a
+  loopback LoRA training dashboard that reads run manifests, loss CSVs,
+  typed JSONL progress events, samples, checkpoints, and adapter artifacts.
 - macOS Studio app: inline audio/video playback (AVKit / AVAudioPlayer) for
   generated speech, music, sound effects, and video; determinate download and
   generation progress with bytes, speed, and percentage; drag-and-drop file
@@ -26,6 +31,11 @@ The format is based on Keep a Changelog.
 - added `mere.run plugin { list, info, install, doctor }` for live official
   companion-plugin catalog discovery, `pipx` install previews, opt-in
   execution, and post-install manifest verification.
+- added hosted Linux x86_64 CUDA release artifacts alongside the default
+  x86_64/amd64 CPU tarball and Debian package lanes.
+- added dedicated benchmarking docs plus local `model benchmark api-workload`
+  and `model benchmark code` lanes for serving workloads and generated-code
+  eval slices.
 - added `vision caption --prompt-file`, `--focus`, and `--trigger-token` for
   domain-aware dataset captions and deterministic LoRA trigger prefixes.
 - added FLUX.2 Klein support to `image train-lora` when `--model` resolves to a
@@ -42,12 +52,22 @@ The format is based on Keep a Changelog.
 - added `vision-ocr-infinity-pro-int8` as an explicit-pull native Infinity
   Pro OCR option for quality-focused evals while keeping LightOnOCR as the
   default `vision ocr` backend.
+- added `text-code-north-mini` as a managed GGUF coding model target for Cohere
+  Labs North Mini Code through the local `text-code` runtime.
 - added `text-agent-ornith-9b` as an experimental native Qwen-family MLX/OptiQ
   coding-agent target backed by the pinned public Ornith 1.0 9B snapshot.
 - added `text-agent-ornith-35b-mlx` as a local native Qwen-family MLX Q4
   coding-agent target for testing converted Ornith 1.0 35B snapshots.
 - added `text-agent-ornith-35b` as a managed native GGUF coding-agent target
   for larger Ornith evals through the existing `text-code` runtime.
+
+### Changed
+
+- improved native Qwen-family and Gemma decode paths, including Q35 switch
+  routing alignment with MLX-LM, dense-path MLXFast attention learnings, and
+  faster Gemma4 greedy decode.
+- locked fast Krea and Klein LoRA recipes to the proven local training step
+  counts used for the current native image-training workflow.
 
 ### Fixed
 
@@ -67,6 +87,9 @@ The format is based on Keep a Changelog.
   visible response text across native chat responses, API non-streaming output,
   and code benchmark reports, including reopened-reasoning diagnostics for
   loop-like model output.
+- fixed code benchmark stop handling for generated-code eval slices.
+- fixed Qwen3 Code GGUF pull validation so preferred nested hub files are
+  accepted through symlinked managed install roots.
 - fixed MLX CUDA BF16 sigmoid JIT smoke failures by patching the upstream CUDA
   unary kernel path during `scripts/prepare-linux-native.sh`.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for the current
 validation boundary, CUDA notes, and first commands:
 
 ```bash
-tag=v0.17.0
+tag=v0.18.0
 version="${tag#v}"
 
 # Portable tarball
@@ -124,7 +124,7 @@ during NVRTC JIT compilation:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.17.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
 ```
 
 Current CUDA validation should be treated as limited to the exact hosts that
@@ -169,7 +169,7 @@ swift run mere.run --help
 To build Linux release packages from a Linux x86_64 Swift toolchain host:
 
 ```bash
-scripts/package-linux.sh --version 0.17.0
+scripts/package-linux.sh --version 0.18.0
 ls dist/linux/
 ```
 
@@ -178,14 +178,14 @@ builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.17.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
 On Linux arm64, use a CUDA-provisioned host:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.17.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.18.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.17.0"
+    static let current = "0.18.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.17.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.18.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -100,7 +100,7 @@ artifacts. The default GitHub release workflow publishes x86_64/amd64 CPU
 artifacts and x86_64 CUDA artifacts:
 
 ```bash
-scripts/package-linux.sh --version 0.17.0
+scripts/package-linux.sh --version 0.18.0
 ls dist/linux/
 ```
 
@@ -113,7 +113,7 @@ CUDA variants use a suffix so they can ship beside the CPU artifacts:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.17.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
 ```
 
 That writes artifacts such as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Linux-only setup path, first commands, release checks, and CUDA validation
 limits, see [Linux QuickStart](./linux-quickstart.md).
 
 ```bash
-tag=v0.17.0
+tag=v0.18.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64; deb_arch=amd64 ;;

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -33,7 +33,7 @@ manifests, and CUDA-gated arm64 package work.
 Use this path on Debian or Ubuntu-style systems:
 
 ```bash
-tag=v0.17.0
+tag=v0.18.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) deb_arch=amd64 ;;
@@ -54,7 +54,7 @@ assets that the CLI needs at runtime.
 Use this path when you do not want to install a Debian package:
 
 ```bash
-tag=v0.17.0
+tag=v0.18.0
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -82,7 +82,7 @@ Use this artifact for GPU worker images, remote trainers, and other x86_64 CUDA
 hosts:
 
 ```bash
-tag=v0.17.0
+tag=v0.18.0
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run-${tag}-linux-x86_64-cuda.tar.gz" -o mere-run-linux-cuda.tar.gz
 tar -xzf mere-run-linux-cuda.tar.gz
 cd "mere-run-${tag}-linux-x86_64-cuda"
@@ -134,7 +134,7 @@ that build locally on a Linux x86_64 CUDA development host:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.17.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
@@ -148,7 +148,7 @@ MERERUN_LINUX_ACCEL=cuda \
 MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
 MERERUN_NATIVE_BUILD_JOBS=14 \
 MERERUN_CUDA_ARCHITECTURES="86-real;90-virtual" \
-  scripts/package-linux.sh --version 0.17.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
 ```
 
 Run a real GPU smoke on the target runtime class before widening support claims.
@@ -165,7 +165,7 @@ repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.17.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.18.0
 ls dist/linux/
 ```
 
@@ -242,7 +242,7 @@ studio, and DMG packaging are macOS-only.
 Each Linux release includes `SHA256SUMS` beside the tarball and `.deb`:
 
 ```bash
-tag=v0.17.0
+tag=v0.18.0
 
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/SHA256SUMS" -o SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,7 +90,7 @@ CPU-oriented Linux manifest path.
 Linux release packaging has its own artifact check:
 
 ```bash
-scripts/package-linux.sh --version 0.17.0
+scripts/package-linux.sh --version 0.18.0
 test -s dist/linux/SHA256SUMS
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
@@ -103,7 +103,7 @@ Linux builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.17.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
 tar -tzf dist/linux/mere-run-*-linux-x86_64-cuda.tar.gz | grep '/.mererun-linux-cuda$'
 dpkg-deb --info dist/linux/mere-run-cuda_*_amd64.deb
 ```
@@ -111,7 +111,7 @@ dpkg-deb --info dist/linux/mere-run-cuda_*_amd64.deb
 On Linux arm64, use CUDA for the package check:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.17.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.18.0
 ```
 
 The `linux-release` workflow runs the hosted package and manifest boundary for

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.17.0"
+default_version="0.18.0"
 if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary
- bump public CLI/app fallback version and install snippets to 0.18.0
- promote accumulated Unreleased notes into 0.18.0 dated 2026-07-01
- add release-note coverage for LoRA run viewer, North Mini, benchmark lanes, hosted CUDA artifacts, and Qwen3 GGUF validation

## Validation
- swift test --filter CLIModelStoreBootstrapTests/testMereRunCLIExposesReleaseVersion
- ./scripts/check.sh
- swift run mere.run --version
- corepack pnpm docs:build