### PR TITLE
Fix macOS package bundle path capture

### DIFF
--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -19,7 +19,13 @@ cd "$repo_root"
 configuration="${1:-release}"
 identity="${MERERUN_CODESIGN_IDENTITY:--}"
 
-bundle="$(MERERUN_CODESIGN_IDENTITY="$identity" "${repo_root}/scripts/build_mere_run_app.sh" "$configuration")"
+build_log="$(mktemp -t mere-run-app-build.XXXXXX)"
+trap 'rm -f "$build_log"' EXIT
+if ! MERERUN_CODESIGN_IDENTITY="$identity" "${repo_root}/scripts/build_mere_run_app.sh" "$configuration" 2>&1 | tee "$build_log"; then
+  echo "build_mere_run_app.sh failed; see build output above." >&2
+  exit 66
+fi
+bundle="$(awk 'NF { line = $0 } END { print line }' "$build_log")"
 if [[ ! -d "$bundle" ]]; then
   echo "build_mere_run_app.sh did not produce a bundle: ${bundle}" >&2
   exit 66


### PR DESCRIPTION
## Summary
- stream macOS app build output while capturing only the final emitted bundle path
- keep package-macos.sh from treating the Swift build log as the bundle path

## Validation
- bash -n scripts/package-macos.sh
- reproduced the failure on book.local during the v0.18.0 release build path