### PR TITLE
Fix Linux CUDA Swift support linkage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -116,6 +116,7 @@ let prebuiltMLXLinkerSettings: [LinkerSetting] = useLinuxPrebuiltMLX
         "-lNumerics",
         "-lComplexModule",
         "-lRealModule",
+        "-lswiftSwiftOnoneSupport",
         "-lpthread",
         "-ldl",
         "-lstdc++",

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -305,6 +305,7 @@ mlx_swift_cuda_link_flags() {
     flags+=("-L" "/usr/lib/$deb_multiarch")
   fi
 
+  flags+=("-lswiftSwiftOnoneSupport")
   flags+=(
     "-lcublasLt"
     "-lnvrtc"

--- a/scripts/prepare-linux-native.sh
+++ b/scripts/prepare-linux-native.sh
@@ -864,6 +864,7 @@ mlx_swift_cuda_link_flags() {
     flags+=("-L" "/usr/lib/$deb_multiarch")
   fi
 
+  flags+=("-lswiftSwiftOnoneSupport")
   flags+=(
     "-lcublasLt"
     "-lnvrtc"


### PR DESCRIPTION
## Summary
- link Swift Onone support for the Linux CUDA prebuilt MLX bridge
- include the same support library in the helper-generated CUDA link flags

## Validation
- bash -n scripts/package-linux.sh scripts/prepare-linux-native.sh
- swift package dump-package
- tensor.local Docker relink test with appended -lswiftSwiftOnoneSupport completed the release SwiftPM build