### PR TITLE
Add macOS release command runner

### DIFF
--- a/release-macos-app.command
+++ b/release-macos-app.command
@@ -1,0 +1,61 @@
+#!/bin/zsh
+set -euo pipefail
+
+# Double-click this file from a maintainer macOS signing host. Running through
+# Terminal.app gives codesign normal access to the user's unlocked login keychain.
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$ROOT_DIR/logs"
+LOG_PATH="$LOG_DIR/release-macos-app-$(date +%Y%m%d-%H%M%S).log"
+
+mkdir -p "$LOG_DIR"
+
+exec > >(tee -a "$LOG_PATH") 2>&1
+
+finish() {
+  local exit_code=$?
+  echo "[release-macos-app.command] done $(date) status=$exit_code"
+  echo "[release-macos-app.command] log: $LOG_PATH"
+}
+trap finish EXIT
+
+source_env_file() {
+  local env_file="$1"
+  if [[ -f "$env_file" ]]; then
+    # shellcheck disable=SC1090
+    source "$env_file"
+    echo "[release-macos-app.command] env file: $env_file"
+  fi
+}
+
+echo "[release-macos-app.command] started $(date)"
+echo "[release-macos-app.command] host $(hostname)"
+echo "[release-macos-app.command] root $ROOT_DIR"
+
+source_env_file "$ROOT_DIR/.notarize.local.env"
+source_env_file "$HOME/.config/mere-run/notary.env"
+source_env_file "$HOME/.config/merekit-console/notary.env"
+
+export MERERUN_CODESIGN_IDENTITY="${MERERUN_CODESIGN_IDENTITY:-${APPLE_SIGNING_IDENTITY:-${SIGN_IDENTITY:-Developer ID Application: Kyle McCullough (S5JDPCT8RC)}}}"
+export MERERUN_NOTARY_KEY_ID="${MERERUN_NOTARY_KEY_ID:-${APPLE_API_KEY:-${KEY_ID:-}}}"
+export MERERUN_NOTARY_ISSUER_ID="${MERERUN_NOTARY_ISSUER_ID:-${APPLE_API_ISSUER:-${ISSUER_ID:-}}}"
+export MERERUN_NOTARY_KEY_PATH="${MERERUN_NOTARY_KEY_PATH:-${APPLE_API_KEY_PATH:-${KEY_PATH:-}}}"
+export MERERUN_NOTARY_TEAM_ID="${MERERUN_NOTARY_TEAM_ID:-${APPLE_TEAM_ID:-${TEAM_ID:-}}}"
+
+echo "[release-macos-app.command] signing identity: $MERERUN_CODESIGN_IDENTITY"
+if [[ -n "${MERERUN_NOTARY_PROFILE:-}" ]]; then
+  echo "[release-macos-app.command] notary auth: keychain profile"
+elif [[ -n "$MERERUN_NOTARY_KEY_ID" && -n "$MERERUN_NOTARY_KEY_PATH" ]]; then
+  echo "[release-macos-app.command] notary auth: App Store Connect API key"
+  echo "[release-macos-app.command] api key path: configured"
+elif [[ -n "${MERERUN_NOTARY_APPLE_ID:-}" ]]; then
+  echo "[release-macos-app.command] notary auth: Apple ID"
+else
+  echo "[release-macos-app.command] notary auth: unset"
+fi
+
+cd "$ROOT_DIR"
+
+bash scripts/package-macos.sh release

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 #   MERERUN_NOTARY_PROFILE      notarytool keychain profile name
 #                               (created via: xcrun notarytool store-credentials)
 #     OR the trio:
+#   MERERUN_NOTARY_KEY_ID, MERERUN_NOTARY_ISSUER_ID, MERERUN_NOTARY_KEY_PATH
+#                               App Store Connect API key notarization
+#     OR the trio:
 #   MERERUN_NOTARY_APPLE_ID, MERERUN_NOTARY_PASSWORD, MERERUN_NOTARY_TEAM_ID
 #
 # Without a codesign identity the script still produces an (ad-hoc, un-notarized) DMG so
@@ -34,12 +37,22 @@ fi
 build_dir="$(dirname "$bundle")"
 app_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${bundle}/Contents/Info.plist" 2>/dev/null || echo "0.0.0")"
 dmg_path="${build_dir}/MereRun-${app_version}.dmg"
+app_zip_path="${build_dir}/MereRun-${app_version}.app.zip"
 staging="${build_dir}/dmg-staging"
 
 notarize() {
   local target="$1"
   if [[ -n "${MERERUN_NOTARY_PROFILE:-}" ]]; then
     xcrun notarytool submit "$target" --keychain-profile "$MERERUN_NOTARY_PROFILE" --wait
+  elif [[ -n "${MERERUN_NOTARY_KEY_ID:-}" && -n "${MERERUN_NOTARY_KEY_PATH:-}" ]]; then
+    local args=(
+      --key "$MERERUN_NOTARY_KEY_PATH"
+      --key-id "$MERERUN_NOTARY_KEY_ID"
+    )
+    if [[ -n "${MERERUN_NOTARY_ISSUER_ID:-}" ]]; then
+      args+=(--issuer "$MERERUN_NOTARY_ISSUER_ID")
+    fi
+    xcrun notarytool submit "$target" "${args[@]}" --wait
   elif [[ -n "${MERERUN_NOTARY_APPLE_ID:-}" && -n "${MERERUN_NOTARY_PASSWORD:-}" && -n "${MERERUN_NOTARY_TEAM_ID:-}" ]]; then
     xcrun notarytool submit "$target" \
       --apple-id "$MERERUN_NOTARY_APPLE_ID" \
@@ -70,9 +83,12 @@ if [[ "$identity" != "-" ]]; then
 fi
 
 if [[ "$identity" != "-" ]]; then
-  if notarize "$bundle"; then
+  rm -f "$app_zip_path"
+  ditto -c -k --keepParent "$bundle" "$app_zip_path"
+  if notarize "$app_zip_path"; then
     xcrun stapler staple "$bundle"
   fi
+  rm -f "$app_zip_path"
   if notarize "$dmg_path"; then
     xcrun stapler staple "$dmg_path"
   fi


### PR DESCRIPTION
## Summary
- add a Terminal.app .command runner for maintainer macOS release builds
- map existing maintainer notary env files into the mere.run package script environment
- support App Store Connect API-key notarization in scripts/package-macos.sh

## Validation
- zsh -n release-macos-app.command
- bash -n scripts/package-macos.sh