### PR TITLE
Add native text LoRA training

### DIFF
--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -113,6 +113,12 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-q36-nano, text-agent-ornith-9b, text-agent-ornith-35b-mlx, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
+    @Option(name: [.customLong("lora")], help: "Optional local LoRA adapter .safetensors path for supported chat models.")
+    var loraPath: String?
+
+    @Option(name: [.customLong("lora-scale")], help: "LoRA adapter scale.")
+    var loraScale: Double = 1.0
+
     @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")
     var thinking: Bool = false
 
@@ -176,12 +182,20 @@ struct TextChat: AsyncParsableCommand {
             throw ValidationError("The 'shell_exec' tool requires --allow-shell-exec.")
         }
 
+        let lora: LoRA?
+        if let loraPath, !loraPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lora = .local(path: URL(fileURLWithPath: loraPath).standardizedFileURL.path, scale: loraScale)
+        } else {
+            lora = nil
+        }
+
         let request = ChatRequest(
             messages: messages,
             maxTokens: maxTokens,
             temperature: temperature,
             topP: topP,
             showThinking: thinking,
+            lora: lora,
             tools: toolDefs
         )
 

--- a/Sources/MereRunCLI/Commands/TextCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextCommand.swift
@@ -9,6 +9,7 @@ struct Text: ParsableCommand {
             TextCode.self,
             TextEmbed.self,
             TextAnonymize.self,
+            TextTrainLoRA.self,
         ]
     )
 }

--- a/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
@@ -1,0 +1,452 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct TextTrainLoRA: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "train-lora",
+        abstract: "Train a native text LoRA adapter from chat-style SFT JSONL.",
+        discussion: """
+        This is the native mere.run text fine-tuning entrypoint. It accepts OpenAI-style chat
+        JSONL records with system/user/assistant messages and writes MereRun adapter metadata.
+        Use --dry-run to validate data, create manifests, and prepare a reproducible run.
+        """
+    )
+
+    @Option(name: [.customShort("d"), .long], help: "SFT JSONL dataset path.")
+    var data: String
+
+    @Option(name: [.customShort("o"), .long], help: "Output .safetensors adapter path.")
+    var output: String
+
+    @Option(name: [.customShort("m"), .long], help: "Base text model id.")
+    var model: String = Gemma4Resources.twelveB4BitModelId
+
+    @Option(name: [.customLong("model-path")], help: "Optional explicit base model directory.")
+    var modelPath: String?
+
+    @Option(name: [.customLong("eval")], help: "Optional eval prompts JSONL path.")
+    var eval: String?
+
+    @Option(name: [.customLong("adapter-name")], help: "Adapter display name.")
+    var adapterName: String = "local-assistant"
+
+    @Option(name: [.customLong("training-steps"), .customLong("steps")], help: "Number of optimizer steps.")
+    var trainingSteps: Int = 600
+
+    @Option(name: [.long], help: "Batch size.")
+    var batchSize: Int = 1
+
+    @Option(name: [.customLong("learning-rate"), .customLong("lr")], help: "Learning rate.")
+    var learningRate: Float = 0.0001
+
+    @Option(name: [.customLong("rank")], help: "LoRA rank.")
+    var rank: Int = 16
+
+    @Option(name: [.customLong("alpha")], help: "LoRA alpha. Defaults to rank.")
+    var alpha: Float?
+
+    @Option(name: [.customLong("max-sequence-length")], help: "Maximum training sequence length.")
+    var maxSequenceLength: Int = 4096
+
+    @Option(name: [.long], help: "Random seed.")
+    var seed: UInt64 = 42
+
+    @Option(name: [.customLong("target-modules")], help: "Comma-separated LoRA target suffixes.")
+    var targetModules: String = "q_proj,k_proj,v_proj,o_proj"
+
+    @Flag(name: [.customLong("dry-run")], help: "Validate data and write manifests without optimizer steps.")
+    var dryRun: Bool = false
+
+    @Flag(name: [.customLong("visualize")], help: "Start a loopback LoRA training dashboard for this run.")
+    var visualize: Bool = false
+
+    @Option(name: [.customLong("visualize-port")], help: "Loopback port for --visualize.")
+    var visualizePort: Int = 8787
+
+    @Flag(name: [.long], help: "Print a machine-readable JSON summary.")
+    var json: Bool = false
+
+    func run() async throws {
+        try validateOptions()
+        guard Gemma4Resources.handles(modelSpec: model) else {
+            throw ValidationError("--model must be a Gemma4 text model id for native text LoRA training.")
+        }
+
+        let dataURL = URL(fileURLWithPath: data).standardizedFileURL
+        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
+        let examples = try TextSFTDataset.load(from: dataURL)
+        let summary = TextSFTDataset.summarize(examples)
+        let evalCount = try eval.map { try Self.countJSONLLines(URL(fileURLWithPath: $0).standardizedFileURL) }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let visualization = try startVisualizationIfNeeded(
+            dataURL: dataURL,
+            outputURL: outputURL,
+            datasetSummary: summary,
+            evalPromptCount: evalCount
+        )
+        defer { visualization?.stop() }
+
+        var report: TextLoRATrainingReport?
+        do {
+            if !dryRun {
+                report = try await Gemma4TextLoRATrainingPipeline.train(
+                    Gemma4TextLoRATrainingPipelineRequest(
+                        modelId: model,
+                        modelPath: modelPath,
+                        examples: examples,
+                        outputURL: outputURL,
+                        trainingConfig: TextLoRATrainingConfig(
+                            trainingSteps: trainingSteps,
+                            batchSize: batchSize,
+                            learningRate: learningRate,
+                            seed: seed
+                        ),
+                        maxSequenceLength: maxSequenceLength,
+                        rank: rank,
+                        alpha: alpha ?? Float(rank),
+                        targetSuffixes: resolvedTargetModules(),
+                        metadata: [
+                            "adapter_name": adapterName,
+                            "dataset_fingerprint": summary.fingerprint,
+                        ]
+                    ),
+                    progressHandler: makeChatProgressHandler(eventLogger: visualization?.logger),
+                    trainingProgressHandler: makeTrainingProgressHandler(eventLogger: visualization?.logger)
+                )
+            }
+        } catch {
+            try? visualization?.logger.record(
+                type: "run_failed",
+                stage: "failed",
+                message: error.localizedDescription,
+                path: outputURL.path
+            )
+            throw error
+        }
+
+        let manifest = makeManifest(
+            outputURL: outputURL,
+            datasetSummary: summary,
+            evalPromptCount: evalCount,
+            status: dryRun ? "prepared" : "trained"
+        )
+        try manifest.write(nextTo: outputURL)
+        if !dryRun {
+            try recordVisualizationRunManifest(
+                dataURL: dataURL,
+                outputURL: outputURL,
+                datasetSummary: summary,
+                evalPromptCount: evalCount,
+                status: "trained",
+                step: trainingSteps
+            )
+            try visualization?.logger.record(
+                type: "run_finished",
+                stage: "finished",
+                step: trainingSteps,
+                totalSteps: trainingSteps,
+                fraction: 1,
+                path: outputURL.path
+            )
+        }
+
+        let result = TextTrainLoRAResult(
+            model: model,
+            adapterName: adapterName,
+            outputPath: outputURL.path,
+            manifestPath: TextLoRATrainingManifest.url(nextTo: outputURL).path,
+            dataset: summary,
+            evalPromptCount: evalCount,
+            dryRun: dryRun,
+            status: manifest.status,
+            trainingReport: report
+        )
+
+        if json {
+            print(try result.jsonString())
+        } else {
+            print("Dataset: \(summary.exampleCount) examples, fingerprint \(summary.fingerprint)")
+            print("Manifest: \(result.manifestPath)")
+            print("Adapter: \(result.outputPath)")
+            if let report {
+                let finalLoss = report.finalLoss.map { String($0) } ?? "n/a"
+                print("Training: \(report.steps) steps, \(report.layerCount) LoRA layers, final loss \(finalLoss)")
+            }
+        }
+    }
+
+    private func validateOptions() throws {
+        guard trainingSteps >= 1 else {
+            throw ValidationError("--training-steps must be >= 1")
+        }
+        guard batchSize >= 1 else {
+            throw ValidationError("--batch-size must be >= 1")
+        }
+        guard learningRate > 0 else {
+            throw ValidationError("--learning-rate must be > 0")
+        }
+        guard rank >= 1 else {
+            throw ValidationError("--rank must be >= 1")
+        }
+        if let alpha {
+            guard alpha > 0 else {
+                throw ValidationError("--alpha must be > 0")
+            }
+        }
+        guard maxSequenceLength >= 128 else {
+            throw ValidationError("--max-sequence-length must be >= 128")
+        }
+        guard !resolvedTargetModules().isEmpty else {
+            throw ValidationError("--target-modules must include at least one target suffix")
+        }
+        if visualize {
+            guard !dryRun else {
+                throw ValidationError("--visualize cannot be combined with --dry-run")
+            }
+            guard (1...65535).contains(visualizePort) else {
+                throw ValidationError("--visualize-port must be between 1 and 65535")
+            }
+        }
+    }
+
+    private func makeManifest(
+        outputURL: URL,
+        datasetSummary: TextSFTDatasetSummary,
+        evalPromptCount: Int?,
+        status: String
+    ) -> TextLoRATrainingManifest {
+        TextLoRATrainingManifest(
+            baseModel: model,
+            outputFile: outputURL.lastPathComponent,
+            adapterName: adapterName,
+            training: TextLoRATrainingManifest.Training(
+                trainingSteps: trainingSteps,
+                batchSize: batchSize,
+                learningRate: learningRate,
+                maxSequenceLength: maxSequenceLength,
+                seed: seed,
+                dataset: datasetSummary
+            ),
+            lora: TextLoRATrainingManifest.LoRA(
+                rank: rank,
+                alpha: alpha ?? Float(rank),
+                targetModules: resolvedTargetModules()
+            ),
+            evalPromptCount: evalPromptCount,
+            status: status
+        )
+    }
+
+    private func resolvedTargetModules() -> [String] {
+        targetModules
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func countJSONLLines(_ url: URL) throws -> Int {
+        let text = String(decoding: try Data(contentsOf: url), as: UTF8.self)
+        return text.split(whereSeparator: \.isNewline).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }.count
+    }
+
+    private func startVisualizationIfNeeded(
+        dataURL: URL,
+        outputURL: URL,
+        datasetSummary: TextSFTDatasetSummary,
+        evalPromptCount: Int?
+    ) throws -> TextLoRATrainingVisualization? {
+        guard visualize else { return nil }
+
+        try recordVisualizationRunManifest(
+            dataURL: dataURL,
+            outputURL: outputURL,
+            datasetSummary: datasetSummary,
+            evalPromptCount: evalPromptCount,
+            status: "running",
+            step: 0
+        )
+
+        let logger = try LoRATrainingEventLogger(baseOutputURL: outputURL)
+        let viewer = LoRATrainingRunViewer(runDirectoryURL: outputURL.deletingLastPathComponent())
+        let host = "127.0.0.1"
+        let port = visualizePort
+        let task = Task {
+            do {
+                try await viewer.run(host: host, port: port)
+            } catch is CancellationError {
+                // The training command owns this helper server and cancels it when the run exits.
+            } catch {
+                CLIStderr.write("[visualize] server stopped: \(error.localizedDescription)\n")
+            }
+        }
+        try logger.record(
+            type: "run_started",
+            stage: "starting",
+            message: "Text LoRA training started.",
+            step: 0,
+            totalSteps: trainingSteps,
+            fraction: 0,
+            path: outputURL.path,
+            metadata: [
+                "viewer_url": "http://\(host):\(port)",
+                "model_id": model,
+                "model_path": modelPath ?? "",
+                "data": dataURL.path,
+                "output": outputURL.path,
+                "dataset_fingerprint": datasetSummary.fingerprint,
+            ]
+        )
+        return TextLoRATrainingVisualization(logger: logger, serverTask: task)
+    }
+
+    private func recordVisualizationRunManifest(
+        dataURL: URL,
+        outputURL: URL,
+        datasetSummary: TextSFTDatasetSummary,
+        evalPromptCount: Int?,
+        status: String,
+        step: Int
+    ) throws {
+        guard visualize else { return }
+        let outputDirectory = outputURL.deletingLastPathComponent()
+        let manifestURL = TextLoRATrainingManifest.url(nextTo: outputURL)
+        let runManifest = LoRATrainingRunManifest(
+            format: TextLoRATrainingManifest.format,
+            model: model,
+            isEdit: false,
+            dataRoot: dataURL.path,
+            dataRootRelative: LoRATrainingRunManifest.relativePath(from: outputDirectory, to: dataURL.path),
+            dataFingerprint: nil,
+            checkpointFiles: [
+                "lora_adapter": outputURL.lastPathComponent,
+                "manifest": manifestURL.lastPathComponent,
+                "loss_csv": outputURL.deletingPathExtension().appendingPathExtension("loss").appendingPathExtension("csv").lastPathComponent,
+                "loss_html": outputURL.deletingPathExtension().appendingPathExtension("loss").appendingPathExtension("html").lastPathComponent,
+            ],
+            step: step,
+            totalSteps: trainingSteps,
+            seed: seed,
+            rngState: nil,
+            datasetFingerprint: datasetSummary.fingerprint,
+            configFingerprint: LoRATrainingFingerprint.sha256Hex([
+                model,
+                modelPath ?? "",
+                adapterName,
+                String(trainingSteps),
+                String(batchSize),
+                String(learningRate),
+                String(rank),
+                String(alpha ?? Float(rank)),
+                String(maxSequenceLength),
+                resolvedTargetModules().joined(separator: ","),
+            ].joined(separator: "\n")),
+            configSnapshot: [
+                "adapter_name": adapterName,
+                "batch_size": String(batchSize),
+                "dataset_examples": String(datasetSummary.exampleCount),
+                "eval_prompt_count": evalPromptCount.map(String.init) ?? "0",
+                "learning_rate": String(learningRate),
+                "lora_alpha": String(alpha ?? Float(rank)),
+                "lora_rank": String(rank),
+                "max_sequence_length": String(maxSequenceLength),
+                "status": status,
+                "target_modules": resolvedTargetModules().joined(separator: ","),
+                "training_steps": String(trainingSteps),
+            ]
+        )
+        try runManifest.write(nextTo: outputURL)
+    }
+
+    private func makeChatProgressHandler(
+        eventLogger: LoRATrainingEventLogger?
+    ) -> (@Sendable (ChatProgress) -> Void)? {
+        guard !json || eventLogger != nil else { return nil }
+        return { progress in
+            if !json, let message = progress.message, !message.isEmpty {
+                FileHandle.standardError.write(Data("[\(progress.stage.rawValue)] \(message)\n".utf8))
+            }
+            guard let eventLogger else { return }
+            try? eventLogger.record(
+                type: "progress",
+                stage: progress.stage.rawValue,
+                message: progress.message
+            )
+        }
+    }
+
+    private func makeTrainingProgressHandler(
+        eventLogger: LoRATrainingEventLogger?
+    ) -> (@Sendable (TextLoRATrainingProgress) -> Void)? {
+        guard !json || eventLogger != nil else { return nil }
+        return { progress in
+            switch progress.stage {
+            case .training(let step, let total, let loss):
+                if !json {
+                    CLIStderr.write(String(format: "\rTraining (%d/%d) loss %.6f\n", step, total, loss))
+                }
+                try? eventLogger?.record(
+                    type: "progress",
+                    stage: "training",
+                    message: "Training.",
+                    step: step,
+                    totalSteps: total,
+                    loss: loss,
+                    fraction: progress.fraction
+                )
+            case .saving:
+                if !json {
+                    CLIStderr.write("Saving text LoRA artifacts...\n")
+                }
+                try? eventLogger?.record(
+                    type: "progress",
+                    stage: "saving",
+                    message: "Saving text LoRA artifacts.",
+                    fraction: progress.fraction
+                )
+            }
+        }
+    }
+}
+
+private struct TextLoRATrainingVisualization {
+    let logger: LoRATrainingEventLogger
+    let serverTask: Task<Void, Never>
+
+    func stop() {
+        serverTask.cancel()
+    }
+}
+
+struct TextTrainLoRAResult: Encodable {
+    let model: String
+    let adapterName: String
+    let outputPath: String
+    let manifestPath: String
+    let dataset: TextSFTDatasetSummary
+    let evalPromptCount: Int?
+    let dryRun: Bool
+    let status: String
+    let trainingReport: TextLoRATrainingReport?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case adapterName = "adapter_name"
+        case outputPath = "output_path"
+        case manifestPath = "manifest_path"
+        case dataset
+        case evalPromptCount = "eval_prompt_count"
+        case dryRun = "dry_run"
+        case status
+        case trainingReport = "training_report"
+    }
+
+    func jsonString() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return String(decoding: try encoder.encode(self), as: UTF8.self)
+    }
+}

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -32,6 +32,37 @@ mere.run model pull text-chat-gemma4-12b-4bit
 mere.run text chat --help
 ```
 
+## Native Assistant Tuning
+
+Use `mere.run text train-lora` for reviewed chat-style SFT data. Keep the data
+source-tagged and run `--dry-run --json` first so the dataset fingerprint,
+manifest path, and eval prompt count are captured before any optimizer work:
+
+```bash
+mere.run text train-lora \
+  --data ./pairs.seed.jsonl \
+  --eval ./eval.prompts.jsonl \
+  --output ./local-assistant.safetensors \
+  --model text-chat-gemma4-12b-4bit \
+  --dry-run \
+  --json
+```
+
+The native optimizer path is intentionally part of `mere.run`; keep local
+fine-tune workflows in the same command plane as model resolution and runtime
+metadata. Drop `--dry-run` when the dataset is reviewed and you are ready for
+the native Gemma LoRA training run. Add `--visualize` to open a loopback
+training dashboard with loss, events, and adapter artifacts:
+
+```bash
+mere.run text train-lora \
+  --data ./pairs.seed.jsonl \
+  --eval ./eval.prompts.jsonl \
+  --output ./local-assistant.safetensors \
+  --model text-chat-gemma4-12b-4bit \
+  --visualize
+```
+
 ## Parameters
 
 - `--prompt`, `-p`: user prompt.
@@ -45,6 +76,8 @@ mere.run text chat --help
 - `--thinking`, `--show-thinking`: include hidden reasoning output when supported.
 - `--stats`: print timing to stderr; Gemma4 runs also include MTP state and accept/draft counts.
 - `--stream`: stream tokens to stdout.
+- `--lora`: local `.safetensors` adapter path for supported native chat models.
+- `--lora-scale`: adapter scale; defaults to `1.0`.
 - `--tools`: comma-separated built-ins, currently `write_file` and `shell_exec`.
 - `--tool-loop`: let the model call tools repeatedly.
 - `--sandbox-dir`: working directory for tool execution.

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MLX
+import MLXNN
 
 public typealias Gemma4PrefixKVCacheStats = PrefixKVCacheStats
 public typealias Gemma4ContinuousBatchingStats = RuntimeDecodeBatchingStats
@@ -110,6 +111,7 @@ public actor Gemma4Generator: ChatGenerator {
     private var loadedMTPModelPath: String?
     private var tokenizerAndTemplate: Gemma4TokenizerAndTemplate?
     private var loadedModelPath: String?
+    private var loadedTextLoRASignature: String?
     private var loadedConfig: Gemma4Config?
     private var lastMTPStats = Gemma4MTPStats()
 
@@ -160,7 +162,12 @@ public actor Gemma4Generator: ChatGenerator {
     ) async throws -> ChatResponse {
         let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
         let loadStart = Date()
+        let requestedLoRASignature = Self.loraSignature(request.lora)
+        if loadedTextLoRASignature != requestedLoRASignature {
+            resetLoadedModel()
+        }
         try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
+        try await applyTextLoRAIfNeeded(request.lora, progressHandler: progressHandler)
         let loadSeconds = Date().timeIntervalSince(loadStart)
 
         var response = try await generate(
@@ -193,6 +200,21 @@ public actor Gemma4Generator: ChatGenerator {
         loadedMTPModelPath = nil
         tokenizerAndTemplate = nil
         loadedModelPath = nil
+        loadedTextLoRASignature = nil
+        loadedConfig = nil
+        lastMTPStats = Gemma4MTPStats()
+        Memory.clearCache()
+    }
+
+    private func resetLoadedModel() {
+        failQueuedDecodeRows(CancellationError())
+        resetPrefixKVCache()
+        model = nil
+        mtpModel = nil
+        loadedMTPModelPath = nil
+        tokenizerAndTemplate = nil
+        loadedModelPath = nil
+        loadedTextLoRASignature = nil
         loadedConfig = nil
         lastMTPStats = Gemma4MTPStats()
         Memory.clearCache()
@@ -275,6 +297,35 @@ public actor Gemma4Generator: ChatGenerator {
         tokenizerAndTemplate = tokenizer
         loadedConfig = config
         loadedModelPath = normalizedRoot.path
+    }
+
+    private func applyTextLoRAIfNeeded(
+        _ lora: LoRA?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        guard let lora else {
+            loadedTextLoRASignature = nil
+            return
+        }
+        let signature = Self.loraSignature(lora)
+        guard loadedTextLoRASignature != signature else { return }
+        guard let model else {
+            throw Gemma4Error.modelNotLoaded
+        }
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 text LoRA"))
+        _ = try await Gemma4TextLoRAAdapter.apply(lora, to: model)
+        loadedTextLoRASignature = signature
+        resetPrefixKVCache()
+    }
+
+    private static func loraSignature(_ lora: LoRA?) -> String? {
+        guard let lora else { return nil }
+        switch lora {
+        case .local(let path, let scale):
+            return "local:\(URL(fileURLWithPath: path).standardizedFileURL.path):\(scale)"
+        case .remote(let reference, let scale):
+            return "remote:\(reference):\(scale)"
+        }
     }
 
     private func generate(

--- a/Sources/MereRunCore/Gemma4/Gemma4TextLoRAAdapter.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextLoRAAdapter.swift
@@ -1,0 +1,61 @@
+import Foundation
+import MLX
+import MLXNN
+
+enum Gemma4TextLoRAAdapterError: Error, LocalizedError, Sendable {
+    case modelIsNotModule
+    case noMatchingWeights([String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelIsNotModule:
+            return "Gemma4 text LoRA adapter can only be applied to a Module-backed Gemma4 model."
+        case .noMatchingWeights(let keys):
+            return "Gemma4 text LoRA adapter did not match injected LoRA layers. Weight keys: \(keys.prefix(8).joined(separator: ", "))"
+        }
+    }
+}
+
+enum Gemma4TextLoRAAdapter {
+    static func apply(
+        _ lora: LoRA,
+        to model: any Gemma4CausalModel,
+        targetSuffixes: [String] = Gemma4TextLoRAInjector.defaultTargetSuffixes
+    ) async throws -> [String: TrainableLoRALayer] {
+        guard let module = model as? Module else {
+            throw Gemma4TextLoRAAdapterError.modelIsNotModule
+        }
+        let weights = try await LoRAWeightLoader.load(from: lora)
+        let scale = scale(for: lora)
+        let layers = try Gemma4TextLoRAInjector.inject(
+            into: module,
+            rank: weights.rank,
+            alpha: weights.alpha * scale,
+            targetSuffixes: targetSuffixes,
+            zeroInitUp: false
+        )
+
+        var matched = 0
+        for (path, pair) in weights.weights {
+            guard let layer = layers[path] else { continue }
+            layer.loraDown = pair.down.asType(.float32)
+            layer.loraUp = pair.up.asType(.float32)
+            layer.role = .assistant
+            layer.isActive = true
+            matched += 1
+        }
+        guard matched > 0 else {
+            throw Gemma4TextLoRAAdapterError.noMatchingWeights(weights.weights.keys.sorted())
+        }
+
+        eval(layers.values.flatMap { [$0.loraDown, $0.loraUp] })
+        return layers
+    }
+
+    private static func scale(for lora: LoRA) -> Float {
+        switch lora {
+        case .local(_, let scale), .remote(_, let scale):
+            return Float(scale)
+        }
+    }
+}

--- a/Sources/MereRunCore/Gemma4/Gemma4TextLoRAAdapter.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextLoRAAdapter.swift
@@ -16,12 +16,17 @@ enum Gemma4TextLoRAAdapterError: Error, LocalizedError, Sendable {
     }
 }
 
+struct Gemma4TextLoRAApplyReport: Sendable, Equatable {
+    let matchedLayerCount: Int
+    let injectedLayerCount: Int
+}
+
 enum Gemma4TextLoRAAdapter {
     static func apply(
         _ lora: LoRA,
         to model: any Gemma4CausalModel,
         targetSuffixes: [String] = Gemma4TextLoRAInjector.defaultTargetSuffixes
-    ) async throws -> [String: TrainableLoRALayer] {
+    ) async throws -> Gemma4TextLoRAApplyReport {
         guard let module = model as? Module else {
             throw Gemma4TextLoRAAdapterError.modelIsNotModule
         }
@@ -49,7 +54,10 @@ enum Gemma4TextLoRAAdapter {
         }
 
         eval(layers.values.flatMap { [$0.loraDown, $0.loraUp] })
-        return layers
+        return Gemma4TextLoRAApplyReport(
+            matchedLayerCount: matched,
+            injectedLayerCount: layers.count
+        )
     }
 
     private static func scale(for lora: LoRA) -> Float {

--- a/Sources/MereRunCore/Gemma4/Gemma4TextLoRAInjector.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextLoRAInjector.swift
@@ -1,0 +1,131 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum Gemma4TextLoRAInjectionError: Error, LocalizedError {
+    case invalidRank(Int)
+    case noMatchingLayers([String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRank(let rank):
+            return "LoRA rank must be >= 1 (got \(rank))."
+        case .noMatchingLayers(let suffixes):
+            return "No matching Gemma4 text Linear layers found for LoRA injection. Target suffixes: \(suffixes.joined(separator: ","))"
+        }
+    }
+}
+public enum Gemma4TextLoRAInjector {
+    public static let defaultTargetSuffixes: [String] = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+    ]
+
+    public static func inject(
+        into model: Module,
+        rank: Int,
+        alpha: Float? = nil,
+        targetSuffixes: [String] = defaultTargetSuffixes,
+        zeroInitUp: Bool = true
+    ) throws -> [String: TrainableLoRALayer] {
+        guard rank >= 1 else {
+            throw Gemma4TextLoRAInjectionError.invalidRank(rank)
+        }
+        let normalizedSuffixes = targetSuffixes
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let leafModules = model.leafModules().flattened()
+        var replacements: [String: Module] = [:]
+        var loraLayers: [String: TrainableLoRALayer] = [:]
+
+        for (path, module) in leafModules {
+            guard shouldTarget(path: path, suffixes: normalizedSuffixes) else { continue }
+            let alphaValue = alpha ?? Float(rank)
+
+            if let existingFused = module as? FusedLoRALinear {
+                let newLoRA = LoRALinear(
+                    base: Linear(weight: existingFused.weight, bias: existingFused.bias),
+                    rank: rank,
+                    alpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                newLoRA.role = .train
+                for lora in existingFused.loras where lora.role == .train {
+                    lora.role = .assistant
+                }
+                existingFused.loras.append(newLoRA)
+                loraLayers[path] = existingFused
+                continue
+            }
+
+            if let loraQuantized = module as? LoRAQuantizedLinear {
+                let fused = FusedLoRALinear(
+                    existingLoRA: loraQuantized,
+                    newRank: rank,
+                    newAlpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = fused
+                loraLayers[path] = fused
+                continue
+            }
+
+            if let loraLinear = module as? LoRALinear {
+                let fused = FusedLoRALinear(
+                    existingLoRA: loraLinear,
+                    newRank: rank,
+                    newAlpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = fused
+                loraLayers[path] = fused
+                continue
+            }
+
+            if let quantized = module as? QuantizedLinear {
+                let wrapped = LoRAQuantizedLinear(
+                    base: quantized,
+                    rank: rank,
+                    alpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = wrapped
+                loraLayers[path] = wrapped
+                continue
+            }
+
+            if let linear = module as? Linear {
+                let wrapped = LoRALinear(
+                    base: linear,
+                    rank: rank,
+                    alpha: alphaValue,
+                    zeroInitUp: zeroInitUp
+                )
+                replacements[path] = wrapped
+                loraLayers[path] = wrapped
+            }
+        }
+
+        guard !loraLayers.isEmpty else {
+            throw Gemma4TextLoRAInjectionError.noMatchingLayers(normalizedSuffixes)
+        }
+
+        applyModuleReplacements(replacements, to: model)
+        return loraLayers
+    }
+
+    static func shouldTarget(path: String, suffixes: [String]) -> Bool {
+        suffixes.contains { suffix in
+            path == suffix || path.hasSuffix(".\(suffix)")
+        }
+    }
+
+    private static func applyModuleReplacements(_ replacements: [String: Module], to model: Module) {
+        guard !replacements.isEmpty else { return }
+        let moduleUpdates = replacements.map { (path: $0.key, module: $0.value) }
+        model.update(modules: ModuleChildren.unflattened(moduleUpdates))
+    }
+}

--- a/Sources/MereRunCore/Gemma4/Gemma4TextLoRATrainingPipeline.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextLoRATrainingPipeline.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public struct Gemma4TextLoRATrainingPipelineRequest: Sendable {
+    public let modelId: String
+    public let modelPath: String?
+    public let examples: [TextSFTExample]
+    public let outputURL: URL
+    public let trainingConfig: TextLoRATrainingConfig
+    public let maxSequenceLength: Int
+    public let rank: Int
+    public let alpha: Float
+    public let targetSuffixes: [String]
+    public let metadata: [String: String]
+
+    public init(
+        modelId: String,
+        modelPath: String? = nil,
+        examples: [TextSFTExample],
+        outputURL: URL,
+        trainingConfig: TextLoRATrainingConfig,
+        maxSequenceLength: Int,
+        rank: Int,
+        alpha: Float,
+        targetSuffixes: [String],
+        metadata: [String: String] = [:]
+    ) {
+        self.modelId = modelId
+        self.modelPath = modelPath
+        self.examples = examples
+        self.outputURL = outputURL
+        self.trainingConfig = trainingConfig
+        self.maxSequenceLength = maxSequenceLength
+        self.rank = rank
+        self.alpha = alpha
+        self.targetSuffixes = targetSuffixes
+        self.metadata = metadata
+    }
+}
+
+public enum Gemma4TextLoRATrainingPipeline {
+    public static func train(
+        _ request: Gemma4TextLoRATrainingPipelineRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil,
+        trainingProgressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)? = nil
+    ) async throws -> TextLoRATrainingReport {
+        let loaded = try await Gemma4TextModelLoader.load(
+            modelId: request.modelId,
+            modelPath: request.modelPath,
+            maxContextLength: request.maxSequenceLength,
+            progressHandler: progressHandler
+        )
+
+        progressHandler?(ChatProgress(stage: .encoding, message: "Tokenizing SFT examples"))
+        let tokenized = try Gemma4TextSFTTokenizer.tokenize(
+            request.examples,
+            tokenizerAndTemplate: loaded.tokenizerAndTemplate,
+            maxSequenceLength: request.maxSequenceLength
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Injecting Gemma4 LoRA layers"))
+        let loraLayers = try Gemma4TextLoRAInjector.inject(
+            into: loaded.model,
+            rank: request.rank,
+            alpha: request.alpha,
+            targetSuffixes: request.targetSuffixes
+        )
+
+        var metadata = request.metadata
+        metadata["base_model"] = request.modelId
+        metadata["model_root"] = loaded.rootURL.path
+        metadata["format"] = "mererun.gemma4.text-lora"
+        metadata["max_sequence_length"] = String(request.maxSequenceLength)
+
+        progressHandler?(ChatProgress(stage: .generating, message: "Training Gemma4 LoRA adapter"))
+        return try TextLoRATrainer.train(
+            model: loaded.model,
+            loraLayers: loraLayers,
+            examples: tokenized,
+            config: request.trainingConfig,
+            outputURL: request.outputURL,
+            metadata: metadata,
+            progressHandler: trainingProgressHandler
+        ) { model, inputIds in
+            model(inputIds)
+        }
+    }
+}

--- a/Sources/MereRunCore/Gemma4/Gemma4TextModelLoader.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextModelLoader.swift
@@ -1,0 +1,263 @@
+import Foundation
+import MLX
+@preconcurrency import Hub
+
+public struct Gemma4LoadedTextModel: Sendable {
+    public let model: Gemma4TextCausalLM
+    public let tokenizerAndTemplate: Gemma4TokenizerAndTemplate
+    public let config: Gemma4Config
+    public let rootURL: URL
+
+    public init(
+        model: Gemma4TextCausalLM,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        config: Gemma4Config,
+        rootURL: URL
+    ) {
+        self.model = model
+        self.tokenizerAndTemplate = tokenizerAndTemplate
+        self.config = config
+        self.rootURL = rootURL
+    }
+}
+
+public enum Gemma4TextModelLoader {
+    public static func load(
+        modelId: String,
+        modelPath: String? = nil,
+        maxContextLength: Int? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws -> Gemma4LoadedTextModel {
+        guard !Gemma4Resources.supportsVision(modelSpec: modelId) else {
+            throw Gemma4Error.unsupportedConfiguration("Native text LoRA training supports Gemma4 text models, not vision/unified Gemma4 models.")
+        }
+
+        let rootURL = try await resolveModelRoot(
+            modelId: modelId,
+            modelPath: modelPath,
+            progressHandler: progressHandler
+        )
+        let normalizedRoot = Gemma4Resources.normalizedRootURL(rootURL)
+        let resources = Gemma4Resources(rootURL: normalizedRoot)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw Gemma4Error.missingFiles(missing.map(\.lastPathComponent))
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 config"))
+        let configData = try Data(contentsOf: resources.configURL)
+        let config = try JSONDecoder().decode(Gemma4Config.self, from: configData)
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 tokenizer"))
+        let tokenizer = try await Gemma4TokenizerAndTemplate.load(
+            from: normalizedRoot,
+            maxLengthOverride: min(
+                maxContextLength ?? Gemma4Resources.defaultContextLength,
+                config.textConfig.maxPositionEmbeddings
+            )
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Gemma4 text weights"))
+        let model = Gemma4TextCausalLM(config: config.textConfig)
+        try loadWeights(into: model, from: resources, config: config)
+
+        return Gemma4LoadedTextModel(
+            model: model,
+            tokenizerAndTemplate: tokenizer,
+            config: config,
+            rootURL: normalizedRoot
+        )
+    }
+
+    public static func resolveModelRoot(
+        modelId: String,
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws -> URL {
+        if let explicit = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            return try await resolveModelLocation(explicit, progressHandler: progressHandler)
+        }
+
+        let trimmedModelId = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestedModelId = trimmedModelId.isEmpty ? Gemma4Resources.defaultModelId : trimmedModelId
+
+        if let modelID = ModelResolver.ModelID(rawValue: requestedModelId),
+           let resolved = ModelResolver().resolveIfPresent(modelID) {
+            return resolved.rootURL
+        }
+
+        if let fallback = resolveInstalledGemmaRoot(for: requestedModelId) {
+            return fallback
+        }
+
+        if requestedModelId != Gemma4Resources.defaultModelId {
+            return try await resolveModelLocation(requestedModelId, progressHandler: progressHandler)
+        }
+
+        return try await resolveHubSnapshot(
+            repoId: Gemma4Resources.defaultUpstreamModelId,
+            progressHandler: progressHandler
+        )
+    }
+
+    public static func loadWeights(
+        into model: Gemma4TextCausalLM,
+        from resources: Gemma4Resources,
+        config: Gemma4Config
+    ) throws {
+        let include: (String) -> Bool = { key in
+            key.hasPrefix("model.language_model.") || key.hasPrefix("language_model.")
+        }
+        let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            if key.hasPrefix("model.language_model.") {
+                return [(String(key.dropFirst("model.".count)), value)]
+            }
+            if key.hasPrefix("language_model.model.") {
+                return [("language_model.\(key.dropFirst("language_model.model.".count))", value)]
+            }
+            if key.hasPrefix("language_model.") {
+                return [(key, value)]
+            }
+            return []
+        }
+        let keyMapper: (String) -> String = { key in
+            if key.hasPrefix("model.language_model.") {
+                return String(key.dropFirst("model.".count))
+            }
+            if key.hasPrefix("language_model.model.") {
+                return "language_model.\(key.dropFirst("language_model.model.".count))"
+            }
+            if key.hasPrefix("language_model.") {
+                return key
+            }
+            return "__unused__.\(key)"
+        }
+        let quantizedMapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
+            key.hasPrefix("__unused__.") ? [] : [(key, value)]
+        }
+        let quantizedModuleResolver: HFSafetensorsWeightsLoader.QuantizedModuleResolver = { _, _, _, _, biases, fallbackGroupSize, fallbackBits in
+            if biases != nil || fallbackBits > 4 {
+                return (groupSize: fallbackGroupSize, bits: fallbackBits, mode: QuantizationMode.affine)
+            }
+            return (groupSize: fallbackGroupSize, bits: fallbackBits, mode: QuantizationMode.nvfp4)
+        }
+
+        if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
+            if try indexContainsQuantizedWeights(resources.modelIndexURL) {
+                try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                    indexURL: resources.modelIndexURL,
+                    to: model,
+                    groupSize: config.textConfig.enableMoEBlock ? 16 : 64,
+                    bits: 4,
+                    quantizedModuleResolver: quantizedModuleResolver,
+                    keyMapper: keyMapper,
+                    mapper: quantizedMapper
+                )
+            } else {
+                try HFSafetensorsWeightsLoader.applyShardedWeights(
+                    indexURL: resources.modelIndexURL,
+                    to: model,
+                    dtype: .bfloat16,
+                    verify: .none,
+                    mapper: mapper
+                )
+            }
+        } else if FileManager.default.fileExists(atPath: resources.modelWeightsURL.path) {
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: resources.modelWeightsURL,
+                to: model,
+                dtype: .bfloat16,
+                verify: .none,
+                include: include,
+                mapper: mapper,
+                batchSize: 24
+            )
+        } else {
+            throw Gemma4Error.missingFiles([resources.modelIndexURL.lastPathComponent, resources.modelWeightsURL.lastPathComponent])
+        }
+    }
+
+    private static func resolveInstalledGemmaRoot(for requestedModelId: String) -> URL? {
+        func existingModelDir(_ id: String) -> URL? {
+            let url = MereRunModelPaths.modelDir(id)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+                return nil
+            }
+            guard (try? FileManager.default.contentsOfDirectory(atPath: url.path))?.isEmpty == false else {
+                return nil
+            }
+            return url.standardizedFileURL
+        }
+
+        if requestedModelId == Gemma4Resources.defaultModelId {
+            return existingModelDir(Gemma4Resources.defaultModelId)
+                ?? existingModelDir(Gemma4Resources.maxModelId)
+                ?? existingModelDir(Gemma4Resources.nanoModelId)
+        }
+
+        return existingModelDir(requestedModelId)
+    }
+
+    private static func resolveModelLocation(
+        _ location: String,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        if let modelID = ModelResolver.ModelID(rawValue: location),
+           Gemma4Resources.handles(modelSpec: modelID.rawValue) {
+            if let resolved = ModelResolver().resolveIfPresent(modelID) {
+                return resolved.rootURL
+            }
+            do {
+                let resolution = try await ManagedModelResolver.resolveForRuntime(
+                    requestedModel: modelID.rawValue,
+                    defaultModelID: modelID.rawValue,
+                    progress: { event in
+                        switch event {
+                        case .downloading(let percent):
+                            progressHandler?(ChatProgress(stage: .loadingModel, message: "Downloading Gemma4... \(percent)%"))
+                        case .extracting:
+                            progressHandler?(ChatProgress(stage: .loadingModel, message: "Extracting Gemma4..."))
+                        }
+                    }
+                )
+                return Gemma4Resources.normalizedRootURL(resolution.url)
+            } catch {
+                throw Gemma4Error.downloadFailed(error.localizedDescription)
+            }
+        }
+
+        let fileURL = URL(fileURLWithPath: location).standardizedFileURL
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            return Gemma4Resources.normalizedRootURL(fileURL)
+        }
+        if Gemma4Resources.isLikelyHubRepoID(location) {
+            return try await resolveHubSnapshot(repoId: location, progressHandler: progressHandler)
+        }
+        throw Gemma4Error.unsupportedModelLocation(location)
+    }
+
+    private static func resolveHubSnapshot(
+        repoId: String,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        let snapshot = try HubSnapshot(options: HubSnapshotOptions(
+            repoId: repoId,
+            patterns: Gemma4Resources.snapshotPatterns
+        ))
+        do {
+            return try await snapshot.prepare { progress in
+                let percent = Int((progress.fractionCompleted * 100).rounded())
+                progressHandler?(ChatProgress(stage: .loadingModel, message: "Downloading Gemma4... \(percent)%"))
+            }
+        } catch {
+            throw Gemma4Error.downloadFailed(error.localizedDescription)
+        }
+    }
+
+    private static func indexContainsQuantizedWeights(_ indexURL: URL) throws -> Bool {
+        let data = try Data(contentsOf: indexURL)
+        let index = try JSONDecoder().decode(HFSafetensorsIndex.self, from: data)
+        return index.weightMap.keys.contains { $0.hasSuffix(".scales") }
+    }
+}

--- a/Sources/MereRunCore/Gemma4/Gemma4TextSFTTokenizer.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextSFTTokenizer.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+public enum Gemma4TextSFTTokenizer {
+    public static func tokenize(
+        _ examples: [TextSFTExample],
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        maxSequenceLength: Int
+    ) throws -> [TextSFTTokenizedExample] {
+        try examples.map { example in
+            guard let assistant = example.messages.last, assistant.role == .assistant else {
+                throw Gemma4TextSFTTokenizerError.lastMessageMustBeAssistant
+            }
+            let prefixMessages = Array(example.messages.dropLast())
+            let prefixTokens = try tokenizerAndTemplate.encodeForGeneration(
+                messages: prefixMessages,
+                addGenerationPrompt: true,
+                includeThinking: false,
+                maxLength: tokenizerAndTemplate.maxLength
+            )
+
+            var targetTokens = tokenizerAndTemplate.encodeRaw(
+                assistantTargetText(assistant.content),
+                addSpecialTokens: false
+            )
+            if let turnTokenId = tokenizerAndTemplate.turnTokenId {
+                targetTokens.append(turnTokenId)
+            }
+
+            return try TextSFTTrainingBatchBuilder.shiftedTargetExample(
+                prefixTokenIds: prefixTokens,
+                targetTokenIds: targetTokens,
+                maxSequenceLength: maxSequenceLength
+            )
+        }
+    }
+
+    static func assistantTargetText(_ content: String) -> String {
+        stripThinking(from: content).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func stripThinking(from text: String) -> String {
+        let marker = "<channel|>"
+        guard text.contains(marker) else { return text }
+        return text
+            .components(separatedBy: marker)
+            .map { part -> String in
+                guard let range = part.range(of: "<|channel>") else { return part }
+                return String(part[..<range.lowerBound])
+            }
+            .joined()
+    }
+
+    public static func messageTokenSpans(
+        messages: [ChatMessage],
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        maxSequenceLength: Int
+    ) throws -> [[Int]] {
+        try legacyMessageTokenSpans(
+            messages: messages,
+            tokenizerAndTemplate: tokenizerAndTemplate,
+            maxSequenceLength: maxSequenceLength
+        )
+    }
+
+    static func legacyTokenize(
+        _ examples: [TextSFTExample],
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        maxSequenceLength: Int
+    ) throws -> [TextSFTTokenizedExample] {
+        try examples.map { example in
+            let spans = try legacyMessageTokenSpans(
+                messages: example.messages,
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                maxSequenceLength: maxSequenceLength
+            )
+            return try TextSFTTrainingBatchBuilder.shiftedExample(
+                messageTokenIds: spans,
+                messageRoles: example.messages.map(\.role),
+                maxSequenceLength: maxSequenceLength
+            )
+        }
+    }
+
+    private static func legacyMessageTokenSpans(
+        messages: [ChatMessage],
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        maxSequenceLength: Int
+    ) throws -> [[Int]] {
+        guard !messages.isEmpty else {
+            throw Gemma4TextSFTTokenizerError.emptyMessages
+        }
+
+        var spans: [[Int]] = []
+        var previous: [Int] = []
+        for endIndex in messages.indices {
+            let prefix = Array(messages[...endIndex])
+            let encoded = try tokenizerAndTemplate.encodeForGeneration(
+                messages: prefix,
+                addGenerationPrompt: false,
+                includeThinking: false,
+                maxLength: tokenizerAndTemplate.maxLength
+            )
+            let common = commonPrefixLength(previous, encoded)
+            let span = Array(encoded.dropFirst(common))
+            guard !span.isEmpty else {
+                throw Gemma4TextSFTTokenizerError.emptyMessageSpan(endIndex)
+            }
+            spans.append(span)
+            previous = encoded
+        }
+
+        let totalCount = spans.reduce(0) { $0 + $1.count }
+        guard totalCount >= 2 else {
+            throw Gemma4TextSFTTokenizerError.tooFewTokens
+        }
+        _ = maxSequenceLength
+        return spans
+    }
+
+    static func commonPrefixLength(_ lhs: [Int], _ rhs: [Int]) -> Int {
+        let limit = min(lhs.count, rhs.count)
+        var index = 0
+        while index < limit, lhs[index] == rhs[index] {
+            index += 1
+        }
+        return index
+    }
+}
+
+public enum Gemma4TextSFTTokenizerError: Error, LocalizedError, Sendable {
+    case emptyMessages
+    case emptyMessageSpan(Int)
+    case tooFewTokens
+    case lastMessageMustBeAssistant
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyMessages:
+            return "Gemma4 text SFT tokenization requires at least one message."
+        case .emptyMessageSpan(let index):
+            return "Gemma4 text SFT tokenization produced no tokens for message index \(index)."
+        case .tooFewTokens:
+            return "Gemma4 text SFT tokenization produced fewer than two tokens."
+        case .lastMessageMustBeAssistant:
+            return "Gemma4 text SFT tokenization requires the last message to be assistant."
+        }
+    }
+}

--- a/Sources/MereRunCore/Gemma4/Gemma4TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TokenizerAndTemplate.swift
@@ -83,6 +83,10 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
         tokenizer.decode(tokens: tokens)
     }
 
+    public func encodeRaw(_ text: String, addSpecialTokens: Bool = false) -> [Int] {
+        tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
     public func decode(token: Int) -> String {
         tokenizer.decode(tokens: [token])
     }

--- a/Sources/MereRunCore/TextLoRATrainer.swift
+++ b/Sources/MereRunCore/TextLoRATrainer.swift
@@ -1,0 +1,334 @@
+import Foundation
+import MLX
+import MLXNN
+
+public struct TextLoRATrainingConfig: Sendable, Hashable {
+    public let trainingSteps: Int
+    public let batchSize: Int
+    public let learningRate: Float
+    public let weightDecay: Float
+    public let beta1: Float
+    public let beta2: Float
+    public let epsilon: Float
+    public let seed: UInt64
+
+    public init(
+        trainingSteps: Int,
+        batchSize: Int,
+        learningRate: Float,
+        weightDecay: Float = 0.0,
+        beta1: Float = 0.9,
+        beta2: Float = 0.999,
+        epsilon: Float = 1e-8,
+        seed: UInt64 = 42
+    ) {
+        self.trainingSteps = trainingSteps
+        self.batchSize = batchSize
+        self.learningRate = learningRate
+        self.weightDecay = weightDecay
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+        self.seed = seed
+    }
+}
+
+public struct TextLoRATrainingReport: Sendable, Hashable, Codable {
+    public let steps: Int
+    public let initialLoss: Float?
+    public let finalLoss: Float?
+    public let layerCount: Int
+    public let outputPath: String?
+}
+
+public struct TextLoRATrainingProgress: Sendable, Hashable {
+    public enum Stage: Sendable, Hashable {
+        case training(step: Int, total: Int, loss: Float)
+        case saving
+    }
+
+    public let stage: Stage
+
+    public var fraction: Float {
+        switch stage {
+        case .training(let step, let total, _):
+            guard total > 0 else { return 0 }
+            return min(max(Float(step) / Float(total), 0), 1)
+        case .saving:
+            return 1
+        }
+    }
+
+    public init(stage: Stage) {
+        self.stage = stage
+    }
+}
+
+public enum TextLoRATrainer {
+    public static func train<Model: Module>(
+        model: Model,
+        loraLayers: [String: TrainableLoRALayer],
+        examples: [TextSFTTokenizedExample],
+        config: TextLoRATrainingConfig,
+        outputURL: URL? = nil,
+        metadata: [String: String] = [:],
+        progressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)? = nil,
+        forward: @escaping (Model, MLXArray) -> MLXArray
+    ) throws -> TextLoRATrainingReport {
+        try validate(config: config, examples: examples, loraLayers: loraLayers)
+        try model.freeze(recursive: true, keys: nil, strict: false)
+        for layer in loraLayers.values {
+            guard let module = layer as? Module else { continue }
+            try module.unfreeze(recursive: false, keys: ["loraDown", "loraUp"], strict: true)
+        }
+        initializeAdamStateIfNeeded(for: loraLayers)
+
+        let orderedLayers = loraLayers
+            .map { (path: $0.key, layer: $0.value) }
+            .sorted { $0.path < $1.path }
+
+        let lossAndGrad = valueAndGrad(model: model) { model, arrays in
+            let logits = forward(model, arrays[0])
+            let loss = TextSFTTrainingLoss.maskedNextTokenCrossEntropy(
+                logits: logits,
+                labels: arrays[1],
+                lossMask: arrays[2]
+            )
+            return [loss]
+        }
+
+        let beta1 = MLXArray(config.beta1)
+        let beta2 = MLXArray(config.beta2)
+        let oneMinusBeta1 = MLXArray(1 - config.beta1)
+        let oneMinusBeta2 = MLXArray(1 - config.beta2)
+        let eps = MLXArray(config.epsilon)
+        let lr = MLXArray(config.learningRate)
+        let oneMinusLrWd = MLXArray(1 - (config.learningRate * config.weightDecay))
+        var initialLoss: Float?
+        var finalLoss: Float?
+        if let outputURL {
+            try FileManager.default.createDirectory(
+                at: outputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        }
+        let metricsLogger = try outputURL.map { try LoRATrainingMetricsLogger(baseOutputURL: $0, resumeExisting: false) }
+        let trainingOrder = makeTrainingOrder(
+            exampleCount: examples.count,
+            drawCount: config.trainingSteps * config.batchSize,
+            seed: config.seed
+        )
+
+        for step in 0..<config.trainingSteps {
+            let batchExamples = scheduledBatch(
+                examples,
+                order: trainingOrder,
+                batchSize: config.batchSize,
+                step: step
+            )
+            let batch = try TextSFTTrainingBatchBuilder.makeBatch(batchExamples)
+            let (values, gradients) = lossAndGrad(model, [batch.inputIds, batch.labels, batch.lossMask])
+            let loss = values[0]
+            let gradMap = Dictionary(uniqueKeysWithValues: gradients.flattened())
+            let stepNumber = step + 1
+            let biasCorrection1 = MLXArray(Float(1.0 - pow(Double(config.beta1), Double(stepNumber))))
+            let biasCorrection2 = MLXArray(Float(1.0 - pow(Double(config.beta2), Double(stepNumber))))
+            applyAdamW(
+                loraLayers: orderedLayers,
+                gradMap: gradMap,
+                lr: lr,
+                beta1: beta1,
+                beta2: beta2,
+                oneMinusBeta1: oneMinusBeta1,
+                oneMinusBeta2: oneMinusBeta2,
+                eps: eps,
+                oneMinusLrWd: oneMinusLrWd,
+                biasCorrection1: biasCorrection1,
+                biasCorrection2: biasCorrection2,
+                useWeightDecay: config.weightDecay > 0
+            )
+            eval([loss] + orderedLayers.flatMap { [$0.layer.loraDown, $0.layer.loraUp] })
+            let scalarLoss = loss.item(Float.self)
+            if initialLoss == nil { initialLoss = scalarLoss }
+            finalLoss = scalarLoss
+            let visibleStep = stepNumber
+            try metricsLogger?.record(step: visibleStep, loss: scalarLoss)
+            progressHandler?(
+                TextLoRATrainingProgress(
+                    stage: .training(step: visibleStep, total: config.trainingSteps, loss: scalarLoss)
+                )
+            )
+        }
+
+        progressHandler?(TextLoRATrainingProgress(stage: .saving))
+        if let outputURL {
+            try LoRASafetensorsWriter.save(
+                loraLayers: loraLayers,
+                to: outputURL,
+                includeOptimizerState: true,
+                metadata: metadata
+            )
+            try metricsLogger?.writeArtifacts()
+        }
+
+        return TextLoRATrainingReport(
+            steps: config.trainingSteps,
+            initialLoss: initialLoss,
+            finalLoss: finalLoss,
+            layerCount: loraLayers.count,
+            outputPath: outputURL?.path
+        )
+    }
+
+    static func initializeAdamStateIfNeeded(for loraLayers: [String: TrainableLoRALayer]) {
+        for layer in loraLayers.values {
+            if layer.loraDownM == nil { layer.loraDownM = MLXArray.zeros(like: layer.loraDown) }
+            if layer.loraDownV == nil { layer.loraDownV = MLXArray.zeros(like: layer.loraDown) }
+            if layer.loraUpM == nil { layer.loraUpM = MLXArray.zeros(like: layer.loraUp) }
+            if layer.loraUpV == nil { layer.loraUpV = MLXArray.zeros(like: layer.loraUp) }
+        }
+    }
+
+    static func applyAdamW(
+        loraLayers: [(path: String, layer: TrainableLoRALayer)],
+        gradMap: [String: MLXArray],
+        lr: MLXArray,
+        beta1: MLXArray,
+        beta2: MLXArray,
+        oneMinusBeta1: MLXArray,
+        oneMinusBeta2: MLXArray,
+        eps: MLXArray,
+        oneMinusLrWd: MLXArray,
+        biasCorrection1: MLXArray,
+        biasCorrection2: MLXArray,
+        useWeightDecay: Bool
+    ) {
+        for (path, layer) in loraLayers {
+            guard let downGrad = gradMap["\(path).loraDown"],
+                  let upGrad = gradMap["\(path).loraUp"] else {
+                continue
+            }
+
+            let mDown = beta1 * layer.loraDownM! + oneMinusBeta1 * downGrad
+            let vDown = beta2 * layer.loraDownV! + oneMinusBeta2 * downGrad.square()
+            let wDown = useWeightDecay ? layer.loraDown * oneMinusLrWd : layer.loraDown
+            let mHatDown = mDown / biasCorrection1
+            let vHatDown = vDown / biasCorrection2
+            let newDown = wDown - lr * mHatDown / (vHatDown.sqrt() + eps)
+            layer.loraDown._updateInternal(newDown)
+            layer.loraDownM!._updateInternal(mDown)
+            layer.loraDownV!._updateInternal(vDown)
+
+            let mUp = beta1 * layer.loraUpM! + oneMinusBeta1 * upGrad
+            let vUp = beta2 * layer.loraUpV! + oneMinusBeta2 * upGrad.square()
+            let wUp = useWeightDecay ? layer.loraUp * oneMinusLrWd : layer.loraUp
+            let mHatUp = mUp / biasCorrection1
+            let vHatUp = vUp / biasCorrection2
+            let newUp = wUp - lr * mHatUp / (vHatUp.sqrt() + eps)
+            layer.loraUp._updateInternal(newUp)
+            layer.loraUpM!._updateInternal(mUp)
+            layer.loraUpV!._updateInternal(vUp)
+        }
+    }
+
+    private static func validate(
+        config: TextLoRATrainingConfig,
+        examples: [TextSFTTokenizedExample],
+        loraLayers: [String: TrainableLoRALayer]
+    ) throws {
+        guard config.trainingSteps >= 1 else {
+            throw TextLoRATrainerError.invalidTrainingSteps(config.trainingSteps)
+        }
+        guard config.batchSize >= 1 else {
+            throw TextLoRATrainerError.invalidBatchSize(config.batchSize)
+        }
+        guard config.learningRate > 0 else {
+            throw TextLoRATrainerError.invalidLearningRate(config.learningRate)
+        }
+        guard !examples.isEmpty else {
+            throw TextLoRATrainerError.emptyDataset
+        }
+        guard !loraLayers.isEmpty else {
+            throw TextLoRATrainerError.noLoRALayers
+        }
+    }
+
+    static func makeTrainingOrder(
+        exampleCount: Int,
+        drawCount: Int,
+        seed: UInt64
+    ) -> [Int] {
+        guard exampleCount > 0, drawCount > 0 else { return [] }
+        var order: [Int] = []
+        order.reserveCapacity(drawCount)
+        var epoch: UInt64 = 0
+        while order.count < drawCount {
+            var indices = Array(0..<exampleCount)
+            var rng = SplitMix64(seed: seed &+ epoch &* 0x9E37_79B9_7F4A_7C15)
+            if indices.count > 1 {
+                for index in stride(from: indices.count - 1, through: 1, by: -1) {
+                    let swapIndex = rng.nextInt(upperBound: index + 1)
+                    indices.swapAt(index, swapIndex)
+                }
+            }
+            order.append(contentsOf: indices.prefix(drawCount - order.count))
+            epoch &+= 1
+        }
+        return order
+    }
+
+    private static func scheduledBatch(
+        _ examples: [TextSFTTokenizedExample],
+        order: [Int],
+        batchSize: Int,
+        step: Int
+    ) -> [TextSFTTokenizedExample] {
+        (0..<batchSize).map { offset in
+            examples[order[step * batchSize + offset]]
+        }
+    }
+
+    struct SplitMix64 {
+        private var state: UInt64
+
+        init(seed: UInt64) {
+            self.state = seed
+        }
+
+        mutating func next() -> UInt64 {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+
+        mutating func nextInt(upperBound: Int) -> Int {
+            guard upperBound > 1 else { return 0 }
+            return Int(next() % UInt64(upperBound))
+        }
+    }
+}
+
+public enum TextLoRATrainerError: Error, LocalizedError, Sendable {
+    case invalidTrainingSteps(Int)
+    case invalidBatchSize(Int)
+    case invalidLearningRate(Float)
+    case emptyDataset
+    case noLoRALayers
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidTrainingSteps(let value):
+            return "Text LoRA training steps must be >= 1 (got \(value))."
+        case .invalidBatchSize(let value):
+            return "Text LoRA batch size must be >= 1 (got \(value))."
+        case .invalidLearningRate(let value):
+            return "Text LoRA learning rate must be > 0 (got \(value))."
+        case .emptyDataset:
+            return "Text LoRA training requires at least one tokenized example."
+        case .noLoRALayers:
+            return "Text LoRA training requires at least one injected LoRA layer."
+        }
+    }
+}

--- a/Sources/MereRunCore/TextLoRATrainingManifest.swift
+++ b/Sources/MereRunCore/TextLoRATrainingManifest.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+public struct TextLoRATrainingManifest: Codable, Sendable, Hashable {
+    public static let schemaVersion = 1
+    public static let format = "mererun.gemma4.text-lora"
+
+    public struct Training: Codable, Sendable, Hashable {
+        public let trainingSteps: Int
+        public let batchSize: Int
+        public let learningRate: Float
+        public let maxSequenceLength: Int
+        public let seed: UInt64
+        public let dataset: TextSFTDatasetSummary
+
+        public init(
+            trainingSteps: Int,
+            batchSize: Int,
+            learningRate: Float,
+            maxSequenceLength: Int,
+            seed: UInt64,
+            dataset: TextSFTDatasetSummary
+        ) {
+            self.trainingSteps = trainingSteps
+            self.batchSize = batchSize
+            self.learningRate = learningRate
+            self.maxSequenceLength = maxSequenceLength
+            self.seed = seed
+            self.dataset = dataset
+        }
+    }
+
+    public struct LoRA: Codable, Sendable, Hashable {
+        public let rank: Int
+        public let alpha: Float
+        public let targetModules: [String]
+
+        public init(rank: Int, alpha: Float, targetModules: [String]) {
+            self.rank = rank
+            self.alpha = alpha
+            self.targetModules = targetModules
+        }
+    }
+
+    public let schemaVersion: Int
+    public let createdAt: Date
+    public let format: String
+    public let baseModel: String
+    public let outputFile: String
+    public let adapterName: String
+    public let training: Training
+    public let lora: LoRA
+    public let evalPromptCount: Int?
+    public let status: String
+
+    public init(
+        createdAt: Date = Date(),
+        baseModel: String,
+        outputFile: String,
+        adapterName: String,
+        training: Training,
+        lora: LoRA,
+        evalPromptCount: Int?,
+        status: String
+    ) {
+        self.schemaVersion = Self.schemaVersion
+        self.createdAt = createdAt
+        self.format = Self.format
+        self.baseModel = baseModel
+        self.outputFile = outputFile
+        self.adapterName = adapterName
+        self.training = training
+        self.lora = lora
+        self.evalPromptCount = evalPromptCount
+        self.status = status
+    }
+
+    public static func url(nextTo outputSafetensorsURL: URL) -> URL {
+        outputSafetensorsURL
+            .deletingPathExtension()
+            .appendingPathExtension("manifest")
+            .appendingPathExtension("json")
+    }
+
+    public func write(nextTo outputSafetensorsURL: URL) throws {
+        let url = Self.url(nextTo: outputSafetensorsURL)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(self).write(to: url, options: [.atomic])
+    }
+}

--- a/Sources/MereRunCore/TextSFTDataset.swift
+++ b/Sources/MereRunCore/TextSFTDataset.swift
@@ -1,0 +1,175 @@
+import CryptoKit
+import Foundation
+
+public struct TextSFTExample: Sendable, Hashable, Codable {
+    public let id: String?
+    public let sources: [String]
+    public let messages: [ChatMessage]
+
+    public init(id: String?, sources: [String], messages: [ChatMessage]) {
+        self.id = id
+        self.sources = sources
+        self.messages = messages
+    }
+}
+public struct TextSFTDatasetSummary: Sendable, Hashable, Codable {
+    public let exampleCount: Int
+    public let messageCount: Int
+    public let sourceCount: Int
+    public let fingerprint: String
+    public let averageAssistantCharacters: Double
+    public let maxAssistantCharacters: Int
+
+    public init(
+        exampleCount: Int,
+        messageCount: Int,
+        sourceCount: Int,
+        fingerprint: String,
+        averageAssistantCharacters: Double,
+        maxAssistantCharacters: Int
+    ) {
+        self.exampleCount = exampleCount
+        self.messageCount = messageCount
+        self.sourceCount = sourceCount
+        self.fingerprint = fingerprint
+        self.averageAssistantCharacters = averageAssistantCharacters
+        self.maxAssistantCharacters = maxAssistantCharacters
+    }
+}
+
+public enum TextSFTDataset {
+    public static func load(from url: URL) throws -> [TextSFTExample] {
+        let data = try Data(contentsOf: url)
+        let text = String(decoding: data, as: UTF8.self)
+        var examples: [TextSFTExample] = []
+        for (index, rawLine) in text.split(whereSeparator: \.isNewline).enumerated() {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            let lineData = Data(line.utf8)
+            do {
+                examples.append(try JSONDecoder().decode(TextSFTExample.self, from: lineData))
+            } catch {
+                throw TextSFTDatasetError.invalidJSONLine(index + 1, error.localizedDescription)
+            }
+        }
+        try validate(examples)
+        return examples
+    }
+
+    public static func validate(_ examples: [TextSFTExample]) throws {
+        guard !examples.isEmpty else {
+            throw TextSFTDatasetError.emptyDataset
+        }
+
+        var ids = Set<String>()
+        var prompts = Set<String>()
+        for (index, example) in examples.enumerated() {
+            let line = index + 1
+            if let id = example.id, !id.isEmpty {
+                guard ids.insert(id).inserted else {
+                    throw TextSFTDatasetError.duplicateID(id)
+                }
+            }
+
+            guard example.messages.count >= 3 else {
+                throw TextSFTDatasetError.tooFewMessages(line)
+            }
+            guard example.messages.first?.role == .system else {
+                throw TextSFTDatasetError.invalidRoleOrder(line, "first message must be system")
+            }
+            guard example.messages.contains(where: { $0.role == .user }) else {
+                throw TextSFTDatasetError.invalidRoleOrder(line, "example must include a user message")
+            }
+            guard example.messages.last?.role == .assistant else {
+                throw TextSFTDatasetError.invalidRoleOrder(line, "last message must be assistant")
+            }
+            guard !example.sources.isEmpty else {
+                throw TextSFTDatasetError.missingSources(line)
+            }
+
+            for message in example.messages {
+                let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.count >= 4 else {
+                    throw TextSFTDatasetError.emptyMessage(line)
+                }
+            }
+
+            if let prompt = example.messages.first(where: { $0.role == .user })?.content {
+                let normalized = prompt.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                guard prompts.insert(normalized).inserted else {
+                    throw TextSFTDatasetError.duplicatePrompt(line)
+                }
+            }
+        }
+    }
+
+    public static func summarize(_ examples: [TextSFTExample]) -> TextSFTDatasetSummary {
+        let messageCount = examples.reduce(0) { $0 + $1.messages.count }
+        let sources = Set(examples.flatMap(\.sources))
+        let assistantLengths = examples.map { example in
+            example.messages.last(where: { $0.role == .assistant })?.content.count ?? 0
+        }
+        let totalAssistantCharacters = assistantLengths.reduce(0, +)
+        let average = examples.isEmpty ? 0 : Double(totalAssistantCharacters) / Double(examples.count)
+        return TextSFTDatasetSummary(
+            exampleCount: examples.count,
+            messageCount: messageCount,
+            sourceCount: sources.count,
+            fingerprint: fingerprint(examples),
+            averageAssistantCharacters: average,
+            maxAssistantCharacters: assistantLengths.max() ?? 0
+        )
+    }
+
+    public static func fingerprint(_ examples: [TextSFTExample]) -> String {
+        var hasher = SHA256()
+        for example in examples {
+            if let id = example.id {
+                hasher.update(data: Data(id.utf8))
+            }
+            for source in example.sources.sorted() {
+                hasher.update(data: Data(source.utf8))
+            }
+            for message in example.messages {
+                hasher.update(data: Data(message.role.rawValue.utf8))
+                hasher.update(data: Data(message.content.utf8))
+                if let imageUrl = message.imageUrl {
+                    hasher.update(data: Data(imageUrl.utf8))
+                }
+            }
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+public enum TextSFTDatasetError: Error, LocalizedError, Sendable {
+    case emptyDataset
+    case invalidJSONLine(Int, String)
+    case duplicateID(String)
+    case duplicatePrompt(Int)
+    case tooFewMessages(Int)
+    case invalidRoleOrder(Int, String)
+    case missingSources(Int)
+    case emptyMessage(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyDataset:
+            return "Text SFT dataset is empty."
+        case .invalidJSONLine(let line, let detail):
+            return "Invalid JSONL record at line \(line): \(detail)"
+        case .duplicateID(let id):
+            return "Duplicate text SFT example id: \(id)"
+        case .duplicatePrompt(let line):
+            return "Duplicate user prompt in text SFT example at line \(line)."
+        case .tooFewMessages(let line):
+            return "Text SFT example at line \(line) must include at least system, user, and assistant messages."
+        case .invalidRoleOrder(let line, let detail):
+            return "Invalid text SFT message order at line \(line): \(detail)."
+        case .missingSources(let line):
+            return "Text SFT example at line \(line) must include at least one source id."
+        case .emptyMessage(let line):
+            return "Text SFT example at line \(line) contains an empty message."
+        }
+    }
+}

--- a/Sources/MereRunCore/TextSFTDataset.swift
+++ b/Sources/MereRunCore/TextSFTDataset.swift
@@ -1,4 +1,8 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 
 public struct TextSFTExample: Sendable, Hashable, Codable {

--- a/Sources/MereRunCore/TextSFTTrainingBatch.swift
+++ b/Sources/MereRunCore/TextSFTTrainingBatch.swift
@@ -1,0 +1,191 @@
+import Foundation
+import MLX
+import MLXNN
+
+public struct TextSFTTokenizedExample: Sendable, Hashable {
+    public let inputTokenIds: [Int]
+    public let labelTokenIds: [Int]
+    public let lossMask: [Float]
+
+    public init(inputTokenIds: [Int], labelTokenIds: [Int], lossMask: [Float]) {
+        self.inputTokenIds = inputTokenIds
+        self.labelTokenIds = labelTokenIds
+        self.lossMask = lossMask
+    }
+}
+
+public enum TextSFTTrainingBatchBuilder {
+    public static func shiftedTargetExample(
+        prefixTokenIds: [Int],
+        targetTokenIds: [Int],
+        maxSequenceLength: Int
+    ) throws -> TextSFTTokenizedExample {
+        guard maxSequenceLength >= 2 else {
+            throw TextSFTTrainingBatchError.maxSequenceLengthTooSmall(maxSequenceLength)
+        }
+        guard !targetTokenIds.isEmpty else {
+            throw TextSFTTrainingBatchError.noAssistantTargets
+        }
+
+        var tokenIds = prefixTokenIds + targetTokenIds
+        var targetMask = Array(repeating: Float(0), count: max(prefixTokenIds.count - 1, 0))
+            + Array(repeating: Float(1), count: targetTokenIds.count)
+
+        if tokenIds.count > maxSequenceLength {
+            let trimCount = tokenIds.count - maxSequenceLength
+            tokenIds = Array(tokenIds.dropFirst(trimCount))
+            targetMask = Array(targetMask.dropFirst(min(trimCount, targetMask.count)))
+        }
+
+        guard tokenIds.count >= 2 else {
+            throw TextSFTTrainingBatchError.notEnoughTokens
+        }
+
+        let inputs = Array(tokenIds.dropLast())
+        let labels = Array(tokenIds.dropFirst())
+        if targetMask.count > labels.count {
+            targetMask = Array(targetMask.suffix(labels.count))
+        }
+        guard targetMask.count == labels.count else {
+            throw TextSFTTrainingBatchError.shiftedLengthMismatch
+        }
+        guard targetMask.contains(where: { $0 > 0 }) else {
+            throw TextSFTTrainingBatchError.noAssistantTargets
+        }
+
+        return TextSFTTokenizedExample(
+            inputTokenIds: inputs,
+            labelTokenIds: labels,
+            lossMask: targetMask
+        )
+    }
+
+    public static func shiftedExample(
+        messageTokenIds: [[Int]],
+        messageRoles: [ChatMessage.Role],
+        maxSequenceLength: Int
+    ) throws -> TextSFTTokenizedExample {
+        guard maxSequenceLength >= 2 else {
+            throw TextSFTTrainingBatchError.maxSequenceLengthTooSmall(maxSequenceLength)
+        }
+        guard messageTokenIds.count == messageRoles.count else {
+            throw TextSFTTrainingBatchError.messageTokenRoleMismatch
+        }
+
+        var tokenIds: [Int] = []
+        var assistantTargets: [Float] = []
+        for (index, tokens) in messageTokenIds.enumerated() {
+            guard !tokens.isEmpty else { continue }
+            let isAssistant = messageRoles[index] == .assistant
+            tokenIds.append(contentsOf: tokens)
+            assistantTargets.append(contentsOf: Array(repeating: isAssistant ? 1 : 0, count: tokens.count))
+        }
+
+        if tokenIds.count > maxSequenceLength {
+            tokenIds = Array(tokenIds.suffix(maxSequenceLength))
+            assistantTargets = Array(assistantTargets.suffix(maxSequenceLength))
+        }
+
+        guard tokenIds.count >= 2 else {
+            throw TextSFTTrainingBatchError.notEnoughTokens
+        }
+
+        let inputs = Array(tokenIds.dropLast())
+        let labels = Array(tokenIds.dropFirst())
+        let shiftedMask = Array(assistantTargets.dropFirst())
+        guard shiftedMask.contains(where: { $0 > 0 }) else {
+            throw TextSFTTrainingBatchError.noAssistantTargets
+        }
+        return TextSFTTokenizedExample(
+            inputTokenIds: inputs,
+            labelTokenIds: labels,
+            lossMask: shiftedMask
+        )
+    }
+
+    public static func makeBatch(
+        _ examples: [TextSFTTokenizedExample],
+        padTokenId: Int = 0
+    ) throws -> (inputIds: MLXArray, labels: MLXArray, lossMask: MLXArray) {
+        guard !examples.isEmpty else {
+            throw TextSFTTrainingBatchError.emptyBatch
+        }
+        let maxLength = examples.map(\.inputTokenIds.count).max() ?? 0
+        guard maxLength > 0 else {
+            throw TextSFTTrainingBatchError.notEnoughTokens
+        }
+
+        var inputValues: [Int32] = []
+        var labelValues: [Int32] = []
+        var maskValues: [Float] = []
+        inputValues.reserveCapacity(examples.count * maxLength)
+        labelValues.reserveCapacity(examples.count * maxLength)
+        maskValues.reserveCapacity(examples.count * maxLength)
+
+        for example in examples {
+            guard example.inputTokenIds.count == example.labelTokenIds.count,
+                  example.inputTokenIds.count == example.lossMask.count else {
+                throw TextSFTTrainingBatchError.shiftedLengthMismatch
+            }
+            let padCount = maxLength - example.inputTokenIds.count
+            inputValues.append(contentsOf: example.inputTokenIds.map(Int32.init))
+            labelValues.append(contentsOf: example.labelTokenIds.map(Int32.init))
+            maskValues.append(contentsOf: example.lossMask)
+            if padCount > 0 {
+                inputValues.append(contentsOf: Array(repeating: Int32(padTokenId), count: padCount))
+                labelValues.append(contentsOf: Array(repeating: Int32(padTokenId), count: padCount))
+                maskValues.append(contentsOf: Array(repeating: Float(0), count: padCount))
+            }
+        }
+
+        return (
+            inputIds: MLXArray(inputValues, [examples.count, maxLength]),
+            labels: MLXArray(labelValues, [examples.count, maxLength]),
+            lossMask: MLXArray(maskValues, [examples.count, maxLength])
+        )
+    }
+}
+
+public enum TextSFTTrainingLoss {
+    public static func maskedNextTokenCrossEntropy(
+        logits: MLXArray,
+        labels: MLXArray,
+        lossMask: MLXArray
+    ) -> MLXArray {
+        let logProbabilities = logSoftmax(logits.asType(.float32), axis: -1)
+        let selected = takeAlong(
+            logProbabilities,
+            labels.asType(.int32).expandedDimensions(axis: -1),
+            axis: -1
+        ).squeezed(axis: -1)
+        let mask = lossMask.asType(.float32)
+        let denominator = mask.sum() + MLXArray(Float(1e-8))
+        return -(selected * mask).sum() / denominator
+    }
+}
+
+public enum TextSFTTrainingBatchError: Error, LocalizedError, Sendable {
+    case emptyBatch
+    case maxSequenceLengthTooSmall(Int)
+    case messageTokenRoleMismatch
+    case notEnoughTokens
+    case noAssistantTargets
+    case shiftedLengthMismatch
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyBatch:
+            return "Text SFT training batch is empty."
+        case .maxSequenceLengthTooSmall(let value):
+            return "Text SFT max sequence length must be >= 2 (got \(value))."
+        case .messageTokenRoleMismatch:
+            return "Text SFT tokenized messages and roles have different counts."
+        case .notEnoughTokens:
+            return "Text SFT example must contain at least two tokens after truncation."
+        case .noAssistantTargets:
+            return "Text SFT example contains no assistant target tokens."
+        case .shiftedLengthMismatch:
+            return "Text SFT shifted input, label, and mask lengths must match."
+        }
+    }
+}

--- a/Tests/MereRunCLITests/TextAnonymizeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextAnonymizeCommandParsingTests.swift
@@ -37,7 +37,7 @@ final class TextAnonymizeCommandParsingTests: XCTestCase {
 
     func testTextSubcommandsIncludeAnonymize() {
         let textNames = Set(Text.configuration.subcommands.map { $0.configuration.commandName })
-        XCTAssertEqual(textNames, Set(["chat", "code", "embed", "anonymize"]))
+        XCTAssertEqual(textNames, Set(["chat", "code", "embed", "anonymize", "train-lora"]))
     }
 
     func testPrivacyFilterManagedModelSpec() {

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -44,6 +44,17 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.stream)
     }
 
+    func testTextChatParsesLoRAAdapterOptions() throws {
+        let cmd = try TextChat.parse([
+            "--prompt", "Use adapter",
+            "--lora", "/tmp/adapter.safetensors",
+            "--lora-scale", "0.75",
+        ])
+
+        XCTAssertEqual(cmd.loraPath, "/tmp/adapter.safetensors")
+        XCTAssertEqual(cmd.loraScale, 0.75)
+    }
+
     func testTextChatBackendDescriptionIdentifiesNativeMLXModels() {
         let backend = TextChat.backendDescription(for: Gemma4Resources.twelveB4BitModelId)
 

--- a/Tests/MereRunCLITests/TextTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextTrainLoRACommandParsingTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class TextTrainLoRACommandParsingTests: XCTestCase {
+    func testTextCommandExposesTrainLoRA() {
+        let commandNames = Set(Text.configuration.subcommands.map { $0.configuration.commandName })
+
+        XCTAssertTrue(commandNames.contains("train-lora"))
+    }
+
+    func testTrainLoRAParsesDefaults() throws {
+        let cmd = try TextTrainLoRA.parse([
+            "--data", "pairs.jsonl",
+            "--output", "local-assistant.safetensors",
+        ])
+
+        XCTAssertEqual(cmd.model, Gemma4Resources.twelveB4BitModelId)
+        XCTAssertEqual(cmd.adapterName, "local-assistant")
+        XCTAssertEqual(cmd.trainingSteps, 600)
+        XCTAssertEqual(cmd.batchSize, 1)
+        XCTAssertEqual(cmd.rank, 16)
+        XCTAssertEqual(cmd.maxSequenceLength, 4096)
+        XCTAssertFalse(cmd.dryRun)
+        XCTAssertFalse(cmd.visualize)
+        XCTAssertEqual(cmd.visualizePort, 8787)
+    }
+
+    func testTrainLoRAParsesOverrides() throws {
+        let cmd = try TextTrainLoRA.parse([
+            "--data", "pairs.jsonl",
+            "--output", "adapter.safetensors",
+            "--model", Gemma4Resources.turboModelId,
+            "--model-path", "/tmp/gemma4",
+            "--eval", "eval.jsonl",
+            "--adapter-name", "support-draft",
+            "--steps", "20",
+            "--batch-size", "2",
+            "--lr", "0.00005",
+            "--rank", "8",
+            "--alpha", "16",
+            "--max-sequence-length", "2048",
+            "--target-modules", "q_proj,v_proj",
+            "--visualize",
+            "--visualize-port", "8788",
+            "--dry-run",
+            "--json",
+        ])
+
+        XCTAssertEqual(cmd.model, Gemma4Resources.turboModelId)
+        XCTAssertEqual(cmd.modelPath, "/tmp/gemma4")
+        XCTAssertEqual(cmd.eval, "eval.jsonl")
+        XCTAssertEqual(cmd.adapterName, "support-draft")
+        XCTAssertEqual(cmd.trainingSteps, 20)
+        XCTAssertEqual(cmd.batchSize, 2)
+        XCTAssertEqual(cmd.learningRate, 0.00005)
+        XCTAssertEqual(cmd.rank, 8)
+        XCTAssertEqual(cmd.alpha, 16)
+        XCTAssertEqual(cmd.maxSequenceLength, 2048)
+        XCTAssertTrue(cmd.visualize)
+        XCTAssertEqual(cmd.visualizePort, 8788)
+        XCTAssertTrue(cmd.dryRun)
+        XCTAssertTrue(cmd.json)
+    }
+}

--- a/Tests/MereRunCoreTests/Gemma4TextLoRAInjectorTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4TextLoRAInjectorTests.swift
@@ -1,0 +1,46 @@
+import MLXNN
+import XCTest
+@testable import MereRunCore
+
+final class Gemma4TextLoRAInjectorTests: XCTestCase {
+    func testTargetMatcherAcceptsGemmaAttentionProjectionSuffixes() {
+        XCTAssertTrue(Gemma4TextLoRAInjector.shouldTarget(path: "language_model.layers.0.self_attn.q_proj", suffixes: ["q_proj"]))
+        XCTAssertTrue(Gemma4TextLoRAInjector.shouldTarget(path: "language_model.layers.0.self_attn.o_proj", suffixes: ["o_proj"]))
+        XCTAssertFalse(Gemma4TextLoRAInjector.shouldTarget(path: "language_model.layers.0.mlp.gate_proj", suffixes: ["q_proj"]))
+    }
+
+    func testInjectsIntoToyGemmaLikeModule() throws {
+        let module = ToyGemmaAttentionModule()
+
+        let layers = try Gemma4TextLoRAInjector.inject(into: module, rank: 2, targetSuffixes: ["q_proj", "v_proj"])
+
+        XCTAssertEqual(Set(layers.keys), ["self_attn.q_proj", "self_attn.v_proj"])
+        XCTAssertTrue(module.namedModules().contains { path, child in
+            path == "self_attn.q_proj" && child is LoRALinear
+        })
+        XCTAssertTrue(module.namedModules().contains { path, child in
+            path == "self_attn.v_proj" && child is LoRALinear
+        })
+    }
+}
+private final class ToyGemmaAttentionModule: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: ToyGemmaSelfAttention
+
+    override init() {
+        self._selfAttention.wrappedValue = ToyGemmaSelfAttention()
+        super.init()
+    }
+}
+
+private final class ToyGemmaSelfAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+
+    override init() {
+        self._qProj.wrappedValue = Linear(4, 4, bias: false)
+        self._vProj.wrappedValue = Linear(4, 4, bias: false)
+        self._gateProj.wrappedValue = Linear(4, 4, bias: false)
+        super.init()
+    }
+}

--- a/Tests/MereRunCoreTests/Gemma4TextLoRAInjectorTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4TextLoRAInjectorTests.swift
@@ -2,7 +2,7 @@ import MLXNN
 import XCTest
 @testable import MereRunCore
 
-final class Gemma4TextLoRAInjectorTests: XCTestCase {
+final class Gemma4TextLoRAInjectorTests: MereRunCoreTestCase {
     func testTargetMatcherAcceptsGemmaAttentionProjectionSuffixes() {
         XCTAssertTrue(Gemma4TextLoRAInjector.shouldTarget(path: "language_model.layers.0.self_attn.q_proj", suffixes: ["q_proj"]))
         XCTAssertTrue(Gemma4TextLoRAInjector.shouldTarget(path: "language_model.layers.0.self_attn.o_proj", suffixes: ["o_proj"]))

--- a/Tests/MereRunCoreTests/Gemma4TextSFTTokenizerTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4TextSFTTokenizerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import MereRunCore
+
+final class Gemma4TextSFTTokenizerTests: XCTestCase {
+    func testAssistantTargetTextStripsThinkingChannels() {
+        XCTAssertEqual(
+            Gemma4TextSFTTokenizer.assistantTargetText("Before <|channel>thought\nhidden\n<channel|> after "),
+            "Before  after"
+        )
+    }
+
+    func testCommonPrefixLengthStopsAtFirstDifference() {
+        XCTAssertEqual(
+            Gemma4TextSFTTokenizer.commonPrefixLength([1, 2, 3, 9], [1, 2, 4, 5]),
+            2
+        )
+    }
+
+    func testCommonPrefixLengthHandlesIdenticalPrefix() {
+        XCTAssertEqual(
+            Gemma4TextSFTTokenizer.commonPrefixLength([1, 2], [1, 2, 3, 4]),
+            2
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
+++ b/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+@testable import MereRunCore
+
+final class TextLoRATrainerTests: XCTestCase {
+    func testTrainingOrderIsSeededAndCoversEpochs() {
+        let first = TextLoRATrainer.makeTrainingOrder(exampleCount: 5, drawCount: 7, seed: 42)
+        let second = TextLoRATrainer.makeTrainingOrder(exampleCount: 5, drawCount: 7, seed: 42)
+        let different = TextLoRATrainer.makeTrainingOrder(exampleCount: 5, drawCount: 7, seed: 43)
+
+        XCTAssertEqual(first, second)
+        XCTAssertNotEqual(first, different)
+        XCTAssertEqual(Set(first.prefix(5)), Set(0..<5))
+        XCTAssertEqual(first.count, 7)
+    }
+
+    func testNativeTrainerUpdatesLoRAAndWritesAdapter() throws {
+        let model = TinyCausalLM()
+        let layers = try Gemma4TextLoRAInjector.inject(into: model, rank: 2, targetSuffixes: ["proj"])
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("tiny-text-lora.safetensors")
+
+        let report = try TextLoRATrainer.train(
+            model: model,
+            loraLayers: layers,
+            examples: [
+                TextSFTTokenizedExample(
+                    inputTokenIds: [0, 1, 2],
+                    labelTokenIds: [1, 2, 3],
+                    lossMask: [0, 1, 1]
+                ),
+            ],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 3,
+                batchSize: 1,
+                learningRate: 0.05
+            ),
+            outputURL: outputURL,
+            metadata: ["format": "mererun.gemma4.text-lora.test"]
+        ) { model, inputIds in
+            model(inputIds)
+        }
+
+        XCTAssertEqual(report.steps, 3)
+        XCTAssertEqual(report.layerCount, 1)
+        XCTAssertNotNil(report.initialLoss)
+        XCTAssertNotNil(report.finalLoss)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.path))
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: outputURL.deletingPathExtension().appendingPathExtension("loss").appendingPathExtension("csv").path
+            )
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: outputURL.deletingPathExtension().appendingPathExtension("loss").appendingPathExtension("html").path
+            )
+        )
+
+        let layer = try XCTUnwrap(layers["proj"])
+        let upNorm = MLX.sqrt((layer.loraUp * layer.loraUp).sum()).item(Float.self)
+        XCTAssertGreaterThan(upNorm, 0)
+    }
+
+    func testNativeTrainerReportsProgress() throws {
+        let model = TinyCausalLM()
+        let layers = try Gemma4TextLoRAInjector.inject(into: model, rank: 2, targetSuffixes: ["proj"])
+        let recorder = TextTrainingProgressRecorder()
+
+        _ = try TextLoRATrainer.train(
+            model: model,
+            loraLayers: layers,
+            examples: [
+                TextSFTTokenizedExample(
+                    inputTokenIds: [0, 1, 2],
+                    labelTokenIds: [1, 2, 3],
+                    lossMask: [0, 1, 1]
+                ),
+            ],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 2,
+                batchSize: 1,
+                learningRate: 0.05
+            ),
+            progressHandler: { progress in
+                switch progress.stage {
+                case .training(let step, _, _):
+                    recorder.record(step: step)
+                case .saving:
+                    recorder.recordSaving()
+                }
+            }
+        ) { model, inputIds in
+            model(inputIds)
+        }
+
+        XCTAssertEqual(recorder.steps, [1, 2])
+        XCTAssertTrue(recorder.savingSeen)
+    }
+
+    func testNativeTrainerRunsOnTinyGemma4TextModel() throws {
+        let config = try tinyGemma4TextConfig()
+        let model = Gemma4TextCausalLM(config: config)
+        let layers = try Gemma4TextLoRAInjector.inject(into: model, rank: 2)
+
+        let report = try TextLoRATrainer.train(
+            model: model,
+            loraLayers: layers,
+            examples: [
+                TextSFTTokenizedExample(
+                    inputTokenIds: [3, 4, 5],
+                    labelTokenIds: [4, 5, 6],
+                    lossMask: [0, 1, 1]
+                ),
+            ],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 2,
+                batchSize: 1,
+                learningRate: 0.01
+            )
+        ) { model, inputIds in
+            model(inputIds)
+        }
+
+        XCTAssertEqual(report.steps, 2)
+        XCTAssertGreaterThan(report.layerCount, 0)
+        XCTAssertNotNil(report.finalLoss)
+    }
+
+    private func tinyGemma4TextConfig() throws -> Gemma4TextConfig {
+        let object: [String: Any] = [
+            "model_type": "gemma4_text",
+            "hidden_size": 8,
+            "num_hidden_layers": 1,
+            "intermediate_size": 16,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "max_position_embeddings": 128,
+            "rms_norm_eps": 0.000001,
+            "vocab_size": 32,
+            "vocab_size_per_layer_input": 32,
+            "hidden_size_per_layer_input": 0,
+            "rope_parameters": [
+                "sliding_attention": [
+                    "rope_type": "default",
+                    "rope_theta": 10000.0,
+                    "partial_rotary_factor": 1.0,
+                ],
+                "full_attention": [
+                    "rope_type": "proportional",
+                    "rope_theta": 1000000.0,
+                    "partial_rotary_factor": 1.0,
+                ],
+            ],
+            "sliding_window": 32,
+            "layer_types": ["full_attention"],
+            "attention_bias": false,
+            "attention_dropout": 0.0,
+            "attention_k_eq_v": false,
+            "use_double_wide_mlp": false,
+            "enable_moe_block": false,
+            "num_kv_shared_layers": 0,
+            "tie_word_embeddings": true,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        return try JSONDecoder().decode(Gemma4TextConfig.self, from: data)
+    }
+}
+
+private final class TextTrainingProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedSteps: [Int] = []
+    private var recordedSaving = false
+
+    var steps: [Int] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSteps
+    }
+
+    var savingSeen: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSaving
+    }
+
+    func record(step: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedSteps.append(step)
+    }
+
+    func recordSaving() {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedSaving = true
+    }
+}
+
+private final class TinyCausalLM: Module {
+    @ModuleInfo(key: "embed") var embed: Embedding
+    @ModuleInfo(key: "proj") var proj: Linear
+
+    override init() {
+        self._embed.wrappedValue = Embedding(embeddingCount: 8, dimensions: 6)
+        self._proj.wrappedValue = Linear(6, 8, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ inputIds: MLXArray) -> MLXArray {
+        proj(embed(inputIds))
+    }
+}

--- a/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
+++ b/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
@@ -4,7 +4,7 @@ import MLXNN
 import XCTest
 @testable import MereRunCore
 
-final class TextLoRATrainerTests: XCTestCase {
+final class TextLoRATrainerTests: MereRunCoreTestCase {
     func testTrainingOrderIsSeededAndCoversEpochs() {
         let first = TextLoRATrainer.makeTrainingOrder(exampleCount: 5, drawCount: 7, seed: 42)
         let second = TextLoRATrainer.makeTrainingOrder(exampleCount: 5, drawCount: 7, seed: 42)

--- a/Tests/MereRunCoreTests/TextSFTDatasetTests.swift
+++ b/Tests/MereRunCoreTests/TextSFTDatasetTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class TextSFTDatasetTests: XCTestCase {
+    func testLoadsChatJSONLDatasetAndSummarizes() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let datasetURL = directory.appendingPathComponent("pairs.jsonl")
+        try """
+        {"id":"local-assistant-0001","sources":["docs:local"],"messages":[{"role":"system","content":"You know Mere."},{"role":"user","content":"What is local mode?"},{"role":"assistant","content":"Local mode is explicit and project-specific."}]}
+        {"id":"local-assistant-0002","sources":["docs:run"],"messages":[{"role":"system","content":"You know Mere."},{"role":"user","content":"Which model?"},{"role":"assistant","content":"Use text-chat-gemma4-12b-4bit for the local assistant lane."}]}
+        """.write(to: datasetURL, atomically: true, encoding: .utf8)
+
+        let examples = try TextSFTDataset.load(from: datasetURL)
+        let summary = TextSFTDataset.summarize(examples)
+
+        XCTAssertEqual(examples.count, 2)
+        XCTAssertEqual(summary.exampleCount, 2)
+        XCTAssertEqual(summary.messageCount, 6)
+        XCTAssertEqual(summary.sourceCount, 2)
+        XCTAssertEqual(summary.fingerprint.count, 64)
+    }
+
+    func testRejectsDuplicatePrompts() throws {
+        let examples = [
+            TextSFTExample(
+                id: "one",
+                sources: ["docs"],
+                messages: [
+                    ChatMessage(role: .system, content: "System"),
+                    ChatMessage(role: .user, content: "Same prompt"),
+                    ChatMessage(role: .assistant, content: "First answer"),
+                ]
+            ),
+            TextSFTExample(
+                id: "two",
+                sources: ["docs"],
+                messages: [
+                    ChatMessage(role: .system, content: "System"),
+                    ChatMessage(role: .user, content: " same PROMPT "),
+                    ChatMessage(role: .assistant, content: "Second answer"),
+                ]
+            ),
+        ]
+
+        XCTAssertThrowsError(try TextSFTDataset.validate(examples)) { error in
+            XCTAssertTrue(String(describing: error).contains("duplicatePrompt"))
+        }
+    }
+}

--- a/Tests/MereRunCoreTests/TextSFTTrainingBatchTests.swift
+++ b/Tests/MereRunCoreTests/TextSFTTrainingBatchTests.swift
@@ -2,7 +2,7 @@ import MLX
 import XCTest
 @testable import MereRunCore
 
-final class TextSFTTrainingBatchTests: XCTestCase {
+final class TextSFTTrainingBatchTests: MereRunCoreTestCase {
     func testShiftedTargetExampleMasksOnlyTargetTokens() throws {
         let example = try TextSFTTrainingBatchBuilder.shiftedTargetExample(
             prefixTokenIds: [10, 11, 12, 13],

--- a/Tests/MereRunCoreTests/TextSFTTrainingBatchTests.swift
+++ b/Tests/MereRunCoreTests/TextSFTTrainingBatchTests.swift
@@ -1,0 +1,92 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class TextSFTTrainingBatchTests: XCTestCase {
+    func testShiftedTargetExampleMasksOnlyTargetTokens() throws {
+        let example = try TextSFTTrainingBatchBuilder.shiftedTargetExample(
+            prefixTokenIds: [10, 11, 12, 13],
+            targetTokenIds: [20, 21, 22],
+            maxSequenceLength: 16
+        )
+
+        XCTAssertEqual(example.inputTokenIds, [10, 11, 12, 13, 20, 21])
+        XCTAssertEqual(example.labelTokenIds, [11, 12, 13, 20, 21, 22])
+        XCTAssertEqual(example.lossMask, [0, 0, 0, 1, 1, 1])
+    }
+
+    func testShiftedTargetExamplePreservesTargetMaskAfterLeftTruncation() throws {
+        let example = try TextSFTTrainingBatchBuilder.shiftedTargetExample(
+            prefixTokenIds: [1, 2, 3, 4],
+            targetTokenIds: [5, 6, 7],
+            maxSequenceLength: 5
+        )
+
+        XCTAssertEqual(example.inputTokenIds, [3, 4, 5, 6])
+        XCTAssertEqual(example.labelTokenIds, [4, 5, 6, 7])
+        XCTAssertEqual(example.lossMask, [0, 1, 1, 1])
+    }
+
+    func testShiftedExampleMasksOnlyAssistantTargets() throws {
+        let example = try TextSFTTrainingBatchBuilder.shiftedExample(
+            messageTokenIds: [[10, 11], [20, 21], [30, 31, 32]],
+            messageRoles: [.system, .user, .assistant],
+            maxSequenceLength: 16
+        )
+
+        XCTAssertEqual(example.inputTokenIds, [10, 11, 20, 21, 30, 31])
+        XCTAssertEqual(example.labelTokenIds, [11, 20, 21, 30, 31, 32])
+        XCTAssertEqual(example.lossMask, [0, 0, 0, 1, 1, 1])
+    }
+
+    func testShiftedExampleKeepsAssistantTargetsAfterLeftTruncation() throws {
+        let example = try TextSFTTrainingBatchBuilder.shiftedExample(
+            messageTokenIds: [[1, 2, 3], [4, 5], [6, 7, 8, 9]],
+            messageRoles: [.system, .user, .assistant],
+            maxSequenceLength: 5
+        )
+
+        XCTAssertEqual(example.inputTokenIds, [5, 6, 7, 8])
+        XCTAssertEqual(example.labelTokenIds, [6, 7, 8, 9])
+        XCTAssertEqual(example.lossMask, [1, 1, 1, 1])
+    }
+
+    func testMakeBatchPadsInputsLabelsAndMasks() throws {
+        let first = TextSFTTokenizedExample(
+            inputTokenIds: [1, 2],
+            labelTokenIds: [2, 3],
+            lossMask: [0, 1]
+        )
+        let second = TextSFTTokenizedExample(
+            inputTokenIds: [4],
+            labelTokenIds: [5],
+            lossMask: [1]
+        )
+
+        let batch = try TextSFTTrainingBatchBuilder.makeBatch([first, second], padTokenId: 99)
+
+        XCTAssertEqual(batch.inputIds.shape, [2, 2])
+        XCTAssertEqual(batch.labels.shape, [2, 2])
+        XCTAssertEqual(batch.lossMask.shape, [2, 2])
+        XCTAssertEqual(batch.inputIds[1, 1].item(Int32.self), 99)
+        XCTAssertEqual(batch.labels[1, 1].item(Int32.self), 99)
+        XCTAssertEqual(batch.lossMask[1, 1].item(Float.self), 0)
+    }
+
+    func testMaskedCrossEntropyIgnoresMaskedTokens() {
+        let logits = MLXArray([
+            Float(10), 0, 0,
+            0, 0, Float(10),
+        ], [1, 2, 3])
+        let labels = MLXArray([Int32(1), Int32(2)], [1, 2])
+        let mask = MLXArray([Float(0), Float(1)], [1, 2])
+
+        let loss = TextSFTTrainingLoss.maskedNextTokenCrossEntropy(
+            logits: logits,
+            labels: labels,
+            lossMask: mask
+        )
+
+        XCTAssertLessThan(loss.item(Float.self), 0.001)
+    }
+}

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -1,7 +1,7 @@
 # Text Runtime
 
 This page covers the text-facing command families: chat, code generation,
-embeddings, and PII anonymization.
+embeddings, PII anonymization, and native text LoRA preparation.
 
 ## Public surface
 
@@ -9,6 +9,7 @@ embeddings, and PII anonymization.
 - `mere.run text code`
 - `mere.run text embed`
 - `mere.run text anonymize`
+- `mere.run text train-lora`
 
 ## Model families
 
@@ -64,9 +65,9 @@ equally recommended:
 | Unified memory | Winner | Notes |
 | --- | --- | --- |
 | 16-23 GB | `text-chat-gemma4-12b-4bit` | Best compact first chat pick; `text-chat-gemma4-nano` is the safer smallest fallback. |
-| 24-63 GB | `text-chat-q36-nano` | Default strong chat tier; `text-chat-gemma4-turbo` is the Gemma-specific alternative. |
-| 64-95 GB | `text-chat-q36-nano` | Extra RAM is better spent on context, concurrency, or code models than dense Gemma 31B as a default. |
-| 96+ GB | `text-agent-deepseek-v4-flash` | Premier agent/API chat tier; keep Q36 for lower-latency interactive chat. |
+| 24-63 GB | `text-chat-gemma4-12b-4bit` | Default grounded local-assistant tier; `text-chat-gemma4-turbo` is the larger Gemma alternate. |
+| 64-95 GB | `text-chat-gemma4-12b-4bit` | Keep the proven Gemma assistant lane; spend headroom on context, concurrency, or larger Gemma alternates. |
+| 96+ GB | `text-agent-deepseek-v4-flash` | Premier agent/API chat tier; keep Gemma 12B 4-bit for normal interactive local chat. |
 
 `text-chat-lfm25-a1b-8bit` installs `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
 and runs through the native Swift LFM2 runtime. It is text-only; use
@@ -122,6 +123,54 @@ swift run mere.run text anonymize \
   "My name is Alice Smith and my email is alice@example.com"
 ```
 
+### Native text LoRA training
+
+```bash
+swift run mere.run text train-lora \
+  --data ./pairs.seed.jsonl \
+  --eval ./eval.prompts.jsonl \
+  --output ./local-assistant.safetensors \
+  --model text-chat-gemma4-12b-4bit \
+  --dry-run \
+  --json
+```
+
+`text train-lora` is the native MereRun entrypoint for chat-style SFT JSONL.
+The data format is one JSON object per line with `sources` and `messages`;
+messages use the same `system`, `user`, and `assistant` roles as the local chat
+runtime. `--dry-run` validates the dataset, fingerprints it, counts optional
+eval prompts, and writes a `.manifest.json` next to the requested adapter path.
+
+Without `--dry-run`, the command resolves the Gemma4 text model through the same
+managed model store as chat, applies the Gemma chat template to each example,
+masks loss to assistant tokens, injects native LoRA layers into attention
+projections, and writes a `.safetensors` adapter plus manifest. Add
+`--visualize` to start the same loopback LoRA training dashboard used by image
+training; text runs write `run.json`, `*.events.jsonl`, `*.loss.csv`, and
+`*.loss.html` beside the adapter so loss and training events can be inspected
+while the optimizer runs. Keep local text fine-tuning in `mere.run` so the same
+model ids, manifests, runtime constraints, and eval artifacts remain under the
+MereRun command plane.
+
+```bash
+swift run mere.run text train-lora \
+  --data ./pairs.seed.jsonl \
+  --eval ./eval.prompts.jsonl \
+  --output ./local-assistant.safetensors \
+  --model text-chat-gemma4-12b-4bit \
+  --visualize \
+  --visualize-port 8787
+```
+
+Use the resulting adapter with native Gemma chat:
+
+```bash
+swift run mere.run text chat \
+  --model text-chat-gemma4-12b-4bit \
+  --lora ./local-assistant.safetensors \
+  --prompt "What should this local assistant know?"
+```
+
 ## Runtime entrypoints
 
 ### CLI
@@ -130,6 +179,7 @@ swift run mere.run text anonymize \
 - `Sources/MereRunCLI/Commands/TextCodeCommand.swift`
 - `Sources/MereRunCLI/Commands/TextEmbedCommand.swift`
 - `Sources/MereRunCLI/Commands/TextAnonymizeCommand.swift`
+- `Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift`
 
 ### Chat families
 
@@ -178,6 +228,12 @@ tasks. It is not a generative command.
 Use this for local PII detection and redaction. It runs the OpenAI Privacy
 Filter token-classification model through the native MLX runtime and can emit
 plain redacted text or structured JSON spans.
+
+### `mere.run text train-lora`
+
+Use this to prepare and train Gemma-family text LoRA adapters from reviewed chat
+SFT data. The first supported target lane is `text-chat-gemma4-12b-4bit` for
+local assistant tuning.
 
 ## Reading the code
 


### PR DESCRIPTION
## Summary
- add `mere.run text train-lora` for chat-style SFT JSONL preparation/training
- add native Gemma4 text LoRA injection, adapter loading for chat, manifests, metrics, and visualization event wiring
- cover command parsing, dataset validation, tokenization, batching, injector, and trainer paths

## Validation
- `./scripts/check.sh` from clean worktree `/tmp/mere-run-text-lora-verify`