### PR TITLE
Refine macOS Studio interface

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,76 @@
+# Design
+
+Visual system for the mere.run macOS Studio (`Sources/MereRunApp`). The source of truth
+in code is `MereRunTheme.swift`; every color resolves dynamically for light and dark.
+
+## Theme
+
+Dual-appearance, warm-neutral. Light is a warm paper palette; dark is a warm charcoal.
+Never pure `#000`/`#fff`; every neutral is tinted toward the bronze brand hue. Theme
+choice follows the system appearance — the app never forces one.
+
+## Color
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| background | `FAF8F3` | `171614` | window base |
+| surface | `FFFFFF` | `23211D` | panels, fields |
+| surfaceRaised | `F1EDE3` | `302D27` | selected/raised fills |
+| border | `D8D2C6` | `4E493F` | hairlines (usually at 0.4–0.8 opacity) |
+| textPrimary | `211C13` | `F1EDE3` | primary text |
+| textSecondary | `5C564A` | `C9C1B3` | supporting text |
+| textMuted | `8A8273` | `918A7C` | captions, metadata |
+| accent | `9C7A2E` | `C9A65D` | bronze/gold brand accent |
+| accentSoft | accent @ ~12% | accent @ ~16% | selection washes, user chat bubble |
+| green / yellow / red | tuned per appearance | | success / caution / failure |
+
+Color strategy: **Restrained** — tinted neutrals plus the single bronze accent (≤10% of
+any surface). Status colors appear only as status. No gradients as decoration beyond the
+existing faint background wash; no gradient text; no glassmorphism (material is used only
+where macOS uses it: sidebar and title-bar regions).
+
+## Typography
+
+- UI: SF Pro via Dynamic-Type-relative tokens (`titleFont`, `sectionFont`, `bodyFont`,
+  `captionFont`, `monoFont` for command/code).
+- Display: New York (system serif) for empty-state headlines, welcome hero, and other
+  short display moments only — never for controls or body copy. This serif-on-paper
+  pairing is a core identity element.
+- Hierarchy through weight + size contrast; body line length capped (~65–75ch → max
+  widths ~560–680pt on text blocks).
+
+## Shape & Depth
+
+- Radius scale: 6 / 8 / 9 / 10 / 18 / 20 (`MereRunTheme.Radius`). Pills and the composer
+  use the large end; fields and rows the small end.
+- Borders are 1pt hairlines of `border` at reduced opacity; selection borders use
+  `accent`.
+- Shadows via `mereShadow` (warm-neutral in light, deep in dark) on floating elements
+  only: composer, overlays, popovers. Flat surfaces stay flat.
+- `merePanel()` = surface fill + hairline; the standard container. Avoid nesting panels.
+
+## Spacing
+
+`MereRunTheme.Spacing`: 8 / 10 / 14 / 18 / 22 / 28 / 32. Rhythm varies — canvases
+breathe (24–32), rows and chips stay tight (8–12).
+
+## Motion
+
+- Ease-out only; 0.15–0.25s for state fades, `.snappy` / gentle springs for selection
+  and entrance. No bounce/elastic overshoot on layout.
+- SF Symbol effects (variableColor, bounce) mark live activity sparingly.
+- Everything decorative degrades under Reduce Motion.
+
+## Components
+
+- `MereBanner` — the only inline notice component (info/warning/error).
+- `MerePrimaryButtonStyle` — accent primary action; `.bordered` for secondary.
+- `mereField()` — canonical text-field chrome.
+- Status is one voice: a compact status cluster (dot + word) with a popover for detail —
+  never rows of always-on pills.
+- Navigation: grouped sidebar (Create / Converse / Voice / Vision) with the standard
+  macOS translucent sidebar material; no horizontal chip rails.
+- Chat: user turns in `accentSoft` bubbles right-aligned; assistant turns as unboxed
+  text blocks with a small mode glyph; fenced code in mono panels with copy.
+- Media: audio renders as an interactive waveform (accent = played), video via AVKit in
+  a rounded, shadowed frame.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,71 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Developers, tinkerers, and creative professionals on Apple Silicon Macs who want to run
+AI models locally: image, video, music, sound, speech, chat, code, and vision — without a
+cloud account and without their prompts or media leaving the machine. They range from
+CLI-fluent engineers (who also use the bundled `mere.run` terminal command and the
+Advanced surface) to prompt-first creators who never open a terminal. The Studio is the
+prompt-first face; the CLI is the engine underneath.
+
+Context of use: a desktop creative/utility session on macOS 15+, often long-running
+(model pulls are gigabytes, video/music renders take minutes). Light and dark
+environments both matter; the app must be a first-class Mac citizen (menus, Quick Look,
+drag-and-drop, VoiceOver, Dynamic Type).
+
+## Product Purpose
+
+mere.run Studio (`Sources/MereRunApp`) is the macOS front end for the open-source
+mere.run local-inference CLI. Tagline: **"Create anything. Locally."** It exists so that
+local-first inference feels as effortless as a hosted tool: pick a mode, type a prompt,
+get a previewable result — while the public CLI does the real work and stays the source
+of truth. Success is a signed, notarized v1.0 where every mode produces a usable inline
+result, state is never silent, and the app feels native rather than like a wrapped web
+page or a terminal with buttons.
+
+## Brand Personality
+
+Warm, precise, quietly confident. A crafted instrument, not a console; a studio, not a
+dashboard. Local-ness and privacy are stated plainly ("stays on this Mac") rather than
+shouted. Copy is short, concrete, and a little literary in display moments ("Make
+something visible." / "Score the moment.") but strictly functional in controls and
+errors.
+
+## Anti-references
+
+- Generic AI-SaaS styling: neon-on-black, purple-blue gradients, glassmorphism cards,
+  gradient text, hero-metric dashboards.
+- Electron/web-wrapper feel: giant in-window branding headers, horizontally scrolling
+  chip navigation, everything-in-a-card.
+- Terminal-wrapper feel: raw log dumps as the primary surface, monospace everywhere,
+  CLI flag names leaking into primary UI copy.
+- Modal-first flows where inline or popover would do.
+
+## Design Principles
+
+1. **Native first.** Structure and behavior should read as macOS: sidebar navigation,
+   thin material toolbars, real keyboard support, Quick Look, drag out as well as in.
+2. **Prompt-first, depth on demand.** The default surface is one field and one button;
+   every extra control must earn its place. Full CLI depth lives one deliberate step
+   away (Options, Advanced) and never drifts from the CLI contract.
+3. **State is never silent.** Readiness, queueing, trimming, progress, and failure are
+   always visible and always explained in words, never color alone.
+4. **Local is a feature.** Surface the on-device story: model store, server status,
+   "stays on this Mac" — as calm facts, not marketing.
+5. **Warmth over chrome.** The paper-and-bronze palette, serif display moments, and a
+   few earned signature details (waveforms, streaming caret) carry the identity; the
+   rest stays quiet.
+
+## Accessibility & Inclusion
+
+- VoiceOver labels/values for all stateful and icon-only controls (established in
+  WS-4.5); color is never the sole carrier of state.
+- Dynamic Type via relative font tokens; layouts tolerate Larger Text.
+- Respect Reduce Motion (decorative animation only, degrade gracefully) and Reduce
+  Transparency (NSVisualEffectView system fallbacks).
+- Contrast target ≈ WCAG AA in both light and dark themes.

--- a/Sources/MereRunApp/MereRunControls.swift
+++ b/Sources/MereRunApp/MereRunControls.swift
@@ -22,6 +22,41 @@ extension ButtonStyle where Self == MerePrimaryButtonStyle {
     static var merePrimary: MerePrimaryButtonStyle { MerePrimaryButtonStyle() }
 }
 
+/// Icon-only buttons that acknowledge the pointer: a soft fill on hover, a slight press dip.
+/// Hover feedback is what separates a native-feeling control from a static glyph.
+struct MereIconButtonStyle: ButtonStyle {
+    var tint: Color = MereRunTheme.textSecondary
+
+    func makeBody(configuration: Configuration) -> some View {
+        MereIconButtonBody(configuration: configuration, tint: tint)
+    }
+
+    private struct MereIconButtonBody: View {
+        let configuration: Configuration
+        let tint: Color
+        @State private var hovering = false
+
+        var body: some View {
+            configuration.label
+                .foregroundStyle(hovering ? MereRunTheme.textPrimary : tint)
+                .background {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                        .fill(hovering ? MereRunTheme.hoverFill : Color.clear)
+                }
+                .scaleEffect(configuration.isPressed ? 0.94 : 1)
+                .onHover { hovering = $0 }
+                .animation(MereRunTheme.Motion.quick, value: hovering)
+                .animation(MereRunTheme.Motion.quick, value: configuration.isPressed)
+        }
+    }
+}
+
+extension ButtonStyle where Self == MereIconButtonStyle {
+    static var mereIcon: MereIconButtonStyle { MereIconButtonStyle() }
+
+    static func mereIcon(tint: Color) -> MereIconButtonStyle { MereIconButtonStyle(tint: tint) }
+}
+
 extension View {
     /// The canonical text-field chrome (plain field over a themed panel), standardizing the
     /// repeated `.textFieldStyle(.plain).padding().merePanel()` pattern and replacing `.roundedBorder`.
@@ -29,5 +64,14 @@ extension View {
         textFieldStyle(.plain)
             .padding(MereRunTheme.Spacing.sm)
             .merePanel(cornerRadius: cornerRadius)
+    }
+
+    /// Row hover treatment for list-like custom rows (library, sidebar, model list).
+    func mereHoverRow(_ hovering: Bool, cornerRadius: CGFloat = MereRunTheme.Radius.md) -> some View {
+        background {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(hovering ? MereRunTheme.hoverFill : Color.clear)
+        }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
     }
 }

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -68,9 +68,7 @@ private struct DockedAdvancedEditor: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             Divider().overlay(MereRunTheme.border.opacity(0.5))
-            ScrollView {
-                CommandEditor()
-            }
+            CommandEditor()
         }
     }
 
@@ -240,6 +238,7 @@ private struct CommandEditor: View {
                 actionRow
             }
             .padding(22)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .background(MereRunTheme.background)
     }
@@ -695,12 +694,25 @@ private struct PathField: View {
     }
 }
 
+private struct AdaptiveControlRow<Content: View>: View {
+    var spacing: CGFloat = 10
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: spacing, content: content)
+            VStack(alignment: .leading, spacing: spacing, content: content)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
 private struct DimensionsGrid: View {
     @EnvironmentObject private var controller: MereRunController
 
     var body: some View {
         EditorSection("Size") {
-            HStack(spacing: 10) {
+            AdaptiveControlRow {
                 NumberStepper(title: "Width", value: $controller.draft.width, range: 64...4096, step: 64)
                 NumberStepper(title: "Height", value: $controller.draft.height, range: 64...4096, step: 64)
             }
@@ -714,7 +726,7 @@ private struct GenerationOptions: View {
     var body: some View {
         EditorSection("Generation") {
             VStack(spacing: 10) {
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     NumberStepper(title: "Steps", value: $controller.draft.steps, range: 1...80, step: 1)
                     NumberField(title: "CFG", value: $controller.draft.cfgScale)
                     NumberField(title: "Strength", value: $controller.draft.strength)
@@ -767,10 +779,9 @@ private struct ImageValidationOptions: View {
                     Text("Klein").tag("klein")
                 }
                 .pickerStyle(.segmented)
-                HStack {
+                AdaptiveControlRow {
                     Toggle("Save reference", isOn: $controller.draft.force)
                     Toggle("Compare", isOn: $controller.draft.all)
-                    Spacer()
                 }
             }
         }
@@ -783,12 +794,12 @@ private struct TextGenerationOptions: View {
     var body: some View {
         EditorSection("Parameters") {
             VStack(spacing: 10) {
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     NumberStepper(title: "Max tokens", value: $controller.draft.maxTokens, range: 1...32768, step: 64)
                     NumberField(title: "Temp", value: $controller.draft.temperature)
                     NumberField(title: "Top-p", value: $controller.draft.topP)
                 }
-                HStack {
+                AdaptiveControlRow {
                     if [.textChat].contains(controller.selectedTemplate.id) {
                         Toggle("Thinking", isOn: $controller.draft.all)
                     }
@@ -804,7 +815,6 @@ private struct TextGenerationOptions: View {
                     if controller.selectedTemplate.id == .textAnonymize {
                         Toggle("JSON", isOn: $controller.draft.all)
                     }
-                    Spacer()
                     Toggle("Quiet", isOn: $controller.draft.quiet)
                 }
 
@@ -814,10 +824,9 @@ private struct TextGenerationOptions: View {
                         .textFieldStyle(.plain)
                         .padding(10)
                         .merePanel()
-                    HStack {
+                    AdaptiveControlRow {
                         Toggle("Tool loop", isOn: $controller.draft.toolLoop)
                         Toggle("Allow shell exec", isOn: $controller.draft.allowShellExec)
-                        Spacer()
                     }
                     PathField(
                         path: $controller.draft.sandboxDir,
@@ -867,7 +876,7 @@ private struct SpeechOptions: View {
                         .merePanel()
                 }
 
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     NumberField(title: "Temperature", value: $controller.draft.temperature)
                     Toggle("Stream", isOn: $controller.draft.stream)
                     Toggle("Quiet", isOn: $controller.draft.quiet)
@@ -894,7 +903,7 @@ private struct SpeechTranscribeOptions: View {
                     Text("Translate").tag("translate")
                 }
                 .pickerStyle(.segmented)
-                HStack {
+                AdaptiveControlRow {
                     NumberStepper(title: "Max tokens", value: $controller.draft.maxTokens, range: 1...4096, step: 64)
                     TextField("Language", text: $controller.draft.language)
                         .textFieldStyle(.plain)
@@ -914,7 +923,7 @@ private struct SpeechProfileCreateOptions: View {
 
     var body: some View {
         EditorSection("Profile") {
-            HStack(spacing: 10) {
+            AdaptiveControlRow {
                 TextField("Language", text: $controller.draft.language)
                     .textFieldStyle(.plain)
                     .padding(10)
@@ -930,12 +939,11 @@ private struct VisionTrackingOptions: View {
 
     var body: some View {
         EditorSection("Vision") {
-            HStack {
+            AdaptiveControlRow {
                 if controller.selectedTemplate.id == .visionTrackLive {
                     NumberField(title: "Seconds", value: $controller.draft.durationSeconds)
                 }
                 Toggle("Show boxes", isOn: $controller.draft.force)
-                Spacer()
             }
         }
     }
@@ -947,7 +955,7 @@ private struct MusicOptions: View {
     var body: some View {
         EditorSection("Music") {
             VStack(spacing: 10) {
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     NumberField(title: "Seconds", value: $controller.draft.durationSeconds)
                     NumberStepper(title: "Steps", value: $controller.draft.steps, range: 1...80, step: 1)
                 }
@@ -967,7 +975,7 @@ private struct SFXOptions: View {
     var body: some View {
         EditorSection("Sound FX") {
             VStack(spacing: 10) {
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     NumberField(title: "Seconds", value: $controller.draft.durationSeconds)
                     NumberStepper(title: "Steps", value: $controller.draft.steps, range: 1...64, step: 1)
                     NumberField(title: "CFG", value: $controller.draft.cfgScale)
@@ -993,7 +1001,7 @@ private struct VideoOptions: View {
                     Text("Unified AV").tag("unified-av")
                 }
                 .pickerStyle(.segmented)
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     NumberStepper(title: "Frames", value: $controller.draft.numFrames, range: 9...257, step: 8)
                     NumberStepper(title: "FPS", value: $controller.draft.fps, range: 1...60, step: 1)
                     NumberField(title: "Image strength", value: $controller.draft.strength)
@@ -1038,7 +1046,7 @@ private struct APIOptions: View {
                     Text("Code").tag("text-code")
                 }
                 .pickerStyle(.segmented)
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     TextField("Host", text: $controller.draft.host)
                         .textFieldStyle(.plain)
                         .padding(10)
@@ -1070,17 +1078,16 @@ private struct AgentStartOptions: View {
     var body: some View {
         EditorSection("Agent") {
             VStack(spacing: 10) {
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     TextField("Host", text: $controller.draft.host)
                         .textFieldStyle(.plain)
                         .padding(10)
                         .merePanel()
                     NumberStepper(title: "Port", value: $controller.draft.port, range: 1...65535, step: 1)
                 }
-                HStack {
+                AdaptiveControlRow {
                     Toggle("Skip server", isOn: $controller.draft.stream)
                     Toggle("Allow unsupported", isOn: $controller.draft.force)
-                    Spacer()
                 }
             }
         }
@@ -1105,7 +1112,7 @@ private struct SetupOptions: View {
                     Text("Premier").tag("premier")
                 }
                 .pickerStyle(.segmented)
-                HStack {
+                AdaptiveControlRow {
                     Toggle("Install", isOn: $controller.draft.force)
                     Toggle("Start", isOn: $controller.draft.stream)
                     Toggle("Quiet", isOn: $controller.draft.quiet)
@@ -1121,12 +1128,12 @@ private struct AgentOptions: View {
     var body: some View {
         EditorSection("Agent") {
             VStack(spacing: 10) {
-                HStack {
+                AdaptiveControlRow {
                     Toggle("Pull recommended", isOn: $controller.draft.force)
                     Toggle("Install Pi", isOn: $controller.draft.all)
                     Toggle("Configure Pi", isOn: $controller.draft.stream)
                 }
-                HStack(spacing: 10) {
+                AdaptiveControlRow {
                     TextField("Host", text: $controller.draft.host)
                         .textFieldStyle(.plain)
                         .padding(10)
@@ -1143,7 +1150,7 @@ private struct ModelPullOptions: View {
 
     var body: some View {
         EditorSection("Download") {
-            HStack {
+            AdaptiveControlRow {
                 Toggle("All", isOn: $controller.draft.all)
                 Toggle("Force", isOn: $controller.draft.force)
                 Toggle("Allow unsupported", isOn: $controller.draft.stream)
@@ -1172,7 +1179,7 @@ private struct ModelInspectionOptions: View {
 
     var body: some View {
         EditorSection("Output") {
-            HStack {
+            AdaptiveControlRow {
                 if controller.selectedTemplate.id == .modelCapabilities {
                     Toggle("All", isOn: $controller.draft.all)
                     Toggle("Recommended", isOn: $controller.draft.force)
@@ -1181,7 +1188,6 @@ private struct ModelInspectionOptions: View {
                     Toggle("JSON", isOn: $controller.draft.all)
                     Toggle("Components", isOn: $controller.draft.force)
                 }
-                Spacer()
             }
         }
     }

--- a/Sources/MereRunApp/MereRunTheme.swift
+++ b/Sources/MereRunApp/MereRunTheme.swift
@@ -13,9 +13,18 @@ enum MereRunTheme {
     static let textSecondary = dynamic(light: "5C564A", dark: "C9C1B3")
     static let textMuted = dynamic(light: "8A8273", dark: "918A7C")
     static let accent = dynamic(light: "9C7A2E", dark: "C9A65D")
+    /// A solid bronze wash for selection fills and the user chat bubble — solid (not
+    /// accent-at-opacity) so stacked layers never drift in tone.
+    static let accentSoft = dynamic(light: "F0E7D2", dark: "39331F")
     static let green = dynamic(light: "5E7A45", dark: "8EAA74")
     static let yellow = dynamic(light: "9C7520", dark: "D2A24E")
     static let red = dynamic(light: "C2493B", dark: "D98072")
+
+    /// Transient pointer-hover fill for rows and icon buttons.
+    static let hoverFill = dynamicNSColor(
+        light: NSColor(calibratedWhite: 0.1, alpha: 0.06),
+        dark: NSColor(calibratedWhite: 1.0, alpha: 0.07)
+    )
 
     /// Drop-shadow color tuned per appearance (soft neutral in light, deep black in dark).
     static let shadowColor = dynamicNSColor(
@@ -30,6 +39,10 @@ enum MereRunTheme {
     static let bodyFont = Font.system(.body)
     static let captionFont = Font.system(.caption, weight: .medium)
     static let monoFont = Font.system(.callout, design: .monospaced)
+    // New York serif is reserved for short display moments (empty-state headlines, the welcome
+    // hero) — never controls or body copy. Serif-on-paper is a core identity element.
+    static let displayFont = Font.system(.largeTitle, design: .serif, weight: .medium)
+    static let displaySmallFont = Font.system(.title2, design: .serif, weight: .medium)
 
     /// Consistent spacing scale for padding/stack spacing.
     enum Spacing {
@@ -53,6 +66,15 @@ enum MereRunTheme {
     }
 
     static let cornerRadius: CGFloat = Radius.base
+
+    /// The app's motion vocabulary: exponential ease-outs for state fades, soft springs for
+    /// selection and entrances. Nothing bounces.
+    enum Motion {
+        static let quick = Animation.easeOut(duration: 0.15)
+        static let standard = Animation.easeOut(duration: 0.22)
+        static let spring = Animation.spring(response: 0.32, dampingFraction: 0.86)
+        static let gentleSpring = Animation.spring(response: 0.5, dampingFraction: 0.9)
+    }
 
     /// A SwiftUI color that resolves to `light` or `dark` against the current appearance.
     static func dynamic(light: String, dark: String) -> Color {
@@ -159,5 +181,20 @@ extension View {
                         .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
                 }
         }
+    }
+
+    /// An accent focus treatment for the element that currently owns keyboard input (the
+    /// composer): a warm ring plus a faint glow, fading with `active`.
+    func mereFocusRing(_ active: Bool, cornerRadius: CGFloat) -> some View {
+        overlay {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .strokeBorder(MereRunTheme.accent.opacity(active ? 0.55 : 0), lineWidth: 1.5)
+        }
+        .shadow(
+            color: active ? MereRunTheme.accent.opacity(0.16) : .clear,
+            radius: active ? 9 : 0,
+            y: 2
+        )
+        .animation(MereRunTheme.Motion.standard, value: active)
     }
 }

--- a/Sources/MereRunApp/StudioCanvas.swift
+++ b/Sources/MereRunApp/StudioCanvas.swift
@@ -1,0 +1,709 @@
+import AppKit
+import SwiftUI
+
+/// The center stage: conversation thread for chat/code, otherwise the latest output with
+/// empty / running / readiness states layered as needed.
+struct StudioCanvas: View {
+    let mode: StudioMode
+    let item: StudioLibraryItem?
+    let conversationItem: StudioLibraryItem?
+    let conversationLiveText: String?
+    let isConversationRunning: Bool
+    let isRunning: Bool
+    let status: String
+    let readiness: ModelReadinessState
+    let error: String?
+    let logs: [LogLine]
+    let liveOutputText: String
+    let progress: StudioRunProgress?
+    let onOpen: () -> Void
+    let onReveal: () -> Void
+    let onQuickLook: () -> Void
+    let onPullModel: () -> Void
+    let onShowDetails: () -> Void
+    let onNewChat: () -> Void
+    let onCopy: (String) -> Void
+    let onRetry: () -> Void
+    let onEdit: (UUID) -> Void
+    let onStop: () -> Void
+    let onUseExample: (String) -> Void
+    let onAttach: () -> Void
+
+    private var visibleLiveOutputText: String? {
+        guard isRunning else { return nil }
+        let text = liveOutputText
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+
+    private var recentLogLines: [String] {
+        logs.suffix(4).map(\.text)
+    }
+
+    private var shouldShowReadinessOverlay: Bool {
+        !isRunning && (readiness.blocksRun || error != nil)
+    }
+
+    var body: some View {
+        ZStack {
+            if mode.isConversational {
+                StudioConversationView(
+                    item: conversationItem,
+                    liveText: conversationLiveText,
+                    isRunning: isConversationRunning,
+                    mode: mode,
+                    onNewChat: onNewChat,
+                    onCopy: onCopy,
+                    onRetry: onRetry,
+                    onEdit: onEdit,
+                    onUseExample: onUseExample
+                )
+                .transition(.opacity)
+            } else if let item {
+                StudioOutputView(
+                    item: item,
+                    liveOutputText: visibleLiveOutputText,
+                    onOpen: onOpen,
+                    onReveal: onReveal,
+                    onQuickLook: onQuickLook,
+                    onCopy: onCopy
+                )
+                .padding(MereRunTheme.Spacing.xxxl)
+                .transition(.opacity.combined(with: .scale(scale: 0.985)))
+            } else {
+                StudioEmptyState(mode: mode, onUseExample: onUseExample, onAttach: onAttach)
+                    .padding(MereRunTheme.Spacing.xxxl)
+            }
+
+            if isRunning && visibleLiveOutputText == nil && !mode.isConversational {
+                StudioRunningOverlay(
+                    mode: mode,
+                    status: status,
+                    progress: progress,
+                    recentLogs: recentLogLines,
+                    onStop: onStop
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.98)))
+            }
+
+            if shouldShowReadinessOverlay {
+                StudioReadinessOverlay(
+                    title: error == nil ? readiness.title : "Needs attention",
+                    message: error ?? readiness.message,
+                    canPull: error == nil && readiness.canPull,
+                    isChecking: error == nil && readiness.isChecking,
+                    onPullModel: onPullModel,
+                    onShowDetails: onShowDetails
+                )
+                .padding(MereRunTheme.Spacing.xxxl)
+                .transition(.opacity.combined(with: .scale(scale: 0.98)))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(MereRunTheme.Motion.standard, value: isRunning)
+        .animation(MereRunTheme.Motion.standard, value: shouldShowReadinessOverlay)
+    }
+}
+
+/// A blank canvas that teaches: serif headline, one line of guidance, and prompts you can
+/// click straight into the composer.
+struct StudioEmptyState: View {
+    let mode: StudioMode
+    var onUseExample: ((String) -> Void)?
+    var onAttach: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: MereRunTheme.Spacing.xl) {
+            Image(systemName: mode.systemImage)
+                .font(.system(size: 42, weight: .medium))
+                .foregroundStyle(MereRunTheme.accent)
+                .frame(width: 96, height: 96)
+                .background {
+                    Circle().fill(MereRunTheme.accentSoft.opacity(0.75))
+                }
+                .overlay {
+                    Circle().strokeBorder(MereRunTheme.accent.opacity(0.18), lineWidth: 1)
+                }
+
+            VStack(spacing: MereRunTheme.Spacing.xs) {
+                Text(mode.emptyTitle)
+                    .font(MereRunTheme.displayFont)
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .multilineTextAlignment(.center)
+                Text(mode.emptyMessage)
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 460)
+            }
+
+            if mode.requiresAttachment, let onAttach {
+                Button(action: onAttach) {
+                    Label(attachLabel, systemImage: "paperclip")
+                }
+                .buttonStyle(.merePrimary)
+            }
+
+            if !mode.examplePrompts.isEmpty, let onUseExample {
+                HStack(spacing: MereRunTheme.Spacing.xs) {
+                    ForEach(mode.examplePrompts, id: \.self) { example in
+                        StudioExampleChip(text: example) { onUseExample(example) }
+                    }
+                }
+                .frame(maxWidth: 720)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var attachLabel: String {
+        switch mode {
+        case .listen: return "Choose audio…"
+        case .track: return "Choose video…"
+        default: return "Choose image…"
+        }
+    }
+}
+
+/// One clickable example prompt. Filling, never auto-running, keeps the user in charge.
+private struct StudioExampleChip: View {
+    let text: String
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text("“\(text)”")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(hovering ? MereRunTheme.textPrimary : MereRunTheme.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.horizontal, 12)
+                .frame(height: 30)
+                .background {
+                    Capsule()
+                        .fill(hovering ? MereRunTheme.surfaceRaised : MereRunTheme.surface.opacity(0.7))
+                        .overlay {
+                            Capsule().strokeBorder(MereRunTheme.border.opacity(0.65), lineWidth: 1)
+                        }
+                }
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .help("Use this prompt")
+        .accessibilityLabel("Use example prompt: \(text)")
+    }
+}
+
+/// The in-flight card: a breathing mode glyph, plain-words status, real progress when the CLI
+/// reports it, elapsed time, cancel right here, and the raw activity tucked behind a disclosure.
+struct StudioRunningOverlay: View {
+    let mode: StudioMode
+    let status: String
+    let progress: StudioRunProgress?
+    let recentLogs: [String]
+    let onStop: () -> Void
+
+    @State private var startedAt: Date?
+    @State private var showActivity = false
+
+    var body: some View {
+        VStack(spacing: MereRunTheme.Spacing.md) {
+            Image(systemName: mode.systemImage)
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+                .symbolEffect(.pulse, options: .repeating)
+
+            Text(statusHeadline)
+                .font(.system(size: 17, weight: .semibold))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+
+            if let progress, let fraction = progress.fractionCompleted {
+                VStack(spacing: 6) {
+                    ProgressView(value: fraction)
+                        .progressViewStyle(.linear)
+                        .tint(MereRunTheme.accent)
+                        .frame(width: 320)
+                    HStack {
+                        Text(progress.label)
+                            .lineLimit(1)
+                        Spacer()
+                        Text("\(Int((fraction * 100).rounded()))%")
+                            .monospacedDigit()
+                    }
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(width: 320)
+                    if let detail = progress.detail {
+                        Text(detail)
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                            .lineLimit(1)
+                    }
+                }
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                if let detail = progress?.detail {
+                    Text(detail)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .lineLimit(1)
+                }
+            }
+
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                elapsedLabel
+                Button("Cancel", action: onStop)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .help("Stop this run (⌘.)")
+            }
+
+            if !recentLogs.isEmpty {
+                DisclosureGroup(isExpanded: $showActivity) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        ForEach(Array(recentLogs.enumerated()), id: \.offset) { _, line in
+                            Text(line)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(MereRunTheme.textMuted)
+                                .lineLimit(2)
+                        }
+                    }
+                    .frame(width: 420, alignment: .leading)
+                    .padding(.top, 6)
+                } label: {
+                    Text("Activity")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                .disclosureGroupStyle(.automatic)
+                .frame(width: 440)
+            }
+        }
+        .padding(MereRunTheme.Spacing.xxl)
+        .merePanel(cornerRadius: MereRunTheme.Radius.xl)
+        .mereShadow(radius: 28, y: 12)
+        .onAppear { if startedAt == nil { startedAt = Date() } }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Running: \(statusHeadline)")
+    }
+
+    private var statusHeadline: String {
+        if progress?.fractionCompleted == nil, let detail = progress?.detail, !detail.isEmpty {
+            return status
+        }
+        return status
+    }
+
+    @ViewBuilder
+    private var elapsedLabel: some View {
+        if let startedAt {
+            TimelineView(.periodic(from: startedAt, by: 1)) { context in
+                Text(StudioTimeFormat.string(context.date.timeIntervalSince(startedAt)))
+                    .font(MereRunTheme.captionFont)
+                    .monospacedDigit()
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+        }
+    }
+}
+
+/// Blocking states (no model, missing CLI, run errors) presented as a calm card with the
+/// one action that fixes it front and center.
+struct StudioReadinessOverlay: View {
+    let title: String
+    let message: String
+    let canPull: Bool
+    let isChecking: Bool
+    let onPullModel: () -> Void
+    let onShowDetails: () -> Void
+
+    var body: some View {
+        VStack(spacing: MereRunTheme.Spacing.md) {
+            Image(systemName: statusImage)
+                .font(.system(size: 26, weight: .semibold))
+                .foregroundStyle(statusColor)
+                .frame(width: 64, height: 64)
+                .background {
+                    Circle().fill(statusColor.opacity(0.12))
+                }
+
+            Text(title)
+                .font(.system(size: 20, weight: .semibold))
+            Text(message)
+                .font(MereRunTheme.bodyFont)
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                if canPull {
+                    Button {
+                        onPullModel()
+                    } label: {
+                        Label("Get the model", systemImage: "arrow.down.circle.fill")
+                    }
+                    .buttonStyle(.merePrimary)
+                }
+                Button {
+                    onShowDetails()
+                } label: {
+                    Label("Details", systemImage: "terminal")
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(MereRunTheme.Spacing.xxl)
+        .merePanel(cornerRadius: MereRunTheme.Radius.xl)
+        .mereShadow(radius: 30, y: 12)
+    }
+
+    private var statusImage: String {
+        if isChecking { return "hourglass" }
+        return canPull ? "arrow.down.circle" : "exclamationmark.triangle"
+    }
+
+    private var statusColor: Color {
+        if isChecking { return MereRunTheme.yellow }
+        return canPull ? MereRunTheme.yellow : MereRunTheme.red
+    }
+}
+
+/// The finished-work stage: a big preview you can Quick Look, drag straight to Finder, copy,
+/// or open — with the run's identity in one quiet meta row.
+struct StudioOutputView: View {
+    let item: StudioLibraryItem
+    let liveOutputText: String?
+    let onOpen: () -> Void
+    let onReveal: () -> Void
+    let onQuickLook: () -> Void
+    var onCopy: ((String) -> Void)?
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(spacing: MereRunTheme.Spacing.md) {
+            outputPreview
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(MereRunTheme.surface.opacity(0.45))
+                .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.xl))
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.xl)
+                        .strokeBorder(MereRunTheme.border.opacity(0.65), lineWidth: 1)
+                }
+                .contextMenu { previewContextMenu }
+
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.displayTitle)
+                        .font(.system(size: 15, weight: .semibold))
+                        .lineLimit(1)
+                    HStack(spacing: 5) {
+                        Text(item.mode.title)
+                        Text("·")
+                        Text(item.updatedAt, format: .relative(presentation: .named))
+                    }
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                }
+
+                Spacer()
+
+                if item.status != .completed {
+                    statusBadge
+                }
+
+                if canCopy {
+                    Button {
+                        copyOutput()
+                    } label: {
+                        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 13, weight: .semibold))
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.mereIcon)
+                    .help(copied ? "Copied" : "Copy output")
+                    .accessibilityLabel("Copy output")
+                }
+
+                if item.outputURL != nil {
+                    Button {
+                        onQuickLook()
+                    } label: {
+                        Image(systemName: "eye")
+                            .font(.system(size: 13, weight: .semibold))
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.mereIcon)
+                    .help("Quick Look (Space)")
+                    .accessibilityLabel("Quick Look")
+
+                    Button {
+                        onReveal()
+                    } label: {
+                        Image(systemName: "folder")
+                            .font(.system(size: 13, weight: .semibold))
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.mereIcon)
+                    .help("Reveal in Finder")
+                    .accessibilityLabel("Reveal in Finder")
+
+                    Button("Open", action: onOpen)
+                        .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var previewContextMenu: some View {
+        if item.outputURL != nil {
+            Button("Open") { onOpen() }
+            Button("Quick Look") { onQuickLook() }
+            Button("Reveal in Finder") { onReveal() }
+            if canCopy {
+                Button("Copy") { copyOutput() }
+            }
+        } else if canCopy {
+            Button("Copy") { copyOutput() }
+        }
+    }
+
+    @ViewBuilder
+    private var outputPreview: some View {
+        if let url = item.outputURL {
+            filePreview(url)
+                .onDrag { NSItemProvider(contentsOf: url) ?? NSItemProvider() }
+        } else if let text = liveOutputText ?? item.outputText,
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            ScrollView {
+                Text(text)
+                    .font(item.mode == .chat ? MereRunTheme.bodyFont : MereRunTheme.monoFont)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(MereRunTheme.Spacing.xl)
+            }
+        } else {
+            VStack(spacing: MereRunTheme.Spacing.sm) {
+                Image(systemName: "doc")
+                    .font(.system(size: 42, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                Text(item.status == .failed ? "Run did not produce a file." : "Output will appear here.")
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func filePreview(_ url: URL) -> some View {
+        switch StudioOutputFileKind.classify(url) {
+        case .image:
+            StudioAsyncImagePreview(
+                url: url,
+                maxPixelSize: 2_200,
+                contentMode: .fit,
+                fallbackSystemImage: iconName(for: url)
+            )
+            .padding(MereRunTheme.Spacing.xl)
+        case .audio:
+            StudioAudioPlayerView(url: url)
+        case .video:
+            StudioVideoPlayerView(url: url)
+        case .text:
+            StudioTextFilePreview(url: url)
+        case .other:
+            filePlaceholder(for: url)
+        }
+    }
+
+    private func filePlaceholder(for url: URL) -> some View {
+        VStack(spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: iconName(for: url))
+                .font(.system(size: 50, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+            Text(url.lastPathComponent)
+                .font(.system(size: 15, weight: .semibold))
+                .lineLimit(1)
+            Text(url.deletingLastPathComponent().path)
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(MereRunTheme.Spacing.xl)
+    }
+
+    private var statusBadge: some View {
+        Text(item.status.rawValue.capitalized)
+            .font(MereRunTheme.captionFont)
+            .foregroundStyle(statusColor)
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+            .background {
+                Capsule().fill(statusColor.opacity(0.14))
+            }
+    }
+
+    private var statusColor: Color {
+        switch item.status {
+        case .queued: return MereRunTheme.textMuted
+        case .running: return MereRunTheme.yellow
+        case .completed: return MereRunTheme.green
+        case .failed: return MereRunTheme.red
+        }
+    }
+
+    private var canCopy: Bool {
+        if let url = item.outputURL {
+            let kind = StudioOutputFileKind.classify(url)
+            return kind == .image || kind == .text
+        }
+        let text = (liveOutputText ?? item.outputText)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return !text.isEmpty
+    }
+
+    private func copyOutput() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        if let url = item.outputURL {
+            pasteboard.writeObjects([url as NSURL])
+        } else if let text = liveOutputText ?? item.outputText {
+            pasteboard.setString(text, forType: .string)
+        }
+        copied = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            copied = false
+        }
+    }
+
+    private func iconName(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "wav", "mp3", "m4a": return "waveform"
+        case "mp4", "mov": return "film"
+        case "json": return "curlybraces"
+        case "safetensors": return "shippingbox"
+        default: return "doc"
+        }
+    }
+}
+
+enum StudioImageContentMode: Equatable {
+    case fit
+    case fill
+}
+
+enum StudioImageLoadState {
+    case loading
+    case loaded(NSImage)
+    case unavailable
+}
+
+/// Downsampled, off-main image preview with a gentle entrance once decoded.
+struct StudioAsyncImagePreview: View {
+    let url: URL
+    let maxPixelSize: CGFloat
+    let contentMode: StudioImageContentMode
+    let fallbackSystemImage: String
+
+    @State private var loadState = StudioImageLoadState.loading
+
+    private var stateKey: Int {
+        switch loadState {
+        case .loading: return 0
+        case .loaded: return 1
+        case .unavailable: return 2
+        }
+    }
+
+    var body: some View {
+        Group {
+            switch loadState {
+            case .loading:
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .loaded(let image):
+                Group {
+                    if contentMode == .fill {
+                        Image(nsImage: image)
+                            .resizable()
+                            .scaledToFill()
+                    } else {
+                        Image(nsImage: image)
+                            .resizable()
+                            .scaledToFit()
+                    }
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.985)))
+            case .unavailable:
+                Image(systemName: fallbackSystemImage)
+                    .font(.system(size: 32, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .animation(MereRunTheme.Motion.gentleSpring, value: stateKey)
+        .task(id: url) {
+            loadState = .loading
+            let loaded = await Task.detached(priority: .userInitiated) {
+                StudioImagePreviewLoader.downsampledImage(from: url, maxPixelSize: maxPixelSize)
+            }.value
+            guard !Task.isCancelled else { return }
+            if let image = loaded?.image {
+                loadState = .loaded(image)
+            } else {
+                loadState = .unavailable
+            }
+        }
+    }
+}
+
+struct StudioTextFilePreview: View {
+    let url: URL
+
+    @State private var text: String?
+    @State private var didLoad = false
+
+    var body: some View {
+        ScrollView {
+            if let text {
+                Text(text)
+                    .font(MereRunTheme.monoFont)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(MereRunTheme.Spacing.xl)
+            } else if didLoad {
+                Text("Text preview unavailable.")
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(MereRunTheme.Spacing.xl)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, minHeight: 180)
+                    .padding(MereRunTheme.Spacing.xl)
+            }
+        }
+        .task(id: url) {
+            text = nil
+            didLoad = false
+            let preview = await Task.detached(priority: .userInitiated) {
+                StudioTextPreviewReader.previewText(from: url)
+            }.value
+            guard !Task.isCancelled else { return }
+            text = preview
+            didLoad = true
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioComposer.swift
+++ b/Sources/MereRunApp/StudioComposer.swift
@@ -1,0 +1,541 @@
+import AppKit
+import SwiftUI
+
+/// The floating command bar at the bottom of the canvas: one field, one run button, and the
+/// depth (attachment, model, options) folded into quiet affordances around it.
+struct StudioComposer: View {
+    let mode: StudioMode
+    @Binding var draft: StudioDraft
+    @Binding var showOptions: Bool
+    let isRunning: Bool
+    let queuedCount: Int
+    let readiness: ModelReadinessState
+    var sendBlocked: Bool = false
+    let installedModels: [StudioModelInventoryRow]
+    var promptFocus: FocusState<Bool>.Binding
+    let onRun: () -> Void
+    let onStop: () -> Void
+    let onAttach: () -> Void
+    let onPaste: () -> Void
+    let onShowModels: () -> Void
+
+    var body: some View {
+        VStack(spacing: MereRunTheme.Spacing.xs) {
+            if !draft.inputPath.isBlank {
+                attachmentChip
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
+            composerBar
+
+            if mode.requiresAttachment && draft.inputPath.isBlank {
+                Label(attachmentHint, systemImage: "arrow.down.doc")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .padding(.leading, 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .animation(MereRunTheme.Motion.standard, value: draft.inputPath.isBlank)
+    }
+
+    private var attachmentChip: some View {
+        HStack(spacing: MereRunTheme.Spacing.xs) {
+            attachmentThumbnail
+                .frame(width: 30, height: 26)
+                .background(MereRunTheme.surface)
+                .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                        .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                }
+
+            Text(URL(fileURLWithPath: draft.inputPath).lastPathComponent)
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Button {
+                draft.inputPath = ""
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 12))
+                    .padding(2)
+            }
+            .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+            .help("Remove attachment")
+            .accessibilityLabel("Remove attachment")
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.xs)
+        .padding(.vertical, 5)
+        .background {
+            Capsule()
+                .fill(MereRunTheme.surface.opacity(0.85))
+                .overlay {
+                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var attachmentThumbnail: some View {
+        let url = URL(fileURLWithPath: draft.inputPath)
+        if StudioOutputFileKind.classify(url) == .image {
+            StudioAsyncImagePreview(
+                url: url,
+                maxPixelSize: 120,
+                contentMode: .fill,
+                fallbackSystemImage: "photo"
+            )
+        } else {
+            Image(systemName: attachmentIcon(for: url))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+        }
+    }
+
+    private var composerBar: some View {
+        HStack(spacing: MereRunTheme.Spacing.sm) {
+            HStack(spacing: 2) {
+                Button(action: onAttach) {
+                    Image(systemName: mode.requiresAttachment ? "paperclip.badge.ellipsis" : "paperclip")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.mereIcon)
+                .disabled(mode.acceptedTypes.isEmpty)
+                .opacity(mode.acceptedTypes.isEmpty ? 0.35 : 1)
+                .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
+                .accessibilityLabel(mode.requiresAttachment ? "Attach required input" : "Attach reference")
+
+                if mode.acceptedTypes.contains(.image) {
+                    Button(action: onPaste) {
+                        Image(systemName: "doc.on.clipboard")
+                            .font(.system(size: 14, weight: .semibold))
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.mereIcon)
+                    .help("Paste image from clipboard (⌘V)")
+                    .accessibilityLabel("Paste image from clipboard")
+                }
+            }
+
+            if mode == .listen {
+                Text(mode.promptPlaceholder)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                TextField(mode.promptPlaceholder, text: $draft.prompt, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 15, weight: .medium))
+                    .lineLimit(1...5)
+                    .focused(promptFocus)
+                    .onSubmit(onRun)
+            }
+
+            HStack(spacing: 6) {
+                modelMenu
+
+                Button {
+                    showOptions.toggle()
+                } label: {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(showOptions ? MereRunTheme.accent : MereRunTheme.textSecondary)
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.mereIcon)
+                .help("Options")
+                .accessibilityLabel("Options")
+                .popover(isPresented: $showOptions, arrowEdge: .top) {
+                    StudioOptionsPanel(mode: mode, draft: $draft)
+                }
+
+                if isRunning {
+                    Button(action: onStop) {
+                        Image(systemName: "stop.fill")
+                            .font(.system(size: 12, weight: .bold))
+                            .frame(width: 30, height: 30)
+                    }
+                    .buttonStyle(.mereIcon(tint: MereRunTheme.red))
+                    .help("Stop current run (⌘.)")
+                    .accessibilityLabel("Stop current run")
+                }
+
+                sendButton
+            }
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.md)
+        .padding(.vertical, MereRunTheme.Spacing.sm)
+        .background {
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.xxl)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.xxl)
+                        .strokeBorder(MereRunTheme.border.opacity(0.75), lineWidth: 1)
+                }
+                .mereShadow(radius: 18, y: 8)
+        }
+        .mereFocusRing(promptFocus.wrappedValue, cornerRadius: MereRunTheme.Radius.xxl)
+    }
+
+    private var sendButton: some View {
+        Button(action: onRun) {
+            ZStack {
+                Circle()
+                    .fill(sendEnabled ? MereRunTheme.accent : MereRunTheme.surfaceRaised)
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(sendEnabled ? MereRunTheme.background : MereRunTheme.textMuted)
+            }
+            .frame(width: 34, height: 34)
+            .overlay(alignment: .topTrailing) {
+                if queuedCount > 0 {
+                    Text("\(queuedCount)")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(MereRunTheme.background)
+                        .padding(.horizontal, 4)
+                        .frame(height: 13)
+                        .background { Capsule().fill(MereRunTheme.yellow) }
+                        .offset(x: 4, y: -3)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!sendEnabled)
+        .help(sendHelp)
+        .accessibilityLabel(isRunning ? "Queue run" : "Run")
+        .accessibilityHint(accessibilityRunHint)
+        .keyboardShortcut(.return, modifiers: .command)
+    }
+
+    private var sendEnabled: Bool {
+        !readiness.blocksRun && !sendBlocked
+    }
+
+    private var sendHelp: String {
+        if sendBlocked { return "Waiting for the current reply…" }
+        if readiness.blocksRun { return readiness.message }
+        if isRunning {
+            return queuedCount == 0 ? "Queue run" : "Queue run (\(queuedCount) waiting)"
+        }
+        return "Run (⌘↩)"
+    }
+
+    /// Spoken explanation of why Run is disabled, so the blocked state is not color-only.
+    private var accessibilityRunHint: String {
+        if sendBlocked { return "Waiting for the current reply to finish" }
+        if readiness.blocksRun { return readiness.message }
+        return ""
+    }
+
+    // MARK: - Model quick-picker
+
+    private var modelMenu: some View {
+        Menu {
+            if installedModels.isEmpty {
+                Text("No local models yet")
+            } else {
+                ForEach(groupedModelCategories, id: \.category) { group in
+                    Section(group.category.capitalized) {
+                        ForEach(group.rows) { row in
+                            Button {
+                                draft.model = row.id
+                            } label: {
+                                if row.id == draft.model {
+                                    Label(row.id, systemImage: "checkmark")
+                                } else {
+                                    Text(row.id)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Divider()
+            Button("Use mode default") { draft.model = "" }
+                .disabled(draft.model.isBlank)
+            Button("Browse Models…", action: onShowModels)
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "cpu")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+                Text(modelLabel)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: 130)
+                    .fixedSize(horizontal: true, vertical: false)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 7.5, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 26)
+            .background {
+                Capsule()
+                    .fill(MereRunTheme.surfaceRaised.opacity(0.8))
+                    .overlay {
+                        Capsule().strokeBorder(MereRunTheme.border.opacity(0.55), lineWidth: 1)
+                    }
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Model for this run")
+        .accessibilityLabel("Model")
+        .accessibilityValue(modelLabel)
+    }
+
+    private var modelLabel: String {
+        let current = draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !current.isEmpty { return shortModelName(current) }
+        let templateDefault = CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
+        return templateDefault.isEmpty ? "Auto" : shortModelName(templateDefault)
+    }
+
+    private func shortModelName(_ id: String) -> String {
+        id.components(separatedBy: "/").last ?? id
+    }
+
+    private var groupedModelCategories: [(category: String, rows: [StudioModelInventoryRow])] {
+        Dictionary(grouping: installedModels, by: \.category)
+            .map { (category: $0.key, rows: $0.value.sorted { $0.id < $1.id }) }
+            .sorted { $0.category < $1.category }
+    }
+
+    private var attachmentHint: String {
+        switch mode {
+        case .listen: return "Attach an audio file to begin — or drop it anywhere"
+        case .track: return "Attach a video to begin — or drop it anywhere"
+        default: return "Attach an image to begin — or drop it anywhere"
+        }
+    }
+
+    private func attachmentIcon(for url: URL) -> String {
+        switch StudioOutputFileKind.classify(url) {
+        case .audio: return "waveform"
+        case .video: return "film"
+        default: return "doc"
+        }
+    }
+}
+
+/// The per-mode depth controls, presented as a popover from the composer's Options button
+/// (inline depth, not a modal interruption). Fields mirror the Advanced surface via
+/// `StudioOptionSchema`, so the two surfaces never drift.
+struct StudioOptionsPanel: View {
+    let mode: StudioMode
+    @Binding var draft: StudioDraft
+    @EnvironmentObject private var controller: MereRunController
+    @State private var voiceProfiles: [StudioVoiceProfile] = []
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.md) {
+                Text("\(mode.title) options")
+                    .font(MereRunTheme.sectionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+
+                if mode == .readImage {
+                    Picker("Task", selection: $draft.readImageAction) {
+                        ForEach(StudioReadImageAction.allCases) { action in
+                            Text(action.title)
+                                .tag(action)
+                                .disabled(readImageActionUnavailableMessage(action) != nil)
+                                .help(readImageActionUnavailableMessage(action) ?? action.title)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                }
+
+                if let secondaryLabel {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(secondaryLabel)
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                        TextField(secondaryLabel, text: $draft.secondaryText, axis: .vertical)
+                            .lineLimit(1...4)
+                            .mereField()
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Model")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    TextField("Model", text: $draft.model)
+                        .mereField()
+                }
+
+                if mode == .speak {
+                    speakOptions
+                }
+
+                if [.createImage, .video].contains(mode) {
+                    HStack(spacing: MereRunTheme.Spacing.sm) {
+                        Stepper("Width \(draft.width)", value: $draft.width, in: 64...4096, step: 64)
+                        Stepper("Height \(draft.height)", value: $draft.height, in: 64...4096, step: 64)
+                    }
+                    .font(MereRunTheme.captionFont)
+                }
+
+                if [.createImage, .music, .sfx].contains(mode) {
+                    Stepper("Steps \(draft.steps)", value: $draft.steps, in: 1...80, step: 1)
+                        .font(MereRunTheme.captionFont)
+                }
+
+                if [.music, .sfx].contains(mode) {
+                    HStack {
+                        Text("Duration seconds")
+                            .font(MereRunTheme.captionFont)
+                        Spacer()
+                        TextField("Seconds", value: $draft.durationSeconds, format: .number)
+                            .frame(width: 80)
+                            .mereField(cornerRadius: MereRunTheme.Radius.sm)
+                    }
+                }
+
+                if [.createImage, .music, .video, .sfx].contains(mode) {
+                    HStack {
+                        Text("Seed")
+                            .font(MereRunTheme.captionFont)
+                        Spacer()
+                        TextField("Random", text: $draft.seed)
+                            .frame(width: 110)
+                            .mereField(cornerRadius: MereRunTheme.Radius.sm)
+                    }
+                }
+
+                if !StudioOptionSchema.fields(for: mode).isEmpty {
+                    Divider().overlay(MereRunTheme.border.opacity(0.4))
+                    ForEach(StudioOptionSchema.fields(for: mode)) { field in
+                        optionRow(field)
+                    }
+                }
+            }
+            .padding(MereRunTheme.Spacing.lg)
+        }
+        .frame(width: 360)
+        .frame(maxHeight: 480)
+        .background(MereRunTheme.background)
+        .foregroundStyle(MereRunTheme.textPrimary)
+        .task {
+            if mode == .speak { voiceProfiles = await controller.loadVoiceProfiles() }
+        }
+    }
+
+    @ViewBuilder
+    private var speakOptions: some View {
+        Picker("Voice", selection: $draft.voiceMode) {
+            Text("Style").tag("style")
+            Text("Clone").tag("clone")
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+
+        if draft.voiceMode == "clone" {
+            Picker("Profile", selection: $draft.voiceProfile) {
+                Text("None").tag("")
+                ForEach(voiceProfiles) { profile in
+                    Text(profile.name).tag(profile.id)
+                }
+            }
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                Text(draft.refAudioPath.isEmpty
+                    ? "No reference audio"
+                    : URL(fileURLWithPath: draft.refAudioPath).lastPathComponent)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+                Spacer()
+                Button("Reference audio…") { chooseReferenceAudio() }
+                    .controlSize(.small)
+            }
+            TextField("Save as profile (optional)", text: $draft.saveProfileName)
+                .mereField()
+        }
+    }
+
+    /// Renders one schema field as the appropriate control, bound through the draft key path.
+    @ViewBuilder
+    private func optionRow(_ field: StudioOptionField) -> some View {
+        switch field.control {
+        case let .int(keyPath, range, step):
+            Stepper("\(field.label): \(draft[keyPath: keyPath])", value: binding(keyPath), in: range, step: step)
+                .font(MereRunTheme.captionFont)
+        case let .double(keyPath):
+            HStack {
+                Text(field.label)
+                    .font(MereRunTheme.captionFont)
+                Spacer()
+                TextField(field.label, value: binding(keyPath), format: .number)
+                    .frame(width: 80)
+                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
+            }
+        case let .bool(keyPath):
+            Toggle(field.label, isOn: binding(keyPath))
+                .font(MereRunTheme.captionFont)
+        case let .text(keyPath, placeholder):
+            HStack {
+                Text(field.label)
+                    .font(MereRunTheme.captionFont)
+                Spacer()
+                TextField(placeholder, text: binding(keyPath))
+                    .frame(width: 150)
+                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
+            }
+        }
+    }
+
+    private func binding<Value>(_ keyPath: WritableKeyPath<StudioDraft, Value>) -> Binding<Value> {
+        Binding(get: { draft[keyPath: keyPath] }, set: { draft[keyPath: keyPath] = $0 })
+    }
+
+    private func chooseReferenceAudio() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.audio]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        if panel.runModal() == .OK, let url = panel.url {
+            draft.refAudioPath = url.path
+        }
+    }
+
+    private func readImageActionUnavailableMessage(_ action: StudioReadImageAction) -> String? {
+        guard mode == .readImage else { return nil }
+        var candidateDraft = draft
+        candidateDraft.readImageAction = action
+        let requirement = StudioCommandAdapter.capabilityRequirement(
+            for: .readImage,
+            draft: candidateDraft
+        )
+
+        switch requirement {
+        case .unavailable(let message):
+            return message
+        case .managedModel(let modelID):
+            return controller.modelCapabilitiesByID[modelID]?.unavailableMessage
+        case nil:
+            return nil
+        }
+    }
+
+    private var secondaryLabel: String? {
+        switch mode {
+        case .createImage: return "Negative prompt"
+        case .chat, .code: return "System"
+        case .speak: return "Voice"
+        case .music: return "Lyrics"
+        default: return nil
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioConversationView.swift
+++ b/Sources/MereRunApp/StudioConversationView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// The chat/code canvas: a scrolling transcript of message bubbles for the active conversation,
-/// plus a live streaming bubble while a turn is in flight. The composer lives in the shared
-/// prompt bar below; this view only renders the thread and a "New chat" affordance.
+/// The chat/code canvas: user turns as warm bubbles on the right, assistant turns as unboxed
+/// Markdown on the left, a live streaming turn while a reply is in flight. The composer lives
+/// in the shared prompt bar below; this view renders the thread and a "New chat" affordance.
 struct StudioConversationView: View {
     let item: StudioLibraryItem?
     let liveText: String?
@@ -12,6 +12,7 @@ struct StudioConversationView: View {
     let onCopy: (String) -> Void
     let onRetry: () -> Void
     let onEdit: (UUID) -> Void
+    var onUseExample: ((String) -> Void)?
 
     private static let streamingBubbleID = "studio.conversation.streaming"
 
@@ -45,7 +46,7 @@ struct StudioConversationView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: MereRunTheme.Spacing.sm) {
             Text(item?.displayTitle ?? "New chat")
                 .font(MereRunTheme.sectionFont)
                 .foregroundStyle(MereRunTheme.textSecondary)
@@ -55,30 +56,32 @@ struct StudioConversationView: View {
             Button(action: onNewChat) {
                 Label("New chat", systemImage: "square.and.pencil")
                     .font(MereRunTheme.captionFont)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(MereRunTheme.accent)
+            .buttonStyle(.mereIcon(tint: MereRunTheme.accent))
             .help("Start a new conversation")
             .accessibilityLabel("Start a new conversation")
         }
         .padding(.horizontal, 24)
-        .padding(.vertical, 14)
+        .padding(.vertical, 10)
     }
 
     @ViewBuilder
     private var content: some View {
         if messages.isEmpty && !isRunning {
-            StudioConversationEmptyState()
+            StudioConversationEmptyState(mode: mode, onUseExample: onUseExample)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 16) {
+                    LazyVStack(alignment: .leading, spacing: MereRunTheme.Spacing.lg) {
                         ForEach(messages) { message in
-                            StudioMessageBubble(
+                            StudioTurnView(
                                 role: message.role,
                                 content: message.content,
                                 failed: message.failed,
                                 monospaced: mode == .code && message.role == .assistant,
+                                modeIcon: mode.systemImage,
                                 onCopy: message.content.isEmpty ? nil : { onCopy(message.content) },
                                 onRetry: retryAction(for: message),
                                 onEdit: editAction(for: message)
@@ -86,12 +89,13 @@ struct StudioConversationView: View {
                             .id(message.id)
                         }
                         if isRunning {
-                            StudioMessageBubble(
+                            StudioTurnView(
                                 role: .assistant,
                                 content: liveText ?? "",
                                 failed: false,
                                 isStreaming: true,
-                                monospaced: mode == .code
+                                monospaced: mode == .code,
+                                modeIcon: mode.systemImage
                             )
                             .id(Self.streamingBubbleID)
                         }
@@ -121,7 +125,7 @@ struct StudioConversationView: View {
     }
 
     private func scrollToEnd(_ proxy: ScrollViewProxy) {
-        withAnimation(.easeOut(duration: 0.15)) {
+        withAnimation(MereRunTheme.Motion.quick) {
             if isRunning {
                 proxy.scrollTo(Self.streamingBubbleID, anchor: .bottom)
             } else if let last = messages.last {
@@ -131,69 +135,163 @@ struct StudioConversationView: View {
     }
 }
 
-private struct StudioMessageBubble: View {
+/// One conversation turn. User turns read as authored notes (warm bubble, right side);
+/// assistant turns read as the document itself (unboxed Markdown behind a small mode glyph).
+private struct StudioTurnView: View {
     let role: StudioMessageRole
     let content: String
     var failed: Bool = false
     var isStreaming: Bool = false
     var monospaced: Bool = false
+    var modeIcon: String = "bubble.left.and.bubble.right"
     var onCopy: (() -> Void)?
     var onRetry: (() -> Void)?
     var onEdit: (() -> Void)?
 
+    @State private var hovering = false
+
     private var isUser: Bool { role == .user }
+    private var hasActions: Bool { onCopy != nil || onRetry != nil || onEdit != nil }
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            if isUser { Spacer(minLength: 64) }
+            if isUser {
+                Spacer(minLength: 80)
+                userBubble
+            } else {
+                assistantBlock
+                Spacer(minLength: 80)
+            }
+        }
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .contextMenu { contextMenuItems }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(isStreaming ? .updatesFrequently : [])
+    }
+
+    private var userBubble: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            Text(content)
+                .font(MereRunTheme.bodyFont)
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .textSelection(.enabled)
+                .padding(.horizontal, MereRunTheme.Spacing.md)
+                .padding(.vertical, MereRunTheme.Spacing.sm)
+                .background {
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 16,
+                        bottomLeadingRadius: 16,
+                        bottomTrailingRadius: 5,
+                        topTrailingRadius: 16
+                    )
+                    .fill(MereRunTheme.accentSoft)
+                    .overlay {
+                        UnevenRoundedRectangle(
+                            topLeadingRadius: 16,
+                            bottomLeadingRadius: 16,
+                            bottomTrailingRadius: 5,
+                            topTrailingRadius: 16
+                        )
+                        .strokeBorder(
+                            failed ? MereRunTheme.red.opacity(0.6) : MereRunTheme.accent.opacity(0.14),
+                            lineWidth: 1
+                        )
+                    }
+                }
+                .frame(maxWidth: 520, alignment: .trailing)
+
+            actionRow
+        }
+    }
+
+    private var assistantBlock: some View {
+        HStack(alignment: .top, spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: modeIcon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+                .frame(width: 26, height: 26)
+                .background {
+                    Circle().fill(MereRunTheme.accentSoft.opacity(0.7))
+                }
+                .padding(.top, 1)
+                .accessibilityHidden(true)
+
             VStack(alignment: .leading, spacing: 6) {
-                Text(isUser ? "You" : "Assistant")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                bubbleBody
+                assistantBody
+
                 if failed {
                     Label("This turn failed", systemImage: "exclamationmark.triangle")
                         .font(MereRunTheme.captionFont)
                         .foregroundStyle(MereRunTheme.red)
                 }
-                if !isStreaming, onCopy != nil || onRetry != nil || onEdit != nil {
-                    HStack(spacing: 14) {
-                        if let onCopy {
-                            Button(action: onCopy) { Label("Copy", systemImage: "doc.on.doc") }
-                                .buttonStyle(.plain)
-                                .help("Copy message")
-                        }
-                        if let onEdit {
-                            Button(action: onEdit) { Label("Edit", systemImage: "pencil") }
-                                .buttonStyle(.plain)
-                                .help("Edit and re-run from this turn")
-                        }
-                        if let onRetry {
-                            Button(action: onRetry) { Label("Retry", systemImage: "arrow.clockwise") }
-                                .buttonStyle(.plain)
-                                .help("Regenerate this reply")
-                        }
-                    }
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .padding(.top, 2)
+
+                actionRow
+            }
+            .frame(maxWidth: 660, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var assistantBody: some View {
+        if isStreaming && content.isEmpty {
+            StudioThinkingIndicator()
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                StudioMarkdownText(
+                    content: content,
+                    bodyFont: monospaced ? MereRunTheme.monoFont : MereRunTheme.bodyFont
+                )
+                if isStreaming {
+                    StudioStreamingCaret()
                 }
             }
-            .padding(14)
-            .background {
-                RoundedRectangle(cornerRadius: MereRunTheme.cornerRadius)
-                    .fill(isUser ? MereRunTheme.surfaceRaised : MereRunTheme.surface)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: MereRunTheme.cornerRadius)
-                            .strokeBorder((failed ? MereRunTheme.red : MereRunTheme.border).opacity(0.6), lineWidth: 1)
-                    }
-            }
-            .frame(maxWidth: 620, alignment: .leading)
-            if !isUser { Spacer(minLength: 64) }
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityText)
-        .accessibilityAddTraits(isStreaming ? .updatesFrequently : [])
+    }
+
+    /// Copy / edit / retry surface on hover; the row keeps its height so nothing jumps.
+    @ViewBuilder
+    private var actionRow: some View {
+        if !isStreaming && hasActions {
+            HStack(spacing: 2) {
+                if let onCopy {
+                    turnAction("Copy", systemImage: "doc.on.doc", help: "Copy message", action: onCopy)
+                }
+                if let onEdit {
+                    turnAction("Edit", systemImage: "pencil", help: "Edit and re-run from this turn", action: onEdit)
+                }
+                if let onRetry {
+                    turnAction("Retry", systemImage: "arrow.clockwise", help: "Regenerate this reply", action: onRetry)
+                }
+            }
+            .opacity(hovering ? 1 : 0)
+            .allowsHitTesting(hovering)
+            .frame(height: 22)
+        }
+    }
+
+    private func turnAction(
+        _ title: String,
+        systemImage: String,
+        help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(MereRunTheme.captionFont)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+        }
+        .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+        .help(help)
+    }
+
+    @ViewBuilder
+    private var contextMenuItems: some View {
+        if let onCopy { Button("Copy") { onCopy() } }
+        if let onEdit { Button("Edit…") { onEdit() } }
+        if let onRetry { Button("Retry") { onRetry() } }
     }
 
     private var accessibilityText: String {
@@ -202,41 +300,53 @@ private struct StudioMessageBubble: View {
         let suffix = failed ? " (this turn failed)" : ""
         return "\(speaker): \(content)\(suffix)"
     }
+}
 
-    @ViewBuilder
-    private var bubbleBody: some View {
-        if isStreaming && content.isEmpty {
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text("Thinking…")
-                    .font(MereRunTheme.bodyFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
+/// The live-reply cursor: a small bronze bar breathing at the end of the streamed text.
+private struct StudioStreamingCaret: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: 1.5)
+            .fill(MereRunTheme.accent)
+            .frame(width: 8, height: 15)
+            .phaseAnimator([0.25, 1.0]) { view, phase in
+                view.opacity(phase)
+            } animation: { _ in
+                .easeInOut(duration: 0.55)
             }
-        } else {
-            Text(content)
-                .font(monospaced ? MereRunTheme.monoFont : MereRunTheme.bodyFont)
-                .foregroundStyle(MereRunTheme.textPrimary)
-                .textSelection(.enabled)
+            .accessibilityHidden(true)
+    }
+}
+
+/// Three quiet dots taking turns while the model decides what to say.
+private struct StudioThinkingIndicator: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 4) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(MereRunTheme.accent)
+                        .frame(width: 6, height: 6)
+                        .phaseAnimator([0, 1, 2]) { view, phase in
+                            view.opacity(phase == Double(index) ? 1 : 0.28)
+                        } animation: { _ in
+                            .easeInOut(duration: 0.38)
+                        }
+                }
+            }
+            Text("Thinking…")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
         }
+        .padding(.vertical, 4)
+        .accessibilityLabel("Generating a reply")
     }
 }
 
 private struct StudioConversationEmptyState: View {
+    let mode: StudioMode
+    var onUseExample: ((String) -> Void)?
+
     var body: some View {
-        VStack(spacing: 14) {
-            Image(systemName: "bubble.left.and.bubble.right")
-                .font(.system(size: 40, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-                .frame(width: 84, height: 84)
-                .background { Circle().fill(MereRunTheme.surfaceRaised) }
-            Text("Start a conversation")
-                .font(.system(size: 22, weight: .semibold))
-            Text("Type a message below. Replies stay on this Mac, and the whole thread is remembered for follow-up turns.")
-                .font(MereRunTheme.bodyFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 420)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        StudioEmptyState(mode: mode, onUseExample: onUseExample, onAttach: nil)
     }
 }

--- a/Sources/MereRunApp/StudioHelpSheet.swift
+++ b/Sources/MereRunApp/StudioHelpSheet.swift
@@ -41,18 +41,15 @@ struct StudioHelpSheet: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 2) {
                 ForEach(topics) { topic in
-                    Button { select(topic) } label: {
-                        Text(topic.title)
-                            .font(MereRunTheme.bodyFont)
-                            .foregroundStyle(selected?.id == topic.id ? MereRunTheme.accent : MereRunTheme.textSecondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.vertical, 6)
-                            .padding(.horizontal, 14)
+                    StudioHelpTopicRow(
+                        title: topic.title,
+                        isSelected: selected?.id == topic.id
+                    ) {
+                        select(topic)
                     }
-                    .buttonStyle(.plain)
                 }
             }
-            .padding(.vertical, 8)
+            .padding(8)
         }
     }
 
@@ -69,18 +66,12 @@ struct StudioHelpSheet: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(24)
             } else {
-                Text(renderedMarkdown)
-                    .font(MereRunTheme.bodyFont)
-                    .textSelection(.enabled)
+                StudioMarkdownText(content: content)
+                    .frame(maxWidth: 680, alignment: .leading)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(24)
             }
         }
-    }
-
-    private var renderedMarkdown: AttributedString {
-        let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        return (try? AttributedString(markdown: content, options: options)) ?? AttributedString(content)
     }
 
     private func loadTopics() async {
@@ -98,5 +89,34 @@ struct StudioHelpSheet: View {
             content = text
             isLoading = false
         }
+    }
+}
+
+private struct StudioHelpTopicRow: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12.5, weight: isSelected ? .semibold : .regular))
+                .foregroundStyle(isSelected ? MereRunTheme.textPrimary : MereRunTheme.textSecondary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .background {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                        .fill(isSelected ? MereRunTheme.accentSoft : (hovering ? MereRunTheme.hoverFill : .clear))
+                }
+                .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/Sources/MereRunApp/StudioLibraryPanel.swift
+++ b/Sources/MereRunApp/StudioLibraryPanel.swift
@@ -1,0 +1,333 @@
+import AppKit
+import SwiftUI
+
+/// Run history as a second column: searchable, grouped by day, keyboard-navigable
+/// (arrows move, Space previews), with Quick Look surfacing on hover.
+struct StudioLibraryPanel: View {
+    let items: [StudioLibraryItem]
+    @Binding var selectedID: UUID?
+    @Binding var isVisible: Bool
+    let onDelete: (UUID) -> Void
+    let onRename: (UUID, String) -> Void
+    let onQuickLook: (URL) -> Void
+
+    @State private var searchText = ""
+    @State private var renamingID: UUID?
+    @State private var renameText = ""
+
+    private var filteredItems: [StudioLibraryItem] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return items }
+        return items.filter { item in
+            item.displayTitle.lowercased().contains(query)
+                || item.mode.title.lowercased().contains(query)
+                || item.prompt.lowercased().contains(query)
+        }
+    }
+
+    private var daySections: [(day: Date, title: String, items: [StudioLibraryItem])] {
+        let calendar = Calendar.current
+        var order: [Date] = []
+        var grouped: [Date: [StudioLibraryItem]] = [:]
+        for item in filteredItems {
+            let day = calendar.startOfDay(for: item.createdAt)
+            if grouped[day] == nil { order.append(day) }
+            grouped[day, default: []].append(item)
+        }
+        return order.map { day in
+            (day: day, title: Self.sectionFormatter.string(from: day), items: grouped[day] ?? [])
+        }
+    }
+
+    private static let sectionFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.doesRelativeDateFormatting = true
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            Divider()
+                .overlay(MereRunTheme.border.opacity(0.5))
+
+            searchField
+
+            if filteredItems.isEmpty {
+                emptyState
+            } else {
+                list
+            }
+        }
+        .background(MereRunTheme.background)
+        .alert("Rename run", isPresented: renameBinding) {
+            TextField("Name", text: $renameText)
+            Button("Save") {
+                if let renamingID { onRename(renamingID, renameText) }
+                renamingID = nil
+            }
+            Button("Cancel", role: .cancel) { renamingID = nil }
+        }
+    }
+
+    private var renameBinding: Binding<Bool> {
+        Binding(get: { renamingID != nil }, set: { if !$0 { renamingID = nil } })
+    }
+
+    private var header: some View {
+        HStack(spacing: MereRunTheme.Spacing.xs) {
+            Text("Library")
+                .font(.system(size: 15, weight: .semibold))
+            Text("\(items.count)")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+            Spacer()
+            Button {
+                withAnimation(MereRunTheme.Motion.standard) {
+                    isVisible = false
+                }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.mereIcon)
+            .help("Hide library (⌃⌘L)")
+            .accessibilityLabel("Hide library")
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.md)
+        .frame(height: 52)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            TextField("Search runs", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12.5))
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.sm)
+        .frame(height: 30)
+        .background {
+            Capsule()
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.7), lineWidth: 1)
+                }
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.sm)
+        .padding(.vertical, MereRunTheme.Spacing.sm)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: "rectangle.stack")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textMuted)
+            Text(items.isEmpty ? "Runs you create will land here." : "No matching runs.")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(MereRunTheme.Spacing.xl)
+    }
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 4, pinnedViews: []) {
+                ForEach(daySections, id: \.day) { section in
+                    Text(section.title)
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .kerning(0.5)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 10)
+                        .padding(.top, MereRunTheme.Spacing.sm)
+                        .padding(.bottom, 2)
+                        .accessibilityAddTraits(.isHeader)
+
+                    ForEach(section.items) { item in
+                        StudioLibraryRow(
+                            item: item,
+                            isSelected: selectedID == item.id,
+                            onQuickLook: item.outputURL.map { url in { onQuickLook(url) } }
+                        ) {
+                            selectedID = item.id
+                        }
+                        .contextMenu {
+                            if let url = item.outputURL {
+                                Button("Quick Look") { onQuickLook(url) }
+                            }
+                            Button("Rename") {
+                                renameText = item.displayTitle
+                                renamingID = item.id
+                            }
+                            Button("Delete", role: .destructive) {
+                                onDelete(item.id)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, MereRunTheme.Spacing.xs)
+            .padding(.bottom, MereRunTheme.Spacing.sm)
+        }
+        .focusable()
+        // Finder-style keys: arrows move the selection, Space previews the selected output
+        // (ignored when it has none, so it never swallows the key destructively).
+        .onKeyPress(.space) {
+            guard let id = selectedID,
+                  let url = items.first(where: { $0.id == id })?.outputURL else { return .ignored }
+            onQuickLook(url)
+            return .handled
+        }
+        .onKeyPress(.upArrow) { moveSelection(by: -1) }
+        .onKeyPress(.downArrow) { moveSelection(by: 1) }
+    }
+
+    private func moveSelection(by offset: Int) -> KeyPress.Result {
+        let visible = filteredItems
+        guard !visible.isEmpty else { return .ignored }
+        guard let selectedID, let index = visible.firstIndex(where: { $0.id == selectedID }) else {
+            self.selectedID = offset > 0 ? visible.first?.id : visible.last?.id
+            return .handled
+        }
+        let next = min(max(index + offset, 0), visible.count - 1)
+        self.selectedID = visible[next].id
+        return .handled
+    }
+}
+
+private struct StudioLibraryRow: View {
+    let item: StudioLibraryItem
+    let isSelected: Bool
+    let onQuickLook: (() -> Void)?
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                thumbnail
+                    .frame(width: 52, height: 42)
+                    .background(isSelected ? MereRunTheme.surface : MereRunTheme.accentSoft.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.base))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.displayTitle)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                        .lineLimit(1)
+                    HStack(spacing: 4) {
+                        if item.status != .completed {
+                            Circle()
+                                .fill(statusColor)
+                                .frame(width: 5, height: 5)
+                        }
+                        Text(subtitle)
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 0)
+
+                if hovering, let onQuickLook {
+                    Button {
+                        onQuickLook()
+                    } label: {
+                        Image(systemName: "eye")
+                            .font(.system(size: 11, weight: .semibold))
+                            .frame(width: 24, height: 24)
+                    }
+                    .buttonStyle(.mereIcon)
+                    .help("Quick Look (Space)")
+                    .accessibilityLabel("Quick Look")
+                    .transition(.opacity)
+                }
+            }
+            .padding(6)
+            .background {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                    .fill(rowFill)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                            .strokeBorder(
+                                isSelected ? MereRunTheme.accent.opacity(0.4) : Color.clear,
+                                lineWidth: 1
+                            )
+                    }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(item.mode.title), \(item.status.rawValue), \(item.displayTitle)")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private var rowFill: Color {
+        if isSelected { return MereRunTheme.accentSoft }
+        if hovering { return MereRunTheme.hoverFill }
+        return .clear
+    }
+
+    private var subtitle: String {
+        if item.status == .completed {
+            return "\(item.mode.title) · \(Self.timeFormatter.string(from: item.createdAt))"
+        }
+        return "\(item.mode.title) · \(item.status.rawValue)"
+    }
+
+    private var statusColor: Color {
+        switch item.status {
+        case .queued: return MereRunTheme.textMuted
+        case .running: return MereRunTheme.yellow
+        case .completed: return MereRunTheme.green
+        case .failed: return MereRunTheme.red
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let url = item.outputURL, StudioOutputFileKind.classify(url) == .image {
+            StudioAsyncImagePreview(
+                url: url,
+                maxPixelSize: 180,
+                contentMode: .fill,
+                fallbackSystemImage: item.mode.systemImage
+            )
+        } else {
+            Image(systemName: item.mode.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioMarkdown.swift
+++ b/Sources/MereRunApp/StudioMarkdown.swift
@@ -1,0 +1,307 @@
+import AppKit
+import SwiftUI
+
+/// A deliberately small Markdown block model for assistant replies. Fenced code gets a real
+/// panel (mono, language chip, copy); prose gets headings, lists, and quotes with inline
+/// styling. Not a CommonMark engine — just the shapes local models actually emit.
+enum StudioMarkdownBlock: Equatable {
+    case paragraph(String)
+    case heading(level: Int, text: String)
+    case bullets([String])
+    case numbered([String])
+    case quote(String)
+    case code(language: String?, content: String)
+    case rule
+}
+
+enum StudioMarkdownParser {
+    /// Parses text into renderable blocks. An unclosed fence swallows the rest of the input as
+    /// code, so a streaming reply renders correctly while the closing fence is still in flight.
+    static func parse(_ text: String) -> [StudioMarkdownBlock] {
+        var blocks: [StudioMarkdownBlock] = []
+        var paragraphLines: [String] = []
+        var bulletItems: [String] = []
+        var numberedItems: [String] = []
+        var quoteLines: [String] = []
+        var codeLines: [String] = []
+        var codeLanguage: String?
+        var inCode = false
+
+        func flushProse() {
+            if !paragraphLines.isEmpty {
+                blocks.append(.paragraph(paragraphLines.joined(separator: "\n")))
+                paragraphLines = []
+            }
+            if !bulletItems.isEmpty {
+                blocks.append(.bullets(bulletItems))
+                bulletItems = []
+            }
+            if !numberedItems.isEmpty {
+                blocks.append(.numbered(numberedItems))
+                numberedItems = []
+            }
+            if !quoteLines.isEmpty {
+                blocks.append(.quote(quoteLines.joined(separator: "\n")))
+                quoteLines = []
+            }
+        }
+
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if inCode {
+                if trimmed == "```" {
+                    blocks.append(.code(language: codeLanguage, content: codeLines.joined(separator: "\n")))
+                    codeLines = []
+                    codeLanguage = nil
+                    inCode = false
+                } else {
+                    codeLines.append(line)
+                }
+                continue
+            }
+
+            if trimmed.hasPrefix("```") {
+                flushProse()
+                let language = trimmed.dropFirst(3).trimmingCharacters(in: .whitespaces)
+                codeLanguage = language.isEmpty ? nil : language
+                inCode = true
+                continue
+            }
+
+            if trimmed.isEmpty {
+                flushProse()
+                continue
+            }
+
+            if let heading = headingBlock(from: trimmed) {
+                flushProse()
+                blocks.append(heading)
+                continue
+            }
+
+            if trimmed == "---" || trimmed == "***" {
+                flushProse()
+                blocks.append(.rule)
+                continue
+            }
+
+            if let item = bulletItem(from: trimmed) {
+                if !paragraphLines.isEmpty || !numberedItems.isEmpty || !quoteLines.isEmpty { flushProse() }
+                bulletItems.append(item)
+                continue
+            }
+
+            if let item = numberedItem(from: trimmed) {
+                if !paragraphLines.isEmpty || !bulletItems.isEmpty || !quoteLines.isEmpty { flushProse() }
+                numberedItems.append(item)
+                continue
+            }
+
+            if trimmed.hasPrefix(">") {
+                if !paragraphLines.isEmpty || !bulletItems.isEmpty || !numberedItems.isEmpty { flushProse() }
+                quoteLines.append(String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces))
+                continue
+            }
+
+            // Indented continuation of the previous list item, if any.
+            if line.hasPrefix("  "), !bulletItems.isEmpty {
+                bulletItems[bulletItems.count - 1] += " " + trimmed
+                continue
+            }
+            if line.hasPrefix("  "), !numberedItems.isEmpty {
+                numberedItems[numberedItems.count - 1] += " " + trimmed
+                continue
+            }
+
+            if !bulletItems.isEmpty || !numberedItems.isEmpty || !quoteLines.isEmpty { flushProse() }
+            paragraphLines.append(line)
+        }
+
+        if inCode {
+            blocks.append(.code(language: codeLanguage, content: codeLines.joined(separator: "\n")))
+        }
+        flushProse()
+        return blocks
+    }
+
+    /// Inline styling (bold/italic/`code`/links) for one prose run.
+    static func inline(_ text: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+    }
+
+    private static func headingBlock(from line: String) -> StudioMarkdownBlock? {
+        guard line.hasPrefix("#") else { return nil }
+        let hashes = line.prefix(while: { $0 == "#" })
+        guard hashes.count <= 6 else { return nil }
+        let rest = line.dropFirst(hashes.count)
+        guard rest.first == " " else { return nil }
+        return .heading(
+            level: hashes.count,
+            text: rest.trimmingCharacters(in: .whitespaces)
+        )
+    }
+
+    private static func bulletItem(from line: String) -> String? {
+        for marker in ["- ", "* ", "• "] where line.hasPrefix(marker) {
+            return String(line.dropFirst(marker.count)).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    private static func numberedItem(from line: String) -> String? {
+        let digits = line.prefix(while: \.isNumber)
+        guard !digits.isEmpty, digits.count <= 3 else { return nil }
+        let rest = line.dropFirst(digits.count)
+        guard rest.hasPrefix(". ") || rest.hasPrefix(") ") else { return nil }
+        return String(rest.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+    }
+}
+
+/// Renders parsed Markdown blocks in the app's voice. Used by assistant chat turns and the
+/// in-app guide so long-form text reads as designed content, not dumped text.
+struct StudioMarkdownText: View {
+    let content: String
+    var bodyFont: Font = MereRunTheme.bodyFont
+
+    var body: some View {
+        let blocks = StudioMarkdownParser.parse(content)
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                blockView(block)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: StudioMarkdownBlock) -> some View {
+        switch block {
+        case .paragraph(let text):
+            Text(StudioMarkdownParser.inline(text))
+                .font(bodyFont)
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        case .heading(let level, let text):
+            Text(StudioMarkdownParser.inline(text))
+                .font(headingFont(level))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .textSelection(.enabled)
+                .padding(.top, level <= 2 ? 4 : 2)
+        case .bullets(let items):
+            listView(items) { _ in Text("•") }
+        case .numbered(let items):
+            listView(items) { index in Text("\(index + 1).").monospacedDigit() }
+        case .quote(let text):
+            Text(StudioMarkdownParser.inline(text))
+                .font(bodyFont.italic())
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(MereRunTheme.Spacing.sm)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.base)
+                        .fill(MereRunTheme.accentSoft.opacity(0.6))
+                }
+        case .code(let language, let content):
+            StudioCodeBlock(language: language, content: content)
+        case .rule:
+            Divider().overlay(MereRunTheme.border.opacity(0.5))
+        }
+    }
+
+    private func listView(_ items: [String], marker: @escaping (Int) -> Text) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    marker(index)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.accent)
+                    Text(StudioMarkdownParser.inline(item))
+                        .font(bodyFont)
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(.leading, 2)
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .system(.title3, weight: .semibold)
+        case 2: return .system(.headline, weight: .semibold)
+        default: return .system(.subheadline, weight: .semibold)
+        }
+    }
+}
+
+/// A fenced code panel: language chip, hover-revealed copy, wrapped monospaced text.
+private struct StudioCodeBlock: View {
+    let language: String?
+    let content: String
+
+    @State private var hovering = false
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Text(language ?? "code")
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .textCase(.uppercase)
+                Spacer(minLength: 0)
+                Button {
+                    copy()
+                } label: {
+                    Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 10.5, weight: .medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                }
+                .buttonStyle(.mereIcon)
+                .opacity(hovering || copied ? 1 : 0)
+                .accessibilityLabel("Copy code")
+            }
+            .padding(.horizontal, MereRunTheme.Spacing.sm)
+            .padding(.top, MereRunTheme.Spacing.xs)
+            .padding(.bottom, 4)
+
+            Text(content)
+                .font(.system(size: 12.5, design: .monospaced))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, MereRunTheme.Spacing.sm)
+                .padding(.bottom, MereRunTheme.Spacing.sm)
+        }
+        .background {
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                        .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                }
+        }
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+    }
+
+    private func copy() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(content, forType: .string)
+        copied = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            copied = false
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioMediaPlayers.swift
+++ b/Sources/MereRunApp/StudioMediaPlayers.swift
@@ -90,46 +90,47 @@ struct StudioAudioPlayerView: View {
 
     @StateObject private var player = StudioAudioPlayer()
     @State private var isScrubbing = false
-    private let ticker = Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()
+    @State private var peaks: [Float]?
+    @State private var peaksLoaded = false
+    private let ticker = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+
+    private var playedFraction: Double {
+        guard player.duration > 0 else { return 0 }
+        return min(1, max(0, player.currentTime / player.duration))
+    }
 
     var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "waveform")
-                .font(.system(size: 48, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-
+        VStack(spacing: 18) {
             if player.isReady {
-                VStack(spacing: 8) {
-                    Slider(
-                        value: $player.currentTime,
-                        in: 0...max(player.duration, 0.1),
-                        onEditingChanged: { editing in
-                            isScrubbing = editing
-                            if !editing { player.seek(to: player.currentTime) }
-                        }
-                    )
-                    .tint(MereRunTheme.accent)
+                waveformOrSlider
+                    .frame(maxWidth: 520)
 
-                    HStack {
-                        Text(StudioTimeFormat.string(player.currentTime))
-                        Spacer()
-                        Text(StudioTimeFormat.string(player.duration))
+                HStack(spacing: 16) {
+                    Text(StudioTimeFormat.string(player.currentTime))
+                        .monospacedDigit()
+                        .frame(minWidth: 44, alignment: .trailing)
+
+                    Button {
+                        player.togglePlay()
+                    } label: {
+                        Image(systemName: player.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                            .font(.system(size: 46))
+                            .foregroundStyle(MereRunTheme.accent)
+                            .contentTransition(.symbolEffect(.replace))
                     }
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                }
-                .frame(maxWidth: 420)
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
 
-                Button {
-                    player.togglePlay()
-                } label: {
-                    Image(systemName: player.isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                        .font(.system(size: 44))
-                        .foregroundStyle(MereRunTheme.accent)
+                    Text(StudioTimeFormat.string(player.duration))
+                        .monospacedDigit()
+                        .frame(minWidth: 44, alignment: .leading)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
             } else {
+                Image(systemName: "waveform.slash")
+                    .font(.system(size: 40, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
                 Text("Audio preview unavailable.")
                     .font(MereRunTheme.bodyFont)
                     .foregroundStyle(MereRunTheme.textMuted)
@@ -137,11 +138,56 @@ struct StudioAudioPlayerView: View {
         }
         .padding(28)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task(id: url) { player.load(url: url) }
+        .task(id: url) {
+            player.load(url: url)
+            peaks = nil
+            peaksLoaded = false
+            let loaded = await Task.detached(priority: .userInitiated) {
+                StudioWaveformLoader.peaks(url: url)
+            }.value
+            guard !Task.isCancelled else { return }
+            peaks = loaded
+            peaksLoaded = true
+        }
         .onReceive(ticker) { _ in
             if !isScrubbing { player.refresh() }
         }
         .onDisappear { player.stop() }
+    }
+
+    /// The waveform is the preferred scrubber; the slider remains for files whose PCM peaks
+    /// can't be decoded, and while peaks are still loading.
+    @ViewBuilder
+    private var waveformOrSlider: some View {
+        if let peaks, !peaks.isEmpty {
+            StudioWaveformView(peaks: peaks, progress: playedFraction) { fraction in
+                player.seek(to: fraction * player.duration)
+            }
+            .frame(height: 72)
+            .transition(.opacity)
+        } else if peaksLoaded {
+            Slider(
+                value: $player.currentTime,
+                in: 0...max(player.duration, 0.1),
+                onEditingChanged: { editing in
+                    isScrubbing = editing
+                    if !editing { player.seek(to: player.currentTime) }
+                }
+            )
+            .tint(MereRunTheme.accent)
+        } else {
+            // Quiet placeholder bars while peaks decode, so the layout doesn't jump.
+            StudioWaveformView(peaks: StudioWaveformView.placeholderPeaks, progress: 0)
+                .frame(height: 72)
+                .opacity(0.35)
+        }
+    }
+}
+
+extension StudioWaveformView {
+    /// A gentle, deterministic bar silhouette for the loading state.
+    static let placeholderPeaks: [Float] = (0..<96).map { index in
+        0.25 + 0.2 * abs(sin(Float(index) * 0.35))
     }
 }
 

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -102,6 +102,7 @@ struct StudioModelsSheet: View {
     @State private var detailText = ""
     @State private var statusMessage = "Loading models"
     @State private var showAll = false
+    @State private var searchText = ""
     @State private var isRefreshing = false
     @State private var loadingInfoID: String?
     @State private var loadingRuntimeID: String?
@@ -121,7 +122,12 @@ struct StudioModelsSheet: View {
     }
 
     private var visibleRows: [StudioModelInventoryRow] {
-        showAll ? rows : installedRows
+        let scoped = showAll ? rows : installedRows
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return scoped }
+        return scoped.filter { row in
+            row.id.lowercased().contains(query) || row.category.lowercased().contains(query)
+        }
     }
 
     private var selectedRow: StudioModelInventoryRow? {
@@ -221,10 +227,17 @@ struct StudioModelsSheet: View {
     }
 
     private var modelList: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 0) {
+            searchField
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
             HStack {
                 Text(showAll ? "All known models" : "Downloaded")
-                    .font(MereRunTheme.sectionFont)
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .kerning(0.5)
+                    .textCase(.uppercase)
                     .foregroundStyle(MereRunTheme.textMuted)
                 Spacer()
                 Text("\(visibleRows.count)")
@@ -232,21 +245,57 @@ struct StudioModelsSheet: View {
                     .foregroundStyle(MereRunTheme.textMuted)
             }
             .padding(.horizontal, 16)
-            .padding(.top, 14)
+            .padding(.bottom, 6)
 
             if visibleRows.isEmpty {
                 emptyList
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 8) {
+                    LazyVStack(spacing: 4) {
                         ForEach(visibleRows) { row in
-                            modelRow(row)
+                            StudioModelListRow(
+                                row: row,
+                                isSelected: selectedID == row.id,
+                                runtime: runtimeSettingsByID[row.id]
+                            ) {
+                                select(row)
+                            }
                         }
                     }
-                    .padding(.horizontal, 12)
+                    .padding(.horizontal, 10)
                     .padding(.bottom, 14)
                 }
             }
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            TextField("Search models", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12.5))
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.sm)
+        .frame(height: 30)
+        .background {
+            Capsule()
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.7), lineWidth: 1)
+                }
         }
     }
 
@@ -255,59 +304,20 @@ struct StudioModelsSheet: View {
             Image(systemName: "shippingbox")
                 .font(.system(size: 28, weight: .medium))
                 .foregroundStyle(MereRunTheme.textMuted)
-            Text(showAll ? "No models reported." : "No downloaded models yet.")
+            Text(emptyListMessage)
                 .font(MereRunTheme.bodyFont)
                 .foregroundStyle(MereRunTheme.textMuted)
+                .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(16)
     }
 
-    private func modelRow(_ row: StudioModelInventoryRow) -> some View {
-        Button {
-            select(row)
-        } label: {
-            HStack(spacing: 10) {
-                Circle()
-                    .fill(row.isInstalled ? MereRunTheme.green : MereRunTheme.border)
-                    .frame(width: 8, height: 8)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(row.id)
-                        .font(.system(size: 13, weight: .semibold))
-                        .lineLimit(1)
-                    HStack(spacing: 8) {
-                        Text(row.category)
-                        Text(row.status)
-                        Text(row.size)
-                        if let runtime = runtimeSettingsByID[row.id] {
-                            if runtime.pinned {
-                                Text("pinned")
-                            }
-                            if let alias = runtime.alias {
-                                Text(alias)
-                            }
-                        }
-                    }
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                }
-
-                Spacer(minLength: 0)
-            }
-            .padding(10)
-            .background {
-                RoundedRectangle(cornerRadius: 9)
-                    .fill(selectedID == row.id ? MereRunTheme.surfaceRaised : MereRunTheme.surface.opacity(0.42))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 9)
-                            .strokeBorder(
-                                selectedID == row.id ? MereRunTheme.accent.opacity(0.85) : MereRunTheme.border.opacity(0.55),
-                                lineWidth: 1
-                            )
-                    }
-            }
+    private var emptyListMessage: String {
+        if !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "No models match the search."
         }
-        .buttonStyle(.plain)
+        return showAll ? "No models reported." : "No downloaded models yet."
     }
 
     private var detailPane: some View {
@@ -418,39 +428,62 @@ struct StudioModelsSheet: View {
     }
 
     private func runtimeSettingsEditor(_ row: StudioModelInventoryRow) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                TextField("Alias", text: $runtimeAlias)
-                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    .frame(minWidth: 110)
-                TextField("TTL", text: $runtimeTTL)
-                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    .frame(width: 72)
-                TextField("Context", text: $runtimeMaxContext)
-                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    .frame(width: 88)
-                TextField("Max tokens", text: $runtimeMaxTokens)
-                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    .frame(width: 88)
-                TextField("Temp", text: $runtimeTemperature)
-                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    .frame(width: 72)
-                TextField("Top P", text: $runtimeTopP)
-                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    .frame(width: 72)
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
+            Text("Runtime settings")
+                .font(.system(size: 10.5, weight: .semibold))
+                .kerning(0.5)
+                .textCase(.uppercase)
+                .foregroundStyle(MereRunTheme.textMuted)
+
+            Grid(alignment: .leading, horizontalSpacing: MereRunTheme.Spacing.sm, verticalSpacing: 8) {
+                GridRow {
+                    runtimeField("Alias", text: $runtimeAlias, width: 150)
+                    runtimeField("TTL seconds", text: $runtimeTTL, width: 100)
+                    runtimeField("Context", text: $runtimeMaxContext, width: 100)
+                }
+                GridRow {
+                    runtimeField("Max tokens", text: $runtimeMaxTokens, width: 150)
+                    runtimeField("Temperature", text: $runtimeTemperature, width: 100)
+                    runtimeField("Top P", text: $runtimeTopP, width: 100)
+                }
+            }
+
+            HStack(spacing: MereRunTheme.Spacing.sm) {
                 Toggle("Pinned", isOn: $runtimePinned)
                     .toggleStyle(.checkbox)
+                    .font(MereRunTheme.captionFont)
+
+                Spacer()
 
                 Button {
                     Task { await saveRuntimeSettings(for: row, pinned: runtimePinned) }
                 } label: {
-                    Label("Save", systemImage: "checkmark")
+                    Label("Save settings", systemImage: "checkmark")
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(MereRunTheme.accent)
+                .buttonStyle(.merePrimary)
                 .disabled(!row.isInstalled || loadingRuntimeID != nil)
             }
-            .font(MereRunTheme.captionFont)
+        }
+        .padding(MereRunTheme.Spacing.md)
+        .background {
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                .fill(MereRunTheme.surface.opacity(0.55))
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                        .strokeBorder(MereRunTheme.border.opacity(0.5), lineWidth: 1)
+                }
+        }
+    }
+
+    private func runtimeField(_ label: String, text: Binding<String>, width: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 10.5, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            TextField(label, text: text)
+                .mereField(cornerRadius: MereRunTheme.Radius.sm)
+                .frame(width: width)
+                .labelsHidden()
         }
     }
 
@@ -691,5 +724,85 @@ struct StudioModelsSheet: View {
         return base
             .appendingPathComponent("MereRun", isDirectory: true)
             .appendingPathComponent("models", isDirectory: true)
+    }
+}
+
+/// One model in the catalog list: install dot, name, category/runtime facts, size in the
+/// trailing column where the eye expects it.
+private struct StudioModelListRow: View {
+    let row: StudioModelInventoryRow
+    let isSelected: Bool
+    let runtime: StudioRuntimeSettings?
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                Circle()
+                    .fill(row.isInstalled ? MereRunTheme.green : MereRunTheme.border)
+                    .frame(width: 7, height: 7)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(row.id)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    HStack(spacing: 6) {
+                        Text(row.category)
+                        if !row.isInstalled {
+                            Text("·")
+                            Text(row.status)
+                        }
+                        if let runtime {
+                            if runtime.pinned {
+                                Label("pinned", systemImage: "pin.fill")
+                                    .labelStyle(.titleAndIcon)
+                            }
+                            if let alias = runtime.alias {
+                                Text("→ \(alias)")
+                            }
+                        }
+                    }
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(row.size)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                    .fill(rowFill)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                            .strokeBorder(
+                                isSelected ? MereRunTheme.accent.opacity(0.5) : Color.clear,
+                                lineWidth: 1
+                            )
+                    }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.md))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .accessibilityLabel("\(row.id), \(row.category), \(row.status), \(row.size)")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private var rowFill: Color {
+        if isSelected { return MereRunTheme.accentSoft }
+        if hovering { return MereRunTheme.hoverFill }
+        return MereRunTheme.surface.opacity(0.35)
     }
 }

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -23,8 +23,11 @@ struct StudioRootView: View {
     @State private var activeConversationID: UUID?
     @State private var pendingPullRefresh: StudioReadinessRefresh?
     @State private var studioError: String?
+    /// Locally installed models feeding the composer's quick-picker.
+    @State private var installedModels: [StudioModelInventoryRow] = []
     @AppStorage("mererun.app.hasCompletedWelcome") private var hasCompletedWelcome = false
     @State private var showWelcome = false
+    @FocusState private var promptFocused: Bool
 
     private var selectedItem: StudioLibraryItem? {
         if let selectedLibraryID, let found = library.items.first(where: { $0.id == selectedLibraryID }) {
@@ -99,125 +102,93 @@ struct StudioRootView: View {
         )
     }
 
+    // The body is staged (shell → panels → sheets → observers) so each stage stays a small,
+    // independently type-checked expression.
     var body: some View {
-        HStack(spacing: 0) {
-            if showLibrary {
-                StudioLibraryPanel(
-                    items: library.items,
-                    selectedID: $selectedLibraryID,
-                    isVisible: $showLibrary,
-                    onDelete: { id in
-                        library.delete(id: id)
-                        if selectedLibraryID == id { selectedLibraryID = nil }
-                    },
-                    onRename: { id, title in
-                        library.rename(id: id, title: title)
-                    },
-                    onQuickLook: { QuickLookCoordinator.shared.preview($0) }
-                )
-                .frame(width: 292)
+        observedShell
+    }
 
-                Divider()
-                    .overlay(MereRunTheme.border.opacity(0.55))
-            }
-
-            VStack(spacing: 0) {
-                StudioTopBar(
+    private var shell: some View {
+        ZStack(alignment: .trailing) {
+            HStack(spacing: 0) {
+                StudioSidebar(
                     mode: $mode,
-                    showLibrary: $showLibrary,
-                    showAdvanced: $showAdvanced,
-                    readiness: readiness,
                     modeCapabilities: modeCapabilities,
-                    resolvedCLI: controller.resolvedCLI,
                     serverStatus: controller.serverStatus,
+                    resolvedCLI: controller.resolvedCLI,
                     onShowModels: { showModels = true },
                     onShowHelp: { showHelp = true }
                 )
 
                 Divider()
-                    .overlay(MereRunTheme.border.opacity(0.45))
+                    .overlay(MereRunTheme.border.opacity(0.4))
 
-                if let persistenceError = library.lastPersistenceError {
-                    MereBanner(
-                        severity: .warning,
-                        text: "Run history not saved: \(persistenceError)"
+                if showLibrary {
+                    StudioLibraryPanel(
+                        items: library.items,
+                        selectedID: $selectedLibraryID,
+                        isVisible: $showLibrary,
+                        onDelete: { id in
+                            library.delete(id: id)
+                            if selectedLibraryID == id { selectedLibraryID = nil }
+                        },
+                        onRename: { id, title in
+                            library.rename(id: id, title: title)
+                        },
+                        onQuickLook: { QuickLookCoordinator.shared.preview($0) }
                     )
-                    .padding(.horizontal, 24)
-                    .padding(.top, 10)
+                    .frame(width: 272)
+
+                    Divider()
+                        .overlay(MereRunTheme.border.opacity(0.5))
                 }
 
-                StudioCanvas(
-                    mode: mode,
-                    item: selectedItem,
-                    conversationItem: activeConversationItem,
-                    conversationLiveText: activeConversationLiveText,
-                    isConversationRunning: activeConversationRunning,
-                    isRunning: controller.isRunning,
-                    status: displayStatus,
-                    readiness: readiness,
-                    error: studioError,
-                    logs: controller.logs,
-                    liveOutputText: controller.liveOutputText,
-                    progress: controller.currentProgress,
-                    onOpen: openSelectedOutput,
-                    onReveal: revealSelectedOutput,
-                    onQuickLook: {
-                        if let url = selectedItem?.outputURL { QuickLookCoordinator.shared.preview(url) }
-                    },
-                    onPullModel: pullModel,
-                    onShowDetails: { showAdvanced = true },
-                    onNewChat: startNewConversation,
-                    onCopy: copyToClipboard,
-                    onRetry: retryLastTurn,
-                    onEdit: editMessage
-                )
-
-                StudioPromptBar(
-                    mode: mode,
-                    draft: $draft,
-                    showOptions: $showOptions,
-                    isRunning: controller.isRunning,
-                    queuedCount: controller.queuedRunCount,
-                    readiness: readiness,
-                    sendBlocked: mode.isConversational && activeConversationRunning,
-                    onRun: runStudioCommand,
-                    onStop: controller.cancel,
-                    onAttach: chooseAttachment,
-                    onPaste: pasteImageFromClipboard
-                )
-                .padding(.horizontal, 24)
-                .padding(.bottom, 22)
+                contentColumn
             }
-            .frame(minWidth: 680)
-            .dropDestination(for: URL.self) { urls, _ in
-                guard !mode.acceptedTypes.isEmpty, let url = urls.first(where: \.isFileURL) else {
-                    return false
-                }
-                draft.inputPath = url.path
-                studioError = nil
-                return true
-            } isTargeted: { targeted in
-                withAnimation(.easeOut(duration: 0.15)) {
-                    isDropTargeted = targeted && !mode.acceptedTypes.isEmpty
-                }
-            }
-            .overlay {
-                if isDropTargeted {
-                    RoundedRectangle(cornerRadius: 18)
-                        .strokeBorder(MereRunTheme.accent, style: StrokeStyle(lineWidth: 2, dash: [8, 6]))
-                        .padding(8)
-                        .allowsHitTesting(false)
-                        .transition(.opacity)
-                }
-            }
-            .onPasteCommand(of: [.image]) { _ in pasteImageFromClipboard() }
 
             if showAdvanced {
-                advancedResizeHandle
-                AdvancedControlSurface(docked: true, onDetach: { advancedDetached = true })
-                    .frame(width: advancedWidth)
+                advancedPanel
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                    .zIndex(1)
             }
         }
+        .background(MereRunTheme.background.ignoresSafeArea())
+    }
+
+    private var advancedPanel: some View {
+        HStack(spacing: 0) {
+            advancedResizeHandle
+            AdvancedControlSurface(docked: true, onDetach: { advancedDetached = true })
+                .frame(width: advancedWidth)
+                .clipped()
+        }
+        .background(MereRunTheme.background)
+        .mereShadow(radius: 24, y: 0)
+    }
+
+    private var contentColumn: some View {
+        VStack(spacing: 0) {
+            topBar
+
+            Divider()
+                .overlay(MereRunTheme.border.opacity(0.45))
+
+            if let persistenceError = library.lastPersistenceError {
+                MereBanner(
+                    severity: .warning,
+                    text: "Run history not saved: \(persistenceError)"
+                )
+                .padding(.horizontal, 24)
+                .padding(.top, 10)
+            }
+
+            canvas
+
+            composer
+                .padding(.horizontal, 24)
+                .padding(.bottom, 20)
+        }
+        .frame(minWidth: 620)
         .background {
             ZStack {
                 MereRunTheme.background
@@ -233,55 +204,134 @@ struct StudioRootView: View {
             }
             .ignoresSafeArea()
         }
-        .sheet(isPresented: $showOptions) {
-            StudioOptionsSheet(mode: mode, draft: $draft)
-                .frame(width: 500)
-        }
-        .sheet(isPresented: $showModels) {
-            StudioModelsSheet(onModelsChanged: refreshReadiness)
-                .environmentObject(controller)
-        }
-        .sheet(isPresented: $showWelcome) {
-            StudioWelcomeSheet(
-                resolvedCLI: controller.resolvedCLI,
-                onBrowseModels: {
-                    hasCompletedWelcome = true
-                    showWelcome = false
-                    showModels = true
-                },
-                onDone: {
-                    hasCompletedWelcome = true
-                    showWelcome = false
-                }
-            )
-        }
-        .sheet(isPresented: $showHelp) {
-            StudioHelpSheet()
-                .environmentObject(controller)
-                .frame(width: 720, height: 560)
-        }
-        .sheet(isPresented: $advancedDetached) {
-            VStack(spacing: 0) {
-                HStack {
-                    Text("Advanced — full control surface")
-                        .font(MereRunTheme.sectionFont)
-                    Spacer()
-                    Button("Dock") { advancedDetached = false }
-                        .keyboardShortcut(.defaultAction)
-                }
-                .padding(16)
-                Divider().overlay(MereRunTheme.border.opacity(0.5))
-                AdvancedControlSurface(docked: false)
+        .dropDestination(for: URL.self) { urls, _ in
+            guard !mode.acceptedTypes.isEmpty, let url = urls.first(where: \.isFileURL) else {
+                return false
             }
-            .frame(width: 1_260, height: 780)
-            .environmentObject(controller)
+            draft.inputPath = url.path
+            studioError = nil
+            return true
+        } isTargeted: { targeted in
+            withAnimation(MereRunTheme.Motion.quick) {
+                isDropTargeted = targeted && !mode.acceptedTypes.isEmpty
+            }
         }
-        .focusedSceneValue(\.showLibrary, $showLibrary)
-        .focusedSceneValue(\.showAdvanced, $showAdvanced)
-        .focusedSceneValue(\.showModels, $showModels)
+        .overlay {
+            if isDropTargeted {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.xl)
+                    .strokeBorder(MereRunTheme.accent, style: StrokeStyle(lineWidth: 2, dash: [8, 6]))
+                    .padding(8)
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+            }
+        }
+        .onPasteCommand(of: [.image]) { _ in pasteImageFromClipboard() }
+    }
+
+    private var canvas: some View {
+        StudioCanvas(
+            mode: mode,
+            item: selectedItem,
+            conversationItem: activeConversationItem,
+            conversationLiveText: activeConversationLiveText,
+            isConversationRunning: activeConversationRunning,
+            isRunning: controller.isRunning,
+            status: displayStatus,
+            readiness: readiness,
+            error: studioError,
+            logs: controller.logs,
+            liveOutputText: controller.liveOutputText,
+            progress: controller.currentProgress,
+            onOpen: openSelectedOutput,
+            onReveal: revealSelectedOutput,
+            onQuickLook: {
+                if let url = selectedItem?.outputURL { QuickLookCoordinator.shared.preview(url) }
+            },
+            onPullModel: pullModel,
+            onShowDetails: { showAdvanced = true },
+            onNewChat: startNewConversation,
+            onCopy: copyToClipboard,
+            onRetry: retryLastTurn,
+            onEdit: editMessage,
+            onStop: controller.cancel,
+            onUseExample: useExamplePrompt,
+            onAttach: chooseAttachment
+        )
+    }
+
+    private var composer: some View {
+        StudioComposer(
+            mode: mode,
+            draft: $draft,
+            showOptions: $showOptions,
+            isRunning: controller.isRunning,
+            queuedCount: controller.queuedRunCount,
+            readiness: readiness,
+            sendBlocked: mode.isConversational && activeConversationRunning,
+            installedModels: installedModels,
+            promptFocus: $promptFocused,
+            onRun: runStudioCommand,
+            onStop: controller.cancel,
+            onAttach: chooseAttachment,
+            onPaste: pasteImageFromClipboard,
+            onShowModels: { showModels = true }
+        )
+    }
+
+    private var sheetedShell: some View {
+        shell
+            .sheet(isPresented: $showModels) {
+                StudioModelsSheet(onModelsChanged: {
+                    refreshReadiness()
+                    refreshInstalledModels()
+                })
+                .environmentObject(controller)
+            }
+            .sheet(isPresented: $showWelcome) {
+                StudioWelcomeSheet(
+                    resolvedCLI: controller.resolvedCLI,
+                    onBrowseModels: {
+                        hasCompletedWelcome = true
+                        showWelcome = false
+                        showModels = true
+                    },
+                    onDone: {
+                        hasCompletedWelcome = true
+                        showWelcome = false
+                    }
+                )
+            }
+            .sheet(isPresented: $showHelp) {
+                StudioHelpSheet()
+                    .environmentObject(controller)
+                    .frame(width: 720, height: 560)
+            }
+            .sheet(isPresented: $advancedDetached) {
+                VStack(spacing: 0) {
+                    HStack {
+                        Text("Advanced — full control surface")
+                            .font(MereRunTheme.sectionFont)
+                        Spacer()
+                        Button("Dock") { advancedDetached = false }
+                            .keyboardShortcut(.defaultAction)
+                    }
+                    .padding(16)
+                    Divider().overlay(MereRunTheme.border.opacity(0.5))
+                    AdvancedControlSurface(docked: false)
+                }
+                .frame(width: 1_260, height: 780)
+                .environmentObject(controller)
+            }
+            .focusedSceneValue(\.showLibrary, $showLibrary)
+            .focusedSceneValue(\.showAdvanced, $showAdvanced)
+            .focusedSceneValue(\.showModels, $showModels)
+    }
+
+    private var lifecycleShell: some View {
+        sheetedShell
         .task {
-            // Poll the local server status for the top-bar pill. status has a 1s probe timeout,
-            // so a modest cadence keeps the pill live without hammering the CLI.
+            // Poll the local server status for the sidebar status cluster. status has a 1s probe
+            // timeout, so a modest cadence keeps it live without hammering the CLI.
             while !Task.isCancelled {
                 await controller.refreshServerStatus()
                 try? await Task.sleep(nanoseconds: 20 * 1_000_000_000)
@@ -302,10 +352,17 @@ struct StudioRootView: View {
                 selectedLibraryID = library.items.first { $0.mode == mode }?.id
             }
             controller.checkReadiness(for: mode, draft: draft)
+            refreshInstalledModels()
             if !hasCompletedWelcome {
                 showWelcome = true
+            } else if mode != .listen {
+                promptFocused = true
             }
         }
+    }
+
+    private var navigationObservedShell: some View {
+        lifecycleShell
         .onChange(of: showAdvanced) { _, isShown in
             if isShown { syncAdvancedToStudio() }
         }
@@ -326,6 +383,7 @@ struct StudioRootView: View {
             }
             draft = nextDraft
             controller.checkReadiness(for: newMode, draft: draft)
+            if newMode != .listen { promptFocused = true }
         }
         .onChange(of: controller.recommendedChatModelID) { _, _ in
             guard mode == .chat, activeConversationID == nil else { return }
@@ -343,6 +401,10 @@ struct StudioRootView: View {
             applyConversationSettings(from: item, to: &draft)
             draft.prompt = ""
         }
+    }
+
+    private var validationObservedShell: some View {
+        navigationObservedShell
         .onChange(of: draft.model) { _, _ in
             studioError = nil
             refreshReadiness()
@@ -372,6 +434,10 @@ struct StudioRootView: View {
             studioError = nil
             refreshReadiness()
         }
+    }
+
+    private var observedShell: some View {
+        validationObservedShell
         .onReceive(controller.runCompletions) { result in
             // Subscribe to the lossless completion stream, not lastRunResult: two runs finishing
             // in the same runloop turn would coalesce through onChange and drop one.
@@ -415,6 +481,10 @@ struct StudioRootView: View {
             } else if mutatedModels || completedLibraryItem {
                 refreshReadiness()
             }
+
+            if mutatedModels {
+                refreshInstalledModels()
+            }
         }
         .onChange(of: controller.activeRunRequestID) { _, requestID in
             // Conversation turns use a per-turn request id with no matching library row, so the
@@ -429,6 +499,57 @@ struct StudioRootView: View {
             library.updateOutput(id: requestID, outputURL: outputURL)
             selectedLibraryID = requestID
         }
+    }
+
+    /// The slim, contextual header for the content column: which mode you're in, and the two
+    /// panel toggles. Machine-wide status lives in the sidebar; blocking states own the canvas.
+    private var topBar: some View {
+        HStack(spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: mode.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(mode.title)
+                    .font(.system(size: 15, weight: .semibold))
+                Text(mode.subtitle)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+
+            Spacer()
+
+            Button {
+                withAnimation(MereRunTheme.Motion.standard) {
+                    showLibrary.toggle()
+                }
+            } label: {
+                Image(systemName: "rectangle.stack")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(showLibrary ? MereRunTheme.accent : MereRunTheme.textSecondary)
+                    .frame(width: 30, height: 30)
+            }
+            .buttonStyle(.mereIcon)
+            .help(showLibrary ? "Hide library (⌃⌘L)" : "Show library (⌃⌘L)")
+            .accessibilityLabel(showLibrary ? "Hide library" : "Show library")
+
+            Button {
+                withAnimation(MereRunTheme.Motion.standard) {
+                    showAdvanced.toggle()
+                }
+            } label: {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(showAdvanced ? MereRunTheme.accent : MereRunTheme.textSecondary)
+                    .frame(width: 30, height: 30)
+            }
+            .buttonStyle(.mereIcon)
+            .help(showAdvanced ? "Hide Advanced (⌃⌘E)" : "Show Advanced (⌃⌘E)")
+            .accessibilityLabel(showAdvanced ? "Hide Advanced" : "Show Advanced")
+        }
+        .padding(.horizontal, MereRunTheme.Spacing.lg)
+        .frame(height: 52)
+        .background(VisualEffectBackground())
     }
 
     private func runStudioCommand() {
@@ -458,7 +579,9 @@ struct StudioRootView: View {
             let request = try StudioCommandAdapter.makeRequest(mode: mode, draft: draft)
             let preview = controller
                 .commandPreview(template: request.template, draft: request.draft, masksSecrets: true)
-            let status: StudioLibraryStatus = controller.isRunning || controller.queuedRunCount > 0 ? .queued : .running
+            let status: StudioLibraryStatus = controller.isRunning || controller.queuedRunCount > 0
+                ? .queued
+                : .running
             library.start(request: request, commandPreview: preview, status: status)
             selectedLibraryID = request.id
             controller.run(studio: request)
@@ -553,8 +676,8 @@ struct StudioRootView: View {
     private var advancedResizeHandle: some View {
         Rectangle()
             .fill(MereRunTheme.border.opacity(0.55))
-            .frame(width: 5)
-            .contentShape(Rectangle())
+            .frame(width: 4)
+            .contentShape(Rectangle().inset(by: -3))
             .onHover { inside in
                 if inside { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
             }
@@ -600,6 +723,13 @@ struct StudioRootView: View {
         return nextDraft
     }
 
+    /// Fills the composer from an empty-state example and hands it focus — never auto-runs.
+    private func useExamplePrompt(_ example: String) {
+        draft.prompt = example
+        studioError = nil
+        promptFocused = true
+    }
+
     /// Edits a prior user turn: truncates the thread at that message and loads its text back into
     /// the composer, so sending re-runs the conversation from that point.
     private func editMessage(_ messageID: UUID) {
@@ -609,6 +739,7 @@ struct StudioRootView: View {
             draft.prompt = removed.content
             // Restore the turn's attached image so re-sending re-runs vision chat as before.
             if mode == .chat { draft.inputPath = removed.imagePath ?? "" }
+            promptFocused = true
         }
         // Editing the first turn empties the thread — drop the now-empty row and act like a new chat.
         if let item = library.items.first(where: { $0.id == conversationID }),
@@ -628,6 +759,7 @@ struct StudioRootView: View {
         fresh.reset(for: mode)
         fresh.prompt = ""
         draft = fresh
+        promptFocused = true
     }
 
     private func applyConversationSettings(from item: StudioLibraryItem, to draft: inout StudioDraft) {
@@ -666,7 +798,8 @@ struct StudioRootView: View {
             }
             pendingPullRefresh = StudioReadinessRefresh(mode: mode, draft: draft)
             controller.readinessByMode[mode] = .checking
-            showAdvanced = true
+            // The canvas running overlay shows pull progress (bytes, speed, cancel) in place,
+            // so the Advanced console no longer needs to open for a pull.
             if !controller.run(studio: request) {
                 pendingPullRefresh = nil
                 refreshReadiness()
@@ -678,6 +811,15 @@ struct StudioRootView: View {
 
     private func refreshReadiness() {
         controller.checkReadiness(for: mode, draft: draft)
+    }
+
+    /// Refreshes the composer's installed-model quick-picker from `model list`.
+    private func refreshInstalledModels() {
+        Task {
+            let result = await controller.utilityCommandResult(args: ["model", "list"])
+            guard result.exitCode == 0 else { return }
+            installedModels = StudioModelInventoryParser.rows(from: result.stdout).filter(\.isInstalled)
+        }
     }
 
     private func chooseAttachment() {
@@ -737,1311 +879,6 @@ struct StudioRootView: View {
 private struct StudioReadinessRefresh: Equatable {
     let mode: StudioMode
     let draft: StudioDraft
-}
-
-private struct StudioTopBar: View {
-    @Binding var mode: StudioMode
-    @Binding var showLibrary: Bool
-    @Binding var showAdvanced: Bool
-    let readiness: ModelReadinessState
-    let modeCapabilities: [StudioMode: StudioModelCapability]
-    let resolvedCLI: String
-    let serverStatus: StudioServerStatus?
-    let onShowModels: () -> Void
-    let onShowHelp: () -> Void
-
-    var body: some View {
-        VStack(spacing: 14) {
-            HStack(spacing: 12) {
-                Button {
-                    withAnimation(.easeOut(duration: 0.18)) {
-                        showLibrary.toggle()
-                    }
-                } label: {
-                    Image(systemName: "sidebar.left")
-                        .frame(width: 30, height: 30)
-                }
-                .buttonStyle(.plain)
-                .help("Show library")
-                .accessibilityLabel(showLibrary ? "Hide library" : "Show library")
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("mere.run")
-                        .font(.system(size: 20, weight: .semibold))
-                    Text("Create anything. Locally.")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                }
-
-                Spacer()
-
-                StudioStatusPill(
-                    title: "Server",
-                    detail: serverStatusDetail,
-                    systemImage: serverStatus?.isReachable == true ? "bolt.horizontal.circle" : "circle.dashed",
-                    color: serverStatusColor
-                )
-
-                StudioStatusPill(
-                    title: readiness.title,
-                    detail: readiness.message,
-                    systemImage: readinessStatusImage,
-                    color: readinessStatusColor
-                )
-
-                StudioStatusPill(
-                    title: "CLI",
-                    detail: resolvedCLI,
-                    systemImage: "terminal",
-                    color: MereRunTheme.accent
-                )
-
-                Button {
-                    onShowModels()
-                } label: {
-                    Label("Models", systemImage: "shippingbox")
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    onShowHelp()
-                } label: {
-                    Label("Help", systemImage: "questionmark.circle")
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    withAnimation(.easeOut(duration: 0.18)) {
-                        showAdvanced.toggle()
-                    }
-                } label: {
-                    Label("Advanced", systemImage: "slider.horizontal.3")
-                }
-                .buttonStyle(.bordered)
-            }
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(StudioMode.allCases) { candidate in
-                        StudioModeChip(
-                            mode: candidate,
-                            isSelected: candidate == mode,
-                            unavailableMessage: modeCapabilities[candidate]?.unavailableMessage
-                        ) {
-                            withAnimation(.easeOut(duration: 0.18)) {
-                                mode = candidate
-                            }
-                        }
-                    }
-                }
-                .padding(.horizontal, 2)
-            }
-        }
-        .padding(.horizontal, 22)
-        .padding(.top, 16)
-        .padding(.bottom, 14)
-        .background(VisualEffectBackground())
-    }
-
-    private var serverStatusDetail: String {
-        guard let serverStatus else { return "checking…" }
-        if serverStatus.isReachable {
-            let model = serverStatus.loadedModelSummary.map { " · \($0)" } ?? ""
-            return "up\(model) · \(serverStatus.installedCount) installed"
-        }
-        return "offline · \(serverStatus.installedCount) installed"
-    }
-
-    private var serverStatusColor: Color {
-        guard let serverStatus else { return MereRunTheme.textMuted }
-        return serverStatus.isReachable ? MereRunTheme.green : MereRunTheme.textMuted
-    }
-
-    private var readinessStatusImage: String {
-        if readiness.isChecking { return "hourglass" }
-        if readiness.canPull { return "arrow.down.circle" }
-        if readiness.blocksRun { return "exclamationmark.triangle" }
-        return "checkmark.circle"
-    }
-
-    private var readinessStatusColor: Color {
-        if readiness.isChecking { return MereRunTheme.yellow }
-        if readiness.canPull { return MereRunTheme.yellow }
-        if readiness.blocksRun { return MereRunTheme.red }
-        return MereRunTheme.green
-    }
-}
-
-private struct StudioModeChip: View {
-    let mode: StudioMode
-    let isSelected: Bool
-    let unavailableMessage: String?
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 7) {
-                Image(systemName: mode.systemImage)
-                    .font(.system(size: 12, weight: .semibold))
-                Text(mode.title)
-                    .font(.system(size: 12, weight: .semibold))
-            }
-            .foregroundStyle(foregroundColor)
-            .padding(.horizontal, 12)
-            .frame(height: 32)
-            .background {
-                Capsule()
-                    .fill(backgroundColor)
-                    .overlay {
-                        Capsule()
-                            .strokeBorder(borderColor, lineWidth: 1)
-                    }
-            }
-        }
-        .buttonStyle(.plain)
-        .disabled(unavailableMessage != nil)
-        .opacity(unavailableMessage == nil ? 1 : 0.52)
-        .help(unavailableMessage ?? mode.subtitle)
-    }
-
-    private var foregroundColor: Color {
-        if unavailableMessage != nil {
-            return MereRunTheme.textMuted
-        }
-        return isSelected ? MereRunTheme.background : MereRunTheme.textSecondary
-    }
-
-    private var backgroundColor: Color {
-        if unavailableMessage != nil {
-            return MereRunTheme.surface.opacity(0.55)
-        }
-        return isSelected ? MereRunTheme.accent : MereRunTheme.surface
-    }
-
-    private var borderColor: Color {
-        if unavailableMessage != nil {
-            return MereRunTheme.border.opacity(0.7)
-        }
-        return MereRunTheme.border.opacity(isSelected ? 0 : 0.8)
-    }
-}
-
-private struct StudioStatusPill: View {
-    let title: String
-    let detail: String
-    let systemImage: String
-    let color: Color
-
-    var body: some View {
-        HStack(spacing: 7) {
-            Image(systemName: systemImage)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(color)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                    .font(.system(size: 11, weight: .semibold))
-                Text(detail)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .lineLimit(1)
-            }
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 38)
-        .frame(maxWidth: 210)
-        .merePanel(cornerRadius: 18)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title): \(detail)")
-    }
-}
-
-private struct StudioCanvas: View {
-    let mode: StudioMode
-    let item: StudioLibraryItem?
-    let conversationItem: StudioLibraryItem?
-    let conversationLiveText: String?
-    let isConversationRunning: Bool
-    let isRunning: Bool
-    let status: String
-    let readiness: ModelReadinessState
-    let error: String?
-    let logs: [LogLine]
-    let liveOutputText: String
-    let progress: StudioRunProgress?
-    let onOpen: () -> Void
-    let onReveal: () -> Void
-    let onQuickLook: () -> Void
-    let onPullModel: () -> Void
-    let onShowDetails: () -> Void
-    let onNewChat: () -> Void
-    let onCopy: (String) -> Void
-    let onRetry: () -> Void
-    let onEdit: (UUID) -> Void
-
-    private var visibleLiveOutputText: String? {
-        guard isRunning else { return nil }
-        let text = liveOutputText
-            .replacingOccurrences(of: "\0", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return text.isEmpty ? nil : text
-    }
-
-    private var recentLogLines: [String] {
-        logs.suffix(4).map(\.text)
-    }
-
-    private var shouldShowReadinessOverlay: Bool {
-        !isRunning && (readiness.blocksRun || error != nil)
-    }
-
-    var body: some View {
-        ZStack {
-            if mode.isConversational {
-                StudioConversationView(
-                    item: conversationItem,
-                    liveText: conversationLiveText,
-                    isRunning: isConversationRunning,
-                    mode: mode,
-                    onNewChat: onNewChat,
-                    onCopy: onCopy,
-                    onRetry: onRetry,
-                    onEdit: onEdit
-                )
-                .transition(.opacity)
-            } else if let item {
-                StudioOutputView(item: item, liveOutputText: visibleLiveOutputText, onOpen: onOpen, onReveal: onReveal, onQuickLook: onQuickLook)
-                    .padding(32)
-                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
-            } else {
-                StudioEmptyState(mode: mode)
-                    .padding(32)
-            }
-
-            if isRunning && visibleLiveOutputText == nil && !mode.isConversational {
-                StudioRunningOverlay(status: status, progress: progress, recentLogs: recentLogLines)
-                    .transition(.opacity)
-            }
-
-            if shouldShowReadinessOverlay {
-                StudioReadinessOverlay(
-                    title: error == nil ? readiness.title : "Needs attention",
-                    message: error ?? readiness.message,
-                    canPull: error == nil && readiness.canPull,
-                    isChecking: error == nil && readiness.isChecking,
-                    onPullModel: onPullModel,
-                    onShowDetails: onShowDetails
-                )
-                .padding(32)
-                .transition(.opacity.combined(with: .scale(scale: 0.98)))
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.easeOut(duration: 0.18), value: isRunning)
-        .animation(.easeOut(duration: 0.18), value: shouldShowReadinessOverlay)
-    }
-}
-
-private struct StudioEmptyState: View {
-    let mode: StudioMode
-
-    var body: some View {
-        VStack(spacing: 18) {
-            Image(systemName: mode.systemImage)
-                .font(.system(size: 48, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-                .frame(width: 92, height: 92)
-                .background {
-                    Circle()
-                        .fill(MereRunTheme.surfaceRaised)
-                }
-
-            VStack(spacing: 8) {
-                Text(mode.emptyTitle)
-                    .font(.system(size: 30, weight: .semibold))
-                Text(mode.emptyMessage)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(MereRunTheme.textSecondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 460)
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
-private struct StudioRunningOverlay: View {
-    let status: String
-    let progress: StudioRunProgress?
-    let recentLogs: [String]
-
-    var body: some View {
-        VStack(spacing: 14) {
-            if let progress, let fraction = progress.fractionCompleted {
-                VStack(spacing: 6) {
-                    ProgressView(value: fraction)
-                        .progressViewStyle(.linear)
-                        .tint(MereRunTheme.accent)
-                        .frame(width: 320)
-                    HStack {
-                        Text(progress.label)
-                            .lineLimit(1)
-                        Spacer()
-                        Text("\(Int((fraction * 100).rounded()))%")
-                    }
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .frame(width: 320)
-                    if let detail = progress.detail {
-                        Text(detail)
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                            .lineLimit(1)
-                    }
-                }
-            } else {
-                ProgressView()
-                    .controlSize(.large)
-            }
-            Text(progress?.detail != nil && progress?.fractionCompleted == nil
-                ? "\(status) · \(progress?.detail ?? "")"
-                : status)
-                .font(.system(size: 18, weight: .semibold))
-                .multilineTextAlignment(.center)
-            if !recentLogs.isEmpty {
-                VStack(alignment: .leading, spacing: 6) {
-                    ForEach(Array(recentLogs.enumerated()), id: \.offset) { _, line in
-                        Text(line)
-                            .font(MereRunTheme.monoFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                            .lineLimit(2)
-                    }
-                }
-                .padding(12)
-                .frame(width: 460, alignment: .leading)
-                .background {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(MereRunTheme.background.opacity(0.55))
-                }
-            }
-        }
-        .padding(28)
-        .merePanel(cornerRadius: 18)
-        .mereShadow(radius: 28, y: 12)
-    }
-}
-
-private struct StudioReadinessOverlay: View {
-    let title: String
-    let message: String
-    let canPull: Bool
-    let isChecking: Bool
-    let onPullModel: () -> Void
-    let onShowDetails: () -> Void
-
-    var body: some View {
-        VStack(spacing: 14) {
-            Image(systemName: statusImage)
-                .font(.system(size: 32, weight: .semibold))
-                .foregroundStyle(statusColor)
-            Text(title)
-                .font(.system(size: 22, weight: .semibold))
-            Text(message)
-                .font(MereRunTheme.bodyFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 280)
-            HStack(spacing: 10) {
-                if canPull {
-                    Button {
-                        onPullModel()
-                    } label: {
-                        Label("Pull Model", systemImage: "arrow.down.circle.fill")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(MereRunTheme.accent)
-                }
-                Button {
-                    onShowDetails()
-                } label: {
-                    Label("Details", systemImage: "terminal")
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-        .padding(28)
-        .merePanel(cornerRadius: 18)
-        .mereShadow(radius: 30, y: 12)
-    }
-
-    private var statusImage: String {
-        if isChecking { return "hourglass" }
-        return canPull ? "arrow.down.circle" : "exclamationmark.triangle"
-    }
-
-    private var statusColor: Color {
-        if isChecking { return MereRunTheme.yellow }
-        return canPull ? MereRunTheme.yellow : MereRunTheme.red
-    }
-}
-
-private struct StudioOutputView: View {
-    let item: StudioLibraryItem
-    let liveOutputText: String?
-    let onOpen: () -> Void
-    let onReveal: () -> Void
-    let onQuickLook: () -> Void
-
-    var body: some View {
-        VStack(spacing: 18) {
-            outputPreview
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(MereRunTheme.surface.opacity(0.45))
-                .clipShape(RoundedRectangle(cornerRadius: 18))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 18)
-                        .strokeBorder(MereRunTheme.border.opacity(0.65), lineWidth: 1)
-                }
-
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(item.mode.title)
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    Text(item.displayTitle)
-                        .font(.system(size: 16, weight: .semibold))
-                        .lineLimit(1)
-                }
-                Spacer()
-                statusBadge
-                if item.outputURL != nil {
-                    Button("Open", action: onOpen)
-                        .buttonStyle(.bordered)
-                    Button {
-                        onQuickLook()
-                    } label: {
-                        Image(systemName: "eye")
-                    }
-                    .buttonStyle(.bordered)
-                    .help("Quick Look")
-                    .accessibilityLabel("Quick Look")
-                    Button {
-                        onReveal()
-                    } label: {
-                        Image(systemName: "magnifyingglass")
-                    }
-                    .buttonStyle(.bordered)
-                    .help("Reveal in Finder")
-                    .accessibilityLabel("Reveal in Finder")
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var outputPreview: some View {
-        if let url = item.outputURL {
-            switch StudioOutputFileKind.classify(url) {
-            case .image:
-                StudioAsyncImagePreview(
-                    url: url,
-                    maxPixelSize: 2_200,
-                    contentMode: .fit,
-                    fallbackSystemImage: iconName(for: url)
-                )
-                .padding(22)
-            case .audio:
-                StudioAudioPlayerView(url: url)
-            case .video:
-                StudioVideoPlayerView(url: url)
-            case .text:
-                StudioTextFilePreview(url: url)
-            case .other:
-                filePlaceholder(for: url)
-            }
-        } else if let text = liveOutputText ?? item.outputText, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            ScrollView {
-                Text(text)
-                    .font(item.mode == .chat ? MereRunTheme.bodyFont : MereRunTheme.monoFont)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(22)
-            }
-        } else {
-            VStack(spacing: 12) {
-                Image(systemName: "doc")
-                    .font(.system(size: 46, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.textMuted)
-                Text(item.status == .failed ? "Run did not produce a file." : "Output will appear here.")
-                    .font(MereRunTheme.bodyFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-            }
-        }
-    }
-
-    private func filePlaceholder(for url: URL) -> some View {
-        VStack(spacing: 12) {
-            Image(systemName: iconName(for: url))
-                .font(.system(size: 54, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-            Text(url.lastPathComponent)
-                .font(.system(size: 16, weight: .semibold))
-                .lineLimit(1)
-            Text(url.deletingLastPathComponent().path)
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textMuted)
-                .lineLimit(1)
-        }
-        .padding(22)
-    }
-
-    private var statusBadge: some View {
-        Text(item.status.rawValue.capitalized)
-            .font(MereRunTheme.captionFont)
-            .foregroundStyle(statusColor)
-            .padding(.horizontal, 10)
-            .frame(height: 28)
-            .background {
-                Capsule()
-                    .fill(statusColor.opacity(0.14))
-            }
-    }
-
-    private var statusColor: Color {
-        switch item.status {
-        case .queued: return MereRunTheme.textMuted
-        case .running: return MereRunTheme.yellow
-        case .completed: return MereRunTheme.green
-        case .failed: return MereRunTheme.red
-        }
-    }
-
-    private func iconName(for url: URL) -> String {
-        switch url.pathExtension.lowercased() {
-        case "wav", "mp3", "m4a": return "waveform"
-        case "mp4", "mov": return "film"
-        case "json": return "curlybraces"
-        case "safetensors": return "shippingbox"
-        default: return "doc"
-        }
-    }
-}
-
-private enum StudioImageContentMode: Equatable {
-    case fit
-    case fill
-}
-
-private enum StudioImageLoadState {
-    case loading
-    case loaded(NSImage)
-    case unavailable
-}
-
-private struct StudioAsyncImagePreview: View {
-    let url: URL
-    let maxPixelSize: CGFloat
-    let contentMode: StudioImageContentMode
-    let fallbackSystemImage: String
-
-    @State private var loadState = StudioImageLoadState.loading
-
-    var body: some View {
-        Group {
-            switch loadState {
-            case .loading:
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .loaded(let image):
-                if contentMode == .fill {
-                    Image(nsImage: image)
-                        .resizable()
-                        .scaledToFill()
-                } else {
-                    Image(nsImage: image)
-                        .resizable()
-                        .scaledToFit()
-                }
-            case .unavailable:
-                Image(systemName: fallbackSystemImage)
-                    .font(.system(size: 32, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.accent)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-        }
-        .task(id: url) {
-            loadState = .loading
-            let loaded = await Task.detached(priority: .userInitiated) {
-                StudioImagePreviewLoader.downsampledImage(from: url, maxPixelSize: maxPixelSize)
-            }.value
-            guard !Task.isCancelled else { return }
-            if let image = loaded?.image {
-                loadState = .loaded(image)
-            } else {
-                loadState = .unavailable
-            }
-        }
-    }
-}
-
-private struct StudioTextFilePreview: View {
-    let url: URL
-
-    @State private var text: String?
-    @State private var didLoad = false
-
-    var body: some View {
-        ScrollView {
-            if let text {
-                Text(text)
-                    .font(MereRunTheme.monoFont)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(22)
-            } else if didLoad {
-                Text("Text preview unavailable.")
-                    .font(MereRunTheme.bodyFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .padding(22)
-            } else {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(maxWidth: .infinity, minHeight: 180)
-                    .padding(22)
-            }
-        }
-        .task(id: url) {
-            text = nil
-            didLoad = false
-            let preview = await Task.detached(priority: .userInitiated) {
-                StudioTextPreviewReader.previewText(from: url)
-            }.value
-            guard !Task.isCancelled else { return }
-            text = preview
-            didLoad = true
-        }
-    }
-}
-
-private struct StudioPromptBar: View {
-    let mode: StudioMode
-    @Binding var draft: StudioDraft
-    @Binding var showOptions: Bool
-    let isRunning: Bool
-    let queuedCount: Int
-    let readiness: ModelReadinessState
-    var sendBlocked: Bool = false
-    let onRun: () -> Void
-    let onStop: () -> Void
-    let onAttach: () -> Void
-    let onPaste: () -> Void
-
-    var body: some View {
-        VStack(spacing: 10) {
-            if !draft.inputPath.isBlank {
-                HStack {
-                    Label(URL(fileURLWithPath: draft.inputPath).lastPathComponent, systemImage: "paperclip")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textSecondary)
-                    Spacer()
-                    Button {
-                        draft.inputPath = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                    }
-                    .buttonStyle(.plain)
-                    .help("Remove attachment")
-                    .accessibilityLabel("Remove attachment")
-                }
-                .padding(.horizontal, 14)
-            }
-
-            HStack(spacing: 12) {
-                Button(action: onAttach) {
-                    Image(systemName: mode.requiresAttachment ? "paperclip.circle.fill" : "paperclip")
-                        .font(.system(size: 18, weight: .semibold))
-                        .frame(width: 34, height: 34)
-                }
-                .buttonStyle(.plain)
-                .disabled(mode.acceptedTypes.isEmpty)
-                .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
-                .accessibilityLabel(mode.requiresAttachment ? "Attach required input" : "Attach reference")
-
-                if mode.acceptedTypes.contains(.image) {
-                    Button(action: onPaste) {
-                        Image(systemName: "doc.on.clipboard")
-                            .font(.system(size: 16, weight: .semibold))
-                            .frame(width: 34, height: 34)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Paste image from clipboard")
-                    .accessibilityLabel("Paste image from clipboard")
-                }
-
-                if mode == .listen {
-                    Text(mode.promptPlaceholder)
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundStyle(MereRunTheme.textMuted)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    TextField(mode.promptPlaceholder, text: $draft.prompt, axis: .vertical)
-                        .textFieldStyle(.plain)
-                        .font(.system(size: 15, weight: .medium))
-                        .lineLimit(1...4)
-                        .onSubmit(onRun)
-                }
-
-                Button {
-                    showOptions = true
-                } label: {
-                    Image(systemName: "slider.horizontal.3")
-                        .frame(width: 34, height: 34)
-                }
-                .buttonStyle(.plain)
-                .help("Options")
-                .accessibilityLabel("Options")
-
-                if isRunning {
-                    Button(action: onStop) {
-                        Image(systemName: "stop.fill")
-                            .font(.system(size: 12, weight: .bold))
-                            .foregroundStyle(MereRunTheme.red)
-                            .frame(width: 34, height: 34)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Stop current run")
-                    .accessibilityLabel("Stop current run")
-                }
-
-                Button {
-                    onRun()
-                } label: {
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(MereRunTheme.background)
-                        .frame(width: 38, height: 38)
-                        .background {
-                            Circle()
-                                .fill(runButtonColor)
-                    }
-                }
-                .buttonStyle(.plain)
-                .disabled(readiness.blocksRun || sendBlocked)
-                .help(sendBlocked ? "Waiting for the current reply…" : runButtonHelp)
-                .accessibilityLabel(isRunning ? "Queue run" : "Run")
-                .accessibilityHint(accessibilityRunHint)
-                .keyboardShortcut(.return, modifiers: .command)
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .background {
-                RoundedRectangle(cornerRadius: 20)
-                    .fill(MereRunTheme.surfaceRaised)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 20)
-                            .strokeBorder(MereRunTheme.border.opacity(0.75), lineWidth: 1)
-                    }
-                    .mereShadow(radius: 20, y: 10)
-            }
-        }
-    }
-
-    private var runButtonColor: Color {
-        if readiness.blocksRun { return MereRunTheme.yellow }
-        return MereRunTheme.accent
-    }
-
-    private var runButtonHelp: String {
-        if readiness.blocksRun { return readiness.message }
-        if isRunning {
-            let queueLabel = queuedCount == 0 ? "Queue run" : "Queue run (\(queuedCount) waiting)"
-            return queueLabel
-        }
-        return "Run"
-    }
-
-    /// Spoken explanation of why Run is disabled, so the blocked state is not color-only.
-    private var accessibilityRunHint: String {
-        if sendBlocked { return "Waiting for the current reply to finish" }
-        if readiness.blocksRun { return readiness.message }
-        return ""
-    }
-}
-
-private struct StudioWelcomeSheet: View {
-    let resolvedCLI: String
-    let onBrowseModels: () -> Void
-    let onDone: () -> Void
-
-    private let highlights: [(String, String, String)] = [
-        ("photo", "Create locally", "Images, video, music, sound effects, and speech — all on-device."),
-        ("bubble.left.and.bubble.right", "Chat & code", "Run local language models for chat, code, OCR, and vision."),
-        ("lock.shield", "Private by default", "Nothing leaves your Mac. The app drives the public mere.run CLI underneath.")
-    ]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Welcome to mere.run")
-                    .font(.system(size: 26, weight: .bold))
-                Text("Create anything. Locally.")
-                    .font(MereRunTheme.bodyFont)
-                    .foregroundStyle(MereRunTheme.textSecondary)
-            }
-
-            VStack(alignment: .leading, spacing: 14) {
-                ForEach(Array(highlights.enumerated()), id: \.offset) { _, item in
-                    HStack(alignment: .top, spacing: 12) {
-                        Image(systemName: item.0)
-                            .font(.system(size: 18, weight: .semibold))
-                            .foregroundStyle(MereRunTheme.accent)
-                            .frame(width: 28)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(item.1)
-                                .font(.system(size: 14, weight: .semibold))
-                            Text(item.2)
-                                .font(MereRunTheme.captionFont)
-                                .foregroundStyle(MereRunTheme.textMuted)
-                        }
-                    }
-                }
-            }
-
-            HStack(spacing: 8) {
-                Image(systemName: "terminal")
-                    .foregroundStyle(MereRunTheme.accent)
-                Text(resolvedCLI)
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .lineLimit(1)
-            }
-            .padding(10)
-            .merePanel()
-
-            Text("First, download a model for the mode you want. Models open the catalog where you can pull and manage local models.")
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textMuted)
-
-            HStack(spacing: 10) {
-                Button {
-                    onBrowseModels()
-                } label: {
-                    Label("Browse models", systemImage: "shippingbox")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(MereRunTheme.accent)
-
-                Button("Get started") {
-                    onDone()
-                }
-                .buttonStyle(.bordered)
-                .keyboardShortcut(.defaultAction)
-            }
-        }
-        .padding(28)
-        .frame(width: 460)
-        .background(MereRunTheme.background)
-        .foregroundStyle(MereRunTheme.textPrimary)
-    }
-}
-
-private struct StudioOptionsSheet: View {
-    let mode: StudioMode
-    @Binding var draft: StudioDraft
-    @EnvironmentObject private var controller: MereRunController
-    @Environment(\.dismiss) private var dismiss
-    @State private var voiceProfiles: [StudioVoiceProfile] = []
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            HStack {
-                Text("\(mode.title) Options")
-                    .font(MereRunTheme.titleFont)
-                Spacer()
-                Button("Done") {
-                    dismiss()
-                }
-                .keyboardShortcut(.defaultAction)
-            }
-
-            if mode == .readImage {
-                Picker("Task", selection: $draft.readImageAction) {
-                    ForEach(StudioReadImageAction.allCases) { action in
-                        Text(action.title)
-                            .foregroundStyle(readImageActionUnavailableMessage(action) == nil
-                                ? MereRunTheme.textPrimary
-                                : MereRunTheme.textMuted)
-                            .tag(action)
-                            .disabled(readImageActionUnavailableMessage(action) != nil)
-                            .help(readImageActionUnavailableMessage(action) ?? action.title)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
-
-            if secondaryLabel != nil {
-                TextField(secondaryLabel!, text: $draft.secondaryText, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .padding(10)
-                    .merePanel()
-            }
-
-            TextField("Model", text: $draft.model)
-                .textFieldStyle(.plain)
-                .padding(10)
-                .merePanel()
-
-            if mode == .speak {
-                Picker("Voice", selection: $draft.voiceMode) {
-                    Text("Style").tag("style")
-                    Text("Clone").tag("clone")
-                }
-                .pickerStyle(.segmented)
-
-                if draft.voiceMode == "clone" {
-                    Picker("Profile", selection: $draft.voiceProfile) {
-                        Text("None").tag("")
-                        ForEach(voiceProfiles) { profile in
-                            Text(profile.name).tag(profile.id)
-                        }
-                    }
-                    HStack(spacing: 10) {
-                        Text(draft.refAudioPath.isEmpty
-                            ? "No reference audio"
-                            : URL(fileURLWithPath: draft.refAudioPath).lastPathComponent)
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                            .lineLimit(1)
-                        Spacer()
-                        Button("Reference audio…") { chooseReferenceAudio() }
-                    }
-                    TextField("Save as profile (optional)", text: $draft.saveProfileName)
-                        .textFieldStyle(.plain)
-                        .padding(10)
-                        .merePanel()
-                }
-            }
-
-            if [.createImage, .video].contains(mode) {
-                HStack(spacing: 10) {
-                    Stepper("Width \(draft.width)", value: $draft.width, in: 64...4096, step: 64)
-                    Stepper("Height \(draft.height)", value: $draft.height, in: 64...4096, step: 64)
-                }
-            }
-
-            if [.createImage, .music, .sfx].contains(mode) {
-                Stepper("Steps \(draft.steps)", value: $draft.steps, in: 1...80, step: 1)
-            }
-
-            if [.music, .sfx].contains(mode) {
-                TextField("Duration seconds", value: $draft.durationSeconds, format: .number)
-                    .textFieldStyle(.plain)
-                    .padding(10)
-                    .merePanel()
-            }
-
-            if [.createImage, .music, .video, .sfx].contains(mode) {
-                TextField("Seed", text: $draft.seed)
-                    .textFieldStyle(.plain)
-                    .padding(10)
-                    .merePanel()
-            }
-
-            if !StudioOptionSchema.fields(for: mode).isEmpty {
-                Divider().overlay(MereRunTheme.border.opacity(0.4))
-                ForEach(StudioOptionSchema.fields(for: mode)) { field in
-                    optionRow(field)
-                }
-            }
-
-            Spacer()
-        }
-        .padding(22)
-        .background(MereRunTheme.background)
-        .foregroundStyle(MereRunTheme.textPrimary)
-        .task {
-            if mode == .speak { voiceProfiles = await controller.loadVoiceProfiles() }
-        }
-    }
-
-    /// Renders one schema field as the appropriate control, bound through the draft key path.
-    @ViewBuilder
-    private func optionRow(_ field: StudioOptionField) -> some View {
-        switch field.control {
-        case let .int(keyPath, range, step):
-            Stepper("\(field.label): \(draft[keyPath: keyPath])", value: binding(keyPath), in: range, step: step)
-        case let .double(keyPath):
-            HStack {
-                Text(field.label)
-                Spacer()
-                TextField(field.label, value: binding(keyPath), format: .number)
-                    .textFieldStyle(.plain)
-                    .frame(width: 90)
-                    .padding(8)
-                    .merePanel()
-            }
-        case let .bool(keyPath):
-            Toggle(field.label, isOn: binding(keyPath))
-        case let .text(keyPath, placeholder):
-            HStack {
-                Text(field.label)
-                Spacer()
-                TextField(placeholder, text: binding(keyPath))
-                    .textFieldStyle(.plain)
-                    .frame(width: 170)
-                    .padding(8)
-                    .merePanel()
-            }
-        }
-    }
-
-    private func binding<Value>(_ keyPath: WritableKeyPath<StudioDraft, Value>) -> Binding<Value> {
-        Binding(get: { draft[keyPath: keyPath] }, set: { draft[keyPath: keyPath] = $0 })
-    }
-
-    private func chooseReferenceAudio() {
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.audio]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        if panel.runModal() == .OK, let url = panel.url {
-            draft.refAudioPath = url.path
-        }
-    }
-
-    private func readImageActionUnavailableMessage(_ action: StudioReadImageAction) -> String? {
-        guard mode == .readImage else { return nil }
-        var candidateDraft = draft
-        candidateDraft.readImageAction = action
-        let requirement = StudioCommandAdapter.capabilityRequirement(
-            for: .readImage,
-            draft: candidateDraft
-        )
-
-        switch requirement {
-        case .unavailable(let message):
-            return message
-        case .managedModel(let modelID):
-            return controller.modelCapabilitiesByID[modelID]?.unavailableMessage
-        case nil:
-            return nil
-        }
-    }
-
-    private var secondaryLabel: String? {
-        switch mode {
-        case .createImage: return "Negative prompt"
-        case .chat, .code: return "System"
-        case .speak: return "Voice"
-        case .music: return "Lyrics"
-        default: return nil
-        }
-    }
-}
-
-private struct StudioLibraryPanel: View {
-    let items: [StudioLibraryItem]
-    @Binding var selectedID: UUID?
-    @Binding var isVisible: Bool
-    let onDelete: (UUID) -> Void
-    let onRename: (UUID, String) -> Void
-    let onQuickLook: (URL) -> Void
-
-    @State private var searchText = ""
-    @State private var renamingID: UUID?
-    @State private var renameText = ""
-
-    private var filteredItems: [StudioLibraryItem] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return items }
-        return items.filter { item in
-            item.displayTitle.lowercased().contains(query)
-                || item.mode.title.lowercased().contains(query)
-                || item.prompt.lowercased().contains(query)
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            header
-
-            Divider()
-                .overlay(MereRunTheme.border.opacity(0.55))
-
-            searchField
-
-            if filteredItems.isEmpty {
-                emptyState
-            } else {
-                list
-            }
-        }
-        .background(MereRunTheme.background)
-        .alert("Rename run", isPresented: renameBinding) {
-            TextField("Name", text: $renameText)
-            Button("Save") {
-                if let renamingID { onRename(renamingID, renameText) }
-                renamingID = nil
-            }
-            Button("Cancel", role: .cancel) { renamingID = nil }
-        }
-    }
-
-    private var renameBinding: Binding<Bool> {
-        Binding(get: { renamingID != nil }, set: { if !$0 { renamingID = nil } })
-    }
-
-    private var header: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 3) {
-                Text("Library")
-                    .font(.system(size: 20, weight: .semibold))
-                Text("\(items.count) local runs")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-            }
-            Spacer()
-            Button {
-                withAnimation(.easeOut(duration: 0.18)) {
-                    isVisible = false
-                }
-            } label: {
-                Image(systemName: "xmark")
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Hide library")
-        }
-        .padding(18)
-    }
-
-    private var searchField: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(MereRunTheme.textMuted)
-            TextField("Search runs", text: $searchText)
-                .textFieldStyle(.plain)
-                .font(MereRunTheme.bodyFont)
-            if !searchText.isEmpty {
-                Button {
-                    searchText = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(MereRunTheme.textMuted)
-                .accessibilityLabel("Clear search")
-            }
-        }
-        .padding(10)
-        .merePanel()
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-    }
-
-    private var emptyState: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "rectangle.stack")
-                .font(.system(size: 30, weight: .semibold))
-                .foregroundStyle(MereRunTheme.textMuted)
-            Text(items.isEmpty ? "Runs you create will land here." : "No matching runs.")
-                .font(MereRunTheme.bodyFont)
-                .foregroundStyle(MereRunTheme.textMuted)
-                .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(22)
-    }
-
-    private var list: some View {
-        ScrollView {
-            LazyVStack(spacing: 8) {
-                ForEach(filteredItems) { item in
-                    StudioLibraryRow(
-                        item: item,
-                        isSelected: selectedID == item.id
-                    ) {
-                        selectedID = item.id
-                    }
-                    .contextMenu {
-                        if let url = item.outputURL {
-                            Button("Quick Look") { onQuickLook(url) }
-                        }
-                        Button("Rename") {
-                            renameText = item.displayTitle
-                            renamingID = item.id
-                        }
-                        Button("Delete", role: .destructive) {
-                            onDelete(item.id)
-                        }
-                    }
-                }
-            }
-            .padding(12)
-        }
-        .focusable()
-        // Finder-style: space previews the selected run's output (ignored when it has none, so it
-        // never swallows the key destructively).
-        .onKeyPress(.space) {
-            guard let id = selectedID,
-                  let url = items.first(where: { $0.id == id })?.outputURL else { return .ignored }
-            onQuickLook(url)
-            return .handled
-        }
-    }
-}
-
-private struct StudioLibraryRow: View {
-    let item: StudioLibraryItem
-    let isSelected: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                thumbnail
-                    .frame(width: 46, height: 38)
-                    .background(MereRunTheme.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: 7))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(item.displayTitle)
-                        .font(.system(size: 12, weight: .semibold))
-                        .lineLimit(1)
-                    Text("\(item.mode.title) · \(item.status.rawValue)")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                }
-                Spacer()
-            }
-            .padding(9)
-            .background {
-                RoundedRectangle(cornerRadius: 9)
-                    .fill(isSelected ? MereRunTheme.surfaceRaised : Color.clear)
-            }
-        }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(item.mode.title), \(item.status.rawValue), \(item.displayTitle)")
-        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
-    }
-
-    @ViewBuilder
-    private var thumbnail: some View {
-        if let url = item.outputURL, StudioOutputFileKind.classify(url) == .image {
-            StudioAsyncImagePreview(
-                url: url,
-                maxPixelSize: 160,
-                contentMode: .fill,
-                fallbackSystemImage: item.mode.systemImage
-            )
-        } else {
-            Image(systemName: item.mode.systemImage)
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-        }
-    }
 }
 
 private extension String {

--- a/Sources/MereRunApp/StudioSidebar.swift
+++ b/Sources/MereRunApp/StudioSidebar.swift
@@ -1,0 +1,368 @@
+import AppKit
+import SwiftUI
+
+/// The Studio's primary navigation: grouped modes over the native translucent sidebar
+/// material, with the machine status living quietly in the footer. Replaces the old
+/// horizontally scrolling chip rail and the always-on status pill row.
+struct StudioSidebar: View {
+    @Binding var mode: StudioMode
+    let modeCapabilities: [StudioMode: StudioModelCapability]
+    let serverStatus: StudioServerStatus?
+    let resolvedCLI: String
+    let onShowModels: () -> Void
+    let onShowHelp: () -> Void
+
+    @Namespace private var selectionNamespace
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Modes in navigation order, for stable ⌘1…⌘9 shortcuts.
+    private static let orderedModes: [StudioMode] = StudioModeGroup.allCases.flatMap(\.modes)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            brandHeader
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: MereRunTheme.Spacing.lg) {
+                    ForEach(StudioModeGroup.allCases) { group in
+                        section(group)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.top, 2)
+                .padding(.bottom, MereRunTheme.Spacing.md)
+            }
+
+            footer
+        }
+        .frame(width: 212)
+        .background {
+            VisualEffectBackground(material: .sidebar, blendingMode: .behindWindow)
+                .ignoresSafeArea()
+        }
+    }
+
+    // Sits below the traffic lights; the serif wordmark is the only branding the shell carries.
+    private var brandHeader: some View {
+        Text("mere.run")
+            .font(.system(size: 16, weight: .semibold, design: .serif))
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .padding(.leading, 20)
+            .padding(.top, 44)
+            .padding(.bottom, MereRunTheme.Spacing.md)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private func section(_ group: StudioModeGroup) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(group.rawValue.uppercased())
+                .font(.system(size: 10.5, weight: .semibold))
+                .kerning(0.7)
+                .foregroundStyle(MereRunTheme.textMuted)
+                .padding(.leading, 10)
+                .padding(.bottom, 3)
+                .accessibilityAddTraits(.isHeader)
+
+            ForEach(group.modes) { candidate in
+                StudioSidebarRow(
+                    mode: candidate,
+                    isSelected: candidate == mode,
+                    unavailableMessage: modeCapabilities[candidate]?.unavailableMessage,
+                    shortcutNumber: Self.orderedModes.firstIndex(of: candidate).flatMap { index in
+                        index < 9 ? index + 1 : nil
+                    },
+                    namespace: selectionNamespace
+                ) {
+                    guard candidate != mode else { return }
+                    if reduceMotion {
+                        mode = candidate
+                    } else {
+                        withAnimation(MereRunTheme.Motion.spring) { mode = candidate }
+                    }
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.xs) {
+            StudioStatusCluster(
+                serverStatus: serverStatus,
+                resolvedCLI: resolvedCLI,
+                onShowModels: onShowModels
+            )
+
+            HStack(spacing: 8) {
+                Button(action: onShowModels) {
+                    Label("Models", systemImage: "shippingbox")
+                        .font(MereRunTheme.captionFont)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Browse and manage local models (⇧⌘M)")
+
+                Button(action: onShowHelp) {
+                    Label("Guide", systemImage: "questionmark.circle")
+                        .font(MereRunTheme.captionFont)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Open the offline guide")
+            }
+        }
+        .padding(MereRunTheme.Spacing.sm)
+    }
+}
+
+/// One mode row. Selection is a bronze pill that slides between rows; hover is a soft fill.
+private struct StudioSidebarRow: View {
+    let mode: StudioMode
+    let isSelected: Bool
+    let unavailableMessage: String?
+    let shortcutNumber: Int?
+    let namespace: Namespace.ID
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 9) {
+                Image(systemName: mode.systemImage)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .frame(width: 19)
+                Text(mode.title)
+                    .font(.system(size: 13, weight: isSelected ? .semibold : .medium))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(foregroundColor)
+            .padding(.horizontal, 10)
+            .frame(height: 30)
+            .background {
+                ZStack {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                            .fill(MereRunTheme.accent)
+                            .matchedGeometryEffect(id: "studio.sidebar.selection", in: namespace)
+                    } else if hovering && unavailableMessage == nil {
+                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                            .fill(MereRunTheme.hoverFill)
+                    }
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.md))
+        }
+        .buttonStyle(.plain)
+        .disabled(unavailableMessage != nil)
+        .opacity(unavailableMessage == nil ? 1 : 0.45)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .help(helpText)
+        .modifier(StudioModeShortcut(number: shortcutNumber))
+        .accessibilityLabel(mode.title)
+        .accessibilityHint(unavailableMessage ?? mode.subtitle)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var foregroundColor: Color {
+        if unavailableMessage != nil { return MereRunTheme.textMuted }
+        return isSelected ? MereRunTheme.background : MereRunTheme.textSecondary
+    }
+
+    private var helpText: String {
+        if let unavailableMessage { return unavailableMessage }
+        if let shortcutNumber { return "\(mode.subtitle) (⌘\(shortcutNumber))" }
+        return mode.subtitle
+    }
+}
+
+/// Applies ⌘1…⌘9 to the first nine modes without duplicating the row body per branch.
+private struct StudioModeShortcut: ViewModifier {
+    let number: Int?
+
+    func body(content: Content) -> some View {
+        if let number, let key = "\(number)".first {
+            content.keyboardShortcut(KeyEquivalent(key), modifiers: .command)
+        } else {
+            content
+        }
+    }
+}
+
+/// One quiet line for machine state — dot, word, count — with the full story in a popover.
+private struct StudioStatusCluster: View {
+    let serverStatus: StudioServerStatus?
+    let resolvedCLI: String
+    let onShowModels: () -> Void
+
+    @State private var showDetails = false
+    @State private var hovering = false
+
+    var body: some View {
+        Button {
+            showDetails.toggle()
+        } label: {
+            HStack(spacing: 7) {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 7, height: 7)
+                Text(summary)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 30)
+            .background {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.base)
+                    .fill(hovering ? MereRunTheme.hoverFill : MereRunTheme.surface.opacity(0.4))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.base)
+                            .strokeBorder(MereRunTheme.border.opacity(0.5), lineWidth: 1)
+                    }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.base))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .popover(isPresented: $showDetails, arrowEdge: .top) {
+            StudioStatusDetails(
+                serverStatus: serverStatus,
+                resolvedCLI: resolvedCLI,
+                onShowModels: {
+                    showDetails = false
+                    onShowModels()
+                }
+            )
+        }
+        .accessibilityLabel("Machine status")
+        .accessibilityValue(summary)
+        .accessibilityHint("Shows local server, models, and CLI details")
+    }
+
+    private var summary: String {
+        guard let serverStatus else { return "Checking status…" }
+        if serverStatus.isReachable {
+            return serverStatus.loadedModelSummary.map { "Server up · \($0)" } ?? "Server up"
+        }
+        let count = serverStatus.installedCount
+        return count == 1 ? "1 model local" : "\(count) models local"
+    }
+
+    private var dotColor: Color {
+        guard let serverStatus else { return MereRunTheme.textMuted }
+        return serverStatus.isReachable ? MereRunTheme.green : MereRunTheme.textMuted.opacity(0.7)
+    }
+}
+
+private struct StudioStatusDetails: View {
+    let serverStatus: StudioServerStatus?
+    let resolvedCLI: String
+    let onShowModels: () -> Void
+
+    @State private var copiedCLI = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.md) {
+            detailRow(
+                icon: "bolt.horizontal.circle",
+                title: "Local server",
+                value: serverValue,
+                valueColor: serverStatus?.isReachable == true ? MereRunTheme.green : MereRunTheme.textSecondary
+            )
+
+            HStack(alignment: .firstTextBaseline) {
+                detailRow(
+                    icon: "shippingbox",
+                    title: "Models",
+                    value: modelsValue,
+                    valueColor: MereRunTheme.textSecondary
+                )
+                Spacer(minLength: 12)
+                Button("Browse…", action: onShowModels)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 7) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.accent)
+                        .frame(width: 16)
+                    Text("CLI")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    Spacer(minLength: 12)
+                    Button {
+                        copyCLI()
+                    } label: {
+                        Image(systemName: copiedCLI ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 10, weight: .semibold))
+                            .padding(3)
+                    }
+                    .buttonStyle(.mereIcon)
+                    .help("Copy CLI path")
+                    .accessibilityLabel("Copy CLI path")
+                }
+                Text(resolvedCLI)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .textSelection(.enabled)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+            }
+        }
+        .padding(MereRunTheme.Spacing.lg)
+        .frame(width: 320)
+    }
+
+    private var serverValue: String {
+        guard let serverStatus else { return "Checking…" }
+        if serverStatus.isReachable {
+            return serverStatus.loadedModelSummary.map { "Up · \($0)" } ?? "Up"
+        }
+        return "Not running — starts on demand"
+    }
+
+    private var modelsValue: String {
+        guard let serverStatus else { return "—" }
+        return "\(serverStatus.installedCount) installed"
+    }
+
+    private func detailRow(icon: String, title: String, value: String, valueColor: Color) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 7) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+                    .frame(width: 16)
+                Text(title)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            Text(value)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(valueColor)
+                .lineLimit(2)
+        }
+    }
+
+    private func copyCLI() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(resolvedCLI, forType: .string)
+        copiedCLI = true
+        Task {
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            copiedCLI = false
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -164,6 +164,88 @@ enum StudioMode: String, CaseIterable, Codable, Identifiable {
         case .sfx: return "Describe a sound effect and render a WAV."
         }
     }
+
+    /// One-click starters shown on the empty canvas. They fill the composer, never auto-run.
+    /// Attachment-first modes keep prompts short (they name the subject, not the scene).
+    var examplePrompts: [String] {
+        switch self {
+        case .createImage:
+            return [
+                "A lighthouse at dusk, gouache on rough paper",
+                "Brass mechanical keyboard, studio product shot",
+                "Isometric cutaway of a tiny bakery, morning light"
+            ]
+        case .chat:
+            return [
+                "Explain how attention works in a transformer, briefly",
+                "Draft a friendly reply declining a meeting",
+                "What can I cook with mushrooms, eggs, and spinach?"
+            ]
+        case .code:
+            return [
+                "A Swift function that debounces async work",
+                "A zsh script that renames photos by EXIF date",
+                "A tiny Python HTTP server that logs request headers"
+            ]
+        case .speak:
+            return [
+                "Welcome aboard. Let's make something worth keeping.",
+                "The forecast calls for slow mornings and warm coffee.",
+                "Three… two… one… liftoff."
+            ]
+        case .listen:
+            return []
+        case .readImage:
+            return [
+                "Describe this scene in one paragraph",
+                "What's written on the receipt?",
+                "List every object on the desk"
+            ]
+        case .findObjects:
+            return ["the red bicycle", "every coffee cup", "the person wearing a hat"]
+        case .segment:
+            return ["the foreground subject", "the dog", "the nearest car"]
+        case .track:
+            return ["the skateboarder", "the white van", "the ball"]
+        case .music:
+            return [
+                "Slow-burn synthwave with a hopeful bridge",
+                "Acoustic folk waltz, brushed drums, dusty piano",
+                "90s boom-bap beat over upright bass"
+            ]
+        case .video:
+            return [
+                "Steam rising from a street-food stall at night",
+                "A paper boat drifting down a rain gutter, macro",
+                "Slow dolly through a sunlit greenhouse"
+            ]
+        case .sfx:
+            return [
+                "Heavy wooden door creaking open",
+                "Retro arcade power-up",
+                "Distant thunder rolling over hills"
+            ]
+        }
+    }
+}
+
+/// Sidebar sections. Order here is the navigation order.
+enum StudioModeGroup: String, CaseIterable, Identifiable {
+    case create = "Create"
+    case converse = "Converse"
+    case voice = "Voice"
+    case vision = "Vision"
+
+    var id: String { rawValue }
+
+    var modes: [StudioMode] {
+        switch self {
+        case .create: return [.createImage, .video, .music, .sfx]
+        case .converse: return [.chat, .code]
+        case .voice: return [.speak, .listen]
+        case .vision: return [.readImage, .findObjects, .segment, .track]
+        }
+    }
 }
 
 enum StudioReadImageAction: String, CaseIterable, Codable, Identifiable {

--- a/Sources/MereRunApp/StudioWaveform.swift
+++ b/Sources/MereRunApp/StudioWaveform.swift
@@ -1,0 +1,114 @@
+import AVFoundation
+import SwiftUI
+
+enum StudioWaveformLoader {
+    /// Downsamples an audio file into `barCount` peak amplitudes normalized to 0…1.
+    /// Long files are sampled sparsely (peaks are visual, not analytic), so cost stays bounded.
+    /// Returns nil when the file can't be decoded to float PCM — callers fall back to a slider.
+    static func peaks(url: URL, barCount: Int = 96) -> [Float]? {
+        guard barCount > 0, let file = try? AVAudioFile(forReading: url) else { return nil }
+        let totalFrames = Int(file.length)
+        guard totalFrames > 0 else { return nil }
+
+        let format = file.processingFormat
+        let channelCount = Int(format.channelCount)
+        guard channelCount > 0 else { return nil }
+
+        let framesPerBar = max(1, totalFrames / barCount)
+        // Cap the per-bar sampling work; visually indistinguishable from exhaustive peaks.
+        let sampleStride = max(1, framesPerBar / 128)
+        var peaks = [Float](repeating: 0, count: barCount)
+
+        let chunkCapacity: AVAudioFrameCount = 65_536
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkCapacity) else {
+            return nil
+        }
+
+        var frameOffset = 0
+        while frameOffset < totalFrames {
+            buffer.frameLength = 0
+            do {
+                try file.read(into: buffer)
+            } catch {
+                break
+            }
+            let frames = Int(buffer.frameLength)
+            guard frames > 0, let channels = buffer.floatChannelData else { break }
+
+            for frame in stride(from: 0, to: frames, by: sampleStride) {
+                var amplitude: Float = 0
+                for channel in 0..<channelCount {
+                    amplitude = max(amplitude, abs(channels[channel][frame]))
+                }
+                let bar = min(barCount - 1, (frameOffset + frame) / framesPerBar)
+                peaks[bar] = max(peaks[bar], amplitude)
+            }
+            frameOffset += frames
+        }
+
+        guard let maxPeak = peaks.max(), maxPeak > 0 else { return peaks }
+        return peaks.map { $0 / maxPeak }
+    }
+}
+
+/// The audio identity element: peak bars around a center line, played bars in accent,
+/// click or drag anywhere to seek.
+struct StudioWaveformView: View {
+    let peaks: [Float]
+    /// Played fraction, 0…1.
+    let progress: Double
+    var onSeek: ((Double) -> Void)?
+
+    var body: some View {
+        GeometryReader { proxy in
+            Canvas { context, size in
+                guard !peaks.isEmpty else { return }
+                let count = peaks.count
+                let slot = size.width / CGFloat(count)
+                let barWidth = max(1.5, slot * 0.6)
+                let playedBoundary = progress * Double(count)
+
+                for index in 0..<count {
+                    let amplitude = CGFloat(peaks[index])
+                    let height = max(2.5, amplitude * size.height * 0.92)
+                    let rect = CGRect(
+                        x: CGFloat(index) * slot + (slot - barWidth) / 2,
+                        y: (size.height - height) / 2,
+                        width: barWidth,
+                        height: height
+                    )
+                    let played = Double(index) + 0.5 <= playedBoundary
+                    let color = played
+                        ? MereRunTheme.accent
+                        : MereRunTheme.textMuted.opacity(0.35)
+                    context.fill(
+                        Path(roundedRect: rect, cornerRadius: barWidth / 2),
+                        with: .color(color)
+                    )
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in seek(at: value.location.x, width: proxy.size.width) }
+                    .onEnded { value in seek(at: value.location.x, width: proxy.size.width) }
+            )
+        }
+        .accessibilityElement()
+        .accessibilityLabel("Waveform")
+        .accessibilityValue("\(Int((progress * 100).rounded())) percent played")
+        .accessibilityAdjustableAction { direction in
+            let step = 0.05
+            switch direction {
+            case .increment: onSeek?(min(1, progress + step))
+            case .decrement: onSeek?(max(0, progress - step))
+            @unknown default: break
+            }
+        }
+    }
+
+    private func seek(at locationX: CGFloat, width: CGFloat) {
+        guard let onSeek, width > 0 else { return }
+        onSeek(min(1, max(0, locationX / width)))
+    }
+}

--- a/Sources/MereRunApp/StudioWelcome.swift
+++ b/Sources/MereRunApp/StudioWelcome.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// First run: the promise in one serif line, what lives here in three, and the single step
+/// that unlocks everything (pulling a first model) as the primary action.
+struct StudioWelcomeSheet: View {
+    let resolvedCLI: String
+    let onBrowseModels: () -> Void
+    let onDone: () -> Void
+
+    private static let heroModes: [String] = [
+        "photo", "film", "music.note", "waveform", "bubble.left.and.bubble.right", "scope"
+    ]
+
+    private let highlights: [(String, String, String)] = [
+        ("photo", "Create locally", "Images, video, music, sound effects, and speech — all on-device."),
+        ("bubble.left.and.bubble.right", "Chat & code", "Run local language models for chat, code, OCR, and vision."),
+        ("lock.shield", "Private by default", "Nothing leaves your Mac. The app drives the public mere.run CLI underneath.")
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.xl) {
+            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.md) {
+                Text("mere.run")
+                    .font(.system(size: 13, weight: .semibold, design: .serif))
+                    .foregroundStyle(MereRunTheme.textMuted)
+
+                Text("Create anything.\nLocally.")
+                    .font(.system(.largeTitle, design: .serif, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineSpacing(3)
+
+                HStack(spacing: MereRunTheme.Spacing.xs) {
+                    ForEach(Self.heroModes, id: \.self) { symbol in
+                        Image(systemName: symbol)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(MereRunTheme.accent)
+                            .frame(width: 32, height: 32)
+                            .background {
+                                Circle().fill(MereRunTheme.accentSoft.opacity(0.8))
+                            }
+                    }
+                }
+                .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.md) {
+                ForEach(Array(highlights.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .top, spacing: MereRunTheme.Spacing.sm) {
+                        Image(systemName: item.0)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(MereRunTheme.accent)
+                            .frame(width: 24)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.1)
+                                .font(.system(size: 13.5, weight: .semibold))
+                            Text(item.2)
+                                .font(MereRunTheme.captionFont)
+                                .foregroundStyle(MereRunTheme.textMuted)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.xs) {
+                Text("Start by pulling a model for the mode you want — the catalog handles the rest.")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: MereRunTheme.Spacing.sm) {
+                    Button {
+                        onBrowseModels()
+                    } label: {
+                        Label("Browse models", systemImage: "shippingbox")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.merePrimary)
+
+                    Button("Start creating") {
+                        onDone()
+                    }
+                    .buttonStyle(.bordered)
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+
+            HStack(spacing: 7) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+                Text(resolvedCLI)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .padding(MereRunTheme.Spacing.xxl)
+        .frame(width: 460)
+        .background(MereRunTheme.background)
+        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+}

--- a/Tests/MereRunAppTests/StudioMarkdownTests.swift
+++ b/Tests/MereRunAppTests/StudioMarkdownTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import MereRunApp
+
+final class StudioMarkdownTests: XCTestCase {
+    func testParagraphsSplitOnBlankLines() {
+        let blocks = StudioMarkdownParser.parse("First paragraph.\n\nSecond paragraph.")
+        XCTAssertEqual(blocks, [
+            .paragraph("First paragraph."),
+            .paragraph("Second paragraph.")
+        ])
+    }
+
+    func testAdjacentLinesStayInOneParagraph() {
+        let blocks = StudioMarkdownParser.parse("line one\nline two")
+        XCTAssertEqual(blocks, [.paragraph("line one\nline two")])
+    }
+
+    func testHeadingLevels() {
+        let blocks = StudioMarkdownParser.parse("# Title\n\n### Sub")
+        XCTAssertEqual(blocks, [
+            .heading(level: 1, text: "Title"),
+            .heading(level: 3, text: "Sub")
+        ])
+    }
+
+    func testHashWithoutSpaceIsNotAHeading() {
+        let blocks = StudioMarkdownParser.parse("#hashtag")
+        XCTAssertEqual(blocks, [.paragraph("#hashtag")])
+    }
+
+    func testFencedCodeWithLanguage() {
+        let blocks = StudioMarkdownParser.parse("""
+        Before.
+
+        ```swift
+        let x = 1
+        ```
+
+        After.
+        """)
+        XCTAssertEqual(blocks, [
+            .paragraph("Before."),
+            .code(language: "swift", content: "let x = 1"),
+            .paragraph("After.")
+        ])
+    }
+
+    func testUnclosedFenceSwallowsRemainderForStreaming() {
+        let blocks = StudioMarkdownParser.parse("Intro.\n\n```python\nprint(1)\nprint(2)")
+        XCTAssertEqual(blocks, [
+            .paragraph("Intro."),
+            .code(language: "python", content: "print(1)\nprint(2)")
+        ])
+    }
+
+    func testFenceWithoutLanguageHasNilLanguage() {
+        let blocks = StudioMarkdownParser.parse("```\nplain\n```")
+        XCTAssertEqual(blocks, [.code(language: nil, content: "plain")])
+    }
+
+    func testBulletsMergeIntoOneBlock() {
+        let blocks = StudioMarkdownParser.parse("- one\n- two\n* three")
+        XCTAssertEqual(blocks, [.bullets(["one", "two", "three"])])
+    }
+
+    func testNumberedList() {
+        let blocks = StudioMarkdownParser.parse("1. first\n2) second")
+        XCTAssertEqual(blocks, [.numbered(["first", "second"])])
+    }
+
+    func testIndentedContinuationJoinsPreviousBulletItem() {
+        let blocks = StudioMarkdownParser.parse("- a long item\n  that continues")
+        XCTAssertEqual(blocks, [.bullets(["a long item that continues"])])
+    }
+
+    func testQuoteLinesMerge() {
+        let blocks = StudioMarkdownParser.parse("> quoted\n> more")
+        XCTAssertEqual(blocks, [.quote("quoted\nmore")])
+    }
+
+    func testHorizontalRule() {
+        let blocks = StudioMarkdownParser.parse("above\n\n---\n\nbelow")
+        XCTAssertEqual(blocks, [
+            .paragraph("above"),
+            .rule,
+            .paragraph("below")
+        ])
+    }
+
+    func testListFollowedByParagraphFlushesCleanly() {
+        let blocks = StudioMarkdownParser.parse("- item\nplain text after")
+        XCTAssertEqual(blocks, [
+            .bullets(["item"]),
+            .paragraph("plain text after")
+        ])
+    }
+
+    func testCodeFenceInterruptsParagraphWithoutBlankLine() {
+        let blocks = StudioMarkdownParser.parse("text\n```\ncode\n```")
+        XCTAssertEqual(blocks, [
+            .paragraph("text"),
+            .code(language: nil, content: "code")
+        ])
+    }
+
+    func testInlineFallsBackToPlainText() {
+        // Inline parsing never throws for plain input; the result preserves the characters.
+        let attributed = StudioMarkdownParser.inline("plain **bold** text")
+        XCTAssertTrue(String(attributed.characters).contains("bold"))
+    }
+
+    func testEmptyInputParsesToNoBlocks() {
+        XCTAssertEqual(StudioMarkdownParser.parse(""), [])
+    }
+}

--- a/Tests/MereRunAppTests/StudioWaveformTests.swift
+++ b/Tests/MereRunAppTests/StudioWaveformTests.swift
@@ -1,0 +1,64 @@
+import AVFoundation
+import XCTest
+@testable import MereRunApp
+
+final class StudioWaveformTests: XCTestCase {
+    /// Writes a mono float WAV whose first half is a loud sine and second half is silence,
+    /// then asserts the downsampled peaks mirror that shape after normalization.
+    func testPeaksReflectLoudThenSilentHalves() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("waveform-test-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let sampleRate = 44_100.0
+        let frames: AVAudioFrameCount = 8_820
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1))
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames))
+        let channel = try XCTUnwrap(buffer.floatChannelData)[0]
+        for frame in 0..<Int(frames) {
+            if frame < Int(frames) / 2 {
+                channel[frame] = 0.9 * sin(2 * .pi * 440 * Float(frame) / Float(sampleRate))
+            } else {
+                channel[frame] = 0
+            }
+        }
+        buffer.frameLength = frames
+        try file.write(from: buffer)
+        // Finalize the WAV header; without closing, the file reads back as empty.
+        file.close()
+
+        let barCount = 10
+        let peaks = try XCTUnwrap(StudioWaveformLoader.peaks(url: url, barCount: barCount))
+
+        XCTAssertEqual(peaks.count, barCount)
+        XCTAssertEqual(peaks.max(), 1.0)
+        for bar in 0..<4 {
+            XCTAssertGreaterThan(peaks[bar], 0.7, "bar \(bar) should carry the sine")
+        }
+        for bar in 6..<barCount {
+            XCTAssertLessThan(peaks[bar], 0.05, "bar \(bar) should be silence")
+        }
+    }
+
+    func testPeaksReturnsNilForMissingFile() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).wav")
+        XCTAssertNil(StudioWaveformLoader.peaks(url: url))
+    }
+
+    func testPeaksRejectsZeroBarCount() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("waveform-zero-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1))
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 441))
+        buffer.frameLength = 441
+        try file.write(from: buffer)
+        file.close()
+
+        XCTAssertNil(StudioWaveformLoader.peaks(url: url, barCount: 0))
+    }
+}


### PR DESCRIPTION
## Summary
- split the Studio surface into focused SwiftUI components for canvas, composer, sidebar, library, markdown, welcome, and waveform views
- refresh Studio theme/control affordances, model management, media preview, and conversation presentation
- add Studio markdown and waveform tests plus product/design notes for the macOS app surface

## Validation
- `./scripts/check.sh` from clean worktree `/tmp/mere-run-studio-verify`