### PR TITLE
Document image LoRA reference inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,19 @@ swift run mere.run image train-lora \
   --visualize \
   --quiet
 
+# Apply a Klein LoRA to a reference image.
+swift run mere.run image generate \
+  --model image-klein-9b \
+  --ref-image ./reference-pose.png \
+  --strength 0.55 \
+  --prompt "TRIGGER_TOKEN two dancers in a rainy city street, natural human anatomy, no extra limbs" \
+  --lora ./style-adapter.safetensors \
+  --lora-scale 1.5 \
+  --width 1024 --height 768 \
+  --steps 16 \
+  --seed 525252 \
+  --output ./style-reference.png
+
 # Reopen the local run dashboard later from the run directory.
 swift run mere.run image visualize-run .
 

--- a/Sources/MereRunCLI/Guides/image-generate.md
+++ b/Sources/MereRunCLI/Guides/image-generate.md
@@ -115,6 +115,37 @@ mere.run image generate \
   --output ./knight.png
 ```
 
+## Klein LoRA Reference Inference
+
+Use `--ref-image` when applying a Klein LoRA to a source composition. This is
+the preferred path for repeatable Klein reference conditioning; `--input` is
+accepted as a single-reference shorthand, but `--ref-image` keeps the recipe
+clear and works with multiple references.
+
+Good starting settings for a style LoRA are `--strength 0.55`,
+`--lora-scale 1.5`, 1024x768 output, 16 steps, and a locked seed once the pose
+is close. Put the trigger token first, then describe the subject, action,
+relationship, and style. For limb-heavy reference poses, state the expected
+body layout explicitly.
+
+```bash
+mere.run image generate \
+  --model image-klein-9b \
+  --ref-image ./reference-pose.png \
+  --strength 0.55 \
+  --prompt "TRIGGER_TOKEN two dancers in a rainy city street, full body pose, natural human anatomy, no extra limbs, clean cinematic film still, crisp faces, reflective pavement" \
+  --lora ./style-adapter.safetensors \
+  --lora-scale 1.5 \
+  --width 1024 --height 768 \
+  --steps 16 \
+  --seed 525252 \
+  --output ./style-reference.png
+```
+
+If edges look crunchy in a showcase render, render the same seed at a larger
+matching aspect ratio, such as 1280x960 with 24 steps, then downsample to the
+delivery size with a high-quality image resizer.
+
 ## Iteration Tips
 
 - Lock `--seed` once composition is close, then change one parameter at a time.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -285,6 +285,18 @@ swift run mere.run image generate \
   --prompt "a trading card character with the same sticker layout" \
   --ref-image ./card-reference.png \
   --output ./card.png
+
+swift run mere.run image generate \
+  --model image-klein-9b \
+  --ref-image ./reference-pose.png \
+  --strength 0.55 \
+  --prompt "TRIGGER_TOKEN two dancers in a rainy city street, natural human anatomy, no extra limbs" \
+  --lora ./style-adapter.safetensors \
+  --lora-scale 1.5 \
+  --width 1024 --height 768 \
+  --steps 16 \
+  --seed 525252 \
+  --output ./style-reference.png
 ```
 
 ### `mere.run image train-lora`

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -84,6 +84,31 @@ swift run mere.run image generate \
   --output ./style-klein.png
 ```
 
+For reference-guided Klein LoRA inference, run the adapter on the distilled
+Klein model and pass the source composition with `--ref-image`. A practical
+starting point for style transfer is `--strength 0.55`, `--lora-scale 1.5`,
+1024x768, 16 steps, and a locked seed once the composition is close. Put the
+trigger token first, then describe the subject/action relationship, visible
+anatomy, and style:
+
+```bash
+swift run mere.run image generate \
+  --model image-klein-9b \
+  --ref-image ./reference-pose.png \
+  --strength 0.55 \
+  --prompt "TRIGGER_TOKEN two dancers in a rainy city street, full body pose, natural human anatomy, no extra limbs, clean cinematic film still, crisp faces, reflective pavement" \
+  --lora ./style-adapter.safetensors \
+  --lora-scale 1.5 \
+  --width 1024 --height 768 \
+  --steps 16 \
+  --seed 525252 \
+  --output ./style-reference.png
+```
+
+For cleaner public-facing exports, keep the seed and prompt fixed, render at a
+larger matching aspect ratio such as 1280x960 with 24 steps, then downsample to
+1024x768 with a high-quality image resizer.
+
 Add `--visualize` during training to start a loopback dashboard with the live
 loss curve, progress events, samples, checkpoints, and run artifacts. Reopen a
 completed or copied run directory later with:


### PR DESCRIPTION
## Summary
- add reference-image LoRA inference examples to README and CLI docs
- document recommended Klein LoRA reference settings and public-safe prompt guidance
- include the same recipe in runtime image docs

## Validation
- `./scripts/check.sh` from clean worktree `/tmp/mere-run-image-docs-verify`