### PR TITLE
Add LoRA training preflight reports

### DIFF
--- a/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
@@ -157,6 +157,12 @@ struct ImageTrainLoRA: AsyncParsableCommand {
     @Option(name: [.customLong("visualize-port")], help: "Loopback port for --visualize.")
     var visualizePort: Int = 8787
 
+    @Flag(name: [.customLong("preflight")], help: "Inspect the LoRA training request without running training.")
+    var preflight: Bool = false
+
+    @Flag(name: [.customLong("json")], help: "Emit a structured preflight JSON report.")
+    var json: Bool = false
+
     @Option(name: [.customLong("lora-target-ranks")], help: "Klein suffix rank map, e.g. .attn.to_q=128,.ff.linear_in=64.")
     var loraTargetRanks: String?
 
@@ -203,9 +209,79 @@ struct ImageTrainLoRA: AsyncParsableCommand {
     var quiet: Bool = false
 
     func run() async throws {
-        try MLXBundleSupport.ensureAvailable(quiet: quiet)
         let resolvedOptions = try resolvedTrainingOptions()
+        try validateResolvedOptions(resolvedOptions)
 
+        if preflight {
+            try runPreflight(options: resolvedOptions)
+            return
+        }
+
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+
+        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
+        guard outputURL.pathExtension.lowercased() == "safetensors" else {
+            throw ValidationError("--output must end in .safetensors")
+        }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let modelRoot = try resolveModelRoot(model: resolvedOptions.model)
+        let modelManifest = try MereRunModelManifest.loadRequired(from: modelRoot)
+        let visualization = try startVisualizationIfNeeded(
+            outputURL: outputURL,
+            modelRoot: modelRoot,
+            modelManifest: modelManifest,
+            options: resolvedOptions
+        )
+        defer { visualization?.stop() }
+
+        do {
+            switch modelManifest.family {
+            case .krea:
+                try await runKreaTraining(
+                    modelRoot: modelRoot,
+                    outputURL: outputURL,
+                    options: resolvedOptions,
+                    eventLogger: visualization?.logger
+                )
+            case .klein:
+                try await runKleinTraining(
+                    modelRoot: modelRoot,
+                    outputURL: outputURL,
+                    options: resolvedOptions,
+                    eventLogger: visualization?.logger
+                )
+            default:
+                let family = modelManifest.family?.rawValue ?? "unknown"
+                throw ValidationError("Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.")
+            }
+            try visualization?.logger.record(
+                type: "run_finished",
+                stage: "finished",
+                step: resolvedOptions.trainingSteps,
+                totalSteps: resolvedOptions.trainingSteps,
+                fraction: 1,
+                path: outputURL.path
+            )
+        } catch {
+            try? visualization?.logger.record(
+                type: "run_failed",
+                stage: "failed",
+                message: error.localizedDescription,
+                path: outputURL.path
+            )
+            throw error
+        }
+
+        if benchmarkSteps == nil {
+            print(outputURL.path)
+        }
+    }
+
+    private func validateResolvedOptions(_ resolvedOptions: ResolvedLoRATrainingOptions) throws {
         guard resolvedOptions.width > 0,
               resolvedOptions.height > 0,
               resolvedOptions.width % 16 == 0,
@@ -302,67 +378,193 @@ struct ImageTrainLoRA: AsyncParsableCommand {
         if let adamWeightDecay, adamWeightDecay < 0 {
             throw ValidationError("--adam-weight-decay must be >= 0")
         }
+    }
 
-        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
-        guard outputURL.pathExtension.lowercased() == "safetensors" else {
-            throw ValidationError("--output must end in .safetensors")
-        }
-        try FileManager.default.createDirectory(
-            at: outputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+    func makePreflightEnvelope(
+        options: ResolvedLoRATrainingOptions,
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init
+    ) -> LoRATrainingPreflightEnvelope {
+        let input = LoRATrainingPreflightInput(
+            data: data,
+            output: output,
+            recipe: recipe,
+            excludePreviewImages: excludePreviewImages,
+            syntheticSamples: syntheticSamples,
+            options: options,
+            trainingArgv: trainingActionArguments(),
+            cwd: fileManager.currentDirectoryPath
         )
+        return LoRATrainingPreflightAnalyzer(
+            input: input,
+            fileManager: fileManager,
+            now: now
+        ).envelope()
+    }
 
-        let modelRoot = try resolveModelRoot(model: resolvedOptions.model)
-        let modelManifest = try MereRunModelManifest.loadRequired(from: modelRoot)
-        let visualization = try startVisualizationIfNeeded(
-            outputURL: outputURL,
-            modelRoot: modelRoot,
-            modelManifest: modelManifest,
-            options: resolvedOptions
-        )
-        defer { visualization?.stop() }
-
-        do {
-            switch modelManifest.family {
-            case .krea:
-                try await runKreaTraining(
-                    modelRoot: modelRoot,
-                    outputURL: outputURL,
-                    options: resolvedOptions,
-                    eventLogger: visualization?.logger
-                )
-            case .klein:
-                try await runKleinTraining(
-                    modelRoot: modelRoot,
-                    outputURL: outputURL,
-                    options: resolvedOptions,
-                    eventLogger: visualization?.logger
-                )
-            default:
-                let family = modelManifest.family?.rawValue ?? "unknown"
-                throw ValidationError("Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.")
+    private func runPreflight(options: ResolvedLoRATrainingOptions) throws {
+        let envelope = makePreflightEnvelope(options: options)
+        if json {
+            print(try StructuredRunOutput.encode(envelope))
+        } else {
+            print(envelope.summary)
+            for diagnostic in envelope.diagnostics {
+                print("[\(diagnostic.severity.rawValue)] \(diagnostic.title): \(diagnostic.message)")
             }
-            try visualization?.logger.record(
-                type: "run_finished",
-                stage: "finished",
-                step: resolvedOptions.trainingSteps,
-                totalSteps: resolvedOptions.trainingSteps,
-                fraction: 1,
-                path: outputURL.path
-            )
-        } catch {
-            try? visualization?.logger.record(
-                type: "run_failed",
-                stage: "failed",
-                message: error.localizedDescription,
-                path: outputURL.path
-            )
-            throw error
         }
+        if envelope.status == .blocked {
+            throw ExitCode.failure
+        }
+    }
 
-        if benchmarkSteps == nil {
-            print(outputURL.path)
+    private func trainingActionArguments() -> [String] {
+        var args = ["mere.run", "image", "train-lora"]
+        if let data {
+            args += ["--data", data]
         }
+        args += ["--output", output]
+        if let model {
+            args += ["--model", model]
+        }
+        if let widthOverride {
+            args += ["--width", String(widthOverride)]
+        }
+        if let heightOverride {
+            args += ["--height", String(heightOverride)]
+        }
+        if let trainingStepsOverride {
+            args += ["--training-steps", String(trainingStepsOverride)]
+        }
+        if batchSize != 1 {
+            args += ["--batch-size", String(batchSize)]
+        }
+        if let learningRateOverride {
+            args += ["--learning-rate", String(learningRateOverride)]
+        }
+        if let rankOverride {
+            args += ["--rank", String(rankOverride)]
+        }
+        if let alphaOverride {
+            args += ["--alpha", String(alphaOverride)]
+        }
+        if maxTextLength != 512 {
+            args += ["--max-text-length", String(maxTextLength)]
+        }
+        if schedulerSteps != 1000 {
+            args += ["--scheduler-steps", String(schedulerSteps)]
+        }
+        if let captionDropoutOverride {
+            args += ["--caption-dropout", String(captionDropoutOverride)]
+        }
+        if seed != 0 {
+            args += ["--seed", String(seed)]
+        }
+        if lite {
+            args.append("--lite")
+        }
+        if excludePreviewImages {
+            args.append("--exclude-preview-images")
+        }
+        if let checkpointInterval {
+            args += ["--checkpoint-interval", String(checkpointInterval)]
+        }
+        if let maxResolution {
+            args += ["--max-resolution", String(maxResolution)]
+        }
+        if progressive {
+            args.append("--progressive")
+        }
+        if lowRam {
+            args.append("--low-ram")
+        }
+        if noCompile {
+            args.append("--no-compile")
+        }
+        if gradientCheckpointing {
+            args.append("--gradient-checkpointing")
+        }
+        if let recipe {
+            args += ["--recipe", recipe]
+        }
+        if let benchmarkSteps {
+            args += ["--benchmark-steps", String(benchmarkSteps)]
+        }
+        if benchmarkWarmupSteps != 5 {
+            args += ["--benchmark-warmup-steps", String(benchmarkWarmupSteps)]
+        }
+        if let sampleInterval {
+            args += ["--sample-interval", String(sampleInterval)]
+        }
+        if let samplePrompt {
+            args += ["--sample-prompt", samplePrompt]
+        }
+        if let sampleModel {
+            args += ["--sample-model", sampleModel]
+        }
+        if sampleSteps != 8 {
+            args += ["--sample-steps", String(sampleSteps)]
+        }
+        if sampleGuidanceScale != 1.0 {
+            args += ["--sample-cfg", String(sampleGuidanceScale)]
+        }
+        if sampleLoRAScale != 1.0 {
+            args += ["--sample-lora-scale", String(sampleLoRAScale)]
+        }
+        if let sampleSeed {
+            args += ["--sample-seed", String(sampleSeed)]
+        }
+        if visualize {
+            args.append("--visualize")
+            if visualizePort != 8787 {
+                args += ["--visualize-port", String(visualizePort)]
+            }
+        }
+        if let loraTargetRanks {
+            args += ["--lora-target-ranks", loraTargetRanks]
+        }
+        if let loraRankPreset {
+            args += ["--lora-rank-preset", loraRankPreset]
+        }
+        if let loraTargetPreset {
+            args += ["--lora-target-preset", loraTargetPreset]
+        }
+        if let loraTargetMode {
+            args += ["--lora-target-mode", loraTargetMode]
+        }
+        if let timestepSampling {
+            args += ["--timestep-sampling", timestepSampling]
+        }
+        if let timestepLossWeighting {
+            args += ["--timestep-loss-weighting", timestepLossWeighting]
+        }
+        if let lossWeighting {
+            args += ["--loss-weighting", lossWeighting]
+        }
+        if let timestepLow {
+            args += ["--timestep-low", String(timestepLow)]
+        }
+        if let timestepHigh {
+            args += ["--timestep-high", String(timestepHigh)]
+        }
+        if let lrWarmupSteps {
+            args += ["--lr-warmup-steps", String(lrWarmupSteps)]
+        }
+        if noCosineScheduler {
+            args.append("--no-cosine-scheduler")
+        }
+        if let lrMinFactor {
+            args += ["--lr-min-factor", String(lrMinFactor)]
+        }
+        if let adamWeightDecay {
+            args += ["--adam-weight-decay", String(adamWeightDecay)]
+        }
+        if let syntheticSamples {
+            args += ["--synthetic-samples", String(syntheticSamples)]
+        }
+        if quiet {
+            args.append("--quiet")
+        }
+        return args
     }
 
     private func runKreaTraining(

--- a/Sources/MereRunCLI/Guides/image-train-lora.md
+++ b/Sources/MereRunCLI/Guides/image-train-lora.md
@@ -99,6 +99,10 @@ the adapter to learn.
   Linear/QuantizedLinear layer.
 - `--lora-target-ranks`: custom FLUX.2 target suffix ranks, for example
   `.attn.to_q=128,.ff.linear_in=64`.
+- `--preflight`: inspect the training request without loading the model or
+  running training.
+- `--json`: with `--preflight`, emit one structured JSON report with dataset
+  counts, model readiness, diagnostics, and declarative next actions.
 - Krea/Klein LR controls: `--lr-warmup-steps`, `--no-cosine-scheduler`, and
   `--lr-min-factor`.
 - Klein-only recipe controls: `--timestep-sampling`, `--timestep-loss-weighting`,
@@ -111,6 +115,22 @@ capture fails during the first training step. Large real datasets may also need
 `MLX_CUDA_GRAPH_CACHE_SIZE=4096` to avoid MLX CUDA graph-cache thrashing.
 
 ## Train
+
+Before spending GPU time, run a preflight. It catches missing captions, missing
+models, suspicious repeated captions, output-path issues, and suggested next
+commands without starting the training runtime:
+
+```bash
+mere.run image train-lora \
+  --data ./dataset \
+  --output ./my-klein-fast-style.safetensors \
+  --recipe klein-fast-style \
+  --preflight \
+  --json
+```
+
+Hard blockers exit nonzero after printing the JSON report, so scripts can
+consume stdout and decide whether to run the emitted `start-training` action.
 
 For the fast Krea style recipe:
 

--- a/Sources/MereRunCLI/Support/LoRATrainingPreflight.swift
+++ b/Sources/MereRunCLI/Support/LoRATrainingPreflight.swift
@@ -1,0 +1,745 @@
+import Foundation
+import MereRunCore
+
+struct LoRATrainingPreflightInput {
+    let data: String?
+    let output: String
+    let recipe: String?
+    let excludePreviewImages: Bool
+    let syntheticSamples: Int?
+    let options: ImageTrainLoRA.ResolvedLoRATrainingOptions
+    let trainingArgv: [String]
+    let cwd: String
+}
+
+struct LoRATrainingPreflightRequest: Codable, Equatable {
+    let data: String?
+    let output: String
+    let model: String
+    let recipe: String?
+    let trainingSteps: Int
+    let width: Int
+    let height: Int
+    let rank: Int
+    let alpha: Float?
+    let learningRate: Float
+    let captionDropout: Float
+
+    enum CodingKeys: String, CodingKey {
+        case data
+        case output
+        case model
+        case recipe
+        case trainingSteps = "training_steps"
+        case width
+        case height
+        case rank
+        case alpha
+        case learningRate = "learning_rate"
+        case captionDropout = "caption_dropout"
+    }
+}
+
+struct LoRATrainingPreflightResult: Codable, Equatable {
+    let dataset: LoRATrainingDatasetPreflightSummary
+    let model: LoRATrainingModelPreflightSummary
+    let output: LoRATrainingOutputPreflightSummary
+    let plan: LoRATrainingPlanPreflightSummary
+}
+
+struct LoRATrainingDatasetPreflightSummary: Codable, Equatable {
+    let directory: String?
+    let mode: String
+    let imageCount: Int
+    let captionCount: Int
+    let usablePairCount: Int
+    let missingCaptionCount: Int
+    let emptyCaptionCount: Int
+    let duplicateCaptionGroupCount: Int
+    let duplicateCaptionCount: Int
+    let excludedPreviewImageCount: Int
+    let placeholderCaptionCount: Int
+    let syntheticSampleCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case directory
+        case mode
+        case imageCount = "image_count"
+        case captionCount = "caption_count"
+        case usablePairCount = "usable_pair_count"
+        case missingCaptionCount = "missing_caption_count"
+        case emptyCaptionCount = "empty_caption_count"
+        case duplicateCaptionGroupCount = "duplicate_caption_group_count"
+        case duplicateCaptionCount = "duplicate_caption_count"
+        case excludedPreviewImageCount = "excluded_preview_image_count"
+        case placeholderCaptionCount = "placeholder_caption_count"
+        case syntheticSampleCount = "synthetic_sample_count"
+    }
+}
+
+struct LoRATrainingModelPreflightSummary: Codable, Equatable {
+    let requested: String
+    let kind: String
+    let installed: Bool
+    let path: String?
+    let family: String?
+    let upstreamRepoID: String?
+    let estimatedDownloadBytes: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case requested
+        case kind
+        case installed
+        case path
+        case family
+        case upstreamRepoID = "upstream_repo_id"
+        case estimatedDownloadBytes = "estimated_download_bytes"
+    }
+}
+
+struct LoRATrainingOutputPreflightSummary: Codable, Equatable {
+    let path: String
+    let parentDirectory: String
+    let parentExists: Bool
+    let parentWillBeCreated: Bool
+    let exists: Bool
+    let extensionValid: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case path
+        case parentDirectory = "parent_directory"
+        case parentExists = "parent_exists"
+        case parentWillBeCreated = "parent_will_be_created"
+        case exists
+        case extensionValid = "extension_valid"
+    }
+}
+
+struct LoRATrainingPlanPreflightSummary: Codable, Equatable {
+    let recipe: String?
+    let trainingSteps: Int
+    let width: Int
+    let height: Int
+    let rank: Int
+    let alpha: Float?
+    let learningRate: Float
+    let captionDropout: Float
+    let checkpointInterval: Int?
+    let expectedCheckpointCount: Int
+    let maxResolution: Int?
+    let lowRam: Bool
+    let noCompile: Bool
+    let loraTargetPreset: String?
+    let lrWarmupSteps: Int?
+    let useCosineScheduler: Bool?
+    let lrMinFactor: Float?
+
+    enum CodingKeys: String, CodingKey {
+        case recipe
+        case trainingSteps = "training_steps"
+        case width
+        case height
+        case rank
+        case alpha
+        case learningRate = "learning_rate"
+        case captionDropout = "caption_dropout"
+        case checkpointInterval = "checkpoint_interval"
+        case expectedCheckpointCount = "expected_checkpoint_count"
+        case maxResolution = "max_resolution"
+        case lowRam = "low_ram"
+        case noCompile = "no_compile"
+        case loraTargetPreset = "lora_target_preset"
+        case lrWarmupSteps = "lr_warmup_steps"
+        case useCosineScheduler = "use_cosine_scheduler"
+        case lrMinFactor = "lr_min_factor"
+    }
+}
+
+typealias LoRATrainingPreflightEnvelope = StructuredRunEnvelope<
+    LoRATrainingPreflightRequest,
+    LoRATrainingPreflightResult
+>
+
+struct LoRATrainingPreflightAnalyzer {
+    let input: LoRATrainingPreflightInput
+    let fileManager: FileManager
+    let now: () -> Date
+
+    init(
+        input: LoRATrainingPreflightInput,
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.input = input
+        self.fileManager = fileManager
+        self.now = now
+    }
+
+    func envelope() -> LoRATrainingPreflightEnvelope {
+        var diagnostics: [PreflightDiagnostic] = []
+        let dataset = datasetSummary(diagnostics: &diagnostics)
+        let model = modelSummary(diagnostics: &diagnostics)
+        let output = outputSummary(diagnostics: &diagnostics)
+        let plan = planSummary()
+        let status = StructuredRunOutput.status(for: diagnostics)
+        let actions = actions(status: status, model: model)
+        let summary = summary(status: status, dataset: dataset, diagnostics: diagnostics)
+
+        return LoRATrainingPreflightEnvelope(
+            schemaVersion: 1,
+            mereRunVersion: MereRunCLIVersion.current,
+            command: ["image", "train-lora"],
+            mode: .preflight,
+            status: status,
+            createdAt: now(),
+            cwd: input.cwd,
+            summary: summary,
+            request: LoRATrainingPreflightRequest(
+                data: input.data,
+                output: input.output,
+                model: input.options.model ?? ImageTrainLoRA.defaultManagedModelID.rawValue,
+                recipe: input.recipe,
+                trainingSteps: input.options.trainingSteps,
+                width: input.options.width,
+                height: input.options.height,
+                rank: input.options.rank,
+                alpha: input.options.alpha,
+                learningRate: input.options.learningRate,
+                captionDropout: input.options.captionDropout
+            ),
+            result: LoRATrainingPreflightResult(
+                dataset: dataset,
+                model: model,
+                output: output,
+                plan: plan
+            ),
+            diagnostics: diagnostics,
+            actions: actions
+        )
+    }
+
+    private func datasetSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> LoRATrainingDatasetPreflightSummary {
+        if let syntheticSamples = input.syntheticSamples {
+            return LoRATrainingDatasetPreflightSummary(
+                directory: nil,
+                mode: "synthetic",
+                imageCount: 0,
+                captionCount: 0,
+                usablePairCount: syntheticSamples,
+                missingCaptionCount: 0,
+                emptyCaptionCount: 0,
+                duplicateCaptionGroupCount: 0,
+                duplicateCaptionCount: 0,
+                excludedPreviewImageCount: 0,
+                placeholderCaptionCount: 0,
+                syntheticSampleCount: syntheticSamples
+            )
+        }
+
+        guard let data = input.data?.trimmingCharacters(in: .whitespacesAndNewlines), !data.isEmpty else {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "data_required",
+                    severity: .blocker,
+                    title: "Dataset required",
+                    message: "--data is required unless --synthetic-samples is set."
+                )
+            )
+            return emptyDatasetSummary(directory: nil, mode: "missing")
+        }
+
+        let directory = URL(fileURLWithPath: data).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "dataset_not_found",
+                    severity: .blocker,
+                    title: "Dataset not found",
+                    message: "Dataset directory not found: \(directory.path)",
+                    locations: [.init(kind: "directory", path: directory.path)]
+                )
+            )
+            return emptyDatasetSummary(directory: directory.path, mode: "missing")
+        }
+
+        let contents: [URL]
+        do {
+            contents = try fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "dataset_unreadable",
+                    severity: .blocker,
+                    title: "Dataset unreadable",
+                    message: error.localizedDescription,
+                    locations: [.init(kind: "directory", path: directory.path)]
+                )
+            )
+            return emptyDatasetSummary(directory: directory.path, mode: "unreadable")
+        }
+
+        let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "webp"]
+        let regularFiles = contents.filter { url in
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            return values?.isRegularFile == true
+        }
+        let allImages = regularFiles
+            .filter { imageExtensions.contains($0.pathExtension.lowercased()) }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        let previewImages = allImages.filter { $0.deletingPathExtension().lastPathComponent.hasPrefix("preview") }
+        let images = input.excludePreviewImages
+            ? allImages.filter { !previewImages.contains($0) }
+            : allImages
+
+        if images.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "no_training_images",
+                    severity: .blocker,
+                    title: "No training images",
+                    message: "No PNG, JPG, JPEG, or WEBP training images were found in \(directory.path).",
+                    locations: [.init(kind: "directory", path: directory.path)]
+                )
+            )
+        }
+
+        let editOutputs = images.filter { $0.deletingPathExtension().lastPathComponent.hasSuffix("_out") }
+        if !editOutputs.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "edit_dataset_not_supported",
+                    severity: .blocker,
+                    title: "Edit dataset detected",
+                    message: "image train-lora currently expects image + .txt caption pairs, not *_in/*_out edit pairs.",
+                    locations: editOutputs.prefix(5).map { .init(kind: "file", path: $0.path) }
+                )
+            )
+        }
+
+        if !previewImages.isEmpty, !input.excludePreviewImages {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "preview_images_included",
+                    severity: .warning,
+                    title: "Preview images included",
+                    message: "\(previewImages.count) preview image(s) will be treated as training images. Use --exclude-preview-images if they are generated previews.",
+                    locations: previewImages.prefix(5).map { .init(kind: "file", path: $0.path) }
+                )
+            )
+        }
+
+        var captionCount = 0
+        var usablePairCount = 0
+        var missingCaptions: [URL] = []
+        var emptyCaptions: [URL] = []
+        var placeholderCaptions: [URL] = []
+        var captionsByText: [String: [URL]] = [:]
+
+        for image in images {
+            let captionURL = image.deletingPathExtension().appendingPathExtension("txt")
+            guard fileManager.fileExists(atPath: captionURL.path) else {
+                missingCaptions.append(captionURL)
+                continue
+            }
+            captionCount += 1
+            let captionData: Data
+            do {
+                captionData = try Data(contentsOf: captionURL)
+            } catch {
+                emptyCaptions.append(captionURL)
+                continue
+            }
+            let caption = String(decoding: captionData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !caption.isEmpty else {
+                emptyCaptions.append(captionURL)
+                continue
+            }
+            usablePairCount += 1
+            captionsByText[caption, default: []].append(captionURL)
+            if Self.isPlaceholderCaption(caption) {
+                placeholderCaptions.append(captionURL)
+            }
+        }
+
+        if !missingCaptions.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "missing_captions",
+                    severity: .blocker,
+                    title: "Missing captions",
+                    message: "\(missingCaptions.count) image file(s) do not have matching .txt captions.",
+                    locations: missingCaptions.prefix(10).map { .init(kind: "file", path: $0.path) }
+                )
+            )
+        }
+        if !emptyCaptions.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "empty_captions",
+                    severity: .blocker,
+                    title: "Empty captions",
+                    message: "\(emptyCaptions.count) caption file(s) are empty.",
+                    locations: emptyCaptions.prefix(10).map { .init(kind: "file", path: $0.path) }
+                )
+            )
+        }
+        if !placeholderCaptions.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "placeholder_captions",
+                    severity: .warning,
+                    title: "Placeholder captions",
+                    message: "\(placeholderCaptions.count) caption file(s) look like placeholders.",
+                    locations: placeholderCaptions.prefix(10).map { .init(kind: "file", path: $0.path) }
+                )
+            )
+        }
+
+        let duplicateGroups = captionsByText.values.filter { $0.count > 1 }
+        let duplicateCaptionCount = duplicateGroups.reduce(0) { $0 + $1.count }
+        if !duplicateGroups.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "duplicate_captions",
+                    severity: .warning,
+                    title: "Repeated captions",
+                    message: "\(duplicateCaptionCount) caption file(s) are part of \(duplicateGroups.count) exact duplicate group(s).",
+                    locations: duplicateGroups.flatMap { $0 }.prefix(10).map { .init(kind: "file", path: $0.path) }
+                )
+            )
+        }
+
+        return LoRATrainingDatasetPreflightSummary(
+            directory: directory.path,
+            mode: editOutputs.isEmpty ? "image_caption" : "edit_detected",
+            imageCount: images.count,
+            captionCount: captionCount,
+            usablePairCount: usablePairCount,
+            missingCaptionCount: missingCaptions.count,
+            emptyCaptionCount: emptyCaptions.count,
+            duplicateCaptionGroupCount: duplicateGroups.count,
+            duplicateCaptionCount: duplicateCaptionCount,
+            excludedPreviewImageCount: input.excludePreviewImages ? previewImages.count : 0,
+            placeholderCaptionCount: placeholderCaptions.count,
+            syntheticSampleCount: nil
+        )
+    }
+
+    private func modelSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> LoRATrainingModelPreflightSummary {
+        let requested = input.options.model ?? ImageTrainLoRA.defaultManagedModelID.rawValue
+        let localURL = URL(fileURLWithPath: requested).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: localURL.path, isDirectory: &isDirectory) {
+            guard isDirectory.boolValue else {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "model_path_not_directory",
+                        severity: .blocker,
+                        title: "Model path is not a directory",
+                        message: "Model path is not a directory: \(localURL.path)",
+                        locations: [.init(kind: "file", path: localURL.path)]
+                    )
+                )
+                return modelResult(requested: requested, kind: "local_path", installed: false, path: localURL.path)
+            }
+            let family = loadManifestFamily(at: localURL, diagnostics: &diagnostics)
+            return modelResult(
+                requested: requested,
+                kind: "local_path",
+                installed: family != nil,
+                path: localURL.path,
+                family: family
+            )
+        }
+
+        if let modelID = ModelResolver.ModelID(rawValue: requested) {
+            let spec = ManagedModelCatalog.spec(for: modelID.rawValue)
+            if let resolution = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID) {
+                let family = loadManifestFamily(at: resolution.rootURL, diagnostics: &diagnostics)
+                return modelResult(
+                    requested: requested,
+                    kind: "managed_model",
+                    installed: family != nil,
+                    path: resolution.rootURL.path,
+                    family: family,
+                    upstreamRepoID: spec?.upstreamRepoId,
+                    estimatedDownloadBytes: spec?.estimatedDownloadBytes
+                )
+            }
+
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "model_missing",
+                    severity: .blocker,
+                    title: "Model missing",
+                    message: "Model \(modelID.rawValue) is not installed. Pull it before training.",
+                    suggestedActionIDs: ["pull-model"]
+                )
+            )
+            return modelResult(
+                requested: requested,
+                kind: "managed_model",
+                installed: false,
+                upstreamRepoID: spec?.upstreamRepoId,
+                estimatedDownloadBytes: spec?.estimatedDownloadBytes
+            )
+        }
+
+        diagnostics.append(
+            PreflightDiagnostic(
+                id: "model_unknown",
+                severity: .blocker,
+                title: "Unknown model",
+                message: "Model path not found and not a known model id: \(requested)."
+            )
+        )
+        return modelResult(requested: requested, kind: "unknown", installed: false)
+    }
+
+    private func outputSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> LoRATrainingOutputPreflightSummary {
+        let outputURL = URL(fileURLWithPath: input.output).standardizedFileURL
+        let parent = outputURL.deletingLastPathComponent()
+        var parentIsDirectory: ObjCBool = false
+        let parentExists = fileManager.fileExists(atPath: parent.path, isDirectory: &parentIsDirectory)
+        let outputExists = fileManager.fileExists(atPath: outputURL.path)
+        let extensionValid = outputURL.pathExtension.lowercased() == "safetensors"
+
+        if !extensionValid {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "output_extension_invalid",
+                    severity: .blocker,
+                    title: "Invalid output extension",
+                    message: "--output must end in .safetensors.",
+                    locations: [.init(kind: "file", path: outputURL.path)]
+                )
+            )
+        }
+        if parentExists, !parentIsDirectory.boolValue {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "output_parent_not_directory",
+                    severity: .blocker,
+                    title: "Output parent is not a directory",
+                    message: "Output parent is not a directory: \(parent.path)",
+                    locations: [.init(kind: "file", path: parent.path)]
+                )
+            )
+        }
+        if outputExists {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "output_exists",
+                    severity: .warning,
+                    title: "Output exists",
+                    message: "Output already exists and may be overwritten: \(outputURL.path)",
+                    locations: [.init(kind: "file", path: outputURL.path)]
+                )
+            )
+        }
+
+        return LoRATrainingOutputPreflightSummary(
+            path: outputURL.path,
+            parentDirectory: parent.path,
+            parentExists: parentExists && parentIsDirectory.boolValue,
+            parentWillBeCreated: !parentExists,
+            exists: outputExists,
+            extensionValid: extensionValid
+        )
+    }
+
+    private func planSummary() -> LoRATrainingPlanPreflightSummary {
+        let checkpointCount: Int
+        if let checkpointInterval = input.options.checkpointInterval {
+            checkpointCount = input.options.trainingSteps / checkpointInterval
+        } else {
+            checkpointCount = 0
+        }
+        return LoRATrainingPlanPreflightSummary(
+            recipe: input.recipe,
+            trainingSteps: input.options.trainingSteps,
+            width: input.options.width,
+            height: input.options.height,
+            rank: input.options.rank,
+            alpha: input.options.alpha,
+            learningRate: input.options.learningRate,
+            captionDropout: input.options.captionDropout,
+            checkpointInterval: input.options.checkpointInterval,
+            expectedCheckpointCount: checkpointCount,
+            maxResolution: input.options.maxResolution,
+            lowRam: input.options.lowRam,
+            noCompile: input.options.noCompile,
+            loraTargetPreset: input.options.loraTargetPreset,
+            lrWarmupSteps: input.options.lrWarmupSteps,
+            useCosineScheduler: input.options.useCosineScheduler,
+            lrMinFactor: input.options.lrMinFactor
+        )
+    }
+
+    private func actions(
+        status: StructuredRunStatus,
+        model: LoRATrainingModelPreflightSummary
+    ) -> [DeclarativeAction] {
+        var actions: [DeclarativeAction] = []
+        let blocked = status == .blocked
+        actions.append(
+            DeclarativeAction(
+                id: "start-training",
+                label: "Start training",
+                kind: .command,
+                style: .primary,
+                enabled: !blocked,
+                disabledReason: blocked ? "Resolve hard blockers first." : nil,
+                command: DeclarativeCommand(
+                    argv: input.trainingArgv,
+                    cwd: input.cwd,
+                    commandPath: ["image", "train-lora"]
+                ),
+                requires: ["preflight.passed"]
+            )
+        )
+
+        if model.kind == "managed_model", !model.installed {
+            actions.append(
+                DeclarativeAction(
+                    id: "pull-model",
+                    label: "Pull model",
+                    kind: .command,
+                    style: .secondary,
+                    command: DeclarativeCommand(
+                        argv: ["mere.run", "model", "pull", model.requested],
+                        cwd: input.cwd,
+                        commandPath: ["model", "pull"]
+                    )
+                )
+            )
+        }
+
+        if let data = input.data {
+            let dataURL = URL(fileURLWithPath: data).standardizedFileURL
+            actions.append(
+                DeclarativeAction(
+                    id: "open-dataset",
+                    label: "Open dataset",
+                    kind: .openDirectory,
+                    style: .link,
+                    enabled: fileManager.fileExists(atPath: dataURL.path),
+                    path: dataURL.path
+                )
+            )
+        }
+
+        return actions
+    }
+
+    private func summary(
+        status: StructuredRunStatus,
+        dataset: LoRATrainingDatasetPreflightSummary,
+        diagnostics: [PreflightDiagnostic]
+    ) -> String {
+        let blockerCount = diagnostics.filter { $0.severity == .blocker }.count
+        let warningCount = diagnostics.filter { $0.severity == .warning }.count
+        switch status {
+        case .blocked:
+            return "\(dataset.usablePairCount) usable pair(s), \(blockerCount) blocker(s), \(warningCount) warning(s)."
+        case .warning:
+            return "\(dataset.usablePairCount) usable pair(s), \(warningCount) warning(s), ready to train."
+        default:
+            return "\(dataset.usablePairCount) usable pair(s), ready to train."
+        }
+    }
+
+    private func emptyDatasetSummary(directory: String?, mode: String) -> LoRATrainingDatasetPreflightSummary {
+        LoRATrainingDatasetPreflightSummary(
+            directory: directory,
+            mode: mode,
+            imageCount: 0,
+            captionCount: 0,
+            usablePairCount: 0,
+            missingCaptionCount: 0,
+            emptyCaptionCount: 0,
+            duplicateCaptionGroupCount: 0,
+            duplicateCaptionCount: 0,
+            excludedPreviewImageCount: 0,
+            placeholderCaptionCount: 0,
+            syntheticSampleCount: nil
+        )
+    }
+
+    private func modelResult(
+        requested: String,
+        kind: String,
+        installed: Bool,
+        path: String? = nil,
+        family: String? = nil,
+        upstreamRepoID: String? = nil,
+        estimatedDownloadBytes: Int64? = nil
+    ) -> LoRATrainingModelPreflightSummary {
+        LoRATrainingModelPreflightSummary(
+            requested: requested,
+            kind: kind,
+            installed: installed,
+            path: path,
+            family: family,
+            upstreamRepoID: upstreamRepoID,
+            estimatedDownloadBytes: estimatedDownloadBytes
+        )
+    }
+
+    private func loadManifestFamily(
+        at modelRoot: URL,
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> String? {
+        do {
+            let manifest = try MereRunModelManifest.loadRequired(from: modelRoot, fileManager: fileManager)
+            let family = manifest.family?.rawValue ?? "unknown"
+            if manifest.family != .krea && manifest.family != .klein {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "model_family_unsupported",
+                        severity: .blocker,
+                        title: "Unsupported model family",
+                        message: "Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.",
+                        locations: [.init(kind: "directory", path: modelRoot.path)]
+                    )
+                )
+            }
+            return family
+        } catch {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "model_manifest_unreadable",
+                    severity: .blocker,
+                    title: "Model manifest unreadable",
+                    message: error.localizedDescription,
+                    locations: [.init(kind: "directory", path: modelRoot.path)]
+                )
+            )
+            return nil
+        }
+    }
+
+    private static func isPlaceholderCaption(_ caption: String) -> Bool {
+        let normalized = caption.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return [
+            "todo",
+            "tbd",
+            "caption",
+            "description",
+            "image",
+            "placeholder",
+        ].contains(normalized)
+    }
+}

--- a/Sources/MereRunCLI/Support/StructuredRunOutput.swift
+++ b/Sources/MereRunCLI/Support/StructuredRunOutput.swift
@@ -1,0 +1,223 @@
+import ArgumentParser
+import Foundation
+
+enum StructuredRunMode: String, Codable, Equatable, Sendable {
+    case preflight
+    case run
+    case dryRun = "dry_run"
+    case status
+    case inspection
+}
+enum StructuredRunStatus: String, Codable, Equatable, Sendable {
+    case ok
+    case warning
+    case blocked
+    case running
+    case finished
+    case failed
+}
+
+struct StructuredRunEnvelope<Request: Codable & Equatable, Result: Codable & Equatable>: Codable, Equatable {
+    let schemaVersion: Int
+    let mereRunVersion: String
+    let command: [String]
+    let mode: StructuredRunMode
+    let status: StructuredRunStatus
+    let createdAt: Date
+    let cwd: String
+    let summary: String
+    let request: Request
+    let result: Result
+    let diagnostics: [PreflightDiagnostic]
+    let actions: [DeclarativeAction]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case mereRunVersion = "mere_run_version"
+        case command
+        case mode
+        case status
+        case createdAt = "created_at"
+        case cwd
+        case summary
+        case request
+        case result
+        case diagnostics
+        case actions
+    }
+}
+
+enum PreflightDiagnosticSeverity: String, Codable, Equatable, Sendable {
+    case blocker
+    case warning
+    case note
+    case estimate
+}
+
+struct PreflightDiagnostic: Codable, Equatable, Sendable {
+    let id: String
+    let severity: PreflightDiagnosticSeverity
+    let title: String
+    let message: String
+    let locations: [DiagnosticLocation]
+    let suggestedActionIDs: [String]
+
+    init(
+        id: String,
+        severity: PreflightDiagnosticSeverity,
+        title: String,
+        message: String,
+        locations: [DiagnosticLocation] = [],
+        suggestedActionIDs: [String] = []
+    ) {
+        self.id = id
+        self.severity = severity
+        self.title = title
+        self.message = message
+        self.locations = locations
+        self.suggestedActionIDs = suggestedActionIDs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case severity
+        case title
+        case message
+        case locations
+        case suggestedActionIDs = "suggested_action_ids"
+    }
+}
+
+struct DiagnosticLocation: Codable, Equatable, Sendable {
+    let kind: String
+    let path: String?
+    let line: Int?
+
+    init(kind: String, path: String? = nil, line: Int? = nil) {
+        self.kind = kind
+        self.path = path
+        self.line = line
+    }
+}
+
+enum DeclarativeActionKind: String, Codable, Equatable, Sendable {
+    case command
+    case openFile = "open_file"
+    case revealFile = "reveal_file"
+    case openDirectory = "open_directory"
+    case openURL = "open_url"
+    case copyText = "copy_text"
+    case none
+}
+
+enum DeclarativeActionStyle: String, Codable, Equatable, Sendable {
+    case primary
+    case secondary
+    case danger
+    case link
+}
+
+struct DeclarativeCommand: Codable, Equatable, Sendable {
+    let argv: [String]
+    let cwd: String
+    let commandPath: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case argv
+        case cwd
+        case commandPath = "command_path"
+    }
+}
+
+struct DeclarativeAction: Codable, Equatable, Sendable {
+    let id: String
+    let label: String
+    let kind: DeclarativeActionKind
+    let style: DeclarativeActionStyle
+    let enabled: Bool
+    let disabledReason: String?
+    let command: DeclarativeCommand?
+    let path: String?
+    let url: String?
+    let text: String?
+    let requires: [String]
+    let confirmation: String?
+    let destructive: Bool
+    let secretsMasked: Bool
+
+    init(
+        id: String,
+        label: String,
+        kind: DeclarativeActionKind,
+        style: DeclarativeActionStyle = .secondary,
+        enabled: Bool = true,
+        disabledReason: String? = nil,
+        command: DeclarativeCommand? = nil,
+        path: String? = nil,
+        url: String? = nil,
+        text: String? = nil,
+        requires: [String] = [],
+        confirmation: String? = nil,
+        destructive: Bool = false,
+        secretsMasked: Bool = true
+    ) {
+        self.id = id
+        self.label = label
+        self.kind = kind
+        self.style = style
+        self.enabled = enabled
+        self.disabledReason = disabledReason
+        self.command = command
+        self.path = path
+        self.url = url
+        self.text = text
+        self.requires = requires
+        self.confirmation = confirmation
+        self.destructive = destructive
+        self.secretsMasked = secretsMasked
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case label
+        case kind
+        case style
+        case enabled
+        case disabledReason = "disabled_reason"
+        case command
+        case path
+        case url
+        case text
+        case requires
+        case confirmation
+        case destructive
+        case secretsMasked = "secrets_masked"
+    }
+}
+
+enum StructuredRunOutput {
+    static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static func encode<T: Encodable>(_ value: T) throws -> String {
+        let data = try encoder().encode(value)
+        guard let output = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Could not encode structured output as UTF-8.")
+        }
+        return output
+    }
+
+    static func status(for diagnostics: [PreflightDiagnostic]) -> StructuredRunStatus {
+        if diagnostics.contains(where: { $0.severity == .blocker }) {
+            return .blocked
+        }
+        if diagnostics.contains(where: { $0.severity == .warning }) {
+            return .warning
+        }
+        return .ok
+    }
+}

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer.swift
@@ -933,7 +933,27 @@ public enum Flux2KleinLoRATrainer {
             guard let module = layer as? Module else { continue }
             try module.unfreeze(recursive: false, keys: ["loraDown", "loraUp"], strict: true)
         }
-        transformer.gradientCheckpointing = config.gradientCheckpointing
+        // Gradient checkpointing follows the explicit config/CLI flag, with
+        // the shared resolution-aware default as fallback (peak training
+        // pixels decide: capped-resolution recipe runs keep the uncompiled
+        // recompute path off). The cache cap bounds the MLX buffer pool,
+        // which otherwise pins the footprint at the worst transient spike.
+        let peakTrainingPixels: Int = {
+            let target = config.width * config.height
+            if let maxResolution = config.maxResolution {
+                return min(target, maxResolution * maxResolution)
+            }
+            return target
+        }()
+        let effectiveGradientCheckpointing = config.gradientCheckpointing
+            || LoRATrainingEnvironment.gradientCheckpointingEnabled(trainingPixels: peakTrainingPixels)
+        transformer.gradientCheckpointing = effectiveGradientCheckpointing
+        if LoRATrainingEnvironment.trainingCacheLimitGB > 0 {
+            MLX.Memory.cacheLimit = LoRATrainingEnvironment.trainingCacheLimitGB * 1_073_741_824
+        }
+        FileHandle.standardError.write(Data(
+            "[flux2-lora-train] grad_checkpoint=\(effectiveGradientCheckpointing) peak_pixels=\(peakTrainingPixels) cache_limit_gb=\(LoRATrainingEnvironment.trainingCacheLimitGB)\n".utf8
+        ))
 
         MLX.eval(transformer)
         progressHandler?(Flux2KleinLoRATrainingProgress(stage: .injectingLoRA(layerCount: loraLayers.count), fraction: 1))
@@ -1128,8 +1148,11 @@ public enum Flux2KleinLoRATrainer {
                 }
 
                 // Compile the full training step (forward + backward + LoRA update) for this shape.
+                // Checkpointed blocks stay uncompiled: nesting checkpoint
+                // closures inside a compiled step is unproven with this
+                // mlx-swift.
                 var compiledTrainStep: (([MLXArray]) -> [MLXArray])? = nil
-                if config.useCompile {
+                if config.useCompile, !transformer.gradientCheckpointing {
                     let state: [any Updatable] = [loraState]
                     if isEditPhase {
                         // Input arrays: [clean, noise, promptEmbeds, referenceLatents, sigma, timestepLossWeight, lr, oneMinusLrWd]
@@ -1408,6 +1431,14 @@ public enum Flux2KleinLoRATrainer {
 
                         if let lossValue {
                             try metricsLogger.record(step: globalStep + 1, loss: lossValue)
+                            var diagnostics = String(
+                                format: "[flux2-lora-train] step=%d/%d loss=%.6f",
+                                globalStep + 1, config.trainingSteps, lossValue
+                            )
+                            if let footprint = LoRATrainingEnvironment.currentPhysicalFootprintGB() {
+                                diagnostics += String(format: " footprint_gb=%.1f", footprint)
+                            }
+                            FileHandle.standardError.write(Data((diagnostics + "\n").utf8))
                             progressHandler?(Flux2KleinLoRATrainingProgress(
                                 stage: .training(step: globalStep + 1, total: config.trainingSteps, loss: lossValue),
                                 fraction: Float(globalStep + 1) / Float(config.trainingSteps)

--- a/Sources/MereRunCore/Krea2/Krea2LoRATrainer.swift
+++ b/Sources/MereRunCore/Krea2/Krea2LoRATrainer.swift
@@ -158,6 +158,14 @@ public struct Krea2LoRATrainingProgress: Sendable {
 }
 
 public enum Krea2LoRATrainer {
+    // Shared training knobs (see LoRATrainingEnvironment): a full-injection
+    // Krea 2 training step at 1024x1024 otherwise peaks ~159 GB and thrashes
+    // any 128 GB machine, so gradient checkpointing and the cache cap default
+    // on here.
+    static var synchronousStepEval: Bool { LoRATrainingEnvironment.synchronousStepEval }
+    static var periodicSaveInterval: Int { LoRATrainingEnvironment.periodicSaveInterval }
+    static var trainingCacheLimitGB: Int { LoRATrainingEnvironment.trainingCacheLimitGB }
+
     public static func train(
         modelPath: String,
         examples: [Krea2LoRATrainingExample],
@@ -449,8 +457,23 @@ public enum Krea2LoRATrainer {
             )
             return values
         }
+        let gradientCheckpointing = LoRATrainingEnvironment.gradientCheckpointingEnabled(
+            trainingPixels: config.width * config.height
+        )
+        transformer.gradientCheckpointing = gradientCheckpointing
+        if Self.trainingCacheLimitGB > 0 {
+            MLX.Memory.cacheLimit = Self.trainingCacheLimitGB * 1_073_741_824
+        }
+        FileHandle.standardError.write(Data(
+            "[krea2-lora-train] grad_checkpoint=\(gradientCheckpointing) peak_pixels=\(config.width * config.height) cache_limit_gb=\(Self.trainingCacheLimitGB)\n".utf8
+        ))
+
         let trainStep: ([MLXArray]) -> [MLXArray]
-        if config.useCompile {
+        // Checkpointed blocks are kept outside compile: nesting the
+        // checkpoint closures inside a compiled trainStep is unproven with
+        // this mlx-swift, and the compile win is small next to a training
+        // step.
+        if config.useCompile, !gradientCheckpointing {
             let state: [any Updatable] = [loraState]
             trainStep = compile(inputs: state, outputs: state) { inputs -> [MLXArray] in
                 runTrainStep(inputs, inputs[6], inputs[7])
@@ -461,8 +484,10 @@ public enum Krea2LoRATrainer {
             }
         }
 
+        let partialURL = outputURL.deletingPathExtension().appendingPathExtension("partial.safetensors")
         for step in 0..<config.trainingSteps {
             try Task.checkCancellation()
+            let stepStart = CFAbsoluteTimeGetCurrent()
             let batchSize = min(config.batchSize, prepared.count)
             var cleanParts: [MLXArray] = []
             var noiseParts: [MLXArray] = []
@@ -516,17 +541,65 @@ public enum Krea2LoRATrainer {
             let lr = MLXArray(scheduledLR)
             let oneMinusLrWd = MLXArray(1.0 - scheduledLR * 0.0001)
             let loss = trainStep([cleanBatch, noiseBatch, textBatch, timestepBatch, positionBatch, maskBatch, lr, oneMinusLrWd])[0]
-            MLX.asyncEval(loss, loraState)
+            if Self.synchronousStepEval {
+                // Memory mode: with async evaluation the next step's graph (and
+                // its full activation set) goes live while this step is still
+                // executing — at training-sized activations that can nearly
+                // double the peak footprint. Synchronous eval keeps one step in
+                // flight; the lost overlap is graph-build time, which is noise
+                // next to a training step.
+                MLX.eval(loss, loraState)
+            } else {
+                MLX.asyncEval(loss, loraState)
+            }
 
             let shouldLog = (step + 1) % max(config.logEvery, 1) == 0 || step == config.trainingSteps - 1
             let lossValue = shouldLog ? loss.item(Float.self) : nil
             if let lossValue {
                 try metricsLogger.record(step: step + 1, loss: lossValue)
+                let stepSeconds = CFAbsoluteTimeGetCurrent() - stepStart
+                var diagnostics = String(
+                    format: "[krea2-lora-train] step=%d/%d loss=%.6f step_s=%.1f",
+                    step + 1, config.trainingSteps, lossValue, stepSeconds
+                )
+                if let footprint = LoRATrainingEnvironment.currentPhysicalFootprintGB() {
+                    diagnostics += String(format: " footprint_gb=%.1f", footprint)
+                }
+                FileHandle.standardError.write(Data((diagnostics + "\n").utf8))
             }
             progressHandler?(Krea2LoRATrainingProgress(
                 stage: .training(step: step + 1, total: config.trainingSteps, loss: lossValue),
                 fraction: Float(step + 1) / Float(config.trainingSteps)
             ))
+
+            // Crash insurance: multi-hour runs previously saved nothing until
+            // the end and memory pressure can kill the process silently. The
+            // partial file is removed after the final save succeeds.
+            if Self.periodicSaveInterval > 0,
+               (step + 1) % Self.periodicSaveInterval == 0,
+               step + 1 < config.trainingSteps {
+                try FileManager.default.createDirectory(
+                    at: outputURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                MLX.eval(loraState)
+                try LoRASafetensorsWriter.save(
+                    loraLayers: loraLayers,
+                    to: partialURL,
+                    dtype: config.saveDType,
+                    includeOptimizerState: false,
+                    metadata: [
+                        "format": "mererun.krea2.lora",
+                        "base_model": config.baseModelId,
+                        "recommended_runtime_model": Krea2Resources.modelId,
+                        "step": "\(step + 1)",
+                        "total_steps": "\(config.trainingSteps)",
+                        "seed": "\(effectiveSeed)",
+                        "dataset_fingerprint": datasetFingerprint,
+                        "config_fingerprint": configFingerprint,
+                    ]
+                )
+            }
         }
 
         progressHandler?(Krea2LoRATrainingProgress(stage: .saving, fraction: 0))
@@ -548,6 +621,7 @@ public enum Krea2LoRATrainer {
             includeOptimizerState: false,
             metadata: metadata
         )
+        try? FileManager.default.removeItem(at: partialURL)
 
         let checkpointState = LoRATrainingCheckpointState(
             format: "mererun.krea2.lora",

--- a/Sources/MereRunCore/Krea2/Krea2Model.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Model.swift
@@ -279,6 +279,33 @@ final class Krea2SingleStreamBlock: Module {
         out = out + postgate * ff((1 + postscale) * norm2(out) + postshift)
         return out
     }
+
+    private var checkpointedForward: (([MLXArray]) -> [MLXArray])?
+
+    /// Gradient-checkpointed block forward: activations inside the block are
+    /// recomputed during backward instead of retained, trading ~one extra
+    /// block forward for a per-block activation footprint.
+    func checkpointed(
+        _ x: MLXArray,
+        modulation: MLXArray,
+        rotary: (cos: MLXArray, sin: MLXArray),
+        mask: MLXArray
+    ) -> MLXArray {
+        if checkpointedForward == nil {
+            checkpointedForward = checkpoint(model: self) { block, inputs in
+                [block(
+                    inputs[0],
+                    modulation: inputs[1],
+                    rotary: (cos: inputs[2], sin: inputs[3]),
+                    mask: inputs[4]
+                )]
+            }
+        }
+        guard let checkpointedForward else {
+            preconditionFailure("Checkpointed Krea 2 block was not initialized.")
+        }
+        return checkpointedForward([x, modulation, rotary.cos, rotary.sin, mask])[0]
+    }
 }
 
 final class Krea2FinalLayer: Module {
@@ -364,6 +391,11 @@ public final class Krea2Transformer: Module {
     @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [Krea2SingleStreamBlock]
     @ModuleInfo(key: "final_layer") var finalLayer: Krea2FinalLayer
 
+    /// Set by trainers: routes each transformer block through the
+    /// gradient-checkpointed forward so backward recomputes activations
+    /// instead of retaining them.
+    public var gradientCheckpointing = false
+
     private let positionalEncoding: Krea2PositionalEncoding
 
     public init(configuration: Krea2TransformerConfiguration) {
@@ -440,7 +472,9 @@ public final class Krea2Transformer: Module {
         let rotary = positionalEncoding(positionIds: combinedPositions)
         for block in transformerBlocks {
             combined = MLX.where(tokenMask, combined, MLX.zeros(combined.shape, dtype: combined.dtype))
-            combined = block(combined, modulation: timeModulation, rotary: rotary, mask: attentionMask)
+            combined = gradientCheckpointing
+                ? block.checkpointed(combined, modulation: timeModulation, rotary: rotary, mask: attentionMask)
+                : block(combined, modulation: timeModulation, rotary: rotary, mask: attentionMask)
         }
         combined = MLX.where(tokenMask, combined, MLX.zeros(combined.shape, dtype: combined.dtype))
         let output = finalLayer(combined, timestepEmbedding: timeEmbedding)

--- a/Sources/MereRunCore/LoRA/LoRATrainingEnvironment.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingEnvironment.swift
@@ -1,0 +1,80 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Environment-tunable training behavior shared by the image-LoRA trainers.
+public enum LoRATrainingEnvironment {
+    /// Explicit gradient-checkpointing override from the environment:
+    /// MERERUN_LORA_TRAIN_GRAD_CHECKPOINT=1 forces on, =0 forces off,
+    /// unset defers to the resolution-aware default.
+    public static let gradientCheckpointingOverride: Bool? = {
+        guard let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_GRAD_CHECKPOINT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !raw.isEmpty else {
+            return nil
+        }
+        if raw == "0" || raw == "false" || raw == "off" { return false }
+        return true
+    }()
+
+    /// Resolution-aware gradient-checkpointing default. Measured on M4 Max /
+    /// 128 GB: full-injection steps at 1024x1024 peak 159 GB (Krea 2) and
+    /// 183 GB (Klein base, crashes), while the recipe workflows at <=512px and
+    /// 768x416 fit comfortably without recompute overhead. The pixel threshold
+    /// keeps proven low-resolution recipes byte-identical in behavior and
+    /// protects high-resolution runs by default.
+    public static func gradientCheckpointingEnabled(trainingPixels: Int) -> Bool {
+        if let forced = gradientCheckpointingOverride {
+            return forced
+        }
+        return trainingPixels >= 768 * 768
+    }
+
+    /// MLX buffer-cache cap during training, in gigabytes. The cache grows to
+    /// the transient high-water mark and never shrinks, pinning the process
+    /// footprint at the worst spike of the run. 0 leaves it unlimited.
+    /// MERERUN_LORA_TRAIN_CACHE_LIMIT_GB overrides.
+    public static let trainingCacheLimitGB: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_CACHE_LIMIT_GB"],
+           let value = Int(raw), value >= 0 {
+            return value
+        }
+        return 16
+    }()
+
+    /// Adapter checkpoint cadence in optimizer steps for trainers without
+    /// their own mid-run checkpointing. MERERUN_LORA_TRAIN_SAVE_EVERY
+    /// overrides; 0 disables.
+    public static let periodicSaveInterval: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_SAVE_EVERY"],
+           let value = Int(raw), value >= 0 {
+            return value
+        }
+        return 100
+    }()
+
+    /// MERERUN_LORA_TRAIN_SYNC_EVAL=1 evaluates each training step
+    /// synchronously, capping in-flight activations at one step's worth.
+    public static let synchronousStepEval: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_SYNC_EVAL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "on"
+    }()
+
+    /// Physical memory footprint (the metric jetsam actually enforces —
+    /// resident plus compressed), in gigabytes.
+    public static func currentPhysicalFootprintGB() -> Double? {
+        #if canImport(Darwin)
+        var usage = rusage_info_current()
+        let status = withUnsafeMutablePointer(to: &usage) { pointer in
+            pointer.withMemoryRebound(to: (rusage_info_t?).self, capacity: 1) { reboundPointer in
+                proc_pid_rusage(getpid(), RUSAGE_INFO_CURRENT, reboundPointer)
+            }
+        }
+        guard status == 0 else { return nil }
+        return Double(usage.ri_phys_footprint) / 1_000_000_000
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
@@ -49,6 +49,8 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
         XCTAssertNil(cmd.sampleSeed)
         XCTAssertFalse(cmd.visualize)
         XCTAssertEqual(cmd.visualizePort, 8787)
+        XCTAssertFalse(cmd.preflight)
+        XCTAssertFalse(cmd.json)
         XCTAssertNil(cmd.loraTargetRanks)
         XCTAssertNil(cmd.loraRankPreset)
         XCTAssertNil(cmd.loraTargetPreset)
@@ -99,6 +101,8 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
             "--sample-seed", "99",
             "--visualize",
             "--visualize-port", "8899",
+            "--preflight",
+            "--json",
             "--lora-target-ranks", ".attn.to_q=128,.ff.linear_in=64",
             "--timestep-sampling", "shift",
             "--timestep-loss-weighting", "weighted",
@@ -143,6 +147,8 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.sampleSeed, 99)
         XCTAssertTrue(cmd.visualize)
         XCTAssertEqual(cmd.visualizePort, 8899)
+        XCTAssertTrue(cmd.preflight)
+        XCTAssertTrue(cmd.json)
         XCTAssertEqual(cmd.loraTargetRanks, ".attn.to_q=128,.ff.linear_in=64")
         XCTAssertNil(cmd.loraRankPreset)
         XCTAssertNil(cmd.loraTargetPreset)
@@ -450,5 +456,121 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
         ])
 
         XCTAssertThrowsError(try cmd.resolvedTrainingOptions())
+    }
+
+    func testTrainLoRAPreflightReportsMissingCaptionsAndDisablesTraining() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let dataset = temp.appendingPathComponent("dataset", isDirectory: true)
+        try FileManager.default.createDirectory(at: dataset, withIntermediateDirectories: true)
+        try Data("not a real png".utf8).write(to: dataset.appendingPathComponent("frame-001.png"))
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(id: "local-krea", family: .krea, to: model)
+
+        let cmd = try ImageTrainLoRA.parse([
+            "--data", dataset.path,
+            "--output", temp.appendingPathComponent("style.safetensors").path,
+            "--model", model.path,
+            "--preflight",
+            "--json",
+        ])
+        let envelope = cmd.makePreflightEnvelope(
+            options: try cmd.resolvedTrainingOptions(),
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertEqual(envelope.result.dataset.imageCount, 1)
+        XCTAssertEqual(envelope.result.dataset.missingCaptionCount, 1)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "missing_captions" && $0.severity == .blocker })
+
+        let startTraining = try XCTUnwrap(envelope.actions.first { $0.id == "start-training" })
+        XCTAssertFalse(startTraining.enabled)
+        XCTAssertEqual(startTraining.command?.argv.prefix(3), ["mere.run", "image", "train-lora"])
+
+        let encoded = try StructuredRunOutput.encode(envelope)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(LoRATrainingPreflightEnvelope.self, from: Data(encoded.utf8))
+        XCTAssertEqual(decoded.status, .blocked)
+        XCTAssertEqual(decoded.command, ["image", "train-lora"])
+    }
+
+    func testTrainLoRAPreflightReportsWarningsAndEnabledTrainingAction() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let dataset = temp.appendingPathComponent("dataset", isDirectory: true)
+        try FileManager.default.createDirectory(at: dataset, withIntermediateDirectories: true)
+        try Data("image 1".utf8).write(to: dataset.appendingPathComponent("frame-001.png"))
+        try Data("image 2".utf8).write(to: dataset.appendingPathComponent("frame-002.png"))
+        try Data("same caption".utf8).write(to: dataset.appendingPathComponent("frame-001.txt"))
+        try Data("same caption".utf8).write(to: dataset.appendingPathComponent("frame-002.txt"))
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(id: "local-klein", family: .klein, to: model)
+
+        let cmd = try ImageTrainLoRA.parse([
+            "--data", dataset.path,
+            "--output", temp.appendingPathComponent("style.safetensors").path,
+            "--model", model.path,
+            "--steps", "10",
+            "--preflight",
+            "--json",
+        ])
+        let envelope = cmd.makePreflightEnvelope(
+            options: try cmd.resolvedTrainingOptions(),
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .warning)
+        XCTAssertEqual(envelope.result.dataset.usablePairCount, 2)
+        XCTAssertEqual(envelope.result.dataset.duplicateCaptionGroupCount, 1)
+        XCTAssertEqual(envelope.result.model.family, "klein")
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "duplicate_captions" && $0.severity == .warning })
+
+        let startTraining = try XCTUnwrap(envelope.actions.first { $0.id == "start-training" })
+        XCTAssertTrue(startTraining.enabled)
+        XCTAssertEqual(startTraining.command?.argv, [
+            "mere.run",
+            "image",
+            "train-lora",
+            "--data",
+            dataset.path,
+            "--output",
+            temp.appendingPathComponent("style.safetensors").path,
+            "--model",
+            model.path,
+            "--training-steps",
+            "10",
+        ])
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-lora-preflight-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        return temp
+    }
+
+    private func writeManifest(
+        id: String,
+        family: MereRunModelManifest.Family,
+        to directory: URL
+    ) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let manifest = MereRunModelManifest(
+            id: id,
+            family: family,
+            variant: .base,
+            precision: .bf16,
+            supports: [.loraTraining]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest)
+            .write(to: directory.appendingPathComponent(MereRunModelManifest.filename))
     }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -83,6 +83,7 @@ export default defineConfig({
         text: 'Internals',
         items: [
           { text: 'CLI and Runtime Internals', link: '/internals/cli-and-runtime' },
+          { text: 'Structured Runs, Preflights, and Declarative Actions', link: '/internals/structured-runs-preflight-actions' },
           { text: 'Source Layout Reference', link: '/internals/source-layout' }
         ]
       }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,4 +24,5 @@
   - [Local API Server](./runtime/api-server.md)
 - Internals
   - [CLI and Runtime Internals](./internals/cli-and-runtime.md)
+  - [Structured Runs, Preflights, and Declarative Actions](./internals/structured-runs-preflight-actions.md)
   - [Source Layout Reference](./internals/source-layout.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -361,6 +361,24 @@ style-dataset/
   002.txt
 ```
 
+Before starting a real LoRA run, use preflight JSON to catch cheap blockers
+without loading the model or allocating the training runtime:
+
+```bash
+swift run mere.run image train-lora \
+  --data ./style-dataset \
+  --output ./style-klein.safetensors \
+  --recipe klein-fast-style \
+  --preflight \
+  --json
+```
+
+The preflight report writes one structured JSON document to stdout. It includes
+dataset counts, model readiness, output-path checks, diagnostics, and
+declarative actions such as `start-training` or `pull-model`. Hard blockers
+exit nonzero after printing the JSON report so scripts and agents can inspect
+the same payload humans do.
+
 Key options:
 
 - `--data`: dataset directory with image + caption pairs
@@ -386,6 +404,8 @@ Key options:
 - `--no-compile`: disable compiled train-step graphs
 - `--lora-target-preset`: exact Klein target preset, including `fal-klein-fast`
 - `--lora-target-mode`: for FLUX.2 Klein, `suffix` or `transformer-linear-walk`
+- `--preflight`: inspect the training request without running training
+- `--json`: with `--preflight`, emit a structured JSON report
 - `--visualize`: start a loopback LoRA training dashboard for the run
 - `--visualize-port`: port for the local dashboard; defaults to `8787`
 - `--quiet`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,48 @@ exact full-vocabulary sort. The truncation only affects requests whose top-p
 nucleus would span more than this many tokens, which does not occur at
 practical temperatures.
 
+### `MERERUN_LORA_TRAIN_GRAD_CHECKPOINT`
+
+Gradient checkpointing for image-LoRA training — Krea 2 and FLUX.2 Klein.
+Transformer blocks recompute their activations during backward instead of
+retaining every intermediate. Unset, the default is resolution-aware: it
+engages when the peak training resolution (after `--max-resolution` capping)
+reaches 768×768-equivalent pixels, and stays off below that. Activation memory
+scales with the token count, so capped-resolution recipes (for example
+`klein-fast-style` at 512, or 768×416 runs) fit comfortably without the
+recompute overhead, while a single full-injection step at 1024×1024 peaks
+around 159 GB on the Krea 2 backbone and crashes outright on Klein base
+(183 GB peak observed) on 128 GB machines. Set `1` to force checkpointing on
+everywhere, or `0`/`false`/`off` to force it off. The explicit
+`--gradient-checkpointing` CLI flag still forces it on regardless of the
+environment. Checkpointed training runs the step uncompiled. Each trainer
+prints its decision at startup (`grad_checkpoint=` on stderr).
+
+### `MERERUN_LORA_TRAIN_CACHE_LIMIT_GB`
+
+MLX buffer-cache cap during image-LoRA training, in gigabytes (default `16`;
+`0` leaves the cache unlimited). The cache grows to the transient high-water
+mark and never shrinks, so without a cap the process footprint stays pinned at
+the worst spike of the run. Applies to both image-LoRA trainers.
+
+### `MERERUN_LORA_TRAIN_SYNC_EVAL`
+
+Set to `1` to evaluate each image-LoRA training step synchronously. The
+default overlapped evaluation lets the next step's graph (and its full
+activation set) go live while the current step executes, which can nearly
+double the peak memory footprint at training-sized activations. Synchronous
+mode caps in-flight activations at one step's worth at the cost of graph-build
+overlap, which is negligible next to a training step.
+
+### `MERERUN_LORA_TRAIN_SAVE_EVERY`
+
+Adapter checkpoint cadence, in optimizer steps, for image-LoRA training
+(default `100`; `0` disables). A `<name>.partial.safetensors` file is written
+next to the output and removed once the final save succeeds, so a run killed
+mid-training — for example by memory pressure — no longer loses everything.
+The trainer also logs `step_s` and `footprint_gb` diagnostics at the metrics
+cadence.
+
 ### `MERERUN_GEMMA4_DECODE_TRACE`
 
 Set to `1` to log a per-decode summary to stderr splitting each token's wall

--- a/docs/internals/structured-runs-preflight-actions.md
+++ b/docs/internals/structured-runs-preflight-actions.md
@@ -1,0 +1,949 @@
+# Structured Runs, Preflights, and Declarative Actions
+
+This document plans the implementation of a headless-first run contract for
+`mere.run`: structured `--json` output, cheap `--preflight` checks, and
+declarative next actions that can later power optional local UIs without making
+the UI the source of behavior.
+
+The immediate goal is not to build another standing app surface. The goal is to
+make every substantial command able to describe what it will do, what it did,
+what artifacts it produced, and what the caller can safely do next.
+
+## Product thesis
+
+`mere.run` is a headless local runtime first.
+
+The optional macOS app and existing LoRA `--visualize` dashboard are secondary
+surfaces. They should read the same structured truth that scripts, agents, and
+terminal users read. A UI can appear when a job benefits from inspection, but it
+must not become the only place where behavior exists.
+
+The ladder is:
+
+1. `--json`: emit machine-readable truth to stdout.
+2. `--preflight`: inspect the requested work before expensive compute.
+3. declarative actions: tell callers what safe next commands or artifact
+   operations are available.
+4. future `--visualize`: render the same contract in a loopback UI when useful.
+
+The durable rule is: UI reads reports and actions emitted by the CLI. The CLI
+and runtime remain the behavioral source of truth.
+
+## Existing pattern
+
+The LoRA viewer already proves the local-control-room model:
+
+- `image train-lora --visualize` starts a loopback dashboard for a live run.
+- `image visualize-run <directory>` reopens a completed run directory.
+- The viewer reads run artifacts from disk instead of duplicating runtime logic.
+- The dashboard is useful, but the most important primitive is the run
+  directory itself: manifest, metrics, events, samples, checkpoints, and final
+  adapter.
+
+This plan generalizes that pattern without requiring the next phase to build UI.
+
+## Non-goals
+
+- Do not build a ComfyUI-style node canvas.
+- Do not make the macOS app the canonical workflow engine.
+- Do not add hosted-service, billing, app-store, or private deployment surfaces.
+- Do not emit JSON mixed with diagnostics on stdout.
+- Do not use untyped `[String: Any]` payload construction.
+- Do not make preflight download large models, run training, or consume paid GPU
+  time.
+- Do not require `--visualize` for the first implementation milestone.
+
+## Design principles
+
+### Headless first
+
+Every feature must work from the CLI and be useful to:
+
+- humans in a terminal
+- scripts
+- Codex or other coding agents
+- local desktop wrappers
+- optional loopback viewers
+- remote GPU workers that run the public CLI
+
+### stdout is contract, stderr is diagnostics
+
+This repo already treats stdout as machine-readable output and stderr as
+diagnostic progress. The new JSON surfaces must preserve that contract.
+
+When `--json` is set:
+
+- stdout contains exactly one JSON document, unless the command is explicitly a
+  streaming command with a documented JSON Lines mode.
+- diagnostics, progress, warnings, and logs go to stderr.
+- errors should still produce useful stderr text, and where practical should
+  produce a JSON error envelope before exiting nonzero.
+
+### Typed contracts
+
+All output contracts should be typed Swift structs with `Codable` conformance.
+Avoid ad hoc dictionaries. This keeps tests, docs, and future UI clients aligned
+with compiler-checked fields.
+
+### Stable but evolvable schemas
+
+Every emitted envelope carries:
+
+- `schema_version`
+- `mere_run_version`
+- `command`
+- `mode`
+
+Additive fields are allowed. Renames and semantic changes require a schema
+version bump.
+
+### Cheap truth before expensive work
+
+`--preflight` should answer:
+
+- Can this run start?
+- What exactly will it run?
+- What will it probably cost in local resources?
+- What inputs look suspicious?
+- What commands are safe next steps?
+
+It should avoid irreversible or expensive work.
+
+### Actions are suggestions, not hidden logic
+
+Actions describe CLI commands or artifact operations. They do not invoke private
+APIs. A UI or agent can render the actions, but all action behavior maps back to
+public commands, local files, or documented URLs.
+
+### Paths are explicit
+
+Payloads may include local absolute paths when the command is running locally,
+but portable reports should also include relative paths when possible. Secrets
+and API keys must be masked.
+
+## Public CLI surface
+
+### `--json`
+
+Add or normalize `--json` across commands that produce structured state.
+
+For commands that currently print a single path or human text, `--json` should
+emit an envelope and keep the existing default output unchanged.
+
+Example:
+
+```bash
+mere.run image train-lora \
+  --data ./dataset \
+  --output ./style.safetensors \
+  --preflight \
+  --json
+```
+
+### `--preflight`
+
+Add `--preflight` to commands where mistakes can waste meaningful time,
+compute, or model downloads.
+
+Initial target:
+
+- `image train-lora`
+
+Next targets:
+
+- `image generate`
+- `video generate`
+- `sfx video generate`
+- `vision track`
+- `api serve`
+- `model benchmark ...`
+- `model pull`
+
+Preflight should exit:
+
+- `0` when no hard blockers are found, even if warnings exist
+- nonzero when hard blockers exist and the command cannot safely proceed
+
+The JSON payload should still include blockers and suggested actions.
+
+### `--dry-run` relationship
+
+Use `--preflight` for input, configuration, model, resource, and action
+analysis.
+
+Use `--dry-run` only when a command already has a dry execution semantic, such
+as preparing manifests, resolving a training plan, or proving a request shape
+without producing the main artifact.
+
+If both exist:
+
+- `--preflight` answers "should this run?"
+- `--dry-run` answers "what would the runtime do?"
+
+For `image train-lora`, the first implementation should prefer `--preflight`
+and avoid overloading `--dry-run`.
+
+### `--actions`
+
+Avoid adding a separate public `--actions` flag in the first phase. Include
+actions in `--json` payloads by default when they are available.
+
+If payload size becomes a problem later, add:
+
+```bash
+--include-actions
+--no-actions
+```
+
+Defaulting actions into JSON is useful because agents and UIs need the same
+next-step information without a second command.
+
+### Run directory options
+
+Commands that produce multi-artifact runs should converge on a run directory
+contract.
+
+Candidate flags:
+
+```bash
+--run-dir ./runs/my-run
+--run-name my-run
+```
+
+Do not force this into the first `--preflight --json` slice. For
+`image train-lora`, continue deriving the run directory from the output path
+until the shared run contract exists.
+
+## JSON envelope
+
+All structured command payloads should use a common envelope.
+
+```json
+{
+  "schema_version": 1,
+  "mere_run_version": "0.16.0",
+  "command": ["image", "train-lora"],
+  "mode": "preflight",
+  "status": "blocked",
+  "created_at": "2026-07-02T12:00:00Z",
+  "cwd": "/path/to/project",
+  "summary": "Dataset has 38 usable images and 2 hard blockers.",
+  "request": {},
+  "result": {},
+  "diagnostics": [],
+  "actions": []
+}
+```
+
+Fields:
+
+- `schema_version`: integer contract version.
+- `mere_run_version`: CLI version string.
+- `command`: public command path, not process argv.
+- `mode`: `preflight`, `run`, `dry_run`, `status`, or `inspection`.
+- `status`: `ok`, `warning`, `blocked`, `running`, `finished`, or `failed`.
+- `created_at`: ISO-8601 timestamp.
+- `cwd`: current working directory used to resolve relative inputs.
+- `summary`: short human-readable summary for logs and UI titles.
+- `request`: typed request summary with secrets masked.
+- `result`: command-specific typed payload.
+- `diagnostics`: typed blockers, warnings, notes, and estimates.
+- `actions`: typed next actions.
+
+## Diagnostic model
+
+Diagnostics should be first-class data, not strings that clients parse.
+
+```json
+{
+  "id": "caption_missing",
+  "severity": "blocker",
+  "title": "Missing captions",
+  "message": "4 image files do not have matching .txt captions.",
+  "locations": [
+    {
+      "kind": "file",
+      "path": "/path/to/project/dataset/frame-004.png"
+    }
+  ],
+  "suggested_action_ids": ["open-dataset", "write-missing-captions"]
+}
+```
+
+Severity values:
+
+- `blocker`: command should not proceed.
+- `warning`: command can proceed, but the result is likely degraded.
+- `note`: useful context.
+- `estimate`: time, memory, storage, or model-size estimate.
+
+## Declarative actions
+
+Actions describe what a caller may do next.
+
+```json
+{
+  "id": "start-training",
+  "label": "Start training",
+  "kind": "command",
+  "style": "primary",
+  "enabled": false,
+  "disabled_reason": "Resolve hard blockers first.",
+  "command": {
+    "argv": [
+      "mere.run",
+      "image",
+      "train-lora",
+      "--data",
+      "./dataset",
+      "--output",
+      "./style.safetensors",
+      "--recipe",
+      "klein-fast-style"
+    ],
+    "cwd": "/path/to/project"
+  },
+  "requires": ["preflight.passed"]
+}
+```
+
+Action kinds:
+
+- `command`: run a public `mere.run` command.
+- `open_file`: open a local artifact.
+- `reveal_file`: reveal a local artifact in the file manager.
+- `open_directory`: open a local directory.
+- `open_url`: open a loopback or docs URL.
+- `copy_text`: copy text such as a command preview.
+- `none`: informational action for clients that only render guidance.
+
+Action styles:
+
+- `primary`: the recommended next step.
+- `secondary`: useful but not central.
+- `danger`: destructive, requires confirmation.
+- `link`: opens docs, files, or URLs.
+
+Action safety fields:
+
+- `enabled`
+- `disabled_reason`
+- `requires`
+- `confirmation`
+- `destructive`
+- `secrets_masked`
+
+Actions should never embed unmasked API keys or private auth tokens.
+
+## Artifact model
+
+Artifacts describe local files produced or consumed by a command.
+
+```json
+{
+  "id": "latest-sample",
+  "kind": "image",
+  "role": "sample",
+  "path": "/path/to/project/runs/style/samples/step-0500.png",
+  "relative_path": "runs/style/samples/step-0500.png",
+  "content_type": "image/png",
+  "size_bytes": 1842210,
+  "created_at": "2026-07-02T12:10:00Z"
+}
+```
+
+Artifact roles:
+
+- `input`
+- `output`
+- `sample`
+- `checkpoint`
+- `metric`
+- `event_log`
+- `manifest`
+- `report`
+- `cache`
+
+## Run directory contract
+
+Multi-artifact commands should converge on this shape:
+
+```text
+run.json
+events.jsonl
+metrics.csv
+actions.json
+artifacts/
+samples/
+checkpoints/
+logs/
+```
+
+Required files:
+
+- `run.json`: latest run envelope and request summary.
+- `events.jsonl`: append-only event stream.
+- `actions.json`: next actions valid for the current run state.
+
+Optional files:
+
+- `metrics.csv`: scalar metrics such as loss, throughput, memory, latency.
+- `artifacts/`: final outputs and reports.
+- `samples/`: previews or intermediate generations.
+- `checkpoints/`: intermediate model artifacts.
+- `logs/`: diagnostic logs, when logs are too large for events.
+
+The first phase can keep the existing LoRA layout. The shared layout should be
+introduced when a second command adopts structured runs.
+
+## First vertical slice: `image train-lora --preflight --json`
+
+This is the most valuable starting point because LoRA training is expensive
+enough that bad input should fail early.
+
+### Command behavior
+
+```bash
+mere.run image train-lora \
+  --data ./style-dataset \
+  --output ./style.safetensors \
+  --recipe klein-fast-style \
+  --preflight \
+  --json
+```
+
+Should:
+
+1. resolve CLI options and named recipes
+2. inspect dataset files and captions
+3. validate output path and parent directory
+4. resolve model id or model path without pulling large missing models
+5. estimate training image buckets
+6. estimate memory and disk footprint when possible
+7. report known incompatibilities
+8. emit diagnostics and actions
+9. exit before loading the full training runtime
+
+### Preflight checks
+
+Dataset checks:
+
+- dataset directory exists
+- supported image extensions exist
+- every training image has a matching caption
+- captions are non-empty
+- repeated exact captions are flagged
+- obvious placeholder captions are flagged
+- optional trigger token appears where expected
+- preview images are excluded or explicitly accepted
+- image dimensions are readable
+- low-information images are flagged when cheap heuristics can catch them
+- duplicate images are flagged when cheap hashing is available
+
+Recipe checks:
+
+- recipe name is known
+- resolved model id is shown
+- recipe-derived width, height, rank, LR, steps, and target presets are shown
+- incompatible options are blockers
+- ignored or overridden options are warnings
+
+Model checks:
+
+- managed model id is known
+- local model availability is reported
+- missing model is a blocker for a real run
+- missing model suggests a `model pull` action
+- model path exists if a local path is provided
+- LoRA target preset is compatible with the selected model family
+
+Output checks:
+
+- output extension is `.safetensors`
+- output parent directory exists or can be created
+- existing output is warned or blocked depending on overwrite policy
+- run directory derivation is shown
+- checkpoint directory plan is shown when checkpoints are enabled
+
+Resource estimates:
+
+- training sample count
+- effective resolution or bucket plan
+- total training steps
+- checkpoint count
+- sample generation count
+- approximate disk footprint
+- memory class, if the runtime can cheaply infer it
+- "unknown" where estimates would require expensive runtime loading
+
+### Example payload
+
+```json
+{
+  "schema_version": 1,
+  "mere_run_version": "0.16.0",
+  "command": ["image", "train-lora"],
+  "mode": "preflight",
+  "status": "warning",
+  "created_at": "2026-07-02T12:00:00Z",
+  "cwd": "/path/to/project",
+  "summary": "38 usable images, 2 warnings, ready to train.",
+  "request": {
+    "data": "./style-dataset",
+    "output": "./style.safetensors",
+    "model": "image-klein-base-9b",
+    "recipe": "klein-fast-style",
+    "training_steps": 1000,
+    "width": 1024,
+    "height": 1024,
+    "rank": 16
+  },
+  "result": {
+    "dataset": {
+      "directory": "/path/to/project/style-dataset",
+      "image_count": 38,
+      "caption_count": 38,
+      "usable_pair_count": 38,
+      "missing_caption_count": 0,
+      "duplicate_caption_count": 4,
+      "low_information_image_count": 1
+    },
+    "model": {
+      "id": "image-klein-base-9b",
+      "installed": true,
+      "family": "klein"
+    },
+    "plan": {
+      "recipe": "klein-fast-style",
+      "training_steps": 1000,
+      "checkpoint_interval": 250,
+      "expected_checkpoint_count": 4,
+      "max_resolution": 512,
+      "low_ram": true,
+      "no_compile": true
+    }
+  },
+  "diagnostics": [
+    {
+      "id": "duplicate_captions",
+      "severity": "warning",
+      "title": "Repeated captions",
+      "message": "4 captions are exact duplicates. Training can proceed, but style learning may be weaker."
+    }
+  ],
+  "actions": [
+    {
+      "id": "start-training",
+      "label": "Start training",
+      "kind": "command",
+      "style": "primary",
+      "enabled": true,
+      "command": {
+        "argv": [
+          "mere.run",
+          "image",
+          "train-lora",
+          "--data",
+          "./style-dataset",
+          "--output",
+          "./style.safetensors",
+          "--recipe",
+          "klein-fast-style"
+        ],
+        "cwd": "/path/to/project"
+      },
+      "requires": ["preflight.passed"]
+    }
+  ]
+}
+```
+
+## Implementation phases
+
+### Phase 0: contract and inventory
+
+Deliverables:
+
+- this planning document
+- inventory of current commands with existing `--json` support
+- inventory of commands where preflight is valuable
+- list of current output conventions that must not break
+
+Likely files:
+
+- `Sources/MereRunCLI/MereRunCLI.swift`
+- `Sources/MereRunCLI/Commands/*`
+- `Sources/MereRunCLI/Support/CLIOutput.swift`
+- `Sources/MereRunCLI/Support/CLIStderr.swift`
+- tests under `Tests/MereRunCLITests`
+
+Acceptance:
+
+- no behavior changes
+- document reviewed against current command tree
+
+### Phase 1: shared typed contracts
+
+Add shared support types for structured CLI output.
+
+Candidate files:
+
+- `Sources/MereRunCLI/Support/StructuredRunEnvelope.swift`
+- `Sources/MereRunCLI/Support/PreflightDiagnostic.swift`
+- `Sources/MereRunCLI/Support/DeclarativeAction.swift`
+- `Sources/MereRunCLI/Support/RunArtifactSummary.swift`
+
+Types:
+
+- `StructuredRunEnvelope<Request: Encodable, Result: Encodable>`
+- `StructuredRunMode`
+- `StructuredRunStatus`
+- `PreflightDiagnostic`
+- `PreflightSeverity`
+- `DeclarativeAction`
+- `DeclarativeCommandAction`
+- `RunArtifactSummary`
+- `MaskedCommandPreview`
+
+Support helpers:
+
+- stable JSON encoder
+- timestamp provider
+- command preview with secret masking
+- relative path helper
+- diagnostics-to-status reducer
+
+Acceptance:
+
+- unit tests cover encoding shape
+- no command behavior changes yet
+- no `[String: Any]`
+
+### Phase 2: LoRA preflight analyzer
+
+Extract preflight analysis from `ImageTrainLoRA` into typed code.
+
+Candidate files:
+
+- `Sources/MereRunCLI/Support/ImageLoRAPreflight.swift`
+- or `Sources/MereRunCLI/Support/LoRATrainingPreflight.swift`
+
+Responsibilities:
+
+- accept resolved training options
+- inspect dataset
+- inspect output plan
+- inspect model availability
+- emit typed result and diagnostics
+- emit declarative actions
+
+Avoid:
+
+- full model loading
+- optimizer setup
+- GPU allocation
+- training runtime initialization
+
+Acceptance:
+
+- `image train-lora --preflight --json` works for a valid tiny fixture
+- blockers produce nonzero exit
+- warnings keep exit zero
+- stderr remains diagnostic only
+
+### Phase 3: command integration
+
+Update `ImageTrainLoRACommand.swift`.
+
+Add:
+
+```swift
+@Flag(name: [.customLong("preflight")], help: "Inspect the LoRA training request without running training.")
+var preflight: Bool = false
+
+@Flag(name: [.customLong("json")], help: "Emit a structured JSON report.")
+var json: Bool = false
+```
+
+Behavior matrix:
+
+| Flags | Behavior |
+| --- | --- |
+| none | current behavior |
+| `--json` | final success emits structured run result, if feasible in this phase |
+| `--preflight` | human-readable preflight summary |
+| `--preflight --json` | structured preflight report |
+| `--preflight --quiet` | either reject as incompatible or print only essential summary |
+
+For the first slice, it is acceptable to implement only
+`--preflight --json` and a human-readable `--preflight` summary, then add
+full-run `--json` in a later phase.
+
+Acceptance:
+
+- existing parsing tests updated
+- existing default stdout contract unchanged
+- `--quiet` behavior remains compatible
+
+### Phase 4: tests
+
+Add focused tests before broad rollout.
+
+Test categories:
+
+- argument parsing includes `--preflight` and `--json`
+- valid preflight fixture emits expected JSON fields
+- missing dataset is a blocker
+- missing captions are blockers
+- duplicate captions are warnings
+- missing model suggests `model pull`
+- existing output warning or blocker follows chosen overwrite policy
+- stdout JSON decodes with `JSONDecoder`
+- stderr contains diagnostics but stdout is clean JSON
+- action argv is shell-safe and secret-masked
+
+Fixtures:
+
+- tiny image dataset with captions
+- dataset with missing captions
+- dataset with duplicate captions
+- dataset with preview images
+
+Acceptance:
+
+- targeted Swift tests pass
+- `./scripts/check.sh` passes before PR
+
+### Phase 5: docs
+
+Update public docs after the first command is real.
+
+Likely files:
+
+- `docs/cli.md`
+- `docs/runtime/image.md`
+- `Sources/MereRunCLI/Guides/image-train-lora.md`
+- `README.md`, only if the behavior is important enough for top-level examples
+
+Docs should show:
+
+- preflight before real training
+- JSON consumption example
+- common blocker examples
+- relationship to `--visualize`, clearly marked as separate
+
+Acceptance:
+
+- docs examples use repo-relative paths
+- no workstation-specific paths
+- no stale model IDs
+
+### Phase 6: structured run directories
+
+After the first preflight slice is stable, extend real long-running commands to
+write `run.json`, `actions.json`, and normalized events.
+
+Start with:
+
+- `image train-lora`, because it already has run artifacts
+
+Then:
+
+- `image generate`
+- `video generate`
+- `sfx video generate`
+- `vision track`
+- `model benchmark`
+
+Acceptance:
+
+- existing LoRA viewer continues to work
+- `image visualize-run` can read both old and new run directories
+- new run files are additive
+
+### Phase 7: cross-command adoption
+
+Adopt the contract where it buys real value.
+
+High-value commands:
+
+- `model pull --preflight --json`
+  - model size, source, installed state, disk estimate, cache path, actions
+- `api serve --preflight --json`
+  - host, port, auth requirement, selected engine, model availability, actions
+- `image generate --preflight --json`
+  - model availability, dimensions, reference images, output path, actions
+- `video generate --preflight --json`
+  - frame count, dimensions, model availability, image inputs, output path
+- `vision track --preflight --json`
+  - video input readability, model availability, prompt, output path
+- `model benchmark ... --json`
+  - benchmark plan, live metrics, final report, rerun action
+
+Lower-value commands can wait.
+
+### Phase 8: optional viewers
+
+Only after JSON and run directories are stable, add viewers as thin clients.
+
+Viewer rule:
+
+- viewer routes read the same report, events, metrics, artifacts, and actions
+  that the CLI already writes
+- viewer buttons render declarative actions
+- viewer does not invent hidden command behavior
+
+Possible future commands:
+
+```bash
+mere.run run view ./runs/my-run
+mere.run image generate --visualize
+mere.run api serve --visualize
+```
+
+This is intentionally not part of the first implementation milestone.
+
+## Command adoption matrix
+
+| Command | `--json` | `--preflight` | actions | run directory | viewer |
+| --- | --- | --- | --- | --- | --- |
+| `image train-lora` | phase 3 | phase 3 | phase 3 | phase 6 | existing, later upgrade |
+| `image generate` | phase 7 | phase 7 | phase 7 | phase 7 | later |
+| `video generate` | phase 7 | phase 7 | phase 7 | phase 7 | later |
+| `sfx video generate` | phase 7 | phase 7 | phase 7 | phase 7 | later |
+| `vision track` | phase 7 | phase 7 | phase 7 | phase 7 | later |
+| `api serve` | phase 7 | phase 7 | phase 7 | not needed | later |
+| `model pull` | phase 7 | phase 7 | phase 7 | not needed | not needed |
+| `model benchmark` | phase 7 | phase 7 | phase 7 | phase 7 | later |
+
+## Error handling
+
+Preflight blockers should produce structured diagnostics and a nonzero exit.
+
+For `--preflight --json`, prefer emitting the JSON report even when blocked.
+This lets agents fix the issue without parsing stderr.
+
+For unexpected internal failures:
+
+- stderr should include the localized error
+- stdout may be empty if the command cannot safely construct the envelope
+- tests should cover expected blocker paths, not every fatal runtime exception
+
+## Security and privacy
+
+The payload is local-first, but it can still expose sensitive details if copied.
+
+Rules:
+
+- mask API keys and auth tokens
+- do not include full environment dumps
+- do not include secret-bearing command arguments
+- include local paths because local tools need them, but also include relative
+  paths where possible
+- keep non-loopback server action suggestions auth-aware
+- treat `open_url` actions to non-loopback hosts carefully
+
+## Compatibility
+
+The implementation should be additive.
+
+Must preserve:
+
+- current default stdout behavior
+- current `--quiet` behavior unless explicitly documented
+- current `--visualize` behavior
+- existing LoRA run directories
+- existing docs examples until the new feature lands
+
+The first PR should not require users to change existing commands.
+
+## Open decisions
+
+1. Should `--preflight` without `--json` print a compact human summary or require
+   `--json` for the first implementation?
+2. Should blockers exit nonzero even though the JSON payload is successfully
+   emitted? Recommended: yes.
+3. Should missing optional models be blockers or warnings? Recommended: blocker
+   when the run cannot start without them, warning when the command can pull or
+   fallback.
+4. Should `actions.command.argv` include `mere.run` as argv[0] or only the
+   public command path? Recommended: include `mere.run` for copy/paste actions
+   and include `command_path` separately if clients need it.
+5. Should the run directory contract live in `MereRunCLI` or `MereRunCore`?
+   Recommended: start in `MereRunCLI/Support`; move shared artifact/event types
+   lower only if runtimes need to write them directly.
+
+## PR sequencing
+
+### PR 1: contract and LoRA preflight JSON
+
+Scope:
+
+- shared typed envelope, diagnostics, actions
+- `image train-lora --preflight --json`
+- tests and docs for the new preflight path
+
+Avoid:
+
+- generalized run directories
+- viewer changes
+- cross-command adoption
+
+### PR 2: LoRA run actions and normalized files
+
+Scope:
+
+- write `run.json` and `actions.json` for LoRA training
+- keep existing viewer working
+- add compatibility tests for old and new run dirs
+
+### PR 3: model and image generation preflights
+
+Scope:
+
+- `model pull --preflight --json`
+- `image generate --preflight --json`
+- shared model availability diagnostics
+
+### PR 4: long-running media commands
+
+Scope:
+
+- `video generate`
+- `sfx video generate`
+- `vision track`
+- benchmark commands where useful
+
+### PR 5: optional viewer refresh
+
+Scope:
+
+- render actions in the LoRA viewer
+- optionally introduce a generic `run view`
+- keep viewer loopback-only
+
+## Acceptance criteria for the first milestone
+
+The first milestone is complete when:
+
+- `mere.run image train-lora --preflight --json` emits a typed, decodeable JSON
+  envelope to stdout
+- blockers and warnings are structured diagnostics
+- hard blockers exit nonzero
+- no expensive model load or training starts during preflight
+- valid preflight includes a `start-training` action
+- missing model includes a `model pull` action
+- missing captions include precise file locations
+- default `image train-lora` behavior is unchanged
+- targeted CLI tests pass
+- `./scripts/check.sh` passes
+
+## Why this matters
+
+This turns `mere.run` into a better headless runtime without expanding the
+standing UI surface.
+
+The runtime becomes easier to drive from scripts, Codex, remote workers, and
+small local dashboards. Bad runs fail earlier. Good runs explain themselves.
+Optional UIs can appear later as faithful renderers of structured truth instead
+of becoming a second workflow engine.

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -109,6 +109,22 @@ For cleaner public-facing exports, keep the seed and prompt fixed, render at a
 larger matching aspect ratio such as 1280x960 with 24 steps, then downsample to
 1024x768 with a high-quality image resizer.
 
+Run a preflight before spending training time:
+
+```bash
+swift run mere.run image train-lora \
+  --data ./style-dataset \
+  --output ./style-klein.safetensors \
+  --recipe klein-fast-style \
+  --preflight \
+  --json
+```
+
+The preflight path inspects the dataset, resolved recipe, model availability,
+output path, warnings, hard blockers, and next actions without loading the full
+model or starting training. It prints a single JSON report to stdout when
+`--json` is set; diagnostics stay out of stdout.
+
 Add `--visualize` during training to start a loopback dashboard with the live
 loss curve, progress events, samples, checkpoints, and run artifacts. Reopen a
 completed or copied run directory later with:


### PR DESCRIPTION
## Summary
- add `image train-lora --preflight` and structured JSON preflight envelopes for LoRA training requests
- surface dataset/model/output diagnostics, resource/environment metadata, and suggested next actions before expensive training work
- update Krea/Klein LoRA training plumbing, docs, and parsing coverage for the preflight/runtime environment contract

## Validation
- `./scripts/check.sh` from clean worktree `/tmp/mere-run-lora-preflight-verify`