### PR TITLE
Text SFT trainer: gathered lm_head loss, async readback cadence, reliability

### DIFF
--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -1577,6 +1577,19 @@ public final class Gemma4TextCausalLM: Module, Gemma4CausalModel, @unchecked Sen
         forward(inputIds: inputIds, cache: cache as? [Gemma4AttentionCache])
     }
 
+    /// Logits for an explicit set of flattened (`[batch * seq]` row-major)
+    /// positions only. SFT training reads logits solely at loss-masked target
+    /// positions, and prompt/pad rows are the majority of a chat batch —
+    /// projecting them through the 262k-vocab lm_head (plus the float32 loss
+    /// chain) is pure waste. Hidden states still flow through every position,
+    /// so gradients match the full-logits path exactly.
+    func trainingLogits(inputIds: MLXArray, flatTargetPositions: MLXArray) -> MLXArray {
+        let hidden = languageModel(inputIds)
+        let flattened = hidden.reshaped([-1, hidden.dim(-1)])
+        let selected = take(flattened, flatTargetPositions.asType(.int32), axis: 0)
+        return applyFinalSoftcap(languageModel.embedTokens.asLinear(selected))
+    }
+
     func forward(inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> MLXArray {
         var logits = languageModel.logits(inputIds, cache: cache)
         if let finalLogitSoftcapping {

--- a/Sources/MereRunCore/Gemma4/Gemma4TextLoRATrainingPipeline.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextLoRATrainingPipeline.swift
@@ -79,7 +79,10 @@ public enum Gemma4TextLoRATrainingPipeline {
             config: request.trainingConfig,
             outputURL: request.outputURL,
             metadata: metadata,
-            progressHandler: trainingProgressHandler
+            progressHandler: trainingProgressHandler,
+            gatheredForward: { model, inputIds, targetPositions in
+                model.trainingLogits(inputIds: inputIds, flatTargetPositions: targetPositions)
+            }
         ) { model, inputIds in
             model(inputIds)
         }

--- a/Sources/MereRunCore/LoRA/LoRATrainingEnvironment.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingEnvironment.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Darwin
+
+/// Environment-tunable training behavior shared by the image-LoRA trainers.
+public enum LoRATrainingEnvironment {
+    /// Explicit gradient-checkpointing override from the environment:
+    /// MERERUN_LORA_TRAIN_GRAD_CHECKPOINT=1 forces on, =0 forces off,
+    /// unset defers to the resolution-aware default.
+    public static let gradientCheckpointingOverride: Bool? = {
+        guard let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_GRAD_CHECKPOINT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !raw.isEmpty else {
+            return nil
+        }
+        if raw == "0" || raw == "false" || raw == "off" { return false }
+        return true
+    }()
+
+    /// Resolution-aware gradient-checkpointing default. Measured on M4 Max /
+    /// 128 GB: full-injection steps at 1024x1024 peak 159 GB (Krea 2) and
+    /// 183 GB (Klein base, crashes), while the recipe workflows at <=512px and
+    /// 768x416 fit comfortably without recompute overhead. The pixel threshold
+    /// keeps proven low-resolution recipes byte-identical in behavior and
+    /// protects high-resolution runs by default.
+    public static func gradientCheckpointingEnabled(trainingPixels: Int) -> Bool {
+        if let forced = gradientCheckpointingOverride {
+            return forced
+        }
+        return trainingPixels >= 768 * 768
+    }
+
+    /// MLX buffer-cache cap during training, in gigabytes. The cache grows to
+    /// the transient high-water mark and never shrinks, pinning the process
+    /// footprint at the worst spike of the run. 0 leaves it unlimited.
+    /// MERERUN_LORA_TRAIN_CACHE_LIMIT_GB overrides.
+    public static let trainingCacheLimitGB: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_CACHE_LIMIT_GB"],
+           let value = Int(raw), value >= 0 {
+            return value
+        }
+        return 16
+    }()
+
+    /// Adapter checkpoint cadence in optimizer steps for trainers without
+    /// their own mid-run checkpointing. MERERUN_LORA_TRAIN_SAVE_EVERY
+    /// overrides; 0 disables.
+    public static let periodicSaveInterval: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_SAVE_EVERY"],
+           let value = Int(raw), value >= 0 {
+            return value
+        }
+        return 100
+    }()
+
+    /// MERERUN_LORA_TRAIN_SYNC_EVAL=1 evaluates each training step
+    /// synchronously, capping in-flight activations at one step's worth.
+    public static let synchronousStepEval: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_SYNC_EVAL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "on"
+    }()
+
+    /// Physical memory footprint (the metric jetsam actually enforces —
+    /// resident plus compressed), in gigabytes.
+    public static func currentPhysicalFootprintGB() -> Double? {
+        var usage = rusage_info_current()
+        let status = withUnsafeMutablePointer(to: &usage) { pointer in
+            pointer.withMemoryRebound(to: (rusage_info_t?).self, capacity: 1) { reboundPointer in
+                proc_pid_rusage(getpid(), RUSAGE_INFO_CURRENT, reboundPointer)
+            }
+        }
+        guard status == 0 else { return nil }
+        return Double(usage.ri_phys_footprint) / 1_000_000_000
+    }
+}

--- a/Sources/MereRunCore/TextLoRATrainer.swift
+++ b/Sources/MereRunCore/TextLoRATrainer.swift
@@ -64,6 +64,50 @@ public struct TextLoRATrainingProgress: Sendable, Hashable {
     }
 }
 
+/// Environment-tunable behavior specific to the text SFT trainer. Shared
+/// image/text knobs (cache limit, save cadence, sync eval, footprint) live in
+/// `LoRATrainingEnvironment`.
+enum TextLoRATrainingEnvironment {
+    /// Gathered-loss path: project only loss-masked target positions through
+    /// the lm_head and use logSumExp-minus-gather cross entropy. Identical
+    /// gradients to the full-logits path; skips the `[B*T, 262k]` matmul and
+    /// float32 chain over prompt/pad rows. MERERUN_TEXT_LORA_TRAIN_GATHERED_LOSS=0
+    /// restores the legacy full-logits loss.
+    static let gatheredLossEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_TEXT_LORA_TRAIN_GATHERED_LOSS"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw != "0" && raw != "false" && raw != "off"
+    }()
+
+    /// Loss-readback cadence in steps. Between boundaries the step is
+    /// scheduled with asyncEval and the loop continues without a GPU→CPU
+    /// sync, so graph construction overlaps execution.
+    /// MERERUN_TEXT_LORA_TRAIN_LOG_EVERY overrides; 1 restores the legacy
+    /// per-step synchronous readback.
+    static let logEvery: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_TEXT_LORA_TRAIN_LOG_EVERY"],
+           let value = Int(raw), value >= 1 {
+            return value
+        }
+        return 10
+    }()
+
+    /// Buffer-cache cap for text training. The shared image default (16 GB)
+    /// starves text step working sets: image steps run minutes so allocation
+    /// churn amortizes, but a text step is seconds and a sub-working-set cap
+    /// showed 2× step time at ~900-token sequences. 32 GB removed the churn
+    /// while still bounding the footprint (uncapped, the cache balloons past
+    /// 100 GB at long sequences). MERERUN_LORA_TRAIN_CACHE_LIMIT_GB still
+    /// overrides for both trainers.
+    static let cacheLimitGB: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_LORA_TRAIN_CACHE_LIMIT_GB"],
+           let value = Int(raw), value >= 0 {
+            return value
+        }
+        return 32
+    }()
+}
+
 public enum TextLoRATrainer {
     public static func train<Model: Module>(
         model: Model,
@@ -73,6 +117,7 @@ public enum TextLoRATrainer {
         outputURL: URL? = nil,
         metadata: [String: String] = [:],
         progressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)? = nil,
+        gatheredForward: ((Model, MLXArray, MLXArray) -> MLXArray)? = nil,
         forward: @escaping (Model, MLXArray) -> MLXArray
     ) throws -> TextLoRATrainingReport {
         try validate(config: config, examples: examples, loraLayers: loraLayers)
@@ -87,15 +132,30 @@ public enum TextLoRATrainer {
             .map { (path: $0.key, layer: $0.value) }
             .sorted { $0.path < $1.path }
 
-        let lossAndGrad = valueAndGrad(model: model) { model, arrays in
-            let logits = forward(model, arrays[0])
-            let loss = TextSFTTrainingLoss.maskedNextTokenCrossEntropy(
-                logits: logits,
-                labels: arrays[1],
-                lossMask: arrays[2]
-            )
-            return [loss]
+        let useGatheredLoss = gatheredForward != nil && TextLoRATrainingEnvironment.gatheredLossEnabled
+        let lossAndGrad: (Model, [MLXArray]) -> ([MLXArray], ModuleParameters)
+        if useGatheredLoss, let gatheredForward {
+            lossAndGrad = valueAndGrad(model: model) { model, arrays in
+                let logits = gatheredForward(model, arrays[0], arrays[1])
+                return [TextSFTTrainingLoss.gatheredNextTokenCrossEntropy(logits: logits, labels: arrays[2])]
+            }
+        } else {
+            lossAndGrad = valueAndGrad(model: model) { model, arrays in
+                let logits = forward(model, arrays[0])
+                let loss = TextSFTTrainingLoss.maskedNextTokenCrossEntropy(
+                    logits: logits,
+                    labels: arrays[1],
+                    lossMask: arrays[2]
+                )
+                return [loss]
+            }
         }
+        if TextLoRATrainingEnvironment.cacheLimitGB > 0 {
+            MLX.Memory.cacheLimit = TextLoRATrainingEnvironment.cacheLimitGB * 1_073_741_824
+        }
+        FileHandle.standardError.write(Data(
+            "[text-lora-train] gathered_loss=\(useGatheredLoss) log_every=\(TextLoRATrainingEnvironment.logEvery) save_every=\(LoRATrainingEnvironment.periodicSaveInterval) cache_limit_gb=\(TextLoRATrainingEnvironment.cacheLimitGB)\n".utf8
+        ))
 
         let beta1 = MLXArray(config.beta1)
         let beta2 = MLXArray(config.beta2)
@@ -119,6 +179,14 @@ public enum TextLoRATrainer {
             seed: config.seed
         )
 
+        let logEvery = TextLoRATrainingEnvironment.logEvery
+        let saveEvery = LoRATrainingEnvironment.periodicSaveInterval
+        let partialURL = outputURL.map {
+            $0.deletingPathExtension().appendingPathExtension("partial").appendingPathExtension("safetensors")
+        }
+        var lastBoundaryTime = Date()
+        var lastBoundaryStep = 0
+
         for step in 0..<config.trainingSteps {
             let batchExamples = scheduledBatch(
                 examples,
@@ -126,8 +194,15 @@ public enum TextLoRATrainer {
                 batchSize: config.batchSize,
                 step: step
             )
-            let batch = try TextSFTTrainingBatchBuilder.makeBatch(batchExamples)
-            let (values, gradients) = lossAndGrad(model, [batch.inputIds, batch.labels, batch.lossMask])
+            let stepInputs: [MLXArray]
+            if useGatheredLoss {
+                let batch = try TextSFTTrainingBatchBuilder.makeGatheredBatch(batchExamples)
+                stepInputs = [batch.inputIds, batch.targetPositions, batch.targetLabels]
+            } else {
+                let batch = try TextSFTTrainingBatchBuilder.makeBatch(batchExamples)
+                stepInputs = [batch.inputIds, batch.labels, batch.lossMask]
+            }
+            let (values, gradients) = lossAndGrad(model, stepInputs)
             let loss = values[0]
             let gradMap = Dictionary(uniqueKeysWithValues: gradients.flattened())
             let stepNumber = step + 1
@@ -147,17 +222,50 @@ public enum TextLoRATrainer {
                 biasCorrection2: biasCorrection2,
                 useWeightDecay: config.weightDecay > 0
             )
-            eval([loss] + orderedLayers.flatMap { [$0.layer.loraDown, $0.layer.loraUp] })
+            let stepState = [loss] + orderedLayers.flatMap { [$0.layer.loraDown, $0.layer.loraUp] }
+            let shouldSavePartial = saveEvery > 0 && stepNumber % saveEvery == 0
+                && stepNumber < config.trainingSteps && partialURL != nil
+            let isBoundary = stepNumber == 1
+                || stepNumber == config.trainingSteps
+                || stepNumber % logEvery == 0
+                || shouldSavePartial
+                || LoRATrainingEnvironment.synchronousStepEval
+            guard isBoundary else {
+                // Off-boundary steps are scheduled without a GPU→CPU sync so
+                // the next step's graph construction overlaps execution;
+                // asyncEval's back-pressure bounds how far the loop runs ahead.
+                asyncEval(stepState)
+                continue
+            }
+            eval(stepState)
             let scalarLoss = loss.item(Float.self)
             if initialLoss == nil { initialLoss = scalarLoss }
             finalLoss = scalarLoss
             let visibleStep = stepNumber
+            let now = Date()
+            let stepsCovered = max(visibleStep - lastBoundaryStep, 1)
+            let secondsPerStep = now.timeIntervalSince(lastBoundaryTime) / Double(stepsCovered)
+            lastBoundaryTime = now
+            lastBoundaryStep = visibleStep
+            let footprint = LoRATrainingEnvironment.currentPhysicalFootprintGB()
+                .map { String(format: "%.1f", $0) } ?? "n/a"
+            FileHandle.standardError.write(Data(
+                "[text-lora-train] step=\(visibleStep)/\(config.trainingSteps) loss=\(scalarLoss) step_s=\(String(format: "%.2f", secondsPerStep)) footprint_gb=\(footprint)\n".utf8
+            ))
             try metricsLogger?.record(step: visibleStep, loss: scalarLoss)
             progressHandler?(
                 TextLoRATrainingProgress(
                     stage: .training(step: visibleStep, total: config.trainingSteps, loss: scalarLoss)
                 )
             )
+            if shouldSavePartial, let partialURL {
+                try LoRASafetensorsWriter.save(
+                    loraLayers: loraLayers,
+                    to: partialURL,
+                    includeOptimizerState: true,
+                    metadata: metadata
+                )
+            }
         }
 
         progressHandler?(TextLoRATrainingProgress(stage: .saving))
@@ -169,6 +277,9 @@ public enum TextLoRATrainer {
                 metadata: metadata
             )
             try metricsLogger?.writeArtifacts()
+            if let partialURL, FileManager.default.fileExists(atPath: partialURL.path) {
+                try? FileManager.default.removeItem(at: partialURL)
+            }
         }
 
         return TextLoRATrainingReport(

--- a/Sources/MereRunCore/TextSFTTrainingBatch.swift
+++ b/Sources/MereRunCore/TextSFTTrainingBatch.swift
@@ -103,6 +103,34 @@ public enum TextSFTTrainingBatchBuilder {
         )
     }
 
+    /// Batch plus the flattened (row-major `[batch * maxLength]`) indices of
+    /// positions with a positive loss mask, and the labels at those
+    /// positions. The gathered training path projects only these rows through
+    /// the lm_head instead of every position in the batch.
+    public static func makeGatheredBatch(
+        _ examples: [TextSFTTokenizedExample],
+        padTokenId: Int = 0
+    ) throws -> (inputIds: MLXArray, targetPositions: MLXArray, targetLabels: MLXArray) {
+        let batch = try makeBatch(examples, padTokenId: padTokenId)
+        let maxLength = batch.inputIds.dim(1)
+        var positions: [Int32] = []
+        var labels: [Int32] = []
+        for (row, example) in examples.enumerated() {
+            for (column, maskValue) in example.lossMask.enumerated() where maskValue > 0 {
+                positions.append(Int32(row * maxLength + column))
+                labels.append(Int32(example.labelTokenIds[column]))
+            }
+        }
+        guard !positions.isEmpty else {
+            throw TextSFTTrainingBatchError.noAssistantTargets
+        }
+        return (
+            inputIds: batch.inputIds,
+            targetPositions: MLXArray(positions),
+            targetLabels: MLXArray(labels)
+        )
+    }
+
     public static func makeBatch(
         _ examples: [TextSFTTokenizedExample],
         padTokenId: Int = 0
@@ -161,6 +189,25 @@ public enum TextSFTTrainingLoss {
         let mask = lossMask.asType(.float32)
         let denominator = mask.sum() + MLXArray(Float(1e-8))
         return -(selected * mask).sum() / denominator
+    }
+
+    /// Cross entropy over pre-gathered target rows: `[N, vocab]` logits and
+    /// `[N]` labels. logSumExp-minus-gather avoids materializing a second
+    /// full-vocabulary log-probability tensor the way logSoftmax does, and
+    /// every gathered row contributes, so no mask is needed. Matches
+    /// `maskedNextTokenCrossEntropy` on the same positions to float precision.
+    public static func gatheredNextTokenCrossEntropy(
+        logits: MLXArray,
+        labels: MLXArray
+    ) -> MLXArray {
+        let float32Logits = logits.asType(.float32)
+        let normalizers = logSumExp(float32Logits, axis: -1)
+        let selected = takeAlong(
+            float32Logits,
+            labels.asType(.int32).expandedDimensions(axis: -1),
+            axis: -1
+        ).squeezed(axis: -1)
+        return (normalizers - selected).mean()
     }
 }
 

--- a/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
+++ b/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MLX
 import MLXNN
+import MLXRandom
 import XCTest
 @testable import MereRunCore
 
@@ -128,6 +129,104 @@ final class TextLoRATrainerTests: MereRunCoreTestCase {
         XCTAssertEqual(report.steps, 2)
         XCTAssertGreaterThan(report.layerCount, 0)
         XCTAssertNotNil(report.finalLoss)
+    }
+
+    func testGatheredBatchMatchesMaskPositions() throws {
+        let examples = [
+            TextSFTTokenizedExample(
+                inputTokenIds: [3, 4, 5, 6],
+                labelTokenIds: [4, 5, 6, 7],
+                lossMask: [0, 1, 0, 1]
+            ),
+            TextSFTTokenizedExample(
+                inputTokenIds: [1, 2],
+                labelTokenIds: [2, 3],
+                lossMask: [0, 1]
+            ),
+        ]
+        let batch = try TextSFTTrainingBatchBuilder.makeGatheredBatch(examples)
+
+        XCTAssertEqual(batch.inputIds.shape, [2, 4])
+        // Row 0 targets columns 1 and 3; row 1 (padded to length 4) column 1.
+        XCTAssertEqual(batch.targetPositions.asArray(Int32.self), [1, 3, 5])
+        XCTAssertEqual(batch.targetLabels.asArray(Int32.self), [5, 7, 3])
+    }
+
+    func testGatheredLossMatchesMaskedLoss() throws {
+        MLXRandom.seed(11)
+        let logits = MLXRandom.normal([2, 4, 8])
+        let labels = MLXArray([Int32]([1, 2, 3, 4, 5, 6, 7, 0]), [2, 4])
+        let mask = MLXArray([Float]([0, 1, 1, 0, 1, 0, 0, 1]), [2, 4])
+
+        let legacy = TextSFTTrainingLoss.maskedNextTokenCrossEntropy(
+            logits: logits,
+            labels: labels,
+            lossMask: mask
+        ).item(Float.self)
+
+        let flatLogits = logits.reshaped([-1, 8])
+        let positions = MLXArray([Int32]([1, 2, 4, 7]))
+        let gathered = TextSFTTrainingLoss.gatheredNextTokenCrossEntropy(
+            logits: take(flatLogits, positions, axis: 0),
+            labels: MLXArray([Int32]([2, 3, 5, 0]))
+        ).item(Float.self)
+
+        XCTAssertEqual(legacy, gathered, accuracy: 1e-5)
+    }
+
+    func testTrainingLogitsMatchesFullForwardAtTargets() throws {
+        MLXRandom.seed(5)
+        let model = Gemma4TextCausalLM(config: try tinyGemma4TextConfig())
+        let inputIds = MLXArray([Int32]([3, 4, 5, 6, 1, 2, 0, 0]), [2, 4])
+        let positions = MLXArray([Int32]([1, 3, 5]))
+
+        let full = model(inputIds).reshaped([-1, 32])
+        let expected = take(full, positions, axis: 0)
+        let gathered = model.trainingLogits(inputIds: inputIds, flatTargetPositions: positions)
+
+        XCTAssertEqual(gathered.shape, expected.shape)
+        let maxDiff = MLX.abs(gathered - expected).max().item(Float.self)
+        XCTAssertLessThan(maxDiff, 1e-5)
+    }
+
+    func testGatheredTrainingMatchesLegacyTrajectory() throws {
+        let examples = [
+            TextSFTTokenizedExample(
+                inputTokenIds: [3, 4, 5, 6],
+                labelTokenIds: [4, 5, 6, 7],
+                lossMask: [0, 1, 1, 1]
+            ),
+            TextSFTTokenizedExample(
+                inputTokenIds: [7, 8, 9],
+                labelTokenIds: [8, 9, 10],
+                lossMask: [0, 0, 1]
+            ),
+        ]
+        let config = TextLoRATrainingConfig(trainingSteps: 3, batchSize: 1, learningRate: 0.02)
+
+        func trainOnce(gathered: Bool) throws -> Float {
+            MLXRandom.seed(21)
+            let model = Gemma4TextCausalLM(config: try tinyGemma4TextConfig())
+            let layers = try Gemma4TextLoRAInjector.inject(into: model, rank: 2)
+            let report = try TextLoRATrainer.train(
+                model: model,
+                loraLayers: layers,
+                examples: examples,
+                config: config,
+                gatheredForward: gathered
+                    ? { model, inputIds, positions in
+                        model.trainingLogits(inputIds: inputIds, flatTargetPositions: positions)
+                    }
+                    : nil
+            ) { model, inputIds in
+                model(inputIds)
+            }
+            return try XCTUnwrap(report.finalLoss)
+        }
+
+        let legacyLoss = try trainOnce(gathered: false)
+        let gatheredLoss = try trainOnce(gathered: true)
+        XCTAssertEqual(legacyLoss, gatheredLoss, accuracy: 2e-4)
     }
 
     private func tinyGemma4TextConfig() throws -> Gemma4TextConfig {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,32 @@ exact full-vocabulary sort. The truncation only affects requests whose top-p
 nucleus would span more than this many tokens, which does not occur at
 practical temperatures.
 
+### `MERERUN_TEXT_LORA_TRAIN_GATHERED_LOSS`
+
+Native text LoRA training (`text train-lora`) projects only loss-masked
+target positions through the 262k-vocabulary lm_head and computes cross
+entropy as logSumExp-minus-gather, instead of materializing full-sequence
+logits plus a second full-vocabulary log-probability tensor. Gradients are
+identical to the full path — prompt and padding rows never contribute loss —
+so this is on by default; set `0`, `false`, or `off` to restore the legacy
+full-logits loss. The trainer prints its decision at startup
+(`gathered_loss=` on stderr).
+
+### `MERERUN_TEXT_LORA_TRAIN_LOG_EVERY`
+
+Loss-readback cadence for text LoRA training, in optimizer steps (default
+`10`). Between boundaries steps are scheduled with asyncEval and the loop
+continues without a GPU→CPU sync, so the next step's graph construction
+overlaps execution. Boundary steps read the loss, update the metrics CSV and
+progress, and print `[text-lora-train] step= loss= step_s= footprint_gb=` to
+stderr. Set `1` for the legacy per-step synchronous readback. The shared
+image/text training knobs (`MERERUN_LORA_TRAIN_CACHE_LIMIT_GB`,
+`MERERUN_LORA_TRAIN_SAVE_EVERY`, `MERERUN_LORA_TRAIN_SYNC_EVAL`) also apply:
+the buffer-cache cap defaults to 32 GB for text training (a sub-working-set
+cap doubles step time at ~900-token sequences, while uncapped the cache
+balloons past 100 GB), and a `<name>.partial.safetensors` adapter checkpoint
+is written every 100 steps and removed after the final save.
+
 ### `MERERUN_GEMMA4_DECODE_TRACE`
 
 Set to `1` to log a per-decode summary to stderr splitting each token's wall

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -152,6 +152,15 @@ while the optimizer runs. Keep local text fine-tuning in `mere.run` so the same
 model ids, manifests, runtime constraints, and eval artifacts remain under the
 MereRun command plane.
 
+The optimizer projects only loss-masked target positions through the lm_head
+(prompt and padding rows never contribute loss, so gradients are unchanged),
+reads the loss back every 10 steps rather than per step, writes a
+`<name>.partial.safetensors` checkpoint every 100 steps so a killed run can be
+salvaged, and prints `[text-lora-train] step= loss= step_s= footprint_gb=`
+diagnostics at each readback. `docs/configuration.md` documents the
+`MERERUN_TEXT_LORA_TRAIN_*` and shared `MERERUN_LORA_TRAIN_*` environment
+switches that tune or disable each behavior.
+
 ```bash
 swift run mere.run text train-lora \
   --data ./pairs.seed.jsonl \


### PR DESCRIPTION
Applies the image-trainer optimization treatment to `text train-lora` (PR #115). All behavior is env-gated; one binary A/Bs legacy vs treated.

## What changed

- **Gathered lm_head loss** (`MERERUN_TEXT_LORA_TRAIN_GATHERED_LOSS=0` reverts): only loss-masked target positions are projected through the 262k-vocab lm_head (`Gemma4TextCausalLM.trainingLogits`), and cross entropy is logSumExp-minus-gather instead of a full-vocabulary logSoftmax. Prompt/pad rows never contribute loss, so gradients are identical; step-1 loss parity holds to 7 significant digits on the 12B in every measured lane.
- **Readback cadence** (`MERERUN_TEXT_LORA_TRAIN_LOG_EVERY`, default 10; `1` = legacy): off-boundary steps schedule via `asyncEval` so graph construction overlaps GPU execution; boundaries read the loss, update the metrics CSV/progress, and print `[text-lora-train] step= loss= step_s= footprint_gb=` diagnostics.
- **32GB buffer-cache cap for text** (`MERERUN_LORA_TRAIN_CACHE_LIMIT_GB` overrides): uncapped, the cache balloons past 110GB at ~900-token sequences and step time degrades 5.6→12.4s within 8 steps; the image trainers' 16GB default starves a text step's working set and doubles step time (image steps run minutes so churn amortizes; text steps are seconds).
- **Mid-run checkpoints** (`MERERUN_LORA_TRAIN_SAVE_EVERY`, default 100): `<name>.partial.safetensors`, removed after the final save. The trainer previously saved only at the end — a killed 2000-step run lost everything.

## Measured (M4 Max 128GB, 12B-4bit QLoRA, batch 1)

| lane | legacy | treated |
|---|---|---|
| short ~180 tok | 0.79 s/step, 34.5GB | 0.75 s/step, 32.6GB |
| medium ~890 tok | 5.65 s/step degrading to 12.4, **110GB** | ~5.1 s/step flat, **53GB** |
| long ~3400 tok | 33.0 s/step, 111GB | 24.7 s/step (−25%), 38GB steady |

Caveats: later benchmark windows were contaminated by concurrent local load (simulator test run + second agent session); the table keeps same-window interleaved comparisons and memory metrics, which are load-independent. A clean idle-GPU verification pass is worth doing before leaning on the exact ratios. Run-to-run losses diverge slightly after several steps in **both** paths (take/takeAlong backward is scatter-add with atomics) — parity should always be judged at step 1.

`LoRATrainingEnvironment` is shared with the image trainers; the identical file is also staged on `codex/lora-training-preflight` and add/add-merges cleanly whichever lands first.

Deployment note: when copying a freshly built binary to another machine (the nerdbot workflow), include `mlx-swift_Cmlx.bundle` and `mlx.metallib` from `.build/release/` — a bare `mere.run` fails with "Failed to load the default metallib".

🤖 Generated with [Claude Code](https://claude.com/claude-code)