### PR TITLE
Fix SAM 3.1 text prompt tokenizer install

### DIFF
--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -996,6 +996,22 @@ public enum ManagedModelCatalog {
                     "*.safetensors",
                 ]
             ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "tokenizer",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "AEmotionStudio/sam3.1",
+                        revision: "main",
+                        patterns: [
+                            "tokenizer.json",
+                            "tokenizer_config.json",
+                            "vocab.json",
+                            "merges.txt",
+                            "special_tokens_map.json",
+                        ]
+                    )
+                ),
+            ],
             upstreamRepoId: "mlx-community/sam3.1-bf16",
             upstreamRevision: "main",
             validationKind: .sam31,

--- a/Sources/MereRunCore/SAM3/SAM31Tokenizer.swift
+++ b/Sources/MereRunCore/SAM3/SAM31Tokenizer.swift
@@ -150,7 +150,7 @@ public final class SAM31Tokenizer {
         return directory
     }
 
-    private static func normalizedTokenizerConfig(
+    static func normalizedTokenizerConfig(
         data: Data,
         url: URL,
         overrideTokenizerClass: String
@@ -160,13 +160,7 @@ public final class SAM31Tokenizer {
             throw SAM31TokenizerError.fileNotFound(url)
         }
 
-        if let tokenizerClass = dictionary["tokenizer_class"] as? String {
-            if tokenizerClass == "TokenizersBackend" {
-                dictionary["tokenizer_class"] = overrideTokenizerClass
-            }
-        } else {
-            dictionary["tokenizer_class"] = overrideTokenizerClass
-        }
+        dictionary["tokenizer_class"] = overrideTokenizerClass
 
         let nsDictionary: [NSString: Any] = dictionary.reduce(into: [:]) { partialResult, pair in
             partialResult[pair.key as NSString] = pair.value

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -141,6 +141,21 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(mounted["scheduler"], "mlx-community/FLUX.2-klein-9B")
     }
 
+    func testSAM31ManagedInstallMountsTokenizerForTextPrompts() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "vision-segment-sam31"))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "mlx-community/sam3.1-bf16")
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("model.safetensors"), true)
+
+        let mounted = Dictionary(uniqueKeysWithValues: spec.mountedHubFallbacks.map {
+            ($0.destinationPath, $0.hubFallback)
+        })
+        let tokenizer = try XCTUnwrap(mounted["tokenizer"])
+        XCTAssertEqual(tokenizer.repoId, "AEmotionStudio/sam3.1")
+        XCTAssertEqual(tokenizer.patterns.contains("tokenizer.json"), true)
+        XCTAssertEqual(tokenizer.patterns.contains("tokenizer_config.json"), true)
+    }
+
     func testBonsaiTernaryUsesPrismMLHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-bonsai-ternary"))
 

--- a/Tests/MereRunCoreTests/SAM31TokenizerCompatibilityTests.swift
+++ b/Tests/MereRunCoreTests/SAM31TokenizerCompatibilityTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class SAM31TokenizerCompatibilityTests: MereRunCoreTestCase {
+
+    private func normalizedTokenizerClass(from object: [String: Any]) throws -> String? {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        let config = try SAM31Tokenizer.normalizedTokenizerConfig(
+            data: data,
+            url: URL(fileURLWithPath: "/tmp/tokenizer_config.json"),
+            overrideTokenizerClass: "GPT2Tokenizer"
+        )
+        return config["tokenizer_class"].string()
+    }
+
+    func testClipTokenizerMirrorConfigIsRemappedToSupportedTokenizer() throws {
+        let tokenizerClass = try normalizedTokenizerClass(from: [
+            "tokenizer_class": "CLIPTokenizer",
+            "model_max_length": 32,
+        ])
+        XCTAssertEqual(tokenizerClass, "GPT2Tokenizer")
+    }
+
+    func testTokenizersBackendConfigIsRemappedToSupportedTokenizer() throws {
+        let tokenizerClass = try normalizedTokenizerClass(from: [
+            "tokenizer_class": "TokenizersBackend",
+            "model_max_length": 32,
+        ])
+        XCTAssertEqual(tokenizerClass, "GPT2Tokenizer")
+    }
+
+    func testMissingTokenizerClassIsFilledForSAM() throws {
+        let tokenizerClass = try normalizedTokenizerClass(from: [
+            "model_max_length": 32,
+        ])
+        XCTAssertEqual(tokenizerClass, "GPT2Tokenizer")
+    }
+}

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -209,10 +209,13 @@ quantized matmul.
 
 - `config.json`
 - `model.safetensors` or `model.safetensors.index.json`
+- `tokenizer/tokenizer.json`
+- `tokenizer/tokenizer_config.json`
 
-Tokenizer files are optional for geometry prompts. Text prompts require
-`tokenizer.json` and `tokenizer_config.json` in the SAM root or tokenizer
-subdirectory.
+Tokenizer files are technically optional for geometry prompts, but managed
+installs include them because text prompts are the preferred segmentation path.
+The managed package mounts tokenizer assets from the SAM 3.1 mirror while the
+native MLX weights come from `mlx-community/sam3.1-bf16`.
 
 The manifest for this package advertises both `vision_segmentation` and
 `vision_tracking` capabilities.


### PR DESCRIPTION
## Summary
- mount SAM 3.1 tokenizer assets into the managed `vision-segment-sam31` install
- normalize SAM tokenizer configs to the supported GPT-2/BPE tokenizer loader, including mirrored `CLIPTokenizer` configs
- document tokenizer assets as part of managed SAM text-prompt installs

## Validation
- `swift test --filter ManagedModelCatalogTests/testSAM31ManagedInstallMountsTokenizerForTextPrompts`
- `swift test --filter "SAM31TokenizerCompatibilityTests|ManagedModelCatalogTests/testSAM31ManagedInstallMountsTokenizerForTextPrompts"`
- `./scripts/check.sh`
- real smoke: `mere.run vision segment ... --model vision-segment-sam31 --prompt "fox character"` produced prompted SAM masks after forced model pull refreshed tokenizer assets
