### PR TITLE
STT: windowed Parakeet transducer decode, pipelined Qwen3 ASR decode

### DIFF
--- a/Sources/AudioSTT/Parakeet/ParakeetDecodingEnvironment.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetDecodingEnvironment.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Environment-tunable decode behavior for the Parakeet transducer models.
+enum ParakeetDecodingEnvironment {
+    /// Number of encoder frames evaluated per batched joint call during
+    /// greedy transducer decoding. The decoder state only changes on token
+    /// emission, so blanks (the majority of frames) scan host-side from a
+    /// single readback instead of one (RNN-T) or two (TDT) scalar readbacks
+    /// per frame. `MERERUN_STT_DECODE_WINDOW` overrides; `1` restores the
+    /// legacy per-frame readback cadence.
+    static let windowedDecodeFrames: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_STT_DECODE_WINDOW"],
+           let value = Int(raw), value >= 1 {
+            return value
+        }
+        return 16
+    }()
+}

--- a/Sources/AudioSTT/Parakeet/ParakeetModel.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetModel.swift
@@ -721,6 +721,7 @@ class ParakeetTDTModel: ParakeetBaseModel {
 
         let vocabularySize = config.vocabulary.count
         let stepSeconds = timePerEncoderStep
+        let windowSize = ParakeetDecodingEnvironment.windowedDecodeFrames
 
         for b in 0..<batch.dim(0) {
             let features = encoded[b..<(b + 1), 0..., 0...]
@@ -732,9 +733,14 @@ class ParakeetTDTModel: ParakeetBaseModel {
             var newSymbols = 0
             var state: (MLXArray, MLXArray)?
 
+            // Greedy TDT decode over windows of frames. The decoder state
+            // only changes when a token is emitted, so the joint can be
+            // evaluated for many contiguous frames against the same state
+            // in one batched call with a single readback; the host then
+            // follows the duration jumps until an emission invalidates the
+            // window. The legacy loop read two argMax scalars back per
+            // frame. Semantics are identical to the per-frame loop.
             while time < maxLength {
-                let feature = features[0..., time..<(time + 1), 0...]
-
                 let tokenInput: MLXArray?
                 if lastToken == vocabularySize {
                     tokenInput = nil
@@ -743,41 +749,72 @@ class ParakeetTDTModel: ParakeetBaseModel {
                 }
 
                 let (decoderOutput, proposedState) = decoder(tokenInput, state: state)
-                let jointOutput = joint(feature, decoderOutput.asType(feature.dtype))
+                let windowStart = time
+                let windowEnd = min(windowStart + windowSize, maxLength)
+                let windowFeatures = features[0..., windowStart..<windowEnd, 0...]
+                let jointOutput = joint(windowFeatures, decoderOutput.asType(windowFeatures.dtype))
 
-                let predictionSlice = jointOutput[0, 0, 0, 0..<(vocabularySize + 1)]
-                let durationSlice = jointOutput[0, 0, 0, (vocabularySize + 1)..<jointOutput.dim(3)]
-
-                let predictedToken = Int(MLX.argMax(predictionSlice).item(Int32.self))
-                let decisionIndex = durationSlice.count > 0
-                    ? Int(MLX.argMax(durationSlice).item(Int32.self))
-                    : 1
-                let clampedDecision = min(max(0, decisionIndex), max(0, durations.count - 1))
-                let durationSteps = max(0, durations[clampedDecision])
-
-                if predictedToken != vocabularySize {
-                    let start = TimeInterval(time) * stepSeconds
-                    let duration = TimeInterval(durationSteps) * stepSeconds
-                    tokens.append(
-                        ParakeetAlignedToken(
-                            id: predictedToken,
-                            text: tokenText(predictedToken),
-                            start: start,
-                            duration: duration
-                        )
-                    )
-                    lastToken = predictedToken
-                    state = proposedState
+                let classCount = jointOutput.dim(3)
+                let predictions = MLX.argMax(
+                    jointOutput[0, 0..., 0, 0..<(vocabularySize + 1)],
+                    axis: -1
+                ).asType(.int32)
+                let hasDurations = classCount > vocabularySize + 1
+                let readback: [Int32]
+                if hasDurations {
+                    let decisions = MLX.argMax(
+                        jointOutput[0, 0..., 0, (vocabularySize + 1)..<classCount],
+                        axis: -1
+                    ).asType(.int32)
+                    readback = MLX.concatenated([predictions, decisions], axis: 0).asArray(Int32.self)
+                } else {
+                    readback = predictions.asArray(Int32.self)
                 }
+                let windowLength = windowEnd - windowStart
+                var emitted = false
 
-                time += durationSteps
-                newSymbols += 1
+                while time < windowEnd {
+                    let row = time - windowStart
+                    let predictedToken = Int(readback[row])
+                    let decisionIndex = hasDurations ? Int(readback[windowLength + row]) : 1
+                    let clampedDecision = min(max(0, decisionIndex), max(0, durations.count - 1))
+                    let durationSteps = max(0, durations[clampedDecision])
 
-                if durationSteps != 0 {
-                    newSymbols = 0
-                } else if let maxSymbols, maxSymbols <= newSymbols {
-                    time += 1
-                    newSymbols = 0
+                    if predictedToken != vocabularySize {
+                        let start = TimeInterval(time) * stepSeconds
+                        let duration = TimeInterval(durationSteps) * stepSeconds
+                        tokens.append(
+                            ParakeetAlignedToken(
+                                id: predictedToken,
+                                text: tokenText(predictedToken),
+                                start: start,
+                                duration: duration
+                            )
+                        )
+                        lastToken = predictedToken
+                        state = proposedState
+                        emitted = true
+                    }
+
+                    time += durationSteps
+                    newSymbols += 1
+
+                    if durationSteps != 0 {
+                        newSymbols = 0
+                    } else if let maxSymbols, maxSymbols <= newSymbols {
+                        time += 1
+                        newSymbols = 0
+                    }
+
+                    if emitted {
+                        break
+                    }
+                    if durationSteps == 0, maxSymbols == nil {
+                        // Blank with zero duration and no symbol cap would
+                        // re-read the same frame forever in the legacy loop
+                        // too; preserve its behavior by re-evaluating.
+                        break
+                    }
                 }
             }
 
@@ -834,9 +871,13 @@ class ParakeetRNNTModel: ParakeetBaseModel {
             var newSymbols = 0
             var state: (MLXArray, MLXArray)?
 
+            // Greedy RNN-T decode over windows of frames: the joint runs for
+            // many contiguous frames against the fixed decoder state in one
+            // batched call with a single readback, and the host scans blanks
+            // forward until an emission changes the state. The legacy loop
+            // read one argMax scalar back per frame. Semantics identical.
+            let windowSize = ParakeetDecodingEnvironment.windowedDecodeFrames
             while time < maxLength {
-                let feature = features[0..., time..<(time + 1), 0...]
-
                 let tokenInput: MLXArray?
                 if lastToken == vocabularySize {
                     tokenInput = nil
@@ -845,30 +886,39 @@ class ParakeetRNNTModel: ParakeetBaseModel {
                 }
 
                 let (decoderOutput, proposedState) = decoder(tokenInput, state: state)
-                let jointOutput = joint(feature, decoderOutput.asType(feature.dtype))
-                let predictedToken = Int(MLX.argMax(jointOutput).item(Int32.self))
+                let windowStart = time
+                let windowEnd = min(windowStart + windowSize, maxLength)
+                let windowFeatures = features[0..., windowStart..<windowEnd, 0...]
+                let jointOutput = joint(windowFeatures, decoderOutput.asType(windowFeatures.dtype))
+                let predictions = MLX.argMax(jointOutput[0, 0..., 0, 0...], axis: -1)
+                    .asType(.int32).asArray(Int32.self)
 
-                if predictedToken != vocabularySize {
-                    let start = TimeInterval(time) * stepSeconds
-                    tokens.append(
-                        ParakeetAlignedToken(
-                            id: predictedToken,
-                            text: tokenText(predictedToken),
-                            start: start,
-                            duration: stepSeconds
+                while time < windowEnd {
+                    let predictedToken = Int(predictions[time - windowStart])
+
+                    if predictedToken != vocabularySize {
+                        let start = TimeInterval(time) * stepSeconds
+                        tokens.append(
+                            ParakeetAlignedToken(
+                                id: predictedToken,
+                                text: tokenText(predictedToken),
+                                start: start,
+                                duration: stepSeconds
+                            )
                         )
-                    )
-                    lastToken = predictedToken
-                    state = proposedState
+                        lastToken = predictedToken
+                        state = proposedState
 
-                    newSymbols += 1
-                    if let maxSymbols, maxSymbols <= newSymbols {
+                        newSymbols += 1
+                        if let maxSymbols, maxSymbols <= newSymbols {
+                            time += 1
+                            newSymbols = 0
+                        }
+                        break
+                    } else {
                         time += 1
                         newSymbols = 0
                     }
-                } else {
-                    time += 1
-                    newSymbols = 0
                 }
             }
 

--- a/Sources/AudioSTT/Qwen3ASR/Qwen3ASRGenerator.swift
+++ b/Sources/AudioSTT/Qwen3ASR/Qwen3ASRGenerator.swift
@@ -27,6 +27,16 @@ public actor Qwen3ASRGenerator: ASRGenerator {
         return raw == "1" || raw == "true" || raw == "yes"
     }()
 
+    /// Depth-1 pipelined decode (default on): the sampled token feeds the
+    /// next forward as a GPU array and the previous token is read back while
+    /// the current step executes. MERERUN_STT_PIPELINED_DECODE=0 restores
+    /// the legacy two-syncs-per-token loop.
+    private static let pipelinedDecodeEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_STT_PIPELINED_DECODE"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw != "0" && raw != "false" && raw != "off"
+    }()
+
     public init(modelId: String = Qwen3ASRResources.defaultModelId) {
         self.modelId = modelId
     }
@@ -492,34 +502,77 @@ public actor Qwen3ASRGenerator: ASRGenerator {
             FileHandle.standardError.write(Data(message.utf8))
         }
 
-        for step in 0..<maxTokens {
-            let lastLogits = logits[0..., (logits.dim(1) - 1), 0...]
-            let nextToken = sampleToken(logits: lastLogits, mode: sampling, previousTokens: generatedTokens)
+        if Self.pipelinedDecodeEnabled {
+            // Depth-1 pipelined decode: the sampled token stays on GPU and
+            // feeds the next forward directly; the previous step's token is
+            // read back while the current step executes. The legacy loop
+            // synchronized twice per token (sample readback + eval).
+            var pendingToken: MLXArray?
+            for step in 0..<maxTokens {
+                let lastLogits = logits[0..., (logits.dim(1) - 1), 0...]
+                let tokenArray = sampleTokenArray(logits: lastLogits, mode: sampling)
+                logits = thinker(inputIds: tokenArray.reshaped(1, 1), cache: cache)
+                asyncEval([logits, tokenArray])
 
-            if nextToken == eosTokenId || nextToken == padTokenId {
-                if Self.debugEnabled {
-                    FileHandle.standardError.write(Data("[ASR DEBUG] Hit EOS at step \(step)\n".utf8))
+                if let previous = pendingToken {
+                    pendingToken = nil
+                    let value = previous.item(Int.self)
+                    if value == eosTokenId || value == padTokenId {
+                        if Self.debugEnabled {
+                            FileHandle.standardError.write(Data("[ASR DEBUG] Hit EOS at step \(step - 1)\n".utf8))
+                        }
+                        break
+                    }
+                    generatedTokens.append(value)
+                    if generatedTokens.count % 10 == 0 {
+                        progressHandler?(ASRProgress(
+                            stage: .transcribing,
+                            tokensGenerated: generatedTokens.count,
+                            message: "Generated \(generatedTokens.count) tokens..."
+                        ))
+                    }
+                    if generatedTokens.count % 50 == 0 {
+                        Memory.clearCache()
+                    }
                 }
-                break
+                pendingToken = tokenArray
             }
-
-            generatedTokens.append(nextToken)
-
-            if step > 0 && step % 10 == 0 {
-                progressHandler?(ASRProgress(
-                    stage: .transcribing,
-                    tokensGenerated: step,
-                    message: "Generated \(step) tokens..."
-                ))
+            if let previous = pendingToken {
+                let value = previous.item(Int.self)
+                if value != eosTokenId && value != padTokenId {
+                    generatedTokens.append(value)
+                }
             }
+        } else {
+            for step in 0..<maxTokens {
+                let lastLogits = logits[0..., (logits.dim(1) - 1), 0...]
+                let nextToken = sampleToken(logits: lastLogits, mode: sampling, previousTokens: generatedTokens)
 
-            // Generate next
-            let nextInput = MLXArray([Int32(nextToken)]).reshaped(1, 1)
-            logits = thinker(inputIds: nextInput, cache: cache)
-            MLX.eval(logits)
+                if nextToken == eosTokenId || nextToken == padTokenId {
+                    if Self.debugEnabled {
+                        FileHandle.standardError.write(Data("[ASR DEBUG] Hit EOS at step \(step)\n".utf8))
+                    }
+                    break
+                }
 
-            if step % 50 == 0 {
-                Memory.clearCache()
+                generatedTokens.append(nextToken)
+
+                if step > 0 && step % 10 == 0 {
+                    progressHandler?(ASRProgress(
+                        stage: .transcribing,
+                        tokensGenerated: step,
+                        message: "Generated \(step) tokens..."
+                    ))
+                }
+
+                // Generate next
+                let nextInput = MLXArray([Int32(nextToken)]).reshaped(1, 1)
+                logits = thinker(inputIds: nextInput, cache: cache)
+                MLX.eval(logits)
+
+                if step % 50 == 0 {
+                    Memory.clearCache()
+                }
             }
         }
 
@@ -535,6 +588,37 @@ public actor Qwen3ASRGenerator: ASRGenerator {
             text: decoded,
             tokensGenerated: generatedTokens.count
         )
+    }
+
+    /// GPU-side variant of `sampleToken`: identical math, but the result
+    /// stays on GPU as a 0-d array so the decode loop can feed it straight
+    /// into the next forward without a host readback.
+    private func sampleTokenArray(
+        logits: MLXArray,
+        mode: SamplingMode
+    ) -> MLXArray {
+        let squeezed = logits.squeezed(axis: 0)
+        switch mode {
+        case .greedy:
+            return argMax(squeezed, axis: -1).asType(.int32)
+        case .topP(let temperature, let topP):
+            var scores = squeezed
+            if scores.dtype == .bfloat16 {
+                scores = scores.asType(.float32)
+            }
+            let probs = softmax(scores / temperature, axis: -1)
+            let sortedIndices = argSort(probs, axis: -1)
+            let sortedProbs = probs.take(sortedIndices, axis: -1)
+            let cumulativeProbs = cumsum(sortedProbs, axis: -1)
+            let topProbs = MLX.where(
+                cumulativeProbs .> (1 - topP),
+                sortedProbs,
+                MLXArray.zeros(like: sortedProbs)
+            )
+            let sortedToken = categorical(MLX.log(topProbs + 1e-10))
+            return sortedIndices.take(sortedToken.reshaped(1), axis: -1)
+                .squeezed(axis: 0).asType(.int32)
+        }
     }
 
     private func sampleToken(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,6 +214,23 @@ cap doubles step time at ~900-token sequences, while uncapped the cache
 balloons past 100 GB), and a `<name>.partial.safetensors` adapter checkpoint
 is written every 100 steps and removed after the final save.
 
+### `MERERUN_STT_DECODE_WINDOW`
+
+Parakeet transducer decoding (TDT and RNN-T) evaluates the joint network for
+this many contiguous encoder frames per batched call (default `16`). The
+decoder state only changes when a token is emitted, so blank frames — the
+majority — scan host-side from a single readback instead of one (RNN-T) or
+two (TDT) scalar readbacks per frame. Greedy semantics are identical to the
+per-frame loop. Set `1` to restore the legacy per-frame readback cadence.
+
+### `MERERUN_STT_PIPELINED_DECODE`
+
+Qwen3 ASR token decoding samples on GPU and pipelines the loop at depth 1:
+the sampled token feeds the next forward as a GPU array and the previous
+step's token is read back while the current step executes (the legacy loop
+synchronized twice per token). Enabled by default; set `0`, `false`, or
+`off` to restore the legacy loop.
+
 ### `MERERUN_GEMMA4_DECODE_TRACE`
 
 Set to `1` to log a per-decode summary to stderr splitting each token's wall


### PR DESCRIPTION
Second PR of the platform perf sweep (Tier 1, verified gap map).

## Parakeet (TDT + RNN-T)

The greedy transducer loops read **1–2 argMax scalars back per encoder frame**. But the decoder state only changes on token emission — so the joint now evaluates a **window of 16 contiguous frames** against the fixed decoder state in one batched call (`[1,W,D] × [1,1,H] → [1,W,1,C]`), reads back once, and the host follows TDT duration jumps / RNN-T blank advances until an emission invalidates the window. Exact greedy semantics preserved, including the `maxSymbols` zero-duration guard. `MERERUN_STT_DECODE_WINDOW=1` restores the per-frame cadence.

## Qwen3 ASR

Two syncs per token (sample `.item()` + blocking `eval`). Now: GPU-side sampling (same greedy/top-p math), the sampled token feeds the next forward as an array, and the previous token is read back while the current step executes — depth-1 pipeline, one speculative forward at EOS. `MERERUN_STT_PIPELINED_DECODE=0` reverts.

## Verification

- **Transcripts byte-identical** legacy vs treated on both engines, using audio synthesized from known text (Parakeet: 95s / 5 segments; Qwen3 ASR: 32s clip) — and both transcribe the source text correctly.
- Parakeet wall: 0.68–0.69s → **0.61–0.62s** on the 95s clip (−10%; the Conformer encoder dominates at ~135× realtime, the decode-loop syncs were most of what remained).
- Qwen3 ASR wall: 2.62s → 2.48s on the short clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)