### PR TITLE
FalconPerception: O(T) KV cache, trace-only decode heads gated

### DIFF
--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
@@ -487,22 +487,27 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
             if let hiddenState = model.lastHiddenState {
                 let hiddenLast = hiddenState[0, hiddenState.dim(1) - 1]
                 let hiddenForDecode = hiddenLast.reshaped(1, hiddenLast.dim(0))
-                let coordLogitsForTrace = model.decodeCoordinates(from: hiddenForDecode)
-                let coordBinsForTrace = MLX.argMax(coordLogitsForTrace, axis: -1).asArray(Int32.self)
-                let coordNumBins = max(1, coordLogitsForTrace.dim(-1) - 1)
-                let traceX = Float(coordBinsForTrace[0]) / Float(coordNumBins)
-                let traceY = Float(coordBinsForTrace[1]) / Float(coordNumBins)
-                let sizeLogitsForTrace = model.decodeSizes(from: hiddenForDecode)
-                let sizeValuesForTrace = model.processSizes(sizeLogitsForTrace).asArray(Float.self)
-                trace(
-                    String(
-                        format: "TRACE runtime hidden_decoded x=%.6f y=%.6f h=%.6f w=%.6f",
-                        traceX,
-                        traceY,
-                        sizeValuesForTrace[0],
-                        sizeValuesForTrace[1]
+                // Trace-only decodes: the coordinate and size heads plus two
+                // GPU readbacks per generated token, so they must not run
+                // when tracing is disabled.
+                if runtimeTraceLogURL != nil {
+                    let coordLogitsForTrace = model.decodeCoordinates(from: hiddenForDecode)
+                    let coordBinsForTrace = MLX.argMax(coordLogitsForTrace, axis: -1).asArray(Int32.self)
+                    let coordNumBins = max(1, coordLogitsForTrace.dim(-1) - 1)
+                    let traceX = Float(coordBinsForTrace[0]) / Float(coordNumBins)
+                    let traceY = Float(coordBinsForTrace[1]) / Float(coordNumBins)
+                    let sizeLogitsForTrace = model.decodeSizes(from: hiddenForDecode)
+                    let sizeValuesForTrace = model.processSizes(sizeLogitsForTrace).asArray(Float.self)
+                    trace(
+                        String(
+                            format: "TRACE runtime hidden_decoded x=%.6f y=%.6f h=%.6f w=%.6f",
+                            traceX,
+                            traceY,
+                            sizeValuesForTrace[0],
+                            sizeValuesForTrace[1]
+                        )
                     )
-                )
+                }
 
                 if tokenID == config.coordTokenID {
                     if let currentXY, let currentHW {

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
@@ -81,22 +81,51 @@ final class FalconPerceptionKVCache: @unchecked Sendable {
     private var keys: MLXArray?
     private var values: MLXArray?
     private(set) var offset: Int = 0
+    private let step = 256
 
-    func updateAndFetch(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
-        if let cachedKeys = self.keys, let cachedValues = self.values {
-            self.keys = falconPerceptionContiguous(concatenated([cachedKeys, keys], axis: 2))
-            self.values = falconPerceptionContiguous(concatenated([cachedValues, values], axis: 2))
+    /// Capacity-padded append: buffers grow in 256-step chunks and new
+    /// keys/values write into a slice, so a decode of T tokens copies O(T)
+    /// data instead of the O(T²) of re-concatenating the whole cache per
+    /// token. The previous implementation also forced an eval per layer per
+    /// token; evaluation is now left to the decode loop's readback.
+    func updateAndFetch(keys newKeys: MLXArray, values newValues: MLXArray) -> (MLXArray, MLXArray) {
+        let previous = offset
+        let required = previous + newKeys.dim(2)
+
+        let needsGrowth: Bool
+        if let currentKeys = keys {
+            needsGrowth = required > currentKeys.dim(2)
         } else {
-            self.keys = falconPerceptionContiguous(keys)
-            self.values = falconPerceptionContiguous(values)
+            needsGrowth = true
         }
 
-        self.offset += keys.dim(2)
-        guard let cachedKeys = self.keys, let cachedValues = self.values else {
+        if needsGrowth {
+            let batch = newKeys.dim(0)
+            let heads = newKeys.dim(1)
+            let keyDim = newKeys.dim(3)
+            let valueDim = newValues.dim(3)
+            let chunks = (required + step - 1) / step
+            let grownKeys = MLXArray.zeros([batch, heads, chunks * step, keyDim], dtype: newKeys.dtype)
+            let grownValues = MLXArray.zeros([batch, heads, chunks * step, valueDim], dtype: newValues.dtype)
+            if let currentKeys = keys, let currentValues = values, previous > 0 {
+                grownKeys[.ellipsis, ..<previous, 0...] = currentKeys[.ellipsis, ..<previous, 0...]
+                grownValues[.ellipsis, ..<previous, 0...] = currentValues[.ellipsis, ..<previous, 0...]
+            }
+            keys = grownKeys
+            values = grownValues
+        }
+
+        keys?[.ellipsis, previous..<required, 0...] = newKeys
+        values?[.ellipsis, previous..<required, 0...] = newValues
+        offset = required
+
+        guard let cachedKeys = keys, let cachedValues = values else {
             preconditionFailure("FalconPerceptionKVCache should hold keys and values after update.")
         }
-        MLX.eval(cachedKeys, cachedValues)
-        return (cachedKeys, cachedValues)
+        return (
+            cachedKeys[.ellipsis, ..<required, 0...],
+            cachedValues[.ellipsis, ..<required, 0...]
+        )
     }
 }
 


### PR DESCRIPTION
Third PR of the platform perf sweep (Tier 1, verified gap map).

## What was wrong

- `FalconPerceptionKVCache.updateAndFetch` re-concatenated the **entire** K/V history per generated token (O(T²) copies) and forced `MLX.eval` on the full cache **per layer per token** (~30 extra sync points/token).
- The grounder loop ran the coordinate + size decode heads and **two `asArray` GPU readbacks per token** solely to format a trace line — even with tracing disabled.

## The fix

- Capacity-padded K/V buffers grown in 256-frame chunks with slice writes (same pattern as `KVCacheSimple` / the Gemma4 quantized-KV fix); evaluation left to the decode loop's own readback.
- Trace-only decode block gated on `runtimeTraceLogURL` being set.

## Verification

- **Detections byte-identical** old-binary vs new on a real grounding workload (3 queries → 6 detections on a dataset frame) and on an empty-result image.
- Wall time within run noise (±1.5s on ~30s runs, order-reversed repeats): this workload is vision-encoder + prefill dominated, and typical decodes are 10–50 tokens. The win is structural — per-token cost now scales linearly with decode length instead of quadratically, and the ~30 forced per-token syncs are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)