### PR TITLE
Prefill lm_head slicing for Q35, LFM2, and GLM-4.7 Flash

### DIFF
--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -293,7 +293,7 @@ public actor LFM2Generator: ChatGenerator {
             let end = min(promptTokens.count, offset + Self.prefillChunkSize)
             let chunk = Array(promptTokens[offset..<end])
             let input = MLXArray(chunk.map(Int32.init)).reshaped(1, chunk.count)
-            let output = model.forward(input, cache: cache)
+            let output = model.forwardPrefill(input, cache: cache)
             MLX.eval(output.logits)
             MLX.eval(output.hidden)
             lastOutput = output

--- a/Sources/MereRunCore/LFM2/LFM2Model.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Model.swift
@@ -542,6 +542,24 @@ public final class LFM2Model: Module, @unchecked Sendable {
         return LFM2ForwardOutput(hidden: hidden, logits: model.embedTokens.asLinear(hidden))
     }
 
+    /// Forward for prefill chunks: hidden states flow through every position
+    /// (the caches need them all), but the tied-embedding lm_head projects
+    /// only the final position — prefill consumers read exactly the last
+    /// position, and the full-chunk projection is a [chunk, vocab] matmul
+    /// plus its materialization per chunk.
+    func forwardPrefill(
+        _ inputIds: MLXArray,
+        cache: [LFM2LayerCache?]?,
+        inputEmbeddings: MLXArray? = nil
+    ) -> LFM2ForwardOutput {
+        var hidden = model(inputIds, cache: cache, inputEmbeddings: inputEmbeddings)
+        let sequenceLength = hidden.dim(1)
+        if sequenceLength > 1 {
+            hidden = hidden[0..., (sequenceLength - 1)..., 0...]
+        }
+        return LFM2ForwardOutput(hidden: hidden, logits: model.embedTokens.asLinear(hidden))
+    }
+
     public func callAsFunction(
         _ inputIds: MLXArray,
         cache: [LFM2LayerCache?]?,

--- a/Sources/MereRunCore/Psi/GLM47Flash.swift
+++ b/Sources/MereRunCore/Psi/GLM47Flash.swift
@@ -61,7 +61,7 @@ public final class GLM47Flash: @unchecked Sendable {
             KVCacheSimple(step: 256)
         }
 
-        var logits = model(inputIds, cache: cache)
+        var logits = model.lastPositionLogits(inputIds, cache: cache)
         MLX.eval(logits)
 
         let eosTokens = Set(config.eosTokenId ?? []).union([tokenizer.eosTokenId ?? -1])
@@ -112,7 +112,7 @@ public final class GLM47Flash: @unchecked Sendable {
             KVCacheSimple(step: 256)
         }
 
-        var logits = model(inputIds, cache: cache)
+        var logits = model.lastPositionLogits(inputIds, cache: cache)
         MLX.eval(logits)
 
         let eosTokens = Set(config.eosTokenId ?? []).union([tokenizer.eosTokenId ?? -1])

--- a/Sources/MereRunCore/Psi/GLM47FlashModel.swift
+++ b/Sources/MereRunCore/Psi/GLM47FlashModel.swift
@@ -391,6 +391,18 @@ public final class GLM47FlashModel: Module {
         let hidden = model(inputIds, cache: cache)
         return lmHead(hidden)
     }
+
+    /// Logits for the final position only. Prefill never reads the other
+    /// positions' logits, and skipping them avoids a [prompt, vocab] lm_head
+    /// matmul plus its materialization.
+    func lastPositionLogits(_ inputIds: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var hidden = model(inputIds, cache: cache)
+        let sequenceLength = hidden.dim(1)
+        if sequenceLength > 1 {
+            hidden = hidden[0..., (sequenceLength - 1)..., 0...]
+        }
+        return lmHead(hidden)
+    }
 }
 
 public final class GLM47FlashTransformer: Module {

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -1414,7 +1414,7 @@ public actor Q35Generator: ChatGenerator {
             let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
                 .reshaped(1, end - processed)
             if retainHidden {
-                let output = model.forward(chunk, cache: cache)
+                let output = model.forwardPrefill(chunk, cache: cache)
                 MLX.eval(output.logits)
                 MLX.eval(output.hidden)
                 logits = output.logits
@@ -1431,9 +1431,9 @@ public actor Q35Generator: ChatGenerator {
                     )
                 }
             } else {
-                let output = model(chunk, cache: cache)
-                MLX.eval(output)
-                logits = output
+                let output = model.forwardPrefill(chunk, cache: cache)
+                MLX.eval(output.logits)
+                logits = output.logits
                 hidden = nil
             }
             processed = end
@@ -1472,7 +1472,7 @@ public actor Q35Generator: ChatGenerator {
             let chunkInput = MLXArray.zeros([1, end - processed], dtype: .int32)
             let chunkPositionIds = positionIds?[0..., 0..., processed..<end]
             if retainHidden {
-                let output = model.forward(
+                let output = model.forwardPrefill(
                     chunkInput,
                     cache: cache,
                     inputEmbeddings: chunkEmbeddings,
@@ -1483,14 +1483,14 @@ public actor Q35Generator: ChatGenerator {
                 logits = output.logits
                 hidden = output.hidden
             } else {
-                let output = model(
+                let output = model.forwardPrefill(
                     chunkInput,
                     cache: cache,
                     inputEmbeddings: chunkEmbeddings,
                     positionIds: chunkPositionIds
                 )
-                MLX.eval(output)
-                logits = output
+                MLX.eval(output.logits)
+                logits = output.logits
                 hidden = nil
             }
             processed = end

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -232,6 +232,32 @@ public final class Q35Model: Module, @unchecked Sendable {
         return Q35ForwardOutput(hidden: hidden, logits: logits(from: hidden))
     }
 
+    /// Forward for prefill chunks: hidden states flow through every position
+    /// (the KV cache needs them all), but the lm_head projects only the
+    /// final position. Prefill consumers — first-token sampling, the MTP
+    /// hidden seed, and prefix-KV checkpoint restores — read exactly the
+    /// last position, while a full-chunk projection is a
+    /// [chunk, 150k-vocab] matmul plus its materialization per chunk and
+    /// pins full-chunk logits inside stored prefix-cache entries.
+    func forwardPrefill(
+        _ inputIds: MLXArray,
+        cache: [Q35LayerCache?]?,
+        inputEmbeddings: MLXArray? = nil,
+        positionIds: MLXArray? = nil
+    ) -> Q35ForwardOutput {
+        var hidden = model(
+            inputIds,
+            cache: cache,
+            inputEmbeddings: inputEmbeddings,
+            positionIds: positionIds
+        )
+        let sequenceLength = hidden.dim(1)
+        if sequenceLength > 1 {
+            hidden = hidden[0..., (sequenceLength - 1)..., 0...]
+        }
+        return Q35ForwardOutput(hidden: hidden, logits: logits(from: hidden))
+    }
+
     public func callAsFunction(
         _ inputIds: MLXArray,
         cache: [Q35LayerCache?]?,


### PR DESCRIPTION
Fourth PR of the platform perf sweep (Tier 2 of the verified gap map): the TTFT treatment that halved Gemma4's time-to-first-token, applied to the three remaining engines that computed full-vocabulary logits for every prefill-chunk position.

## Why it's safe

Every consumer of prefill logits/hidden reads **exactly the final position** — verified at each call site:
- first-token sampling (`lastTokenLogits`, `row.logits[0, -1, 0...]`)
- the Q35 MTP hidden seed (`initialHidden.map(lastTokenHidden)`)
- prefix-KV checkpoint restores (seed flows to the same consumers)
- LFM2's retained prefill hidden had **no consumer at all**

## Changes

- `Q35Model.forwardPrefill` — hidden through all positions (KV cache needs them), lm_head on the last only; both `chunkedPrefill` branches + the embeddings variant. **Bonus**: stored prefix-KV entries pinned full-chunk logits (~600 MB per 2048-token checkpoint at the 150k vocab); they now hold one position.
- `LFM2Model.forwardPrefill` — same shape.
- `GLM47FlashModel.lastPositionLogits` — both generate paths.

## Verification

- **Byte-identical greedy responses** old-vs-new: Ornith 35B (short prompt), LFM2.5 (short **and** 3.5k-token prompts).
- Ornith 35B warm long-prompt prefill: 3.26s → **3.02s** (−7% at 3.5k tokens; the MoE forward dominates).
- Known pre-existing issue surfaced during testing (not introduced here, task chip filed): Ornith 35B long repetitive prompts produce nondeterministic gibberish at temperature 0 **on the old binary too** — MoE accumulation-order drift is the leading suspect.
- GLM-4.7 Flash: both call sites rewritten and compile-verified; no local model installed for an e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)