### PR TITLE
Sampler and readback ports: OCR, GLM-4.7 Flash, embeddings, ACEStep LM

### DIFF
--- a/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
@@ -258,9 +258,12 @@ public final class ACEStep5HzLM {
             let topK = max(config.topK, 0)
             var nextLogits = lastLogits
             if topK > 0 && topK < nextLogits.dim(-1) {
-                let sortedIndices = argSort(nextLogits, axis: -1)
-                let sortedLogits = nextLogits.take(sortedIndices, axis: -1)
-                let threshold = sortedLogits[sortedLogits.dim(-1) - topK]
+                // k-th largest value via argPartition — identical threshold
+                // to the full argSort without sorting the whole vocabulary
+                // every token.
+                let kth = nextLogits.dim(-1) - topK
+                let partition = argPartition(nextLogits, kth: kth, axis: -1)
+                let threshold = nextLogits.take(partition[kth..<(kth + 1)], axis: -1)
                 nextLogits = MLX.where(nextLogits .< threshold, MLXArray(-Float.infinity), nextLogits)
             }
 

--- a/Sources/MereRunCore/Embeddings/Qwen3EmbeddingModel.swift
+++ b/Sources/MereRunCore/Embeddings/Qwen3EmbeddingModel.swift
@@ -137,16 +137,25 @@ public final class Qwen3EmbeddingModel {
             outputHiddenStates: false
         ).lastHiddenState
 
+        // Pool every row's final valid token in one gather and normalize the
+        // whole batch before a single readback. The previous loop evaluated
+        // and read back each embedding separately — N GPU→CPU syncs per
+        // batch.
+        let hiddenSize = hiddenStates.dim(2)
+        let lastIndices = MLXArray(tokenCounts.map { Int32(max(0, $0 - 1)) })
+        let flatHidden = hiddenStates.reshaped([batchSize * sequenceLength, hiddenSize])
+        let rowBases = MLXArray((0..<batchSize).map { Int32($0 * sequenceLength) })
+        let pooled = MLX.take(flatHidden, rowBases + lastIndices, axis: 0).asType(.float32)
+        let eps = MLXArray(Float32(1e-12))
+        let norms = MLX.sqrt(MLX.sum(pooled * pooled, axis: -1, keepDims: true) + eps)
+        let normalized = pooled / norms
+        MLX.eval(normalized)
+        let flat = normalized.asArray(Float.self)
+
         var output: [[Float]] = []
         output.reserveCapacity(batchSize)
-
         for row in 0..<batchSize {
-            let tokenCount = tokenCounts[row]
-            let lastIndex = max(0, tokenCount - 1)
-            let pooled = hiddenStates[row, lastIndex, 0...].asType(.float32)
-            let normalized = l2Normalize(pooled)
-            MLX.eval(normalized)
-            output.append(normalized.asArray(Float.self))
+            output.append(Array(flat[(row * hiddenSize)..<((row + 1) * hiddenSize)]))
         }
 
         return (output, tokenCounts)

--- a/Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator+Inference.swift
+++ b/Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator+Inference.swift
@@ -89,28 +89,50 @@ extension LightOnOCRGenerator {
         )
         MLX.eval(logits)
         log("[Gen] Prefill logits shape: \(logits.shape)")
-        let lastLogitsPrefill = logits[0, -1, 0...]
-        let topIndices = MLX.argSort(lastLogitsPrefill, axis: -1)[(-5)...]
-        eval(topIndices)
-        log("[Gen] Top 5 token indices: \(topIndices.asArray(Int32.self))")
+        if logProgress {
+            // Debug-only: full-vocabulary sort plus a GPU readback.
+            let lastLogitsPrefill = logits[0, -1, 0...]
+            let topIndices = MLX.argSort(lastLogitsPrefill, axis: -1)[(-5)...]
+            eval(topIndices)
+            log("[Gen] Top 5 token indices: \(topIndices.asArray(Int32.self))")
+        }
 
+        // Depth-1 pipelined decode: the sampled token stays on GPU and feeds
+        // the next forward directly; the previous step's token is read back
+        // while the current step executes. The legacy loop synchronized
+        // twice per token (softmax eval inside sampling plus a blocking
+        // logits eval), which dominates OCR's long page transcriptions.
         var generatedTokens: [Int] = []
+        var pendingToken: MLXArray?
+        var scheduledCount = 0
         for _ in 0..<config.maxNewTokens {
-            let nextToken = sampleToken(logits: logits[0, -1, 0...], temperature: config.temperature)
-            if nextToken == eosTokenId || nextToken == padTokenId {
-                break
-            }
-
-            generatedTokens.append(nextToken)
-            let nextInput = MLXArray([Int32(nextToken)]).reshaped(1, 1)
+            let tokenArray = sampleTokenArray(logits: logits[0, -1, 0...], temperature: config.temperature)
+            scheduledCount += 1
+            let nextInput = tokenArray.reshaped(1, 1)
             if positionIds != nil {
-                let posValue = Int32(promptSeqLen + generatedTokens.count - 1 + ropeDelta)
+                let posValue = Int32(promptSeqLen + scheduledCount - 1 + ropeDelta)
                 let posIds = MLXArray([posValue]).reshaped(1, 1)
                 logits = textDecoder.encoder.forwardCausal(inputIds: nextInput, cache: cache, positionIds: posIds)
             } else {
                 logits = textDecoder.encoder.forwardCausal(inputIds: nextInput, cache: cache)
             }
-            MLX.eval(logits)
+            asyncEval([logits, tokenArray])
+
+            if let previous = pendingToken {
+                pendingToken = nil
+                let value = previous.item(Int.self)
+                if value == eosTokenId || value == padTokenId {
+                    return generatedTokens
+                }
+                generatedTokens.append(value)
+            }
+            pendingToken = tokenArray
+        }
+        if let previous = pendingToken {
+            let value = previous.item(Int.self)
+            if value != eosTokenId && value != padTokenId {
+                generatedTokens.append(value)
+            }
         }
 
         return generatedTokens
@@ -160,6 +182,20 @@ extension LightOnOCRGenerator {
 
         let flat = positions.flatMap { $0.map(Int32.init) }
         return MLXArray(flat, [3, 1, finalSeqLen])
+    }
+
+    /// GPU-side variant of `sampleToken`: greedy skips the softmax (argMax
+    /// over logits picks the same token) and the sampled path uses GPU
+    /// categorical sampling; both return a 0-d array with no host readback,
+    /// so the decode loop can pipeline. The legacy sampled path drew from an
+    /// unseeded host RNG, so sampled outputs were nondeterministic before
+    /// and after this change.
+    func sampleTokenArray(logits: MLXArray, temperature: Float) -> MLXArray {
+        if temperature <= 0.1 {
+            return MLX.argMax(logits, axis: -1).asType(.int32)
+        }
+        let scores = (logits.asType(.float32)) / temperature
+        return categorical(scores).asType(.int32)
     }
 
     func sampleToken(logits: MLXArray, temperature: Float) -> Int {

--- a/Sources/MereRunCore/Psi/GLM47Flash.swift
+++ b/Sources/MereRunCore/Psi/GLM47Flash.swift
@@ -75,22 +75,38 @@ public final class GLM47Flash: @unchecked Sendable {
             repetitionContextSize: 32
         )
 
+        // Depth-1 pipelined decode; see generateStream for the shape. The
+        // legacy loop synchronized twice per token.
+        var repetitionHistory = repetitionHistoryArray(promptTokens: tokens, config: genConfig)
+        var pendingToken: MLXArray?
         for _ in 0..<maxNewTokens {
             let lastLogits = logits[0, -1, 0...]
-            let nextToken = sampleToken(
+            let tokenArray = sampledTokenArray(
                 logits: lastLogits,
                 config: genConfig,
-                previousTokens: tokens + generatedTokens
+                previousTokenIndices: repetitionHistory,
+                banMask: nil
             )
+            repetitionHistory = appendingRepetitionHistory(repetitionHistory, token: tokenArray, config: genConfig)
+            logits = model(tokenArray.asType(.int32).reshaped(1, 1), cache: cache)
+            asyncEval([logits, tokenArray])
 
-            if eosTokens.contains(nextToken) {
-                break
+            if let previous = pendingToken {
+                pendingToken = nil
+                let value = previous.item(Int.self)
+                if eosTokens.contains(value) {
+                    let decoded = tokenizer.decode(tokens: generatedTokens)
+                    return (decoded.trimmingCharacters(in: .whitespacesAndNewlines), generatedTokens.count)
+                }
+                generatedTokens.append(value)
             }
-
-            generatedTokens.append(nextToken)
-            let nextInput = MLXArray([Int32(nextToken)]).reshaped(1, 1)
-            logits = model(nextInput, cache: cache)
-            MLX.eval(logits)
+            pendingToken = tokenArray
+        }
+        if let previous = pendingToken {
+            let value = previous.item(Int.self)
+            if !eosTokens.contains(value) {
+                generatedTokens.append(value)
+            }
         }
 
         let decoded = tokenizer.decode(tokens: generatedTokens)
@@ -126,26 +142,46 @@ public final class GLM47Flash: @unchecked Sendable {
             repetitionContextSize: 32
         )
 
+        // Depth-1 pipelined decode: GPU-side sampling with an on-GPU
+        // repetition window, the sampled token feeding the next forward
+        // directly, and the previous step's token read back while the
+        // current step executes. The legacy loop synchronized twice per
+        // token (sample readback plus a blocking logits eval).
+        var repetitionHistory = repetitionHistoryArray(promptTokens: tokens, config: genConfig)
+        var pendingToken: MLXArray?
         for _ in 0..<maxNewTokens {
             let lastLogits = logits[0, -1, 0...]
-            let nextToken = sampleToken(
+            let tokenArray = sampledTokenArray(
                 logits: lastLogits,
                 config: genConfig,
-                previousTokens: tokens + generatedTokens
+                previousTokenIndices: repetitionHistory,
+                banMask: nil
             )
+            repetitionHistory = appendingRepetitionHistory(repetitionHistory, token: tokenArray, config: genConfig)
+            logits = model(tokenArray.asType(.int32).reshaped(1, 1), cache: cache)
+            asyncEval([logits, tokenArray])
 
-            if eosTokens.contains(nextToken) {
-                break
+            if let previous = pendingToken {
+                pendingToken = nil
+                let value = previous.item(Int.self)
+                if eosTokens.contains(value) {
+                    let decoded = tokenizer.decode(tokens: generatedTokens)
+                    return decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                generatedTokens.append(value)
+                if let onUpdate {
+                    onUpdate(tokenizer.decode(tokens: generatedTokens))
+                }
             }
-
-            generatedTokens.append(nextToken)
-            let nextInput = MLXArray([Int32(nextToken)]).reshaped(1, 1)
-            logits = model(nextInput, cache: cache)
-            MLX.eval(logits)
-
-            if let onUpdate {
-                let partial = tokenizer.decode(tokens: generatedTokens)
-                onUpdate(partial)
+            pendingToken = tokenArray
+        }
+        if let previous = pendingToken {
+            let value = previous.item(Int.self)
+            if !eosTokens.contains(value) {
+                generatedTokens.append(value)
+                if let onUpdate {
+                    onUpdate(tokenizer.decode(tokens: generatedTokens))
+                }
             }
         }
 


### PR DESCRIPTION
Fifth PR of the platform perf sweep (Tier 3 of the verified gap map): mechanical ports of the proven GPU-sampling/readback patterns to four engines.

## Changes

- **LightOnOCR** — GPU-side sampling (greedy argMaxes logits directly; softmax is rank-preserving) + depth-1 pipelined loop; a debug top-5 block that ran a full-vocab argSort + readback per page even with logging disabled is now gated.
- **GLM-4.7 Flash (Psi)** — both generate paths now use the shared `sampledTokenArray` + GPU repetition-window machinery (the exact functions Q35/Gemma4 ship in production) with lagged readback.
- **Qwen3 embeddings** (`/v1/embeddings`, `text embed`) — one gather + batched normalize + single readback instead of N per-row syncs.
- **ACEStep 5Hz LM** — full-vocab argSort per token → argPartition (identical k-th-largest threshold).

## Verification

| engine | parity | timing |
|---|---|---|
| OCR (rendered text page, ~370 tok) | **byte-identical** 1450-char transcription | 4.4–4.5s → **3.66–3.69s (−17%)**, stable |
| Embeddings (3 texts × 1024 dims) | **bit-exact** (max abs diff 0.0) | n/a (batch) |
| ACEStep | threshold equality — same pattern unit-tested in the TTS suite (PR #121) | — |
| GLM-4.7 Flash | no local model; compile-verified; sampler is the shared production impl (distribution notes as documented on `sampledTokenArray`: top-p argPartition prefilter, f32 top-k) | — |

Notes: OCR's sampled (temperature > 0.1) path moves from an **unseeded host RNG** to GPU categorical — it was nondeterministic before and remains so. The VLM captioner shares the OCR pattern but is not user-facing (dataset prep) and was left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)