### PR TITLE
Denoise-loop hygiene: HiDream sigma precompute, Klein debug guard, Krea2 hoist

### DIFF
--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
@@ -191,10 +191,7 @@ extension Flux2KleinGenerator {
             try Task.checkCancellation()
             progressHandler?(GenerationProgress(stage: .denoising, stepIndex: step, totalSteps: request.steps))
 
-            // Get sigma for logging and timestep for model
             // mflux passes raw timestep (sigma * 1000), transformer handles scaling conditionally
-            let sigma = scheduler.sigma(at: step)
-            let sigmaValue = sigma.item(Float.self)
             let timestepTensor = scheduler.timestep(at: step).expandedDimensions(axis: 0)
 
             // Run transformer (with CFG if enabled)
@@ -236,6 +233,9 @@ extension Flux2KleinGenerator {
             }
 
             if let debugLog {
+                // Debug-only: the sigma readback lived outside this guard and
+                // forced a GPU sync every denoise step in production runs.
+                let sigmaValue = scheduler.sigma(at: step).item(Float.self)
                 MLX.eval(noisePred)
                 let npMean = noisePred.mean().item(Float.self)
                 let npStd = sqrt((noisePred * noisePred).mean().item(Float.self))

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Model.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Model.swift
@@ -398,6 +398,18 @@ enum HiDreamO1Denoiser {
         var uniPCState = scheduler.usesFlashStep ? nil : HiDreamO1UniPCState(scheduler: scheduler)
         var z = initialPatches(height: height, width: width, seed: seed)
 
+        // Read the sigma schedule once: the flash step's terminal branch
+        // needs each sigmaNext's sign on the host, and reading it inside the
+        // loop forced a GPU sync every denoise step.
+        let sigmaNextPositive: [Bool]
+        if scheduler.usesFlashStep, steps > 0 {
+            let sigmaNextValues = MLX.stacked((0..<steps).map { scheduler.sigma(at: $0 + 1) })
+                .asType(.float32).asArray(Float.self)
+            sigmaNextPositive = sigmaNextValues.map { $0 > 0 }
+        } else {
+            sigmaNextPositive = []
+        }
+
         progressHandler?(GenerationProgress(stage: .denoising, stepIndex: 0, totalSteps: steps))
         for stepIndex in 0..<steps {
             let timestep = scheduler.timestep(at: stepIndex)
@@ -435,6 +447,7 @@ enum HiDreamO1Denoiser {
                     sample: z,
                     sigma: scheduler.sigma(at: stepIndex),
                     sigmaNext: scheduler.sigma(at: stepIndex + 1),
+                    sigmaNextIsPositive: sigmaNextPositive[stepIndex],
                     noiseScale: scheduler.noiseScales[stepIndex],
                     seed: seed &+ UInt64(stepIndex + 10_000)
                 ).asType(.bfloat16)
@@ -477,12 +490,13 @@ enum HiDreamO1Denoiser {
         sample: MLXArray,
         sigma: MLXArray,
         sigmaNext: MLXArray,
+        sigmaNextIsPositive: Bool,
         noiseScale: Float,
         seed: UInt64
     ) -> MLXArray {
         let sampleF32 = sample.asType(.float32)
         let denoised = sampleF32 - modelOutput.asType(.float32) * sigma.asType(.float32)
-        guard sigmaNext.item(Float.self) > 0 else {
+        guard sigmaNextIsPositive else {
             return denoised
         }
         let noise = MLXRandom.normal(sample.shape, key: MLXRandom.key(seed)).asType(.float32)

--- a/Sources/MereRunCore/Krea2/Krea2Generator.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Generator.swift
@@ -138,6 +138,11 @@ public final class Krea2Generator: ImageGenerator {
             mu: mu
         )
 
+        // The text context never changes across steps; casting it inside the
+        // loop rebuilt the same bfloat16 tensor every iteration. (The image
+        // tokens intentionally accumulate in float32 with a per-step bfloat16
+        // cast for the transformer — that precision policy stays.)
+        let textContextBF16 = text.hiddenStates.asType(.bfloat16)
         for step in 0..<request.steps {
             try Task.checkCancellation()
             progressHandler?(GenerationProgress(stage: .denoising, stepIndex: step, totalSteps: request.steps))
@@ -146,7 +151,7 @@ public final class Krea2Generator: ImageGenerator {
             let timestep = MLXArray([tCurrent]).asType(.bfloat16)
             let velocity = transformer(
                 imageTokens: imageTokens.asType(.bfloat16),
-                textContext: text.hiddenStates.asType(.bfloat16),
+                textContext: textContextBF16,
                 timestep: timestep,
                 positionIds: prepared.positionIds,
                 validMask: prepared.validMask


### PR DESCRIPTION
Sixth PR of the platform perf sweep (Tier 4 of the verified gap map): removing per-step GPU syncs and redundant work from three denoise loops.

- **HiDreamO1** — `flashStep` read `sigmaNext.item()` **every step** for the terminal-branch check. The schedule is now read once (one stacked readback) and the branch takes a precomputed `Bool`. GPU math unchanged.
- **Flux2Klein** — the unconditional per-step `sigma.item()` sync fed only `MERERUN_FLUX2_DEBUG` logging (flagged in the original image-stack profile); now inside the debug guard.
- **Krea2** — the text context was re-cast to bf16 in every step despite never changing; hoisted. The intentional fp32-accumulate/bf16-forward latent policy is untouched.

## Verification

- **Seeded Klein generations byte-identical** old-vs-new (shasum-equal, three runs).
- Krea2/HiDream: exactness-by-construction (same tensor / same schedule values); HiDream compile-verified, no local model for e2e.
- Timing honestly deferred: host under sustained load during measurement (10.5GB VM + sessions), and these remove a handful of syncs per generation — small wall effect on few-step models, real hygiene on many-step runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)