### PR TITLE
Q35: fused q/k/v quantized projections

### DIFF
--- a/Sources/MereRunCore/Q35/Q35FullAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35FullAttention.swift
@@ -11,6 +11,34 @@ final class Q35FullAttention: Module {
     @ModuleInfo(key: "q_norm") var qNorm: Q35RMSNorm
     @ModuleInfo(key: "k_norm") var kNorm: Q35RMSNorm
 
+    /// Row-concatenated q/k/v quantized weights so each attention call issues
+    /// one quantized matmul instead of three (bit-identical: quantized
+    /// packing is per-output-row). Lives outside the module tree; invalidated
+    /// whenever the source modules are replaced. MERERUN_Q35_FUSED_QKV=0
+    /// falls back to separate projections. Trades a second resident copy of
+    /// the attention projection weights for the fused matmul.
+    private var fusedQKV: Gemma4FusedQuantizedProjection?
+    private static let fusedQKVEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_Q35_FUSED_QKV"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw != "0" && raw != "false" && raw != "off"
+    }()
+    private static let logFusionOnce: Void = {
+        FileHandle.standardError.write(Data("[q35] fused_qkv=true\n".utf8))
+    }()
+
+    private func resolvedFusedQKV() -> Gemma4FusedQuantizedProjection? {
+        guard Self.fusedQKVEnabled else { return nil }
+        if let fusedQKV, fusedQKV.matches([qProj, kProj, vProj]) {
+            return fusedQKV
+        }
+        fusedQKV = Gemma4FusedQuantizedProjection.fuse([qProj, kProj, vProj])
+        if fusedQKV != nil {
+            _ = Self.logFusionOnce
+        }
+        return fusedQKV
+    }
+
     private let numHeads: Int
     private let numKVHeads: Int
     private let headDim: Int
@@ -69,7 +97,21 @@ final class Q35FullAttention: Module {
         let b = x.dim(0)
         let s = x.dim(1)
 
-        let qProjection = qProj(x).reshaped(b, s, numHeads, hasOutputGate ? headDim * 2 : headDim)
+        let qFlat: MLXArray
+        let kFlat: MLXArray
+        let vFlat: MLXArray
+        if let fused = resolvedFusedQKV() {
+            let parts = fused.callSplit(x)
+            qFlat = parts[0]
+            kFlat = parts[1]
+            vFlat = parts[2]
+        } else {
+            qFlat = qProj(x)
+            kFlat = kProj(x)
+            vFlat = vProj(x)
+        }
+
+        let qProjection = qFlat.reshaped(b, s, numHeads, hasOutputGate ? headDim * 2 : headDim)
 
         let queries: MLXArray
         let gate: MLXArray?
@@ -81,8 +123,8 @@ final class Q35FullAttention: Module {
             gate = nil
         }
 
-        let keys = kProj(x).reshaped(b, s, numKVHeads, headDim)
-        let values = vProj(x).reshaped(b, s, numKVHeads, headDim)
+        let keys = kFlat.reshaped(b, s, numKVHeads, headDim)
+        let values = vFlat.reshaped(b, s, numKVHeads, headDim)
 
         var q = qNorm(queries).transposed(0, 2, 1, 3)
         var k = kNorm(keys).transposed(0, 2, 1, 3)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,17 @@ Qwen-family MoE blocks stack the gate and up expert weights so each
 to `0`, `false`, or `off` to fall back to separate gate/up gathers. The stack
 keeps a second resident copy of the gate/up expert weights.
 
+### `MERERUN_Q35_FUSED_QKV`
+
+Qwen-family attention concatenates the q/k/v quantized projection weights so
+each attention call issues one fused matmul instead of three. Quantized
+packing is per-output-row, so results are bit-identical to the separate
+projections (greedy outputs verified byte-equal). Enabled by default; set to
+`0`, `false`, or `off` to fall back. On the 35B MoE this measured +1% decode
+throughput for roughly 130 MB of additional resident weight copies —
+attention is a small slice of a MoE's per-token weights, unlike the dense
+Gemma case where the same fusion bought +17%.
+
 ### `MERERUN_GEMMA4_FUSED_PROJ`
 
 Gemma4 concatenates the q/k/v and gate/up quantized projection weights after


### PR DESCRIPTION
Seventh PR of the platform perf sweep (Tier 3, final measurable lane).

Row-concatenates the q/k/v quantized weights (reusing `Gemma4FusedQuantizedProjection`, which is generic over projection lists) so each Qwen-family attention call issues **one** fused matmul instead of three. Per-output-row quantized packing makes it bit-identical; the fusion lives outside the module tree with identity-fingerprint invalidation, and biased/non-plain-quantized projections fall back automatically. `MERERUN_Q35_FUSED_QKV=0` disables.

## Measured (Ornith 35B, idle GPU — VM stopped first, ±0.2% run spread)

| | decode tok/s | peak footprint |
|---|---|---|
| unfused | 119.0–119.4 | 32.46 GB |
| fused | **120.2–120.6 (+1.0%)** | 32.59 GB (+130 MB) |

Greedy responses **byte-identical** fused vs unfused.

Honest framing: +1% is the MoE reality — attention is a thin slice of per-token weights next to the expert FFNs (dense Gemma4 got +17% from the same fusion). It's a strictly-positive trade at +130 MB, so it ships default-on; flip the env if the margin isn't worth the memory on constrained deployments.

Scope notes: Psi3 fusion omitted (no local model to verify), ACEStep omitted (its attention is the shared QwenEncoder used by ZImage/embeddings/HiDream — too much blast radius for an unmeasured win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)