### PR TITLE
MagentaRT2: opt-in non-blocking prompt swaps, 1ms prompt-wait poll

### DIFF
--- a/Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift
+++ b/Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift
@@ -134,6 +134,7 @@ public enum MagentaRT2Renderer {
                 rendered.reserveCapacity(frameCount * MagentaRT2Resources.frameSamples * MagentaRT2Resources.channels)
                 var left = [Float](repeating: 0, count: MagentaRT2Resources.frameSamples)
                 var right = [Float](repeating: 0, count: MagentaRT2Resources.frameSamples)
+                var promptSwapPending = false
                 for frameIndex in 0..<frameCount {
                     try Task.checkCancellation()
                     if let snapshot = try liveControls?(frameIndex) {
@@ -153,7 +154,27 @@ public enum MagentaRT2Renderer {
                         }
                         if let prompt = snapshot.prompt {
                             mrt2_engine_set_text_prompt(engine, prompt)
-                            try waitForPrompt(engine)
+                            if nonBlockingPromptSwap {
+                                // The engine encodes the new prompt on its own
+                                // thread and switches when ready; frames keep
+                                // rendering on the previous prompt meanwhile.
+                                // Blocking here stalled the render thread for
+                                // the whole encode — a guaranteed underrun for
+                                // any live audio consumer.
+                                promptSwapPending = true
+                            } else {
+                                try waitForPrompt(engine)
+                            }
+                        }
+                    }
+                    if promptSwapPending {
+                        let textStatus = mrt2_engine_get_text_encoder_status(engine)
+                        let quantizerStatus = mrt2_engine_get_quantizer_status(engine)
+                        guard textStatus != 3, quantizerStatus != 3 else {
+                            throw MagentaRT2Error.promptEncodingFailed
+                        }
+                        if textStatus != 1 && quantizerStatus != 1 {
+                            promptSwapPending = false
                         }
                     }
                     let didGenerate = left.withUnsafeMutableBufferPointer { leftBuffer in
@@ -198,13 +219,29 @@ public enum MagentaRT2Renderer {
         mrt2_engine_set_seed_rotation(engine, controls.seedRotation)
     }
 
+    /// Opt-in (MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP=1): mid-session prompt
+    /// swaps leave the render loop free-running while the engine encodes
+    /// asynchronously (frames continue on the previous prompt, the engine
+    /// switches when ready) instead of blocking the render thread for the
+    /// whole encode. Off by default: the vendored engine currently fails to
+    /// load its Metal library on this toolchain (tracked separately), so the
+    /// behavior cannot be validated live yet —
+    /// MagentaRT2PromptSwapTests.testNonBlockingPromptSwapKeepsRendering is
+    /// the promotion gate once the engine runs again. Read per swap so tests
+    /// can flip it via setenv.
+    private static var nonBlockingPromptSwap: Bool {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "on"
+    }
+
     private static func waitForPrompt(_ engine: OpaquePointer) throws {
         let deadline = Date().addingTimeInterval(30)
         while mrt2_engine_get_text_encoder_status(engine) == 1 || mrt2_engine_get_quantizer_status(engine) == 1 {
             if Date() > deadline {
                 throw MagentaRT2Error.promptEncodingFailed
             }
-            Thread.sleep(forTimeInterval: 0.01)
+            Thread.sleep(forTimeInterval: 0.001)
         }
         guard mrt2_engine_get_text_encoder_status(engine) != 3,
               mrt2_engine_get_quantizer_status(engine) != 3 else {

--- a/Tests/MereRunCoreTests/MagentaRT2PromptSwapTests.swift
+++ b/Tests/MereRunCoreTests/MagentaRT2PromptSwapTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+/// Live-session prompt-swap behavior against the real Magenta RT2 engine.
+/// Heavy (loads the native engine plus a multi-GB model), so it only runs
+/// when explicitly enabled:
+///   MERERUN_TEST_RUN_MAGENTA=1 swift test --filter MagentaRT2PromptSwapTests
+/// The model root defaults to the installed managed model and can be
+/// overridden with MERERUN_TEST_MAGENTA_MODEL_ROOT.
+final class MagentaRT2PromptSwapTests: XCTestCase {
+    private func resolvedResources() throws -> MagentaRT2Resources {
+        let env = ProcessInfo.processInfo.environment
+        guard env["MERERUN_TEST_RUN_MAGENTA"] == "1" else {
+            throw XCTSkip("Set MERERUN_TEST_RUN_MAGENTA=1 to run Magenta RT2 engine tests.")
+        }
+        let root: URL
+        if let override = env["MERERUN_TEST_MAGENTA_MODEL_ROOT"], !override.isEmpty {
+            root = URL(fileURLWithPath: override)
+        } else {
+            root = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support/MereRun/models/music-magenta-rt2-small")
+        }
+        guard FileManager.default.fileExists(atPath: root.path) else {
+            throw XCTSkip("No Magenta RT2 model at \(root.path).")
+        }
+        let resources = MagentaRT2Resources(rootURL: root, modelID: "music-magenta-rt2-small")
+        guard resources.validate().isEmpty else {
+            throw XCTSkip("Magenta RT2 model at \(root.path) is missing assets.")
+        }
+        return resources
+    }
+
+    /// Renders through a mid-session prompt swap without blocking and checks
+    /// that every frame around the swap keeps rendering (no stall anywhere
+    /// near the multi-second encode time) and produces finite, non-silent
+    /// audio. This is the empirical proof that mrt2_engine_generate_frame is
+    /// safe while the engine encodes a new prompt on its own thread.
+    func testNonBlockingPromptSwapKeepsRendering() async throws {
+        let resources = try resolvedResources()
+        setenv("MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP", "1", 1)
+        defer { unsetenv("MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP") }
+
+        let frameCount = 50
+        let swapFrame = 20
+        let recorder = FrameRecorder()
+
+        let request = MagentaRT2RenderRequest(
+            prompt: "gentle ambient piano",
+            resources: resources,
+            durationSeconds: Float(frameCount) / Float(MagentaRT2Resources.frameRate)
+        )
+
+        do {
+            try await runSwapStream(request: request, frameCount: frameCount, swapFrame: swapFrame, recorder: recorder)
+        } catch let error as MagentaRT2Error {
+            // The vendored engine currently fails to load its Metal library
+            // on newer toolchains; skip rather than fail until the
+            // xcframework is rebuilt (tracked separately).
+            throw XCTSkip("Magenta RT2 engine unavailable: \(error.localizedDescription)")
+        }
+
+        let stats = recorder.snapshot()
+        XCTAssertEqual(stats.framesRendered, frameCount)
+        XCTAssertTrue(stats.allFinite, "engine produced non-finite samples")
+        XCTAssertGreaterThan(stats.peakAfterSwap, 0, "audio went silent after the prompt swap")
+
+        // The whole point: no frame near the swap may stall for anything
+        // like the prompt-encode time. Frames run ~real-time (tens of ms);
+        // the legacy blocking swap stalled one frame for the full encode
+        // (hundreds of ms to seconds). 250ms is far above any normal frame
+        // yet far below the encode stall.
+        XCTAssertLessThan(
+            stats.maxFrameSecondsAroundSwap,
+            0.25,
+            "a frame near the swap stalled — non-blocking swap is not working"
+        )
+        print("[magenta-test] max_frame_s_around_swap=\(stats.maxFrameSecondsAroundSwap) peak_after_swap=\(stats.peakAfterSwap)")
+    }
+
+    private func runSwapStream(
+        request: MagentaRT2RenderRequest,
+        frameCount: Int,
+        swapFrame: Int,
+        recorder: FrameRecorder
+    ) async throws {
+        try await MagentaRT2Renderer.renderFrameStream(
+            request,
+            frameCount: frameCount,
+            liveControls: { frameIndex in
+                recorder.markFrameStart()
+                if frameIndex == swapFrame {
+                    return MagentaRT2LiveControlSnapshot(prompt: "energetic drum and bass")
+                }
+                return nil
+            },
+            onFrame: { frameIndex, frame in
+                recorder.record(frameIndex: frameIndex, frame: frame)
+            }
+        )
+    }
+
+    private final class FrameRecorder: @unchecked Sendable {
+        struct Stats {
+            let framesRendered: Int
+            let allFinite: Bool
+            let peakAfterSwap: Float
+            let maxFrameSecondsAroundSwap: Double
+        }
+
+        private let lock = NSLock()
+        private var framesRendered = 0
+        private var allFinite = true
+        private var peakAfterSwap: Float = 0
+        private var maxFrameSecondsAroundSwap: Double = 0
+        private var lastFrameStart: Date?
+
+        func markFrameStart() {
+            lock.lock()
+            defer { lock.unlock() }
+            lastFrameStart = Date()
+        }
+
+        func record(frameIndex: Int, frame: MagentaRT2Frame) {
+            lock.lock()
+            defer { lock.unlock() }
+            framesRendered += 1
+            let peak = frame.left.reduce(Float(0)) { max($0, abs($1)) }
+            if frame.left.contains(where: { !$0.isFinite }) || frame.right.contains(where: { !$0.isFinite }) {
+                allFinite = false
+            }
+            if frameIndex >= 20 {
+                peakAfterSwap = max(peakAfterSwap, peak)
+            }
+            if frameIndex >= 18, frameIndex <= 30, let start = lastFrameStart {
+                maxFrameSecondsAroundSwap = max(maxFrameSecondsAroundSwap, Date().timeIntervalSince(start))
+            }
+        }
+
+        func snapshot() -> Stats {
+            lock.lock()
+            defer { lock.unlock() }
+            return Stats(
+                framesRendered: framesRendered,
+                allFinite: allFinite,
+                peakAfterSwap: peakAfterSwap,
+                maxFrameSecondsAroundSwap: maxFrameSecondsAroundSwap
+            )
+        }
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,6 +137,18 @@ default: with mlx-swift 0.31.4 every compiled call serializes on the global
 eval lock, which measured slower than the interpreted path at decode call
 rates. Kept for evaluation against future mlx-swift releases.
 
+### `MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP`
+
+Opt-in (`1`, `true`, or `on`): Magenta RT2 mid-session prompt swaps keep the
+render loop generating frames on the previous prompt while the engine encodes
+the new one on its own thread, switching when ready, instead of blocking the
+render thread in a status poll for the whole encode (a guaranteed underrun
+for live audio). Off by default until the vendored engine's Metal-library
+regression is fixed and the gated
+`MagentaRT2PromptSwapTests.testNonBlockingPromptSwapKeepsRendering`
+integration test can validate the behavior live. The blocking wait's poll
+interval is also reduced from 10ms to 1ms.
+
 ### `MERERUN_SAMPLER_TOP_P_PREFILTER`
 
 GPU-side top-p sampling prefilters to this many top-logit candidates (via


### PR DESCRIPTION
Lane H of the platform perf sweep.

## The underrun mechanism

A mid-session prompt swap called `waitForPrompt`, blocking the render thread in a **10ms status poll for the engine's entire asynchronous prompt encode** — the audio buffer drains and the live stream glitches, every time, by construction.

## The fix

- `MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP=1`: after `set_text_prompt`, frames keep rendering on the previous prompt while the engine encodes on its own thread and switches when ready (also the musically correct behavior for live jamming). Encode failures still surface via cheap per-frame status probes while a swap is pending.
- Blocking path poll: 10ms → 1ms.

## Why opt-in, and what the promotion gate is

Validation hit a wall that isn't this PR: **`music realtime` is broken on current main** — the vendored `magentart.xcframework` fails to load its bundled Metal library on this toolchain (`Invalid library file`; reproduced with and without a colocated `mlx.metallib`; worked historically). Task chip filed for the xcframework rebuild.

Since zero live validation is possible, the swap behavior ships **off by default** with its evidence bar checked in: `MagentaRT2PromptSwapTests` (gated on `MERERUN_TEST_RUN_MAGENTA=1`) renders 50 frames through a swap at frame 20 and asserts no frame near the swap stalls >250ms plus non-silent finite audio after it. It skips cleanly while the engine is down; once the engine loads again, a green run is the signal to flip the default.

Assessed and rejected from the audit: pre-C-boundary frame batching (buffers already reused; would add 48–96ms control latency for negligible gain). The library's own threaded `runner_*` API with a buffered ring is the right long-term architecture — noted in the engine-fix task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)