### PR TITLE
Q35: batched GPU-side sampling for continuous-batching decode

### DIFF
--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -52,6 +52,10 @@ private final class Q35BatchedDecodeRow: @unchecked Sendable {
     var layerCaches: [Q35LayerCache?]
     var generatedTokens: [Int]
     var repetitionHistory: [Int]
+    /// GPU-resident repetition window for batched GPU-side sampling; seeded
+    /// lazily from `repetitionHistory` and appended without host readbacks.
+    var repetitionHistoryGPU: MLXArray?
+    var repetitionHistoryGPUSeeded = false
     var stopped = false
 
     init(
@@ -105,6 +109,17 @@ public actor Q35Generator: ChatGenerator {
     private static let prefillChunkSize = 512
     private static let prefixKVCacheMaxEntries = 4
     private static let defaultMTPBlockSize = 4
+
+    /// Continuous-batching decode samples every row on GPU (the same sampler
+    /// the serial pipelined path uses) and reads the whole batch back in one
+    /// sync per step; the legacy path performed one blocking readback per row
+    /// per step. MERERUN_Q35_BATCHED_GPU_SAMPLING=0 restores per-row host
+    /// sampling.
+    private static let batchedGPUSamplingEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_Q35_BATCHED_GPU_SAMPLING"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw != "0" && raw != "false" && raw != "off"
+    }()
     public static let qwen3VLMinPixels = 2_048
     public static let qwen3VLMaxPixels = 16_777_216
 
@@ -1218,22 +1233,68 @@ public actor Q35Generator: ChatGenerator {
         let sampledRows = rows.filter(\.needsDecodeStep)
         guard !sampledRows.isEmpty else { return }
 
-        for row in sampledRows {
-            let next = sampleToken(
-                logits: row.logits[0, -1, 0...],
-                config: row.generationConfig,
-                previousTokens: row.repetitionHistory
-            )
-            guard !row.eosSet.contains(next) else {
-                row.stopped = true
-                continue
+        if Self.batchedGPUSamplingEnabled {
+            // Sample every row on GPU (same sampler the serial pipelined
+            // decode uses), then read the whole batch back in one sync —
+            // the legacy path performed one blocking readback per row per
+            // step, which scales linearly with serve concurrency.
+            var tokenArrays: [MLXArray] = []
+            tokenArrays.reserveCapacity(sampledRows.count)
+            for row in sampledRows {
+                if !row.repetitionHistoryGPUSeeded {
+                    row.repetitionHistoryGPU = repetitionHistoryArray(
+                        promptTokens: row.repetitionHistory,
+                        config: row.generationConfig
+                    )
+                    row.repetitionHistoryGPUSeeded = true
+                }
+                let tokenArray = sampledTokenArray(
+                    logits: row.logits[0, -1, 0...],
+                    config: row.generationConfig,
+                    previousTokenIndices: row.repetitionHistoryGPU,
+                    banMask: nil
+                )
+                row.repetitionHistoryGPU = appendingRepetitionHistory(
+                    row.repetitionHistoryGPU,
+                    token: tokenArray,
+                    config: row.generationConfig
+                )
+                tokenArrays.append(tokenArray.reshaped(1))
             }
-            row.generatedTokens.append(next)
-            row.repetitionHistory.append(next)
-            if let progressHandler = row.progressHandler {
-                let piece = tokenizerAndTemplate.decode(token: next)
-                if !piece.isEmpty {
-                    progressHandler(ChatProgress(stage: .generating, message: piece))
+            let values = MLX.concatenated(tokenArrays, axis: 0).asArray(Int32.self)
+            for (index, row) in sampledRows.enumerated() {
+                let next = Int(values[index])
+                guard !row.eosSet.contains(next) else {
+                    row.stopped = true
+                    continue
+                }
+                row.generatedTokens.append(next)
+                row.repetitionHistory.append(next)
+                if let progressHandler = row.progressHandler {
+                    let piece = tokenizerAndTemplate.decode(token: next)
+                    if !piece.isEmpty {
+                        progressHandler(ChatProgress(stage: .generating, message: piece))
+                    }
+                }
+            }
+        } else {
+            for row in sampledRows {
+                let next = sampleToken(
+                    logits: row.logits[0, -1, 0...],
+                    config: row.generationConfig,
+                    previousTokens: row.repetitionHistory
+                )
+                guard !row.eosSet.contains(next) else {
+                    row.stopped = true
+                    continue
+                }
+                row.generatedTokens.append(next)
+                row.repetitionHistory.append(next)
+                if let progressHandler = row.progressHandler {
+                    let piece = tokenizerAndTemplate.decode(token: next)
+                    if !piece.isEmpty {
+                        progressHandler(ChatProgress(stage: .generating, message: piece))
+                    }
                 }
             }
         }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,15 @@ Qwen-family MoE blocks stack the gate and up expert weights so each
 to `0`, `false`, or `off` to fall back to separate gate/up gathers. The stack
 keeps a second resident copy of the gate/up expert weights.
 
+### `MERERUN_Q35_BATCHED_GPU_SAMPLING`
+
+Qwen-family continuous-batching decode samples every active request's row on
+GPU (the same sampler the serial pipelined path uses, including the on-GPU
+repetition window) and reads the whole batch back in a single sync per step.
+The legacy path sampled per row on the host — one blocking GPU→CPU readback
+per request per token, scaling linearly with serve concurrency. Enabled by
+default; set to `0`, `false`, or `off` to restore per-row host sampling.
+
 ### `MERERUN_GEMMA4_FUSED_PROJ`
 
 Gemma4 concatenates the q/k/v and gate/up quantized projection weights after


### PR DESCRIPTION
Lane I (part 1) of the platform perf sweep — the parked "batched sampling for continuous batching" item.

## What was wrong

`decodeOneStep` sampled each active row **on the host**: one blocking GPU→CPU readback per request per token (linear in serve concurrency), using a *different* sampler than the serial pipelined path.

## The fix

Rows sample on GPU via the shared `sampledTokenArray` — the same production sampler the serial path uses — with a per-row on-GPU repetition window seeded from the prompt, and the **whole batch reads back in one sync per step**. `MERERUN_Q35_BATCHED_GPU_SAMPLING=0` restores per-row host sampling.

## Verification (live `api serve`, Ornith 35B, `MERERUN_Q35_CONTINUOUS_BATCHING=1 --max-active-requests 3`)

- 3 concurrent sampled requests → coherent, distinct responses.
- **Engagement confirmed** via `/runtime/status`: `batchedDecodeSteps=9, maxBatchSize=3, totalBatchedRows=26` (first attempt without the continuous-batching env showed `batchedDecodeSteps=0` — the assert-engagement check caught it).
- Legacy path re-run under the same setup: coherent responses.

Also unifies sampling semantics: the batched path now shares the serial path's documented `sampledTokenArray` behavior (argPartition top-p prefilter, f32 top-k) instead of diverging from it.

Remaining lane-I item (LFM2 prefix-KV port) is scoped in the perf gap map as its own follow-up — it's a feature-scale port of the Q35/Gemma prefix-cache system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)