### PR TITLE
MagentaRT2: root-cause engine metallib failure (LFS), drop unsafe swap option

### DIFF
--- a/Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift
+++ b/Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift
@@ -134,7 +134,6 @@ public enum MagentaRT2Renderer {
                 rendered.reserveCapacity(frameCount * MagentaRT2Resources.frameSamples * MagentaRT2Resources.channels)
                 var left = [Float](repeating: 0, count: MagentaRT2Resources.frameSamples)
                 var right = [Float](repeating: 0, count: MagentaRT2Resources.frameSamples)
-                var promptSwapPending = false
                 for frameIndex in 0..<frameCount {
                     try Task.checkCancellation()
                     if let snapshot = try liveControls?(frameIndex) {
@@ -153,28 +152,16 @@ public enum MagentaRT2Renderer {
                             mrt2_engine_reset_state(engine)
                         }
                         if let prompt = snapshot.prompt {
+                            // The wait is mandatory: overlapping
+                            // mrt2_engine_generate_frame with the engine's
+                            // asynchronous prompt encode segfaults (verified
+                            // via MagentaRT2PromptSwapTests against the live
+                            // engine), so a mid-session swap stalls the
+                            // render loop for the encode. The engine's
+                            // mrt2_runner_* API with its buffered audio ring
+                            // is the path to stall-free swaps.
                             mrt2_engine_set_text_prompt(engine, prompt)
-                            if nonBlockingPromptSwap {
-                                // The engine encodes the new prompt on its own
-                                // thread and switches when ready; frames keep
-                                // rendering on the previous prompt meanwhile.
-                                // Blocking here stalled the render thread for
-                                // the whole encode — a guaranteed underrun for
-                                // any live audio consumer.
-                                promptSwapPending = true
-                            } else {
-                                try waitForPrompt(engine)
-                            }
-                        }
-                    }
-                    if promptSwapPending {
-                        let textStatus = mrt2_engine_get_text_encoder_status(engine)
-                        let quantizerStatus = mrt2_engine_get_quantizer_status(engine)
-                        guard textStatus != 3, quantizerStatus != 3 else {
-                            throw MagentaRT2Error.promptEncodingFailed
-                        }
-                        if textStatus != 1 && quantizerStatus != 1 {
-                            promptSwapPending = false
+                            try waitForPrompt(engine)
                         }
                     }
                     let didGenerate = left.withUnsafeMutableBufferPointer { leftBuffer in
@@ -217,22 +204,6 @@ public enum MagentaRT2Renderer {
         mrt2_engine_set_drumless(engine, controls.drumless)
         mrt2_engine_set_unmask_width(engine, controls.unmaskWidth)
         mrt2_engine_set_seed_rotation(engine, controls.seedRotation)
-    }
-
-    /// Opt-in (MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP=1): mid-session prompt
-    /// swaps leave the render loop free-running while the engine encodes
-    /// asynchronously (frames continue on the previous prompt, the engine
-    /// switches when ready) instead of blocking the render thread for the
-    /// whole encode. Off by default: the vendored engine currently fails to
-    /// load its Metal library on this toolchain (tracked separately), so the
-    /// behavior cannot be validated live yet —
-    /// MagentaRT2PromptSwapTests.testNonBlockingPromptSwapKeepsRendering is
-    /// the promotion gate once the engine runs again. Read per swap so tests
-    /// can flip it via setenv.
-    private static var nonBlockingPromptSwap: Bool {
-        let raw = ProcessInfo.processInfo.environment["MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return raw == "1" || raw == "true" || raw == "on"
     }
 
     private static func waitForPrompt(_ engine: OpaquePointer) throws {

--- a/Sources/MereRunCore/MagentaRT2/MagentaRT2Resources.swift
+++ b/Sources/MereRunCore/MagentaRT2/MagentaRT2Resources.swift
@@ -221,7 +221,11 @@ public enum MagentaRT2Error: LocalizedError, Sendable {
         case .engineInitializationFailed(let path):
             return "Failed to initialize Magenta RT2 assets from \(path)."
         case .modelLoadFailed(let path):
-            return "Failed to load Magenta RT2 model from \(path)."
+            return "Failed to load Magenta RT2 model from \(path). "
+                + "If the engine reported a metallib failure, the vendored "
+                + "magentart.xcframework Metal libraries are Git LFS objects "
+                + "and may be un-hydrated pointer stubs — run "
+                + "`git lfs install --local && git lfs pull` in the repo and rebuild."
         case .promptEncodingFailed:
             return "Magenta RT2 prompt encoding failed."
         case .generationFailed(let frame):

--- a/Tests/MereRunCoreTests/MagentaRT2PromptSwapTests.swift
+++ b/Tests/MereRunCoreTests/MagentaRT2PromptSwapTests.swift
@@ -2,12 +2,21 @@ import Foundation
 import XCTest
 @testable import MereRunCore
 
-/// Live-session prompt-swap behavior against the real Magenta RT2 engine.
-/// Heavy (loads the native engine plus a multi-GB model), so it only runs
-/// when explicitly enabled:
+/// Live prompt-swap behavior against the real Magenta RT2 engine. Heavy
+/// (loads the native engine plus a multi-GB model), so it only runs when
+/// explicitly enabled:
 ///   MERERUN_TEST_RUN_MAGENTA=1 swift test --filter MagentaRT2PromptSwapTests
 /// The model root defaults to the installed managed model and can be
 /// overridden with MERERUN_TEST_MAGENTA_MODEL_ROOT.
+///
+/// History (2026-07-03): a non-blocking swap variant — keep calling
+/// mrt2_engine_generate_frame while the engine encodes the new prompt on its
+/// own thread — SEGFAULTED deterministically when run against the live
+/// engine (signal 11 in the xctest process; the engine API is not safe for
+/// cross-thread overlap with its asynchronous encode). The render loop
+/// therefore blocks on prompt swaps by design; stall-free swaps need the
+/// engine's threaded mrt2_runner_* API with its buffered audio ring. This
+/// suite pins the supported blocking behavior.
 final class MagentaRT2PromptSwapTests: XCTestCase {
     private func resolvedResources() throws -> MagentaRT2Resources {
         let env = ProcessInfo.processInfo.environment
@@ -31,16 +40,12 @@ final class MagentaRT2PromptSwapTests: XCTestCase {
         return resources
     }
 
-    /// Renders through a mid-session prompt swap without blocking and checks
-    /// that every frame around the swap keeps rendering (no stall anywhere
-    /// near the multi-second encode time) and produces finite, non-silent
-    /// audio. This is the empirical proof that mrt2_engine_generate_frame is
-    /// safe while the engine encodes a new prompt on its own thread.
-    func testNonBlockingPromptSwapKeepsRendering() async throws {
+    /// A mid-session prompt swap must complete the stream with finite,
+    /// non-silent audio on both sides of the swap. The swap stalls the
+    /// render loop for the encode by design (see the type comment), so
+    /// there is deliberately no frame-time assertion around it.
+    func testPromptSwapRendersToCompletion() async throws {
         let resources = try resolvedResources()
-        setenv("MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP", "1", 1)
-        defer { unsetenv("MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP") }
-
         let frameCount = 50
         let swapFrame = 20
         let recorder = FrameRecorder()
@@ -52,11 +57,20 @@ final class MagentaRT2PromptSwapTests: XCTestCase {
         )
 
         do {
-            try await runSwapStream(request: request, frameCount: frameCount, swapFrame: swapFrame, recorder: recorder)
+            try await MagentaRT2Renderer.renderFrameStream(
+                request,
+                frameCount: frameCount,
+                liveControls: { frameIndex in
+                    if frameIndex == swapFrame {
+                        return MagentaRT2LiveControlSnapshot(prompt: "energetic drum and bass")
+                    }
+                    return nil
+                },
+                onFrame: { frameIndex, frame in
+                    recorder.record(frameIndex: frameIndex, frame: frame)
+                }
+            )
         } catch let error as MagentaRT2Error {
-            // The vendored engine currently fails to load its Metal library
-            // on newer toolchains; skip rather than fail until the
-            // xcframework is rebuilt (tracked separately).
             throw XCTSkip("Magenta RT2 engine unavailable: \(error.localizedDescription)")
         }
 
@@ -64,40 +78,7 @@ final class MagentaRT2PromptSwapTests: XCTestCase {
         XCTAssertEqual(stats.framesRendered, frameCount)
         XCTAssertTrue(stats.allFinite, "engine produced non-finite samples")
         XCTAssertGreaterThan(stats.peakAfterSwap, 0, "audio went silent after the prompt swap")
-
-        // The whole point: no frame near the swap may stall for anything
-        // like the prompt-encode time. Frames run ~real-time (tens of ms);
-        // the legacy blocking swap stalled one frame for the full encode
-        // (hundreds of ms to seconds). 250ms is far above any normal frame
-        // yet far below the encode stall.
-        XCTAssertLessThan(
-            stats.maxFrameSecondsAroundSwap,
-            0.25,
-            "a frame near the swap stalled — non-blocking swap is not working"
-        )
-        print("[magenta-test] max_frame_s_around_swap=\(stats.maxFrameSecondsAroundSwap) peak_after_swap=\(stats.peakAfterSwap)")
-    }
-
-    private func runSwapStream(
-        request: MagentaRT2RenderRequest,
-        frameCount: Int,
-        swapFrame: Int,
-        recorder: FrameRecorder
-    ) async throws {
-        try await MagentaRT2Renderer.renderFrameStream(
-            request,
-            frameCount: frameCount,
-            liveControls: { frameIndex in
-                recorder.markFrameStart()
-                if frameIndex == swapFrame {
-                    return MagentaRT2LiveControlSnapshot(prompt: "energetic drum and bass")
-                }
-                return nil
-            },
-            onFrame: { frameIndex, frame in
-                recorder.record(frameIndex: frameIndex, frame: frame)
-            }
-        )
+        print("[magenta-test] blocking swap completed, peak_after_swap=\(stats.peakAfterSwap)")
     }
 
     private final class FrameRecorder: @unchecked Sendable {
@@ -105,21 +86,12 @@ final class MagentaRT2PromptSwapTests: XCTestCase {
             let framesRendered: Int
             let allFinite: Bool
             let peakAfterSwap: Float
-            let maxFrameSecondsAroundSwap: Double
         }
 
         private let lock = NSLock()
         private var framesRendered = 0
         private var allFinite = true
         private var peakAfterSwap: Float = 0
-        private var maxFrameSecondsAroundSwap: Double = 0
-        private var lastFrameStart: Date?
-
-        func markFrameStart() {
-            lock.lock()
-            defer { lock.unlock() }
-            lastFrameStart = Date()
-        }
 
         func record(frameIndex: Int, frame: MagentaRT2Frame) {
             lock.lock()
@@ -132,9 +104,6 @@ final class MagentaRT2PromptSwapTests: XCTestCase {
             if frameIndex >= 20 {
                 peakAfterSwap = max(peakAfterSwap, peak)
             }
-            if frameIndex >= 18, frameIndex <= 30, let start = lastFrameStart {
-                maxFrameSecondsAroundSwap = max(maxFrameSecondsAroundSwap, Date().timeIntervalSince(start))
-            }
         }
 
         func snapshot() -> Stats {
@@ -143,8 +112,7 @@ final class MagentaRT2PromptSwapTests: XCTestCase {
             return Stats(
                 framesRendered: framesRendered,
                 allFinite: allFinite,
-                peakAfterSwap: peakAfterSwap,
-                maxFrameSecondsAroundSwap: maxFrameSecondsAroundSwap
+                peakAfterSwap: peakAfterSwap
             )
         }
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,17 +169,17 @@ default: with mlx-swift 0.31.4 every compiled call serializes on the global
 eval lock, which measured slower than the interpreted path at decode call
 rates. Kept for evaluation against future mlx-swift releases.
 
-### `MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP`
+### Magenta RT2 prompt swaps (no switch)
 
-Opt-in (`1`, `true`, or `on`): Magenta RT2 mid-session prompt swaps keep the
-render loop generating frames on the previous prompt while the engine encodes
-the new one on its own thread, switching when ready, instead of blocking the
-render thread in a status poll for the whole encode (a guaranteed underrun
-for live audio). Off by default until the vendored engine's Metal-library
-regression is fixed and the gated
-`MagentaRT2PromptSwapTests.testNonBlockingPromptSwapKeepsRendering`
-integration test can validate the behavior live. The blocking wait's poll
-interval is also reduced from 10ms to 1ms.
+Magenta RT2 mid-session prompt swaps block the render loop for the engine's
+prompt encode (1ms status poll). This is a hard engine constraint, not a
+tunable: overlapping `mrt2_engine_generate_frame` with the asynchronous
+encode segfaults, verified live against the engine by the gated
+`MagentaRT2PromptSwapTests`. Stall-free swaps require the engine's threaded
+`mrt2_runner_*` API with its buffered audio ring. Note the engine's Metal
+libraries inside `vendor/magentart.xcframework` are Git LFS objects — a
+checkout without hydrated LFS fails at model load with a metallib error; run
+`git lfs install --local && git lfs pull` and rebuild.
 
 ### `MERERUN_SAMPLER_TOP_P_PREFILTER`
 


### PR DESCRIPTION
Closes out the Magenta RT2 investigation with two corrections to the record.

## 1. The engine was never toolchain-broken — it's Git LFS

`vendor/magentart.xcframework/**/Resources/*.metallib` are **LFS-tracked 107MB objects**; un-hydrated checkouts carry 134-byte pointer stubs, and Metal's "Invalid library file ×2" was it rejecting those stubs. `git lfs install --local && git lfs pull` fixes it — verified: `music realtime` renders 101 frames / 5s of audio immediately after hydration. The `modelLoadFailed` message now includes the LFS hint, and the docs note the constraint. (The earlier task chip's "rebuild the xcframework" hypothesis was wrong; chip dismissed. Related context: this is a sibling of the tracked-stale-metallib class of problem fixed in #131 — binary Metal artifacts in git that don't obviously fail when wrong.)

## 2. The promotion gate ran — and rejected the non-blocking swap

With the engine live, the gated integration test shipped in #128 delivered its verdict: overlapping `mrt2_engine_generate_frame` with the engine's async prompt encode **segfaults deterministically** (signal 11). The opt-in `MERERUN_MAGENTA_NONBLOCKING_PROMPT_SWAP` and its code path are removed; mid-session swaps block for the encode **by engine constraint** (1ms poll retained from #128). Stall-free swaps need the engine's threaded `mrt2_runner_*` API with its buffered ring — documented as the future path.

The rewritten test suite pins the supported blocking behavior and passes live:
```
[magenta-test] blocking swap completed, peak_after_swap=0.33
Executed 1 test, with 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)