### PR TITLE
Q35 prefill chunk 1024, Ornith q36-mtp bench gate, code-bench thinking flag

### DIFF
--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -32,6 +32,12 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     @Option(name: [.long], help: "Top-p for generation.")
     var topP: Double = 1
 
+    @Flag(
+        name: [.long],
+        help: "Enable model thinking before the answer. Reasoning is split from the scored code; HumanEval-specific stop sequences are disabled because they can fire inside the thinking block."
+    )
+    var thinking: Bool = false
+
     @Option(name: [.long], help: "Generated-code execution timeout in seconds.")
     var executionTimeout: Double = 5
 
@@ -238,9 +244,11 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
                 maxTokens: maxTokens,
                 temperature: temperature,
                 topP: topP,
-                showThinking: false,
+                showThinking: thinking,
                 stopOnEOS: true,
-                stopSequences: Self.codeBenchmarkStopSequences
+                stopSequences: thinking
+                    ? TextGenerationStopSequences.defaultRenderedChatStops
+                    : Self.codeBenchmarkStopSequences
             )
             let generationStart = Date()
             do {

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -79,8 +79,15 @@ struct ModelBenchmarkQ36MTP: AsyncParsableCommand {
         if prompt != nil && promptFile != nil {
             throw ValidationError("Specify either --prompt or --prompt-file, not both.")
         }
-        guard model == Q35Resources.q36NanoModelId else {
-            throw ValidationError("model benchmark q36-mtp only supports \(Q35Resources.q36NanoModelId).")
+        let supportedModels = [
+            Q35Resources.q36NanoModelId,
+            Q35Resources.ornith9BModelId,
+            Q35Resources.ornith35BMLXModelId,
+        ]
+        guard supportedModels.contains(model) else {
+            throw ValidationError(
+                "model benchmark q36-mtp only supports \(supportedModels.joined(separator: ", "))."
+            )
         }
         guard promptRepeat > 0 else {
             throw ValidationError("--prompt-repeat must be greater than zero.")

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -136,8 +136,10 @@ benchmark, not a model-quality eval.
 
 ## Qwen3.6 MTP Benchmark
 
-`model benchmark q36-mtp` runs requested-token comparisons for
-`text-chat-q36-nano`:
+`model benchmark q36-mtp` runs requested-token comparisons for Qwen-family
+models with MTP draft heads (`text-chat-q36-nano` by default; `--model` also
+accepts `text-agent-ornith-9b` and `text-agent-ornith-35b-mlx` when an
+`mtp.safetensors` sidecar is present in the model root):
 
 - `baseline`: MTP disabled with `MERERUN_Q35_MTP_SPECULATION=0`.
 - `adaptive`: production policy with the default long-context threshold.

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -106,7 +106,18 @@ private final class Q35BatchedDecodeRow: @unchecked Sendable {
 }
 
 public actor Q35Generator: ChatGenerator {
-    private static let prefillChunkSize = 512
+    /// MERERUN_Q35_PREFILL_CHUNK_TOKENS overrides the prefill chunk length.
+    /// Larger chunks batch more routed-expert rows per gather matmul: on
+    /// Ornith 35B (M4 Max) a 6.8K-token prefill runs 1116 tok/s at 512,
+    /// 1238 tok/s at 1024, and regresses at 2048; outputs are byte-identical
+    /// across chunk sizes (causal chunking is exact).
+    private static let prefillChunkSize: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_Q35_PREFILL_CHUNK_TOKENS"],
+           let value = Int(raw), (64...8192).contains(value) {
+            return value
+        }
+        return 1024
+    }()
     private static let prefixKVCacheMaxEntries = 4
     private static let defaultMTPBlockSize = 4
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1293,8 +1293,9 @@ comparison, not model-quality evaluation.
 
 ### `mere.run model benchmark q36-mtp`
 
-Run a requested-token real-checkpoint Qwen3.6 MTP comparison. The command runs
-`text-chat-q36-nano` with three policies:
+Run a requested-token real-checkpoint Qwen-family MTP comparison. The command
+supports `text-chat-q36-nano` (default), `text-agent-ornith-9b`, and
+`text-agent-ornith-35b-mlx`, and runs the selected model with three policies:
 
 - `baseline`: MTP disabled with `MERERUN_Q35_MTP_SPECULATION=0`.
 - `adaptive`: production long-context policy.
@@ -1388,6 +1389,12 @@ executed. `reasoning_reopened=true` flags a second generated reasoning block,
 which usually indicates a loop or phase restart. Use `--models` and `--tasks`
 to narrow the slice while iterating. Use `--models text-agent-ornith-35b` for
 the larger Ornith GGUF eval target.
+
+Pass `--thinking` to let the model reason before answering (matching
+thinking-enabled published evals). Reasoning is split from the scored code as
+usual; the HumanEval-specific stop sequences are disabled for thinking runs
+because they can fire inside the reasoning block, so pair `--thinking` with a
+larger `--max-tokens` (for example 3072).
 
 For a larger slice from the official HumanEval data, download and decompress
 `HumanEval.jsonl.gz`, then pass the JSONL file with `--humaneval-file`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,16 @@ throughput for roughly 130 MB of additional resident weight copies —
 attention is a small slice of a MoE's per-token weights, unlike the dense
 Gemma case where the same fusion bought +17%.
 
+### `MERERUN_Q35_PREFILL_CHUNK_TOKENS`
+
+Prefill chunk length for Qwen-family models, accepted range 64–8192, default
+1024. Larger chunks batch more routed-expert rows per gather matmul: on the
+Ornith 35B MoE (M4 Max) a 6.8K-token prefill measured 1116 tok/s at 512,
+1238 tok/s at 1024, and regressed at 2048. Chunked causal prefill is exact,
+so outputs are byte-identical across chunk sizes; the setting only trades
+throughput against progress-report granularity and per-chunk activation
+memory.
+
 ### `MERERUN_Q35_BATCHED_GPU_SAMPLING`
 
 Qwen-family continuous-batching decode samples every active request's row on


### PR DESCRIPTION
## Context

Head-to-head against the HF `programmer-666/Ornith-1.0-35B-MLX-oQ7-mtp` card (optiq stack), run on the same hardware class as their published numbers (M4 Max 128GB, pp~1024/tg128):

| | optiq card (oQ7 7.75bpw + MTP) | mere.run `text-agent-ornith-35b-mlx` (Q4 g64) |
|---|---|---|
| decode tg128 | 94.2 tok/s | **117 greedy CLI / 118–120 sustained serve** |
| prefill pp~1K (warm) | 1300.6 tok/s | **~1350 tok/s** (serve TTFT 0.77s), marginal 1238 |
| weights | 37.4 GB | **19.5 GB** |

The apparent one-shot-CLI prefill deficit was ~0.9–1.2s of fixed per-process overhead (first-forward kernel compile + weight residency), not steady-state throughput; warm `api serve` numbers are the comparable ones.

## Changes

- **Q35 prefill chunk 512 → 1024** (`MERERUN_Q35_PREFILL_CHUNK_TOKENS` override, range 64–8192). 6.8K-token prefill: 1116 → 1238 tok/s; 2048 regresses. Outputs byte-identical across chunk sizes at temp 0 (causal chunking is exact). Documented in `docs/configuration.md`.
- **`model benchmark q36-mtp` accepts the Ornith lanes** (`text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`) so MTP sidecar experiments can be measured with the existing counters. Measured with the programmer-666 grafted `mtp.safetensors`: loads via the existing sidecar path, greedy output byte-identical, but speculation **regresses** decode at every tested context (pp1039: 117→65 block4; pp6808: 107→74; pp16346: 73→41) — Ornith's hybrid-linear serial decode barely slows with context, leaving no per-token cost for block-verify to amortize. The sidecar is therefore not shipped with the lane.
- **`model benchmark code --thinking`** enables reasoning for protocol parity with thinking-enabled published evals (reasoning is already split from scored code by the harness). HumanEval-specific stop sequences are disabled for thinking runs since they can fire inside the reasoning block; pair with a larger `--max-tokens`.

## Validation

- `swift test --filter "ModelBenchmarkCommandTests|SetupCommandParsingTests"`: 63 tests, 0 failures.
- Greedy parity at temp 0: chunk 512 vs 1024 byte-identical on a 6.8K-token prompt (128 generated tokens); MTP on/off byte-identical at 1K/7K contexts.
- Decode throughput unchanged (my changes touch prefill chunking and CLI flags only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)