### PR TITLE
api serve: report real prompt_tokens in chat completion usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Fixed
+
+- `api serve` chat completions now report real `prompt_tokens` in the `usage`
+  object for both streaming (`stream_options.include_usage`) and non-streaming
+  responses, and `total_tokens` includes the prompt side. Previously
+  `prompt_tokens` was always `0` and `total_tokens` only counted completion
+  tokens.
+
 ## 0.18.0 - 2026-07-01
 
 ### Added

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -2121,11 +2121,7 @@ actor CodeGenServer {
                     finish_reason: openAIFinishReason(for: result)
                 )
             ],
-            usage: OpenAIUsage(
-                prompt_tokens: 0,
-                completion_tokens: result.tokensGenerated,
-                total_tokens: result.tokensGenerated
-            )
+            usage: Self.openAIUsage(for: result)
         )
 
         let data = try JSONEncoder().encode(response)
@@ -2720,11 +2716,7 @@ actor CodeGenServer {
                         created: Int(Date().timeIntervalSince1970),
                         model: modelID,
                         choices: [],
-                        usage: OpenAIUsage(
-                            prompt_tokens: 0,
-                            completion_tokens: result.tokensGenerated,
-                            total_tokens: result.tokensGenerated
-                        )
+                        usage: Self.openAIUsage(for: result)
                     )
                     if let data = try? encoder.encode(usageChunk),
                        let json = String(data: data, encoding: .utf8) {
@@ -2780,6 +2772,17 @@ actor CodeGenServer {
             return "tool_calls"
         }
         return result.finishReason == .length ? "length" : "stop"
+    }
+
+    /// Generators that don't report a prompt token count fall back to zero
+    /// rather than omitting the usage object, matching OpenAI's schema.
+    nonisolated static func openAIUsage(for result: ChatResponse) -> OpenAIUsage {
+        let promptTokens = result.promptTokens ?? 0
+        return OpenAIUsage(
+            prompt_tokens: promptTokens,
+            completion_tokens: result.tokensGenerated,
+            total_tokens: promptTokens + result.tokensGenerated
+        )
     }
 
     private nonisolated func jsonString(from arguments: [String: String]) -> String {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -981,4 +981,28 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertTrue(APIServerContract.isStreamingStatusMessage("DS4 chat completion"))
         XCTAssertFalse(APIServerContract.isStreamingStatusMessage("Actual generated text"))
     }
+
+    func testOpenAIUsageReportsPromptAndCompletionTokenCounts() {
+        let result = ChatResponse(
+            response: "hello",
+            tokensGenerated: 128,
+            promptTokens: 1039
+        )
+
+        let usage = CodeGenServer.openAIUsage(for: result)
+
+        XCTAssertEqual(usage.prompt_tokens, 1039)
+        XCTAssertEqual(usage.completion_tokens, 128)
+        XCTAssertEqual(usage.total_tokens, 1167)
+    }
+
+    func testOpenAIUsageFallsBackToZeroPromptTokensWhenUnreported() {
+        let result = ChatResponse(response: "hello", tokensGenerated: 7)
+
+        let usage = CodeGenServer.openAIUsage(for: result)
+
+        XCTAssertEqual(usage.prompt_tokens, 0)
+        XCTAssertEqual(usage.completion_tokens, 7)
+        XCTAssertEqual(usage.total_tokens, 7)
+    }
 }


### PR DESCRIPTION
## Bug

`POST /v1/chat/completions` returned `usage.prompt_tokens = 0` (and `total_tokens` counting only completion tokens) in **both** the streaming usage chunk (`stream_options.include_usage: true`) and the non-streaming response. Observed against `api serve --engine text-chat-q36 --model text-agent-ornith-35b-mlx`: a ~1039-token prompt streamed 128 completion tokens with `usage.prompt_tokens=0`.

Both sites hardcoded `prompt_tokens: 0` even though `ChatResponse.promptTokens` is already populated by the Q35, Gemma4, and LFM2 generators — the serve layer never read it.

## Fix

- New `CodeGenServer.openAIUsage(for:)` builds the usage object from `ChatResponse`: real `prompt_tokens` (zero fallback for generators that don't report one), `completion_tokens = tokensGenerated`, and `total_tokens` as their sum.
- Both the streaming usage chunk and the non-streaming response now route through it.
- CHANGELOG entry under Unreleased.

## Validation

- Two new unit tests: prompt/completion propagation (1039/128/1167) and the nil-`promptTokens` fallback (0/7/7).
- `swift test --filter APIServeCommandTests`: 45 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)