### PR TITLE
Default Ornith lanes to thinking-enabled generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Changed
+
+- Ornith lanes (`text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`) now
+  generate with thinking enabled by default in `text chat` and `api serve`,
+  and default to the model's published sampling (temperature 1.0, top-p 0.95,
+  top-k 20) when none is set explicitly. These R1-style tunes degenerate into
+  repetition loops or signature echo without reasoning. `text chat` gains
+  `--no-thinking` to disable reasoning generation and `--top-k` for explicit
+  cutoff control; reasoning output stays hidden unless `--thinking` is passed.
+  Other Qwen-family lanes keep the existing no-think default.
+
 ## 0.18.0 - 2026-07-01
 
 ### Added

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -758,7 +758,8 @@ enum APIServerContract {
         from openaiRequest: OpenAIChatRequest,
         fallbackLoraPath: String?,
         contextSize: Int,
-        capabilities: APIEngineCapabilities = .localText
+        capabilities: APIEngineCapabilities = .localText,
+        servedModelID: String? = nil
     ) throws -> ChatRequest {
         guard !openaiRequest.messages.isEmpty else {
             throw APIRequestValidationError.invalidField("messages", "must contain at least one message")
@@ -800,12 +801,19 @@ enum APIServerContract {
             lora = nil
         }
 
+        // R1-style lanes degenerate without reasoning; their published top_k
+        // applies only when the client did not set explicit sampling.
+        let laneModelID = servedModelID ?? ""
+        let recommendedSampling = Q35Resources.recommendedSampling(forModelId: laneModelID)
+        let usesExplicitSampling = openaiRequest.temperature != nil || openaiRequest.top_p != nil
+
         return ChatRequest(
             messages: messages,
             maxTokens: maxTokens,
             temperature: temperature,
             topP: topP,
-            showThinking: false,
+            topK: usesExplicitSampling ? nil : recommendedSampling?.topK,
+            showThinking: Q35Resources.thinkingDefault(forModelId: laneModelID),
             lora: lora,
             requiresJSON: requiresJSON,
             tools: tools,

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -33,6 +33,8 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-psi-agent
         Models are cached under ~/Library/Application Support/MereRun/models/<model-id>.
         Thinking output is hidden by default; pass --thinking to include it.
+        R1-style lanes (text-agent-ornith-*) generate with thinking enabled even
+        when it is hidden; pass --no-thinking to disable reasoning generation.
         Use --models-root or MERERUN_MODELS_DIR to override the model store path.
         """
     )
@@ -49,11 +51,14 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.long], help: "Max new tokens.")
     var maxTokens: Int = 2048
 
-    @Option(name: [.long], help: "Temperature.")
-    var temperature: Double = 0.7
+    @Option(name: [.long], help: "Temperature. Default: 0.7, or the model's published value where one exists (Ornith: 1.0).")
+    var temperature: Double?
 
-    @Option(name: [.long], help: "Top-p.")
-    var topP: Double = 0.9
+    @Option(name: [.long], help: "Top-p. Default: 0.9, or the model's published value where one exists (Ornith: 0.95).")
+    var topP: Double?
+
+    @Option(name: [.customLong("top-k")], help: "Top-k sampling cutoff. Default: no cutoff, or the model's published value where one exists (Ornith: 20).")
+    var topK: Int?
 
     @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform/polar and integer/.5 widths for turboquant.")
     var kvBits: Double?
@@ -119,8 +124,12 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.customLong("lora-scale")], help: "LoRA adapter scale.")
     var loraScale: Double = 1.0
 
-    @Flag(name: [.customLong("thinking"), .customLong("show-thinking")], help: "Show model reasoning output.")
-    var thinking: Bool = false
+    @Flag(
+        name: [.customLong("thinking"), .customLong("show-thinking")],
+        inversion: .prefixedNo,
+        help: "Show model reasoning output. R1-style lanes (text-agent-ornith-*) generate with thinking enabled by default; pass --no-thinking to disable reasoning generation."
+    )
+    var thinking: Bool?
 
     @Flag(name: [.customLong("stats")], help: "Print generation timing and tokens/sec.")
     var stats: Bool = false
@@ -189,12 +198,14 @@ struct TextChat: AsyncParsableCommand {
             lora = nil
         }
 
+        let recommendedSampling = Q35Resources.recommendedSampling(forModelId: model)
         let request = ChatRequest(
             messages: messages,
             maxTokens: maxTokens,
-            temperature: temperature,
-            topP: topP,
-            showThinking: thinking,
+            temperature: temperature ?? recommendedSampling?.temperature ?? 0.7,
+            topP: topP ?? recommendedSampling?.topP ?? 0.9,
+            topK: topK ?? recommendedSampling?.topK,
+            showThinking: thinking ?? Q35Resources.thinkingDefault(forModelId: model),
             lora: lora,
             tools: toolDefs
         )
@@ -279,7 +290,7 @@ struct TextChat: AsyncParsableCommand {
                     if stream && streamingOutput.hasWritten {
                         streamingOutput.finishLine()
                     } else {
-                        print(cleanResponse(result.response, showThinking: thinking))
+                        print(cleanResponse(result.response, showThinking: thinking == true))
                     }
                     return
                 }
@@ -289,7 +300,7 @@ struct TextChat: AsyncParsableCommand {
                     .replacingOccurrences(of: "<\\|tool_call>.*?<tool_call\\|>", with: "", options: .regularExpression)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if !textBeforeTools.isEmpty {
-                    CLIStderr.write(cleanResponse(textBeforeTools, showThinking: thinking) + "\n")
+                    CLIStderr.write(cleanResponse(textBeforeTools, showThinking: thinking == true) + "\n")
                 }
 
                 loopMessages.append(ChatMessage(role: .assistant, content: result.response))
@@ -358,7 +369,7 @@ struct TextChat: AsyncParsableCommand {
             if stream && streamingOutput.hasWritten {
                 streamingOutput.finishLine()
             } else {
-                print(cleanResponse(result.response, showThinking: thinking))
+                print(cleanResponse(result.response, showThinking: thinking == true))
             }
         }
     }

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -921,7 +921,8 @@ actor RuntimeModelPool {
             from: effectiveRequest,
             fallbackLoraPath: fallbackLoraPath,
             contextSize: contextSize,
-            capabilities: capabilities
+            capabilities: capabilities,
+            servedModelID: resolved.id
         )
         chatRequest.kvCacheMode = resolved.settings.kvCacheMode
         let includeUsage = try APIServerContract.includeUsageInStreaming(

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -257,6 +257,8 @@ public struct ChatRequest: Sendable, Hashable {
     public var maxTokens: Int
     public var temperature: Double
     public var topP: Double
+    /// Top-k sampling cutoff; nil leaves the engine's default (no cutoff).
+    public var topK: Int?
     public var showThinking: Bool
     public var lora: LoRA?
     public var requiresJSON: Bool
@@ -271,6 +273,7 @@ public struct ChatRequest: Sendable, Hashable {
         maxTokens: Int = 512,
         temperature: Double = 0.7,
         topP: Double = 0.9,
+        topK: Int? = nil,
         showThinking: Bool = true,
         lora: LoRA? = nil,
         requiresJSON: Bool = false,
@@ -284,6 +287,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.maxTokens = maxTokens
         self.temperature = temperature
         self.topP = topP
+        self.topK = topK
         self.showThinking = showThinking
         self.lora = lora
         self.requiresJSON = requiresJSON

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -428,6 +428,7 @@ public actor Q35Generator: ChatGenerator {
         let generationConfig = GenerationConfig(
             maxTokens: request.maxTokens,
             temperature: Float(request.temperature),
+            topK: request.topK ?? 0,
             topP: Float(request.topP),
             repetitionPenalty: nil,
             repetitionContextSize: 64

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -33,6 +33,37 @@ public struct Q35Resources: Sendable, Hashable {
     public static let infinityParser2ProInt8ModelId = "vision-ocr-infinity-pro-int8"
     public static let defaultModelId = q36NanoModelId
 
+    /// R1-style agent tunes degenerate without reasoning enabled: no-think
+    /// output is signature echo or repetition loops at any temperature
+    /// (HumanEval no-think scored 1/164 on Ornith 35B vs a ~90% thinking-mode
+    /// model card), so these lanes default to thinking-enabled generation.
+    public static func thinkingDefault(forModelId modelId: String) -> Bool {
+        modelId == ornith9BModelId || modelId == ornith35BMLXModelId
+    }
+
+    public struct RecommendedSampling: Sendable, Hashable {
+        public let temperature: Double
+        public let topP: Double
+        public let topK: Int
+
+        public init(temperature: Double, topP: Double, topK: Int) {
+            self.temperature = temperature
+            self.topP = topP
+            self.topK = topK
+        }
+    }
+
+    /// Published `generation_config.json` sampling for lanes whose models ship
+    /// one; callers use it when the user did not set explicit sampling.
+    public static func recommendedSampling(forModelId modelId: String) -> RecommendedSampling? {
+        switch modelId {
+        case ornith9BModelId, ornith35BMLXModelId:
+            return RecommendedSampling(temperature: 1.0, topP: 0.95, topK: 20)
+        default:
+            return nil
+        }
+    }
+
     public static let q36NanoUpstreamRepoId = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit"
     public static let q36NanoUpstreamRevision = "63d520640ca7461f31ba66104612135770090340"
     public static let ornith9BUpstreamRepoId = "sahilchachra/ornith-1.0-9b-optiq-5bpw-mlx"

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -981,4 +981,59 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertTrue(APIServerContract.isStreamingStatusMessage("DS4 chat completion"))
         XCTAssertFalse(APIServerContract.isStreamingStatusMessage("Actual generated text"))
     }
+
+    func testChatRequestDefaultsToThinkingForOrnithLanes() throws {
+        let request = OpenAIChatRequest(
+            model: Q35Resources.ornith35BMLXModelId,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")]
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            servedModelID: Q35Resources.ornith35BMLXModelId
+        )
+
+        XCTAssertTrue(chatRequest.showThinking)
+        XCTAssertEqual(chatRequest.topK, 20)
+        XCTAssertEqual(chatRequest.temperature, 1.0)
+        XCTAssertEqual(chatRequest.topP, 0.95)
+    }
+
+    func testChatRequestExplicitSamplingSkipsRecommendedTopK() throws {
+        var request = OpenAIChatRequest(
+            model: Q35Resources.ornith35BMLXModelId,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")]
+        )
+        request.temperature = 0.2
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            servedModelID: Q35Resources.ornith35BMLXModelId
+        )
+
+        XCTAssertTrue(chatRequest.showThinking)
+        XCTAssertNil(chatRequest.topK)
+        XCTAssertEqual(chatRequest.temperature, 0.2)
+    }
+
+    func testChatRequestKeepsNoThinkDefaultForNonOrnithLanes() throws {
+        let request = OpenAIChatRequest(
+            model: Q35Resources.q36NanoModelId,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")]
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            servedModelID: Q35Resources.q36NanoModelId
+        )
+
+        XCTAssertFalse(chatRequest.showThinking)
+        XCTAssertNil(chatRequest.topK)
+    }
 }

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -149,4 +149,45 @@ final class TextChatCommandParsingTests: XCTestCase {
 
         XCTAssertEqual(cleaned, "")
     }
+
+    func testTextChatThinkingFlagParsesAsTriState() throws {
+        let unset = try TextChat.parse(["--prompt", "hi"])
+        XCTAssertNil(unset.thinking)
+
+        let enabled = try TextChat.parse(["--prompt", "hi", "--thinking"])
+        XCTAssertEqual(enabled.thinking, true)
+
+        let disabled = try TextChat.parse(["--prompt", "hi", "--no-thinking"])
+        XCTAssertEqual(disabled.thinking, false)
+    }
+
+    func testTextChatSamplingOptionsDefaultToNilForModelResolution() throws {
+        let cmd = try TextChat.parse(["--prompt", "hi"])
+        XCTAssertNil(cmd.temperature)
+        XCTAssertNil(cmd.topP)
+        XCTAssertNil(cmd.topK)
+
+        let explicit = try TextChat.parse([
+            "--prompt", "hi",
+            "--temperature", "0.2",
+            "--top-p", "0.8",
+            "--top-k", "40",
+        ])
+        XCTAssertEqual(explicit.temperature, 0.2)
+        XCTAssertEqual(explicit.topP, 0.8)
+        XCTAssertEqual(explicit.topK, 40)
+    }
+
+    func testOrnithLanesDefaultToThinkingAndRecommendedSampling() {
+        XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.ornith35BMLXModelId))
+        XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.ornith9BModelId))
+        XCTAssertFalse(Q35Resources.thinkingDefault(forModelId: Q35Resources.q36NanoModelId))
+        XCTAssertFalse(Q35Resources.thinkingDefault(forModelId: Gemma4Resources.twelveB4BitModelId))
+
+        let sampling = Q35Resources.recommendedSampling(forModelId: Q35Resources.ornith35BMLXModelId)
+        XCTAssertEqual(sampling?.temperature, 1.0)
+        XCTAssertEqual(sampling?.topP, 0.95)
+        XCTAssertEqual(sampling?.topK, 20)
+        XCTAssertNil(Q35Resources.recommendedSampling(forModelId: Q35Resources.q36NanoModelId))
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -455,10 +455,14 @@ Key options:
 - `--model`: canonical model id
 - `--model-root`: explicit local model root
 - `--max-tokens`
-- `--temperature`
-- `--top-p`
+- `--temperature`: defaults to 0.7, or the model's published value where one
+  exists (Ornith lanes: 1.0)
+- `--top-p`: defaults to 0.9, or the model's published value (Ornith: 0.95)
+- `--top-k`: defaults to no cutoff, or the model's published value (Ornith: 20)
+- `--thinking` / `--no-thinking`: show reasoning output / disable reasoning
+  generation. R1-style lanes (`text-agent-ornith-*`) generate with thinking
+  enabled by default even though the reasoning stays hidden.
 - `--stream`
-- `--thinking`
 - `--stats`: includes Gemma4 MTP state and accept/draft counts when a Gemma4 model is used
 - `--quiet`
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -306,6 +306,11 @@ Engine compatibility:
 - `text-agent-ornith-35b-mlx`: uses the Qwen-family serving engine for a local
   converted Ornith 1.0 35B Q4 MLX snapshot; start it with
   `api serve --engine text-chat-q36 --model text-agent-ornith-35b-mlx`.
+- Both Ornith lanes serve with thinking-enabled generation by default (the
+  models degenerate without it); the reasoning arrives in the response's
+  `reasoning_content` field while `content` carries only the visible answer.
+  When a request sets no explicit `temperature`/`top_p`, these lanes also apply
+  the model's published top-k of 20.
 - `text-chat-lfm25-a1b-8bit`: uses the LFM2 serving engine with the
   LiquidAI LFM2.5 8B-A1B MLX 8-bit weights, accepts function tools, and rejects
   image content parts.

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -82,6 +82,16 @@ smoke tests.
 locally converted Ornith 1.0 35B Q4 MLX directory. It does not auto-download
 from Hugging Face until a converted snapshot is published.
 
+Both Ornith lanes are R1-style reasoning tunes and generate with thinking
+enabled by default in `text chat` and `api serve` — without it the models
+degenerate into repetition loops or signature echo on constrained prompts.
+The reasoning stays hidden in `text chat` unless `--thinking` is passed;
+`--no-thinking` disables reasoning generation entirely. When sampling options
+are not set explicitly, these lanes also use the model's published
+`generation_config.json` sampling (temperature 1.0, top-p 0.95, top-k 20)
+instead of the generic chat defaults. Other Qwen-family lanes such as
+`text-chat-q36-nano` keep the existing no-think default.
+
 ### Local code generation
 
 ```bash


### PR DESCRIPTION
## Why

The Ornith 1.0 lanes (`text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`) are R1-style reasoning tunes that **degenerate in no-think mode**: signature echo without a body, or repetition loops, at both temp 0 and their recommended sampling. Measured 2026-07-03: HumanEval no-think scored **1/164** on the 35B while the model's card reports ~90% thinking-enabled. Their `generation_config.json` publishes temperature 1.0 / top_p 0.95 / top_k 20.

## Changes

- **`Q35Resources.thinkingDefault(forModelId:)` + `recommendedSampling(forModelId:)`** — true/(1.0, 0.95, 20) for the two Ornith ids; all other lanes (incl. `text-chat-q36-nano`) unchanged.
- **`text chat`**: `--thinking` becomes tri-state with `--no-thinking` to disable reasoning generation; `--temperature`/`--top-p` now default to the model's published sampling where one exists; new `--top-k` option. Reasoning display stays hidden unless `--thinking` is passed — Ornith generates with thinking but prints only the visible answer.
- **`ChatRequest.topK`** (new, nil = engine default) threaded into the Q35 sampler, which already supported top-k.
- **`api serve`**: `APIServerContract.chatRequest` gains `servedModelID`; Ornith lanes serve thinking-enabled by default with reasoning in `reasoning_content`, and apply the published top-k only when the client set no explicit sampling. Serve's nil-defaults (1.0/0.95) already matched Ornith's config.
- Docs (`cli.md`, `runtime/text.md`, `runtime/api-server.md`) + CHANGELOG.

## Validation

- 61 tests, 0 failures (`TextChatCommandParsingTests` + `APIServeCommandTests`), including new coverage: tri-state flag parsing, nil sampling options, resource defaults, contract wiring for Ornith vs q36, explicit-sampling top-k skip.
- Live serve check on the 9B lane: default `/v1/chat/completions` returns non-null `reasoning_content` (410 chars) split from `content` (427 chars); an explicit-sampling request serves unchanged.

## Known limitation

Output *quality* on both Ornith lanes is currently bounded by the open Q35 forward-pass divergence (systematic repetition bias vs the mlx_lm reference on identical weights, tracked separately). This change is a prerequisite for those lanes matching their thinking-mode card once that lands, and the serve/CLI mechanics are verified independently of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)