### PR TITLE
Q35: default norm_topk_prob to true (fixes Qwen-family repetition pathology), add reference-parity harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Fixed
+
+- Qwen-family (Q35 runtime) MoE routing now renormalizes top-k router scores
+  by default, matching the Qwen3.5 architecture default in HF transformers
+  and mlx_lm. Checkpoints that omit `norm_topk_prob` (Ornith 35B, Qwen3.6
+  nano) were previously routed with un-renormalized scores, dampening every
+  MoE block's output by the top-k softmax mass and compounding into
+  systematically repetition-biased logits — reasoning models looped instead
+  of terminating. Per-layer hidden states now match the mlx_lm reference to
+  within quantized-kernel noise, and greedy decode openings match verbatim.
+- Added an env-gated reference-parity harness: the runtime dumps per-layer
+  hidden-state stats (`MERERUN_Q35_DEBUG_LAYER_DUMP`) and prompt token ids
+  (`MERERUN_Q35_DEBUG_PROMPT_TOKENS`), with matching mlx_lm dump/compare
+  scripts under `scripts/reference-parity/`. Self-referential byte-parity
+  gates cannot catch bugs that are wrong the same way on both sides.
+
 ## 0.18.0 - 2026-07-01
 
 ### Added

--- a/Sources/MereRunCore/Q35/Q35Config.swift
+++ b/Sources/MereRunCore/Q35/Q35Config.swift
@@ -117,7 +117,13 @@ public struct Q35TextConfig: Codable, Sendable, Hashable {
         self.headDim = try container.decode(Int.self, forKey: .headDim)
         self.numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts) ?? 0
         self.numExpertsPerTok = try container.decodeIfPresent(Int.self, forKey: .numExpertsPerTok) ?? 0
-        self.normTopKProb = try container.decodeIfPresent(Bool.self, forKey: .normTopKProb) ?? false
+        // Qwen3.5-family checkpoints omit norm_topk_prob and the architecture
+        // default is TRUE (HF transformers and mlx_lm both renormalize the
+        // top-k router scores). Defaulting to false scales every MoE block's
+        // routed output by the sum of top-k softmax mass (<1), which dampens
+        // the residual stream a few percent per layer and compounds into
+        // repetition-biased logits by mid-stack.
+        self.normTopKProb = try container.decodeIfPresent(Bool.self, forKey: .normTopKProb) ?? true
         self.layerTypes = try container.decode([String].self, forKey: .layerTypes)
         self.mlpOnlyLayers = try container.decodeIfPresent([Int].self, forKey: .mlpOnlyLayers) ?? []
         self.linearNumValueHeads = try container.decode(Int.self, forKey: .linearNumValueHeads)

--- a/Sources/MereRunCore/Q35/Q35DebugDump.swift
+++ b/Sources/MereRunCore/Q35/Q35DebugDump.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MLX
+
+/// Env-gated reference-parity instrumentation. Set
+/// MERERUN_Q35_DEBUG_LAYER_DUMP=<path> to write one JSON line per stage
+/// (embeddings, each decoder layer, final norm) with the float32 L2 norm and
+/// leading values of the LAST prompt position during a multi-token forward.
+/// Decode steps (single-token forwards) are ignored so the dump captures the
+/// prompt prefill only. The matching mlx_lm-side script lives in the
+/// reference-parity harness; keys and value layout must stay in sync with it.
+enum Q35DebugLayerDump {
+    static let path: String? = ProcessInfo.processInfo.environment["MERERUN_Q35_DEBUG_LAYER_DUMP"]
+
+    /// Debug-only accumulation on the single generation path; not
+    /// concurrency-safe by design (the dump is meaningless under concurrent
+    /// generation anyway).
+    nonisolated(unsafe) private static var lines: [String] = []
+
+    static var isEnabled: Bool { path != nil }
+
+    static func record(stage: String, _ hidden: MLXArray) {
+        guard isEnabled, hidden.ndim == 3, hidden.dim(1) > 1 else { return }
+        let last = hidden[0, hidden.dim(1) - 1, 0...].asType(.float32)
+        MLX.eval(last)
+        let norm = sqrt(MLX.sum(last * last).item(Float.self))
+        let head = last[0..<8].asArray(Float.self)
+        let headJSON = head.map { String(format: "%.6g", $0) }.joined(separator: ",")
+        lines.append("{\"stage\":\"\(stage)\",\"norm\":\(String(format: "%.6g", norm)),\"head\":[\(headJSON)]}")
+    }
+
+    static func flush() {
+        guard let path, !lines.isEmpty else { return }
+        try? (lines.joined(separator: "\n") + "\n").write(
+            toFile: path,
+            atomically: true,
+            encoding: .utf8
+        )
+        lines.removeAll()
+    }
+}

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -423,6 +423,10 @@ public actor Q35Generator: ChatGenerator {
         if promptTokens.count > effectiveContext {
             promptTokens = Array(promptTokens.suffix(effectiveContext))
         }
+        if let dumpPath = ProcessInfo.processInfo.environment["MERERUN_Q35_DEBUG_PROMPT_TOKENS"] {
+            try? promptTokens.map(String.init).joined(separator: ",")
+                .write(toFile: dumpPath, atomically: true, encoding: .utf8)
+        }
 
         let eosSet = Set(loadedConfig.eosTokenIds + [tokenizerAndTemplate.eosTokenId].compactMap { $0 })
         let generationConfig = GenerationConfig(

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -170,6 +170,7 @@ final class Q35Transformer: Module {
         var hidden = inputEmbeddings ?? embeddings(for: inputIds)
 
         let fullMask = createAttentionMask(h: hidden, cache: firstFullCache(from: cache))
+        Q35DebugLayerDump.record(stage: "embeddings", hidden)
 
         for (index, layer) in layers.enumerated() {
             let layerCache = cache?[index] ?? nil
@@ -179,9 +180,13 @@ final class Q35Transformer: Module {
                 cache: layerCache,
                 positionIds: positionIds
             )
+            Q35DebugLayerDump.record(stage: "layer\(index)", hidden)
         }
 
-        return norm(hidden)
+        let normed = norm(hidden)
+        Q35DebugLayerDump.record(stage: "final_norm", normed)
+        Q35DebugLayerDump.flush()
+        return normed
     }
 }
 

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -468,14 +468,18 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         textConfig.removeValue(forKey: "norm_topk_prob")
         configObject["text_config"] = textConfig
 
+        // Qwen3.5-family default is TRUE (HF transformers and mlx_lm both
+        // renormalize top-k router scores when the key is absent). The older
+        // Qwen3-MoE family defaulted to false; porting that default here
+        // dampened every MoE block on checkpoints that omit the key.
         let defaulted = try decodeConfig(configObject)
-        XCTAssertFalse(defaulted.textConfig.normTopKProb)
+        XCTAssertTrue(defaulted.textConfig.normTopKProb)
 
-        textConfig["norm_topk_prob"] = true
+        textConfig["norm_topk_prob"] = false
         configObject["text_config"] = textConfig
 
         let explicit = try decodeConfig(configObject)
-        XCTAssertTrue(explicit.textConfig.normTopKProb)
+        XCTAssertFalse(explicit.textConfig.normTopKProb)
     }
 
     func testQ35DenseFeedForwardRuntimeProducesLogits() throws {

--- a/scripts/reference-parity/README.md
+++ b/scripts/reference-parity/README.md
@@ -1,0 +1,51 @@
+# Reference-parity harness (Q35 / Qwen-family)
+
+Byte-identical greedy parity gates compare this runtime against itself, so they
+cannot catch a whole class of bug: a systematically wrong forward pass that is
+wrong the same way on both sides of a refactor. This harness compares the
+native runtime against `mlx_lm` running the **same installed checkpoint**, at
+two levels:
+
+1. **Token streams** — greedy decode of the same rendered prompt on both
+   stacks; any divergence in the first tokens is a red flag.
+2. **Per-layer hidden states** — the runtime dumps per-stage stats when
+   `MERERUN_Q35_DEBUG_LAYER_DUMP=<path>` is set (embeddings, every decoder
+   layer, final norm; float32 L2 norm + leading values of the last prompt
+   position). `mlxlm_layer_dump.py` produces the matching dump from `mlx_lm`,
+   and `compare_layers.py` reports the first diverging stage.
+
+This harness found the `norm_topk_prob` default bug (2026-07-04): checkpoints
+that omit the key were routed with un-renormalized top-k scores, dampening
+every MoE block ~25% by mid-stack and biasing logits toward repetition.
+
+## Setup
+
+```bash
+uv venv --python 3.14 /tmp/mlxlm-venv
+uv pip install --python /tmp/mlxlm-venv/bin/python mlx-lm "transformers<5"
+```
+
+## Run
+
+```bash
+# 1. reference side (writes ref_layers.jsonl + ref_ids.txt)
+/tmp/mlxlm-venv/bin/python scripts/reference-parity/mlxlm_layer_dump.py \
+  "$HOME/Library/Application Support/MereRun/models/text-agent-ornith-35b-mlx" \
+  "<system prompt>" "<user prompt>" ref_layers.jsonl ref_ids.txt
+
+# 2. native side (same prompts)
+MERERUN_Q35_DEBUG_LAYER_DUMP=our_layers.jsonl \
+MERERUN_Q35_DEBUG_PROMPT_TOKENS=our_ids.txt \
+swift run -c release mere.run text chat --model text-agent-ornith-35b-mlx \
+  --thinking --temperature 0 --max-tokens 4 -s "<system prompt>" -p "<user prompt>"
+
+# 3. compare
+python3 scripts/reference-parity/compare_layers.py \
+  our_layers.jsonl ref_layers.jsonl our_ids.txt ref_ids.txt
+```
+
+Interpretation: prompt ids must be identical (else the bug is in the
+template/tokenizer, not numerics). Norm ratios drifting ±2% late in the stack
+is normal quantized-kernel accumulation noise; a *systematic* ratio away from
+1.0 that compounds layer over layer is a real defect, and the first stage
+where it appears names the guilty component.

--- a/scripts/reference-parity/compare_layers.py
+++ b/scripts/reference-parity/compare_layers.py
@@ -30,7 +30,8 @@ def main(ours_path, ref_path, ours_ids, ref_ids):
             print("  (length mismatch)")
 
     ours, ref = load(ours_path), load(ref_path)
-    stages = ["embeddings"] + [f"layer{i}" for i in range(40)] + ["final_norm"]
+    layer_count = sum(1 for k in ref if k.startswith("layer"))
+    stages = ["embeddings"] + [f"layer{i}" for i in range(layer_count)] + ["final_norm"]
     print(f"{'stage':<12}{'ours_norm':>12}{'ref_norm':>12}{'norm_ratio':>12}{'max_head_diff':>15}")
     first_bad = None
     for s in stages:

--- a/scripts/reference-parity/compare_layers.py
+++ b/scripts/reference-parity/compare_layers.py
@@ -1,0 +1,53 @@
+import json
+import sys
+
+
+def load(path):
+    out = {}
+    for line in open(path):
+        line = line.strip()
+        if not line:
+            continue
+        r = json.loads(line)
+        out[r["stage"]] = r
+    return out
+
+
+def main(ours_path, ref_path, ours_ids, ref_ids):
+    a = open(ours_ids).read().strip().split(",")
+    b = open(ref_ids).read().strip().split(",")
+    if a == b:
+        print(f"PROMPT IDS: identical ({len(a)} tokens)")
+    else:
+        print(f"PROMPT IDS DIFFER: ours={len(a)} ref={len(b)}")
+        for i, (x, y) in enumerate(zip(a, b)):
+            if x != y:
+                print(f"  first diff at pos {i}: ours={x} ref={y}")
+                print(f"  ours[{max(0,i-2)}:{i+3}] = {a[max(0,i-2):i+3]}")
+                print(f"  ref [{max(0,i-2)}:{i+3}] = {b[max(0,i-2):i+3]}")
+                break
+        if len(a) != len(b):
+            print("  (length mismatch)")
+
+    ours, ref = load(ours_path), load(ref_path)
+    stages = ["embeddings"] + [f"layer{i}" for i in range(40)] + ["final_norm"]
+    print(f"{'stage':<12}{'ours_norm':>12}{'ref_norm':>12}{'norm_ratio':>12}{'max_head_diff':>15}")
+    first_bad = None
+    for s in stages:
+        o, r = ours.get(s), ref.get(s)
+        if not o or not r:
+            print(f"{s:<12} MISSING {'ours' if not o else 'ref'}")
+            continue
+        ratio = o["norm"] / r["norm"] if r["norm"] else float("inf")
+        hd = max(abs(x - y) for x, y in zip(o["head"], r["head"]))
+        rel = hd / (max(abs(v) for v in r["head"]) + 1e-9)
+        flag = ""
+        if (abs(ratio - 1) > 0.05 or rel > 0.2) and first_bad is None:
+            first_bad = s
+            flag = "  <-- FIRST DIVERGENCE"
+        print(f"{s:<12}{o['norm']:>12.4f}{r['norm']:>12.4f}{ratio:>12.4f}{hd:>15.5f}{flag}")
+    print("\nfirst clearly diverging stage:", first_bad or "none (within tolerance)")
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:5])

--- a/scripts/reference-parity/mlxlm_layer_dump.py
+++ b/scripts/reference-parity/mlxlm_layer_dump.py
@@ -1,0 +1,97 @@
+import json
+import sys
+
+import mlx.core as mx
+from mlx_lm import load
+
+def main(model_path, system_prompt, user_prompt, out_path, ids_out_path):
+    model, tokenizer = load(model_path)
+    ids = tokenizer.apply_chat_template(
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        add_generation_prompt=True,
+    )
+    open(ids_out_path, "w").write(",".join(str(i) for i in ids))
+
+    records = []
+
+    def record(stage, hidden):
+        last = hidden[0, -1, :].astype(mx.float32)
+        mx.eval(last)
+        norm = float(mx.sqrt((last * last).sum()).item())
+        head = [float(x) for x in last[:8].tolist()]
+        records.append({"stage": stage, "norm": norm, "head": head})
+
+    # locate inner transformer: object with a .layers list and a .norm
+    def find_inner(module, depth=0):
+        if depth > 4:
+            return None
+        layers = getattr(module, "layers", None)
+        if isinstance(layers, list) and layers and hasattr(module, "norm"):
+            return module
+        for _, child in module.children().items():
+            if hasattr(child, "children"):
+                found = find_inner(child, depth + 1)
+                if found is not None:
+                    return found
+        return None
+
+    inner = find_inner(model)
+    assert inner is not None, "could not locate transformer with .layers/.norm"
+
+    class LayerProxy:
+        def __init__(self, orig, stage):
+            object.__setattr__(self, "_orig", orig)
+            object.__setattr__(self, "_stage", stage)
+
+        def __call__(self, *args, **kwargs):
+            out = self._orig(*args, **kwargs)
+            record(self._stage, out)
+            return out
+
+        def __getattr__(self, name):
+            return getattr(object.__getattribute__(self, "_orig"), name)
+
+    class EmbedProxy:
+        def __init__(self, orig):
+            object.__setattr__(self, "_orig", orig)
+
+        def __call__(self, x):
+            out = self._orig(x)
+            if out.ndim == 3 and out.shape[1] > 1:
+                record("embeddings", out)
+            return out
+
+        def __getattr__(self, name):
+            return getattr(object.__getattribute__(self, "_orig"), name)
+
+    inner.layers = [LayerProxy(l, f"layer{i}") for i, l in enumerate(inner.layers)]
+    if hasattr(inner, "embed_tokens"):
+        inner.embed_tokens = EmbedProxy(inner.embed_tokens)
+
+    orig_norm = inner.norm
+    class NormProxy:
+        def __call__(self, x):
+            out = orig_norm(x)
+            if out.ndim == 3 and out.shape[1] > 1:
+                record("final_norm", out)
+            return out
+
+        def __getattr__(self, name):
+            return getattr(orig_norm, name)
+
+    inner.norm = NormProxy()
+
+    logits = model(mx.array(ids)[None])
+    mx.eval(logits)
+
+    with open(out_path, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+    print(f"wrote {len(records)} stages, {len(ids)} prompt tokens")
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:6])


### PR DESCRIPTION
## Root cause

`Q35Config` decoded an absent `norm_topk_prob` as **false** — the older Qwen3-MoE family default, faithfully enshrined by `testQ35ConfigUsesMLXLMNormTopKDefault`. The Qwen3.5 architecture default is **true** (HF transformers and mlx_lm 0.31.3 both renormalize top-k router scores). Every shipped Q35 MoE checkpoint omits the key (`text-agent-ornith-35b-mlx`, `text-chat-q36-nano`), so every MoE block's routed output was scaled by the sum of top-8 softmax mass (< 1) instead of renormalized.

Effect: the residual stream ran at ~0.75× the mlx_lm reference norm by mid-stack; the final RMSNorm masked the scale deficit well enough that output stayed grammatical, but logits were systematically repetition-biased. Reasoning models looped instead of terminating (HumanEval thinking-mode: **1/60** pre-fix; mlx_lm on the same Q4 weights solves the tasks).

## Evidence chain

- Prompt token ids: byte-identical between our runtime and mlx_lm (template/tokenizer exonerated).
- Embeddings: exact match. Layer 0: ours 3.6% low, compounding to ~25% by mid-stack — a *multiplicative deficit at every layer*, pointing at the one component every layer shares (MoE), not a layer-type-specific kernel.
- The gated-delta kernel matches mlx_lm's line-for-line; norm conventions (−1 at load, `(1+w)` at runtime) match the reference's shift list exactly; fusion kill-switches changed nothing under controlled prompts.

## Fix + validation

One-line default change (`?? true`), corrected test, plus the diagnosis tooling made permanent:

- Per-layer parity after fix: layer0 norm ratio 0.9637 → **1.0006**, final norm 0.9425 → **1.0037**; remaining late-stack ±2% is quantized-kernel accumulation noise.
- Greedy decode opening now matches mlx_lm **verbatim**; reasoning closes `</think>` and emits a correct HumanEval solution.
- Decode throughput unchanged (104–113 tok/s band, same as pre-fix).
- `text-chat-q36-nano` (equally affected all along) now answers crisply; q36 quality results predating this fix should be treated as stale.
- `Q35ConfigDecodingTests`: 31 tests, 0 failures.

## Reference-parity harness (new)

`MERERUN_Q35_DEBUG_LAYER_DUMP` / `MERERUN_Q35_DEBUG_PROMPT_TOKENS` (env-gated, zero cost when unset) + `scripts/reference-parity/` (mlx_lm dump twin, comparator, README). Byte-identical self-parity gates cannot catch defaults that are wrong the same way on both sides of a refactor — this harness compares against an independent implementation and names the first diverging layer. The comparator derives the layer count from the dump, validated on both the 40-layer MoE 35B and the 32-layer dense 9B.

## 9B lane: cleared

Follow-up investigation with this harness **cleared `text-agent-ornith-9b`**: prefill layer parity is clean across all 32 layers, greedy decode matches mlx_lm verbatim, and sampled decode at the model's recommended settings is coherent 3/3 on both stacks with identical openers. The earlier "degenerate 9B" report was one unlucky temp-1.0 sample mis-read as systematic during the 35B investigation. No 9B fix is needed.

## Not re-measured here

The 16K prefill cliff / decode droop has not been re-measured post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
