### PR TITLE
music realtime: CoreMIDI steering for Magenta RT2 (OP-1 and friends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added CoreMIDI steering for `music realtime` on macOS, including
+  `--list-midi-inputs`, `--midi-input`, channel/note-offset filters, and
+  repeatable `--midi-cc` mappings for Magenta RT2 note and control changes.
+
 ## 0.18.0 - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -499,6 +499,16 @@ swift run mere.run music realtime \
   --output ./live.wav \
   --no-play
 
+# Steer realtime Magenta RT2 from a CoreMIDI controller such as OP-1
+swift run mere.run music realtime --list-midi-inputs
+swift run mere.run music realtime \
+  "minimal synth pop, dry drums, tape-warped bass" \
+  --model music-magenta-rt2-small \
+  --duration 120 \
+  --midi-input "OP-1" \
+  --midi-cc 1=temp:0.2:1.4 \
+  --midi-cc 2=drums:0:2
+
 # Generate a Foley / sound-effect WAV with Woosh
 swift run mere.run model pull sfx-woosh-dflow
 swift run mere.run model pull sfx-woosh-flow

--- a/Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift
@@ -25,7 +25,7 @@ struct MusicRealtime: AsyncParsableCommand {
     )
 
     @Argument(help: "Text prompt describing the target music.")
-    var prompt: String
+    var prompt: String?
 
     @Option(name: [.customShort("m"), .long], help: "Managed Magenta RT2 model id or local Magenta RT2 root.")
     var model: String = MagentaRT2Resources.smallModelId
@@ -75,10 +75,33 @@ struct MusicRealtime: AsyncParsableCommand {
     @Flag(name: [.customLong("interactive")], help: "Read live steering commands from stdin while generation runs.")
     var interactive: Bool = false
 
+    @Flag(name: [.customLong("list-midi-inputs")], help: "List available CoreMIDI input sources and exit.")
+    var listMIDIInputs: Bool = false
+
+    @Option(name: [.customLong("midi-input")], help: "CoreMIDI input source name or unique ID to steer realtime notes and controls.")
+    var midiInput: String?
+
+    @Option(name: [.customLong("midi-channel")], help: "MIDI channel to listen to, 1-16 or all.")
+    var midiChannel: String = "all"
+
+    @Option(name: [.customLong("midi-note-offset")], help: "Transpose incoming MIDI notes before sending them to Magenta RT2.")
+    var midiNoteOffset: Int = 0
+
+    @Option(name: [.customLong("midi-cc")], help: "Map a MIDI CC as cc=target:min:max, for example 1=temp:0.2:1.4.")
+    var midiCCMappings: [String] = []
+
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
     func run() async throws {
+        if listMIDIInputs {
+            try printMIDIInputs()
+            return
+        }
+        guard let prompt, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError("Provide a prompt or use --list-midi-inputs.")
+        }
+        let midiConfiguration = try resolvedMIDIConfiguration()
         guard MagentaRT2Resources.isMagentaRT2Model(model)
             || MagentaRT2Resources.looksLikeMagentaRT2Root(URL(fileURLWithPath: model).standardizedFileURL) else {
             throw ValidationError("music realtime requires a Magenta RT2 model id or local Magenta RT2 root.")
@@ -107,29 +130,42 @@ struct MusicRealtime: AsyncParsableCommand {
             try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         }
         let initialControls = try controls()
-        let liveControls = interactive ? MagentaRT2InteractiveControls(initialControls: initialControls) : nil
+        let liveControls = interactive || midiConfiguration != nil
+            ? MagentaRT2LiveControlQueue(initialControls: initialControls)
+            : nil
         let sink = try MagentaRT2RealtimeOutputSink(outputURL: outputURL, play: play)
         defer { try? sink.close() }
+        let midiInputConnection = try liveControls.flatMap { liveControls in
+            try midiConfiguration.map { configuration in
+                try MagentaRT2MIDIInput(configuration: configuration, controls: liveControls)
+            }
+        }
+        defer { midiInputConnection?.stop() }
 
         if !quiet {
             CLIStderr.write("Starting Magenta RT2 realtime model \(resources.modelID)\n")
         }
-        if let liveControls, !quiet {
+        if let liveControls, interactive, !quiet {
             CLIStderr.write(liveControls.helpText)
         }
-        let inputTask = liveControls.map { controls in
-            Task.detached {
-                while let line = readLine(strippingNewline: true) {
-                    let response = controls.applyCommand(line)
-                    if !response.isEmpty {
-                        CLIStderr.write(response + "\n")
-                    }
-                    if controls.shouldStop {
-                        break
+        if let midiInputConnection, !quiet {
+            CLIStderr.write("Connected MIDI input \(midiInputConnection.sourceDisplayName)\n")
+        }
+        let inputTask: Task<Void, Never>? = interactive
+            ? liveControls.map { controls in
+                Task.detached {
+                    while let line = readLine(strippingNewline: true) {
+                        let response = controls.applyCommand(line)
+                        if !response.isEmpty {
+                            CLIStderr.write(response + "\n")
+                        }
+                        if controls.shouldStop {
+                            break
+                        }
                     }
                 }
             }
-        }
+            : nil
         defer { inputTask?.cancel() }
 
         let startedAt = Date()
@@ -141,8 +177,8 @@ struct MusicRealtime: AsyncParsableCommand {
                     durationSeconds: durationSeconds,
                     controls: initialControls
                 ),
-                liveControls: { frameIndex in
-                    liveControls?.snapshot(frameIndex: frameIndex)
+                liveControls: { _ in
+                    liveControls?.snapshot()
                 }
             ) { frameIndex, frame in
                 try sink.consume(frameIndex: frameIndex, frame: frame)
@@ -187,177 +223,41 @@ struct MusicRealtime: AsyncParsableCommand {
         )
     }
 
+    private func resolvedMIDIConfiguration() throws -> MagentaRT2MIDIInputConfiguration? {
+        let trimmedInput = midiInput?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedInput, !trimmedInput.isEmpty else {
+            if midiChannel.lowercased() != "all" || midiNoteOffset != 0 || !midiCCMappings.isEmpty {
+                throw ValidationError("Use --midi-input when setting MIDI channel, note offset, or CC mappings.")
+            }
+            return nil
+        }
+        return MagentaRT2MIDIInputConfiguration(
+            source: trimmedInput,
+            channel: try MagentaRT2MIDIInputConfiguration.parseChannel(midiChannel),
+            noteOffset: midiNoteOffset,
+            ccMappings: try midiCCMappings.map(MagentaRT2MIDICCMapping.parse)
+        )
+    }
+
+    private func printMIDIInputs() throws {
+        let sources = try MagentaRT2MIDIInput.availableSources()
+        guard !sources.isEmpty else {
+            print("No MIDI input sources found.")
+            return
+        }
+        for source in sources {
+            print(source.displayName)
+        }
+    }
+
     private func paceFrameIfNeeded(frameIndex: Int, startedAt: Date) {
-        guard play || interactive else { return }
+        guard play || interactive || midiInput != nil else { return }
         let targetElapsed = Double(frameIndex + 1) / Double(MagentaRT2Resources.frameRate)
         let actualElapsed = Date().timeIntervalSince(startedAt)
         let sleepSeconds = targetElapsed - actualElapsed
         if sleepSeconds > 0 {
             Thread.sleep(forTimeInterval: sleepSeconds)
         }
-    }
-}
-
-private final class MagentaRT2InteractiveControls: @unchecked Sendable {
-    private let lock = NSLock()
-    private var controls: MagentaRT2Controls
-    private var pendingPrompt: String?
-    private var pendingNoteOn: [Int32] = []
-    private var pendingNoteOff: [Int32] = []
-    private var pendingOnsetMode: Int32?
-    private var pendingControls: Bool = false
-    private var pendingReset: Bool = false
-    private(set) var shouldStop: Bool = false
-
-    let helpText = """
-    Interactive steering enabled. Commands:
-      prompt <text>
-      style streaming|full
-      temp <value> | topk <value> | mc <value> | notes <value> | drums <value>
-      noteon <0-131> | noteoff <0-131> | onset 0|1
-      drumless on|off | unmask <value> | seed <value> | reset | quit | help
-
-    """
-
-    init(initialControls: MagentaRT2Controls) {
-        controls = initialControls
-    }
-
-    func applyCommand(_ rawLine: String) -> String {
-        let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !line.isEmpty else { return "" }
-        let parts = line.split(maxSplits: 1, whereSeparator: \.isWhitespace).map(String.init)
-        let command = parts[0].lowercased()
-        let value = parts.count > 1 ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
-
-        lock.lock()
-        defer { lock.unlock() }
-
-        switch command {
-        case "prompt":
-            guard !value.isEmpty else { return "usage: prompt <text>" }
-            pendingPrompt = value
-            return "queued prompt"
-        case "style", "style-conditioning":
-            guard let parsed = MagentaRT2StyleConditioning(rawValue: value.lowercased()) else {
-                return "usage: style streaming|full"
-            }
-            controls.styleConditioning = parsed
-            pendingControls = true
-            return "style-conditioning \(parsed.rawValue)"
-        case "temp", "temperature":
-            guard let parsed = Float(value) else { return "usage: temp <value>" }
-            controls.temperature = parsed
-            pendingControls = true
-            return "temperature \(parsed)"
-        case "topk", "top-k":
-            guard let parsed = Int32(value), parsed >= 0 else { return "usage: topk <value>" }
-            controls.topK = parsed
-            pendingControls = true
-            return "top-k \(parsed)"
-        case "mc", "musiccoca", "cfg-musiccoca":
-            guard let parsed = Float(value) else { return "usage: mc <value>" }
-            controls.cfgMusicCoCa = parsed
-            pendingControls = true
-            return "cfg-musiccoca \(parsed)"
-        case "notes", "cfg-notes":
-            guard let parsed = Float(value) else { return "usage: notes <value>" }
-            controls.cfgNotes = parsed
-            pendingControls = true
-            return "cfg-notes \(parsed)"
-        case "drums", "cfg-drums":
-            guard let parsed = Float(value) else { return "usage: drums <value>" }
-            controls.cfgDrums = parsed
-            pendingControls = true
-            return "cfg-drums \(parsed)"
-        case "drumless":
-            guard let parsed = parseBool(value) else { return "usage: drumless on|off" }
-            controls.drumless = parsed
-            pendingControls = true
-            return "drumless \(parsed ? "on" : "off")"
-        case "unmask", "unmask-width":
-            guard let parsed = Int32(value), parsed >= 0 else { return "usage: unmask <value>" }
-            controls.unmaskWidth = parsed
-            pendingControls = true
-            return "unmask-width \(parsed)"
-        case "seed", "seed-rotation":
-            guard let parsed = Int32(value) else { return "usage: seed <value>" }
-            controls.seedRotation = parsed
-            pendingControls = true
-            return "seed-rotation \(parsed)"
-        case "noteon", "note-on":
-            guard let parsed = parseMIDINote(value) else { return "usage: noteon <0-131>" }
-            pendingNoteOn.append(parsed)
-            return "note on \(parsed)"
-        case "noteoff", "note-off":
-            guard let parsed = parseMIDINote(value) else { return "usage: noteoff <0-131>" }
-            pendingNoteOff.append(parsed)
-            return "note off \(parsed)"
-        case "onset", "onset-mode":
-            guard let parsed = Int32(value), parsed == 0 || parsed == 1 else { return "usage: onset 0|1" }
-            pendingOnsetMode = parsed
-            return "onset \(parsed)"
-        case "reset":
-            pendingReset = true
-            return "queued reset"
-        case "quit", "exit", "stop":
-            shouldStop = true
-            return "stopping"
-        case "help", "?":
-            return helpText
-        default:
-            return "unknown command: \(command)"
-        }
-    }
-
-    func snapshot(frameIndex: Int) -> MagentaRT2LiveControlSnapshot? {
-        _ = frameIndex
-        lock.lock()
-        defer { lock.unlock() }
-        if shouldStop {
-            return MagentaRT2LiveControlSnapshot(shouldStop: true)
-        }
-        guard pendingPrompt != nil
-            || pendingControls
-            || !pendingNoteOn.isEmpty
-            || !pendingNoteOff.isEmpty
-            || pendingOnsetMode != nil
-            || pendingReset else {
-            return nil
-        }
-        let snapshot = MagentaRT2LiveControlSnapshot(
-            prompt: pendingPrompt,
-            controls: pendingControls ? controls : nil,
-            noteOn: pendingNoteOn,
-            noteOff: pendingNoteOff,
-            onsetMode: pendingOnsetMode,
-            resetState: pendingReset
-        )
-        pendingPrompt = nil
-        pendingNoteOn = []
-        pendingNoteOff = []
-        pendingOnsetMode = nil
-        pendingControls = false
-        pendingReset = false
-        return snapshot
-    }
-
-    private func parseBool(_ value: String) -> Bool? {
-        switch value.lowercased() {
-        case "1", "true", "yes", "on":
-            return true
-        case "0", "false", "no", "off":
-            return false
-        default:
-            return nil
-        }
-    }
-
-    private func parseMIDINote(_ value: String) -> Int32? {
-        guard let parsed = Int32(value), parsed >= 0, parsed < 132 else {
-            return nil
-        }
-        return parsed
     }
 }
 

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -76,6 +76,13 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--drumless`: Magenta RT2 drumless generation.
 - `--unmask-width`, `--seed-rotation`: Magenta RT2 generation controls.
 - `--prefill-silence`, `--prefill-duration`: Magenta RT2 realtime prefill controls.
+- `--list-midi-inputs`: list CoreMIDI input sources and exit.
+- `--midi-input`: CoreMIDI source name or unique ID for live note/control steering.
+- `--midi-channel`: MIDI channel to listen to, `1` through `16` or `all`.
+- `--midi-note-offset`: transpose incoming MIDI notes before sending them to Magenta RT2.
+- `--midi-cc`: repeatable CC mapping in the form `cc=target:min:max`; targets
+  include `temp`, `topk`, `mc`, `notes`, `drums`, `drumless`, `unmask`,
+  `seed`, and `onset`.
 - `--quiet`, `-q`: suppress diagnostics.
 
 ACE-Step uses upstream-style native Haar DCW sampler correction by default for
@@ -92,7 +99,9 @@ For realtime Magenta RT2 runs, use `mere.run music realtime`. It accepts the
 same Magenta controls plus `--play` or `--no-play` and optional `--output` WAV
 capture. Add `--interactive` to steer while it runs with stdin commands such as
 `prompt <text>`, `temp <value>`, `noteon <0-131>`, `noteoff <0-131>`,
-`style streaming|full`, `drumless on|off`, `reset`, and `quit`.
+`style streaming|full`, `drumless on|off`, `reset`, and `quit`. On macOS, add
+`--midi-input` to steer notes and mapped controls from a CoreMIDI device such
+as OP-1.
 
 ## Workflow Choices
 
@@ -205,6 +214,17 @@ mere.run music realtime \
   --no-play
 ```
 
+```bash
+mere.run music realtime --list-midi-inputs
+mere.run music realtime \
+  "minimal synth pop, dry drums, tape-warped bass" \
+  --model music-magenta-rt2-small \
+  --duration 120 \
+  --midi-input "OP-1" \
+  --midi-cc 1=temp:0.2:1.4 \
+  --midi-cc 2=drums:0:2
+```
+
 ## Iteration Tips
 
 - First iterate caption and lyrics at 10 to 20 seconds.
@@ -225,6 +245,9 @@ mere.run music realtime \
   `--source-audio`.
 - For Magenta RT2, use `music realtime --output --no-play --duration 2` for a
   fast headless smoke before running an audible session.
+- For MIDI control, run `music realtime --list-midi-inputs` first, then pass a
+  stable source name or unique ID with `--midi-input`. Keep prompt changes on
+  stdin; MIDI is intended for notes and continuous controls.
 
 ## Troubleshooting
 

--- a/Sources/MereRunCLI/Support/MagentaRT2LiveControlQueue.swift
+++ b/Sources/MereRunCLI/Support/MagentaRT2LiveControlQueue.swift
@@ -1,0 +1,192 @@
+import Foundation
+import MereRunCore
+
+final class MagentaRT2LiveControlQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var controls: MagentaRT2Controls
+    private var pendingPrompt: String?
+    private var pendingNoteOn: [Int32] = []
+    private var pendingNoteOff: [Int32] = []
+    private var pendingOnsetMode: Int32?
+    private var pendingControls = false
+    private var pendingReset = false
+    private(set) var shouldStop = false
+
+    let helpText = """
+    Interactive steering enabled. Commands:
+      prompt <text>
+      style streaming|full
+      temp <value> | topk <value> | mc <value> | notes <value> | drums <value>
+      noteon <0-131> | noteoff <0-131> | onset 0|1
+      drumless on|off | unmask <value> | seed <value> | reset | quit | help
+
+    """
+
+    init(initialControls: MagentaRT2Controls) {
+        controls = initialControls
+    }
+
+    func applyCommand(_ rawLine: String) -> String {
+        let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty else { return "" }
+        let parts = line.split(maxSplits: 1, whereSeparator: \.isWhitespace).map(String.init)
+        let command = parts[0].lowercased()
+        let value = parts.count > 1 ? parts[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        switch command {
+        case "prompt":
+            guard !value.isEmpty else { return "usage: prompt <text>" }
+            pendingPrompt = value
+            return "queued prompt"
+        case "style", "style-conditioning":
+            guard let parsed = MagentaRT2StyleConditioning(rawValue: value.lowercased()) else {
+                return "usage: style streaming|full"
+            }
+            controls.styleConditioning = parsed
+            pendingControls = true
+            return "style-conditioning \(parsed.rawValue)"
+        case "temp", "temperature":
+            guard let parsed = Float(value) else { return "usage: temp <value>" }
+            controls.temperature = parsed
+            pendingControls = true
+            return "temperature \(parsed)"
+        case "topk", "top-k":
+            guard let parsed = Int32(value), parsed >= 0 else { return "usage: topk <value>" }
+            controls.topK = parsed
+            pendingControls = true
+            return "top-k \(parsed)"
+        case "mc", "musiccoca", "cfg-musiccoca":
+            guard let parsed = Float(value) else { return "usage: mc <value>" }
+            controls.cfgMusicCoCa = parsed
+            pendingControls = true
+            return "cfg-musiccoca \(parsed)"
+        case "notes", "cfg-notes":
+            guard let parsed = Float(value) else { return "usage: notes <value>" }
+            controls.cfgNotes = parsed
+            pendingControls = true
+            return "cfg-notes \(parsed)"
+        case "drums", "cfg-drums":
+            guard let parsed = Float(value) else { return "usage: drums <value>" }
+            controls.cfgDrums = parsed
+            pendingControls = true
+            return "cfg-drums \(parsed)"
+        case "drumless":
+            guard let parsed = parseBool(value) else { return "usage: drumless on|off" }
+            controls.drumless = parsed
+            pendingControls = true
+            return "drumless \(parsed ? "on" : "off")"
+        case "unmask", "unmask-width":
+            guard let parsed = Int32(value), parsed >= 0 else { return "usage: unmask <value>" }
+            controls.unmaskWidth = parsed
+            pendingControls = true
+            return "unmask-width \(parsed)"
+        case "seed", "seed-rotation":
+            guard let parsed = Int32(value) else { return "usage: seed <value>" }
+            controls.seedRotation = parsed
+            pendingControls = true
+            return "seed-rotation \(parsed)"
+        case "noteon", "note-on":
+            guard let parsed = Self.parseMIDINote(value) else { return "usage: noteon <0-131>" }
+            pendingNoteOn.append(parsed)
+            return "note on \(parsed)"
+        case "noteoff", "note-off":
+            guard let parsed = Self.parseMIDINote(value) else { return "usage: noteoff <0-131>" }
+            pendingNoteOff.append(parsed)
+            return "note off \(parsed)"
+        case "onset", "onset-mode":
+            guard let parsed = Int32(value), parsed == 0 || parsed == 1 else { return "usage: onset 0|1" }
+            pendingOnsetMode = parsed
+            return "onset \(parsed)"
+        case "reset":
+            pendingReset = true
+            return "queued reset"
+        case "quit", "exit", "stop":
+            shouldStop = true
+            return "stopping"
+        case "help", "?":
+            return helpText
+        default:
+            return "unknown command: \(command)"
+        }
+    }
+
+    func enqueueNoteOn(_ note: Int32) {
+        guard (0..<132).contains(note) else { return }
+        lock.lock()
+        pendingNoteOn.append(note)
+        lock.unlock()
+    }
+
+    func enqueueNoteOff(_ note: Int32) {
+        guard (0..<132).contains(note) else { return }
+        lock.lock()
+        pendingNoteOff.append(note)
+        lock.unlock()
+    }
+
+    func setOnsetMode(_ value: Int32) {
+        guard value == 0 || value == 1 else { return }
+        lock.lock()
+        pendingOnsetMode = value
+        lock.unlock()
+    }
+
+    func updateControls(_ update: (inout MagentaRT2Controls) -> Void) {
+        lock.lock()
+        update(&controls)
+        pendingControls = true
+        lock.unlock()
+    }
+
+    func snapshot() -> MagentaRT2LiveControlSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        if shouldStop {
+            return MagentaRT2LiveControlSnapshot(shouldStop: true)
+        }
+        guard pendingPrompt != nil
+            || pendingControls
+            || !pendingNoteOn.isEmpty
+            || !pendingNoteOff.isEmpty
+            || pendingOnsetMode != nil
+            || pendingReset else {
+            return nil
+        }
+        let snapshot = MagentaRT2LiveControlSnapshot(
+            prompt: pendingPrompt,
+            controls: pendingControls ? controls : nil,
+            noteOn: pendingNoteOn,
+            noteOff: pendingNoteOff,
+            onsetMode: pendingOnsetMode,
+            resetState: pendingReset
+        )
+        pendingPrompt = nil
+        pendingNoteOn = []
+        pendingNoteOff = []
+        pendingOnsetMode = nil
+        pendingControls = false
+        pendingReset = false
+        return snapshot
+    }
+
+    private func parseBool(_ value: String) -> Bool? {
+        switch value.lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    private static func parseMIDINote(_ value: String) -> Int32? {
+        guard let parsed = Int32(value), parsed >= 0, parsed < 132 else {
+            return nil
+        }
+        return parsed
+    }
+}

--- a/Sources/MereRunCLI/Support/MagentaRT2MIDIInput.swift
+++ b/Sources/MereRunCLI/Support/MagentaRT2MIDIInput.swift
@@ -1,0 +1,446 @@
+import Foundation
+import MereRunCore
+
+#if canImport(CoreMIDI) && os(macOS)
+@preconcurrency import CoreMIDI
+#endif
+
+struct MagentaRT2MIDISource: Equatable {
+    let name: String
+    let manufacturer: String?
+    let model: String?
+    let uniqueID: Int32?
+
+    var displayName: String {
+        var parts = [name]
+        if let manufacturer, !manufacturer.isEmpty {
+            parts.append(manufacturer)
+        }
+        if let model, !model.isEmpty, model != name {
+            parts.append(model)
+        }
+        if let uniqueID {
+            parts.append("id \(uniqueID)")
+        }
+        return parts.joined(separator: " | ")
+    }
+}
+
+struct MagentaRT2MIDIInputConfiguration: Equatable {
+    let source: String
+    let channel: Int?
+    let noteOffset: Int
+    let ccMappings: [MagentaRT2MIDICCMapping]
+
+    static func parseChannel(_ value: String) throws -> Int? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed.lowercased() == "all" {
+            return nil
+        }
+        guard let parsed = Int(trimmed), (1...16).contains(parsed) else {
+            throw MagentaRT2MIDIInputError.invalidChannel(value)
+        }
+        return parsed
+    }
+}
+
+struct MagentaRT2MIDICCMapping: Equatable {
+    enum Target: Equatable {
+        case temperature
+        case topK
+        case cfgMusicCoCa
+        case cfgNotes
+        case cfgDrums
+        case drumless
+        case unmaskWidth
+        case seedRotation
+        case onsetMode
+
+        init(rawValue: String) throws {
+            switch rawValue.lowercased() {
+            case "temp", "temperature":
+                self = .temperature
+            case "topk", "top-k":
+                self = .topK
+            case "mc", "musiccoca", "cfg-musiccoca":
+                self = .cfgMusicCoCa
+            case "notes", "cfg-notes":
+                self = .cfgNotes
+            case "drums", "cfg-drums":
+                self = .cfgDrums
+            case "drumless":
+                self = .drumless
+            case "unmask", "unmask-width":
+                self = .unmaskWidth
+            case "seed", "seed-rotation":
+                self = .seedRotation
+            case "onset", "onset-mode":
+                self = .onsetMode
+            default:
+                throw MagentaRT2MIDIInputError.invalidCCMapping(rawValue, "unsupported target")
+            }
+        }
+    }
+
+    let controller: UInt8
+    let target: Target
+    let minimum: Float
+    let maximum: Float
+
+    static func parse(_ rawValue: String) throws -> Self {
+        let parts = rawValue.split(separator: "=", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else {
+            throw MagentaRT2MIDIInputError.invalidCCMapping(rawValue, "expected cc=target:min:max")
+        }
+        guard let controller = UInt8(parts[0]), controller < 128 else {
+            throw MagentaRT2MIDIInputError.invalidCCMapping(rawValue, "CC number must be 0-127")
+        }
+        let targetParts = parts[1].split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard !targetParts.isEmpty else {
+            throw MagentaRT2MIDIInputError.invalidCCMapping(rawValue, "missing target")
+        }
+        let target = try Target(rawValue: targetParts[0])
+        let minimum: Float
+        let maximum: Float
+        if targetParts.count == 1 {
+            minimum = 0
+            maximum = 1
+        } else if targetParts.count == 3,
+                  let parsedMinimum = Float(targetParts[1]),
+                  let parsedMaximum = Float(targetParts[2]) {
+            minimum = parsedMinimum
+            maximum = parsedMaximum
+        } else {
+            throw MagentaRT2MIDIInputError.invalidCCMapping(rawValue, "expected cc=target or cc=target:min:max")
+        }
+        return Self(controller: controller, target: target, minimum: minimum, maximum: maximum)
+    }
+
+    func apply(rawValue: UInt8, to queue: MagentaRT2LiveControlQueue) {
+        let scaled = scaledValue(rawValue)
+        switch target {
+        case .temperature:
+            queue.updateControls { $0.temperature = scaled }
+        case .topK:
+            queue.updateControls { $0.topK = max(0, Int32(scaled.rounded())) }
+        case .cfgMusicCoCa:
+            queue.updateControls { $0.cfgMusicCoCa = scaled }
+        case .cfgNotes:
+            queue.updateControls { $0.cfgNotes = scaled }
+        case .cfgDrums:
+            queue.updateControls { $0.cfgDrums = scaled }
+        case .drumless:
+            queue.updateControls { $0.drumless = rawValue >= 64 }
+        case .unmaskWidth:
+            queue.updateControls { $0.unmaskWidth = max(0, Int32(scaled.rounded())) }
+        case .seedRotation:
+            queue.updateControls { $0.seedRotation = Int32(scaled.rounded()) }
+        case .onsetMode:
+            queue.setOnsetMode(rawValue >= 64 ? 1 : 0)
+        }
+    }
+
+    func scaledValue(_ rawValue: UInt8) -> Float {
+        minimum + ((maximum - minimum) * Float(rawValue) / 127)
+    }
+}
+
+/// Channel-voice events surfaced to the realtime control queue. Note-on with
+/// velocity zero is normalized to note-off per the MIDI 1.0 specification.
+enum MagentaRT2MIDIEvent: Equatable {
+    case noteOn(channel: Int, note: UInt8, velocity: UInt8)
+    case noteOff(channel: Int, note: UInt8)
+    case controlChange(channel: Int, controller: UInt8, value: UInt8)
+}
+
+/// Incremental MIDI 1.0 byte-stream parser.
+///
+/// CoreMIDI packets may carry several messages, use running status (a status
+/// byte followed by multiple data-byte groups), and interleave system-realtime
+/// bytes (clock 0xF8, active sensing 0xFE) anywhere — including inside a
+/// message. The parser is stateful so running status survives packet
+/// boundaries; feed each packet's bytes in arrival order.
+struct MagentaRT2MIDIStreamParser {
+    private var runningStatus: UInt8?
+    private var pendingData: [UInt8] = []
+
+    mutating func consume(_ bytes: some Sequence<UInt8>, onEvent: (MagentaRT2MIDIEvent) -> Void) {
+        for byte in bytes {
+            if byte >= 0xF8 {
+                // System realtime: ignored, does not disturb running status.
+                continue
+            }
+            if byte >= 0xF0 {
+                // System common (incl. SysEx start/end) cancels running status.
+                runningStatus = nil
+                pendingData.removeAll(keepingCapacity: true)
+                continue
+            }
+            if byte >= 0x80 {
+                runningStatus = byte
+                pendingData.removeAll(keepingCapacity: true)
+                continue
+            }
+            guard let status = runningStatus else {
+                // Data byte with no status context (e.g. inside SysEx): drop.
+                continue
+            }
+            pendingData.append(byte)
+            if pendingData.count == Self.dataByteCount(for: status) {
+                emit(status: status, data: pendingData, onEvent: onEvent)
+                // Keep runningStatus: subsequent data bytes reuse it.
+                pendingData.removeAll(keepingCapacity: true)
+            }
+        }
+    }
+
+    private static func dataByteCount(for status: UInt8) -> Int {
+        switch status & 0xF0 {
+        case 0xC0, 0xD0:
+            return 1
+        default:
+            return 2
+        }
+    }
+
+    private func emit(status: UInt8, data: [UInt8], onEvent: (MagentaRT2MIDIEvent) -> Void) {
+        let channel = Int(status & 0x0F) + 1
+        switch status & 0xF0 {
+        case 0x90 where data[1] > 0:
+            onEvent(.noteOn(channel: channel, note: data[0], velocity: data[1]))
+        case 0x80, 0x90:
+            onEvent(.noteOff(channel: channel, note: data[0]))
+        case 0xB0:
+            onEvent(.controlChange(channel: channel, controller: data[0], value: data[1]))
+        default:
+            break
+        }
+    }
+}
+
+enum MagentaRT2MIDIInputError: Error, LocalizedError {
+    case unsupportedPlatform
+    case noSources
+    case sourceNotFound(String, available: [String])
+    case ambiguousSource(String, matches: [String])
+    case coreMIDIStatus(String, Int32)
+    case invalidChannel(String)
+    case invalidCCMapping(String, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedPlatform:
+            return "MIDI input requires CoreMIDI on macOS."
+        case .noSources:
+            return "No MIDI input sources are available."
+        case .sourceNotFound(let requested, let available):
+            let suffix = available.isEmpty ? "" : " Available: \(available.joined(separator: ", "))"
+            return "MIDI input source not found: \(requested).\(suffix)"
+        case .ambiguousSource(let requested, let matches):
+            return "MIDI input '\(requested)' matches several sources: \(matches.joined(separator: ", ")). Use the unique ID."
+        case .coreMIDIStatus(let operation, let status):
+            return "\(operation) failed with CoreMIDI status \(status)."
+        case .invalidChannel(let value):
+            return "--midi-channel must be all or an integer from 1 to 16. Received: \(value)"
+        case .invalidCCMapping(let value, let reason):
+            return "Invalid --midi-cc mapping '\(value)': \(reason)."
+        }
+    }
+}
+
+#if canImport(CoreMIDI) && os(macOS)
+final class MagentaRT2MIDIInput: @unchecked Sendable {
+    private let configuration: MagentaRT2MIDIInputConfiguration
+    private let controls: MagentaRT2LiveControlQueue
+    private let ccMappings: [UInt8: MagentaRT2MIDICCMapping]
+    private let sourceEndpoint: MIDIEndpointRef
+    private var client = MIDIClientRef()
+    private var inputPort = MIDIPortRef()
+    /// Touched only on the CoreMIDI read thread.
+    private var parser = MagentaRT2MIDIStreamParser()
+
+    let sourceDisplayName: String
+
+    init(configuration: MagentaRT2MIDIInputConfiguration, controls: MagentaRT2LiveControlQueue) throws {
+        self.configuration = configuration
+        self.controls = controls
+        var mappings: [UInt8: MagentaRT2MIDICCMapping] = [:]
+        for mapping in configuration.ccMappings {
+            mappings[mapping.controller] = mapping
+        }
+        self.ccMappings = mappings
+        let source = try Self.resolveSource(configuration.source)
+        self.sourceEndpoint = source.endpoint
+        self.sourceDisplayName = source.description.displayName
+        try createClient()
+    }
+
+    deinit {
+        stop()
+    }
+
+    static func availableSources() throws -> [MagentaRT2MIDISource] {
+        (0..<MIDIGetNumberOfSources()).map { index in
+            describeSource(MIDIGetSource(index)).description
+        }
+    }
+
+    func stop() {
+        if inputPort != 0 {
+            MIDIPortDisconnectSource(inputPort, sourceEndpoint)
+            MIDIPortDispose(inputPort)
+            inputPort = 0
+        }
+        if client != 0 {
+            MIDIClientDispose(client)
+            client = 0
+        }
+    }
+
+    private func createClient() throws {
+        var status = MIDIClientCreate("mere.run Magenta RT2" as CFString, nil, nil, &client)
+        guard status == noErr else {
+            throw MagentaRT2MIDIInputError.coreMIDIStatus("MIDIClientCreate", status)
+        }
+        status = MIDIInputPortCreate(
+            client,
+            "Magenta RT2 MIDI In" as CFString,
+            Self.readProc,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &inputPort
+        )
+        guard status == noErr else {
+            throw MagentaRT2MIDIInputError.coreMIDIStatus("MIDIInputPortCreate", status)
+        }
+        status = MIDIPortConnectSource(inputPort, sourceEndpoint, nil)
+        guard status == noErr else {
+            throw MagentaRT2MIDIInputError.coreMIDIStatus("MIDIPortConnectSource", status)
+        }
+    }
+
+    private static func resolveSource(_ requested: String) throws -> (endpoint: MIDIEndpointRef, description: MagentaRT2MIDISource) {
+        let sources = (0..<MIDIGetNumberOfSources()).map { describeSource(MIDIGetSource($0)) }
+        guard !sources.isEmpty else {
+            throw MagentaRT2MIDIInputError.noSources
+        }
+        let normalized = requested.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if let requestedID = Int32(normalized),
+           let exactID = sources.first(where: { $0.description.uniqueID == requestedID }) {
+            return exactID
+        }
+        if let exactName = sources.first(where: { $0.description.name.lowercased() == normalized }) {
+            return exactName
+        }
+        let contained = sources.filter { $0.description.displayName.lowercased().contains(normalized) }
+        if contained.count == 1 {
+            return contained[0]
+        }
+        if contained.count > 1 {
+            throw MagentaRT2MIDIInputError.ambiguousSource(
+                requested,
+                matches: contained.map(\.description.displayName)
+            )
+        }
+        throw MagentaRT2MIDIInputError.sourceNotFound(
+            requested,
+            available: sources.map(\.description.displayName)
+        )
+    }
+
+    private static func describeSource(_ endpoint: MIDIEndpointRef) -> (
+        endpoint: MIDIEndpointRef,
+        description: MagentaRT2MIDISource
+    ) {
+        let name = stringProperty(endpoint, kMIDIPropertyDisplayName)
+            ?? stringProperty(endpoint, kMIDIPropertyName)
+            ?? "MIDI source \(endpoint)"
+        return (
+            endpoint,
+            MagentaRT2MIDISource(
+                name: name,
+                manufacturer: stringProperty(endpoint, kMIDIPropertyManufacturer),
+                model: stringProperty(endpoint, kMIDIPropertyModel),
+                uniqueID: integerProperty(endpoint, kMIDIPropertyUniqueID)
+            )
+        )
+    }
+
+    private static func stringProperty(_ object: MIDIObjectRef, _ property: CFString) -> String? {
+        var unmanaged: Unmanaged<CFString>?
+        let status = MIDIObjectGetStringProperty(object, property, &unmanaged)
+        guard status == noErr, let value = unmanaged?.takeRetainedValue() else {
+            return nil
+        }
+        return value as String
+    }
+
+    private static func integerProperty(_ object: MIDIObjectRef, _ property: CFString) -> Int32? {
+        var value: Int32 = 0
+        let status = MIDIObjectGetIntegerProperty(object, property, &value)
+        guard status == noErr else { return nil }
+        return value
+    }
+
+    private static let readProc: MIDIReadProc = { packetList, refCon, _ in
+        guard let refCon else { return }
+        let input = Unmanaged<MagentaRT2MIDIInput>.fromOpaque(refCon).takeUnretainedValue()
+        input.handle(packetList: packetList)
+    }
+
+    private func handle(packetList: UnsafePointer<MIDIPacketList>) {
+        // MIDIPacket is variable-length; walking a value copy with
+        // MIDIPacketNext reads past the copy's storage once numPackets > 1.
+        // unsafeSequence() walks the real buffer.
+        for packetPtr in packetList.unsafeSequence() {
+            let length = Int(packetPtr.pointee.length)
+            guard length > 0 else { continue }
+            let dataOffset = MemoryLayout<MIDIPacket>.offset(of: \.data) ?? 0
+            let data = UnsafeRawBufferPointer(
+                start: UnsafeRawPointer(packetPtr) + dataOffset,
+                count: length
+            )
+            parser.consume(data) { [self] event in
+                handle(event: event)
+            }
+        }
+    }
+
+    private func handle(event: MagentaRT2MIDIEvent) {
+        switch event {
+        case .noteOn(let channel, let note, _):
+            guard accepts(channel: channel) else { return }
+            let adjusted = Int(note) + configuration.noteOffset
+            guard (0..<132).contains(adjusted) else { return }
+            controls.enqueueNoteOn(Int32(adjusted))
+        case .noteOff(let channel, let note):
+            guard accepts(channel: channel) else { return }
+            let adjusted = Int(note) + configuration.noteOffset
+            guard (0..<132).contains(adjusted) else { return }
+            controls.enqueueNoteOff(Int32(adjusted))
+        case .controlChange(let channel, let controller, let value):
+            guard accepts(channel: channel), let mapping = ccMappings[controller] else { return }
+            mapping.apply(rawValue: value, to: controls)
+        }
+    }
+
+    private func accepts(channel: Int) -> Bool {
+        configuration.channel.map { $0 == channel } ?? true
+    }
+}
+#else
+final class MagentaRT2MIDIInput: @unchecked Sendable {
+    let sourceDisplayName = ""
+
+    init(configuration: MagentaRT2MIDIInputConfiguration, controls: MagentaRT2LiveControlQueue) throws {
+        _ = configuration
+        _ = controls
+        throw MagentaRT2MIDIInputError.unsupportedPlatform
+    }
+
+    static func availableSources() throws -> [MagentaRT2MIDISource] {
+        throw MagentaRT2MIDIInputError.unsupportedPlatform
+    }
+
+    func stop() {}
+}
+#endif

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -259,4 +259,107 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.prefillSilence)
         XCTAssertEqual(cmd.prefillDuration, 1.5, accuracy: 0.0001)
     }
+
+    func testMusicRealtimeParsesMIDIControls() throws {
+        let cmd = try MusicRealtime.parse([
+            "minimal synth pop",
+            "--midi-input", "OP-1",
+            "--midi-channel", "2",
+            "--midi-note-offset", "12",
+            "--midi-cc", "1=temp:0.2:1.4",
+            "--midi-cc", "2=drums:0:2",
+        ])
+
+        XCTAssertEqual(cmd.prompt, "minimal synth pop")
+        XCTAssertEqual(cmd.midiInput, "OP-1")
+        XCTAssertEqual(cmd.midiChannel, "2")
+        XCTAssertEqual(cmd.midiNoteOffset, 12)
+        XCTAssertEqual(cmd.midiCCMappings, ["1=temp:0.2:1.4", "2=drums:0:2"])
+    }
+
+    func testMusicRealtimeParsesMIDIInputListingWithoutPrompt() throws {
+        let cmd = try MusicRealtime.parse([
+            "--list-midi-inputs",
+        ])
+
+        XCTAssertNil(cmd.prompt)
+        XCTAssertTrue(cmd.listMIDIInputs)
+    }
+
+    func testMagentaRT2MIDICCMappingScalesValues() throws {
+        let mapping = try MagentaRT2MIDICCMapping.parse("1=temp:0.2:1.4")
+
+        XCTAssertEqual(mapping.controller, 1)
+        XCTAssertEqual(mapping.scaledValue(0), 0.2, accuracy: 0.0001)
+        XCTAssertEqual(mapping.scaledValue(127), 1.4, accuracy: 0.0001)
+    }
+
+    func testMagentaRT2LiveControlQueueCollectsMIDINotesAndControls() throws {
+        let queue = MagentaRT2LiveControlQueue(initialControls: MagentaRT2Controls())
+        queue.enqueueNoteOn(60)
+        queue.enqueueNoteOff(64)
+        try MagentaRT2MIDICCMapping.parse("1=temp:0.2:1.4").apply(rawValue: 127, to: queue)
+
+        let snapshot = try XCTUnwrap(queue.snapshot())
+        XCTAssertEqual(snapshot.noteOn, [60])
+        XCTAssertEqual(snapshot.noteOff, [64])
+        let controls = try XCTUnwrap(snapshot.controls)
+        XCTAssertEqual(controls.temperature, Float(1.4), accuracy: 0.0001)
+    }
+
+    private func parsedEvents(
+        _ parser: inout MagentaRT2MIDIStreamParser,
+        _ bytes: [UInt8]
+    ) -> [MagentaRT2MIDIEvent] {
+        var events: [MagentaRT2MIDIEvent] = []
+        parser.consume(bytes) { events.append($0) }
+        return events
+    }
+
+    func testMIDIStreamParserParsesMultipleMessagesPerPacket() {
+        var parser = MagentaRT2MIDIStreamParser()
+        let events = parsedEvents(&parser, [0x90, 60, 100, 0x80, 60, 0, 0xB1, 1, 64])
+
+        XCTAssertEqual(events, [
+            .noteOn(channel: 1, note: 60, velocity: 100),
+            .noteOff(channel: 1, note: 60),
+            .controlChange(channel: 2, controller: 1, value: 64),
+        ])
+    }
+
+    func testMIDIStreamParserHandlesRunningStatus() {
+        var parser = MagentaRT2MIDIStreamParser()
+        // One 0x90 status followed by three note pairs: a chord under
+        // running status, with a velocity-0 pair meaning note-off.
+        let events = parsedEvents(&parser, [0x90, 60, 100, 64, 100, 60, 0])
+
+        XCTAssertEqual(events, [
+            .noteOn(channel: 1, note: 60, velocity: 100),
+            .noteOn(channel: 1, note: 64, velocity: 100),
+            .noteOff(channel: 1, note: 60),
+        ])
+    }
+
+    func testMIDIStreamParserSurvivesInterleavedRealtimeAndPacketBoundaries() {
+        var parser = MagentaRT2MIDIStreamParser()
+        // Clock (0xF8) interrupts a note-on mid-message, and the message's
+        // final byte arrives in the next packet.
+        var events = parsedEvents(&parser, [0x90, 0xF8, 60])
+        XCTAssertTrue(events.isEmpty)
+        events = parsedEvents(&parser, [100])
+        XCTAssertEqual(events, [.noteOn(channel: 1, note: 60, velocity: 100)])
+    }
+
+    func testMIDIStreamParserSkipsUnrelatedMessagesAndSysEx() {
+        var parser = MagentaRT2MIDIStreamParser()
+        let events = parsedEvents(&parser, [
+            0xC0, 5, // program change: 1 data byte, ignored
+            0xE0, 0, 64, // pitch bend: 2 data bytes, ignored
+            0xF0, 1, 2, 3, 0xF7, // sysex: dropped, cancels running status
+            33, 44, // stray data bytes with no status: dropped
+            0x91, 62, 90, // then a normal note-on still parses
+        ])
+
+        XCTAssertEqual(events, [.noteOn(channel: 2, note: 62, velocity: 90)])
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -961,6 +961,11 @@ Key options:
 - `--prefill-silence`
 - `--prefill-duration`
 - `--interactive`: read live steering commands from stdin
+- `--list-midi-inputs`: list CoreMIDI input sources and exit
+- `--midi-input`: CoreMIDI source name or unique ID for live note/control steering
+- `--midi-channel`: `all` or `1` through `16`
+- `--midi-note-offset`: transpose incoming MIDI notes before sending them to Magenta RT2
+- `--midi-cc`: repeatable mapping as `cc=target:min:max`, for example `1=temp:0.2:1.4`
 - `--quiet`
 
 Interactive commands:
@@ -994,6 +999,16 @@ swift run mere.run music realtime \
   --model music-magenta-rt2-small \
   --duration 30 \
   --interactive
+
+swift run mere.run music realtime --list-midi-inputs
+
+swift run mere.run music realtime \
+  "minimal synth pop, dry drums, tape-warped bass" \
+  --model music-magenta-rt2-small \
+  --duration 120 \
+  --midi-input "OP-1" \
+  --midi-cc 1=temp:0.2:1.4 \
+  --midi-cc 2=drums:0:2
 ```
 
 ### `mere.run sfx generate`

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -125,6 +125,28 @@ Supported steering commands are `prompt <text>`, `style streaming|full`,
 `drumless on|off`, `unmask <value>`, `seed <value>`, `reset`, `quit`, and
 `help`.
 
+On macOS, `music realtime` can also listen to CoreMIDI input. Use
+`--list-midi-inputs` to find the source name or unique ID, then pass
+`--midi-input` to map incoming note-on/note-off messages to the same Magenta
+RT2 note controls used by stdin:
+
+```bash
+swift run mere.run music realtime --list-midi-inputs
+swift run mere.run music realtime \
+  "minimal synth pop, dry drums, tape-warped bass" \
+  --model music-magenta-rt2-small \
+  --duration 120 \
+  --midi-input "OP-1" \
+  --midi-channel all \
+  --midi-cc 1=temp:0.2:1.4 \
+  --midi-cc 2=drums:0:2
+```
+
+`--midi-cc` mappings use `cc=target:min:max`. Supported targets are `temp`,
+`topk`, `mc`, `notes`, `drums`, `drumless`, `unmask`, `seed`, and `onset`.
+Prompt changes still use stdin and may briefly stall while the prompt encoder
+runs; MIDI is intended for notes and continuous controls.
+
 ## Runtime entrypoints
 
 ### CLI


### PR DESCRIPTION
## Feature

Live MIDI control for `music realtime` on macOS:

- `--list-midi-inputs` — enumerate CoreMIDI sources (name | manufacturer | model | unique ID)
- `--midi-input <name-or-id>` — connect a source; exact-ID and exact-name matches win, substring matches must be unambiguous
- `--midi-channel all|1-16`, `--midi-note-offset <n>`
- repeatable `--midi-cc cc=target:min:max` mappings (`temp`, `topk`, `mc`, `notes`, `drums`, `drumless`, `unmask`, `seed`, `onset`)

Note-on/off and mapped CCs feed the same `MagentaRT2LiveControlQueue` as interactive stdin steering (the former private interactive-controls class, extracted to `Support/` and shared by both paths). Prompt changes stay on stdin — the prompt encoder swap can stall a frame, so MIDI is for notes and continuous controls (matching the engine constraints established in #132).

## Review hardening on top of the initial implementation

- **Fixed a memory-safety bug in packet iteration**: the original loop copied `MIDIPacket` into a local and called `MIDIPacketNext` on the copy — that walks past the copy's stack storage and reads garbage whenever a `MIDIPacketList` carries more than one packet (chords, CC sweeps, clock+note bursts). Now uses `MIDIPacketList.unsafeSequence()` and reads the true variable-length payload via the `data` field offset.
- **Running status support**: the original parser treated every data byte outside a leading status byte as stray and dropped it — under running status (one status byte, many data pairs, common from hardware) every message after the first was lost. Parsing is now a small stateful MIDI 1.0 parser (`MagentaRT2MIDIStreamParser`) that keeps running status across packet boundaries, tolerates system-realtime bytes (clock, active sensing) interleaved mid-message, advances correctly past pitch-bend/program-change, and normalizes velocity-0 note-on to note-off per spec.
- **Testability**: the parser is pure and platform-independent, so the protocol edge cases above are unit-tested directly (multi-message packets, running-status chords, split messages, SysEx + stray-byte recovery).
- **Ambiguous source matches fail loudly** with the candidate list instead of silently binding the first substring hit.
- Minor: stdin reader task only spawns in interactive mode; `snapshot()` drops an unused parameter.

## Validation

- `swift test --filter MusicGenerateCommandParsingTests`: 19 tests, 0 failures (7 new: 3 CLI/mapping parsing from the original work, 4 parser protocol tests from review).
- Flag surface documented in `docs/cli.md`, `docs/runtime/music.md`, the `music-generate` guide, README example, and CHANGELOG.
- Live end-to-end (OP-1 in hand) remains the promotion gate per the #128/#132 pattern — the engine-side realtime loop is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)