### PR TITLE
Prepare 0.19.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ scripts/upload_release.sh
 .claude/settings.local.json
 .claude/
 .agents/
+live.wav
 
 # Local release/notarization credentials
 .notarize.local.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,88 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.19.0 - 2026-07-04
+
 ### Added
 
+- added native `text train-lora` for reviewed chat-style SFT data, with
+  Gemma4 LoRA injection, loss-masked training batches, JSONL dataset loading,
+  training metrics, generated artifacts, and a loopback viewer through
+  `--visualize`.
+- added `image train-lora --preflight --json`, a typed structured preflight
+  report for expensive LoRA runs. It checks dataset/caption shape, edit-pair
+  mismatches, placeholder text, duplicate captions, model-family support,
+  output overwrite risk, and emits follow-up actions instead of starting
+  training blindly.
 - added CoreMIDI steering for `music realtime` on macOS, including
-  `--list-midi-inputs`, `--midi-input`, channel/note-offset filters, and
-  repeatable `--midi-cc` mappings for Magenta RT2 note and control changes.
+  `--list-midi-inputs`, `--midi-input`, channel/note-offset filters, a robust
+  MIDI 1.0 stream parser, note on/off handling, and repeatable `--midi-cc`
+  mappings for Magenta RT2 note and control changes.
+- added `model benchmark code --thinking` for reasoning-enabled code evals.
+  The benchmark keeps reasoning split away from scored code and disables
+  HumanEval stop sequences that can fire inside a thinking block.
+- added Ornith support to the `model benchmark q36-mtp` lane so MTP sidecar
+  experiments can be measured against `text-agent-ornith-9b` and
+  `text-agent-ornith-35b-mlx` with the existing counters.
+- added an env-gated Q35 reference-parity harness:
+  `MERERUN_Q35_DEBUG_LAYER_DUMP`, `MERERUN_Q35_DEBUG_PROMPT_TOKENS`, and
+  matching mlx_lm dump/compare scripts under `scripts/reference-parity/`.
+  Self-parity gates cannot catch defaults that are wrong the same way on both
+  sides, so this compares against an independent implementation.
+- added `scripts/build_mlx_metallib.sh`, a stamped MLX Metal kernel-library
+  builder/verifier that records the mlx core version, mlx-swift pin, toolchain,
+  and kernel-source hash next to `default.metallib`.
+- added Linux CUDA package hardening for release artifacts: CUDA package
+  suffixes, CUDA runtime/JIT `.deb` dependencies, CUDA CCCL discovery in the
+  installed launcher, and an arm64 release guard that requires
+  `MERERUN_LINUX_ACCEL=cuda` for meaningful arm64 packages.
+- added docs for the mlx-swift fork policy, the measured compiled-call
+  overhead cliff, and why the public repo stays on stock upstream mlx-swift
+  until the fast-path lock removal is proven thread-safe.
+- added image-generation docs for applying Klein LoRAs to reference images with
+  `--ref-image`, including starting strength/LoRA-scale guidance.
 
 ### Changed
 
+- shipped a large decode-performance train across Gemma4 and Q35. Measured
+  highlights include Q35 MoE decode improving from 53.1 to 87.3 tok/s,
+  Q35 prefill from 558-703 to 803-847 tok/s, Gemma4 sampled chat from
+  26.0 to 30-35 tok/s, Gemma4 short-prompt TTFT from 5.4s to 2.7s, and
+  quantized-KV long-context decode copy traffic dropping from about
+  1.4 GB/token to zero.
+- changed Q35 prefill chunking from 512 to 1024 tokens by default, with
+  `MERERUN_Q35_PREFILL_CHUNK_TOKENS` for controlled overrides. Warm Ornith
+  35B MLX prefill now reaches roughly 1350 tok/s in serve mode while keeping
+  greedy output byte-identical across exact causal chunk sizes.
+- optimized native text LoRA training with gathered lm_head loss,
+  logSumExp-minus-gather cross entropy, async loss-readback cadence, a
+  text-appropriate MLX buffer-cache cap, and mid-run partial checkpoints.
+  Long 12B-4bit QLoRA steps improved from about 33.0 to 24.7 s/step while
+  steady memory dropped from about 111 GB to 38 GB.
+- optimized Q35 decode with fused q/k/v quantized projections, batched
+  GPU-side sampling, stacked gate/up expert matmuls, and Q35 prefix/prefill
+  plumbing that keeps sampling and prefill work on the GPU longer.
+- optimized Gemma4 decode with pipelined sampled-token readback, top-p
+  prefiltering, fused quantized projection loads, in-place quantized KV cache
+  growth, single-query sliding-window cache reuse, final-position-only prefill
+  logits, and MTP round batching for greedy verification.
+- optimized LFM2 repeated-prompt serving with opt-in prefix-KV reuse and fork
+  isolation for `KVCacheSimple`; local repeated-prompt TTFT moved from about
+  11.7s to 0.3s in the measured lane.
+- optimized Qwen3 TTS with GPU-side sampling and a depth-1 pipelined talker
+  decode path, yielding roughly 20-25% faster local synthesis in the measured
+  lane.
+- optimized STT, OCR, embeddings, GLM-4.7 Flash, and ACEStep LM paths by
+  reducing readbacks and batching decode/sampler operations; OCR throughput
+  improved by roughly 17% in the measured lane.
+- optimized FalconPerception decode with an O(T) KV cache and gated trace-only
+  heads, replacing repeated full-prefix work in the vision-language path.
+- tightened denoise-loop hygiene across HiDream, Klein, and Krea2 by
+  precomputing sigma/control values, gating debug-only work, and hoisting
+  repeated setup out of inner loops.
+- made Magenta RT2 prompt swaps opt-in non-blocking, with a 1ms prompt-wait
+  poll so realtime audio generation can keep moving while control state
+  changes.
 - Ornith lanes (`text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`) now
   generate with thinking enabled by default in `text chat` and `api serve`,
   and default to the model's published sampling (temperature 1.0, top-p 0.95,
@@ -22,6 +96,15 @@ The format is based on Keep a Changelog.
   `--no-thinking` to disable reasoning generation and `--top-k` for explicit
   cutoff control; reasoning output stays hidden unless `--thinking` is passed.
   Other Qwen-family lanes keep the existing no-think default.
+- improved the macOS Studio interface with a more polished command surface,
+  clearer generated-media handling, and command-catalog coverage for the newer
+  music, benchmark, plugin, and Open WebUI flows.
+- refreshed release and Linux documentation around the supported public
+  boundary: macOS app/DMG remain macOS-only, Linux artifacts stay headless
+  CLI-only, x86_64 CPU/CUDA artifacts are the hosted release lanes, and arm64
+  release packaging is CUDA/self-hosted only.
+- bumped GitHub Actions dependencies, including checkout, upload-artifact, and
+  action-gh-release, to the current major versions used by the release lanes.
 
 ### Fixed
 
@@ -30,19 +113,38 @@ The format is based on Keep a Changelog.
   and mlx_lm. Checkpoints that omit `norm_topk_prob` (Ornith 35B, Qwen3.6
   nano) were previously routed with un-renormalized scores, dampening every
   MoE block's output by the top-k softmax mass and compounding into
-  systematically repetition-biased logits — reasoning models looped instead
+  systematically repetition-biased logits, so reasoning models looped instead
   of terminating. Per-layer hidden states now match the mlx_lm reference to
   within quantized-kernel noise, and greedy decode openings match verbatim.
-- Added an env-gated reference-parity harness: the runtime dumps per-layer
-  hidden-state stats (`MERERUN_Q35_DEBUG_LAYER_DUMP`) and prompt token ids
-  (`MERERUN_Q35_DEBUG_PROMPT_TOKENS`), with matching mlx_lm dump/compare
-  scripts under `scripts/reference-parity/`. Self-referential byte-parity
-  gates cannot catch bugs that are wrong the same way on both sides.
 - `api serve` chat completions now report real `prompt_tokens` in the `usage`
   object for both streaming (`stream_options.include_usage`) and non-streaming
   responses, and `total_tokens` includes the prompt side. Previously
   `prompt_tokens` was always `0` and `total_tokens` only counted completion
   tokens.
+- fixed stale MLX metallib handling. The runtime now detects unstamped or
+  mismatched `default.metallib` resources, can replace stale libraries from a
+  matching build product, fails loudly when no compatible metallib is
+  available, and keeps the app bundle layout notarization-safe by flattening
+  MLX resources under `Contents/Helpers`.
+- fixed the Magenta RT2 engine failure caused by an unhydrated LFS metallib and
+  removed the unsafe swap option that made the failure mode harder to reason
+  about.
+- fixed Linux CUDA Swift support linkage so hosted CUDA package builds can link
+  against prepared native mlx-swift artifacts and explicit CUDA library paths.
+- fixed macOS package bundle path capture in packaging scripts so release
+  workflows inspect and sign the bundle that was actually built.
+- fixed SAM 3.1 text-prompt tokenizer installation so segmentation prompts use
+  the intended tokenizer assets.
+- fixed strict-concurrency and stale test-support issues surfaced by Linux
+  builds after the Qwen3 TTS pipelining work.
+- fixed local generated artifacts by ignoring the root `live.wav` capture file
+  without broadly ignoring audio fixtures.
+
+### Removed
+
+- removed public-repo maintainer release command wrappers after confirming
+  operator-only release flows belong in the private `mere-run-release-tools`
+  repo, not in the public OSS distribution.
 
 ## 0.18.0 - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for the current
 validation boundary, CUDA notes, and first commands:
 
 ```bash
-tag=v0.18.0
+tag=v0.19.0
 version="${tag#v}"
 
 # Portable tarball
@@ -124,7 +124,7 @@ during NVRTC JIT compilation:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.19.0 --artifact-suffix cuda
 ```
 
 Current CUDA validation should be treated as limited to the exact hosts that
@@ -169,7 +169,7 @@ swift run mere.run --help
 To build Linux release packages from a Linux x86_64 Swift toolchain host:
 
 ```bash
-scripts/package-linux.sh --version 0.18.0
+scripts/package-linux.sh --version 0.19.0
 ls dist/linux/
 ```
 
@@ -178,14 +178,14 @@ builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.19.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
 On Linux arm64, use a CUDA-provisioned host:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.18.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.19.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.18.0"
+    static let current = "0.19.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.18.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.19.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -100,7 +100,7 @@ artifacts. The default GitHub release workflow publishes x86_64/amd64 CPU
 artifacts and x86_64 CUDA artifacts:
 
 ```bash
-scripts/package-linux.sh --version 0.18.0
+scripts/package-linux.sh --version 0.19.0
 ls dist/linux/
 ```
 
@@ -113,7 +113,7 @@ CUDA variants use a suffix so they can ship beside the CPU artifacts:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.19.0 --artifact-suffix cuda
 ```
 
 That writes artifacts such as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Linux-only setup path, first commands, release checks, and CUDA validation
 limits, see [Linux QuickStart](./linux-quickstart.md).
 
 ```bash
-tag=v0.18.0
+tag=v0.19.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64; deb_arch=amd64 ;;

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -33,7 +33,7 @@ manifests, and CUDA-gated arm64 package work.
 Use this path on Debian or Ubuntu-style systems:
 
 ```bash
-tag=v0.18.0
+tag=v0.19.0
 version="${tag#v}"
 case "$(uname -m)" in
   x86_64|amd64) deb_arch=amd64 ;;
@@ -54,7 +54,7 @@ assets that the CLI needs at runtime.
 Use this path when you do not want to install a Debian package:
 
 ```bash
-tag=v0.18.0
+tag=v0.19.0
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -82,7 +82,7 @@ Use this artifact for GPU worker images, remote trainers, and other x86_64 CUDA
 hosts:
 
 ```bash
-tag=v0.18.0
+tag=v0.19.0
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/mere-run-${tag}-linux-x86_64-cuda.tar.gz" -o mere-run-linux-cuda.tar.gz
 tar -xzf mere-run-linux-cuda.tar.gz
 cd "mere-run-${tag}-linux-x86_64-cuda"
@@ -134,7 +134,7 @@ that build locally on a Linux x86_64 CUDA development host:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.19.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
@@ -148,7 +148,7 @@ MERERUN_LINUX_ACCEL=cuda \
 MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
 MERERUN_NATIVE_BUILD_JOBS=14 \
 MERERUN_CUDA_ARCHITECTURES="86-real;90-virtual" \
-  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.19.0 --artifact-suffix cuda
 ```
 
 Run a real GPU smoke on the target runtime class before widening support claims.
@@ -165,7 +165,7 @@ repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.18.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.19.0
 ls dist/linux/
 ```
 
@@ -242,7 +242,7 @@ studio, and DMG packaging are macOS-only.
 Each Linux release includes `SHA256SUMS` beside the tarball and `.deb`:
 
 ```bash
-tag=v0.18.0
+tag=v0.19.0
 
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/SHA256SUMS" -o SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,7 +90,7 @@ CPU-oriented Linux manifest path.
 Linux release packaging has its own artifact check:
 
 ```bash
-scripts/package-linux.sh --version 0.18.0
+scripts/package-linux.sh --version 0.19.0
 test -s dist/linux/SHA256SUMS
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
@@ -103,7 +103,7 @@ Linux builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.18.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.19.0 --artifact-suffix cuda
 tar -tzf dist/linux/mere-run-*-linux-x86_64-cuda.tar.gz | grep '/.mererun-linux-cuda$'
 dpkg-deb --info dist/linux/mere-run-cuda_*_amd64.deb
 ```
@@ -111,7 +111,7 @@ dpkg-deb --info dist/linux/mere-run-cuda_*_amd64.deb
 On Linux arm64, use CUDA for the package check:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.18.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.19.0
 ```
 
 The `linux-release` workflow runs the hosted package and manifest boundary for

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.18.0"
+default_version="0.19.0"
 if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the public CLI/app fallback version and release install snippets from 0.18.0 to 0.19.0
- expand CHANGELOG.md with the full 0.19.0 release notes covering the July performance train, text LoRA, preflight, MIDI realtime, Q35/Ornith correctness, metallib safety, Linux CUDA packaging, and release-tooling cleanup
- ignore the local root live.wav capture artifact without ignoring audio fixtures broadly

## Validation

- swift test --filter CLIModelStoreBootstrapTests/testMereRunCLIExposesReleaseVersion
- ./scripts/check.sh
- CI=true corepack pnpm@10.28.0 install --frozen-lockfile && corepack pnpm@10.28.0 docs:build
