### PR TITLE
Fix macOS release DMG path capture

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -58,7 +58,11 @@ jobs:
           MERERUN_NOTARY_TEAM_ID: ${{ secrets.MERERUN_NOTARY_TEAM_ID }}
         run: |
           set -euo pipefail
-          dmg="$(./scripts/package-macos.sh release)"
+          build_log="$(mktemp)"
+          ./scripts/package-macos.sh release 2>&1 | tee "$build_log"
+          dmg="$(awk 'NF { line = $0 } END { print line }' "$build_log")"
+          rm -f "$build_log"
+          test -f "$dmg"
           echo "DMG_PATH=$dmg" >> "$GITHUB_ENV"
 
       - name: Upload DMG artifact


### PR DESCRIPTION
## Summary
- capture the macOS packaging log separately from the final DMG path
- validate the extracted DMG path before exporting it to GitHub Actions env

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-release.yml"); puts "yaml ok"'