### PR TITLE
Add mere.run gate: end-to-end quality flight recorder

### DIFF
--- a/Sources/MereRunCLI/Commands/GateCommand.swift
+++ b/Sources/MereRunCLI/Commands/GateCommand.swift
@@ -1,0 +1,213 @@
+import ArgumentParser
+import Crypto
+import Foundation
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import CoreText
+import ImageIO
+import UniformTypeIdentifiers
+#endif
+
+/// End-to-end quality gate: runs the real user-facing commands against the
+/// installed models, hashes their outputs, checks in-run determinism, and
+/// compares against machine-local baselines. Exists because the platform
+/// shipped a broken decode path (stale Metal library, garbage above 1024
+/// tokens) for two months without anything noticing: every check here runs
+/// the actual product surface, and the text checks deliberately include a
+/// long-context lane in the historically blind regime.
+struct Gate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gate",
+        abstract: "Run the end-to-end quality gate against installed models.",
+        discussion: """
+        Each check shells out to this executable's real subcommands (text
+        chat, speech synthesize/transcribe, vision ocr, image generate, text
+        embed) at temperature 0, hashes the output, and runs twice to prove
+        determinism. Correctness failures (hash mismatch vs baseline,
+        nondeterminism, roundtrip failures) exit nonzero; performance
+        regressions warn unless --strict-perf is set. Checks whose models are
+        not installed are skipped and reported.
+
+        First run on a machine: `mere.run gate --update-baselines` records
+        the baseline hashes and timings. Re-run after intentional
+        output-changing merges to refresh them.
+        """
+    )
+
+    @Option(name: [.customLong("suite")], help: "Comma-separated suites: text, speech, vision, image, embed (default: all).")
+    var suite: String = "all"
+
+    @Flag(name: [.customLong("update-baselines")], help: "Record current outputs and timings as the new baselines.")
+    var updateBaselines: Bool = false
+
+    @Flag(name: [.customLong("strict-perf")], help: "Treat performance regressions (vs baseline) as failures, not warnings.")
+    var strictPerf: Bool = false
+
+    @Option(name: [.customLong("json-output")], help: "Write the full gate report as JSON to this path.")
+    var jsonOutput: String?
+
+    @Flag(name: [.customLong("list")], help: "List available checks and exit.")
+    var listOnly: Bool = false
+
+    func run() async throws {
+        let checks = GateChecks.all
+        if listOnly {
+            for check in checks {
+                print("\(check.id)  [\(check.suite)]  requires: \(check.requiredModels.joined(separator: ", "))")
+            }
+            return
+        }
+
+        let selectedSuites = Set(
+            suite.lowercased() == "all"
+                ? checks.map(\.suite)
+                : suite.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+        )
+
+        let runner = GateRunner(
+            executableURL: URL(fileURLWithPath: CommandLine.arguments[0]).standardizedFileURL,
+            workDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("mererun-gate-\(ProcessInfo.processInfo.processIdentifier)", isDirectory: true)
+        )
+        try FileManager.default.createDirectory(at: runner.workDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: runner.workDirectory) }
+
+        var baselines = GateBaselineStore.load()
+        var results: [GateResult] = []
+
+        for check in checks where selectedSuites.contains(check.suite) {
+            guard check.requiredModels.allSatisfy(GateRunner.modelInstalled) else {
+                results.append(GateResult(
+                    id: check.id, status: .skipped,
+                    detail: "missing model: \(check.requiredModels.joined(separator: ", "))",
+                    observation: nil
+                ))
+                continue
+            }
+            FileHandle.standardError.write(Data("[gate] running \(check.id)…\n".utf8))
+            do {
+                let observation = try await check.run(runner)
+                let result = Self.judge(
+                    check: check,
+                    observation: observation,
+                    baseline: baselines.entries[check.id],
+                    strictPerf: strictPerf
+                )
+                results.append(result)
+                if updateBaselines || (baselines.entries[check.id] == nil && result.status != .failed) {
+                    baselines.entries[check.id] = GateBaseline(
+                        hash: observation.hash,
+                        wallSeconds: observation.wallSeconds,
+                        decodeTps: observation.decodeTps
+                    )
+                }
+            } catch {
+                results.append(GateResult(
+                    id: check.id, status: .failed,
+                    detail: "check threw: \(error.localizedDescription)",
+                    observation: nil
+                ))
+            }
+        }
+
+        if updateBaselines || results.contains(where: { $0.status != .skipped }) {
+            try GateBaselineStore.save(baselines)
+        }
+
+        let report = GateReport(
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            hostModel: GateRunner.hardwareModel(),
+            results: results
+        )
+        Self.printTable(report)
+        if let jsonOutput {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(report).write(to: URL(fileURLWithPath: jsonOutput))
+        }
+
+        if results.contains(where: { $0.status == .failed }) {
+            throw ExitCode(1)
+        }
+    }
+
+    private static func judge(
+        check: GateCheck,
+        observation: GateObservation,
+        baseline: GateBaseline?,
+        strictPerf: Bool
+    ) -> GateResult {
+        if let deterministicHash = observation.secondRunHash, deterministicHash != observation.hash {
+            return GateResult(
+                id: check.id, status: .failed,
+                detail: "NONDETERMINISTIC: run1=\(observation.hash.prefix(12)) run2=\(deterministicHash.prefix(12))",
+                observation: observation
+            )
+        }
+        if let semantic = observation.semanticFailure {
+            return GateResult(id: check.id, status: .failed, detail: semantic, observation: observation)
+        }
+        guard let baseline else {
+            return GateResult(
+                id: check.id, status: .passed,
+                detail: "baseline recorded (\(observation.hash.prefix(12)))",
+                observation: observation
+            )
+        }
+        if observation.hash != baseline.hash {
+            return GateResult(
+                id: check.id, status: .failed,
+                detail: "OUTPUT CHANGED vs baseline: \(baseline.hash.prefix(12)) -> \(observation.hash.prefix(12)) (re-run with --update-baselines if intentional)",
+                observation: observation
+            )
+        }
+        var perfNotes: [String] = []
+        var perfFailed = false
+        if let baseTps = baseline.decodeTps, let tps = observation.decodeTps, tps < baseTps * 0.75 {
+            perfNotes.append(String(format: "decode_tps %.1f < 0.75x baseline %.1f", tps, baseTps))
+            perfFailed = true
+        }
+        if observation.wallSeconds > baseline.wallSeconds * 1.5 {
+            perfNotes.append(String(format: "wall %.1fs > 1.5x baseline %.1fs", observation.wallSeconds, baseline.wallSeconds))
+            perfFailed = true
+        }
+        if perfFailed {
+            let detail = "perf regression: " + perfNotes.joined(separator: "; ")
+            return GateResult(
+                id: check.id,
+                status: strictPerf ? .failed : .warned,
+                detail: detail,
+                observation: observation
+            )
+        }
+        return GateResult(id: check.id, status: .passed, detail: "matches baseline", observation: observation)
+    }
+
+    private static func printTable(_ report: GateReport) {
+        print("\nGATE REPORT (\(report.hostModel))")
+        for result in report.results {
+            let mark: String
+            switch result.status {
+            case .passed: mark = "PASS"
+            case .warned: mark = "WARN"
+            case .failed: mark = "FAIL"
+            case .skipped: mark = "SKIP"
+            }
+            var line = "  [\(mark)] \(result.id) — \(result.detail)"
+            if let observation = result.observation {
+                line += String(format: " (%.1fs", observation.wallSeconds)
+                if let tps = observation.decodeTps {
+                    line += String(format: ", %.1f tok/s", tps)
+                }
+                line += ")"
+            }
+            print(line)
+        }
+        let failed = report.results.filter { $0.status == .failed }.count
+        let warned = report.results.filter { $0.status == .warned }.count
+        let passed = report.results.filter { $0.status == .passed }.count
+        let skipped = report.results.filter { $0.status == .skipped }.count
+        print("  \(passed) passed, \(warned) warned, \(failed) failed, \(skipped) skipped\n")
+    }
+}

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -27,6 +27,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Video.self,
             Model.self,
             Status.self,
+            Gate.self,
             Config.self,
             API.self,
             OpenWebUI.self,

--- a/Sources/MereRunCLI/Support/GateSupport.swift
+++ b/Sources/MereRunCLI/Support/GateSupport.swift
@@ -1,0 +1,492 @@
+import Crypto
+import Foundation
+
+#if canImport(CoreGraphics)
+import CoreGraphics
+import CoreText
+import ImageIO
+import UniformTypeIdentifiers
+#endif
+
+// MARK: - Report types
+
+enum GateStatus: String, Codable {
+    case passed
+    case warned
+    case failed
+    case skipped
+}
+
+struct GateObservation: Codable {
+    let hash: String
+    let secondRunHash: String?
+    let wallSeconds: Double
+    let decodeTps: Double?
+    let semanticFailure: String?
+}
+
+struct GateResult: Codable {
+    let id: String
+    let status: GateStatus
+    let detail: String
+    let observation: GateObservation?
+}
+
+struct GateReport: Codable {
+    let createdAt: String
+    let hostModel: String
+    let results: [GateResult]
+}
+
+struct GateBaseline: Codable {
+    let hash: String
+    let wallSeconds: Double
+    let decodeTps: Double?
+}
+
+struct GateBaselines: Codable {
+    var entries: [String: GateBaseline] = [:]
+}
+
+enum GateBaselineStore {
+    static var applicationSupport: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MereRun", isDirectory: true)
+    }
+
+    static var url: URL {
+        applicationSupport
+            .appendingPathComponent("gate", isDirectory: true)
+            .appendingPathComponent("baselines.json")
+    }
+
+    static func load() -> GateBaselines {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(GateBaselines.self, from: data) else {
+            return GateBaselines()
+        }
+        return decoded
+    }
+
+    static func save(_ baselines: GateBaselines) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(baselines).write(to: url)
+    }
+}
+
+// MARK: - Check definitions
+
+struct GateCheck: Sendable {
+    let id: String
+    let suite: String
+    let requiredModels: [String]
+    let run: @Sendable (GateRunner) async throws -> GateObservation
+}
+
+enum GateChecks {
+    /// A fixed paragraph repeated to push prompts past ~1200 tokens — the
+    /// regime where the stale-metallib SDPA corruption lived undetected.
+    static let longContextFiller = String(
+        repeating: "The runtime schedules quantized matmuls, rotary embeddings, and "
+            + "attention over unified memory while the sampler stays on the GPU. ",
+        count: 90
+    )
+
+    static let all: [GateCheck] = textChecks + speechChecks + visionChecks + imageChecks + embedChecks
+
+    private static let textModels: [(label: String, id: String)] = [
+        ("gemma", "text-chat-gemma4-12b-4bit"),
+        ("ornith", "text-agent-ornith-35b-mlx"),
+        ("lfm2", "text-chat-lfm25-a1b-8bit"),
+    ]
+
+    private static var textChecks: [GateCheck] {
+        textModels.flatMap { model in
+            [
+                GateCheck(id: "text-\(model.label)-short", suite: "text", requiredModels: [model.id]) { runner in
+                    try await runner.chatCheck(
+                        model: model.id,
+                        prompt: "List the first four prime numbers, comma separated, nothing else.",
+                        maxTokens: 160
+                    )
+                },
+                GateCheck(id: "text-\(model.label)-long", suite: "text", requiredModels: [model.id]) { runner in
+                    try await runner.chatCheck(
+                        model: model.id,
+                        prompt: "Summarize the following note in exactly one sentence. NOTE: "
+                            + longContextFiller,
+                        maxTokens: 160
+                    )
+                },
+            ]
+        }
+    }
+
+    private static var speechChecks: [GateCheck] {
+        let sentence = "The quality gate proves every voice and every model still speaks correctly."
+        return [
+            GateCheck(id: "tts-wav", suite: "speech", requiredModels: ["speech-tts-qwen3-nano"]) { runner in
+                let wav = runner.workDirectory.appendingPathComponent("gate-tts.wav")
+                let run = try await runner.exec(
+                    ["speech", "synthesize", sentence, "-o", wav.path, "--temperature", "0", "-q"],
+                    timeout: 600
+                )
+                let bytes = try Data(contentsOf: wav)
+                return GateObservation(
+                    hash: GateRunner.sha256(bytes),
+                    secondRunHash: nil,
+                    wallSeconds: run.wallSeconds,
+                    decodeTps: nil,
+                    semanticFailure: bytes.count > 10_000 ? nil : "WAV suspiciously small (\(bytes.count) bytes)"
+                )
+            },
+            GateCheck(
+                id: "stt-roundtrip", suite: "speech",
+                requiredModels: ["speech-tts-qwen3-nano", "speech-asr-parakeet"]
+            ) { runner in
+                let wav = runner.workDirectory.appendingPathComponent("gate-tts.wav")
+                if !FileManager.default.fileExists(atPath: wav.path) {
+                    _ = try await runner.exec(
+                        ["speech", "synthesize", sentence, "-o", wav.path, "--temperature", "0", "-q"],
+                        timeout: 600
+                    )
+                }
+                let first = try await runner.exec(
+                    ["speech", "transcribe", wav.path, "-m", "speech-asr-parakeet"], timeout: 600
+                )
+                let second = try await runner.exec(
+                    ["speech", "transcribe", wav.path, "-m", "speech-asr-parakeet"], timeout: 600
+                )
+                let transcript = GateRunner.normalizeWords(first.stdout)
+                let overlap = GateRunner.wordOverlap(source: sentence, candidate: first.stdout)
+                return GateObservation(
+                    hash: GateRunner.sha256(Data(transcript.utf8)),
+                    secondRunHash: GateRunner.sha256(Data(GateRunner.normalizeWords(second.stdout).utf8)),
+                    wallSeconds: first.wallSeconds,
+                    decodeTps: nil,
+                    semanticFailure: overlap >= 0.85
+                        ? nil
+                        : String(format: "STT roundtrip lost the sentence (%.0f%% word overlap): %@", overlap * 100, transcript.prefix(120) as CVarArg)
+                )
+            },
+        ]
+    }
+
+    private static var visionChecks: [GateCheck] {
+        [
+            GateCheck(id: "ocr-page", suite: "vision", requiredModels: ["vision-ocr-lighton"]) { runner in
+                #if canImport(CoreGraphics)
+                let page = runner.workDirectory.appendingPathComponent("gate-ocr.png")
+                let sourceText = GateTextPageRenderer.render(to: page)
+                let first = try await runner.exec(
+                    ["vision", "ocr", page.path, "-m", "vision-ocr-lighton"], timeout: 600
+                )
+                let second = try await runner.exec(
+                    ["vision", "ocr", page.path, "-m", "vision-ocr-lighton"], timeout: 600
+                )
+                let overlap = GateRunner.wordOverlap(source: sourceText, candidate: first.stdout)
+                return GateObservation(
+                    hash: GateRunner.sha256(Data(GateRunner.normalizeWords(first.stdout).utf8)),
+                    secondRunHash: GateRunner.sha256(Data(GateRunner.normalizeWords(second.stdout).utf8)),
+                    wallSeconds: first.wallSeconds,
+                    decodeTps: nil,
+                    semanticFailure: overlap >= 0.9
+                        ? nil
+                        : String(format: "OCR lost the page (%.0f%% word overlap)", overlap * 100)
+                )
+                #else
+                throw GateError.unsupportedPlatform("OCR page rendering requires CoreGraphics")
+                #endif
+            }
+        ]
+    }
+
+    private static var imageChecks: [GateCheck] {
+        [
+            GateCheck(id: "image-klein-seed7", suite: "image", requiredModels: ["image-klein-nano"]) { runner in
+                let png = runner.workDirectory.appendingPathComponent("gate-klein.png")
+                let run = try await runner.exec(
+                    [
+                        "image", "generate", "--model", "image-klein-nano",
+                        "--prompt", "a lighthouse at dusk, oil painting",
+                        "--seed", "7", "-o", png.path,
+                    ],
+                    timeout: 900
+                )
+                let bytes = try Data(contentsOf: png)
+                return GateObservation(
+                    hash: GateRunner.sha256(bytes),
+                    secondRunHash: nil,
+                    wallSeconds: run.wallSeconds,
+                    decodeTps: nil,
+                    semanticFailure: bytes.count > 50_000 ? nil : "PNG suspiciously small (\(bytes.count) bytes)"
+                )
+            }
+        ]
+    }
+
+    private static var embedChecks: [GateCheck] {
+        [
+            GateCheck(id: "embeddings", suite: "embed", requiredModels: ["text-embed-qwen3-0.6b"]) { runner in
+                let out1 = runner.workDirectory.appendingPathComponent("gate-embed-1.json")
+                let out2 = runner.workDirectory.appendingPathComponent("gate-embed-2.json")
+                let texts = ["quality gates protect platforms", "unified memory bandwidth", "gate"]
+                let run = try await runner.exec(
+                    ["text", "embed"] + texts + ["-o", out1.path], timeout: 300
+                )
+                _ = try await runner.exec(
+                    ["text", "embed"] + texts + ["-o", out2.path], timeout: 300
+                )
+                return GateObservation(
+                    hash: try GateRunner.embeddingVectorHash(try Data(contentsOf: out1)),
+                    secondRunHash: try GateRunner.embeddingVectorHash(try Data(contentsOf: out2)),
+                    wallSeconds: run.wallSeconds,
+                    decodeTps: nil,
+                    semanticFailure: nil
+                )
+            }
+        ]
+    }
+}
+
+// MARK: - Runner
+
+enum GateError: Error, LocalizedError {
+    case commandFailed(String, exitCode: Int32, stderr: String)
+    case timedOut(String)
+    case unsupportedPlatform(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let command, let code, let stderr):
+            return "`\(command)` exited \(code): \(stderr.suffix(300))"
+        case .timedOut(let command):
+            return "`\(command)` timed out"
+        case .unsupportedPlatform(let reason):
+            return reason
+        }
+    }
+}
+
+private final class GateProcessBox: @unchecked Sendable {
+    let process: Process
+    init(_ process: Process) { self.process = process }
+}
+
+struct GateRunner: Sendable {
+    struct ExecResult {
+        let stdout: String
+        let stderr: String
+        let wallSeconds: Double
+    }
+
+    let executableURL: URL
+    let workDirectory: URL
+
+    /// Runs a real `mere.run` subcommand end-to-end in a subprocess.
+    func exec(_ arguments: [String], timeout: TimeInterval) async throws -> ExecResult {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let start = Date()
+        try process.run()
+
+        let box = GateProcessBox(process)
+        let watchdog = Task.detached {
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            if box.process.isRunning {
+                box.process.terminate()
+            }
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            process.terminationHandler = { _ in continuation.resume() }
+        }
+        watchdog.cancel()
+        let wall = Date().timeIntervalSince(start)
+        let timedOut = wall >= timeout
+        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let outText = String(decoding: outData, as: UTF8.self)
+        let errText = String(decoding: errData, as: UTF8.self)
+
+        if timedOut {
+            throw GateError.timedOut(arguments.joined(separator: " "))
+        }
+        guard process.terminationStatus == 0 else {
+            throw GateError.commandFailed(
+                arguments.prefix(3).joined(separator: " "),
+                exitCode: process.terminationStatus,
+                stderr: errText
+            )
+        }
+        return ExecResult(stdout: outText, stderr: errText, wallSeconds: wall)
+    }
+
+    /// Temperature-0 chat run, executed twice for in-run determinism, with
+    /// decode throughput parsed from --stats when the engine reports it.
+    func chatCheck(model: String, prompt: String, maxTokens: Int) async throws -> GateObservation {
+        func once() async throws -> (hash: String, tps: Double?, wall: Double, response: String) {
+            let run = try await exec(
+                [
+                    "text", "chat", "--model", model, "--prompt", prompt,
+                    "--temperature", "0", "--max-tokens", String(maxTokens),
+                    "--thinking", "--stats",
+                ],
+                timeout: 900
+            )
+            let response = Self.stripStatsAndProgress(run.stdout)
+            let tps = Self.parseDecodeTps(run.stdout + run.stderr)
+            return (GateRunner.sha256(Data(response.utf8)), tps, run.wallSeconds, response)
+        }
+        let first = try await once()
+        let second = try await once()
+        return GateObservation(
+            hash: first.hash,
+            secondRunHash: second.hash,
+            wallSeconds: second.wall,
+            decodeTps: second.tps,
+            semanticFailure: first.response.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "empty response"
+                : nil
+        )
+    }
+
+    static func modelInstalled(_ id: String) -> Bool {
+        let root = ProcessInfo.processInfo.environment["MERERUN_MODELS_DIR"]
+            .map { URL(fileURLWithPath: $0) }
+            ?? GateBaselineStore.applicationSupport.appendingPathComponent("models", isDirectory: true)
+        return FileManager.default.fileExists(atPath: root.appendingPathComponent(id).path)
+    }
+
+    static func hardwareModel() -> String {
+        var size = 0
+        sysctlbyname("hw.model", nil, &size, nil, 0)
+        var value = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.model", &value, &size, nil, 0)
+        return String(cString: value)
+    }
+
+    /// Hashes only the embedding vectors from a /v1/embeddings-shaped JSON
+    /// document — response metadata (ids, created timestamps) legitimately
+    /// varies per call and must not participate in determinism checks.
+    static func embeddingVectorHash(_ data: Data) throws -> String {
+        struct EmbedFile: Decodable {
+            struct Item: Decodable { let embedding: [Double] }
+            let data: [Item]
+        }
+        let decoded = try JSONDecoder().decode(EmbedFile.self, from: data)
+        var canonical = ""
+        for item in decoded.data {
+            for value in item.embedding {
+                canonical += String(format: "%.8f,", value)
+            }
+            canonical += ";"
+        }
+        return sha256(Data(canonical.utf8))
+    }
+
+    static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func normalizeWords(_ text: String) -> String {
+        text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    static func wordOverlap(source: String, candidate: String) -> Double {
+        let sourceWords = normalizeWords(source).split(separator: " ").map(String.init)
+        guard !sourceWords.isEmpty else { return 1 }
+        let candidateWords = Set(normalizeWords(candidate).split(separator: " ").map(String.init))
+        let hit = sourceWords.filter(candidateWords.contains).count
+        return Double(hit) / Double(sourceWords.count)
+    }
+
+    private static func stripStatsAndProgress(_ stdout: String) -> String {
+        stdout
+            .split(whereSeparator: \.isNewline)
+            .filter { line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("[") && trimmed.contains("]") { return false }
+                if trimmed.hasPrefix("time=") && trimmed.contains("decode_tps=") { return false }
+                return true
+            }
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func parseDecodeTps(_ text: String) -> Double? {
+        guard let range = text.range(of: "decode_tps=") else { return nil }
+        let tail = text[range.upperBound...].prefix(16)
+        let number = tail.prefix { $0.isNumber || $0 == "." }
+        return Double(number)
+    }
+}
+
+// MARK: - Deterministic OCR page
+
+#if canImport(CoreGraphics)
+enum GateTextPageRenderer {
+    static let lines: [String] = [
+        "Performance work rewards patience and measurement in equal parts.",
+        "Every token kept on the accelerator is a round trip the processor",
+        "never waits for, and every mask built once per generation replaces",
+        "a thousand uploads. The buffer cache grows to the high-water mark",
+        "and never shrinks, so a cap keeps the footprint honest. Blank",
+        "frames scan host-side from a single readback, and decoder state",
+        "only changes when a token is emitted downstream of the joint.",
+    ]
+
+    /// Renders the fixed paragraph to a PNG and returns the source text used,
+    /// so the OCR check can score word overlap against it.
+    @discardableResult
+    static func render(to url: URL) -> String {
+        let width = 1100
+        let height = 460
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return lines.joined(separator: " ")
+        }
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        let font = CTFontCreateWithName("Helvetica" as CFString, 24, nil)
+        for (index, line) in lines.enumerated() {
+            let attributed = NSAttributedString(string: line, attributes: [
+                NSAttributedString.Key(kCTFontAttributeName as String): font,
+                NSAttributedString.Key(kCTForegroundColorAttributeName as String): CGColor(red: 0, green: 0, blue: 0, alpha: 1),
+            ])
+            let ctLine = CTLineCreateWithAttributedString(attributed)
+            context.textPosition = CGPoint(x: 40, y: height - 60 - index * 52)
+            CTLineDraw(ctLine, context)
+        }
+
+        guard let image = context.makeImage(),
+              let destination = CGImageDestinationCreateWithURL(
+                url as CFURL, UTType.png.identifier as CFString, 1, nil
+              ) else {
+            return lines.joined(separator: " ")
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        CGImageDestinationFinalize(destination)
+        return lines.joined(separator: " ")
+    }
+}
+#endif

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -101,6 +101,16 @@ enum MLXBundleSupport {
             return
 
         case .unstamped:
+            // Provenance unknown — an unstamped flat copy is exactly how the
+            // pre-stamping era's stale libraries survive purges of the Cmlx
+            // bundle. Self-heal from a stamp-matched candidate when one
+            // exists (the vendored bundle usually does) instead of running
+            // on a library that may silently corrupt output.
+            if let replacement = locateCandidateBundle(executableDir: executableDir, matchedOnly: true) {
+                try installCompatibilityMetallibs(bundleURL: replacement, executableDir: executableDir)
+                CLIStderr.write("[mererun] Replaced unstamped MLX metallib in \(resourcesURL.path) with stamped copy from \(replacement.path).\n")
+                return
+            }
             CLIStderr.write(
                 """
                 [mererun] WARNING: the MLX Metal shader library has no version stamp:
@@ -156,6 +166,17 @@ enum MLXBundleSupport {
             try installCompatibilityMetallibs(bundleURL: bundleURL, executableDir: executableDir)
 
         case .unstamped:
+            // Same self-heal as the flat-Resources path: prefer a
+            // stamp-matched candidate over a bundle of unknown provenance.
+            if !justInstalled,
+               let replacement = locateCandidateBundle(executableDir: executableDir, matchedOnly: true) {
+                let fm = FileManager.default
+                try? fm.removeItem(at: bundleURL)
+                try fm.copyItem(at: replacement, to: bundleURL)
+                CLIStderr.write("[mererun] Replaced unstamped MLX metallib bundle with stamped copy from \(replacement.path).\n")
+                try installCompatibilityMetallibs(bundleURL: bundleURL, executableDir: executableDir)
+                return
+            }
             CLIStderr.write(
                 """
                 [mererun] WARNING: the MLX Metal shader library has no version stamp:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,6 +48,7 @@ export default defineConfig({
           { text: 'CLI Reference', link: '/cli' },
           { text: 'Cookbooks', link: '/cookbooks' },
           { text: 'Configuration', link: '/configuration' },
+          { text: 'Quality Gate', link: '/gate' },
           { text: 'Model Sources', link: '/model-sources' }
         ]
       },

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Benchmarking](./benchmarking.md)
 - [Cookbooks](./cookbooks.md)
 - [Configuration](./configuration.md)
+- [Quality Gate](./gate.md)
 - [Model Sources](./model-sources.md)
 - [Repository Tour](./repository-tour.md)
 - [Development Workflow](./development-workflow.md)

--- a/docs/gate.md
+++ b/docs/gate.md
@@ -1,0 +1,99 @@
+# Quality gate
+
+`mere.run gate` is the platform's flight recorder: it runs the real
+user-facing commands against the installed models at temperature 0, hashes
+their outputs, proves in-run determinism, and compares everything against
+machine-local baselines. It exists because a stale Metal library once shipped
+broken ≥1024-token decode to every clone for two months without anything
+noticing — the gate's text checks deliberately include a long-context lane in
+exactly that regime, and its determinism check would have caught the failure
+on the first nightly run.
+
+## What it checks
+
+| check | what it runs | hard-fails on |
+| --- | --- | --- |
+| `text-*-short` / `text-*-long` | `text chat` at temp 0 (Gemma 4 12B, Ornith 35B, LFM2.5), long lane ≥1200 prompt tokens, each executed twice | run-to-run nondeterminism, empty output, output hash drift vs baseline |
+| `tts-wav` | `speech synthesize` at temp 0 | WAV hash drift, truncated audio |
+| `stt-roundtrip` | `speech transcribe` on the TTS output, twice | transcript nondeterminism, <85% word recovery of the spoken sentence |
+| `ocr-page` | `vision ocr` on a deterministically rendered text page, twice | transcript nondeterminism, <90% word recovery |
+| `image-klein-seed7` | seeded `image generate` | PNG hash drift, truncated file |
+| `embeddings` | `text embed`, twice | vector bytes nondeterministic or drifted |
+
+Performance (wall time, `decode_tps` where the engine reports it) is compared
+against the baseline too: regressions beyond 0.75× tok/s or 1.5× wall are
+warnings by default and failures with `--strict-perf` (suitable for a
+dedicated runner; on a shared workstation, background load makes hard perf
+gates noisy).
+
+Checks whose models are not installed are skipped and reported. Every check
+shells out to the same `mere.run` binary that users run — the gate covers the
+CLI surface, model resolution, and the runtime together, not a parallel test
+path.
+
+## Usage
+
+```bash
+# First run on a machine: record baselines
+mere.run gate --update-baselines
+
+# Routine run: exits nonzero on any correctness failure
+mere.run gate
+
+# One suite, JSON report, hard perf gates
+mere.run gate --suite text --strict-perf --json-output /tmp/gate.json
+```
+
+Baselines live at `~/Library/Application Support/MereRun/gate/baselines.json`.
+After an intentionally output-changing merge (sampler changes, model updates,
+scheduler changes), refresh them with `--update-baselines` — the failure
+message says so when a hash drifts.
+
+## Running it nightly
+
+launchd (per-machine, recommended for workstations):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>run.mere.gate</string>
+  <key>ProgramArguments</key><array>
+    <string>/usr/local/bin/mere.run</string>
+    <string>gate</string>
+    <string>--json-output</string>
+    <string>/tmp/mere-gate-latest.json</string>
+  </array>
+  <key>StartCalendarInterval</key><dict>
+    <key>Hour</key><integer>3</integer><key>Minute</key><integer>30</integer>
+  </dict>
+  <key>StandardOutPath</key><string>/tmp/mere-gate.log</string>
+  <key>StandardErrorPath</key><string>/tmp/mere-gate.log</string>
+</dict></plist>
+```
+
+Save as `~/Library/LaunchAgents/run.mere.gate.plist`, then
+`launchctl load ~/Library/LaunchAgents/run.mere.gate.plist`.
+
+GitHub Actions (requires a self-hosted Apple-silicon runner with models
+installed; the hosted runners have no GPU or model store):
+
+```yaml
+name: quality-gate
+on:
+  schedule: [{cron: "30 6 * * *"}]
+  workflow_dispatch:
+jobs:
+  gate:
+    runs-on: [self-hosted, macOS, arm64]
+    steps:
+      - uses: actions/checkout@v7
+        with: {lfs: true}
+      - run: ./scripts/build_mlx_metallib.sh
+      - run: swift build -c release
+      - run: .build/release/mere.run gate --strict-perf --json-output gate-report.json
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with: {name: gate-report, path: gate-report.json}
+```


### PR DESCRIPTION
Power move #1 of the five: the standing quality gate. It exists because a stale Metal library shipped broken ≥1024-token decode to every clone for two months with nothing watching — and on its **maiden run it caught a live recurrence of exactly that bug**, in the very worktree all recent perf PRs were built from.

## What it is

`mere.run gate` shells out to the **real** user-facing commands (text chat, speech synthesize/transcribe, vision ocr, image generate, text embed) at temperature 0, hashes outputs, runs each hashable check **twice for in-run determinism**, and compares against machine-local baselines.

| suite | checks | hard-fails on |
|---|---|---|
| text | Gemma 4 / Ornith 35B / LFM2.5 × short + **≥1200-token long** context | nondeterminism, hash drift, empty output |
| speech | TTS WAV hash; STT roundtrip on the TTS output | drift, <85% word recovery |
| vision | OCR of a CoreGraphics-rendered page | drift, <90% word recovery |
| image | seeded Klein generation | PNG hash drift |
| embed | vector bytes (metadata excluded) | nondeterminism, drift |

Perf (wall, `decode_tps`) warns at 0.75×/1.5× vs baseline; `--strict-perf` hard-fails for dedicated runners. Missing models skip cleanly. `--update-baselines` refreshes after intentional output changes; `--json-output` for automation. `docs/gate.md` covers nightly wiring (launchd + self-hosted Actions).

## What its first run found

1. **Live stale-metallib recurrence + a guard gap.** Long-context Ornith was gibberish/nondeterministic again: an unstamped pre-#131 metallib survived in the products dir's flat `Resources/`, and `MLXBundleSupport` treated *unstamped* as warn-and-continue (warning swallowed by any captured stderr). **Fixed in this PR**: unstamped libraries now self-heal from a stamp-matched candidate (the vendored bundle) in both lookup paths, warn-only as a true last resort.
2. **LFM2.5 spends whole small budgets inside `<think>`** — not a bug, a check-design lesson: chat checks run `--thinking` with a 160-token budget so hashes cover the full deterministic output.

## Proof

Two full passes on the healed metallib: pass 1 records 11 baselines (all determinism sub-checks green), pass 2 matches **11/11, exit 0** (~90s + one 20s image gen per pass, M4 Max).

🤖 Generated with [Claude Code](https://claude.com/claude-code)