### PR TITLE
Serve hardening: single-flag batching, LFM2 prefix default-on, recent-tps

### DIFF
--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -1605,11 +1605,22 @@ actor CodeGenServer {
         self.fallbackLoraPath = fallbackLoraPath
         self.defaultModelID = defaultModelID
         self.requestLimiter = APIRateLimiter(limitPerMinute: rateLimitPerMinute)
+        // Continuous batching follows the request-concurrency setting: any
+        // --max-active-requests above 1 enables it for the engines that
+        // support it, with the per-engine env switches as explicit overrides.
+        // (The previous double-gate — env AND flag — shipped a serve that
+        // silently never batched: /runtime/status showed batchedDecodeSteps=0
+        // under concurrent load until the env was discovered.)
+        let batchingDefault = maxActiveRequests > 1
         let runtimePool = RuntimeModelPool(
             defaultModelID: defaultModelID,
             defaultEngine: engine.runtimeServingEngine,
             startupModelPath: modelPath,
             gemma4KVCacheQuantization: gemma4KVCacheQuantization,
+            gemma4ContinuousBatchingEnabled:
+                runtimeOptionalEnvironmentFlag("MERERUN_GEMMA4_CONTINUOUS_BATCHING") ?? batchingDefault,
+            q35ContinuousBatchingEnabled:
+                runtimeOptionalEnvironmentFlag("MERERUN_Q35_CONTINUOUS_BATCHING") ?? batchingDefault,
             memoryPressurePolicy: memoryPressurePolicy
         )
         self.pool = runtimePool

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -4,6 +4,17 @@ import MereRunCore
 import Darwin
 #endif
 
+/// Tri-state environment flag: nil when unset, so callers can supply a
+/// context-dependent default (e.g. continuous batching following
+/// --max-active-requests).
+func runtimeOptionalEnvironmentFlag(_ key: String) -> Bool? {
+    guard let rawValue = ProcessInfo.processInfo.environment[key] else {
+        return nil
+    }
+    let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return !["0", "false", "no", "off"].contains(normalized)
+}
+
 private func runtimeDefaultOnEnvironmentFlag(_ key: String) -> Bool {
     guard let rawValue = ProcessInfo.processInfo.environment[key] else {
         return true
@@ -56,7 +67,7 @@ struct RuntimeControlPlaneCapabilities: Codable, Equatable, Sendable {
                 enabled: continuousBatchingEnabled,
                 detail: continuousBatchingEnabled
                     ? "Gemma4 and Qwen-family decode rows are packed when typed cache state is compatible; Qwen linear-only rows may batch across decode positions."
-                    : "Decode batching is available behind MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 and MERERUN_Q35_CONTINUOUS_BATCHING=1; set --max-active-requests above 1 to allow overlap."
+                    : "Decode batching engages automatically when --max-active-requests is above 1; MERERUN_GEMMA4_CONTINUOUS_BATCHING / MERERUN_Q35_CONTINUOUS_BATCHING override per engine."
             ),
             prefixKVReuse: RuntimeCapabilityStatus(
                 available: true,
@@ -131,6 +142,10 @@ struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
     let averageDecodeSeconds: Double?
     let averageTotalSeconds: Double?
     let decodeTokensPerSecond: Double?
+    /// Decode throughput over the most recent completions (rolling window of
+    /// 10) — lifetime averages hide mid-flight regressions on long-running
+    /// servers.
+    let recentDecodeTokensPerSecond: Double?
     let lastCompletedAt: Date?
 
     init(
@@ -140,6 +155,8 @@ struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
         totalLoadSeconds: Double,
         totalPrefillSeconds: Double,
         totalDecodeSeconds: Double,
+        recentDecodeTokens: Int = 0,
+        recentDecodeSeconds: Double = 0,
         lastCompletedAt: Date?
     ) {
         self.completedRequests = completedRequests
@@ -154,6 +171,9 @@ struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
         )
         self.decodeTokensPerSecond = totalDecodeSeconds > 0
             ? Double(generatedTokens) / totalDecodeSeconds
+            : nil
+        self.recentDecodeTokensPerSecond = recentDecodeSeconds > 0
+            ? Double(recentDecodeTokens) / recentDecodeSeconds
             : nil
         self.lastCompletedAt = lastCompletedAt
     }
@@ -694,6 +714,7 @@ actor RuntimeModelPool {
         var totalLoadSeconds: Double = 0
         var totalPrefillSeconds: Double = 0
         var totalDecodeSeconds: Double = 0
+        var recentDecodeSamples: [(tokens: Int, seconds: Double)] = []
         var lastCompletedAt: Date?
 
         var benchmarkStats: RuntimeModelBenchmarkStats {
@@ -704,6 +725,8 @@ actor RuntimeModelPool {
                 totalLoadSeconds: totalLoadSeconds,
                 totalPrefillSeconds: totalPrefillSeconds,
                 totalDecodeSeconds: totalDecodeSeconds,
+                recentDecodeTokens: recentDecodeSamples.reduce(0) { $0 + $1.tokens },
+                recentDecodeSeconds: recentDecodeSamples.reduce(0) { $0 + $1.seconds },
                 lastCompletedAt: lastCompletedAt
             )
         }
@@ -740,6 +763,7 @@ actor RuntimeModelPool {
     private let gemma4ContinuousBatchingEnabled: Bool
     private let q35PrefixKVCacheEnabled: Bool
     private let q35ContinuousBatchingEnabled: Bool
+    private let lfm2PrefixKVCacheEnabled: Bool
     private let currentDate: @Sendable () -> Date
     private let currentMemorySample: @Sendable () -> RuntimeMemorySample
     private let memoryPressurePolicy: RuntimeMemoryPressurePolicy
@@ -757,6 +781,7 @@ actor RuntimeModelPool {
         gemma4ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_CONTINUOUS_BATCHING"] == "1",
         q35PrefixKVCacheEnabled: Bool = runtimeDefaultOnEnvironmentFlag("MERERUN_Q35_PREFIX_KV_CACHE"),
         q35ContinuousBatchingEnabled: Bool = ProcessInfo.processInfo.environment["MERERUN_Q35_CONTINUOUS_BATCHING"] == "1",
+        lfm2PrefixKVCacheEnabled: Bool = runtimeDefaultOnEnvironmentFlag("MERERUN_LFM2_PREFIX_KV_CACHE"),
         currentDate: @escaping @Sendable () -> Date = { Date() },
         currentMemorySample: @escaping @Sendable () -> RuntimeMemorySample = { RuntimeMemorySample.current() },
         memoryPressurePolicy: RuntimeMemoryPressurePolicy = .default
@@ -770,6 +795,7 @@ actor RuntimeModelPool {
         self.gemma4ContinuousBatchingEnabled = gemma4ContinuousBatchingEnabled
         self.q35PrefixKVCacheEnabled = q35PrefixKVCacheEnabled
         self.q35ContinuousBatchingEnabled = q35ContinuousBatchingEnabled
+        self.lfm2PrefixKVCacheEnabled = lfm2PrefixKVCacheEnabled
         self.currentDate = currentDate
         self.currentMemorySample = currentMemorySample
         self.memoryPressurePolicy = memoryPressurePolicy
@@ -961,6 +987,10 @@ actor RuntimeModelPool {
             state.totalLoadSeconds += timing.loadSeconds
             state.totalPrefillSeconds += timing.prefillSeconds
             state.totalDecodeSeconds += timing.decodeSeconds
+            state.recentDecodeSamples.append((tokens: response.tokensGenerated, seconds: timing.decodeSeconds))
+            if state.recentDecodeSamples.count > 10 {
+                state.recentDecodeSamples.removeFirst(state.recentDecodeSamples.count - 10)
+            }
         }
         state.lastCompletedAt = currentDate()
         state.lastError = nil
@@ -1126,7 +1156,10 @@ actor RuntimeModelPool {
             )
         case .textChatLFM2:
             return .textChatLFM2(
-                LFM2Generator(modelId: resolved.id),
+                LFM2Generator(
+                    modelId: resolved.id,
+                    prefixKVCacheEnabled: lfm2PrefixKVCacheEnabled
+                ),
                 modelPath: resolved.installPath
             )
         case .textChatDeepseekV4Flash:

--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -27,14 +27,16 @@ public actor LFM2Generator: ChatGenerator {
     private static let prefillChunkSize = 512
     private static let prefixKVCacheMaxEntries = 4
 
-    /// Opt-in (MERERUN_LFM2_PREFIX_KV_CACHE=1) in-memory prompt-prefix reuse,
-    /// mirroring the Qwen-family implementation: forked layer caches (both
-    /// attention KV and conv states support forking) are stored at prefill
-    /// chunk boundaries and the longest matching token prefix seeds the next
-    /// request. Chunk-boundary checkpoints only for now — the Gemma4-style
-    /// semantic chat-template checkpoints are not yet derived for LFM2.
-    private static let prefixKVCacheEnabled: Bool =
-        ProcessInfo.processInfo.environment["MERERUN_LFM2_PREFIX_KV_CACHE"] == "1"
+    /// In-memory prompt-prefix reuse, mirroring the Qwen-family
+    /// implementation: forked layer caches (both attention KV and conv states
+    /// support forking) are stored at prefill chunk boundaries and the
+    /// longest matching token prefix seeds the next request. Chunk-boundary
+    /// checkpoints only for now — the Gemma4-style semantic chat-template
+    /// checkpoints are not yet derived for LFM2. The serve pool passes
+    /// default-on (MERERUN_LFM2_PREFIX_KV_CACHE=0 opts out, matching the
+    /// Gemma4/Q35 pattern); one-shot CLI processes keep it off since a
+    /// prefix cache cannot outlive the process.
+    private let prefixKVCacheEnabled: Bool
 
     private var prefixKVCache: [LFM2PrefixKVCacheKey: LFM2PrefixKVCacheEntry] = [:]
     private var prefixKVCacheHits = 0
@@ -49,8 +51,13 @@ public actor LFM2Generator: ChatGenerator {
 
     private let modelId: String
 
-    public init(modelId: String = LFM2Resources.defaultModelId) {
+    public init(
+        modelId: String = LFM2Resources.defaultModelId,
+        prefixKVCacheEnabled: Bool =
+            ProcessInfo.processInfo.environment["MERERUN_LFM2_PREFIX_KV_CACHE"] == "1"
+    ) {
         self.modelId = modelId
+        self.prefixKVCacheEnabled = prefixKVCacheEnabled
     }
 
     public func chat(
@@ -368,7 +375,7 @@ public actor LFM2Generator: ChatGenerator {
 
     public func prefixKVCacheStats() -> PrefixKVCacheStats {
         PrefixKVCacheStats(
-            enabled: Self.prefixKVCacheEnabled,
+            enabled: prefixKVCacheEnabled,
             entries: prefixKVCache.count,
             maxEntries: Self.prefixKVCacheMaxEntries,
             hits: prefixKVCacheHits,
@@ -383,7 +390,7 @@ public actor LFM2Generator: ChatGenerator {
         modelPath: String?,
         promptTokens: [Int]
     ) -> (tokenCount: Int, caches: [LFM2LayerCache?], logits: MLXArray)? {
-        guard Self.prefixKVCacheEnabled, let modelPath else { return nil }
+        guard prefixKVCacheEnabled, let modelPath else { return nil }
         let matchingKey = prefixKVCache.keys
             .filter { key in
                 key.modelPath == modelPath
@@ -415,7 +422,7 @@ public actor LFM2Generator: ChatGenerator {
         cache: [LFM2LayerCache?],
         logits: MLXArray
     ) {
-        guard Self.prefixKVCacheEnabled, tokenCount > 0 else { return }
+        guard prefixKVCacheEnabled, tokenCount > 0 else { return }
         let key = LFM2PrefixKVCacheKey(
             modelPath: modelPath,
             tokens: Array(promptTokens.prefix(tokenCount))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,9 @@ Continuous batching and SSD KV cache are not enabled by this flag.
 
 ### `MERERUN_LFM2_PREFIX_KV_CACHE`
 
-Opt-in (`1`): in-memory prompt-prefix reuse for the LFM2 chat runtime,
+In-memory prompt-prefix reuse for the LFM2 chat runtime, enabled by default
+in `mere.run api serve` (set `0`, `false`, or `off` to disable; one-shot CLI
+invocations keep it off since a prefix cache cannot outlive the process),
 mirroring the Qwen-family implementation. Forked layer caches (attention KV
 and short-conv states both support forking) are stored at prefill chunk
 boundaries and the longest matching token prefix seeds later requests, so a
@@ -82,6 +84,18 @@ checkpoints only — Gemma4-style semantic chat-template checkpoints are not
 yet derived for LFM2. Bounded to 4 entries with the shared retention planner.
 Measured on a ~2.9k-token prompt: repeat requests drop from 11.7s to 0.3s
 end to end.
+
+### Continuous batching (`MERERUN_GEMMA4_CONTINUOUS_BATCHING`, `MERERUN_Q35_CONTINUOUS_BATCHING`)
+
+Decode batching for concurrent requests engages automatically when
+`mere.run api serve` runs with `--max-active-requests` above 1 — the
+concurrency flag is the single switch. The per-engine environment variables
+remain as explicit overrides in both directions (`1` forces batching on even
+at concurrency 1, `0` forces the serial path). `/runtime/status` reports
+engagement under `decodeBatching` (`batchedDecodeSteps`, `maxBatchSize`);
+per-model stats include `recentDecodeTokensPerSecond`, a rolling last-10
+window that surfaces mid-flight throughput regressions lifetime averages
+hide.
 
 ### `MERERUN_GEMMA4_MTP`
 


### PR DESCRIPTION
Power move #5: make `api serve` behave like the product spine it is — the good machinery stops hiding behind flag combinations.

## Changes

1. **Continuous batching = `--max-active-requests`.** Above 1, decode batching engages automatically (env switches remain as explicit overrides both ways). The old double-gate shipped servers that silently never batched — the `batchedDecodeSteps=0` incident from the platform sweep is now structurally impossible.
2. **LFM2 prefix-KV default-on under serve** (env `=0` opts out), joining the Gemma4/Q35 pattern via pool wiring; one-shot CLI stays off (a prefix cache can't outlive the process).
3. **`recentDecodeTokensPerSecond`** per model in `/runtime/status`: rolling last-10 window, because lifetime averages hide mid-flight regressions on long-running servers.

## Verified live — zero env configuration in all three

| check | result |
|---|---|
| `--max-active-requests 3`, 3 concurrent sampled Ornith requests | `batchedDecodeSteps=47, maxBatchSize=3`, coherent responses |
| LFM2 ~2.2k-token prompt repeated | **6.63s → 0.27s** |
| serial request telemetry | `recentDecodeTokensPerSecond: 127.9` |

Known gap carried honestly: batched-decode responses don't populate `ChatTiming` (pre-existing), so batch-served rows count in request totals but not timing-derived stats — a natural follow-up when the batch scheduler grows per-row timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)