### PR TITLE
Prompt-lookup speculative decoding for Gemma4 greedy decode

### DIFF
--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -103,6 +103,64 @@ private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
 }
 
 public actor Gemma4Generator: ChatGenerator {
+    /// Draft-model-free speculation for greedy decode when no MTP assistant
+    /// is loaded: drafts are the continuation of the most recent earlier
+    /// occurrence of the current token suffix in the context. Opt-in via
+    /// MERERUN_GEMMA4_PROMPT_LOOKUP=1 because eligible requests leave the
+    /// pipelined loop for the serial one — a large win when generation echoes
+    /// the context (quoted documents, code edits, tool loops), a small tax
+    /// when nothing repeats.
+    private static let promptLookupSpeculationEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PROMPT_LOOKUP"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "1" || raw == "true" || raw == "on"
+    }()
+
+    /// Draft length for prompt-lookup speculation
+    /// (MERERUN_GEMMA4_PROMPT_LOOKUP_BLOCK, default 8). Lookup drafts cost
+    /// nothing to produce, so they run longer than assistant-model blocks.
+    private static let promptLookupBlockSize: Int = {
+        if let raw = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PROMPT_LOOKUP_BLOCK"],
+           let value = Int(raw), value >= 1, value <= 64 {
+            return value
+        }
+        return 8
+    }()
+
+    /// Finds the most recent earlier occurrence of the context's trailing
+    /// 3-gram (falling back to 2-gram) and proposes the tokens that followed
+    /// it. Host-side scan over Ints — microseconds at chat context lengths.
+    static func promptLookupDraft(
+        context: [Int],
+        blockSize: Int,
+        maxMatchLength: Int = 3,
+        minMatchLength: Int = 2
+    ) -> [Int] {
+        guard blockSize >= 1, context.count >= minMatchLength + 2 else { return [] }
+        for matchLength in stride(from: maxMatchLength, through: minMatchLength, by: -1) {
+            guard context.count > matchLength else { continue }
+            let suffixStart = context.count - matchLength
+            var start = suffixStart - 1
+            while start >= 0 {
+                var matched = true
+                for offset in 0..<matchLength where context[start + offset] != context[suffixStart + offset] {
+                    matched = false
+                    break
+                }
+                if matched {
+                    let followStart = start + matchLength
+                    let followEnd = min(followStart + blockSize, context.count)
+                    if followStart < followEnd {
+                        return Array(context[followStart..<followEnd])
+                    }
+                    return []
+                }
+                start -= 1
+            }
+        }
+        return []
+    }
+
     private static let prefillChunkSize = 512
     private static let prefixKVCacheMaxEntries = 4
 
@@ -816,6 +874,7 @@ public actor Gemma4Generator: ChatGenerator {
         var mtpStats = mtpStatsTemplate
         var firstTokenSeconds: Double?
         var pendingSampledToken: Int?
+        var promptLookupMisses = 0
         var jsonScanner = JSONPrefixScanner()
         let decodeStart = Date()
         let traceEnabled = Gemma4DecodeTrace.enabled
@@ -878,8 +937,9 @@ public actor Gemma4Generator: ChatGenerator {
                 break
             }
 
+            var draftTokens: [Int] = []
+            var speculationBaseCaches: [Gemma4AttentionCache]?
             if let mtpModel, let hidden = previousHidden, !jsonConstrained, !currentSharedKVStates.isEmpty {
-                let baseCaches = layerCaches
                 let blockSize = min(
                     mtpStats.blockSize,
                     max(2, tokenBudget - generated.count + 1)
@@ -901,12 +961,38 @@ public actor Gemma4Generator: ChatGenerator {
                     generationConfig: draftConfig,
                     repetitionHistory: repetitionHistory
                 )
-                if !draft.tokens.isEmpty {
+                draftTokens = draft.tokens
+                speculationBaseCaches = layerCaches
+            } else if mtpModel == nil,
+                      Self.promptLookupSpeculationEnabled,
+                      // Three straight zero-accept rounds mean the text repeats
+                      // n-grams without repeating continuations (common phrases
+                      // in fresh prose); stop paying for verify forwards.
+                      promptLookupMisses < 3,
+                      !jsonConstrained,
+                      generationConfig.temperature <= 0 {
+                // Draft-model-free speculation: if the tokens just generated
+                // echo an earlier stretch of the context (tool loops, quoted
+                // documents, code edits), propose the continuation of that
+                // earlier stretch and let the standard verify pass keep only
+                // exact matches. Free when nothing repeats — no match, no
+                // draft, no extra forward.
+                draftTokens = Self.promptLookupDraft(
+                    context: repetitionHistory,
+                    blockSize: Self.promptLookupBlockSize
+                )
+                if !draftTokens.isEmpty {
+                    speculationBaseCaches = layerCaches
+                    mtpStats.reason = "prompt-lookup speculation"
+                }
+            }
+            if let baseCaches = speculationBaseCaches, !draftTokens.isEmpty {
+                do {
                     mtpStats.rounds += 1
-                    mtpStats.draftedTokens += draft.tokens.count
+                    mtpStats.draftedTokens += draftTokens.count
                     let candidateCaches = forkLayerCaches(baseCaches)
-                    let candidateInput = MLXArray(([next] + draft.tokens).map(Int32.init))
-                        .reshaped(1, draft.tokens.count + 1)
+                    let candidateInput = MLXArray(([next] + draftTokens).map(Int32.init))
+                        .reshaped(1, draftTokens.count + 1)
                     let candidate = model.forwardForSpeculation(
                         inputIds: candidateInput,
                         cache: candidateCaches
@@ -925,9 +1011,9 @@ public actor Gemma4Generator: ChatGenerator {
                         tokens: generationConfig.bannedTokens
                     )
                     var verifySampleArrays: [MLXArray] = []
-                    verifySampleArrays.reserveCapacity(draft.tokens.count + 1)
+                    verifySampleArrays.reserveCapacity(draftTokens.count + 1)
                     var prospectiveHistory = repetitionHistory
-                    for index in 0...draft.tokens.count {
+                    for index in 0...draftTokens.count {
                         verifySampleArrays.append(sampledTokenArray(
                             logits: candidate.logits[0, index, 0...],
                             config: generationConfig,
@@ -937,8 +1023,8 @@ public actor Gemma4Generator: ChatGenerator {
                             ),
                             banMask: verifyBanMask
                         ))
-                        if index < draft.tokens.count {
-                            prospectiveHistory.append(draft.tokens[index])
+                        if index < draftTokens.count {
+                            prospectiveHistory.append(draftTokens[index])
                         }
                     }
                     let stackedVerify = MLX.stacked(verifySampleArrays)
@@ -947,7 +1033,7 @@ public actor Gemma4Generator: ChatGenerator {
 
                     var accepted = 0
                     var replacement: Int?
-                    for (index, draftToken) in draft.tokens.enumerated() {
+                    for (index, draftToken) in draftTokens.enumerated() {
                         guard verifySamples[index] == draftToken else {
                             replacement = verifySamples[index]
                             mtpStats.rejectedTokens += 1
@@ -955,10 +1041,13 @@ public actor Gemma4Generator: ChatGenerator {
                         }
                         accepted += 1
                     }
+                    if mtpModel == nil {
+                        promptLookupMisses = accepted == 0 ? promptLookupMisses + 1 : 0
+                    }
 
-                    if accepted == draft.tokens.count {
+                    if accepted == draftTokens.count {
                         var hitEOS = false
-                        for token in draft.tokens {
+                        for token in draftTokens {
                             if eosSet.contains(token) {
                                 hitEOS = true
                                 break
@@ -982,14 +1071,14 @@ public actor Gemma4Generator: ChatGenerator {
                         }
                         // The bonus token was already sampled in the batched
                         // verify pass (last position, full-draft history).
-                        pendingSampledToken = verifySamples[draft.tokens.count]
+                        pendingSampledToken = verifySamples[draftTokens.count]
                         if let previousHidden {
                             MLX.eval(previousHidden)
                         }
                         continue
                     }
 
-                    let acceptedPrefix = Array(draft.tokens.prefix(accepted))
+                    let acceptedPrefix = Array(draftTokens.prefix(accepted))
                     var hitEOS = false
                     for token in acceptedPrefix {
                         if eosSet.contains(token) {
@@ -1090,7 +1179,15 @@ public actor Gemma4Generator: ChatGenerator {
         // the CPU before the next forward; everything else can pipeline, sampling
         // included — the token stays on the GPU and only the previous step's
         // readback blocks.
-        mtpModel == nil && !jsonConstrained
+        if mtpModel != nil || jsonConstrained {
+            return false
+        }
+        // Prompt-lookup speculation also needs each confirmed token host-side
+        // to scan for n-gram matches, so eligible requests take the serial loop.
+        if Self.promptLookupSpeculationEnabled, config.temperature <= 0 {
+            return false
+        }
+        return true
     }
 
     private func decodeTokensPipelined(

--- a/Tests/MereRunCoreTests/PromptLookupDraftTests.swift
+++ b/Tests/MereRunCoreTests/PromptLookupDraftTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import MereRunCore
+
+/// The n-gram matcher behind Gemma4 prompt-lookup speculation. Pure host
+/// function: no models involved.
+final class PromptLookupDraftTests: XCTestCase {
+    func testDraftsContinuationOfEarlierTrigram() {
+        // ... 1 2 3 9 9 ... 1 2 3 -> should draft [9, 9, ...]
+        let context = [5, 1, 2, 3, 9, 9, 8, 7, 6, 1, 2, 3]
+        let draft = Gemma4Generator.promptLookupDraft(context: context, blockSize: 4)
+        XCTAssertEqual(draft, [9, 9, 8, 7])
+    }
+
+    func testPrefersMostRecentOccurrence() {
+        // 1 2 3 appears twice earlier; the LATER one (followed by 42) wins.
+        let context = [1, 2, 3, 7, 0, 1, 2, 3, 42, 5, 1, 2, 3]
+        let draft = Gemma4Generator.promptLookupDraft(context: context, blockSize: 2)
+        XCTAssertEqual(draft, [42, 5])
+    }
+
+    func testFallsBackToBigramWhenNoTrigramMatch() {
+        // trailing trigram [9, 2, 3] never occurred; bigram [2, 3] did.
+        let context = [1, 2, 3, 8, 8, 8, 9, 2, 3]
+        let draft = Gemma4Generator.promptLookupDraft(context: context, blockSize: 3)
+        XCTAssertEqual(draft, [8, 8, 8])
+    }
+
+    func testClipsAtContextEnd() {
+        let context = [1, 2, 3, 4, 1, 2, 3]
+        // Match at start; only [4] follows before running into the tail —
+        // the draft can extend across the tail region.
+        let draft = Gemma4Generator.promptLookupDraft(context: context, blockSize: 8)
+        XCTAssertEqual(draft, [4, 1, 2, 3])
+    }
+
+    func testNoMatchDraftsNothing() {
+        XCTAssertEqual(Gemma4Generator.promptLookupDraft(context: [1, 2, 3, 4, 5, 6, 7], blockSize: 4), [])
+    }
+
+    func testDegenerateContextsDraftNothing() {
+        XCTAssertEqual(Gemma4Generator.promptLookupDraft(context: [], blockSize: 4), [])
+        XCTAssertEqual(Gemma4Generator.promptLookupDraft(context: [1, 2], blockSize: 4), [])
+        XCTAssertEqual(Gemma4Generator.promptLookupDraft(context: [1, 2, 3, 1, 2, 3], blockSize: 0), [])
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,26 @@ maximize the match rate. Off by default: with the current assistant the
 acceptance economics measured below the pipelined sampled decode path at long
 context.
 
+### `MERERUN_GEMMA4_PROMPT_LOOKUP`
+
+Opt-in (`1`, `true`, or `on`) draft-model-free speculation for Gemma 4 12B
+greedy (temperature 0) requests when no MTP assistant is active. Drafts are
+the continuation of the most recent earlier occurrence of the trailing token
+3-gram (2-gram fallback) in the context, verified exactly like MTP drafts, so
+outputs are token-identical to plain greedy decode. A large win when
+generation echoes the context — quoted documents, retrieval answers, code
+edits, tool loops (measured 2.2× on an echo workload) — but eligible requests
+leave the pipelined decode loop for the serial one, which costs roughly 15%
+when nothing repeats; three consecutive zero-accept rounds stop further
+lookups for the request. MTP takes precedence when its assistant is active;
+JSON-constrained requests never use lookup.
+
+### `MERERUN_GEMMA4_PROMPT_LOOKUP_BLOCK`
+
+Draft length for prompt-lookup speculation (default `8`, range 1–64). Lookup
+drafts cost nothing to produce, so they run longer than assistant-model draft
+blocks.
+
 ### `MERERUN_Q35_FUSED_SWITCH_GLU`
 
 Qwen-family MoE blocks stack the gate and up expert weights so each

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -59,6 +59,10 @@ companion as `text-chat-gemma4-12b-mtp`; when it is present, greedy serial
 decode can use native MTP on the decode tail after text or multimodal prefill.
 Sampled requests, prefix-KV seeded requests, continuous batching, raw local
 model paths, and prompts below the MTP threshold fall back to baseline decode.
+When no assistant is active, `MERERUN_GEMMA4_PROMPT_LOOKUP=1` enables
+draft-model-free speculation for greedy requests that drafts from repeated
+context n-grams — output-identical, and worth ~2× when generation echoes the
+prompt (see [Configuration](../configuration.md#mererun_gemma4_prompt_lookup)).
 Use these chat winners by RAM band instead of treating every supported model as
 equally recommended:
 


### PR DESCRIPTION
## What

Draft-model-free speculative decoding for Gemma 4 12B greedy requests, opt-in via `MERERUN_GEMMA4_PROMPT_LOOKUP=1` (`MERERUN_GEMMA4_PROMPT_LOOKUP_BLOCK` sets draft length, default 8, 1–64).

When the tokens just generated echo an earlier stretch of the context — quoted documents, retrieval answers, code edits, tool loops — the continuation of the most recent earlier occurrence of the trailing 3-gram (2-gram fallback) is proposed as a draft block and verified in **one batched forward**, exactly like an MTP draft. The matcher is a host-side backward scan over `Int`s (microseconds at chat context lengths; no allocations until a match).

## How

- The serial loop's speculation block is generalized: `draftTokens` + `speculationBaseCaches` are populated by **either** the MTP assistant (unchanged, takes precedence when active) **or** the new `promptLookupDraft` matcher. Verify/accept/reject/bonus-token logic is shared, so lookup inherits the batched verify sampling with prospective repetition histories.
- `canUsePipelinedDecode` routes eligible requests (greedy, non-JSON, lookup enabled, no MTP) to the serial loop — lookup needs each confirmed token host-side to scan for matches.
- **Miss backoff**: three consecutive zero-accept rounds stop further lookups for the request (fresh prose repeats n-grams without repeating continuations; no point paying for verify forwards).
- Engagement is observable: `MERERUN_GEMMA4_DECODE_TRACE=1` reports `mode=serial … reason=prompt-lookup speculation rounds/drafted/accepted/rejected`.

## Why opt-in

Eligible requests leave the pipelined loop, whose schedule/readback overlap is worth ~15% when nothing repeats. Default stays pipelined; the flag targets echo-heavy workloads.

## Measurements (`text-chat-gemma4-12b-4bit`, MTP off, temp 0, 120 tokens, M4 Max)

| workload | lookup off | lookup on | outputs |
|---|---|---|---|
| echo (repeat a 500-char paragraph) | 36.25 tok/s | **79.43 tok/s (2.19×)**, 63/64 drafted accepted | identical |
| fresh prose control | 37.1 tok/s | 31.5 tok/s (rounds capped at 3 by backoff) | identical |

Correctness: greedy verify emits the target model's own argmax at every position, so outputs are token-identical by construction — confirmed on both workloads.

## Verification

- `PromptLookupDraftTests` 6/6 (trigram continuation, most-recent preference, bigram fallback, tail clipping, no-match, degenerate inputs)
- Gate text suite (merged with #140 on a throwaway branch): **6/6 hashes match baselines** with the flag unset — default path untouched. One soft WARN on `text-lfm2-long` wall time, an engine this PR doesn't touch, consistent with load-time variance seen in #140's own passes.
- JSON-constrained and sampled requests never take the lookup path; MTP behavior unchanged.

## Follow-up

Integrating lookup bursts directly into the pipelined loop would remove the ~15% miss tax and make the flag default-on material; noted for a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
