### PR TITLE
Gemma4 prompt-lookup speculation as pipelined-loop bursts, default on

### DIFF
--- a/Sources/MereRunCLI/Support/GateSupport.swift
+++ b/Sources/MereRunCLI/Support/GateSupport.swift
@@ -1,6 +1,10 @@
 import Crypto
 import Foundation
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 #if canImport(CoreGraphics)
 import CoreGraphics
 import CoreText
@@ -369,11 +373,18 @@ struct GateRunner: Sendable {
     }
 
     static func hardwareModel() -> String {
+        #if canImport(Darwin)
         var size = 0
         sysctlbyname("hw.model", nil, &size, nil, 0)
         var value = [CChar](repeating: 0, count: size)
         sysctlbyname("hw.model", &value, &size, nil, 0)
-        return String(cString: value)
+        let bytes = value.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+        #elseif os(Linux)
+        return "Linux"
+        #else
+        return "Unknown"
+        #endif
     }
 
     /// Hashes only the embedding vectors from a /v1/embeddings-shaped JSON

--- a/Sources/MereRunCLI/Support/RunInspection.swift
+++ b/Sources/MereRunCLI/Support/RunInspection.swift
@@ -1104,16 +1104,22 @@ struct RunListAnalyzer {
         let runDirectory = envelope.result.runDirectory
         let report = envelope.result.report
         let plan = envelope.result.plan
-        let createdAt = runDirectory?.manifest?.createdAt ??
-            runDirectory?.legacyManifest?.createdAt ??
-            report?.createdAt ??
-            plan?.createdAt
-        let updatedAt = runDirectory?.events.latest?.createdAt ??
-            runDirectory?.legacyManifest?.updatedAt ??
-            runDirectory?.legacyManifest?.createdAt ??
-            runDirectory?.manifest?.createdAt ??
-            report?.createdAt ??
-            plan?.createdAt
+        let manifestCreatedAt = runDirectory?.manifest?.createdAt
+        let legacyCreatedAt = runDirectory?.legacyManifest?.createdAt
+        let reportCreatedAt = report?.createdAt
+        let planCreatedAt = plan?.createdAt
+        let eventCreatedAt = runDirectory?.events.latest?.createdAt
+        let legacyUpdatedAt = runDirectory?.legacyManifest?.updatedAt
+        let createdAt = manifestCreatedAt ??
+            legacyCreatedAt ??
+            reportCreatedAt ??
+            planCreatedAt
+        let updatedAt = eventCreatedAt ??
+            legacyUpdatedAt ??
+            legacyCreatedAt ??
+            manifestCreatedAt ??
+            reportCreatedAt ??
+            planCreatedAt
         return RunListEntry(
             id: Self.entryID(for: relativePath, kind: envelope.result.kind),
             kind: envelope.result.kind,

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -105,15 +105,14 @@ private final class Gemma4BatchedDecodeRow: @unchecked Sendable {
 public actor Gemma4Generator: ChatGenerator {
     /// Draft-model-free speculation for greedy decode when no MTP assistant
     /// is loaded: drafts are the continuation of the most recent earlier
-    /// occurrence of the current token suffix in the context. Opt-in via
-    /// MERERUN_GEMMA4_PROMPT_LOOKUP=1 because eligible requests leave the
-    /// pipelined loop for the serial one — a large win when generation echoes
-    /// the context (quoted documents, code edits, tool loops), a small tax
-    /// when nothing repeats.
+    /// occurrence of the current token suffix in the context, verified in
+    /// bursts inside the pipelined loop. A no-match token costs one host-side
+    /// scan (microseconds) and no GPU work, so this is enabled by default;
+    /// MERERUN_GEMMA4_PROMPT_LOOKUP=0 disables.
     private static let promptLookupSpeculationEnabled: Bool = {
         let raw = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_PROMPT_LOOKUP"]?
             .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return raw == "1" || raw == "true" || raw == "on"
+        return raw != "0" && raw != "false" && raw != "off"
     }()
 
     /// Draft length for prompt-lookup speculation
@@ -874,7 +873,6 @@ public actor Gemma4Generator: ChatGenerator {
         var mtpStats = mtpStatsTemplate
         var firstTokenSeconds: Double?
         var pendingSampledToken: Int?
-        var promptLookupMisses = 0
         var jsonScanner = JSONPrefixScanner()
         let decodeStart = Date()
         let traceEnabled = Gemma4DecodeTrace.enabled
@@ -963,28 +961,6 @@ public actor Gemma4Generator: ChatGenerator {
                 )
                 draftTokens = draft.tokens
                 speculationBaseCaches = layerCaches
-            } else if mtpModel == nil,
-                      Self.promptLookupSpeculationEnabled,
-                      // Three straight zero-accept rounds mean the text repeats
-                      // n-grams without repeating continuations (common phrases
-                      // in fresh prose); stop paying for verify forwards.
-                      promptLookupMisses < 3,
-                      !jsonConstrained,
-                      generationConfig.temperature <= 0 {
-                // Draft-model-free speculation: if the tokens just generated
-                // echo an earlier stretch of the context (tool loops, quoted
-                // documents, code edits), propose the continuation of that
-                // earlier stretch and let the standard verify pass keep only
-                // exact matches. Free when nothing repeats — no match, no
-                // draft, no extra forward.
-                draftTokens = Self.promptLookupDraft(
-                    context: repetitionHistory,
-                    blockSize: Self.promptLookupBlockSize
-                )
-                if !draftTokens.isEmpty {
-                    speculationBaseCaches = layerCaches
-                    mtpStats.reason = "prompt-lookup speculation"
-                }
             }
             if let baseCaches = speculationBaseCaches, !draftTokens.isEmpty {
                 do {
@@ -1040,9 +1016,6 @@ public actor Gemma4Generator: ChatGenerator {
                             break
                         }
                         accepted += 1
-                    }
-                    if mtpModel == nil {
-                        promptLookupMisses = accepted == 0 ? promptLookupMisses + 1 : 0
                     }
 
                     if accepted == draftTokens.count {
@@ -1178,16 +1151,9 @@ public actor Gemma4Generator: ChatGenerator {
         // MTP verification and JSON-constrained decoding both need each token on
         // the CPU before the next forward; everything else can pipeline, sampling
         // included — the token stays on the GPU and only the previous step's
-        // readback blocks.
-        if mtpModel != nil || jsonConstrained {
-            return false
-        }
-        // Prompt-lookup speculation also needs each confirmed token host-side
-        // to scan for n-gram matches, so eligible requests take the serial loop.
-        if Self.promptLookupSpeculationEnabled, config.temperature <= 0 {
-            return false
-        }
-        return true
+        // readback blocks. Prompt-lookup speculation runs as bursts inside the
+        // pipelined loop itself, so it never forces the serial path.
+        mtpModel == nil && !jsonConstrained
     }
 
     private func decodeTokensPipelined(
@@ -1202,7 +1168,9 @@ public actor Gemma4Generator: ChatGenerator {
         mtpStatsTemplate: Gemma4MTPStats,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Gemma4BatchedDecodeResult {
-        let layerCaches = layerCaches
+        var layerCaches = layerCaches
+        var mtpStats = mtpStatsTemplate
+        var promptLookupMisses = 0
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = greedyRepetitionHistoryArray(
@@ -1230,7 +1198,7 @@ public actor Gemma4Generator: ChatGenerator {
         var traceSampleSeconds = 0.0
         var traceScheduleSeconds = 0.0
 
-        while generated.count < tokenBudget {
+        decode: while generated.count < tokenBudget {
             try Task.checkCancellation()
 
             let buildStart = CFAbsoluteTimeGetCurrent()
@@ -1283,6 +1251,36 @@ public actor Gemma4Generator: ChatGenerator {
                 }
             }
 
+            if Self.promptLookupSpeculationEnabled,
+               generationConfig.temperature <= 0,
+               promptLookupMisses < 3,
+               let scheduled,
+               generated.count < tokenBudget {
+                switch promptLookupBurst(
+                    model: model,
+                    tokenizerAndTemplate: tokenizerAndTemplate,
+                    scheduledToken: scheduled.token,
+                    promptTokens: promptTokens,
+                    eosSet: eosSet,
+                    generationConfig: generationConfig,
+                    tokenBudget: tokenBudget,
+                    generated: &generated,
+                    layerCaches: &layerCaches,
+                    pendingToken: &pendingToken,
+                    repetitionHistory: &repetitionHistory,
+                    mtpStats: &mtpStats,
+                    promptLookupMisses: &promptLookupMisses,
+                    progressHandler: progressHandler
+                ) {
+                case .notAttempted:
+                    break
+                case .resumed:
+                    continue decode
+                case .finished:
+                    break decode
+                }
+            }
+
             guard let scheduled, generated.count < tokenBudget else {
                 break
             }
@@ -1308,8 +1306,225 @@ public actor Gemma4Generator: ChatGenerator {
             generatedTokens: generated,
             decodeSeconds: Date().timeIntervalSince(decodeStart),
             firstTokenSeconds: firstTokenSeconds,
-            mtpStats: mtpStatsTemplate
+            mtpStats: mtpStats
         )
+    }
+
+    private enum PromptLookupBurstOutcome {
+        /// No n-gram match; the caller proceeds with the normal lagged step.
+        case notAttempted
+        /// Burst ran; pendingToken/repetitionHistory/layerCaches rebuilt — caller continues the loop.
+        case resumed
+        /// EOS or token budget reached inside the burst — caller ends decode.
+        case finished
+    }
+
+    /// One prompt-lookup speculation round inside the pipelined loop. Fires
+    /// only when the trailing n-gram of the confirmed context recurs earlier
+    /// (host-side scan, no GPU cost when it doesn't). The already-scheduled
+    /// token is confirmed early — the burst's only pipeline cost — and
+    /// anchors a serial-style batched verify of the lookup draft, after
+    /// which the lagged loop resumes with rebuilt state. Verify sampling is
+    /// the same sampler with the same prospective histories the plain loop
+    /// would have used, so greedy outputs are token-identical.
+    private func promptLookupBurst(
+        model: any Gemma4CausalModel,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        scheduledToken: MLXArray,
+        promptTokens: [Int],
+        eosSet: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        generated: inout [Int],
+        layerCaches: inout [Gemma4AttentionCache],
+        pendingToken: inout MLXArray,
+        repetitionHistory: inout MLXArray?,
+        mtpStats: inout Gemma4MTPStats,
+        promptLookupMisses: inout Int,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) -> PromptLookupBurstOutcome {
+        let probe = Self.promptLookupDraft(
+            context: promptTokens + generated,
+            blockSize: Self.promptLookupBlockSize
+        )
+        guard !probe.isEmpty else { return .notAttempted }
+
+        func emit(_ token: Int) {
+            if let progressHandler {
+                let piece = tokenizerAndTemplate.decode(token: token)
+                if !piece.isEmpty {
+                    progressHandler(ChatProgress(stage: .generating, message: piece))
+                }
+            }
+        }
+
+        // Confirm the scheduled token; it becomes the verify anchor (the
+        // serial loop's `next`): sampled and appended, forward not yet run.
+        let anchor = scheduledToken.item(Int.self)
+        if eosSet.contains(anchor) {
+            return .finished
+        }
+        generated.append(anchor)
+        emit(anchor)
+        if generated.count >= tokenBudget {
+            return .finished
+        }
+
+        var hostContext = promptTokens + generated
+        let draftTokens = Self.promptLookupDraft(
+            context: hostContext,
+            blockSize: Self.promptLookupBlockSize
+        )
+
+        func resume(samplingFrom logits: MLXArray, contextBeforePending: [Int]) {
+            let history = repetitionHistoryArray(promptTokens: contextBeforePending, config: generationConfig)
+            let banMask = tokenBanMask(
+                vocabularySize: logits.dim(-1),
+                dtype: logits.dtype,
+                tokens: generationConfig.bannedTokens
+            )
+            let sampled = sampledTokenArray(
+                logits: logits[0, -1, 0...],
+                config: generationConfig,
+                previousTokenIndices: history,
+                banMask: banMask
+            )
+            MLX.asyncEval(sampled)
+            pendingToken = sampled
+            repetitionHistory = appendingRepetitionHistory(history, token: sampled, config: generationConfig)
+        }
+
+        guard !draftTokens.isEmpty else {
+            // The anchor broke the match. Its forward has not run yet, so run
+            // it and sample the next token — one synchronous step, then the
+            // lag re-establishes. Counted as a miss: repeated anchor-breaks
+            // mean the text repeats n-grams without repeating continuations.
+            promptLookupMisses += 1
+            let logits = model.forward(
+                inputIds: MLXArray([Int32(anchor)]).reshaped(1, 1),
+                cache: layerCaches
+            )
+            resume(samplingFrom: logits, contextBeforePending: hostContext)
+            return .resumed
+        }
+
+        mtpStats.rounds += 1
+        mtpStats.draftedTokens += draftTokens.count
+        mtpStats.reason = "prompt-lookup speculation"
+
+        let candidateCaches = forkLayerCaches(layerCaches)
+        let candidateInput = MLXArray(([anchor] + draftTokens).map(Int32.init))
+            .reshaped(1, draftTokens.count + 1)
+        let candidate = model.forwardForSpeculation(
+            inputIds: candidateInput,
+            cache: candidateCaches
+        )
+
+        // Batched verify sampling with prospective histories — one graph,
+        // one readback, identical math to the serial speculation block.
+        let verifyBanMask = tokenBanMask(
+            vocabularySize: candidate.logits.dim(-1),
+            dtype: candidate.logits.dtype,
+            tokens: generationConfig.bannedTokens
+        )
+        var verifySampleArrays: [MLXArray] = []
+        verifySampleArrays.reserveCapacity(draftTokens.count + 1)
+        var prospectiveHistory = hostContext
+        for index in 0...draftTokens.count {
+            verifySampleArrays.append(sampledTokenArray(
+                logits: candidate.logits[0, index, 0...],
+                config: generationConfig,
+                previousTokenIndices: repetitionHistoryArray(
+                    promptTokens: prospectiveHistory,
+                    config: generationConfig
+                ),
+                banMask: verifyBanMask
+            ))
+            if index < draftTokens.count {
+                prospectiveHistory.append(draftTokens[index])
+            }
+        }
+        let stackedVerify = MLX.stacked(verifySampleArrays)
+        MLX.eval(stackedVerify)
+        let verifySamples = stackedVerify.asArray(Int32.self).map(Int.init)
+
+        var accepted = 0
+        var replacement: Int?
+        for (index, draftToken) in draftTokens.enumerated() {
+            guard verifySamples[index] == draftToken else {
+                replacement = verifySamples[index]
+                mtpStats.rejectedTokens += 1
+                break
+            }
+            accepted += 1
+        }
+        promptLookupMisses = accepted == 0 ? promptLookupMisses + 1 : 0
+
+        if accepted == draftTokens.count {
+            for token in draftTokens {
+                if eosSet.contains(token) {
+                    return .finished
+                }
+                generated.append(token)
+                hostContext.append(token)
+                mtpStats.acceptedTokens += 1
+                emit(token)
+            }
+            layerCaches = candidateCaches
+            if generated.count >= tokenBudget {
+                return .finished
+            }
+            // The bonus token was already sampled in the batched verify pass
+            // (last position, full-draft history) — it becomes pendingToken.
+            let bonus = verifySamples[draftTokens.count]
+            pendingToken = MLXArray([Int32(bonus)])
+            repetitionHistory = appendingRepetitionHistory(
+                repetitionHistoryArray(promptTokens: hostContext, config: generationConfig),
+                token: pendingToken,
+                config: generationConfig
+            )
+            return .resumed
+        }
+
+        let acceptedPrefix = Array(draftTokens.prefix(accepted))
+        for token in acceptedPrefix {
+            if eosSet.contains(token) {
+                return .finished
+            }
+            generated.append(token)
+            hostContext.append(token)
+            mtpStats.acceptedTokens += 1
+            emit(token)
+        }
+        if generated.count >= tokenBudget {
+            return .finished
+        }
+        guard let replacement else {
+            return .finished
+        }
+        if eosSet.contains(replacement) {
+            return .finished
+        }
+        generated.append(replacement)
+        hostContext.append(replacement)
+        emit(replacement)
+        if generated.count >= tokenBudget {
+            return .finished
+        }
+
+        // Rebuild real cache state through the replacement (the candidate
+        // fork carries rejected draft positions) — same replay the serial
+        // loop uses on partial accepts.
+        let replacementCaches = forkLayerCaches(layerCaches)
+        let replacementInput = MLXArray(([anchor] + acceptedPrefix + [replacement]).map(Int32.init))
+            .reshaped(1, acceptedPrefix.count + 2)
+        let replacementLogits = model.forward(
+            inputIds: replacementInput,
+            cache: replacementCaches
+        )
+        layerCaches = replacementCaches
+        resume(samplingFrom: replacementLogits, contextBeforePending: hostContext)
+        return .resumed
     }
 
     private func greedyRepetitionHistoryArray(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,16 +129,18 @@ context.
 
 ### `MERERUN_GEMMA4_PROMPT_LOOKUP`
 
-Opt-in (`1`, `true`, or `on`) draft-model-free speculation for Gemma 4 12B
-greedy (temperature 0) requests when no MTP assistant is active. Drafts are
-the continuation of the most recent earlier occurrence of the trailing token
-3-gram (2-gram fallback) in the context, verified exactly like MTP drafts, so
-outputs are token-identical to plain greedy decode. A large win when
-generation echoes the context — quoted documents, retrieval answers, code
-edits, tool loops (measured 2.2× on an echo workload) — but eligible requests
-leave the pipelined decode loop for the serial one, which costs roughly 15%
-when nothing repeats; three consecutive zero-accept rounds stop further
-lookups for the request. MTP takes precedence when its assistant is active;
+Draft-model-free speculation for Gemma 4 12B greedy (temperature 0)
+requests when no MTP assistant is active. Enabled by default; set to `0`,
+`false`, or `off` to disable. When the trailing token 3-gram (2-gram
+fallback) of the generated context recurs earlier in the context, the
+pipelined decode loop runs a burst: the continuation of that earlier
+occurrence is drafted and verified in one batched forward, exactly like an
+MTP draft, so outputs are token-identical to plain greedy decode. A
+no-match token costs one host-side scan and no GPU work — decode speed on
+non-repetitive text is unchanged — while echo-heavy generation (quoted
+documents, retrieval answers, code edits, tool loops) measured 1.9× on an
+echo workload. Three consecutive zero-accept rounds stop further lookups
+for the request. MTP takes precedence when its assistant is active;
 JSON-constrained requests never use lookup.
 
 ### `MERERUN_GEMMA4_PROMPT_LOOKUP_BLOCK`

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -59,10 +59,12 @@ companion as `text-chat-gemma4-12b-mtp`; when it is present, greedy serial
 decode can use native MTP on the decode tail after text or multimodal prefill.
 Sampled requests, prefix-KV seeded requests, continuous batching, raw local
 model paths, and prompts below the MTP threshold fall back to baseline decode.
-When no assistant is active, `MERERUN_GEMMA4_PROMPT_LOOKUP=1` enables
-draft-model-free speculation for greedy requests that drafts from repeated
-context n-grams — output-identical, and worth ~2× when generation echoes the
-prompt (see [Configuration](../configuration.md#mererun_gemma4_prompt_lookup)).
+When no assistant is active, greedy requests use draft-model-free
+prompt-lookup speculation by default: repeated context n-grams are drafted
+and verified in bursts inside the pipelined loop — output-identical, free on
+non-repetitive text, and worth ~2× when generation echoes the prompt
+(`MERERUN_GEMMA4_PROMPT_LOOKUP=0` disables; see
+[Configuration](../configuration.md#mererun_gemma4_prompt_lookup)).
 Use these chat winners by RAM band instead of treating every supported model as
 equally recommended:
 


### PR DESCRIPTION
## What

Completes the follow-up noted in #143: prompt-lookup speculation moves from the serial loop into **bursts inside the pipelined decode loop**, and the flag flips to **default-on** (`MERERUN_GEMMA4_PROMPT_LOOKUP=0` disables).

## How it works

Each confirmed token costs one host-side n-gram scan (microseconds, no GPU work). Only when the trailing 3-gram (2-gram fallback) recurs earlier in the context does a burst fire:

1. The already-scheduled next token is confirmed early — the burst's only pipeline cost — and becomes the verify anchor (playing exactly the serial loop's `next`: sampled, appended, forward not yet run).
2. One serial-style batched verify round runs on a cache fork (`[anchor] + draft` in one forward, prospective repetition histories, one readback).
3. The lagged loop resumes with rebuilt state: full accept adopts the fork and carries the bonus token as the new `pendingToken`; partial accept replays `[anchor] + accepted + [replacement]` on a fresh fork, the same recovery the serial MTP path uses.

Three consecutive zero-accept rounds (including anchor-breaks) stop lookups for the request. JSON-constrained and sampled requests never burst; MTP still takes precedence when active.

## Why default-on is now safe

The #143 integration routed eligible requests to the serial loop, taxing non-repetitive text ~15% — hence opt-in. The burst keeps everything in the pipelined loop; a no-match token does no GPU work at all.

## Measurements (`text-chat-gemma4-12b-4bit`, MTP off, temp 0, 120 tokens, M4 Max)

| workload | lookup off | lookup on (default) | outputs |
|---|---|---|---|
| echo (repeat a 500-char paragraph) | 38.67 tok/s | **73.32 tok/s (1.90×)**, 56/56 drafted accepted, `mode=pipelined` | identical |
| fresh prose control | 39.66 tok/s | 39.64 tok/s (zero verify forwards fired) | identical |

## Verification

- Gate text suite with the new default: **6/6 hashes match baselines** (`text-gemma-long` visibly benefits — its repeated-paragraph prompt is lookup food — while remaining hash-identical).
- `PromptLookupDraftTests` 6/6 (matcher unchanged).
- Serial-loop lookup branch removed (dead there); MTP drafts unaffected; `canUsePipelinedDecode` restored to `mtpModel == nil && !jsonConstrained`.
- Docs updated: configuration.md entry rewritten for the burst + default-on; text runtime page updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)