### PR TITLE
Decode-engine timing: TTFT everywhere + Q35 pipelined-loop engine adoption

### DIFF
--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -353,6 +353,9 @@ struct TextChat: AsyncParsableCommand {
                     if let prefillTps = timing.prefillTokensPerSecond {
                         line += String(format: " prefill_tps=%.2f", prefillTps)
                     }
+                    if let firstToken = timing.firstTokenSeconds {
+                        line += String(format: " first_token_s=%.3f", firstToken)
+                    }
                     CLIStderr.write("\(line)\n")
                     if let mtp = lastGemma4MTPStats {
                         CLIStderr.write(Self.formatGemma4MTPStats(mtp) + "\n")

--- a/Sources/MereRunCLI/Support/GateSupport.swift
+++ b/Sources/MereRunCLI/Support/GateSupport.swift
@@ -1,6 +1,10 @@
 import Crypto
 import Foundation
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 #if canImport(CoreGraphics)
 import CoreGraphics
 import CoreText
@@ -369,11 +373,18 @@ struct GateRunner: Sendable {
     }
 
     static func hardwareModel() -> String {
+        #if canImport(Darwin)
         var size = 0
         sysctlbyname("hw.model", nil, &size, nil, 0)
         var value = [CChar](repeating: 0, count: size)
         sysctlbyname("hw.model", &value, &size, nil, 0)
-        return String(cString: value)
+        let bytes = value.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+        #elseif os(Linux)
+        return "Linux"
+        #else
+        return "Unknown"
+        #endif
     }
 
     /// Hashes only the embedding vectors from a /v1/embeddings-shaped JSON

--- a/Sources/MereRunCLI/Support/RunInspection.swift
+++ b/Sources/MereRunCLI/Support/RunInspection.swift
@@ -1104,16 +1104,22 @@ struct RunListAnalyzer {
         let runDirectory = envelope.result.runDirectory
         let report = envelope.result.report
         let plan = envelope.result.plan
-        let createdAt = runDirectory?.manifest?.createdAt ??
-            runDirectory?.legacyManifest?.createdAt ??
-            report?.createdAt ??
-            plan?.createdAt
-        let updatedAt = runDirectory?.events.latest?.createdAt ??
-            runDirectory?.legacyManifest?.updatedAt ??
-            runDirectory?.legacyManifest?.createdAt ??
-            runDirectory?.manifest?.createdAt ??
-            report?.createdAt ??
-            plan?.createdAt
+        let manifestCreatedAt = runDirectory?.manifest?.createdAt
+        let legacyCreatedAt = runDirectory?.legacyManifest?.createdAt
+        let reportCreatedAt = report?.createdAt
+        let planCreatedAt = plan?.createdAt
+        let eventCreatedAt = runDirectory?.events.latest?.createdAt
+        let legacyUpdatedAt = runDirectory?.legacyManifest?.updatedAt
+        let createdAt = manifestCreatedAt ??
+            legacyCreatedAt ??
+            reportCreatedAt ??
+            planCreatedAt
+        let updatedAt = eventCreatedAt ??
+            legacyUpdatedAt ??
+            legacyCreatedAt ??
+            manifestCreatedAt ??
+            reportCreatedAt ??
+            planCreatedAt
         return RunListEntry(
             id: Self.entryID(for: relativePath, kind: envelope.result.kind),
             kind: envelope.result.kind,

--- a/Sources/MereRunCore/Decode/AutoregressiveDecodeEngine.swift
+++ b/Sources/MereRunCore/Decode/AutoregressiveDecodeEngine.swift
@@ -36,15 +36,25 @@ public struct AutoregressiveDecodeResult {
     /// Seconds from decode start to the first confirmed token (time to
     /// first token, excluding prefill). Nil when nothing was generated.
     public let firstTokenSeconds: Double?
+    /// Host time spent building/scheduling each step's graph (sample +
+    /// forward + asyncEval). With the wait time, callers can emit the same
+    /// build/wait decode-trace lines the hand-rolled loops printed.
+    public let buildSeconds: Double
+    /// Host time spent blocked on step confirmation readbacks.
+    public let waitSeconds: Double
 
     public init(
         generatedTokens: [Int],
         decodeSeconds: Double,
-        firstTokenSeconds: Double? = nil
+        firstTokenSeconds: Double? = nil,
+        buildSeconds: Double = 0,
+        waitSeconds: Double = 0
     ) {
         self.generatedTokens = generatedTokens
         self.decodeSeconds = decodeSeconds
         self.firstTokenSeconds = firstTokenSeconds
+        self.buildSeconds = buildSeconds
+        self.waitSeconds = waitSeconds
     }
 }
 
@@ -110,10 +120,13 @@ public enum AutoregressiveDecodeEngine {
 
         var logits = request.initialLogits
         var pending: MLXArray?
+        var buildSeconds = 0.0
+        var waitSeconds = 0.0
 
         while generated.count < request.tokenBudget {
             try checkCancellation?()
 
+            let buildStart = CFAbsoluteTimeGetCurrent()
             let tokenArray = sampledTokenArray(
                 logits: logits[0, -1, 0...],
                 config: request.generationConfig,
@@ -127,14 +140,20 @@ public enum AutoregressiveDecodeEngine {
             )
             logits = try stepForward(tokenArray.asType(.int32).reshaped(1, 1))
             asyncEval([logits, tokenArray])
+            let buildEnd = CFAbsoluteTimeGetCurrent()
+            buildSeconds += buildEnd - buildStart
 
             if let previous = pending {
                 pending = nil
-                guard confirm(previous) else {
+                let confirmed = confirm(previous)
+                waitSeconds += CFAbsoluteTimeGetCurrent() - buildEnd
+                guard confirmed else {
                     return AutoregressiveDecodeResult(
                         generatedTokens: generated,
                         decodeSeconds: Date().timeIntervalSince(start),
-                        firstTokenSeconds: firstTokenSeconds
+                        firstTokenSeconds: firstTokenSeconds,
+                        buildSeconds: buildSeconds,
+                        waitSeconds: waitSeconds
                     )
                 }
             }
@@ -148,7 +167,9 @@ public enum AutoregressiveDecodeEngine {
         return AutoregressiveDecodeResult(
             generatedTokens: generated,
             decodeSeconds: Date().timeIntervalSince(start),
-            firstTokenSeconds: firstTokenSeconds
+            firstTokenSeconds: firstTokenSeconds,
+            buildSeconds: buildSeconds,
+            waitSeconds: waitSeconds
         )
     }
 }

--- a/Sources/MereRunCore/Decode/AutoregressiveDecodeEngine.swift
+++ b/Sources/MereRunCore/Decode/AutoregressiveDecodeEngine.swift
@@ -33,6 +33,19 @@ public struct AutoregressiveDecodeRequest {
 public struct AutoregressiveDecodeResult {
     public let generatedTokens: [Int]
     public let decodeSeconds: Double
+    /// Seconds from decode start to the first confirmed token (time to
+    /// first token, excluding prefill). Nil when nothing was generated.
+    public let firstTokenSeconds: Double?
+
+    public init(
+        generatedTokens: [Int],
+        decodeSeconds: Double,
+        firstTokenSeconds: Double? = nil
+    ) {
+        self.generatedTokens = generatedTokens
+        self.decodeSeconds = decodeSeconds
+        self.firstTokenSeconds = firstTokenSeconds
+    }
 }
 
 /// The platform's one serial decode loop. Every autoregressive engine that
@@ -65,6 +78,7 @@ public enum AutoregressiveDecodeEngine {
         let start = Date()
         var generated: [Int] = []
         generated.reserveCapacity(request.tokenBudget)
+        var firstTokenSeconds: Double?
         var repetitionHistory = repetitionHistoryArray(
             promptTokens: request.historySeedTokens,
             config: request.generationConfig
@@ -77,6 +91,9 @@ public enum AutoregressiveDecodeEngine {
                 return false
             }
             generated.append(token)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(start)
+            }
             if let decodeToken, let emitPiece {
                 let piece = decodeToken(token)
                 if !piece.isEmpty {
@@ -116,7 +133,8 @@ public enum AutoregressiveDecodeEngine {
                 guard confirm(previous) else {
                     return AutoregressiveDecodeResult(
                         generatedTokens: generated,
-                        decodeSeconds: Date().timeIntervalSince(start)
+                        decodeSeconds: Date().timeIntervalSince(start),
+                        firstTokenSeconds: firstTokenSeconds
                     )
                 }
             }
@@ -129,7 +147,8 @@ public enum AutoregressiveDecodeEngine {
 
         return AutoregressiveDecodeResult(
             generatedTokens: generated,
-            decodeSeconds: Date().timeIntervalSince(start)
+            decodeSeconds: Date().timeIntervalSince(start),
+            firstTokenSeconds: firstTokenSeconds
         )
     }
 }

--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -9,6 +9,7 @@ private struct LFM2PrefillOutput {
 private struct LFM2DecodeResult {
     let generatedTokens: [Int]
     let decodeSeconds: Double
+    var firstTokenSeconds: Double? = nil
 }
 
 private struct LFM2PrefixKVCacheKey: Hashable {
@@ -251,7 +252,8 @@ public actor LFM2Generator: ChatGenerator {
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,
-                decodeSeconds: decodeResult.decodeSeconds
+                decodeSeconds: decodeResult.decodeSeconds,
+                firstTokenSeconds: decodeResult.firstTokenSeconds
             ),
             toolCalls: toolCalls,
             promptTokens: promptTokens.count
@@ -293,7 +295,8 @@ public actor LFM2Generator: ChatGenerator {
         )
         return LFM2DecodeResult(
             generatedTokens: result.generatedTokens,
-            decodeSeconds: result.decodeSeconds
+            decodeSeconds: result.decodeSeconds,
+            firstTokenSeconds: result.firstTokenSeconds
         )
     }
 

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -25,6 +25,7 @@ private struct Q35PrefillOutput {
 private struct Q35BatchedDecodeResult {
     let generatedTokens: [Int]
     let decodeSeconds: Double
+    var firstTokenSeconds: Double? = nil
 }
 
 private struct Q35VisionReplacement {
@@ -56,6 +57,7 @@ private final class Q35BatchedDecodeRow: @unchecked Sendable {
     /// lazily from `repetitionHistory` and appended without host readbacks.
     var repetitionHistoryGPU: MLXArray?
     var repetitionHistoryGPUSeeded = false
+    var firstTokenSeconds: Double?
     var stopped = false
 
     init(
@@ -95,7 +97,8 @@ private final class Q35BatchedDecodeRow: @unchecked Sendable {
         continuation.resume(
             returning: Q35BatchedDecodeResult(
                 generatedTokens: generatedTokens,
-                decodeSeconds: Date().timeIntervalSince(decodeStart)
+                decodeSeconds: Date().timeIntervalSince(decodeStart),
+                firstTokenSeconds: firstTokenSeconds
             )
         )
     }
@@ -585,7 +588,8 @@ public actor Q35Generator: ChatGenerator {
             timing: ChatTiming(
                 loadSeconds: 0,
                 prefillSeconds: prefillSeconds,
-                decodeSeconds: decodeResult.decodeSeconds
+                decodeSeconds: decodeResult.decodeSeconds,
+                firstTokenSeconds: decodeResult.firstTokenSeconds
             ),
             toolCalls: toolCalls,
             promptTokens: promptTokens.count,
@@ -745,11 +749,15 @@ public actor Q35Generator: ChatGenerator {
         generated.reserveCapacity(tokenBudget)
         var repetitionHistory = promptTokens
         var pendingProgressWhitespace = ""
+        var firstTokenSeconds: Double?
         let decodeStart = Date()
 
         func emit(_ token: Int) {
             generated.append(token)
             repetitionHistory.append(token)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(decodeStart)
+            }
             guard let progressHandler else { return }
             let piece = tokenizerAndTemplate.decode(token: token)
             guard !piece.isEmpty else { return }
@@ -965,7 +973,8 @@ public actor Q35Generator: ChatGenerator {
 
         return Q35BatchedDecodeResult(
             generatedTokens: generated,
-            decodeSeconds: Date().timeIntervalSince(decodeStart)
+            decodeSeconds: Date().timeIntervalSince(decodeStart),
+            firstTokenSeconds: firstTokenSeconds
         )
     }
 
@@ -1002,6 +1011,7 @@ public actor Q35Generator: ChatGenerator {
         var generated: [Int] = []
         generated.reserveCapacity(tokenBudget)
         var pendingProgressWhitespace = ""
+        var firstTokenSeconds: Double?
         let decodeStart = Date()
         let traceEnabled = Gemma4DecodeTrace.enabled
         var traceBuildSeconds = 0.0
@@ -1009,6 +1019,9 @@ public actor Q35Generator: ChatGenerator {
 
         func emit(_ token: Int) {
             generated.append(token)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(decodeStart)
+            }
             guard let progressHandler else { return }
             let piece = tokenizerAndTemplate.decode(token: token)
             guard !piece.isEmpty else { return }
@@ -1088,7 +1101,8 @@ public actor Q35Generator: ChatGenerator {
 
         return Q35BatchedDecodeResult(
             generatedTokens: generated,
-            decodeSeconds: Date().timeIntervalSince(decodeStart)
+            decodeSeconds: Date().timeIntervalSince(decodeStart),
+            firstTokenSeconds: firstTokenSeconds
         )
     }
 
@@ -1286,6 +1300,9 @@ public actor Q35Generator: ChatGenerator {
                 }
                 row.generatedTokens.append(next)
                 row.repetitionHistory.append(next)
+                if row.firstTokenSeconds == nil {
+                    row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
+                }
                 if let progressHandler = row.progressHandler {
                     let piece = tokenizerAndTemplate.decode(token: next)
                     if !piece.isEmpty {
@@ -1306,6 +1323,9 @@ public actor Q35Generator: ChatGenerator {
                 }
                 row.generatedTokens.append(next)
                 row.repetitionHistory.append(next)
+                if row.firstTokenSeconds == nil {
+                    row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
+                }
                 if let progressHandler = row.progressHandler {
                     let piece = tokenizerAndTemplate.decode(token: next)
                     if !piece.isEmpty {

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -996,113 +996,47 @@ public actor Q35Generator: ChatGenerator {
             dtype: initialLogits.dtype,
             tokens: generationConfig.bannedTokens
         )
-        var repetitionHistory = repetitionHistoryArray(
-            promptTokens: promptTokens,
-            config: generationConfig
-        )
-        var pendingToken = sampledTokenArray(
-            logits: initialLogits[0, -1, 0...],
-            config: generationConfig,
-            previousTokenIndices: repetitionHistory,
-            banMask: banMask
-        )
-        asyncEval(pendingToken)
 
-        var generated: [Int] = []
-        generated.reserveCapacity(tokenBudget)
-        var pendingProgressWhitespace = ""
-        var firstTokenSeconds: Double?
-        let decodeStart = Date()
-        let traceEnabled = Gemma4DecodeTrace.enabled
-        var traceBuildSeconds = 0.0
-        var traceWaitSeconds = 0.0
-
-        func emit(_ token: Int) {
-            generated.append(token)
-            if firstTokenSeconds == nil {
-                firstTokenSeconds = Date().timeIntervalSince(decodeStart)
-            }
-            guard let progressHandler else { return }
-            let piece = tokenizerAndTemplate.decode(token: token)
-            guard !piece.isEmpty else { return }
-            if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                pendingProgressWhitespace += piece
-                return
-            }
-
-            let visiblePiece: String
-            if pendingProgressWhitespace.isEmpty {
-                visiblePiece = piece
-            } else {
-                visiblePiece = pendingProgressWhitespace + piece
-                pendingProgressWhitespace = ""
-            }
-            progressHandler(ChatProgress(stage: .generating, message: visiblePiece))
-        }
-
-        while generated.count < tokenBudget {
-            try Task.checkCancellation()
-
-            let buildStart = CFAbsoluteTimeGetCurrent()
-            let scheduled: (token: MLXArray, history: MLXArray?)?
-            if generated.count + 1 < tokenBudget {
-                let nextInput = pendingToken.asType(.int32).reshaped(1, 1)
-                let nextLogits = model(
-                    nextInput,
+        // Shared pipelined decode; mRoPE positions derive from the cache
+        // offset, so the step closure computes them per forward.
+        let result = try AutoregressiveDecodeEngine.decode(
+            AutoregressiveDecodeRequest(
+                initialLogits: initialLogits,
+                generationConfig: generationConfig,
+                eosTokens: eosSet,
+                tokenBudget: tokenBudget,
+                historySeedTokens: promptTokens,
+                banMask: banMask
+            ),
+            stepForward: { token in
+                model(
+                    token,
                     cache: layerCaches,
                     positionIds: decodePositionIds(layerCaches: layerCaches, tokenCount: 1, ropeDelta: mropeRopeDelta)
                 )
-                let nextHistory = appendingRepetitionHistory(
-                    repetitionHistory,
-                    token: pendingToken,
-                    config: generationConfig
-                )
-                let nextToken = sampledTokenArray(
-                    logits: nextLogits[0, -1, 0...],
-                    config: generationConfig,
-                    previousTokenIndices: nextHistory,
-                    banMask: banMask
-                )
-                asyncEval(nextToken, nextLogits)
-                scheduled = (nextToken, nextHistory)
-            } else {
-                scheduled = nil
-            }
-            let buildEnd = CFAbsoluteTimeGetCurrent()
+            },
+            decodeToken: { tokenizerAndTemplate.decode(token: $0) },
+            emitPiece: { _, piece in
+                progressHandler?(ChatProgress(stage: .generating, message: piece))
+            },
+            checkCancellation: { try Task.checkCancellation() }
+        )
 
-            let token = pendingToken.item(Int.self)
-            if traceEnabled {
-                traceBuildSeconds += buildEnd - buildStart
-                traceWaitSeconds += CFAbsoluteTimeGetCurrent() - buildEnd
-            }
-            if eosSet.contains(token) {
-                break
-            }
-
-            emit(token)
-
-            guard let scheduled else {
-                break
-            }
-            pendingToken = scheduled.token
-            repetitionHistory = scheduled.history
-        }
-
-        if traceEnabled, !generated.isEmpty {
-            let count = Double(generated.count)
+        if Gemma4DecodeTrace.enabled, !result.generatedTokens.isEmpty {
+            let count = Double(result.generatedTokens.count)
             Gemma4DecodeTrace.emit(String(
                 format: "[q35-decode-trace] mode=pipelined temp=\(generationConfig.temperature) tokens=%d build=%.2fms/tok wait=%.2fms/tok wall=%.2fms/tok",
-                generated.count,
-                traceBuildSeconds / count * 1000,
-                traceWaitSeconds / count * 1000,
-                Date().timeIntervalSince(decodeStart) / count * 1000
+                result.generatedTokens.count,
+                result.buildSeconds / count * 1000,
+                result.waitSeconds / count * 1000,
+                result.decodeSeconds / count * 1000
             ))
         }
 
         return Q35BatchedDecodeResult(
-            generatedTokens: generated,
-            decodeSeconds: Date().timeIntervalSince(decodeStart),
-            firstTokenSeconds: firstTokenSeconds
+            generatedTokens: result.generatedTokens,
+            decodeSeconds: result.decodeSeconds,
+            firstTokenSeconds: result.firstTokenSeconds
         )
     }
 

--- a/Tests/MereRunCoreTests/AutoregressiveDecodeEngineTests.swift
+++ b/Tests/MereRunCoreTests/AutoregressiveDecodeEngineTests.swift
@@ -53,6 +53,16 @@ final class AutoregressiveDecodeEngineTests: XCTestCase {
             stepForward: scriptedModel([7, 2, 9, eos])
         )
         XCTAssertEqual(result.generatedTokens, [3, 7, 2, 9])
+        let firstToken = try XCTUnwrap(result.firstTokenSeconds)
+        XCTAssertLessThanOrEqual(firstToken, result.decodeSeconds)
+    }
+
+    func testImmediateEOSReportsNoFirstToken() throws {
+        let result = try AutoregressiveDecodeEngine.decode(
+            request(firstToken: eos, budget: 8),
+            stepForward: scriptedModel([1, 2, 3])
+        )
+        XCTAssertNil(result.firstTokenSeconds)
     }
 
     func testBudgetCutsGenerationExactly() throws {


### PR DESCRIPTION
Two related commits closing the remaining decode-engine follow-ups from #141/#142.

## 1. Time-to-first-token everywhere

Gemma responses populated `ChatTiming.firstTokenSeconds`; Q35 and LFM2 (including all serve rows) reported nothing.

- **Shared engine**: `AutoregressiveDecodeResult` gains `firstTokenSeconds` (set at first confirmed token) — LFM2 and any adopter inherit it.
- **Q35**: field threaded through `Q35BatchedDecodeResult`, the serial and pipelined loops, and **continuous-batching rows** (both GPU-sampled and host-sampled step paths) via `finish()`.
- **CLI**: `text chat --stats` appends `first_token_s=`.

## 2. Q35 pipelined loop → shared engine

The hand-rolled Q35 pipelined loop was the engine's exact shape; sampler-order math verified identical by construction. Q35-specific pieces preserved:

- **mRoPE positions** computed inside the `stepForward` closure from the cache offset.
- **Decode trace**: the engine result gains always-on `buildSeconds`/`waitSeconds` accumulators (two clock reads per token) so adopters keep their `build=/wait=` trace lines; `[q35-decode-trace]` is formatted from them.

**Deliberately not adopted**: Gemma4 (its pipelined loop hosts the #145 prompt-lookup burst; its serial loop is MTP verification) and Q35's serial loop (MTP-only). Those loops are speculation engines, not vanilla decoders — documented here so the follow-up doesn't linger.

## Verification

- Gate text suite: **6/6 hashes match baselines** — Ornith byte-identical through the engine.
- Engine contract tests 6/6 (incl. first-token populated / nil-on-immediate-EOS).
- `RuntimeModelPoolTests` 24/24.
- Live engagement: `[q35-decode-trace] mode=pipelined ... build=14.43ms/tok wait=0.03ms/tok` and `first_token_s=0.024` (Ornith 9B), `first_token_s=0.021` (LFM2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)