### PR TITLE
Adapt code benchmark defaults to machine support

### DIFF
--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -162,6 +162,24 @@ enum StudioChatDefaults {
     }
 }
 
+enum StudioCodeDefaults {
+    static let fallbackModelID = "text-code-north-mini"
+
+    static func shouldReplaceModelDefault(_ modelID: String, oldRecommendation: String? = nil) -> Bool {
+        let normalized = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty { return true }
+        var replaceable: Set<String> = [
+            fallbackModelID,
+            "text-agent-qwen35-9b",
+            "text-code-qwen3",
+        ]
+        if let oldRecommendation, !oldRecommendation.isBlank {
+            replaceable.insert(oldRecommendation)
+        }
+        return replaceable.contains(normalized)
+    }
+}
+
 struct CommandDraft: Equatable {
     var prompt = ""
     var secondaryText = ""
@@ -735,7 +753,7 @@ enum CommandCatalog {
             title: "Agent onboarding",
             subtitle: "Check local readiness and prepare Pi integration",
             systemImage: "person.crop.circle.badge.gearshape",
-            defaultModel: "text-code-qwen3"
+            defaultModel: StudioCodeDefaults.fallbackModelID
         ),
         CommandTemplate(
             id: .agentInstallPi,
@@ -810,7 +828,7 @@ enum CommandCatalog {
             promptLabel: "Prompt",
             secondaryLabel: "System",
             defaultPrompt: "Write a tiny Swift function that formats byte counts.",
-            defaultModel: "text-code-qwen3"
+            defaultModel: StudioCodeDefaults.fallbackModelID
         ),
         CommandTemplate(
             id: .textEmbed,

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -461,6 +461,12 @@ final class MereRunController: ObservableObject {
             applyRecommendedChatDefaultsToCurrentDraft(replacing: oldValue)
         }
     }
+    @Published private(set) var recommendedCodeModelID: String? = nil {
+        didSet {
+            guard oldValue != recommendedCodeModelID else { return }
+            applyRecommendedCodeDefaultsToCurrentDraft(replacing: oldValue)
+        }
+    }
     @Published var cliPath: String {
         didSet { UserDefaults.standard.set(cliPath, forKey: Keys.cliPath) }
     }
@@ -589,6 +595,7 @@ final class MereRunController: ObservableObject {
     func defaultDraft(for template: CommandTemplate) -> CommandDraft {
         var nextDraft = template.defaultDraft()
         applyRecommendedChatDefaults(to: &nextDraft, templateID: template.id, replacing: nil)
+        applyRecommendedCodeDefaults(to: &nextDraft, templateID: template.id, replacing: nil)
         return nextDraft
     }
 
@@ -596,16 +603,37 @@ final class MereRunController: ObservableObject {
         recommendedChatModelID ?? StudioChatDefaults.fallbackModelID
     }
 
+    func recommendedCodeModelForStudioDefault() -> String {
+        recommendedCodeModelID ?? StudioCodeDefaults.fallbackModelID
+    }
+
     func applyRecommendedDefaults(to studioDraft: inout StudioDraft, for mode: StudioMode) {
-        guard mode == .chat else { return }
-        let recommended = recommendedChatModelForStudioDefault()
-        if StudioChatDefaults.shouldReplaceModelDefault(studioDraft.model) {
-            studioDraft.model = recommended
+        switch mode {
+        case .chat:
+            let recommended = recommendedChatModelForStudioDefault()
+            if StudioChatDefaults.shouldReplaceModelDefault(studioDraft.model) {
+                studioDraft.model = recommended
+            }
+        case .code:
+            let recommended = recommendedCodeModelForStudioDefault()
+            if StudioCodeDefaults.shouldReplaceModelDefault(studioDraft.model) {
+                studioDraft.model = recommended
+            }
+        default:
+            break
         }
     }
 
     private func applyRecommendedChatDefaultsToCurrentDraft(replacing oldRecommendation: String?) {
         applyRecommendedChatDefaults(
+            to: &draft,
+            templateID: selectedTemplate.id,
+            replacing: oldRecommendation
+        )
+    }
+
+    private func applyRecommendedCodeDefaultsToCurrentDraft(replacing oldRecommendation: String?) {
+        applyRecommendedCodeDefaults(
             to: &draft,
             templateID: selectedTemplate.id,
             replacing: oldRecommendation
@@ -632,6 +660,22 @@ final class MereRunController: ObservableObject {
                 oldRecommendation: oldRecommendation
             ) {
                 draft.engine = StudioChatDefaults.servingEngine(for: recommended)
+            }
+        default:
+            break
+        }
+    }
+
+    private func applyRecommendedCodeDefaults(
+        to draft: inout CommandDraft,
+        templateID: CommandTemplateID,
+        replacing oldRecommendation: String?
+    ) {
+        let recommended = recommendedCodeModelForStudioDefault()
+        switch templateID {
+        case .textCode, .agentOnboard:
+            if StudioCodeDefaults.shouldReplaceModelDefault(draft.model, oldRecommendation: oldRecommendation) {
+                draft.model = recommended
             }
         default:
             break
@@ -950,6 +994,10 @@ final class MereRunController: ObservableObject {
                         if let recommendedChatModelID = report.recommendedChatModelID,
                            !recommendedChatModelID.isBlank {
                             self.recommendedChatModelID = recommendedChatModelID
+                        }
+                        if let recommendedCodeModelID = report.recommendedCodeModelID,
+                           !recommendedCodeModelID.isBlank {
+                            self.recommendedCodeModelID = recommendedCodeModelID
                         }
 
                         if let message = self.modelCapabilitiesByID[modelID]?.unavailableMessage {

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -390,6 +390,11 @@ struct StudioRootView: View {
             controller.applyRecommendedDefaults(to: &draft, for: mode)
             refreshReadiness()
         }
+        .onChange(of: controller.recommendedCodeModelID) { _, _ in
+            guard mode == .code, activeConversationID == nil else { return }
+            controller.applyRecommendedDefaults(to: &draft, for: mode)
+            refreshReadiness()
+        }
         .onChange(of: selectedLibraryID) { _, id in
             // Selecting a thread of the current conversation mode opens it in the canvas.
             guard mode.isConversational,

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -796,6 +796,7 @@ struct StudioModelCapability: Equatable {
 struct StudioModelCapabilityReport: Equatable {
     let capabilitiesByID: [String: StudioModelCapability]
     let recommendedChatModelID: String?
+    let recommendedCodeModelID: String?
 }
 
 enum ModelCapabilitiesParser {
@@ -805,7 +806,8 @@ enum ModelCapabilitiesParser {
         }
         return StudioModelCapabilityReport(
             capabilitiesByID: capabilities(from: output),
-            recommendedChatModelID: nil
+            recommendedChatModelID: nil,
+            recommendedCodeModelID: nil
         )
     }
 
@@ -844,6 +846,10 @@ enum ModelCapabilitiesParser {
             struct ChatBand: Decodable {
                 let modelID: String
             }
+            struct RecommendedModel: Decodable {
+                let id: String?
+                let modelID: String?
+            }
             struct Model: Decodable {
                 let id: String
                 let supported: Bool
@@ -854,6 +860,7 @@ enum ModelCapabilitiesParser {
             }
 
             let recommendedChatModel: ChatBand?
+            let recommendedCodeModel: RecommendedModel?
             let models: [Model]
         }
 
@@ -873,7 +880,9 @@ enum ModelCapabilitiesParser {
         })
         return StudioModelCapabilityReport(
             capabilitiesByID: capabilities,
-            recommendedChatModelID: payload.recommendedChatModel?.modelID
+            recommendedChatModelID: payload.recommendedChatModel?.modelID,
+            recommendedCodeModelID: payload.recommendedCodeModel?.modelID
+                ?? payload.recommendedCodeModel?.id
         )
     }
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -56,12 +56,6 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     @Flag(name: [.long], help: "Emit machine-readable JSON.")
     var json: Bool = false
 
-    private static let defaultModelIDs = [
-        Q35Resources.ornith9BModelId,
-        NorthMiniCodeResources.modelId,
-        CodeGenResources.defaultModelId,
-    ]
-
     func validate() throws {
         guard maxTokens > 0 else {
             throw ValidationError("--max-tokens must be greater than zero.")
@@ -126,12 +120,20 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
     private func selectedModelIDs() throws -> [String] {
         let rawModels = models?.split(separator: ",").map {
             $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        } ?? Self.defaultModelIDs
+        } ?? Self.defaultModelIDs()
         let modelIDs = rawModels.filter { !$0.isEmpty }
         guard !modelIDs.isEmpty else {
             throw ValidationError("--models must include at least one model id.")
         }
         return modelIDs
+    }
+
+    static func defaultModelIDs(on machine: MereRunMachineProfile = .current) -> [String] {
+        let supported = ManagedModelCapabilityCatalog.supportedCodeBenchmarkModelIDs(on: machine)
+        if !supported.isEmpty {
+            return supported
+        }
+        return [Q35Resources.ornith9BModelId]
     }
 
     private func selectedTasks() throws -> [CodeBenchmarkTask] {

--- a/Sources/MereRunCLI/Commands/ModelCapabilitiesCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCapabilitiesCommand.swift
@@ -20,6 +20,7 @@ struct ModelCapabilities: ParsableCommand {
     func run() throws {
         let machine = MereRunMachineProfile.current
         let reports = ManagedModelCapabilityCatalog.supportReports(on: machine)
+        let recommendedCodeReport = ManagedModelCapabilityCatalog.recommendedCodeModelReport(on: machine)
         let visibleReports = reports.filter { report in
             if recommended {
                 return report.isSupported
@@ -43,6 +44,7 @@ struct ModelCapabilities: ParsableCommand {
                 recommendedChatModel: chatBands
                     .first { $0.contains(unifiedMemoryGB: machine.unifiedMemoryGB) }
                     .map { .init($0, machine: machine) },
+                recommendedCodeModel: recommendedCodeReport.map(ModelCapabilitiesModel.init),
                 setupAgent: MereRunAgentModelCatalog
                     .recommendation(for: .tier, on: machine)
                     .map(ModelCapabilitiesSetupAgent.init),
@@ -71,6 +73,12 @@ struct ModelCapabilities: ParsableCommand {
                     print("    alternatives: \(band.alternateModelIDs.joined(separator: ", "))")
                 }
             }
+        }
+
+        if let recommendedCodeReport {
+            print("\nRecommended code model")
+            print("  \(CLICommandDisplay.command("model pull \(recommendedCodeReport.spec.id)"))")
+            print("  \(recommendedCodeReport.descriptor.title): \(recommendedCodeReport.descriptor.summary)")
         }
 
         if let agent = MereRunAgentModelCatalog.recommendation(for: .tier, on: machine) {
@@ -129,6 +137,7 @@ struct ModelCapabilitiesOutput: Codable, Equatable {
     let machine: ModelCapabilitiesMachine
     let chatBands: [ModelCapabilitiesChatBand]
     let recommendedChatModel: ModelCapabilitiesChatBand?
+    let recommendedCodeModel: ModelCapabilitiesModel?
     let setupAgent: ModelCapabilitiesSetupAgent?
     let recommendedSetupModels: [ModelCapabilitiesModel]
     let unavailableRecommendedModelIDs: [String]

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -296,11 +296,13 @@ mere.run model benchmark tool-calls \
 
 `model benchmark code` runs a tiny, fixed HumanEval slice against local coding
 models. It is a real functional-code eval slice, not a full pass@k benchmark or
-leaderboard substitute. The default comparison is:
+leaderboard substitute. The default comparison auto-selects the supported
+members of this lane for the current machine:
 
 - `text-agent-ornith-9b`: native Q35/MLX OptiQ coding-agent target.
 - `text-code-north-mini`: native llama.cpp/GGUF North Mini Code target.
-- `text-code-qwen3`: native llama.cpp/GGUF Qwen3-Coder baseline.
+- `text-code-qwen3`: native llama.cpp/GGUF Qwen3-Coder baseline, included by
+  default only on 64 GB and larger machines.
 
 For larger explicit Ornith runs, pass `--models text-agent-ornith-35b-mlx` for
 the local native MLX Q4 conversion or `--models text-agent-ornith-35b` for the
@@ -436,7 +438,7 @@ mere.run model benchmark vlm \
 ## Notes
 
 - Pull `text-chat-gemma4-turbo` before running the benchmark.
-- Pull `text-agent-ornith-9b`, `text-code-north-mini`, and `text-code-qwen3`
+- Pull the supported models shown by `mere.run model benchmark code --dry-run`
   before running the default code benchmark comparison.
 - Pull `text-agent-ornith-35b` before running larger explicit Ornith code evals.
 - Pull `vision-chat-gemma4-12b` before using it in the VLM benchmark.

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -739,6 +739,50 @@ public enum ManagedModelCapabilityCatalog {
         ]
     }
 
+    public static func recommendedCodeModelReport(
+        on machine: MereRunMachineProfile = .current
+    ) -> ManagedModelSupportReport? {
+        let candidateIDs: [String]
+        if machine.unifiedMemoryGB >= 64 {
+            candidateIDs = [
+                CodeGenResources.defaultModelId,
+                NorthMiniCodeResources.modelId,
+                AgentModelResources.qwen35NineBModelId,
+            ]
+        } else if machine.unifiedMemoryGB >= 24 {
+            candidateIDs = [
+                NorthMiniCodeResources.modelId,
+                AgentModelResources.qwen35NineBModelId,
+            ]
+        } else {
+            candidateIDs = [
+                AgentModelResources.qwen35NineBModelId,
+            ]
+        }
+
+        return candidateIDs.compactMap { modelID -> ManagedModelSupportReport? in
+            guard let spec = ManagedModelCatalog.spec(for: modelID) else { return nil }
+            let report = support(for: spec, on: machine)
+            return report.isSupported ? report : nil
+        }.first
+    }
+
+    public static func supportedCodeBenchmarkModelIDs(
+        on machine: MereRunMachineProfile = .current
+    ) -> [String] {
+        [
+            Q35Resources.ornith9BModelId,
+            NorthMiniCodeResources.modelId,
+            CodeGenResources.defaultModelId,
+        ].filter { modelID in
+            guard let spec = ManagedModelCatalog.spec(for: modelID),
+                  spec.category == .textCode else {
+                return false
+            }
+            return support(for: spec, on: machine).isSupported
+        }
+    }
+
     private static func descriptor(
         _ modelID: String,
         _ title: String,

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -115,7 +115,7 @@ final class MereRunControllerTests: XCTestCase {
         XCTAssertEqual(controller.modelCapabilitiesByID["image-zimage-nano"]?.minimumUnifiedMemoryGB, 12)
     }
 
-    func testReadinessCapturesRecommendedChatModelFromJSONCapabilities() async throws {
+    func testReadinessCapturesRecommendedModelsFromJSONCapabilities() async throws {
         let runner = RecordingProcessRunner()
         let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
         controller.cliPath = "/usr/bin/true"
@@ -133,6 +133,7 @@ final class MereRunControllerTests: XCTestCase {
 
         runner.starts[0].stdout(jsonCapabilitiesOutput(
             recommendedChatModelID: "text-agent-deepseek-v4-flash",
+            recommendedCodeModelID: "text-code-north-mini",
             supportedModelID: StudioChatDefaults.fallbackModelID
         ))
         runner.starts[0].termination(0)
@@ -140,6 +141,7 @@ final class MereRunControllerTests: XCTestCase {
         await Task.yield()
 
         XCTAssertEqual(controller.recommendedChatModelID, "text-agent-deepseek-v4-flash")
+        XCTAssertEqual(controller.recommendedCodeModelID, "text-code-north-mini")
         XCTAssertEqual(controller.draft.model, "text-agent-deepseek-v4-flash")
         XCTAssertEqual(runner.starts.count, 2)
     }
@@ -635,11 +637,18 @@ private func supportedCapabilitiesOutput(for modelID: String, minimum: Int) -> S
     """
 }
 
-private func jsonCapabilitiesOutput(recommendedChatModelID: String, supportedModelID: String) -> String {
+private func jsonCapabilitiesOutput(
+    recommendedChatModelID: String,
+    recommendedCodeModelID: String = "text-code-north-mini",
+    supportedModelID: String
+) -> String {
     """
     {
       "recommendedChatModel" : {
         "modelID" : "\(recommendedChatModelID)"
+      },
+      "recommendedCodeModel" : {
+        "id" : "\(recommendedCodeModelID)"
       },
       "models" : [
         {

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -18,12 +18,12 @@ final class StudioTypesTests: XCTestCase {
 
     func testCodeStudioDefaultsUsePublicModelID() throws {
         let codeTemplate = try XCTUnwrap(CommandCatalog.template(id: .textCode))
-        XCTAssertEqual(codeTemplate.defaultModel, "text-code-qwen3")
+        XCTAssertEqual(codeTemplate.defaultModel, StudioCodeDefaults.fallbackModelID)
 
         var draft = StudioDraft()
         draft.reset(for: .code)
-        XCTAssertEqual(draft.model, "text-code-qwen3")
-        XCTAssertEqual(StudioCommandAdapter.requiredModel(for: .code, draft: draft), "text-code-qwen3")
+        XCTAssertEqual(draft.model, StudioCodeDefaults.fallbackModelID)
+        XCTAssertEqual(StudioCommandAdapter.requiredModel(for: .code, draft: draft), StudioCodeDefaults.fallbackModelID)
     }
 
     func testChatStudioDefaultsToStreamingOutput() throws {
@@ -636,6 +636,9 @@ final class StudioTypesTests: XCTestCase {
           "recommendedChatModel" : {
             "modelID" : "text-chat-q36-nano"
           },
+          "recommendedCodeModel" : {
+            "id" : "text-code-north-mini"
+          },
           "models" : [
             {
               "download" : "hugging-face",
@@ -661,6 +664,7 @@ final class StudioTypesTests: XCTestCase {
 
         let report = ModelCapabilitiesParser.report(from: output)
         XCTAssertEqual(report.recommendedChatModelID, "text-chat-q36-nano")
+        XCTAssertEqual(report.recommendedCodeModelID, "text-code-north-mini")
         let q36 = try XCTUnwrap(report.capabilitiesByID["text-chat-q36-nano"])
         let gemma = try XCTUnwrap(report.capabilitiesByID["text-chat-gemma4"])
 

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -50,6 +50,29 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertFalse(cmd.json)
     }
 
+    func testCodeBenchmarkDefaultModelsAdaptToMachineMemory() {
+        let thirtyTwoGB = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M4",
+            isAppleSiliconMac: true
+        )
+        let sixtyFourGB = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        XCTAssertEqual(ModelBenchmarkCode.defaultModelIDs(on: thirtyTwoGB), [
+            Q35Resources.ornith9BModelId,
+            NorthMiniCodeResources.modelId,
+        ])
+        XCTAssertEqual(ModelBenchmarkCode.defaultModelIDs(on: sixtyFourGB), [
+            Q35Resources.ornith9BModelId,
+            NorthMiniCodeResources.modelId,
+            CodeGenResources.defaultModelId,
+        ])
+    }
+
     func testCodeBenchmarkParsesOverrides() throws {
         let cmd = try ModelBenchmarkCode.parse([
             "--models", "text-agent-ornith-35b-mlx,text-code-north-mini",

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -128,6 +128,9 @@ final class ModelPullCommandParsingTests: XCTestCase {
             recommendedChatModel: bands
                 .first { $0.contains(unifiedMemoryGB: machine.unifiedMemoryGB) }
                 .map { .init($0, machine: machine) },
+            recommendedCodeModel: ManagedModelCapabilityCatalog
+                .recommendedCodeModelReport(on: machine)
+                .map(ModelCapabilitiesModel.init),
             setupAgent: MereRunAgentModelCatalog
                 .recommendation(for: .tier, on: machine)
                 .map(ModelCapabilitiesSetupAgent.init),
@@ -148,6 +151,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
             "text-chat-q36-nano",
         ])
         XCTAssertTrue(decoded.recommendedChatModel?.currentMachine == true)
+        XCTAssertEqual(decoded.recommendedCodeModel?.id, "text-code-north-mini")
         XCTAssertEqual(decoded.setupAgent?.id, "text-chat-gemma4-12b-4bit")
     }
 

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -101,6 +101,47 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textCode)
     }
 
+    func testRecommendedCodeModelUsesNorthMiniOnThirtyTwoGB() throws {
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M4",
+            isAppleSiliconMac: true
+        )
+
+        let recommendation = try XCTUnwrap(ManagedModelCapabilityCatalog.recommendedCodeModelReport(on: machine))
+
+        XCTAssertEqual(recommendation.spec.id, NorthMiniCodeResources.modelId)
+        XCTAssertTrue(recommendation.isSupported)
+    }
+
+    func testRecommendedCodeModelUsesQwen3CoderOnSixtyFourGB() throws {
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let recommendation = try XCTUnwrap(ManagedModelCapabilityCatalog.recommendedCodeModelReport(on: machine))
+
+        XCTAssertEqual(recommendation.spec.id, CodeGenResources.defaultModelId)
+        XCTAssertTrue(recommendation.isSupported)
+    }
+
+    func testSupportedCodeBenchmarkModelsExcludeQwen3BelowSixtyFourGB() {
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 32 * 1_073_741_824,
+            processorName: "M4",
+            isAppleSiliconMac: true
+        )
+
+        let modelIDs = ManagedModelCapabilityCatalog.supportedCodeBenchmarkModelIDs(on: machine)
+
+        XCTAssertEqual(modelIDs, [
+            Q35Resources.ornith9BModelId,
+            NorthMiniCodeResources.modelId,
+        ])
+    }
+
     func testOrnith9BIsSupportedOnTwentyFourGBAndStartableThroughQ35() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.ornith9BModelId))
         let machine = MereRunMachineProfile(

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -104,10 +104,14 @@ command requires `--allow-code-execution` unless you are using `--dry-run`.
 
 ```bash
 swift run mere.run model benchmark code \
-  --models text-agent-ornith-9b,text-code-north-mini,text-code-qwen3 \
   --allow-code-execution \
   --json
 ```
+
+Without `--models`, the code benchmark uses the supported members of the default
+comparison lane for the current machine. On 32 GB Macs that means
+`text-agent-ornith-9b` and `text-code-north-mini`; `text-code-qwen3` joins the
+default comparison on 64 GB and larger machines.
 
 By default, `--sandbox auto` uses `sandbox-exec` on macOS and `bubblewrap` on
 Linux when available. Use `--sandbox none` only for trusted local smokes where

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1566,8 +1566,11 @@ single decode steps, and whether SSD KV cache is available. Use
 
 Run a small real coding-eval slice against installed local coding models. The
 default suite is `humaneval-slice`, a three-task HumanEval subset covering
-`HumanEval/0`, `HumanEval/3`, and `HumanEval/8`. The default model comparison is
-`text-agent-ornith-9b`, `text-code-north-mini`, and `text-code-qwen3`.
+`HumanEval/0`, `HumanEval/3`, and `HumanEval/8`. The default model comparison
+uses the supported members of the coding comparison lane for this machine:
+`text-agent-ornith-9b` and `text-code-north-mini` on 32 GB Macs, with
+`text-code-qwen3` added on 64 GB and larger machines. Pass `--models` to force a
+specific explicit comparison.
 
 ```bash
 swift run mere.run model benchmark code \


### PR DESCRIPTION
## Summary
- add hardware-aware code model recommendations to model capabilities
- make `model benchmark code` default to the supported comparison lane on the current machine
- update Studio code defaults and docs so 32 GB Macs do not auto-pull `text-code-qwen3`

## Tests
- `swift test --filter ManagedModelSupportTests --filter ModelBenchmarkCommandTests`
- `swift test --filter StudioTypesTests --filter MereRunControllerTests`
- `swift test --filter ModelPullCommandParsingTests`
- `swift run mere.run model benchmark code --dry-run --json`
- `./scripts/check.sh`