### PR TITLE
Fix model store override preflight paths

### DIFF
--- a/Sources/MereRunCore/MereRunModelPaths.swift
+++ b/Sources/MereRunCore/MereRunModelPaths.swift
@@ -195,6 +195,15 @@ public enum MereRunModelPaths {
             )
         }
 
+        if source == .processOverride || source == .environment {
+            return ModelStoreResolution(
+                source: source,
+                activeModelsDir: standardized,
+                configuredModelsDir: standardized,
+                isFallbackToDefault: false
+            )
+        }
+
         if isReadableDirectory(standardized, fileManager: fileManager) {
             return ModelStoreResolution(
                 source: source,

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -74,6 +74,43 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertEqual(decoded.result.models.first?.id, "image-zimage-nano")
     }
 
+    func testModelPullPreflightUsesMissingProcessModelStoreOverride() throws {
+        let temp = try makeTemporaryDirectory()
+        let fileManager = FileManager.default
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? fileManager.removeItem(at: temp)
+        }
+
+        let missingModelStore = temp.appendingPathComponent("models", isDirectory: true)
+        let hubCache = temp.appendingPathComponent("hub", isDirectory: true)
+        try fileManager.createDirectory(at: hubCache, withIntermediateDirectories: true)
+        MereRunModelPaths.setProcessModelsDirOverride(missingModelStore)
+
+        let cmd = try ModelPull.parse([
+            "image-zimage-nano",
+            "--allow-unsupported",
+            "--preflight",
+            "--json",
+        ])
+        let envelope = cmd.makePreflightEnvelope(
+            fileManager: fileManager,
+            hubCacheURL: hubCache,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertFalse(fileManager.fileExists(atPath: missingModelStore.path))
+        XCTAssertEqual(envelope.result.modelStore.path, missingModelStore.standardizedFileURL.path)
+        XCTAssertEqual(
+            envelope.result.models.first?.installPath,
+            missingModelStore
+                .appendingPathComponent("image-zimage-nano", isDirectory: true)
+                .standardizedFileURL
+                .path
+        )
+        XCTAssertEqual(envelope.result.models.first?.status, "will_download")
+    }
+
     func testModelPullPreflightBlocksUnknownModel() throws {
         let cmd = try ModelPull.parse([
             "image-not-real",

--- a/Tests/MereRunCoreTests/MereRunModelPathsTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelPathsTests.swift
@@ -61,6 +61,21 @@ final class MereRunModelPathsTests: XCTestCase {
         )
     }
 
+    func testModelStoreResolutionUsesMissingProcessOverrideWithoutFallback() throws {
+        let temp = try makeTemporaryDirectory(named: "mererun-models-missing-process-parent")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let missingRoot = temp.appendingPathComponent("models", isDirectory: true)
+
+        MereRunModelPaths.setProcessModelsDirOverride(missingRoot)
+
+        let resolution = MereRunModelPaths.modelStoreResolution()
+
+        XCTAssertEqual(resolution.source, .processOverride)
+        XCTAssertEqual(resolution.activeModelsDir.standardizedFileURL.path, missingRoot.standardizedFileURL.path)
+        XCTAssertEqual(resolution.configuredModelsDir?.standardizedFileURL.path, missingRoot.standardizedFileURL.path)
+        XCTAssertFalse(resolution.isFallbackToDefault)
+    }
+
     func testModelStoreResolutionUsesEnvironmentOverride() throws {
         let fm = FileManager.default
         let envRoot = try makeTemporaryDirectory(named: "mererun-models-env")
@@ -72,6 +87,21 @@ final class MereRunModelPathsTests: XCTestCase {
 
         XCTAssertEqual(resolution.source, .environment)
         XCTAssertEqual(resolution.activeModelsDir.standardizedFileURL, envRoot.standardizedFileURL)
+        XCTAssertFalse(resolution.isFallbackToDefault)
+    }
+
+    func testModelStoreResolutionUsesMissingEnvironmentOverrideWithoutFallback() throws {
+        let temp = try makeTemporaryDirectory(named: "mererun-models-missing-env-parent")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let missingRoot = temp.appendingPathComponent("models", isDirectory: true)
+
+        setenv(MereRunModelPaths.modelsDirEnvironmentKey, missingRoot.path, 1)
+
+        let resolution = MereRunModelPaths.modelStoreResolution()
+
+        XCTAssertEqual(resolution.source, .environment)
+        XCTAssertEqual(resolution.activeModelsDir.standardizedFileURL.path, missingRoot.standardizedFileURL.path)
+        XCTAssertEqual(resolution.configuredModelsDir?.standardizedFileURL.path, missingRoot.standardizedFileURL.path)
         XCTAssertFalse(resolution.isFallbackToDefault)
     }
 


### PR DESCRIPTION
## Summary
- keep explicit --models-root / MERERUN_MODELS_DIR overrides authoritative even when the target model-store directory does not exist yet
- preserve fallback-to-default behavior for missing persisted model-store paths
- add regression coverage for missing process/env overrides and model pull preflight install paths

## Validation
- swift test --filter MereRunModelPathsTests --filter ModelPullCommandParsingTests
- missing MERERUN_MODELS_DIR CLI smoke for model pull --preflight --json
- ./scripts/check.sh