### PR TITLE
Make Studio layout responsive

### DIFF
--- a/Sources/MereRunApp/MereRunApp.swift
+++ b/Sources/MereRunApp/MereRunApp.swift
@@ -31,7 +31,10 @@ struct MereRunApp: App {
         WindowGroup {
             MereRunRootView()
                 .environmentObject(controller)
-                .frame(minWidth: 880, minHeight: 600)
+                .frame(
+                    minWidth: StudioLayoutPolicy.minimumWindowWidth,
+                    minHeight: StudioLayoutPolicy.minimumWindowHeight
+                )
                 .onAppear {
                     appDelegate.onTerminate = { [weak controller] in
                         MainActor.assumeIsolated {

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -21,11 +21,12 @@ struct AdvancedControlSurface: View {
     /// detached shows the full three-pane (sidebar · editor · console).
     var docked = false
     var onDetach: (() -> Void)?
+    var onClose: (() -> Void)?
 
     var body: some View {
         Group {
             if docked {
-                DockedAdvancedEditor(onDetach: onDetach)
+                DockedAdvancedEditor(onDetach: onDetach, onClose: onClose)
             } else {
                 fullSurface
             }
@@ -63,6 +64,7 @@ struct AdvancedControlSurface: View {
 private struct DockedAdvancedEditor: View {
     @EnvironmentObject private var controller: MereRunController
     var onDetach: (() -> Void)?
+    var onClose: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -101,11 +103,22 @@ private struct DockedAdvancedEditor: View {
 
             Spacer(minLength: 0)
 
+            if let onClose {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.mereIcon)
+                .help("Hide Advanced (⌃⌘E)")
+                .accessibilityLabel("Hide Advanced")
+            }
+
             if let onDetach {
                 Button(action: onDetach) {
                     Image(systemName: "arrow.up.left.and.arrow.down.right")
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.mereIcon)
                 .help("Detach to the full control surface")
                 .accessibilityLabel("Detach to the full control surface")
             }

--- a/Sources/MereRunApp/StudioCanvas.swift
+++ b/Sources/MereRunApp/StudioCanvas.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// empty / running / readiness states layered as needed.
 struct StudioCanvas: View {
     let mode: StudioMode
+    var isCompact = false
     let item: StudioLibraryItem?
     let conversationItem: StudioLibraryItem?
     let conversationLiveText: String?
@@ -69,11 +70,16 @@ struct StudioCanvas: View {
                     onQuickLook: onQuickLook,
                     onCopy: onCopy
                 )
-                .padding(MereRunTheme.Spacing.xxxl)
+                .padding(isCompact ? MereRunTheme.Spacing.md : MereRunTheme.Spacing.xxxl)
                 .transition(.opacity.combined(with: .scale(scale: 0.985)))
             } else {
-                StudioEmptyState(mode: mode, onUseExample: onUseExample, onAttach: onAttach)
-                    .padding(MereRunTheme.Spacing.xxxl)
+                StudioEmptyState(
+                    mode: mode,
+                    isCompact: isCompact,
+                    onUseExample: onUseExample,
+                    onAttach: onAttach
+                )
+                .padding(isCompact ? MereRunTheme.Spacing.md : MereRunTheme.Spacing.xxxl)
             }
 
             if isRunning && visibleLiveOutputText == nil && !mode.isConversational {
@@ -96,7 +102,7 @@ struct StudioCanvas: View {
                     onPullModel: onPullModel,
                     onShowDetails: onShowDetails
                 )
-                .padding(MereRunTheme.Spacing.xxxl)
+                .padding(isCompact ? MereRunTheme.Spacing.md : MereRunTheme.Spacing.xxxl)
                 .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
@@ -110,15 +116,16 @@ struct StudioCanvas: View {
 /// click straight into the composer.
 struct StudioEmptyState: View {
     let mode: StudioMode
+    var isCompact = false
     var onUseExample: ((String) -> Void)?
     var onAttach: (() -> Void)?
 
     var body: some View {
-        VStack(spacing: MereRunTheme.Spacing.xl) {
+        VStack(spacing: isCompact ? MereRunTheme.Spacing.md : MereRunTheme.Spacing.xl) {
             Image(systemName: mode.systemImage)
-                .font(.system(size: 42, weight: .medium))
+                .font(.system(size: isCompact ? 28 : 42, weight: .medium))
                 .foregroundStyle(MereRunTheme.accent)
-                .frame(width: 96, height: 96)
+                .frame(width: isCompact ? 64 : 96, height: isCompact ? 64 : 96)
                 .background {
                     Circle().fill(MereRunTheme.accentSoft.opacity(0.75))
                 }
@@ -128,7 +135,7 @@ struct StudioEmptyState: View {
 
             VStack(spacing: MereRunTheme.Spacing.xs) {
                 Text(mode.emptyTitle)
-                    .font(MereRunTheme.displayFont)
+                    .font(isCompact ? MereRunTheme.displaySmallFont : MereRunTheme.displayFont)
                     .foregroundStyle(MereRunTheme.textPrimary)
                     .multilineTextAlignment(.center)
                 Text(mode.emptyMessage)
@@ -146,15 +153,28 @@ struct StudioEmptyState: View {
             }
 
             if !mode.examplePrompts.isEmpty, let onUseExample {
-                HStack(spacing: MereRunTheme.Spacing.xs) {
-                    ForEach(mode.examplePrompts, id: \.self) { example in
-                        StudioExampleChip(text: example) { onUseExample(example) }
+                Group {
+                    if isCompact {
+                        VStack(spacing: 6) {
+                            examplePrompts(onUseExample: onUseExample)
+                        }
+                    } else {
+                        HStack(spacing: MereRunTheme.Spacing.xs) {
+                            examplePrompts(onUseExample: onUseExample)
+                        }
                     }
                 }
                 .frame(maxWidth: 720)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func examplePrompts(onUseExample: @escaping (String) -> Void) -> some View {
+        ForEach(mode.examplePrompts, id: \.self) { example in
+            StudioExampleChip(text: example) { onUseExample(example) }
+        }
     }
 
     private var attachLabel: String {

--- a/Sources/MereRunApp/StudioComposer.swift
+++ b/Sources/MereRunApp/StudioComposer.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// depth (attachment, model, options) folded into quiet affordances around it.
 struct StudioComposer: View {
     let mode: StudioMode
+    var isCompact = false
     @Binding var draft: StudioDraft
     @Binding var showOptions: Bool
     let isRunning: Bool
@@ -97,78 +98,14 @@ struct StudioComposer: View {
     }
 
     private var composerBar: some View {
-        HStack(spacing: MereRunTheme.Spacing.sm) {
-            HStack(spacing: 2) {
-                Button(action: onAttach) {
-                    Image(systemName: mode.requiresAttachment ? "paperclip.badge.ellipsis" : "paperclip")
-                        .font(.system(size: 16, weight: .semibold))
-                        .frame(width: 30, height: 30)
-                }
-                .buttonStyle(.mereIcon)
-                .disabled(mode.acceptedTypes.isEmpty)
-                .opacity(mode.acceptedTypes.isEmpty ? 0.35 : 1)
-                .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
-                .accessibilityLabel(mode.requiresAttachment ? "Attach required input" : "Attach reference")
-
-                if mode.acceptedTypes.contains(.image) {
-                    Button(action: onPaste) {
-                        Image(systemName: "doc.on.clipboard")
-                            .font(.system(size: 14, weight: .semibold))
-                            .frame(width: 30, height: 30)
-                    }
-                    .buttonStyle(.mereIcon)
-                    .help("Paste image from clipboard (⌘V)")
-                    .accessibilityLabel("Paste image from clipboard")
-                }
-            }
-
-            if mode == .listen {
-                Text(mode.promptPlaceholder)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        Group {
+            if isCompact {
+                compactComposerContent
             } else {
-                TextField(mode.promptPlaceholder, text: $draft.prompt, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 15, weight: .medium))
-                    .lineLimit(1...5)
-                    .focused(promptFocus)
-                    .onSubmit(onRun)
-            }
-
-            HStack(spacing: 6) {
-                modelMenu
-
-                Button {
-                    showOptions.toggle()
-                } label: {
-                    Image(systemName: "slider.horizontal.3")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(showOptions ? MereRunTheme.accent : MereRunTheme.textSecondary)
-                        .frame(width: 30, height: 30)
-                }
-                .buttonStyle(.mereIcon)
-                .help("Options")
-                .accessibilityLabel("Options")
-                .popover(isPresented: $showOptions, arrowEdge: .top) {
-                    StudioOptionsPanel(mode: mode, draft: $draft)
-                }
-
-                if isRunning {
-                    Button(action: onStop) {
-                        Image(systemName: "stop.fill")
-                            .font(.system(size: 12, weight: .bold))
-                            .frame(width: 30, height: 30)
-                    }
-                    .buttonStyle(.mereIcon(tint: MereRunTheme.red))
-                    .help("Stop current run (⌘.)")
-                    .accessibilityLabel("Stop current run")
-                }
-
-                sendButton
+                regularComposerContent
             }
         }
-        .padding(.horizontal, MereRunTheme.Spacing.md)
+        .padding(.horizontal, isCompact ? MereRunTheme.Spacing.sm : MereRunTheme.Spacing.md)
         .padding(.vertical, MereRunTheme.Spacing.sm)
         .background {
             RoundedRectangle(cornerRadius: MereRunTheme.Radius.xxl)
@@ -180,6 +117,108 @@ struct StudioComposer: View {
                 .mereShadow(radius: 18, y: 8)
         }
         .mereFocusRing(promptFocus.wrappedValue, cornerRadius: MereRunTheme.Radius.xxl)
+    }
+
+    private var regularComposerContent: some View {
+        HStack(spacing: MereRunTheme.Spacing.sm) {
+            attachmentControls
+            promptEntry
+
+            HStack(spacing: 6) {
+                modelMenu
+                optionsButton
+                if isRunning { stopButton }
+                sendButton
+            }
+        }
+    }
+
+    private var compactComposerContent: some View {
+        VStack(spacing: 5) {
+            HStack(spacing: MereRunTheme.Spacing.xs) {
+                promptEntry
+                sendButton
+            }
+
+            HStack(spacing: 4) {
+                attachmentControls
+                modelMenu
+                Spacer(minLength: 0)
+                optionsButton
+                if isRunning { stopButton }
+            }
+        }
+    }
+
+    private var attachmentControls: some View {
+        HStack(spacing: 2) {
+            Button(action: onAttach) {
+                Image(systemName: mode.requiresAttachment ? "paperclip.badge.ellipsis" : "paperclip")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 30, height: 30)
+            }
+            .buttonStyle(.mereIcon)
+            .disabled(mode.acceptedTypes.isEmpty)
+            .opacity(mode.acceptedTypes.isEmpty ? 0.35 : 1)
+            .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
+            .accessibilityLabel(mode.requiresAttachment ? "Attach required input" : "Attach reference")
+
+            if mode.acceptedTypes.contains(.image) {
+                Button(action: onPaste) {
+                    Image(systemName: "doc.on.clipboard")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.mereIcon)
+                .help("Paste image from clipboard (⌘V)")
+                .accessibilityLabel("Paste image from clipboard")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var promptEntry: some View {
+        if mode == .listen {
+            Text(mode.promptPlaceholder)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            TextField(mode.promptPlaceholder, text: $draft.prompt, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(.system(size: 15, weight: .medium))
+                .lineLimit(1...5)
+                .focused(promptFocus)
+                .onSubmit(onRun)
+        }
+    }
+
+    private var optionsButton: some View {
+        Button {
+            showOptions.toggle()
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(showOptions ? MereRunTheme.accent : MereRunTheme.textSecondary)
+                .frame(width: 30, height: 30)
+        }
+        .buttonStyle(.mereIcon)
+        .help("Options")
+        .accessibilityLabel("Options")
+        .popover(isPresented: $showOptions, arrowEdge: .top) {
+            StudioOptionsPanel(mode: mode, draft: $draft)
+        }
+    }
+
+    private var stopButton: some View {
+        Button(action: onStop) {
+            Image(systemName: "stop.fill")
+                .font(.system(size: 12, weight: .bold))
+                .frame(width: 30, height: 30)
+        }
+        .buttonStyle(.mereIcon(tint: MereRunTheme.red))
+        .help("Stop current run (⌘.)")
+        .accessibilityLabel("Stop current run")
     }
 
     private var sendButton: some View {

--- a/Sources/MereRunApp/StudioLayout.swift
+++ b/Sources/MereRunApp/StudioLayout.swift
@@ -1,0 +1,32 @@
+import CoreGraphics
+
+/// The Studio has two deliberate window presentations. Regular keeps the desktop three-column
+/// workspace; compact promotes the canvas and composer while moving navigation into overlays.
+enum StudioLayoutClass: Equatable {
+    case compact
+    case regular
+
+    var isCompact: Bool { self == .compact }
+}
+
+enum StudioLayoutPolicy {
+    static let sidebarWidth: CGFloat = 212
+    static let libraryWidth: CGFloat = 272
+    static let minimumCanvasWidth: CGFloat = 620
+
+    /// The regular shell needs room for sidebar + library + canvas. Crossing this content-driven
+    /// breakpoint changes the information architecture instead of squeezing those columns.
+    static let compactBreakpoint: CGFloat = sidebarWidth + libraryWidth + minimumCanvasWidth + 16
+
+    static let minimumWindowWidth: CGFloat = 480
+    static let minimumWindowHeight: CGFloat = 440
+    static let compactPanelInset: CGFloat = 12
+
+    static func layoutClass(for width: CGFloat) -> StudioLayoutClass {
+        width < compactBreakpoint ? .compact : .regular
+    }
+
+    static func compactPanelWidth(availableWidth: CGFloat, preferredWidth: CGFloat) -> CGFloat {
+        min(preferredWidth, max(availableWidth - (compactPanelInset * 2), 0))
+    }
+}

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -3,12 +3,16 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct StudioRootView: View {
+    private static let orderedModes = StudioModeGroup.allCases.flatMap(\.modes)
+
     @EnvironmentObject private var controller: MereRunController
     @StateObject private var library = StudioLibraryStore()
     // Persisted per scene so relaunch restores the last mode and panel layout.
     @SceneStorage("studio.mode") private var mode: StudioMode = .createImage
     @SceneStorage("studio.showLibrary") private var showLibrary = true
     @SceneStorage("studio.showAdvanced") private var showAdvanced = false
+    @State private var layoutClass: StudioLayoutClass = .regular
+    @State private var showCompactLibrary = false
     @State private var draft = StudioDraft()
     @State private var showOptions = false
     @State private var showModels = false
@@ -109,66 +113,180 @@ struct StudioRootView: View {
     }
 
     private var shell: some View {
+        GeometryReader { geometry in
+            let layout = StudioLayoutPolicy.layoutClass(for: geometry.size.width)
+
+            adaptiveShell(layout: layout, availableWidth: geometry.size.width)
+                .onAppear { updateLayoutClass(layout) }
+                .onChange(of: layout) { _, nextLayout in
+                    updateLayoutClass(nextLayout)
+                }
+        }
+        .background(MereRunTheme.background.ignoresSafeArea())
+    }
+
+    private func adaptiveShell(layout: StudioLayoutClass, availableWidth: CGFloat) -> some View {
         ZStack(alignment: .trailing) {
             HStack(spacing: 0) {
-                StudioSidebar(
-                    mode: $mode,
-                    modeCapabilities: modeCapabilities,
-                    serverStatus: controller.serverStatus,
-                    resolvedCLI: controller.resolvedCLI,
-                    onShowModels: { showModels = true },
-                    onShowHelp: { showHelp = true }
-                )
+                if !layout.isCompact {
+                    regularNavigation
 
-                Divider()
-                    .overlay(MereRunTheme.border.opacity(0.4))
+                    Divider()
+                        .overlay(MereRunTheme.border.opacity(0.4))
+                }
 
-                if showLibrary {
-                    StudioLibraryPanel(
-                        items: library.items,
-                        selectedID: $selectedLibraryID,
-                        isVisible: $showLibrary,
-                        onDelete: { id in
-                            library.delete(id: id)
-                            if selectedLibraryID == id { selectedLibraryID = nil }
-                        },
-                        onRename: { id, title in
-                            library.rename(id: id, title: title)
-                        },
-                        onQuickLook: { QuickLookCoordinator.shared.preview($0) }
-                    )
-                    .frame(width: 272)
+                if !layout.isCompact, showLibrary {
+                    regularLibrary
 
                     Divider()
                         .overlay(MereRunTheme.border.opacity(0.5))
                 }
 
-                contentColumn
+                contentColumn(isCompact: layout.isCompact)
+            }
+
+            if layout.isCompact, showCompactLibrary {
+                compactDismissLayer { showCompactLibrary = false }
+
+                HStack(spacing: 0) {
+                    compactLibraryPanel(availableWidth: availableWidth)
+                    Spacer(minLength: 0)
+                }
+                .transition(.move(edge: .leading).combined(with: .opacity))
+                .zIndex(1)
             }
 
             if showAdvanced {
-                advancedPanel
+                advancedPanel(layout: layout, availableWidth: availableWidth)
                     .transition(.move(edge: .trailing).combined(with: .opacity))
-                    .zIndex(1)
+                    .zIndex(2)
             }
         }
         .background(MereRunTheme.background.ignoresSafeArea())
     }
 
-    private var advancedPanel: some View {
-        HStack(spacing: 0) {
-            advancedResizeHandle
-            AdvancedControlSurface(docked: true, onDetach: { advancedDetached = true })
-                .frame(width: advancedWidth)
-                .clipped()
+    private var regularNavigation: some View {
+        StudioSidebar(
+            mode: $mode,
+            modeCapabilities: modeCapabilities,
+            serverStatus: controller.serverStatus,
+            resolvedCLI: controller.resolvedCLI,
+            onShowModels: { showModels = true },
+            onShowHelp: { showHelp = true }
+        )
+        .frame(width: StudioLayoutPolicy.sidebarWidth)
+    }
+
+    private var regularLibrary: some View {
+        StudioLibraryPanel(
+            items: library.items,
+            selectedID: $selectedLibraryID,
+            isVisible: $showLibrary,
+            onDelete: deleteLibraryItem,
+            onRename: library.rename,
+            onQuickLook: { QuickLookCoordinator.shared.preview($0) }
+        )
+        .frame(width: StudioLayoutPolicy.libraryWidth)
+    }
+
+    private func compactLibraryPanel(availableWidth: CGFloat) -> some View {
+        StudioLibraryPanel(
+            items: library.items,
+            selectedID: compactLibrarySelection,
+            isVisible: $showCompactLibrary,
+            onDelete: deleteLibraryItem,
+            onRename: library.rename,
+            onQuickLook: { QuickLookCoordinator.shared.preview($0) }
+        )
+        .frame(
+            width: StudioLayoutPolicy.compactPanelWidth(
+                availableWidth: availableWidth,
+                preferredWidth: 320
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.xl))
+        .mereShadow(radius: 24, y: 0)
+        .padding(StudioLayoutPolicy.compactPanelInset)
+    }
+
+    private func compactDismissLayer(action: @escaping () -> Void) -> some View {
+        MereRunTheme.textPrimary.opacity(0.06)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: action)
+            .transition(.opacity)
+            .zIndex(0)
+            .accessibilityHidden(true)
+    }
+
+    private func advancedPanel(layout: StudioLayoutClass, availableWidth: CGFloat) -> some View {
+        Group {
+            if layout.isCompact {
+                AdvancedControlSurface(
+                    docked: true,
+                    onClose: { showAdvanced = false }
+                )
+                    .frame(
+                        width: StudioLayoutPolicy.compactPanelWidth(
+                            availableWidth: availableWidth,
+                            preferredWidth: advancedWidth
+                        )
+                    )
+                    .clipped()
+            } else {
+                HStack(spacing: 0) {
+                    advancedResizeHandle
+                    AdvancedControlSurface(
+                        docked: true,
+                        onDetach: { advancedDetached = true },
+                        onClose: { showAdvanced = false }
+                    )
+                        .frame(width: advancedWidth)
+                        .clipped()
+                }
+            }
         }
         .background(MereRunTheme.background)
         .mereShadow(radius: 24, y: 0)
     }
 
-    private var contentColumn: some View {
+    private var compactLibrarySelection: Binding<UUID?> {
+        Binding(
+            get: { selectedLibraryID },
+            set: { nextSelection in
+                selectedLibraryID = nextSelection
+                if nextSelection != nil { showCompactLibrary = false }
+            }
+        )
+    }
+
+    private var visibleLibraryBinding: Binding<Bool> {
+        Binding(
+            get: { layoutClass.isCompact ? showCompactLibrary : showLibrary },
+            set: { isVisible in
+                if layoutClass.isCompact {
+                    showCompactLibrary = isVisible
+                    if isVisible { showAdvanced = false }
+                } else {
+                    showLibrary = isVisible
+                }
+            }
+        )
+    }
+
+    private func deleteLibraryItem(_ id: UUID) {
+        library.delete(id: id)
+        if selectedLibraryID == id { selectedLibraryID = nil }
+    }
+
+    private func updateLayoutClass(_ nextLayout: StudioLayoutClass) {
+        guard layoutClass != nextLayout else { return }
+        layoutClass = nextLayout
+        if nextLayout == .regular { showCompactLibrary = false }
+    }
+
+    private func contentColumn(isCompact: Bool) -> some View {
         VStack(spacing: 0) {
-            topBar
+            topBar(isCompact: isCompact)
 
             Divider()
                 .overlay(MereRunTheme.border.opacity(0.45))
@@ -182,13 +300,13 @@ struct StudioRootView: View {
                 .padding(.top, 10)
             }
 
-            canvas
+            canvas(isCompact: isCompact)
 
-            composer
-                .padding(.horizontal, 24)
-                .padding(.bottom, 20)
+            composer(isCompact: isCompact)
+                .padding(.horizontal, isCompact ? 12 : 24)
+                .padding(.bottom, isCompact ? 12 : 20)
         }
-        .frame(minWidth: 620)
+        .frame(minWidth: isCompact ? 0 : StudioLayoutPolicy.minimumCanvasWidth)
         .background {
             ZStack {
                 MereRunTheme.background
@@ -228,9 +346,10 @@ struct StudioRootView: View {
         .onPasteCommand(of: [.image]) { _ in pasteImageFromClipboard() }
     }
 
-    private var canvas: some View {
+    private func canvas(isCompact: Bool) -> some View {
         StudioCanvas(
             mode: mode,
+            isCompact: isCompact,
             item: selectedItem,
             conversationItem: activeConversationItem,
             conversationLiveText: activeConversationLiveText,
@@ -259,9 +378,10 @@ struct StudioRootView: View {
         )
     }
 
-    private var composer: some View {
+    private func composer(isCompact: Bool) -> some View {
         StudioComposer(
             mode: mode,
+            isCompact: isCompact,
             draft: $draft,
             showOptions: $showOptions,
             isRunning: controller.isRunning,
@@ -322,7 +442,7 @@ struct StudioRootView: View {
                 .frame(width: 1_260, height: 780)
                 .environmentObject(controller)
             }
-            .focusedSceneValue(\.showLibrary, $showLibrary)
+            .focusedSceneValue(\.showLibrary, visibleLibraryBinding)
             .focusedSceneValue(\.showAdvanced, $showAdvanced)
             .focusedSceneValue(\.showModels, $showModels)
     }
@@ -364,7 +484,10 @@ struct StudioRootView: View {
     private var navigationObservedShell: some View {
         lifecycleShell
         .onChange(of: showAdvanced) { _, isShown in
-            if isShown { syncAdvancedToStudio() }
+            if isShown {
+                if layoutClass.isCompact { showCompactLibrary = false }
+                syncAdvancedToStudio()
+            }
         }
         .onChange(of: mode) { _, newMode in
             var nextDraft = freshDraft(for: newMode)
@@ -508,38 +631,47 @@ struct StudioRootView: View {
 
     /// The slim, contextual header for the content column: which mode you're in, and the two
     /// panel toggles. Machine-wide status lives in the sidebar; blocking states own the canvas.
-    private var topBar: some View {
+    private func topBar(isCompact: Bool) -> some View {
         HStack(spacing: MereRunTheme.Spacing.sm) {
-            Image(systemName: mode.systemImage)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-
-            VStack(alignment: .leading, spacing: 1) {
-                Text(mode.title)
+            if isCompact {
+                compactModePicker
+            } else {
+                Image(systemName: mode.systemImage)
                     .font(.system(size: 15, weight: .semibold))
-                Text(mode.subtitle)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(MereRunTheme.textMuted)
+                    .foregroundStyle(MereRunTheme.accent)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(mode.title)
+                        .font(.system(size: 15, weight: .semibold))
+                    Text(mode.subtitle)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
             }
 
             Spacer()
 
             Button {
                 withAnimation(MereRunTheme.Motion.standard) {
-                    showLibrary.toggle()
+                    toggleLibrary(isCompact: isCompact)
                 }
             } label: {
                 Image(systemName: "rectangle.stack")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(showLibrary ? MereRunTheme.accent : MereRunTheme.textSecondary)
+                    .foregroundStyle(
+                        libraryIsVisible(isCompact: isCompact)
+                            ? MereRunTheme.accent
+                            : MereRunTheme.textSecondary
+                    )
                     .frame(width: 30, height: 30)
             }
             .buttonStyle(.mereIcon)
-            .help(showLibrary ? "Hide library (⌃⌘L)" : "Show library (⌃⌘L)")
-            .accessibilityLabel(showLibrary ? "Hide library" : "Show library")
+            .help(libraryIsVisible(isCompact: isCompact) ? "Hide library (⌃⌘L)" : "Show library (⌃⌘L)")
+            .accessibilityLabel(libraryIsVisible(isCompact: isCompact) ? "Hide library" : "Show library")
 
             Button {
                 withAnimation(MereRunTheme.Motion.standard) {
+                    if isCompact { showCompactLibrary = false }
                     showAdvanced.toggle()
                 }
             } label: {
@@ -552,9 +684,80 @@ struct StudioRootView: View {
             .help(showAdvanced ? "Hide Advanced (⌃⌘E)" : "Show Advanced (⌃⌘E)")
             .accessibilityLabel(showAdvanced ? "Hide Advanced" : "Show Advanced")
         }
-        .padding(.horizontal, MereRunTheme.Spacing.lg)
+        .padding(.horizontal, isCompact ? MereRunTheme.Spacing.md : MereRunTheme.Spacing.lg)
         .frame(height: 52)
         .background(VisualEffectBackground())
+    }
+
+    private var compactModePicker: some View {
+        Menu {
+            ForEach(StudioModeGroup.allCases) { group in
+                Section(group.rawValue) {
+                    ForEach(group.modes) { candidate in
+                        Button {
+                            mode = candidate
+                        } label: {
+                            if candidate == mode {
+                                Label(candidate.title, systemImage: "checkmark")
+                            } else {
+                                Label(candidate.title, systemImage: candidate.systemImage)
+                            }
+                        }
+                        .disabled(modeCapabilities[candidate]?.unavailableMessage != nil)
+                        .modifier(
+                            StudioModeShortcut(
+                                number: Self.orderedModes.firstIndex(of: candidate).flatMap { index in
+                                    index < 9 ? index + 1 : nil
+                                }
+                            )
+                        )
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: mode.systemImage)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+                    .frame(width: 20)
+                Text(mode.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 30)
+            .background {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                    .fill(MereRunTheme.surface.opacity(0.62))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                            .strokeBorder(MereRunTheme.border.opacity(0.45), lineWidth: 1)
+                    }
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Switch creation mode")
+        .accessibilityLabel("Mode")
+        .accessibilityValue(mode.title)
+    }
+
+    private func libraryIsVisible(isCompact: Bool) -> Bool {
+        isCompact ? showCompactLibrary : showLibrary
+    }
+
+    private func toggleLibrary(isCompact: Bool) {
+        if isCompact {
+            showAdvanced = false
+            showCompactLibrary.toggle()
+        } else {
+            showLibrary.toggle()
+        }
     }
 
     private func runStudioCommand() {

--- a/Sources/MereRunApp/StudioSidebar.swift
+++ b/Sources/MereRunApp/StudioSidebar.swift
@@ -179,7 +179,7 @@ private struct StudioSidebarRow: View {
 }
 
 /// Applies ⌘1…⌘9 to the first nine modes without duplicating the row body per branch.
-private struct StudioModeShortcut: ViewModifier {
+struct StudioModeShortcut: ViewModifier {
     let number: Int?
 
     func body(content: Content) -> some View {

--- a/Tests/MereRunAppTests/StudioLayoutTests.swift
+++ b/Tests/MereRunAppTests/StudioLayoutTests.swift
@@ -1,0 +1,26 @@
+@testable import MereRunApp
+import XCTest
+
+final class StudioLayoutTests: XCTestCase {
+    func testLayoutBecomesCompactBeforeRegularColumnsWouldCollide() {
+        XCTAssertEqual(
+            StudioLayoutPolicy.layoutClass(for: StudioLayoutPolicy.compactBreakpoint - 1),
+            .compact
+        )
+        XCTAssertEqual(
+            StudioLayoutPolicy.layoutClass(for: StudioLayoutPolicy.compactBreakpoint),
+            .regular
+        )
+    }
+
+    func testCompactPanelRespectsWindowInsetsAndPreferredWidth() {
+        XCTAssertEqual(
+            StudioLayoutPolicy.compactPanelWidth(availableWidth: 480, preferredWidth: 560),
+            456
+        )
+        XCTAssertEqual(
+            StudioLayoutPolicy.compactPanelWidth(availableWidth: 900, preferredWidth: 320),
+            320
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a content-driven compact/regular Studio layout policy
- move navigation, library, and Advanced controls into compact overlays when the window narrows
- adapt the canvas, empty state, composer, and mode picker for compact windows
- add breakpoint and compact-panel sizing tests

## Why
The existing three-column Studio shell had a fixed minimum width and compressed poorly in smaller macOS windows. This preserves the full desktop workspace while giving narrow windows a deliberate, usable presentation.

## Validation
- `./scripts/check.sh` (1,192 tests passed; 61 skipped)
- `swift test --filter StudioLayoutTests` (2 passed)
- built and launched the `mere.run.app` executable

## Remaining validation
The Mac was locked during final review, so regular/compact visual QA could not be completed in the live app.