### PR TITLE
Harden quantized MoE long-sequence execution

### DIFF
--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -46,12 +46,20 @@ final class Q35SwitchLinear: Module {
         self.groupSize = groupSize
         self.bits = bits
 
-        let scale = sqrt(1.0 / Float(max(1, inputDims)))
-        self._weight.wrappedValue = MLXRandom.uniform(
-            low: -scale,
-            high: scale,
-            [numExperts, outputDims, inputDims]
-        )
+        if quantized {
+            let packedInputDims = (inputDims * bits + 31) / 32
+            self._weight.wrappedValue = MLXArray.zeros(
+                [numExperts, outputDims, packedInputDims],
+                dtype: .uint32
+            )
+        } else {
+            let scale = sqrt(1.0 / Float(max(1, inputDims)))
+            self._weight.wrappedValue = MLXRandom.uniform(
+                low: -scale,
+                high: scale,
+                [numExperts, outputDims, inputDims]
+            )
+        }
         let groups = max(1, (inputDims + groupSize - 1) / groupSize)
         self._scales.wrappedValue = quantized
             ? MLXArray.zeros([numExperts, outputDims, groups])

--- a/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
+++ b/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
@@ -92,6 +92,74 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
         XCTAssertLessThan(maxDiff, 0.001)
     }
 
+    func testQ35SwitchLinearAcross1024TokenBoundary() throws {
+        let numExperts = 16
+        let inputDims = 32
+        let outputDims = 16
+        let topK = 8
+        let denseWeight = MLXArray(
+            (0..<(numExperts * outputDims * inputDims)).map {
+                Float(($0 % 37) - 18) / 24.0
+            },
+            [numExperts, outputDims, inputDims]
+        )
+        let (weight, scales, biases) = MLX.quantized(
+            denseWeight,
+            groupSize: 32,
+            bits: 4
+        )
+        let layer = Q35SwitchLinear(
+            inputDims: inputDims,
+            outputDims: outputDims,
+            numExperts: numExperts,
+            groupSize: 32,
+            bits: 4,
+            quantized: true,
+            bias: false
+        )
+        var updates = [
+            ("weight", weight),
+            ("scales", scales),
+        ]
+        if let biases {
+            updates.append(("biases", biases))
+        }
+        try layer.update(parameters: ModuleParameters.unflattened(updates), verify: .none)
+
+        for tokenCount in [1000, 1240] {
+            let input = MLXArray(
+                (0..<(tokenCount * inputDims)).map {
+                    Float(($0 % 29) - 14) / 17.0
+                },
+                [1, tokenCount, inputDims]
+            ).asType(.bfloat16)
+            let indices = MLXArray(
+                (0..<(tokenCount * topK)).map { Int32(($0 * 5 + 3) % numExperts) },
+                [1, tokenCount, topK]
+            )
+
+            let actual = layer(input, indices: indices).asType(.float32)
+            let expandedInput = MLX.expandedDimensions(input, axes: [-2, -3])
+            let expected = portableGatherQuantizedMM(
+                expandedInput,
+                weight,
+                scales: scales,
+                biases: biases,
+                rhsIndices: indices,
+                transpose: true,
+                groupSize: 32,
+                bits: 4,
+                mode: .affine,
+                sortedIndices: false,
+                forceDequantizedFallback: true
+            ).squeezed(axis: -2).asType(.float32)
+            MLX.eval(actual, expected)
+
+            let maxDiff = MLX.max(MLX.abs(actual - expected)).item(Float.self)
+            XCTAssertLessThan(maxDiff, 0.02, "GatherQMM diverged at tokenCount=\(tokenCount)")
+        }
+    }
+
     func testQ35SwitchLinearSortedRouteMatchesUnsortedRoute() throws {
         let routeCount = 64
         let inputDims = 4

--- a/Tests/MereRunCoreTests/SDPAVectorKernelTests.swift
+++ b/Tests/MereRunCoreTests/SDPAVectorKernelTests.swift
@@ -95,4 +95,54 @@ final class SDPAVectorKernelTests: MereRunCoreTestCase {
             }
         }
     }
+
+    func testFullSequenceAttentionAcross1024Boundary() throws {
+        try skipUnlessGPU()
+
+        let headCount = 16
+        let headDim = 128
+        let scale = 1.0 / Float(Double(headDim).squareRoot())
+
+        for sequenceLength in [1000, 1240] {
+            MLXRandom.seed(0)
+            let queries = (MLXRandom.normal([1, headCount, sequenceLength, headDim]) * 0.5)
+                .asType(.bfloat16)
+            let keys = (MLXRandom.normal([1, headCount, sequenceLength, headDim]) * 0.5)
+                .asType(.bfloat16)
+            let values = (MLXRandom.normal([1, headCount, sequenceLength, headDim]) * 0.5)
+                .asType(.bfloat16)
+
+            let output = MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+            MLX.eval(output)
+
+            let queryIndices = MLXArray([
+                Int32(0),
+                Int32(sequenceLength / 2),
+                Int32(sequenceLength - 1),
+            ])
+            let selectedQueries = queries.take(queryIndices, axis: 2)
+            let selectedOutput = output.take(queryIndices, axis: 2).asType(.float32)
+            let reference = referenceAttention(
+                queries: selectedQueries,
+                keys: keys,
+                values: values,
+                scale: scale
+            )
+            MLX.eval(reference)
+
+            let referenceError = MLX.abs(selectedOutput - reference).max().item(Float.self)
+            XCTAssertFalse(referenceError.isNaN, "SDPA produced NaN at sequenceLength=\(sequenceLength)")
+            XCTAssertLessThanOrEqual(
+                referenceError,
+                0.02,
+                "full-sequence SDPA diverged at sequenceLength=\(sequenceLength)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- initialize quantized switch-expert weights directly in packed UInt32 form
- avoid allocating dense random expert tensors before quantized weights are loaded
- cover routed quantized matmul on both sides of the 1,024-token boundary
- cover full-sequence Metal SDPA on both sides of the same boundary

## Why
Large routed-expert models should not pay for a dense temporary allocation during construction, and long video/text sequences need explicit regression coverage for the MLX gather-QMM and attention paths.

## Validation
- `./scripts/check.sh` (1,192 tests passed; 61 skipped)
- `swift test --filter "PortableQuantizedMatmulTests|SDPAVectorKernelTests"` (5 passed; 2 Metal tests skipped without GPU opt-in)
- `MERERUN_TEST_MLX_DEVICE=gpu swift test --filter SDPAVectorKernelTests` (2 passed on Metal)