### PR TITLE
Add `image generate --progress-json` for machine-readable per-step progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on Keep a Changelog.
   Psi/GLM runtime, with numerical, structural-memory, and policy tests. Affine
   8-bit is a memory control relative to full-precision KV; Gemma Turbo's default
   4-bit TurboQuant cache remains smaller.
+- added `image generate --progress-json`, a machine-readable progress stream
+  for wrappers: one JSON object per event on stderr
+  (`{"event":"progress","stage":"denoising","step":2,"total_steps":4}`),
+  replacing the human-readable progress text and taking precedence over
+  `--quiet` for progress output.
 - added native MuScriptor full-mix audio-to-MIDI transcription through
   `music transcribe`, with managed small/medium/large checkpoints, exact HTK
   mel preprocessing, MLX transformer inference, instrument conditioning,

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -118,6 +118,12 @@ struct ImageGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Print only the output path.")
     var quiet: Bool = false
 
+    @Flag(
+        name: [.customLong("progress-json")],
+        help: "Stream progress to stderr as JSON lines (one object per event) instead of human-readable text. Takes precedence over --quiet for progress output."
+    )
+    var progressJson: Bool = false
+
     func run() async throws {
         try validateStaticOptions()
         let kreaConditioningRebalance = try Self.resolveKreaConditioningRebalance(
@@ -295,8 +301,14 @@ struct ImageGenerate: AsyncParsableCommand {
                 kreaConditioningRebalance: kreaConditioningRebalance
             )
 
-            let progressHandler: (@Sendable (GenerationProgress) -> Void)? =
-                quiet ? nil : CLIGenerationProgressPrinter.makeProgressHandler()
+            let progressHandler: (@Sendable (GenerationProgress) -> Void)?
+            if progressJson {
+                progressHandler = CLIGenerationProgressPrinter.makeJSONProgressHandler()
+            } else if quiet {
+                progressHandler = nil
+            } else {
+                progressHandler = CLIGenerationProgressPrinter.makeProgressHandler()
+            }
             if !quiet {
                 CLIStderr.write("[runtime] image backend: \(NativeMLXRuntime.backendDescription)\n")
             }

--- a/Sources/MereRunCLI/Support/CLIGenerationProgressPrinter.swift
+++ b/Sources/MereRunCLI/Support/CLIGenerationProgressPrinter.swift
@@ -2,6 +2,32 @@ import Foundation
 import MereRunCore
 
 enum CLIGenerationProgressPrinter {
+    /// One NDJSON object per distinct progress event, e.g.
+    /// `{"event":"progress","stage":"denoising","step":2,"total_steps":4}`.
+    /// `step` is the generator's raw 0-based step index; stages emit a final
+    /// event with `step == total_steps` when they finish.
+    static func progressJSONLine(_ progress: GenerationProgress) -> String {
+        "{\"event\":\"progress\",\"stage\":\"\(progress.stage.rawValue)\"," +
+            "\"step\":\(progress.stepIndex),\"total_steps\":\(progress.totalSteps)}"
+    }
+
+    /// Machine-readable progress for wrappers (`--progress-json`): one JSON
+    /// line per event on stderr, so stdout stays reserved for the output path.
+    static func makeJSONProgressHandler(
+        write: @escaping @Sendable (String) -> Void = { CLIStderr.write($0) }
+    ) -> (@Sendable (GenerationProgress) -> Void) {
+        final class State: @unchecked Sendable {
+            var last: GenerationProgress?
+        }
+
+        let state = State()
+        return { progress in
+            guard progress != state.last else { return }
+            state.last = progress
+            write(progressJSONLine(progress) + "\n")
+        }
+    }
+
     static func makeProgressHandler() -> (@Sendable (GenerationProgress) -> Void) {
         final class State: @unchecked Sendable {
             var lastStage: GenerationStage?

--- a/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
+++ b/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class CLIGenerationProgressPrinterTests: XCTestCase {
+    func testProgressJSONLineEncodesStageStepAndTotal() {
+        let line = CLIGenerationProgressPrinter.progressJSONLine(
+            GenerationProgress(stage: .denoising, stepIndex: 2, totalSteps: 4)
+        )
+
+        XCTAssertEqual(
+            line,
+            #"{"event":"progress","stage":"denoising","step":2,"total_steps":4}"#
+        )
+
+        let decoded = try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        XCTAssertEqual(decoded?["event"] as? String, "progress")
+        XCTAssertEqual(decoded?["stage"] as? String, "denoising")
+        XCTAssertEqual(decoded?["step"] as? Int, 2)
+        XCTAssertEqual(decoded?["total_steps"] as? Int, 4)
+    }
+
+    func testProgressJSONLineEncodesLoadingStages() {
+        let line = CLIGenerationProgressPrinter.progressJSONLine(
+            GenerationProgress(stage: .loadingModel, stepIndex: 3, totalSteps: 7)
+        )
+
+        XCTAssertEqual(
+            line,
+            #"{"event":"progress","stage":"loadingModel","step":3,"total_steps":7}"#
+        )
+    }
+
+    func testJSONProgressHandlerEmitsOneLinePerDistinctEvent() {
+        final class Sink: @unchecked Sendable {
+            var lines: [String] = []
+        }
+
+        let sink = Sink()
+        let handler = CLIGenerationProgressPrinter.makeJSONProgressHandler { text in
+            sink.lines.append(text)
+        }
+
+        let events = [
+            GenerationProgress(stage: .encodingText, stepIndex: 0, totalSteps: 1),
+            GenerationProgress(stage: .denoising, stepIndex: 0, totalSteps: 4),
+            GenerationProgress(stage: .denoising, stepIndex: 0, totalSteps: 4),
+            GenerationProgress(stage: .denoising, stepIndex: 1, totalSteps: 4),
+            GenerationProgress(stage: .denoising, stepIndex: 4, totalSteps: 4),
+        ]
+        events.forEach(handler)
+
+        XCTAssertEqual(sink.lines, [
+            "{\"event\":\"progress\",\"stage\":\"encodingText\",\"step\":0,\"total_steps\":1}\n",
+            "{\"event\":\"progress\",\"stage\":\"denoising\",\"step\":0,\"total_steps\":4}\n",
+            "{\"event\":\"progress\",\"stage\":\"denoising\",\"step\":1,\"total_steps\":4}\n",
+            "{\"event\":\"progress\",\"stage\":\"denoising\",\"step\":4,\"total_steps\":4}\n",
+        ])
+        XCTAssertTrue(sink.lines.allSatisfy { $0.hasSuffix("\n") && !$0.dropLast().contains("\n") })
+    }
+}

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -177,6 +177,21 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.json)
     }
 
+    func testParsesProgressJSONFlag() throws {
+        let defaulted = try ImageGenerate.parse([
+            "--prompt", "a clean product render",
+        ])
+        XCTAssertFalse(defaulted.progressJson)
+
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "a clean product render",
+            "--progress-json",
+            "--quiet",
+        ])
+        XCTAssertTrue(cmd.progressJson)
+        XCTAssertTrue(cmd.quiet)
+    }
+
     func testImageGenerationPreflightReportsReadyLocalRequest() throws {
         let temp = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -266,6 +266,13 @@ Key options:
 - `--preflight`: inspect the generation request without loading the model or writing an image
 - `--json`: with `--preflight`, emit a structured JSON report
 - `--quiet`
+- `--progress-json`: stream progress to stderr as JSON lines instead of
+  human-readable text, one object per event, e.g.
+  `{"event":"progress","stage":"denoising","step":2,"total_steps":4}`.
+  `step` is the generator's 0-based step index; each stage emits a final event
+  with `step == total_steps`. Takes precedence over `--quiet` for progress
+  output, so wrappers can keep stdout limited to the output path while still
+  observing per-step progress.
 
 Unless `--quiet` is set, progress diagnostics on stderr include the native image
 backend, for example `native MLX/Metal (default device: gpu)` on Apple Silicon.


### PR DESCRIPTION
## What & why

`image generate` already computes per-step denoising callbacks (they drive the human `Generating (N/M)` stderr text), but nothing emitted them in a form a wrapper could parse. The mere.run relay node consequently sent a single `step: 0` progress message per job, so clients polling the relay saw a **frozen step counter** for the whole generation.

This adds **`--progress-json`**: when set, progress is streamed to **stderr as NDJSON**, one object per event:

```
{"event":"progress","stage":"denoising","step":2,"total_steps":4}
```

- stdout still prints only the output path.
- Takes precedence over `--quiet`, so wrappers keep a clean stdout while still observing per-step progress.
- `step` is the generator's 0-based index; each stage emits a final event with `step == total_steps`.
- No behavior change without the flag — the human printer is untouched.

## Changes

- `CLIGenerationProgressPrinter`: `progressJSONLine(_:)` + `makeJSONProgressHandler()` (dedupes on the full event).
- `ImageGenerateCommand`: `--progress-json` flag and handler selection (`--progress-json` → JSON, else `--quiet` → nil, else human printer).
- Tests: new `CLIGenerationProgressPrinterTests` (encoding + dedupe) and a parsing test for the flag.
- `docs/cli.md`, `CHANGELOG.md`.

## Verification

- `swift build` + `swiftlint --strict`: clean.
- Targeted tests + full `swift test` suite: green.
- **Real MLX generation** with `--progress-json` (zimage-nano, 4 steps) emitted the exact NDJSON sequence, and the mere.run relay node consumed it to advance a live job's step counter 1→4 against production `relay.mere.run` (node side is a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
