### PR TITLE
Add native Wan2.2 world runtime

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -312,6 +312,7 @@ targets.append(contentsOf: [
       "VideoDepth/README.md",
       "VideoDepth/VDA/README.md",
       "VisionGeometry/MoGe2/README.md",
+      "Wan2/README.md",
       "Woosh/README.md",
       "ZImageI2L/README.md",
       "ZImageI2L/Model/README.md",

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -126,7 +126,7 @@ struct VideoExportLatents: AsyncParsableCommand {
 struct VideoGenerate: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "generate",
-        abstract: "Generate MP4 video with native Swift/MLX LTX.",
+        abstract: "Generate MP4 video with native Swift/MLX video models.",
         discussion: """
         Prints the output MP4 path to stdout.
         Progress and diagnostics are printed to stderr.
@@ -140,6 +140,7 @@ struct VideoGenerate: AsyncParsableCommand {
           swift run mere.run video generate "woman walking in neon rain" --image frame.png
           swift run mere.run video generate "a car drives from dawn into sunset" --image start.png --end-image end.png
           swift run mere.run video generate "dialogue with clean background music" --variant unified-av --model video-ltx23-av-mlx --duration 15 --fps 24
+          swift run mere.run video generate "the camera walks forward" --model video-wan22-ti2v-5b-mlx --image frame.png --num-frames 41 --width 1280 --height 704
         """
     )
 
@@ -149,7 +150,7 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.customShort("o"), .long], help: "Output MP4 path (default: ./mererun-video-<timestamp>.mp4).")
     var output: String?
 
-    @Option(name: [.customShort("m"), .long], help: "Managed model id or local path to the LTX model root.")
+    @Option(name: [.customShort("m"), .long], help: "Managed video model id or local model root.")
     var model: String = ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
 
     @Option(name: [.customLong("variant")], help: "Native LTX lane: distilled for faster video-only drafts, unified-av for synchronized audio/video.")
@@ -158,16 +159,16 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("model-root")], help: "Local LTX model root. Takes precedence over --model.")
     var modelRoot: String?
 
-    @Option(name: [.long], help: "Output width (must be divisible by 64; auto-snapped down).")
+    @Option(name: [.long], help: "Output width (snapped to the selected model's native geometry).")
     var width: Int = 768
 
-    @Option(name: [.long], help: "Output height (must be divisible by 64; auto-snapped down).")
+    @Option(name: [.long], help: "Output height (snapped to the selected model's native geometry).")
     var height: Int = 512
 
-    @Option(name: [.customLong("num-frames")], help: "Frame count (must be 8n+1; auto-adjusted).")
+    @Option(name: [.customLong("num-frames")], help: "Frame count (adjusted to the selected model's native cadence).")
     var numFrames: Int = 65
 
-    @Option(name: [.long], help: "Target output duration in seconds. Overrides --num-frames by choosing the nearest 8n+1 frame count for --fps.")
+    @Option(name: [.long], help: "Target output duration in seconds. Overrides --num-frames using the selected model's native cadence.")
     var duration: Double?
 
     @Option(name: [.long], help: "Frames per second.")
@@ -175,6 +176,18 @@ struct VideoGenerate: AsyncParsableCommand {
 
     @Option(name: [.long], help: "Seed value.")
     var seed: Int?
+
+    @Option(name: [.long], help: "Wan denoising steps.")
+    var steps: Int = 40
+
+    @Option(name: [.customLong("guidance-scale")], help: "Wan classifier-free guidance scale.")
+    var guidanceScale: Float = 5
+
+    @Option(name: [.long], help: "Wan flow-schedule shift.")
+    var shift: Float = 5
+
+    @Option(name: [.customLong("negative-prompt")], help: "Wan negative prompt. Defaults to the official TI2V negative prompt.")
+    var negativePrompt: String?
 
     @Option(name: [.long], help: "Optional source image path (enables image-to-video).")
     var image: String?
@@ -221,14 +234,23 @@ struct VideoGenerate: AsyncParsableCommand {
                 throw ValidationError("--duration must be > 0")
             }
         }
-        guard width >= 64 else {
-            throw ValidationError("--width must be >= 64")
+        guard width >= 32 else {
+            throw ValidationError("--width must be >= 32")
         }
-        guard height >= 64 else {
-            throw ValidationError("--height must be >= 64")
+        guard height >= 32 else {
+            throw ValidationError("--height must be >= 32")
         }
-        guard numFrames >= 9 else {
-            throw ValidationError("--num-frames must be >= 9")
+        guard numFrames >= 5 else {
+            throw ValidationError("--num-frames must be >= 5")
+        }
+        guard steps > 0 else {
+            throw ValidationError("--steps must be >= 1")
+        }
+        guard guidanceScale >= 0 else {
+            throw ValidationError("--guidance-scale must be >= 0")
+        }
+        guard shift > 0 else {
+            throw ValidationError("--shift must be > 0")
         }
         guard (0...1).contains(imageStrength) else {
             throw ValidationError("--image-strength must be between 0 and 1")
@@ -244,24 +266,6 @@ struct VideoGenerate: AsyncParsableCommand {
         let resolvedHeight = max(64, (height / 64) * 64)
         let requestedNumFrames = duration.map { nearestLTXFrameCount(duration: $0, fps: fps) } ?? numFrames
         let resolvedNumFrames = max(9, ((requestedNumFrames - 1) / 8) * 8 + 1)
-        if !quiet {
-            if resolvedWidth != width || resolvedHeight != height {
-                CLIStderr.write("Adjusted size to \(resolvedWidth)x\(resolvedHeight) (must be divisible by 64)\n")
-            }
-            if let duration {
-                let resolvedSeconds = Double(resolvedNumFrames) / Double(fps)
-                CLIStderr.write(
-                    "Resolved duration \(String(format: "%.2f", duration))s to \(resolvedNumFrames) frames at \(fps) fps (~\(String(format: "%.2f", resolvedSeconds))s; must satisfy 8n+1)\n"
-                )
-            } else if resolvedNumFrames != numFrames {
-                CLIStderr.write("Adjusted frame count to \(resolvedNumFrames) (must satisfy 8n+1)\n")
-            }
-            if variant == .unifiedAV && fps != 24 {
-                CLIStderr.write(
-                    "Warning: LTX unified AV is trained for 24 fps; --fps \(fps) can make generated motion look time-stretched relative to audio.\n"
-                )
-            }
-        }
 
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
@@ -293,6 +297,68 @@ struct VideoGenerate: AsyncParsableCommand {
             variant: variant
         ).path
 
+        let resolvedRootURL = URL(fileURLWithPath: resolvedModelRoot).standardizedFileURL
+        if isWan2ModelRoot(resolvedRootURL) {
+            guard let sourceImageURL else {
+                throw ValidationError("Wan2.2 TI2V requires --image.")
+            }
+            guard endImageURL == nil else {
+                throw ValidationError("Wan2.2 TI2V does not support --end-image yet.")
+            }
+            let wanWidth = max(32, (width / 32) * 32)
+            let wanHeight = max(32, (height / 32) * 32)
+            let requestedWanFrames = duration.map { nearestWanFrameCount(duration: $0, fps: fps) } ?? numFrames
+            let wanFrames = max(5, ((requestedWanFrames - 1) / 4) * 4 + 1)
+            if !quiet {
+                if wanWidth != width || wanHeight != height {
+                    CLIStderr.write("Adjusted Wan size to \(wanWidth)x\(wanHeight) (must be divisible by 32)\n")
+                }
+                if let duration {
+                    let resolvedSeconds = Double(wanFrames) / Double(fps)
+                    CLIStderr.write(
+                        "Resolved Wan duration \(String(format: "%.2f", duration))s to \(wanFrames) frames at \(fps) fps (~\(String(format: "%.2f", resolvedSeconds))s; must satisfy 4n+1)\n"
+                    )
+                } else if wanFrames != numFrames {
+                    CLIStderr.write("Adjusted Wan frame count to \(wanFrames) (must satisfy 4n+1)\n")
+                }
+            }
+            try await runNativeWanGenerate(
+                prompt: trimmedPrompt,
+                negativePrompt: negativePrompt ?? Wan2Resources.defaultNegativePrompt,
+                width: wanWidth,
+                height: wanHeight,
+                numFrames: wanFrames,
+                steps: steps,
+                guidanceScale: guidanceScale,
+                shift: shift,
+                fps: fps,
+                seed: seed ?? 42,
+                sourceImageURL: sourceImageURL,
+                modelRoot: resolvedRootURL,
+                outputURL: outputURL
+            )
+            return
+        }
+
+        if !quiet {
+            if resolvedWidth != width || resolvedHeight != height {
+                CLIStderr.write("Adjusted size to \(resolvedWidth)x\(resolvedHeight) (must be divisible by 64)\n")
+            }
+            if let duration {
+                let resolvedSeconds = Double(resolvedNumFrames) / Double(fps)
+                CLIStderr.write(
+                    "Resolved duration \(String(format: "%.2f", duration))s to \(resolvedNumFrames) frames at \(fps) fps (~\(String(format: "%.2f", resolvedSeconds))s; must satisfy 8n+1)\n"
+                )
+            } else if resolvedNumFrames != numFrames {
+                CLIStderr.write("Adjusted frame count to \(resolvedNumFrames) (must satisfy 8n+1)\n")
+            }
+            if variant == .unifiedAV && fps != 24 {
+                CLIStderr.write(
+                    "Warning: LTX unified AV is trained for 24 fps; --fps \(fps) can make generated motion look time-stretched relative to audio.\n"
+                )
+            }
+        }
+
         try await runNativeGenerate(
             prompt: trimmedPrompt,
             width: resolvedWidth,
@@ -308,6 +374,71 @@ struct VideoGenerate: AsyncParsableCommand {
             modelRoot: resolvedModelRoot,
             outputURL: outputURL
         )
+    }
+
+    private func isWan2ModelRoot(_ rootURL: URL) -> Bool {
+        let resources = Wan2Resources(rootURL: rootURL)
+        return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
+    }
+
+    private func runNativeWanGenerate(
+        prompt: String,
+        negativePrompt: String,
+        width: Int,
+        height: Int,
+        numFrames: Int,
+        steps: Int,
+        guidanceScale: Float,
+        shift: Float,
+        fps: Int,
+        seed: Int,
+        sourceImageURL: URL,
+        modelRoot: URL,
+        outputURL: URL
+    ) async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        let options = try Wan2GenerationOptions(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            sourceImageURL: sourceImageURL,
+            outputURL: outputURL,
+            width: width,
+            height: height,
+            numFrames: numFrames,
+            steps: steps,
+            guidanceScale: guidanceScale,
+            shift: shift,
+            seed: UInt64(bitPattern: Int64(seed)),
+            fps: fps
+        )
+        if !quiet {
+            CLIStderr.write("Engine: native Wan2.2 TI2V\n")
+            CLIStderr.write("Model root: \(modelRoot.path)\n")
+            CLIStderr.write("Mode: image-to-video\n")
+        }
+        let reportsProgress = !quiet
+        let generator = Wan2TI2VGenerator()
+        let result = try await generator.generate(
+            options: options,
+            resources: Wan2Resources(rootURL: modelRoot),
+            progressHandler: { progress in
+                guard reportsProgress else { return }
+                if progress.stage == .denoising {
+                    CLIStderr.write("Denoising \(progress.stepIndex + 1)/\(progress.totalSteps)\n")
+                } else {
+                    CLIStderr.write("\(progress.stage.rawValue)\n")
+                }
+            }
+        )
+        if !quiet {
+            CLIStderr.write("Decoded frames shape: \(shapeString(result.frames.shape))\n")
+            CLIStderr.write("Writing MP4...\n")
+        }
+        try LTXVideoMP4Writer.writeMP4(frames: result.frames, fps: fps, to: outputURL)
+        if !quiet {
+            CLIStderr.write("Saved: \(outputURL.path)\n")
+        }
+        print(outputURL.path)
     }
 
     private func runNativeGenerate(
@@ -537,6 +668,11 @@ func validateNativeModelRoot(_ rootURL: URL) throws {
         throw ValidationError("Model root directory not found: \(rootURL.path)")
     }
 
+    let wanResources = Wan2Resources(rootURL: rootURL)
+    if wanResources.validate().isEmpty, (try? wanResources.loadConfiguration()) != nil {
+        return
+    }
+
     if isLTX23SplitModelRoot(rootURL) {
         return
     }
@@ -667,6 +803,12 @@ func nearestLTXFrameCount(duration: Double, fps: Int) -> Int {
     let targetFrames = max(9.0, duration * Double(max(1, fps)))
     let chunks = max(1, Int(((targetFrames - 1.0) / 8.0).rounded()))
     return chunks * 8 + 1
+}
+
+func nearestWanFrameCount(duration: Double, fps: Int) -> Int {
+    let targetFrames = max(5.0, duration * Double(max(1, fps)))
+    let chunks = max(1, Int(((targetFrames - 1.0) / 4.0).rounded()))
+    return chunks * 4 + 1
 }
 
 private func isNativeVideoModelRootAvailable(at path: String) -> Bool {

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -188,6 +188,16 @@ struct VideoGenerationPreflightAnalyzer {
         self.now = now
     }
 
+    private var usesWanGeometry: Bool {
+        if input.model.trimmingCharacters(in: .whitespacesAndNewlines) == Wan2Resources.modelID {
+            return true
+        }
+        let candidate = input.modelRoot ?? input.model
+        let url = URL(fileURLWithPath: candidate).standardizedFileURL
+        let resources = Wan2Resources(rootURL: url)
+        return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
+    }
+
     func envelope() -> VideoGenerationPreflightEnvelope {
         var diagnostics: [PreflightDiagnostic] = []
         validateStaticOptions(diagnostics: &diagnostics)
@@ -269,33 +279,35 @@ struct VideoGenerationPreflightAnalyzer {
                 )
             )
         }
-        if input.width < 64 {
+        let minimumSpatialDimension = usesWanGeometry ? 32 : 64
+        let minimumFrameCount = usesWanGeometry ? 5 : 9
+        if input.width < minimumSpatialDimension {
             diagnostics.append(
                 PreflightDiagnostic(
                     id: "width_too_small",
                     severity: .blocker,
                     title: "Width is too small",
-                    message: "--width must be >= 64."
+                    message: "--width must be >= \(minimumSpatialDimension)."
                 )
             )
         }
-        if input.height < 64 {
+        if input.height < minimumSpatialDimension {
             diagnostics.append(
                 PreflightDiagnostic(
                     id: "height_too_small",
                     severity: .blocker,
                     title: "Height is too small",
-                    message: "--height must be >= 64."
+                    message: "--height must be >= \(minimumSpatialDimension)."
                 )
             )
         }
-        if input.numFrames < 9 {
+        if input.numFrames < minimumFrameCount {
             diagnostics.append(
                 PreflightDiagnostic(
                     id: "num_frames_too_small",
                     severity: .blocker,
                     title: "Frame count is too small",
-                    message: "--num-frames must be >= 9."
+                    message: "--num-frames must be >= \(minimumFrameCount)."
                 )
             )
         }
@@ -534,7 +546,11 @@ struct VideoGenerationPreflightAnalyzer {
     }
 
     private func videoLayout(at url: URL) -> String? {
-        isLTX23SplitModelRoot(url, fileManager: fileManager) ? "ltx23_split" : "ltx_merged"
+        let resources = Wan2Resources(rootURL: url)
+        if resources.validate().isEmpty, (try? resources.loadConfiguration()) != nil {
+            return "wan22_ti2v_mlx"
+        }
+        return isLTX23SplitModelRoot(url, fileManager: fileManager) ? "ltx23_split" : "ltx_merged"
     }
 
     private func outputSummary(
@@ -646,12 +662,24 @@ struct VideoGenerationPreflightAnalyzer {
         inputs: VideoGenerationInputPreflightSummary,
         diagnostics: inout [PreflightDiagnostic]
     ) -> VideoGenerationPlanPreflightSummary {
-        let resolvedWidth = max(64, (input.width / 64) * 64)
-        let resolvedHeight = max(64, (input.height / 64) * 64)
-        let requestedFrames = input.duration.map { nearestLTXFrameCount(duration: $0, fps: input.fps) } ?? input.numFrames
-        let resolvedFrames = max(9, ((requestedFrames - 1) / 8) * 8 + 1)
+        let spatialMultiple = usesWanGeometry ? 32 : 64
+        let temporalMultiple = usesWanGeometry ? 4 : 8
+        let minimumFrames = usesWanGeometry ? 5 : 9
+        let resolvedWidth = max(spatialMultiple, (input.width / spatialMultiple) * spatialMultiple)
+        let resolvedHeight = max(spatialMultiple, (input.height / spatialMultiple) * spatialMultiple)
+        let requestedFrames = input.duration.map {
+            usesWanGeometry
+                ? nearestWanFrameCount(duration: $0, fps: input.fps)
+                : nearestLTXFrameCount(duration: $0, fps: input.fps)
+        } ?? input.numFrames
+        let resolvedFrames = max(
+            minimumFrames,
+            ((requestedFrames - 1) / temporalMultiple) * temporalMultiple + 1
+        )
 
-        if input.width >= 64, input.height >= 64, (resolvedWidth != input.width || resolvedHeight != input.height) {
+        if input.width >= spatialMultiple,
+           input.height >= spatialMultiple,
+           resolvedWidth != input.width || resolvedHeight != input.height {
             diagnostics.append(
                 PreflightDiagnostic(
                     id: "dimensions_will_be_adjusted",
@@ -661,13 +689,13 @@ struct VideoGenerationPreflightAnalyzer {
                 )
             )
         }
-        if input.numFrames >= 9, input.duration == nil, resolvedFrames != input.numFrames {
+        if input.numFrames >= minimumFrames, input.duration == nil, resolvedFrames != input.numFrames {
             diagnostics.append(
                 PreflightDiagnostic(
                     id: "num_frames_will_be_adjusted",
                     severity: .note,
                     title: "Frame count will be adjusted",
-                    message: "Frame count will be snapped from \(input.numFrames) to \(resolvedFrames) to satisfy 8n+1."
+                    message: "Frame count will be snapped from \(input.numFrames) to \(resolvedFrames) to satisfy \(temporalMultiple)n+1."
                 )
             )
         }
@@ -690,7 +718,7 @@ struct VideoGenerationPreflightAnalyzer {
         }
 
         return VideoGenerationPlanPreflightSummary(
-            variant: input.variant.rawValue,
+            variant: usesWanGeometry ? "wan22-ti2v" : input.variant.rawValue,
             inputMode: inputs.mode,
             requestedWidth: input.width,
             requestedHeight: input.height,
@@ -702,7 +730,7 @@ struct VideoGenerationPreflightAnalyzer {
             resolvedNumFrames: resolvedFrames,
             resolvedDurationSeconds: input.fps > 0 ? Double(resolvedFrames) / Double(input.fps) : nil,
             seed: input.seed ?? 42,
-            writesAudio: input.variant == .unifiedAV
+            writesAudio: !usesWanGeometry && input.variant == .unifiedAV
         )
     }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -61,6 +61,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case wooshSynchformer
     case ltxVideo
     case ltxVideo23MLX
+    case wan22TI2VMLX
     case hfTextChat
 }
 
@@ -1536,6 +1537,22 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["video generate"],
             companionModelIDs: [ModelResolver.ModelID.ltxGemma3TwelveB4Bit.rawValue]
         ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.wan22TI2V5BMLX.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Wan2Resources.managedRepoID,
+                revision: Wan2Resources.managedRevision,
+                patterns: Wan2Resources.snapshotPatterns
+            ),
+            upstreamRepoId: Wan2Resources.managedRepoID,
+            upstreamRevision: Wan2Resources.managedRevision,
+            validationKind: .wan22TI2VMLX,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 24_200_000_000,
+            defaultCLICommands: ["video generate"]
+        ),
     ]
 
     public static var allModelIDs: [String] {
@@ -1743,6 +1760,8 @@ public extension ManagedModelSpec {
             return Self.missingLTXVideoPaths(in: rootURL, fileManager: fileManager)
         case .ltxVideo23MLX:
             return Self.missingLTXVideo23MLXPaths(in: rootURL, fileManager: fileManager)
+        case .wan22TI2VMLX:
+            return Wan2Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .hfTextChat:
             return Self.missingHFTextRootPaths(in: rootURL, fileManager: fileManager)
         }
@@ -1784,6 +1803,18 @@ public extension ManagedModelSpec {
                 in: normalizedRootURL(rootURL, fileManager: fileManager),
                 fileManager: fileManager
             ).map { "Missing required LTX 2.3 MLX file: \($0.path)" }
+        case .wan22TI2VMLX:
+            let resources = Wan2Resources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager))
+            let missing = resources.validate(fileManager: fileManager)
+            if !missing.isEmpty {
+                return missing.map { "Missing required Wan2.2 TI2V MLX file: \($0.path)" }
+            }
+            do {
+                _ = try resources.loadConfiguration()
+                return []
+            } catch {
+                return [error.localizedDescription]
+            }
         case .magentaRT2:
             return Self.missingMagentaRT2Paths(
                 modelID: id,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -687,6 +687,13 @@ public enum ManagedModelCapabilityCatalog {
                 minimum: 96,
                 recommended: 128
             ),
+            descriptor(
+                ModelResolver.ModelID.wan22TI2V5BMLX.rawValue,
+                "Wan2.2 TI2V 5B MLX",
+                "Generates text- and image-conditioned pixel video with the native Swift MLX Wan2.2 runtime.",
+                minimum: 64,
+                recommended: 96
+            ),
         ]
         return Dictionary(uniqueKeysWithValues: descriptors.map { ($0.modelID, $0) })
     }()

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -70,6 +70,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case woosh = "woosh"
         /// LTX video family.
         case ltxVideo = "ltx-video"
+        /// Wan2 native video family.
+        case wanVideo = "wan-video"
         /// Psi agent chat family.
         case psiChat = "psi-chat"
         /// DeepSeek V4 Flash family, served by the bundled `ds4-server` subprocess.
@@ -1469,6 +1471,26 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.videoGeneration],
                 components: nil,
                 upstreamRepoId: isLTX23 ? "dgrauet/ltx-2.3-mlx@main" : "mlx-community/LTX-2-distilled-bf16",
+                createdAt: createdAt
+            )
+        case .wan22TI2V5BMLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .wanVideo,
+                family: .video,
+                tier: .base,
+                variant: .base,
+                precision: .bf16,
+                defaults: Defaults(steps: 40, cfg: 5.0, sigmaShift: 5.0),
+                supports: [.videoGeneration],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: .local(path: "."),
+                    scheduler: nil
+                ),
+                upstreamRepoId: "\(Wan2Resources.managedRepoID)@\(Wan2Resources.managedRevision)",
                 createdAt: createdAt
             )
         }

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -150,7 +150,8 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .videoDepthAnything
             || spec?.validationKind == .depthAnything3
             || spec?.validationKind == .tripoSR
-            || spec?.validationKind == .instantMesh {
+            || spec?.validationKind == .instantMesh
+            || spec?.validationKind == .wan22TI2VMLX {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil
             textEncoderDir = nil
@@ -384,8 +385,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=music expects ace-step, magenta-rt2, or muscriptor.")
             case .sfx where engine != .woosh:
                 warnings.append("Manifest engine mismatch: family=sfx expects woosh.")
-            case .video where engine != .ltxVideo:
-                warnings.append("Manifest engine mismatch: family=video expects ltx-video.")
+            case .video where engine != .ltxVideo && engine != .wanVideo:
+                warnings.append("Manifest engine mismatch: family=video expects ltx-video or wan-video.")
             case .psi where engine != .psiChat:
                 warnings.append("Manifest engine mismatch: family=psi expects psi-chat.")
             default:
@@ -459,7 +460,7 @@ public enum MereRunModelValidator {
             }
             switch manifest.engine {
             case .qwen3Coder?, .northMiniCode?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .ltxVideo?,
-                 .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?:
+                 .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?:
                 return true
             default:
                 return false

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -80,6 +80,7 @@ public struct ModelResolver {
         case wooshDVFlow8s = "sfx-woosh-dvflow-8s"
         case ltxVideoAV = "video-ltx-av"
         case ltxVideo23AVMLX = "video-ltx23-av-mlx"
+        case wan22TI2V5BMLX = "video-wan22-ti2v-5b-mlx"
     }
 
     public enum Source: String, Hashable, Sendable {

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -66,7 +66,7 @@ public enum QuantizedModelManifestWriter {
             case .lightOnOCR: return .ocr
             case .aceStep, .magentaRT2, .muScriptor: return .music
             case .woosh: return .sfx
-            case .ltxVideo: return .video
+            case .ltxVideo, .wanVideo: return .video
             case .psiChat: return .psi
             case .deepseekV4Flash: return .deepseek
             }
@@ -143,7 +143,7 @@ public enum QuantizedModelManifestWriter {
                     return [.musicTranscription]
                 case .woosh:
                     return [.soundEffectGeneration]
-                case .ltxVideo:
+                case .ltxVideo, .wanVideo:
                     return [.videoGeneration]
                 case .psiChat:
                     return [.chat]
@@ -224,6 +224,8 @@ public enum QuantizedModelManifestWriter {
                 break
             case .aceStep, .magentaRT2, .ltxVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)
+            case .wanVideo:
+                manifest.defaults = MereRunModelManifest.Defaults(steps: 40, cfg: 5.0, sigmaShift: 5.0)
             }
         }
 

--- a/Sources/MereRunCore/Wan2/README.md
+++ b/Sources/MereRunCore/Wan2/README.md
@@ -1,0 +1,49 @@
+# Wan2 native runtime
+
+This directory owns the native Swift/MLX Wan2.2 TI2V-5B runtime. The managed
+model root is `video-wan22-ti2v-5b-mlx` and contains:
+
+- `config.json`: typed Wan2.2 TI2V-5B architecture and inference defaults.
+- `model.safetensors`: single 5B diffusion transformer in MLX layout.
+- `t5_encoder.safetensors`: UMT5-XXL encoder weights in MLX layout.
+- `tokenizer.json`: local UMT5 tokenizer; inference must not fetch it at runtime.
+- `vae.safetensors`: float32 Wan2.2 48-channel VAE encoder and decoder weights.
+
+The model is derived from the official `Wan-AI/Wan2.2-TI2V-5B` checkpoint.
+`Wan2Resources` pins both the official source revision and the managed converted
+snapshot used by `mere.run model pull`.
+
+## Runtime boundaries
+
+`Wan2TI2VGenerator` is a reusable warm runtime. Reusing one instance retains the
+tokenizer, UMT5 encoder, diffusion transformer, VAE, prompt embeddings, and the
+latest terminal-frame latent. `Wan2WorldSession` owns that runtime behind an
+actor and exposes serial world transitions without passing mutable MLX tensors
+to callers or launching a process per move.
+
+World transitions carry a stable camera-control record with XYZ translation and
+rotation. The base TI2V checkpoint currently applies that control through the
+motion prompt and first-frame conditioning (`textAndFirstFrame`). A future
+DreamX-derived camera adapter can consume the same control as causal camera
+latents and report `causalCameraLatents` without changing the session request or
+receipt schema.
+
+The session writes one MP4 and one terminal PNG per transition. The next
+transition consumes the terminal latent directly in memory; the PNG is an
+observable state artifact, not the internal chaining path.
+
+## Verified parity
+
+The real-checkpoint harnesses compare native Swift/MLX against independent
+upstream implementations:
+
+- UMT5 output against Wan's PyTorch encoder.
+- One-block and full 30-block transformer output against the public MLX Wan
+  implementation.
+- VAE image latents against Wan's official PyTorch VAE.
+- Two consecutive world transitions with warm model reuse and terminal-latent
+  chaining.
+
+Tiny 128-pixel renders are structural tests only. Quality acceptance should use
+at least a 512x320 spatial canvas; Wan geometry is divisible by 32 and frame
+counts follow 4n+1.

--- a/Sources/MereRunCore/Wan2/Wan2Generation.swift
+++ b/Sources/MereRunCore/Wan2/Wan2Generation.swift
@@ -1,0 +1,280 @@
+import Foundation
+import MLX
+
+public enum Wan2GenerationError: LocalizedError, Sendable {
+    case invalidResolution(width: Int, height: Int)
+    case invalidFrameCount(Int)
+    case invalidStepCount(Int)
+    case sourceImageRequired
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResolution(let width, let height):
+            return "Wan2.2 TI2V resolution must be positive, divisible by 32, and at most 901120 pixels; received \(width)x\(height)."
+        case .invalidFrameCount(let count):
+            return "Wan2.2 TI2V frame count must be 4n+1 and at least 5; received \(count)."
+        case .invalidStepCount(let count):
+            return "Wan2.2 TI2V step count must be positive; received \(count)."
+        case .sourceImageRequired:
+            return "Wan2.2 TI2V generation requires a source image."
+        }
+    }
+}
+
+public struct Wan2GenerationOptions: Hashable, Sendable {
+    public let prompt: String
+    public let negativePrompt: String
+    public let sourceImageURL: URL
+    public let outputURL: URL
+    public let width: Int
+    public let height: Int
+    public let numFrames: Int
+    public let steps: Int
+    public let guidanceScale: Float
+    public let shift: Float
+    public let seed: UInt64
+    public let fps: Int
+
+    public init(
+        prompt: String,
+        negativePrompt: String,
+        sourceImageURL: URL,
+        outputURL: URL,
+        width: Int = 1_280,
+        height: Int = 704,
+        numFrames: Int = 41,
+        steps: Int = 40,
+        guidanceScale: Float = 5,
+        shift: Float = 5,
+        seed: UInt64 = 42,
+        fps: Int = 24
+    ) throws {
+        guard width > 0,
+              height > 0,
+              width % 32 == 0,
+              height % 32 == 0,
+              width * height <= 704 * 1_280 else {
+            throw Wan2GenerationError.invalidResolution(width: width, height: height)
+        }
+        guard numFrames >= 5, (numFrames - 1) % 4 == 0 else {
+            throw Wan2GenerationError.invalidFrameCount(numFrames)
+        }
+        guard steps > 0 else {
+            throw Wan2GenerationError.invalidStepCount(steps)
+        }
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.sourceImageURL = sourceImageURL
+        self.outputURL = outputURL
+        self.width = width
+        self.height = height
+        self.numFrames = numFrames
+        self.steps = steps
+        self.guidanceScale = guidanceScale
+        self.shift = shift
+        self.seed = seed
+        self.fps = fps
+    }
+
+    public var latentShape: [Int] {
+        [48, (numFrames - 1) / 4 + 1, height / 16, width / 16]
+    }
+
+    public var patchGridShape: [Int] {
+        let latent = latentShape
+        return [latent[1], latent[2] / 2, latent[3] / 2]
+    }
+
+    public var sequenceLength: Int {
+        patchGridShape.reduce(1, *)
+    }
+}
+
+public struct Wan2FlowMatchEulerScheduler: Sendable {
+    public let timesteps: [Float]
+    public let sigmas: [Float]
+    private var stepIndex = 0
+
+    public init(steps: Int, shift: Float = 5, trainTimesteps: Int = 1_000) {
+        precondition(steps > 0)
+        precondition(trainTimesteps > 1)
+        var shifted: [Float] = []
+        shifted.reserveCapacity(steps + 1)
+        let sigmaMax = Float(trainTimesteps - 1) / Float(trainTimesteps)
+        for index in 0..<steps {
+            let fraction = Float(index) / Float(steps)
+            let sigma = sigmaMax * (1 - fraction)
+            shifted.append(shift * sigma / (1 + (shift - 1) * sigma))
+        }
+        shifted.append(0)
+        self.sigmas = shifted
+        self.timesteps = shifted.dropLast().map {
+            Float(Int(($0 * Float(trainTimesteps)).rounded(.towardZero)))
+        }
+    }
+
+    public mutating func step(velocity: MLXArray, sample: MLXArray) -> MLXArray {
+        precondition(stepIndex < timesteps.count)
+        let delta = sigmas[stepIndex + 1] - sigmas[stepIndex]
+        stepIndex += 1
+        return sample + delta * velocity
+    }
+
+    public mutating func reset() {
+        stepIndex = 0
+    }
+}
+
+public struct Wan2UniPCScheduler {
+    public let timesteps: [Float]
+    public let sigmas: [Float]
+    private var modelOutputs: [MLXArray?] = [nil, nil]
+    private var lowerOrderCount = 0
+    private var lastSample: MLXArray?
+    private var stepIndex = 0
+    private var currentOrder = 1
+
+    public init(steps: Int, shift: Float = 5, trainTimesteps: Int = 1_000) {
+        precondition(steps > 0)
+        precondition(shift > 0)
+        var shifted: [Float] = []
+        shifted.reserveCapacity(steps + 1)
+        for index in 0..<steps {
+            let fraction = Float(index) / Float(steps)
+            let sigma = 1 + (1 / Float(trainTimesteps) - 1) * fraction
+            shifted.append(shift * sigma / (1 + (shift - 1) * sigma))
+        }
+        if abs(shifted[0] - 1) < 1e-6 {
+            shifted[0] -= 1e-6
+        }
+        shifted.append(0)
+        self.sigmas = shifted
+        self.timesteps = shifted.dropLast().map {
+            Float(Int(($0 * Float(trainTimesteps)).rounded(.towardZero)))
+        }
+    }
+
+    public mutating func step(modelOutput: MLXArray, sample initialSample: MLXArray) -> MLXArray {
+        precondition(stepIndex < timesteps.count)
+        let converted = initialSample.asType(.float32) - sigmas[stepIndex] * modelOutput.asType(.float32)
+        var sample = initialSample.asType(.float32)
+        if stepIndex > 0, let lastSample {
+            sample = correct(
+                currentModelOutput: converted,
+                lastSample: lastSample,
+                currentSample: sample,
+                order: currentOrder
+            )
+        }
+
+        modelOutputs[0] = modelOutputs[1]
+        modelOutputs[1] = converted
+        currentOrder = min(2, timesteps.count - stepIndex, lowerOrderCount + 1)
+        lastSample = sample
+        let previous = predict(sample: sample, order: currentOrder)
+        lowerOrderCount = min(lowerOrderCount + 1, 2)
+        stepIndex += 1
+        return previous.asType(.float32)
+    }
+
+    private func predict(sample: MLXArray, order: Int) -> MLXArray {
+        let sigmaTarget = Double(sigmas[stepIndex + 1])
+        let sigmaSource = Double(sigmas[stepIndex])
+        let alphaTarget = 1 - sigmaTarget
+        let alphaSource = 1 - sigmaSource
+        let lambdaTarget = log(alphaTarget) - log(sigmaTarget)
+        let lambdaSource = log(alphaSource) - log(sigmaSource)
+        let h = lambdaTarget - lambdaSource
+        let phi = expm1(-h)
+        guard let current = modelOutputs[1] else { preconditionFailure("Missing UniPC model output") }
+
+        var result = Float(sigmaTarget / sigmaSource) * sample
+            - Float(alphaTarget * phi) * current
+        if order == 2, stepIndex > 0, let previous = modelOutputs[0] {
+            let sigmaHistory = Double(sigmas[stepIndex - 1])
+            let alphaHistory = 1 - sigmaHistory
+            let lambdaHistory = log(alphaHistory) - log(sigmaHistory)
+            let ratio = (lambdaHistory - lambdaSource) / h
+            let firstDifference = (previous - current) / Float(ratio)
+            result = result - Float(alphaTarget * phi * 0.5) * firstDifference
+        }
+        return result
+    }
+
+    private func correct(
+        currentModelOutput: MLXArray,
+        lastSample: MLXArray,
+        currentSample: MLXArray,
+        order: Int
+    ) -> MLXArray {
+        let sigmaTarget = Double(sigmas[stepIndex])
+        let sigmaSource = Double(sigmas[stepIndex - 1])
+        let alphaTarget = 1 - sigmaTarget
+        let alphaSource = 1 - sigmaSource
+        let lambdaTarget = log(alphaTarget) - log(sigmaTarget)
+        let lambdaSource = log(alphaSource) - log(sigmaSource)
+        let h = lambdaTarget - lambdaSource
+        let phi = expm1(-h)
+        guard let previousModelOutput = modelOutputs[1] else {
+            preconditionFailure("Missing UniPC previous output")
+        }
+
+        var historicalCorrection = MLX.zeros(currentSample.shape, dtype: .float32)
+        let coefficients: [Float]
+        if order == 2, stepIndex > 1, let historicalOutput = modelOutputs[0] {
+            let sigmaHistory = Double(sigmas[stepIndex - 2])
+            let alphaHistory = 1 - sigmaHistory
+            let lambdaHistory = log(alphaHistory) - log(sigmaHistory)
+            let ratio = (lambdaHistory - lambdaSource) / h
+            let firstDifference = (historicalOutput - previousModelOutput) / Float(ratio)
+            coefficients = Self.correctorCoefficients(ratio: ratio, h: -h, phi: phi)
+            historicalCorrection = coefficients[0] * firstDifference
+        } else {
+            coefficients = [0.5]
+        }
+        let currentDifference = currentModelOutput - previousModelOutput
+        return Float(sigmaTarget / sigmaSource) * lastSample
+            - Float(alphaTarget * phi) * previousModelOutput
+            - Float(alphaTarget * phi) * (historicalCorrection + coefficients.last! * currentDifference)
+    }
+
+    private static func correctorCoefficients(ratio: Double, h: Double, phi: Double) -> [Float] {
+        let firstPhi = expm1(h)
+        var higherPhi = firstPhi / h - 1
+        let b0 = higherPhi / phi
+        higherPhi = higherPhi / h - 0.5
+        let b1 = higherPhi * 2 / phi
+        let first = (b0 - b1) / (1 - ratio)
+        return [Float(first), Float(b0 - first)]
+    }
+}
+
+public enum Wan2TI2VConditioning {
+    public static func latentMask(shape: [Int], dtype: DType = .float32) -> MLXArray {
+        precondition(shape.count == 4)
+        let firstFrame = MLX.zeros([shape[0], 1, shape[2], shape[3]], dtype: dtype)
+        let remaining = MLX.ones([shape[0], max(shape[1] - 1, 0), shape[2], shape[3]], dtype: dtype)
+        return shape[1] == 1 ? firstFrame : MLX.concatenated([firstFrame, remaining], axis: 1)
+    }
+
+    public static func tokenMask(
+        latentShape: [Int],
+        patchSize: [Int] = [1, 2, 2],
+        dtype: DType = .float32
+    ) -> MLXArray {
+        precondition(latentShape.count == 4)
+        precondition(patchSize.count == 3)
+        let temporal = latentShape[1] / patchSize[0]
+        let height = latentShape[2] / patchSize[1]
+        let width = latentShape[3] / patchSize[2]
+        let firstFrameTokens = height * width
+        let total = temporal * firstFrameTokens
+        let frozen = MLX.zeros([1, firstFrameTokens], dtype: dtype)
+        let denoised = MLX.ones([1, max(total - firstFrameTokens, 0)], dtype: dtype)
+        return total == firstFrameTokens ? frozen : MLX.concatenated([frozen, denoised], axis: 1)
+    }
+
+    public static func blend(imageLatent: MLXArray, noise: MLXArray, mask: MLXArray) -> MLXArray {
+        (1 - mask) * imageLatent + mask * noise
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2ModelLoader.swift
+++ b/Sources/MereRunCore/Wan2/Wan2ModelLoader.swift
@@ -1,0 +1,126 @@
+import Foundation
+import MLX
+
+public enum Wan2ModelLoaderError: LocalizedError, Sendable {
+    case textEncodingFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .textEncodingFailed:
+            return "Wan2 text encoder did not return the expected batch."
+        }
+    }
+}
+
+public struct Wan2TextConditioning {
+    public let prompt: MLXArray
+    public let negativePrompt: MLXArray
+}
+
+public enum Wan2ModelLoader {
+    public static func loadTokenizer(resources: Wan2Resources) throws -> Wan2Tokenizer {
+        try Wan2Tokenizer.load(from: resources.tokenizerURL)
+    }
+
+    public static func loadTextEncoder(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TextEncoderModel {
+        progress?("Loading UMT5 encoder")
+        let encoder = Wan2TextEncoderModel()
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: resources.textEncoderURL,
+            to: encoder,
+            dtype: .bfloat16,
+            verify: .none,
+            batchSize: 12
+        )
+        eval(encoder.parameters().flattened().map(\.1))
+        return encoder
+    }
+
+    public static func encodePrompts(
+        tokenizer: Wan2Tokenizer,
+        encoder: Wan2TextEncoderModel,
+        prompt: String,
+        negativePrompt: String
+    ) throws -> Wan2TextConditioning {
+        let promptTokens = tokenizer.encode(prompt)
+        let negativeTokens = tokenizer.encode(negativePrompt)
+        let promptLength = max(promptTokens.mask.reduce(0, +), 1)
+        let negativeLength = max(negativeTokens.mask.reduce(0, +), 1)
+        let encodedLength = max(promptLength, negativeLength)
+        let promptIDs = Array(promptTokens.tokenIDs.prefix(encodedLength))
+        let negativeIDs = Array(negativeTokens.tokenIDs.prefix(encodedLength))
+        let promptMask = Array(promptTokens.mask.prefix(encodedLength))
+        let negativeMask = Array(negativeTokens.mask.prefix(encodedLength))
+        let tokenIDs = MLXArray(promptIDs + negativeIDs, [2, encodedLength])
+        let mask = MLXArray(promptMask + negativeMask, [2, encodedLength])
+        let encoded = encoder(tokenIDs: tokenIDs, mask: mask)
+        eval(encoded)
+        guard encoded.dim(0) == 2 else {
+            throw Wan2ModelLoaderError.textEncodingFailed
+        }
+        return Wan2TextConditioning(
+            prompt: encoded[0, 0..<promptLength].asType(.bfloat16),
+            negativePrompt: encoded[1, 0..<negativeLength].asType(.bfloat16)
+        )
+    }
+
+    public static func encodePrompts(
+        resources: Wan2Resources,
+        prompt: String,
+        negativePrompt: String,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TextConditioning {
+        progress?("Loading UMT5 tokenizer")
+        let tokenizer = try loadTokenizer(resources: resources)
+        let encoder = try loadTextEncoder(resources: resources, progress: progress)
+        return try encodePrompts(
+            tokenizer: tokenizer,
+            encoder: encoder,
+            prompt: prompt,
+            negativePrompt: negativePrompt
+        )
+    }
+
+    public static func loadTransformer(
+        resources: Wan2Resources,
+        dtype: DType = .bfloat16,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TransformerModel {
+        progress?("Loading Wan2.2 TI2V transformer")
+        let model = Wan2TransformerModel()
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: resources.transformerURL,
+            to: model,
+            dtype: nil,
+            verify: .none,
+            mapper: { key, value in
+                let targetType: DType = key.hasSuffix("modulation") ? .float32 : dtype
+                return [(key, value.asType(targetType))]
+            },
+            batchSize: 12
+        )
+        eval(model.parameters().flattened().map(\.1))
+        return model
+    }
+
+    public static func loadVAE(
+        resources: Wan2Resources,
+        dtype: DType = .float32,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2VAEModel {
+        progress?("Loading Wan2.2 TI2V VAE")
+        let model = Wan2VAEModel()
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: resources.vaeURL,
+            to: model,
+            dtype: dtype,
+            verify: .none,
+            batchSize: 12
+        )
+        eval(model.parameters().flattened().map(\.1))
+        return model
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2Resources.swift
+++ b/Sources/MereRunCore/Wan2/Wan2Resources.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+public enum Wan2ResourcesError: LocalizedError, Sendable {
+    case invalidConfiguration(URL, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let url, let reason):
+            return "Invalid Wan2 configuration at \(url.path): \(reason)"
+        }
+    }
+}
+
+public struct Wan2TI2VConfiguration: Codable, Hashable, Sendable {
+    public let modelType: String
+    public let modelVersion: String
+    public let patchSize: [Int]
+    public let textLen: Int
+    public let inDim: Int
+    public let dim: Int
+    public let ffnDim: Int
+    public let textDim: Int
+    public let outDim: Int
+    public let numHeads: Int
+    public let numLayers: Int
+    public let vaeStride: [Int]
+    public let vaeZDim: Int
+    public let sampleShift: Double
+    public let sampleSteps: Int
+    public let sampleGuideScale: Double
+    public let sampleFPS: Int
+    public let frameNum: Int
+    public let maxArea: Int
+    public let quantization: Wan2QuantizationConfiguration?
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case modelVersion = "model_version"
+        case patchSize = "patch_size"
+        case textLen = "text_len"
+        case inDim = "in_dim"
+        case dim
+        case ffnDim = "ffn_dim"
+        case textDim = "text_dim"
+        case outDim = "out_dim"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case vaeStride = "vae_stride"
+        case vaeZDim = "vae_z_dim"
+        case sampleShift = "sample_shift"
+        case sampleSteps = "sample_steps"
+        case sampleGuideScale = "sample_guide_scale"
+        case sampleFPS = "sample_fps"
+        case frameNum = "frame_num"
+        case maxArea = "max_area"
+        case quantization
+    }
+
+    public func validationIssues() -> [String] {
+        var issues: [String] = []
+        if modelType != "ti2v" { issues.append("model_type must be ti2v") }
+        if modelVersion != "2.2" { issues.append("model_version must be 2.2") }
+        if patchSize != [1, 2, 2] { issues.append("patch_size must be [1, 2, 2]") }
+        if inDim != 48 || outDim != 48 { issues.append("in_dim and out_dim must both be 48") }
+        if dim != 3_072 { issues.append("dim must be 3072") }
+        if ffnDim != 14_336 { issues.append("ffn_dim must be 14336") }
+        if numHeads != 24 { issues.append("num_heads must be 24") }
+        if numLayers != 30 { issues.append("num_layers must be 30") }
+        if vaeStride != [4, 16, 16] { issues.append("vae_stride must be [4, 16, 16]") }
+        if vaeZDim != 48 { issues.append("vae_z_dim must be 48") }
+        if maxArea != 704 * 1_280 { issues.append("max_area must be 901120") }
+        return issues
+    }
+}
+
+public struct Wan2QuantizationConfiguration: Codable, Hashable, Sendable {
+    public let bits: Int
+    public let groupSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case bits
+        case groupSize = "group_size"
+    }
+}
+
+public struct Wan2Resources: Hashable, Sendable {
+    public static let modelID = "video-wan22-ti2v-5b-mlx"
+    public static let managedRepoID = "SceneWorks/wan2.2-ti2v-5b-mlx"
+    public static let managedRevision = "bb1b055249614cf9d7cf4373fbdbc184b77dee88"
+    public static let officialRepoID = "Wan-AI/Wan2.2-TI2V-5B"
+    public static let officialRevision = "921dbaf3f1674a56f47e83fb80a34bac8a8f203e"
+    public static let defaultNegativePrompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+    public static let snapshotPatterns = [
+        "LICENSE",
+        "README.md",
+        "config.json",
+        "model.safetensors",
+        "t5_encoder.safetensors",
+        "tokenizer.json",
+        "vae.safetensors",
+    ]
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var configURL: URL { rootURL.appendingPathComponent("config.json") }
+    public var transformerURL: URL { rootURL.appendingPathComponent("model.safetensors") }
+    public var textEncoderURL: URL { rootURL.appendingPathComponent("t5_encoder.safetensors") }
+    public var tokenizerURL: URL { rootURL.appendingPathComponent("tokenizer.json") }
+    public var vaeURL: URL { rootURL.appendingPathComponent("vae.safetensors") }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        [configURL, transformerURL, textEncoderURL, tokenizerURL, vaeURL]
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+
+    public func loadConfiguration() throws -> Wan2TI2VConfiguration {
+        let configuration: Wan2TI2VConfiguration
+        do {
+            configuration = try JSONDecoder().decode(
+                Wan2TI2VConfiguration.self,
+                from: Data(contentsOf: configURL)
+            )
+        } catch {
+            throw Wan2ResourcesError.invalidConfiguration(configURL, error.localizedDescription)
+        }
+        let issues = configuration.validationIssues()
+        guard issues.isEmpty else {
+            throw Wan2ResourcesError.invalidConfiguration(configURL, issues.joined(separator: "; "))
+        }
+        return configuration
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2TI2VGenerator.swift
+++ b/Sources/MereRunCore/Wan2/Wan2TI2VGenerator.swift
@@ -1,0 +1,350 @@
+import Foundation
+import MediaIO
+import MLX
+import MLXRandom
+
+public enum Wan2TI2VGeneratorError: LocalizedError {
+    case sourceImageNotFound(URL)
+    case sourceImageDecodeFailed(URL)
+    case missingModelFiles([URL])
+
+    public var errorDescription: String? {
+        switch self {
+        case .sourceImageNotFound(let url):
+            return "Wan2.2 source image not found: \(url.path)"
+        case .sourceImageDecodeFailed(let url):
+            return "Wan2.2 could not decode source image: \(url.path)"
+        case .missingModelFiles(let urls):
+            return "Wan2.2 model root is missing: \(urls.map(\.lastPathComponent).joined(separator: ", "))"
+        }
+    }
+}
+
+public struct Wan2VideoGenerationResult {
+    public let frames: MLXArray
+    public let seed: UInt64
+    public let terminalFrameLatent: MLXArray?
+
+    public init(frames: MLXArray, seed: UInt64, terminalFrameLatent: MLXArray? = nil) {
+        self.frames = frames
+        self.seed = seed
+        self.terminalFrameLatent = terminalFrameLatent
+    }
+}
+
+public final class Wan2TI2VGenerator: @unchecked Sendable {
+    private struct PromptCacheKey: Hashable {
+        let prompt: String
+        let negativePrompt: String
+    }
+
+    private var loadedRootURL: URL?
+    private var tokenizer: Wan2Tokenizer?
+    private var textEncoder: Wan2TextEncoderModel?
+    private var vae: Wan2VAEModel?
+    private var transformer: Wan2TransformerModel?
+    private var promptCache: [PromptCacheKey: Wan2TextConditioning] = [:]
+    private var chainedTerminalFrameLatent: MLXArray?
+
+    public init() {}
+
+    public var isWarm: Bool {
+        tokenizer != nil && textEncoder != nil && vae != nil && transformer != nil
+    }
+
+    public var hasChainedTerminalFrameLatent: Bool {
+        chainedTerminalFrameLatent != nil
+    }
+
+    public func clearChain() {
+        chainedTerminalFrameLatent = nil
+    }
+
+    public func prepare(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws {
+        try ensureRoot(resources)
+        _ = try loadedTextComponents(resources: resources, progress: progress)
+        _ = try loadedVAE(resources: resources, progress: progress)
+        _ = try loadedTransformer(resources: resources, progress: progress)
+    }
+
+    public func unload() {
+        tokenizer = nil
+        textEncoder = nil
+        vae = nil
+        transformer = nil
+        loadedRootURL = nil
+        promptCache.removeAll(keepingCapacity: false)
+        chainedTerminalFrameLatent = nil
+        Memory.clearCache()
+    }
+
+    public func generate(
+        options: Wan2GenerationOptions,
+        resources: Wan2Resources,
+        useChainedSourceLatent: Bool = false,
+        captureTerminalFrameLatent: Bool = false,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)? = nil
+    ) async throws -> Wan2VideoGenerationResult {
+        guard FileManager.default.fileExists(atPath: options.sourceImageURL.path) else {
+            throw Wan2TI2VGeneratorError.sourceImageNotFound(options.sourceImageURL)
+        }
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw Wan2TI2VGeneratorError.missingModelFiles(missing)
+        }
+        try ensureRoot(resources)
+
+        progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 0, totalSteps: options.steps))
+        let conditioning = try conditioning(options: options, resources: resources)
+        eval(conditioning.prompt, conditioning.negativePrompt)
+        Memory.clearCache()
+
+        progressHandler?(GenerationProgress(stage: .encodingReferenceImages, stepIndex: 0, totalSteps: options.steps))
+        let imageLatent: MLXArray
+        if useChainedSourceLatent, let chainedTerminalFrameLatent {
+            imageLatent = chainedTerminalFrameLatent
+        } else {
+            imageLatent = try encodeSourceImage(options: options, resources: resources)
+        }
+        Memory.clearCache()
+
+        MLXRandom.seed(options.seed)
+        let noise = MLXRandom.normal(options.latentShape).asType(.float32)
+        let latentMask = Wan2TI2VConditioning.latentMask(shape: options.latentShape)
+        let tokenMask = Wan2TI2VConditioning.tokenMask(latentShape: options.latentShape)
+        var latent = Wan2TI2VConditioning.blend(imageLatent: imageLatent, noise: noise, mask: latentMask)
+        eval(latent, latentMask, tokenMask)
+
+        progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 0, totalSteps: options.steps))
+        latent = try await denoise(
+            latent: latent,
+            imageLatent: imageLatent,
+            latentMask: latentMask,
+            tokenMask: tokenMask,
+            conditioning: conditioning,
+            options: options,
+            resources: resources,
+            progressHandler: progressHandler
+        )
+        eval(latent)
+        Memory.clearCache()
+
+        progressHandler?(GenerationProgress(stage: .decoding, stepIndex: options.steps, totalSteps: options.steps))
+        let frames = try decode(latent: latent, resources: resources)
+        eval(frames)
+        let terminalFrameLatent = captureTerminalFrameLatent
+            ? try encodeTerminalFrame(frames, resources: resources)
+            : nil
+        if let terminalFrameLatent {
+            eval(terminalFrameLatent)
+            chainedTerminalFrameLatent = terminalFrameLatent
+        }
+        Memory.clearCache()
+        return Wan2VideoGenerationResult(
+            frames: frames,
+            seed: options.seed,
+            terminalFrameLatent: terminalFrameLatent
+        )
+    }
+
+    private func encodeSourceImage(
+        options: Wan2GenerationOptions,
+        resources: Wan2Resources
+    ) throws -> MLXArray {
+        let decoded: MediaImage
+        do {
+            decoded = try MediaImageIO.decode(options.sourceImageURL)
+        } catch {
+            throw Wan2TI2VGeneratorError.sourceImageDecodeFailed(options.sourceImageURL)
+        }
+        let image = try MediaImageIO.centerCropped(decoded, width: options.width, height: options.height)
+        let channels = MediaImageIO.rgbCHWFloat(image, normalizedToMinusOneToOne: true)
+        let tensor = MLXArray(channels)
+            .reshaped(3, options.height, options.width)
+            .transposed(1, 2, 0)
+            .reshaped(1, 1, options.height, options.width, 3)
+
+        let vae = try loadedVAE(resources: resources)
+        let encoded = vae.encodeImage(tensor)
+        let latent = encoded[0].transposed(3, 0, 1, 2).asType(.float32)
+        eval(latent)
+        return latent
+    }
+
+    private func denoise(
+        latent initialLatent: MLXArray,
+        imageLatent: MLXArray,
+        latentMask: MLXArray,
+        tokenMask: MLXArray,
+        conditioning: Wan2TextConditioning,
+        options: Wan2GenerationOptions,
+        resources: Wan2Resources,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> MLXArray {
+        let transformer = try loadedTransformer(resources: resources)
+        let positiveContext = transformer.embedText(conditioning.prompt.expandedDimensions(axis: 0))
+        let negativeContext = transformer.embedText(conditioning.negativePrompt.expandedDimensions(axis: 0))
+        let positiveCaches = transformer.prepareCrossAttentionCaches(context: positiveContext)
+        let negativeCaches = transformer.prepareCrossAttentionCaches(context: negativeContext)
+        eval(
+            positiveContext,
+            negativeContext,
+            positiveCaches.flatMap { [$0.key, $0.value] },
+            negativeCaches.flatMap { [$0.key, $0.value] }
+        )
+
+        var scheduler = Wan2UniPCScheduler(steps: options.steps, shift: options.shift)
+        var latent = initialLatent
+        let debugStats = ProcessInfo.processInfo.environment["MERERUN_WAN2_DEBUG_STATS"] == "1"
+        for (stepIndex, timestep) in scheduler.timesteps.enumerated() {
+            try Task.checkCancellation()
+            progressHandler?(GenerationProgress(
+                stage: .denoising,
+                stepIndex: stepIndex,
+                totalSteps: options.steps
+            ))
+            let tokenTimesteps = tokenMask * timestep
+            let conditional = transformer(
+                latents: [latent],
+                timesteps: tokenTimesteps,
+                embeddedContext: positiveContext,
+                crossCaches: positiveCaches
+            )[0]
+            eval(conditional)
+            Memory.clearCache()
+
+            let unconditional = transformer(
+                latents: [latent],
+                timesteps: tokenTimesteps,
+                embeddedContext: negativeContext,
+                crossCaches: negativeCaches
+            )[0]
+            let velocity = unconditional + options.guidanceScale * (conditional - unconditional)
+            latent = scheduler.step(modelOutput: velocity, sample: latent)
+            latent = Wan2TI2VConditioning.blend(
+                imageLatent: imageLatent,
+                noise: latent,
+                mask: latentMask
+            )
+            eval(latent)
+            if debugStats {
+                Self.writeDebugStats(
+                    stepIndex: stepIndex,
+                    timestep: timestep,
+                    conditional: conditional,
+                    unconditional: unconditional,
+                    velocity: velocity,
+                    latent: latent
+                )
+            }
+            Memory.clearCache()
+        }
+        return latent
+    }
+
+    private func decode(latent: MLXArray, resources: Wan2Resources) throws -> MLXArray {
+        let vae = try loadedVAE(resources: resources)
+        let channelsLast = latent.transposed(1, 2, 3, 0).expandedDimensions(axis: 0)
+        let decoded = vae.decode(channelsLast)
+        return MLX.clip((decoded + 1) * 127.5, min: 0, max: 255).asType(.uint8)
+    }
+
+    private func encodeTerminalFrame(
+        _ frames: MLXArray,
+        resources: Wan2Resources
+    ) throws -> MLXArray {
+        precondition(frames.ndim == 5 && frames.dim(0) == 1 && frames.dim(4) == 3)
+        let terminal = frames[0, frames.dim(1) - 1]
+            .asType(.float32) / 127.5 - 1
+        let image = terminal.reshaped(1, 1, frames.dim(2), frames.dim(3), 3)
+        let encoded = try loadedVAE(resources: resources).encodeImage(image)
+        return encoded[0].transposed(3, 0, 1, 2).asType(.float32)
+    }
+
+    private func conditioning(
+        options: Wan2GenerationOptions,
+        resources: Wan2Resources
+    ) throws -> Wan2TextConditioning {
+        let key = PromptCacheKey(prompt: options.prompt, negativePrompt: options.negativePrompt)
+        if let cached = promptCache[key] {
+            return cached
+        }
+        let components = try loadedTextComponents(resources: resources)
+        let value = try Wan2ModelLoader.encodePrompts(
+            tokenizer: components.tokenizer,
+            encoder: components.encoder,
+            prompt: options.prompt,
+            negativePrompt: options.negativePrompt
+        )
+        promptCache[key] = value
+        return value
+    }
+
+    private func ensureRoot(_ resources: Wan2Resources) throws {
+        let root = resources.rootURL.standardizedFileURL
+        if let loadedRootURL, loadedRootURL != root {
+            unload()
+        }
+        loadedRootURL = root
+    }
+
+    private func loadedTextComponents(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> (tokenizer: Wan2Tokenizer, encoder: Wan2TextEncoderModel) {
+        try ensureRoot(resources)
+        if tokenizer == nil {
+            progress?("Loading UMT5 tokenizer")
+            tokenizer = try Wan2ModelLoader.loadTokenizer(resources: resources)
+        }
+        if textEncoder == nil {
+            textEncoder = try Wan2ModelLoader.loadTextEncoder(resources: resources, progress: progress)
+        }
+        return (tokenizer!, textEncoder!)
+    }
+
+    private func loadedVAE(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2VAEModel {
+        try ensureRoot(resources)
+        if vae == nil {
+            vae = try Wan2ModelLoader.loadVAE(resources: resources, progress: progress)
+        }
+        return vae!
+    }
+
+    private func loadedTransformer(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TransformerModel {
+        try ensureRoot(resources)
+        if transformer == nil {
+            transformer = try Wan2ModelLoader.loadTransformer(resources: resources, progress: progress)
+        }
+        return transformer!
+    }
+
+    private static func writeDebugStats(
+        stepIndex: Int,
+        timestep: Float,
+        conditional: MLXArray,
+        unconditional: MLXArray,
+        velocity: MLXArray,
+        latent: MLXArray
+    ) {
+        func summary(_ array: MLXArray) -> String {
+            let value = array.asType(.float32)
+            let mean = MLX.mean(value).item(Float.self)
+            let standardDeviation = MLX.std(value).item(Float.self)
+            let minimum = MLX.min(value).item(Float.self)
+            let maximum = MLX.max(value).item(Float.self)
+            return String(format: "mean=%.5f std=%.5f min=%.5f max=%.5f", mean, standardDeviation, minimum, maximum)
+        }
+        let line = "[Wan2 debug] step=\(stepIndex + 1) t=\(timestep) cond{\(summary(conditional))} uncond{\(summary(unconditional))} velocity{\(summary(velocity))} latent{\(summary(latent))}\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2TextEncoder.swift
+++ b/Sources/MereRunCore/Wan2/Wan2TextEncoder.swift
@@ -1,0 +1,233 @@
+import Foundation
+@preconcurrency import Hub
+import MLX
+import MLXFast
+import MLXNN
+@preconcurrency import Tokenizers
+
+public struct Wan2TextEncoderConfiguration: Hashable, Sendable {
+    public let vocabularySize: Int
+    public let hiddenSize: Int
+    public let attentionSize: Int
+    public let feedForwardSize: Int
+    public let headCount: Int
+    public let layerCount: Int
+    public let relativePositionBuckets: Int
+
+    public init(
+        vocabularySize: Int = 256_384,
+        hiddenSize: Int = 4_096,
+        attentionSize: Int = 4_096,
+        feedForwardSize: Int = 10_240,
+        headCount: Int = 64,
+        layerCount: Int = 24,
+        relativePositionBuckets: Int = 32
+    ) {
+        precondition(attentionSize % headCount == 0)
+        self.vocabularySize = vocabularySize
+        self.hiddenSize = hiddenSize
+        self.attentionSize = attentionSize
+        self.feedForwardSize = feedForwardSize
+        self.headCount = headCount
+        self.layerCount = layerCount
+        self.relativePositionBuckets = relativePositionBuckets
+    }
+}
+
+final class Wan2T5LayerNorm: Module {
+    let epsilon: Float
+    @ModuleInfo(key: "weight") var weight: MLXArray
+
+    init(dimensions: Int, epsilon: Float = 1e-6) {
+        self.epsilon = epsilon
+        self._weight.wrappedValue = MLX.ones([dimensions])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(input, weight: weight, eps: epsilon)
+    }
+}
+
+final class Wan2T5RelativeEmbedding: Module {
+    let bucketCount: Int
+    let headCount: Int
+    let maxDistance: Int
+    @ModuleInfo(key: "embedding") var embedding: Embedding
+
+    init(bucketCount: Int, headCount: Int, maxDistance: Int = 128) {
+        self.bucketCount = bucketCount
+        self.headCount = headCount
+        self.maxDistance = maxDistance
+        self._embedding.wrappedValue = Embedding(embeddingCount: bucketCount, dimensions: headCount)
+    }
+
+    func callAsFunction(queryLength: Int, keyLength: Int) -> MLXArray {
+        let keyPositions = MLX.arange(keyLength).expandedDimensions(axis: 0)
+        let queryPositions = MLX.arange(queryLength).expandedDimensions(axis: 1)
+        let relative = keyPositions - queryPositions
+        let halfBuckets = bucketCount / 2
+        var buckets = (relative .> 0).asType(.int32) * halfBuckets
+        let distance = MLX.abs(relative)
+        let maxExact = halfBuckets / 2
+        let isSmall = distance .< maxExact
+        let distanceFloat = distance.asType(.float32)
+        let large = maxExact + (
+            MLX.log(distanceFloat / Float(maxExact))
+                / log(Float(maxDistance) / Float(maxExact))
+                * Float(halfBuckets - maxExact)
+        ).asType(.int32)
+        let capped = MLX.minimum(large, MLX.ones(large.shape, dtype: .int32) * (halfBuckets - 1))
+        buckets = buckets + MLX.where(isSmall, distance.asType(.int32), capped)
+        return embedding(buckets).transposed(2, 0, 1).expandedDimensions(axis: 0)
+    }
+}
+
+final class Wan2T5Attention: Module {
+    let heads: Int
+    let headDimension: Int
+    @ModuleInfo(key: "q") var query: Linear
+    @ModuleInfo(key: "k") var key: Linear
+    @ModuleInfo(key: "v") var value: Linear
+    @ModuleInfo(key: "o") var output: Linear
+
+    init(dimensions: Int, attentionDimensions: Int, heads: Int) {
+        self.heads = heads
+        self.headDimension = attentionDimensions / heads
+        self._query.wrappedValue = Linear(dimensions, attentionDimensions, bias: false)
+        self._key.wrappedValue = Linear(dimensions, attentionDimensions, bias: false)
+        self._value.wrappedValue = Linear(dimensions, attentionDimensions, bias: false)
+        self._output.wrappedValue = Linear(attentionDimensions, dimensions, bias: false)
+    }
+
+    func callAsFunction(_ input: MLXArray, mask: MLXArray?, positionBias: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let q = query(input).reshaped(batch, -1, heads, headDimension).transposed(0, 2, 1, 3)
+        let k = key(input).reshaped(batch, -1, heads, headDimension).transposed(0, 2, 1, 3)
+        let v = value(input).reshaped(batch, -1, heads, headDimension).transposed(0, 2, 1, 3)
+        var scores = matmul(q.asType(.float32), k.asType(.float32).transposed(0, 1, 3, 2))
+        scores = scores + positionBias.asType(.float32)
+        if let mask {
+            let expanded = mask.ndim == 2
+                ? mask.expandedDimensions(axes: [1, 2])
+                : mask.expandedDimensions(axis: 1)
+            let additive = MLX.where(expanded .== 0, MLXArray(-3.389e38), MLXArray(0)).asType(.float32)
+            scores = scores + additive
+        }
+        let probabilities = MLX.softmax(scores, axis: -1).asType(q.dtype)
+        let attended = matmul(probabilities, v)
+            .transposed(0, 2, 1, 3)
+            .reshaped(batch, -1, heads * headDimension)
+        return output(attended)
+    }
+}
+
+final class Wan2T5FeedForward: Module {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "fc1") var input: Linear
+    @ModuleInfo(key: "fc2") var output: Linear
+
+    init(dimensions: Int, hiddenDimensions: Int) {
+        self._gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        self._input.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        self._output.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(input(value) * MLXNN.geluApproximate(gate(value)))
+    }
+}
+
+final class Wan2T5Block: Module {
+    @ModuleInfo(key: "norm1") var attentionNorm: Wan2T5LayerNorm
+    @ModuleInfo(key: "attn") var attention: Wan2T5Attention
+    @ModuleInfo(key: "norm2") var feedForwardNorm: Wan2T5LayerNorm
+    @ModuleInfo(key: "ffn") var feedForward: Wan2T5FeedForward
+    @ModuleInfo(key: "pos_embedding") var positionEmbedding: Wan2T5RelativeEmbedding
+
+    init(configuration: Wan2TextEncoderConfiguration) {
+        self._attentionNorm.wrappedValue = Wan2T5LayerNorm(dimensions: configuration.hiddenSize)
+        self._attention.wrappedValue = Wan2T5Attention(
+            dimensions: configuration.hiddenSize,
+            attentionDimensions: configuration.attentionSize,
+            heads: configuration.headCount
+        )
+        self._feedForwardNorm.wrappedValue = Wan2T5LayerNorm(dimensions: configuration.hiddenSize)
+        self._feedForward.wrappedValue = Wan2T5FeedForward(
+            dimensions: configuration.hiddenSize,
+            hiddenDimensions: configuration.feedForwardSize
+        )
+        self._positionEmbedding.wrappedValue = Wan2T5RelativeEmbedding(
+            bucketCount: configuration.relativePositionBuckets,
+            headCount: configuration.headCount
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray, mask: MLXArray?) -> MLXArray {
+        let bias = positionEmbedding(queryLength: input.dim(1), keyLength: input.dim(1))
+        let attended = input + attention(attentionNorm(input), mask: mask, positionBias: bias)
+        return attended + feedForward(feedForwardNorm(attended))
+    }
+}
+
+public final class Wan2TextEncoderModel: Module {
+    public let configuration: Wan2TextEncoderConfiguration
+    @ModuleInfo(key: "token_embedding") var tokenEmbedding: Embedding
+    @ModuleInfo(key: "blocks") var blocks: [Wan2T5Block]
+    @ModuleInfo(key: "norm") var norm: Wan2T5LayerNorm
+
+    public init(configuration: Wan2TextEncoderConfiguration = Wan2TextEncoderConfiguration()) {
+        self.configuration = configuration
+        self._tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.vocabularySize,
+            dimensions: configuration.hiddenSize
+        )
+        self._blocks.wrappedValue = (0..<configuration.layerCount).map { _ in
+            Wan2T5Block(configuration: configuration)
+        }
+        self._norm.wrappedValue = Wan2T5LayerNorm(dimensions: configuration.hiddenSize)
+    }
+
+    public func callAsFunction(tokenIDs: MLXArray, mask: MLXArray?) -> MLXArray {
+        var hidden = tokenEmbedding(tokenIDs)
+        for block in blocks {
+            hidden = block(hidden, mask: mask)
+        }
+        return norm(hidden)
+    }
+}
+
+public final class Wan2Tokenizer: @unchecked Sendable {
+    private let tokenizer: any Tokenizer
+    public let maxLength: Int
+
+    init(tokenizer: any Tokenizer, maxLength: Int = 512) {
+        self.tokenizer = tokenizer
+        self.maxLength = maxLength
+    }
+
+    public static func load(from tokenizerURL: URL, hubApi: HubApi = .shared) throws -> Wan2Tokenizer {
+        let tokenizerData = try hubApi.configuration(fileURL: tokenizerURL)
+        let tokenizerConfig: Config = [
+            "tokenizer_class": "T5Tokenizer",
+            "model_max_length": 512,
+            "eos_token": "</s>",
+            "pad_token": "<pad>",
+        ]
+        let tokenizer = try AutoTokenizer.from(
+            tokenizerConfig: tokenizerConfig,
+            tokenizerData: tokenizerData,
+            strict: false
+        )
+        return Wan2Tokenizer(tokenizer: tokenizer)
+    }
+
+    public func encode(_ text: String) -> (tokenIDs: [Int], mask: [Int]) {
+        var ids = tokenizer.encode(text: text, addSpecialTokens: true)
+        if ids.count > maxLength {
+            ids = Array(ids.prefix(maxLength))
+        }
+        let count = ids.count
+        ids.append(contentsOf: repeatElement(0, count: maxLength - ids.count))
+        return (ids, Array(repeating: 1, count: count) + Array(repeating: 0, count: maxLength - count))
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2Transformer.swift
+++ b/Sources/MereRunCore/Wan2/Wan2Transformer.swift
@@ -1,0 +1,577 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+public struct Wan2TransformerConfiguration: Hashable, Sendable {
+    public let patchSize: [Int]
+    public let textLength: Int
+    public let inputChannels: Int
+    public let hiddenSize: Int
+    public let feedForwardSize: Int
+    public let timestepFrequencySize: Int
+    public let textEmbeddingSize: Int
+    public let outputChannels: Int
+    public let headCount: Int
+    public let layerCount: Int
+    public let epsilon: Float
+
+    public init(
+        patchSize: [Int] = [1, 2, 2],
+        textLength: Int = 512,
+        inputChannels: Int = 48,
+        hiddenSize: Int = 3_072,
+        feedForwardSize: Int = 14_336,
+        timestepFrequencySize: Int = 256,
+        textEmbeddingSize: Int = 4_096,
+        outputChannels: Int = 48,
+        headCount: Int = 24,
+        layerCount: Int = 30,
+        epsilon: Float = 1e-6
+    ) {
+        precondition(patchSize.count == 3)
+        precondition(hiddenSize % headCount == 0)
+        precondition((hiddenSize / headCount) % 2 == 0)
+        self.patchSize = patchSize
+        self.textLength = textLength
+        self.inputChannels = inputChannels
+        self.hiddenSize = hiddenSize
+        self.feedForwardSize = feedForwardSize
+        self.timestepFrequencySize = timestepFrequencySize
+        self.textEmbeddingSize = textEmbeddingSize
+        self.outputChannels = outputChannels
+        self.headCount = headCount
+        self.layerCount = layerCount
+        self.epsilon = epsilon
+    }
+}
+
+public struct Wan2GridSize: Hashable, Sendable {
+    public let frames: Int
+    public let height: Int
+    public let width: Int
+
+    public init(frames: Int, height: Int, width: Int) {
+        self.frames = frames
+        self.height = height
+        self.width = width
+    }
+
+    public var sequenceLength: Int { frames * height * width }
+}
+
+enum Wan2PatchLayout {
+    static func flatten(_ latent: MLXArray, patchSize: [Int]) -> (value: MLXArray, grid: Wan2GridSize) {
+        precondition(latent.ndim == 4)
+        precondition(patchSize.count == 3)
+        let channels = latent.dim(0)
+        let temporalPatch = patchSize[0]
+        let heightPatch = patchSize[1]
+        let widthPatch = patchSize[2]
+        let grid = Wan2GridSize(
+            frames: latent.dim(1) / temporalPatch,
+            height: latent.dim(2) / heightPatch,
+            width: latent.dim(3) / widthPatch
+        )
+        let flattened = latent
+            .reshaped(
+                channels,
+                grid.frames, temporalPatch,
+                grid.height, heightPatch,
+                grid.width, widthPatch
+            )
+            .transposed(1, 3, 5, 0, 2, 4, 6)
+            .reshaped(grid.sequenceLength, -1)
+        return (flattened, grid)
+    }
+}
+
+public struct Wan2AttentionKVCache {
+    public let key: MLXArray
+    public let value: MLXArray
+}
+
+final class Wan2RMSNorm: Module {
+    let epsilon: Float
+    @ModuleInfo(key: "weight") var weight: MLXArray
+
+    init(dimensions: Int, epsilon: Float) {
+        self.epsilon = epsilon
+        self._weight.wrappedValue = MLX.ones([dimensions])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(input, weight: weight, eps: epsilon)
+    }
+}
+
+final class Wan2LayerNorm: Module {
+    let epsilon: Float
+    let weight: MLXArray?
+    let bias: MLXArray?
+
+    init(dimensions: Int, epsilon: Float, affine: Bool = false) {
+        self.epsilon = epsilon
+        self.weight = affine ? MLX.ones([dimensions]) : nil
+        self.bias = affine ? MLX.zeros([dimensions]) : nil
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        MLXFast.layerNorm(
+            input,
+            weight: weight,
+            bias: bias,
+            eps: epsilon
+        )
+    }
+}
+
+enum Wan2RoPE {
+    struct Cache {
+        let cosine: MLXArray
+        let sine: MLXArray
+    }
+
+    static func frequencies(maxSequence: Int, dimensions: [Int]) -> MLXArray {
+        var tables: [MLXArray] = []
+        tables.reserveCapacity(dimensions.count)
+        for dimension in dimensions {
+            precondition(dimension % 2 == 0)
+            var values: [Float] = []
+            values.reserveCapacity(maxSequence * dimension)
+            for position in 0..<maxSequence {
+                for index in stride(from: 0, to: dimension, by: 2) {
+                    let angle = Float(position) / pow(10_000, Float(index) / Float(dimension))
+                    values.append(cos(angle))
+                    values.append(sin(angle))
+                }
+            }
+            tables.append(MLXArray(values).reshaped(maxSequence, dimension / 2, 2))
+        }
+        return MLX.concatenated(tables, axis: 1)
+    }
+
+    static func prepare(grid: Wan2GridSize, frequencies: MLXArray, dtype: DType) -> Cache {
+        let halfDimension = frequencies.dim(1)
+        let temporalDimension = halfDimension - 2 * (halfDimension / 3)
+        let heightDimension = halfDimension / 3
+        let widthDimension = halfDimension / 3
+        let typed = frequencies.asType(.float32)
+        let temporal = MLX.broadcast(
+            typed[0..<grid.frames, 0..<temporalDimension]
+                .reshaped(grid.frames, 1, 1, temporalDimension, 2),
+            to: [grid.frames, grid.height, grid.width, temporalDimension, 2]
+        )
+        let vertical = MLX.broadcast(
+            typed[0..<grid.height, temporalDimension..<(temporalDimension + heightDimension)]
+                .reshaped(1, grid.height, 1, heightDimension, 2),
+            to: [grid.frames, grid.height, grid.width, heightDimension, 2]
+        )
+        let horizontalSource = typed[
+            0..<grid.width,
+            (temporalDimension + heightDimension)..<(temporalDimension + heightDimension + widthDimension)
+        ]
+        .reshaped(1, 1, grid.width, widthDimension, 2)
+        let horizontal = MLX.broadcast(
+            horizontalSource,
+            to: [grid.frames, grid.height, grid.width, widthDimension, 2]
+        )
+        let combined = MLX.concatenated([temporal, vertical, horizontal], axis: 3)
+            .reshaped(grid.sequenceLength, 1, halfDimension, 2)
+        return Cache(
+            cosine: combined[0..., 0..., 0..., 0],
+            sine: combined[0..., 0..., 0..., 1]
+        )
+    }
+
+    static func apply(_ input: MLXArray, grid: Wan2GridSize, cache: Cache) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = grid.sequenceLength
+        let heads = input.dim(2)
+        let dimension = input.dim(3)
+        let paired = input[0..., 0..<sequence].reshaped(batch, sequence, heads, dimension / 2, 2)
+        let real = paired[0..., 0..., 0..., 0..., 0]
+        let imaginary = paired[0..., 0..., 0..., 0..., 1]
+        let cosine = cache.cosine.expandedDimensions(axis: 0)
+        let sine = cache.sine.expandedDimensions(axis: 0)
+        let rotated = MLX.stacked(
+            [real * cosine - imaginary * sine, real * sine + imaginary * cosine],
+            axis: -1
+        ).reshaped(batch, sequence, heads, dimension)
+        guard sequence < input.dim(1) else { return rotated }
+        return MLX.concatenated([rotated, input[0..., sequence...]], axis: 1)
+    }
+}
+
+final class Wan2SelfAttention: Module {
+    let heads: Int
+    let headDimension: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q") var query: Linear
+    @ModuleInfo(key: "k") var key: Linear
+    @ModuleInfo(key: "v") var value: Linear
+    @ModuleInfo(key: "o") var output: Linear
+    @ModuleInfo(key: "norm_q") var queryNorm: Wan2RMSNorm
+    @ModuleInfo(key: "norm_k") var keyNorm: Wan2RMSNorm
+
+    init(dimensions: Int, heads: Int, epsilon: Float) {
+        self.heads = heads
+        self.headDimension = dimensions / heads
+        self.scale = 1 / Float(headDimension).squareRoot()
+        self._query.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._key.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._value.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._output.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._queryNorm.wrappedValue = Wan2RMSNorm(dimensions: dimensions, epsilon: epsilon)
+        self._keyNorm.wrappedValue = Wan2RMSNorm(dimensions: dimensions, epsilon: epsilon)
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        grid: Wan2GridSize,
+        rope: Wan2RoPE.Cache,
+        mask: MLXArray?
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let dtype = query.weight.dtype
+        let typed = input.asType(dtype)
+        var q = queryNorm(query(typed)).reshaped(batch, sequence, heads, headDimension)
+        var k = keyNorm(key(typed)).reshaped(batch, sequence, heads, headDimension)
+        let v = value(typed).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        q = Wan2RoPE.apply(q.asType(.float32), grid: grid, cache: rope).transposed(0, 2, 1, 3)
+        k = Wan2RoPE.apply(k.asType(.float32), grid: grid, cache: rope).transposed(0, 2, 1, 3)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: mask.map { .array($0) } ?? .none
+        )
+        let merged = attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, heads * headDimension)
+        return output(merged)
+    }
+}
+
+final class Wan2CrossAttention: Module {
+    let heads: Int
+    let headDimension: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q") var query: Linear
+    @ModuleInfo(key: "k") var key: Linear
+    @ModuleInfo(key: "v") var value: Linear
+    @ModuleInfo(key: "o") var output: Linear
+    @ModuleInfo(key: "norm_q") var queryNorm: Wan2RMSNorm
+    @ModuleInfo(key: "norm_k") var keyNorm: Wan2RMSNorm
+
+    init(dimensions: Int, heads: Int, epsilon: Float) {
+        self.heads = heads
+        self.headDimension = dimensions / heads
+        self.scale = 1 / Float(headDimension).squareRoot()
+        self._query.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._key.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._value.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._output.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._queryNorm.wrappedValue = Wan2RMSNorm(dimensions: dimensions, epsilon: epsilon)
+        self._keyNorm.wrappedValue = Wan2RMSNorm(dimensions: dimensions, epsilon: epsilon)
+    }
+
+    func prepareCache(context: MLXArray) -> Wan2AttentionKVCache {
+        let batch = context.dim(0)
+        let typed = context.asType(key.weight.dtype)
+        let k = keyNorm(key(typed)).reshaped(batch, -1, heads, headDimension).transposed(0, 2, 1, 3)
+        let v = value(typed).reshaped(batch, -1, heads, headDimension).transposed(0, 2, 1, 3)
+        return Wan2AttentionKVCache(key: k, value: v)
+    }
+
+    func callAsFunction(_ input: MLXArray, context: MLXArray, cache: Wan2AttentionKVCache?) -> MLXArray {
+        let batch = input.dim(0)
+        let dtype = query.weight.dtype
+        let q = queryNorm(query(input.asType(dtype)))
+            .reshaped(batch, -1, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let prepared = cache ?? prepareCache(context: context)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: prepared.key,
+            values: prepared.value,
+            scale: scale,
+            mask: .none
+        )
+        let merged = attended.transposed(0, 2, 1, 3).reshaped(batch, -1, heads * headDimension)
+        return output(merged)
+    }
+}
+
+final class Wan2FeedForward: Module {
+    @ModuleInfo(key: "fc1") var input: Linear
+    @ModuleInfo(key: "fc2") var output: Linear
+
+    init(dimensions: Int, hiddenDimensions: Int) {
+        self._input.wrappedValue = Linear(dimensions, hiddenDimensions, bias: true)
+        self._output.wrappedValue = Linear(hiddenDimensions, dimensions, bias: true)
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(MLXNN.geluApproximate(input(value.asType(input.weight.dtype))))
+    }
+}
+
+final class Wan2TransformerBlock: Module {
+    @ModuleInfo(key: "norm1") var selfNorm: Wan2LayerNorm
+    @ModuleInfo(key: "self_attn") var selfAttention: Wan2SelfAttention
+    @ModuleInfo(key: "norm3") var crossNorm: Wan2LayerNorm
+    @ModuleInfo(key: "cross_attn") var crossAttention: Wan2CrossAttention
+    @ModuleInfo(key: "norm2") var feedForwardNorm: Wan2LayerNorm
+    @ModuleInfo(key: "ffn") var feedForward: Wan2FeedForward
+    @ModuleInfo(key: "modulation") var modulation: MLXArray
+
+    init(configuration: Wan2TransformerConfiguration) {
+        let dimensions = configuration.hiddenSize
+        self._selfNorm.wrappedValue = Wan2LayerNorm(dimensions: dimensions, epsilon: configuration.epsilon)
+        self._selfAttention.wrappedValue = Wan2SelfAttention(
+            dimensions: dimensions,
+            heads: configuration.headCount,
+            epsilon: configuration.epsilon
+        )
+        self._crossNorm.wrappedValue = Wan2LayerNorm(
+            dimensions: dimensions,
+            epsilon: configuration.epsilon,
+            affine: true
+        )
+        self._crossAttention.wrappedValue = Wan2CrossAttention(
+            dimensions: dimensions,
+            heads: configuration.headCount,
+            epsilon: configuration.epsilon
+        )
+        self._feedForwardNorm.wrappedValue = Wan2LayerNorm(dimensions: dimensions, epsilon: configuration.epsilon)
+        self._feedForward.wrappedValue = Wan2FeedForward(
+            dimensions: dimensions,
+            hiddenDimensions: configuration.feedForwardSize
+        )
+        self._modulation.wrappedValue = MLX.zeros([1, 6, dimensions], dtype: .float32)
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        modulationInput: MLXArray,
+        context: MLXArray,
+        grid: Wan2GridSize,
+        rope: Wan2RoPE.Cache,
+        selfMask: MLXArray?,
+        crossCache: Wan2AttentionKVCache?
+    ) -> MLXArray {
+        let parts = MLX.split(modulation.expandedDimensions(axis: 1) + modulationInput, parts: 6, axis: 2)
+            .map { $0.squeezed(axis: 2) }
+        var hidden = input
+        let hiddenType = hidden.dtype
+        let selfInput = selfNorm(hidden.asType(.float32)) * (1 + parts[1]) + parts[0]
+        let selfOutput = selfAttention(
+            selfInput.asType(hiddenType),
+            grid: grid,
+            rope: rope,
+            mask: selfMask
+        )
+        hidden = (hidden.asType(.float32) + selfOutput * parts[2]).asType(hiddenType)
+
+        let crossInput = crossNorm(hidden.asType(.float32)).asType(hiddenType)
+        hidden = hidden + crossAttention(crossInput, context: context, cache: crossCache)
+
+        let feedForwardInput = feedForwardNorm(hidden.asType(.float32)) * (1 + parts[4]) + parts[3]
+        let feedForwardOutput = feedForward(feedForwardInput.asType(hiddenType))
+        hidden = (hidden.asType(.float32) + feedForwardOutput.asType(.float32) * parts[5])
+            .asType(hiddenType)
+        return hidden
+    }
+}
+
+final class Wan2OutputHead: Module {
+    let outputChannels: Int
+    let patchSize: [Int]
+    @ModuleInfo(key: "norm") var norm: Wan2LayerNorm
+    @ModuleInfo(key: "head") var projection: Linear
+    @ModuleInfo(key: "modulation") var modulation: MLXArray
+
+    init(configuration: Wan2TransformerConfiguration) {
+        self.outputChannels = configuration.outputChannels
+        self.patchSize = configuration.patchSize
+        let projectionSize = configuration.patchSize.reduce(1, *) * configuration.outputChannels
+        self._norm.wrappedValue = Wan2LayerNorm(dimensions: configuration.hiddenSize, epsilon: configuration.epsilon)
+        self._projection.wrappedValue = Linear(configuration.hiddenSize, projectionSize, bias: true)
+        self._modulation.wrappedValue = MLX.zeros([1, 2, configuration.hiddenSize], dtype: .float32)
+    }
+
+    func callAsFunction(_ input: MLXArray, timestepEmbedding: MLXArray) -> MLXArray {
+        let embedding = timestepEmbedding.ndim == 2
+            ? timestepEmbedding.expandedDimensions(axis: 1)
+            : timestepEmbedding
+        let parts = MLX.split(
+            modulation.expandedDimensions(axis: 1) + embedding.expandedDimensions(axis: 2),
+            parts: 2,
+            axis: 2
+        ).map { $0.squeezed(axis: 2) }
+        let normalized = norm(input.asType(.float32)) * (1 + parts[1]) + parts[0]
+        return projection(normalized.asType(timestepEmbedding.dtype))
+    }
+}
+
+public final class Wan2TransformerModel: Module {
+    public let configuration: Wan2TransformerConfiguration
+    let inverseTimestepFrequencies: MLXArray
+    let ropeFrequencies: MLXArray
+
+    @ModuleInfo(key: "patch_embedding_proj") var patchProjection: Linear
+    @ModuleInfo(key: "text_embedding_0") var textProjectionIn: Linear
+    @ModuleInfo(key: "text_embedding_1") var textProjectionOut: Linear
+    @ModuleInfo(key: "time_embedding_0") var timestepProjectionIn: Linear
+    @ModuleInfo(key: "time_embedding_1") var timestepProjectionOut: Linear
+    @ModuleInfo(key: "time_projection") var modulationProjection: Linear
+    @ModuleInfo(key: "blocks") var blocks: [Wan2TransformerBlock]
+    @ModuleInfo(key: "head") var outputHead: Wan2OutputHead
+
+    public init(configuration: Wan2TransformerConfiguration = Wan2TransformerConfiguration()) {
+        self.configuration = configuration
+        let patchVolume = configuration.patchSize.reduce(1, *)
+        self._patchProjection.wrappedValue = Linear(
+            configuration.inputChannels * patchVolume,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._textProjectionIn.wrappedValue = Linear(
+            configuration.textEmbeddingSize,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._textProjectionOut.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._timestepProjectionIn.wrappedValue = Linear(
+            configuration.timestepFrequencySize,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._timestepProjectionOut.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._modulationProjection.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.hiddenSize * 6,
+            bias: true
+        )
+        self._blocks.wrappedValue = (0..<configuration.layerCount).map { _ in
+            Wan2TransformerBlock(configuration: configuration)
+        }
+        self._outputHead.wrappedValue = Wan2OutputHead(configuration: configuration)
+
+        let half = configuration.timestepFrequencySize / 2
+        self.inverseTimestepFrequencies = MLXArray((0..<half).map {
+            pow(10_000, -Float($0) / Float(half))
+        })
+        let headDimension = configuration.hiddenSize / configuration.headCount
+        let sixth = headDimension / 6
+        self.ropeFrequencies = Wan2RoPE.frequencies(
+            maxSequence: 1_024,
+            dimensions: [headDimension - 4 * sixth, 2 * sixth, 2 * sixth]
+        )
+    }
+
+    public func embedText(_ embeddings: MLXArray) -> MLXArray {
+        precondition(embeddings.ndim == 3)
+        let context: MLXArray
+        if embeddings.dim(1) < configuration.textLength {
+            let padding = MLX.zeros(
+                [embeddings.dim(0), configuration.textLength - embeddings.dim(1), embeddings.dim(2)],
+                dtype: embeddings.dtype
+            )
+            context = MLX.concatenated([embeddings, padding], axis: 1)
+        } else {
+            context = embeddings[0..., 0..<configuration.textLength]
+        }
+        return textProjectionOut(MLXNN.geluApproximate(textProjectionIn(context)))
+            .asType(patchProjection.weight.dtype)
+    }
+
+    public func prepareCrossAttentionCaches(context: MLXArray) -> [Wan2AttentionKVCache] {
+        blocks.map { $0.crossAttention.prepareCache(context: context) }
+    }
+
+    public func callAsFunction(
+        latents: [MLXArray],
+        timesteps: MLXArray,
+        embeddedContext: MLXArray,
+        crossCaches: [Wan2AttentionKVCache]? = nil
+    ) -> [MLXArray] {
+        precondition(!latents.isEmpty)
+        let patchified = latents.map(patchify)
+        let grid = patchified[0].grid
+        precondition(patchified.allSatisfy { $0.grid == grid })
+        var hidden = MLX.concatenated(patchified.map(\.value), axis: 0)
+
+        let sinusoid = timesteps.asType(.float32).expandedDimensions(axis: -1) * inverseTimestepFrequencies
+        let frequencyEmbedding = MLX.concatenated([MLX.cos(sinusoid), MLX.sin(sinusoid)], axis: -1)
+            .asType(timestepProjectionIn.weight.dtype)
+        let timestepEmbedding = timestepProjectionOut(MLXNN.silu(timestepProjectionIn(frequencyEmbedding)))
+            .asType(embeddedContext.dtype)
+        let modulation = modulationProjection(MLXNN.silu(timestepEmbedding)).asType(.float32)
+            .reshaped(timesteps.dim(0), timesteps.ndim == 1 ? 1 : timesteps.dim(1), 6, configuration.hiddenSize)
+
+        let context = embeddedContext.dim(0) == hidden.dim(0)
+            ? embeddedContext
+            : MLX.broadcast(
+                embeddedContext,
+                to: [hidden.dim(0), embeddedContext.dim(1), embeddedContext.dim(2)]
+            )
+        let rope = Wan2RoPE.prepare(grid: grid, frequencies: ropeFrequencies, dtype: patchProjection.weight.dtype)
+        for (index, block) in blocks.enumerated() {
+            hidden = block(
+                hidden,
+                modulationInput: modulation,
+                context: context,
+                grid: grid,
+                rope: rope,
+                selfMask: nil,
+                crossCache: crossCaches?[index]
+            )
+        }
+        let projected = outputHead(hidden, timestepEmbedding: timestepEmbedding)
+        return unpatchify(projected, grid: grid)
+    }
+
+    private func patchify(_ latent: MLXArray) -> (value: MLXArray, grid: Wan2GridSize) {
+        let patch = Wan2PatchLayout.flatten(latent, patchSize: configuration.patchSize)
+        let projected = patchProjection(patch.value).asType(patchProjection.weight.dtype)
+        return (projected.expandedDimensions(axis: 0), patch.grid)
+    }
+
+    private func unpatchify(_ patches: MLXArray, grid: Wan2GridSize) -> [MLXArray] {
+        let temporalPatch = configuration.patchSize[0]
+        let heightPatch = configuration.patchSize[1]
+        let widthPatch = configuration.patchSize[2]
+        return (0..<patches.dim(0)).map { index in
+            patches[index, 0..<grid.sequenceLength]
+                .reshaped(
+                    grid.frames,
+                    grid.height,
+                    grid.width,
+                    temporalPatch,
+                    heightPatch,
+                    widthPatch,
+                    configuration.outputChannels
+                )
+                .transposed(6, 0, 3, 1, 4, 2, 5)
+                .reshaped(
+                    configuration.outputChannels,
+                    grid.frames * temporalPatch,
+                    grid.height * heightPatch,
+                    grid.width * widthPatch
+                )
+                .asType(.float32)
+        }
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2VAE.swift
+++ b/Sources/MereRunCore/Wan2/Wan2VAE.swift
@@ -1,0 +1,652 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+private let wan2VAE22MeanValues: [Float] = [
+    -0.2289, -0.0052, -0.1323, -0.2339, -0.2799, 0.0174, 0.1838, 0.1557,
+    -0.1382, 0.0542, 0.2813, 0.0891, 0.1570, -0.0098, 0.0375, -0.1825,
+    -0.2246, -0.1207, -0.0698, 0.5109, 0.2665, -0.2108, -0.2158, 0.2502,
+    -0.2055, -0.0322, 0.1109, 0.1567, -0.0729, 0.0899, -0.2799, -0.1230,
+    -0.0313, -0.1649, 0.0117, 0.0723, -0.2839, -0.2083, -0.0520, 0.3748,
+    0.0152, 0.1957, 0.1433, -0.2944, 0.3573, -0.0548, -0.1681, -0.0667,
+]
+
+private let wan2VAE22StandardDeviationValues: [Float] = [
+    0.4765, 1.0364, 0.4514, 1.1677, 0.5313, 0.4990, 0.4818, 0.5013,
+    0.8158, 1.0344, 0.5894, 1.0901, 0.6885, 0.6165, 0.8454, 0.4978,
+    0.5759, 0.3523, 0.7135, 0.6804, 0.5833, 1.4146, 0.8986, 0.5659,
+    0.7069, 0.5338, 0.4889, 0.4917, 0.4069, 0.4999, 0.6866, 0.4093,
+    0.5709, 0.6065, 0.6415, 0.4944, 0.5726, 1.2042, 0.5458, 1.6887,
+    0.3971, 1.0600, 0.3943, 0.5537, 0.5444, 0.4089, 0.7468, 0.7744,
+]
+
+final class Wan2VAECausalConv3D: Module {
+    let kernel: (temporal: Int, height: Int, width: Int)
+    let stride: (temporal: Int, height: Int, width: Int)
+    let temporalPadding: Int
+    let heightPadding: Int
+    let widthPadding: Int
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "bias") var bias: MLXArray
+
+    init(
+        inputChannels: Int,
+        outputChannels: Int,
+        kernel: (Int, Int, Int),
+        stride: (Int, Int, Int) = (1, 1, 1),
+        padding: (Int, Int, Int) = (0, 0, 0)
+    ) {
+        self.kernel = kernel
+        self.stride = stride
+        self.temporalPadding = 2 * padding.0
+        self.heightPadding = padding.1
+        self.widthPadding = padding.2
+        self._weight.wrappedValue = MLX.zeros([
+            outputChannels, kernel.0, kernel.1, kernel.2, inputChannels,
+        ])
+        self._bias.wrappedValue = MLX.zeros([outputChannels])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        precondition(input.ndim == 5)
+        let batch = input.dim(0)
+        var hidden = input
+        if temporalPadding > 0 {
+            let prefix = MLX.zeros(
+                [batch, temporalPadding, input.dim(2), input.dim(3), input.dim(4)],
+                dtype: input.dtype
+            )
+            hidden = MLX.concatenated([prefix, hidden], axis: 1)
+        }
+        if heightPadding > 0 || widthPadding > 0 {
+            hidden = MLX.padded(hidden, widths: [
+                [0, 0], [0, 0],
+                [heightPadding, heightPadding],
+                [widthPadding, widthPadding],
+                [0, 0],
+            ])
+        }
+        let outputFrames = (hidden.dim(1) - kernel.temporal) / stride.temporal + 1
+        var frames: [MLXArray] = []
+        frames.reserveCapacity(outputFrames)
+        for outputIndex in 0..<outputFrames {
+            let start = outputIndex * stride.temporal
+            var accumulated: MLXArray?
+            for kernelIndex in 0..<kernel.temporal {
+                let frame = hidden[0..., start + kernelIndex]
+                let kernel2D = weight[0..., kernelIndex]
+                let convolved = MLX.convGeneral(
+                    frame,
+                    kernel2D,
+                    strides: [stride.height, stride.width]
+                )
+                accumulated = accumulated.map { $0 + convolved } ?? convolved
+            }
+            frames.append(accumulated! + bias)
+        }
+        return MLX.stacked(frames, axis: 1)
+    }
+}
+
+final class Wan2VAERMSNorm: Module {
+    let scale: Float
+    @ModuleInfo(key: "gamma") var gamma: MLXArray
+
+    init(dimensions: Int) {
+        self.scale = Float(dimensions).squareRoot()
+        self._gamma.wrappedValue = MLX.ones([dimensions])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let squaredNorm = MLX.sum(input * input, axis: -1, keepDims: true)
+        return input * MLX.rsqrt(MLX.maximum(squaredNorm, MLXArray(1e-24))) * scale * gamma
+    }
+}
+
+final class Wan2VAEResidualLayers: Module {
+    @ModuleInfo(key: "layer_0") var norm1: Wan2VAERMSNorm
+    @ModuleInfo(key: "layer_2") var conv1: Wan2VAECausalConv3D
+    @ModuleInfo(key: "layer_3") var norm2: Wan2VAERMSNorm
+    @ModuleInfo(key: "layer_6") var conv2: Wan2VAECausalConv3D
+
+    init(inputChannels: Int, outputChannels: Int) {
+        self._norm1.wrappedValue = Wan2VAERMSNorm(dimensions: inputChannels)
+        self._conv1.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernel: (3, 3, 3),
+            padding: (1, 1, 1)
+        )
+        self._norm2.wrappedValue = Wan2VAERMSNorm(dimensions: outputChannels)
+        self._conv2.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: outputChannels,
+            outputChannels: outputChannels,
+            kernel: (3, 3, 3),
+            padding: (1, 1, 1)
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = conv1(MLXNN.silu(norm1(input)))
+        eval(hidden)
+        hidden = conv2(MLXNN.silu(norm2(hidden)))
+        return hidden
+    }
+}
+
+final class Wan2VAEResidualBlock: Module {
+    @ModuleInfo(key: "residual") var residual: Wan2VAEResidualLayers
+    @ModuleInfo(key: "shortcut") var shortcut: Wan2VAECausalConv3D?
+
+    init(inputChannels: Int, outputChannels: Int) {
+        self._residual.wrappedValue = Wan2VAEResidualLayers(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels
+        )
+        self._shortcut.wrappedValue = inputChannels == outputChannels ? nil : Wan2VAECausalConv3D(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernel: (1, 1, 1)
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        residual(input) + (shortcut?(input) ?? input)
+    }
+}
+
+final class Wan2VAEAttentionBlock: Module {
+    let dimensions: Int
+    @ModuleInfo(key: "norm") var norm: Wan2VAERMSNorm
+    @ModuleInfo(key: "to_qkv_weight") var qkvWeight: MLXArray
+    @ModuleInfo(key: "to_qkv_bias") var qkvBias: MLXArray
+    @ModuleInfo(key: "proj_weight") var projectionWeight: MLXArray
+    @ModuleInfo(key: "proj_bias") var projectionBias: MLXArray
+
+    init(dimensions: Int) {
+        self.dimensions = dimensions
+        self._norm.wrappedValue = Wan2VAERMSNorm(dimensions: dimensions)
+        self._qkvWeight.wrappedValue = MLX.zeros([3 * dimensions, 1, 1, dimensions])
+        self._qkvBias.wrappedValue = MLX.zeros([3 * dimensions])
+        self._projectionWeight.wrappedValue = MLX.zeros([dimensions, 1, 1, dimensions])
+        self._projectionBias.wrappedValue = MLX.zeros([dimensions])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let frames = input.dim(1)
+        let height = input.dim(2)
+        let width = input.dim(3)
+        let flattened = norm(input.reshaped(batch * frames, height, width, dimensions))
+        let qkv = (MLX.convGeneral(flattened, qkvWeight) + qkvBias)
+            .reshaped(batch * frames, height * width, 3 * dimensions)
+        let parts = MLX.split(qkv, parts: 3, axis: -1)
+        let queries = parts[0].expandedDimensions(axis: 1)
+        let keys = parts[1].expandedDimensions(axis: 1)
+        let values = parts[2].expandedDimensions(axis: 1)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: 1 / Float(dimensions).squareRoot(),
+            mask: .none
+        ).squeezed(axis: 1).reshaped(batch * frames, height, width, dimensions)
+        let projected = MLX.convGeneral(attended, projectionWeight) + projectionBias
+        return input + projected.reshaped(batch, frames, height, width, dimensions)
+    }
+}
+
+final class Wan2VAEDuplicateUpsample: Module {
+    let outputChannels: Int
+    let temporalFactor: Int
+    let spatialFactor: Int
+    let repeats: Int
+
+    init(inputChannels: Int, outputChannels: Int, temporalFactor: Int, spatialFactor: Int) {
+        self.outputChannels = outputChannels
+        self.temporalFactor = temporalFactor
+        self.spatialFactor = spatialFactor
+        self.repeats = outputChannels * temporalFactor * spatialFactor * spatialFactor / inputChannels
+    }
+
+    func callAsFunction(_ input: MLXArray, firstChunk: Bool) -> MLXArray {
+        let batch = input.dim(0)
+        let frames = input.dim(1)
+        let height = input.dim(2)
+        let width = input.dim(3)
+        var hidden = MLX.repeated(input, count: repeats, axis: -1)
+            .reshaped(
+                batch, frames, height, width, outputChannels,
+                temporalFactor, spatialFactor, spatialFactor
+            )
+            .transposed(0, 1, 5, 2, 6, 3, 7, 4)
+            .reshaped(
+                batch, frames * temporalFactor,
+                height * spatialFactor, width * spatialFactor,
+                outputChannels
+            )
+        if firstChunk && temporalFactor > 1 {
+            hidden = hidden[0..., (temporalFactor - 1)...]
+        }
+        return hidden
+    }
+}
+
+final class Wan2VAEAverageDownsample: Module {
+    let outputChannels: Int
+    let temporalFactor: Int
+    let spatialFactor: Int
+    let groupSize: Int
+
+    init(inputChannels: Int, outputChannels: Int, temporalFactor: Int, spatialFactor: Int) {
+        self.outputChannels = outputChannels
+        self.temporalFactor = temporalFactor
+        self.spatialFactor = spatialFactor
+        self.groupSize = inputChannels * temporalFactor * spatialFactor * spatialFactor / outputChannels
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        var frames = input.dim(1)
+        let height = input.dim(2)
+        let width = input.dim(3)
+        let channels = input.dim(4)
+        var hidden = input
+        let temporalPadding = (temporalFactor - frames % temporalFactor) % temporalFactor
+        if temporalPadding > 0 {
+            hidden = MLX.padded(hidden, widths: [
+                [0, 0], [temporalPadding, 0], [0, 0], [0, 0], [0, 0],
+            ])
+            frames += temporalPadding
+        }
+        return hidden
+            .reshaped(
+                batch, frames / temporalFactor, temporalFactor,
+                height / spatialFactor, spatialFactor,
+                width / spatialFactor, spatialFactor, channels
+            )
+            .transposed(0, 1, 3, 5, 7, 2, 4, 6)
+            .reshaped(
+                batch, frames / temporalFactor,
+                height / spatialFactor, width / spatialFactor,
+                outputChannels, groupSize
+            )
+            .mean(axis: -1)
+    }
+}
+
+final class Wan2VAEResample: Module {
+    enum Mode { case up2D, up3D, down2D, down3D }
+    let dimensions: Int
+    let mode: Mode
+    @ModuleInfo(key: "resample_weight") var spatialWeight: MLXArray
+    @ModuleInfo(key: "resample_bias") var spatialBias: MLXArray
+    @ModuleInfo(key: "time_conv") var temporalConv: Wan2VAECausalConv3D?
+
+    init(dimensions: Int, mode: Mode) {
+        self.dimensions = dimensions
+        self.mode = mode
+        self._spatialWeight.wrappedValue = MLX.zeros([dimensions, 3, 3, dimensions])
+        self._spatialBias.wrappedValue = MLX.zeros([dimensions])
+        switch mode {
+        case .up3D:
+            self._temporalConv.wrappedValue = Wan2VAECausalConv3D(
+                inputChannels: dimensions,
+                outputChannels: dimensions * 2,
+                kernel: (3, 1, 1),
+                padding: (1, 0, 0)
+            )
+        case .down3D:
+            self._temporalConv.wrappedValue = Wan2VAECausalConv3D(
+                inputChannels: dimensions,
+                outputChannels: dimensions,
+                kernel: (3, 1, 1),
+                stride: (2, 1, 1),
+                padding: (0, 0, 0)
+            )
+        case .up2D, .down2D:
+            self._temporalConv.wrappedValue = nil
+        }
+    }
+
+    func callAsFunction(_ input: MLXArray, firstChunk: Bool = false) -> MLXArray {
+        let batch = input.dim(0)
+        var frames = input.dim(1)
+        var height = input.dim(2)
+        var width = input.dim(3)
+        var hidden = input
+        if mode == .up3D, let temporalConv {
+            if firstChunk && frames > 1 {
+                let first = hidden[0..., 0..<1]
+                let rest = temporalConv(hidden[0..., 1...])
+                    .reshaped(batch, frames - 1, height, width, 2, dimensions)
+                let interleaved = MLX.stacked(
+                    [rest[0..., 0..., 0..., 0..., 0, 0...], rest[0..., 0..., 0..., 0..., 1, 0...]],
+                    axis: 2
+                ).reshaped(batch, (frames - 1) * 2, height, width, dimensions)
+                hidden = MLX.concatenated([first, interleaved], axis: 1)
+            } else {
+                let temporal = temporalConv(hidden).reshaped(batch, frames, height, width, 2, dimensions)
+                hidden = MLX.stacked(
+                    [temporal[0..., 0..., 0..., 0..., 0, 0...], temporal[0..., 0..., 0..., 0..., 1, 0...]],
+                    axis: 2
+                ).reshaped(batch, frames * 2, height, width, dimensions)
+            }
+            eval(hidden)
+            frames = hidden.dim(1)
+        }
+
+        switch mode {
+        case .up2D, .up3D:
+            var flattened = hidden.reshaped(batch * frames, height, width, dimensions)
+            flattened = MLX.repeated(flattened, count: 2, axis: 1)
+            flattened = MLX.repeated(flattened, count: 2, axis: 2)
+            flattened = MLX.padded(flattened, widths: [[0, 0], [1, 1], [1, 1], [0, 0]])
+            flattened = MLX.convGeneral(flattened, spatialWeight) + spatialBias
+            height = flattened.dim(1)
+            width = flattened.dim(2)
+            hidden = flattened.reshaped(batch, frames, height, width, dimensions)
+        case .down2D, .down3D:
+            var flattened = hidden.reshaped(batch * frames, height, width, dimensions)
+            flattened = MLX.padded(flattened, widths: [[0, 0], [0, 1], [0, 1], [0, 0]])
+            flattened = MLX.convGeneral(flattened, spatialWeight, strides: [2, 2]) + spatialBias
+            height = flattened.dim(1)
+            width = flattened.dim(2)
+            hidden = flattened.reshaped(batch, frames, height, width, dimensions)
+        }
+
+        if mode == .down3D, frames > 1, let temporalConv {
+            let first = hidden[0..., 0..<1]
+            let downsampled = temporalConv(hidden)
+            hidden = MLX.concatenated([first, downsampled], axis: 1)
+            eval(hidden)
+        }
+        return hidden
+    }
+}
+
+final class Wan2VAEUpBlock: Module {
+    @ModuleInfo(key: "avg_shortcut") var shortcut: Wan2VAEDuplicateUpsample?
+    @ModuleInfo(key: "upsamples") var layers: [Module]
+
+    init(inputChannels: Int, outputChannels: Int, temporalUpsample: Bool, upsample: Bool) {
+        self._shortcut.wrappedValue = upsample ? Wan2VAEDuplicateUpsample(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            temporalFactor: temporalUpsample ? 2 : 1,
+            spatialFactor: 2
+        ) : nil
+        var modules: [Module] = []
+        var input = inputChannels
+        for _ in 0..<3 {
+            modules.append(Wan2VAEResidualBlock(inputChannels: input, outputChannels: outputChannels))
+            input = outputChannels
+        }
+        if upsample {
+            modules.append(Wan2VAEResample(
+                dimensions: outputChannels,
+                mode: temporalUpsample ? .up3D : .up2D
+            ))
+        }
+        self._layers.wrappedValue = modules
+    }
+
+    func callAsFunction(_ input: MLXArray, firstChunk: Bool) -> MLXArray {
+        var hidden = input
+        for layer in layers {
+            if let residual = layer as? Wan2VAEResidualBlock {
+                hidden = residual(hidden)
+            } else if let resample = layer as? Wan2VAEResample {
+                hidden = resample(hidden, firstChunk: firstChunk)
+            }
+            eval(hidden)
+        }
+        guard let shortcut else { return hidden }
+        let skip = shortcut(input, firstChunk: firstChunk)
+        eval(skip)
+        return hidden + skip
+    }
+}
+
+final class Wan2VAEDownBlock: Module {
+    @ModuleInfo(key: "avg_shortcut") var shortcut: Wan2VAEAverageDownsample
+    @ModuleInfo(key: "downsamples") var layers: [Module]
+
+    init(inputChannels: Int, outputChannels: Int, temporalDownsample: Bool, downsample: Bool) {
+        self._shortcut.wrappedValue = Wan2VAEAverageDownsample(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            temporalFactor: temporalDownsample ? 2 : 1,
+            spatialFactor: downsample ? 2 : 1
+        )
+        var modules: [Module] = []
+        var input = inputChannels
+        for _ in 0..<2 {
+            modules.append(Wan2VAEResidualBlock(inputChannels: input, outputChannels: outputChannels))
+            input = outputChannels
+        }
+        if downsample {
+            modules.append(Wan2VAEResample(
+                dimensions: outputChannels,
+                mode: temporalDownsample ? .down3D : .down2D
+            ))
+        }
+        self._layers.wrappedValue = modules
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let skip = shortcut(input)
+        eval(skip)
+        var hidden = input
+        for layer in layers {
+            if let residual = layer as? Wan2VAEResidualBlock {
+                hidden = residual(hidden)
+            } else if let resample = layer as? Wan2VAEResample {
+                hidden = resample(hidden)
+            }
+            eval(hidden)
+        }
+        return hidden + skip
+    }
+}
+
+final class Wan2VAEHead: Module {
+    @ModuleInfo(key: "layer_0") var norm: Wan2VAERMSNorm
+    @ModuleInfo(key: "layer_2") var conv: Wan2VAECausalConv3D
+
+    init(inputChannels: Int, outputChannels: Int = 12) {
+        self._norm.wrappedValue = Wan2VAERMSNorm(dimensions: inputChannels)
+        self._conv.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernel: (3, 3, 3),
+            padding: (1, 1, 1)
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        conv(MLXNN.silu(norm(input)))
+    }
+}
+
+final class Wan2VAEDecoder3D: Module {
+    @ModuleInfo(key: "conv1") var inputConv: Wan2VAECausalConv3D
+    @ModuleInfo(key: "middle") var middle: [Module]
+    @ModuleInfo(key: "upsamples") var upsampleBlocks: [Wan2VAEUpBlock]
+    @ModuleInfo(key: "head") var head: Wan2VAEHead
+
+    init(baseDimensions: Int = 256, latentChannels: Int = 48) {
+        let dimensions = [baseDimensions * 4, baseDimensions * 4, baseDimensions * 4, baseDimensions * 2, baseDimensions]
+        self._inputConv.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: latentChannels,
+            outputChannels: dimensions[0],
+            kernel: (3, 3, 3),
+            padding: (1, 1, 1)
+        )
+        self._middle.wrappedValue = [
+            Wan2VAEResidualBlock(inputChannels: dimensions[0], outputChannels: dimensions[0]),
+            Wan2VAEAttentionBlock(dimensions: dimensions[0]),
+            Wan2VAEResidualBlock(inputChannels: dimensions[0], outputChannels: dimensions[0]),
+        ]
+        self._upsampleBlocks.wrappedValue = (0..<4).map { index in
+            Wan2VAEUpBlock(
+                inputChannels: dimensions[index],
+                outputChannels: dimensions[index + 1],
+                temporalUpsample: index < 2,
+                upsample: index < 3
+            )
+        }
+        self._head.wrappedValue = Wan2VAEHead(inputChannels: dimensions.last!)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = inputConv(input)
+        for layer in middle {
+            if let residual = layer as? Wan2VAEResidualBlock {
+                hidden = residual(hidden)
+            } else if let attention = layer as? Wan2VAEAttentionBlock {
+                hidden = attention(hidden)
+            }
+        }
+        eval(hidden)
+        for block in upsampleBlocks {
+            hidden = block(hidden, firstChunk: true)
+            eval(hidden)
+        }
+        return head(hidden)
+    }
+}
+
+final class Wan2VAEEncoder3D: Module {
+    @ModuleInfo(key: "conv1") var inputConv: Wan2VAECausalConv3D
+    @ModuleInfo(key: "downsamples") var downsampleBlocks: [Wan2VAEDownBlock]
+    @ModuleInfo(key: "middle") var middle: [Module]
+    @ModuleInfo(key: "head") var head: Wan2VAEHead
+
+    init(baseDimensions: Int = 160, outputChannels: Int = 96) {
+        let dimensions = [baseDimensions, baseDimensions, baseDimensions * 2, baseDimensions * 4, baseDimensions * 4]
+        self._inputConv.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: 12,
+            outputChannels: dimensions[0],
+            kernel: (3, 3, 3),
+            padding: (1, 1, 1)
+        )
+        self._downsampleBlocks.wrappedValue = (0..<4).map { index in
+            Wan2VAEDownBlock(
+                inputChannels: dimensions[index],
+                outputChannels: dimensions[index + 1],
+                temporalDownsample: index == 1 || index == 2,
+                downsample: index < 3
+            )
+        }
+        self._middle.wrappedValue = [
+            Wan2VAEResidualBlock(inputChannels: dimensions.last!, outputChannels: dimensions.last!),
+            Wan2VAEAttentionBlock(dimensions: dimensions.last!),
+            Wan2VAEResidualBlock(inputChannels: dimensions.last!, outputChannels: dimensions.last!),
+        ]
+        self._head.wrappedValue = Wan2VAEHead(inputChannels: dimensions.last!, outputChannels: outputChannels)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = inputConv(input)
+        for block in downsampleBlocks {
+            hidden = block(hidden)
+        }
+        for layer in middle {
+            if let residual = layer as? Wan2VAEResidualBlock {
+                hidden = residual(hidden)
+            } else if let attention = layer as? Wan2VAEAttentionBlock {
+                hidden = attention(hidden)
+            }
+        }
+        eval(hidden)
+        return head(hidden)
+    }
+}
+
+public final class Wan2VAEModel: Module {
+    let latentChannels: Int
+    @ModuleInfo(key: "conv1") var encoderProjection: Wan2VAECausalConv3D
+    @ModuleInfo(key: "encoder") var encoder: Wan2VAEEncoder3D
+    @ModuleInfo(key: "conv2") var decoderProjection: Wan2VAECausalConv3D
+    @ModuleInfo(key: "decoder") var decoder: Wan2VAEDecoder3D
+
+    public init(latentChannels: Int = 48, encoderDimensions: Int = 160, decoderDimensions: Int = 256) {
+        self.latentChannels = latentChannels
+        self._encoderProjection.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: latentChannels * 2,
+            outputChannels: latentChannels * 2,
+            kernel: (1, 1, 1)
+        )
+        self._encoder.wrappedValue = Wan2VAEEncoder3D(
+            baseDimensions: encoderDimensions,
+            outputChannels: latentChannels * 2
+        )
+        self._decoderProjection.wrappedValue = Wan2VAECausalConv3D(
+            inputChannels: latentChannels,
+            outputChannels: latentChannels,
+            kernel: (1, 1, 1)
+        )
+        self._decoder.wrappedValue = Wan2VAEDecoder3D(
+            baseDimensions: decoderDimensions,
+            latentChannels: latentChannels
+        )
+    }
+
+    public func encodeImage(_ image: MLXArray) -> MLXArray {
+        precondition(image.ndim == 5 && image.dim(1) == 1 && image.dim(4) == 3)
+        return encodeVideo(image)
+    }
+
+    public func encodeVideo(_ video: MLXArray) -> MLXArray {
+        precondition(video.ndim == 5 && video.dim(4) == 3)
+        precondition(video.dim(1) >= 1 && (video.dim(1) - 1) % 4 == 0)
+        let packed = Self.patchify(video)
+        let moments = encoderProjection(encoder(packed))
+        let mean = moments[0..., 0..., 0..., 0..., 0..<latentChannels]
+        return Self.normalize(mean)
+    }
+
+    public func decode(_ normalizedLatents: MLXArray) -> MLXArray {
+        let denormalized = Self.denormalize(normalizedLatents)
+        let decoded = decoder(decoderProjection(denormalized))
+        return MLX.clip(Self.unpatchify(decoded), min: -1, max: 1)
+    }
+
+    public static func normalize(_ latents: MLXArray) -> MLXArray {
+        let mean = MLXArray(wan2VAE22MeanValues).reshaped(1, 1, 1, 1, 48)
+        let standardDeviation = MLXArray(wan2VAE22StandardDeviationValues).reshaped(1, 1, 1, 1, 48)
+        return (latents - mean) / standardDeviation
+    }
+
+    public static func denormalize(_ latents: MLXArray) -> MLXArray {
+        let mean = MLXArray(wan2VAE22MeanValues).reshaped(1, 1, 1, 1, 48)
+        let standardDeviation = MLXArray(wan2VAE22StandardDeviationValues).reshaped(1, 1, 1, 1, 48)
+        return latents * standardDeviation + mean
+    }
+
+    static func patchify(_ input: MLXArray, patchSize: Int = 2) -> MLXArray {
+        let batch = input.dim(0)
+        let frames = input.dim(1)
+        let height = input.dim(2) / patchSize
+        let width = input.dim(3) / patchSize
+        let channels = input.dim(4)
+        return input
+            .reshaped(batch, frames, height, patchSize, width, patchSize, channels)
+            .transposed(0, 1, 2, 4, 6, 5, 3)
+            .reshaped(batch, frames, height, width, channels * patchSize * patchSize)
+    }
+
+    static func unpatchify(_ input: MLXArray, patchSize: Int = 2) -> MLXArray {
+        let batch = input.dim(0)
+        let frames = input.dim(1)
+        let height = input.dim(2)
+        let width = input.dim(3)
+        let channels = input.dim(4) / (patchSize * patchSize)
+        return input
+            .reshaped(batch, frames, height, width, channels, patchSize, patchSize)
+            .transposed(0, 1, 2, 6, 3, 5, 4)
+            .reshaped(batch, frames, height * patchSize, width * patchSize, channels)
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2WorldSession.swift
+++ b/Sources/MereRunCore/Wan2/Wan2WorldSession.swift
@@ -1,0 +1,311 @@
+import Foundation
+import MediaIO
+import MLX
+
+public enum Wan2WorldMotion: String, Codable, Hashable, Sendable {
+    case hold
+    case forward
+    case backward
+    case strafeLeft
+    case strafeRight
+    case yawLeft
+    case yawRight
+    case custom
+}
+
+public struct Wan2WorldCameraControl: Codable, Hashable, Sendable {
+    public let motion: Wan2WorldMotion
+    public let translationMeters: [Float]
+    public let rotationDegrees: [Float]
+
+    public init(
+        motion: Wan2WorldMotion,
+        translationMeters: [Float] = [0, 0, 0],
+        rotationDegrees: [Float] = [0, 0, 0]
+    ) {
+        precondition(translationMeters.count == 3)
+        precondition(rotationDegrees.count == 3)
+        self.motion = motion
+        self.translationMeters = translationMeters
+        self.rotationDegrees = rotationDegrees
+    }
+
+    public static func forward(meters: Float = 1) -> Self {
+        Self(motion: .forward, translationMeters: [0, 0, meters])
+    }
+
+    public static func backward(meters: Float = 1) -> Self {
+        Self(motion: .backward, translationMeters: [0, 0, -meters])
+    }
+
+    public static func yawLeft(degrees: Float = 30) -> Self {
+        Self(motion: .yawLeft, rotationDegrees: [0, -degrees, 0])
+    }
+
+    public static func yawRight(degrees: Float = 30) -> Self {
+        Self(motion: .yawRight, rotationDegrees: [0, degrees, 0])
+    }
+
+    var promptClause: String {
+        switch motion {
+        case .hold:
+            return "The camera remains stationary with no translation or rotation."
+        case .forward:
+            return "The first-person camera translates straight forward through the existing three-dimensional space without yaw or sideways movement."
+        case .backward:
+            return "The first-person camera translates straight backward through the existing three-dimensional space without yaw or sideways movement."
+        case .strafeLeft:
+            return "The first-person camera sidesteps left while preserving its viewing direction, with no yaw."
+        case .strafeRight:
+            return "The first-person camera sidesteps right while preserving its viewing direction, with no yaw."
+        case .yawLeft:
+            return "The first-person camera pivots left in place with no forward translation."
+        case .yawRight:
+            return "The first-person camera pivots right in place with no forward translation."
+        case .custom:
+            let translation = translationMeters.map { String(format: "%.3f", $0) }.joined(separator: ",")
+            let rotation = rotationDegrees.map { String(format: "%.3f", $0) }.joined(separator: ",")
+            return "The camera follows translation [\(translation)] meters and XYZ rotation [\(rotation)] degrees while preserving scene identity."
+        }
+    }
+}
+
+public enum Wan2WorldConditioningMode: String, Codable, Hashable, Sendable {
+    case textAndFirstFrame
+    case causalCameraLatents
+}
+
+public struct Wan2WorldTransitionRequest: Hashable, Sendable {
+    public let requestID: UUID
+    public let prompt: String
+    public let negativePrompt: String
+    public let camera: Wan2WorldCameraControl
+    public let sourceImageURL: URL?
+    public let outputURL: URL?
+    public let width: Int
+    public let height: Int
+    public let numFrames: Int
+    public let steps: Int
+    public let guidanceScale: Float
+    public let shift: Float
+    public let seed: UInt64
+    public let fps: Int
+
+    public init(
+        requestID: UUID = UUID(),
+        prompt: String,
+        negativePrompt: String = Wan2Resources.defaultNegativePrompt,
+        camera: Wan2WorldCameraControl,
+        sourceImageURL: URL? = nil,
+        outputURL: URL? = nil,
+        width: Int = 512,
+        height: Int = 320,
+        numFrames: Int = 17,
+        steps: Int = 40,
+        guidanceScale: Float = 5,
+        shift: Float = 5,
+        seed: UInt64 = 42,
+        fps: Int = 24
+    ) {
+        self.requestID = requestID
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.camera = camera
+        self.sourceImageURL = sourceImageURL
+        self.outputURL = outputURL
+        self.width = width
+        self.height = height
+        self.numFrames = numFrames
+        self.steps = steps
+        self.guidanceScale = guidanceScale
+        self.shift = shift
+        self.seed = seed
+        self.fps = fps
+    }
+}
+
+public enum Wan2WorldSessionPhase: String, Codable, Hashable, Sendable {
+    case cold
+    case ready
+    case generating
+}
+
+public struct Wan2WorldSessionSnapshot: Codable, Hashable, Sendable {
+    public let sessionID: UUID
+    public let phase: Wan2WorldSessionPhase
+    public let transitionCount: Int
+    public let currentStateID: UUID?
+    public let currentFrameURL: URL?
+    public let conditioningMode: Wan2WorldConditioningMode
+    public let keepsModelsWarm: Bool
+    public let keepsTerminalLatent: Bool
+}
+
+public struct Wan2WorldTransitionReceipt: Codable, Hashable, Sendable {
+    public let requestID: UUID
+    public let previousStateID: UUID?
+    public let stateID: UUID
+    public let transitionIndex: Int
+    public let outputURL: URL
+    public let terminalFrameURL: URL
+    public let camera: Wan2WorldCameraControl
+    public let conditioningMode: Wan2WorldConditioningMode
+    public let seed: UInt64
+}
+
+public enum Wan2WorldSessionError: LocalizedError, Sendable {
+    case busy
+    case sourceImageRequired
+    case terminalLatentMissing
+
+    public var errorDescription: String? {
+        switch self {
+        case .busy:
+            return "The Wan world session is already generating a transition."
+        case .sourceImageRequired:
+            return "The first world transition requires a source image."
+        case .terminalLatentMissing:
+            return "Wan generation did not return the terminal-frame latent required for chaining."
+        }
+    }
+}
+
+public actor Wan2WorldSession {
+    public let sessionID: UUID
+    public let resources: Wan2Resources
+    public let stateDirectory: URL
+
+    private let generator: Wan2TI2VGenerator
+    private var phase: Wan2WorldSessionPhase = .cold
+    private var transitionCount = 0
+    private var currentStateID: UUID?
+    private var currentFrameURL: URL?
+
+    public init(
+        resources: Wan2Resources,
+        stateDirectory: URL,
+        sessionID: UUID = UUID()
+    ) {
+        self.resources = resources
+        self.stateDirectory = stateDirectory.standardizedFileURL
+        self.sessionID = sessionID
+        self.generator = Wan2TI2VGenerator()
+    }
+
+    public func prepare(progress: (@Sendable (String) -> Void)? = nil) throws {
+        guard phase != .generating else { throw Wan2WorldSessionError.busy }
+        try FileManager.default.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        try generator.prepare(resources: resources, progress: progress)
+        phase = .ready
+    }
+
+    public func transition(
+        _ request: Wan2WorldTransitionRequest,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)? = nil
+    ) async throws -> Wan2WorldTransitionReceipt {
+        guard phase != .generating else { throw Wan2WorldSessionError.busy }
+        try FileManager.default.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+
+        let usesExplicitSource = request.sourceImageURL != nil
+        guard let sourceImageURL = request.sourceImageURL ?? currentFrameURL else {
+            throw Wan2WorldSessionError.sourceImageRequired
+        }
+        let nextIndex = transitionCount + 1
+        let outputURL = request.outputURL ?? stateDirectory
+            .appendingPathComponent(String(format: "transition-%04d.mp4", nextIndex))
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let effectivePrompt = request.prompt + "\n\nCamera behavior: " + request.camera.promptClause
+        let options = try Wan2GenerationOptions(
+            prompt: effectivePrompt,
+            negativePrompt: request.negativePrompt,
+            sourceImageURL: sourceImageURL,
+            outputURL: outputURL,
+            width: request.width,
+            height: request.height,
+            numFrames: request.numFrames,
+            steps: request.steps,
+            guidanceScale: request.guidanceScale,
+            shift: request.shift,
+            seed: request.seed,
+            fps: request.fps
+        )
+
+        phase = .generating
+        do {
+            let result = try await generator.generate(
+                options: options,
+                resources: resources,
+                useChainedSourceLatent: !usesExplicitSource,
+                captureTerminalFrameLatent: true,
+                progressHandler: progressHandler
+            )
+            guard result.terminalFrameLatent != nil else {
+                throw Wan2WorldSessionError.terminalLatentMissing
+            }
+            try LTXVideoMP4Writer.writeMP4(frames: result.frames, fps: request.fps, to: outputURL)
+
+            let terminalFrameURL = stateDirectory
+                .appendingPathComponent(String(format: "state-%04d.png", nextIndex))
+            let terminal = result.frames[0, result.frames.dim(1) - 1]
+            eval(terminal)
+            let image = try MediaImageIO.imageFromRGBHWC(
+                terminal.asArray(UInt8.self),
+                width: result.frames.dim(3),
+                height: result.frames.dim(2)
+            )
+            try MediaImageIO.writePNG(image, to: terminalFrameURL)
+
+            let previousStateID = currentStateID
+            let nextStateID = UUID()
+            currentFrameURL = terminalFrameURL
+            currentStateID = nextStateID
+            transitionCount = nextIndex
+            phase = .ready
+            return Wan2WorldTransitionReceipt(
+                requestID: request.requestID,
+                previousStateID: previousStateID,
+                stateID: nextStateID,
+                transitionIndex: nextIndex,
+                outputURL: outputURL,
+                terminalFrameURL: terminalFrameURL,
+                camera: request.camera,
+                conditioningMode: .textAndFirstFrame,
+                seed: result.seed
+            )
+        } catch {
+            phase = generator.isWarm ? .ready : .cold
+            throw error
+        }
+    }
+
+    public func reset(sourceImageURL: URL? = nil) throws {
+        guard phase != .generating else { throw Wan2WorldSessionError.busy }
+        currentFrameURL = sourceImageURL
+        generator.clearChain()
+        currentStateID = sourceImageURL == nil ? nil : UUID()
+        transitionCount = 0
+        phase = generator.isWarm ? .ready : .cold
+    }
+
+    public func unload() throws {
+        guard phase != .generating else { throw Wan2WorldSessionError.busy }
+        generator.unload()
+        phase = .cold
+    }
+
+    public func snapshot() -> Wan2WorldSessionSnapshot {
+        Wan2WorldSessionSnapshot(
+            sessionID: sessionID,
+            phase: phase,
+            transitionCount: transitionCount,
+            currentStateID: currentStateID,
+            currentFrameURL: currentFrameURL,
+            conditioningMode: .textAndFirstFrame,
+            keepsModelsWarm: generator.isWarm,
+            keepsTerminalLatent: generator.hasChainedTerminalFrameLatent
+        )
+    }
+}

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -98,6 +98,12 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(nearestLTXFrameCount(duration: 15, fps: 8), 121)
     }
 
+    func testNearestWanFrameCountUsesFourFrameLatentCadence() {
+        XCTAssertEqual(nearestWanFrameCount(duration: 1, fps: 24), 25)
+        XCTAssertEqual(nearestWanFrameCount(duration: 0.5, fps: 24), 13)
+        XCTAssertEqual(nearestWanFrameCount(duration: 0.1, fps: 24), 5)
+    }
+
     func testVideoGeneratePreflightReportsResolvedPlan() throws {
         let modelRoot = try makeValidLTXModelRoot()
         let sourceImage = try makeTempFile(name: "start.png")
@@ -259,6 +265,37 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertNoThrow(try validateNativeModelRoot(rootURL))
     }
 
+    func testWanPreflightUsesNativeSpatialAndTemporalGeometry() throws {
+        let modelRoot = try makeValidWanModelRoot()
+        let sourceImage = try makeTempFile(name: "start.png")
+        let output = makeTempOutput(name: "clip.mp4")
+        let cmd = try VideoGenerate.parse([
+            "the camera walks forward",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--width", "1057",
+            "--height", "577",
+            "--num-frames", "18",
+            "--image", sourceImage.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.layout, "wan22_ti2v_mlx")
+        XCTAssertEqual(envelope.result.plan.variant, "wan22-ti2v")
+        XCTAssertEqual(envelope.result.plan.resolvedWidth, 1_056)
+        XCTAssertEqual(envelope.result.plan.resolvedHeight, 576)
+        XCTAssertEqual(envelope.result.plan.resolvedNumFrames, 17)
+        XCTAssertFalse(envelope.result.plan.writesAudio)
+    }
+
     private func makeTempDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("VideoCommandTests.\(UUID().uuidString)", isDirectory: true)
@@ -286,6 +323,38 @@ final class VideoCommandTests: XCTestCase {
         )
         try createFile(rootURL.appendingPathComponent("ltx-2-19b-distilled.safetensors"))
         try createFile(rootURL.appendingPathComponent("ltx-2-spatial-upscaler-x2-1.0.safetensors"))
+        return rootURL
+    }
+
+    private func makeValidWanModelRoot() throws -> URL {
+        let rootURL = try makeTempDirectory()
+        let config = """
+        {
+          "model_type": "ti2v",
+          "model_version": "2.2",
+          "patch_size": [1, 2, 2],
+          "text_len": 512,
+          "in_dim": 48,
+          "dim": 3072,
+          "ffn_dim": 14336,
+          "text_dim": 4096,
+          "out_dim": 48,
+          "num_heads": 24,
+          "num_layers": 30,
+          "vae_stride": [4, 16, 16],
+          "vae_z_dim": 48,
+          "sample_shift": 5.0,
+          "sample_steps": 40,
+          "sample_guide_scale": 5.0,
+          "sample_fps": 24,
+          "frame_num": 81,
+          "max_area": 901120
+        }
+        """
+        try Data(config.utf8).write(to: rootURL.appendingPathComponent("config.json"))
+        for name in ["model.safetensors", "t5_encoder.safetensors", "tokenizer.json", "vae.safetensors"] {
+            try createFile(rootURL.appendingPathComponent(name))
+        }
         return rootURL
     }
 

--- a/Tests/MereRunCoreTests/Wan2GenerationTests.swift
+++ b/Tests/MereRunCoreTests/Wan2GenerationTests.swift
@@ -1,0 +1,81 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2GenerationTests: MereRunCoreTestCase {
+    func testNativeResolutionAndLatentGeometry() throws {
+        let options = try makeOptions()
+        XCTAssertEqual(options.latentShape, [48, 11, 44, 80])
+        XCTAssertEqual(options.patchGridShape, [11, 22, 40])
+        XCTAssertEqual(options.sequenceLength, 9_680)
+    }
+
+    func testRejectsInvalidFrameAndResolutionGeometry() throws {
+        XCTAssertThrowsError(try makeOptions(width: 1_279))
+        XCTAssertThrowsError(try makeOptions(numFrames: 40))
+    }
+
+    func testShiftedFlowScheduleMatchesWanEndpoints() {
+        let scheduler = Wan2FlowMatchEulerScheduler(steps: 4, shift: 5)
+        XCTAssertEqual(scheduler.sigmas.count, 5)
+        XCTAssertEqual(scheduler.timesteps.count, 4)
+        XCTAssertEqual(scheduler.sigmas.last, 0)
+        XCTAssertEqual(scheduler.timesteps.last, 624)
+        XCTAssertEqual(scheduler.sigmas[0], 4.995 / 4.996, accuracy: 1e-6)
+    }
+
+    func testEulerStepUsesNextMinusCurrentSigma() {
+        var scheduler = Wan2FlowMatchEulerScheduler(steps: 2, shift: 1)
+        let sample = MLXArray([1, 2], [1, 2])
+        let velocity = MLXArray([2, 4], [1, 2])
+        let result = scheduler.step(velocity: velocity, sample: sample)
+        eval(result)
+        let values = result.asArray(Float.self)
+        XCTAssertEqual(values.count, 2)
+        XCTAssertLessThan(abs(values[0] - 0.001), 1e-5)
+        XCTAssertLessThan(abs(values[1] - 0.002), 1e-5)
+    }
+
+    func testUniPCScheduleAndFirstOrderStepAreFinite() {
+        var scheduler = Wan2UniPCScheduler(steps: 4, shift: 5)
+        XCTAssertEqual(scheduler.timesteps.count, 4)
+        XCTAssertEqual(scheduler.sigmas.count, 5)
+        XCTAssertEqual(scheduler.sigmas.last, 0)
+        let sample = MLXArray([Float(1), 2], [1, 2])
+        let output = MLXArray([Float(0.25), -0.5], [1, 2])
+        var result = sample
+        for _ in scheduler.timesteps {
+            result = scheduler.step(modelOutput: output, sample: result)
+            eval(result)
+            XCTAssertTrue(result.asArray(Float.self).allSatisfy(\.isFinite))
+        }
+    }
+
+    func testImageConditioningFreezesFirstLatentFrameAndTokens() {
+        let shape = [2, 3, 2, 2]
+        let mask = Wan2TI2VConditioning.latentMask(shape: shape)
+        let tokenMask = Wan2TI2VConditioning.tokenMask(latentShape: shape, patchSize: [1, 1, 1])
+        let image = MLX.ones(shape)
+        let noise = MLX.zeros(shape)
+        let blended = Wan2TI2VConditioning.blend(imageLatent: image, noise: noise, mask: mask)
+        eval(mask, tokenMask, blended)
+
+        XCTAssertEqual(mask[0, 0].asArray(Float.self), [0, 0, 0, 0])
+        XCTAssertEqual(mask[0, 1].asArray(Float.self), [1, 1, 1, 1])
+        XCTAssertEqual(tokenMask.asArray(Float.self), [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1])
+        XCTAssertEqual(blended[0, 0].asArray(Float.self), [1, 1, 1, 1])
+        XCTAssertEqual(blended[0, 1].asArray(Float.self), [0, 0, 0, 0])
+    }
+
+    private func makeOptions(width: Int = 1_280, numFrames: Int = 41) throws -> Wan2GenerationOptions {
+        try Wan2GenerationOptions(
+            prompt: "walk forward",
+            negativePrompt: "static",
+            sourceImageURL: URL(fileURLWithPath: "/tmp/source.png"),
+            outputURL: URL(fileURLWithPath: "/tmp/output.mp4"),
+            width: width,
+            height: 704,
+            numFrames: numFrames
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2RealModelCompatibilityTests.swift
+++ b/Tests/MereRunCoreTests/Wan2RealModelCompatibilityTests.swift
@@ -1,0 +1,121 @@
+import MLX
+import MLXNN
+import XCTest
+@testable import MereRunCore
+
+final class Wan2RealModelCompatibilityTests: MereRunCoreTestCase {
+    func testInstalledCheckpointKeysAndShapesMatchNativeModules() throws {
+        guard let root = ProcessInfo.processInfo.environment["MERERUN_WAN2_MODEL_ROOT"] else {
+            throw XCTSkip("Set MERERUN_WAN2_MODEL_ROOT to inspect an installed checkpoint.")
+        }
+        let resources = Wan2Resources(rootURL: URL(fileURLWithPath: root))
+        try assertCompatible(model: Wan2TextEncoderModel(), weightsURL: resources.textEncoderURL)
+        Memory.clearCache()
+        try assertCompatible(model: Wan2TransformerModel(), weightsURL: resources.transformerURL)
+        Memory.clearCache()
+        try assertCompatible(model: Wan2VAEModel(), weightsURL: resources.vaeURL)
+        Memory.clearCache()
+    }
+
+    func testOneBlockOutputMatchesReferenceHarness() throws {
+        try writeReferenceHarnessOutput(layerCount: 1, outputPath: "/tmp/wan-swift-oneblock.npy")
+    }
+
+    func testFullStackOutputMatchesReferenceHarness() throws {
+        try writeReferenceHarnessOutput(layerCount: 30, outputPath: "/tmp/wan-swift-fullstack.npy")
+    }
+
+    func testTextEncoderOutputMatchesReferenceHarness() throws {
+        guard let root = ProcessInfo.processInfo.environment["MERERUN_WAN2_MODEL_ROOT"] else {
+            throw XCTSkip("Set MERERUN_WAN2_MODEL_ROOT to inspect an installed checkpoint.")
+        }
+        let resources = Wan2Resources(rootURL: URL(fileURLWithPath: root))
+        let model = Wan2TextEncoderModel()
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: resources.textEncoderURL,
+            to: model,
+            dtype: .bfloat16,
+            verify: .none,
+            batchSize: 12
+        )
+        eval(model.parameters().flattened().map(\.1))
+
+        let tokenIDs = MLXArray([42, 43, 44, 1], [1, 4])
+        let mask = MLX.ones([1, 4], dtype: .int32)
+        let output = model(tokenIDs: tokenIDs, mask: mask).asType(.float32)
+        eval(output)
+        let outputURL = URL(fileURLWithPath: "/tmp/wan-swift-t5.npy")
+        try MLX.save(array: output, url: outputURL)
+        let values = output.asArray(Float.self)
+        let mean = values.reduce(0, +) / Float(values.count)
+        let variance = values.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Float(values.count)
+        print(
+            "Wan T5 Swift output shape=\(output.shape) mean=\(mean) std=\(sqrt(variance)) "
+                + "min=\(values.min() ?? .nan) max=\(values.max() ?? .nan) path=\(outputURL.path)"
+        )
+        XCTAssertTrue(values.allSatisfy(\.isFinite))
+    }
+
+    private func writeReferenceHarnessOutput(layerCount: Int, outputPath: String) throws {
+        guard let root = ProcessInfo.processInfo.environment["MERERUN_WAN2_MODEL_ROOT"] else {
+            throw XCTSkip("Set MERERUN_WAN2_MODEL_ROOT to inspect an installed checkpoint.")
+        }
+        let resources = Wan2Resources(rootURL: URL(fileURLWithPath: root))
+        let configuration = Wan2TransformerConfiguration(layerCount: layerCount)
+        let model = Wan2TransformerModel(configuration: configuration)
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: resources.transformerURL,
+            to: model,
+            verify: .none,
+            include: { key in
+                guard key.hasPrefix("blocks.") else { return true }
+                guard layerCount < 30 else { return true }
+                return (0..<layerCount).contains { key.hasPrefix("blocks.\($0).") }
+            },
+            mapper: { key, value in
+                let dtype: DType = key.hasSuffix("modulation") ? .float32 : .bfloat16
+                return [(key, value.asType(dtype))]
+            },
+            batchSize: 12
+        )
+        eval(model.parameters().flattened().map(\.1))
+
+        let latent = MLX.zeros([48, 3, 8, 8], dtype: .bfloat16)
+        let rawContext = MLX.zeros([1, 512, 4_096], dtype: .bfloat16)
+        let context = model.embedText(rawContext)
+        let timesteps = MLX.concatenated([
+            MLX.zeros([1, 16], dtype: .float32),
+            MLX.ones([1, 32], dtype: .float32) * 999,
+        ], axis: 1)
+        let output = model(
+            latents: [latent],
+            timesteps: timesteps,
+            embeddedContext: context
+        )[0].asType(.float32)
+        eval(output)
+
+        let outputURL = URL(fileURLWithPath: outputPath)
+        try MLX.save(array: output, url: outputURL)
+        let values = output.asArray(Float.self)
+        let mean = values.reduce(0, +) / Float(values.count)
+        let variance = values.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Float(values.count)
+        print(
+            "Wan \(layerCount)-block Swift output shape=\(output.shape) mean=\(mean) std=\(sqrt(variance)) "
+                + "min=\(values.min() ?? .nan) max=\(values.max() ?? .nan) path=\(outputURL.path)"
+        )
+        XCTAssertTrue(values.allSatisfy(\.isFinite))
+    }
+
+    private func assertCompatible(model: Module, weightsURL: URL) throws {
+        let parameters = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
+        let metadata = try SafetensorsStreamingLoader.metadata(url: weightsURL)
+        let runtimeBuffers: Set<String> = ["inverseTimestepFrequencies", "ropeFrequencies"]
+        let parameterKeys = Set(parameters.keys).subtracting(runtimeBuffers)
+        let weightKeys = Set(metadata.keys)
+        XCTAssertEqual(parameterKeys.subtracting(weightKeys), [], "Native parameters missing from checkpoint")
+        XCTAssertEqual(weightKeys.subtracting(parameterKeys), [], "Checkpoint parameters missing from native module")
+        for key in parameterKeys.intersection(weightKeys) {
+            XCTAssertEqual(parameters[key]?.shape, metadata[key]?.shape, "Shape mismatch for \(key)")
+        }
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2RealVAERoundTripTests.swift
+++ b/Tests/MereRunCoreTests/Wan2RealVAERoundTripTests.swift
@@ -1,0 +1,66 @@
+import MediaIO
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2RealVAERoundTripTests: MereRunCoreTestCase {
+    func testImageEncoderMatchesReferenceHarness() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"] else {
+            throw XCTSkip("Set the Wan2 model and source image environment variables.")
+        }
+        let source = try MediaImageIO.centerCropped(
+            MediaImageIO.decode(URL(fileURLWithPath: sourcePath)),
+            width: 128,
+            height: 128
+        )
+        let channels = MediaImageIO.rgbCHWFloat(source, normalizedToMinusOneToOne: true)
+        let frame = MLXArray(channels)
+            .reshaped(3, 128, 128)
+            .transposed(1, 2, 0)
+            .reshaped(1, 1, 128, 128, 3)
+        let resources = Wan2Resources(rootURL: URL(fileURLWithPath: root))
+        let vae = try Wan2ModelLoader.loadVAE(resources: resources)
+        let latents = vae.encodeImage(frame).asType(.float32)
+        eval(latents)
+        let outputURL = URL(fileURLWithPath: "/tmp/wan-swift-vae-encode.npy")
+        try MLX.save(array: latents, url: outputURL)
+        print(
+            "Wan VAE Swift encode shape=\(latents.shape) "
+                + "mean=\(MLX.mean(latents).item(Float.self)) "
+                + "std=\(MLX.std(latents).item(Float.self)) path=\(outputURL.path)"
+        )
+    }
+
+    func testStaticVideoRoundTripWithInstalledVAE() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"],
+              let outputPath = environment["MERERUN_WAN2_VAE_OUTPUT"] else {
+            throw XCTSkip("Set the Wan2 model, source image, and VAE output environment variables.")
+        }
+        let source = try MediaImageIO.centerCropped(
+            MediaImageIO.decode(URL(fileURLWithPath: sourcePath)),
+            width: 128,
+            height: 128
+        )
+        let channels = MediaImageIO.rgbCHWFloat(source, normalizedToMinusOneToOne: true)
+        let frame = MLXArray(channels)
+            .reshaped(3, 128, 128)
+            .transposed(1, 2, 0)
+            .reshaped(1, 1, 128, 128, 3)
+        let video = MLX.repeated(frame, count: 9, axis: 1)
+        let resources = Wan2Resources(rootURL: URL(fileURLWithPath: root))
+        let vae = try Wan2ModelLoader.loadVAE(resources: resources)
+        let latents = vae.encodeVideo(video)
+        let decoded = MLX.clip((vae.decode(latents) + 1) * 127.5, min: 0, max: 255).asType(.uint8)
+        eval(decoded)
+        XCTAssertEqual(decoded.shape, [1, 9, 128, 128, 3])
+        try LTXVideoMP4Writer.writeMP4(
+            frames: decoded,
+            fps: 24,
+            to: URL(fileURLWithPath: outputPath)
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2RealWorldSessionTests.swift
+++ b/Tests/MereRunCoreTests/Wan2RealWorldSessionTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class Wan2RealWorldSessionTests: MereRunCoreTestCase {
+    func testTwoTransitionsReuseWarmModelsAndTerminalLatent() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"],
+              let outputPath = environment["MERERUN_WAN2_SESSION_OUTPUT"] else {
+            throw XCTSkip("Set the Wan2 model, source image, and session output environment variables.")
+        }
+        let output = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.removeItem(at: output)
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: URL(fileURLWithPath: root)),
+            stateDirectory: output
+        )
+
+        let first = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: "The same empty corridor remains coherent and rigid.",
+            camera: .forward(meters: 0.25),
+            sourceImageURL: URL(fileURLWithPath: sourcePath),
+            width: 128,
+            height: 128,
+            numFrames: 5,
+            steps: 1,
+            seed: 7
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.outputURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.terminalFrameURL.path))
+        XCTAssertNil(first.previousStateID)
+
+        var snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.phase, .ready)
+        XCTAssertEqual(snapshot.transitionCount, 1)
+        XCTAssertTrue(snapshot.keepsModelsWarm)
+        XCTAssertTrue(snapshot.keepsTerminalLatent)
+
+        let second = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: "The same empty corridor remains coherent and rigid.",
+            camera: .yawLeft(degrees: 15),
+            width: 128,
+            height: 128,
+            numFrames: 5,
+            steps: 1,
+            seed: 8
+        ))
+        XCTAssertEqual(second.previousStateID, first.stateID)
+        XCTAssertNotEqual(second.stateID, first.stateID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.outputURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: second.terminalFrameURL.path))
+
+        snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.transitionCount, 2)
+        XCTAssertEqual(snapshot.currentStateID, second.stateID)
+        XCTAssertEqual(snapshot.currentFrameURL, second.terminalFrameURL)
+        XCTAssertTrue(snapshot.keepsModelsWarm)
+        XCTAssertTrue(snapshot.keepsTerminalLatent)
+
+        try await session.unload()
+        snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.phase, .cold)
+        XCTAssertFalse(snapshot.keepsModelsWarm)
+        XCTAssertFalse(snapshot.keepsTerminalLatent)
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2ResourcesTests.swift
+++ b/Tests/MereRunCoreTests/Wan2ResourcesTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class Wan2ResourcesTests: MereRunCoreTestCase {
+    func testValidConvertedRootLoadsTypedConfiguration() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeValidRoot(root)
+
+        let resources = Wan2Resources(rootURL: root)
+        XCTAssertTrue(resources.validate().isEmpty)
+        let config = try resources.loadConfiguration()
+        XCTAssertEqual(config.modelType, "ti2v")
+        XCTAssertEqual(config.dim, 3_072)
+        XCTAssertEqual(config.numLayers, 30)
+        XCTAssertEqual(config.vaeZDim, 48)
+    }
+
+    func testValidationReportsEveryMissingAsset() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        XCTAssertEqual(
+            Set(Wan2Resources(rootURL: root).validate().map(\.lastPathComponent)),
+            Set(["config.json", "model.safetensors", "t5_encoder.safetensors", "tokenizer.json", "vae.safetensors"])
+        )
+    }
+
+    func testConfigurationRejectsNonTI2VArchitecture() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeValidRoot(root, modelType: "t2v")
+
+        XCTAssertThrowsError(try Wan2Resources(rootURL: root).loadConfiguration()) { error in
+            XCTAssertTrue(error.localizedDescription.contains("model_type must be ti2v"))
+        }
+    }
+
+    func testManagedCatalogUsesPinnedConvertedSnapshot() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Wan2Resources.modelID))
+        XCTAssertEqual(spec.modelID, .wan22TI2V5BMLX)
+        XCTAssertEqual(spec.validationKind, .wan22TI2VMLX)
+        XCTAssertEqual(spec.hubFallback?.repoId, Wan2Resources.managedRepoID)
+        XCTAssertEqual(spec.hubFallback?.revision, Wan2Resources.managedRevision)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+    }
+
+    func testManifestTemplateDeclaresWanVideoRuntime() {
+        let manifest = MereRunModelManifest.template(
+            for: .wan22TI2V5BMLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.id, Wan2Resources.modelID)
+        XCTAssertEqual(manifest.engine, .wanVideo)
+        XCTAssertEqual(manifest.family, .video)
+        XCTAssertEqual(manifest.variant, .base)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(manifest.defaults?.steps, 40)
+        XCTAssertEqual(manifest.defaults?.cfg, 5.0)
+        XCTAssertEqual(manifest.defaults?.sigmaShift, 5.0)
+    }
+
+    private func writeValidRoot(_ root: URL, modelType: String = "ti2v") throws {
+        let config = """
+        {
+          "model_type": "\(modelType)",
+          "model_version": "2.2",
+          "patch_size": [1, 2, 2],
+          "text_len": 512,
+          "in_dim": 48,
+          "dim": 3072,
+          "ffn_dim": 14336,
+          "text_dim": 4096,
+          "out_dim": 48,
+          "num_heads": 24,
+          "num_layers": 30,
+          "vae_stride": [4, 16, 16],
+          "vae_z_dim": 48,
+          "sample_shift": 5.0,
+          "sample_steps": 40,
+          "sample_guide_scale": 5.0,
+          "sample_fps": 24,
+          "frame_num": 81,
+          "max_area": 901120
+        }
+        """
+        try TestFileSystem.writeFile(root.appendingPathComponent("config.json"), contents: Data(config.utf8))
+        for filename in ["model.safetensors", "t5_encoder.safetensors", "tokenizer.json", "vae.safetensors"] {
+            try TestFileSystem.writeFile(root.appendingPathComponent(filename), contents: Data())
+        }
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2TextEncoderTests.swift
+++ b/Tests/MereRunCoreTests/Wan2TextEncoderTests.swift
@@ -1,0 +1,25 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2TextEncoderTests: MereRunCoreTestCase {
+    func testTinyT5EncoderPreservesTokenGeometry() {
+        let configuration = Wan2TextEncoderConfiguration(
+            vocabularySize: 32,
+            hiddenSize: 16,
+            attentionSize: 16,
+            feedForwardSize: 32,
+            headCount: 2,
+            layerCount: 2,
+            relativePositionBuckets: 8
+        )
+        let model = Wan2TextEncoderModel(configuration: configuration)
+        let ids = MLXArray([1, 2, 3, 0], [1, 4])
+        let mask = MLXArray([1, 1, 1, 0], [1, 4])
+        let output = model(tokenIDs: ids, mask: mask)
+        eval(output)
+
+        XCTAssertEqual(output.shape, [1, 4, 16])
+        XCTAssertTrue(output.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2TransformerTests.swift
+++ b/Tests/MereRunCoreTests/Wan2TransformerTests.swift
@@ -1,0 +1,83 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2TransformerTests: MereRunCoreTestCase {
+    func testPatchLayoutMatchesSceneWorksSourceOrder() {
+        let channel0 = MLXArray([Float(0), 1, 2, 3], [1, 1, 2, 2])
+        let channel1 = MLXArray([Float(10), 11, 12, 13], [1, 1, 2, 2])
+        let latent = MLX.concatenated([channel0, channel1], axis: 0)
+        let patch = Wan2PatchLayout.flatten(latent, patchSize: [1, 2, 2])
+        eval(patch.value)
+
+        XCTAssertEqual(patch.grid, Wan2GridSize(frames: 1, height: 1, width: 1))
+        XCTAssertEqual(patch.value.asArray(Float.self), [0, 1, 2, 3, 10, 11, 12, 13])
+    }
+
+    func testTinyTransformerPreservesVideoShapeForTokenTimesteps() {
+        let configuration = Wan2TransformerConfiguration(
+            patchSize: [1, 2, 2],
+            textLength: 4,
+            inputChannels: 4,
+            hiddenSize: 16,
+            feedForwardSize: 32,
+            timestepFrequencySize: 8,
+            textEmbeddingSize: 6,
+            outputChannels: 4,
+            headCount: 2,
+            layerCount: 2
+        )
+        let model = Wan2TransformerModel(configuration: configuration)
+        let latent = MLX.zeros([4, 2, 4, 4])
+        let text = MLX.zeros([1, 4, 6])
+        let context = model.embedText(text)
+        let timesteps = MLX.ones([1, 8]) * 500
+        let output = model(latents: [latent], timesteps: timesteps, embeddedContext: context)
+        eval(output)
+
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(output[0].shape, [4, 2, 4, 4])
+        XCTAssertEqual(output[0].dtype, .float32)
+        XCTAssertTrue(output[0].asArray(Float.self).allSatisfy(\.isFinite))
+    }
+
+    func testCrossAttentionCachesMatchLayerCountAndBatch() {
+        let configuration = Wan2TransformerConfiguration(
+            textLength: 4,
+            inputChannels: 4,
+            hiddenSize: 16,
+            feedForwardSize: 32,
+            timestepFrequencySize: 8,
+            textEmbeddingSize: 6,
+            outputChannels: 4,
+            headCount: 2,
+            layerCount: 3
+        )
+        let model = Wan2TransformerModel(configuration: configuration)
+        let context = model.embedText(MLX.zeros([2, 4, 6]))
+        let caches = model.prepareCrossAttentionCaches(context: context)
+        eval(caches.flatMap { [$0.key, $0.value] })
+
+        XCTAssertEqual(caches.count, 3)
+        XCTAssertEqual(caches[0].key.shape, [2, 2, 4, 8])
+        XCTAssertEqual(caches[0].value.shape, [2, 2, 4, 8])
+    }
+
+    func testTextEmbeddingPadsRawContextBeforeProjection() {
+        let configuration = Wan2TransformerConfiguration(
+            textLength: 4,
+            inputChannels: 4,
+            hiddenSize: 16,
+            feedForwardSize: 32,
+            timestepFrequencySize: 8,
+            textEmbeddingSize: 6,
+            outputChannels: 4,
+            headCount: 2,
+            layerCount: 1
+        )
+        let model = Wan2TransformerModel(configuration: configuration)
+        let context = model.embedText(MLX.zeros([1, 2, 6]))
+        eval(context)
+        XCTAssertEqual(context.shape, [1, 4, 16])
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2VAETests.swift
+++ b/Tests/MereRunCoreTests/Wan2VAETests.swift
@@ -1,0 +1,33 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2VAETests: MereRunCoreTestCase {
+    func testPatchifyRoundTripPreservesPixels() {
+        let input = MLXArray((0..<48).map(Float.init), [1, 1, 4, 4, 3])
+        let packed = Wan2VAEModel.patchify(input)
+        let output = Wan2VAEModel.unpatchify(packed)
+        eval(output)
+        XCTAssertEqual(packed.shape, [1, 1, 2, 2, 12])
+        XCTAssertEqual(output.shape, input.shape)
+        XCTAssertEqual(output.asArray(Float.self), input.asArray(Float.self))
+    }
+
+    func testLatentNormalizationRoundTrip() {
+        let input = MLX.zeros([1, 1, 1, 1, 48])
+        let output = Wan2VAEModel.denormalize(Wan2VAEModel.normalize(input))
+        eval(output)
+        XCTAssertTrue(output.asArray(Float.self).allSatisfy { abs($0) < 1e-6 })
+    }
+
+    func testTinyVAEEncoderAndDecoderGeometry() {
+        let model = Wan2VAEModel(latentChannels: 48, encoderDimensions: 4, decoderDimensions: 4)
+        let image = MLX.zeros([1, 1, 32, 32, 3])
+        let latent = model.encodeImage(image)
+        let decoded = model.decode(MLX.zeros([1, 2, 2, 2, 48]))
+        eval(latent, decoded)
+        XCTAssertEqual(latent.shape, [1, 1, 2, 2, 48])
+        XCTAssertEqual(decoded.shape, [1, 5, 32, 32, 3])
+        XCTAssertTrue(decoded.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2WorldSessionTests.swift
+++ b/Tests/MereRunCoreTests/Wan2WorldSessionTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class Wan2WorldSessionTests: MereRunCoreTestCase {
+    func testCameraControlsUseStableWorldAxesAndPromptSemantics() {
+        let forward = Wan2WorldCameraControl.forward(meters: 1.25)
+        XCTAssertEqual(forward.motion, .forward)
+        XCTAssertEqual(forward.translationMeters, [0, 0, 1.25])
+        XCTAssertTrue(forward.promptClause.contains("straight forward"))
+
+        let left = Wan2WorldCameraControl.yawLeft(degrees: 30)
+        XCTAssertEqual(left.motion, .yawLeft)
+        XCTAssertEqual(left.rotationDegrees, [0, -30, 0])
+        XCTAssertTrue(left.promptClause.contains("pivots left in place"))
+    }
+
+    func testColdSessionCanResetToAnExplicitWorldFrame() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wan-session-model-\(UUID().uuidString)")
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wan-session-state-\(UUID().uuidString)")
+        let source = state.appendingPathComponent("seed.png")
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: root),
+            stateDirectory: state
+        )
+
+        var snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.phase, .cold)
+        XCTAssertEqual(snapshot.transitionCount, 0)
+        XCTAssertNil(snapshot.currentStateID)
+        XCTAssertFalse(snapshot.keepsModelsWarm)
+        XCTAssertFalse(snapshot.keepsTerminalLatent)
+
+        try await session.reset(sourceImageURL: source)
+        snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.currentFrameURL, source)
+        XCTAssertNotNil(snapshot.currentStateID)
+        XCTAssertEqual(snapshot.conditioningMode, .textAndFirstFrame)
+    }
+
+    func testTransitionRequestDefaultsToShortWorldClipGeometry() {
+        let request = Wan2WorldTransitionRequest(
+            prompt: "Keep the corridor coherent.",
+            camera: .forward()
+        )
+        XCTAssertEqual(request.width, 512)
+        XCTAssertEqual(request.height, 320)
+        XCTAssertEqual(request.numFrames, 17)
+        XCTAssertEqual(request.steps, 40)
+        XCTAssertEqual(request.guidanceScale, 5)
+        XCTAssertEqual(request.shift, 5)
+        XCTAssertEqual(request.fps, 24)
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,7 +89,7 @@ are:
 - Vision grounding: `vision-ground-falcon-perception`
 - Music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - SFX: `sfx-woosh-dflow`, `sfx-woosh-flow`
-- Video: `video-ltx-av`, `video-ltx23-av-mlx`
+- Video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-wan22-ti2v-5b-mlx`
 
 For subsystem-specific implementation guides, see:
 
@@ -1336,7 +1336,7 @@ preflight or generation.
 
 ### `mere.run video generate`
 
-Generate MP4 video with the native LTX pipelines.
+Generate MP4 video with the native LTX and Wan2.2 pipelines.
 
 ```bash
 swift run mere.run video generate "<prompt>" [options]
@@ -1352,6 +1352,7 @@ Key options:
 - `--duration`
 - `--fps`
 - `--seed`
+- `--steps`, `--guidance-scale`, `--shift`, `--negative-prompt` for Wan2.2
 - `--image`
 - `--image-strength`
 - `--end-image`
@@ -1373,6 +1374,12 @@ for clip length so the CLI can choose the nearest legal `8n+1` frame count.
 Use the default `distilled` lane for faster video-only drafts. Use
 `--variant unified-av --model video-ltx23-av-mlx` for the current high-quality
 synchronized audio/video lane.
+
+For native Wan2.2 image-to-video, pass
+`--model video-wan22-ti2v-5b-mlx --image <frame>`. Wan dimensions are snapped
+to multiples of 32 and frame counts follow `4n+1`; 512x320 with 17 frames is a
+useful short world-transition baseline. Tiny 128-pixel outputs are structural
+smokes, not quality renders.
 
 Preflight mode:
 
@@ -1403,6 +1410,16 @@ swift run mere.run video generate \
   --output ./clip.mp4 \
   --preflight \
   --json
+
+swift run mere.run video generate \
+  "the first-person camera walks straight forward through the same corridor" \
+  --model video-wan22-ti2v-5b-mlx \
+  --image ./corridor.png \
+  --width 512 \
+  --height 320 \
+  --num-frames 17 \
+  --steps 40 \
+  --output ./corridor-forward.mp4
 
 swift run mere.run video generate \
   "two actors talking beside a window while a restrained orchestral score and distant city sirens play underneath" \

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -95,6 +95,7 @@ from the runtime catalog used by `mere.run model list`,
 | `sfx` | `sfx-woosh-dvflow-8s` |
 | `video` | `video-ltx-av` |
 | `video` | `video-ltx23-av-mlx` |
+| `video` | `video-wan22-ti2v-5b-mlx` |
 <!-- managed-model-catalog:end -->
 
 Most catalog IDs have managed Hugging Face sources and can be installed with
@@ -553,3 +554,25 @@ VAE files, BWE vocoder, and MLX-native tensor layouts. Use this model for the
 current high-quality synchronized audio/video lane.
 The Unsloth `LTX-2.3-GGUF` checkpoint family is a separate quantized GGUF lane
 and is not loaded by the native MLX video runtime.
+
+### `video-wan22-ti2v-5b-mlx`
+
+The native Wan2.2 TI2V-5B model root is:
+
+```text
+.../models/video-wan22-ti2v-5b-mlx
+```
+
+`mere.run model pull video-wan22-ti2v-5b-mlx` installs a pinned MLX conversion
+of `Wan-AI/Wan2.2-TI2V-5B`. The root contains the single 5B transformer, local
+UMT5 tokenizer and encoder, and the float32 48-channel Wan2.2 VAE required for
+image conditioning. The managed snapshot is pinned by revision; inference does
+not fetch tokenizer or model components at runtime.
+
+The core runtime also exposes `Wan2WorldSession` for long-lived world
+generation. One session retains the models, prompt cache, and terminal-frame
+latent across transitions; callers receive MP4/PNG state artifacts and opaque
+state IDs rather than mutable MLX tensors. Camera controls are represented as
+XYZ translation and rotation so a DreamX-derived causal camera conditioner can
+replace the current text-plus-first-frame mode without changing the session
+schema.

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -44,7 +44,7 @@ Examples:
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - sfx: `sfx-woosh-dflow`, `sfx-woosh-flow`, `sfx-woosh-clap`, `sfx-woosh-synchformer`, `sfx-woosh-dvflow-8s`, `sfx-woosh-vflow-8s`
-- video: `video-ltx-av`, `video-ltx23-av-mlx`
+- video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-wan22-ti2v-5b-mlx`
 
 The public runtime resolves these IDs directly, so docs and examples should use
 the canonical names shown by `mere.run model list`.


### PR DESCRIPTION
## What changed

- adds the managed `video-wan22-ti2v-5b-mlx` model and native Swift/MLX loaders for Wan2.2 TI2V 5B
- implements the T5 text encoder, Wan transformer, Wan VAE, shifted-flow/UniPC generation, and native video output path
- wires Wan into `mere.run video`, model validation, preflight, CLI geometry checks, and model documentation
- adds `Wan2WorldSession`, which keeps heavyweight model components warm and chains each transition from the prior terminal latent
- defines stable XYZ camera controls and short world-transition request geometry for local world runtimes
- adds focused unit, CLI, checkpoint compatibility, VAE parity, and real warm-session tests

## Why

This establishes the fully local Apple Silicon foundation for navigable generative worlds inside `mere.run`: no CUDA host, remote generation service, or subprocess per move. The session API separates expensive model residency from cheap transition requests so higher-level world plugins can keep continuity state alive across navigation.

## Current boundary

The production generation mode in this PR is image-conditioned `textAndFirstFrame`. The API reserves `causalCameraLatents` for learned DreamX-style camera conditioning, but does not claim that conditioning yet. Camera actions currently provide stable world-axis semantics and prompt controls on top of the base Wan runtime; a compatible conditioned checkpoint/runtime adapter is the next layer.

## Validation

- `./scripts/check.sh`
  - SwiftLint: 0 violations across 855 files
  - agent readiness: OK
  - 1,636 tests, 97 expected fixture/model skips, 0 failures
- `swift test --filter VideoCommandTests`
- `swift test --filter Wan2`
  - 29 tests, 7 expected installed-model skips, 0 failures
- installed-checkpoint smoke using `video-wan22-ti2v-5b-mlx`
  - two sequential world transitions completed in one warm `Wan2WorldSession`
  - terminal latent from transition one was reused by transition two
  - 1 test passed in 119.754 seconds on Apple Silicon
- independent conversion/runtime parity established during implementation
  - T5 output cosine vs upstream PyTorch: 0.9991635
  - one transformer block cosine vs public MLX: 0.99997675
  - full 30-block transformer cosine: 0.9998563
  - VAE output cosine vs official PyTorch: 1.0 (MAE 7.3e-7)

## Review notes

The branch was rebased onto current `main` (`7cdec2e`) before publication. The Wan change is contained in one commit.
