### PR TITLE
Add native DreamX causal world runtime

### DIFF
--- a/Sources/MereRunCLI/Commands/WorldCommand.swift
+++ b/Sources/MereRunCLI/Commands/WorldCommand.swift
@@ -1,0 +1,513 @@
+import ArgumentParser
+import Foundation
+import Hummingbird
+import MereRunCore
+import NIOCore
+import NIOPosix
+
+struct World: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "world",
+        abstract: "Run persistent local conditioned-video world sessions.",
+        subcommands: [WorldServe.self]
+    )
+}
+
+struct WorldServe: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Serve one warm DreamX causal world session over loopback HTTP."
+    )
+
+    @Option(name: [.long], help: "Host to bind to.")
+    var host = "127.0.0.1"
+
+    @Option(name: [.long], help: "Port to listen on.")
+    var port = 8791
+
+    @Option(name: [.long], help: "Bearer token required by world endpoints.")
+    var apiKey: String?
+
+    @Option(name: [.long], help: "Wan2.2 TI2V base resource model id or local root.")
+    var baseModel = Wan2Resources.modelID
+
+    @Option(name: [.long], help: "Converted DreamX-World-5B AR model id or local root.")
+    var model = Wan2DreamXCausalResources.modelID
+
+    @Option(name: [.long], help: "Directory for transition videos and terminal state frames.")
+    var stateDirectory: String?
+
+    @Flag(name: [.long], help: "Load and warm all models before accepting requests.")
+    var prepare = false
+
+    func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: false)
+        let resolvedKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !Self.isLoopback(host), resolvedKey?.isEmpty != false {
+            throw ValidationError("Non-loopback world servers require --api-key.")
+        }
+        let baseRoot = try resolveRoot(baseModel)
+        let causalRoot = try resolveRoot(model)
+        let baseResources = Wan2Resources(rootURL: baseRoot)
+        let missingBase = baseResources.validate()
+        guard missingBase.isEmpty else {
+            throw ValidationError("Wan2.2 base resources are incomplete: \(missingBase.map(\.path).joined(separator: ", "))")
+        }
+        let causalResources = Wan2DreamXCausalResources(rootURL: causalRoot)
+        let missingCausal = causalResources.validate()
+        guard missingCausal.isEmpty else {
+            throw ValidationError("DreamX causal resources are incomplete: \(missingCausal.map(\.path).joined(separator: ", "))")
+        }
+        let stateURL = stateDirectory.map { URL(fileURLWithPath: $0).standardizedFileURL }
+            ?? Self.defaultStateDirectory()
+        let session = Wan2WorldSession(
+            resources: baseResources,
+            stateDirectory: stateURL,
+            causalWeightsURL: causalResources.weightsURL
+        )
+        let runtime = WorldHTTPRuntime(session: session)
+        if prepare {
+            try await runtime.prepare()
+        }
+        let server = WorldHTTPServer(runtime: runtime, apiKey: resolvedKey)
+        try await server.run(host: host, port: port)
+    }
+
+    private func resolveRoot(_ value: String) throws -> URL {
+        let expanded = NSString(string: value).expandingTildeInPath
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: expanded, isDirectory: &isDirectory), isDirectory.boolValue {
+            return URL(fileURLWithPath: expanded).standardizedFileURL
+        }
+        guard let modelID = ModelResolver.ModelID(rawValue: value) else {
+            throw ValidationError("World model is neither an installed model id nor a local directory: \(value)")
+        }
+        return try ModelResolver().resolve(modelID).rootURL
+    }
+
+    private static func isLoopback(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        return normalized == "localhost" || normalized == "127.0.0.1" || normalized == "::1"
+    }
+
+    private static func defaultStateDirectory() -> URL {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return support
+            .appendingPathComponent("MereRun", isDirectory: true)
+            .appendingPathComponent("world-sessions", isDirectory: true)
+            .appendingPathComponent("default", isDirectory: true)
+    }
+}
+
+private struct WorldRequestContext: RequestContext, RemoteAddressRequestContext {
+    var coreContext: CoreRequestContextStorage
+    let remoteAddress: SocketAddress?
+
+    init(source: Source) {
+        coreContext = CoreRequestContextStorage(source: source)
+        remoteAddress = source.channel.remoteAddress
+    }
+}
+
+private struct WorldTransitionPayload: Codable, Sendable {
+    let prompt: String
+    let camera: Wan2WorldCameraControl
+    let sourceImage: String?
+    let output: String?
+    let width: Int?
+    let height: Int?
+    let seed: UInt64?
+    let fps: Int?
+
+    func request() -> Wan2WorldTransitionRequest {
+        Wan2WorldTransitionRequest(
+            prompt: prompt,
+            camera: camera,
+            sourceImageURL: sourceImage.map { URL(fileURLWithPath: $0).standardizedFileURL },
+            outputURL: output.map { URL(fileURLWithPath: $0).standardizedFileURL },
+            width: width ?? 512,
+            height: height ?? 288,
+            seed: seed ?? 42,
+            fps: fps ?? 24
+        )
+    }
+}
+
+private struct WorldResetPayload: Codable, Sendable {
+    let sourceImage: String?
+}
+
+private enum WorldJobStatus: String, Codable, Sendable {
+    case queued
+    case generating
+    case cancelling
+    case completed
+    case cancelled
+    case failed
+
+    var isActive: Bool {
+        self == .queued || self == .generating || self == .cancelling
+    }
+}
+
+private struct WorldJobProgress: Codable, Sendable {
+    let stage: String
+    let stepIndex: Int
+    let totalSteps: Int
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case stage
+        case stepIndex = "step_index"
+        case totalSteps = "total_steps"
+        case updatedAt = "updated_at"
+    }
+}
+
+private struct WorldJobSnapshot: Codable, Sendable {
+    let jobID: UUID
+    let status: WorldJobStatus
+    let createdAt: Date
+    let startedAt: Date?
+    let completedAt: Date?
+    let progress: WorldJobProgress?
+    let progressEvents: [WorldJobProgress]
+    let receipt: Wan2WorldTransitionReceipt?
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case status, progress, receipt, error
+        case progressEvents = "progress_events"
+        case jobID = "job_id"
+        case createdAt = "created_at"
+        case startedAt = "started_at"
+        case completedAt = "completed_at"
+    }
+}
+
+private struct WorldRuntimeSnapshot: Codable, Sendable {
+    let object = "world.session"
+    let session: Wan2WorldSessionSnapshot
+    let activeJob: WorldJobSnapshot?
+
+    enum CodingKeys: String, CodingKey {
+        case object, session
+        case activeJob = "active_job"
+    }
+}
+
+private struct WorldHealth: Encodable, Sendable {
+    let status = "ok"
+    let object = "world.health"
+}
+
+private struct WorldErrorPayload: Codable, Sendable {
+    let error: String
+}
+
+private enum WorldHTTPRuntimeError: LocalizedError {
+    case busy
+    case jobNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .busy: "A world transition is already active."
+        case .jobNotFound: "World transition job not found."
+        }
+    }
+}
+
+private actor WorldHTTPRuntime {
+    private let session: Wan2WorldSession
+    private var jobs: [UUID: WorldJobSnapshot] = [:]
+    private var tasks: [UUID: Task<Void, Never>] = [:]
+
+    init(session: Wan2WorldSession) {
+        self.session = session
+    }
+
+    func prepare() async throws {
+        guard activeJob == nil else { throw WorldHTTPRuntimeError.busy }
+        try await session.prepare()
+    }
+
+    func snapshot() async -> WorldRuntimeSnapshot {
+        WorldRuntimeSnapshot(session: await session.snapshot(), activeJob: activeJob)
+    }
+
+    func startTransition(_ payload: WorldTransitionPayload) throws -> WorldJobSnapshot {
+        guard activeJob == nil else { throw WorldHTTPRuntimeError.busy }
+        let id = UUID()
+        let job = WorldJobSnapshot(
+            jobID: id,
+            status: .queued,
+            createdAt: Date(),
+            startedAt: nil,
+            completedAt: nil,
+            progress: nil,
+            progressEvents: [],
+            receipt: nil,
+            error: nil
+        )
+        jobs[id] = job
+        tasks[id] = Task { [weak self] in
+            await self?.runTransition(id: id, request: payload.request())
+        }
+        return job
+    }
+
+    func job(id: UUID) throws -> WorldJobSnapshot {
+        guard let job = jobs[id] else { throw WorldHTTPRuntimeError.jobNotFound }
+        return job
+    }
+
+    func cancel(id: UUID) throws -> WorldJobSnapshot {
+        guard let job = jobs[id] else { throw WorldHTTPRuntimeError.jobNotFound }
+        guard job.status.isActive else { return job }
+        tasks[id]?.cancel()
+        let updated = WorldJobSnapshot(
+            jobID: job.jobID,
+            status: .cancelling,
+            createdAt: job.createdAt,
+            startedAt: job.startedAt,
+            completedAt: nil,
+            progress: job.progress,
+            progressEvents: job.progressEvents,
+            receipt: nil,
+            error: nil
+        )
+        jobs[id] = updated
+        return updated
+    }
+
+    func reset(_ payload: WorldResetPayload?) async throws -> WorldRuntimeSnapshot {
+        guard activeJob == nil else { throw WorldHTTPRuntimeError.busy }
+        try await session.reset(sourceImageURL: payload?.sourceImage.map {
+            URL(fileURLWithPath: $0).standardizedFileURL
+        })
+        return await snapshot()
+    }
+
+    func unload() async throws -> WorldRuntimeSnapshot {
+        guard activeJob == nil else { throw WorldHTTPRuntimeError.busy }
+        try await session.unload()
+        return await snapshot()
+    }
+
+    private var activeJob: WorldJobSnapshot? {
+        jobs.values
+            .filter { $0.status.isActive }
+            .sorted { $0.createdAt < $1.createdAt }
+            .first
+    }
+
+    private func runTransition(id: UUID, request: Wan2WorldTransitionRequest) async {
+        guard let job = jobs[id] else { return }
+        jobs[id] = WorldJobSnapshot(
+            jobID: id,
+            status: .generating,
+            createdAt: job.createdAt,
+            startedAt: Date(),
+            completedAt: nil,
+            progress: nil,
+            progressEvents: [],
+            receipt: nil,
+            error: nil
+        )
+        do {
+            let receipt = try await session.transition(request) { [weak self] progress in
+                Task { await self?.recordProgress(id: id, progress: progress) }
+            }
+            let current = jobs[id]!
+            jobs[id] = WorldJobSnapshot(
+                jobID: id,
+                status: .completed,
+                createdAt: current.createdAt,
+                startedAt: current.startedAt,
+                completedAt: Date(),
+                progress: current.progress,
+                progressEvents: current.progressEvents,
+                receipt: receipt,
+                error: nil
+            )
+        } catch is CancellationError {
+            finish(id: id, status: .cancelled, error: nil)
+        } catch {
+            finish(id: id, status: .failed, error: error.localizedDescription)
+        }
+        tasks[id] = nil
+    }
+
+    private func recordProgress(id: UUID, progress: GenerationProgress) {
+        guard let job = jobs[id], job.status.isActive else { return }
+        let event = WorldJobProgress(
+            stage: progress.stage.rawValue,
+            stepIndex: progress.stepIndex,
+            totalSteps: progress.totalSteps,
+            updatedAt: Date()
+        )
+        jobs[id] = WorldJobSnapshot(
+            jobID: id,
+            status: job.status == .cancelling ? .cancelling : .generating,
+            createdAt: job.createdAt,
+            startedAt: job.startedAt,
+            completedAt: nil,
+            progress: event,
+            progressEvents: job.progressEvents + [event],
+            receipt: nil,
+            error: nil
+        )
+    }
+
+    private func finish(id: UUID, status: WorldJobStatus, error: String?) {
+        guard let job = jobs[id] else { return }
+        jobs[id] = WorldJobSnapshot(
+            jobID: id,
+            status: status,
+            createdAt: job.createdAt,
+            startedAt: job.startedAt,
+            completedAt: Date(),
+            progress: job.progress,
+            progressEvents: job.progressEvents,
+            receipt: nil,
+            error: error
+        )
+    }
+}
+
+private struct WorldHTTPServer: Sendable {
+    let runtime: WorldHTTPRuntime
+    let apiKey: String?
+
+    func run(host: String, port: Int) async throws {
+        let app = Application(
+            router: router(),
+            configuration: .init(address: .hostname(host, port: port))
+        )
+        print("DreamX world server: http://\(host):\(port)/v1/world/session")
+        print("Press Ctrl+C to stop.")
+        try await app.runService()
+    }
+
+    private func router() -> Router<WorldRequestContext> {
+        let router = Router(context: WorldRequestContext.self)
+        router.get("/health") { _, _ in
+            try response(WorldHealth())
+        }
+        router.get("/v1/world/session") { request, _ in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            return try response(await runtime.snapshot())
+        }
+        router.post("/v1/world/session/prepare") { request, _ in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            do {
+                try await runtime.prepare()
+                return try response(await runtime.snapshot())
+            } catch {
+                return try errorResponse(error)
+            }
+        }
+        router.post("/v1/world/session/transitions") { request, _ in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            do {
+                let payload: WorldTransitionPayload = try await decode(request)
+                return try response(try await runtime.startTransition(payload), status: .accepted)
+            } catch {
+                return try errorResponse(error)
+            }
+        }
+        router.get("/v1/world/jobs/:id") { request, context in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            do {
+                guard let raw = context.parameters.get("id", as: String.self), let id = UUID(uuidString: raw) else {
+                    return try response(WorldErrorPayload(error: "Invalid job id."), status: .badRequest)
+                }
+                return try response(try await runtime.job(id: id))
+            } catch {
+                return try errorResponse(error)
+            }
+        }
+        router.delete("/v1/world/jobs/:id") { request, context in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            do {
+                guard let raw = context.parameters.get("id", as: String.self), let id = UUID(uuidString: raw) else {
+                    return try response(WorldErrorPayload(error: "Invalid job id."), status: .badRequest)
+                }
+                return try response(try await runtime.cancel(id: id), status: .accepted)
+            } catch {
+                return try errorResponse(error)
+            }
+        }
+        router.post("/v1/world/session/reset") { request, _ in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            do {
+                let payload: WorldResetPayload? = try await decodeOptional(request)
+                return try response(try await runtime.reset(payload))
+            } catch {
+                return try errorResponse(error)
+            }
+        }
+        router.post("/v1/world/session/unload") { request, _ in
+            if let denied = unauthorized(request, apiKey: apiKey) { return denied }
+            do {
+                return try response(try await runtime.unload())
+            } catch {
+                return try errorResponse(error)
+            }
+        }
+        return router
+    }
+}
+
+private func decode<T: Decodable>(_ request: Request, as _: T.Type = T.self) async throws -> T {
+    let body = try await request.body.collect(upTo: 1024 * 1024)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try decoder.decode(T.self, from: Data(body.readableBytesView))
+}
+
+private func decodeOptional<T: Decodable>(_ request: Request, as _: T.Type = T.self) async throws -> T? {
+    let body = try await request.body.collect(upTo: 1024 * 1024)
+    guard body.readableBytes > 0 else { return nil }
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try decoder.decode(T.self, from: Data(body.readableBytesView))
+}
+
+private func response<T: Encodable>(
+    _ payload: T,
+    status: HTTPResponse.Status = .ok
+) throws -> Response {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(payload)
+    return Response(
+        status: status,
+        headers: [.contentType: "application/json"],
+        body: .init(byteBuffer: ByteBuffer(bytes: data))
+    )
+}
+
+private func errorResponse(_ error: Error) throws -> Response {
+    let status: HTTPResponse.Status
+    switch error {
+    case WorldHTTPRuntimeError.busy, Wan2WorldSessionError.busy:
+        status = .conflict
+    case WorldHTTPRuntimeError.jobNotFound:
+        status = .notFound
+    default:
+        status = .badRequest
+    }
+    return try response(WorldErrorPayload(error: error.localizedDescription), status: status)
+}
+
+private func unauthorized(_ request: Request, apiKey: String?) -> Response? {
+    guard let apiKey, !apiKey.isEmpty else { return nil }
+    guard request.headers[.authorization] == "Bearer \(apiKey)" else {
+        return try? response(WorldErrorPayload(error: "Unauthorized."), status: .unauthorized)
+    }
+    return nil
+}

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -25,6 +25,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Music.self,
             SFX.self,
             Video.self,
+            World.self,
             Run.self,
             Model.self,
             Status.self,

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -62,6 +62,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case ltxVideo
     case ltxVideo23MLX
     case wan22TI2VMLX
+    case dreamXCausalMLX
     case hfTextChat
 }
 
@@ -1553,6 +1554,18 @@ public enum ManagedModelCatalog {
             estimatedDownloadBytes: 24_200_000_000,
             defaultCLICommands: ["video generate"]
         ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.dreamXWorld5BARMLX.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            upstreamRepoId: Wan2DreamXCausalResources.upstreamRepoID,
+            upstreamRevision: Wan2DreamXCausalResources.upstreamRevision,
+            validationKind: .dreamXCausalMLX,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 10_566_339_320,
+            defaultCLICommands: ["world serve"],
+            companionModelIDs: [ModelResolver.ModelID.wan22TI2V5BMLX.rawValue]
+        ),
     ]
 
     public static var allModelIDs: [String] {
@@ -1762,6 +1775,8 @@ public extension ManagedModelSpec {
             return Self.missingLTXVideo23MLXPaths(in: rootURL, fileManager: fileManager)
         case .wan22TI2VMLX:
             return Wan2Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .dreamXCausalMLX:
+            return Wan2DreamXCausalResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .hfTextChat:
             return Self.missingHFTextRootPaths(in: rootURL, fileManager: fileManager)
         }
@@ -1814,6 +1829,12 @@ public extension ManagedModelSpec {
                 return []
             } catch {
                 return [error.localizedDescription]
+            }
+        case .dreamXCausalMLX:
+            return Wan2DreamXCausalResources(
+                rootURL: normalizedRootURL(rootURL, fileManager: fileManager)
+            ).validate(fileManager: fileManager).map {
+                "Missing required DreamX causal MLX file: \($0.path)"
             }
         case .magentaRT2:
             return Self.missingMagentaRT2Paths(

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -694,6 +694,13 @@ public enum ManagedModelCapabilityCatalog {
                 minimum: 64,
                 recommended: 96
             ),
+            descriptor(
+                ModelResolver.ModelID.dreamXWorld5BARMLX.rawValue,
+                "DreamX World 5B AR MLX",
+                "Runs persistent camera-conditioned world generation with the native causal Swift MLX runtime.",
+                minimum: 64,
+                recommended: 128
+            ),
         ]
         return Dictionary(uniqueKeysWithValues: descriptors.map { ($0.modelID, $0) })
     }()

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1493,6 +1493,26 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "\(Wan2Resources.managedRepoID)@\(Wan2Resources.managedRevision)",
                 createdAt: createdAt
             )
+        case .dreamXWorld5BARMLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .wanVideo,
+                family: .video,
+                tier: .latest,
+                variant: .base,
+                precision: .bf16,
+                defaults: Defaults(steps: 4, cfg: 1.0, sigmaShift: 5.0),
+                supports: [.videoGeneration],
+                components: Components(
+                    tokenizer: nil,
+                    textEncoder: nil,
+                    transformer: .local(path: Wan2DreamXCausalResources.weightsFilename),
+                    vae: nil,
+                    scheduler: nil
+                ),
+                upstreamRepoId: "\(Wan2DreamXCausalResources.upstreamRepoID)@\(Wan2DreamXCausalResources.upstreamRevision)",
+                createdAt: createdAt
+            )
         }
     }
 }

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -112,6 +112,7 @@ public enum MereRunModelValidator {
                     && spec.validationKind != .depthAnything3
                     && spec.validationKind != .tripoSR
                     && spec.validationKind != .instantMesh
+                    && spec.validationKind != .dreamXCausalMLX
             }
         }()
         if !hasRootMarker && !usesMFluxZImage && requiresRootMarker {
@@ -151,7 +152,8 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .depthAnything3
             || spec?.validationKind == .tripoSR
             || spec?.validationKind == .instantMesh
-            || spec?.validationKind == .wan22TI2VMLX {
+            || spec?.validationKind == .wan22TI2VMLX
+            || spec?.validationKind == .dreamXCausalMLX {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil
             textEncoderDir = nil

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -81,6 +81,7 @@ public struct ModelResolver {
         case ltxVideoAV = "video-ltx-av"
         case ltxVideo23AVMLX = "video-ltx23-av-mlx"
         case wan22TI2V5BMLX = "video-wan22-ti2v-5b-mlx"
+        case dreamXWorld5BARMLX = "video-dreamx-world-5b-ar-mlx"
     }
 
     public enum Source: String, Hashable, Sendable {

--- a/Sources/MereRunCore/Wan2/README.md
+++ b/Sources/MereRunCore/Wan2/README.md
@@ -22,15 +22,50 @@ actor and exposes serial world transitions without passing mutable MLX tensors
 to callers or launching a process per move.
 
 World transitions carry a stable camera-control record with XYZ translation and
-rotation. The base TI2V checkpoint currently applies that control through the
-motion prompt and first-frame conditioning (`textAndFirstFrame`). A future
-DreamX-derived camera adapter can consume the same control as causal camera
-latents and report `causalCameraLatents` without changing the session request or
-receipt schema.
+rotation. The base TI2V checkpoint applies that control through the motion
+prompt and first-frame conditioning (`textAndFirstFrame`). When a pinned DreamX
+camera-adapter file is supplied, the same request is compiled into relative
+camera extrinsics and intrinsics and the session reports
+`projectiveCameraLatents`. Supplying the converted
+`video-dreamx-world-5b-ar-mlx` checkpoint selects the released DreamX causal
+transformer, persistent block-causal and cross-attention caches, four-pass
+AR-forcing schedule, three-latent-frame chunks, chunk-relative PRoPE camera
+conditioning, and `causalCameraLatents` session mode.
 
-The session writes one MP4 and one terminal PNG per transition. The next
-transition consumes the terminal latent directly in memory; the PNG is an
-observable state artifact, not the internal chaining path.
+DreamX camera conditioning is a learned parallel self-attention branch in every
+Wan transformer block. It applies PRoPE projection matrices to Q/K/V, performs
+attention in camera-projective space, applies the inverse output transform, and
+joins the base self-attention residual. It is not prompt steering.
+
+The causal session writes one MP4 and one terminal PNG per transition while
+keeping the complete latent history and rolling 12-frame attention window in
+memory. The PNG is an observable artifact, not the chaining path. Its official
+DreamX color-statistics pass runs after VAE decode to stabilize each generated
+chunk against the preceding world state.
+
+`mere.run world serve` owns one such session in a long-lived process. Its
+loopback HTTP API exposes cold/warm snapshots, asynchronous transition jobs,
+pollable denoising progress, cancellation, reset, unload, receipts, and opaque
+state IDs:
+
+```bash
+mere.run world serve --prepare
+curl http://127.0.0.1:8791/v1/world/session
+curl -X POST http://127.0.0.1:8791/v1/world/session/transitions \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "prompt":"A continuous first-person view of the same corridor.",
+    "camera":{"motion":"forward","translation_meters":[0,0,0.25],"rotation_degrees":[0,0,0]},
+    "source_image":"/absolute/path/to/seed.png",
+    "width":512,"height":288
+  }'
+```
+
+Non-loopback binds require `--api-key`. The converted causal model is a
+local-only managed artifact because the public upstream checkpoint is FP32 and
+does not match the streamed BF16 MLX layout; `mere.run` will not silently pull
+that incompatible file. The base Wan model is declared as its companion for
+UMT5, tokenizer, and VAE resources.
 
 ## Verified parity
 
@@ -43,7 +78,20 @@ upstream implementations:
 - VAE image latents against Wan's official PyTorch VAE.
 - Two consecutive world transitions with warm model reuse and terminal-latent
   chaining.
+- DreamX trajectory, latent-frame alignment, intrinsics/extrinsics, and PRoPE
+  Q/K/V/output transforms against the upstream PyTorch implementation.
+- A real released block-0 camera-attention output against native Swift/MLX and a
+  full 30-block projective-camera transition using the extracted 300-tensor
+  adapter.
+- The released DreamX AR checkpoint across initial, same-block recomputation,
+  and appended cached blocks. Measured cosine similarities are 0.99943,
+  0.99793, and 0.99988 respectively.
+- A real two-move causal session with a 1.5-2.2 RGB-level encoded boundary
+  difference, plus a clean 512x288 nine-frame quality candidate.
 
-Tiny 128-pixel renders are structural tests only. Quality acceptance should use
-at least a 512x320 spatial canvas; Wan geometry is divisible by 32 and frame
-counts follow 4n+1.
+Tiny 128-256 pixel renders are structural tests only. Quality acceptance starts
+at 512x288. On the reference 128 GB Apple Silicon host, one 512x288 move took
+1,012.6 seconds: model passes began at 34.7s, 210.9s, 388.2s, 564.9s, and
+739.4s; decode began at 917.7s. Product navigation must therefore use warm
+sessions, queued graph edges, speculative neighboring moves, and cached clips
+instead of presenting quality generation as an immediate keypress response.

--- a/Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift
+++ b/Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift
@@ -1,0 +1,587 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+public struct Wan2DreamXTrajectorySegment: Hashable, Sendable {
+    public let action: String
+    public let speed: Float
+
+    public init(action: String, speed: Float = 1) {
+        precondition(speed > 0)
+        self.action = action.lowercased()
+        self.speed = speed
+    }
+}
+
+public struct Wan2ProjectiveCameraConditioning: Hashable, Sendable {
+    public let frameCount: Int
+    public let viewMatrices: [Float]
+    public let intrinsics: [Float]
+
+    public init(frameCount: Int, viewMatrices: [Float], intrinsics: [Float]) {
+        precondition(frameCount > 0)
+        precondition(viewMatrices.count == frameCount * 16)
+        precondition(intrinsics.count == frameCount * 9)
+        self.frameCount = frameCount
+        self.viewMatrices = viewMatrices
+        self.intrinsics = intrinsics
+    }
+}
+
+public enum Wan2DreamXCameraTrajectory {
+    public static let defaultFocalX: Float = 969.696_96 / (960 * 2)
+    public static let defaultFocalY: Float = 969.696_96 / (540 * 2)
+
+    public static func segments(for control: Wan2WorldCameraControl) -> [Wan2DreamXTrajectorySegment] {
+        switch control.motion {
+        case .hold:
+            return [Wan2DreamXTrajectorySegment(action: " ")]
+        case .forward:
+            return [Wan2DreamXTrajectorySegment(action: "w", speed: max(abs(control.translationMeters[2]), 0.001))]
+        case .backward:
+            return [Wan2DreamXTrajectorySegment(action: "s", speed: max(abs(control.translationMeters[2]), 0.001))]
+        case .strafeLeft:
+            return [Wan2DreamXTrajectorySegment(action: "a", speed: max(abs(control.translationMeters[0]), 0.001))]
+        case .strafeRight:
+            return [Wan2DreamXTrajectorySegment(action: "d", speed: max(abs(control.translationMeters[0]), 0.001))]
+        case .yawLeft:
+            return [Wan2DreamXTrajectorySegment(action: "j", speed: max(abs(control.rotationDegrees[1]) / 10, 0.001))]
+        case .yawRight:
+            return [Wan2DreamXTrajectorySegment(action: "l", speed: max(abs(control.rotationDegrees[1]) / 10, 0.001))]
+        case .custom:
+            var action = ""
+            if control.translationMeters[2] > 0 { action.append("w") }
+            if control.translationMeters[2] < 0 { action.append("s") }
+            if control.translationMeters[0] < 0 { action.append("a") }
+            if control.translationMeters[0] > 0 { action.append("d") }
+            if control.rotationDegrees[0] > 0 { action.append("i") }
+            if control.rotationDegrees[0] < 0 { action.append("k") }
+            if control.rotationDegrees[1] < 0 { action.append("j") }
+            if control.rotationDegrees[1] > 0 { action.append("l") }
+            let translationSpeed = control.translationMeters.map(abs).max() ?? 0
+            let rotationSpeed = (control.rotationDegrees.map(abs).max() ?? 0) / 10
+            return [Wan2DreamXTrajectorySegment(
+                action: action.isEmpty ? " " : action,
+                speed: max(max(translationSpeed, rotationSpeed), 0.001)
+            )]
+        }
+    }
+
+    public static func compile(
+        control: Wan2WorldCameraControl,
+        pixelFrameCount: Int
+    ) -> Wan2ProjectiveCameraConditioning {
+        compile(segments: segments(for: control), pixelFrameCount: pixelFrameCount)
+    }
+
+    public static func compile(
+        segments: [Wan2DreamXTrajectorySegment],
+        pixelFrameCount: Int,
+        focalX: Float = defaultFocalX,
+        focalY: Float = defaultFocalY,
+        principalX: Float = 0,
+        principalY: Float = 0
+    ) -> Wan2ProjectiveCameraConditioning {
+        precondition(!segments.isEmpty)
+        precondition(pixelFrameCount > 0)
+        let duration = Int(ceil(Double(pixelFrameCount) / Double(segments.count)))
+        var position = SIMD3<Float>(repeating: 0)
+        var rotationDegrees = SIMD3<Float>(repeating: 0)
+        var worldToCamera: [Wan2Matrix4] = [.identity]
+        worldToCamera.reserveCapacity(pixelFrameCount + 1)
+
+        for segment in segments {
+            let action = segment.action
+            let translationStep = translationStep(
+                action: action,
+                speed: segment.speed,
+                rotationDegrees: rotationDegrees,
+                duration: duration
+            )
+            let rotationStep = rotationStep(action: action, speed: segment.speed, duration: duration)
+            for frame in 1...duration {
+                let nextPosition = position + translationStep * Float(frame)
+                let nextRotation = rotationDegrees + rotationStep * Float(frame)
+                let rotation = Wan2Matrix4.cameraRotation(
+                    pitchDegrees: nextRotation.x,
+                    yawDegrees: nextRotation.y,
+                    rollDegrees: nextRotation.z
+                )
+                worldToCamera.append(rotation.withTranslation(-rotation.transformDirection(nextPosition)))
+            }
+            position += translationStep * Float(duration)
+            rotationDegrees += rotationStep * Float(duration)
+        }
+
+        worldToCamera = Array(worldToCamera.prefix(pixelFrameCount))
+        let aligned = latentFrameIndices(pixelFrameCount: pixelFrameCount)
+        let views = aligned.flatMap { worldToCamera[$0].values }
+        let intrinsic = [
+            focalX, 0, principalX,
+            0, focalY, principalY,
+            0, 0, 1
+        ]
+        return Wan2ProjectiveCameraConditioning(
+            frameCount: aligned.count,
+            viewMatrices: views,
+            intrinsics: aligned.flatMap { _ in intrinsic }
+        )
+    }
+
+    public static func latentFrameIndices(pixelFrameCount: Int) -> [Int] {
+        precondition(pixelFrameCount > 0 && (pixelFrameCount - 1).isMultiple(of: 4))
+        return Array(stride(from: 0, through: pixelFrameCount - 1, by: 4))
+    }
+
+    private static func translationStep(
+        action: String,
+        speed: Float,
+        rotationDegrees: SIMD3<Float>,
+        duration: Int
+    ) -> SIMD3<Float> {
+        let yaw = rotationDegrees.y * .pi / 180
+        let pitch = rotationDegrees.x * .pi / 180
+        var translation = SIMD3<Float>(repeating: 0)
+        if action.contains("w") || action.contains("s") {
+            let direction: Float = action.contains("w") ? 1 : -1
+            translation += SIMD3(
+                -sin(yaw) * cos(pitch),
+                sin(pitch),
+                cos(yaw) * cos(pitch)
+            ) * speed * direction
+        }
+        if action.contains("a") || action.contains("d") {
+            let direction: Float = action.contains("d") ? 1 : -1
+            translation += SIMD3(cos(yaw), 0, sin(yaw)) * speed * direction
+        }
+        return translation / Float(duration)
+    }
+
+    private static func rotationStep(action: String, speed: Float, duration: Int) -> SIMD3<Float> {
+        var rotation = SIMD3<Float>(repeating: 0)
+        if action.contains("j") { rotation.y += speed * 10 }
+        if action.contains("l") { rotation.y -= speed * 10 }
+        if action.contains("i") { rotation.x -= speed * 10 }
+        if action.contains("k") { rotation.x += speed * 10 }
+        return rotation / Float(duration)
+    }
+}
+
+public struct Wan2DreamXARTrajectorySegment: Hashable, Sendable {
+    public let action: String
+    public let weight: Float
+
+    public init(action: String, weight: Float = 1) {
+        precondition(weight > 0)
+        self.action = action.lowercased()
+        self.weight = weight
+    }
+}
+
+public enum Wan2DreamXARTrajectory {
+    public static func segments(for control: Wan2WorldCameraControl) -> [Wan2DreamXARTrajectorySegment] {
+        let action: String
+        switch control.motion {
+        case .hold: action = " "
+        case .forward: action = "w"
+        case .backward: action = "s"
+        case .strafeLeft: action = "a"
+        case .strafeRight: action = "d"
+        case .yawLeft: action = "j"
+        case .yawRight: action = "l"
+        case .custom:
+            var composite = ""
+            if control.translationMeters[2] > 0 { composite.append("w") }
+            if control.translationMeters[2] < 0 { composite.append("s") }
+            if control.translationMeters[0] < 0 { composite.append("a") }
+            if control.translationMeters[0] > 0 { composite.append("d") }
+            if control.rotationDegrees[0] > 0 { composite.append("i") }
+            if control.rotationDegrees[0] < 0 { composite.append("k") }
+            if control.rotationDegrees[1] < 0 { composite.append("j") }
+            if control.rotationDegrees[1] > 0 { composite.append("l") }
+            action = composite.isEmpty ? " " : composite
+        }
+        return [Wan2DreamXARTrajectorySegment(action: action)]
+    }
+
+    public static func compile(
+        control: Wan2WorldCameraControl,
+        pixelFrameCount: Int,
+        speed: Float? = nil,
+        chunkRelative: Bool = true
+    ) -> Wan2ProjectiveCameraConditioning {
+        compile(
+            segments: segments(for: control),
+            pixelFrameCount: pixelFrameCount,
+            speed: speed ?? physicalSpeed(for: control, pixelFrameCount: pixelFrameCount),
+            chunkRelative: chunkRelative
+        )
+    }
+
+    private static func physicalSpeed(
+        for control: Wan2WorldCameraControl,
+        pixelFrameCount: Int
+    ) -> Float {
+        precondition(pixelFrameCount > 0)
+        let translation = control.translationMeters.map(abs).max() ?? 0
+        let rotation = control.rotationDegrees.map(abs).max() ?? 0
+        switch control.motion {
+        case .hold:
+            return 1.5
+        case .forward, .backward, .strafeLeft, .strafeRight:
+            return max(translation / (0.05 * Float(pixelFrameCount)), 0.001)
+        case .yawLeft, .yawRight:
+            return max(rotation / Float(pixelFrameCount), 0.001)
+        case .custom:
+            return max(
+                max(translation / (0.05 * Float(pixelFrameCount)), rotation / Float(pixelFrameCount)),
+                0.001
+            )
+        }
+    }
+
+    public static func compile(
+        segments: [Wan2DreamXARTrajectorySegment],
+        pixelFrameCount: Int,
+        speed: Float = 1.5,
+        chunkRelative: Bool = true
+    ) -> Wan2ProjectiveCameraConditioning {
+        precondition(!segments.isEmpty)
+        precondition(pixelFrameCount > 0 && (pixelFrameCount - 1).isMultiple(of: 4))
+        let totalWeight = segments.reduce(Float(0)) { $0 + $1.weight }
+        var allocated = 0
+        var weightedSegments: [(String, Int)] = []
+        for (index, segment) in segments.enumerated() {
+            let frames: Int
+            if index == segments.count - 1 {
+                frames = pixelFrameCount - allocated
+            } else {
+                frames = max(1, Int((Float(pixelFrameCount) * segment.weight / totalWeight).rounded(.toNearestOrEven)))
+            }
+            let clamped = min(frames, pixelFrameCount - allocated)
+            if clamped > 0 {
+                weightedSegments.append((segment.action, clamped))
+                allocated += clamped
+            }
+        }
+
+        var position = SIMD3<Float>(repeating: 0)
+        var cameraToWorldRotation = Wan2Matrix4.identity
+        var absoluteViews: [Wan2Matrix4] = []
+        absoluteViews.reserveCapacity(pixelFrameCount)
+        let movementStep = speed * 0.05
+        let rotationStep = speed * .pi / 180
+        for (action, frameCount) in weightedSegments {
+            for _ in 0..<frameCount {
+                var pitchDelta: Float = 0
+                var yawDelta: Float = 0
+                if action.contains("i") { pitchDelta += rotationStep }
+                if action.contains("k") { pitchDelta -= rotationStep }
+                if action.contains("j") { yawDelta -= rotationStep }
+                if action.contains("l") { yawDelta += rotationStep }
+                if pitchDelta != 0 || yawDelta != 0 {
+                    cameraToWorldRotation = cameraToWorldRotation
+                        * Wan2Matrix4.euler(roll: pitchDelta, pitch: yawDelta, yaw: 0)
+                }
+                var localMovement = SIMD3<Float>(repeating: 0)
+                if action.contains("w") { localMovement.z += movementStep }
+                if action.contains("s") { localMovement.z -= movementStep }
+                if action.contains("a") { localMovement.x -= movementStep }
+                if action.contains("d") { localMovement.x += movementStep }
+                position += cameraToWorldRotation.transformDirection(localMovement)
+                let worldToCameraRotation = cameraToWorldRotation.transposed()
+                absoluteViews.append(
+                    worldToCameraRotation.withTranslation(-worldToCameraRotation.transformDirection(position))
+                )
+            }
+        }
+
+        let alignedIndices = [0] + Array(stride(from: 1, to: pixelFrameCount, by: 4))
+        let alignedViews = alignedIndices.map { absoluteViews[$0] }
+        var relativeViews: [Wan2Matrix4] = []
+        relativeViews.reserveCapacity(alignedViews.count)
+        if chunkRelative {
+            for chunkStart in stride(from: 0, to: alignedViews.count, by: 3) {
+                let reference = alignedViews[chunkStart == 0 ? 0 : chunkStart - 1].invertedRigid()
+                let chunkEnd = min(chunkStart + 3, alignedViews.count)
+                relativeViews.append(contentsOf: (chunkStart..<chunkEnd).map { alignedViews[$0] * reference })
+            }
+        } else {
+            let reference = alignedViews[0].invertedRigid()
+            relativeViews = alignedViews.map { $0 * reference }
+        }
+        let intrinsic: [Float] = [
+            Wan2DreamXCameraTrajectory.defaultFocalX, 0, 0.5,
+            0, Wan2DreamXCameraTrajectory.defaultFocalY, 0.5,
+            0, 0, 1
+        ]
+        return Wan2ProjectiveCameraConditioning(
+            frameCount: relativeViews.count,
+            viewMatrices: relativeViews.flatMap(\.values),
+            intrinsics: relativeViews.flatMap { _ in intrinsic }
+        )
+    }
+}
+
+struct Wan2ProjectiveTransforms {
+    let query: MLXArray
+    let keyValue: MLXArray
+    let output: MLXArray
+}
+
+enum Wan2ProjectivePositionEncoding {
+    static func prepare(
+        conditioning: Wan2ProjectiveCameraConditioning,
+        batchSize: Int,
+        dtype: DType
+    ) -> Wan2ProjectiveTransforms {
+        var query: [Float] = []
+        var keyValue: [Float] = []
+        var output: [Float] = []
+        query.reserveCapacity(conditioning.frameCount * 16)
+        keyValue.reserveCapacity(conditioning.frameCount * 16)
+        output.reserveCapacity(conditioning.frameCount * 16)
+
+        for frame in 0..<conditioning.frameCount {
+            let view = Wan2Matrix4(Array(conditioning.viewMatrices[(frame * 16)..<((frame + 1) * 16)]))
+            let intrinsicOffset = frame * 9
+            let focalX = conditioning.intrinsics[intrinsicOffset]
+            let focalY = conditioning.intrinsics[intrinsicOffset + 4]
+            let lifted = Wan2Matrix4.diagonal(focalX, focalY, 1, 1)
+            let liftedInverse = Wan2Matrix4.diagonal(1 / focalX, 1 / focalY, 1, 1)
+            let projection = lifted * view
+            query.append(contentsOf: projection.transposed().values)
+            keyValue.append(contentsOf: (view.invertedRigid() * liftedInverse).values)
+            output.append(contentsOf: projection.values)
+        }
+
+        func tensor(_ values: [Float]) -> MLXArray {
+            let single = MLXArray(values).reshaped(1, conditioning.frameCount, 4, 4).asType(dtype)
+            return batchSize == 1
+                ? single
+                : MLX.broadcast(single, to: [batchSize, conditioning.frameCount, 4, 4])
+        }
+        return Wan2ProjectiveTransforms(
+            query: tensor(query),
+            keyValue: tensor(keyValue),
+            output: tensor(output)
+        )
+    }
+
+    static func apply(_ input: MLXArray, matrices: MLXArray, cameraFrames: Int) -> MLXArray {
+        precondition(input.ndim == 4)
+        precondition(matrices.shape == [input.dim(0), cameraFrames, 4, 4])
+        precondition(input.dim(2).isMultiple(of: cameraFrames))
+        precondition(input.dim(3).isMultiple(of: 4))
+        let batch = input.dim(0)
+        let heads = input.dim(1)
+        let patchesPerFrame = input.dim(2) / cameraFrames
+        let vectorGroups = input.dim(3) / 4
+        let vectors = input
+            .reshaped(batch, heads, cameraFrames, patchesPerFrame, vectorGroups, 4)
+            .expandedDimensions(axis: -1)
+        let tiledMatrices = matrices
+            .reshaped(batch, 1, cameraFrames, 1, 1, 4, 4)
+        return MLX.matmul(tiledMatrices, vectors)
+            .squeezed(axis: -1)
+            .reshaped(input.shape)
+    }
+}
+
+final class Wan2ProjectiveSelfAttention: Module {
+    let heads: Int
+    let headDimension: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var query: Linear
+    @ModuleInfo(key: "k_proj") var key: Linear
+    @ModuleInfo(key: "v_proj") var value: Linear
+    @ModuleInfo(key: "out_proj") var output: Linear
+    @ModuleInfo(key: "norm_q") var queryNorm: Wan2RMSNorm
+    @ModuleInfo(key: "norm_k") var keyNorm: Wan2RMSNorm
+
+    init(
+        dimensions: Int,
+        attentionDimensions: Int? = nil,
+        heads: Int,
+        epsilon: Float
+    ) {
+        let attentionDimensions = attentionDimensions ?? dimensions
+        precondition(attentionDimensions.isMultiple(of: heads))
+        self.heads = heads
+        self.headDimension = attentionDimensions / heads
+        self.scale = 1 / Float(headDimension).squareRoot()
+        self._query.wrappedValue = Linear(dimensions, attentionDimensions, bias: true)
+        self._key.wrappedValue = Linear(dimensions, attentionDimensions, bias: true)
+        self._value.wrappedValue = Linear(dimensions, attentionDimensions, bias: true)
+        self._output.wrappedValue = Linear(attentionDimensions, dimensions, bias: true)
+        self._queryNorm.wrappedValue = Wan2RMSNorm(dimensions: attentionDimensions, epsilon: epsilon)
+        self._keyNorm.wrappedValue = Wan2RMSNorm(dimensions: attentionDimensions, epsilon: epsilon)
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        conditioning: Wan2ProjectiveCameraConditioning
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let dtype = query.weight.dtype
+        let typed = input.asType(dtype)
+        var q = queryNorm(query(typed)).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        var k = keyNorm(key(typed)).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        var v = value(typed).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        let transforms = Wan2ProjectivePositionEncoding.prepare(
+            conditioning: conditioning,
+            batchSize: batch,
+            dtype: dtype
+        )
+        q = Wan2ProjectivePositionEncoding.apply(q, matrices: transforms.query, cameraFrames: conditioning.frameCount)
+        k = Wan2ProjectivePositionEncoding.apply(k, matrices: transforms.keyValue, cameraFrames: conditioning.frameCount)
+        v = Wan2ProjectivePositionEncoding.apply(v, matrices: transforms.keyValue, cameraFrames: conditioning.frameCount)
+        var attended = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: scale,
+            mask: .none
+        )
+        attended = Wan2ProjectivePositionEncoding.apply(
+            attended,
+            matrices: transforms.output,
+            cameraFrames: conditioning.frameCount
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, heads * headDimension))
+    }
+}
+
+private struct Wan2Matrix4: Hashable {
+    let values: [Float]
+
+    init(_ values: [Float]) {
+        precondition(values.count == 16)
+        self.values = values
+    }
+
+    static let identity = Wan2Matrix4([
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+    ])
+
+    static func diagonal(_ x: Float, _ y: Float, _ z: Float, _ w: Float) -> Wan2Matrix4 {
+        Wan2Matrix4([
+            x, 0, 0, 0,
+            0, y, 0, 0,
+            0, 0, z, 0,
+            0, 0, 0, w
+        ])
+    }
+
+    static func euler(roll: Float, pitch: Float, yaw: Float) -> Wan2Matrix4 {
+        let sineX = sin(roll)
+        let cosineX = cos(roll)
+        let sineY = sin(pitch)
+        let cosineY = cos(pitch)
+        let sineZ = sin(yaw)
+        let cosineZ = cos(yaw)
+        let rotationX = Wan2Matrix4([
+            1, 0, 0, 0,
+            0, cosineX, -sineX, 0,
+            0, sineX, cosineX, 0,
+            0, 0, 0, 1
+        ])
+        let rotationY = Wan2Matrix4([
+            cosineY, 0, sineY, 0,
+            0, 1, 0, 0,
+            -sineY, 0, cosineY, 0,
+            0, 0, 0, 1
+        ])
+        let rotationZ = Wan2Matrix4([
+            cosineZ, -sineZ, 0, 0,
+            sineZ, cosineZ, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1
+        ])
+        return rotationZ * rotationY * rotationX
+    }
+
+    static func cameraRotation(
+        pitchDegrees: Float,
+        yawDegrees: Float,
+        rollDegrees: Float
+    ) -> Wan2Matrix4 {
+        let pitch = pitchDegrees * .pi / 180
+        let yaw = yawDegrees * .pi / 180
+        let roll = rollDegrees * .pi / 180
+        let cosineYaw = cos(yaw * 0.5)
+        let sineYaw = sin(yaw * 0.5)
+        let cosinePitch = cos(pitch * 0.5)
+        let sinePitch = sin(pitch * 0.5)
+        let cosineRoll = cos(roll * 0.5)
+        let sineRoll = sin(roll * 0.5)
+        let quaternionW = cosineYaw * cosinePitch * cosineRoll + sineYaw * sinePitch * sineRoll
+        let quaternionX = cosineYaw * sinePitch * cosineRoll + sineYaw * cosinePitch * sineRoll
+        let quaternionY = sineYaw * cosinePitch * cosineRoll - cosineYaw * sinePitch * sineRoll
+        let quaternionZ = cosineYaw * cosinePitch * sineRoll - sineYaw * sinePitch * cosineRoll
+        return Wan2Matrix4([
+            1 - 2 * (quaternionY * quaternionY + quaternionZ * quaternionZ),
+            2 * (quaternionX * quaternionY - quaternionW * quaternionZ),
+            2 * (quaternionX * quaternionZ + quaternionW * quaternionY),
+            0,
+            2 * (quaternionX * quaternionY + quaternionW * quaternionZ),
+            1 - 2 * (quaternionX * quaternionX + quaternionZ * quaternionZ),
+            2 * (quaternionY * quaternionZ - quaternionW * quaternionX),
+            0,
+            2 * (quaternionX * quaternionZ - quaternionW * quaternionY),
+            2 * (quaternionY * quaternionZ + quaternionW * quaternionX),
+            1 - 2 * (quaternionX * quaternionX + quaternionY * quaternionY),
+            0,
+            0, 0, 0, 1
+        ])
+    }
+
+    static func * (left: Wan2Matrix4, right: Wan2Matrix4) -> Wan2Matrix4 {
+        var output = Array(repeating: Float(0), count: 16)
+        for row in 0..<4 {
+            for column in 0..<4 {
+                output[row * 4 + column] = (0..<4).reduce(Float(0)) {
+                    $0 + left.values[row * 4 + $1] * right.values[$1 * 4 + column]
+                }
+            }
+        }
+        return Wan2Matrix4(output)
+    }
+
+    func transposed() -> Wan2Matrix4 {
+        Wan2Matrix4((0..<16).map { values[($0 % 4) * 4 + ($0 / 4)] })
+    }
+
+    func withTranslation(_ translation: SIMD3<Float>) -> Wan2Matrix4 {
+        var output = values
+        output[3] = translation.x
+        output[7] = translation.y
+        output[11] = translation.z
+        return Wan2Matrix4(output)
+    }
+
+    func transformDirection(_ direction: SIMD3<Float>) -> SIMD3<Float> {
+        SIMD3(
+            values[0] * direction.x + values[1] * direction.y + values[2] * direction.z,
+            values[4] * direction.x + values[5] * direction.y + values[6] * direction.z,
+            values[8] * direction.x + values[9] * direction.y + values[10] * direction.z
+        )
+    }
+
+    func invertedRigid() -> Wan2Matrix4 {
+        let rotationTranspose = Wan2Matrix4([
+            values[0], values[4], values[8], 0,
+            values[1], values[5], values[9], 0,
+            values[2], values[6], values[10], 0,
+            0, 0, 0, 1
+        ])
+        let translation = SIMD3(values[3], values[7], values[11])
+        return rotationTranspose.withTranslation(-rotationTranspose.transformDirection(translation))
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift
+++ b/Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift
@@ -546,9 +546,11 @@ private struct Wan2Matrix4: Hashable {
         var output = Array(repeating: Float(0), count: 16)
         for row in 0..<4 {
             for column in 0..<4 {
-                output[row * 4 + column] = (0..<4).reduce(Float(0)) {
-                    $0 + left.values[row * 4 + $1] * right.values[$1 * 4 + column]
+                var value = Float(0)
+                for index in 0..<4 {
+                    value += left.values[row * 4 + index] * right.values[index * 4 + column]
                 }
+                output[row * 4 + column] = value
             }
         }
         return Wan2Matrix4(output)

--- a/Sources/MereRunCore/Wan2/Wan2CausalAttention.swift
+++ b/Sources/MereRunCore/Wan2/Wan2CausalAttention.swift
@@ -1,0 +1,318 @@
+import MLX
+import MLXFast
+
+public struct Wan2CausalTransformerStateSnapshot: Hashable, Sendable {
+    public let cachedFrames: Int
+    public let globalFrames: Int
+    public let localAttentionFrames: Int
+    public let sinkFrames: Int
+}
+
+public final class Wan2CausalTransformerState: @unchecked Sendable {
+    let blocks: [Wan2CausalBlockState]
+    public let localAttentionFrames: Int
+    public let sinkFrames: Int
+    public let cachesProjectiveAttention: Bool
+
+    public init(
+        layerCount: Int = 30,
+        localAttentionFrames: Int = 12,
+        sinkFrames: Int = 3,
+        cachesProjectiveAttention: Bool = false
+    ) {
+        precondition(layerCount > 0)
+        precondition(localAttentionFrames > 0)
+        precondition(sinkFrames >= 0 && sinkFrames < localAttentionFrames)
+        self.localAttentionFrames = localAttentionFrames
+        self.sinkFrames = sinkFrames
+        self.cachesProjectiveAttention = cachesProjectiveAttention
+        self.blocks = (0..<layerCount).map { _ in
+            Wan2CausalBlockState(
+                localAttentionFrames: localAttentionFrames,
+                sinkFrames: sinkFrames,
+                cachesProjectiveAttention: cachesProjectiveAttention
+            )
+        }
+    }
+
+    public func reset() {
+        blocks.forEach { $0.reset() }
+    }
+
+    public func snapshot(spatialTokensPerFrame: Int) -> Wan2CausalTransformerStateSnapshot {
+        precondition(spatialTokensPerFrame > 0)
+        let cache = blocks[0].selfAttention
+        return Wan2CausalTransformerStateSnapshot(
+            cachedFrames: cache.cachedTokenCount / spatialTokensPerFrame,
+            globalFrames: cache.globalEndToken / spatialTokensPerFrame,
+            localAttentionFrames: localAttentionFrames,
+            sinkFrames: sinkFrames
+        )
+    }
+}
+
+final class Wan2CausalBlockState {
+    let selfAttention: Wan2CausalKVCache
+    let cameraAttention: Wan2CausalKVCache
+    let cachesProjectiveAttention: Bool
+
+    init(localAttentionFrames: Int, sinkFrames: Int, cachesProjectiveAttention: Bool) {
+        self.cachesProjectiveAttention = cachesProjectiveAttention
+        self.selfAttention = Wan2CausalKVCache(
+            localAttentionFrames: localAttentionFrames,
+            sinkFrames: sinkFrames
+        )
+        self.cameraAttention = Wan2CausalKVCache(
+            localAttentionFrames: localAttentionFrames,
+            sinkFrames: sinkFrames
+        )
+    }
+
+    func reset() {
+        selfAttention.reset()
+        cameraAttention.reset()
+    }
+}
+
+struct Wan2CausalCacheWindow {
+    let key: MLXArray
+    let value: MLXArray
+    let frameCount: Int
+    let queryFrameIndices: [Int]
+}
+
+final class Wan2CausalKVCache {
+    let localAttentionFrames: Int
+    let sinkFrames: Int
+    private var key: MLXArray?
+    private var value: MLXArray?
+    private(set) var globalEndToken = 0
+
+    init(localAttentionFrames: Int, sinkFrames: Int) {
+        self.localAttentionFrames = localAttentionFrames
+        self.sinkFrames = sinkFrames
+    }
+
+    var cachedTokenCount: Int { key?.dim(1) ?? 0 }
+
+    func reset() {
+        key = nil
+        value = nil
+        globalEndToken = 0
+    }
+
+    func update(
+        key newKey: MLXArray,
+        value newValue: MLXArray,
+        currentStartToken: Int,
+        spatialTokensPerFrame: Int
+    ) -> Wan2CausalCacheWindow {
+        precondition(newKey.ndim == 4 && newValue.ndim == 4)
+        precondition(newKey.shape == newValue.shape)
+        precondition(newKey.dim(1).isMultiple(of: spatialTokensPerFrame))
+        precondition(currentStartToken.isMultiple(of: spatialTokensPerFrame))
+        let newTokenCount = newKey.dim(1)
+        let currentEnd = currentStartToken + newTokenCount
+        let maxTokens = localAttentionFrames * spatialTokensPerFrame
+        let sinkTokens = sinkFrames * spatialTokensPerFrame
+
+        let mergedKey: MLXArray
+        let mergedValue: MLXArray
+        if let key, let value {
+            if currentStartToken == globalEndToken {
+                mergedKey = MLX.concatenated([key, newKey], axis: 1)
+                mergedValue = MLX.concatenated([value, newValue], axis: 1)
+                globalEndToken = currentEnd
+            } else {
+                precondition(
+                    currentEnd == globalEndToken,
+                    "Causal Wan cache only accepts sequential appends or latest-chunk recomputation."
+                )
+                precondition(newTokenCount <= key.dim(1))
+                let start = key.dim(1) - newTokenCount
+                let keyCopy = key + MLX.zeros(key.shape, dtype: key.dtype)
+                let valueCopy = value + MLX.zeros(value.shape, dtype: value.dtype)
+                keyCopy[0..., start..<key.dim(1), 0..., 0...] = newKey
+                valueCopy[0..., start..<value.dim(1), 0..., 0...] = newValue
+                mergedKey = keyCopy
+                mergedValue = valueCopy
+            }
+        } else {
+            precondition(currentStartToken == 0)
+            mergedKey = newKey
+            mergedValue = newValue
+            globalEndToken = currentEnd
+        }
+
+        if mergedKey.dim(1) > maxTokens {
+            let tailCount = maxTokens - sinkTokens
+            self.key = MLX.concatenated([
+                mergedKey[0..., 0..<sinkTokens, 0..., 0...],
+                mergedKey[0..., (mergedKey.dim(1) - tailCount)..., 0..., 0...]
+            ], axis: 1)
+            self.value = MLX.concatenated([
+                mergedValue[0..., 0..<sinkTokens, 0..., 0...],
+                mergedValue[0..., (mergedValue.dim(1) - tailCount)..., 0..., 0...]
+            ], axis: 1)
+        } else {
+            self.key = mergedKey
+            self.value = mergedValue
+        }
+
+        let storedKey = self.key!
+        let storedValue = self.value!
+        let frameCount = storedKey.dim(1) / spatialTokensPerFrame
+        let newFrameCount = newTokenCount / spatialTokensPerFrame
+        return Wan2CausalCacheWindow(
+            key: storedKey,
+            value: storedValue,
+            frameCount: frameCount,
+            queryFrameIndices: Array((frameCount - newFrameCount)..<frameCount)
+        )
+    }
+}
+
+extension Wan2SelfAttention {
+    func callCausal(
+        _ input: MLXArray,
+        grid: Wan2GridSize,
+        frequencies: MLXArray,
+        cache: Wan2CausalKVCache,
+        currentStartToken: Int
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let dtype = query.weight.dtype
+        let typed = input.asType(dtype)
+        let q = queryNorm(query(typed)).reshaped(batch, sequence, heads, headDimension)
+        let k = keyNorm(key(typed)).reshaped(batch, sequence, heads, headDimension)
+        let v = value(typed).reshaped(batch, sequence, heads, headDimension)
+        let spatialTokens = grid.height * grid.width
+        let window = cache.update(
+            key: k,
+            value: v,
+            currentStartToken: currentStartToken,
+            spatialTokensPerFrame: spatialTokens
+        )
+        let queryRoPE = Wan2RoPE.prepare(
+            grid: grid,
+            frequencies: frequencies,
+            dtype: .float32,
+            temporalFrameIndices: window.queryFrameIndices
+        )
+        let keyGrid = Wan2GridSize(frames: window.frameCount, height: grid.height, width: grid.width)
+        let keyRoPE = Wan2RoPE.prepare(
+            grid: keyGrid,
+            frequencies: frequencies,
+            dtype: .float32,
+            temporalFrameIndices: Array(0..<window.frameCount)
+        )
+        let rotatedQuery = Wan2RoPE.apply(q.asType(.float32), grid: grid, cache: queryRoPE)
+            .transposed(0, 2, 1, 3)
+        let rotatedKey = Wan2RoPE.apply(window.key.asType(.float32), grid: keyGrid, cache: keyRoPE)
+            .transposed(0, 2, 1, 3)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: rotatedQuery,
+            keys: rotatedKey,
+            values: window.value.transposed(0, 2, 1, 3),
+            scale: scale,
+            mask: .none
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, heads * headDimension))
+    }
+}
+
+extension Wan2ProjectiveSelfAttention {
+    func callCausal(
+        _ input: MLXArray,
+        conditioning: Wan2ProjectiveCameraConditioning,
+        grid: Wan2GridSize,
+        cache: Wan2CausalKVCache,
+        currentStartToken: Int
+    ) -> MLXArray {
+        precondition(conditioning.frameCount == grid.frames)
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let dtype = query.weight.dtype
+        let typed = input.asType(dtype)
+        var q = queryNorm(query(typed)).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        var k = keyNorm(key(typed)).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        var v = value(typed).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
+        let transforms = Wan2ProjectivePositionEncoding.prepare(
+            conditioning: conditioning,
+            batchSize: batch,
+            dtype: dtype
+        )
+        q = Wan2ProjectivePositionEncoding.apply(q, matrices: transforms.query, cameraFrames: grid.frames)
+        k = Wan2ProjectivePositionEncoding.apply(k, matrices: transforms.keyValue, cameraFrames: grid.frames)
+        v = Wan2ProjectivePositionEncoding.apply(v, matrices: transforms.keyValue, cameraFrames: grid.frames)
+        let window = cache.update(
+            key: k.transposed(0, 2, 1, 3),
+            value: v.transposed(0, 2, 1, 3),
+            currentStartToken: currentStartToken,
+            spatialTokensPerFrame: grid.height * grid.width
+        )
+        var attended = MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: window.key.transposed(0, 2, 1, 3),
+            values: window.value.transposed(0, 2, 1, 3),
+            scale: scale,
+            mask: .none
+        )
+        attended = Wan2ProjectivePositionEncoding.apply(
+            attended,
+            matrices: transforms.output,
+            cameraFrames: grid.frames
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, heads * headDimension))
+    }
+}
+
+extension Wan2TransformerBlock {
+    func callCausal(
+        _ input: MLXArray,
+        modulationInput: MLXArray,
+        context: MLXArray,
+        grid: Wan2GridSize,
+        frequencies: MLXArray,
+        crossCache: Wan2AttentionKVCache?,
+        cameraConditioning: Wan2ProjectiveCameraConditioning?,
+        state: Wan2CausalBlockState,
+        currentStartToken: Int
+    ) -> MLXArray {
+        let parts = MLX.split(modulation.expandedDimensions(axis: 1) + modulationInput, parts: 6, axis: 2)
+            .map { $0.squeezed(axis: 2) }
+        var hidden = input
+        let hiddenType = hidden.dtype
+        let selfInput = selfNorm(hidden.asType(.float32)) * (1 + parts[1]) + parts[0]
+        var selfOutput = selfAttention.callCausal(
+            selfInput.asType(hiddenType),
+            grid: grid,
+            frequencies: frequencies,
+            cache: state.selfAttention,
+            currentStartToken: currentStartToken
+        )
+        if let cameraAttention, let cameraConditioning {
+            let cameraOutput = state.cachesProjectiveAttention
+                ? cameraAttention.callCausal(
+                    selfInput.asType(hiddenType),
+                    conditioning: cameraConditioning,
+                    grid: grid,
+                    cache: state.cameraAttention,
+                    currentStartToken: currentStartToken
+                )
+                : cameraAttention(
+                    selfInput.asType(hiddenType),
+                    conditioning: cameraConditioning
+                )
+            selfOutput = selfOutput + cameraOutput
+        }
+        hidden = (hidden.asType(.float32) + selfOutput * parts[2]).asType(hiddenType)
+        let crossInput = crossNorm(hidden.asType(.float32)).asType(hiddenType)
+        hidden = hidden + crossAttention(crossInput, context: context, cache: crossCache)
+        let feedForwardInput = feedForwardNorm(hidden.asType(.float32)) * (1 + parts[4]) + parts[3]
+        let feedForwardOutput = feedForward(feedForwardInput.asType(hiddenType))
+        return (hidden.asType(.float32) + feedForwardOutput.asType(.float32) * parts[5])
+            .asType(hiddenType)
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2CausalWorldGenerator.swift
+++ b/Sources/MereRunCore/Wan2/Wan2CausalWorldGenerator.swift
@@ -1,0 +1,340 @@
+import Foundation
+import MediaIO
+import MLX
+import MLXRandom
+
+public enum Wan2CausalWorldGeneratorError: LocalizedError {
+    case sourceImageRequired
+    case sourceImageNotFound(URL)
+    case invalidResolution(width: Int, height: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .sourceImageRequired:
+            return "The first DreamX causal block requires a source image."
+        case .sourceImageNotFound(let url):
+            return "DreamX causal source image not found: \(url.path)"
+        case .invalidResolution(let width, let height):
+            return "DreamX causal resolution must be positive and divisible by 32; received \(width)x\(height)."
+        }
+    }
+}
+
+struct Wan2CausalDecodePlan: Equatable {
+    let latentStart: Int
+    let latentCount: Int
+    let transitionStartPixelFrame: Int
+
+    static func make(
+        previousLatentFrames: Int,
+        currentLatentFrames: Int,
+        maximumContextLatentFrames: Int = 3
+    ) -> Self {
+        precondition(previousLatentFrames >= 0)
+        precondition(currentLatentFrames > 0)
+        precondition(maximumContextLatentFrames >= 0)
+        let contextFrames = min(previousLatentFrames, maximumContextLatentFrames)
+        return Self(
+            latentStart: previousLatentFrames - contextFrames,
+            latentCount: contextFrames + currentLatentFrames,
+            transitionStartPixelFrame: contextFrames == 0 ? 0 : (contextFrames - 1) * 4
+        )
+    }
+}
+
+public final class Wan2CausalWorldGenerator: @unchecked Sendable {
+    private let weightsURL: URL
+    private var loadedRootURL: URL?
+    private var tokenizer: Wan2Tokenizer?
+    private var textEncoder: Wan2TextEncoderModel?
+    private var vae: Wan2VAEModel?
+    private var transformer: Wan2TransformerModel?
+    private var causalState = Wan2CausalTransformerState()
+    private var accumulatedLatents: MLXArray?
+    private var promptKey: String?
+    private var embeddedContext: MLXArray?
+    private var crossCaches: [Wan2AttentionKVCache]?
+
+    public init(weightsURL: URL) {
+        self.weightsURL = weightsURL.standardizedFileURL
+    }
+
+    public var isWarm: Bool {
+        tokenizer != nil && textEncoder != nil && vae != nil && transformer != nil
+    }
+
+    public var latentFrameCount: Int { accumulatedLatents?.dim(1) ?? 0 }
+
+    public func prepare(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws {
+        try ensureRoot(resources)
+        _ = try loadedTextComponents(resources: resources, progress: progress)
+        _ = try loadedVAE(resources: resources, progress: progress)
+        _ = try loadedTransformer(progress: progress)
+    }
+
+    public func reset() {
+        causalState.reset()
+        accumulatedLatents = nil
+    }
+
+    public func unload() {
+        tokenizer = nil
+        textEncoder = nil
+        vae = nil
+        transformer = nil
+        loadedRootURL = nil
+        accumulatedLatents = nil
+        promptKey = nil
+        embeddedContext = nil
+        crossCaches = nil
+        causalState = Wan2CausalTransformerState()
+        Memory.clearCache()
+    }
+
+    public func generateBlock(
+        prompt: String,
+        camera: Wan2WorldCameraControl,
+        sourceImageURL: URL? = nil,
+        resources: Wan2Resources,
+        width: Int = 1_280,
+        height: Int = 704,
+        seed: UInt64 = 42,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)? = nil
+    ) async throws -> Wan2VideoGenerationResult {
+        guard width > 0, height > 0, width.isMultiple(of: 32), height.isMultiple(of: 32) else {
+            throw Wan2CausalWorldGeneratorError.invalidResolution(width: width, height: height)
+        }
+        try ensureRoot(resources)
+        let model = try loadedTransformer()
+        let vae = try loadedVAE(resources: resources)
+        let context = try conditioning(prompt: prompt, resources: resources, model: model)
+
+        let previousLatentFrames = latentFrameCount
+        let isFirstBlock = previousLatentFrames == 0
+        let latentHeight = height / 16
+        let latentWidth = width / 16
+        MLXRandom.seed(seed)
+        var noisyBlock = MLXRandom.normal([48, 3, latentHeight, latentWidth]).asType(.bfloat16)
+        if isFirstBlock {
+            guard let sourceImageURL else { throw Wan2CausalWorldGeneratorError.sourceImageRequired }
+            guard FileManager.default.fileExists(atPath: sourceImageURL.path) else {
+                throw Wan2CausalWorldGeneratorError.sourceImageNotFound(sourceImageURL)
+            }
+            let source = try encodeSourceImage(
+                sourceImageURL,
+                width: width,
+                height: height,
+                vae: vae
+            )
+            noisyBlock = MLX.concatenated([source, noisyBlock[0..., 1...]], axis: 1)
+        }
+        eval(noisyBlock)
+
+        let spatialTokens = (latentHeight / 2) * (latentWidth / 2)
+        let currentStartToken = previousLatentFrames * spatialTokens
+        let cameraConditioning = Wan2DreamXARTrajectory.compile(
+            control: camera,
+            pixelFrameCount: 9,
+            chunkRelative: true
+        )
+        let scheduler = Wan2CausalForcingScheduler()
+        let frozenMask = isFirstBlock
+            ? Wan2TI2VConditioning.latentMask(shape: noisyBlock.shape).asType(.bfloat16)
+            : MLX.ones(noisyBlock.shape, dtype: .bfloat16)
+        var latents = noisyBlock
+        for (index, timestep) in scheduler.timesteps.enumerated() {
+            try Task.checkCancellation()
+            progressHandler?(GenerationProgress(
+                stage: .denoising,
+                stepIndex: index,
+                totalSteps: scheduler.timesteps.count + 1
+            ))
+            let tokenTimesteps = causalTokenTimesteps(
+                timestep: timestep,
+                spatialTokens: spatialTokens,
+                freezesFirstFrame: isFirstBlock
+            )
+            let flow = model(
+                latents: [latents],
+                timesteps: tokenTimesteps,
+                embeddedContext: context,
+                crossCaches: crossCaches,
+                cameraConditioning: cameraConditioning,
+                causalState: causalState,
+                currentStartToken: currentStartToken
+            )[0]
+            var clean = scheduler.predictClean(flow: flow, sample: latents, timestep: timestep)
+            clean = frozenMask * clean + (1 - frozenMask) * noisyBlock
+            if index + 1 < scheduler.timesteps.count {
+                let nextNoise = MLXRandom.normal(clean.shape).asType(.bfloat16)
+                latents = scheduler.addNoise(
+                    clean: clean,
+                    noise: nextNoise,
+                    timestep: scheduler.timesteps[index + 1]
+                )
+                latents = frozenMask * latents + (1 - frozenMask) * noisyBlock
+            } else {
+                latents = clean
+            }
+            eval(latents)
+            Memory.clearCache()
+        }
+
+        progressHandler?(GenerationProgress(
+            stage: .denoising,
+            stepIndex: scheduler.timesteps.count,
+            totalSteps: scheduler.timesteps.count + 1
+        ))
+        let contextTimesteps = MLX.ones([1, 3 * spatialTokens]) * Float(0.1)
+        let contextFlow = model(
+            latents: [latents],
+            timesteps: contextTimesteps,
+            embeddedContext: context,
+            crossCaches: crossCaches,
+            cameraConditioning: cameraConditioning,
+            causalState: causalState,
+            currentStartToken: currentStartToken
+        )
+        eval(contextFlow)
+        accumulatedLatents = accumulatedLatents.map {
+            MLX.concatenated([$0, latents], axis: 1)
+        } ?? latents
+        eval(accumulatedLatents!)
+        Memory.clearCache()
+
+        progressHandler?(GenerationProgress(
+            stage: .decoding,
+            stepIndex: scheduler.timesteps.count + 1,
+            totalSteps: scheduler.timesteps.count + 1
+        ))
+        let decodePlan = Wan2CausalDecodePlan.make(
+            previousLatentFrames: previousLatentFrames,
+            currentLatentFrames: latents.dim(1)
+        )
+        let decodeLatents = accumulatedLatents![
+            0...,
+            decodePlan.latentStart..<(decodePlan.latentStart + decodePlan.latentCount),
+            0...,
+            0...
+        ]
+        let decodedFrames = decode(decodeLatents, vae: vae)
+        let allFrames = Wan2DreamXColorStabilizer.process(decodedFrames)
+        eval(allFrames)
+        let transitionFrames = allFrames[0..., decodePlan.transitionStartPixelFrame...]
+        eval(transitionFrames)
+        let terminalLatent = accumulatedLatents![0..., (accumulatedLatents!.dim(1) - 1)...]
+        return Wan2VideoGenerationResult(
+            frames: transitionFrames,
+            seed: seed,
+            terminalFrameLatent: terminalLatent
+        )
+    }
+
+    private func causalTokenTimesteps(
+        timestep: Float,
+        spatialTokens: Int,
+        freezesFirstFrame: Bool
+    ) -> MLXArray {
+        guard freezesFirstFrame else {
+            return MLX.ones([1, 3 * spatialTokens]) * timestep
+        }
+        return MLX.concatenated([
+            MLX.zeros([1, spatialTokens]),
+            MLX.ones([1, 2 * spatialTokens]) * timestep
+        ], axis: 1)
+    }
+
+    private func conditioning(
+        prompt: String,
+        resources: Wan2Resources,
+        model: Wan2TransformerModel
+    ) throws -> MLXArray {
+        if promptKey == prompt, let embeddedContext { return embeddedContext }
+        let components = try loadedTextComponents(resources: resources)
+        let encoded = try Wan2ModelLoader.encodePrompts(
+            tokenizer: components.tokenizer,
+            encoder: components.encoder,
+            prompt: prompt,
+            negativePrompt: Wan2Resources.defaultNegativePrompt
+        )
+        let context = model.embedText(encoded.prompt.expandedDimensions(axis: 0))
+        let caches = model.prepareCrossAttentionCaches(context: context)
+        eval(context, caches.flatMap { [$0.key, $0.value] })
+        promptKey = prompt
+        embeddedContext = context
+        crossCaches = caches
+        return context
+    }
+
+    private func encodeSourceImage(
+        _ url: URL,
+        width: Int,
+        height: Int,
+        vae: Wan2VAEModel
+    ) throws -> MLXArray {
+        let decoded = try MediaImageIO.decode(url)
+        let image = try MediaImageIO.centerCropped(decoded, width: width, height: height)
+        let channels = MediaImageIO.rgbCHWFloat(image, normalizedToMinusOneToOne: true)
+        let tensor = MLXArray(channels)
+            .reshaped(3, height, width)
+            .transposed(1, 2, 0)
+            .reshaped(1, 1, height, width, 3)
+        let encoded = vae.encodeImage(tensor)
+        let latent = encoded[0].transposed(3, 0, 1, 2).asType(.bfloat16)
+        eval(latent)
+        return latent
+    }
+
+    private func decode(_ latents: MLXArray, vae: Wan2VAEModel) -> MLXArray {
+        let decoded = vae.decode(latents.transposed(1, 2, 3, 0).expandedDimensions(axis: 0))
+        return MLX.clip((decoded + 1) * 127.5, min: 0, max: 255).asType(.uint8)
+    }
+
+    private func loadedTextComponents(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> (tokenizer: Wan2Tokenizer, encoder: Wan2TextEncoderModel) {
+        try ensureRoot(resources)
+        if tokenizer == nil {
+            tokenizer = try Wan2ModelLoader.loadTokenizer(resources: resources)
+        }
+        if textEncoder == nil {
+            textEncoder = try Wan2ModelLoader.loadTextEncoder(resources: resources, progress: progress)
+        }
+        return (tokenizer!, textEncoder!)
+    }
+
+    private func loadedVAE(
+        resources: Wan2Resources,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2VAEModel {
+        try ensureRoot(resources)
+        if vae == nil {
+            vae = try Wan2ModelLoader.loadVAE(resources: resources, progress: progress)
+        }
+        return vae!
+    }
+
+    private func loadedTransformer(
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TransformerModel {
+        if transformer == nil {
+            transformer = try Wan2ModelLoader.loadDreamXCausalTransformer(
+                weightsURL: weightsURL,
+                progress: progress
+            )
+        }
+        return transformer!
+    }
+
+    private func ensureRoot(_ resources: Wan2Resources) throws {
+        let root = resources.rootURL.standardizedFileURL
+        if loadedRootURL != root {
+            unload()
+            loadedRootURL = root
+        }
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2DreamXCausalResources.swift
+++ b/Sources/MereRunCore/Wan2/Wan2DreamXCausalResources.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct Wan2DreamXCausalResources: Hashable, Sendable {
+    public static let modelID = "video-dreamx-world-5b-ar-mlx"
+    public static let upstreamRepoID = "GD-ML/DreamX-World-5B"
+    public static let upstreamRevision = "67487c4a61466bb7166d30b7187dd465e0ac9f6c"
+    public static let weightsFilename = "model.safetensors"
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public var weightsURL: URL {
+        rootURL.appendingPathComponent(Self.weightsFilename)
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        fileManager.fileExists(atPath: weightsURL.path) ? [] : [weightsURL]
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2DreamXPostprocessing.swift
+++ b/Sources/MereRunCore/Wan2/Wan2DreamXPostprocessing.swift
@@ -1,0 +1,158 @@
+import Foundation
+import MLX
+
+enum Wan2DreamXColorStabilizer {
+    static func process(_ frames: MLXArray, strength: Double = 0.3) -> MLXArray {
+        precondition(frames.ndim == 5 && frames.dim(4) == 3)
+        guard frames.dim(1) > 1, strength > 0 else { return frames }
+        let batchCount = frames.dim(0)
+        let frameCount = frames.dim(1)
+        let height = frames.dim(2)
+        let width = frames.dim(3)
+        let pixelsPerFrame = height * width
+        var values = frames.asArray(UInt8.self)
+        let reference = statistics(values, offset: 0, pixelCount: pixelsPerFrame)
+
+        for batch in 0..<batchCount {
+            var target = reference
+            for frame in 0..<frameCount {
+                let frameOffset = (batch * frameCount + frame) * pixelsPerFrame * 3
+                if frame == 9 {
+                    target = statistics(values, offset: frameOffset - pixelsPerFrame * 3, pixelCount: pixelsPerFrame)
+                } else if frame > 9, (frame - 9).isMultiple(of: 12) {
+                    target = statistics(values, offset: frameOffset - pixelsPerFrame * 3, pixelCount: pixelsPerFrame)
+                }
+                stabilize(
+                    &values,
+                    offset: frameOffset,
+                    pixelCount: pixelsPerFrame,
+                    target: target,
+                    strength: strength
+                )
+            }
+        }
+        return MLXArray(values).reshaped(frames.shape)
+    }
+
+    private struct Statistics {
+        let mean: SIMD3<Double>
+        let deviation: SIMD3<Double>
+    }
+
+    private static func statistics(
+        _ values: [UInt8],
+        offset: Int,
+        pixelCount: Int
+    ) -> Statistics {
+        var sum = SIMD3<Double>(repeating: 0)
+        var squared = SIMD3<Double>(repeating: 0)
+        for pixel in 0..<pixelCount {
+            let index = offset + pixel * 3
+            let lab = rgbToLab(
+                Double(values[index]) / 255,
+                Double(values[index + 1]) / 255,
+                Double(values[index + 2]) / 255
+            )
+            sum += lab
+            squared += lab * lab
+        }
+        let count = Double(pixelCount)
+        let mean = sum / count
+        let variance = squared / count - mean * mean
+        return Statistics(
+            mean: mean,
+            deviation: SIMD3(
+                Foundation.sqrt(Swift.max(0, variance.x)),
+                Foundation.sqrt(Swift.max(0, variance.y)),
+                Foundation.sqrt(Swift.max(0, variance.z))
+            )
+        )
+    }
+
+    private static func stabilize(
+        _ values: inout [UInt8],
+        offset: Int,
+        pixelCount: Int,
+        target: Statistics,
+        strength: Double
+    ) {
+        let source = statistics(values, offset: offset, pixelCount: pixelCount)
+        for pixel in 0..<pixelCount {
+            let index = offset + pixel * 3
+            let original = SIMD3(
+                Double(values[index]) / 255,
+                Double(values[index + 1]) / 255,
+                Double(values[index + 2]) / 255
+            )
+            var correctedLab = rgbToLab(original.x, original.y, original.z)
+            for channel in 0..<3 {
+                if source.deviation[channel] > 1e-6 {
+                    correctedLab[channel] = (correctedLab[channel] - source.mean[channel])
+                        * (target.deviation[channel] / source.deviation[channel])
+                        + target.mean[channel]
+                } else {
+                    correctedLab[channel] = target.mean[channel]
+                }
+            }
+            let corrected = labToRGB(correctedLab)
+            let blended = (1 - strength) * original + strength * corrected
+            values[index] = channel(blended.x)
+            values[index + 1] = channel(blended.y)
+            values[index + 2] = channel(blended.z)
+        }
+    }
+
+    private static func rgbToLab(_ red: Double, _ green: Double, _ blue: Double) -> SIMD3<Double> {
+        let r = linear(red)
+        let g = linear(green)
+        let b = linear(blue)
+        let x = (0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / 0.95047
+        let y = 0.2126729 * r + 0.7151522 * g + 0.0721750 * b
+        let z = (0.0193339 * r + 0.1191920 * g + 0.9503041 * b) / 1.08883
+        let fx = labCurve(x)
+        let fy = labCurve(y)
+        let fz = labCurve(z)
+        return SIMD3(116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz))
+    }
+
+    private static func labToRGB(_ lab: SIMD3<Double>) -> SIMD3<Double> {
+        let fy = (lab.x + 16) / 116
+        let fx = fy + lab.y / 500
+        let fz = fy - lab.z / 200
+        let x = 0.95047 * inverseLabCurve(fx)
+        let y = inverseLabCurve(fy)
+        let z = 1.08883 * inverseLabCurve(fz)
+        let r = 3.2404542 * x - 1.5371385 * y - 0.4985314 * z
+        let g = -0.9692660 * x + 1.8760108 * y + 0.0415560 * z
+        let b = 0.0556434 * x - 0.2040259 * y + 1.0572252 * z
+        return SIMD3(sRGB(r), sRGB(g), sRGB(b))
+    }
+
+    private static func linear(_ value: Double) -> Double {
+        value <= 0.04045 ? value / 12.92 : Foundation.pow((value + 0.055) / 1.055, 2.4)
+    }
+
+    private static func sRGB(_ value: Double) -> Double {
+        let encoded = value <= 0.0031308
+            ? 12.92 * value
+            : 1.055 * Foundation.pow(Swift.max(0, value), 1.0 / 2.4) - 0.055
+        return Swift.min(1, Swift.max(0, encoded))
+    }
+
+    private static func labCurve(_ value: Double) -> Double {
+        value > 216.0 / 24_389.0
+            ? Foundation.pow(value, 1.0 / 3.0)
+            : (24_389.0 / 27.0 * value + 16) / 116
+    }
+
+    private static func inverseLabCurve(_ value: Double) -> Double {
+        let cube = value * value * value
+        return cube > 216.0 / 24_389.0
+            ? cube
+            : (116 * value - 16) * 27.0 / 24_389.0
+    }
+
+    private static func channel(_ value: Double) -> UInt8 {
+        UInt8(clamping: Int((Swift.min(1, Swift.max(0, value)) * 255).rounded()))
+    }
+}

--- a/Sources/MereRunCore/Wan2/Wan2Generation.swift
+++ b/Sources/MereRunCore/Wan2/Wan2Generation.swift
@@ -34,6 +34,7 @@ public struct Wan2GenerationOptions: Hashable, Sendable {
     public let shift: Float
     public let seed: UInt64
     public let fps: Int
+    public let cameraConditioning: Wan2ProjectiveCameraConditioning?
 
     public init(
         prompt: String,
@@ -47,7 +48,8 @@ public struct Wan2GenerationOptions: Hashable, Sendable {
         guidanceScale: Float = 5,
         shift: Float = 5,
         seed: UInt64 = 42,
-        fps: Int = 24
+        fps: Int = 24,
+        cameraConditioning: Wan2ProjectiveCameraConditioning? = nil
     ) throws {
         guard width > 0,
               height > 0,
@@ -74,6 +76,7 @@ public struct Wan2GenerationOptions: Hashable, Sendable {
         self.shift = shift
         self.seed = seed
         self.fps = fps
+        self.cameraConditioning = cameraConditioning
     }
 
     public var latentShape: [Int] {
@@ -98,19 +101,19 @@ public struct Wan2FlowMatchEulerScheduler: Sendable {
     public init(steps: Int, shift: Float = 5, trainTimesteps: Int = 1_000) {
         precondition(steps > 0)
         precondition(trainTimesteps > 1)
+        precondition(shift > 0)
         var shifted: [Float] = []
         shifted.reserveCapacity(steps + 1)
-        let sigmaMax = Float(trainTimesteps - 1) / Float(trainTimesteps)
+        let trainSigmaMin = 1 / Float(trainTimesteps)
+        let sigmaMin = shift * trainSigmaMin / (1 + (shift - 1) * trainSigmaMin)
         for index in 0..<steps {
-            let fraction = Float(index) / Float(steps)
-            let sigma = sigmaMax * (1 - fraction)
+            let fraction = steps == 1 ? 0 : Float(index) / Float(steps - 1)
+            let sigma = 1 + (sigmaMin - 1) * fraction
             shifted.append(shift * sigma / (1 + (shift - 1) * sigma))
         }
         shifted.append(0)
         self.sigmas = shifted
-        self.timesteps = shifted.dropLast().map {
-            Float(Int(($0 * Float(trainTimesteps)).rounded(.towardZero)))
-        }
+        self.timesteps = shifted.dropLast().map { $0 * Float(trainTimesteps) }
     }
 
     public mutating func step(velocity: MLXArray, sample: MLXArray) -> MLXArray {
@@ -122,6 +125,29 @@ public struct Wan2FlowMatchEulerScheduler: Sendable {
 
     public mutating func reset() {
         stepIndex = 0
+    }
+}
+
+public struct Wan2CausalForcingScheduler: Sendable {
+    public let timesteps: [Float]
+
+    public init(shift: Float = 5) {
+        precondition(shift > 0)
+        let trainingIndices: [Float] = [1, 0.75, 0.5, 0.25]
+        self.timesteps = trainingIndices.map { sigma in
+            1_000 * shift * sigma / (1 + (shift - 1) * sigma)
+        }
+    }
+
+    public func predictClean(flow: MLXArray, sample: MLXArray, timestep: Float) -> MLXArray {
+        (sample.asType(.float32) - (timestep / 1_000) * flow.asType(.float32))
+            .asType(flow.dtype)
+    }
+
+    public func addNoise(clean: MLXArray, noise: MLXArray, timestep: Float) -> MLXArray {
+        let sigma = timestep / 1_000
+        return ((1 - sigma) * clean.asType(.float32) + sigma * noise.asType(.float32))
+            .asType(noise.dtype)
     }
 }
 

--- a/Sources/MereRunCore/Wan2/Wan2ModelLoader.swift
+++ b/Sources/MereRunCore/Wan2/Wan2ModelLoader.swift
@@ -1,13 +1,20 @@
 import Foundation
 import MLX
+import MLXNN
 
 public enum Wan2ModelLoaderError: LocalizedError, Sendable {
     case textEncodingFailed
+    case invalidDreamXCameraWeights(expected: Int, actual: Int)
+    case invalidDreamXCausalWeights(expected: Int, actual: Int)
 
     public var errorDescription: String? {
         switch self {
         case .textEncodingFailed:
             return "Wan2 text encoder did not return the expected batch."
+        case .invalidDreamXCameraWeights(let expected, let actual):
+            return "DreamX camera adapter must contain \(expected) tensors, found \(actual)."
+        case .invalidDreamXCausalWeights(let expected, let actual):
+            return "DreamX causal checkpoint must contain \(expected) tensors, found \(actual)."
         }
     }
 }
@@ -91,16 +98,81 @@ public enum Wan2ModelLoader {
     ) throws -> Wan2TransformerModel {
         progress?("Loading Wan2.2 TI2V transformer")
         let model = Wan2TransformerModel()
-        try SafetensorsStreamingLoader.applyWeightsStreaming(
+        try applyTransformerWeights(
             url: resources.transformerURL,
             to: model,
-            dtype: nil,
-            verify: .none,
-            mapper: { key, value in
-                let targetType: DType = key.hasSuffix("modulation") ? .float32 : dtype
-                return [(key, value.asType(targetType))]
-            },
-            batchSize: 12
+            dtype: dtype,
+            verify: .none
+        )
+        eval(model.parameters().flattened().map(\.1))
+        return model
+    }
+
+    public static func loadDreamXCameraTransformer(
+        resources: Wan2Resources,
+        cameraWeightsURL: URL,
+        dtype: DType = .bfloat16,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TransformerModel {
+        let metadata = try SafetensorsStreamingLoader.metadata(url: cameraWeightsURL)
+        let cameraTensorCount = metadata.keys.filter { $0.contains(".cam_self_attn.") }.count
+        guard cameraTensorCount == 300, metadata.count == 300 else {
+            throw Wan2ModelLoaderError.invalidDreamXCameraWeights(
+                expected: 300,
+                actual: cameraTensorCount
+            )
+        }
+        progress?("Loading Wan2.2 TI2V transformer")
+        let model = Wan2TransformerModel(configuration: Wan2TransformerConfiguration(
+            projectiveCameraConditioning: true
+        ))
+        try applyTransformerWeights(
+            url: resources.transformerURL,
+            to: model,
+            dtype: dtype,
+            verify: .none
+        )
+        progress?("Loading DreamX projective camera attention")
+        try applyTransformerWeights(
+            url: cameraWeightsURL,
+            to: model,
+            dtype: dtype,
+            verify: .noUnusedKeys
+        )
+        eval(model.parameters().flattened().map(\.1))
+        return model
+    }
+
+    public static func loadDreamXCausalTransformer(
+        weightsURL: URL,
+        dtype: DType = .bfloat16,
+        progress: (@Sendable (String) -> Void)? = nil
+    ) throws -> Wan2TransformerModel {
+        let metadata = try SafetensorsStreamingLoader.metadata(url: weightsURL)
+        guard metadata.count == 1_125 else {
+            throw Wan2ModelLoaderError.invalidDreamXCausalWeights(
+                expected: 1_125,
+                actual: metadata.count
+            )
+        }
+        let cameraPrefix = "blocks.0.cam_self_attn."
+        guard metadata[cameraPrefix + "q_proj.weight"]?.shape == [768, 3_072],
+              metadata[cameraPrefix + "out_proj.weight"]?.shape == [3_072, 768] else {
+            throw Wan2ModelLoaderError.invalidDreamXCausalWeights(
+                expected: 1_125,
+                actual: metadata.count
+            )
+        }
+        progress?("Loading DreamX causal Wan2 transformer")
+        let model = Wan2TransformerModel(configuration: Wan2TransformerConfiguration(
+            projectiveCameraConditioning: true,
+            projectiveCameraAttentionCompression: 4
+        ))
+        try applyTransformerWeights(
+            url: weightsURL,
+            to: model,
+            dtype: dtype,
+            verify: .noUnusedKeys
         )
         eval(model.parameters().flattened().map(\.1))
         return model
@@ -122,5 +194,24 @@ public enum Wan2ModelLoader {
         )
         eval(model.parameters().flattened().map(\.1))
         return model
+    }
+
+    private static func applyTransformerWeights(
+        url: URL,
+        to model: Wan2TransformerModel,
+        dtype: DType,
+        verify: Module.VerifyUpdate
+    ) throws {
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: url,
+            to: model,
+            dtype: nil,
+            verify: verify,
+            mapper: { key, value in
+                let targetType: DType = key.hasSuffix("modulation") ? .float32 : dtype
+                return [(key, value.asType(targetType))]
+            },
+            batchSize: 12
+        )
     }
 }

--- a/Sources/MereRunCore/Wan2/Wan2TI2VGenerator.swift
+++ b/Sources/MereRunCore/Wan2/Wan2TI2VGenerator.swift
@@ -45,8 +45,15 @@ public final class Wan2TI2VGenerator: @unchecked Sendable {
     private var transformer: Wan2TransformerModel?
     private var promptCache: [PromptCacheKey: Wan2TextConditioning] = [:]
     private var chainedTerminalFrameLatent: MLXArray?
+    private let cameraWeightsURL: URL?
 
-    public init() {}
+    public init(cameraWeightsURL: URL? = nil) {
+        self.cameraWeightsURL = cameraWeightsURL?.standardizedFileURL
+    }
+
+    public var conditioningMode: Wan2WorldConditioningMode {
+        cameraWeightsURL == nil ? .textAndFirstFrame : .projectiveCameraLatents
+    }
 
     public var isWarm: Bool {
         tokenizer != nil && textEncoder != nil && vae != nil && transformer != nil
@@ -196,10 +203,13 @@ public final class Wan2TI2VGenerator: @unchecked Sendable {
             negativeCaches.flatMap { [$0.key, $0.value] }
         )
 
-        var scheduler = Wan2UniPCScheduler(steps: options.steps, shift: options.shift)
+        var eulerScheduler = Wan2FlowMatchEulerScheduler(steps: options.steps, shift: options.shift)
+        var uniPCScheduler = Wan2UniPCScheduler(steps: options.steps, shift: options.shift)
+        let usesDreamXSampler = options.cameraConditioning != nil
+        let timesteps = usesDreamXSampler ? eulerScheduler.timesteps : uniPCScheduler.timesteps
         var latent = initialLatent
         let debugStats = ProcessInfo.processInfo.environment["MERERUN_WAN2_DEBUG_STATS"] == "1"
-        for (stepIndex, timestep) in scheduler.timesteps.enumerated() {
+        for (stepIndex, timestep) in timesteps.enumerated() {
             try Task.checkCancellation()
             progressHandler?(GenerationProgress(
                 stage: .denoising,
@@ -211,7 +221,8 @@ public final class Wan2TI2VGenerator: @unchecked Sendable {
                 latents: [latent],
                 timesteps: tokenTimesteps,
                 embeddedContext: positiveContext,
-                crossCaches: positiveCaches
+                crossCaches: positiveCaches,
+                cameraConditioning: options.cameraConditioning
             )[0]
             eval(conditional)
             Memory.clearCache()
@@ -220,10 +231,13 @@ public final class Wan2TI2VGenerator: @unchecked Sendable {
                 latents: [latent],
                 timesteps: tokenTimesteps,
                 embeddedContext: negativeContext,
-                crossCaches: negativeCaches
+                crossCaches: negativeCaches,
+                cameraConditioning: options.cameraConditioning
             )[0]
             let velocity = unconditional + options.guidanceScale * (conditional - unconditional)
-            latent = scheduler.step(modelOutput: velocity, sample: latent)
+            latent = usesDreamXSampler
+                ? eulerScheduler.step(velocity: velocity, sample: latent)
+                : uniPCScheduler.step(modelOutput: velocity, sample: latent)
             latent = Wan2TI2VConditioning.blend(
                 imageLatent: imageLatent,
                 noise: latent,
@@ -323,7 +337,15 @@ public final class Wan2TI2VGenerator: @unchecked Sendable {
     ) throws -> Wan2TransformerModel {
         try ensureRoot(resources)
         if transformer == nil {
-            transformer = try Wan2ModelLoader.loadTransformer(resources: resources, progress: progress)
+            if let cameraWeightsURL {
+                transformer = try Wan2ModelLoader.loadDreamXCameraTransformer(
+                    resources: resources,
+                    cameraWeightsURL: cameraWeightsURL,
+                    progress: progress
+                )
+            } else {
+                transformer = try Wan2ModelLoader.loadTransformer(resources: resources, progress: progress)
+            }
         }
         return transformer!
     }

--- a/Sources/MereRunCore/Wan2/Wan2TI2VGenerator.swift
+++ b/Sources/MereRunCore/Wan2/Wan2TI2VGenerator.swift
@@ -20,7 +20,7 @@ public enum Wan2TI2VGeneratorError: LocalizedError {
     }
 }
 
-public struct Wan2VideoGenerationResult {
+public struct Wan2VideoGenerationResult: @unchecked Sendable {
     public let frames: MLXArray
     public let seed: UInt64
     public let terminalFrameLatent: MLXArray?

--- a/Sources/MereRunCore/Wan2/Wan2Transformer.swift
+++ b/Sources/MereRunCore/Wan2/Wan2Transformer.swift
@@ -15,6 +15,8 @@ public struct Wan2TransformerConfiguration: Hashable, Sendable {
     public let headCount: Int
     public let layerCount: Int
     public let epsilon: Float
+    public let projectiveCameraConditioning: Bool
+    public let projectiveCameraAttentionCompression: Int
 
     public init(
         patchSize: [Int] = [1, 2, 2],
@@ -27,11 +29,16 @@ public struct Wan2TransformerConfiguration: Hashable, Sendable {
         outputChannels: Int = 48,
         headCount: Int = 24,
         layerCount: Int = 30,
-        epsilon: Float = 1e-6
+        epsilon: Float = 1e-6,
+        projectiveCameraConditioning: Bool = false,
+        projectiveCameraAttentionCompression: Int = 1
     ) {
         precondition(patchSize.count == 3)
         precondition(hiddenSize % headCount == 0)
         precondition((hiddenSize / headCount) % 2 == 0)
+        precondition(projectiveCameraAttentionCompression > 0)
+        precondition(hiddenSize.isMultiple(of: projectiveCameraAttentionCompression))
+        precondition(headCount.isMultiple(of: projectiveCameraAttentionCompression))
         self.patchSize = patchSize
         self.textLength = textLength
         self.inputChannels = inputChannels
@@ -43,6 +50,8 @@ public struct Wan2TransformerConfiguration: Hashable, Sendable {
         self.headCount = headCount
         self.layerCount = layerCount
         self.epsilon = epsilon
+        self.projectiveCameraConditioning = projectiveCameraConditioning
+        self.projectiveCameraAttentionCompression = projectiveCameraAttentionCompression
     }
 }
 
@@ -151,14 +160,30 @@ enum Wan2RoPE {
         return MLX.concatenated(tables, axis: 1)
     }
 
-    static func prepare(grid: Wan2GridSize, frequencies: MLXArray, dtype: DType) -> Cache {
+    static func prepare(
+        grid: Wan2GridSize,
+        frequencies: MLXArray,
+        dtype: DType,
+        temporalFrameIndices: [Int]? = nil
+    ) -> Cache {
         let halfDimension = frequencies.dim(1)
         let temporalDimension = halfDimension - 2 * (halfDimension / 3)
         let heightDimension = halfDimension / 3
         let widthDimension = halfDimension / 3
         let typed = frequencies.asType(.float32)
+        let temporalRows: MLXArray
+        if let temporalFrameIndices {
+            precondition(temporalFrameIndices.count == grid.frames)
+            temporalRows = MLX.take(
+                typed,
+                MLXArray(temporalFrameIndices.map(Int32.init)),
+                axis: 0
+            )[0..., 0..<temporalDimension]
+        } else {
+            temporalRows = typed[0..<grid.frames, 0..<temporalDimension]
+        }
         let temporal = MLX.broadcast(
-            typed[0..<grid.frames, 0..<temporalDimension]
+            temporalRows
                 .reshaped(grid.frames, 1, 1, temporalDimension, 2),
             to: [grid.frames, grid.height, grid.width, temporalDimension, 2]
         )
@@ -326,6 +351,7 @@ final class Wan2TransformerBlock: Module {
     @ModuleInfo(key: "cross_attn") var crossAttention: Wan2CrossAttention
     @ModuleInfo(key: "norm2") var feedForwardNorm: Wan2LayerNorm
     @ModuleInfo(key: "ffn") var feedForward: Wan2FeedForward
+    @ModuleInfo(key: "cam_self_attn") var cameraAttention: Wan2ProjectiveSelfAttention?
     @ModuleInfo(key: "modulation") var modulation: MLXArray
 
     init(configuration: Wan2TransformerConfiguration) {
@@ -351,6 +377,14 @@ final class Wan2TransformerBlock: Module {
             dimensions: dimensions,
             hiddenDimensions: configuration.feedForwardSize
         )
+        self._cameraAttention.wrappedValue = configuration.projectiveCameraConditioning
+            ? Wan2ProjectiveSelfAttention(
+                dimensions: dimensions,
+                attentionDimensions: dimensions / configuration.projectiveCameraAttentionCompression,
+                heads: configuration.headCount,
+                epsilon: configuration.epsilon
+            )
+            : nil
         self._modulation.wrappedValue = MLX.zeros([1, 6, dimensions], dtype: .float32)
     }
 
@@ -361,19 +395,27 @@ final class Wan2TransformerBlock: Module {
         grid: Wan2GridSize,
         rope: Wan2RoPE.Cache,
         selfMask: MLXArray?,
-        crossCache: Wan2AttentionKVCache?
+        crossCache: Wan2AttentionKVCache?,
+        cameraConditioning: Wan2ProjectiveCameraConditioning?
     ) -> MLXArray {
         let parts = MLX.split(modulation.expandedDimensions(axis: 1) + modulationInput, parts: 6, axis: 2)
             .map { $0.squeezed(axis: 2) }
         var hidden = input
         let hiddenType = hidden.dtype
         let selfInput = selfNorm(hidden.asType(.float32)) * (1 + parts[1]) + parts[0]
-        let selfOutput = selfAttention(
+        var selfOutput = selfAttention(
             selfInput.asType(hiddenType),
             grid: grid,
             rope: rope,
             mask: selfMask
         )
+        if let cameraAttention, let cameraConditioning {
+            precondition(cameraConditioning.frameCount == grid.frames)
+            selfOutput = selfOutput + cameraAttention(
+                selfInput.asType(hiddenType),
+                conditioning: cameraConditioning
+            )
+        }
         hidden = (hidden.asType(.float32) + selfOutput * parts[2]).asType(hiddenType)
 
         let crossInput = crossNorm(hidden.asType(.float32)).asType(hiddenType)
@@ -505,7 +547,10 @@ public final class Wan2TransformerModel: Module {
         latents: [MLXArray],
         timesteps: MLXArray,
         embeddedContext: MLXArray,
-        crossCaches: [Wan2AttentionKVCache]? = nil
+        crossCaches: [Wan2AttentionKVCache]? = nil,
+        cameraConditioning: Wan2ProjectiveCameraConditioning? = nil,
+        causalState: Wan2CausalTransformerState? = nil,
+        currentStartToken: Int = 0
     ) -> [MLXArray] {
         precondition(!latents.isEmpty)
         let patchified = latents.map(patchify)
@@ -528,16 +573,34 @@ public final class Wan2TransformerModel: Module {
                 to: [hidden.dim(0), embeddedContext.dim(1), embeddedContext.dim(2)]
             )
         let rope = Wan2RoPE.prepare(grid: grid, frequencies: ropeFrequencies, dtype: patchProjection.weight.dtype)
+        if let causalState {
+            precondition(causalState.blocks.count == blocks.count)
+        }
         for (index, block) in blocks.enumerated() {
-            hidden = block(
-                hidden,
-                modulationInput: modulation,
-                context: context,
-                grid: grid,
-                rope: rope,
-                selfMask: nil,
-                crossCache: crossCaches?[index]
-            )
+            if let causalState {
+                hidden = block.callCausal(
+                    hidden,
+                    modulationInput: modulation,
+                    context: context,
+                    grid: grid,
+                    frequencies: ropeFrequencies,
+                    crossCache: crossCaches?[index],
+                    cameraConditioning: cameraConditioning,
+                    state: causalState.blocks[index],
+                    currentStartToken: currentStartToken
+                )
+            } else {
+                hidden = block(
+                    hidden,
+                    modulationInput: modulation,
+                    context: context,
+                    grid: grid,
+                    rope: rope,
+                    selfMask: nil,
+                    crossCache: crossCaches?[index],
+                    cameraConditioning: cameraConditioning
+                )
+            }
         }
         let projected = outputHead(hidden, timestepEmbedding: timestepEmbedding)
         return unpatchify(projected, grid: grid)

--- a/Sources/MereRunCore/Wan2/Wan2WorldSession.swift
+++ b/Sources/MereRunCore/Wan2/Wan2WorldSession.swift
@@ -72,6 +72,7 @@ public struct Wan2WorldCameraControl: Codable, Hashable, Sendable {
 
 public enum Wan2WorldConditioningMode: String, Codable, Hashable, Sendable {
     case textAndFirstFrame
+    case projectiveCameraLatents
     case causalCameraLatents
 }
 
@@ -176,6 +177,7 @@ public actor Wan2WorldSession {
     public let stateDirectory: URL
 
     private let generator: Wan2TI2VGenerator
+    private let causalGenerator: Wan2CausalWorldGenerator?
     private var phase: Wan2WorldSessionPhase = .cold
     private var transitionCount = 0
     private var currentStateID: UUID?
@@ -184,18 +186,34 @@ public actor Wan2WorldSession {
     public init(
         resources: Wan2Resources,
         stateDirectory: URL,
+        cameraWeightsURL: URL? = nil,
+        causalWeightsURL: URL? = nil,
         sessionID: UUID = UUID()
     ) {
+        precondition(cameraWeightsURL == nil || causalWeightsURL == nil)
         self.resources = resources
         self.stateDirectory = stateDirectory.standardizedFileURL
         self.sessionID = sessionID
-        self.generator = Wan2TI2VGenerator()
+        self.generator = Wan2TI2VGenerator(cameraWeightsURL: cameraWeightsURL)
+        self.causalGenerator = causalWeightsURL.map(Wan2CausalWorldGenerator.init(weightsURL:))
+    }
+
+    private var conditioningMode: Wan2WorldConditioningMode {
+        causalGenerator == nil ? generator.conditioningMode : .causalCameraLatents
+    }
+
+    private var isWarm: Bool {
+        causalGenerator?.isWarm ?? generator.isWarm
     }
 
     public func prepare(progress: (@Sendable (String) -> Void)? = nil) throws {
         guard phase != .generating else { throw Wan2WorldSessionError.busy }
         try FileManager.default.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
-        try generator.prepare(resources: resources, progress: progress)
+        if let causalGenerator {
+            try causalGenerator.prepare(resources: resources, progress: progress)
+        } else {
+            try generator.prepare(resources: resources, progress: progress)
+        }
         phase = .ready
     }
 
@@ -217,31 +235,57 @@ public actor Wan2WorldSession {
             at: outputURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        let effectivePrompt = request.prompt + "\n\nCamera behavior: " + request.camera.promptClause
-        let options = try Wan2GenerationOptions(
-            prompt: effectivePrompt,
-            negativePrompt: request.negativePrompt,
-            sourceImageURL: sourceImageURL,
-            outputURL: outputURL,
-            width: request.width,
-            height: request.height,
-            numFrames: request.numFrames,
-            steps: request.steps,
-            guidanceScale: request.guidanceScale,
-            shift: request.shift,
-            seed: request.seed,
-            fps: request.fps
-        )
-
+        let usesProjectiveCamera = conditioningMode == .projectiveCameraLatents
+        let effectivePrompt = usesProjectiveCamera
+            ? request.prompt
+            : request.prompt + "\n\nCamera behavior: " + request.camera.promptClause
+        let cameraConditioning = usesProjectiveCamera
+            ? Wan2DreamXCameraTrajectory.compile(
+                control: request.camera,
+                pixelFrameCount: request.numFrames
+            )
+            : nil
         phase = .generating
         do {
-            let result = try await generator.generate(
-                options: options,
-                resources: resources,
-                useChainedSourceLatent: !usesExplicitSource,
-                captureTerminalFrameLatent: true,
-                progressHandler: progressHandler
-            )
+            let result: Wan2VideoGenerationResult
+            if let causalGenerator {
+                if usesExplicitSource, transitionCount > 0 {
+                    causalGenerator.reset()
+                }
+                result = try await causalGenerator.generateBlock(
+                    prompt: request.prompt,
+                    camera: request.camera,
+                    sourceImageURL: causalGenerator.latentFrameCount == 0 ? sourceImageURL : nil,
+                    resources: resources,
+                    width: request.width,
+                    height: request.height,
+                    seed: request.seed,
+                    progressHandler: progressHandler
+                )
+            } else {
+                let options = try Wan2GenerationOptions(
+                    prompt: effectivePrompt,
+                    negativePrompt: request.negativePrompt,
+                    sourceImageURL: sourceImageURL,
+                    outputURL: outputURL,
+                    width: request.width,
+                    height: request.height,
+                    numFrames: request.numFrames,
+                    steps: request.steps,
+                    guidanceScale: request.guidanceScale,
+                    shift: request.shift,
+                    seed: request.seed,
+                    fps: request.fps,
+                    cameraConditioning: cameraConditioning
+                )
+                result = try await generator.generate(
+                    options: options,
+                    resources: resources,
+                    useChainedSourceLatent: !usesExplicitSource,
+                    captureTerminalFrameLatent: true,
+                    progressHandler: progressHandler
+                )
+            }
             guard result.terminalFrameLatent != nil else {
                 throw Wan2WorldSessionError.terminalLatentMissing
             }
@@ -272,11 +316,11 @@ public actor Wan2WorldSession {
                 outputURL: outputURL,
                 terminalFrameURL: terminalFrameURL,
                 camera: request.camera,
-                conditioningMode: .textAndFirstFrame,
+                conditioningMode: conditioningMode,
                 seed: result.seed
             )
         } catch {
-            phase = generator.isWarm ? .ready : .cold
+            phase = isWarm ? .ready : .cold
             throw error
         }
     }
@@ -284,15 +328,23 @@ public actor Wan2WorldSession {
     public func reset(sourceImageURL: URL? = nil) throws {
         guard phase != .generating else { throw Wan2WorldSessionError.busy }
         currentFrameURL = sourceImageURL
-        generator.clearChain()
+        if let causalGenerator {
+            causalGenerator.reset()
+        } else {
+            generator.clearChain()
+        }
         currentStateID = sourceImageURL == nil ? nil : UUID()
         transitionCount = 0
-        phase = generator.isWarm ? .ready : .cold
+        phase = isWarm ? .ready : .cold
     }
 
     public func unload() throws {
         guard phase != .generating else { throw Wan2WorldSessionError.busy }
-        generator.unload()
+        if let causalGenerator {
+            causalGenerator.unload()
+        } else {
+            generator.unload()
+        }
         phase = .cold
     }
 
@@ -303,9 +355,10 @@ public actor Wan2WorldSession {
             transitionCount: transitionCount,
             currentStateID: currentStateID,
             currentFrameURL: currentFrameURL,
-            conditioningMode: .textAndFirstFrame,
-            keepsModelsWarm: generator.isWarm,
-            keepsTerminalLatent: generator.hasChainedTerminalFrameLatent
+            conditioningMode: conditioningMode,
+            keepsModelsWarm: isWarm,
+            keepsTerminalLatent: causalGenerator.map { $0.latentFrameCount > 0 }
+                ?? generator.hasChainedTerminalFrameLatent
         )
     }
 }

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -70,6 +70,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "music",
             "sfx",
             "video",
+            "world",
             "run",
             "model",
             "status",

--- a/Tests/MereRunCLITests/WorldCommandTests.swift
+++ b/Tests/MereRunCLITests/WorldCommandTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class WorldCommandTests: XCTestCase {
+    func testWorldCommandExposesServe() {
+        XCTAssertEqual(World.configuration.subcommands.map { $0.configuration.commandName }, ["serve"])
+    }
+
+    func testWorldServeParsesPersistentRuntimeOptions() throws {
+        let command = try WorldServe.parse([
+            "--host", "127.0.0.1",
+            "--port", "9911",
+            "--base-model", "/tmp/wan",
+            "--model", "/tmp/dreamx",
+            "--state-directory", "/tmp/world",
+            "--prepare",
+        ])
+        XCTAssertEqual(command.port, 9_911)
+        XCTAssertEqual(command.baseModel, "/tmp/wan")
+        XCTAssertEqual(command.model, "/tmp/dreamx")
+        XCTAssertEqual(command.stateDirectory, "/tmp/world")
+        XCTAssertTrue(command.prepare)
+    }
+
+    func testWorldServeDefaultsToNativeManagedModels() throws {
+        let command = try WorldServe.parse([])
+        XCTAssertEqual(command.baseModel, Wan2Resources.modelID)
+        XCTAssertEqual(command.model, Wan2DreamXCausalResources.modelID)
+        XCTAssertEqual(command.port, 8_791)
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2CameraConditioningTests.swift
+++ b/Tests/MereRunCoreTests/Wan2CameraConditioningTests.swift
@@ -1,0 +1,221 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2CameraConditioningTests: MereRunCoreTestCase {
+    func testDreamXLatentFrameAlignmentMatchesOnePlusFourKContract() {
+        XCTAssertEqual(Wan2DreamXCameraTrajectory.latentFrameIndices(pixelFrameCount: 1), [0])
+        XCTAssertEqual(Wan2DreamXCameraTrajectory.latentFrameIndices(pixelFrameCount: 17), [0, 4, 8, 12, 16])
+        XCTAssertEqual(Wan2DreamXCameraTrajectory.latentFrameIndices(pixelFrameCount: 81).count, 21)
+        XCTAssertEqual(Wan2DreamXCameraTrajectory.latentFrameIndices(pixelFrameCount: 81).last, 80)
+    }
+
+    func testYawLeftProducesProjectiveViewRotationWithoutTranslation() {
+        let conditioning = Wan2DreamXCameraTrajectory.compile(
+            segments: [Wan2DreamXTrajectorySegment(action: "j", speed: 1.5)],
+            pixelFrameCount: 17
+        )
+        XCTAssertEqual(conditioning.frameCount, 5)
+        XCTAssertEqual(conditioning.viewMatrices.count, 80)
+        let first = Array(conditioning.viewMatrices[0..<16])
+        XCTAssertEqual(first, [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1
+        ])
+        let last = Array(conditioning.viewMatrices[64..<80])
+        XCTAssertEqual(last[3], 0, accuracy: 1e-6)
+        XCTAssertEqual(last[7], 0, accuracy: 1e-6)
+        XCTAssertEqual(last[11], 0, accuracy: 1e-6)
+        XCTAssertGreaterThan(last[2], 0)
+        XCTAssertLessThan(last[8], 0)
+    }
+
+    func testForwardTrajectoryUsesRelativeFirstFrameAndPositiveCameraDepth() {
+        let conditioning = Wan2DreamXCameraTrajectory.compile(
+            segments: [Wan2DreamXTrajectorySegment(action: "w", speed: 1.5)],
+            pixelFrameCount: 17
+        )
+        let first = Array(conditioning.viewMatrices[0..<16])
+        let last = Array(conditioning.viewMatrices[64..<80])
+        XCTAssertEqual(first[11], 0, accuracy: 1e-6)
+        XCTAssertLessThan(last[11], 0)
+        XCTAssertEqual(last[11], -1.5 * 16 / 17, accuracy: 1e-5)
+    }
+
+    func testProjectiveTransformsRoundTripIdentityCameraFeatures() {
+        let conditioning = Wan2DreamXCameraTrajectory.compile(
+            segments: [Wan2DreamXTrajectorySegment(action: " ")],
+            pixelFrameCount: 5
+        )
+        let transforms = Wan2ProjectivePositionEncoding.prepare(
+            conditioning: conditioning,
+            batchSize: 1,
+            dtype: .float32
+        )
+        let features = MLXArray((0..<32).map(Float.init), [1, 1, 4, 8])
+        let encoded = Wan2ProjectivePositionEncoding.apply(
+            features,
+            matrices: transforms.keyValue,
+            cameraFrames: conditioning.frameCount
+        )
+        let decoded = Wan2ProjectivePositionEncoding.apply(
+            encoded,
+            matrices: transforms.output,
+            cameraFrames: conditioning.frameCount
+        )
+        eval(decoded)
+        for (actual, expected) in zip(decoded.asArray(Float.self), features.asArray(Float.self)) {
+            XCTAssertEqual(actual, expected, accuracy: 1e-5)
+        }
+    }
+
+    func testTinyTransformerAcceptsDreamXProjectiveConditioning() {
+        let configuration = Wan2TransformerConfiguration(
+            patchSize: [1, 2, 2],
+            textLength: 4,
+            inputChannels: 4,
+            hiddenSize: 16,
+            feedForwardSize: 32,
+            timestepFrequencySize: 8,
+            textEmbeddingSize: 6,
+            outputChannels: 4,
+            headCount: 2,
+            layerCount: 2,
+            projectiveCameraConditioning: true
+        )
+        let model = Wan2TransformerModel(configuration: configuration)
+        let context = model.embedText(MLX.zeros([1, 4, 6]))
+        let conditioning = Wan2DreamXCameraTrajectory.compile(
+            segments: [Wan2DreamXTrajectorySegment(action: "j")],
+            pixelFrameCount: 5
+        )
+        let output = model(
+            latents: [MLX.zeros([4, 2, 4, 4])],
+            timesteps: MLX.ones([1, 8]) * 500,
+            embeddedContext: context,
+            cameraConditioning: conditioning
+        )
+        eval(output)
+        XCTAssertEqual(output[0].shape, [4, 2, 4, 4])
+        XCTAssertTrue(output[0].asArray(Float.self).allSatisfy(\.isFinite))
+    }
+
+    func testCameraTransformerUsesReleasedDreamXParameterNames() {
+        let configuration = Wan2TransformerConfiguration(
+            inputChannels: 4,
+            hiddenSize: 16,
+            feedForwardSize: 32,
+            timestepFrequencySize: 8,
+            textEmbeddingSize: 6,
+            outputChannels: 4,
+            headCount: 2,
+            layerCount: 3,
+            projectiveCameraConditioning: true
+        )
+        let names = Wan2TransformerModel(configuration: configuration)
+            .parameters()
+            .flattened()
+            .map(\.0)
+            .filter { $0.contains(".cam_self_attn.") }
+        XCTAssertEqual(names.count, 30)
+        XCTAssertTrue(names.contains("blocks.0.cam_self_attn.q_proj.weight"))
+        XCTAssertTrue(names.contains("blocks.2.cam_self_attn.out_proj.bias"))
+        XCTAssertTrue(names.contains("blocks.1.cam_self_attn.norm_k.weight"))
+    }
+
+    func testCausalCameraTransformerUsesReleasedCompressedShapes() {
+        let configuration = Wan2TransformerConfiguration(
+            hiddenSize: 3_072,
+            feedForwardSize: 14_336,
+            headCount: 24,
+            layerCount: 1,
+            projectiveCameraConditioning: true,
+            projectiveCameraAttentionCompression: 4
+        )
+        let parameters = Dictionary(uniqueKeysWithValues: Wan2TransformerModel(configuration: configuration)
+            .parameters()
+            .flattened())
+        XCTAssertEqual(parameters["blocks.0.cam_self_attn.q_proj.weight"]?.shape, [768, 3_072])
+        XCTAssertEqual(parameters["blocks.0.cam_self_attn.out_proj.weight"]?.shape, [3_072, 768])
+        XCTAssertEqual(parameters["blocks.0.cam_self_attn.norm_q.weight"]?.shape, [768])
+    }
+
+    func testCausalTransformerStateAppendsRecomputesAndRolls() {
+        let configuration = Wan2TransformerConfiguration(
+            patchSize: [1, 2, 2],
+            textLength: 4,
+            inputChannels: 4,
+            hiddenSize: 16,
+            feedForwardSize: 32,
+            timestepFrequencySize: 8,
+            textEmbeddingSize: 6,
+            outputChannels: 4,
+            headCount: 2,
+            layerCount: 2,
+            projectiveCameraConditioning: true
+        )
+        let model = Wan2TransformerModel(configuration: configuration)
+        let state = Wan2CausalTransformerState(
+            layerCount: 2,
+            localAttentionFrames: 4,
+            sinkFrames: 1,
+            cachesProjectiveAttention: true
+        )
+        let context = model.embedText(MLX.zeros([1, 4, 6]))
+        let conditioning = Wan2DreamXCameraTrajectory.compile(
+            segments: [Wan2DreamXTrajectorySegment(action: "j")],
+            pixelFrameCount: 5
+        )
+        let latent = MLX.zeros([4, 2, 4, 4])
+        let timesteps = MLX.ones([1, 8]) * 500
+
+        let first = model(
+            latents: [latent],
+            timesteps: timesteps,
+            embeddedContext: context,
+            cameraConditioning: conditioning,
+            causalState: state,
+            currentStartToken: 0
+        )[0]
+        eval(first)
+        XCTAssertEqual(state.snapshot(spatialTokensPerFrame: 4).globalFrames, 2)
+
+        let second = model(
+            latents: [latent],
+            timesteps: timesteps,
+            embeddedContext: context,
+            cameraConditioning: conditioning,
+            causalState: state,
+            currentStartToken: 8
+        )[0]
+        eval(second)
+        XCTAssertEqual(state.snapshot(spatialTokensPerFrame: 4).globalFrames, 4)
+
+        let recomputed = model(
+            latents: [latent],
+            timesteps: timesteps,
+            embeddedContext: context,
+            cameraConditioning: conditioning,
+            causalState: state,
+            currentStartToken: 8
+        )[0]
+        eval(recomputed)
+        XCTAssertEqual(state.snapshot(spatialTokensPerFrame: 4).globalFrames, 4)
+
+        let rolled = model(
+            latents: [latent],
+            timesteps: timesteps,
+            embeddedContext: context,
+            cameraConditioning: conditioning,
+            causalState: state,
+            currentStartToken: 16
+        )[0]
+        eval(rolled)
+        let snapshot = state.snapshot(spatialTokensPerFrame: 4)
+        XCTAssertEqual(snapshot.globalFrames, 6)
+        XCTAssertEqual(snapshot.cachedFrames, 4)
+        XCTAssertTrue(rolled.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2DreamXCameraParityTests.swift
+++ b/Tests/MereRunCoreTests/Wan2DreamXCameraParityTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2DreamXCameraParityTests: MereRunCoreTestCase {
+    func testARTrajectoryMatchesDreamXChunkRelativeFixture() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_DREAMX_AR_CAMERA_FIXTURE"] else {
+            throw XCTSkip("Set MERERUN_DREAMX_AR_CAMERA_FIXTURE to a DreamX AR camera fixture JSON file.")
+        }
+        let fixture = try JSONDecoder().decode(
+            DreamXARCameraFixture.self,
+            from: Data(contentsOf: URL(fileURLWithPath: path))
+        )
+        let compiled = Wan2DreamXARTrajectory.compile(
+            segments: fixture.trajectory.segments.map {
+                Wan2DreamXARTrajectorySegment(action: $0.action, weight: $0.value)
+            },
+            pixelFrameCount: fixture.trajectory.pixelFrameCount,
+            speed: fixture.trajectory.speed,
+            chunkRelative: fixture.trajectory.chunkRelative
+        )
+        assertClose(compiled.viewMatrices, fixture.viewMatrices.values, tolerance: 3e-5)
+        assertClose(compiled.intrinsics, fixture.intrinsics.values, tolerance: 1e-6)
+    }
+
+    func testTrajectoryAndProjectiveTransformsMatchDreamX() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_DREAMX_CAMERA_FIXTURE"] else {
+            throw XCTSkip("Set MERERUN_DREAMX_CAMERA_FIXTURE to a DreamX camera fixture JSON file.")
+        }
+        let fixture = try JSONDecoder().decode(
+            DreamXCameraFixture.self,
+            from: Data(contentsOf: URL(fileURLWithPath: path))
+        )
+        let compiled = Wan2DreamXCameraTrajectory.compile(
+            segments: fixture.trajectory.segments.map {
+                Wan2DreamXTrajectorySegment(action: $0.action, speed: $0.speed)
+            },
+            pixelFrameCount: fixture.trajectory.pixelFrameCount
+        )
+        assertClose(compiled.viewMatrices, fixture.viewMatrices.values, tolerance: 2e-5)
+        assertClose(compiled.intrinsics, fixture.intrinsics.values, tolerance: 1e-6)
+
+        let conditioning = Wan2ProjectiveCameraConditioning(
+            frameCount: fixture.viewMatrices.shape[1],
+            viewMatrices: fixture.viewMatrices.values,
+            intrinsics: fixture.intrinsics.values
+        )
+        let transforms = Wan2ProjectivePositionEncoding.prepare(
+            conditioning: conditioning,
+            batchSize: 1,
+            dtype: .float32
+        )
+        try assertTransform(
+            input: fixture.queryInput,
+            expected: fixture.queryOutput,
+            matrices: transforms.query,
+            frameCount: conditioning.frameCount
+        )
+        try assertTransform(
+            input: fixture.keyInput,
+            expected: fixture.keyOutput,
+            matrices: transforms.keyValue,
+            frameCount: conditioning.frameCount
+        )
+        try assertTransform(
+            input: fixture.valueInput,
+            expected: fixture.valueOutput,
+            matrices: transforms.keyValue,
+            frameCount: conditioning.frameCount
+        )
+        try assertTransform(
+            input: fixture.outputInput,
+            expected: fixture.outputOutput,
+            matrices: transforms.output,
+            frameCount: conditioning.frameCount
+        )
+    }
+
+    private func assertTransform(
+        input: TensorFixture,
+        expected: TensorFixture,
+        matrices: MLXArray,
+        frameCount: Int
+    ) throws {
+        let source = MLXArray(input.values, input.shape)
+        let result = Wan2ProjectivePositionEncoding.apply(
+            source,
+            matrices: matrices,
+            cameraFrames: frameCount
+        )
+        eval(result)
+        XCTAssertEqual(result.shape, expected.shape)
+        assertClose(result.asArray(Float.self), expected.values, tolerance: 2e-5)
+    }
+
+    private func assertClose(_ actual: [Float], _ expected: [Float], tolerance: Float) {
+        XCTAssertEqual(actual.count, expected.count)
+        for (index, pair) in zip(actual, expected).enumerated() {
+            XCTAssertEqual(pair.0, pair.1, accuracy: tolerance, "Mismatch at index \(index)")
+        }
+    }
+}
+
+private struct DreamXARCameraFixture: Decodable {
+    let trajectory: ARTrajectoryFixture
+    let viewMatrices: TensorFixture
+    let intrinsics: TensorFixture
+
+    enum CodingKeys: String, CodingKey {
+        case trajectory
+        case viewMatrices = "view_matrices"
+        case intrinsics
+    }
+}
+
+private struct ARTrajectoryFixture: Decodable {
+    let segments: [ARTrajectorySegmentFixture]
+    let pixelFrameCount: Int
+    let speed: Float
+    let chunkRelative: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case segments
+        case pixelFrameCount = "pixel_frame_count"
+        case speed
+        case chunkRelative = "chunk_relative"
+    }
+}
+
+private struct ARTrajectorySegmentFixture: Decodable {
+    let action: String
+    let value: Float
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        action = try container.decode(String.self)
+        value = try container.decode(Float.self)
+    }
+}
+
+private struct DreamXCameraFixture: Decodable {
+    let trajectory: TrajectoryFixture
+    let viewMatrices: TensorFixture
+    let intrinsics: TensorFixture
+    let queryInput: TensorFixture
+    let queryOutput: TensorFixture
+    let keyInput: TensorFixture
+    let keyOutput: TensorFixture
+    let valueInput: TensorFixture
+    let valueOutput: TensorFixture
+    let outputInput: TensorFixture
+    let outputOutput: TensorFixture
+
+    enum CodingKeys: String, CodingKey {
+        case trajectory
+        case viewMatrices = "view_matrices"
+        case intrinsics
+        case queryInput = "query_input"
+        case queryOutput = "query_output"
+        case keyInput = "key_input"
+        case keyOutput = "key_output"
+        case valueInput = "value_input"
+        case valueOutput = "value_output"
+        case outputInput = "output_input"
+        case outputOutput = "output_output"
+    }
+}
+
+private struct TrajectoryFixture: Decodable {
+    let segments: [TrajectorySegmentFixture]
+    let pixelFrameCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case segments
+        case pixelFrameCount = "pixel_frame_count"
+    }
+}
+
+private struct TrajectorySegmentFixture: Decodable {
+    let action: String
+    let speed: Float
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        action = try container.decode(String.self)
+        speed = try container.decode(Float.self)
+    }
+}
+
+private struct TensorFixture: Decodable {
+    let shape: [Int]
+    let values: [Float]
+}

--- a/Tests/MereRunCoreTests/Wan2DreamXCameraWeightsTests.swift
+++ b/Tests/MereRunCoreTests/Wan2DreamXCameraWeightsTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Wan2DreamXCameraWeightsTests: MereRunCoreTestCase {
+    func testConvertedCausalCheckpointMatchesReleasedInventory() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_DREAMX_CAUSAL_WEIGHTS"] else {
+            throw XCTSkip("Set MERERUN_DREAMX_CAUSAL_WEIGHTS to the converted causal checkpoint.")
+        }
+        let url = URL(fileURLWithPath: path)
+        let metadata = try SafetensorsStreamingLoader.metadata(url: url)
+        XCTAssertEqual(metadata.count, 1_125)
+        XCTAssertEqual(metadata["blocks.0.cam_self_attn.q_proj.weight"]?.shape, [768, 3_072])
+        XCTAssertEqual(metadata["blocks.29.cam_self_attn.out_proj.weight"]?.shape, [3_072, 768])
+        XCTAssertEqual(metadata["patch_embedding_proj.weight"]?.shape, [3_072, 192])
+        let model = try Wan2ModelLoader.loadDreamXCausalTransformer(weightsURL: url)
+        let parameterKeys = Set(model.parameters().flattened().map(\.0))
+            .subtracting(["inverseTimestepFrequencies", "ropeFrequencies"])
+        XCTAssertEqual(parameterKeys, Set(metadata.keys))
+    }
+
+    func testExtractedCameraAdapterMatchesReleasedInventory() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_DREAMX_CAMERA_WEIGHTS"] else {
+            throw XCTSkip("Set MERERUN_DREAMX_CAMERA_WEIGHTS to the extracted camera adapter.")
+        }
+        let metadata = try SafetensorsStreamingLoader.metadata(url: URL(fileURLWithPath: path))
+        XCTAssertEqual(metadata.count, 300)
+        XCTAssertTrue(metadata.keys.allSatisfy { $0.contains(".cam_self_attn.") })
+        for block in 0..<30 {
+            let prefix = "blocks.\(block).cam_self_attn."
+            XCTAssertEqual(metadata.keys.filter { $0.hasPrefix(prefix) }.count, 10)
+            XCTAssertEqual(metadata[prefix + "q_proj.weight"]?.shape, [3_072, 3_072])
+            XCTAssertEqual(metadata[prefix + "out_proj.bias"]?.shape, [3_072])
+            XCTAssertEqual(metadata[prefix + "norm_q.weight"]?.shape, [3_072])
+        }
+    }
+
+    func testRealBlockCameraAttentionMatchesDreamXFixture() throws {
+        guard let weightsPath = ProcessInfo.processInfo.environment["MERERUN_DREAMX_CAMERA_WEIGHTS"],
+              let fixturePath = ProcessInfo.processInfo.environment["MERERUN_DREAMX_CAMERA_BLOCK_FIXTURE"] else {
+            throw XCTSkip("Set DreamX camera weights and block fixture environment variables.")
+        }
+        let weightsURL = URL(fileURLWithPath: weightsPath)
+        let fixture = try SafetensorsStreamingLoader.loadArrays(url: URL(fileURLWithPath: fixturePath))
+        let attention = Wan2ProjectiveSelfAttention(dimensions: 3_072, heads: 24, epsilon: 1e-6)
+        let prefix = "blocks.0.cam_self_attn."
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: weightsURL,
+            to: attention,
+            dtype: .float32,
+            verify: .noUnusedKeys,
+            include: { $0.hasPrefix(prefix) },
+            mapper: { key, value in [(String(key.dropFirst(prefix.count)), value)] },
+            batchSize: 10
+        )
+        guard let input = fixture["input"],
+              let views = fixture["view_matrices"],
+              let intrinsics = fixture["intrinsics"],
+              let expected = fixture["output"] else {
+            XCTFail("DreamX camera block fixture is incomplete.")
+            return
+        }
+        let conditioning = Wan2ProjectiveCameraConditioning(
+            frameCount: views.dim(1),
+            viewMatrices: views.asArray(Float.self),
+            intrinsics: intrinsics.asArray(Float.self)
+        )
+        let actual = attention(input, conditioning: conditioning).asType(.float32)
+        eval(actual)
+        XCTAssertEqual(actual.shape, expected.shape)
+        let actualValues = actual.asArray(Float.self)
+        let expectedValues = expected.asArray(Float.self)
+        let dot = zip(actualValues, expectedValues).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+        let actualNorm = sqrt(actualValues.reduce(Float(0)) { $0 + $1 * $1 })
+        let expectedNorm = sqrt(expectedValues.reduce(Float(0)) { $0 + $1 * $1 })
+        let meanAbsoluteError = zip(actualValues, expectedValues)
+            .reduce(Float(0)) { $0 + abs($1.0 - $1.1) } / Float(actualValues.count)
+        XCTAssertGreaterThan(dot / (actualNorm * expectedNorm), 0.9999)
+        XCTAssertLessThan(meanAbsoluteError, 2e-4)
+    }
+
+    func testFullReleasedTransformerMatchesDreamXFixture() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let weightsPath = environment["MERERUN_DREAMX_CAMERA_WEIGHTS"],
+              let fixturePath = environment["MERERUN_DREAMX_CAMERA_TRANSFORMER_FIXTURE"] else {
+            throw XCTSkip("Set the Wan2 model, DreamX camera weights, and full transformer fixture variables.")
+        }
+        let fixture = try SafetensorsStreamingLoader.loadArrays(
+            url: URL(fileURLWithPath: fixturePath)
+        )
+        guard let input = fixture["input"],
+              let timesteps = fixture["timesteps"],
+              let context = fixture["context"],
+              let views = fixture["view_matrices"],
+              let intrinsics = fixture["intrinsics"],
+              let expected = fixture["output"] else {
+            XCTFail("DreamX full transformer fixture is incomplete.")
+            return
+        }
+        let model = try Wan2ModelLoader.loadDreamXCameraTransformer(
+            resources: Wan2Resources(rootURL: URL(fileURLWithPath: root)),
+            cameraWeightsURL: URL(fileURLWithPath: weightsPath)
+        )
+        let conditioning = Wan2ProjectiveCameraConditioning(
+            frameCount: views.dim(1),
+            viewMatrices: views.asArray(Float.self),
+            intrinsics: intrinsics.asArray(Float.self)
+        )
+        let embeddedContext = model.embedText(context.expandedDimensions(axis: 0))
+        let actual = model(
+            latents: [input],
+            timesteps: timesteps,
+            embeddedContext: embeddedContext,
+            cameraConditioning: conditioning
+        )[0].asType(.float32)
+        eval(actual)
+        XCTAssertEqual(actual.shape, expected.shape)
+        let actualValues = actual.asArray(Float.self)
+        let expectedValues = expected.asArray(Float.self)
+        let dot = zip(actualValues, expectedValues).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+        let actualNorm = sqrt(actualValues.reduce(Float(0)) { $0 + $1 * $1 })
+        let expectedNorm = sqrt(expectedValues.reduce(Float(0)) { $0 + $1 * $1 })
+        let meanAbsoluteError = zip(actualValues, expectedValues)
+            .reduce(Float(0)) { $0 + abs($1.0 - $1.1) } / Float(actualValues.count)
+        let cosineSimilarity = dot / (actualNorm * expectedNorm)
+        XCTAssertGreaterThan(cosineSimilarity, 0.9995)
+        XCTAssertLessThan(meanAbsoluteError, 0.02)
+    }
+
+    func testFullReleasedCausalTransformerMatchesDreamXFixture() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let weightsPath = environment["MERERUN_DREAMX_CAUSAL_WEIGHTS"],
+              let fixturePath = environment["MERERUN_DREAMX_CAUSAL_TRANSFORMER_FIXTURE"] else {
+            throw XCTSkip("Set the DreamX causal weights and transformer fixture variables.")
+        }
+        let fixture = try SafetensorsStreamingLoader.loadArrays(
+            url: URL(fileURLWithPath: fixturePath)
+        )
+        guard let input = fixture["input"],
+              let timesteps = fixture["timesteps"],
+              let context = fixture["context"],
+              let views = fixture["view_matrices"],
+              let intrinsics = fixture["intrinsics"],
+              let expected = fixture["output"],
+              let recomputeInput = fixture["recompute_input"],
+              let recomputeTimesteps = fixture["recompute_timesteps"],
+              let recomputeExpected = fixture["recompute_output"],
+              let secondInput = fixture["second_input"],
+              let secondTimesteps = fixture["second_timesteps"],
+              let secondViews = fixture["second_view_matrices"],
+              let secondExpected = fixture["second_output"] else {
+            XCTFail("DreamX causal transformer fixture is incomplete.")
+            return
+        }
+        let model = try Wan2ModelLoader.loadDreamXCausalTransformer(
+            weightsURL: URL(fileURLWithPath: weightsPath)
+        )
+        let conditioning = Wan2ProjectiveCameraConditioning(
+            frameCount: views.dim(1),
+            viewMatrices: views.asArray(Float.self),
+            intrinsics: intrinsics.asArray(Float.self)
+        )
+        let state = Wan2CausalTransformerState(
+            layerCount: 30,
+            localAttentionFrames: 12,
+            sinkFrames: 3
+        )
+        let embeddedContext = model.embedText(context.expandedDimensions(axis: 0))
+        let crossCaches = model.prepareCrossAttentionCaches(context: embeddedContext)
+        let actual = model(
+            latents: [input],
+            timesteps: timesteps,
+            embeddedContext: embeddedContext,
+            crossCaches: crossCaches,
+            cameraConditioning: conditioning,
+            causalState: state,
+            currentStartToken: 0
+        )[0].asType(.float32)
+        eval(actual)
+        assertParity(actual: actual, expected: expected, label: "initial block")
+
+        let recomputeActual = model(
+            latents: [recomputeInput],
+            timesteps: recomputeTimesteps,
+            embeddedContext: embeddedContext,
+            crossCaches: crossCaches,
+            cameraConditioning: conditioning,
+            causalState: state,
+            currentStartToken: 0
+        )[0].asType(.float32)
+        eval(recomputeActual)
+        assertParity(actual: recomputeActual, expected: recomputeExpected, label: "recomputed block")
+
+        let secondConditioning = Wan2ProjectiveCameraConditioning(
+            frameCount: secondViews.dim(1),
+            viewMatrices: secondViews.asArray(Float.self),
+            intrinsics: intrinsics.asArray(Float.self)
+        )
+        let secondActual = model(
+            latents: [secondInput],
+            timesteps: secondTimesteps,
+            embeddedContext: embeddedContext,
+            crossCaches: crossCaches,
+            cameraConditioning: secondConditioning,
+            causalState: state,
+            currentStartToken: 6
+        )[0].asType(.float32)
+        eval(secondActual)
+        assertParity(actual: secondActual, expected: secondExpected, label: "appended block")
+        let snapshot = state.snapshot(spatialTokensPerFrame: 2)
+        XCTAssertEqual(snapshot.cachedFrames, 6)
+        XCTAssertEqual(snapshot.globalFrames, 6)
+    }
+
+    private func assertParity(
+        actual: MLXArray,
+        expected: MLXArray,
+        label: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.shape, expected.shape, label, file: file, line: line)
+        let actualValues = actual.asArray(Float.self)
+        let expectedValues = expected.asArray(Float.self)
+        let dot = zip(actualValues, expectedValues).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+        let actualNorm = sqrt(actualValues.reduce(Float(0)) { $0 + $1 * $1 })
+        let expectedNorm = sqrt(expectedValues.reduce(Float(0)) { $0 + $1 * $1 })
+        let meanAbsoluteError = zip(actualValues, expectedValues)
+            .reduce(Float(0)) { $0 + abs($1.0 - $1.1) } / Float(actualValues.count)
+        let cosine = dot / (actualNorm * expectedNorm)
+        print("DreamX causal parity \(label): cosine=\(cosine), mae=\(meanAbsoluteError)")
+        XCTAssertGreaterThan(cosine, 0.995, label, file: file, line: line)
+        XCTAssertLessThan(meanAbsoluteError, 0.05, label, file: file, line: line)
+    }
+}

--- a/Tests/MereRunCoreTests/Wan2GenerationTests.swift
+++ b/Tests/MereRunCoreTests/Wan2GenerationTests.swift
@@ -3,6 +3,36 @@ import XCTest
 @testable import MereRunCore
 
 final class Wan2GenerationTests: MereRunCoreTestCase {
+    func testCausalDecodeWindowStaysBoundedAfterSecondBlock() {
+        XCTAssertEqual(
+            Wan2CausalDecodePlan.make(previousLatentFrames: 0, currentLatentFrames: 3),
+            Wan2CausalDecodePlan(latentStart: 0, latentCount: 3, transitionStartPixelFrame: 0)
+        )
+        XCTAssertEqual(
+            Wan2CausalDecodePlan.make(previousLatentFrames: 3, currentLatentFrames: 3),
+            Wan2CausalDecodePlan(latentStart: 0, latentCount: 6, transitionStartPixelFrame: 8)
+        )
+        XCTAssertEqual(
+            Wan2CausalDecodePlan.make(previousLatentFrames: 36, currentLatentFrames: 3),
+            Wan2CausalDecodePlan(latentStart: 33, latentCount: 6, transitionStartPixelFrame: 8)
+        )
+    }
+
+    func testDreamXColorStabilizerPullsLaterFramesTowardReferencePalette() {
+        let values: [UInt8] = [
+            90, 110, 130, 100, 120, 140,
+            210, 80, 30, 230, 100, 50,
+        ]
+        let frames = MLXArray(values).reshaped(1, 2, 1, 2, 3)
+        let stabilized = Wan2DreamXColorStabilizer.process(frames, strength: 1)
+        let output = stabilized.asArray(UInt8.self)
+        let originalDistance = zip(values[0..<6], values[6..<12])
+            .reduce(0) { $0 + abs(Int($1.0) - Int($1.1)) }
+        let correctedDistance = zip(output[0..<6], output[6..<12])
+            .reduce(0) { $0 + abs(Int($1.0) - Int($1.1)) }
+        XCTAssertLessThan(correctedDistance, originalDistance)
+    }
+
     func testNativeResolutionAndLatentGeometry() throws {
         let options = try makeOptions()
         XCTAssertEqual(options.latentShape, [48, 11, 44, 80])
@@ -20,8 +50,10 @@ final class Wan2GenerationTests: MereRunCoreTestCase {
         XCTAssertEqual(scheduler.sigmas.count, 5)
         XCTAssertEqual(scheduler.timesteps.count, 4)
         XCTAssertEqual(scheduler.sigmas.last, 0)
-        XCTAssertEqual(scheduler.timesteps.last, 624)
-        XCTAssertEqual(scheduler.sigmas[0], 4.995 / 4.996, accuracy: 1e-6)
+        XCTAssertEqual(scheduler.timesteps[0], 1_000, accuracy: 1e-5)
+        XCTAssertEqual(scheduler.timesteps[1], 909.707_15, accuracy: 1e-4)
+        XCTAssertEqual(scheduler.timesteps.last!, 24.414_066, accuracy: 1e-4)
+        XCTAssertEqual(scheduler.sigmas[0], 1, accuracy: 1e-6)
     }
 
     func testEulerStepUsesNextMinusCurrentSigma() {
@@ -32,8 +64,8 @@ final class Wan2GenerationTests: MereRunCoreTestCase {
         eval(result)
         let values = result.asArray(Float.self)
         XCTAssertEqual(values.count, 2)
-        XCTAssertLessThan(abs(values[0] - 0.001), 1e-5)
-        XCTAssertLessThan(abs(values[1] - 0.002), 1e-5)
+        XCTAssertLessThan(abs(values[0] + 0.998), 1e-5)
+        XCTAssertLessThan(abs(values[1] + 1.996), 1e-5)
     }
 
     func testUniPCScheduleAndFirstOrderStepAreFinite() {
@@ -49,6 +81,26 @@ final class Wan2GenerationTests: MereRunCoreTestCase {
             eval(result)
             XCTAssertTrue(result.asArray(Float.self).allSatisfy(\.isFinite))
         }
+    }
+
+    func testCausalForcingScheduleMatchesDreamXWarpedSteps() {
+        let scheduler = Wan2CausalForcingScheduler(shift: 5)
+        XCTAssertEqual(scheduler.timesteps[0], 1_000, accuracy: 1e-5)
+        XCTAssertEqual(scheduler.timesteps[1], 937.5, accuracy: 1e-5)
+        XCTAssertEqual(scheduler.timesteps[2], 833.333_3, accuracy: 1e-4)
+        XCTAssertEqual(scheduler.timesteps[3], 625, accuracy: 1e-5)
+        let sample = MLXArray([Float(1), 2], [1, 2])
+        let flow = MLXArray([Float(0.25), -0.5], [1, 2])
+        let clean = scheduler.predictClean(flow: flow, sample: sample, timestep: 1_000)
+        let noised = scheduler.addNoise(
+            clean: clean,
+            noise: MLX.zeros([1, 2]),
+            timestep: 625
+        )
+        eval(clean, noised)
+        XCTAssertEqual(clean.asArray(Float.self), [0.75, 2.5])
+        XCTAssertEqual(noised.asArray(Float.self)[0], 0.28125, accuracy: 1e-6)
+        XCTAssertEqual(noised.asArray(Float.self)[1], 0.9375, accuracy: 1e-6)
     }
 
     func testImageConditioningFreezesFirstLatentFrameAndTokens() {

--- a/Tests/MereRunCoreTests/Wan2RealWorldSessionTests.swift
+++ b/Tests/MereRunCoreTests/Wan2RealWorldSessionTests.swift
@@ -3,6 +3,188 @@ import XCTest
 @testable import MereRunCore
 
 final class Wan2RealWorldSessionTests: MereRunCoreTestCase {
+    func testCausalDreamXProducesPersistentWorldMoves() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"],
+              let causalWeightsPath = environment["MERERUN_DREAMX_CAUSAL_WEIGHTS"],
+              let outputPath = environment["MERERUN_DREAMX_CAUSAL_OUTPUT"] else {
+            throw XCTSkip("Set the Wan2 resources, source image, DreamX causal weights, and output variables.")
+        }
+        let width = Int(environment["MERERUN_DREAMX_CAUSAL_WIDTH"] ?? "256") ?? 256
+        let height = Int(environment["MERERUN_DREAMX_CAUSAL_HEIGHT"] ?? "160") ?? 160
+        let output = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.removeItem(at: output)
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: URL(fileURLWithPath: root)),
+            stateDirectory: output,
+            causalWeightsURL: URL(fileURLWithPath: causalWeightsPath)
+        )
+        let prompt = "A continuous first-person exploration of the same empty yellow backrooms interior, with stained yellow walls, beige carpet, fluorescent ceiling panels, rigid architecture, stable lighting, and no people. Preserve the exact environment and spatial identity across every camera move."
+        let started = Date()
+        let progress: @Sendable (GenerationProgress) -> Void = { update in
+            let elapsed = String(format: "%.1f", Date().timeIntervalSince(started))
+            print("DreamX causal progress stage=\(update.stage.rawValue) step=\(update.stepIndex)/\(update.totalSteps) elapsed=\(elapsed)s")
+        }
+        let forward = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: prompt,
+            camera: .forward(meters: 0.35),
+            sourceImageURL: URL(fileURLWithPath: sourcePath),
+            outputURL: output.appendingPathComponent("move-01-forward.mp4"),
+            width: width,
+            height: height,
+            seed: 42,
+            fps: 24
+        ), progressHandler: progress)
+        XCTAssertEqual(forward.conditioningMode, .causalCameraLatents)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: forward.outputURL.path))
+        if environment["MERERUN_DREAMX_CAUSAL_MOVE_COUNT"] == "1" {
+            let snapshot = await session.snapshot()
+            XCTAssertEqual(snapshot.transitionCount, 1)
+            XCTAssertTrue(snapshot.keepsModelsWarm)
+            try await session.unload()
+            return
+        }
+        let yaw = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: prompt,
+            camera: .yawLeft(degrees: 15),
+            outputURL: output.appendingPathComponent("move-02-yaw-left.mp4"),
+            width: width,
+            height: height,
+            seed: 43,
+            fps: 24
+        ), progressHandler: progress)
+        XCTAssertEqual(yaw.previousStateID, forward.stateID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: yaw.outputURL.path))
+        let snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.transitionCount, 2)
+        XCTAssertTrue(snapshot.keepsModelsWarm)
+        XCTAssertTrue(snapshot.keepsTerminalLatent)
+        try await session.unload()
+    }
+
+    func testProjectiveCameraOfficialStyleQualityCandidate() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"],
+              let cameraWeightsPath = environment["MERERUN_DREAMX_CAMERA_WEIGHTS"],
+              let outputPath = environment["MERERUN_DREAMX_CAMERA_QUALITY_OUTPUT"] else {
+            throw XCTSkip("Set the Wan2 model, source image, DreamX camera weights, and quality output variables.")
+        }
+        let output = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.removeItem(at: output)
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: URL(fileURLWithPath: root)),
+            stateDirectory: output,
+            cameraWeightsURL: URL(fileURLWithPath: cameraWeightsPath)
+        )
+        let receipt = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: "A continuous first-person camera view inside the exact same empty yellow backrooms corridor. The rigid walls, beige carpet, fluorescent ceiling panels, far doorway, lighting, geometry, and visual identity remain stable while the camera smoothly pivots left in place. No forward travel, no scene cut, no new room, no replacement environment.",
+            camera: .yawLeft(degrees: 30),
+            sourceImageURL: URL(fileURLWithPath: sourcePath),
+            outputURL: output.appendingPathComponent("yaw-left-30-step.mp4"),
+            width: 128,
+            height: 128,
+            numFrames: 17,
+            steps: 30,
+            guidanceScale: 5,
+            shift: 5,
+            seed: 42
+        ))
+        XCTAssertEqual(receipt.conditioningMode, .projectiveCameraLatents)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: receipt.outputURL.path))
+        try await session.unload()
+    }
+
+    func testProjectiveCameraLeftAndRightCandidatesFromSameSource() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"],
+              let cameraWeightsPath = environment["MERERUN_DREAMX_CAMERA_WEIGHTS"],
+              let outputPath = environment["MERERUN_DREAMX_CAMERA_DIRECTIONAL_OUTPUT"] else {
+            throw XCTSkip("Set the Wan2 model, source image, DreamX camera weights, and directional output variables.")
+        }
+        let sourceURL = URL(fileURLWithPath: sourcePath)
+        let output = URL(fileURLWithPath: outputPath)
+        let width = Int(environment["MERERUN_DREAMX_CAMERA_WIDTH"] ?? "192") ?? 192
+        let height = Int(environment["MERERUN_DREAMX_CAMERA_HEIGHT"] ?? "128") ?? 128
+        let frames = Int(environment["MERERUN_DREAMX_CAMERA_FRAMES"] ?? "17") ?? 17
+        let steps = Int(environment["MERERUN_DREAMX_CAMERA_STEPS"] ?? "8") ?? 8
+        try? FileManager.default.removeItem(at: output)
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: URL(fileURLWithPath: root)),
+            stateDirectory: output,
+            cameraWeightsURL: URL(fileURLWithPath: cameraWeightsPath)
+        )
+        let prompt = "A first-person view inside the same yellow backrooms corridor, preserving its walls, carpet, fluorescent ceiling lights, geometry, and identity."
+        let left = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: prompt,
+            camera: .yawLeft(degrees: 30),
+            sourceImageURL: sourceURL,
+            outputURL: output.appendingPathComponent("yaw-left.mp4"),
+            width: width,
+            height: height,
+            numFrames: frames,
+            steps: steps,
+            guidanceScale: 3,
+            seed: 42
+        ))
+        try await session.reset(sourceImageURL: sourceURL)
+        let right = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: prompt,
+            camera: .yawRight(degrees: 30),
+            sourceImageURL: sourceURL,
+            outputURL: output.appendingPathComponent("yaw-right.mp4"),
+            width: width,
+            height: height,
+            numFrames: frames,
+            steps: steps,
+            guidanceScale: 3,
+            seed: 42
+        ))
+        XCTAssertEqual(left.conditioningMode, .projectiveCameraLatents)
+        XCTAssertEqual(right.conditioningMode, .projectiveCameraLatents)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: left.outputURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: right.outputURL.path))
+        try await session.unload()
+    }
+
+    func testProjectiveCameraTransitionUsesReleasedDreamXWeights() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],
+              let sourcePath = environment["MERERUN_WAN2_SOURCE_IMAGE"],
+              let cameraWeightsPath = environment["MERERUN_DREAMX_CAMERA_WEIGHTS"],
+              let outputPath = environment["MERERUN_DREAMX_CAMERA_SESSION_OUTPUT"] else {
+            throw XCTSkip("Set the Wan2 model, source image, DreamX camera weights, and output variables.")
+        }
+        let output = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.removeItem(at: output)
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: URL(fileURLWithPath: root)),
+            stateDirectory: output,
+            cameraWeightsURL: URL(fileURLWithPath: cameraWeightsPath)
+        )
+        let receipt = try await session.transition(Wan2WorldTransitionRequest(
+            prompt: "The same empty corridor remains coherent and rigid.",
+            camera: .yawLeft(degrees: 15),
+            sourceImageURL: URL(fileURLWithPath: sourcePath),
+            width: 128,
+            height: 128,
+            numFrames: 5,
+            steps: 1,
+            guidanceScale: 1,
+            seed: 17
+        ))
+        XCTAssertEqual(receipt.conditioningMode, .projectiveCameraLatents)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: receipt.outputURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: receipt.terminalFrameURL.path))
+        let snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.conditioningMode, .projectiveCameraLatents)
+        XCTAssertTrue(snapshot.keepsModelsWarm)
+        XCTAssertTrue(snapshot.keepsTerminalLatent)
+        try await session.unload()
+    }
+
     func testTwoTransitionsReuseWarmModelsAndTerminalLatent() async throws {
         let environment = ProcessInfo.processInfo.environment
         guard let root = environment["MERERUN_WAN2_MODEL_ROOT"],

--- a/Tests/MereRunCoreTests/Wan2ResourcesTests.swift
+++ b/Tests/MereRunCoreTests/Wan2ResourcesTests.swift
@@ -61,6 +61,32 @@ final class Wan2ResourcesTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.defaults?.sigmaShift, 5.0)
     }
 
+    func testDreamXCausalModelIsLocalOnlyAndDeclaresWanCompanion() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Wan2DreamXCausalResources.modelID))
+        XCTAssertEqual(spec.modelID, .dreamXWorld5BARMLX)
+        XCTAssertEqual(spec.validationKind, .dreamXCausalMLX)
+        XCTAssertNil(spec.hubFallback)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.companionModelIDs, [Wan2Resources.modelID])
+
+        let manifest = MereRunModelManifest.template(
+            for: .dreamXWorld5BARMLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.engine, .wanVideo)
+        XCTAssertEqual(manifest.defaults?.steps, 4)
+        XCTAssertEqual(manifest.defaults?.cfg, 1)
+    }
+
+    func testDreamXCausalResourcesRequireConvertedWeights() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resources = Wan2DreamXCausalResources(rootURL: root)
+        XCTAssertEqual(resources.validate().map(\.lastPathComponent), ["model.safetensors"])
+        try TestFileSystem.writeFile(resources.weightsURL, contents: Data())
+        XCTAssertTrue(resources.validate().isEmpty)
+    }
+
     private func writeValidRoot(_ root: URL, modelType: String = "ti2v") throws {
         let config = """
         {

--- a/Tests/MereRunCoreTests/Wan2WorldSessionTests.swift
+++ b/Tests/MereRunCoreTests/Wan2WorldSessionTests.swift
@@ -15,6 +15,28 @@ final class Wan2WorldSessionTests: MereRunCoreTestCase {
         XCTAssertTrue(left.promptClause.contains("pivots left in place"))
     }
 
+    func testCausalCameraTrajectoryHonorsRequestedMotionMagnitude() {
+        let fifteen = Wan2DreamXARTrajectory.compile(
+            control: .yawLeft(degrees: 15),
+            pixelFrameCount: 9
+        )
+        let thirty = Wan2DreamXARTrajectory.compile(
+            control: .yawLeft(degrees: 30),
+            pixelFrameCount: 9
+        )
+        XCTAssertNotEqual(fifteen.viewMatrices, thirty.viewMatrices)
+
+        let near = Wan2DreamXARTrajectory.compile(
+            control: .forward(meters: 0.25),
+            pixelFrameCount: 9
+        )
+        let far = Wan2DreamXARTrajectory.compile(
+            control: .forward(meters: 1),
+            pixelFrameCount: 9
+        )
+        XCTAssertNotEqual(near.viewMatrices, far.viewMatrices)
+    }
+
     func testColdSessionCanResetToAnExplicitWorldFrame() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("wan-session-model-\(UUID().uuidString)")
@@ -52,5 +74,37 @@ final class Wan2WorldSessionTests: MereRunCoreTestCase {
         XCTAssertEqual(request.guidanceScale, 5)
         XCTAssertEqual(request.shift, 5)
         XCTAssertEqual(request.fps, 24)
+    }
+
+    func testCameraWeightsSelectProjectiveConditioningWithoutLoadingModels() async {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wan-camera-session-model-\(UUID().uuidString)")
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wan-camera-session-state-\(UUID().uuidString)")
+        let cameraWeights = root.appendingPathComponent("camera_adapter.safetensors")
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: root),
+            stateDirectory: state,
+            cameraWeightsURL: cameraWeights
+        )
+        let snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.conditioningMode, .projectiveCameraLatents)
+        XCTAssertFalse(snapshot.keepsModelsWarm)
+    }
+
+    func testCausalWeightsSelectPersistentConditioningWithoutLoadingModels() async {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wan-causal-session-model-\(UUID().uuidString)")
+        let state = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wan-causal-session-state-\(UUID().uuidString)")
+        let session = Wan2WorldSession(
+            resources: Wan2Resources(rootURL: root),
+            stateDirectory: state,
+            causalWeightsURL: root.appendingPathComponent("causal.safetensors")
+        )
+        let snapshot = await session.snapshot()
+        XCTAssertEqual(snapshot.conditioningMode, .causalCameraLatents)
+        XCTAssertFalse(snapshot.keepsModelsWarm)
+        XCTAssertFalse(snapshot.keepsTerminalLatent)
     }
 }

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -96,6 +96,7 @@ from the runtime catalog used by `mere.run model list`,
 | `video` | `video-ltx-av` |
 | `video` | `video-ltx23-av-mlx` |
 | `video` | `video-wan22-ti2v-5b-mlx` |
+| `video` | `video-dreamx-world-5b-ar-mlx` |
 <!-- managed-model-catalog:end -->
 
 Most catalog IDs have managed Hugging Face sources and can be installed with
@@ -576,3 +577,18 @@ state IDs rather than mutable MLX tensors. Camera controls are represented as
 XYZ translation and rotation so a DreamX-derived causal camera conditioner can
 replace the current text-plus-first-frame mode without changing the session
 schema.
+
+### `video-dreamx-world-5b-ar-mlx`
+
+The native DreamX-World autoregressive checkpoint root is:
+
+```text
+.../models/video-dreamx-world-5b-ar-mlx
+```
+
+`mere.run world prepare` converts the pinned `GD-ML/DreamX-World-5B`
+checkpoint into the MLX-native root. The runtime pairs it with
+`video-wan22-ti2v-5b-mlx` for the tokenizer, text encoder, and VAE resources.
+The checkpoint provides learned camera conditioning, block-causal attention,
+persistent attention caches, and autoregressive forcing for long-lived local
+world sessions. It is not downloaded automatically at runtime.

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -10,6 +10,26 @@ the byte count and SHA-256 of every emitted weights, configuration, provenance,
 and license file before publishing the staged directory. Their `--license-file`
 argument is mandatory and accepts only the exact pinned upstream license bytes.
 
+## DreamX-World 5B camera adapter
+
+`extract_dreamx_camera_adapter.py` reads safetensors headers and downloads only
+the 300 `cam_self_attn` tensors from the pinned public
+`GD-ML/DreamX-World-5B-Cam` release. The tensors occupy 30 contiguous HTTP byte
+ranges and produce a 4.22 GiB adapter instead of duplicating the 24.5 GB full
+checkpoint. A sampled ordinary transformer weight from the DreamX release is
+bit-identical to the managed Wan base after BF16 conversion, so the native
+package composes that base with the learned camera branch.
+
+```bash
+python3 scripts/model-conversion/extract_dreamx_camera_adapter.py \
+  --output camera_adapter.safetensors
+```
+
+The extractor pins revision
+`a4379c7723f6ebd02139e2e8fd62d6ef523e86e3`, rejects ignored HTTP range
+requests, validates every index/header entry, and writes the output atomically.
+Python is acquisition tooling only; inference remains native Swift/MLX.
+
 ## Video Depth Anything Small
 
 `convert_vda_small.py` accepts only the pinned relative or metric Apache-2.0

--- a/scripts/model-conversion/convert_dreamx_ar_checkpoint.py
+++ b/scripts/model-conversion/convert_dreamx_ar_checkpoint.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Stream and convert the released DreamX AR checkpoint to native BF16."""
+
+import argparse
+import json
+import os
+import struct
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+
+DEFAULT_REPO = "GD-ML/DreamX-World-5B"
+DEFAULT_REVISION = "67487c4a61466bb7166d30b7187dd465e0ac9f6c"
+DEFAULT_FILENAME = "model.safetensors"
+
+
+def request(url, byte_range=None):
+    headers = {"User-Agent": "mere.run-dreamx-ar-converter/1"}
+    if byte_range is not None:
+        headers["Range"] = f"bytes={byte_range[0]}-{byte_range[1]}"
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.urlopen(urllib.request.Request(url, headers=headers))
+
+
+def read_range(url, start, end):
+    with request(url, (start, end)) as response:
+        if response.status != 206:
+            raise RuntimeError(f"Server ignored byte range {start}-{end}: HTTP {response.status}")
+        payload = response.read()
+    expected = end - start + 1
+    if len(payload) != expected:
+        raise RuntimeError(f"Short range response: expected {expected}, received {len(payload)}")
+    return payload
+
+
+def read_header(url):
+    header_size = struct.unpack("<Q", read_range(url, 0, 7))[0]
+    header = json.loads(read_range(url, 8, 7 + header_size).decode("utf-8"))
+    return header, 8 + header_size
+
+
+def native_key_and_shape(key, shape):
+    if key == "patch_embedding.weight":
+        return "patch_embedding_proj.weight", [shape[0], int(np.prod(shape[1:]))]
+    exact = {
+        "patch_embedding.bias": "patch_embedding_proj.bias",
+        "text_embedding.0.weight": "text_embedding_0.weight",
+        "text_embedding.0.bias": "text_embedding_0.bias",
+        "text_embedding.2.weight": "text_embedding_1.weight",
+        "text_embedding.2.bias": "text_embedding_1.bias",
+        "time_embedding.0.weight": "time_embedding_0.weight",
+        "time_embedding.0.bias": "time_embedding_0.bias",
+        "time_embedding.2.weight": "time_embedding_1.weight",
+        "time_embedding.2.bias": "time_embedding_1.bias",
+        "time_projection.1.weight": "time_projection.weight",
+        "time_projection.1.bias": "time_projection.bias",
+    }
+    if key in exact:
+        return exact[key], shape
+    if ".ffn.0." in key:
+        return key.replace(".ffn.0.", ".ffn.fc1."), shape
+    if ".ffn.2." in key:
+        return key.replace(".ffn.2.", ".ffn.fc2."), shape
+    return key, shape
+
+
+def f32_to_bf16(payload):
+    values = np.frombuffer(payload, dtype="<u4")
+    special = (values & np.uint32(0x7F80_0000)) == np.uint32(0x7F80_0000)
+    bias = np.uint32(0x0000_7FFF) + ((values >> np.uint32(16)) & np.uint32(1))
+    rounded = np.where(special, values, values + bias)
+    return (rounded >> np.uint32(16)).astype("<u2", copy=False).tobytes()
+
+
+def build_manifest(source_header, repo, revision):
+    tensors = []
+    output_offset = 0
+    for source_key, entry in source_header.items():
+        if source_key == "__metadata__":
+            continue
+        if entry["dtype"] != "F32":
+            raise RuntimeError(f"Expected F32 source tensor, got {entry['dtype']} for {source_key}")
+        source_start, source_end = entry["data_offsets"]
+        native_key, native_shape = native_key_and_shape(source_key, entry["shape"])
+        output_size = (source_end - source_start) // 2
+        tensors.append({
+            "source_key": source_key,
+            "native_key": native_key,
+            "shape": native_shape,
+            "source_start": source_start,
+            "source_end": source_end,
+            "output_start": output_offset,
+            "output_end": output_offset + output_size,
+        })
+        output_offset += output_size
+
+    output_header = {
+        "__metadata__": {
+            "format": "pt",
+            "source_repo": repo,
+            "source_revision": revision,
+            "conversion": "F32-to-BF16-rne",
+            "runtime": "mere.run-native-causal-wan2",
+        }
+    }
+    for tensor in tensors:
+        output_header[tensor["native_key"]] = {
+            "dtype": "BF16",
+            "shape": tensor["shape"],
+            "data_offsets": [tensor["output_start"], tensor["output_end"]],
+        }
+    encoded = json.dumps(output_header, separators=(",", ":")).encode("utf-8")
+    encoded += b" " * ((8 - len(encoded) % 8) % 8)
+    return tensors, encoded, output_offset
+
+
+def convert(url, destination, tensors, header, source_data_start, output_bytes, chunk_bytes):
+    temporary = destination.with_suffix(destination.suffix + ".partial")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    output_data_start = 8 + len(header)
+    expected_prefix = struct.pack("<Q", len(header)) + header
+
+    if temporary.exists():
+        with temporary.open("rb") as existing:
+            if existing.read(len(expected_prefix)) != expected_prefix:
+                raise RuntimeError(f"Partial file has a different header: {temporary}")
+    else:
+        with temporary.open("wb") as output:
+            output.write(expected_prefix)
+
+    with temporary.open("r+b") as output:
+        for index, tensor in enumerate(tensors, start=1):
+            output_start = output_data_start + tensor["output_start"]
+            output_end = output_data_start + tensor["output_end"]
+            current_size = output.seek(0, os.SEEK_END)
+            if current_size >= output_end:
+                continue
+            if current_size != output_start:
+                output.truncate(output_start)
+                output.seek(output_start)
+
+            source_start = source_data_start + tensor["source_start"]
+            source_end = source_data_start + tensor["source_end"]
+            cursor = source_start
+            while cursor < source_end:
+                end = min(cursor + chunk_bytes, source_end) - 1
+                payload = read_range(url, cursor, end)
+                if len(payload) % 4:
+                    raise RuntimeError(f"Unaligned F32 range for {tensor['source_key']}")
+                output.write(f32_to_bf16(payload))
+                output.flush()
+                cursor = end + 1
+
+            completed = tensor["output_end"]
+            if index == len(tensors) or index % 10 == 0:
+                print(
+                    f"[{index}/{len(tensors)}] {completed / (1024 ** 3):.2f}/"
+                    f"{output_bytes / (1024 ** 3):.2f} GiB {tensor['native_key']}",
+                    flush=True,
+                )
+
+        final_size = output.seek(0, os.SEEK_END)
+        expected_size = output_data_start + output_bytes
+        if final_size != expected_size:
+            raise RuntimeError(f"Output size mismatch: expected {expected_size}, got {final_size}")
+    temporary.replace(destination)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--revision", default=DEFAULT_REVISION)
+    parser.add_argument("--filename", default=DEFAULT_FILENAME)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--chunk-mib", type=int, default=64)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    url = f"https://huggingface.co/{args.repo}/resolve/{args.revision}/{args.filename}"
+    source_header, source_data_start = read_header(url)
+    tensors, output_header, output_bytes = build_manifest(source_header, args.repo, args.revision)
+    summary = {
+        "repo": args.repo,
+        "revision": args.revision,
+        "tensor_count": len(tensors),
+        "source_bytes": sum(t["source_end"] - t["source_start"] for t in tensors),
+        "output_bytes": output_bytes,
+        "output_gibibytes": output_bytes / (1024 ** 3),
+        "output": str(args.output),
+    }
+    print(json.dumps(summary, indent=2), flush=True)
+    if not args.dry_run:
+        convert(
+            url,
+            args.output,
+            tensors,
+            output_header,
+            source_data_start,
+            output_bytes,
+            args.chunk_mib * 1024 * 1024,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model-conversion/extract_dreamx_camera_adapter.py
+++ b/scripts/model-conversion/extract_dreamx_camera_adapter.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Range-extract DreamX camera-attention tensors without downloading the 24.5 GB model."""
+
+import argparse
+import json
+import os
+import re
+import struct
+import sys
+import urllib.request
+from pathlib import Path
+
+
+DEFAULT_REPO = "GD-ML/DreamX-World-5B-Cam"
+DEFAULT_REVISION = "a4379c7723f6ebd02139e2e8fd62d6ef523e86e3"
+
+
+def request(url, byte_range=None):
+    headers = {"User-Agent": "mere.run-dreamx-camera-extractor/1"}
+    if byte_range is not None:
+        headers["Range"] = f"bytes={byte_range[0]}-{byte_range[1]}"
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.urlopen(urllib.request.Request(url, headers=headers))
+
+
+def read_json(url):
+    with request(url) as response:
+        return json.load(response)
+
+
+def read_range(url, start, end):
+    with request(url, (start, end)) as response:
+        if response.status != 206:
+            raise RuntimeError(f"Server ignored byte range {start}-{end}: HTTP {response.status}")
+        payload = response.read()
+    expected = end - start + 1
+    if len(payload) != expected:
+        raise RuntimeError(f"Short range response: expected {expected}, received {len(payload)}")
+    return payload
+
+
+def read_safetensors_header(url):
+    header_size = struct.unpack("<Q", read_range(url, 0, 7))[0]
+    header = json.loads(read_range(url, 8, 7 + header_size).decode("utf-8"))
+    return header, 8 + header_size
+
+
+def selected_tensors(repo, revision, pattern):
+    base = f"https://huggingface.co/{repo}/resolve/{revision}"
+    index = read_json(f"{base}/diffusion_pytorch_model.safetensors.index.json")
+    selected_keys = sorted(key for key in index["weight_map"] if pattern.search(key))
+    if not selected_keys:
+        raise RuntimeError(f"No tensors matched {pattern.pattern!r}")
+    shard_names = sorted({index["weight_map"][key] for key in selected_keys})
+    tensors = []
+    for shard_name in shard_names:
+        shard_url = f"{base}/{shard_name}"
+        header, data_start = read_safetensors_header(shard_url)
+        for key in selected_keys:
+            if index["weight_map"][key] != shard_name:
+                continue
+            entry = header.get(key)
+            if entry is None:
+                raise RuntimeError(f"Index key missing from shard header: {key}")
+            start, end = entry["data_offsets"]
+            tensors.append({
+                "key": key,
+                "dtype": entry["dtype"],
+                "shape": entry["shape"],
+                "url": shard_url,
+                "shard": shard_name,
+                "start": data_start + start,
+                "end": data_start + end,
+                "size": end - start,
+            })
+    tensors.sort(key=lambda item: (item["shard"], item["start"]))
+    return tensors
+
+
+def contiguous_groups(tensors):
+    groups = []
+    for tensor in tensors:
+        if groups and groups[-1][-1]["shard"] == tensor["shard"] and groups[-1][-1]["end"] == tensor["start"]:
+            groups[-1].append(tensor)
+        else:
+            groups.append([tensor])
+    return groups
+
+
+def output_header(tensors, repo, revision):
+    header = {
+        "__metadata__": {
+            "format": "pt",
+            "source_repo": repo,
+            "source_revision": revision,
+            "selection": ".cam_self_attn.",
+        }
+    }
+    offset = 0
+    for tensor in tensors:
+        header[tensor["key"]] = {
+            "dtype": tensor["dtype"],
+            "shape": tensor["shape"],
+            "data_offsets": [offset, offset + tensor["size"]],
+        }
+        offset += tensor["size"]
+    encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    encoded += b" " * ((8 - len(encoded) % 8) % 8)
+    return encoded
+
+
+def extract(tensors, destination, repo, revision):
+    header = output_header(tensors, repo, revision)
+    groups = contiguous_groups(tensors)
+    temporary = destination.with_suffix(destination.suffix + ".partial")
+    temporary.parent.mkdir(parents=True, exist_ok=True)
+    completed = 0
+    total = sum(tensor["size"] for tensor in tensors)
+    with temporary.open("wb") as output:
+        output.write(struct.pack("<Q", len(header)))
+        output.write(header)
+        for index, group in enumerate(groups, start=1):
+            start = group[0]["start"]
+            end = group[-1]["end"] - 1
+            payload = read_range(group[0]["url"], start, end)
+            output.write(payload)
+            completed += len(payload)
+            print(
+                f"[{index}/{len(groups)}] {group[0]['shard']} "
+                f"{completed / (1024 ** 3):.2f}/{total / (1024 ** 3):.2f} GiB",
+                file=sys.stderr,
+                flush=True,
+            )
+    temporary.replace(destination)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--revision", default=DEFAULT_REVISION)
+    parser.add_argument("--match", default=r"\.cam_self_attn\.")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    tensors = selected_tensors(args.repo, args.revision, re.compile(args.match))
+    groups = contiguous_groups(tensors)
+    total = sum(tensor["size"] for tensor in tensors)
+    summary = {
+        "repo": args.repo,
+        "revision": args.revision,
+        "tensor_count": len(tensors),
+        "range_count": len(groups),
+        "bytes": total,
+        "gibibytes": total / (1024 ** 3),
+        "output": str(args.output),
+    }
+    print(json.dumps(summary, indent=2))
+    if not args.dry_run:
+        extract(tensors, args.output, args.repo, args.revision)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reference-parity/README.md
+++ b/scripts/reference-parity/README.md
@@ -114,3 +114,42 @@ python scripts/reference-parity/export_instantmesh_preprocess_fixture.py \
 MERERUN_TEST_INSTANTMESH_PREPROCESS=/tmp/instantmesh-preprocess-parity \
   swift test --filter InstantMeshPreprocessorTests
 ```
+
+## DreamX camera conditioning
+
+`export_dreamx_camera_fixture.py` imports the pinned DreamX trajectory and
+PRoPE source files directly and freezes relative views, normalized intrinsics,
+and projective Q/K/V/output transforms. `export_dreamx_camera_block_fixture.py`
+adds the released block-0 camera weights and freezes a complete learned
+camera-attention output. `export_dreamx_camera_transformer_fixture.py` combines
+the native Wan base with the extracted camera adapter and freezes a tiny full
+30-block BF16 forward pass without downloading a duplicate 24.5 GB checkpoint.
+
+```bash
+uv run --with torch --with safetensors --with numpy --with pillow \
+  --with einops --with packaging \
+  python scripts/reference-parity/export_dreamx_camera_fixture.py \
+  --dreamx-root /path/to/DreamX-World \
+  --output /tmp/dreamx-camera-fixture.json
+
+uv run --with torch --with safetensors --with numpy --with pillow \
+  --with einops --with packaging \
+  python scripts/reference-parity/export_dreamx_camera_block_fixture.py \
+  --dreamx-root /path/to/DreamX-World \
+  --camera-weights /path/to/camera_adapter.safetensors \
+  --output /tmp/dreamx-camera-block0.safetensors
+
+uv run --with torch --with safetensors --with numpy --with scipy \
+  --with diffusers --with einops --with packaging \
+  python scripts/reference-parity/export_dreamx_camera_transformer_fixture.py \
+  --dreamx-root /path/to/DreamX-World \
+  --base-weights /path/to/model.safetensors \
+  --camera-weights /path/to/camera_adapter.safetensors \
+  --output /tmp/dreamx-camera-transformer.safetensors
+```
+
+Set `MERERUN_DREAMX_CAMERA_FIXTURE`, `MERERUN_DREAMX_CAMERA_WEIGHTS`, and
+`MERERUN_DREAMX_CAMERA_BLOCK_FIXTURE` or
+`MERERUN_DREAMX_CAMERA_TRANSFORMER_FIXTURE` when running the corresponding
+Swift parity tests. These scripts are reference tooling and are never imported
+by the runtime.

--- a/scripts/reference-parity/export_dreamx_ar_camera_fixture.py
+++ b/scripts/reference-parity/export_dreamx_ar_camera_fixture.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Export the released DreamX AR trajectory dialect for Swift parity."""
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+
+def load_source_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dreamx-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import numpy as np
+
+    trajectory = load_source_module(
+        "dreamx_ar_trajectory_processor",
+        args.dreamx_root / "utils" / "trajectory_processor.py",
+    )
+    segments = [("w", 3), ("j", 5)]
+    pixel_frame_count = 21
+    speed = 1.5
+    _, camera_parameters, _ = trajectory.generate_trajectory_from_json(
+        trajectory_spec=segments,
+        num_frames=pixel_frame_count,
+        speed=speed,
+        return_cam_params=True,
+    )
+    cameras = [trajectory.Camera(row.tolist()) for row in camera_parameters]
+    aligned_indices = [0] + list(range(1, pixel_frame_count, 4))
+    cameras = [cameras[index] for index in aligned_indices]
+    relative_c2w = []
+    for chunk_start in range(0, len(cameras), 3):
+        chunk_end = min(chunk_start + 3, len(cameras))
+        if chunk_start == 0:
+            chunk = cameras[chunk_start:chunk_end]
+            relative_c2w.extend(trajectory.get_relative_pose(chunk))
+        else:
+            chunk = [cameras[chunk_start - 1]] + cameras[chunk_start:chunk_end]
+            relative_c2w.extend(trajectory.get_relative_pose(chunk)[1:])
+    views = np.linalg.inv(np.asarray(relative_c2w, dtype=np.float32)).astype(np.float32)
+    intrinsic = np.zeros((len(views), 3, 3), dtype=np.float32)
+    intrinsic[:, 0, 0] = 969.6969696969696 / (960 * 2)
+    intrinsic[:, 1, 1] = 969.6969696969696 / (540 * 2)
+    intrinsic[:, 0, 2] = 0.5
+    intrinsic[:, 1, 2] = 0.5
+    intrinsic[:, 2, 2] = 1
+    output = {
+        "source_revision": "AMAP-ML/DreamX-World@f2bf6bf",
+        "trajectory": {
+            "segments": segments,
+            "pixel_frame_count": pixel_frame_count,
+            "speed": speed,
+            "chunk_relative": True,
+        },
+        "view_matrices": {
+            "shape": [1, len(views), 4, 4],
+            "values": views.reshape(-1).tolist(),
+        },
+        "intrinsics": {
+            "shape": [1, len(views), 3, 3],
+            "values": intrinsic.reshape(-1).tolist(),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2) + "\n")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reference-parity/export_dreamx_ar_transformer_fixture.py
+++ b/scripts/reference-parity/export_dreamx_ar_transformer_fixture.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Export a tiny real-weight DreamX AR causal-transformer fixture."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def upstream_tensor(key, value):
+    if key == "patch_embedding_proj.weight":
+        return "patch_embedding.weight", value.reshape(3072, 48, 1, 2, 2)
+    exact = {
+        "patch_embedding_proj.bias": "patch_embedding.bias",
+        "text_embedding_0.weight": "text_embedding.0.weight",
+        "text_embedding_0.bias": "text_embedding.0.bias",
+        "text_embedding_1.weight": "text_embedding.2.weight",
+        "text_embedding_1.bias": "text_embedding.2.bias",
+        "time_embedding_0.weight": "time_embedding.0.weight",
+        "time_embedding_0.bias": "time_embedding.0.bias",
+        "time_embedding_1.weight": "time_embedding.2.weight",
+        "time_embedding_1.bias": "time_embedding.2.bias",
+        "time_projection.weight": "time_projection.1.weight",
+        "time_projection.bias": "time_projection.1.bias",
+    }
+    if key in exact:
+        return exact[key], value
+    if ".ffn.fc1." in key:
+        return key.replace(".ffn.fc1.", ".ffn.0."), value
+    if ".ffn.fc2." in key:
+        return key.replace(".ffn.fc2.", ".ffn.2."), value
+    return key, value
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dreamx-root", type=Path, required=True)
+    parser.add_argument("--weights", type=Path, required=True)
+    parser.add_argument("--camera-fixture", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import torch
+    import torch.nn.functional as F
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    sys.path.insert(0, str(args.dreamx_root))
+    from wan.modules.causal_camera_model_2_2_prope_infinity import CausalWanModel
+    import wan.modules.model_2_2 as wan_model
+    from wan.modules.model_2_2 import rope_params
+
+    def cpu_flash_attention(q, k, v, k_lens=None, softmax_scale=None, **_):
+        """Match DreamX's flash-attention contract with portable PyTorch SDPA."""
+        if k_lens is not None:
+            assert q.shape[0] == 1
+            key_length = int(k_lens[0])
+            k = k[:, :key_length]
+            v = v[:, :key_length]
+        output = F.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            scale=softmax_scale,
+        )
+        return output.transpose(1, 2).to(v.dtype)
+
+    wan_model.flash_attention = cpu_flash_attention
+
+    with torch.device("meta"):
+        model = CausalWanModel(
+            model_type="ti2v",
+            in_dim=48,
+            dim=3072,
+            ffn_dim=14336,
+            freq_dim=256,
+            text_dim=4096,
+            out_dim=48,
+            num_heads=24,
+            num_layers=30,
+            local_attn_size=12,
+            sink_size=3,
+            cross_attn_norm=True,
+            add_control_adapter=True,
+            cam_method="prope",
+            attn_compress=4,
+        )
+    state = {}
+    with safe_open(args.weights, framework="pt", device="cpu") as source:
+        for key in source.keys():
+            mapped_key, value = upstream_tensor(key, source.get_tensor(key))
+            state[mapped_key] = value
+    missing, unexpected = model.load_state_dict(state, strict=False, assign=True)
+    if missing or unexpected:
+        raise RuntimeError(f"Checkpoint mismatch: missing={missing}, unexpected={unexpected}")
+    del state
+    head_dimension = 128
+    model.freqs = torch.cat([
+        rope_params(1024, head_dimension - 4 * (head_dimension // 6)),
+        rope_params(1024, 2 * (head_dimension // 6)),
+        rope_params(1024, 2 * (head_dimension // 6)),
+    ], dim=1)
+    for module in model.modules():
+        if isinstance(module, torch.nn.LayerNorm) and module.elementwise_affine:
+            module.weight.data = module.weight.data.float()
+            module.bias.data = module.bias.data.float()
+    model.eval()
+
+    camera_json = json.loads(args.camera_fixture.read_text())
+    camera_frames = camera_json["view_matrices"]["shape"][1]
+    views = torch.tensor(camera_json["view_matrices"]["values"], dtype=torch.bfloat16).reshape(
+        1, camera_frames, 4, 4
+    )[:, :3]
+    intrinsics = torch.tensor(camera_json["intrinsics"]["values"], dtype=torch.bfloat16).reshape(
+        1, camera_frames, 3, 3
+    )[:, :3]
+    latent_values = torch.arange(48 * 3 * 2 * 4, dtype=torch.float32).reshape(48, 3, 2, 4)
+    latent = (torch.sin(latent_values / 79) * 0.25).to(torch.bfloat16)
+    context_values = torch.arange(4 * 4096, dtype=torch.float32).reshape(4, 4096)
+    context = (torch.cos(context_values / 113) * 0.125).to(torch.bfloat16)
+    timesteps = torch.full((1, 6), 937.5, dtype=torch.float32)
+    timesteps[:, :2] = 0
+    cache_tokens = 12 * 2
+    caches = [{
+        "k": torch.zeros((1, cache_tokens, 24, 128), dtype=torch.bfloat16),
+        "v": torch.zeros((1, cache_tokens, 24, 128), dtype=torch.bfloat16),
+        "global_end_index": torch.tensor([0], dtype=torch.long),
+        "local_end_index": torch.tensor([0], dtype=torch.long),
+    } for _ in range(30)]
+    cross_caches = [{"is_init": False} for _ in range(30)]
+    with torch.inference_mode(), torch.autocast("cpu", dtype=torch.bfloat16):
+        output = model(
+            x=[latent],
+            t=timesteps,
+            context=[context],
+            seq_len=6,
+            y_camera={"viewmats": views, "K": intrinsics},
+            kv_cache=caches,
+            crossattn_cache=cross_caches,
+            current_start=0,
+        )[0]
+        recompute_input = latent + (torch.cos(latent_values / 53) * 0.01).to(torch.bfloat16)
+        recompute_timesteps = torch.full((1, 6), 833.333333, dtype=torch.float32)
+        recompute_timesteps[:, :2] = 0
+        recompute_output = model(
+            x=[recompute_input],
+            t=recompute_timesteps,
+            context=[context],
+            seq_len=6,
+            y_camera={"viewmats": views, "K": intrinsics},
+            kv_cache=caches,
+            crossattn_cache=cross_caches,
+            current_start=0,
+        )[0]
+        second_values = latent_values + 48 * 3 * 2 * 4
+        second_input = (torch.sin(second_values / 71) * 0.25).to(torch.bfloat16)
+        second_timesteps = torch.full((1, 6), 937.5, dtype=torch.float32)
+        second_views = views.clone()
+        second_views[:, :, 0, 3] += torch.tensor(
+            [0.025, 0.05, 0.075], dtype=torch.bfloat16
+        ).reshape(1, 3)
+        second_output = model(
+            x=[second_input],
+            t=second_timesteps,
+            context=[context],
+            seq_len=6,
+            y_camera={"viewmats": second_views, "K": intrinsics},
+            kv_cache=caches,
+            crossattn_cache=cross_caches,
+            current_start=6,
+        )[0]
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_file({
+        "input": latent.contiguous(),
+        "timesteps": timesteps.contiguous(),
+        "context": context.contiguous(),
+        "view_matrices": views.contiguous(),
+        "intrinsics": intrinsics.contiguous(),
+        "output": output.float().contiguous(),
+        "recompute_input": recompute_input.contiguous(),
+        "recompute_timesteps": recompute_timesteps.contiguous(),
+        "recompute_output": recompute_output.float().contiguous(),
+        "second_input": second_input.contiguous(),
+        "second_timesteps": second_timesteps.contiguous(),
+        "second_view_matrices": second_views.contiguous(),
+        "second_output": second_output.float().contiguous(),
+        "block0_cache_key": caches[0]["k"][:, :12].float().contiguous(),
+        "block0_cache_value": caches[0]["v"][:, :12].float().contiguous(),
+    }, args.output, metadata={
+        "source_revision": "AMAP-ML/DreamX-World@f2bf6bf",
+        "checkpoint_revision": "67487c4a61466bb7166d30b7187dd465e0ac9f6c",
+        "compute_dtype": "bfloat16",
+        "local_attention_frames": "12",
+        "sink_frames": "3",
+    })
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reference-parity/export_dreamx_camera_block_fixture.py
+++ b/scripts/reference-parity/export_dreamx_camera_block_fixture.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Export a real DreamX camera-attention block fixture from the released weights."""
+
+import argparse
+import importlib.util
+import math
+from pathlib import Path
+import sys
+import types
+
+
+def load_source_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_dreamx_inference_utils(dreamx_root):
+    package_name = "dreamx_block_fixture_utils"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(dreamx_root / "utils")]
+    sys.modules[package_name] = package
+    load_source_module(
+        f"{package_name}.pose_utils",
+        dreamx_root / "utils" / "pose_utils.py",
+    )
+    return load_source_module(
+        f"{package_name}.inference_utils",
+        dreamx_root / "utils" / "inference_utils.py",
+    )
+
+
+def rms_norm(value, weight, epsilon=1e-6):
+    import torch
+
+    normalized = value.float() * torch.rsqrt(value.float().pow(2).mean(dim=-1, keepdim=True) + epsilon)
+    return normalized.to(value.dtype) * weight
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dreamx-root", type=Path, required=True)
+    parser.add_argument("--camera-weights", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--block", type=int, default=0)
+    args = parser.parse_args()
+
+    import torch
+    import torch.nn.functional as functional
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    inference = load_dreamx_inference_utils(args.dreamx_root)
+    prope = load_source_module(
+        "dreamx_camera_prope",
+        args.dreamx_root / "wan" / "modules" / "camera_prope.py",
+    )
+    pixel_frame_count = 17
+    poses = inference.ActionToPoseFromID(
+        ["j"],
+        [3],
+        duration=pixel_frame_count,
+    )
+    camera, _ = inference.GetPoseEmbedsFromPosesPrope(
+        poses[:pixel_frame_count],
+        h=704,
+        w=1280,
+        target_length=pixel_frame_count,
+        dtype=torch.float32,
+    )
+    views = camera["viewmats"].unsqueeze(0)
+    intrinsics = camera["K"].unsqueeze(0)
+
+    prefix = f"blocks.{args.block}.cam_self_attn."
+    with safe_open(args.camera_weights, framework="pt", device="cpu") as source:
+        weights = {key.removeprefix(prefix): source.get_tensor(key).float() for key in source.keys() if key.startswith(prefix)}
+    if len(weights) != 10:
+        raise RuntimeError(f"Expected 10 camera tensors for {prefix}, found {len(weights)}")
+
+    sequence = views.shape[1] * 2
+    dimensions = weights["q_proj.weight"].shape[1]
+    heads = 24
+    head_dimension = dimensions // heads
+    values = torch.arange(sequence * dimensions, dtype=torch.float32).reshape(1, sequence, dimensions)
+    model_input = torch.sin(values / 113) * 0.25 + torch.cos(values / 47) * 0.125
+
+    query = rms_norm(functional.linear(model_input, weights["q_proj.weight"], weights["q_proj.bias"]), weights["norm_q.weight"])
+    key = rms_norm(functional.linear(model_input, weights["k_proj.weight"], weights["k_proj.bias"]), weights["norm_k.weight"])
+    value = functional.linear(model_input, weights["v_proj.weight"], weights["v_proj.bias"])
+    query = query.reshape(1, sequence, heads, head_dimension).transpose(1, 2)
+    key = key.reshape(1, sequence, heads, head_dimension).transpose(1, 2)
+    value = value.reshape(1, sequence, heads, head_dimension).transpose(1, 2)
+    query, key, value, apply_output = prope.prope_qkv(
+        query,
+        key,
+        value,
+        viewmats=views,
+        Ks=intrinsics,
+    )
+    attended = functional.scaled_dot_product_attention(query, key, value)
+    attended = apply_output(attended).transpose(1, 2).reshape(1, sequence, dimensions)
+    output = functional.linear(attended, weights["out_proj.weight"], weights["out_proj.bias"])
+    tensors = {
+        "input": model_input.contiguous(),
+        "view_matrices": views.contiguous(),
+        "intrinsics": intrinsics.contiguous(),
+        "query": query.contiguous(),
+        "key": key.contiguous(),
+        "value": value.contiguous(),
+        "output": output.contiguous(),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, args.output, metadata={
+        "source": "GD-ML/DreamX-World-5B-Cam",
+        "revision": "a4379c7723f6ebd02139e2e8fd62d6ef523e86e3",
+        "block": str(args.block),
+        "attention_scale": str(1 / math.sqrt(head_dimension)),
+    })
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reference-parity/export_dreamx_camera_fixture.py
+++ b/scripts/reference-parity/export_dreamx_camera_fixture.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Export DreamX trajectory and PRoPE tensors for the Swift/MLX parity tests."""
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+
+
+def tensor_payload(tensor):
+    value = tensor.detach().cpu().float().contiguous()
+    return {"shape": list(value.shape), "values": value.flatten().tolist()}
+
+
+def load_source_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_dreamx_inference_utils(dreamx_root):
+    package_name = "dreamx_fixture_utils"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(dreamx_root / "utils")]
+    sys.modules[package_name] = package
+    load_source_module(
+        f"{package_name}.pose_utils",
+        dreamx_root / "utils" / "pose_utils.py",
+    )
+    return load_source_module(
+        f"{package_name}.inference_utils",
+        dreamx_root / "utils" / "inference_utils.py",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dreamx-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import torch
+
+    inference_module = load_dreamx_inference_utils(args.dreamx_root)
+    prope_module = load_source_module(
+        "dreamx_camera_prope",
+        args.dreamx_root / "wan" / "modules" / "camera_prope.py",
+    )
+
+    torch.manual_seed(0)
+    segments = [("w", 3), ("j", 5)]
+    pixel_frame_count = 17
+    duration = -(-pixel_frame_count // len(segments))
+    poses = inference_module.ActionToPoseFromID(
+        [action for action, _ in segments],
+        [speed for _, speed in segments],
+        duration=duration,
+    )
+    camera, _ = inference_module.GetPoseEmbedsFromPosesPrope(
+        poses[:pixel_frame_count],
+        h=704,
+        w=1280,
+        target_length=pixel_frame_count,
+        dtype=torch.float32,
+    )
+    view_matrices = camera["viewmats"].unsqueeze(0)
+    intrinsics = camera["K"].unsqueeze(0)
+    frame_count = view_matrices.shape[1]
+    sequence = frame_count * 2
+    heads = 2
+    dimension = 8
+    total = heads * sequence * dimension
+    query = torch.arange(total, dtype=torch.float32).reshape(1, heads, sequence, dimension) / 101
+    key = (torch.arange(total, dtype=torch.float32) + 7).reshape(1, heads, sequence, dimension) / 97
+    value = (torch.arange(total, dtype=torch.float32) - 11).reshape(1, heads, sequence, dimension) / 89
+    output_input = (torch.arange(total, dtype=torch.float32) + 3).reshape(1, heads, sequence, dimension) / 83
+    encoded_query, encoded_key, encoded_value, apply_output = prope_module.prope_qkv(
+        query,
+        key,
+        value,
+        viewmats=view_matrices,
+        Ks=intrinsics,
+    )
+    output = {
+        "source_revision": "AMAP-ML/DreamX-World@f2bf6bf",
+        "trajectory": {
+            "segments": segments,
+            "pixel_frame_count": pixel_frame_count,
+        },
+        "view_matrices": tensor_payload(view_matrices),
+        "intrinsics": tensor_payload(intrinsics),
+        "query_input": tensor_payload(query),
+        "query_output": tensor_payload(encoded_query),
+        "key_input": tensor_payload(key),
+        "key_output": tensor_payload(encoded_key),
+        "value_input": tensor_payload(value),
+        "value_output": tensor_payload(encoded_value),
+        "output_input": tensor_payload(output_input),
+        "output_output": tensor_payload(apply_output(output_input)),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2) + "\n")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reference-parity/export_dreamx_camera_transformer_fixture.py
+++ b/scripts/reference-parity/export_dreamx_camera_transformer_fixture.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Export a tiny full-transformer DreamX-5B-Cam BF16 reference fixture."""
+
+import argparse
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_source_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_dreamx_transformer(dreamx_root):
+    package_name = "dreamx_fixture_models"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(dreamx_root / "models")]
+    sys.modules[package_name] = package
+    load_source_module(
+        f"{package_name}.attention_utils",
+        dreamx_root / "models" / "attention_utils.py",
+    )
+    load_source_module(
+        f"{package_name}.prope_utils",
+        dreamx_root / "models" / "prope_utils.py",
+    )
+    distributed = types.ModuleType("dist")
+    distributed.get_sequence_parallel_rank = lambda: 0
+    distributed.get_sequence_parallel_world_size = lambda: 1
+    distributed.get_sp_group = lambda: None
+    distributed.usp_attn_forward = None
+    distributed.sp_prope_forward = None
+    sys.modules["dist"] = distributed
+    return load_source_module(
+        f"{package_name}.wan_transformer3d",
+        dreamx_root / "models" / "wan_transformer3d.py",
+    )
+
+
+def load_dreamx_inference_utils(dreamx_root):
+    package_name = "dreamx_transformer_fixture_utils"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(dreamx_root / "utils")]
+    sys.modules[package_name] = package
+    load_source_module(
+        f"{package_name}.pose_utils",
+        dreamx_root / "utils" / "pose_utils.py",
+    )
+    return load_source_module(
+        f"{package_name}.inference_utils",
+        dreamx_root / "utils" / "inference_utils.py",
+    )
+
+
+def upstream_base_tensor(key, value):
+    if key == "patch_embedding_proj.weight":
+        return "patch_embedding.weight", value.reshape(3072, 48, 1, 2, 2)
+    exact = {
+        "patch_embedding_proj.bias": "patch_embedding.bias",
+        "text_embedding_0.weight": "text_embedding.0.weight",
+        "text_embedding_0.bias": "text_embedding.0.bias",
+        "text_embedding_1.weight": "text_embedding.2.weight",
+        "text_embedding_1.bias": "text_embedding.2.bias",
+        "time_embedding_0.weight": "time_embedding.0.weight",
+        "time_embedding_0.bias": "time_embedding.0.bias",
+        "time_embedding_1.weight": "time_embedding.2.weight",
+        "time_embedding_1.bias": "time_embedding.2.bias",
+        "time_projection.weight": "time_projection.1.weight",
+        "time_projection.bias": "time_projection.1.bias",
+    }
+    if key in exact:
+        return exact[key], value
+    if ".ffn.fc1." in key:
+        return key.replace(".ffn.fc1.", ".ffn.0."), value
+    if ".ffn.fc2." in key:
+        return key.replace(".ffn.fc2.", ".ffn.2."), value
+    return key, value
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dreamx-root", type=Path, required=True)
+    parser.add_argument("--base-weights", type=Path, required=True)
+    parser.add_argument("--camera-weights", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    import torch
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    transformer_module = load_dreamx_transformer(args.dreamx_root)
+    inference = load_dreamx_inference_utils(args.dreamx_root)
+    with torch.device("meta"):
+        model = transformer_module.Wan2_2Transformer3DModel(
+            model_type="ti2v",
+            in_dim=48,
+            dim=3072,
+            ffn_dim=14336,
+            freq_dim=256,
+            text_dim=4096,
+            out_dim=48,
+            num_heads=24,
+            num_layers=30,
+            cross_attn_norm=True,
+            add_control_adapter=True,
+            cam_method="prope",
+        )
+
+    state = {}
+    with safe_open(args.base_weights, framework="pt", device="cpu") as source:
+        for key in source.keys():
+            mapped_key, value = upstream_base_tensor(key, source.get_tensor(key))
+            state[mapped_key] = value
+    with safe_open(args.camera_weights, framework="pt", device="cpu") as source:
+        for key in source.keys():
+            state[key] = source.get_tensor(key).to(torch.bfloat16)
+    missing, unexpected = model.load_state_dict(state, strict=False, assign=True)
+    if missing or unexpected:
+        raise RuntimeError(f"Checkpoint mismatch: missing={missing}, unexpected={unexpected}")
+    del state
+    head_dimension = model.dim // model.num_heads
+    model.freqs = torch.cat([
+        transformer_module.rope_params(1024, head_dimension - 4 * (head_dimension // 6)),
+        transformer_module.rope_params(1024, 2 * (head_dimension // 6)),
+        transformer_module.rope_params(1024, 2 * (head_dimension // 6)),
+    ], dim=1)
+    for module in model.modules():
+        if isinstance(module, torch.nn.LayerNorm) and module.elementwise_affine:
+            module.weight.data = module.weight.data.float()
+            module.bias.data = module.bias.data.float()
+    model.eval()
+
+    pixel_frame_count = 17
+    poses = inference.ActionToPoseFromID(["j"], [3], duration=pixel_frame_count)
+    camera, _ = inference.GetPoseEmbedsFromPosesPrope(
+        poses[:pixel_frame_count],
+        h=704,
+        w=1280,
+        target_length=pixel_frame_count,
+        dtype=torch.bfloat16,
+    )
+    sequence = 10
+    latent_values = torch.arange(48 * 5 * 2 * 4, dtype=torch.float32).reshape(48, 5, 2, 4)
+    latent = (torch.sin(latent_values / 79) * 0.25).to(torch.bfloat16)
+    context_values = torch.arange(4 * 4096, dtype=torch.float32).reshape(4, 4096)
+    context = (torch.cos(context_values / 113) * 0.125).to(torch.bfloat16)
+    timesteps = torch.full((1, sequence), 1000, dtype=torch.float32)
+    timesteps[:, :2] = 0
+    with torch.inference_mode(), torch.autocast("cpu", dtype=torch.bfloat16):
+        output = model(
+            x=[latent],
+            t=timesteps,
+            context=[context],
+            seq_len=sequence,
+            y_camera={
+                "viewmats": camera["viewmats"].unsqueeze(0),
+                "K": camera["K"].unsqueeze(0),
+            },
+        )[0]
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_file({
+        "input": latent.contiguous(),
+        "timesteps": timesteps.contiguous(),
+        "context": context.contiguous(),
+        "view_matrices": camera["viewmats"].unsqueeze(0).contiguous(),
+        "intrinsics": camera["K"].unsqueeze(0).contiguous(),
+        "output": output.float().contiguous(),
+    }, args.output, metadata={
+        "source": "AMAP-ML/DreamX-World",
+        "source_revision": "f2bf6bf9ab716e9e9b5a27288abc5b9b97420adb",
+        "camera_revision": "a4379c7723f6ebd02139e2e8fd62d6ef523e86e3",
+        "compute_dtype": "bfloat16",
+    })
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- ports DreamX camera trajectories, projective camera attention, PRoPE, released adapter loading, and full DreamX-World-5B-AR checkpoint conversion into native Swift/MLX
- adds block-causal self-attention with rolling KV caches, cross-attention caches, official causal forcing schedule, BF16 precision boundaries, and DreamX Lab color stabilization
- adds a bounded temporal VAE decode window so long world sessions remain constant-memory instead of decoding the full history every move
- adds a warm `mere.run world serve` HTTP lifecycle with prepare, transition jobs, progress history, cancellation, reset, unload, receipts, and persistent opaque state
- registers local-only managed model metadata for the converted causal checkpoint and documents conversion, parity, and serving workflows
- adds focused unit, inventory, real-checkpoint, and PyTorch parity coverage

## Why

The existing Wan TI2V path could generate isolated clips but could not maintain a navigable conditioned-video world. Full-history VAE decoding also made each move progressively slower and caused the macOS service to be killed after three 512x288 moves.

The new causal world mode keeps the released DreamX transformer behavior while bounding both attention history and decoder context for interactive local sessions.

## Validation

- `swift test --filter Wan2`: 56 tests, 0 failures
- fixture-backed DreamX suite: 7 tests, 0 failures
- full causal parity:
  - initial block cosine 0.9994272, MAE 0.015085176
  - recompute cosine 0.9979337, MAE 0.018270388
  - appended block cosine 0.9998847, MAE 0.010188606
- `WorldCommandTests`: 3 tests, 0 failures
- Python conversion/parity scripts compile cleanly
- real Apple Silicon run: 12 consecutive 512x288 causal moves in one session, flat RSS around 25.98 GB, with transition-boundary SSIM 0.965-0.981
- Local Recon Lab browser path verified W/S/A/D/Q/E generation, exact inverse playback, warm state reuse, endpoint locks, and graph persistence

## Developer impact

The released DreamX checkpoints remain external local assets; this PR does not redistribute model weights. The causal model manifest intentionally has no incompatible hub fallback.
