### PR TITLE
Polish the Studio app: icon rail, step progress, and detail fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ The format is based on Keep a Changelog.
 
 ### Changed
 
+- polished the macOS Studio app: narrow windows keep an icon rail for mode
+  navigation instead of hiding the sidebar; image generation shows a
+  determinate per-step progress bar (parsing both the human `Generating (N/M)`
+  stderr text and the `--progress-json` event stream); example prompt chips
+  wrap instead of truncating; a blank chat no longer shows a duplicate
+  "New chat" header; the composer's model pill shows a human-readable model
+  name (exact id in the tooltip) and the paste button appears only when the
+  clipboard holds an image; results cap to a readable width on wide windows;
+  Listen uses a mic-badged waveform icon; sidebar footer controls use themed
+  styling.
 - reduced autoregressive prefill and decode work across shared Qwen, ACE-Step,
   ASR, TTS, OCR, VLM, MuScriptor, and Falcon paths with final-position output
   projection, pipelined GPU sampling, compact grouped-query caches, and true

--- a/Sources/MereRunApp/MereRunControls.swift
+++ b/Sources/MereRunApp/MereRunControls.swift
@@ -22,6 +22,44 @@ extension ButtonStyle where Self == MerePrimaryButtonStyle {
     static var merePrimary: MerePrimaryButtonStyle { MerePrimaryButtonStyle() }
 }
 
+/// A quiet secondary action: themed surface + border with hover feedback, replacing the
+/// native `.bordered` look so custom panels stay visually consistent in both appearances.
+struct MereSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        MereSecondaryButtonBody(configuration: configuration)
+    }
+
+    private struct MereSecondaryButtonBody: View {
+        let configuration: Configuration
+        @State private var hovering = false
+
+        var body: some View {
+            configuration.label
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(hovering ? MereRunTheme.textPrimary : MereRunTheme.textSecondary)
+                .padding(.horizontal, MereRunTheme.Spacing.sm)
+                .frame(minHeight: 26)
+                .background {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                        .fill(hovering ? MereRunTheme.surfaceRaised : MereRunTheme.surface.opacity(0.5))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                                .strokeBorder(MereRunTheme.border.opacity(0.7), lineWidth: 1)
+                        }
+                }
+                .contentShape(Rectangle())
+                .scaleEffect(configuration.isPressed ? 0.98 : 1)
+                .onHover { hovering = $0 }
+                .animation(MereRunTheme.Motion.quick, value: hovering)
+                .animation(MereRunTheme.Motion.quick, value: configuration.isPressed)
+        }
+    }
+}
+
+extension ButtonStyle where Self == MereSecondaryButtonStyle {
+    static var mereSecondary: MereSecondaryButtonStyle { MereSecondaryButtonStyle() }
+}
+
 /// Icon-only buttons that acknowledge the pointer: a soft fill on hover, a slight press dip.
 /// Hover feedback is what separates a native-feeling control from a static glyph.
 struct MereIconButtonStyle: ButtonStyle {

--- a/Sources/MereRunApp/StudioCanvas.swift
+++ b/Sources/MereRunApp/StudioCanvas.swift
@@ -153,18 +153,10 @@ struct StudioEmptyState: View {
             }
 
             if !mode.examplePrompts.isEmpty, let onUseExample {
-                Group {
-                    if isCompact {
-                        VStack(spacing: 6) {
-                            examplePrompts(onUseExample: onUseExample)
-                        }
-                    } else {
-                        HStack(spacing: MereRunTheme.Spacing.xs) {
-                            examplePrompts(onUseExample: onUseExample)
-                        }
-                    }
+                FlowLayout(spacing: MereRunTheme.Spacing.xs, lineSpacing: 8) {
+                    examplePrompts(onUseExample: onUseExample)
                 }
-                .frame(maxWidth: 720)
+                .frame(maxWidth: isCompact ? 320 : 620)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -198,24 +190,86 @@ private struct StudioExampleChip: View {
             Text("“\(text)”")
                 .font(MereRunTheme.captionFont)
                 .foregroundStyle(hovering ? MereRunTheme.textPrimary : MereRunTheme.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 300, alignment: .leading)
                 .padding(.horizontal, 12)
-                .frame(height: 30)
+                .padding(.vertical, 7)
                 .background {
-                    Capsule()
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
                         .fill(hovering ? MereRunTheme.surfaceRaised : MereRunTheme.surface.opacity(0.7))
                         .overlay {
-                            Capsule().strokeBorder(MereRunTheme.border.opacity(0.65), lineWidth: 1)
+                            RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                                .strokeBorder(MereRunTheme.border.opacity(0.65), lineWidth: 1)
                         }
                 }
-                .contentShape(Capsule())
+                .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg))
         }
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .animation(MereRunTheme.Motion.quick, value: hovering)
         .help("Use this prompt")
         .accessibilityLabel("Use example prompt: \(text)")
+    }
+}
+
+/// Places example chips left-to-right and wraps to a new centered row when the next
+/// chip would overflow the available width — so prompts size to their content and
+/// never truncate mid-word regardless of window width.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+    var lineSpacing: CGFloat = 8
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = arrange(subviews: subviews, maxWidth: maxWidth)
+        let height = rows.map(\.height).reduce(0, +)
+            + CGFloat(max(0, rows.count - 1)) * lineSpacing
+        let width = rows.map(\.width).max() ?? 0
+        return CGSize(width: min(width, maxWidth), height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let rows = arrange(subviews: subviews, maxWidth: bounds.width)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX + (bounds.width - row.width) / 2
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += row.height + lineSpacing
+        }
+    }
+
+    private func arrange(subviews: Subviews, maxWidth: CGFloat) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let projected = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            if !current.indices.isEmpty, projected > maxWidth {
+                rows.append(current)
+                current = Row()
+            }
+            current.width = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            current.height = max(current.height, size.height)
+            current.indices.append(index)
+        }
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
     }
 }
 
@@ -476,10 +530,14 @@ struct StudioOutputView: View {
                     .accessibilityLabel("Reveal in Finder")
 
                     Button("Open", action: onOpen)
-                        .buttonStyle(.bordered)
+                        .buttonStyle(.mereSecondary)
                 }
             }
         }
+        // Cap to a comfortable reading measure and center, so a single result
+        // doesn't stretch into a lonely island on very wide windows.
+        .frame(maxWidth: 900)
+        .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder

--- a/Sources/MereRunApp/StudioComposer.swift
+++ b/Sources/MereRunApp/StudioComposer.swift
@@ -20,6 +20,10 @@ struct StudioComposer: View {
     let onPaste: () -> Void
     let onShowModels: () -> Void
 
+    /// Whether the clipboard currently holds an image, so the paste affordance only
+    /// appears when it can actually do something (refreshed on appear + on focus).
+    @State private var clipboardHasImage = false
+
     var body: some View {
         VStack(spacing: MereRunTheme.Spacing.xs) {
             if !draft.inputPath.isBlank {
@@ -38,6 +42,14 @@ struct StudioComposer: View {
             }
         }
         .animation(MereRunTheme.Motion.standard, value: draft.inputPath.isBlank)
+        .onAppear(perform: refreshClipboardImageState)
+        .onChange(of: promptFocus.wrappedValue) { _, focused in
+            if focused { refreshClipboardImageState() }
+        }
+    }
+
+    private func refreshClipboardImageState() {
+        clipboardHasImage = NSPasteboard.general.canReadObject(forClasses: [NSImage.self], options: nil)
     }
 
     private var attachmentChip: some View {
@@ -163,7 +175,7 @@ struct StudioComposer: View {
             .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
             .accessibilityLabel(mode.requiresAttachment ? "Attach required input" : "Attach reference")
 
-            if mode.acceptedTypes.contains(.image) {
+            if mode.acceptedTypes.contains(.image), clipboardHasImage {
                 Button(action: onPaste) {
                     Image(systemName: "doc.on.clipboard")
                         .font(.system(size: 14, weight: .semibold))
@@ -172,8 +184,10 @@ struct StudioComposer: View {
                 .buttonStyle(.mereIcon)
                 .help("Paste image from clipboard (⌘V)")
                 .accessibilityLabel("Paste image from clipboard")
+                .transition(.opacity.combined(with: .scale(scale: 0.8)))
             }
         }
+        .animation(MereRunTheme.Motion.quick, value: clipboardHasImage)
     }
 
     @ViewBuilder
@@ -328,20 +342,44 @@ struct StudioComposer: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
-        .help("Model for this run")
+        .help(rawModelID.isEmpty ? "Auto — the mode's default model" : "Model: \(rawModelID)")
         .accessibilityLabel("Model")
-        .accessibilityValue(modelLabel)
+        .accessibilityValue(rawModelID.isEmpty ? "Automatic" : rawModelID)
+    }
+
+    /// The resolved model id for this run: the explicit draft model, else the
+    /// mode's template default, else empty (Auto).
+    private var rawModelID: String {
+        let current = draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !current.isEmpty { return current }
+        return CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
     }
 
     private var modelLabel: String {
-        let current = draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !current.isEmpty { return shortModelName(current) }
-        let templateDefault = CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
-        return templateDefault.isEmpty ? "Auto" : shortModelName(templateDefault)
+        rawModelID.isEmpty ? "Auto" : Self.displayModelName(rawModelID)
     }
 
-    private func shortModelName(_ id: String) -> String {
-        id.components(separatedBy: "/").last ?? id
+    /// A human-facing label for a model id: drop the modality/category prefix and
+    /// title-case the distinctive remainder ("text-agent-deepseek-v4-flash" →
+    /// "Deepseek V4 Flash"). The exact id stays in the pill's tooltip, so the
+    /// friendly name never hides what the CLI actually expects.
+    static func displayModelName(_ id: String) -> String {
+        let leaf = id.components(separatedBy: "/").last ?? id
+        let prefixes = [
+            "text-chat-", "text-agent-", "text-embed-", "text-code-",
+            "image-", "video-", "music-", "sfx-", "speech-", "embed-", "vision-", "text-"
+        ]
+        var core = leaf
+        for prefix in prefixes where core.hasPrefix(prefix) {
+            core = String(core.dropFirst(prefix.count))
+            break
+        }
+        let words = core.split(separator: "-").map { token -> String in
+            guard let first = token.first, first.isLetter else { return String(token) }
+            return first.uppercased() + token.dropFirst()
+        }
+        let label = words.joined(separator: " ")
+        return label.isEmpty ? leaf : label
     }
 
     private var groupedModelCategories: [(category: String, rows: [StudioModelInventoryRow])] {

--- a/Sources/MereRunApp/StudioConversationView.swift
+++ b/Sources/MereRunApp/StudioConversationView.swift
@@ -27,12 +27,20 @@ struct StudioConversationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-            Divider().overlay(MereRunTheme.border.opacity(0.4))
+            // A blank new chat shows only its empty state — no header, so the
+            // thread title and the "New chat" action never read as duplicates.
+            if hasActiveConversation {
+                header
+                Divider().overlay(MereRunTheme.border.opacity(0.4))
+            }
             if droppedFromContext > 0 { contextTrimBanner }
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var hasActiveConversation: Bool {
+        item != nil || !messages.isEmpty || isRunning
     }
 
     private var contextTrimBanner: some View {
@@ -47,7 +55,7 @@ struct StudioConversationView: View {
 
     private var header: some View {
         HStack(spacing: MereRunTheme.Spacing.sm) {
-            Text(item?.displayTitle ?? "New chat")
+            Text(item?.displayTitle ?? "Untitled chat")
                 .font(MereRunTheme.sectionFont)
                 .foregroundStyle(MereRunTheme.textSecondary)
                 .lineLimit(1)

--- a/Sources/MereRunApp/StudioLayout.swift
+++ b/Sources/MereRunApp/StudioLayout.swift
@@ -1,7 +1,8 @@
 import CoreGraphics
 
 /// The Studio has two deliberate window presentations. Regular keeps the desktop three-column
-/// workspace; compact promotes the canvas and composer while moving navigation into overlays.
+/// workspace; compact promotes the canvas and composer, narrowing navigation to an icon rail
+/// and moving the library into an overlay.
 enum StudioLayoutClass: Equatable {
     case compact
     case regular
@@ -11,6 +12,9 @@ enum StudioLayoutClass: Equatable {
 
 enum StudioLayoutPolicy {
     static let sidebarWidth: CGFloat = 212
+    /// The narrow-window icon rail: keeps every mode reachable when the full sidebar
+    /// doesn't fit, rather than hiding navigation entirely.
+    static let railWidth: CGFloat = 60
     static let libraryWidth: CGFloat = 272
     static let minimumCanvasWidth: CGFloat = 620
 

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -3,8 +3,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct StudioRootView: View {
-    private static let orderedModes = StudioModeGroup.allCases.flatMap(\.modes)
-
     @EnvironmentObject private var controller: MereRunController
     @StateObject private var library = StudioLibraryStore()
     // Persisted per scene so relaunch restores the last mode and panel layout.
@@ -128,18 +126,28 @@ struct StudioRootView: View {
     private func adaptiveShell(layout: StudioLayoutClass, availableWidth: CGFloat) -> some View {
         ZStack(alignment: .trailing) {
             HStack(spacing: 0) {
-                if !layout.isCompact {
+                if layout.isCompact {
+                    StudioSidebarRail(
+                        mode: $mode,
+                        modeCapabilities: modeCapabilities,
+                        onShowModels: { showModels = true },
+                        onShowHelp: { showHelp = true }
+                    )
+
+                    Divider()
+                        .overlay(MereRunTheme.border.opacity(0.4))
+                } else {
                     regularNavigation
 
                     Divider()
                         .overlay(MereRunTheme.border.opacity(0.4))
-                }
 
-                if !layout.isCompact, showLibrary {
-                    regularLibrary
+                    if showLibrary {
+                        regularLibrary
 
-                    Divider()
-                        .overlay(MereRunTheme.border.opacity(0.5))
+                        Divider()
+                            .overlay(MereRunTheme.border.opacity(0.5))
+                    }
                 }
 
                 contentColumn(isCompact: layout.isCompact)
@@ -633,20 +641,18 @@ struct StudioRootView: View {
     /// panel toggles. Machine-wide status lives in the sidebar; blocking states own the canvas.
     private func topBar(isCompact: Bool) -> some View {
         HStack(spacing: MereRunTheme.Spacing.sm) {
-            if isCompact {
-                compactModePicker
-            } else {
-                Image(systemName: mode.systemImage)
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.accent)
+            // The mode name is a static label in both layouts; switching lives in the
+            // sidebar (regular) or the icon rail (compact), never a subtle header menu.
+            Image(systemName: mode.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(MereRunTheme.accent)
 
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(mode.title)
-                        .font(.system(size: 15, weight: .semibold))
-                    Text(mode.subtitle)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(MereRunTheme.textMuted)
-                }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(mode.title)
+                    .font(.system(size: 15, weight: .semibold))
+                Text(mode.subtitle)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
             }
 
             Spacer()
@@ -687,64 +693,6 @@ struct StudioRootView: View {
         .padding(.horizontal, isCompact ? MereRunTheme.Spacing.md : MereRunTheme.Spacing.lg)
         .frame(height: 52)
         .background(VisualEffectBackground())
-    }
-
-    private var compactModePicker: some View {
-        Menu {
-            ForEach(StudioModeGroup.allCases) { group in
-                Section(group.rawValue) {
-                    ForEach(group.modes) { candidate in
-                        Button {
-                            mode = candidate
-                        } label: {
-                            if candidate == mode {
-                                Label(candidate.title, systemImage: "checkmark")
-                            } else {
-                                Label(candidate.title, systemImage: candidate.systemImage)
-                            }
-                        }
-                        .disabled(modeCapabilities[candidate]?.unavailableMessage != nil)
-                        .modifier(
-                            StudioModeShortcut(
-                                number: Self.orderedModes.firstIndex(of: candidate).flatMap { index in
-                                    index < 9 ? index + 1 : nil
-                                }
-                            )
-                        )
-                    }
-                }
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: mode.systemImage)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.accent)
-                    .frame(width: 20)
-                Text(mode.title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.textPrimary)
-                    .lineLimit(1)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.textMuted)
-            }
-            .padding(.horizontal, 10)
-            .frame(height: 30)
-            .background {
-                RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
-                    .fill(MereRunTheme.surface.opacity(0.62))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
-                            .strokeBorder(MereRunTheme.border.opacity(0.45), lineWidth: 1)
-                    }
-            }
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help("Switch creation mode")
-        .accessibilityLabel("Mode")
-        .accessibilityValue(mode.title)
     }
 
     private func libraryIsVisible(isCompact: Bool) -> Bool {

--- a/Sources/MereRunApp/StudioSidebar.swift
+++ b/Sources/MereRunApp/StudioSidebar.swift
@@ -95,20 +95,16 @@ struct StudioSidebar: View {
             HStack(spacing: 8) {
                 Button(action: onShowModels) {
                     Label("Models", systemImage: "shippingbox")
-                        .font(MereRunTheme.captionFont)
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                .buttonStyle(.mereSecondary)
                 .help("Browse and manage local models (⇧⌘M)")
 
                 Button(action: onShowHelp) {
                     Label("Guide", systemImage: "questionmark.circle")
-                        .font(MereRunTheme.captionFont)
                         .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
+                .buttonStyle(.mereSecondary)
                 .help("Open the offline guide")
             }
         }
@@ -175,6 +171,150 @@ private struct StudioSidebarRow: View {
         if let unavailableMessage { return unavailableMessage }
         if let shortcutNumber { return "\(mode.subtitle) (⌘\(shortcutNumber))" }
         return mode.subtitle
+    }
+}
+
+/// The narrow-window navigation: an icon-only rail so every mode stays reachable when the
+/// full sidebar doesn't fit — instead of hiding navigation behind a subtle header menu.
+struct StudioSidebarRail: View {
+    @Binding var mode: StudioMode
+    let modeCapabilities: [StudioMode: StudioModelCapability]
+    let onShowModels: () -> Void
+    let onShowHelp: () -> Void
+
+    @Namespace private var selectionNamespace
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private static let orderedModes: [StudioMode] = StudioModeGroup.allCases.flatMap(\.modes)
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("m")
+                .font(.system(size: 18, weight: .semibold, design: .serif))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .frame(height: 30)
+                .padding(.top, 42)
+                .padding(.bottom, MereRunTheme.Spacing.sm)
+                .accessibilityHidden(true)
+
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 5) {
+                    ForEach(Array(StudioModeGroup.allCases.enumerated()), id: \.element) { index, group in
+                        if index > 0 {
+                            Divider()
+                                .overlay(MereRunTheme.border.opacity(0.4))
+                                .frame(width: 22)
+                                .padding(.vertical, 3)
+                        }
+                        ForEach(group.modes) { candidate in
+                            StudioRailRow(
+                                mode: candidate,
+                                isSelected: candidate == mode,
+                                unavailableMessage: modeCapabilities[candidate]?.unavailableMessage,
+                                shortcutNumber: Self.orderedModes.firstIndex(of: candidate).flatMap { index in
+                                    index < 9 ? index + 1 : nil
+                                },
+                                namespace: selectionNamespace
+                            ) {
+                                guard candidate != mode else { return }
+                                if reduceMotion {
+                                    mode = candidate
+                                } else {
+                                    withAnimation(MereRunTheme.Motion.spring) { mode = candidate }
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+
+            Spacer(minLength: 0)
+
+            VStack(spacing: 4) {
+                railAction(system: "shippingbox", help: "Models (⇧⌘M)", label: "Models", action: onShowModels)
+                railAction(system: "questionmark.circle", help: "Guide", label: "Guide", action: onShowHelp)
+            }
+            .padding(.bottom, MereRunTheme.Spacing.sm)
+        }
+        .frame(width: StudioLayoutPolicy.railWidth)
+        .background {
+            VisualEffectBackground(material: .sidebar, blendingMode: .behindWindow)
+                .ignoresSafeArea()
+        }
+    }
+
+    private func railAction(
+        system: String,
+        help: String,
+        label: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: system)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .frame(width: 38, height: 32)
+        }
+        .buttonStyle(.mereIcon)
+        .help(help)
+        .accessibilityLabel(label)
+    }
+}
+
+/// One icon-only rail row: the same bronze sliding selection pill as the full sidebar,
+/// with a soft hover fill and the mode title in a tooltip.
+private struct StudioRailRow: View {
+    let mode: StudioMode
+    let isSelected: Bool
+    let unavailableMessage: String?
+    let shortcutNumber: Int?
+    let namespace: Namespace.ID
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: mode.systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(foregroundColor)
+                .frame(width: 40, height: 34)
+                .background {
+                    ZStack {
+                        if isSelected {
+                            RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                                .fill(MereRunTheme.accent)
+                                .matchedGeometryEffect(id: "studio.rail.selection", in: namespace)
+                        } else if hovering && unavailableMessage == nil {
+                            RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                                .fill(MereRunTheme.hoverFill)
+                        }
+                    }
+                }
+                .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.md))
+        }
+        .buttonStyle(.plain)
+        .disabled(unavailableMessage != nil)
+        .opacity(unavailableMessage == nil ? 1 : 0.4)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .help(helpText)
+        .modifier(StudioModeShortcut(number: shortcutNumber))
+        .accessibilityLabel(mode.title)
+        .accessibilityHint(unavailableMessage ?? mode.subtitle)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var foregroundColor: Color {
+        if unavailableMessage != nil { return MereRunTheme.textMuted }
+        return isSelected ? MereRunTheme.background : MereRunTheme.textSecondary
+    }
+
+    private var helpText: String {
+        if let unavailableMessage { return unavailableMessage }
+        if let shortcutNumber { return "\(mode.title) (⌘\(shortcutNumber))" }
+        return mode.title
     }
 }
 

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -62,7 +62,7 @@ enum StudioMode: String, CaseIterable, Codable, Identifiable {
         case .chat: return "bubble.left.and.bubble.right"
         case .code: return "chevron.left.forwardslash.chevron.right"
         case .speak: return "waveform"
-        case .listen: return "captions.bubble"
+        case .listen: return "waveform.badge.mic"
         case .readImage: return "doc.viewfinder"
         case .findObjects: return "scope"
         case .segment: return "square.dashed"
@@ -975,11 +975,69 @@ struct StudioRunProgress: Equatable {
     let detail: String?
 }
 
-/// Parses the carriage-return progress lines the CLI writes for downloads/extraction, e.g.
-/// `[image-zimage-nano] 45%  1.2 GB / 3.4 GB` or `[image-zimage-nano] 45%  (45 MB/s)`.
+/// Parses the progress lines `mere.run` writes to stderr — model download/extraction
+/// (`[image-zimage-nano] 45%  1.2 GB / 3.4 GB`) and per-step generation, in both the
+/// human `Generating (2/4)` form and the `--progress-json` NDJSON event stream — into a
+/// single determinate-or-indeterminate value the canvas can render.
 enum StudioProgressParser {
     static func parse(_ rawLine: String) -> StudioRunProgress? {
         let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Structured generation progress (from `--progress-json`):
+        // {"event":"progress","stage":"denoising","step":2,"total_steps":4}
+        if line.hasPrefix("{"), let generation = parseGenerationJSON(line) {
+            return generation
+        }
+
+        // Human generation progress the CLI prints during denoising, e.g. "Generating (2/4)".
+        if let generation = parseGeneratingLine(line) {
+            return generation
+        }
+
+        return parseDownloadLine(line)
+    }
+
+    /// "Generating (2/4)" → a determinate step fraction (the CLI prints 1-based steps).
+    private static func parseGeneratingLine(_ line: String) -> StudioRunProgress? {
+        guard let marker = line.range(of: "Generating (") else { return nil }
+        let inner = line[marker.upperBound...]
+        guard let slash = inner.firstIndex(of: "/"),
+              let close = inner.firstIndex(of: ")"), slash < close else { return nil }
+        let stepText = inner[inner.startIndex..<slash].trimmingCharacters(in: .whitespaces)
+        let totalText = inner[inner.index(after: slash)..<close].trimmingCharacters(in: .whitespaces)
+        guard let step = Int(stepText), let total = Int(totalText), total > 0 else { return nil }
+        let current = min(max(step, 0), total)
+        return StudioRunProgress(
+            label: "Generating",
+            fractionCompleted: Double(current) / Double(total),
+            detail: "Step \(current) of \(total)"
+        )
+    }
+
+    /// One NDJSON progress event; only the denoising stage carries the step bar (load
+    /// stages stay indeterminate and are left to the running overlay's status line).
+    private static func parseGenerationJSON(_ line: String) -> StudioRunProgress? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (object["event"] as? String) == "progress",
+              (object["stage"] as? String) == "denoising",
+              let step = intValue(object["step"]),
+              let total = intValue(object["total_steps"]), total > 0 else { return nil }
+        let current = min(step + 1, total) // the CLI emits a 0-based step index
+        return StudioRunProgress(
+            label: "Generating",
+            fractionCompleted: Double(current) / Double(total),
+            detail: "Step \(current) of \(total)"
+        )
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let double = value as? Double { return Int(double) }
+        return nil
+    }
+
+    private static func parseDownloadLine(_ line: String) -> StudioRunProgress? {
         guard line.hasPrefix("["), let close = line.firstIndex(of: "]") else { return nil }
         let label = String(line[line.index(after: line.startIndex)..<close])
             .trimmingCharacters(in: .whitespaces)


### PR DESCRIPTION
## What & why

A polish pass over the macOS Studio app, driven by a live review of the running app in both layout classes. Two structural improvements plus seven detail fixes. No behavior changes outside `Sources/MereRunApp`.

## Structural

- **Icon rail for narrow windows.** Below the regular breakpoint (1120px — including the default first-launch size) the sidebar used to disappear entirely, leaving mode switching behind a subtle header menu. It now collapses to a 60px icon rail: same bronze sliding selection pill, group dividers, ⌘1–9 shortcuts, capability-gated modes, Models/Guide at the foot. The header mode-menu is removed; the mode title is a static label in both layouts.
- **Determinate generation progress.** `StudioProgressParser` now parses per-step generation progress — both the human `Generating (N/M)` stderr text the CLI prints today and the `--progress-json` NDJSON event stream (#157) — alongside the existing `[model] 45% …` download format. The running card shows a real step bar ("Step 3 of 4", 75%) instead of a spinner.

## Detail fixes

- Example prompt chips wrap in a new `FlowLayout` (2-line max, content-sized) instead of truncating mid-word in fixed thirds.
- A blank chat no longer renders a redundant header where the title *and* the button both said "New chat"; active chats fall back to "Untitled chat".
- The composer's model pill shows a humanized name ("Zimage Nano", "Deepseek V4 Flash"); the exact model id moves to the tooltip and accessibility value.
- The paste-image button only appears when the clipboard actually holds an image (checked on appear/focus).
- Result cards cap at a 900px reading measure and center on wide windows.
- Listen's icon is now `waveform.badge.mic` — an input glyph pairing with Speak's `waveform`, no longer colliding with Chat's bubble (Library rows inherit it).
- Sidebar footer Models/Guide buttons use a new `mereSecondary` themed button style instead of native `.bordered`.

## Verification

- `swift build`, `swiftlint --strict` (changed files): clean
- Full `swift test`: **1348 tests, 0 failures**
- Every change exercised live in the running app at compact and regular widths, light mode — including a real zimage-nano generation showing the determinate step bar advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
