### PR TITLE
Add native MMAudio generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added native MMAudio large 44.1 kHz text-to-audio and video-to-audio SFX
+  generation, including managed pinned assets, DFN5B CLIP and Synchformer video
+  conditioning, the joint/fused MMDiT flow model, magnitude-preserving VAE,
+  BigVGAN-v2 decoding, negative prompts, preflight support, and explicit
+  CC-BY-NC-4.0 checkpoint, Apple research-only CLIP, and MIT BigVGAN licensing
+  metadata.
 - added explicit affine 8-bit resident KV caches for Gemma4, Qwen-family, and
   LFM2 plus opt-in compressed-MLA and fused sparse-MoE execution for the native
   Psi/GLM runtime, with numerical, structural-memory, and policy tests. Affine

--- a/Package.swift
+++ b/Package.swift
@@ -296,6 +296,7 @@ targets.append(contentsOf: [
       "LTX/README.md",
       "LoRA/README.md",
       "MagentaRT2/README.md",
+      "MMAudio/README.md",
       "PrivacyFilter/README.md",
       "Pose/README.md",
       "OpticalFlow/README.md",

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ swift run mere.run music realtime \
   --midi-cc 1=temp:0.2:1.4 \
   --midi-cc 2=drums:0:2
 
-# Generate a Foley / sound-effect WAV with Woosh
+# Generate a Foley / sound-effect WAV with Woosh or MMAudio
 swift run mere.run model pull sfx-woosh-dflow
 swift run mere.run model pull sfx-woosh-flow
 swift run mere.run sfx generate \
@@ -537,6 +537,17 @@ swift run mere.run sfx video generate \
   --output ./hallway-footsteps.wav \
   --preflight \
   --json
+swift run mere.run model pull sfx-mmaudio-large-44k-v2
+swift run mere.run sfx generate \
+  "ocean waves striking a stone breakwater" \
+  --negative-prompt "speech, music" \
+  --model sfx-mmaudio-large-44k-v2 \
+  --duration 8 \
+  --steps 25 \
+  --output ./breakwater.wav
+
+# MMAudio weights are non-commercial; its Apple CLIP component is research-only.
+# See docs/model-sources.md for the component-level licenses.
 
 # Generate a fast video-only draft
 swift run mere.run video generate \
@@ -711,7 +722,7 @@ Core guides:
 - [`docs/development-workflow.md`](./docs/development-workflow.md): how to work in the repo day to day
 - [`docs/testing.md`](./docs/testing.md): validation layers, smoke runs, and troubleshooting
 - [`docs/runtime/vision.md`](./docs/runtime/vision.md): native SAM 3.1 segmentation and tracking details
-- [`docs/runtime/sfx.md`](./docs/runtime/sfx.md): native Woosh SFX generation, CLAP scoring, and V2A feature-conditioned generation details
+- [`docs/runtime/sfx.md`](./docs/runtime/sfx.md): native Woosh and MMAudio SFX generation, CLAP scoring, and video-conditioned generation details
 
 Configuration and model management:
 

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -980,6 +980,20 @@ struct StudioRunProgress: Equatable {
 /// human `Generating (2/4)` form and the `--progress-json` NDJSON event stream — into a
 /// single determinate-or-indeterminate value the canvas can render.
 enum StudioProgressParser {
+    private struct GenerationProgressEvent: Decodable {
+        let event: String
+        let stage: String
+        let step: Int
+        let totalSteps: Int
+
+        enum CodingKeys: String, CodingKey {
+            case event
+            case stage
+            case step
+            case totalSteps = "total_steps"
+        }
+    }
+
     static func parse(_ rawLine: String) -> StudioRunProgress? {
         let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -1018,23 +1032,16 @@ enum StudioProgressParser {
     /// stages stay indeterminate and are left to the running overlay's status line).
     private static func parseGenerationJSON(_ line: String) -> StudioRunProgress? {
         guard let data = line.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              (object["event"] as? String) == "progress",
-              (object["stage"] as? String) == "denoising",
-              let step = intValue(object["step"]),
-              let total = intValue(object["total_steps"]), total > 0 else { return nil }
-        let current = min(step + 1, total) // the CLI emits a 0-based step index
+              let progress = try? JSONDecoder().decode(GenerationProgressEvent.self, from: data),
+              progress.event == "progress",
+              progress.stage == "denoising",
+              progress.totalSteps > 0 else { return nil }
+        let current = min(progress.step + 1, progress.totalSteps) // the CLI emits a 0-based step index
         return StudioRunProgress(
             label: "Generating",
-            fractionCompleted: Double(current) / Double(total),
-            detail: "Step \(current) of \(total)"
+            fractionCompleted: Double(current) / Double(progress.totalSteps),
+            detail: "Step \(current) of \(progress.totalSteps)"
         )
-    }
-
-    private static func intValue(_ value: Any?) -> Int? {
-        if let int = value as? Int { return int }
-        if let double = value as? Double { return Int(double) }
-        return nil
     }
 
     private static func parseDownloadLine(_ line: String) -> StudioRunProgress? {

--- a/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
@@ -18,19 +18,22 @@ struct SFXGenerate: AsyncParsableCommand {
     @Argument(help: "Prompt describing the target sound effect.")
     var prompt: String
 
+    @Option(name: [.customLong("negative-prompt")], help: "Negative text conditioning (MMAudio only).")
+    var negativePrompt: String = ""
+
     @Option(name: [.customShort("o"), .long], help: "Output WAV path (default: ./mererun-sfx-<timestamp>.wav).")
     var output: String?
 
-    @Option(name: [.customShort("m"), .long], help: "Managed model id or local Woosh checkpoints root.")
+    @Option(name: [.customShort("m"), .long], help: "Managed model id or local Woosh/MMAudio root.")
     var model: String = ModelResolver.ModelID.wooshDFlow.rawValue
 
-    @Option(name: [.customLong("duration")], help: "Output duration in seconds.")
-    var durationSeconds: Float = 5.0
+    @Option(name: [.customLong("duration")], help: "Output duration in seconds (default: 5 for Woosh, 8 for MMAudio).")
+    var durationOverride: Float?
 
-    @Option(name: [.customShort("s"), .long], help: "Number of denoise steps. DFlow usually uses 4; Flow usually uses 32.")
-    var steps: Int = 4
+    @Option(name: [.customShort("s"), .customLong("steps")], help: "Denoise steps (default: 4 for Woosh DFlow, 25 for MMAudio).")
+    var stepsOverride: Int?
 
-    @Option(name: [.customLong("cfg")], help: "Woosh guidance scale.")
+    @Option(name: [.customLong("cfg")], help: "Classifier-free guidance scale.")
     var guidanceScale: Float = 4.5
 
     @Option(name: [.long], help: "Seed for deterministic generation.")
@@ -42,6 +45,18 @@ struct SFXGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
+    var durationSeconds: Float {
+        durationOverride ?? (SFXMMAudioRuntime.isMMAudio(model: model)
+            ? MMAudioResources.defaultDurationSeconds
+            : 5)
+    }
+
+    var steps: Int {
+        stepsOverride ?? (SFXMMAudioRuntime.isMMAudio(model: model)
+            ? MMAudioResources.defaultSteps
+            : 4)
+    }
+
     func run() async throws {
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
         guard durationSeconds > 0 else {
@@ -52,6 +67,13 @@ struct SFXGenerate: AsyncParsableCommand {
         }
         guard guidanceScale >= 0 else {
             throw ValidationError("--cfg must be >= 0")
+        }
+        if SFXMMAudioRuntime.isMMAudio(model: model) {
+            try await runMMAudio()
+            return
+        }
+        guard negativePrompt.isEmpty else {
+            throw ValidationError("--negative-prompt is only supported by MMAudio models.")
         }
         let renoiseSchedule = try parseRenoiseSchedule()
 
@@ -79,6 +101,49 @@ struct SFXGenerate: AsyncParsableCommand {
         )
 
         try SFXWAVWriter.writeMonoPCM16(samples: result.samples, to: outputURL, sampleRate: result.sampleRate)
+        if !quiet {
+            CLIStderr.write("Saved audio: \(outputURL.path)\n")
+        }
+        print(outputURL.path)
+    }
+
+    private func runMMAudio() async throws {
+        guard renoise == nil else {
+            throw ValidationError("--renoise is only supported by Woosh models.")
+        }
+        let outputURL = CLIOutput.resolveOutputURL(
+            output,
+            defaultPrefix: "mererun-mmaudio",
+            defaultExtension: "wav"
+        )
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let resources = try await SFXMMAudioRuntime.resolve(model: model, quiet: quiet)
+        if !quiet {
+            CLIStderr.write("Loading native MMAudio assets from \(resources.rootURL.path)\n")
+        }
+        let generator = try MMAudioGenerator(resources: resources)
+        let result = try await generator.generateText(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            config: MMAudioGenerationConfig(
+                durationSeconds: durationSeconds,
+                steps: steps,
+                guidanceScale: guidanceScale,
+                seed: seed
+            ),
+            progress: { completed, total in
+                guard !quiet else { return }
+                CLIStderr.write("Generated MMAudio step \(completed)/\(total)\n")
+            }
+        )
+        try SFXWAVWriter.writeMonoPCM16(
+            samples: result.samples,
+            to: outputURL,
+            sampleRate: result.sampleRate
+        )
         if !quiet {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
@@ -133,6 +198,49 @@ struct SFXGenerate: AsyncParsableCommand {
         let missing = resources.missingFiles()
         guard missing.isEmpty else {
             throw ValidationError(WooshError.missingFiles(missing).localizedDescription)
+        }
+        return resources
+    }
+}
+
+enum SFXMMAudioRuntime {
+    static func isMMAudio(model: String, fileManager: FileManager = .default) -> Bool {
+        if model == MMAudioResources.modelID {
+            return true
+        }
+        let root = URL(fileURLWithPath: model).standardizedFileURL
+        return fileManager.fileExists(
+            atPath: root.appendingPathComponent(MMAudioResources.networkFilename).path
+        )
+    }
+
+    static func resolve(model: String, quiet: Bool) async throws -> MMAudioModelResources {
+        let explicit = URL(fileURLWithPath: model).standardizedFileURL
+        if FileManager.default.fileExists(atPath: explicit.path), isMMAudio(model: model) {
+            let resources = MMAudioModelResources(rootURL: explicit)
+            let missing = resources.validate()
+            guard missing.isEmpty else {
+                throw ValidationError(MMAudioGeneratorError.missingFiles(missing).localizedDescription)
+            }
+            return resources
+        }
+        let resolution = try await ManagedModelResolver.resolveForRuntime(
+            requestedModel: model,
+            defaultModelID: MMAudioResources.modelID,
+            progress: { event in
+                guard !quiet else { return }
+                switch event {
+                case .downloading(let percent):
+                    CLIStderr.write("Downloading MMAudio assets... \(percent)%\n")
+                case .extracting:
+                    CLIStderr.write("Extracting MMAudio assets...\n")
+                }
+            }
+        )
+        let resources = MMAudioModelResources(rootURL: resolution.url)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw ValidationError(MMAudioGeneratorError.missingFiles(missing).localizedDescription)
         }
         return resources
     }

--- a/Sources/MereRunCLI/Commands/SFXVideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/SFXVideoCommand.swift
@@ -27,6 +27,9 @@ struct SFXVideoGenerate: AsyncParsableCommand {
     @Argument(help: "Prompt describing the video sound.")
     var prompt: String
 
+    @Option(name: [.customLong("negative-prompt")], help: "Negative text conditioning (MMAudio only).")
+    var negativePrompt: String = ""
+
     @Argument(help: "Input video file, or Synchformer .npy features.")
     var input: String
 
@@ -56,6 +59,9 @@ struct SFXVideoGenerate: AsyncParsableCommand {
 
     @Option(name: [.customLong("sync-batch-size")], help: "Synchformer segment batch size for raw video input.")
     var syncBatchSize: Int = 1
+
+    @Option(name: [.customLong("clip-batch-size")], help: "MMAudio CLIP video-frame batch size.")
+    var clipBatchSize: Int = 4
 
     @Flag(name: [.customLong("preflight")], help: "Inspect the SFX video request without loading MLX or generating audio.")
     var preflight: Bool = false
@@ -92,14 +98,22 @@ struct SFXVideoGenerate: AsyncParsableCommand {
                 throw ValidationError("--cfg must be >= 0")
             }
         }
-        guard syncBatchSize > 0 else {
-            throw ValidationError("--sync-batch-size must be >= 1")
+        guard syncBatchSize > 0, clipBatchSize > 0 else {
+            throw ValidationError("--sync-batch-size and --clip-batch-size must be >= 1")
         }
 
         guard FileManager.default.fileExists(atPath: inputURL.path) else {
             throw ValidationError("Input not found: \(input)")
         }
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        if SFXMMAudioRuntime.isMMAudio(model: model) {
+            try await runMMAudio(inputURL: inputURL, outputURL: outputURL)
+            return
+        }
+        guard negativePrompt.isEmpty else {
+            throw ValidationError("--negative-prompt is only supported by MMAudio models.")
+        }
 
         let resolved = try await SFXWooshRuntime.resolve(model: model, quiet: quiet)
         guard resolved.variant == .vflow8s || resolved.variant == .dvflow8s else {
@@ -131,6 +145,48 @@ struct SFXVideoGenerate: AsyncParsableCommand {
         )
 
         try SFXWAVWriter.writeMonoPCM16(samples: result.samples, to: outputURL, sampleRate: result.sampleRate)
+        if !quiet {
+            CLIStderr.write("Saved audio: \(outputURL.path)\n")
+        }
+        print(outputURL.path)
+    }
+
+    private func runMMAudio(inputURL: URL, outputURL: URL) async throws {
+        guard inputURL.pathExtension.lowercased() != "npy" else {
+            throw ValidationError("MMAudio video generation requires the original video, not Synchformer-only .npy features.")
+        }
+        guard renoise == nil else {
+            throw ValidationError("--renoise is only supported by Woosh models.")
+        }
+        let resources = try await SFXMMAudioRuntime.resolve(model: model, quiet: quiet)
+        let stepCount = steps ?? MMAudioResources.defaultSteps
+        let cfg = guidanceScale ?? MMAudioResources.defaultGuidanceScale
+        if !quiet {
+            CLIStderr.write("Loading native MMAudio assets from \(resources.rootURL.path)\n")
+        }
+        let generator = try MMAudioGenerator(resources: resources)
+        let result = try await generator.generateVideo(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            videoURL: inputURL,
+            config: MMAudioGenerationConfig(
+                durationSeconds: durationSeconds,
+                steps: stepCount,
+                guidanceScale: cfg,
+                seed: seed
+            ),
+            clipBatchSize: clipBatchSize,
+            syncBatchSize: syncBatchSize,
+            progress: { completed, total in
+                guard !quiet else { return }
+                CLIStderr.write("Generated MMAudio step \(completed)/\(total)\n")
+            }
+        )
+        try SFXWAVWriter.writeMonoPCM16(
+            samples: result.samples,
+            to: outputURL,
+            sampleRate: result.sampleRate
+        )
         if !quiet {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }

--- a/Sources/MereRunCLI/Support/SFXVideoPreflight.swift
+++ b/Sources/MereRunCLI/Support/SFXVideoPreflight.swift
@@ -300,6 +300,16 @@ struct SFXVideoPreflightAnalyzer {
                     message: ".npy feature inputs are not loaded during preflight; runtime still validates shape [frames, 768] or [1, frames, 768]."
                 )
             )
+            if isMMAudioRequest {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "mmaudio_requires_video",
+                        severity: .blocker,
+                        title: "MMAudio requires the original video",
+                        message: "MMAudio needs both CLIP and Synchformer video features; a Synchformer-only .npy input is insufficient."
+                    )
+                )
+            }
         }
         return SFXVideoInputPreflightSummary(
             requested: input.inputURL.path,
@@ -307,7 +317,7 @@ struct SFXVideoPreflightAnalyzer {
             exists: exists,
             isDirectory: exists && isDirectory.boolValue,
             kind: kind,
-            requiresSynchformer: kind != "features"
+            requiresSynchformer: kind != "features" && !isMMAudioRequest
         )
     }
 
@@ -364,7 +374,10 @@ struct SFXVideoPreflightAnalyzer {
     }
 
     private func modelSummary(diagnostics: inout [PreflightDiagnostic]) -> SFXVideoModelPreflightSummary {
-        wooshModelSummary(
+        if isMMAudioRequest {
+            return mmaudioModelSummary(diagnostics: &diagnostics)
+        }
+        return wooshModelSummary(
             requested: input.model,
             role: "model",
             missingDiagnosticID: "model_missing",
@@ -372,6 +385,102 @@ struct SFXVideoPreflightAnalyzer {
             suggestedActionID: "pull-model",
             requireVideoVariant: true,
             diagnostics: &diagnostics
+        )
+    }
+
+    private var isMMAudioRequest: Bool {
+        SFXMMAudioRuntime.isMMAudio(model: input.model, fileManager: fileManager)
+    }
+
+    private func mmaudioModelSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> SFXVideoModelPreflightSummary {
+        let requested = input.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitURL = URL(fileURLWithPath: requested).standardizedFileURL
+        if fileManager.fileExists(atPath: explicitURL.path) {
+            let resources = MMAudioModelResources(rootURL: explicitURL)
+            let missing = resources.validate(fileManager: fileManager)
+            if !missing.isEmpty {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "model_missing_files",
+                        severity: .blocker,
+                        title: "MMAudio files missing",
+                        message: "MMAudio is missing \(missing.count) required file(s).",
+                        locations: missing.map { .init(kind: "file", path: $0.path) }
+                    )
+                )
+            }
+            return modelResult(
+                requested: requested,
+                kind: "local_path",
+                installed: missing.isEmpty,
+                path: explicitURL.path,
+                variant: "large_44k_v2",
+                supportedForVideo: true,
+                missingFiles: missing.map(\.path),
+                upstreamRepoID: MMAudioResources.upstreamRepoID
+            )
+        }
+
+        guard let modelID = ModelResolver.ModelID(rawValue: requested),
+              modelID == .mmaudioLarge44kV2,
+              let spec = ManagedModelCatalog.spec(for: requested) else {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "model_unknown",
+                    severity: .blocker,
+                    title: "Unknown MMAudio model",
+                    message: "MMAudio path not found and not a known model id: \(requested)."
+                )
+            )
+            return modelResult(requested: requested, kind: "unknown", installed: false)
+        }
+        if let resolution = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID) {
+            let resources = MMAudioModelResources(rootURL: resolution.rootURL)
+            let missing = resources.validate(fileManager: fileManager)
+            if !missing.isEmpty {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "model_missing_files",
+                        severity: .blocker,
+                        title: "MMAudio files missing",
+                        message: "Installed MMAudio is missing \(missing.count) required file(s).",
+                        locations: missing.map { .init(kind: "file", path: $0.path) }
+                    )
+                )
+            }
+            return modelResult(
+                requested: requested,
+                kind: "managed_model",
+                installed: missing.isEmpty,
+                path: resolution.rootURL.path,
+                id: modelID.rawValue,
+                variant: "large_44k_v2",
+                supportedForVideo: true,
+                missingFiles: missing.map(\.path),
+                upstreamRepoID: spec.upstreamRepoId,
+                estimatedDownloadBytes: spec.estimatedDownloadBytes
+            )
+        }
+        diagnostics.append(
+            PreflightDiagnostic(
+                id: "model_missing",
+                severity: .blocker,
+                title: "MMAudio model missing",
+                message: "Model \(requested) is not installed. Pull it before generation.",
+                suggestedActionIDs: ["pull-model"]
+            )
+        )
+        return modelResult(
+            requested: requested,
+            kind: "managed_model",
+            installed: false,
+            id: modelID.rawValue,
+            variant: "large_44k_v2",
+            supportedForVideo: true,
+            upstreamRepoID: spec.upstreamRepoId,
+            estimatedDownloadBytes: spec.estimatedDownloadBytes
         )
     }
 
@@ -682,6 +791,23 @@ struct SFXVideoPreflightAnalyzer {
         model: SFXVideoModelPreflightSummary,
         diagnostics: inout [PreflightDiagnostic]
     ) -> SFXVideoPlanPreflightSummary {
+        if isMMAudioRequest {
+            if input.renoise != nil {
+                diagnostics.append(renoiseDiagnostic("--renoise is only supported by Woosh models."))
+            }
+            return SFXVideoPlanPreflightSummary(
+                inputKind: input.inputURL.pathExtension.lowercased() == "npy" ? "features" : "video",
+                durationSeconds: input.durationSeconds,
+                requestedSteps: input.steps,
+                effectiveSteps: input.steps ?? MMAudioResources.defaultSteps,
+                requestedGuidanceScale: input.guidanceScale,
+                effectiveGuidanceScale: input.guidanceScale ?? MMAudioResources.defaultGuidanceScale,
+                seed: input.seed,
+                renoiseSchedule: [],
+                syncBatchSize: input.syncBatchSize,
+                sampleRate: MMAudioResources.sampleRate
+            )
+        }
         let variant = model.variant.flatMap(WooshVariant.init(rawValue:))
             ?? WooshVariant.resolve(model: input.model, fileManager: fileManager)
             ?? .dvflow8s

--- a/Sources/MereRunCore/MMAudio/MMAudioBigVGAN.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioBigVGAN.swift
@@ -1,0 +1,356 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+private final class MMAudioWeightNormParameters: Module {
+    @ParameterInfo(key: "original0") var magnitude: MLXArray
+    @ParameterInfo(key: "original1") var direction: MLXArray
+
+    init(magnitudeShape: [Int], directionShape: [Int]) {
+        self._magnitude.wrappedValue = MLXArray.ones(magnitudeShape)
+        self._direction.wrappedValue = MLXRandom.normal(directionShape) * 0.02
+    }
+}
+
+private final class MMAudioWeightParametrization: Module {
+    @ModuleInfo(key: "weight") var weight: MMAudioWeightNormParameters
+
+    init(magnitudeShape: [Int], directionShape: [Int]) {
+        self._weight.wrappedValue = MMAudioWeightNormParameters(
+            magnitudeShape: magnitudeShape,
+            directionShape: directionShape
+        )
+    }
+}
+
+private final class MMAudioBigVGANConv1D: Module {
+    @ModuleInfo(key: "parametrizations") var parametrizations: MMAudioWeightParametrization
+    @ParameterInfo(key: "bias") var bias: MLXArray?
+
+    private let stride: Int
+    private let padding: Int
+    private let dilation: Int
+
+    init(
+        inputChannels: Int,
+        outputChannels: Int,
+        kernelSize: Int,
+        stride: Int = 1,
+        padding: Int,
+        dilation: Int = 1,
+        bias: Bool = true
+    ) {
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self._parametrizations.wrappedValue = MMAudioWeightParametrization(
+            magnitudeShape: [outputChannels, 1, 1],
+            directionShape: [outputChannels, kernelSize, inputChannels]
+        )
+        self._bias.wrappedValue = bias ? MLXArray.zeros([outputChannels]) : nil
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let parameters = parametrizations.weight
+        let norm = MLX.sqrt(
+            MLX.sum(parameters.direction * parameters.direction, axes: [1, 2], keepDims: true) + 1e-12
+        )
+        let weight = parameters.direction * (parameters.magnitude / norm)
+        var output = MLX.conv1d(
+            x,
+            weight,
+            stride: stride,
+            padding: padding,
+            dilation: dilation
+        )
+        if let bias {
+            output = output + bias
+        }
+        return output
+    }
+}
+
+private final class MMAudioBigVGANConvTranspose1D: Module {
+    @ModuleInfo(key: "parametrizations") var parametrizations: MMAudioWeightParametrization
+    @ParameterInfo(key: "bias") var bias: MLXArray?
+
+    private let stride: Int
+    private let padding: Int
+
+    init(inputChannels: Int, outputChannels: Int, kernelSize: Int, stride: Int, padding: Int) {
+        self.stride = stride
+        self.padding = padding
+        self._parametrizations.wrappedValue = MMAudioWeightParametrization(
+            magnitudeShape: [inputChannels, 1, 1],
+            directionShape: [outputChannels, kernelSize, inputChannels]
+        )
+        self._bias.wrappedValue = MLXArray.zeros([outputChannels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let parameters = parametrizations.weight
+        let norm = MLX.sqrt(
+            MLX.sum(parameters.direction * parameters.direction, axes: [0, 1], keepDims: true) + 1e-12
+        )
+        let magnitude = parameters.magnitude.reshaped(1, 1, -1)
+        let weight = parameters.direction * (magnitude / norm)
+        var output = MLX.convTransposed1d(x, weight, stride: stride, padding: padding)
+        if let bias {
+            output = output + bias
+        }
+        return output
+    }
+}
+
+private final class MMAudioSnakeBeta: Module {
+    @ParameterInfo(key: "alpha") var alpha: MLXArray
+    @ParameterInfo(key: "beta") var beta: MLXArray
+
+    init(channels: Int) {
+        self._alpha.wrappedValue = MLXArray.zeros([channels])
+        self._beta.wrappedValue = MLXArray.zeros([channels])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let frequency = MLX.exp(alpha).reshaped(1, 1, -1)
+        let magnitude = MLX.exp(beta).reshaped(1, 1, -1)
+        let periodic = MLX.sin(x * frequency)
+        return x + periodic * periodic / (magnitude + 1e-9)
+    }
+}
+
+private enum MMAudioAliasFreeFilter {
+    static let values: [Float] = [
+        0.00202896645, 0.00938946394, -0.0255434641, -0.0576573755,
+        0.128572609, 0.4432098, 0.4432098, 0.128572609,
+        -0.0576573755, -0.0255434641, 0.00938946394, 0.00202896645,
+    ]
+
+    static func weight(channels: Int, dtype: DType) -> MLXArray {
+        MLX.tiled(
+            MLXArray(values).reshaped(1, values.count, 1),
+            repetitions: [channels, 1, 1]
+        ).asType(dtype)
+    }
+}
+
+private final class MMAudioAliasFreeActivation: Module {
+    @ModuleInfo(key: "act") var activation: MMAudioSnakeBeta
+
+    init(channels: Int) {
+        self._activation.wrappedValue = MMAudioSnakeBeta(channels: channels)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let channels = x.dim(2)
+        let left = MLX.repeated(x[0..., 0..<1, 0...], count: 5, axis: 1)
+        let right = MLX.repeated(x[0..., (x.dim(1) - 1)..., 0...], count: 5, axis: 1)
+        let padded = MLX.concatenated([left, x, right], axis: 1)
+        var upsampled = MLX.convTransposed1d(
+            padded,
+            MMAudioAliasFreeFilter.weight(channels: channels, dtype: x.dtype) * 2,
+            stride: 2,
+            padding: 0,
+            groups: channels
+        )
+        upsampled = upsampled[0..., 15..<(upsampled.dim(1) - 15), 0...]
+        let activated = activation(upsampled)
+        let downLeft = MLX.repeated(activated[0..., 0..<1, 0...], count: 5, axis: 1)
+        let downRight = MLX.repeated(activated[0..., (activated.dim(1) - 1)..., 0...], count: 6, axis: 1)
+        return MLX.conv1d(
+            MLX.concatenated([downLeft, activated, downRight], axis: 1),
+            MMAudioAliasFreeFilter.weight(channels: channels, dtype: x.dtype),
+            stride: 2,
+            padding: 0,
+            groups: channels
+        )
+    }
+}
+
+private final class MMAudioAMPBlock: Module {
+    @ModuleInfo(key: "convs1") var firstConvolutions: [MMAudioBigVGANConv1D]
+    @ModuleInfo(key: "convs2") var secondConvolutions: [MMAudioBigVGANConv1D]
+    @ModuleInfo(key: "activations") var activations: [MMAudioAliasFreeActivation]
+
+    init(channels: Int, kernelSize: Int) {
+        let dilations = [1, 3, 5]
+        self._firstConvolutions.wrappedValue = dilations.map { dilation in
+            MMAudioBigVGANConv1D(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: kernelSize,
+                padding: (kernelSize * dilation - dilation) / 2,
+                dilation: dilation
+            )
+        }
+        self._secondConvolutions.wrappedValue = dilations.map { _ in
+            MMAudioBigVGANConv1D(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: kernelSize,
+                padding: (kernelSize - 1) / 2
+            )
+        }
+        self._activations.wrappedValue = (0..<6).map { _ in
+            MMAudioAliasFreeActivation(channels: channels)
+        }
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = input
+        for index in 0..<firstConvolutions.count {
+            var update = activations[index * 2](hidden)
+            update = firstConvolutions[index](update)
+            update = activations[index * 2 + 1](update)
+            update = secondConvolutions[index](update)
+            hidden = hidden + update
+        }
+        return hidden
+    }
+}
+
+private final class MMAudioBigVGANUpsample: Module {
+    @ModuleInfo(key: "convolution") var convolution: MMAudioBigVGANConvTranspose1D
+
+    init(inputChannels: Int, outputChannels: Int, kernelSize: Int, stride: Int) {
+        self._convolution.wrappedValue = MMAudioBigVGANConvTranspose1D(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: kernelSize,
+            stride: stride,
+            padding: (kernelSize - stride) / 2
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        convolution(x)
+    }
+}
+
+public final class MMAudioBigVGAN: Module {
+    @ModuleInfo(key: "conv_pre") private var preConvolution: MMAudioBigVGANConv1D
+    @ModuleInfo(key: "ups") private var upsamplers: [MMAudioBigVGANUpsample]
+    @ModuleInfo(key: "resblocks") private var residualBlocks: [MMAudioAMPBlock]
+    @ModuleInfo(key: "activation_post") private var postActivation: MMAudioAliasFreeActivation
+    @ModuleInfo(key: "conv_post") private var postConvolution: MMAudioBigVGANConv1D
+
+    public override init() {
+        let rates = [8, 4, 2, 2, 2, 2]
+        let kernels = [16, 8, 4, 4, 4, 4]
+        var upsamplers: [MMAudioBigVGANUpsample] = []
+        var residualBlocks: [MMAudioAMPBlock] = []
+        for stage in rates.indices {
+            let inputChannels = 1_536 / (1 << stage)
+            let outputChannels = 1_536 / (1 << (stage + 1))
+            upsamplers.append(MMAudioBigVGANUpsample(
+                inputChannels: inputChannels,
+                outputChannels: outputChannels,
+                kernelSize: kernels[stage],
+                stride: rates[stage]
+            ))
+            for residualKernel in [3, 7, 11] {
+                residualBlocks.append(MMAudioAMPBlock(
+                    channels: outputChannels,
+                    kernelSize: residualKernel
+                ))
+            }
+        }
+
+        self._preConvolution.wrappedValue = MMAudioBigVGANConv1D(
+            inputChannels: 128,
+            outputChannels: 1_536,
+            kernelSize: 7,
+            padding: 3
+        )
+        self._upsamplers.wrappedValue = upsamplers
+        self._residualBlocks.wrappedValue = residualBlocks
+        self._postActivation.wrappedValue = MMAudioAliasFreeActivation(channels: 24)
+        self._postConvolution.wrappedValue = MMAudioBigVGANConv1D(
+            inputChannels: 24,
+            outputChannels: 1,
+            kernelSize: 7,
+            padding: 3,
+            bias: false
+        )
+    }
+
+    public func callAsFunction(_ spectrogram: MLXArray) -> MLXArray {
+        var hidden = preConvolution(spectrogram.asType(.float16))
+        for stage in upsamplers.indices {
+            hidden = upsamplers[stage](hidden)
+            let start = stage * 3
+            hidden = (
+                residualBlocks[start](hidden)
+                    + residualBlocks[start + 1](hidden)
+                    + residualBlocks[start + 2](hidden)
+            ) / 3
+        }
+        hidden = postConvolution(postActivation(hidden))
+        return MLX.clip(hidden, min: -1, max: 1)
+    }
+
+    public static func load(resources: MMAudioModelResources) throws -> MMAudioBigVGAN {
+        let model = MMAudioBigVGAN()
+        let weightsURL = resources.bigVGANWeightsURL()
+        if weightsURL.pathExtension == "safetensors" {
+            try HFSafetensorsWeightsLoader.applyWeights(
+                url: weightsURL,
+                to: model,
+                dtype: .float16,
+                verify: .none,
+                mapper: mapSafetensorsWeights
+            )
+        } else {
+            try MMAudioBigVGANCheckpointLoader.load(url: weightsURL, into: model)
+        }
+        return model
+    }
+
+    static func mapCheckpointWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key.hasSuffix(".filter") {
+            return []
+        }
+        let mappedKey = remapUpsampleKey(key)
+        if mappedKey.hasSuffix(".weight_g") {
+            let base = String(mappedKey.dropLast(".weight_g".count))
+            return [("\(base).parametrizations.weight.original0", value)]
+        }
+        if mappedKey.hasSuffix(".weight_v"), value.ndim == 3 {
+            let base = String(mappedKey.dropLast(".weight_v".count))
+            let isTranspose = mappedKey.hasPrefix("ups.")
+            let transposed = isTranspose ? value.transposed(1, 2, 0) : value.transposed(0, 2, 1)
+            return [(
+                "\(base).parametrizations.weight.original1",
+                transposed.reshaped(-1).reshaped(transposed.shape)
+            )]
+        }
+        return [(mappedKey, value)]
+    }
+
+    private static func remapUpsampleKey(_ key: String) -> String {
+        var components = key.split(separator: ".").map(String.init)
+        if components.count >= 4, components[0] == "ups", components[2] == "0" {
+            components[2] = "convolution"
+        }
+        return components.joined(separator: ".")
+    }
+
+    private static func mapSafetensorsWeights(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key.hasSuffix(".weight"), value.ndim == 3 {
+            let base = String(key.dropLast(".weight".count))
+            let isTranspose = key.hasPrefix("ups.")
+            let transposed = isTranspose ? value.transposed(1, 2, 0) : value.transposed(0, 2, 1)
+            let magnitudeAxes = isTranspose ? [0, 1] : [1, 2]
+            let magnitude = MLX.sqrt(MLX.sum(transposed * transposed, axes: magnitudeAxes, keepDims: true))
+            let reshapedMagnitude = isTranspose
+                ? magnitude.reshaped(-1, 1, 1)
+                : magnitude
+            return [
+                ("\(base).parametrizations.weight.original0", reshapedMagnitude),
+                ("\(base).parametrizations.weight.original1", transposed),
+            ]
+        }
+        return mapCheckpointWeight(key: key, value: value)
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioBigVGANCheckpoint.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioBigVGANCheckpoint.swift
@@ -1,0 +1,19 @@
+import Foundation
+import MLX
+import MLXNN
+
+enum MMAudioBigVGANCheckpointLoader {
+    static func load(url: URL, into model: MMAudioBigVGAN) throws {
+        let archive = try PyTorchStateDictArchive(url: url)
+        var updates: [(String, MLXArray)] = []
+        updates.reserveCapacity(archive.tensors.count)
+        for descriptor in archive.tensors {
+            let value = try archive.loadArray(for: descriptor, dtype: .float16)
+            updates.append(contentsOf: MMAudioBigVGAN.mapCheckpointWeight(
+                key: descriptor.name,
+                value: value
+            ))
+        }
+        try model.update(parameters: ModuleParameters.unflattened(updates), verify: .none)
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioCLIP.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioCLIP.swift
@@ -1,0 +1,408 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+private enum MMAudioCLIPConfig {
+    static let outputDimensions = 1_024
+    static let imageSize = 384
+    static let patchSize = 14
+    static let visionWidth = 1_280
+    static let visionLayers = 32
+    static let visionHeads = 16
+    static let textWidth = 1_024
+    static let textLayers = 24
+    static let textHeads = 16
+    static let vocabularySize = 49_408
+    static let contextLength = 77
+}
+
+private struct MMAudioCLIPTokenizerDocument: Decodable {
+    struct Model: Decodable {
+        let vocab: [String: Int]
+        let merges: [String]
+    }
+
+    let model: Model
+}
+
+private struct MMAudioCLIPBytePair: Hashable {
+    let left: String
+    let right: String
+}
+
+private enum MMAudioCLIPTokenizerError: LocalizedError {
+    case malformedMerge(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .malformedMerge(merge):
+            "Malformed CLIP BPE merge: \(merge)"
+        }
+    }
+}
+
+private final class MMAudioCLIPTokenizer {
+    private let vocabulary: [String: Int]
+    private let mergeRanks: [MMAudioCLIPBytePair: Int]
+    private let byteEncoder: [UInt8: String]
+    private let tokenRegex: NSRegularExpression
+    private let whitespaceRegex: NSRegularExpression
+
+    init(tokenizerURL: URL) throws {
+        let document = try JSONDecoder().decode(
+            MMAudioCLIPTokenizerDocument.self,
+            from: Data(contentsOf: tokenizerURL)
+        )
+        self.vocabulary = document.model.vocab
+        var mergeRanks: [MMAudioCLIPBytePair: Int] = [:]
+        for (index, merge) in document.model.merges.enumerated() {
+            let pieces = merge.split(separator: " ", omittingEmptySubsequences: false)
+            guard pieces.count == 2 else {
+                throw MMAudioCLIPTokenizerError.malformedMerge(merge)
+            }
+            mergeRanks[MMAudioCLIPBytePair(left: String(pieces[0]), right: String(pieces[1]))] = index
+        }
+        self.mergeRanks = mergeRanks
+        self.byteEncoder = Self.makeByteEncoder()
+        self.tokenRegex = try NSRegularExpression(
+            pattern: #"'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+"#
+        )
+        self.whitespaceRegex = try NSRegularExpression(pattern: #"\s+"#)
+    }
+
+    func encode(_ text: String) -> [Int] {
+        let normalized = normalize(text)
+        let nsText = normalized as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var ids = [49_406]
+        tokenRegex.enumerateMatches(in: normalized, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            let token = nsText.substring(with: match.range)
+            let encoded = token.utf8.map { byteEncoder[$0]! }.joined()
+            ids.append(contentsOf: bytePairEncode(encoded).map { vocabulary[$0] ?? 49_407 })
+        }
+        ids.append(49_407)
+        return ids
+    }
+
+    private func normalize(_ text: String) -> String {
+        let canonical = text.precomposedStringWithCanonicalMapping.lowercased()
+        let range = NSRange(location: 0, length: (canonical as NSString).length)
+        return whitespaceRegex.stringByReplacingMatches(
+            in: canonical,
+            range: range,
+            withTemplate: " "
+        )
+    }
+
+    private func bytePairEncode(_ token: String) -> [String] {
+        var symbols = token.unicodeScalars.map(String.init)
+        guard !symbols.isEmpty else { return [] }
+        symbols[symbols.count - 1] += "</w>"
+
+        while symbols.count > 1 {
+            var selectedPair: MMAudioCLIPBytePair?
+            var selectedRank = Int.max
+            for index in 0..<(symbols.count - 1) {
+                let pair = MMAudioCLIPBytePair(left: symbols[index], right: symbols[index + 1])
+                if let rank = mergeRanks[pair], rank < selectedRank {
+                    selectedPair = pair
+                    selectedRank = rank
+                }
+            }
+            guard let selectedPair else { break }
+
+            var merged: [String] = []
+            var index = 0
+            while index < symbols.count {
+                if index + 1 < symbols.count,
+                   symbols[index] == selectedPair.left,
+                   symbols[index + 1] == selectedPair.right {
+                    merged.append(symbols[index] + symbols[index + 1])
+                    index += 2
+                } else {
+                    merged.append(symbols[index])
+                    index += 1
+                }
+            }
+            symbols = merged
+        }
+        return symbols
+    }
+
+    private static func makeByteEncoder() -> [UInt8: String] {
+        var bytes = Array(UInt8(ascii: "!")...UInt8(ascii: "~"))
+        bytes.append(contentsOf: UInt8(0xA1)...UInt8(0xAC))
+        bytes.append(contentsOf: UInt8(0xAE)...UInt8(0xFF))
+        var codePoints = bytes.map(Int.init)
+        var extra = 0
+        for byte in UInt8.min...UInt8.max where !bytes.contains(byte) {
+            bytes.append(byte)
+            codePoints.append(256 + extra)
+            extra += 1
+        }
+        return Dictionary(uniqueKeysWithValues: zip(bytes, codePoints).map { byte, codePoint in
+            (byte, String(UnicodeScalar(codePoint)!))
+        })
+    }
+}
+
+private final class MMAudioCLIPAttention: Module {
+    @ParameterInfo(key: "in_proj_weight") var inputProjectionWeight: MLXArray
+    @ParameterInfo(key: "in_proj_bias") var inputProjectionBias: MLXArray
+    @ModuleInfo(key: "out_proj") var outputProjection: Linear
+
+    private let dimensions: Int
+    private let heads: Int
+    private let headDimensions: Int
+
+    init(dimensions: Int, heads: Int) {
+        self.dimensions = dimensions
+        self.heads = heads
+        self.headDimensions = dimensions / heads
+        self._inputProjectionWeight.wrappedValue = MLXRandom.normal([dimensions * 3, dimensions]) * 0.02
+        self._inputProjectionBias.wrappedValue = MLXArray.zeros([dimensions * 3])
+        self._outputProjection.wrappedValue = Linear(dimensions, dimensions, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+        let qkv = (matmul(x, inputProjectionWeight.transposed()) + inputProjectionBias)
+            .reshaped(batch, sequence, 3, heads, headDimensions)
+        let query = qkv[0..., 0..., 0, 0..., 0...].transposed(0, 2, 1, 3)
+        let key = qkv[0..., 0..., 1, 0..., 0...].transposed(0, 2, 1, 3)
+        let value = qkv[0..., 0..., 2, 0..., 0...].transposed(0, 2, 1, 3)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: query,
+            keys: key,
+            values: value,
+            scale: 1 / sqrt(Float(headDimensions)),
+            mask: mask.map { .array($0) } ?? .none
+        )
+        return outputProjection(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, dimensions))
+    }
+}
+
+private final class MMAudioCLIPMLP: Module {
+    @ModuleInfo(key: "c_fc") var input: Linear
+    @ModuleInfo(key: "c_proj") var output: Linear
+
+    init(dimensions: Int) {
+        self._input.wrappedValue = Linear(dimensions, dimensions * 4, bias: true)
+        self._output.wrappedValue = Linear(dimensions * 4, dimensions, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let projected = input(x)
+        return output(projected * MLX.sigmoid(1.702 * projected))
+    }
+}
+
+private final class MMAudioCLIPResidualBlock: Module {
+    @ModuleInfo(key: "ln_1") var firstNorm: LayerNorm
+    @ModuleInfo(key: "attn") var attention: MMAudioCLIPAttention
+    @ModuleInfo(key: "ln_2") var secondNorm: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: MMAudioCLIPMLP
+
+    init(dimensions: Int, heads: Int) {
+        self._firstNorm.wrappedValue = LayerNorm(dimensions: dimensions)
+        self._attention.wrappedValue = MMAudioCLIPAttention(dimensions: dimensions, heads: heads)
+        self._secondNorm.wrappedValue = LayerNorm(dimensions: dimensions)
+        self._mlp.wrappedValue = MMAudioCLIPMLP(dimensions: dimensions)
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
+        let attended = x + attention(firstNorm(x), mask: mask)
+        return attended + mlp(secondNorm(attended))
+    }
+}
+
+private final class MMAudioCLIPTransformer: Module {
+    @ModuleInfo(key: "resblocks") var blocks: [MMAudioCLIPResidualBlock]
+
+    init(dimensions: Int, heads: Int, layers: Int) {
+        self._blocks.wrappedValue = (0..<layers).map { _ in
+            MMAudioCLIPResidualBlock(dimensions: dimensions, heads: heads)
+        }
+    }
+
+    func callAsFunction(_ input: MLXArray, mask: MLXArray? = nil) -> MLXArray {
+        blocks.reduce(input) { hidden, block in
+            block(hidden, mask: mask)
+        }
+    }
+}
+
+private final class MMAudioCLIPVisionTower: Module {
+    @ModuleInfo(key: "conv1") var patchEmbedding: Conv2d
+    @ParameterInfo(key: "class_embedding") var classEmbedding: MLXArray
+    @ParameterInfo(key: "positional_embedding") var positionalEmbedding: MLXArray
+    @ModuleInfo(key: "ln_pre") var preNorm: LayerNorm
+    @ModuleInfo(key: "transformer") var transformer: MMAudioCLIPTransformer
+    @ModuleInfo(key: "ln_post") var postNorm: LayerNorm
+    @ParameterInfo(key: "proj") var projection: MLXArray
+
+    override init() {
+        let grid = MMAudioCLIPConfig.imageSize / MMAudioCLIPConfig.patchSize
+        self._patchEmbedding.wrappedValue = Conv2d(
+            inputChannels: 3,
+            outputChannels: MMAudioCLIPConfig.visionWidth,
+            kernelSize: IntOrPair(MMAudioCLIPConfig.patchSize),
+            stride: IntOrPair(MMAudioCLIPConfig.patchSize),
+            bias: false
+        )
+        self._classEmbedding.wrappedValue = MLXRandom.normal([MMAudioCLIPConfig.visionWidth]) * 0.02
+        self._positionalEmbedding.wrappedValue = MLXRandom.normal([
+            grid * grid + 1, MMAudioCLIPConfig.visionWidth,
+        ]) * 0.02
+        self._preNorm.wrappedValue = LayerNorm(dimensions: MMAudioCLIPConfig.visionWidth)
+        self._transformer.wrappedValue = MMAudioCLIPTransformer(
+            dimensions: MMAudioCLIPConfig.visionWidth,
+            heads: MMAudioCLIPConfig.visionHeads,
+            layers: MMAudioCLIPConfig.visionLayers
+        )
+        self._postNorm.wrappedValue = LayerNorm(dimensions: MMAudioCLIPConfig.visionWidth)
+        self._projection.wrappedValue = MLXRandom.normal([
+            MMAudioCLIPConfig.visionWidth, MMAudioCLIPConfig.outputDimensions,
+        ]) * 0.02
+    }
+
+    func callAsFunction(_ imagesNHWC: MLXArray) -> MLXArray {
+        var hidden = patchEmbedding(imagesNHWC)
+        let batch = hidden.dim(0)
+        hidden = hidden.reshaped(batch, -1, MMAudioCLIPConfig.visionWidth)
+        let classTokens = MLX.broadcast(
+            classEmbedding.reshaped(1, 1, MMAudioCLIPConfig.visionWidth),
+            to: [batch, 1, MMAudioCLIPConfig.visionWidth]
+        )
+        hidden = MLX.concatenated([classTokens, hidden], axis: 1)
+        hidden = preNorm(hidden + positionalEmbedding.expandedDimensions(axis: 0).asType(hidden.dtype))
+        hidden = transformer(hidden)
+        let pooled = postNorm(hidden[0..., 0, 0...])
+        return matmul(pooled, projection)
+    }
+}
+
+private final class MMAudioCLIPModel: Module {
+    @ModuleInfo(key: "visual") var visual: MMAudioCLIPVisionTower
+    @ModuleInfo(key: "token_embedding") var tokenEmbedding: Embedding
+    @ParameterInfo(key: "positional_embedding") var textPositionEmbedding: MLXArray
+    @ModuleInfo(key: "transformer") var textTransformer: MMAudioCLIPTransformer
+    @ModuleInfo(key: "ln_final") var textFinalNorm: LayerNorm
+    @ParameterInfo(key: "text_projection") var textProjection: MLXArray
+    @ParameterInfo(key: "logit_scale") var logitScale: MLXArray
+
+    override init() {
+        self._visual.wrappedValue = MMAudioCLIPVisionTower()
+        self._tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: MMAudioCLIPConfig.vocabularySize,
+            dimensions: MMAudioCLIPConfig.textWidth
+        )
+        self._textPositionEmbedding.wrappedValue = MLXRandom.normal([
+            MMAudioCLIPConfig.contextLength, MMAudioCLIPConfig.textWidth,
+        ]) * 0.01
+        self._textTransformer.wrappedValue = MMAudioCLIPTransformer(
+            dimensions: MMAudioCLIPConfig.textWidth,
+            heads: MMAudioCLIPConfig.textHeads,
+            layers: MMAudioCLIPConfig.textLayers
+        )
+        self._textFinalNorm.wrappedValue = LayerNorm(dimensions: MMAudioCLIPConfig.textWidth)
+        self._textProjection.wrappedValue = MLXRandom.normal([
+            MMAudioCLIPConfig.textWidth, MMAudioCLIPConfig.outputDimensions,
+        ]) * 0.02
+        self._logitScale.wrappedValue = MLXArray([Float(log(1 / 0.07))])
+    }
+
+    func encodeText(_ tokenIDs: MLXArray) -> MLXArray {
+        let length = tokenIDs.dim(1)
+        var hidden = tokenEmbedding(tokenIDs)
+        hidden = hidden + textPositionEmbedding[0..<length, 0...].expandedDimensions(axis: 0).asType(hidden.dtype)
+        hidden = textTransformer(hidden, mask: causalMask(length: length, dtype: hidden.dtype))
+        return normalize(textFinalNorm(hidden))
+    }
+
+    func encodeImages(_ imagesNHWC: MLXArray) -> MLXArray {
+        normalize(visual(imagesNHWC))
+    }
+
+    private func causalMask(length: Int, dtype: DType) -> MLXArray {
+        var values = [Float](repeating: 0, count: length * length)
+        for row in 0..<length {
+            for column in (row + 1)..<length {
+                values[row * length + column] = -.infinity
+            }
+        }
+        return MLXArray(values).reshaped(length, length).asType(dtype)
+    }
+
+    private func normalize(_ features: MLXArray) -> MLXArray {
+        let norm = MLX.sqrt((features * features).sum(axis: -1, keepDims: true))
+        return features / MLX.maximum(norm, MLXArray(1e-12).asType(features.dtype))
+    }
+}
+
+public final class MMAudioCLIPConditioner {
+    private let model: MMAudioCLIPModel
+    private let tokenizer: MMAudioCLIPTokenizer
+
+    private init(model: MMAudioCLIPModel, tokenizer: MMAudioCLIPTokenizer) {
+        self.model = model
+        self.tokenizer = tokenizer
+    }
+
+    public static func load(resources: MMAudioModelResources) async throws -> MMAudioCLIPConditioner {
+        let tokenizer = try MMAudioCLIPTokenizer(
+            tokenizerURL: resources.clipTokenizerURL.appendingPathComponent("tokenizer.json")
+        )
+        let model = MMAudioCLIPModel()
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.clipWeightsURL,
+            to: model,
+            dtype: .float16,
+            verify: .none,
+            mapper: mapWeights
+        )
+        return MMAudioCLIPConditioner(model: model, tokenizer: tokenizer)
+    }
+
+    public func encodeText(_ prompts: [String]) -> MLXArray {
+        let rows = tokenRows(for: prompts)
+        return model.encodeText(
+            MLXArray(rows.flatMap { $0 }).reshaped(rows.count, MMAudioCLIPConfig.contextLength)
+        )
+    }
+
+    func tokenIDs(for prompts: [String]) -> [Int32] {
+        tokenRows(for: prompts).flatMap { $0 }
+    }
+
+    private func tokenRows(for prompts: [String]) -> [[Int32]] {
+        prompts.map { prompt -> [Int32] in
+            var ids = tokenizer.encode(prompt).map(Int32.init)
+            if ids.count > MMAudioCLIPConfig.contextLength {
+                ids = Array(ids.prefix(MMAudioCLIPConfig.contextLength))
+                ids[ids.count - 1] = 49_407
+            }
+            ids.append(contentsOf: repeatElement(0, count: MMAudioCLIPConfig.contextLength - ids.count))
+            return ids
+        }
+    }
+
+    public func encodeImages(_ normalizedImagesNHWC: MLXArray) -> MLXArray {
+        model.encodeImages(normalizedImagesNHWC.asType(.float16))
+    }
+
+    private static func mapWeights(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "logit_bias" {
+            return []
+        }
+        if key == "visual.conv1.weight" {
+            let transposed = value.transposed(0, 2, 3, 1)
+            return [(key, transposed.reshaped(-1).reshaped(transposed.shape))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioCLIP.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioCLIP.swift
@@ -80,8 +80,8 @@ private final class MMAudioCLIPTokenizer {
         tokenRegex.enumerateMatches(in: normalized, range: fullRange) { match, _, _ in
             guard let match else { return }
             let token = nsText.substring(with: match.range)
-            let encoded = token.utf8.map { byteEncoder[$0]! }.joined()
-            ids.append(contentsOf: bytePairEncode(encoded).map { vocabulary[$0] ?? 49_407 })
+            let encoded = token.utf8.map { self.byteEncoder[$0]! }.joined()
+            ids.append(contentsOf: self.bytePairEncode(encoded).map { self.vocabulary[$0] ?? 49_407 })
         }
         ids.append(49_407)
         return ids

--- a/Sources/MereRunCore/MMAudio/MMAudioConditioner.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioConditioner.swift
@@ -1,0 +1,146 @@
+import Foundation
+import MediaIO
+import MLX
+
+public enum MMAudioConditioningError: LocalizedError {
+    case emptyVideo
+    case invalidFeatureShape(name: String, shape: [Int])
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyVideo:
+            "The input video contains no decodable frames."
+        case .invalidFeatureShape(let name, let shape):
+            "Invalid MMAudio \(name) feature shape: \(shape)."
+        }
+    }
+}
+
+public struct MMAudioConditioningResult {
+    public let positive: MMAudioConditionFeatures
+    public let negativeText: MLXArray
+
+    public init(positive: MMAudioConditionFeatures, negativeText: MLXArray) {
+        self.positive = positive
+        self.negativeText = negativeText
+    }
+}
+
+public final class MMAudioConditioner {
+    private let resources: MMAudioModelResources
+    private let clip: MMAudioCLIPConditioner
+
+    private init(resources: MMAudioModelResources, clip: MMAudioCLIPConditioner) {
+        self.resources = resources
+        self.clip = clip
+    }
+
+    public static func load(resources: MMAudioModelResources) async throws -> MMAudioConditioner {
+        MMAudioConditioner(
+            resources: resources,
+            clip: try await MMAudioCLIPConditioner.load(resources: resources)
+        )
+    }
+
+    public func textConditions(
+        prompt: String,
+        negativePrompt: String,
+        config: MMAudioGenerationConfig
+    ) -> MMAudioConditioningResult {
+        let text = clip.encodeText([prompt])
+        let negative = clip.encodeText([negativePrompt])
+        return MMAudioConditioningResult(
+            positive: MMAudioConditionFeatures(
+                clip: MLXArray.zeros([
+                    1, config.clipSequenceLength, MMAudioResources.clipDimension,
+                ], dtype: text.dtype),
+                sync: MLXArray.zeros([
+                    1, config.syncSequenceLength, MMAudioResources.syncDimension,
+                ], dtype: text.dtype),
+                text: text
+            ),
+            negativeText: negative
+        )
+    }
+
+    public func videoConditions(
+        prompt: String,
+        negativePrompt: String,
+        videoURL: URL,
+        config: MMAudioGenerationConfig,
+        clipBatchSize: Int = 4,
+        syncBatchSize: Int = 1
+    ) throws -> MMAudioConditioningResult {
+        let text = clip.encodeText([prompt])
+        let negative = clip.encodeText([negativePrompt])
+        let clipFeatures = try extractCLIPVideoFeatures(
+            videoURL: videoURL,
+            durationSeconds: config.durationSeconds,
+            batchSize: clipBatchSize
+        )
+        let synchformer = try WooshSynchformer(
+            resources: WooshSynchformerResources(rootURL: resources.rootURL)
+        )
+        let syncFeatures = try synchformer.extractMMAudioFeatures(
+            videoURL: videoURL,
+            durationSeconds: config.durationSeconds,
+            segmentBatchSize: syncBatchSize
+        )
+        guard clipFeatures.shape == [1, config.clipSequenceLength, MMAudioResources.clipDimension] else {
+            throw MMAudioConditioningError.invalidFeatureShape(name: "CLIP", shape: clipFeatures.shape)
+        }
+        guard syncFeatures.shape == [1, config.syncSequenceLength, MMAudioResources.syncDimension] else {
+            throw MMAudioConditioningError.invalidFeatureShape(name: "Synchformer", shape: syncFeatures.shape)
+        }
+        return MMAudioConditioningResult(
+            positive: MMAudioConditionFeatures(
+                clip: clipFeatures,
+                sync: syncFeatures,
+                text: text
+            ),
+            negativeText: negative
+        )
+    }
+
+    private func extractCLIPVideoFeatures(
+        videoURL: URL,
+        durationSeconds: Float,
+        batchSize: Int
+    ) throws -> MLXArray {
+        precondition(batchSize > 0)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-mmaudio-clip-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sequence = try MediaVideoIO.extractFrames(from: videoURL, into: directory)
+        guard !sequence.frameURLs.isEmpty else {
+            throw MMAudioConditioningError.emptyVideo
+        }
+        let targetCount = max(1, Int(durationSeconds * MMAudioResources.clipFramesPerSecond))
+        let indices = MMAudioVideoPreprocessor.sampledFrameIndices(
+            sourceFrameRate: max(1, sequence.fps),
+            sourceFrameCount: sequence.frameURLs.count,
+            targetFrameRate: Double(MMAudioResources.clipFramesPerSecond),
+            targetFrameCount: targetCount
+        )
+        var featureBatches: [MLXArray] = []
+        var start = 0
+        while start < indices.count {
+            let end = min(indices.count, start + batchSize)
+            let frames = try indices[start..<end].map { index in
+                MMAudioVideoPreprocessor.normalizedCLIPFrame(
+                    try MediaImageIO.decode(sequence.frameURLs[index])
+                )
+            }
+            let batch = MLX.concatenated(frames, axis: 0)
+            let encoded = clip.encodeImages(batch)
+            MLX.eval(encoded)
+            featureBatches.append(encoded)
+            start = end
+        }
+        let features = featureBatches.count == 1
+            ? featureBatches[0]
+            : MLX.concatenated(featureBatches, axis: 0)
+        return features.expandedDimensions(axis: 0)
+    }
+
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioGenerator.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioGenerator.swift
@@ -1,0 +1,183 @@
+import Foundation
+import MLX
+
+public struct MMAudioGenerationResult: Sendable, Hashable {
+    public let samples: [Float]
+    public let sampleRate: Int
+
+    public init(samples: [Float], sampleRate: Int = MMAudioResources.sampleRate) {
+        self.samples = samples
+        self.sampleRate = sampleRate
+    }
+}
+
+public final class MMAudioGenerator {
+    private let resources: MMAudioModelResources
+
+    public init(resources: MMAudioModelResources) throws {
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw MMAudioGeneratorError.missingFiles(missing)
+        }
+        self.resources = resources
+    }
+
+    public func generateText(
+        prompt: String,
+        negativePrompt: String = "",
+        config: MMAudioGenerationConfig,
+        progress: (@Sendable (_ completedStep: Int, _ totalSteps: Int) -> Void)? = nil
+    ) async throws -> MMAudioGenerationResult {
+        try validate(config)
+        let conditions = try await makeTextConditions(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            config: config
+        )
+        return try generate(conditions: conditions, config: config, progress: progress)
+    }
+
+    public func generateVideo(
+        prompt: String,
+        negativePrompt: String = "",
+        videoURL: URL,
+        config: MMAudioGenerationConfig,
+        clipBatchSize: Int = 4,
+        syncBatchSize: Int = 1,
+        progress: (@Sendable (_ completedStep: Int, _ totalSteps: Int) -> Void)? = nil
+    ) async throws -> MMAudioGenerationResult {
+        try validate(config)
+        let conditions = try await makeVideoConditions(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            videoURL: videoURL,
+            config: config,
+            clipBatchSize: clipBatchSize,
+            syncBatchSize: syncBatchSize
+        )
+        return try generate(conditions: conditions, config: config, progress: progress)
+    }
+
+    private func makeTextConditions(
+        prompt: String,
+        negativePrompt: String,
+        config: MMAudioGenerationConfig
+    ) async throws -> MMAudioConditioningResult {
+        let conditioner = try await MMAudioConditioner.load(resources: resources)
+        let conditions = conditioner.textConditions(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            config: config
+        )
+        MLX.eval(
+            conditions.positive.clip,
+            conditions.positive.sync,
+            conditions.positive.text,
+            conditions.negativeText
+        )
+        return conditions
+    }
+
+    private func makeVideoConditions(
+        prompt: String,
+        negativePrompt: String,
+        videoURL: URL,
+        config: MMAudioGenerationConfig,
+        clipBatchSize: Int,
+        syncBatchSize: Int
+    ) async throws -> MMAudioConditioningResult {
+        let conditioner = try await MMAudioConditioner.load(resources: resources)
+        let conditions = try conditioner.videoConditions(
+            prompt: prompt,
+            negativePrompt: negativePrompt,
+            videoURL: videoURL,
+            config: config,
+            clipBatchSize: clipBatchSize,
+            syncBatchSize: syncBatchSize
+        )
+        MLX.eval(
+            conditions.positive.clip,
+            conditions.positive.sync,
+            conditions.positive.text,
+            conditions.negativeText
+        )
+        return conditions
+    }
+
+    private func generate(
+        conditions: MMAudioConditioningResult,
+        config: MMAudioGenerationConfig,
+        progress: (@Sendable (_ completedStep: Int, _ totalSteps: Int) -> Void)?
+    ) throws -> MMAudioGenerationResult {
+        Memory.clearCache()
+        let latent = try sampleLatents(conditions: conditions, config: config, progress: progress)
+        Memory.clearCache()
+        let spectrogram = try decodeLatents(latent)
+        Memory.clearCache()
+        let samples = try vocode(spectrogram)
+        Memory.clearCache()
+        return MMAudioGenerationResult(samples: samples)
+    }
+
+    private func sampleLatents(
+        conditions: MMAudioConditioningResult,
+        config: MMAudioGenerationConfig,
+        progress: (@Sendable (_ completedStep: Int, _ totalSteps: Int) -> Void)?
+    ) throws -> MLXArray {
+        let network = try MMAudioNetwork.load(resources: resources)
+        let latent = network.sampleLatents(
+            conditions: conditions.positive,
+            negativeText: conditions.negativeText,
+            config: config,
+            progress: progress
+        )
+        MLX.eval(latent)
+        return latent
+    }
+
+    private func decodeLatents(_ latent: MLXArray) throws -> MLXArray {
+        let vae = try MMAudioVAE.load(resources: resources)
+        let spectrogram = vae.decode(latent)
+        MLX.eval(spectrogram)
+        return spectrogram
+    }
+
+    private func vocode(_ spectrogram: MLXArray) throws -> [Float] {
+        let vocoder = try MMAudioBigVGAN.load(resources: resources)
+        let waveform = vocoder(spectrogram)
+        MLX.eval(waveform)
+        return waveform[0, 0..., 0].asType(.float32).asArray(Float.self)
+    }
+
+    private func validate(_ config: MMAudioGenerationConfig) throws {
+        guard config.durationSeconds > 0 else {
+            throw MMAudioGeneratorError.invalidDuration(config.durationSeconds)
+        }
+        guard config.steps > 0 else {
+            throw MMAudioGeneratorError.invalidSteps(config.steps)
+        }
+        guard config.guidanceScale >= 0 else {
+            throw MMAudioGeneratorError.invalidGuidance(config.guidanceScale)
+        }
+    }
+}
+
+public enum MMAudioGeneratorError: LocalizedError {
+    case missingFiles([URL])
+    case invalidDuration(Float)
+    case invalidSteps(Int)
+    case invalidGuidance(Float)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingFiles(let urls):
+            "Missing MMAudio files:\n" + urls.map { "- \($0.path)" }.joined(separator: "\n")
+        case .invalidDuration(let value):
+            "MMAudio duration must be greater than zero; got \(value)."
+        case .invalidSteps(let value):
+            "MMAudio steps must be at least one; got \(value)."
+        case .invalidGuidance(let value):
+            "MMAudio guidance must be non-negative; got \(value)."
+        }
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioLayers.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioLayers.swift
@@ -1,0 +1,214 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+enum MMAudioTensorOps {
+    static func layerNorm(_ x: MLXArray, eps: Float = 1e-5) -> MLXArray {
+        let promoted = x.asType(.float32)
+        let mean = promoted.mean(axis: -1, keepDims: true)
+        let centered = promoted - mean
+        let variance = (centered * centered).mean(axis: -1, keepDims: true)
+        return (centered / MLX.sqrt(variance + eps)).asType(x.dtype)
+    }
+
+    static func rmsNorm(_ x: MLXArray) -> MLXArray {
+        let eps: Float = x.dtype == .float16 ? 0.000_976_562_5 : 0.000_000_119_209_29
+        let promoted = x.asType(.float32)
+        let variance = (promoted * promoted).mean(axis: -1, keepDims: true)
+        return (promoted / MLX.sqrt(variance + eps)).asType(x.dtype)
+    }
+
+    static func nearestInterpolateSequence(_ x: MLXArray, length: Int) -> MLXArray {
+        let sourceLength = x.dim(1)
+        let indices = (0..<length).map { index in
+            Int32(min(
+                sourceLength - 1,
+                Int(floor((Float(index) + 0.5) * Float(sourceLength) / Float(length)))
+            ))
+        }
+        return MLX.take(x, MLXArray(indices), axis: 1)
+    }
+}
+
+final class MMAudioDenseOrConv1D: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    @ParameterInfo(key: "bias") var bias: MLXArray?
+
+    private let kernelSize: Int
+    private let padding: Int
+
+    init(inputChannels: Int, outputChannels: Int, kernelSize: Int, padding: Int, bias: Bool) {
+        self.kernelSize = kernelSize
+        self.padding = padding
+        if kernelSize == 1 {
+            self._weight.wrappedValue = MLXRandom.normal([outputChannels, inputChannels]) * 0.02
+        } else {
+            self._weight.wrappedValue = MLXRandom.normal([outputChannels, kernelSize, inputChannels]) * 0.02
+        }
+        self._bias.wrappedValue = bias ? MLXArray.zeros([outputChannels]) : nil
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        if kernelSize == 1 {
+            var output = matmul(x, weight.transposed())
+            if let bias {
+                output = output + bias
+            }
+            return output
+        }
+        var output = MLX.conv1d(x, weight, stride: 1, padding: padding)
+        if let bias {
+            output = output + bias
+        }
+        return output
+    }
+}
+
+final class MMAudioRMSNorm: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+
+    init(dimensions: Int) {
+        self._weight.wrappedValue = MLXArray.ones([dimensions])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MMAudioTensorOps.rmsNorm(x) * weight
+    }
+}
+
+final class MMAudioMLP: Module {
+    @ModuleInfo(key: "w1") var w1: Linear
+    @ModuleInfo(key: "w2") var w2: Linear
+    @ModuleInfo(key: "w3") var w3: Linear
+
+    init(dimensions: Int, requestedHiddenDimensions: Int) {
+        let hidden = Self.roundedHiddenDimension(requestedHiddenDimensions)
+        self._w1.wrappedValue = Linear(dimensions, hidden, bias: false)
+        self._w2.wrappedValue = Linear(hidden, dimensions, bias: false)
+        self._w3.wrappedValue = Linear(dimensions, hidden, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        w2(MLXNN.silu(w1(x)) * w3(x))
+    }
+
+    private static func roundedHiddenDimension(_ requested: Int) -> Int {
+        let reduced = 2 * requested / 3
+        return 256 * ((reduced + 255) / 256)
+    }
+}
+
+final class MMAudioConvMLP: Module {
+    @ModuleInfo(key: "w1") var w1: MMAudioDenseOrConv1D
+    @ModuleInfo(key: "w2") var w2: MMAudioDenseOrConv1D
+    @ModuleInfo(key: "w3") var w3: MMAudioDenseOrConv1D
+
+    init(dimensions: Int, requestedHiddenDimensions: Int, kernelSize: Int, padding: Int) {
+        let reduced = 2 * requestedHiddenDimensions / 3
+        let hidden = 256 * ((reduced + 255) / 256)
+        self._w1.wrappedValue = MMAudioDenseOrConv1D(
+            inputChannels: dimensions,
+            outputChannels: hidden,
+            kernelSize: kernelSize,
+            padding: padding,
+            bias: false
+        )
+        self._w2.wrappedValue = MMAudioDenseOrConv1D(
+            inputChannels: hidden,
+            outputChannels: dimensions,
+            kernelSize: kernelSize,
+            padding: padding,
+            bias: false
+        )
+        self._w3.wrappedValue = MMAudioDenseOrConv1D(
+            inputChannels: dimensions,
+            outputChannels: hidden,
+            kernelSize: kernelSize,
+            padding: padding,
+            bias: false
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        w2(MLXNN.silu(w1(x)) * w3(x))
+    }
+}
+
+struct MMAudioRoPE {
+    let cos: MLXArray
+    let sin: MLXArray
+
+    static func make(length: Int, dimensions: Int, frequencyScaling: Float) -> MMAudioRoPE {
+        let positions = MLXArray((0..<length).map(Float.init)).expandedDimensions(axis: 1)
+        let frequencies = MLXArray(stride(from: 0, to: dimensions, by: 2).map { index in
+            frequencyScaling / pow(10_000, Float(index) / Float(dimensions))
+        }).expandedDimensions(axis: 0)
+        let angles = positions * frequencies
+        return MMAudioRoPE(cos: MLX.cos(angles), sin: MLX.sin(angles))
+    }
+
+    func apply(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let heads = x.dim(1)
+        let sequence = x.dim(2)
+        let dimensions = x.dim(3)
+        let paired = x.reshaped(batch, heads, sequence, dimensions / 2, 2)
+        let first = paired[0..., 0..., 0..., 0..., 0]
+        let second = paired[0..., 0..., 0..., 0..., 1]
+        let cosValues = cos[0..<sequence, 0...].expandedDimensions(axes: [0, 1])
+        let sinValues = sin[0..<sequence, 0...].expandedDimensions(axes: [0, 1])
+        let rotatedFirst = first * cosValues - second * sinValues
+        let rotatedSecond = first * sinValues + second * cosValues
+        return MLX.stacked([rotatedFirst, rotatedSecond], axis: -1)
+            .reshaped(x.shape)
+            .asType(x.dtype)
+    }
+}
+
+final class MMAudioSelfAttention: Module {
+    @ModuleInfo(key: "qkv") var qkv: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: MMAudioRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: MMAudioRMSNorm
+
+    private let dimensions: Int
+    private let heads: Int
+    private let headDimensions: Int
+
+    init(dimensions: Int, heads: Int) {
+        self.dimensions = dimensions
+        self.heads = heads
+        self.headDimensions = dimensions / heads
+        self._qkv.wrappedValue = Linear(dimensions, dimensions * 3, bias: true)
+        self._qNorm.wrappedValue = MMAudioRMSNorm(dimensions: dimensions / heads)
+        self._kNorm.wrappedValue = MMAudioRMSNorm(dimensions: dimensions / heads)
+    }
+
+    func project(_ x: MLXArray, rope: MMAudioRoPE?) -> (MLXArray, MLXArray, MLXArray) {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+        let packed = qkv(x).reshaped(batch, sequence, heads, headDimensions, 3)
+        var query = packed[0..., 0..., 0..., 0..., 0].transposed(0, 2, 1, 3)
+        var key = packed[0..., 0..., 0..., 0..., 1].transposed(0, 2, 1, 3)
+        let value = packed[0..., 0..., 0..., 0..., 2].transposed(0, 2, 1, 3)
+        query = qNorm(query)
+        key = kNorm(key)
+        if let rope {
+            query = rope.apply(query)
+            key = rope.apply(key)
+        }
+        return (query, key, value)
+    }
+
+    func attend(query: MLXArray, key: MLXArray, value: MLXArray) -> MLXArray {
+        let output = MLXFast.scaledDotProductAttention(
+            queries: query,
+            keys: key,
+            values: value,
+            scale: 1 / sqrt(Float(headDimensions)),
+            mask: .none
+        )
+        return output.transposed(0, 2, 1, 3).reshaped(output.dim(0), output.dim(2), dimensions)
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioNetwork.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioNetwork.swift
@@ -1,0 +1,350 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+public struct MMAudioConditionFeatures {
+    public let clip: MLXArray
+    public let sync: MLXArray
+    public let text: MLXArray
+
+    public init(clip: MLXArray, sync: MLXArray, text: MLXArray) {
+        self.clip = clip
+        self.sync = sync
+        self.text = text
+    }
+}
+
+struct MMAudioProjectedConditions {
+    var clip: MLXArray
+    var sync: MLXArray
+    var text: MLXArray
+    var clipGlobal: MLXArray
+    var textGlobal: MLXArray
+}
+
+final class MMAudioAudioInputProjection: Module {
+    @ModuleInfo(key: "input") var input: MMAudioDenseOrConv1D
+    @ModuleInfo(key: "mixer") var mixer: MMAudioConvMLP
+
+    override init() {
+        self._input.wrappedValue = MMAudioDenseOrConv1D(
+            inputChannels: MMAudioResources.latentDimension,
+            outputChannels: MMAudioResources.hiddenDimension,
+            kernelSize: 7,
+            padding: 3,
+            bias: true
+        )
+        self._mixer.wrappedValue = MMAudioConvMLP(
+            dimensions: MMAudioResources.hiddenDimension,
+            requestedHiddenDimensions: MMAudioResources.hiddenDimension * 4,
+            kernelSize: 7,
+            padding: 3
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        mixer(MLXNN.silu(input(x)))
+    }
+}
+
+final class MMAudioCLIPInputProjection: Module {
+    @ModuleInfo(key: "input") var input: Linear
+    @ModuleInfo(key: "mixer") var mixer: MMAudioConvMLP
+
+    override init() {
+        self._input.wrappedValue = Linear(
+            MMAudioResources.clipDimension,
+            MMAudioResources.hiddenDimension,
+            bias: true
+        )
+        self._mixer.wrappedValue = MMAudioConvMLP(
+            dimensions: MMAudioResources.hiddenDimension,
+            requestedHiddenDimensions: MMAudioResources.hiddenDimension * 4,
+            kernelSize: 3,
+            padding: 1
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        mixer(MLXNN.silu(input(x)))
+    }
+}
+
+final class MMAudioSyncInputProjection: Module {
+    @ModuleInfo(key: "input") var input: MMAudioDenseOrConv1D
+    @ModuleInfo(key: "mixer") var mixer: MMAudioConvMLP
+
+    override init() {
+        self._input.wrappedValue = MMAudioDenseOrConv1D(
+            inputChannels: MMAudioResources.syncDimension,
+            outputChannels: MMAudioResources.hiddenDimension,
+            kernelSize: 7,
+            padding: 3,
+            bias: true
+        )
+        self._mixer.wrappedValue = MMAudioConvMLP(
+            dimensions: MMAudioResources.hiddenDimension,
+            requestedHiddenDimensions: MMAudioResources.hiddenDimension * 4,
+            kernelSize: 3,
+            padding: 1
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        mixer(MLXNN.silu(input(x)))
+    }
+}
+
+final class MMAudioTextInputProjection: Module {
+    @ModuleInfo(key: "input") var input: Linear
+    @ModuleInfo(key: "mixer") var mixer: MMAudioMLP
+
+    override init() {
+        self._input.wrappedValue = Linear(
+            MMAudioResources.textDimension,
+            MMAudioResources.hiddenDimension,
+            bias: true
+        )
+        self._mixer.wrappedValue = MMAudioMLP(
+            dimensions: MMAudioResources.hiddenDimension,
+            requestedHiddenDimensions: MMAudioResources.hiddenDimension * 4
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        mixer(MLXNN.silu(input(x)))
+    }
+}
+
+public final class MMAudioNetwork: Module {
+    @ModuleInfo(key: "audio_input_proj") var audioInputProjection: MMAudioAudioInputProjection
+    @ModuleInfo(key: "clip_input_proj") var clipInputProjection: MMAudioCLIPInputProjection
+    @ModuleInfo(key: "sync_input_proj") var syncInputProjection: MMAudioSyncInputProjection
+    @ModuleInfo(key: "text_input_proj") var textInputProjection: MMAudioTextInputProjection
+    @ModuleInfo(key: "clip_cond_proj") var clipConditionProjection: Linear
+    @ModuleInfo(key: "text_cond_proj") var textConditionProjection: Linear
+    @ModuleInfo(key: "global_cond_mlp") var globalConditionMLP: MMAudioMLP
+    @ModuleInfo(key: "t_embed") var timestepEmbedder: MMAudioTimestepEmbedder
+    @ModuleInfo(key: "joint_blocks") var jointBlocks: [MMAudioJointBlock]
+    @ModuleInfo(key: "fused_blocks") var fusedBlocks: [MMAudioSingleBlock]
+    @ModuleInfo(key: "final_layer") var finalLayer: MMAudioFinalBlock
+
+    @ParameterInfo(key: "sync_pos_emb") var syncPositionEmbedding: MLXArray
+    @ParameterInfo(key: "latent_mean") var latentMean: MLXArray
+    @ParameterInfo(key: "latent_std") var latentStandardDeviation: MLXArray
+    @ParameterInfo(key: "empty_string_feat") var emptyStringFeatures: MLXArray
+    @ParameterInfo(key: "empty_clip_feat") var emptyCLIPFeatures: MLXArray
+    @ParameterInfo(key: "empty_sync_feat") var emptySyncFeatures: MLXArray
+
+    public override init() {
+        self._audioInputProjection.wrappedValue = MMAudioAudioInputProjection()
+        self._clipInputProjection.wrappedValue = MMAudioCLIPInputProjection()
+        self._syncInputProjection.wrappedValue = MMAudioSyncInputProjection()
+        self._textInputProjection.wrappedValue = MMAudioTextInputProjection()
+        self._clipConditionProjection.wrappedValue = Linear(
+            MMAudioResources.hiddenDimension,
+            MMAudioResources.hiddenDimension,
+            bias: true
+        )
+        self._textConditionProjection.wrappedValue = Linear(
+            MMAudioResources.hiddenDimension,
+            MMAudioResources.hiddenDimension,
+            bias: true
+        )
+        self._globalConditionMLP.wrappedValue = MMAudioMLP(
+            dimensions: MMAudioResources.hiddenDimension,
+            requestedHiddenDimensions: MMAudioResources.hiddenDimension * 4
+        )
+        self._timestepEmbedder.wrappedValue = MMAudioTimestepEmbedder(
+            dimensions: MMAudioResources.hiddenDimension
+        )
+        self._jointBlocks.wrappedValue = (0..<(MMAudioResources.depth - MMAudioResources.fusedDepth)).map { index in
+            MMAudioJointBlock(
+                dimensions: MMAudioResources.hiddenDimension,
+                heads: MMAudioResources.attentionHeads,
+                preOnly: index == MMAudioResources.depth - MMAudioResources.fusedDepth - 1
+            )
+        }
+        self._fusedBlocks.wrappedValue = (0..<MMAudioResources.fusedDepth).map { _ in
+            MMAudioSingleBlock(
+                dimensions: MMAudioResources.hiddenDimension,
+                heads: MMAudioResources.attentionHeads,
+                preOnly: false,
+                kernelSize: 3,
+                padding: 1
+            )
+        }
+        self._finalLayer.wrappedValue = MMAudioFinalBlock(
+            dimensions: MMAudioResources.hiddenDimension,
+            outputDimensions: MMAudioResources.latentDimension
+        )
+        self._syncPositionEmbedding.wrappedValue = MLXArray.zeros([
+            1, 1, 8, MMAudioResources.syncDimension,
+        ])
+        self._latentMean.wrappedValue = MLXArray.zeros([1, 1, MMAudioResources.latentDimension])
+        self._latentStandardDeviation.wrappedValue = MLXArray.ones([1, 1, MMAudioResources.latentDimension])
+        self._emptyStringFeatures.wrappedValue = MLXArray.zeros([
+            MMAudioResources.textSequenceLength, MMAudioResources.textDimension,
+        ])
+        self._emptyCLIPFeatures.wrappedValue = MLXArray.zeros([1, MMAudioResources.clipDimension])
+        self._emptySyncFeatures.wrappedValue = MLXArray.zeros([1, MMAudioResources.syncDimension])
+        super.init()
+    }
+
+    public static func load(resources: MMAudioModelResources) throws -> MMAudioNetwork {
+        let model = MMAudioNetwork()
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.networkWeightsURL,
+            to: model,
+            dtype: .float16,
+            verify: .none,
+            mapper: mapWeights
+        )
+        return model
+    }
+
+    public func sampleLatents(
+        conditions: MMAudioConditionFeatures,
+        negativeText: MLXArray? = nil,
+        config: MMAudioGenerationConfig,
+        progress: (@Sendable (_ completedStep: Int, _ totalSteps: Int) -> Void)? = nil
+    ) -> MLXArray {
+        if let seed = config.seed {
+            MLXRandom.seed(seed)
+        }
+        let projected = preprocess(conditions, config: config)
+        let empty = emptyConditions(config: config, negativeText: negativeText)
+        var latent = MLXRandom.normal([
+            1, config.latentSequenceLength, MMAudioResources.latentDimension,
+        ]).asType(.float16)
+        let stepSize = Float(1) / Float(config.steps)
+
+        for step in 0..<config.steps {
+            let timestep = MLXArray([Float(step) * stepSize]).asType(latent.dtype)
+            let conditionedFlow = predictFlow(latent, timestep: timestep, conditions: projected, config: config)
+            let flow: MLXArray
+            if config.guidanceScale < 1 {
+                flow = conditionedFlow
+            } else {
+                let emptyFlow = predictFlow(latent, timestep: timestep, conditions: empty, config: config)
+                flow = config.guidanceScale * conditionedFlow + (1 - config.guidanceScale) * emptyFlow
+            }
+            latent = latent + stepSize * flow
+            MLX.eval(latent)
+            progress?(step + 1, config.steps)
+        }
+        return unnormalize(latent)
+    }
+
+    public func normalize(_ latent: MLXArray) -> MLXArray {
+        (latent - latentMean) / latentStandardDeviation
+    }
+
+    public func unnormalize(_ latent: MLXArray) -> MLXArray {
+        latent * latentStandardDeviation + latentMean
+    }
+
+    func preprocess(
+        _ conditions: MMAudioConditionFeatures,
+        config: MMAudioGenerationConfig
+    ) -> MMAudioProjectedConditions {
+        let batch = conditions.clip.dim(0)
+        let segments = conditions.sync.dim(1) / 8
+        let positionedSync = conditions.sync
+            .reshaped(batch, segments, 8, MMAudioResources.syncDimension)
+            + syncPositionEmbedding
+        var sync = positionedSync.reshaped(batch, segments * 8, MMAudioResources.syncDimension)
+        let clip = clipInputProjection(conditions.clip.asType(.float16))
+        sync = syncInputProjection(sync.asType(.float16))
+        let text = textInputProjection(conditions.text.asType(.float16))
+        sync = MMAudioTensorOps.nearestInterpolateSequence(sync, length: config.latentSequenceLength)
+        let clipGlobal = clipConditionProjection(clip.mean(axis: 1))
+        let textGlobal = textConditionProjection(text.mean(axis: 1))
+        MLX.eval(clip, sync, text, clipGlobal, textGlobal)
+        return MMAudioProjectedConditions(
+            clip: clip,
+            sync: sync,
+            text: text,
+            clipGlobal: clipGlobal,
+            textGlobal: textGlobal
+        )
+    }
+
+    func predictFlow(
+        _ latent: MLXArray,
+        timestep: MLXArray,
+        conditions: MMAudioProjectedConditions,
+        config: MMAudioGenerationConfig
+    ) -> MLXArray {
+        let headDimensions = MMAudioResources.hiddenDimension / MMAudioResources.attentionHeads
+        let latentRoPE = MMAudioRoPE.make(
+            length: config.latentSequenceLength,
+            dimensions: headDimensions,
+            frequencyScaling: 1
+        )
+        let clipRoPE = MMAudioRoPE.make(
+            length: config.clipSequenceLength,
+            dimensions: headDimensions,
+            frequencyScaling: Float(config.latentSequenceLength) / Float(config.clipSequenceLength)
+        )
+        var latentHidden = audioInputProjection(latent)
+        var clip = conditions.clip
+        var text = conditions.text
+        let globalBase = globalConditionMLP(conditions.clipGlobal + conditions.textGlobal)
+        let global = timestepEmbedder(timestep).expandedDimensions(axis: 1) + globalBase.expandedDimensions(axis: 1)
+        let extended = global + conditions.sync
+
+        for block in jointBlocks {
+            (latentHidden, clip, text) = block(
+                latent: latentHidden,
+                clip: clip,
+                text: text,
+                globalCondition: global,
+                extendedCondition: extended,
+                latentRoPE: latentRoPE,
+                clipRoPE: clipRoPE
+            )
+        }
+        for block in fusedBlocks {
+            latentHidden = block(latentHidden, condition: extended, rope: latentRoPE)
+        }
+        return finalLayer(latentHidden, condition: global)
+    }
+
+    private func emptyConditions(
+        config: MMAudioGenerationConfig,
+        negativeText: MLXArray?
+    ) -> MMAudioProjectedConditions {
+        let text = negativeText ?? emptyStringFeatures.expandedDimensions(axis: 0)
+        let conditions = MMAudioConditionFeatures(
+            clip: MLX.broadcast(
+                emptyCLIPFeatures.expandedDimensions(axis: 0),
+                to: [1, config.clipSequenceLength, MMAudioResources.clipDimension]
+            ),
+            sync: MLX.broadcast(
+                emptySyncFeatures.expandedDimensions(axis: 0),
+                to: [1, config.syncSequenceLength, MMAudioResources.syncDimension]
+            ),
+            text: text
+        )
+        return preprocess(conditions, config: config)
+    }
+
+    private static func mapWeights(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "t_embed.freqs" || key == "latent_rot" || key == "clip_rot" {
+            return []
+        }
+        let mappedKey = key
+            .replacingOccurrences(of: "_input_proj.0.", with: "_input_proj.input.")
+            .replacingOccurrences(of: "_input_proj.2.", with: "_input_proj.mixer.")
+            .replacingOccurrences(of: "t_embed.mlp.0.", with: "t_embed.mlp.first.")
+            .replacingOccurrences(of: "t_embed.mlp.2.", with: "t_embed.mlp.second.")
+            .replacingOccurrences(of: "adaLN_modulation.1.", with: "adaLN_modulation.linear.")
+        if mappedKey.hasSuffix(".weight"), value.ndim == 3 {
+            let transposed = value.transposed(0, 2, 1)
+            return [(mappedKey, transposed.reshaped(-1).reshaped(transposed.shape))]
+        }
+        return [(mappedKey, value)]
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioResources.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioResources.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+public enum MMAudioResources {
+    public static let modelID = "sfx-mmaudio-large-44k-v2"
+    public static let upstreamRepoID = "hkchengrex/MMAudio"
+    public static let upstreamRevision = "974010a026c731054592d8f777218bd9d85a6c24"
+    public static let convertedWeightsRepoID = "Kijai/MMAudio_safetensors"
+    public static let convertedWeightsRevision = "5984623e6b436818c6ff287ef6eec93e3e05aa3f"
+    public static let clipRepoID = "apple/DFN5B-CLIP-ViT-H-14-378"
+    public static let clipRevision = "01b771ed0d1395ca5ffdd279897d665ebe00dfd2"
+    public static let bigVGANRepoID = "nvidia/bigvgan_v2_44khz_128band_512x"
+    public static let bigVGANRevision = "95a9d1dcb12906c03edd938d77b9333d6ded7dfb"
+
+    public static let networkFilename = "mmaudio_large_44k_v2_fp16.safetensors"
+    public static let clipFilename = "apple_DFN5B-CLIP-ViT-H-14-384_fp16.safetensors"
+    public static let synchformerFilename = "mmaudio_synchformer_fp16.safetensors"
+    public static let vaeFilename = "mmaudio_vae_44k_fp16.safetensors"
+    public static let bigVGANSafetensorsFilename = "bigvgan_generator.safetensors"
+    public static let bigVGANPyTorchFilename = "bigvgan_generator.pt"
+
+    public static let sampleRate = 44_100
+    public static let defaultDurationSeconds: Float = 8
+    public static let spectrogramFrameRate = 512
+    public static let latentDownsampleRate = 2
+    public static let latentDimension = 40
+    public static let clipDimension = 1_024
+    public static let syncDimension = 768
+    public static let textDimension = 1_024
+    public static let hiddenDimension = 896
+    public static let depth = 21
+    public static let fusedDepth = 14
+    public static let attentionHeads = 14
+    public static let textSequenceLength = 77
+    public static let clipFramesPerSecond: Float = 8
+    public static let syncInputFramesPerSecond: Float = 25
+    public static let defaultSteps = 25
+    public static let defaultGuidanceScale: Float = 4.5
+
+    /// The upstream source is MIT. The published MMAudio checkpoints are
+    /// CC-BY-NC-4.0 and must not be presented as commercially licensed assets.
+    public static let architectureLicense = "MIT"
+    public static let checkpointLicense = "CC-BY-NC-4.0"
+    public static let clipModelLicense = "Apple Machine Learning Research Model License Agreement"
+    public static let bigVGANLicense = "MIT"
+
+    public static func latentSequenceLength(durationSeconds: Float) -> Int {
+        let spectrogramFrames = ceil(
+            durationSeconds * Float(sampleRate) / Float(spectrogramFrameRate)
+        )
+        return max(1, Int(ceil(spectrogramFrames / Float(latentDownsampleRate))))
+    }
+
+    public static func clipSequenceLength(durationSeconds: Float) -> Int {
+        max(1, Int(durationSeconds * clipFramesPerSecond))
+    }
+
+    public static func syncSequenceLength(durationSeconds: Float) -> Int {
+        let frameCount = durationSeconds * syncInputFramesPerSecond
+        let segmentCount = floor((frameCount - 16) / 8) + 1
+        return max(8, Int(segmentCount * 8))
+    }
+}
+
+public struct MMAudioModelResources: Sendable, Hashable {
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public var networkWeightsURL: URL {
+        rootURL.appendingPathComponent(MMAudioResources.networkFilename)
+    }
+
+    public var clipWeightsURL: URL {
+        rootURL.appendingPathComponent(MMAudioResources.clipFilename)
+    }
+
+    public var synchformerWeightsURL: URL {
+        rootURL.appendingPathComponent(MMAudioResources.synchformerFilename)
+    }
+
+    public var vaeWeightsURL: URL {
+        rootURL.appendingPathComponent(MMAudioResources.vaeFilename)
+    }
+
+    public var clipTokenizerURL: URL {
+        rootURL.appendingPathComponent("clip", isDirectory: true)
+    }
+
+    public var bigVGANURL: URL {
+        rootURL.appendingPathComponent("bigvgan", isDirectory: true)
+    }
+
+    public var bigVGANConfigURL: URL {
+        bigVGANURL.appendingPathComponent("config.json")
+    }
+
+    public func bigVGANWeightsURL(fileManager: FileManager = .default) -> URL {
+        let safetensors = bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANSafetensorsFilename)
+        if fileManager.fileExists(atPath: safetensors.path) {
+            return safetensors
+        }
+        return bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANPyTorchFilename)
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing = [
+            networkWeightsURL,
+            clipWeightsURL,
+            synchformerWeightsURL,
+            vaeWeightsURL,
+            clipTokenizerURL.appendingPathComponent("tokenizer.json"),
+            bigVGANConfigURL,
+        ].filter { !fileManager.fileExists(atPath: $0.path) }
+
+        let safetensors = bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANSafetensorsFilename)
+        let pytorch = bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANPyTorchFilename)
+        if !fileManager.fileExists(atPath: safetensors.path)
+            && !fileManager.fileExists(atPath: pytorch.path) {
+            missing.append(safetensors)
+        }
+        return missing
+    }
+}
+
+public struct MMAudioGenerationConfig: Sendable, Hashable {
+    public let durationSeconds: Float
+    public let steps: Int
+    public let guidanceScale: Float
+    public let seed: UInt64?
+
+    public init(
+        durationSeconds: Float = MMAudioResources.defaultDurationSeconds,
+        steps: Int = MMAudioResources.defaultSteps,
+        guidanceScale: Float = MMAudioResources.defaultGuidanceScale,
+        seed: UInt64? = nil
+    ) {
+        self.durationSeconds = durationSeconds
+        self.steps = steps
+        self.guidanceScale = guidanceScale
+        self.seed = seed
+    }
+
+    public var latentSequenceLength: Int {
+        MMAudioResources.latentSequenceLength(durationSeconds: durationSeconds)
+    }
+
+    public var clipSequenceLength: Int {
+        MMAudioResources.clipSequenceLength(durationSeconds: durationSeconds)
+    }
+
+    public var syncSequenceLength: Int {
+        MMAudioResources.syncSequenceLength(durationSeconds: durationSeconds)
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioTransformer.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioTransformer.swift
@@ -1,0 +1,259 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+final class MMAudioAdaLN: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+    private let chunks: Int
+
+    init(dimensions: Int, chunks: Int) {
+        self.chunks = chunks
+        self._linear.wrappedValue = Linear(dimensions, dimensions * chunks, bias: true)
+    }
+
+    func callAsFunction(_ condition: MLXArray) -> [MLXArray] {
+        MLX.split(linear(MLXNN.silu(condition)), parts: chunks, axis: -1)
+    }
+}
+
+struct MMAudioPostAttentionModulation {
+    let gateAttention: MLXArray?
+    let shiftMLP: MLXArray?
+    let scaleMLP: MLXArray?
+    let gateMLP: MLXArray?
+}
+
+struct MMAudioAttentionProjection {
+    let query: MLXArray
+    let key: MLXArray
+    let value: MLXArray
+    let modulation: MMAudioPostAttentionModulation
+}
+
+final class MMAudioSingleBlock: Module {
+    @ModuleInfo(key: "attn") var attention: MMAudioSelfAttention
+    @ModuleInfo(key: "linear1") var linear1: MMAudioDenseOrConv1D?
+    @ModuleInfo(key: "ffn") var feedForward: MMAudioConvMLP?
+    @ModuleInfo(key: "adaLN_modulation") var adaLN: MMAudioAdaLN
+
+    private let preOnly: Bool
+
+    init(dimensions: Int, heads: Int, preOnly: Bool, kernelSize: Int, padding: Int) {
+        self.preOnly = preOnly
+        self._attention.wrappedValue = MMAudioSelfAttention(dimensions: dimensions, heads: heads)
+        self._adaLN.wrappedValue = MMAudioAdaLN(dimensions: dimensions, chunks: preOnly ? 2 : 6)
+        self._linear1.wrappedValue = preOnly ? nil : MMAudioDenseOrConv1D(
+            inputChannels: dimensions,
+            outputChannels: dimensions,
+            kernelSize: kernelSize,
+            padding: padding,
+            bias: true
+        )
+        self._feedForward.wrappedValue = preOnly ? nil : MMAudioConvMLP(
+            dimensions: dimensions,
+            requestedHiddenDimensions: dimensions * 4,
+            kernelSize: kernelSize,
+            padding: padding
+        )
+    }
+
+    func projectAttention(_ x: MLXArray, condition: MLXArray, rope: MMAudioRoPE?) -> MMAudioAttentionProjection {
+        let modulation = adaLN(condition)
+        let shiftAttention = modulation[0]
+        let scaleAttention = modulation[1]
+        let normalized = MMAudioTensorOps.layerNorm(x)
+        let modulated = normalized * (1 + scaleAttention) + shiftAttention
+        let projected = attention.project(modulated, rope: rope)
+        return MMAudioAttentionProjection(
+            query: projected.0,
+            key: projected.1,
+            value: projected.2,
+            modulation: MMAudioPostAttentionModulation(
+                gateAttention: preOnly ? nil : modulation[2],
+                shiftMLP: preOnly ? nil : modulation[3],
+                scaleMLP: preOnly ? nil : modulation[4],
+                gateMLP: preOnly ? nil : modulation[5]
+            )
+        )
+    }
+
+    func finishAttention(
+        _ residual: MLXArray,
+        attended: MLXArray,
+        modulation: MMAudioPostAttentionModulation
+    ) -> MLXArray {
+        if preOnly {
+            return residual
+        }
+        let gateAttention = modulation.gateAttention!
+        let shiftMLP = modulation.shiftMLP!
+        let scaleMLP = modulation.scaleMLP!
+        let gateMLP = modulation.gateMLP!
+        var output = residual + linear1!(attended) * gateAttention
+        let normalized = MMAudioTensorOps.layerNorm(output)
+        let modulated = normalized * (1 + scaleMLP) + shiftMLP
+        output = output + feedForward!(modulated) * gateMLP
+        return output
+    }
+
+    func callAsFunction(_ x: MLXArray, condition: MLXArray, rope: MMAudioRoPE?) -> MLXArray {
+        let projection = projectAttention(x, condition: condition, rope: rope)
+        let attended = attention.attend(
+            query: projection.query,
+            key: projection.key,
+            value: projection.value
+        )
+        return finishAttention(x, attended: attended, modulation: projection.modulation)
+    }
+}
+
+final class MMAudioJointBlock: Module {
+    @ModuleInfo(key: "latent_block") var latentBlock: MMAudioSingleBlock
+    @ModuleInfo(key: "clip_block") var clipBlock: MMAudioSingleBlock
+    @ModuleInfo(key: "text_block") var textBlock: MMAudioSingleBlock
+
+    private let preOnly: Bool
+
+    init(dimensions: Int, heads: Int, preOnly: Bool) {
+        self.preOnly = preOnly
+        self._latentBlock.wrappedValue = MMAudioSingleBlock(
+            dimensions: dimensions,
+            heads: heads,
+            preOnly: false,
+            kernelSize: 3,
+            padding: 1
+        )
+        self._clipBlock.wrappedValue = MMAudioSingleBlock(
+            dimensions: dimensions,
+            heads: heads,
+            preOnly: preOnly,
+            kernelSize: 3,
+            padding: 1
+        )
+        self._textBlock.wrappedValue = MMAudioSingleBlock(
+            dimensions: dimensions,
+            heads: heads,
+            preOnly: preOnly,
+            kernelSize: 1,
+            padding: 0
+        )
+    }
+
+    func callAsFunction(
+        latent: MLXArray,
+        clip: MLXArray,
+        text: MLXArray,
+        globalCondition: MLXArray,
+        extendedCondition: MLXArray,
+        latentRoPE: MMAudioRoPE,
+        clipRoPE: MMAudioRoPE
+    ) -> (MLXArray, MLXArray, MLXArray) {
+        let latentProjection = latentBlock.projectAttention(
+            latent,
+            condition: extendedCondition,
+            rope: latentRoPE
+        )
+        let clipProjection = clipBlock.projectAttention(
+            clip,
+            condition: globalCondition,
+            rope: clipRoPE
+        )
+        let textProjection = textBlock.projectAttention(
+            text,
+            condition: globalCondition,
+            rope: nil
+        )
+
+        let query = MLX.concatenated([
+            latentProjection.query,
+            clipProjection.query,
+            textProjection.query,
+        ], axis: 2)
+        let key = MLX.concatenated([
+            latentProjection.key,
+            clipProjection.key,
+            textProjection.key,
+        ], axis: 2)
+        let value = MLX.concatenated([
+            latentProjection.value,
+            clipProjection.value,
+            textProjection.value,
+        ], axis: 2)
+        let attended = latentBlock.attention.attend(query: query, key: key, value: value)
+
+        let latentLength = latent.dim(1)
+        let clipLength = clip.dim(1)
+        let latentAttended = attended[0..., 0..<latentLength, 0...]
+        let clipAttended = attended[0..., latentLength..<(latentLength + clipLength), 0...]
+        let textAttended = attended[0..., (latentLength + clipLength)..., 0...]
+        let nextLatent = latentBlock.finishAttention(
+            latent,
+            attended: latentAttended,
+            modulation: latentProjection.modulation
+        )
+        guard !preOnly else {
+            return (nextLatent, clip, text)
+        }
+        return (
+            nextLatent,
+            clipBlock.finishAttention(clip, attended: clipAttended, modulation: clipProjection.modulation),
+            textBlock.finishAttention(text, attended: textAttended, modulation: textProjection.modulation)
+        )
+    }
+}
+
+final class MMAudioFinalBlock: Module {
+    @ModuleInfo(key: "adaLN_modulation") var adaLN: MMAudioAdaLN
+    @ModuleInfo(key: "conv") var conv: MMAudioDenseOrConv1D
+
+    init(dimensions: Int, outputDimensions: Int) {
+        self._adaLN.wrappedValue = MMAudioAdaLN(dimensions: dimensions, chunks: 2)
+        self._conv.wrappedValue = MMAudioDenseOrConv1D(
+            inputChannels: dimensions,
+            outputChannels: outputDimensions,
+            kernelSize: 7,
+            padding: 3,
+            bias: true
+        )
+    }
+
+    func callAsFunction(_ latent: MLXArray, condition: MLXArray) -> MLXArray {
+        let modulation = adaLN(condition)
+        let normalized = MMAudioTensorOps.layerNorm(latent)
+        return conv(normalized * (1 + modulation[1]) + modulation[0])
+    }
+}
+
+final class MMAudioTimestepEmbedder: Module {
+    @ModuleInfo(key: "mlp") var mlp: MMAudioTimestepMLP
+    @ParameterInfo(key: "freqs") var frequencies: MLXArray
+
+    init(dimensions: Int) {
+        let half = dimensions / 2
+        self._frequencies.wrappedValue = MLXArray((0..<half).map { index in
+            10_000 * pow(10_000, -Float(index * 2) / Float(dimensions))
+        })
+        self._mlp.wrappedValue = MMAudioTimestepMLP(dimensions: dimensions)
+    }
+
+    func callAsFunction(_ timestep: MLXArray) -> MLXArray {
+        let angles = timestep.asType(.float32).expandedDimensions(axis: 1) * frequencies.expandedDimensions(axis: 0)
+        let embedding = MLX.concatenated([MLX.cos(angles), MLX.sin(angles)], axis: -1).asType(timestep.dtype)
+        return mlp(embedding)
+    }
+}
+
+final class MMAudioTimestepMLP: Module {
+    @ModuleInfo(key: "first") var first: Linear
+    @ModuleInfo(key: "second") var second: Linear
+
+    init(dimensions: Int) {
+        self._first.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._second.wrappedValue = Linear(dimensions, dimensions, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        second(MLXNN.silu(first(x)))
+    }
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioVAE.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioVAE.swift
@@ -1,0 +1,330 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+private enum MMAudioVAETensorOps {
+    static func normalizeChannels(_ x: MLXArray, eps: Float = 1e-4) -> MLXArray {
+        let channels = x.dim(-1)
+        let norm = MLX.sqrt((x.asType(.float32) * x.asType(.float32)).sum(axis: -1, keepDims: true))
+        let stabilized = eps + norm / sqrt(Float(channels))
+        return x / stabilized.asType(x.dtype)
+    }
+
+    static func magnitudePreservingSiLU(_ x: MLXArray) -> MLXArray {
+        MLXNN.silu(x) / 0.596
+    }
+
+    static func magnitudePreservingSum(_ residual: MLXArray, _ update: MLXArray) -> MLXArray {
+        (0.7 * residual + 0.3 * update) / sqrt(Float(0.58))
+    }
+}
+
+private final class MMAudioMPConv1D: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    private let kernelSize: Int
+    private let inputChannels: Int
+
+    init(inputChannels: Int, outputChannels: Int, kernelSize: Int) {
+        self.kernelSize = kernelSize
+        self.inputChannels = inputChannels
+        self._weight.wrappedValue = MLXRandom.normal([outputChannels, kernelSize, inputChannels])
+    }
+
+    func callAsFunction(_ x: MLXArray, gain: MLXArray? = nil) -> MLXArray {
+        let effectiveWeight = effectiveWeight(gain: gain)
+        return MLX.conv1d(
+            x,
+            effectiveWeight.asType(x.dtype),
+            stride: 1,
+            padding: kernelSize / 2
+        )
+    }
+
+    func effectiveWeight(gain: MLXArray? = nil) -> MLXArray {
+        let flattened = weight.asType(.float32).reshaped(weight.dim(0), -1)
+        let norm = MLX.sqrt((flattened * flattened).sum(axis: 1, keepDims: true))
+        let normalized = flattened / (1e-4 + norm / sqrt(Float(inputChannels * kernelSize)))
+        var effectiveWeight = normalized.reshaped(weight.shape) / sqrt(Float(inputChannels * kernelSize))
+        if let gain {
+            effectiveWeight = effectiveWeight * gain
+        }
+        return effectiveWeight
+    }
+}
+
+private final class MMAudioVAEResidualBlock: Module {
+    @ModuleInfo(key: "conv1") var first: MMAudioMPConv1D
+    @ModuleInfo(key: "conv2") var second: MMAudioMPConv1D
+    @ModuleInfo(key: "nin_shortcut") var shortcut: MMAudioMPConv1D?
+
+    init(inputChannels: Int, outputChannels: Int) {
+        self._first.wrappedValue = MMAudioMPConv1D(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: 3
+        )
+        self._second.wrappedValue = MMAudioMPConv1D(
+            inputChannels: outputChannels,
+            outputChannels: outputChannels,
+            kernelSize: 3
+        )
+        self._shortcut.wrappedValue = inputChannels == outputChannels ? nil : MMAudioMPConv1D(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: 1
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let normalized = MMAudioVAETensorOps.normalizeChannels(input)
+        var hidden = first(MMAudioVAETensorOps.magnitudePreservingSiLU(normalized))
+        hidden = second(MMAudioVAETensorOps.magnitudePreservingSiLU(hidden))
+        let residual = shortcut?(normalized) ?? normalized
+        return MMAudioVAETensorOps.magnitudePreservingSum(residual, hidden)
+    }
+}
+
+private final class MMAudioVAEAttentionBlock: Module {
+    @ModuleInfo(key: "qkv") var qkv: MMAudioMPConv1D
+    @ModuleInfo(key: "proj_out") var output: MMAudioMPConv1D
+
+    init(channels: Int) {
+        self._qkv.wrappedValue = MMAudioMPConv1D(
+            inputChannels: channels,
+            outputChannels: channels * 3,
+            kernelSize: 1
+        )
+        self._output.wrappedValue = MMAudioMPConv1D(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 1
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let channels = input.dim(2)
+        let packed = qkv(input).reshaped(batch, sequence, 1, channels, 3)
+        var query = packed[0..., 0..., 0..., 0..., 0].transposed(0, 2, 1, 3)
+        var key = packed[0..., 0..., 0..., 0..., 1].transposed(0, 2, 1, 3)
+        var value = packed[0..., 0..., 0..., 0..., 2].transposed(0, 2, 1, 3)
+        query = MMAudioVAETensorOps.normalizeChannels(query)
+        key = MMAudioVAETensorOps.normalizeChannels(key)
+        value = MMAudioVAETensorOps.normalizeChannels(value)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: query,
+            keys: key,
+            values: value,
+            scale: 1 / sqrt(Float(channels)),
+            mask: .none
+        ).transposed(0, 2, 1, 3).reshaped(batch, sequence, channels)
+        return MMAudioVAETensorOps.magnitudePreservingSum(input, output(attended))
+    }
+}
+
+private final class MMAudioVAEMiddle: Module {
+    @ModuleInfo(key: "block_1") var first: MMAudioVAEResidualBlock
+    @ModuleInfo(key: "attn_1") var attention: MMAudioVAEAttentionBlock
+    @ModuleInfo(key: "block_2") var second: MMAudioVAEResidualBlock
+
+    init(channels: Int) {
+        self._first.wrappedValue = MMAudioVAEResidualBlock(inputChannels: channels, outputChannels: channels)
+        self._attention.wrappedValue = MMAudioVAEAttentionBlock(channels: channels)
+        self._second.wrappedValue = MMAudioVAEResidualBlock(inputChannels: channels, outputChannels: channels)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        second(attention(first(x)))
+    }
+}
+
+private final class MMAudioVAEUpsample: Module {
+    @ModuleInfo(key: "conv") var conv: MMAudioMPConv1D
+
+    init(channels: Int) {
+        self._conv.wrappedValue = MMAudioMPConv1D(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 3
+        )
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        conv(MLX.repeated(x, count: 2, axis: 1))
+    }
+}
+
+private final class MMAudioVAEUpLevel: Module {
+    @ModuleInfo(key: "block") var blocks: [MMAudioVAEResidualBlock]
+    @ModuleInfo(key: "upsample") var upsample: MMAudioVAEUpsample?
+
+    init(inputChannels: Int, outputChannels: Int, upsample: Bool) {
+        self._blocks.wrappedValue = [
+            MMAudioVAEResidualBlock(inputChannels: inputChannels, outputChannels: outputChannels),
+            MMAudioVAEResidualBlock(inputChannels: outputChannels, outputChannels: outputChannels),
+            MMAudioVAEResidualBlock(inputChannels: outputChannels, outputChannels: outputChannels),
+        ]
+        self._upsample.wrappedValue = upsample ? MMAudioVAEUpsample(channels: outputChannels) : nil
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let hidden = blocks.reduce(input) { value, block in
+            MLX.clip(block(value), min: -256, max: 256)
+        }
+        return upsample?(hidden) ?? hidden
+    }
+}
+
+private final class MMAudioVAEDecoder: Module {
+    @ModuleInfo(key: "conv_in") var input: MMAudioMPConv1D
+    @ModuleInfo(key: "mid") var middle: MMAudioVAEMiddle
+    @ModuleInfo(key: "up") var up: [MMAudioVAEUpLevel]
+    @ModuleInfo(key: "conv_out") var output: MMAudioMPConv1D
+    @ParameterInfo(key: "learnable_gain") var learnableGain: MLXArray
+
+    override init() {
+        self._input.wrappedValue = MMAudioMPConv1D(inputChannels: 40, outputChannels: 2_048, kernelSize: 3)
+        self._middle.wrappedValue = MMAudioVAEMiddle(channels: 2_048)
+        self._up.wrappedValue = [
+            MMAudioVAEUpLevel(inputChannels: 1_024, outputChannels: 512, upsample: false),
+            MMAudioVAEUpLevel(inputChannels: 2_048, outputChannels: 1_024, upsample: true),
+            MMAudioVAEUpLevel(inputChannels: 2_048, outputChannels: 2_048, upsample: false),
+        ]
+        self._output.wrappedValue = MMAudioMPConv1D(inputChannels: 512, outputChannels: 128, kernelSize: 3)
+        self._learnableGain.wrappedValue = MLXArray(Float(0))
+    }
+
+    func callAsFunction(_ latent: MLXArray) -> MLXArray {
+        var hidden = input(latent)
+        hidden = MLX.clip(middle(hidden), min: -256, max: 256)
+        for level in up.reversed() {
+            hidden = level(hidden)
+        }
+        hidden = MMAudioVAETensorOps.magnitudePreservingSiLU(hidden)
+        return output(hidden, gain: learnableGain + 1)
+    }
+
+    func parityStages(_ latent: MLXArray) -> MMAudioVAEParityStages {
+        let inputProjection = input(latent)
+        let middleFirst = middle.first(inputProjection)
+        let middleAttention = middle.attention(middleFirst)
+        let middleSecond = MLX.clip(middle.second(middleAttention), min: -256, max: 256)
+        var hidden = middleSecond
+        var upLevels: [MLXArray] = []
+        for level in up.reversed() {
+            hidden = level(hidden)
+            upLevels.append(hidden)
+        }
+        let preOutput = MMAudioVAETensorOps.magnitudePreservingSiLU(hidden)
+        let rawOutput = output(preOutput, gain: learnableGain + 1)
+        return MMAudioVAEParityStages(
+            rawInputWeight: input.weight,
+            effectiveInputWeight: input.effectiveWeight(),
+            inputProjection: inputProjection,
+            middleFirst: middleFirst,
+            middleAttention: middleAttention,
+            middleSecond: middleSecond,
+            upLevels: upLevels,
+            preOutput: preOutput,
+            rawOutput: rawOutput
+        )
+    }
+}
+
+struct MMAudioVAEParityStages {
+    let rawInputWeight: MLXArray
+    let effectiveInputWeight: MLXArray
+    let inputProjection: MLXArray
+    let middleFirst: MLXArray
+    let middleAttention: MLXArray
+    let middleSecond: MLXArray
+    let upLevels: [MLXArray]
+    let preOutput: MLXArray
+    let rawOutput: MLXArray
+}
+
+public final class MMAudioVAE: Module {
+    @ModuleInfo(key: "decoder") private var decoder: MMAudioVAEDecoder
+
+    private let dataMean: MLXArray
+    private let dataStandardDeviation: MLXArray
+
+    public override init() {
+        self._decoder.wrappedValue = MMAudioVAEDecoder()
+        self.dataMean = MLXArray(Self.meanValues).reshaped(1, 1, 128)
+        self.dataStandardDeviation = MLXArray(Self.standardDeviationValues).reshaped(1, 1, 128)
+        super.init()
+    }
+
+    public static func load(resources: MMAudioModelResources) throws -> MMAudioVAE {
+        let model = MMAudioVAE()
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.vaeWeightsURL,
+            to: model,
+            dtype: .float16,
+            verify: .none,
+            mapper: mapWeights
+        )
+        return model
+    }
+
+    public func decode(_ latent: MLXArray) -> MLXArray {
+        let spectrogram = decoder(latent.asType(.float16))
+        return spectrogram * dataStandardDeviation.asType(spectrogram.dtype)
+            + dataMean.asType(spectrogram.dtype)
+    }
+
+    func parityStages(_ latent: MLXArray) -> MMAudioVAEParityStages {
+        decoder.parityStages(latent.asType(.float16))
+    }
+
+    private static func mapWeights(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        guard key.hasPrefix("decoder.") else { return [] }
+        if key.hasSuffix(".weight"), value.ndim == 3 {
+            let transposed = value.transposed(0, 2, 1)
+            return [(key, transposed.reshaped(-1).reshaped(transposed.shape))]
+        }
+        return [(key, value)]
+    }
+
+    private static let meanValues: [Float] = [
+        -3.3462, -2.6723, -2.4893, -2.3143, -2.2664, -2.3317, -2.1802, -2.4006,
+        -2.2357, -2.4597, -2.3717, -2.4690, -2.5142, -2.4919, -2.6610, -2.5047,
+        -2.7483, -2.5926, -2.7462, -2.7033, -2.7386, -2.8112, -2.7502, -2.9594,
+        -2.7473, -3.0035, -2.8891, -2.9922, -2.9856, -3.0157, -3.1191, -2.9893,
+        -3.1718, -3.0745, -3.1879, -3.2310, -3.1424, -3.2296, -3.2791, -3.2782,
+        -3.2756, -3.3134, -3.3509, -3.3750, -3.3951, -3.3698, -3.4505, -3.4509,
+        -3.5089, -3.4647, -3.5536, -3.5788, -3.5867, -3.6036, -3.6400, -3.6747,
+        -3.7072, -3.7279, -3.7283, -3.7795, -3.8259, -3.8447, -3.8663, -3.9182,
+        -3.9605, -3.9861, -4.0105, -4.0373, -4.0762, -4.1121, -4.1488, -4.1874,
+        -4.2461, -4.3170, -4.3639, -4.4452, -4.5282, -4.6297, -4.7019, -4.7960,
+        -4.8700, -4.9507, -5.0303, -5.0866, -5.1634, -5.2342, -5.3242, -5.4053,
+        -5.4927, -5.5712, -5.6464, -5.7052, -5.7619, -5.8410, -5.9188, -6.0103,
+        -6.0955, -6.1673, -6.2362, -6.3120, -6.3926, -6.4797, -6.5565, -6.6511,
+        -6.8130, -6.9961, -7.1275, -7.2457, -7.3576, -7.4663, -7.6136, -7.7469,
+        -7.8815, -8.0132, -8.1515, -8.3071, -8.4722, -8.7418, -9.3975, -9.6628,
+        -9.7671, -9.8863, -9.9992, -10.0860, -10.1709, -10.5418, -11.2795, -11.3861,
+    ]
+
+    private static let standardDeviationValues: [Float] = [
+        2.3804, 2.4368, 2.3772, 2.3145, 2.2803, 2.2510, 2.2316, 2.2083,
+        2.1996, 2.1835, 2.1769, 2.1659, 2.1631, 2.1618, 2.1540, 2.1606,
+        2.1571, 2.1567, 2.1612, 2.1579, 2.1679, 2.1683, 2.1634, 2.1557,
+        2.1668, 2.1518, 2.1415, 2.1449, 2.1406, 2.1350, 2.1313, 2.1415,
+        2.1281, 2.1352, 2.1219, 2.1182, 2.1327, 2.1195, 2.1137, 2.1080,
+        2.1179, 2.1036, 2.1087, 2.1036, 2.1015, 2.1068, 2.0975, 2.0991,
+        2.0902, 2.1015, 2.0857, 2.0920, 2.0893, 2.0897, 2.0910, 2.0881,
+        2.0925, 2.0873, 2.0960, 2.0900, 2.0957, 2.0958, 2.0978, 2.0936,
+        2.0886, 2.0905, 2.0845, 2.0855, 2.0796, 2.0840, 2.0813, 2.0817,
+        2.0838, 2.0840, 2.0917, 2.1061, 2.1431, 2.1976, 2.2482, 2.3055,
+        2.3700, 2.4088, 2.4372, 2.4609, 2.4731, 2.4847, 2.5072, 2.5451,
+        2.5772, 2.6147, 2.6529, 2.6596, 2.6645, 2.6726, 2.6803, 2.6812,
+        2.6899, 2.6916, 2.6931, 2.6998, 2.7062, 2.7262, 2.7222, 2.7158,
+        2.7041, 2.7485, 2.7491, 2.7451, 2.7485, 2.7233, 2.7297, 2.7233,
+        2.7145, 2.6958, 2.6788, 2.6439, 2.6007, 2.4786, 2.2469, 2.1877,
+        2.1392, 2.0717, 2.0107, 1.9676, 1.9140, 1.7102, 0.9101, 0.7164,
+    ]
+}

--- a/Sources/MereRunCore/MMAudio/MMAudioVideoPreprocessor.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioVideoPreprocessor.swift
@@ -1,0 +1,84 @@
+import Foundation
+import MediaIO
+import MLX
+
+enum MMAudioVideoPreprocessor {
+    static func sampledFrameIndices(
+        sourceFrameRate: Double,
+        sourceFrameCount: Int,
+        targetFrameRate: Double,
+        targetFrameCount: Int
+    ) -> [Int] {
+        precondition(sourceFrameCount > 0)
+        precondition(sourceFrameRate > 0 && targetFrameRate > 0)
+        precondition(targetFrameCount > 0)
+        return (0..<targetFrameCount).map { targetIndex in
+            let sourcePosition = Double(targetIndex) * sourceFrameRate / targetFrameRate
+            return min(sourceFrameCount - 1, Int(ceil(sourcePosition - 1e-9)))
+        }
+    }
+
+    static func normalizedCLIPFrame(_ image: MediaImage) -> MLXArray {
+        let resized = InstantMeshPreprocessor.antialiasedBicubicResize(
+            rgbHWC(image),
+            sourceWidth: image.width,
+            sourceHeight: image.height,
+            targetWidth: 384,
+            targetHeight: 384
+        )
+        let frame = MLXArray(resized.map(quantizedUnit)).reshaped(1, 384, 384, 3)
+        let mean = MLXArray([Float(0.48145466), 0.4578275, 0.40821073])
+            .reshaped(1, 1, 1, 3)
+        let standardDeviation = MLXArray([Float(0.26862954), 0.26130258, 0.27577711])
+            .reshaped(1, 1, 1, 3)
+        return (frame - mean) / standardDeviation
+    }
+
+    static func normalizedSynchformerFrameCHW(_ image: MediaImage) -> [Float] {
+        let target = 224
+        let scale = Double(target) / Double(min(image.width, image.height))
+        let resizedWidth = image.width <= image.height
+            ? target
+            : max(target, Int(Double(image.width) * scale))
+        let resizedHeight = image.height <= image.width
+            ? target
+            : max(target, Int(Double(image.height) * scale))
+        let resized = InstantMeshPreprocessor.antialiasedBicubicResize(
+            rgbHWC(image),
+            sourceWidth: image.width,
+            sourceHeight: image.height,
+            targetWidth: resizedWidth,
+            targetHeight: resizedHeight
+        )
+        let originX = (resizedWidth - target) / 2
+        let originY = (resizedHeight - target) / 2
+        let pixels = target * target
+        var chw = [Float](repeating: 0, count: pixels * 3)
+        for y in 0..<target {
+            for x in 0..<target {
+                let source = ((originY + y) * resizedWidth + originX + x) * 3
+                let destination = y * target + x
+                chw[destination] = quantizedUnit(resized[source]) * 2 - 1
+                chw[pixels + destination] = quantizedUnit(resized[source + 1]) * 2 - 1
+                chw[pixels * 2 + destination] = quantizedUnit(resized[source + 2]) * 2 - 1
+            }
+        }
+        return chw
+    }
+
+    private static func rgbHWC(_ image: MediaImage) -> [Float] {
+        var rgb = [Float]()
+        rgb.reserveCapacity(image.width * image.height * 3)
+        for pixel in 0..<(image.width * image.height) {
+            let source = pixel * 4
+            rgb.append(Float(image.rgba8[source]) / 255)
+            rgb.append(Float(image.rgba8[source + 1]) / 255)
+            rgb.append(Float(image.rgba8[source + 2]) / 255)
+        }
+        return rgb
+    }
+
+    private static func quantizedUnit(_ value: Float) -> Float {
+        Float(UInt8(clamping: Int((min(1, max(0, value)) * 255).rounded()))) / 255
+    }
+}

--- a/Sources/MereRunCore/MMAudio/README.md
+++ b/Sources/MereRunCore/MMAudio/README.md
@@ -1,0 +1,40 @@
+# MMAudio Runtime
+
+Swift-native MLX runtime for MMAudio text-to-audio and video-to-audio sound
+effect generation.
+
+## Managed model
+
+- Canonical id: `sfx-mmaudio-large-44k-v2`
+- Architecture source: `hkchengrex/MMAudio` at the pinned revision in
+  `MMAudioResources.swift`
+- Converted MLX-readable weights: `Kijai/MMAudio_safetensors`
+- CLIP tokenizer/config: `apple/DFN5B-CLIP-ViT-H-14-378`
+- Vocoder: `nvidia/bigvgan_v2_44khz_128band_512x`
+- Serving engine: `mmaudio`
+- Checkpoint license: CC-BY-NC-4.0 (non-commercial)
+
+The architecture source is MIT-licensed. That does not change the separate
+non-commercial license on the published MMAudio checkpoints. The mounted Apple
+DFN5B CLIP model is separately research-only under the Apple Machine Learning
+Research Model License Agreement. NVIDIA BigVGAN-v2 is MIT-licensed. Exact
+component license files are installed beside the managed assets.
+
+## Architecture
+
+- `MMAudioResources.swift`: pinned sources, model dimensions, sequence-length
+  contract, managed-root validation, and generation defaults.
+- `MMAudioCLIP.swift`: DFN5B CLIP ViT-H/14 image and text towers.
+- `MMAudioConditioner.swift`: text, CLIP-frame, and Synchformer conditioning.
+- `MMAudioLayers.swift`, `MMAudioTransformer.swift`, and
+  `MMAudioNetwork.swift`: the large-v2 joint/fused MMDiT and Euler flow sampler.
+- `MMAudioVAE.swift`: 44.1 kHz magnitude-preserving latent decoder.
+- `MMAudioBigVGAN.swift`: native BigVGAN-v2 generator and alias-free
+  activations.
+- `MMAudioBigVGANCheckpoint.swift`: restricted official PyTorch checkpoint
+  mapping; it does not execute Python or arbitrary pickle globals.
+- `MMAudioGenerator.swift`: staged conditioning, sampling, decoding, and PCM
+  output with MLX cache release between large components.
+
+The public surface remains under `mere.run sfx`. Keep stdout limited to the
+output path and send progress or diagnostics to stderr.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -59,6 +59,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case woosh
     case wooshClap
     case wooshSynchformer
+    case mmaudio
     case ltxVideo
     case ltxVideo23MLX
     case wan22TI2VMLX
@@ -234,6 +235,27 @@ public enum ManagedModelCatalog {
         "special_tokens_map.json",
         "vocab.json",
         "merges.txt",
+    ]
+    private static let mmaudioSnapshotPatterns = [
+        "README.md",
+        MMAudioResources.networkFilename,
+        MMAudioResources.clipFilename,
+        MMAudioResources.synchformerFilename,
+        MMAudioResources.vaeFilename,
+    ]
+    private static let mmaudioCLIPTokenizerPatterns = [
+        "LICENSE",
+        "open_clip_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "vocab.json",
+        "merges.txt",
+    ]
+    private static let mmaudioBigVGANPatterns = [
+        "LICENSE",
+        "config.json",
+        MMAudioResources.bigVGANPyTorchFilename,
     ]
     private static let ltx23MLXUpstreamRepoId = "dgrauet/ltx-2.3-mlx"
     private static let ltx23MLXSnapshotPatterns = [
@@ -1502,6 +1524,39 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["sfx video generate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.mmaudioLarge44kV2.rawValue,
+            category: .sfx,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: MMAudioResources.convertedWeightsRepoID,
+                revision: MMAudioResources.convertedWeightsRevision,
+                patterns: mmaudioSnapshotPatterns
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "clip",
+                    hubFallback: HubFallbackConfig(
+                        repoId: MMAudioResources.clipRepoID,
+                        revision: MMAudioResources.clipRevision,
+                        patterns: mmaudioCLIPTokenizerPatterns
+                    )
+                ),
+                MountedHubFallbackConfig(
+                    destinationPath: "bigvgan",
+                    hubFallback: HubFallbackConfig(
+                        repoId: MMAudioResources.bigVGANRepoID,
+                        revision: MMAudioResources.bigVGANRevision,
+                        patterns: mmaudioBigVGANPatterns
+                    )
+                ),
+            ],
+            upstreamRepoId: "\(MMAudioResources.upstreamRepoID)@\(MMAudioResources.upstreamRevision)",
+            upstreamRevision: MMAudioResources.upstreamRevision,
+            validationKind: .mmaudio,
+            estimatedDownloadBytes: 5_700_000_000,
+            defaultCLICommands: ["sfx generate", "sfx video generate"]
+        ),
+        ManagedModelSpec(
             id: "video-ltx-av",
             category: .video,
             installShape: .structuredRoot,
@@ -1769,6 +1824,8 @@ public extension ManagedModelSpec {
         case .wooshSynchformer:
             return WooshSynchformerResources(rootURL: rootURL)
                 .missingFiles(fileManager: fileManager)
+        case .mmaudio:
+            return MMAudioModelResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .ltxVideo:
             return Self.missingLTXVideoPaths(in: rootURL, fileManager: fileManager)
         case .ltxVideo23MLX:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -674,6 +674,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 64
             ),
             descriptor(
+                ModelResolver.ModelID.mmaudioLarge44kV2.rawValue,
+                "MMAudio large 44.1 kHz v2",
+                "Generates 44.1 kHz sound effects from text or synchronized video with native MMAudio.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
                 "video-ltx-av",
                 "Video generation",
                 "Generates short audio-video clips with the LTX unified AV model stack.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -68,6 +68,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case muScriptor = "muscriptor"
         /// Sony Research Woosh sound-effect generation family.
         case woosh = "woosh"
+        /// MMAudio synchronized video-to-audio and text-to-audio family.
+        case mmaudio = "mmaudio"
         /// LTX video family.
         case ltxVideo = "ltx-video"
         /// Wan2 native video family.
@@ -1456,6 +1458,23 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.videoToAudioGeneration],
                 components: nil,
                 upstreamRepoId: WooshResources.synchformerRepoId,
+                createdAt: createdAt
+            )
+        case .mmaudioLarge44kV2:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .mmaudio,
+                family: .sfx,
+                tier: .max,
+                variant: .standard,
+                precision: .fp16,
+                defaults: Defaults(
+                    steps: MMAudioResources.defaultSteps,
+                    cfg: Double(MMAudioResources.defaultGuidanceScale)
+                ),
+                supports: [.soundEffectGeneration, .videoToAudioGeneration],
+                components: nil,
+                upstreamRepoId: "\(MMAudioResources.upstreamRepoID)@\(MMAudioResources.upstreamRevision)",
                 createdAt: createdAt
             )
         case .ltxVideoAV, .ltxVideo23AVMLX:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -107,6 +107,7 @@ public enum MereRunModelValidator {
                     && spec.validationKind != .woosh
                     && spec.validationKind != .wooshClap
                     && spec.validationKind != .wooshSynchformer
+                    && spec.validationKind != .mmaudio
                     && spec.validationKind != .moge2
                     && spec.validationKind != .videoDepthAnything
                     && spec.validationKind != .depthAnything3
@@ -145,6 +146,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .woosh
             || spec?.validationKind == .wooshClap
             || spec?.validationKind == .wooshSynchformer
+            || spec?.validationKind == .mmaudio
             || spec?.validationKind == .ltxVideo
             || spec?.validationKind == .ltxVideo23MLX
             || spec?.validationKind == .moge2
@@ -385,8 +387,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=ocr expects lighton-ocr or qwen3.5-hybrid-moe.")
             case .music where engine != .aceStep && engine != .magentaRT2 && engine != .muScriptor:
                 warnings.append("Manifest engine mismatch: family=music expects ace-step, magenta-rt2, or muscriptor.")
-            case .sfx where engine != .woosh:
-                warnings.append("Manifest engine mismatch: family=sfx expects woosh.")
+            case .sfx where engine != .woosh && engine != .mmaudio:
+                warnings.append("Manifest engine mismatch: family=sfx expects woosh or mmaudio.")
             case .video where engine != .ltxVideo && engine != .wanVideo:
                 warnings.append("Manifest engine mismatch: family=video expects ltx-video or wan-video.")
             case .psi where engine != .psiChat:
@@ -461,7 +463,7 @@ public enum MereRunModelValidator {
                 return true
             }
             switch manifest.engine {
-            case .qwen3Coder?, .northMiniCode?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .ltxVideo?,
+            case .qwen3Coder?, .northMiniCode?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .mmaudio?, .ltxVideo?,
                  .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?:
                 return true
             default:

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -78,6 +78,7 @@ public struct ModelResolver {
         case wooshSynchformer = "sfx-woosh-synchformer"
         case wooshVFlow8s = "sfx-woosh-vflow-8s"
         case wooshDVFlow8s = "sfx-woosh-dvflow-8s"
+        case mmaudioLarge44kV2 = "sfx-mmaudio-large-44k-v2"
         case ltxVideoAV = "video-ltx-av"
         case ltxVideo23AVMLX = "video-ltx23-av-mlx"
         case wan22TI2V5BMLX = "video-wan22-ti2v-5b-mlx"

--- a/Sources/MereRunCore/PyTorchCheckpoint/Pickle/RestrictedStateDictPickle.swift
+++ b/Sources/MereRunCore/PyTorchCheckpoint/Pickle/RestrictedStateDictPickle.swift
@@ -71,12 +71,15 @@ struct RestrictedStateDictPickle {
             case 0x71: try memoize(Int(readByte())) // BINPUT
             case 0x72: try memoize(Int(readUInt32())) // LONG_BINPUT
             case 0x68: try push(memoized(Int(readByte()))) // BINGET
+            case 0x6A: try push(memoized(Int(readUInt32()))) // LONG_BINGET
             case 0x74: try buildTuple() // TUPLE
             case 0x85: try buildFixedTuple(1) // TUPLE1
             case 0x86: try buildFixedTuple(2) // TUPLE2
             case 0x87: try buildFixedTuple(3) // TUPLE3
             case 0x51: try persistentStorage() // BINPERSID
             case 0x52: try reduce() // REDUCE
+            case 0x62: try build() // BUILD (OrderedDict metadata only)
+            case 0x73: try setItem() // SETITEM
             case 0x75: try setItems() // SETITEMS
             case 0x2E: return try finish() // STOP
             default: throw PyTorchStateDictError.unsupportedPickleOpcode(opcode, offset: opcodeOffset)
@@ -108,9 +111,9 @@ struct RestrictedStateDictPickle {
     private mutating func persistentStorage() throws {
         guard case .tuple(let fields) = try pop(), fields.count == 5,
               case .string("storage") = fields[0], case .global(.storage(let type)) = fields[1],
-              case .string(let key) = fields[2], case .string("cpu") = fields[3],
+              case .string(let key) = fields[2], case .string(let device) = fields[3],
               case .integer(let count) = fields[4], count >= 0,
-              isASCIIDecimal(key) else {
+              isASCIIDecimal(key), isSupportedStorageDevice(device) else {
             throw PyTorchStateDictError.malformedPickle("invalid persistent storage identifier")
         }
         try push(.storage(ParsedStorage(key: key, dataType: type, elementCount: count)))
@@ -166,11 +169,51 @@ struct RestrictedStateDictPickle {
         try push(.dictionary(dictionary))
     }
 
+    private mutating func setItem() throws {
+        let value = try pop()
+        guard case .string(let key) = try pop(),
+              case .dictionary(var dictionary) = try pop(),
+              !dictionary.contains(where: { $0.0 == key }) else {
+            throw PyTorchStateDictError.malformedPickle("SETITEM requires a unique string key and dictionary")
+        }
+        dictionary.append((key, value))
+        try push(.dictionary(dictionary))
+    }
+
+    private mutating func build() throws {
+        guard case .dictionary(let state) = try pop(),
+              case .dictionary(let instance) = try pop(),
+              state.count == 1,
+              state[0].0 == "_metadata",
+              isSafeOrderedDictionaryMetadata(state[0].1) else {
+            throw PyTorchStateDictError.malformedPickle("BUILD only accepts OrderedDict tensor metadata")
+        }
+        try push(.dictionary(instance))
+    }
+
+    private func isSafeOrderedDictionaryMetadata(_ value: PickleValue) -> Bool {
+        guard case .dictionary(let entries) = value else { return false }
+        return entries.allSatisfy { _, metadata in
+            guard case .dictionary(let fields) = metadata else { return false }
+            return fields.count == 1
+                && fields[0].0 == "version"
+                && { if case .integer = fields[0].1 { true } else { false } }()
+        }
+    }
+
     private mutating func finish() throws -> [ParsedTensor] {
         guard index == data.count, stack.count == 1, case .dictionary(let dictionary) = stack[0] else {
             throw PyTorchStateDictError.malformedPickle("STOP did not terminate one state dictionary")
         }
-        return try dictionary.map { name, value in
+        let stateDictionary: [(String, PickleValue)]
+        if dictionary.count == 1,
+           dictionary[0].0 == "generator",
+           case .dictionary(let generator) = dictionary[0].1 {
+            stateDictionary = generator
+        } else {
+            stateDictionary = dictionary
+        }
+        return try stateDictionary.map { name, value in
             guard case .tensor(let tensor) = value else {
                 throw PyTorchStateDictError.malformedPickle("state-dict value '\(name)' is not a tensor")
             }
@@ -277,5 +320,11 @@ struct RestrictedStateDictPickle {
 
     private func isASCIIDecimal(_ value: String) -> Bool {
         !value.isEmpty && value.utf8.allSatisfy { (0x30...0x39).contains($0) }
+    }
+
+    private func isSupportedStorageDevice(_ value: String) -> Bool {
+        if value == "cpu" { return true }
+        guard value.hasPrefix("cuda:") else { return false }
+        return isASCIIDecimal(String(value.dropFirst("cuda:".count)))
     }
 }

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -65,7 +65,7 @@ public enum QuantizedModelManifestWriter {
             case .qwen3Coder, .northMiniCode: return .code
             case .lightOnOCR: return .ocr
             case .aceStep, .magentaRT2, .muScriptor: return .music
-            case .woosh: return .sfx
+            case .woosh, .mmaudio: return .sfx
             case .ltxVideo, .wanVideo: return .video
             case .psiChat: return .psi
             case .deepseekV4Flash: return .deepseek
@@ -143,6 +143,8 @@ public enum QuantizedModelManifestWriter {
                     return [.musicTranscription]
                 case .woosh:
                     return [.soundEffectGeneration]
+                case .mmaudio:
+                    return [.soundEffectGeneration, .videoToAudioGeneration]
                 case .ltxVideo, .wanVideo:
                     return [.videoGeneration]
                 case .psiChat:
@@ -219,7 +221,7 @@ public enum QuantizedModelManifestWriter {
                  .tripoSR, .instantMesh:
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .qwen3Embedding, .openAIPrivacyFilter,
-                 .qwen3Coder, .northMiniCode, .lightOnOCR, .woosh, .psiChat, .deepseekV4Flash,
+                 .qwen3Coder, .northMiniCode, .lightOnOCR, .woosh, .mmaudio, .psiChat, .deepseekV4Flash,
                  .muScriptor:
                 break
             case .aceStep, .magentaRT2, .ltxVideo:

--- a/Sources/MereRunCore/Woosh/WooshSynchformer.swift
+++ b/Sources/MereRunCore/Woosh/WooshSynchformer.swift
@@ -53,6 +53,81 @@ public final class WooshSynchformer {
         )
     }
 
+    public func extractMMAudioFeatures(
+        videoURL: URL,
+        durationSeconds: Float,
+        segmentBatchSize: Int = 1
+    ) throws -> MLXArray {
+        guard durationSeconds > 0, segmentBatchSize > 0 else {
+            throw WooshError.invalidVideoShape([Int(durationSeconds), segmentBatchSize])
+        }
+        let framesDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-mmaudio-sync-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: framesDirectory) }
+        let sequence = try MediaVideoIO.extractFrames(from: videoURL, into: framesDirectory)
+        let frames = try Self.loadMMAudioSyncFrames(
+            sequence: sequence,
+            durationSeconds: durationSeconds
+        )
+        return try extractMMAudioFeatures(
+            framesCHW: frames.values,
+            frameCount: frames.frameCount,
+            segmentBatchSize: segmentBatchSize
+        )
+    }
+
+    public func extractMMAudioFeatures(
+        framesCHW: [Float],
+        frameCount: Int,
+        segmentBatchSize: Int = 1
+    ) throws -> MLXArray {
+        let spatialSize = WooshSynchformerConfig.imageSize * WooshSynchformerConfig.imageSize
+        let frameStride = WooshSynchformerConfig.channels * spatialSize
+        guard frameCount >= WooshSynchformerConfig.segmentSize,
+              framesCHW.count == frameCount * frameStride,
+              segmentBatchSize > 0 else {
+            throw WooshError.invalidVideoShape([frameCount, framesCHW.count, segmentBatchSize])
+        }
+        let segmentCount = (frameCount - WooshSynchformerConfig.segmentSize)
+            / WooshSynchformerConfig.stepSize + 1
+        var outputs: [MLXArray] = []
+        var segmentStart = 0
+        while segmentStart < segmentCount {
+            let currentBatch = min(segmentBatchSize, segmentCount - segmentStart)
+            var segmentValues: [Float] = []
+            segmentValues.reserveCapacity(
+                currentBatch * WooshSynchformerConfig.channels
+                    * WooshSynchformerConfig.segmentSize * spatialSize
+            )
+            for batchOffset in 0..<currentBatch {
+                let sourceStart = (segmentStart + batchOffset) * WooshSynchformerConfig.stepSize
+                for channel in 0..<WooshSynchformerConfig.channels {
+                    for localFrame in 0..<WooshSynchformerConfig.segmentSize {
+                        let sourceOffset = ((sourceStart + localFrame) * frameStride) + (channel * spatialSize)
+                        segmentValues.append(contentsOf: framesCHW[sourceOffset..<(sourceOffset + spatialSize)])
+                    }
+                }
+            }
+            let input = MLXArray(segmentValues).reshaped(
+                currentBatch,
+                1,
+                WooshSynchformerConfig.channels,
+                WooshSynchformerConfig.segmentSize,
+                WooshSynchformerConfig.imageSize,
+                WooshSynchformerConfig.imageSize
+            ).asType(.float32)
+            let features = model(input).reshaped(
+                1,
+                currentBatch * WooshSynchformerConfig.outputFramesPerSegment,
+                WooshSynchformerConfig.dim
+            )
+            MLX.eval(features)
+            outputs.append(features)
+            segmentStart += currentBatch
+        }
+        return outputs.count == 1 ? outputs[0] : MLX.concatenated(outputs, axis: 1)
+    }
+
     public func extractFeatures(
         framesCHW: [Float],
         frameCount: Int,
@@ -164,6 +239,35 @@ public final class WooshSynchformer {
                 height: WooshSynchformerConfig.imageSize
             )
             values.append(contentsOf: MediaImageIO.rgbCHWFloat(cropped, normalizedToMinusOneToOne: true))
+        }
+        return (values, indices.count)
+    }
+
+    private static func loadMMAudioSyncFrames(
+        sequence: VideoFrameSequence,
+        durationSeconds: Float
+    ) throws -> (values: [Float], frameCount: Int) {
+        guard !sequence.frameURLs.isEmpty else {
+            throw WooshError.invalidVideoShape([0])
+        }
+        let targetCount = max(
+            WooshSynchformerConfig.segmentSize,
+            Int((durationSeconds * Float(MMAudioResources.syncInputFramesPerSecond)).rounded())
+        )
+        let indices = MMAudioVideoPreprocessor.sampledFrameIndices(
+            sourceFrameRate: max(1, sequence.fps),
+            sourceFrameCount: sequence.frameURLs.count,
+            targetFrameRate: Double(MMAudioResources.syncInputFramesPerSecond),
+            targetFrameCount: targetCount
+        )
+        let frameStride = WooshSynchformerConfig.channels
+            * WooshSynchformerConfig.imageSize
+            * WooshSynchformerConfig.imageSize
+        var values: [Float] = []
+        values.reserveCapacity(indices.count * frameStride)
+        for index in indices {
+            let image = try MediaImageIO.decode(sequence.frameURLs[index])
+            values.append(contentsOf: MMAudioVideoPreprocessor.normalizedSynchformerFrameCHW(image))
         }
         return (values, indices.count)
     }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -122,6 +122,23 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### MMAudio and bundled conditioning/decoding models
+
+- purpose: native Swift/MLX text-to-audio and synchronized video-to-audio
+  runtime
+- architecture source: [`hkchengrex/MMAudio`](https://github.com/hkchengrex/MMAudio)
+  at commit `974010a026c731054592d8f777218bd9d85a6c24`; MIT
+- MMAudio model weights: downloaded separately; CC-BY-NC-4.0
+- DFN5B CLIP model: downloaded separately from
+  `apple/DFN5B-CLIP-ViT-H-14-378`; Apple Machine Learning Research Model
+  License Agreement (research-only)
+- BigVGAN-v2 source and model: downloaded separately from
+  `nvidia/bigvgan_v2_44khz_128band_512x`; MIT
+
+Managed installs retain the exact Apple and NVIDIA license files at
+`clip/LICENSE` and `bigvgan/LICENSE`. These model licenses are separate from
+the mere.run source license and from the MIT license on the MMAudio graph.
+
 ## Vendored artifacts
 
 ### `vendor/llama.xcframework`

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -257,6 +257,13 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertEqual(fractional?.fractionCompleted ?? -1, 0.004, accuracy: 0.0001)
         XCTAssertEqual(fractional?.detail, "4 MB / 1 GB 2 MB/s ETA 8m 18s")
 
+        let generation = StudioProgressParser.parse(
+            #"{"event":"progress","stage":"denoising","step":2,"total_steps":4}"#
+        )
+        XCTAssertEqual(generation?.label, "Generating")
+        XCTAssertEqual(generation?.fractionCompleted ?? -1, 0.75, accuracy: 0.001)
+        XCTAssertEqual(generation?.detail, "Step 3 of 4")
+
         // Non-progress lines are not misclassified.
         XCTAssertNil(StudioProgressParser.parse("just a normal log line"))
         XCTAssertNil(StudioProgressParser.parse("[info] starting up"))

--- a/Tests/MereRunCLITests/SFXGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SFXGenerateCommandParsingTests.swift
@@ -39,6 +39,46 @@ final class SFXGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.output, "/tmp/wrench-clang.wav")
     }
 
+    func testSFXGenerateParsesMMAudioConditioningOptions() throws {
+        let cmd = try SFXGenerate.parse([
+            "waves breaking against a stone pier",
+            "--negative-prompt", "speech, music",
+            "--model", MMAudioResources.modelID,
+            "--duration", "8",
+            "--steps", "25",
+            "--cfg", "4.5",
+        ])
+
+        XCTAssertEqual(cmd.negativePrompt, "speech, music")
+        XCTAssertEqual(cmd.model, MMAudioResources.modelID)
+        XCTAssertEqual(cmd.durationSeconds, 8)
+        XCTAssertEqual(cmd.steps, 25)
+        XCTAssertEqual(cmd.guidanceScale, 4.5)
+    }
+
+    func testSFXGenerateUsesModelSpecificMMAudioDefaults() throws {
+        let cmd = try SFXGenerate.parse([
+            "waves breaking against a stone pier",
+            "--model", MMAudioResources.modelID,
+        ])
+
+        XCTAssertEqual(cmd.durationSeconds, MMAudioResources.defaultDurationSeconds)
+        XCTAssertEqual(cmd.steps, MMAudioResources.defaultSteps)
+        XCTAssertEqual(cmd.guidanceScale, MMAudioResources.defaultGuidanceScale)
+    }
+
+    func testSFXGeneratePreservesExplicitWooshDefaultsForMMAudio() throws {
+        let cmd = try SFXGenerate.parse([
+            "short impact",
+            "--model", MMAudioResources.modelID,
+            "--duration", "5",
+            "--steps", "4",
+        ])
+
+        XCTAssertEqual(cmd.durationSeconds, 5)
+        XCTAssertEqual(cmd.steps, 4)
+    }
+
     func testSFXGenerateRejectsWrongRenoiseCount() throws {
         let cmd = try SFXGenerate.parse([
             "glass break",
@@ -125,11 +165,66 @@ final class SFXGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.steps, 4)
         XCTAssertEqual(cmd.guidanceScale, 3)
         XCTAssertEqual(cmd.syncBatchSize, 2)
+        XCTAssertEqual(cmd.clipBatchSize, 4)
         XCTAssertEqual(try cmd.parseRenoiseSchedule(steps: 4), [0, 0.5, 0.5, 0.3])
         XCTAssertEqual(cmd.output, "/tmp/video-sfx.wav")
         XCTAssertTrue(cmd.quiet)
         XCTAssertFalse(cmd.preflight)
         XCTAssertFalse(cmd.json)
+    }
+
+    func testSFXVideoGenerateParsesMMAudioOptions() throws {
+        let cmd = try SFXVideoGenerate.parse([
+            "a skateboard rolling over rough pavement",
+            "/tmp/skateboard.mp4",
+            "--negative-prompt", "music",
+            "--model", MMAudioResources.modelID,
+            "--clip-batch-size", "3",
+            "--sync-batch-size", "2",
+        ])
+
+        XCTAssertEqual(cmd.negativePrompt, "music")
+        XCTAssertEqual(cmd.model, MMAudioResources.modelID)
+        XCTAssertEqual(cmd.clipBatchSize, 3)
+        XCTAssertEqual(cmd.syncBatchSize, 2)
+    }
+
+    func testSFXVideoPreflightReportsNativeMMAudioPlan() throws {
+        let temp = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let modelRoot = temp.appendingPathComponent("mmaudio", isDirectory: true)
+        try writeMinimalMMAudioModel(at: modelRoot)
+        let videoURL = try makeTempFile(name: "skateboard.mp4", in: temp)
+        let outputURL = temp.appendingPathComponent("skateboard.wav")
+        let cmd = try SFXVideoGenerate.parse([
+            "a skateboard rolling over rough pavement",
+            videoURL.path,
+            "--model", modelRoot.path,
+            "--output", outputURL.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            inputURL: videoURL,
+            outputURL: outputURL,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.variant, "large_44k_v2")
+        XCTAssertTrue(envelope.result.model.supportedForVideo == true)
+        XCTAssertNil(envelope.result.synchformer)
+        XCTAssertFalse(envelope.result.input.requiresSynchformer)
+        XCTAssertEqual(envelope.result.plan.effectiveSteps, MMAudioResources.defaultSteps)
+        XCTAssertEqual(
+            envelope.result.plan.effectiveGuidanceScale,
+            MMAudioResources.defaultGuidanceScale,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(envelope.result.plan.sampleRate, MMAudioResources.sampleRate)
     }
 
     func testSFXVideoGenerateParsesPreflightJSONFlags() throws {
@@ -355,5 +450,28 @@ final class SFXGenerateCommandParsingTests: XCTestCase {
         try Data("fixture".utf8).write(
             to: root.appendingPathComponent(WooshResources.synchformerFilename)
         )
+    }
+
+    private func writeMinimalMMAudioModel(at root: URL) throws {
+        let resources = MMAudioModelResources(rootURL: root)
+        try FileManager.default.createDirectory(
+            at: resources.clipTokenizerURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: resources.bigVGANURL,
+            withIntermediateDirectories: true
+        )
+        for url in [
+            resources.networkWeightsURL,
+            resources.clipWeightsURL,
+            resources.synchformerWeightsURL,
+            resources.vaeWeightsURL,
+            resources.clipTokenizerURL.appendingPathComponent("tokenizer.json"),
+            resources.bigVGANConfigURL,
+            resources.bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANPyTorchFilename),
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        }
     }
 }

--- a/Tests/MereRunCoreTests/MMAudioParityTests.swift
+++ b/Tests/MereRunCoreTests/MMAudioParityTests.swift
@@ -1,0 +1,311 @@
+import Foundation
+import MediaIO
+import MLX
+import MLXNN
+@testable import MereRunCore
+import XCTest
+
+final class MMAudioParityTests: XCTestCase {
+    func testTorchvisionPreprocessingParityWhenTraceIsAvailable() throws {
+        let arrays = try traceArrays()
+        let source = try XCTUnwrap(arrays["preprocess_rgb_hwc_u8"])
+        let expectedCLIP = try XCTUnwrap(arrays["preprocess_clip_nhwc"])
+        let expectedSync = try XCTUnwrap(arrays["preprocess_sync_chw"])
+        let height = source.dim(0)
+        let width = source.dim(1)
+        let rgb = source.asArray(UInt8.self)
+        var rgba = [UInt8](repeating: 255, count: height * width * 4)
+        for pixel in 0..<(height * width) {
+            rgba[pixel * 4] = rgb[pixel * 3]
+            rgba[pixel * 4 + 1] = rgb[pixel * 3 + 1]
+            rgba[pixel * 4 + 2] = rgb[pixel * 3 + 2]
+        }
+        let image = try MediaImage(width: width, height: height, rgba8: rgba)
+
+        // Accelerate and Torchvision use different bicubic integer kernels;
+        // these bounds are below one source pixel after CLIP normalization.
+        assertClose(
+            MMAudioVideoPreprocessor.normalizedCLIPFrame(image),
+            expectedCLIP,
+            maxTolerance: 0.08,
+            meanTolerance: 0.0035,
+            name: "CLIP preprocessing"
+        )
+        let actualSync = MLXArray(
+            MMAudioVideoPreprocessor.normalizedSynchformerFrameCHW(image)
+        ).reshaped(expectedSync.shape)
+        assertClose(
+            actualSync,
+            expectedSync,
+            maxTolerance: 0.008,
+            meanTolerance: 0.0018,
+            name: "Synchformer preprocessing"
+        )
+    }
+
+    func testCLIPTextAndImageParityWhenTraceIsAvailable() async throws {
+        let arrays = try traceArrays()
+        let resources = try modelResources()
+        let conditioner = try await MMAudioCLIPConditioner.load(resources: resources)
+        let expectedTokenIDs = try XCTUnwrap(arrays["clip_token_ids"])
+        XCTAssertEqual(
+            conditioner.tokenIDs(for: ["a wooden door slamming shut"]),
+            expectedTokenIDs.asArray(Int32.self)
+        )
+        assertClose(
+            conditioner.encodeText(["a wooden door slamming shut"]),
+            try XCTUnwrap(arrays["clip_text_hidden"]),
+            maxTolerance: 0.025,
+            meanTolerance: 0.001,
+            name: "CLIP text"
+        )
+        assertClose(
+            conditioner.encodeImages(try XCTUnwrap(arrays["clip_image_nhwc"])),
+            try XCTUnwrap(arrays["clip_image_features"]),
+            maxTolerance: 0.025,
+            meanTolerance: 0.001,
+            name: "CLIP image"
+        )
+    }
+
+    func testMMDiTFlowParityWhenTraceIsAvailable() throws {
+        let arrays = try traceArrays()
+        let network = try MMAudioNetwork.load(resources: modelResources())
+        let parameters = Dictionary(uniqueKeysWithValues: network.parameters().flattened())
+        let expectedFinalWeight = try XCTUnwrap(arrays["network_final_conv_weight_oik"])
+            .transposed(0, 2, 1)
+        assertClose(
+            try XCTUnwrap(parameters["final_layer.conv.weight"]),
+            expectedFinalWeight,
+            maxTolerance: 0,
+            meanTolerance: 0,
+            name: "final convolution weight"
+        )
+        assertClose(
+            try XCTUnwrap(parameters["final_layer.conv.bias"]),
+            try XCTUnwrap(arrays["network_final_conv_bias"]),
+            maxTolerance: 0,
+            meanTolerance: 0,
+            name: "final convolution bias"
+        )
+        assertClose(
+            try XCTUnwrap(parameters["final_layer.adaLN_modulation.linear.weight"]),
+            try XCTUnwrap(arrays["network_final_adaln_weight"]),
+            maxTolerance: 0,
+            meanTolerance: 0,
+            name: "final AdaLN weight"
+        )
+        assertClose(
+            try XCTUnwrap(parameters["final_layer.adaLN_modulation.linear.bias"]),
+            try XCTUnwrap(arrays["network_final_adaln_bias"]),
+            maxTolerance: 0,
+            meanTolerance: 0,
+            name: "final AdaLN bias"
+        )
+        let config = MMAudioGenerationConfig(durationSeconds: 1, steps: 1, guidanceScale: 0)
+        let conditions = MMAudioConditionFeatures(
+            clip: try XCTUnwrap(arrays["network_clip_ntc"]),
+            sync: try XCTUnwrap(arrays["network_sync_ntc"]),
+            text: try XCTUnwrap(arrays["network_text_ntc"])
+        )
+        let projected = network.preprocess(conditions, config: config)
+        assertClose(projected.clip, try XCTUnwrap(arrays["network_projected_clip"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "projected CLIP")
+        assertClose(projected.sync, try XCTUnwrap(arrays["network_projected_sync"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "projected sync")
+        assertClose(projected.text, try XCTUnwrap(arrays["network_projected_text"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "projected text")
+        assertClose(projected.clipGlobal, try XCTUnwrap(arrays["network_clip_global"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "CLIP global")
+        assertClose(projected.textGlobal, try XCTUnwrap(arrays["network_text_global"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "text global")
+        let latent = try XCTUnwrap(arrays["network_latent_ntc"]).asType(.float16)
+        let timestep = try XCTUnwrap(arrays["network_timestep"]).asType(.float16)
+        let audioProjected = network.audioInputProjection(latent)
+        assertClose(audioProjected, try XCTUnwrap(arrays["network_audio_projected"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "audio projection")
+        let timestepEmbedding = network.timestepEmbedder(timestep)
+        assertClose(timestepEmbedding, try XCTUnwrap(arrays["network_timestep_embedding"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "timestep embedding")
+        let globalBase = network.globalConditionMLP(projected.clipGlobal + projected.textGlobal)
+        let global = timestepEmbedding.expandedDimensions(axis: 1) + globalBase.expandedDimensions(axis: 1)
+        let extended = global + projected.sync
+        assertClose(global, try XCTUnwrap(arrays["network_global_condition"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "global condition")
+        assertClose(extended, try XCTUnwrap(arrays["network_extended_condition"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "extended condition")
+        let rope = MMAudioRoPE.make(length: config.latentSequenceLength, dimensions: 64, frequencyScaling: 1)
+        let projection = network.jointBlocks[0].latentBlock.projectAttention(
+            audioProjected,
+            condition: extended,
+            rope: rope
+        )
+        assertClose(projection.query, try XCTUnwrap(arrays["network_block0_latent_query"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "block 0 query")
+        assertClose(projection.key, try XCTUnwrap(arrays["network_block0_latent_key"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "block 0 key")
+        assertClose(projection.value, try XCTUnwrap(arrays["network_block0_latent_value"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "block 0 value")
+        let clipRoPE = MMAudioRoPE.make(
+            length: config.clipSequenceLength,
+            dimensions: 64,
+            frequencyScaling: Float(config.latentSequenceLength) / Float(config.clipSequenceLength)
+        )
+        var latentHidden = audioProjected
+        var clipHidden = projected.clip
+        var textHidden = projected.text
+        for (index, block) in network.jointBlocks.enumerated() {
+            (latentHidden, clipHidden, textHidden) = block(
+                latent: latentHidden,
+                clip: clipHidden,
+                text: textHidden,
+                globalCondition: global,
+                extendedCondition: extended,
+                latentRoPE: rope,
+                clipRoPE: clipRoPE
+            )
+            assertClose(latentHidden, try XCTUnwrap(arrays["network_joint_\(index)_latent"]), maxTolerance: 0.4, meanTolerance: 0.011, name: "joint \(index) latent")
+            assertClose(clipHidden, try XCTUnwrap(arrays["network_joint_\(index)_clip"]), maxTolerance: 0.4, meanTolerance: 0.011, name: "joint \(index) CLIP")
+            assertClose(textHidden, try XCTUnwrap(arrays["network_joint_\(index)_text"]), maxTolerance: 0.4, meanTolerance: 0.011, name: "joint \(index) text")
+        }
+        for (index, block) in network.fusedBlocks.enumerated() {
+            latentHidden = block(latentHidden, condition: extended, rope: rope)
+            assertClose(latentHidden, try XCTUnwrap(arrays["network_fused_\(index)_latent"]), maxTolerance: 2.1, meanTolerance: 0.06, name: "fused \(index) latent")
+        }
+        let referenceFinalInput = try XCTUnwrap(arrays["network_fused_13_latent"]).asType(.float16)
+        let referenceGlobal = try XCTUnwrap(arrays["network_global_condition"]).asType(.float16)
+        assertClose(
+            network.finalLayer.adaLN.linear(MLXNN.silu(referenceGlobal)),
+            try XCTUnwrap(arrays["network_final_modulation_raw"]),
+            maxTolerance: 0.02,
+            meanTolerance: 0.002,
+            name: "final modulation projection"
+        )
+        let finalModulation = network.finalLayer.adaLN(referenceGlobal)
+        assertClose(finalModulation[0], try XCTUnwrap(arrays["network_final_shift"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "final shift")
+        assertClose(finalModulation[1], try XCTUnwrap(arrays["network_final_scale"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "final scale")
+        let finalNormalized = MMAudioTensorOps.layerNorm(referenceFinalInput)
+        assertClose(finalNormalized, try XCTUnwrap(arrays["network_final_normalized"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "final normalization")
+        let finalModulated = finalNormalized * (1 + finalModulation[1]) + finalModulation[0]
+        assertClose(finalModulated, try XCTUnwrap(arrays["network_final_modulated"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "final modulation")
+        assertClose(network.finalLayer.conv(finalModulated), try XCTUnwrap(arrays["network_final_from_blocks"]), maxTolerance: 0.08, meanTolerance: 0.008, name: "isolated final convolution")
+        assertClose(
+            network.finalLayer(referenceFinalInput, condition: referenceGlobal),
+            try XCTUnwrap(arrays["network_final_from_blocks"]),
+            maxTolerance: 0.08,
+            meanTolerance: 0.008,
+            name: "isolated final block"
+        )
+        assertClose(network.finalLayer(latentHidden, condition: global), try XCTUnwrap(arrays["network_final_from_blocks"]), maxTolerance: 0.08, meanTolerance: 0.008, name: "final block")
+        let actual = network.predictFlow(
+            latent,
+            timestep: timestep,
+            conditions: projected,
+            config: config
+        )
+        assertClose(
+            actual,
+            try XCTUnwrap(arrays["network_flow_ntc"]),
+            maxTolerance: 0.08,
+            meanTolerance: 0.008,
+            name: "MMDiT flow"
+        )
+    }
+
+    func testVAEParityWhenTraceIsAvailable() throws {
+        let arrays = try traceArrays()
+        let vae = try MMAudioVAE.load(resources: modelResources())
+        let latent = try XCTUnwrap(arrays["vae_latent_ntc"])
+        let actual = vae.decode(latent)
+        let expected = try XCTUnwrap(arrays["vae_spectrogram_ntc"])
+        let stages = vae.parityStages(latent)
+        assertClose(stages.rawInputWeight, try XCTUnwrap(arrays["vae_input_weight_raw_oik"]).transposed(0, 2, 1), maxTolerance: 0, meanTolerance: 0, name: "VAE raw input weight")
+        assertClose(stages.effectiveInputWeight, try XCTUnwrap(arrays["vae_input_weight_effective_oik"]).transposed(0, 2, 1), maxTolerance: 0.000_2, meanTolerance: 0.000_02, name: "VAE effective input weight")
+        assertClose(stages.inputProjection, try XCTUnwrap(arrays["vae_input_projection_ntc"]), maxTolerance: 0.02, meanTolerance: 0.002, name: "VAE input projection")
+        assertClose(stages.middleFirst, try XCTUnwrap(arrays["vae_middle_first_ntc"]), maxTolerance: 0.03, meanTolerance: 0.003, name: "VAE middle first")
+        assertClose(stages.middleAttention, try XCTUnwrap(arrays["vae_middle_attention_ntc"]), maxTolerance: 0.04, meanTolerance: 0.004, name: "VAE middle attention")
+        assertClose(stages.middleSecond, try XCTUnwrap(arrays["vae_middle_second_ntc"]), maxTolerance: 0.05, meanTolerance: 0.005, name: "VAE middle second")
+        for index in stages.upLevels.indices {
+            assertClose(stages.upLevels[index], try XCTUnwrap(arrays["vae_up_\(index)_ntc"]), maxTolerance: 0.08, meanTolerance: 0.008, name: "VAE up \(index)")
+        }
+        assertClose(stages.preOutput, try XCTUnwrap(arrays["vae_pre_output_ntc"]), maxTolerance: 0.08, meanTolerance: 0.008, name: "VAE pre-output")
+        assertClose(stages.rawOutput, try XCTUnwrap(arrays["vae_raw_spectrogram_ntc"]), maxTolerance: 0.08, meanTolerance: 0.008, name: "VAE raw output")
+        assertClose(
+            actual,
+            expected,
+            maxTolerance: 0.08,
+            meanTolerance: 0.008,
+            name: "VAE decode"
+        )
+    }
+
+    func testBigVGANParityWhenTraceIsAvailable() throws {
+        let arrays = try traceArrays()
+        let vocoder = try MMAudioBigVGAN.load(resources: modelResources())
+        let input = try XCTUnwrap(arrays["bigvgan_spectrogram_nct"]).transposed(0, 2, 1)
+        let expected = try XCTUnwrap(arrays["bigvgan_waveform_nct"]).transposed(0, 2, 1)
+        assertClose(
+            vocoder(input),
+            expected,
+            maxTolerance: 0.08,
+            meanTolerance: 0.008,
+            name: "BigVGAN"
+        )
+    }
+
+    func testSynchformerParityWhenTraceIsAvailable() throws {
+        let arrays = try traceArrays()
+        let frames = try XCTUnwrap(arrays["synchformer_frames_tchw"])
+        let synchformer = try WooshSynchformer(
+            resources: WooshSynchformerResources(rootURL: modelResources().rootURL)
+        )
+        let actual = try synchformer.extractMMAudioFeatures(
+            framesCHW: frames.asArray(Float.self),
+            frameCount: frames.dim(0)
+        )
+        assertClose(
+            actual,
+            try XCTUnwrap(arrays["synchformer_features_ntc"]),
+            maxTolerance: 0.03,
+            meanTolerance: 0.003,
+            name: "Synchformer"
+        )
+    }
+
+    private func traceArrays() throws -> [String: MLXArray] {
+        let path = ProcessInfo.processInfo.environment["MERERUN_TEST_MMAUDIO_TRACE"] ?? ""
+        try XCTSkipIf(
+            path.isEmpty || !FileManager.default.fileExists(atPath: path),
+            "Set MERERUN_TEST_MMAUDIO_TRACE to export_mmaudio_trace.py output."
+        )
+        return try MLX.loadArrays(url: URL(fileURLWithPath: path))
+    }
+
+    private func modelResources() throws -> MMAudioModelResources {
+        let path = ProcessInfo.processInfo.environment["MERERUN_TEST_MMAUDIO_ROOT"] ?? ""
+        try XCTSkipIf(
+            path.isEmpty || !FileManager.default.fileExists(atPath: path),
+            "Set MERERUN_TEST_MMAUDIO_ROOT to the installed MMAudio root."
+        )
+        return MMAudioModelResources(rootURL: URL(fileURLWithPath: path))
+    }
+
+    private func assertClose(
+        _ actual: MLXArray,
+        _ expected: MLXArray,
+        maxTolerance: Float,
+        meanTolerance: Float,
+        name: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.shape, expected.shape, "\(name) shape", file: file, line: line)
+        guard actual.shape == expected.shape else { return }
+        let difference = MLX.abs(actual.asType(.float32) - expected.asType(.float32))
+        MLX.eval(difference)
+        let maximum = MLX.max(difference).item(Float.self)
+        let mean = MLX.mean(difference).item(Float.self)
+        XCTAssertLessThanOrEqual(
+            maximum,
+            maxTolerance,
+            "\(name) max difference \(maximum)",
+            file: file,
+            line: line
+        )
+        XCTAssertLessThanOrEqual(
+            mean,
+            meanTolerance,
+            "\(name) mean difference \(mean)",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/MMAudioResourcesTests.swift
+++ b/Tests/MereRunCoreTests/MMAudioResourcesTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import MLX
+@testable import MereRunCore
+import XCTest
+
+final class MMAudioResourcesTests: XCTestCase {
+    func testEightSecond44KSequenceContractMatchesUpstream() {
+        let config = MMAudioGenerationConfig()
+
+        XCTAssertEqual(config.latentSequenceLength, 345)
+        XCTAssertEqual(config.clipSequenceLength, 64)
+        XCTAssertEqual(config.syncSequenceLength, 192)
+        XCTAssertEqual(
+            config.latentSequenceLength
+                * MMAudioResources.spectrogramFrameRate
+                * MMAudioResources.latentDownsampleRate,
+            353_280
+        )
+    }
+
+    func testFrameSamplingUsesFirstDecodedFrameAtOrAfterEachTargetTimestamp() {
+        XCTAssertEqual(
+            MMAudioVideoPreprocessor.sampledFrameIndices(
+                sourceFrameRate: 30,
+                sourceFrameCount: 240,
+                targetFrameRate: 8,
+                targetFrameCount: 8
+            ),
+            [0, 4, 8, 12, 15, 19, 23, 27]
+        )
+        XCTAssertEqual(
+            MMAudioVideoPreprocessor.sampledFrameIndices(
+                sourceFrameRate: 24,
+                sourceFrameCount: 24,
+                targetFrameRate: 25,
+                targetFrameCount: 6
+            ),
+            [0, 1, 2, 3, 4, 5]
+        )
+    }
+
+    func testNearestExactSequenceInterpolationMatchesPyTorchIndexConvention() {
+        let source = MLXArray((0..<16).map(Float.init)).reshaped(1, 16, 1)
+        let actual = MMAudioTensorOps.nearestInterpolateSequence(source, length: 44)
+        XCTAssertEqual(actual.asArray(Float.self).map(Int.init), [
+            0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5,
+            6, 6, 6, 7, 7, 7, 8, 8, 8, 9, 9, 10, 10, 10, 11, 11,
+            11, 12, 12, 12, 13, 13, 14, 14, 14, 15, 15, 15,
+        ])
+    }
+
+    func testResourceValidationAcceptsOfficialPyTorchVocoderCheckpoint() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mmaudio-resources-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resources = MMAudioModelResources(rootURL: root)
+        try FileManager.default.createDirectory(
+            at: resources.clipTokenizerURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: resources.bigVGANURL,
+            withIntermediateDirectories: true
+        )
+        for url in [
+            resources.networkWeightsURL,
+            resources.clipWeightsURL,
+            resources.synchformerWeightsURL,
+            resources.vaeWeightsURL,
+            resources.clipTokenizerURL.appendingPathComponent("tokenizer.json"),
+            resources.bigVGANConfigURL,
+            resources.bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANPyTorchFilename),
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        }
+
+        XCTAssertEqual(resources.validate(), [])
+        XCTAssertEqual(
+            resources.bigVGANWeightsURL().lastPathComponent,
+            MMAudioResources.bigVGANPyTorchFilename
+        )
+    }
+
+    func testSafetensorsVocoderCheckpointTakesPrecedence() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mmaudio-vocoder-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resources = MMAudioModelResources(rootURL: root)
+        try FileManager.default.createDirectory(
+            at: resources.bigVGANURL,
+            withIntermediateDirectories: true
+        )
+        for filename in [
+            MMAudioResources.bigVGANPyTorchFilename,
+            MMAudioResources.bigVGANSafetensorsFilename,
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: resources.bigVGANURL.appendingPathComponent(filename).path,
+                contents: Data()
+            ))
+        }
+
+        XCTAssertEqual(
+            resources.bigVGANWeightsURL().lastPathComponent,
+            MMAudioResources.bigVGANSafetensorsFilename
+        )
+    }
+
+    func testManagedManifestValidatesAsNativeMMAudioWithoutDiffusersComponents() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mmaudio-manifest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resources = MMAudioModelResources(rootURL: root)
+        try FileManager.default.createDirectory(
+            at: resources.clipTokenizerURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: resources.bigVGANURL,
+            withIntermediateDirectories: true
+        )
+        for url in [
+            resources.networkWeightsURL,
+            resources.clipWeightsURL,
+            resources.synchformerWeightsURL,
+            resources.vaeWeightsURL,
+            resources.clipTokenizerURL.appendingPathComponent("tokenizer.json"),
+            resources.bigVGANConfigURL,
+            resources.bigVGANURL.appendingPathComponent(MMAudioResources.bigVGANPyTorchFilename),
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        }
+        _ = try MereRunModelManifest.writeTemplateIfKnown(
+            modelId: MMAudioResources.modelID,
+            to: root
+        )
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: MMAudioResources.modelID
+        )
+        XCTAssertEqual(report.errors, [])
+        XCTAssertFalse(report.warnings.contains { $0.contains("engine mismatch") })
+        XCTAssertFalse(report.warnings.contains { $0.contains("model root marker") })
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -970,6 +970,70 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
     }
 
+    func testMMAudioSpecUsesPinnedNativeAssetsAndNonCommercialCheckpointSource() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.mmaudioLarge44kV2.rawValue)
+        )
+
+        XCTAssertEqual(spec.category, .sfx)
+        XCTAssertEqual(spec.validationKind, .mmaudio)
+        XCTAssertEqual(spec.hubFallback?.repoId, MMAudioResources.convertedWeightsRepoID)
+        XCTAssertEqual(spec.hubFallback?.revision, MMAudioResources.convertedWeightsRevision)
+        XCTAssertEqual(spec.defaultCLICommands, ["sfx generate", "sfx video generate"])
+        XCTAssertEqual(spec.mountedHubFallbacks.map(\.destinationPath), ["clip", "bigvgan"])
+        XCTAssertEqual(spec.upstreamRevision, MMAudioResources.upstreamRevision)
+        XCTAssertEqual(MMAudioResources.architectureLicense, "MIT")
+        XCTAssertEqual(MMAudioResources.checkpointLicense, "CC-BY-NC-4.0")
+        XCTAssertEqual(
+            MMAudioResources.clipModelLicense,
+            "Apple Machine Learning Research Model License Agreement"
+        )
+        XCTAssertEqual(MMAudioResources.bigVGANLicense, "MIT")
+    }
+
+    func testMMAudioRootRequiresGeneratorConditionersCodecAndVocoder() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.mmaudioLarge44kV2.rawValue)
+        )
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let clip = root.appendingPathComponent("clip", isDirectory: true)
+        let bigvgan = root.appendingPathComponent("bigvgan", isDirectory: true)
+        try FileManager.default.createDirectory(at: clip, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: bigvgan, withIntermediateDirectories: true)
+        for file in [
+            MMAudioResources.networkFilename,
+            MMAudioResources.clipFilename,
+            MMAudioResources.synchformerFilename,
+            MMAudioResources.vaeFilename,
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: root.appendingPathComponent(file).path,
+                contents: Data()
+            ))
+        }
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: clip.appendingPathComponent("tokenizer.json").path,
+            contents: Data("{}".utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: bigvgan.appendingPathComponent("config.json").path,
+            contents: Data("{}".utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: bigvgan.appendingPathComponent(MMAudioResources.bigVGANPyTorchFilename).path,
+            contents: Data()
+        ))
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+
+        try FileManager.default.removeItem(at: root.appendingPathComponent(MMAudioResources.vaeFilename))
+        XCTAssertEqual(
+            spec.missingPaths(in: root, fileManager: .default).map(\.lastPathComponent),
+            [MMAudioResources.vaeFilename]
+        )
+    }
+
     func testLTX23MLXSpecUsesDgrauetSplitSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.ltxVideo23AVMLX.rawValue))
 

--- a/Tests/MereRunCoreTests/PyTorchStateDictArchiveTests.swift
+++ b/Tests/MereRunCoreTests/PyTorchStateDictArchiveTests.swift
@@ -27,6 +27,33 @@ final class PyTorchStateDictArchiveTests: XCTestCase {
         XCTAssertEqual(array.asArray(Float.self), [1.5, -2])
     }
 
+    func testAcceptsExactGeneratorStateDictWrapper() throws {
+        let url = try writeCheckpoint(
+            pickle: generatorStateDictPickle(shape: [2], stride: [1], storageElementCount: 2),
+            storage: floatData([1.5, -2])
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try PyTorchStateDictArchive(url: url)
+        XCTAssertEqual(archive.tensors.map(\.name), ["weight"])
+        XCTAssertEqual(try archive.rawData(named: "weight"), floatData([1.5, -2]))
+    }
+
+    func testAcceptsCUDAStorageLocationWithoutExecutingDeviceCode() throws {
+        let url = try writeCheckpoint(
+            pickle: stateDictPickle(
+                shape: [1],
+                stride: [1],
+                storageElementCount: 1,
+                storageDevice: "cuda:0"
+            ),
+            storage: floatData([2])
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertEqual(try PyTorchStateDictArchive(url: url).rawData(named: "weight"), floatData([2]))
+    }
+
     func testAcceptsExactModernTorchSerializationIdentifier() throws {
         let url = try writeCheckpoint(
             pickle: stateDictPickle(shape: [1], stride: [1], storageElementCount: 1),
@@ -188,6 +215,20 @@ final class PyTorchStateDictArchiveTests: XCTestCase {
         XCTAssertEqual(cls.size, 384)
     }
 
+    func testPinnedMMAudioBigVGANInventoryWhenFixtureIsAvailable() throws {
+        let path = ProcessInfo.processInfo.environment["MERERUN_TEST_MMAUDIO_BIGVGAN"] ?? ""
+        try XCTSkipIf(
+            path.isEmpty || !FileManager.default.fileExists(atPath: path),
+            "Set MERERUN_TEST_MMAUDIO_BIGVGAN to the pinned bigvgan_generator.pt fixture."
+        )
+
+        let archive = try PyTorchStateDictArchive(url: URL(fileURLWithPath: path))
+        XCTAssertEqual(archive.tensors.count, 783)
+        XCTAssertNotNil(archive.descriptor(named: "conv_pre.bias"))
+        XCTAssertNotNil(archive.descriptor(named: "conv_post.weight_g"))
+        XCTAssertNotNil(archive.descriptor(named: "conv_post.weight_v"))
+    }
+
     private func writeCheckpoint(
         pickle: Data,
         storage: Data,
@@ -226,6 +267,7 @@ private func stateDictPickle(
     stride: [Int],
     storageElementCount: Int,
     storageKey: String = "0",
+    storageDevice: String = "cpu",
     rebuildGlobal: (module: String, name: String) = ("torch._utils", "_rebuild_tensor_v2")
 ) -> Data {
     var data = Data([0x80, 0x02, 0x7D, 0x28]) // PROTO 2, EMPTY_DICT, MARK
@@ -236,7 +278,7 @@ private func stateDictPickle(
     appendUnicode("storage", to: &data)
     appendGlobal("torch", "FloatStorage", to: &data)
     appendUnicode(storageKey, to: &data)
-    appendUnicode("cpu", to: &data)
+    appendUnicode(storageDevice, to: &data)
     appendInteger(storageElementCount, to: &data)
     data.append(contentsOf: [0x74, 0x51]) // TUPLE, BINPERSID
     appendInteger(0, to: &data)
@@ -246,6 +288,26 @@ private func stateDictPickle(
     appendGlobal("collections", "OrderedDict", to: &data)
     data.append(contentsOf: [0x29, 0x52]) // EMPTY_TUPLE, REDUCE
     data.append(contentsOf: [0x74, 0x52]) // TUPLE, REDUCE
+    data.append(contentsOf: [0x75, 0x2E]) // SETITEMS, STOP
+    return data
+}
+
+private func generatorStateDictPickle(
+    shape: [Int],
+    stride: [Int],
+    storageElementCount: Int
+) -> Data {
+    var inner = stateDictPickle(
+        shape: shape,
+        stride: stride,
+        storageElementCount: storageElementCount
+    )
+    inner.removeFirst(2) // The outer container owns PROTO 2.
+    inner.removeLast() // The outer container owns STOP.
+
+    var data = Data([0x80, 0x02, 0x7D, 0x28]) // PROTO 2, EMPTY_DICT, MARK
+    appendUnicode("generator", to: &data)
+    data.append(inner)
     data.append(contentsOf: [0x75, 0x2E]) // SETITEMS, STOP
     return data
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1255,7 +1255,8 @@ swift run mere.run music realtime \
 
 Generate a mono WAV sound effect from a text prompt. The default model uses the
 native Sony Research Woosh DFlow path; the original Woosh Flow checkpoint is
-also available as `sfx-woosh-flow`.
+also available as `sfx-woosh-flow`. `sfx-mmaudio-large-44k-v2` selects the
+native 44.1 kHz MMAudio large-v2 runtime.
 
 ```bash
 swift run mere.run sfx generate "<prompt>" [options]
@@ -1263,7 +1264,9 @@ swift run mere.run sfx generate "<prompt>" [options]
 
 Key options:
 
-- `--model`: `sfx-woosh-dflow`, `sfx-woosh-flow`, or a local Woosh checkpoints root
+- `--model`: `sfx-woosh-dflow`, `sfx-woosh-flow`,
+  `sfx-mmaudio-large-44k-v2`, or a matching local model root
+- `--negative-prompt`: negative text conditioning for MMAudio
 - `--output`
 - `--duration`
 - `--steps`
@@ -1282,6 +1285,16 @@ swift run mere.run sfx generate \
   --steps 4 \
   --cfg 4.5 \
   --output ./wrench-clang.wav
+```
+
+```bash
+swift run mere.run sfx generate \
+  "ocean waves striking a stone breakwater" \
+  --negative-prompt "speech, music" \
+  --model sfx-mmaudio-large-44k-v2 \
+  --duration 8 \
+  --steps 25 \
+  --output ./breakwater.wav
 ```
 
 ### `mere.run sfx ae`
@@ -1316,7 +1329,8 @@ swift run mere.run sfx clap score "glass breaking" ./glass.wav
 
 Generate a mono WAV sound effect from a raw video file or precomputed
 Synchformer video features. `.npy` feature inputs must have shape
-`[frames, 768]` or `[1, frames, 768]`.
+`[frames, 768]` or `[1, frames, 768]` for Woosh. MMAudio requires the original
+video so it can compute both CLIP and Synchformer conditioning.
 
 ```bash
 swift run mere.run model pull sfx-woosh-synchformer
@@ -1328,8 +1342,19 @@ swift run mere.run sfx video generate \
   --output ./hallway-footsteps.wav
 ```
 
+```bash
+swift run mere.run sfx video generate \
+  "a skateboard rolling over rough pavement" \
+  ./skateboard.mp4 \
+  --model sfx-mmaudio-large-44k-v2 \
+  --negative-prompt "speech, music" \
+  --clip-batch-size 4 \
+  --sync-batch-size 1 \
+  --output ./skateboard.wav
+```
+
 Use `--preflight --json` to inspect input mode, output path state, VFlow/DVFlow
-model availability, raw-video Synchformer requirements, duration, effective
+model availability, raw-video conditioning requirements, duration, effective
 step count, CFG, renoise schedule, and follow-up actions before loading MLX or
 generating audio. `.npy` feature inputs do not require Synchformer during
 preflight or generation.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -93,6 +93,7 @@ from the runtime catalog used by `mere.run model list`,
 | `sfx` | `sfx-woosh-synchformer` |
 | `sfx` | `sfx-woosh-vflow-8s` |
 | `sfx` | `sfx-woosh-dvflow-8s` |
+| `sfx` | `sfx-mmaudio-large-44k-v2` |
 | `video` | `video-ltx-av` |
 | `video` | `video-ltx23-av-mlx` |
 | `video` | `video-wan22-ti2v-5b-mlx` |
@@ -519,6 +520,38 @@ Both include `checkpoints/Woosh-AE/` and `checkpoints/TextConditionerV/`.
 `Kijai/MMAudio_safetensors`. `mere.run sfx video generate` uses it when the
 input is a raw video file; `.npy` inputs can still provide precomputed
 Synchformer `synch_out` features directly.
+
+### `sfx-mmaudio-large-44k-v2`
+
+The native MMAudio install combines pinned public artifacts into one managed
+root:
+
+```text
+.../models/sfx-mmaudio-large-44k-v2
+├── mmaudio_large_44k_v2_fp16.safetensors
+├── apple_DFN5B-CLIP-ViT-H-14-384_fp16.safetensors
+├── mmaudio_synchformer_fp16.safetensors
+├── mmaudio_vae_44k_fp16.safetensors
+├── clip/tokenizer.json
+└── bigvgan/
+    ├── config.json
+    └── bigvgan_generator.pt
+```
+
+The MMAudio, CLIP, Synchformer, and VAE safetensors come from the pinned
+`Kijai/MMAudio_safetensors` snapshot. CLIP tokenizer/config files are mounted
+from Apple's pinned DFN5B CLIP repository. BigVGAN-v2 config and generator
+weights are mounted from NVIDIA's pinned 44.1 kHz repository. The Swift runtime
+loads the official BigVGAN PyTorch state dictionary with a restricted parser;
+it does not execute Python or arbitrary pickle globals.
+
+The `hkchengrex/MMAudio` architecture source is MIT-licensed. The released
+MMAudio checkpoints are separately CC-BY-NC-4.0 and therefore non-commercial.
+Apple's mounted DFN5B CLIP model is separately restricted to research purposes
+under the Apple Machine Learning Research Model License Agreement. NVIDIA's
+BigVGAN-v2 source and model are MIT-licensed. The managed install retains the
+exact Apple and NVIDIA license files beside those components. Review all model
+terms before downloading or using generated output.
 
 ### `video-ltx-av`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -43,7 +43,7 @@ Examples:
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
-- sfx: `sfx-woosh-dflow`, `sfx-woosh-flow`, `sfx-woosh-clap`, `sfx-woosh-synchformer`, `sfx-woosh-dvflow-8s`, `sfx-woosh-vflow-8s`
+- sfx: `sfx-woosh-dflow`, `sfx-woosh-flow`, `sfx-woosh-clap`, `sfx-woosh-synchformer`, `sfx-woosh-dvflow-8s`, `sfx-woosh-vflow-8s`, `sfx-mmaudio-large-44k-v2`
 - video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-wan22-ti2v-5b-mlx`
 
 The public runtime resolves these IDs directly, so docs and examples should use

--- a/docs/runtime/sfx.md
+++ b/docs/runtime/sfx.md
@@ -19,6 +19,7 @@ This page covers the native sound-effect runtime exposed through `mere.run sfx`.
 - `sfx-woosh-synchformer`
 - `sfx-woosh-dvflow-8s`
 - `sfx-woosh-vflow-8s`
+- `sfx-mmaudio-large-44k-v2`
 
 ## Guides
 
@@ -86,6 +87,34 @@ swift run mere.run sfx video generate \
   -o ./hallway-footsteps.wav
 ```
 
+MMAudio provides a second, native 44.1 kHz path for both text-to-audio and
+video-to-audio generation:
+
+```bash
+swift run mere.run model pull sfx-mmaudio-large-44k-v2
+swift run mere.run sfx generate \
+  "ocean waves striking a stone breakwater, close and detailed" \
+  --negative-prompt "speech, music" \
+  --model sfx-mmaudio-large-44k-v2 \
+  --duration 8 \
+  --steps 25 \
+  --output ./breakwater.wav
+
+swift run mere.run sfx video generate \
+  "a skateboard rolling over rough pavement" \
+  ./skateboard.mp4 \
+  --negative-prompt "speech, music" \
+  --model sfx-mmaudio-large-44k-v2 \
+  --clip-batch-size 4 \
+  --sync-batch-size 1 \
+  --output ./skateboard.wav
+```
+
+MMAudio video generation needs the original video because it conditions on
+both DFN5B CLIP frames and Synchformer features. A Synchformer-only `.npy`
+input cannot supply the CLIP stream. The model produces 44.1 kHz audio and
+defaults to 8 seconds, 25 Euler flow steps, and CFG 4.5.
+
 ## Runtime entrypoints
 
 ### CLI
@@ -107,6 +136,11 @@ swift run mere.run sfx video generate \
 - `Sources/MereRunCore/Woosh/WooshRobertaTextEncoder.swift`
 - `Sources/MereRunCore/Woosh/WooshVocosDecoder.swift`
 - `Sources/MereRunCore/Woosh/WooshResources.swift`
+- `Sources/MereRunCore/MMAudio/MMAudioGenerator.swift`
+- `Sources/MereRunCore/MMAudio/MMAudioNetwork.swift`
+- `Sources/MereRunCore/MMAudio/MMAudioCLIP.swift`
+- `Sources/MereRunCore/MMAudio/MMAudioVAE.swift`
+- `Sources/MereRunCore/MMAudio/MMAudioBigVGAN.swift`
 
 ## Reading order
 
@@ -137,3 +171,9 @@ swift run mere.run sfx video generate \
   `[frames, 768]` or `[1, frames, 768]`.
 - The open weights are CC-BY-NC 4.0. Generated outputs inherit the
   non-commercial restriction described by the mirror and upstream release.
+- The MMAudio architecture source is MIT, while the released MMAudio
+  checkpoints are separately licensed CC-BY-NC 4.0. The managed catalog and
+  model-source documentation preserve that non-commercial checkpoint boundary.
+- MMAudio's mounted Apple DFN5B CLIP conditioner is separately research-only
+  under the Apple Machine Learning Research Model License Agreement. The
+  managed model keeps Apple's exact license file under `clip/LICENSE`.

--- a/scripts/reference-parity/README.md
+++ b/scripts/reference-parity/README.md
@@ -1,5 +1,23 @@
 # Reference-parity harness (Q35 / Qwen-family)
 
+## MMAudio component oracle
+
+`export_mmaudio_trace.py` runs the pinned upstream PyTorch modules against the
+same managed checkpoints used by the native runtime. It writes deterministic
+CLIP, preprocessing, MMDiT, VAE, BigVGAN-v2, and Synchformer traces. The Swift
+comparison suite is opt-in because the fixture and installed model are large.
+
+```bash
+python scripts/reference-parity/export_mmaudio_trace.py \
+  --model-root "$HOME/Library/Application Support/MereRun/models/sfx-mmaudio-large-44k-v2" \
+  --mmaudio-source /path/to/hkchengrex/MMAudio \
+  --output /tmp/mmaudio-reference.safetensors
+
+MERERUN_TEST_MMAUDIO_ROOT="$HOME/Library/Application Support/MereRun/models/sfx-mmaudio-large-44k-v2" \
+MERERUN_TEST_MMAUDIO_TRACE=/tmp/mmaudio-reference.safetensors \
+swift test --filter MMAudioParityTests
+```
+
 Byte-identical greedy parity gates compare this runtime against itself, so they
 cannot catch a whole class of bug: a systematically wrong forward pass that is
 wrong the same way on both sides of a refactor. This harness compares the

--- a/scripts/reference-parity/export_mmaudio_trace.py
+++ b/scripts/reference-parity/export_mmaudio_trace.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Export deterministic PyTorch MMAudio component traces for Swift parity tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import open_clip
+import torch
+from safetensors.torch import load_file, save_file
+from torchvision.transforms import v2
+
+
+PROMPT = "a wooden door slamming shut"
+
+
+def deterministic(shape: tuple[int, ...], *, scale: float, phase: float = 0) -> torch.Tensor:
+    count = 1
+    for dimension in shape:
+        count *= dimension
+    values = torch.arange(count, dtype=torch.float32)
+    return torch.sin(values * scale + phase).reshape(shape)
+
+
+def cpu_float(tensor: torch.Tensor) -> torch.Tensor:
+    # Clone on the source device before crossing to CPU. PyTorch/MPS otherwise
+    # loses the storage offset of some chunk/slice views during the transfer.
+    return tensor.detach().clone().to(device="cpu", dtype=torch.float32).contiguous()
+
+
+def export_preprocessing(traces: dict[str, torch.Tensor]) -> None:
+    height, width = 241, 319
+    values = torch.arange(height * width * 3, dtype=torch.int64).reshape(height, width, 3)
+    rgb = ((values * 37 + 17) % 256).to(torch.uint8)
+    chw = rgb.permute(2, 0, 1)
+    clip = v2.Resize((384, 384), interpolation=v2.InterpolationMode.BICUBIC)(chw)
+    clip = v2.ToDtype(torch.float32, scale=True)(clip)
+    clip = v2.Normalize(
+        mean=[0.48145466, 0.4578275, 0.40821073],
+        std=[0.26862954, 0.26130258, 0.27577711],
+    )(clip)
+    sync = v2.Resize(224, interpolation=v2.InterpolationMode.BICUBIC)(chw)
+    sync = v2.CenterCrop(224)(sync)
+    sync = v2.ToDtype(torch.float32, scale=True)(sync)
+    sync = v2.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])(sync)
+    traces["preprocess_rgb_hwc_u8"] = rgb.contiguous()
+    traces["preprocess_clip_nhwc"] = clip.permute(1, 2, 0).unsqueeze(0).contiguous()
+    traces["preprocess_sync_chw"] = sync.contiguous()
+
+
+def export_clip(root: Path, device: torch.device, traces: dict[str, torch.Tensor]) -> None:
+    model = open_clip.create_model("ViT-H-14-378-quickgelu", pretrained=None)
+    state = load_file(str(root / "apple_DFN5B-CLIP-ViT-H-14-384_fp16.safetensors"))
+    state.pop("logit_bias", None)
+    model.load_state_dict(state, strict=True)
+    model = model.eval().to(device=device, dtype=torch.float16)
+    tokenizer = open_clip.get_tokenizer("ViT-H-14-378-quickgelu")
+    token_ids = tokenizer([PROMPT])
+
+    def encode_hidden(tokens: torch.Tensor) -> torch.Tensor:
+        hidden = model.token_embedding(tokens).to(torch.float16)
+        hidden = hidden + model.positional_embedding.to(torch.float16)
+        hidden = model.transformer(hidden, attn_mask=model.attn_mask)
+        return torch.nn.functional.normalize(model.ln_final(hidden), dim=-1)
+
+    image = deterministic((1, 384, 384, 3), scale=0.000_13, phase=0.2)
+    image = image.permute(0, 3, 1, 2).to(device=device, dtype=torch.float16)
+    with torch.inference_mode():
+        text = encode_hidden(token_ids.to(device))
+        visual = model.encode_image(image, normalize=True)
+    traces["clip_token_ids"] = token_ids.to(torch.int32).contiguous()
+    traces["clip_text_hidden"] = cpu_float(text)
+    traces["clip_image_nhwc"] = cpu_float(image.permute(0, 2, 3, 1))
+    traces["clip_image_features"] = cpu_float(visual)
+
+
+def export_network(root: Path, device: torch.device, traces: dict[str, torch.Tensor]) -> None:
+    from mmaudio.model.networks import get_my_mmaudio
+
+    model = get_my_mmaudio("large_44k_v2")
+    state = load_file(str(root / "mmaudio_large_44k_v2_fp16.safetensors"))
+    model.load_weights(state)
+    model.update_seq_lengths(44, 8, 16)
+    model = model.eval().to(device=device, dtype=torch.float16)
+    latent = deterministic((1, 44, 40), scale=0.013, phase=0.1)
+    clip = deterministic((1, 8, 1024), scale=0.003, phase=0.2)
+    sync = deterministic((1, 16, 768), scale=0.002, phase=0.3)
+    text = deterministic((1, 77, 1024), scale=0.001, phase=0.4)
+    timestep = torch.tensor([0.25], dtype=torch.float32)
+    with torch.inference_mode():
+        projected = model.preprocess_conditions(
+            clip.to(device=device, dtype=torch.float16),
+            sync.to(device=device, dtype=torch.float16),
+            text.to(device=device, dtype=torch.float16),
+        )
+        latent_device = latent.to(device=device, dtype=torch.float16)
+        audio_projected = model.audio_input_proj(latent_device)
+        timestep_device = timestep.to(device=device, dtype=torch.float16)
+        global_base = model.global_cond_mlp(projected.clip_f_c + projected.text_f_c)
+        global_condition = model.t_embed(timestep_device).unsqueeze(1) + global_base.unsqueeze(1)
+        extended_condition = global_condition + projected.sync_f
+        block = model.joint_blocks[0]
+        latent_qkv, _ = block.latent_block.pre_attention(
+            audio_projected,
+            extended_condition,
+            model.latent_rot,
+        )
+        latent_hidden = audio_projected
+        clip_hidden = projected.clip_f
+        text_hidden = projected.text_f
+        block_outputs: dict[str, torch.Tensor] = {}
+        for index, joint_block in enumerate(model.joint_blocks):
+            latent_hidden, clip_hidden, text_hidden = joint_block(
+                latent_hidden,
+                clip_hidden,
+                text_hidden,
+                global_condition,
+                extended_condition,
+                model.latent_rot,
+                model.clip_rot,
+            )
+            block_outputs[f"network_joint_{index}_latent"] = cpu_float(latent_hidden)
+            block_outputs[f"network_joint_{index}_clip"] = cpu_float(clip_hidden)
+            block_outputs[f"network_joint_{index}_text"] = cpu_float(text_hidden)
+        for index, fused_block in enumerate(model.fused_blocks):
+            latent_hidden = fused_block(latent_hidden, extended_condition, model.latent_rot)
+            block_outputs[f"network_fused_{index}_latent"] = cpu_float(latent_hidden)
+        final_modulation = model.final_layer.adaLN_modulation(global_condition)
+        final_shift, final_scale = final_modulation.chunk(2, dim=-1)
+        final_normalized = model.final_layer.norm(latent_hidden)
+        final_modulated = final_normalized * (1 + final_scale) + final_shift
+        block_outputs["network_final_modulation_raw"] = cpu_float(final_modulation)
+        block_outputs["network_final_shift"] = cpu_float(final_shift)
+        block_outputs["network_final_scale"] = cpu_float(final_scale)
+        block_outputs["network_final_normalized"] = cpu_float(final_normalized)
+        block_outputs["network_final_modulated"] = cpu_float(final_modulated)
+        block_outputs["network_final_from_blocks"] = cpu_float(
+            model.final_layer(latent_hidden, global_condition)
+        )
+        flow = model.predict_flow(
+            latent_device,
+            timestep_device,
+            projected,
+        )
+    traces["network_latent_ntc"] = latent.contiguous()
+    traces["network_clip_ntc"] = clip.contiguous()
+    traces["network_sync_ntc"] = sync.contiguous()
+    traces["network_text_ntc"] = text.contiguous()
+    traces["network_timestep"] = timestep.contiguous()
+    traces["network_final_conv_weight_oik"] = cpu_float(state["final_layer.conv.weight"])
+    traces["network_final_conv_bias"] = cpu_float(state["final_layer.conv.bias"])
+    traces["network_final_adaln_weight"] = cpu_float(state["final_layer.adaLN_modulation.1.weight"])
+    traces["network_final_adaln_bias"] = cpu_float(state["final_layer.adaLN_modulation.1.bias"])
+    traces["network_projected_clip"] = cpu_float(projected.clip_f)
+    traces["network_projected_sync"] = cpu_float(projected.sync_f)
+    traces["network_projected_text"] = cpu_float(projected.text_f)
+    traces["network_clip_global"] = cpu_float(projected.clip_f_c)
+    traces["network_text_global"] = cpu_float(projected.text_f_c)
+    traces["network_audio_projected"] = cpu_float(audio_projected)
+    traces["network_timestep_embedding"] = cpu_float(model.t_embed(timestep_device))
+    traces["network_global_condition"] = cpu_float(global_condition)
+    traces["network_extended_condition"] = cpu_float(extended_condition)
+    traces["network_block0_latent_query"] = cpu_float(latent_qkv[0])
+    traces["network_block0_latent_key"] = cpu_float(latent_qkv[1])
+    traces["network_block0_latent_value"] = cpu_float(latent_qkv[2])
+    traces.update(block_outputs)
+    traces["network_flow_ntc"] = cpu_float(flow)
+
+
+def export_vae(root: Path, device: torch.device, traces: dict[str, torch.Tensor]) -> torch.Tensor:
+    from mmaudio.ext.autoencoder.vae import get_my_vae
+
+    model = get_my_vae("44k")
+    incompatible = model.load_state_dict(
+        load_file(str(root / "mmaudio_vae_44k_fp16.safetensors")),
+        strict=False,
+    )
+    if incompatible.unexpected_keys or any(not key.startswith("encoder.") for key in incompatible.missing_keys):
+        raise RuntimeError(f"Unexpected VAE checkpoint inventory: {incompatible}")
+    model.remove_weight_norm()
+    model = model.eval().to(device=device, dtype=torch.float16)
+    raw_input_weight = load_file(str(root / "mmaudio_vae_44k_fp16.safetensors"))["decoder.conv_in.weight"]
+    traces["vae_input_weight_raw_oik"] = cpu_float(raw_input_weight)
+    traces["vae_input_weight_effective_oik"] = cpu_float(model.decoder.conv_in.weight)
+    latent_ntc = deterministic((1, 4, 40), scale=0.017, phase=0.5)
+    with torch.inference_mode():
+        latent_nct = latent_ntc.transpose(1, 2).to(device=device, dtype=torch.float16)
+        decoder = model.decoder
+        hidden = decoder.conv_in(latent_nct)
+        traces["vae_input_projection_ntc"] = cpu_float(hidden.transpose(1, 2))
+        hidden = decoder.mid.block_1(hidden)
+        traces["vae_middle_first_ntc"] = cpu_float(hidden.transpose(1, 2))
+        hidden = decoder.mid.attn_1(hidden)
+        traces["vae_middle_attention_ntc"] = cpu_float(hidden.transpose(1, 2))
+        hidden = decoder.mid.block_2(hidden).clamp(-decoder.clip_act, decoder.clip_act)
+        traces["vae_middle_second_ntc"] = cpu_float(hidden.transpose(1, 2))
+        for trace_index, level_index in enumerate(reversed(range(decoder.num_layers))):
+            for block_index in range(decoder.num_res_blocks + 1):
+                hidden = decoder.up[level_index].block[block_index](hidden)
+                if len(decoder.up[level_index].attn) > 0:
+                    hidden = decoder.up[level_index].attn[block_index](hidden)
+                hidden = hidden.clamp(-decoder.clip_act, decoder.clip_act)
+            if level_index in decoder.down_layers:
+                hidden = decoder.up[level_index].upsample(hidden)
+            traces[f"vae_up_{trace_index}_ntc"] = cpu_float(hidden.transpose(1, 2))
+        hidden = torch.nn.functional.silu(hidden) / 0.596
+        traces["vae_pre_output_ntc"] = cpu_float(hidden.transpose(1, 2))
+        raw = decoder.conv_out(hidden, gain=(decoder.learnable_gain + 1))
+        traces["vae_raw_spectrogram_ntc"] = cpu_float(raw.transpose(1, 2))
+        spectrogram = model.unnormalize(raw)
+    traces["vae_latent_ntc"] = latent_ntc.contiguous()
+    traces["vae_spectrogram_ntc"] = cpu_float(spectrogram.transpose(1, 2))
+    return spectrogram
+
+
+def export_bigvgan(
+    root: Path,
+    device: torch.device,
+    spectrogram: torch.Tensor,
+    traces: dict[str, torch.Tensor],
+) -> None:
+    from mmaudio.ext.bigvgan_v2.bigvgan import BigVGAN, load_hparams_from_json
+
+    config = load_hparams_from_json(root / "bigvgan" / "config.json")
+    model = BigVGAN(config, use_cuda_kernel=False)
+    checkpoint = torch.load(
+        root / "bigvgan" / "bigvgan_generator.pt",
+        map_location="cpu",
+        weights_only=True,
+    )["generator"]
+    model.load_state_dict(checkpoint, strict=True)
+    model = model.eval().to(device=device, dtype=torch.float16)
+    with torch.inference_mode():
+        waveform = model(spectrogram.to(device=device, dtype=torch.float16))
+    traces["bigvgan_spectrogram_nct"] = cpu_float(spectrogram)
+    traces["bigvgan_waveform_nct"] = cpu_float(waveform)
+
+
+def export_synchformer(root: Path, device: torch.device, traces: dict[str, torch.Tensor]) -> None:
+    from mmaudio.ext.synchformer import Synchformer
+
+    model = Synchformer()
+    model.load_state_dict(
+        load_file(str(root / "mmaudio_synchformer_fp16.safetensors")),
+        strict=True,
+    )
+    model = model.eval().to(device=device, dtype=torch.float32)
+    frames_tchw = deterministic((16, 3, 224, 224), scale=0.000_011, phase=0.6)
+    with torch.inference_mode():
+        output = model(frames_tchw.unsqueeze(0).unsqueeze(0).to(device))
+    traces["synchformer_frames_tchw"] = frames_tchw.contiguous()
+    traces["synchformer_features_ntc"] = cpu_float(output.reshape(1, 8, 768))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-root", type=Path, required=True)
+    parser.add_argument("--mmaudio-source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--components",
+        default="preprocess,clip,network,vae,bigvgan,synchformer",
+        help="Comma-separated trace groups.",
+    )
+    parser.add_argument("--device", choices=["auto", "cpu", "mps"], default="auto")
+    args = parser.parse_args()
+    root = args.model_root.resolve()
+    source = args.mmaudio_source.resolve()
+    sys.path.insert(0, str(source))
+    requested = set(args.components.split(","))
+    device = torch.device(
+        "mps" if args.device == "auto" and torch.backends.mps.is_available() else
+        "cpu" if args.device == "auto" else args.device
+    )
+    traces: dict[str, torch.Tensor] = {}
+    if "preprocess" in requested:
+        export_preprocessing(traces)
+    if "clip" in requested:
+        export_clip(root, device, traces)
+    if "network" in requested:
+        export_network(root, device, traces)
+    spectrogram = export_vae(root, device, traces) if {"vae", "bigvgan"} & requested else None
+    if "bigvgan" in requested:
+        assert spectrogram is not None
+        export_bigvgan(root, device, spectrogram, traces)
+    if "synchformer" in requested:
+        export_synchformer(root, device, traces)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_file(traces, str(args.output), metadata={
+        "prompt": PROMPT,
+        "mmaudio_revision": "974010a026c731054592d8f777218bd9d85a6c24",
+        "device": str(device),
+    })
+    print(json.dumps({"output": str(args.output), "tensors": sorted(traces), "device": str(device)}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a native Swift/MLX MMAudio large 44.1 kHz runtime for text-to-audio and synchronized video-to-audio generation
- integrate pinned managed assets, DFN5B CLIP text/image conditioning, Synchformer, joint/fused MMDiT flow, magnitude-preserving VAE, and BigVGAN-v2 decoding
- add model-aware CLI defaults, negative prompts, video preflight, batch controls, model capabilities/validation, documentation, and licensing metadata
- add a restricted official PyTorch state-dict reader plus a reference trace exporter and Swift/PyTorch parity coverage
- replace the Studio JSON compatibility boundary with typed decoding so the repository hygiene gate remains satisfied

## Why

MMAudio provides substantially richer 44.1 kHz sound-effect generation and video-synchronized audio while preserving mere.run's local-first, native-runtime contract. The implementation does not require a Python runtime, sidecar, hosted inference service, or runtime network inference.

## User impact

After installing `sfx-mmaudio-large-44k-v2`, users can run:

```bash
mere.run sfx generate "ocean waves striking a stone breakwater" \
  --model sfx-mmaudio-large-44k-v2 \
  --negative-prompt "speech, music"

mere.run sfx video generate "a skateboard rolling over rough pavement" \
  ./skateboard.mp4 \
  --model sfx-mmaudio-large-44k-v2 \
  --negative-prompt "speech, music"
```

The managed model is approximately 5.61 GB and reports 32 GB minimum / 64 GB recommended unified memory.

## Licensing

- MMAudio architecture: MIT
- released MMAudio checkpoints: CC-BY-NC-4.0
- Apple DFN5B CLIP: Apple Machine Learning Research Model License Agreement, research-only
- NVIDIA BigVGAN-v2: MIT

Managed installs preserve the exact Apple and NVIDIA license files. The catalog, model-source docs, README, and third-party notices explicitly expose the non-commercial and research-only restrictions.

## Validation

- `./scripts/check.sh` — passed (1,688 tests, 115 skipped, 0 failures; SwiftLint, CLI help sweep, agent-readiness, and hygiene scans passed)
- `swift build -c release` — passed
- `pnpm docs:build` — passed
- `git diff --check` — passed
- PyTorch ↔ Swift parity suite passed for preprocessing, CLIP text/image towers, MMDiT, Synchformer, VAE including decoder stages, and BigVGAN
- native text generation passed at 44.1 kHz
- native video-to-audio generation passed at 44.1 kHz
- untouched public defaults produced an 8.010884-second, 353,280-frame, non-silent WAV
- managed model info, capability reporting, validation, and JSON video preflight passed
