### PR TITLE
Add MuScriptor musical context to MIDI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on Keep a Changelog.
   `music transcribe`, with managed small/medium/large checkpoints, exact HTK
   mel preprocessing, MLX transformer inference, instrument conditioning,
   JSON/JSONL note events, and multi-track MIDI output.
+- added native MuScriptor musical-context enrichment for MIDI output: tempo,
+  beat phase, meter, and key detection with per-field confidence, reviewable
+  beat-position JSON, and standard MIDI tempo/time/key meta events without
+  quantizing source-relative note timing.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,9 @@ swift run mere.run music analyze ./song.mp3 \
 
 # Transcribe a full mix into instrument-separated MIDI with MuScriptor
 swift run mere.run model pull music-muscriptor-medium
-swift run mere.run music transcribe ./song.mp3 --output ./song.mid
+swift run mere.run music transcribe ./song.mp3 \
+  --output ./song.mid \
+  --context-output ./song-context.json
 
 # Generate a style-transfer cover from a source song
 swift run mere.run music generate \

--- a/Sources/MereRunCLI/Commands/MusicTranscribeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicTranscribeCommand.swift
@@ -74,6 +74,18 @@ struct MusicTranscribe: ParsableCommand {
     @Option(name: [.long], help: "Model compute type: bfloat16, float16, or float32.")
     var dtype: String = "bfloat16"
 
+    @Flag(
+        name: [.customLong("no-musical-context")],
+        help: "Keep legacy fixed-tempo MIDI instead of detecting tempo, meter, key, and beat phase."
+    )
+    var noMusicalContext: Bool = false
+
+    @Option(
+        name: [.customLong("context-output")],
+        help: "Write detected musical context and beat positions as JSON. Use '-' for stdout."
+    )
+    var contextOutput: String?
+
     @Flag(name: [.short, .long], help: "Suppress progress diagnostics on stderr.")
     var quiet: Bool = false
 
@@ -96,6 +108,12 @@ struct MusicTranscribe: ParsableCommand {
         }
         guard ["bfloat16", "float16", "float32"].contains(dtype.lowercased()) else {
             throw ValidationError("--dtype must be bfloat16, float16, or float32")
+        }
+        guard !noMusicalContext || contextOutput == nil else {
+            throw ValidationError("--context-output cannot be combined with --no-musical-context")
+        }
+        guard output != "-" || contextOutput != "-" else {
+            throw ValidationError("MIDI/events and musical context cannot both use stdout")
         }
     }
 
@@ -155,10 +173,42 @@ struct MusicTranscribe: ParsableCommand {
             progress: progress
         )
 
+        let shouldAnalyzeContext = !noMusicalContext && (format == .midi || contextOutput != nil)
+        let musicalContext: MuScriptorMusicalContext?
+        if shouldAnalyzeContext {
+            if !quiet {
+                CLIStderr.write("Detecting tempo, meter, key, and beat phase\n")
+            }
+            musicalContext = try MuScriptorMusicalContextAnalyzer().analyze(
+                samples: decoded.samples,
+                sampleRate: 16_000,
+                notes: transcription.notes
+            )
+            if !quiet, let musicalContext {
+                CLIStderr.write("Musical context: \(musicalContext.summary)\n")
+            }
+        } else {
+            musicalContext = nil
+        }
+
+        if let contextOutput, let musicalContext {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try write(encoder.encode(musicalContext), to: contextOutput)
+            if !quiet, contextOutput != "-" {
+                CLIStderr.write("Saved musical context to \(Self.userURL(contextOutput).path)\n")
+            }
+        }
+
         let destination = output ?? Self.defaultOutput(for: inputURL, format: format)
         switch format {
         case .midi:
-            try write(MuScriptorMIDI.encode(notes: transcription.notes), to: destination)
+            let data = if let musicalContext {
+                try MuScriptorMIDI.encode(notes: transcription.notes, context: musicalContext)
+            } else {
+                try MuScriptorMIDI.encode(notes: transcription.notes)
+            }
+            try write(data, to: destination)
         case .json:
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/MereRunCLI/Guides/music-transcribe.md
+++ b/Sources/MereRunCLI/Guides/music-transcribe.md
@@ -39,6 +39,31 @@ List the exact instrument group names with:
 mere.run music transcribe --list-instruments
 ```
 
+## Musical context
+
+MIDI output detects tempo, beat phase, time signature, and key after MuScriptor
+finishes decoding. The native post-processor combines spectral-flux accents
+from the source audio with MuScriptor note onsets, then estimates key from the
+duration-weighted pitch classes. It writes standard MIDI tempo (`FF 51`), time
+signature (`FF 58`), and key signature (`FF 59`) events. The meter event is
+repeated at the first detected downbeat to establish the bar boundary, and a
+marker labels it without quantizing notes or changing their timing relative to
+the source audio.
+
+Write the detected values, per-field confidence scores, and beat positions to
+reviewable JSON with:
+
+```bash
+mere.run music transcribe ./song.mp3 \
+  --output ./song.mid \
+  --context-output ./song-context.json
+```
+
+Low-evidence meter or key fields are omitted instead of guessed. Use
+`--no-musical-context` when byte-compatible legacy behavior with the fixed
+120 BPM conductor track is required. JSON and JSONL note-event output remains
+unchanged unless `--context-output` is requested.
+
 ## Structured output
 
 Use JSON for one event array or JSONL for a stream-friendly file. Stdout stays

--- a/Sources/MereRunCore/MuScriptor/MuScriptorConfiguration.swift
+++ b/Sources/MereRunCore/MuScriptor/MuScriptorConfiguration.swift
@@ -84,6 +84,7 @@ public enum MuScriptorError: LocalizedError {
     case invalidToken(Int)
     case generationLimit(chunk: Int, limit: Int)
     case malformedTokenStream(String)
+    case invalidAudio(String)
     case invalidMIDI(String)
 
     public var errorDescription: String? {
@@ -102,6 +103,8 @@ public enum MuScriptorError: LocalizedError {
             "MuScriptor chunk \(chunk) did not emit EOS within \(limit) tokens."
         case .malformedTokenStream(let message):
             "Malformed MuScriptor token stream: \(message)"
+        case .invalidAudio(let message):
+            "Could not analyze MuScriptor audio: \(message)"
         case .invalidMIDI(let message):
             "Could not encode MuScriptor MIDI: \(message)"
         }

--- a/Sources/MereRunCore/MuScriptor/MuScriptorMIDI.swift
+++ b/Sources/MereRunCore/MuScriptor/MuScriptorMIDI.swift
@@ -13,13 +13,47 @@ public enum MuScriptorMIDI {
         tempoBPM: Int = 120,
         velocity: Int = 100
     ) throws -> Data {
-        guard tempoBPM > 0 else { throw MuScriptorError.invalidMIDI("tempo must be positive") }
+        try encode(
+            notes: notes,
+            tempoBPM: Double(tempoBPM),
+            context: nil,
+            velocity: velocity
+        )
+    }
+
+    /// Encodes detected musical context into the conductor track while preserving
+    /// MuScriptor's absolute note timing relative to the source audio.
+    public static func encode(
+        notes: [MuScriptorNote],
+        context: MuScriptorMusicalContext,
+        velocity: Int = 100
+    ) throws -> Data {
+        try encode(
+            notes: notes,
+            tempoBPM: context.tempo?.bpm ?? 120,
+            context: context,
+            velocity: velocity
+        )
+    }
+
+    private static func encode(
+        notes: [MuScriptorNote],
+        tempoBPM: Double,
+        context: MuScriptorMusicalContext?,
+        velocity: Int
+    ) throws -> Data {
+        guard tempoBPM.isFinite, tempoBPM > 0 else {
+            throw MuScriptorError.invalidMIDI("tempo must be positive")
+        }
         guard (1...127).contains(velocity) else {
             throw MuScriptorError.invalidMIDI("velocity must be between 1 and 127")
         }
 
         let ticksPerBeat = 480
-        let microsecondsPerBeat = 60_000_000 / tempoBPM
+        let microsecondsPerBeat = Int((60_000_000 / tempoBPM).rounded())
+        guard (1...0xFF_FFFF).contains(microsecondsPerBeat) else {
+            throw MuScriptorError.invalidMIDI("tempo is outside the Standard MIDI File range")
+        }
         let ticksPerSecond = Double(ticksPerBeat) * 1_000_000 / Double(microsecondsPerBeat)
         let grouped = Dictionary(grouping: notes) { $0.instrument }
         let trackNames = grouped.keys.sorted()
@@ -30,14 +64,53 @@ public enum MuScriptorMIDI {
         result.appendBigEndian(UInt16(trackNames.count + 1))
         result.appendBigEndian(UInt16(ticksPerBeat))
 
-        let tempoBytes: [UInt8] = [
+        var conductorBytes: [UInt8] = [
             0x00, 0xFF, 0x51, 0x03,
             UInt8((microsecondsPerBeat >> 16) & 0xFF),
             UInt8((microsecondsPerBeat >> 8) & 0xFF),
             UInt8(microsecondsPerBeat & 0xFF),
-            0x00, 0xFF, 0x2F, 0x00,
         ]
-        result.appendChunk(type: "MTrk", payload: Data(tempoBytes))
+        let timeSignatureMeta: [UInt8]?
+        if let timeSignature = context?.timeSignature {
+            guard (1...255).contains(timeSignature.numerator),
+                  let denominatorPower = denominatorPower(timeSignature.denominator) else {
+                throw MuScriptorError.invalidMIDI("invalid time signature \(timeSignature.name)")
+            }
+            let metronomeClocks = timeSignature.denominator == 8 && timeSignature.numerator.isMultiple(of: 3)
+                ? 36
+                : 24
+            let meta: [UInt8] = [
+                0xFF, 0x58, 0x04,
+                UInt8(timeSignature.numerator), UInt8(denominatorPower), UInt8(metronomeClocks), 0x08,
+            ]
+            timeSignatureMeta = meta
+            conductorBytes.append(0)
+            conductorBytes += meta
+        } else {
+            timeSignatureMeta = nil
+        }
+        if let keySignature = context?.keySignature {
+            guard (-7...7).contains(keySignature.sharpsFlats) else {
+                throw MuScriptorError.invalidMIDI("key signature must be between seven flats and seven sharps")
+            }
+            conductorBytes += [
+                0x00, 0xFF, 0x59, 0x02,
+                UInt8(bitPattern: Int8(keySignature.sharpsFlats)), keySignature.isMinor ? 0x01 : 0x00,
+            ]
+        }
+        if let downbeat = context?.timeSignature?.downbeatOffsetSeconds, downbeat > 0 {
+            let marker = Array("Detected downbeat".utf8)
+            conductorBytes.appendVariableLength(max(0, Int((downbeat * ticksPerSecond).rounded())))
+            if let timeSignatureMeta {
+                conductorBytes += timeSignatureMeta
+            }
+            conductorBytes.append(0)
+            conductorBytes += [0xFF, 0x06]
+            conductorBytes.appendVariableLength(marker.count)
+            conductorBytes += marker
+        }
+        conductorBytes += [0x00, 0xFF, 0x2F, 0x00]
+        result.appendChunk(type: "MTrk", payload: Data(conductorBytes))
 
         var nextMelodicChannel = 0
         for name in trackNames {
@@ -93,6 +166,24 @@ public enum MuScriptorMIDI {
             result.appendChunk(type: "MTrk", payload: payload)
         }
         return result
+    }
+
+    private static func denominatorPower(_ denominator: Int) -> Int? {
+        guard denominator > 0, denominator.nonzeroBitCount == 1 else { return nil }
+        return denominator.trailingZeroBitCount
+    }
+}
+
+private extension Array where Element == UInt8 {
+    mutating func appendVariableLength(_ rawValue: Int) {
+        var value = Swift.max(0, rawValue)
+        var bytes = [UInt8(value & 0x7F)]
+        value /= 128
+        while value > 0 {
+            bytes.append(UInt8((value & 0x7F) | 0x80))
+            value /= 128
+        }
+        append(contentsOf: bytes.reversed())
     }
 }
 

--- a/Sources/MereRunCore/MuScriptor/MuScriptorMusicalContext.swift
+++ b/Sources/MereRunCore/MuScriptor/MuScriptorMusicalContext.swift
@@ -1,0 +1,513 @@
+import AudioCodecs
+import Foundation
+
+public struct MuScriptorTempo: Codable, Hashable, Sendable {
+    public let bpm: Double
+    public let beatOffsetSeconds: Double
+    public let confidence: Double
+
+    public init(bpm: Double, beatOffsetSeconds: Double, confidence: Double) {
+        self.bpm = bpm
+        self.beatOffsetSeconds = beatOffsetSeconds
+        self.confidence = confidence
+    }
+}
+
+public struct MuScriptorTimeSignature: Codable, Hashable, Sendable {
+    public let numerator: Int
+    public let denominator: Int
+    public let downbeatOffsetSeconds: Double
+    public let confidence: Double
+
+    public init(
+        numerator: Int,
+        denominator: Int,
+        downbeatOffsetSeconds: Double,
+        confidence: Double
+    ) {
+        self.numerator = numerator
+        self.denominator = denominator
+        self.downbeatOffsetSeconds = downbeatOffsetSeconds
+        self.confidence = confidence
+    }
+
+    public var name: String { "\(numerator)/\(denominator)" }
+}
+
+public struct MuScriptorKeySignature: Codable, Hashable, Sendable {
+    public let name: String
+    public let sharpsFlats: Int
+    public let isMinor: Bool
+    public let confidence: Double
+
+    public init(name: String, sharpsFlats: Int, isMinor: Bool, confidence: Double) {
+        self.name = name
+        self.sharpsFlats = sharpsFlats
+        self.isMinor = isMinor
+        self.confidence = confidence
+    }
+}
+
+public struct MuScriptorBeat: Codable, Hashable, Sendable {
+    public let timeSeconds: Double
+    public let strength: Double
+    public let isDownbeat: Bool
+
+    public init(timeSeconds: Double, strength: Double, isDownbeat: Bool) {
+        self.timeSeconds = timeSeconds
+        self.strength = strength
+        self.isDownbeat = isDownbeat
+    }
+}
+
+public struct MuScriptorMusicalContext: Codable, Hashable, Sendable {
+    public let tempo: MuScriptorTempo?
+    public let timeSignature: MuScriptorTimeSignature?
+    public let keySignature: MuScriptorKeySignature?
+    public let beats: [MuScriptorBeat]
+
+    public init(
+        tempo: MuScriptorTempo?,
+        timeSignature: MuScriptorTimeSignature?,
+        keySignature: MuScriptorKeySignature?,
+        beats: [MuScriptorBeat]
+    ) {
+        self.tempo = tempo
+        self.timeSignature = timeSignature
+        self.keySignature = keySignature
+        self.beats = beats
+    }
+
+    public var summary: String {
+        var fields: [String] = []
+        if let tempo {
+            fields.append(String(format: "%.2f BPM (%.2f)", tempo.bpm, tempo.confidence))
+        }
+        if let timeSignature {
+            fields.append("\(timeSignature.name) (\(Self.confidence(timeSignature.confidence)))")
+        }
+        if let keySignature {
+            fields.append("\(keySignature.name) (\(Self.confidence(keySignature.confidence)))")
+        }
+        return fields.isEmpty ? "no reliable musical context detected" : fields.joined(separator: ", ")
+    }
+
+    private static func confidence(_ value: Double) -> String {
+        String(format: "%.2f", value)
+    }
+}
+
+/// Estimates tempo, beat phase, meter, and key from decoded audio plus MuScriptor notes.
+///
+/// MuScriptor deliberately predicts absolute note events rather than score-level metadata.
+/// This post-processor combines spectral-flux accents with note onsets for rhythm and uses
+/// duration-weighted pitch-class profiles for key recognition. Low-evidence fields remain nil.
+public struct MuScriptorMusicalContextAnalyzer: Sendable {
+    public let minimumBPM: Double
+    public let maximumBPM: Double
+
+    public init(minimumBPM: Double = 45, maximumBPM: Double = 220) {
+        precondition(minimumBPM > 0 && maximumBPM > minimumBPM)
+        self.minimumBPM = minimumBPM
+        self.maximumBPM = maximumBPM
+    }
+
+    public func analyze(
+        samples: [Float],
+        sampleRate: Int,
+        notes: [MuScriptorNote]
+    ) throws -> MuScriptorMusicalContext {
+        guard sampleRate > 0 else {
+            throw MuScriptorError.invalidAudio("sample rate must be positive")
+        }
+
+        let key = estimateKey(notes: notes)
+        guard samples.count >= sampleRate * 4 else {
+            return MuScriptorMusicalContext(
+                tempo: nil,
+                timeSignature: nil,
+                keySignature: key,
+                beats: []
+            )
+        }
+
+        let hopLength = max(128, sampleRate / 64)
+        let audioEnvelope = try spectralFluxEnvelope(
+            samples: samples,
+            sampleRate: sampleRate,
+            hopLength: hopLength
+        )
+        let noteEnvelope = noteOnsetEnvelope(
+            notes: notes,
+            frameCount: audioEnvelope.count,
+            sampleRate: sampleRate,
+            hopLength: hopLength
+        )
+        let envelope = combine(audio: audioEnvelope, notes: noteEnvelope)
+        guard envelope.max() ?? 0 > 1e-6,
+              let tempoEstimate = estimateTempo(
+                envelope: envelope,
+                framesPerSecond: Double(sampleRate) / Double(hopLength)
+              ) else {
+            return MuScriptorMusicalContext(
+                tempo: nil,
+                timeSignature: nil,
+                keySignature: key,
+                beats: []
+            )
+        }
+
+        let rawBeats = beatGrid(
+            envelope: envelope,
+            periodFrames: tempoEstimate.periodFrames,
+            phaseFrame: tempoEstimate.phaseFrame,
+            framesPerSecond: Double(sampleRate) / Double(hopLength),
+            durationSeconds: Double(samples.count) / Double(sampleRate)
+        )
+        let meter = estimateMeter(beats: rawBeats)
+        let beats = rawBeats.enumerated().map { index, beat in
+            MuScriptorBeat(
+                timeSeconds: beat.timeSeconds,
+                strength: beat.strength,
+                isDownbeat: meter.map {
+                    (index - $0.phaseIndex).isMultiple(of: $0.numerator)
+                } ?? false
+            )
+        }
+        let timeSignature = meter.flatMap { value -> MuScriptorTimeSignature? in
+            guard beats.indices.contains(value.phaseIndex) else { return nil }
+            return MuScriptorTimeSignature(
+                numerator: value.numerator,
+                denominator: 4,
+                downbeatOffsetSeconds: beats[value.phaseIndex].timeSeconds,
+                confidence: value.confidence
+            )
+        }
+        let tempo = MuScriptorTempo(
+            bpm: tempoEstimate.bpm,
+            beatOffsetSeconds: beats.first?.timeSeconds ?? 0,
+            confidence: tempoEstimate.confidence
+        )
+        return MuScriptorMusicalContext(
+            tempo: tempo,
+            timeSignature: timeSignature,
+            keySignature: key,
+            beats: beats
+        )
+    }
+
+    private struct TempoEstimate {
+        let bpm: Double
+        let periodFrames: Double
+        let phaseFrame: Int
+        let confidence: Double
+    }
+
+    private struct MeterEstimate {
+        let numerator: Int
+        let phaseIndex: Int
+        let confidence: Double
+    }
+
+    private func spectralFluxEnvelope(
+        samples: [Float],
+        sampleRate: Int,
+        hopLength: Int
+    ) throws -> [Double] {
+        let fftSize = 1_024
+        let plan = try RealFFTPlan(size: fftSize)
+        let window = (0..<fftSize).map { index in
+            0.5 - 0.5 * cos(2 * Float.pi * Float(index) / Float(fftSize))
+        }
+        let frameCount = max(1, 1 + (samples.count - fftSize) / hopLength)
+        var flux = [Double](repeating: 0, count: frameCount)
+        var previous = [Double](repeating: 0, count: fftSize / 2 + 1)
+        var frame = [Float](repeating: 0, count: fftSize)
+
+        for frameIndex in 0..<frameCount {
+            let start = frameIndex * hopLength
+            for sampleIndex in 0..<fftSize {
+                frame[sampleIndex] = samples[start + sampleIndex] * window[sampleIndex]
+            }
+            let power = plan.powerSpectrum(frame)
+            var value = 0.0
+            for bin in 1..<power.count {
+                let current = log1p(Double(max(power[bin], 0)))
+                value += max(0, current - previous[bin])
+                previous[bin] = current
+            }
+            flux[frameIndex] = value
+        }
+
+        let thresholdRadius = max(2, Int((0.20 * Double(sampleRate) / Double(hopLength)).rounded()))
+        var prefix = [Double](repeating: 0, count: flux.count + 1)
+        for index in flux.indices {
+            prefix[index + 1] = prefix[index] + flux[index]
+        }
+        var filtered = [Double](repeating: 0, count: flux.count)
+        for index in flux.indices {
+            let lower = max(0, index - thresholdRadius)
+            let upper = min(flux.count, index + thresholdRadius + 1)
+            let localMean = (prefix[upper] - prefix[lower]) / Double(upper - lower)
+            filtered[index] = max(0, flux[index] - localMean)
+        }
+        return normalized(filtered)
+    }
+
+    private func noteOnsetEnvelope(
+        notes: [MuScriptorNote],
+        frameCount: Int,
+        sampleRate: Int,
+        hopLength: Int
+    ) -> [Double] {
+        var envelope = [Double](repeating: 0, count: frameCount)
+        for note in notes {
+            let frame = Int((note.onset * Double(sampleRate) / Double(hopLength)).rounded())
+            guard envelope.indices.contains(frame) else { continue }
+            envelope[frame] += note.isDrum ? 2.0 : 1.0
+        }
+        envelope = envelope.map(log1p)
+        guard envelope.count > 2 else { return normalized(envelope) }
+        var smoothed = envelope
+        for index in 1..<(envelope.count - 1) {
+            smoothed[index] = 0.25 * envelope[index - 1]
+                + 0.5 * envelope[index]
+                + 0.25 * envelope[index + 1]
+        }
+        return normalized(smoothed)
+    }
+
+    private func combine(audio: [Double], notes: [Double]) -> [Double] {
+        zip(audio, notes).map { audioValue, noteValue in
+            0.72 * audioValue + 0.28 * noteValue
+        }
+    }
+
+    private func normalized(_ values: [Double]) -> [Double] {
+        guard !values.isEmpty else { return [] }
+        let energy = sqrt(values.reduce(0) { $0 + $1 * $1 } / Double(values.count))
+        guard energy > 1e-12 else { return values }
+        return values.map { $0 / energy }
+    }
+
+    private func estimateTempo(
+        envelope: [Double],
+        framesPerSecond: Double
+    ) -> TempoEstimate? {
+        let minimumLag = max(2, Int((60 * framesPerSecond / maximumBPM).rounded()))
+        let maximumLag = min(
+            envelope.count / 3,
+            Int((60 * framesPerSecond / minimumBPM).rounded())
+        )
+        guard maximumLag > minimumLag else { return nil }
+
+        var correlations = [Double](repeating: 0, count: maximumLag + 1)
+        for lag in minimumLag...maximumLag {
+            correlations[lag] = normalizedCorrelation(envelope, lag: lag)
+        }
+        var scored: [(lag: Int, score: Double)] = []
+        for lag in minimumLag...maximumLag {
+            let bpm = 60 * framesPerSecond / Double(lag)
+            let doublePeriod = lag * 2 <= maximumLag ? correlations[lag * 2] : 0
+            let triplePeriod = lag * 3 <= maximumLag ? correlations[lag * 3] : 0
+            let prior = exp(-pow(log(bpm / 120) / 0.75, 2))
+            scored.append((lag, correlations[lag] + 0.45 * doublePeriod + 0.20 * triplePeriod + 0.08 * prior))
+        }
+        guard let rawBest = scored.max(by: { $0.score < $1.score }), rawBest.score > 0.08 else {
+            return nil
+        }
+        var best = rawBest
+        let rawBPM = 60 * framesPerSecond / Double(rawBest.lag)
+        if rawBPM > 180, rawBest.lag * 2 <= maximumLag {
+            let halfTempo = scored[rawBest.lag * 2 - minimumLag]
+            if halfTempo.score >= rawBest.score * 0.60 {
+                best = halfTempo
+            }
+        } else if rawBPM < 70, rawBest.lag / 2 >= minimumLag {
+            let doubleTempo = scored[rawBest.lag / 2 - minimumLag]
+            if doubleTempo.score >= rawBest.score * 0.60 {
+                best = doubleTempo
+            }
+        }
+        let competitors = scored.filter { candidate in
+            guard abs(candidate.lag - best.lag) > 3 else { return false }
+            let halfAlias = abs(candidate.lag * 2 - best.lag) <= 3
+            let doubleAlias = abs(candidate.lag - best.lag * 2) <= 3
+            return !halfAlias && !doubleAlias
+        }
+        let second = competitors.max(by: { $0.score < $1.score })?.score ?? 0
+        let confidence = min(1, max(0, 0.55 * best.score + 1.8 * (best.score - second)))
+        guard confidence >= 0.10 else { return nil }
+
+        let lower = max(minimumLag, best.lag - 1)
+        let upper = min(maximumLag, best.lag + 1)
+        let weights = (lower...upper).map { max(0, scored[$0 - minimumLag].score) }
+        let weightSum = weights.reduce(0, +)
+        let period = weightSum > 0
+            ? zip(lower...upper, weights).reduce(0) { $0 + Double($1.0) * $1.1 } / weightSum
+            : Double(best.lag)
+        let phase = strongestPhase(envelope: envelope, periodFrames: period)
+        return TempoEstimate(
+            bpm: 60 * framesPerSecond / period,
+            periodFrames: period,
+            phaseFrame: phase,
+            confidence: confidence
+        )
+    }
+
+    private func normalizedCorrelation(_ values: [Double], lag: Int) -> Double {
+        guard lag > 0, lag < values.count else { return 0 }
+        var dot = 0.0
+        var leftEnergy = 0.0
+        var rightEnergy = 0.0
+        for index in lag..<values.count {
+            let left = values[index]
+            let right = values[index - lag]
+            dot += left * right
+            leftEnergy += left * left
+            rightEnergy += right * right
+        }
+        let denominator = sqrt(leftEnergy * rightEnergy)
+        return denominator > 1e-12 ? dot / denominator : 0
+    }
+
+    private func strongestPhase(envelope: [Double], periodFrames: Double) -> Int {
+        let phaseCount = max(1, Int(periodFrames.rounded()))
+        var bestPhase = 0
+        var bestScore = -Double.infinity
+        for phase in 0..<phaseCount {
+            var score = 0.0
+            var frame = Double(phase)
+            while Int(frame.rounded()) < envelope.count {
+                let index = Int(frame.rounded())
+                score += envelope[index]
+                if index > 0 { score += 0.25 * envelope[index - 1] }
+                if index + 1 < envelope.count { score += 0.25 * envelope[index + 1] }
+                frame += periodFrames
+            }
+            if score > bestScore {
+                bestScore = score
+                bestPhase = phase
+            }
+        }
+        return bestPhase
+    }
+
+    private func beatGrid(
+        envelope: [Double],
+        periodFrames: Double,
+        phaseFrame: Int,
+        framesPerSecond: Double,
+        durationSeconds: Double
+    ) -> [MuScriptorBeat] {
+        let maximum = max(envelope.max() ?? 0, 1e-12)
+        var beats: [MuScriptorBeat] = []
+        var frame = Double(phaseFrame)
+        while frame / framesPerSecond <= durationSeconds {
+            let index = min(envelope.count - 1, max(0, Int(frame.rounded())))
+            let lower = max(0, index - 1)
+            let upper = min(envelope.count - 1, index + 1)
+            let strength = envelope[lower...upper].max() ?? 0
+            beats.append(MuScriptorBeat(
+                timeSeconds: frame / framesPerSecond,
+                strength: min(1, strength / maximum),
+                isDownbeat: false
+            ))
+            frame += periodFrames
+        }
+        return beats
+    }
+
+    private func estimateMeter(beats: [MuScriptorBeat]) -> MeterEstimate? {
+        guard beats.count >= 8 else { return nil }
+        let strengths = beats.map(\.strength)
+        var candidates: [(numerator: Int, phase: Int, score: Double)] = []
+        for numerator in [2, 3, 4] {
+            let repetition = normalizedCorrelation(strengths, lag: numerator)
+            for phase in 0..<numerator {
+                let downbeats = strengths.enumerated().compactMap { index, value in
+                    (index - phase).isMultiple(of: numerator) ? value : nil
+                }
+                let others = strengths.enumerated().compactMap { index, value in
+                    (index - phase).isMultiple(of: numerator) ? nil : value
+                }
+                guard !downbeats.isEmpty, !others.isEmpty else { continue }
+                let downbeatMean = downbeats.reduce(0, +) / Double(downbeats.count)
+                let otherMean = others.reduce(0, +) / Double(others.count)
+                let contrast = downbeatMean - otherMean
+                let prior = numerator == 4 ? 0.04 : (numerator == 3 ? 0.02 : 0)
+                candidates.append((numerator, phase, contrast + 0.35 * repetition + prior))
+            }
+        }
+        let ranked = candidates.sorted { $0.score > $1.score }
+        guard let best = ranked.first, best.score > 0.03 else { return nil }
+        let second = ranked.first { $0.numerator != best.numerator }?.score ?? 0
+        let confidence = min(1, max(0, 0.5 * best.score + 2.0 * (best.score - second)))
+        guard confidence >= 0.15 else { return nil }
+        return MeterEstimate(
+            numerator: best.numerator,
+            phaseIndex: best.phase,
+            confidence: confidence
+        )
+    }
+
+    private func estimateKey(notes: [MuScriptorNote]) -> MuScriptorKeySignature? {
+        let pitched = notes.filter { !$0.isDrum && (0...127).contains($0.pitch) }
+        guard pitched.count >= 3 else { return nil }
+        var histogram = [Double](repeating: 0, count: 12)
+        for note in pitched {
+            let duration = min(4, max(0.01, note.offset - note.onset))
+            histogram[note.pitch % 12] += sqrt(duration)
+        }
+        guard histogram.reduce(0, +) > 0 else { return nil }
+
+        let major = [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88]
+        let minor = [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
+        var candidates: [(tonic: Int, minor: Bool, score: Double)] = []
+        for tonic in 0..<12 {
+            candidates.append((tonic, false, profileCorrelation(histogram, profile: major, tonic: tonic)))
+            candidates.append((tonic, true, profileCorrelation(histogram, profile: minor, tonic: tonic)))
+        }
+        candidates.sort { $0.score > $1.score }
+        guard let best = candidates.first, best.score > 0.10 else { return nil }
+        let second = candidates.dropFirst().first?.score ?? -1
+        let confidence = min(1, max(0, 0.55 * best.score + 1.5 * (best.score - second)))
+        guard confidence >= 0.15 else { return nil }
+        let signature = keySignature(tonic: best.tonic, isMinor: best.minor)
+        return MuScriptorKeySignature(
+            name: signature.name,
+            sharpsFlats: signature.sharpsFlats,
+            isMinor: best.minor,
+            confidence: confidence
+        )
+    }
+
+    private func profileCorrelation(_ histogram: [Double], profile: [Double], tonic: Int) -> Double {
+        let rotated = histogram.indices.map { profile[($0 - tonic + 12) % 12] }
+        let histogramMean = histogram.reduce(0, +) / 12
+        let profileMean = rotated.reduce(0, +) / 12
+        var dot = 0.0
+        var histogramEnergy = 0.0
+        var profileEnergy = 0.0
+        for index in histogram.indices {
+            let left = histogram[index] - histogramMean
+            let right = rotated[index] - profileMean
+            dot += left * right
+            histogramEnergy += left * left
+            profileEnergy += right * right
+        }
+        let denominator = sqrt(histogramEnergy * profileEnergy)
+        return denominator > 1e-12 ? dot / denominator : 0
+    }
+
+    private func keySignature(tonic: Int, isMinor: Bool) -> (name: String, sharpsFlats: Int) {
+        let majorNames = ["C", "D-flat", "D", "E-flat", "E", "F", "F-sharp", "G", "A-flat", "A", "B-flat", "B"]
+        let majorSharpsFlats = [0, -5, 2, -3, 4, -1, 6, 1, -4, 3, -2, 5]
+        let minorNames = ["C", "C-sharp", "D", "E-flat", "E", "F", "F-sharp", "G", "G-sharp", "A", "B-flat", "B"]
+        let minorSharpsFlats = [-3, 4, -1, 6, 1, -4, 3, -2, 5, 0, -5, 2]
+        if isMinor {
+            return ("\(minorNames[tonic]) minor", minorSharpsFlats[tonic])
+        }
+        return ("\(majorNames[tonic]) major", majorSharpsFlats[tonic])
+    }
+}

--- a/Sources/MereRunCore/MuScriptor/README.md
+++ b/Sources/MereRunCore/MuScriptor/README.md
@@ -9,6 +9,15 @@ conditioning tokens, and autoregressively decodes the MT3 event vocabulary.
 The decoder carries tied notes across chunk boundaries and emits either note
 events or a Standard MIDI File with one track per detected instrument.
 
+For MIDI output, `MuScriptorMusicalContextAnalyzer` adds the score-level
+metadata that is intentionally outside the checkpoint output vocabulary. It
+combines audio spectral flux with decoded note onsets to estimate tempo, beat
+phase, and meter, and applies duration-weighted pitch-class profiles for key.
+The MIDI writer embeds standard tempo, time-signature, and key-signature meta
+events while retaining the source-relative note timing. Low-evidence fields
+remain absent, and the CLI can export confidence scores and beat positions as
+JSON.
+
 `chunkBatchSize` is a ceiling on independent five-second chunks, not a forced
 allocation. After loading the model, Apple Silicon inference selects an
 effective group size from current MLX active/cache headroom, a system reserve,

--- a/Tests/MereRunCLITests/MusicTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicTranscribeCommandParsingTests.swift
@@ -11,6 +11,8 @@ final class MusicTranscribeCommandParsingTests: XCTestCase {
         XCTAssertEqual(command.dtype, "bfloat16")
         XCTAssertFalse(command.sampling)
         XCTAssertEqual(command.chunkBatchSize, 4)
+        XCTAssertFalse(command.noMusicalContext)
+        XCTAssertNil(command.contextOutput)
     }
 
     func testParsesStructuredOutputAndConditioning() throws {
@@ -25,6 +27,7 @@ final class MusicTranscribeCommandParsingTests: XCTestCase {
             "--strict-eos",
             "--chunk-batch-size", "2",
             "--dtype", "float32",
+            "--context-output", "song-context.json",
         ])
         XCTAssertEqual(command.model, ModelResolver.ModelID.muScriptorSmall.rawValue)
         XCTAssertEqual(command.format, .jsonl)
@@ -36,6 +39,7 @@ final class MusicTranscribeCommandParsingTests: XCTestCase {
         XCTAssertEqual(command.beamSize, 1)
         XCTAssertEqual(command.chunkBatchSize, 2)
         XCTAssertEqual(command.dtype, "float32")
+        XCTAssertEqual(command.contextOutput, "song-context.json")
     }
 
     func testParsesBeamSearch() throws {
@@ -59,9 +63,22 @@ final class MusicTranscribeCommandParsingTests: XCTestCase {
         XCTAssertThrowsError(try command.validate())
     }
 
+    func testRejectsContextOutputWhenDetectionIsDisabled() throws {
+        XCTAssertThrowsError(try MusicTranscribe.parse([
+            "song.wav",
+            "--no-musical-context",
+            "--context-output", "context.json",
+        ]))
+        XCTAssertNoThrow(try MusicTranscribe.parse([
+            "song.wav",
+            "--no-musical-context",
+        ]))
+    }
+
     func testHelpDescribesChunkBatchSizeAsAdaptiveMaximum() {
         let help = MusicTranscribe.helpMessage()
         XCTAssertTrue(help.contains("Maximum five-second chunks"))
         XCTAssertTrue(help.contains("live-beam limits may reduce it"))
+        XCTAssertTrue(help.contains("tempo, meter, key, and beat phase"))
     }
 }

--- a/Tests/MereRunCoreTests/MuScriptorTests.swift
+++ b/Tests/MereRunCoreTests/MuScriptorTests.swift
@@ -516,6 +516,207 @@ final class MuScriptorTests: MereRunCoreTestCase {
         XCTAssertEqual(Array(data[10..<12]), [0, 3])
         XCTAssertEqual(data.windows(ofCount: 4).filter { Array($0) == Array("MTrk".utf8) }.count, 3)
     }
+
+    func testMusicalContextAnalyzerDetectsTempoMeterAndKey() throws {
+        let sampleRate = 16_000
+        let bpm = 120.0
+        let beatDuration = 60 / bpm
+        let beatCount = 32
+        var samples = [Float](repeating: 0, count: Int(Double(sampleRate) * beatDuration * Double(beatCount)))
+        var notes: [MuScriptorNote] = []
+
+        for beat in 0..<beatCount {
+            let start = Int((Double(beat) * beatDuration * Double(sampleRate)).rounded())
+            let amplitude: Float = beat.isMultiple(of: 4) ? 1 : 0.35
+            for offset in 0..<min(240, samples.count - start) {
+                let decay = exp(-Float(offset) / 45)
+                samples[start + offset] += amplitude * decay * sin(2 * Float.pi * 1_200 * Float(offset) / Float(sampleRate))
+            }
+            for pitch in [60, 64, 67] {
+                notes.append(MuScriptorNote(
+                    instrument: "acoustic_piano",
+                    program: 0,
+                    pitch: pitch,
+                    onset: Double(beat) * beatDuration,
+                    offset: Double(beat + 1) * beatDuration - 0.05,
+                    isDrum: false
+                ))
+            }
+        }
+
+        let context = try MuScriptorMusicalContextAnalyzer().analyze(
+            samples: samples,
+            sampleRate: sampleRate,
+            notes: notes
+        )
+        let tempo = try XCTUnwrap(context.tempo)
+        XCTAssertEqual(tempo.bpm, bpm, accuracy: 2)
+        XCTAssertGreaterThan(tempo.confidence, 0.1)
+        let meter = try XCTUnwrap(context.timeSignature)
+        XCTAssertEqual(meter.numerator, 4)
+        XCTAssertEqual(meter.denominator, 4)
+        let key = try XCTUnwrap(context.keySignature)
+        XCTAssertEqual(key.name, "C major")
+        XCTAssertEqual(key.sharpsFlats, 0)
+        XCTAssertFalse(key.isMinor)
+        XCTAssertEqual(context.beats.filter(\.isDownbeat).count, 8)
+    }
+
+    func testMusicalContextAnalyzerLeavesRhythmNilForShortAudio() throws {
+        let notes = [60, 64, 67].map { pitch in
+            MuScriptorNote(
+                instrument: "acoustic_piano",
+                program: 0,
+                pitch: pitch,
+                onset: 0,
+                offset: 1,
+                isDrum: false
+            )
+        }
+        let context = try MuScriptorMusicalContextAnalyzer().analyze(
+            samples: [Float](repeating: 0, count: 16_000),
+            sampleRate: 16_000,
+            notes: notes
+        )
+        XCTAssertNil(context.tempo)
+        XCTAssertNil(context.timeSignature)
+        XCTAssertNotNil(context.keySignature)
+        XCTAssertTrue(context.beats.isEmpty)
+    }
+
+    func testMusicalContextAnalyzerDetectsTripleMeterWithoutPitchedNotes() throws {
+        let sampleRate = 16_000
+        let bpm = 90.0
+        let beatDuration = 60 / bpm
+        let beatCount = 24
+        var samples = [Float](repeating: 0, count: Int(Double(sampleRate) * beatDuration * Double(beatCount)))
+        var notes: [MuScriptorNote] = []
+
+        for beat in 0..<beatCount {
+            let onset = Double(beat) * beatDuration
+            let start = Int((onset * Double(sampleRate)).rounded())
+            let amplitude: Float = beat.isMultiple(of: 3) ? 1 : 0.3
+            for offset in 0..<min(200, samples.count - start) {
+                samples[start + offset] += amplitude * exp(-Float(offset) / 40)
+            }
+            notes.append(MuScriptorNote(
+                instrument: "drums",
+                program: 128,
+                pitch: beat.isMultiple(of: 3) ? 36 : 42,
+                onset: onset,
+                offset: onset + 0.05,
+                isDrum: true
+            ))
+        }
+
+        let context = try MuScriptorMusicalContextAnalyzer().analyze(
+            samples: samples,
+            sampleRate: sampleRate,
+            notes: notes
+        )
+        XCTAssertEqual(try XCTUnwrap(context.tempo).bpm, bpm, accuracy: 2)
+        XCTAssertEqual(try XCTUnwrap(context.timeSignature).numerator, 3)
+        XCTAssertNil(context.keySignature)
+    }
+
+    func testMusicalContextAnalyzerRejectsDoubleTempoAlias() throws {
+        let sampleRate = 16_000
+        let bpm = 101.0
+        let eighthDuration = 30 / bpm
+        let eighthCount = 64
+        var samples = [Float](
+            repeating: 0,
+            count: Int(Double(sampleRate) * eighthDuration * Double(eighthCount))
+        )
+        var notes: [MuScriptorNote] = []
+
+        for eighth in 0..<eighthCount {
+            let onset = Double(eighth) * eighthDuration
+            let start = Int((onset * Double(sampleRate)).rounded())
+            let amplitude: Float = if eighth.isMultiple(of: 8) {
+                1
+            } else if eighth.isMultiple(of: 2) {
+                0.65
+            } else {
+                0.45
+            }
+            for offset in 0..<min(180, samples.count - start) {
+                samples[start + offset] += amplitude * exp(-Float(offset) / 35)
+            }
+            notes.append(MuScriptorNote(
+                instrument: "drums",
+                program: 128,
+                pitch: eighth.isMultiple(of: 2) ? 36 : 42,
+                onset: onset,
+                offset: onset + 0.04,
+                isDrum: true
+            ))
+        }
+
+        let context = try MuScriptorMusicalContextAnalyzer().analyze(
+            samples: samples,
+            sampleRate: sampleRate,
+            notes: notes
+        )
+        XCTAssertEqual(try XCTUnwrap(context.tempo).bpm, bpm, accuracy: 2)
+        XCTAssertEqual(try XCTUnwrap(context.timeSignature).numerator, 4)
+    }
+
+    func testMusicalContextAnalyzerPreservesSlowTempoWithoutSubdivisionEvidence() throws {
+        let sampleRate = 16_000
+        let bpm = 60.0
+        let beatCount = 16
+        var samples = [Float](repeating: 0, count: sampleRate * beatCount)
+        var notes: [MuScriptorNote] = []
+
+        for beat in 0..<beatCount {
+            let start = beat * sampleRate
+            let amplitude: Float = beat.isMultiple(of: 4) ? 1 : 0.4
+            for offset in 0..<180 {
+                samples[start + offset] += amplitude * exp(-Float(offset) / 35)
+            }
+            notes.append(MuScriptorNote(
+                instrument: "drums",
+                program: 128,
+                pitch: 36,
+                onset: Double(beat),
+                offset: Double(beat) + 0.05,
+                isDrum: true
+            ))
+        }
+
+        let context = try MuScriptorMusicalContextAnalyzer().analyze(
+            samples: samples,
+            sampleRate: sampleRate,
+            notes: notes
+        )
+        XCTAssertEqual(try XCTUnwrap(context.tempo).bpm, bpm, accuracy: 2)
+    }
+
+    func testMIDIEncoderWritesMusicalContextMetaEvents() throws {
+        let context = MuScriptorMusicalContext(
+            tempo: MuScriptorTempo(bpm: 90, beatOffsetSeconds: 0, confidence: 0.9),
+            timeSignature: MuScriptorTimeSignature(
+                numerator: 3,
+                denominator: 4,
+                downbeatOffsetSeconds: 0.5,
+                confidence: 0.8
+            ),
+            keySignature: MuScriptorKeySignature(
+                name: "F major",
+                sharpsFlats: -1,
+                isMinor: false,
+                confidence: 0.7
+            ),
+            beats: []
+        )
+        let data = try MuScriptorMIDI.encode(notes: [], context: context)
+        XCTAssertTrue(data.contains(bytes: [0xFF, 0x51, 0x03, 0x0A, 0x2C, 0x2B]))
+        XCTAssertTrue(data.contains(bytes: [0xFF, 0x58, 0x04, 0x03, 0x02, 0x18, 0x08]))
+        XCTAssertEqual(data.count(of: [0xFF, 0x58, 0x04, 0x03, 0x02, 0x18, 0x08]), 2)
+        XCTAssertTrue(data.contains(bytes: [0xFF, 0x59, 0x02, 0xFF, 0x00]))
+        XCTAssertTrue(data.contains(bytes: Array("Detected downbeat".utf8)))
+    }
 }
 
 private extension Data {
@@ -524,5 +725,13 @@ private extension Data {
         return (startIndex...index(endIndex, offsetBy: -count)).map { start in
             self[start..<index(start, offsetBy: count)]
         }
+    }
+
+    func contains(bytes: [UInt8]) -> Bool {
+        windows(ofCount: bytes.count).contains { Array($0) == bytes }
+    }
+
+    func count(of bytes: [UInt8]) -> Int {
+        windows(ofCount: bytes.count).filter { Array($0) == bytes }.count
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1149,6 +1149,9 @@ Key options:
   reduce it for current unified-memory headroom and model/beam saturation;
   `1` always selects the single-chunk path.
 - `--dtype`: `bfloat16`, `float16`, or `float32`
+- `--context-output`: optional JSON path for detected tempo, meter, key,
+  confidence scores, and beat positions; use `-` for stdout
+- `--no-musical-context`: retain the legacy fixed-120-BPM MIDI conductor track
 - `--quiet`
 
 The model repositories are gated and the weights are CC BY-NC 4.0. Accept the
@@ -1157,10 +1160,19 @@ upstream Hugging Face terms before pulling.
 ```bash
 swift run mere.run model pull music-muscriptor-medium
 swift run mere.run music transcribe ./song.mp3 --output ./song.mid
+swift run mere.run music transcribe ./song.mp3 \
+  --output ./song.mid --context-output ./song-context.json
 swift run mere.run music transcribe ./song.wav \
   --instruments voice,drums,electric_bass \
   --format jsonl --output -
 ```
+
+MIDI output detects musical context by default and writes Standard MIDI File
+tempo, time-signature, and key-signature meta events. The detector combines
+source-audio accents with MuScriptor note onsets and preserves absolute note
+timing. It repeats the meter event and adds a marker at the first detected
+downbeat rather than quantizing the notes. Fields without sufficient evidence
+are omitted.
 
 ### `mere.run music realtime`
 

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -92,6 +92,16 @@ swift run mere.run model pull music-muscriptor-medium
 swift run mere.run music transcribe ./song.mp3 --output ./song.mid
 ```
 
+MuScriptor predicts notes, instruments, and absolute event times. For MIDI
+output, mere.run adds a native musical-context pass that estimates tempo and
+beat phase from source-audio accents plus decoded note onsets, estimates meter
+from the beat-accent cycle, and estimates key from duration-weighted pitch
+classes. Standard tempo, time-signature, and key-signature events are embedded,
+with the meter repeated at the first downbeat to establish the bar boundary,
+without quantizing or moving notes. Use `--context-output` to inspect the
+values, confidence scores, and beat positions as JSON, or
+`--no-musical-context` for the legacy fixed-120-BPM writer.
+
 MuScriptor treats `--chunk-batch-size` (default `4`) as an upper bound, not a
 forced allocation. On Apple Silicon, the runtime subtracts current MLX active
 and cache allocations plus a reserve of the greater of 4 GiB or one-eighth of


### PR DESCRIPTION
## Summary

- add native tempo, beat-phase, meter, and key estimation after MuScriptor note decoding
- embed Standard MIDI tempo, time-signature, key-signature, and first-downbeat alignment events while preserving source-relative note timing
- add optional confidence and beat-position JSON output plus a legacy fixed-120-BPM opt-out
- document the public CLI behavior and cover tempo-octave, meter, key, MIDI metadata, and parsing contracts

## Why

MuScriptor predicts note events and instruments, but its MIDI writer previously hardcoded 120 BPM and emitted no meter or key metadata. This adds the application-level musical context needed for DAW-ready exports without requiring another model.

## Validation

- `./scripts/check.sh`
  - strict lint and agent-readiness passed
  - build passed
  - 1,695 tests passed, 115 expected skips, zero failures
  - CLI help sweep passed
- focused MuScriptor suite: 25 tests passed
- focused CLI parsing suite: 7 tests passed
- full 3:55 real-song run with `music-muscriptor-large`: 5,537 notes, 101.32 BPM, 4/4, D major
- independent ACE-Step analysis reported 100 BPM for the same source
- conductor bytes verified tempo (`FF 51`), time signature at tick zero and first downbeat (`FF 58`), key signature (`FF 59`), and downbeat marker