### PR TITLE
Add native MLX TRELLIS.2 image-to-3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added native Swift/MLX Microsoft TRELLIS.2-4B image-to-3D reconstruction at
+  512 resolution, including direct official safetensors loading, pinned DINOv3
+  ViT-L/16 conditioning, three 12-step flow stages, sparse ConvNeXt O-Voxel
+  shape/PBR decoding, flexible-dual-grid mesh extraction, managed model pull,
+  reference-threshold small-hole repair, separate image/vision CLI commands,
+  and hashed OBJ/PLY/GLB plus six-channel `.pbrvox` material artifacts. The DINOv3 dependency remains separately
+  license-gated and requires user acceptance/authentication.
 - added native MMAudio large 44.1 kHz text-to-audio and video-to-audio SFX
   generation, including managed pinned assets, DFN5B CLIP and Synchformer video
   conditioning, the joint/fused MMDiT flow model, magnitude-preserving VAE,

--- a/Package.swift
+++ b/Package.swift
@@ -308,6 +308,7 @@ targets.append(contentsOf: [
       "QwenImageEdit/Model/VAE/README.md",
       "SAM3/README.md",
       "Support/README.md",
+      "Trellis2/README.md",
       "TripoSR/README.md",
       "VLM/README.md",
       "VideoDepth/README.md",

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -370,6 +370,16 @@ enum GuideRegistry {
             resourceName: "vision-image-to-3d.md"
         ),
         GuideTopic(
+            topic: "vision-image-to-3d-trellis2",
+            title: "Native TRELLIS.2 Image to 3D",
+            commandPaths: [
+                ["vision", "image-to-3d-trellis2"],
+                ["image", "reconstruct-3d-trellis2"],
+            ],
+            models: ["image-3d-trellis2-4b"],
+            resourceName: "vision-image-to-3d-trellis2.md"
+        ),
+        GuideTopic(
             topic: "vision-image-to-3d-multiview",
             title: "Native Multi-view Image to 3D",
             commandPaths: [

--- a/Sources/MereRunCLI/Commands/ImageCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageCommand.swift
@@ -8,6 +8,7 @@ struct Image: ParsableCommand {
             ImageDataset.self,
             ImageGenerate.self,
             ImageReconstruct3D.self,
+            ImageReconstruct3DTrellis2.self,
             ImageReconstruct3DMultiview.self,
             ImageRunPlan.self,
             ImageTrainLoRA.self,

--- a/Sources/MereRunCLI/Commands/ImageReconstruct3DTrellis2Command.swift
+++ b/Sources/MereRunCLI/Commands/ImageReconstruct3DTrellis2Command.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import MereRunCore
+
+struct ImageReconstruct3DTrellis2: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "reconstruct-3d-trellis2",
+        abstract: "Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2."
+    )
+
+    @Argument(help: "Input object image path. Transparent alpha is required unless --already-framed is used.")
+    var input: String
+
+    @Option(name: [.customShort("o"), .long], help: "Output mesh and PBR artifact directory.")
+    var output: String?
+
+    @Option(name: [.long], help: "Managed TRELLIS.2 model id or verified checkpoint directory.")
+    var model: String?
+
+    @Option(name: [.long], help: "Deterministic MLX random seed.")
+    var seed: UInt64 = 42
+
+    @Option(name: [.long], help: "Safety limit for decoded 512-resolution O-Voxels.")
+    var maxTokens: Int = Trellis2Generator.defaultMaximumSparseTokens
+
+    @Flag(name: [.long], help: "Preserve framing and composite alpha over black without foreground cropping.")
+    var alreadyFramed = false
+
+    @Flag(name: [.long], help: "Verify inputs and checkpoints, then print the execution plan without loading weights.")
+    var dryRun = false
+
+    @Flag(name: [.long], help: "Print structured JSON on stdout.")
+    var json = false
+
+    mutating func run() async throws {
+        try await VisionImageTo3DTrellis2.execute(
+            input: input,
+            output: output,
+            model: model,
+            seed: seed,
+            maxTokens: maxTokens,
+            alreadyFramed: alreadyFramed,
+            dryRun: dryRun,
+            json: json
+        )
+    }
+}

--- a/Sources/MereRunCLI/Commands/VisionCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionCommand.swift
@@ -17,6 +17,7 @@ struct Vision: ParsableCommand {
             VisionGeometry.self,
             VisionGeometryMultiView.self,
             VisionImageTo3D.self,
+            VisionImageTo3DTrellis2.self,
             VisionImageTo3DMultiview.self,
             VisionOCR.self,
         ]

--- a/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
+++ b/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
@@ -1,0 +1,243 @@
+import ArgumentParser
+import Foundation
+import MediaIO
+import MereRunCore
+
+struct VisionImageTo3DTrellis2: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "image-to-3d-trellis2",
+        abstract: "Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2."
+    )
+
+    @Argument(help: "Input object image path. Transparent alpha is required unless --already-framed is used.")
+    var input: String
+
+    @Option(name: [.customShort("o"), .long], help: "Output mesh and PBR artifact directory.")
+    var output: String?
+
+    @Option(name: [.long], help: "Managed TRELLIS.2 model id or verified checkpoint directory.")
+    var model: String?
+
+    @Option(name: [.long], help: "Deterministic MLX random seed.")
+    var seed: UInt64 = 42
+
+    @Option(name: [.long], help: "Safety limit for decoded 512-resolution O-Voxels.")
+    var maxTokens: Int = Trellis2Generator.defaultMaximumSparseTokens
+
+    @Flag(name: [.long], help: "Preserve framing and composite alpha over black without foreground cropping.")
+    var alreadyFramed = false
+
+    @Flag(name: [.long], help: "Verify inputs and checkpoints, then print the execution plan without loading weights.")
+    var dryRun = false
+
+    @Flag(name: [.long], help: "Print structured JSON on stdout.")
+    var json = false
+
+    mutating func run() async throws {
+        try await Self.execute(
+            input: input,
+            output: output,
+            model: model,
+            seed: seed,
+            maxTokens: maxTokens,
+            alreadyFramed: alreadyFramed,
+            dryRun: dryRun,
+            json: json
+        )
+    }
+
+    static func execute(
+        input: String,
+        output: String?,
+        model: String?,
+        seed: UInt64,
+        maxTokens: Int,
+        alreadyFramed: Bool,
+        dryRun: Bool,
+        json: Bool
+    ) async throws {
+        guard maxTokens >= 4_096 else {
+            throw ValidationError("--max-tokens must be at least 4096")
+        }
+        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: inputURL.path) else {
+            throw ValidationError("Input image not found: \(inputURL.path)")
+        }
+        do {
+            _ = try VFXImageInputValidator.inspectAndValidate([inputURL])
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        let outputURL = resolveOutputURL(output, inputURL: inputURL)
+        let policy: Trellis2ForegroundPolicy = alreadyFramed ? .alreadyFramed : .transparentAlpha
+
+        if dryRun {
+            let checkpoint = try await Trellis2Resources.resolve(requestedModel: model)
+            let size = try MediaImageIO.size(of: inputURL)
+            print(try jsonString(Trellis2PlanPayload(
+                inputPath: inputURL.path,
+                outputDirectory: outputURL.path,
+                inputWidth: size.width,
+                inputHeight: size.height,
+                checkpoint: checkpoint,
+                seed: seed,
+                maximumSparseTokens: maxTokens,
+                foregroundPolicy: alreadyFramed ? "already-framed" : "transparent-alpha"
+            )))
+            return
+        }
+
+        try MLXBundleSupport.ensureAvailable(quiet: true)
+        let generator = Trellis2Generator()
+        do {
+            let result = try await generator.generate(
+                imageURL: inputURL,
+                outputDirectory: outputURL,
+                model: model,
+                foregroundPolicy: policy,
+                seed: seed,
+                maximumSparseTokens: maxTokens,
+                progress: { event in
+                    CLIStderr.write("[image-to-3d-trellis2] \(event.message)\n")
+                }
+            )
+            await generator.unload()
+            if json {
+                print(try jsonString(try Trellis2RunPayload(result: result)))
+            } else {
+                print(result.runManifest.manifestURL.path)
+            }
+        } catch {
+            await generator.unload()
+            throw error
+        }
+    }
+
+    static func resolveOutputURL(_ raw: String?, inputURL: URL) -> URL {
+        if let raw, !raw.isEmpty {
+            return URL(fileURLWithPath: raw).standardizedFileURL
+        }
+        return inputURL.deletingLastPathComponent().appendingPathComponent(
+            "\(inputURL.deletingPathExtension().lastPathComponent)-trellis2-3d",
+            isDirectory: true
+        )
+    }
+
+    static func jsonString<Value: Encodable>(_ value: Value) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return String(decoding: try encoder.encode(value), as: UTF8.self)
+    }
+}
+
+struct Trellis2PlanPayload: Codable, Equatable {
+    let schemaVersion: Int
+    let status: String
+    let inputPath: String
+    let outputDirectory: String
+    let inputWidth: Int
+    let inputHeight: Int
+    let modelID: String
+    let checkpointRoot: String
+    let repository: String
+    let revision: String
+    let checkpointVerified: Bool
+    let conditioningRepository: String
+    let conditioningRevision: String
+    let conditioningLicense: String
+    let pipelineResolution: Int
+    let seed: UInt64
+    let maximumSparseTokens: Int
+    let foregroundPolicy: String
+    let inferenceBackend: String
+    let outputKinds: [String]
+
+    init(
+        schemaVersion: Int = 1,
+        status: String = "planned",
+        inputPath: String,
+        outputDirectory: String,
+        inputWidth: Int,
+        inputHeight: Int,
+        checkpoint: Trellis2Checkpoint,
+        seed: UInt64,
+        maximumSparseTokens: Int,
+        foregroundPolicy: String
+    ) {
+        self.schemaVersion = schemaVersion
+        self.status = status
+        self.inputPath = inputPath
+        self.outputDirectory = outputDirectory
+        self.inputWidth = inputWidth
+        self.inputHeight = inputHeight
+        self.modelID = checkpoint.modelID
+        self.checkpointRoot = checkpoint.rootURL.path
+        self.repository = Trellis2Resources.repository
+        self.revision = Trellis2Resources.revision
+        self.checkpointVerified = true
+        self.conditioningRepository = Trellis2Resources.dinoV3Repository
+        self.conditioningRevision = Trellis2Resources.dinoV3Revision
+        self.conditioningLicense = "DINOv3 License"
+        self.pipelineResolution = 512
+        self.seed = seed
+        self.maximumSparseTokens = maximumSparseTokens
+        self.foregroundPolicy = foregroundPolicy
+        self.inferenceBackend = "mere.run-native-mlx"
+        self.outputKinds = [
+            "mesh-obj", "mesh-ply", "mesh-glb", "pbr-voxels",
+            "mesh-manifest-json", "trellis2-run-manifest-json",
+        ]
+    }
+}
+
+struct Trellis2RunPayload: Codable {
+    let schemaVersion: Int
+    let status: String
+    let manifestPath: String
+    let manifestSHA256: String
+    let meshManifestPath: String
+    let meshManifestSHA256: String
+    let pbrVoxelPath: String
+    let pbrVoxelSHA256: String
+    let modelID: String
+    let repository: String
+    let revision: String
+    let seed: UInt64
+    let maximumSparseTokens: Int
+    let sourceWidth: Int
+    let sourceHeight: Int
+    let foregroundPolicy: String
+    let croppedTransparentForeground: Bool
+    let vertexCount: Int
+    let triangleCount: Int
+    let pbrVoxelCount: Int
+    let artifacts: [Trellis2RunArtifact]
+
+    init(result: Trellis2RunResult, schemaVersion: Int = 1, status: String = "completed") throws {
+        let manifest = result.runManifest.manifest
+        self.schemaVersion = schemaVersion
+        self.status = status
+        self.manifestPath = result.runManifest.manifestURL.path
+        self.manifestSHA256 = try ModelArtifactPin.fileSHA256(result.runManifest.manifestURL)
+        self.meshManifestPath = result.meshExport.manifestURL.path
+        self.meshManifestSHA256 = try ModelArtifactPin.fileSHA256(result.meshExport.manifestURL)
+        self.pbrVoxelPath = URL(
+            fileURLWithPath: manifest.outputDirectory,
+            isDirectory: true
+        ).appendingPathComponent(result.pbrExport.relativePath).path
+        self.pbrVoxelSHA256 = result.pbrExport.sha256
+        self.modelID = result.checkpoint.modelID
+        self.repository = Trellis2Resources.repository
+        self.revision = Trellis2Resources.revision
+        self.seed = result.seed
+        self.maximumSparseTokens = result.maximumSparseTokens
+        self.sourceWidth = result.sourceWidth
+        self.sourceHeight = result.sourceHeight
+        self.foregroundPolicy = result.foregroundPolicy
+        self.croppedTransparentForeground = result.croppedTransparentForeground
+        self.vertexCount = manifest.mesh.vertexCount
+        self.triangleCount = manifest.mesh.triangleCount
+        self.pbrVoxelCount = manifest.mesh.pbrVoxelCount
+        self.artifacts = manifest.artifacts
+    }
+}

--- a/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
+++ b/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
@@ -1,0 +1,60 @@
+# Native TRELLIS.2 Image to 3D
+
+## Purpose
+
+`mere.run vision image-to-3d-trellis2` reconstructs one isolated object as a
+512-resolution O-Voxel mesh with base color, metallic, roughness, and alpha.
+The equivalent image-family command is `mere.run image reconstruct-3d-trellis2`.
+All neural stages run in native Swift/MLX from Microsoft's official
+safetensors; no Python, PyTorch, CUDA, or converted weight copy is used.
+
+First accept the DINOv3 license on Hugging Face and authenticate the local Hub
+client. Then install the pinned model graph and run reconstruction:
+
+```bash
+mere.run model pull image-3d-trellis2-4b
+mere.run vision image-to-3d-trellis2 ./chair.png \
+  --output ./chair-trellis2 \
+  --seed 42 \
+  --json
+```
+
+The default foreground policy requires meaningful transparent alpha and crops
+the object before 512px DINOv3 conditioning. Fully opaque images fail with an
+actionable error. Pass `--already-framed` only when the image is already an
+isolated, centered object on an appropriate black background.
+
+`--max-tokens` is a decoded O-Voxel safety limit and defaults to 1,048,576.
+Raising it can materially increase unified-memory use. This is deliberately
+separate from Microsoft's 49,152-token cascade-resolution budget, which does
+not cap the direct 512 decoder. The three flow stages use the official 12-step
+Euler schedules. `--seed` controls deterministic MLX noise and defaults to 42.
+
+Use `--dry-run` to validate the input, checksum every pinned component, and
+print the plan without loading a neural graph:
+
+```bash
+mere.run image reconstruct-3d-trellis2 ./chair.png --dry-run --already-framed
+```
+
+The output directory contains OBJ, binary PLY, and GLB files with sampled RGBA
+vertex color; a shared mesh manifest; a `.pbrvox` sparse material field; and an
+authoritative TRELLIS.2 run manifest. `.pbrvox` preserves base color RGB,
+metallic, roughness, and alpha for every decoded O-Voxel because the canonical
+mesh formats currently do not author a texture atlas. All artifacts and all
+seven checkpoint components are named, pinned, and hashed in provenance.
+
+Coordinates are normalized object space with X right, Y up, and Z forward.
+They are not meters, and unseen geometry is inferred from the single image.
+
+This command currently supports the official 512 pipeline. It does not claim
+support for the 1024/1536 cascade or byte-identical mesh ordering with the CUDA
+reference implementation.
+
+## Sources
+
+- [Microsoft TRELLIS.2 source](https://github.com/microsoft/TRELLIS.2)
+- [Pinned TRELLIS.2-4B checkpoint](https://huggingface.co/microsoft/TRELLIS.2-4B/tree/af44b45f2e35a493886929c6d786e563ec68364d)
+- [TRELLIS.2 paper](https://arxiv.org/abs/2512.14692)
+- [DINOv3 source](https://github.com/facebookresearch/dinov3)
+- [Pinned DINOv3 ViT-L/16 checkpoint](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m/tree/ea8dc2863c51be0a264bab82070e3e8836b02d51)

--- a/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
+++ b/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
@@ -24,7 +24,7 @@ the object before 512px DINOv3 conditioning. Fully opaque images fail with an
 actionable error. Pass `--already-framed` only when the image is already an
 isolated, centered object on an appropriate black background.
 
-`--max-tokens` is a decoded O-Voxel safety limit and defaults to 1,048,576.
+`--max-tokens` is a decoded O-Voxel safety limit and defaults to 2,097,152.
 Raising it can materially increase unified-memory use. This is deliberately
 separate from Microsoft's 49,152-token cascade-resolution budget, which does
 not cap the direct 512 decoder. The three flow stages use the official 12-step
@@ -46,6 +46,8 @@ seven checkpoint components are named, pinned, and hashed in provenance.
 
 Coordinates are normalized object space with X right, Y up, and Z forward.
 They are not meters, and unseen geometry is inferred from the single image.
+The `.pbrvox` sidecar instead preserves integer indices in TRELLIS.2's native
+Z-up O-Voxel grid so its six-channel material field stays lossless.
 
 This command currently supports the official 512 pipeline. It does not claim
 support for the 1024/1536 cascade or byte-identical mesh ordering with the CUDA

--- a/Sources/MereRunCore/Asset3D/README.md
+++ b/Sources/MereRunCore/Asset3D/README.md
@@ -15,4 +15,7 @@ PLY, and binary glTF writers used by native reconstruction runtimes.
   boundary, which is why it is listed in the repository's dynamic-JSON
   inventory. No untyped JSON escapes this writer.
 
-Model-specific inference and provenance belong in `TripoSR` and `InstantMesh`.
+Model-specific inference and provenance belong in `TripoSR`, `InstantMesh`, and
+`Trellis2`. TRELLIS.2 additionally writes its six-channel sparse PBR field as a
+model-specific `.pbrvox` sidecar because the canonical mesh contract currently
+stores vertex color, not a generated texture atlas.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -53,6 +53,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case depthAnything3
     case tripoSR
     case instantMesh
+    case trellis2
     case aceStep
     case magentaRT2
     case muScriptor
@@ -1195,6 +1196,22 @@ public enum ManagedModelCatalog {
             ]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.image3DTrellis2.rawValue,
+            category: .image3D,
+            installShape: .structuredRoot,
+            hubFallback: Trellis2Resources.primaryHubFallback,
+            mountedHubFallbacks: Trellis2Resources.mountedHubFallbacks,
+            upstreamRepoId: Trellis2Resources.repository,
+            upstreamRevision: Trellis2Resources.revision,
+            validationKind: .trellis2,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 11_010_775_158,
+            defaultCLICommands: [
+                "image reconstruct-3d-trellis2",
+                "vision image-to-3d-trellis2",
+            ]
+        ),
+        ManagedModelSpec(
             id: "music-acestep",
             category: .music,
             installShape: .structuredRoot,
@@ -1689,7 +1706,7 @@ public extension ManagedModelSpec {
 
     var usesPinnedGeometryArtifacts: Bool {
         switch validationKind {
-        case .moge2, .videoDepthAnything, .depthAnything3, .tripoSR, .instantMesh:
+        case .moge2, .videoDepthAnything, .depthAnything3, .tripoSR, .instantMesh, .trellis2:
             true
         default:
             false
@@ -1786,6 +1803,8 @@ public extension ManagedModelSpec {
             }
             guard let pin = GeometryModelPins.pin(for: id) else { return [rootURL] }
             return Self.invalidPinnedArtifacts(pin.artifacts, in: rootURL, fileManager: fileManager)
+        case .trellis2:
+            return Trellis2Resources.validate(rootURL: rootURL, fileManager: fileManager)
         case .qwen3TTS:
             return Self.missingQwen3TTSPaths(in: rootURL, fileManager: fileManager)
         case .qwen3ASR:
@@ -1861,6 +1880,11 @@ public extension ManagedModelSpec {
             return Self.pinnedArtifactValidationMessages(
                 pin.artifacts,
                 in: normalized,
+                fileManager: fileManager
+            )
+        case .trellis2:
+            return Trellis2Resources.validationMessages(
+                in: normalizedRootURL(rootURL, fileManager: fileManager),
                 fileManager: fileManager
             )
         case .sam31:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -576,6 +576,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 48
             ),
             descriptor(
+                ModelResolver.ModelID.image3DTrellis2.rawValue,
+                "PBR O-Voxel object mesh",
+                "Reconstructs a 512-resolution PBR O-Voxel mesh with the native Swift MLX TRELLIS.2 runtime.",
+                minimum: 64,
+                recommended: 128
+            ),
+            descriptor(
                 "music-acestep",
                 "Music generation",
                 "Generates music from text prompts with the ACE-Step model stack.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -44,6 +44,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case tripoSR = "triposr"
         /// InstantMesh multi-view object reconstruction family.
         case instantMesh = "instantmesh"
+        /// Microsoft TRELLIS.2 image-to-PBR-mesh family.
+        case trellis2 = "trellis2"
         /// Qwen3 TTS family.
         case qwen3TTS = "qwen3-tts"
         /// Qwen3 ASR family.
@@ -1209,6 +1211,19 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.multiViewReconstruction, .meshGeneration],
                 components: nil,
                 upstreamRepoId: "TencentARC/InstantMesh@b785b4ecfb6636ef34a08c748f96f6a5686244d0",
+                createdAt: createdAt
+            )
+        case .image3DTrellis2:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .trellis2,
+                family: .threeD,
+                tier: .max,
+                variant: .standard,
+                precision: .bf16,
+                supports: [.imageTo3D, .meshGeneration],
+                components: nil,
+                upstreamRepoId: "microsoft/TRELLIS.2-4B@af44b45f2e35a493886929c6d786e563ec68364d",
                 createdAt: createdAt
             )
         case .psiAgent:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -466,7 +466,7 @@ public enum MereRunModelValidator {
             }
             switch manifest.engine {
             case .qwen3Coder?, .northMiniCode?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .mmaudio?, .ltxVideo?,
-                 .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?:
+                 .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?:
                 return true
             default:
                 return false

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -113,6 +113,7 @@ public enum MereRunModelValidator {
                     && spec.validationKind != .depthAnything3
                     && spec.validationKind != .tripoSR
                     && spec.validationKind != .instantMesh
+                    && spec.validationKind != .trellis2
                     && spec.validationKind != .dreamXCausalMLX
             }
         }()
@@ -154,6 +155,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .depthAnything3
             || spec?.validationKind == .tripoSR
             || spec?.validationKind == .instantMesh
+            || spec?.validationKind == .trellis2
             || spec?.validationKind == .wan22TI2VMLX
             || spec?.validationKind == .dreamXCausalMLX {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -64,6 +64,7 @@ public struct ModelResolver {
         case visionGeometryDA3Small = "vision-geometry-da3-small"
         case image3DTripoSR = "image-3d-triposr"
         case image3DInstantMeshBase = "image-3d-instantmesh-base"
+        case image3DTrellis2 = "image-3d-trellis2-4b"
         case aceStep = "music-acestep"
         case aceStepXLTurbo = "music-acestep-xl-turbo"
         case aceStepXLTurboLM4B = "music-acestep-xl-turbo-lm4b"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -57,7 +57,7 @@ public enum QuantizedModelManifestWriter {
             case .falconPerception: return .falcon
             case .moge2, .depthAnything3: return .geometry
             case .videoDepthAnything: return .depth
-            case .tripoSR, .instantMesh: return .threeD
+            case .tripoSR, .instantMesh, .trellis2: return .threeD
             case .qwen3TTS: return .tts
             case .qwen3ASR, .parakeetASR: return .asr
             case .qwen3Embedding: return .embed
@@ -121,7 +121,7 @@ public enum QuantizedModelManifestWriter {
                     return [.temporalDepth]
                 case .depthAnything3:
                     return [.relativeDepth, .cameraIntrinsics, .cameraExtrinsics, .pointCloud]
-                case .tripoSR:
+                case .tripoSR, .trellis2:
                     return [.imageTo3D, .meshGeneration]
                 case .instantMesh:
                     return [.multiViewReconstruction, .meshGeneration]
@@ -218,7 +218,7 @@ public enum QuantizedModelManifestWriter {
             case .qwen35HybridMoE:
                 break
             case .samSegmentation, .falconPerception, .moge2, .videoDepthAnything, .depthAnything3,
-                 .tripoSR, .instantMesh:
+                 .tripoSR, .instantMesh, .trellis2:
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .qwen3Embedding, .openAIPrivacyFilter,
                  .qwen3Coder, .northMiniCode, .lightOnOCR, .woosh, .mmaudio, .psiChat, .deepseekV4Flash,

--- a/Sources/MereRunCore/Trellis2/README.md
+++ b/Sources/MereRunCore/Trellis2/README.md
@@ -16,9 +16,10 @@ does not launch Python, PyTorch, or CUDA.
 4. `Trellis2SparseDecoder.swift` decodes the adaptive shape subdivision tree
    and the matching six-channel PBR O-Voxel field using native sparse
    submanifold convolutions.
-5. `Trellis2FlexibleDualGrid.swift` extracts the indexed 512-grid mesh, fills
-   small boundary loops at the reference threshold, and samples RGBA,
-   metallic, and roughness at its vertices.
+5. `Trellis2FlexibleDualGrid.swift` extracts the indexed 512-grid mesh, rotates
+   O-Voxel's Z-up basis into the canonical Y-up mesh contract, fills small
+   boundary loops at the reference threshold, and samples RGBA, metallic, and
+   roughness at its vertices.
 6. `Trellis2ArtifactExporter.swift` writes canonical OBJ, PLY, and GLB meshes,
    plus a deterministic `.pbrvox` sidecar that preserves all six PBR channels.
 
@@ -42,7 +43,9 @@ The initial native surface is the official 512 pipeline. The 1024/1536 cascade
 checkpoints and texture-atlas conversion are not represented as supported.
 GLB/PLY/OBJ carry sampled vertex RGBA. Metallic, roughness, alpha, and base
 color remain losslessly available in the hashed `.pbrvox` sidecar and run
-manifest.
+manifest. Mesh artifacts use the canonical X-right, Y-up, Z-forward basis;
+`.pbrvox` coordinates remain integer O-Voxel indices in the model's native
+Z-up grid so consumers can reproduce material sampling exactly.
 
 The TRELLIS.2 weights are MIT-licensed. DINOv3 is a separately pinned,
 license-gated dependency; users must accept its terms and authenticate with

--- a/Sources/MereRunCore/Trellis2/README.md
+++ b/Sources/MereRunCore/Trellis2/README.md
@@ -1,0 +1,49 @@
+# Native TRELLIS.2
+
+This directory is the native Swift/MLX 512-resolution image-to-3D runtime for
+Microsoft's TRELLIS.2-4B checkpoint. It consumes the official safetensors
+directly; installation does not create converted weight copies and inference
+does not launch Python, PyTorch, or CUDA.
+
+## Pipeline
+
+1. `Trellis2ImageConditioning.swift` crops transparent foregrounds, composites
+   on black, resizes to 512, and runs the pinned DINOv3 ViT-L/16 conditioner.
+2. `Trellis2FlowModel.swift` runs the 12-step sparse-structure, shape, and
+   texture flow models. Texture sampling concatenates the normalized shape
+   latent at every model evaluation.
+3. `Trellis2StructureDecoder.swift` produces occupied 32-grid coordinates.
+4. `Trellis2SparseDecoder.swift` decodes the adaptive shape subdivision tree
+   and the matching six-channel PBR O-Voxel field using native sparse
+   submanifold convolutions.
+5. `Trellis2FlexibleDualGrid.swift` extracts the indexed 512-grid mesh, fills
+   small boundary loops at the reference threshold, and samples RGBA,
+   metallic, and roughness at its vertices.
+6. `Trellis2ArtifactExporter.swift` writes canonical OBJ, PLY, and GLB meshes,
+   plus a deterministic `.pbrvox` sidecar that preserves all six PBR channels.
+
+Every large stage is loaded and released separately so the three 1.3B flow
+checkpoints and two sparse decoders are not resident together.
+
+## Public boundary
+
+```bash
+mere.run model pull image-3d-trellis2-4b
+mere.run vision image-to-3d-trellis2 ./object.png --output ./object-3d
+# Equivalent catalog-oriented spelling:
+mere.run image reconstruct-3d-trellis2 ./object.png --output ./object-3d
+```
+
+Transparent alpha is the default foreground contract. Fully opaque input is
+rejected unless the caller explicitly passes `--already-framed`; the runtime
+does not hide a background-removal service or model behind this command.
+
+The initial native surface is the official 512 pipeline. The 1024/1536 cascade
+checkpoints and texture-atlas conversion are not represented as supported.
+GLB/PLY/OBJ carry sampled vertex RGBA. Metallic, roughness, alpha, and base
+color remain losslessly available in the hashed `.pbrvox` sidecar and run
+manifest.
+
+The TRELLIS.2 weights are MIT-licensed. DINOv3 is a separately pinned,
+license-gated dependency; users must accept its terms and authenticate with
+Hugging Face before `model pull` can complete.

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+public struct Trellis2PBRVoxelExport: Codable, Equatable, Sendable {
+    public let relativePath: String
+    public let mediaType: String
+    public let byteCount: Int64
+    public let sha256: String
+
+    public init(relativePath: String, mediaType: String, byteCount: Int64, sha256: String) {
+        self.relativePath = relativePath
+        self.mediaType = mediaType
+        self.byteCount = byteCount
+        self.sha256 = sha256
+    }
+}
+
+/// Deterministic little-endian storage for TRELLIS.2's six-channel sparse PBR
+/// field. OBJ/PLY/GLB retain sampled RGBA vertex color; this sidecar preserves
+/// base color, metallic, roughness, and alpha at every decoded O-Voxel.
+public enum Trellis2PBRVoxelWriter {
+    public static let mediaType = "application/vnd.mere-run.trellis2-pbrvox"
+
+    @discardableResult
+    public static func write(_ grid: Trellis2PBRVoxelGrid, to url: URL) throws -> Trellis2PBRVoxelExport {
+        var data = Data("MRPBRV01".utf8)
+        append(UInt32(1), to: &data)
+        append(UInt32(grid.resolution), to: &data)
+        append(UInt32(grid.coordinates.count), to: &data)
+        append(UInt32(6), to: &data)
+        for (index, coordinate) in grid.coordinates.enumerated() {
+            append(coordinate.x, to: &data)
+            append(coordinate.y, to: &data)
+            append(coordinate.z, to: &data)
+            for channel in 0..<6 {
+                append(grid.attributes[index * 6 + channel], to: &data)
+            }
+        }
+        try data.write(to: url, options: .atomic)
+        return Trellis2PBRVoxelExport(
+            relativePath: url.lastPathComponent,
+            mediaType: mediaType,
+            byteCount: Int64(data.count),
+            sha256: try ModelArtifactPin.fileSHA256(url)
+        )
+    }
+
+    private static func append(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private static func append(_ value: Int32, to data: inout Data) {
+        append(UInt32(bitPattern: value), to: &data)
+    }
+
+    private static func append(_ value: Float, to data: inout Data) {
+        append(value.bitPattern, to: &data)
+    }
+}
+
+public struct Trellis2CheckpointComponentManifest: Codable, Equatable, Sendable {
+    public let name: String
+    public let repository: String
+    public let revision: String
+    public let relativePath: String
+    public let byteCount: Int64
+    public let sha256: String
+    public let license: String
+}
+
+public struct Trellis2InputManifest: Codable, Equatable, Sendable {
+    public let path: String
+    public let byteCount: Int64
+    public let sha256: String
+    public let sourceWidth: Int
+    public let sourceHeight: Int
+    public let conditioningResolution: Int
+    public let foregroundPolicy: String
+    public let croppedTransparentForeground: Bool
+}
+
+public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
+    public let seed: UInt64
+    public let pipelineResolution: Int
+    public let maximumSparseTokens: Int
+    public let sparseStructureSteps: Int
+    public let shapeSteps: Int
+    public let textureSteps: Int
+    public let extractionAlgorithm: String
+    public let pbrRepresentation: String
+}
+
+public struct Trellis2MeshManifest: Codable, Equatable, Sendable {
+    public let coordinateSystem: MeshCoordinateSystem
+    public let units: MeshUnits
+    public let inferredUnseenGeometry: Bool
+    public let vertexCount: Int
+    public let triangleCount: Int
+    public let bounds: MeshBounds
+    public let pbrVoxelCount: Int
+    public let includesVertexColors: Bool
+    public let includesMetallicRoughnessSidecar: Bool
+}
+
+public struct Trellis2RunArtifact: Codable, Equatable, Sendable {
+    public let kind: String
+    public let relativePath: String
+    public let mediaType: String
+    public let byteCount: Int64
+    public let sha256: String
+}
+
+public struct Trellis2RunManifest: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let createdAt: Date
+    public let outputDirectory: String
+    public let modelID: String
+    public let repository: String
+    public let revision: String
+    public let license: String
+    public let inferenceBackend: String
+    public let checkpointComponents: [Trellis2CheckpointComponentManifest]
+    public let input: Trellis2InputManifest
+    public let generation: Trellis2GenerationManifest
+    public let mesh: Trellis2MeshManifest
+    public let artifacts: [Trellis2RunArtifact]
+}
+
+public struct Trellis2RunManifestExport: Equatable, Sendable {
+    public let manifest: Trellis2RunManifest
+    public let manifestURL: URL
+}
+
+public enum Trellis2ArtifactExporter {
+    public static let extractionAlgorithm = "native-ovoxel-flexible-dual-grid-small-hole-fill"
+    public static let pbrRepresentation = "vertex-rgba-plus-sparse-pbrvox"
+
+    public static func export(
+        asset: Trellis2DecodedAsset,
+        checkpoint: Trellis2Checkpoint,
+        inputURL: URL,
+        inputRecord: MeshInputRecord,
+        outputDirectory: URL,
+        stem: String,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        foregroundPolicy: String,
+        croppedTransparentForeground: Bool,
+        seed: UInt64,
+        maximumSparseTokens: Int,
+        createdAt: Date = Date()
+    ) throws -> (mesh: MeshExportResult, pbr: Trellis2PBRVoxelExport, run: Trellis2RunManifestExport) {
+        let root = outputDirectory.standardizedFileURL
+        let mesh = try MeshArtifactExporter.export(
+            mesh: asset.mesh,
+            inputURLs: [inputURL.standardizedFileURL],
+            outputDirectory: root,
+            stem: stem,
+            provenance: GeometryModelProvenance(
+                modelID: checkpoint.modelID,
+                upstreamRepository: Trellis2Resources.repository,
+                upstreamRevision: Trellis2Resources.revision,
+                license: "MIT",
+                weightsSHA256: Trellis2Resources.primaryWeightsSHA256
+            ),
+            inputRecords: [inputRecord],
+            createdAt: createdAt
+        )
+        let cleanStem = mesh.manifestURL.lastPathComponent
+            .replacingOccurrences(of: "-manifest.json", with: "")
+        let pbr = try Trellis2PBRVoxelWriter.write(
+            asset.pbrVoxels,
+            to: root.appendingPathComponent("\(cleanStem).pbrvox")
+        )
+        let input = try mesh.manifest.inputRecord(for: inputURL)
+        var artifacts = mesh.manifest.artifacts.map {
+            Trellis2RunArtifact(
+                kind: $0.kind.rawValue,
+                relativePath: $0.relativePath,
+                mediaType: $0.mediaType,
+                byteCount: $0.byteCount,
+                sha256: $0.sha256
+            )
+        }
+        artifacts.append(Trellis2RunArtifact(
+            kind: "pbr-voxels",
+            relativePath: pbr.relativePath,
+            mediaType: pbr.mediaType,
+            byteCount: pbr.byteCount,
+            sha256: pbr.sha256
+        ))
+        artifacts.append(try artifact(
+            kind: "mesh-manifest",
+            url: mesh.manifestURL,
+            mediaType: "application/json"
+        ))
+        artifacts.sort {
+            ($0.kind, $0.relativePath) < ($1.kind, $1.relativePath)
+        }
+
+        let manifest = Trellis2RunManifest(
+            schemaVersion: 1,
+            createdAt: createdAt,
+            outputDirectory: root.path,
+            modelID: checkpoint.modelID,
+            repository: Trellis2Resources.repository,
+            revision: Trellis2Resources.revision,
+            license: "MIT",
+            inferenceBackend: "mere.run-native-mlx",
+            checkpointComponents: Trellis2Resources.checkpointComponentManifests,
+            input: Trellis2InputManifest(
+                path: input.path,
+                byteCount: input.byteCount,
+                sha256: input.sha256,
+                sourceWidth: sourceWidth,
+                sourceHeight: sourceHeight,
+                conditioningResolution: 512,
+                foregroundPolicy: foregroundPolicy,
+                croppedTransparentForeground: croppedTransparentForeground
+            ),
+            generation: Trellis2GenerationManifest(
+                seed: seed,
+                pipelineResolution: 512,
+                maximumSparseTokens: maximumSparseTokens,
+                sparseStructureSteps: Trellis2SamplerConfiguration.sparseStructure.steps,
+                shapeSteps: Trellis2SamplerConfiguration.shape.steps,
+                textureSteps: Trellis2SamplerConfiguration.texture.steps,
+                extractionAlgorithm: extractionAlgorithm,
+                pbrRepresentation: pbrRepresentation
+            ),
+            mesh: Trellis2MeshManifest(
+                coordinateSystem: mesh.manifest.coordinateSystem,
+                units: mesh.manifest.units,
+                inferredUnseenGeometry: mesh.manifest.inferredUnseenGeometry,
+                vertexCount: mesh.manifest.vertexCount,
+                triangleCount: mesh.manifest.triangleCount,
+                bounds: mesh.manifest.bounds,
+                pbrVoxelCount: asset.pbrVoxels.coordinates.count,
+                includesVertexColors: asset.mesh.colorsRGBA8 != nil,
+                includesMetallicRoughnessSidecar: true
+            ),
+            artifacts: artifacts
+        )
+        let manifestURL = root.appendingPathComponent("\(cleanStem)-trellis2-run-manifest.json")
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+        return (mesh, pbr, Trellis2RunManifestExport(manifest: manifest, manifestURL: manifestURL))
+    }
+
+    private static func artifact(kind: String, url: URL, mediaType: String) throws -> Trellis2RunArtifact {
+        Trellis2RunArtifact(
+            kind: kind,
+            relativePath: url.lastPathComponent,
+            mediaType: mediaType,
+            byteCount: try ModelArtifactPin.fileByteCount(url),
+            sha256: try ModelArtifactPin.fileSHA256(url)
+        )
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2Configuration.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Configuration.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+public struct Trellis2FlowConfiguration: Codable, Equatable, Sendable {
+    public let resolution: Int
+    public let inputChannels: Int
+    public let outputChannels: Int
+    public let modelChannels: Int
+    public let conditionChannels: Int
+    public let blockCount: Int
+    public let headCount: Int
+    public let mlpRatio: Float
+
+    public init(
+        resolution: Int,
+        inputChannels: Int,
+        outputChannels: Int,
+        modelChannels: Int,
+        conditionChannels: Int,
+        blockCount: Int,
+        headCount: Int,
+        mlpRatio: Float
+    ) {
+        precondition(modelChannels.isMultiple(of: headCount))
+        self.resolution = resolution
+        self.inputChannels = inputChannels
+        self.outputChannels = outputChannels
+        self.modelChannels = modelChannels
+        self.conditionChannels = conditionChannels
+        self.blockCount = blockCount
+        self.headCount = headCount
+        self.mlpRatio = mlpRatio
+    }
+
+    public var headDimension: Int { modelChannels / headCount }
+    public var mlpChannels: Int { Int(Float(modelChannels) * mlpRatio) }
+
+    public static let sparseStructure512 = Trellis2FlowConfiguration(
+        resolution: 16,
+        inputChannels: 8,
+        outputChannels: 8,
+        modelChannels: 1_536,
+        conditionChannels: 1_024,
+        blockCount: 30,
+        headCount: 12,
+        mlpRatio: 5.3334
+    )
+
+    public static let shape512 = Trellis2FlowConfiguration(
+        resolution: 32,
+        inputChannels: 32,
+        outputChannels: 32,
+        modelChannels: 1_536,
+        conditionChannels: 1_024,
+        blockCount: 30,
+        headCount: 12,
+        mlpRatio: 5.3334
+    )
+
+    /// The texture flow concatenates the normalized 32-channel shape latent
+    /// with 32 channels of texture noise.
+    public static let texture512 = Trellis2FlowConfiguration(
+        resolution: 32,
+        inputChannels: 64,
+        outputChannels: 32,
+        modelChannels: 1_536,
+        conditionChannels: 1_024,
+        blockCount: 30,
+        headCount: 12,
+        mlpRatio: 5.3334
+    )
+}
+
+public struct Trellis2SamplerConfiguration: Codable, Equatable, Sendable {
+    public let steps: Int
+    public let sigmaMinimum: Float
+    public let guidanceStrength: Float
+    public let guidanceRescale: Float
+    public let guidanceInterval: ClosedRange<Float>
+    public let timestepRescale: Float
+
+    public init(
+        steps: Int,
+        sigmaMinimum: Float = 1e-5,
+        guidanceStrength: Float,
+        guidanceRescale: Float,
+        guidanceInterval: ClosedRange<Float>,
+        timestepRescale: Float
+    ) {
+        precondition(steps > 0)
+        self.steps = steps
+        self.sigmaMinimum = sigmaMinimum
+        self.guidanceStrength = guidanceStrength
+        self.guidanceRescale = guidanceRescale
+        self.guidanceInterval = guidanceInterval
+        self.timestepRescale = timestepRescale
+    }
+
+    public static let sparseStructure = Trellis2SamplerConfiguration(
+        steps: 12,
+        guidanceStrength: 7.5,
+        guidanceRescale: 0.7,
+        guidanceInterval: 0.6...1.0,
+        timestepRescale: 5.0
+    )
+
+    public static let shape = Trellis2SamplerConfiguration(
+        steps: 12,
+        guidanceStrength: 7.5,
+        guidanceRescale: 0.5,
+        guidanceInterval: 0.6...1.0,
+        timestepRescale: 3.0
+    )
+
+    public static let texture = Trellis2SamplerConfiguration(
+        steps: 12,
+        guidanceStrength: 1.0,
+        guidanceRescale: 0,
+        guidanceInterval: 0.6...0.9,
+        timestepRescale: 3.0
+    )
+
+    public var timesteps: [Float] {
+        (0...steps).map { index in
+            let linear = 1 - Float(index) / Float(steps)
+            return timestepRescale * linear / (1 + (timestepRescale - 1) * linear)
+        }
+    }
+}
+
+public enum Trellis2Normalization {
+    public static let shapeMean: [Float] = [
+        0.781296, 0.018091, -0.495192, -0.558457, 1.060530, 0.093252, 1.518149, -0.933218,
+        -0.732996, 2.604095, -0.118341, -2.143904, 0.495076, -2.179512, -2.130751, -0.996944,
+        0.261421, -2.217463, 1.260067, -0.150213, 3.790713, 1.481266, -1.046058, -1.523667,
+        -0.059621, 2.220780, 1.621212, 0.877230, 0.567247, -3.175944, -3.186688, 1.578665,
+    ]
+
+    public static let shapeStandardDeviation: [Float] = [
+        5.972266, 4.706852, 5.445010, 5.209927, 5.320220, 4.547237, 5.020802, 5.444004,
+        5.226681, 5.683095, 4.831436, 5.286469, 5.652043, 5.367606, 5.525084, 4.730578,
+        4.805265, 5.124013, 5.530808, 5.619001, 5.103930, 5.417670, 5.269677, 5.547194,
+        5.634698, 5.235274, 6.110351, 5.511298, 6.237273, 4.879207, 5.347008, 5.405691,
+    ]
+
+    public static let textureMean: [Float] = [
+        3.501659, 2.212398, 2.226094, 0.251093, -0.026248, -0.687364, 0.439898, -0.928075,
+        0.029398, -0.339596, -0.869527, 1.038479, -0.972385, 0.126042, -1.129303, 0.455149,
+        -1.209521, 2.069067, 0.544735, 2.569128, -0.323407, 2.293000, -1.925608, -1.217717,
+        1.213905, 0.971588, -0.023631, 0.106750, 2.021786, 0.250524, -0.662387, -0.768862,
+    ]
+
+    public static let textureStandardDeviation: [Float] = [
+        2.665652, 2.743913, 2.765121, 2.595319, 3.037293, 2.291316, 2.144656, 2.911822,
+        2.969419, 2.501689, 2.154811, 3.163343, 2.621215, 2.381943, 3.186697, 3.021588,
+        2.295916, 3.234985, 3.233086, 2.260140, 2.874801, 2.810596, 3.292720, 2.674999,
+        2.680878, 2.372054, 2.451546, 2.353556, 2.995195, 2.379849, 2.786195, 2.775190,
+    ]
+}
+
+public struct Trellis2VoxelCoordinate: Codable, Hashable, Sendable {
+    public let x: Int32
+    public let y: Int32
+    public let z: Int32
+
+    public init(x: Int32, y: Int32, z: Int32) {
+        self.x = x
+        self.y = y
+        self.z = z
+    }
+
+    public subscript(axis: Int) -> Int32 {
+        switch axis {
+        case 0: x
+        case 1: y
+        default: z
+        }
+    }
+
+    public func offset(x deltaX: Int32, y deltaY: Int32, z deltaZ: Int32) -> Trellis2VoxelCoordinate {
+        Trellis2VoxelCoordinate(x: x + deltaX, y: y + deltaY, z: z + deltaZ)
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
@@ -1,0 +1,215 @@
+import Foundation
+@preconcurrency import MLX
+
+public struct Trellis2PBRVoxelGrid: Sendable {
+    public let resolution: Int
+    public let coordinates: [Trellis2VoxelCoordinate]
+    /// Six row-major channels: base color RGB, metallic, roughness, alpha.
+    public let attributes: [Float]
+
+    public init(
+        resolution: Int,
+        coordinates: [Trellis2VoxelCoordinate],
+        attributes: [Float]
+    ) throws {
+        guard attributes.count == coordinates.count * 6 else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[\(coordinates.count), 6] PBR attributes",
+                actual: [attributes.count]
+            )
+        }
+        self.resolution = resolution
+        self.coordinates = coordinates
+        self.attributes = attributes
+    }
+}
+
+public struct Trellis2DecodedAsset: Sendable {
+    public let mesh: MeshAsset
+    public let pbrVoxels: Trellis2PBRVoxelGrid
+    public let metallic: [Float]
+    public let roughness: [Float]
+
+    public init(
+        mesh: MeshAsset,
+        pbrVoxels: Trellis2PBRVoxelGrid,
+        metallic: [Float],
+        roughness: [Float]
+    ) {
+        self.mesh = mesh
+        self.pbrVoxels = pbrVoxels
+        self.metallic = metallic
+        self.roughness = roughness
+    }
+}
+
+enum Trellis2FlexibleDualGrid {
+    private static let edgeOffsets: [[Trellis2VoxelCoordinate]] = [
+        [
+            .init(x: 0, y: 0, z: 0), .init(x: 0, y: 0, z: 1),
+            .init(x: 0, y: 1, z: 1), .init(x: 0, y: 1, z: 0),
+        ],
+        [
+            .init(x: 0, y: 0, z: 0), .init(x: 1, y: 0, z: 0),
+            .init(x: 1, y: 0, z: 1), .init(x: 0, y: 0, z: 1),
+        ],
+        [
+            .init(x: 0, y: 0, z: 0), .init(x: 0, y: 1, z: 0),
+            .init(x: 1, y: 1, z: 0), .init(x: 1, y: 0, z: 0),
+        ],
+    ]
+    private static let splitOne = [0, 1, 2, 0, 2, 3]
+    private static let splitTwo = [0, 1, 3, 3, 1, 2]
+
+    static func decode(
+        shape: Trellis2SparseTensor,
+        texture: Trellis2SparseTensor,
+        resolution: Int
+    ) throws -> Trellis2DecodedAsset {
+        guard shape.coordinates == texture.coordinates,
+              shape.channels == 7,
+              texture.channels == 6 else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "matching [tokens, 7] shape and [tokens, 6] texture voxels",
+                actual: [shape.count, shape.channels, texture.count, texture.channels]
+            )
+        }
+        MLX.eval(shape.features, texture.features)
+        let shapeValues = shape.features.asType(.float32).asArray(Float.self)
+        let rawTextureValues = texture.features.asType(.float32).asArray(Float.self)
+        let textureValues = rawTextureValues.map { 0.5 * $0 + 0.5 }
+        let coordinateIndices = Dictionary(
+            uniqueKeysWithValues: shape.coordinates.enumerated().map { ($1, $0) }
+        )
+
+        var vertices = [Float]()
+        var dualOffsets = [Float]()
+        var intersections = [Bool]()
+        var splitWeights = [Float]()
+        vertices.reserveCapacity(shape.count * 3)
+        dualOffsets.reserveCapacity(shape.count * 3)
+        intersections.reserveCapacity(shape.count * 3)
+        splitWeights.reserveCapacity(shape.count)
+        for index in 0..<shape.count {
+            let coordinate = shape.coordinates[index]
+            for axis in 0..<3 {
+                let offset = 2 * sigmoid(shapeValues[index * 7 + axis]) - 0.5
+                dualOffsets.append(offset)
+                vertices.append(
+                    (Float(coordinate[axis]) + offset) / Float(resolution) - 0.5
+                )
+                intersections.append(shapeValues[index * 7 + 3 + axis] > 0)
+            }
+            splitWeights.append(softplus(shapeValues[index * 7 + 6]))
+        }
+
+        var indices = [UInt32]()
+        for voxel in 0..<shape.count {
+            let coordinate = shape.coordinates[voxel]
+            for axis in 0..<3 where intersections[voxel * 3 + axis] {
+                let connected = Self.edgeOffsets[axis].compactMap { offset -> Int? in
+                    coordinateIndices[coordinate.offset(x: offset.x, y: offset.y, z: offset.z)]
+                }
+                guard connected.count == 4 else { continue }
+                let diagonal02 = splitWeights[connected[0]] * splitWeights[connected[2]]
+                let diagonal13 = splitWeights[connected[1]] * splitWeights[connected[3]]
+                let split = diagonal02 > diagonal13 ? Self.splitOne : Self.splitTwo
+                indices.append(contentsOf: split.map { UInt32(connected[$0]) })
+            }
+        }
+        guard !indices.isEmpty else { throw Trellis2ModelError.emptyExtractedMesh }
+
+        let sampledAttributes = sampleTextureAttributes(
+            coordinates: texture.coordinates,
+            attributes: textureValues,
+            coordinateIndices: coordinateIndices,
+            dualOffsets: dualOffsets
+        )
+        var colors = [UInt8]()
+        var metallic = [Float]()
+        var roughness = [Float]()
+        colors.reserveCapacity(shape.count * 4)
+        metallic.reserveCapacity(shape.count)
+        roughness.reserveCapacity(shape.count)
+        for vertex in 0..<shape.count {
+            colors.append(byte(sampledAttributes[vertex * 6]))
+            colors.append(byte(sampledAttributes[vertex * 6 + 1]))
+            colors.append(byte(sampledAttributes[vertex * 6 + 2]))
+            metallic.append(clamp(sampledAttributes[vertex * 6 + 3]))
+            roughness.append(clamp(sampledAttributes[vertex * 6 + 4]))
+            colors.append(byte(sampledAttributes[vertex * 6 + 5]))
+        }
+
+        let extractedMesh = try MeshAsset(
+            vertices: vertices,
+            indices: indices,
+            colorsRGBA8: colors,
+            inferredUnseenGeometry: true
+        )
+        let mesh = try Trellis2MeshHoleFiller.fillSmallHoles(in: extractedMesh)
+        let voxels = try Trellis2PBRVoxelGrid(
+            resolution: resolution,
+            coordinates: texture.coordinates,
+            attributes: textureValues
+        )
+        return Trellis2DecodedAsset(
+            mesh: mesh,
+            pbrVoxels: voxels,
+            metallic: metallic,
+            roughness: roughness
+        )
+    }
+
+    private static func sampleTextureAttributes(
+        coordinates: [Trellis2VoxelCoordinate],
+        attributes: [Float],
+        coordinateIndices: [Trellis2VoxelCoordinate: Int],
+        dualOffsets: [Float]
+    ) -> [Float] {
+        var result = [Float](repeating: 0, count: coordinates.count * 6)
+        for vertex in 0..<coordinates.count {
+            let coordinate = coordinates[vertex]
+            let sample = [
+                Float(coordinate.x) + dualOffsets[vertex * 3],
+                Float(coordinate.y) + dualOffsets[vertex * 3 + 1],
+                Float(coordinate.z) + dualOffsets[vertex * 3 + 2],
+            ]
+            let base = sample.map { Int32(floor($0)) }
+            let fraction = zip(sample, base).map { $0 - Float($1) }
+            for corner in 0..<8 {
+                let x = Int32(corner & 1)
+                let y = Int32((corner >> 1) & 1)
+                let z = Int32((corner >> 2) & 1)
+                let weight = (x == 0 ? 1 - fraction[0] : fraction[0])
+                    * (y == 0 ? 1 - fraction[1] : fraction[1])
+                    * (z == 0 ? 1 - fraction[2] : fraction[2])
+                let neighbor = Trellis2VoxelCoordinate(
+                    x: base[0] + x,
+                    y: base[1] + y,
+                    z: base[2] + z
+                )
+                guard let source = coordinateIndices[neighbor] else { continue }
+                for channel in 0..<6 {
+                    result[vertex * 6 + channel] += attributes[source * 6 + channel] * weight
+                }
+            }
+        }
+        return result
+    }
+
+    private static func sigmoid(_ value: Float) -> Float {
+        1 / (1 + exp(-value))
+    }
+
+    private static func softplus(_ value: Float) -> Float {
+        value > 20 ? value : log1p(exp(value))
+    }
+
+    private static func clamp(_ value: Float) -> Float {
+        min(max(value, 0), 1)
+    }
+
+    private static func byte(_ value: Float) -> UInt8 {
+        UInt8((255 * clamp(value)).rounded())
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
@@ -92,14 +92,22 @@ enum Trellis2FlexibleDualGrid {
         splitWeights.reserveCapacity(shape.count)
         for index in 0..<shape.count {
             let coordinate = shape.coordinates[index]
+            var rawPosition = [Float]()
+            rawPosition.reserveCapacity(3)
             for axis in 0..<3 {
                 let offset = 2 * sigmoid(shapeValues[index * 7 + axis]) - 0.5
                 dualOffsets.append(offset)
-                vertices.append(
+                rawPosition.append(
                     (Float(coordinate[axis]) + offset) / Float(resolution) - 0.5
                 )
                 intersections.append(shapeValues[index * 7 + 3 + axis] > 0)
             }
+            // O-Voxel geometry is Z-up. The shared mesh exporters and glTF
+            // contract use X-right, Y-up, Z-forward, so rotate into that
+            // canonical basis without changing handedness.
+            vertices.append(rawPosition[0])
+            vertices.append(rawPosition[2])
+            vertices.append(-rawPosition[1])
             splitWeights.append(softplus(shapeValues[index * 7 + 6]))
         }
 

--- a/Sources/MereRunCore/Trellis2/Trellis2FlowModel.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2FlowModel.swift
@@ -1,0 +1,455 @@
+import Foundation
+@preconcurrency import MLX
+import MLXFast
+import MLXNN
+
+public enum Trellis2ModelError: Error, Equatable, LocalizedError, Sendable {
+    case missingWeight(String)
+    case invalidWeightShape(name: String, expected: [Int], actual: [Int])
+    case invalidInputShape(expected: String, actual: [Int])
+    case emptySparseStructure
+    case emptyExtractedMesh
+    case excessiveSparseStructure(actual: Int, maximum: Int)
+    case unsupportedCheckpoint(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingWeight(let name):
+            "TRELLIS.2 checkpoint is missing tensor '\(name)'."
+        case .invalidWeightShape(let name, let expected, let actual):
+            "TRELLIS.2 tensor '\(name)' has shape \(actual); expected \(expected)."
+        case .invalidInputShape(let expected, let actual):
+            "TRELLIS.2 input has shape \(actual); expected \(expected)."
+        case .emptySparseStructure:
+            "TRELLIS.2 produced an empty sparse structure."
+        case .emptyExtractedMesh:
+            "TRELLIS.2 decoded sparse voxels but did not produce a connected mesh."
+        case .excessiveSparseStructure(let actual, let maximum):
+            "TRELLIS.2 produced \(actual) sparse tokens, exceeding the \(maximum)-token safety limit."
+        case .unsupportedCheckpoint(let reason):
+            "Unsupported TRELLIS.2 checkpoint: \(reason)"
+        }
+    }
+}
+
+/// Direct safetensors view used by the TRELLIS.2 functional runtime. Keeping
+/// PyTorch names intact lets mere.run load Microsoft's BF16 files without a
+/// multi-gigabyte conversion or a second on-disk copy.
+struct Trellis2WeightStore {
+    let values: [String: MLXArray]
+
+    init(url: URL) throws {
+        self.values = try MLX.loadArrays(url: url)
+    }
+
+    init(values: [String: MLXArray]) {
+        self.values = values
+    }
+
+    func tensor(_ name: String) throws -> MLXArray {
+        guard let value = values[name] else { throw Trellis2ModelError.missingWeight(name) }
+        return value
+    }
+
+    func checkedTensor(_ name: String, shape: [Int]) throws -> MLXArray {
+        let value = try tensor(name)
+        guard value.shape == shape else {
+            throw Trellis2ModelError.invalidWeightShape(name: name, expected: shape, actual: value.shape)
+        }
+        return value
+    }
+
+    func linear(_ input: MLXArray, prefix: String) throws -> MLXArray {
+        let weight = try tensor("\(prefix).weight")
+        guard weight.ndim == 2 else {
+            throw Trellis2ModelError.invalidInputShape(expected: "rank-2 linear weight", actual: weight.shape)
+        }
+        var output = MLX.matmul(input.asType(weight.dtype), weight.transposed())
+        if let bias = values["\(prefix).bias"] {
+            output = output + bias
+        }
+        return output
+    }
+}
+
+struct Trellis2RotaryEmbedding {
+    let cosine: MLXArray
+    let sine: MLXArray
+    let headDimension: Int
+
+    init(coordinates: [Trellis2VoxelCoordinate], headDimension: Int) {
+        precondition(headDimension.isMultiple(of: 2))
+        self.headDimension = headDimension
+        let pairCount = headDimension / 2
+        let frequencyCount = pairCount / 3
+        var frequencies = [Float]()
+        frequencies.reserveCapacity(frequencyCount)
+        for index in 0..<frequencyCount {
+            frequencies.append(1 / pow(10_000, Float(index) / Float(frequencyCount)))
+        }
+
+        var angles = [Float]()
+        angles.reserveCapacity(coordinates.count * pairCount)
+        for coordinate in coordinates {
+            for axis in 0..<3 {
+                let position = Float(coordinate[axis])
+                for frequency in frequencies {
+                    angles.append(position * frequency)
+                }
+            }
+            angles.append(contentsOf: repeatElement(0, count: pairCount - 3 * frequencyCount))
+        }
+        let phase = MLXArray(angles).reshaped(coordinates.count, pairCount)
+        self.cosine = MLX.cos(phase)
+        self.sine = MLX.sin(phase)
+    }
+
+    func apply(_ input: MLXArray) -> MLXArray {
+        precondition(input.ndim == 4 && input.dim(3) == headDimension)
+        let batch = input.dim(0)
+        let length = input.dim(1)
+        let heads = input.dim(2)
+        let pairs = headDimension / 2
+        let paired = input.asType(.float32).reshaped(batch, length, heads, pairs, 2)
+        let real = paired[0..., 0..., 0..., 0..., 0..<1]
+        let imaginary = paired[0..., 0..., 0..., 0..., 1..<2]
+        let cosValue = cosine.expandedDimensions(axes: [0, 2, 4])
+        let sinValue = sine.expandedDimensions(axes: [0, 2, 4])
+        return MLX.concatenated([
+            real * cosValue - imaginary * sinValue,
+            real * sinValue + imaginary * cosValue,
+        ], axis: -1).reshaped(batch, length, heads, headDimension).asType(input.dtype)
+    }
+}
+
+/// Native MLX implementation of both the dense sparse-structure DiT and the
+/// sparse shape/texture SLat DiTs. The three official checkpoints share this
+/// exact 30-block architecture; only input channels and token coordinates
+/// differ.
+struct Trellis2FlowModel {
+    let configuration: Trellis2FlowConfiguration
+    private let weights: Trellis2WeightStore
+
+    init(configuration: Trellis2FlowConfiguration, checkpointURL: URL) throws {
+        self.configuration = configuration
+        self.weights = try Trellis2WeightStore(url: checkpointURL)
+        try validateWeights()
+    }
+
+    init(configuration: Trellis2FlowConfiguration, weights: [String: MLXArray]) throws {
+        self.configuration = configuration
+        self.weights = Trellis2WeightStore(values: weights)
+        try validateWeights()
+    }
+
+    private func validateWeights() throws {
+        let channels = configuration.modelChannels
+        let conditionChannels = configuration.conditionChannels
+        let headDimension = configuration.headDimension
+        _ = try weights.checkedTensor("input_layer.weight", shape: [channels, configuration.inputChannels])
+        _ = try weights.checkedTensor("out_layer.weight", shape: [configuration.outputChannels, channels])
+        _ = try weights.checkedTensor("t_embedder.mlp.0.weight", shape: [channels, 256])
+        _ = try weights.checkedTensor("t_embedder.mlp.2.weight", shape: [channels, channels])
+        _ = try weights.checkedTensor("adaLN_modulation.1.weight", shape: [6 * channels, channels])
+        for index in 0..<configuration.blockCount {
+            let prefix = "blocks.\(index)"
+            _ = try weights.checkedTensor("\(prefix).modulation", shape: [6 * channels])
+            _ = try weights.checkedTensor("\(prefix).self_attn.to_qkv.weight", shape: [3 * channels, channels])
+            _ = try weights.checkedTensor(
+                "\(prefix).cross_attn.to_kv.weight",
+                shape: [2 * channels, conditionChannels]
+            )
+            _ = try weights.checkedTensor(
+                "\(prefix).self_attn.q_rms_norm.gamma",
+                shape: [configuration.headCount, headDimension]
+            )
+            _ = try weights.checkedTensor(
+                "\(prefix).cross_attn.k_rms_norm.gamma",
+                shape: [configuration.headCount, headDimension]
+            )
+        }
+    }
+
+    func predict(
+        input: MLXArray,
+        coordinates: [Trellis2VoxelCoordinate],
+        timestep: Float,
+        condition: MLXArray
+    ) throws -> MLXArray {
+        guard input.ndim == 3,
+              input.dim(1) == coordinates.count,
+              input.dim(2) == configuration.inputChannels else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[batch, \(coordinates.count), \(configuration.inputChannels)]",
+                actual: input.shape
+            )
+        }
+        guard condition.ndim == 3,
+              condition.dim(0) == input.dim(0),
+              condition.dim(2) == configuration.conditionChannels else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[\(input.dim(0)), tokens, \(configuration.conditionChannels)] conditioning",
+                actual: condition.shape
+            )
+        }
+
+        let modelType = try weights.tensor("input_layer.weight").dtype
+        var hidden = try weights.linear(input, prefix: "input_layer").asType(modelType)
+        let timeEmbedding = try timeEmbedding(timestep: timestep, batch: input.dim(0)).asType(modelType)
+        let sharedModulation = try weights.linear(silu(timeEmbedding), prefix: "adaLN_modulation.1")
+            .asType(modelType)
+        let context = condition.asType(modelType)
+        let rotary = Trellis2RotaryEmbedding(
+            coordinates: coordinates,
+            headDimension: configuration.headDimension
+        )
+
+        for index in 0..<configuration.blockCount {
+            hidden = try block(
+                hidden,
+                context: context,
+                sharedModulation: sharedModulation,
+                rotary: rotary,
+                index: index
+            )
+            MLX.eval(hidden)
+            Memory.clearCache()
+        }
+
+        hidden = MLXFast.layerNorm(hidden.asType(.float32), eps: 1e-6).asType(modelType)
+        return try weights.linear(hidden, prefix: "out_layer").asType(input.dtype)
+    }
+
+    private func timeEmbedding(timestep: Float, batch: Int) throws -> MLXArray {
+        let half = 128
+        var values = [Float]()
+        values.reserveCapacity(256)
+        for index in 0..<half {
+            let frequency = exp(-log(10_000) * Float(index) / Float(half))
+            values.append(cos(timestep * frequency))
+        }
+        for index in 0..<half {
+            let frequency = exp(-log(10_000) * Float(index) / Float(half))
+            values.append(sin(timestep * frequency))
+        }
+        let frequencyEmbedding = MLX.broadcast(MLXArray(values).reshaped(1, 256), to: [batch, 256])
+        var hidden = try weights.linear(frequencyEmbedding, prefix: "t_embedder.mlp.0")
+        hidden = silu(hidden)
+        return try weights.linear(hidden, prefix: "t_embedder.mlp.2")
+    }
+
+    private func block(
+        _ input: MLXArray,
+        context: MLXArray,
+        sharedModulation: MLXArray,
+        rotary: Trellis2RotaryEmbedding,
+        index: Int
+    ) throws -> MLXArray {
+        let prefix = "blocks.\(index)"
+        let blockModulation = try weights.tensor("\(prefix).modulation")
+        let modulation = sharedModulation + blockModulation
+        let parts = MLX.split(modulation, parts: 6, axis: -1)
+        let shiftAttention = parts[0].expandedDimensions(axis: 1)
+        let scaleAttention = parts[1].expandedDimensions(axis: 1)
+        let gateAttention = parts[2].expandedDimensions(axis: 1)
+        let shiftMLP = parts[3].expandedDimensions(axis: 1)
+        let scaleMLP = parts[4].expandedDimensions(axis: 1)
+        let gateMLP = parts[5].expandedDimensions(axis: 1)
+
+        let dtype = input.dtype
+        var hidden = MLXFast.layerNorm(input.asType(.float32), eps: 1e-6)
+        hidden = (hidden * (1 + scaleAttention.asType(.float32)) + shiftAttention.asType(.float32)).asType(dtype)
+        hidden = try selfAttention(hidden, rotary: rotary, prefix: "\(prefix).self_attn")
+        var output = (input.asType(.float32) + hidden.asType(.float32) * gateAttention.asType(.float32)).asType(dtype)
+
+        hidden = try affineLayerNorm(output, prefix: "\(prefix).norm2")
+        hidden = try crossAttention(hidden, context: context, prefix: "\(prefix).cross_attn")
+        output = output + hidden
+
+        hidden = MLXFast.layerNorm(output.asType(.float32), eps: 1e-6)
+        hidden = (hidden * (1 + scaleMLP.asType(.float32)) + shiftMLP.asType(.float32)).asType(dtype)
+        hidden = try weights.linear(hidden, prefix: "\(prefix).mlp.mlp.0")
+        hidden = approximateGELU(hidden)
+        hidden = try weights.linear(hidden, prefix: "\(prefix).mlp.mlp.2")
+        return (output.asType(.float32) + hidden.asType(.float32) * gateMLP.asType(.float32)).asType(dtype)
+    }
+
+    private func selfAttention(
+        _ input: MLXArray,
+        rotary: Trellis2RotaryEmbedding,
+        prefix: String
+    ) throws -> MLXArray {
+        let batch = input.dim(0)
+        let length = input.dim(1)
+        let heads = configuration.headCount
+        let headDimension = configuration.headDimension
+        let qkv = try weights.linear(input, prefix: "\(prefix).to_qkv")
+            .reshaped(batch, length, 3, heads, headDimension)
+        let pieces = MLX.split(qkv, parts: 3, axis: 2).map { $0.squeezed(axis: 2) }
+        var query = try multiHeadRMSNorm(pieces[0], prefix: "\(prefix).q_rms_norm")
+        var key = try multiHeadRMSNorm(pieces[1], prefix: "\(prefix).k_rms_norm")
+        query = rotary.apply(query)
+        key = rotary.apply(key)
+        let attended = attention(query: query, key: key, value: pieces[2])
+            .reshaped(batch, length, configuration.modelChannels)
+        return try weights.linear(attended, prefix: "\(prefix).to_out")
+    }
+
+    private func crossAttention(
+        _ input: MLXArray,
+        context: MLXArray,
+        prefix: String
+    ) throws -> MLXArray {
+        let batch = input.dim(0)
+        let queryLength = input.dim(1)
+        let contextLength = context.dim(1)
+        let heads = configuration.headCount
+        let headDimension = configuration.headDimension
+        var query = try weights.linear(input, prefix: "\(prefix).to_q")
+            .reshaped(batch, queryLength, heads, headDimension)
+        let keyValue = try weights.linear(context, prefix: "\(prefix).to_kv")
+            .reshaped(batch, contextLength, 2, heads, headDimension)
+        let pieces = MLX.split(keyValue, parts: 2, axis: 2).map { $0.squeezed(axis: 2) }
+        query = try multiHeadRMSNorm(query, prefix: "\(prefix).q_rms_norm")
+        let key = try multiHeadRMSNorm(pieces[0], prefix: "\(prefix).k_rms_norm")
+        let attended = attention(query: query, key: key, value: pieces[1])
+            .reshaped(batch, queryLength, configuration.modelChannels)
+        return try weights.linear(attended, prefix: "\(prefix).to_out")
+    }
+
+    private func multiHeadRMSNorm(_ input: MLXArray, prefix: String) throws -> MLXArray {
+        let gamma = try weights.tensor("\(prefix).gamma").asType(.float32)
+        let squaredNorm = MLX.sum(input.asType(.float32) * input.asType(.float32), axis: -1, keepDims: true)
+        let normalized = input.asType(.float32) * MLX.rsqrt(MLX.maximum(squaredNorm, MLXArray(1e-24)))
+        return (normalized * gamma * sqrt(Float(configuration.headDimension))).asType(input.dtype)
+    }
+
+    private func attention(query: MLXArray, key: MLXArray, value: MLXArray) -> MLXArray {
+        let q = query.transposed(0, 2, 1, 3)
+        let k = key.transposed(0, 2, 1, 3)
+        let v = value.transposed(0, 2, 1, 3)
+        return MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: 1 / sqrt(Float(configuration.headDimension)),
+            mask: .none
+        ).transposed(0, 2, 1, 3)
+    }
+
+    private func affineLayerNorm(_ input: MLXArray, prefix: String) throws -> MLXArray {
+        try MLXFast.layerNorm(
+            input.asType(.float32),
+            weight: weights.tensor("\(prefix).weight").asType(.float32),
+            bias: weights.tensor("\(prefix).bias").asType(.float32),
+            eps: 1e-6
+        ).asType(input.dtype)
+    }
+
+    private func approximateGELU(_ input: MLXArray) -> MLXArray {
+        let value = input.asType(.float32)
+        let cubic = value * value * value
+        let output = 0.5 * value * (1 + MLX.tanh(0.797_884_6 * (value + 0.044715 * cubic)))
+        return output.asType(input.dtype)
+    }
+}
+
+enum Trellis2FlowSampler {
+    static func sample(
+        noise: MLXArray,
+        coordinates: [Trellis2VoxelCoordinate],
+        condition: MLXArray,
+        negativeCondition: MLXArray,
+        model: Trellis2FlowModel,
+        configuration: Trellis2SamplerConfiguration,
+        staticInput: MLXArray? = nil,
+        progress: ((Int, Int) -> Void)? = nil
+    ) throws -> MLXArray {
+        if let staticInput {
+            guard staticInput.ndim == 3,
+                  staticInput.dim(0) == noise.dim(0),
+                  staticInput.dim(1) == noise.dim(1),
+                  staticInput.dim(2) + noise.dim(2) == model.configuration.inputChannels else {
+                throw Trellis2ModelError.invalidInputShape(
+                    expected: "[batch, tokens, \(model.configuration.inputChannels - noise.dim(2))] static input",
+                    actual: staticInput.shape
+                )
+            }
+        }
+
+        func modelInput(_ dynamic: MLXArray) -> MLXArray {
+            guard let staticInput else { return dynamic }
+            return MLX.concatenated([dynamic, staticInput], axis: -1)
+        }
+
+        var sample = noise
+        let timesteps = configuration.timesteps
+        for index in 0..<configuration.steps {
+            let timestep = timesteps[index]
+            let previous = timesteps[index + 1]
+            let strength = configuration.guidanceInterval.contains(timestep)
+                ? configuration.guidanceStrength
+                : 1
+            let velocity: MLXArray
+            if strength == 1 {
+                velocity = try model.predict(
+                    input: modelInput(sample),
+                    coordinates: coordinates,
+                    timestep: 1_000 * timestep,
+                    condition: condition
+                )
+            } else {
+                // The reference sampler evaluates positive and negative CFG
+                // branches sequentially. Preserve that order to avoid doubling
+                // the peak activation footprint on unified memory.
+                let positive = try model.predict(
+                    input: modelInput(sample),
+                    coordinates: coordinates,
+                    timestep: 1_000 * timestep,
+                    condition: condition
+                )
+                MLX.eval(positive)
+                Memory.clearCache()
+                let negative = try model.predict(
+                    input: modelInput(sample),
+                    coordinates: coordinates,
+                    timestep: 1_000 * timestep,
+                    condition: negativeCondition
+                )
+                MLX.eval(negative)
+                Memory.clearCache()
+                var guided = strength * positive + (1 - strength) * negative
+                if configuration.guidanceRescale > 0 {
+                    let sigma = configuration.sigmaMinimum + (1 - configuration.sigmaMinimum) * timestep
+                    let positiveStart = (1 - configuration.sigmaMinimum) * sample - sigma * positive
+                    let guidedStart = (1 - configuration.sigmaMinimum) * sample - sigma * guided
+                    let reductionAxes = Array(1..<positiveStart.ndim)
+                    let positiveDeviation = MLX.std(
+                        positiveStart,
+                        axes: reductionAxes,
+                        keepDims: true,
+                        ddof: 1
+                    )
+                    let guidedDeviation = MLX.std(
+                        guidedStart,
+                        axes: reductionAxes,
+                        keepDims: true,
+                        ddof: 1
+                    )
+                    let rescaledStart = guidedStart * (
+                        positiveDeviation / MLX.maximum(guidedDeviation, MLXArray(1e-6))
+                    )
+                    let blendedStart = configuration.guidanceRescale * rescaledStart
+                        + (1 - configuration.guidanceRescale) * guidedStart
+                    guided = ((1 - configuration.sigmaMinimum) * sample - blendedStart) / sigma
+                }
+                velocity = guided
+            }
+            sample = sample - (timestep - previous) * velocity
+            MLX.eval(sample)
+            Memory.clearCache()
+            progress?(index + 1, configuration.steps)
+        }
+        return sample
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
@@ -102,7 +102,7 @@ public actor Trellis2Generator {
     /// Safety ceiling for decoded 512-resolution O-Voxels. Microsoft's
     /// 49,152-token option is only used to select a cascade resolution and is
     /// not a decoder limit for the direct 512 pipeline.
-    public static let defaultMaximumSparseTokens = 1_048_576
+    public static let defaultMaximumSparseTokens = 2_097_152
 
     public init() {}
 

--- a/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
@@ -1,0 +1,440 @@
+import Foundation
+import MediaIO
+@preconcurrency import MLX
+import MLXRandom
+
+public enum Trellis2Progress: Equatable, Sendable {
+    case verifyingCheckpoint
+    case decodingImage
+    case preprocessingImage
+    case encodingImage
+    case samplingSparseStructure(completed: Int, total: Int)
+    case decodingSparseStructure
+    case samplingShape(completed: Int, total: Int)
+    case samplingTexture(completed: Int, total: Int)
+    case decodingShape
+    case decodingTexture
+    case extractingMesh
+    case exportingAssets
+
+    public var message: String {
+        switch self {
+        case .verifyingCheckpoint:
+            "Verifying pinned TRELLIS.2 and DINOv3 checkpoints"
+        case .decodingImage:
+            "Decoding source image"
+        case .preprocessingImage:
+            "Preparing 512px DINOv3 conditioning image"
+        case .encodingImage:
+            "Encoding image with native MLX DINOv3 ViT-L/16"
+        case .samplingSparseStructure(let completed, let total):
+            "Sampling sparse structure \(completed)/\(total)"
+        case .decodingSparseStructure:
+            "Decoding occupied 32-grid coordinates"
+        case .samplingShape(let completed, let total):
+            "Sampling O-Voxel shape latent \(completed)/\(total)"
+        case .samplingTexture(let completed, let total):
+            "Sampling PBR texture latent \(completed)/\(total)"
+        case .decodingShape:
+            "Decoding shape and adaptive subdivision tree"
+        case .decodingTexture:
+            "Decoding six-channel PBR O-Voxels"
+        case .extractingMesh:
+            "Extracting flexible-dual-grid mesh and filling small boundary holes"
+        case .exportingAssets:
+            "Writing OBJ, PLY, GLB, PBR voxels, and manifests"
+        }
+    }
+}
+
+public enum Trellis2GeneratorError: Error, Equatable, LocalizedError, Sendable {
+    case inputImageNotFound(String)
+    case invalidMaximumSparseTokens(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .inputImageNotFound(let path):
+            "TRELLIS.2 input image was not found: \(path)"
+        case .invalidMaximumSparseTokens(let value):
+            "TRELLIS.2 maximum sparse tokens must be at least 4096; received \(value)."
+        }
+    }
+}
+
+public struct Trellis2RunResult: Sendable {
+    public let meshExport: MeshExportResult
+    public let pbrExport: Trellis2PBRVoxelExport
+    public let runManifest: Trellis2RunManifestExport
+    public let checkpoint: Trellis2Checkpoint
+    public let sourceWidth: Int
+    public let sourceHeight: Int
+    public let croppedTransparentForeground: Bool
+    public let foregroundPolicy: String
+    public let seed: UInt64
+    public let maximumSparseTokens: Int
+
+    public init(
+        meshExport: MeshExportResult,
+        pbrExport: Trellis2PBRVoxelExport,
+        runManifest: Trellis2RunManifestExport,
+        checkpoint: Trellis2Checkpoint,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        croppedTransparentForeground: Bool,
+        foregroundPolicy: String,
+        seed: UInt64,
+        maximumSparseTokens: Int
+    ) {
+        self.meshExport = meshExport
+        self.pbrExport = pbrExport
+        self.runManifest = runManifest
+        self.checkpoint = checkpoint
+        self.sourceWidth = sourceWidth
+        self.sourceHeight = sourceHeight
+        self.croppedTransparentForeground = croppedTransparentForeground
+        self.foregroundPolicy = foregroundPolicy
+        self.seed = seed
+        self.maximumSparseTokens = maximumSparseTokens
+    }
+}
+
+public actor Trellis2Generator {
+    /// Safety ceiling for decoded 512-resolution O-Voxels. Microsoft's
+    /// 49,152-token option is only used to select a cascade resolution and is
+    /// not a decoder limit for the direct 512 pipeline.
+    public static let defaultMaximumSparseTokens = 1_048_576
+
+    public init() {}
+
+    public func generate(
+        imageURL: URL,
+        outputDirectory: URL,
+        model requestedModel: String? = nil,
+        foregroundPolicy: Trellis2ForegroundPolicy = .transparentAlpha,
+        seed: UInt64 = 42,
+        maximumSparseTokens: Int = defaultMaximumSparseTokens,
+        progress: (@Sendable (Trellis2Progress) -> Void)? = nil
+    ) async throws -> Trellis2RunResult {
+        let inputURL = imageURL.standardizedFileURL
+        guard FileManager.default.fileExists(atPath: inputURL.path) else {
+            throw Trellis2GeneratorError.inputImageNotFound(inputURL.path)
+        }
+        guard maximumSparseTokens >= 4_096 else {
+            throw Trellis2GeneratorError.invalidMaximumSparseTokens(maximumSparseTokens)
+        }
+
+        let admittedInput = try VFXImageInputSnapshotBatch.capture([inputURL])
+        defer { admittedInput.cleanup() }
+        let snapshotURL = admittedInput.snapshotURLs[0]
+
+        progress?(.verifyingCheckpoint)
+        let checkpoint = try await Trellis2Resources.resolve(requestedModel: requestedModel)
+
+        progress?(.decodingImage)
+        let image = try MediaImageIO.decode(snapshotURL)
+        _ = try VFXImageInputValidator.validate(
+            width: image.width,
+            height: image.height,
+            path: inputURL.path
+        )
+
+        progress?(.preprocessingImage)
+        let prepared = try Trellis2Preprocessor.prepare(
+            image: image,
+            size: 512,
+            foregroundPolicy: foregroundPolicy
+        )
+
+        progress?(.encodingImage)
+        let condition = try encodeCondition(
+            prepared.conditionInput,
+            checkpointURL: checkpoint.dinoV3URL
+        )
+        let negativeCondition = MLX.zeros(condition.shape, dtype: condition.dtype)
+        MLX.eval(condition, negativeCondition)
+
+        MLXRandom.seed(seed)
+        let structureCoordinates = Self.denseCoordinates(resolution: 16)
+        let structureLatent = try sampleStructure(
+            coordinates: structureCoordinates,
+            condition: condition,
+            negativeCondition: negativeCondition,
+            checkpointURL: checkpoint.sparseStructureFlowURL,
+            progress: progress
+        )
+
+        progress?(.decodingSparseStructure)
+        let coordinates = try decodeStructure(
+            structureLatent,
+            checkpointURL: checkpoint.sparseStructureDecoderURL,
+            maximumSparseTokens: maximumSparseTokens
+        )
+
+        let shapeLatents = try sampleShape(
+            coordinates: coordinates,
+            condition: condition,
+            negativeCondition: negativeCondition,
+            checkpointURL: checkpoint.shapeFlowURL,
+            progress: progress
+        )
+        let textureLatent = try sampleTexture(
+            coordinates: coordinates,
+            normalizedShape: shapeLatents.normalized,
+            condition: condition,
+            negativeCondition: negativeCondition,
+            checkpointURL: checkpoint.textureFlowURL,
+            progress: progress
+        )
+
+        progress?(.decodingShape)
+        let shape = try decodeShape(
+            latent: shapeLatents.denormalized,
+            coordinates: coordinates,
+            checkpointURL: checkpoint.shapeDecoderURL,
+            maximumSparseTokens: maximumSparseTokens
+        )
+        progress?(.decodingTexture)
+        let texture = try decodeTexture(
+            latent: textureLatent,
+            coordinates: coordinates,
+            guides: shape.subdivisions,
+            checkpointURL: checkpoint.textureDecoderURL,
+            maximumSparseTokens: maximumSparseTokens
+        )
+
+        progress?(.extractingMesh)
+        let decoded = try Trellis2FlexibleDualGrid.decode(
+            shape: shape.tensor,
+            texture: texture,
+            resolution: 512
+        )
+        MLX.Memory.clearCache()
+
+        progress?(.exportingAssets)
+        let policyName = foregroundPolicy == .alreadyFramed
+            ? "already-framed"
+            : "transparent-alpha"
+        let artifacts = try Trellis2ArtifactExporter.export(
+            asset: decoded,
+            checkpoint: checkpoint,
+            inputURL: inputURL,
+            inputRecord: admittedInput.inputRecords[0],
+            outputDirectory: outputDirectory.standardizedFileURL,
+            stem: inputURL.deletingPathExtension().lastPathComponent,
+            sourceWidth: prepared.sourceWidth,
+            sourceHeight: prepared.sourceHeight,
+            foregroundPolicy: policyName,
+            croppedTransparentForeground: prepared.croppedTransparentForeground,
+            seed: seed,
+            maximumSparseTokens: maximumSparseTokens
+        )
+        MLX.Memory.clearCache()
+        return Trellis2RunResult(
+            meshExport: artifacts.mesh,
+            pbrExport: artifacts.pbr,
+            runManifest: artifacts.run,
+            checkpoint: checkpoint,
+            sourceWidth: prepared.sourceWidth,
+            sourceHeight: prepared.sourceHeight,
+            croppedTransparentForeground: prepared.croppedTransparentForeground,
+            foregroundPolicy: policyName,
+            seed: seed,
+            maximumSparseTokens: maximumSparseTokens
+        )
+    }
+
+    public func unload() {
+        MLX.Memory.clearCache()
+    }
+
+    private func encodeCondition(_ input: MLXArray, checkpointURL: URL) throws -> MLXArray {
+        let condition: MLXArray = try {
+            let conditioner = try Trellis2DINOv3Conditioner(checkpointURL: checkpointURL)
+            return conditioner.encode(input)
+        }()
+        MLX.eval(condition)
+        MLX.Memory.clearCache()
+        return condition
+    }
+
+    private func sampleStructure(
+        coordinates: [Trellis2VoxelCoordinate],
+        condition: MLXArray,
+        negativeCondition: MLXArray,
+        checkpointURL: URL,
+        progress: (@Sendable (Trellis2Progress) -> Void)?
+    ) throws -> MLXArray {
+        let latent: MLXArray = try {
+            let model = try Trellis2FlowModel(
+                configuration: .sparseStructure512,
+                checkpointURL: checkpointURL
+            )
+            let noise = MLXRandom.normal([1, coordinates.count, 8]).asType(.float32)
+            return try Trellis2FlowSampler.sample(
+                noise: noise,
+                coordinates: coordinates,
+                condition: condition,
+                negativeCondition: negativeCondition,
+                model: model,
+                configuration: .sparseStructure,
+                progress: { completed, total in
+                    progress?(.samplingSparseStructure(completed: completed, total: total))
+                }
+            )
+        }()
+        MLX.eval(latent)
+        MLX.Memory.clearCache()
+        return latent
+    }
+
+    private func decodeStructure(
+        _ latent: MLXArray,
+        checkpointURL: URL,
+        maximumSparseTokens: Int
+    ) throws -> [Trellis2VoxelCoordinate] {
+        let coordinates: [Trellis2VoxelCoordinate] = try {
+            let decoder = try Trellis2StructureDecoder(checkpointURL: checkpointURL)
+            return try decoder.decode(
+                latentTokens: latent,
+                outputResolution: 32,
+                maximumTokens: maximumSparseTokens
+            )
+        }()
+        MLX.Memory.clearCache()
+        return coordinates
+    }
+
+    private func sampleShape(
+        coordinates: [Trellis2VoxelCoordinate],
+        condition: MLXArray,
+        negativeCondition: MLXArray,
+        checkpointURL: URL,
+        progress: (@Sendable (Trellis2Progress) -> Void)?
+    ) throws -> (normalized: MLXArray, denormalized: MLXArray) {
+        let normalized: MLXArray = try {
+            let model = try Trellis2FlowModel(configuration: .shape512, checkpointURL: checkpointURL)
+            let noise = MLXRandom.normal([1, coordinates.count, 32]).asType(.float32)
+            return try Trellis2FlowSampler.sample(
+                noise: noise,
+                coordinates: coordinates,
+                condition: condition,
+                negativeCondition: negativeCondition,
+                model: model,
+                configuration: .shape,
+                progress: { completed, total in
+                    progress?(.samplingShape(completed: completed, total: total))
+                }
+            )
+        }()
+        MLX.eval(normalized)
+        let denormalized = Self.denormalize(
+            normalized,
+            mean: Trellis2Normalization.shapeMean,
+            standardDeviation: Trellis2Normalization.shapeStandardDeviation
+        )
+        MLX.eval(denormalized)
+        MLX.Memory.clearCache()
+        return (normalized, denormalized)
+    }
+
+    private func sampleTexture(
+        coordinates: [Trellis2VoxelCoordinate],
+        normalizedShape: MLXArray,
+        condition: MLXArray,
+        negativeCondition: MLXArray,
+        checkpointURL: URL,
+        progress: (@Sendable (Trellis2Progress) -> Void)?
+    ) throws -> MLXArray {
+        let normalized: MLXArray = try {
+            let model = try Trellis2FlowModel(configuration: .texture512, checkpointURL: checkpointURL)
+            let noise = MLXRandom.normal([1, coordinates.count, 32]).asType(.float32)
+            return try Trellis2FlowSampler.sample(
+                noise: noise,
+                coordinates: coordinates,
+                condition: condition,
+                negativeCondition: negativeCondition,
+                model: model,
+                configuration: .texture,
+                staticInput: normalizedShape,
+                progress: { completed, total in
+                    progress?(.samplingTexture(completed: completed, total: total))
+                }
+            )
+        }()
+        MLX.eval(normalized)
+        let denormalized = Self.denormalize(
+            normalized,
+            mean: Trellis2Normalization.textureMean,
+            standardDeviation: Trellis2Normalization.textureStandardDeviation
+        )
+        MLX.eval(denormalized)
+        MLX.Memory.clearCache()
+        return denormalized
+    }
+
+    private func decodeShape(
+        latent: MLXArray,
+        coordinates: [Trellis2VoxelCoordinate],
+        checkpointURL: URL,
+        maximumSparseTokens: Int
+    ) throws -> Trellis2SparseDecoderOutput {
+        let output: Trellis2SparseDecoderOutput = try {
+            let decoder = try Trellis2SparseDecoder(kind: .shape, checkpointURL: checkpointURL)
+            let sparse = try Trellis2SparseTensor(
+                features: latent.squeezed(axis: 0),
+                coordinates: coordinates
+            )
+            return try decoder.decode(sparse, maximumTokens: maximumSparseTokens)
+        }()
+        MLX.eval(output.tensor.features)
+        MLX.Memory.clearCache()
+        return output
+    }
+
+    private func decodeTexture(
+        latent: MLXArray,
+        coordinates: [Trellis2VoxelCoordinate],
+        guides: [Trellis2Subdivision],
+        checkpointURL: URL,
+        maximumSparseTokens: Int
+    ) throws -> Trellis2SparseTensor {
+        let output: Trellis2SparseTensor = try {
+            let decoder = try Trellis2SparseDecoder(kind: .texture, checkpointURL: checkpointURL)
+            let sparse = try Trellis2SparseTensor(
+                features: latent.squeezed(axis: 0),
+                coordinates: coordinates
+            )
+            return try decoder.decode(
+                sparse,
+                guideSubdivisions: guides,
+                maximumTokens: maximumSparseTokens
+            ).tensor
+        }()
+        MLX.eval(output.features)
+        MLX.Memory.clearCache()
+        return output
+    }
+
+    static func denseCoordinates(resolution: Int) -> [Trellis2VoxelCoordinate] {
+        var result = [Trellis2VoxelCoordinate]()
+        result.reserveCapacity(resolution * resolution * resolution)
+        for x in 0..<resolution {
+            for y in 0..<resolution {
+                for z in 0..<resolution {
+                    result.append(Trellis2VoxelCoordinate(x: Int32(x), y: Int32(y), z: Int32(z)))
+                }
+            }
+        }
+        return result
+    }
+
+    private static func denormalize(
+        _ input: MLXArray,
+        mean: [Float],
+        standardDeviation: [Float]
+    ) -> MLXArray {
+        let meanArray = MLXArray(mean).reshaped(1, 1, mean.count)
+        let stdArray = MLXArray(standardDeviation).reshaped(1, 1, standardDeviation.count)
+        return input * stdArray + meanArray
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2ImageConditioning.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ImageConditioning.swift
@@ -1,0 +1,311 @@
+import Foundation
+import MediaIO
+@preconcurrency import MLX
+import MLXNN
+
+public enum Trellis2ForegroundPolicy: Equatable, Sendable {
+    /// Use non-opaque alpha to isolate and center the object. Fully opaque
+    /// images require the caller to explicitly confirm that framing is ready.
+    case transparentAlpha
+    /// Preserve the supplied framing and composite any alpha over black.
+    case alreadyFramed
+}
+
+public enum Trellis2PreprocessingError: Error, Equatable, LocalizedError, Sendable {
+    case invalidImageSize(Int)
+    case emptyForeground
+    case backgroundRemovalRequired
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidImageSize(let size):
+            "TRELLIS.2 conditioning image size must be positive; received \(size)."
+        case .emptyForeground:
+            "TRELLIS.2 input alpha contains no foreground pixels."
+        case .backgroundRemovalRequired:
+            "TRELLIS.2 received a fully opaque image. Supply transparent alpha or pass the already-framed option."
+        }
+    }
+}
+
+public struct Trellis2PreprocessingResult {
+    /// `[1, 3, size, size]`, ImageNet-normalized RGB.
+    public let conditionInput: MLXArray
+    public let sourceWidth: Int
+    public let sourceHeight: Int
+    public let croppedTransparentForeground: Bool
+}
+
+public enum Trellis2Preprocessor {
+    public static func prepare(
+        image: MediaImage,
+        size: Int = 512,
+        foregroundPolicy: Trellis2ForegroundPolicy = .transparentAlpha
+    ) throws -> Trellis2PreprocessingResult {
+        guard size > 0 else { throw Trellis2PreprocessingError.invalidImageSize(size) }
+        let hasTransparency = stride(from: 3, to: image.rgba8.count, by: 4)
+            .contains { image.rgba8[$0] < 255 }
+
+        let prepared: PreparedRGB
+        let cropped: Bool
+        switch foregroundPolicy {
+        case .transparentAlpha:
+            guard hasTransparency else {
+                throw Trellis2PreprocessingError.backgroundRemovalRequired
+            }
+            prepared = try cropAndCompositeOnBlack(boundedForegroundImage(image))
+            cropped = true
+        case .alreadyFramed:
+            prepared = compositeOnBlack(image)
+            cropped = false
+        }
+
+        let resized = lanczosResize(
+            prepared.values,
+            sourceWidth: prepared.width,
+            sourceHeight: prepared.height,
+            targetWidth: size,
+            targetHeight: size
+        )
+        let mean: [Float] = [0.485, 0.456, 0.406]
+        let standardDeviation: [Float] = [0.229, 0.224, 0.225]
+        var normalized = [Float](repeating: 0, count: resized.count)
+        for pixel in 0..<(size * size) {
+            for channel in 0..<3 {
+                normalized[pixel * 3 + channel] = (
+                    resized[pixel * 3 + channel] - mean[channel]
+                ) / standardDeviation[channel]
+            }
+        }
+        return Trellis2PreprocessingResult(
+            conditionInput: MLXArray(normalized)
+                .reshaped(1, size, size, 3)
+                .transposed(0, 3, 1, 2),
+            sourceWidth: image.width,
+            sourceHeight: image.height,
+            croppedTransparentForeground: cropped
+        )
+    }
+
+    private struct PreparedRGB {
+        let width: Int
+        let height: Int
+        let values: [Float]
+    }
+
+    private static func compositeOnBlack(_ image: MediaImage) -> PreparedRGB {
+        PreparedRGB(
+            width: image.width,
+            height: image.height,
+            values: premultipliedRGB(
+                image.rgba8,
+                width: image.width,
+                height: image.height
+            )
+        )
+    }
+
+    /// Microsoft's reference pipeline bounds the source to 1024px before
+    /// alpha-box discovery. Preserve that order so large inputs produce the
+    /// same foreground framing before the final 512px conditioning resize.
+    private static func boundedForegroundImage(_ image: MediaImage) throws -> MediaImage {
+        let maximumDimension = max(image.width, image.height)
+        guard maximumDimension > 1_024 else { return image }
+        let scale = Float(1_024) / Float(maximumDimension)
+        let width = max(1, Int(Float(image.width) * scale))
+        let height = max(1, Int(Float(image.height) * scale))
+        let values = image.rgba8.map { Float($0) / 255 }
+        let resized = lanczosResize(
+            values,
+            sourceWidth: image.width,
+            sourceHeight: image.height,
+            targetWidth: width,
+            targetHeight: height,
+            channels: 4
+        )
+        return try MediaImage(
+            width: width,
+            height: height,
+            rgba8: resized.map { UInt8((255 * min(max($0, 0), 1)).rounded()) }
+        )
+    }
+
+    private static func cropAndCompositeOnBlack(_ image: MediaImage) throws -> PreparedRGB {
+        var minimumX = image.width
+        var minimumY = image.height
+        var maximumX = -1
+        var maximumY = -1
+        for y in 0..<image.height {
+            for x in 0..<image.width where image.rgba8[(y * image.width + x) * 4 + 3] > 204 {
+                minimumX = min(minimumX, x)
+                minimumY = min(minimumY, y)
+                maximumX = max(maximumX, x)
+                maximumY = max(maximumY, y)
+            }
+        }
+        guard maximumX >= minimumX, maximumY >= minimumY else {
+            throw Trellis2PreprocessingError.emptyForeground
+        }
+
+        let width = max(1, maximumX - minimumX)
+        let height = max(1, maximumY - minimumY)
+        let side = max(width, height)
+        let centerX = (minimumX + maximumX) / 2
+        let centerY = (minimumY + maximumY) / 2
+        let originX = centerX - side / 2
+        let originY = centerY - side / 2
+        var rgba = [UInt8](repeating: 0, count: side * side * 4)
+        for y in 0..<side {
+            for x in 0..<side {
+                let sourceX = originX + x
+                let sourceY = originY + y
+                guard sourceX >= 0, sourceX < image.width,
+                      sourceY >= 0, sourceY < image.height else { continue }
+                let source = (sourceY * image.width + sourceX) * 4
+                let destination = (y * side + x) * 4
+                rgba[destination] = image.rgba8[source]
+                rgba[destination + 1] = image.rgba8[source + 1]
+                rgba[destination + 2] = image.rgba8[source + 2]
+                rgba[destination + 3] = image.rgba8[source + 3]
+            }
+        }
+        return PreparedRGB(
+            width: side,
+            height: side,
+            values: premultipliedRGB(rgba, width: side, height: side)
+        )
+    }
+
+    private static func premultipliedRGB(
+        _ rgba: [UInt8],
+        width: Int,
+        height: Int
+    ) -> [Float] {
+        var result = [Float](repeating: 0, count: width * height * 3)
+        for pixel in 0..<(width * height) {
+            let alpha = Float(rgba[pixel * 4 + 3]) / 255
+            for channel in 0..<3 {
+                result[pixel * 3 + channel] = Float(rgba[pixel * 4 + channel]) / 255 * alpha
+            }
+        }
+        return result
+    }
+
+    /// Separable Lanczos-3 resize matching PIL's high-quality conditioning
+    /// resize closely while remaining deterministic and dependency-free.
+    static func lanczosResize(
+        _ source: [Float],
+        sourceWidth: Int,
+        sourceHeight: Int,
+        targetWidth: Int,
+        targetHeight: Int,
+        channels: Int = 3
+    ) -> [Float] {
+        precondition(channels > 0)
+        precondition(source.count == sourceWidth * sourceHeight * channels)
+        if sourceWidth == targetWidth, sourceHeight == targetHeight { return source }
+        let horizontal = lanczosWeights(sourceSize: sourceWidth, targetSize: targetWidth)
+        var intermediate = [Float](repeating: 0, count: sourceHeight * targetWidth * channels)
+        for y in 0..<sourceHeight {
+            for targetX in 0..<targetWidth {
+                for (sourceX, weight) in horizontal[targetX] {
+                    for channel in 0..<channels {
+                        intermediate[(y * targetWidth + targetX) * channels + channel]
+                            += source[(y * sourceWidth + sourceX) * channels + channel] * weight
+                    }
+                }
+            }
+        }
+        let vertical = lanczosWeights(sourceSize: sourceHeight, targetSize: targetHeight)
+        var output = [Float](repeating: 0, count: targetHeight * targetWidth * channels)
+        for targetY in 0..<targetHeight {
+            for (sourceY, weight) in vertical[targetY] {
+                for x in 0..<targetWidth {
+                    for channel in 0..<channels {
+                        output[(targetY * targetWidth + x) * channels + channel]
+                            += intermediate[(sourceY * targetWidth + x) * channels + channel] * weight
+                    }
+                }
+            }
+        }
+        return output.map { min(max($0, 0), 1) }
+    }
+
+    private static func lanczosWeights(
+        sourceSize: Int,
+        targetSize: Int
+    ) -> [[(Int, Float)]] {
+        let scale = Float(sourceSize) / Float(targetSize)
+        let filterScale = max(scale, 1)
+        let support = 3 * filterScale
+        return (0..<targetSize).map { destination in
+            let center = scale * (Float(destination) + 0.5)
+            let first = max(0, Int(ceil(center - support - 0.5)))
+            let last = min(sourceSize - 1, Int(floor(center + support - 0.5)))
+            var weights = [(Int, Float)]()
+            var total: Float = 0
+            if first <= last {
+                for index in first...last {
+                    let distance = (Float(index) + 0.5 - center) / filterScale
+                    let weight = lanczos(distance)
+                    if weight != 0 {
+                        weights.append((index, weight))
+                        total += weight
+                    }
+                }
+            }
+            return weights.map { ($0.0, $0.1 / total) }
+        }
+    }
+
+    private static func lanczos(_ value: Float) -> Float {
+        let magnitude = abs(value)
+        if magnitude < Float.ulpOfOne { return 1 }
+        if magnitude >= 3 { return 0 }
+        let piValue = Float.pi * value
+        return sin(piValue) / piValue * sin(piValue / 3) / (piValue / 3)
+    }
+}
+
+struct Trellis2DINOv3Conditioner {
+    private let model: DINOv3VisionModel
+
+    init(checkpointURL: URL) throws {
+        var configuration = DINOv3Config()
+        configuration.hiddenSize = 1_024
+        configuration.intermediateSize = 4_096
+        configuration.numHiddenLayers = 24
+        configuration.numAttentionHeads = 16
+        configuration.patchSize = 16
+        configuration.imageSize = 512
+        configuration.numRegisterTokens = 4
+        configuration.useGatedMLP = false
+        configuration.queryBias = true
+        configuration.keyBias = false
+        configuration.valueBias = true
+        configuration.projectionBias = true
+        configuration.mlpBias = true
+
+        let model = DINOv3VisionModel(config: configuration)
+        let rawWeights = try MLX.loadArrays(url: checkpointURL)
+        var converted = [String: MLXArray]()
+        converted.reserveCapacity(rawWeights.count)
+        for (key, value) in rawWeights {
+            converted[key] = value.ndim == 4
+                ? HFSafetensorsWeightsLoader.convWeightOIHWToOHWI(value)
+                : value
+        }
+        try model.update(
+            parameters: ModuleParameters.unflattened(converted),
+            verify: .all
+        )
+        MLX.eval(model)
+        self.model = model
+    }
+
+    func encode(_ input: MLXArray) -> MLXArray {
+        let condition = model.preNormalizedTokens(input)
+        MLX.eval(condition)
+        return condition
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2MeshHoleFiller.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2MeshHoleFiller.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// Deterministic CPU counterpart to the reference pipeline's final small-hole
+/// repair. It caps only closed manifold boundary loops below the same
+/// normalized-object-space perimeter threshold and never introduces vertices.
+enum Trellis2MeshHoleFiller {
+    private struct EdgeKey: Hashable {
+        let lower: UInt32
+        let upper: UInt32
+
+        init(_ start: UInt32, _ end: UInt32) {
+            self.lower = min(start, end)
+            self.upper = max(start, end)
+        }
+    }
+
+    private struct EdgeRecord {
+        var count: Int
+        let start: UInt32
+        let end: UInt32
+    }
+
+    private struct DirectedEdge {
+        let start: UInt32
+        let end: UInt32
+    }
+
+    private struct Point2D {
+        let x: Float
+        let y: Float
+    }
+
+    static func fillSmallHoles(
+        in mesh: MeshAsset,
+        maximumPerimeter: Float = 0.03
+    ) throws -> MeshAsset {
+        precondition(maximumPerimeter > 0)
+        let boundaries = boundaryEdges(indices: mesh.indices)
+        guard !boundaries.isEmpty else { return mesh }
+
+        var additions = [UInt32]()
+        for loop in closedLoops(edges: boundaries) {
+            guard perimeter(of: loop, vertices: mesh.vertices) <= maximumPerimeter,
+                  let triangles = triangulate(loop: Array(loop.reversed()), vertices: mesh.vertices) else {
+                continue
+            }
+            additions.append(contentsOf: triangles)
+        }
+        guard !additions.isEmpty else { return mesh }
+
+        let repaired = try MeshAsset(
+            vertices: mesh.vertices,
+            indices: mesh.indices + additions,
+            normals: nil,
+            colorsRGBA8: mesh.colorsRGBA8,
+            textureCoordinates: mesh.textureCoordinates,
+            coordinateSystem: mesh.coordinateSystem,
+            units: mesh.units,
+            inferredUnseenGeometry: mesh.inferredUnseenGeometry
+        )
+        return mesh.normals == nil ? repaired : try repaired.withGeneratedNormals()
+    }
+
+    private static func boundaryEdges(indices: [UInt32]) -> [DirectedEdge] {
+        var records = [EdgeKey: EdgeRecord]()
+        records.reserveCapacity(indices.count)
+        for triangle in stride(from: 0, to: indices.count, by: 3) {
+            let a = indices[triangle]
+            let b = indices[triangle + 1]
+            let c = indices[triangle + 2]
+            for (start, end) in [(a, b), (b, c), (c, a)] {
+                let key = EdgeKey(start, end)
+                if var record = records[key] {
+                    record.count += 1
+                    records[key] = record
+                } else {
+                    records[key] = EdgeRecord(count: 1, start: start, end: end)
+                }
+            }
+        }
+        return records.values
+            .filter { $0.count == 1 }
+            .map { DirectedEdge(start: $0.start, end: $0.end) }
+            .sorted { ($0.start, $0.end) < ($1.start, $1.end) }
+    }
+
+    private static func closedLoops(edges: [DirectedEdge]) -> [[UInt32]] {
+        var outgoing = [UInt32: [Int]]()
+        for (index, edge) in edges.enumerated() {
+            outgoing[edge.start, default: []].append(index)
+        }
+        for vertex in outgoing.keys {
+            outgoing[vertex]?.sort { edges[$0].end < edges[$1].end }
+        }
+
+        var used = [Bool](repeating: false, count: edges.count)
+        var loops = [[UInt32]]()
+        for firstIndex in edges.indices where !used[firstIndex] {
+            let first = edges[firstIndex]
+            var loop = [first.start]
+            var seen = Set(loop)
+            var current = first.end
+            used[firstIndex] = true
+
+            while current != first.start {
+                guard seen.insert(current).inserted,
+                      let nextIndex = outgoing[current]?.first(where: { !used[$0] }) else {
+                    loop.removeAll()
+                    break
+                }
+                loop.append(current)
+                used[nextIndex] = true
+                current = edges[nextIndex].end
+            }
+            if loop.count >= 3, current == first.start {
+                loops.append(loop)
+            }
+        }
+        return loops
+    }
+
+    private static func perimeter(of loop: [UInt32], vertices: [Float]) -> Float {
+        var result: Float = 0
+        for index in loop.indices {
+            let start = Int(loop[index]) * 3
+            let end = Int(loop[(index + 1) % loop.count]) * 3
+            let deltaX = vertices[end] - vertices[start]
+            let deltaY = vertices[end + 1] - vertices[start + 1]
+            let deltaZ = vertices[end + 2] - vertices[start + 2]
+            result += sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ)
+        }
+        return result
+    }
+
+    private static func triangulate(loop: [UInt32], vertices: [Float]) -> [UInt32]? {
+        let points = projectedPoints(loop: loop, vertices: vertices)
+        let signedArea = area(points)
+        guard abs(signedArea) > Float.ulpOfOne else { return nil }
+        let orientation: Float = signedArea > 0 ? 1 : -1
+        var remaining = Array(loop.indices)
+        var triangles = [UInt32]()
+        triangles.reserveCapacity((loop.count - 2) * 3)
+
+        while remaining.count > 3 {
+            var clipped = false
+            for position in remaining.indices {
+                let previous = remaining[(position + remaining.count - 1) % remaining.count]
+                let current = remaining[position]
+                let next = remaining[(position + 1) % remaining.count]
+                guard orientation * cross(points[previous], points[current], points[next]) > 1e-10 else {
+                    continue
+                }
+                let containsVertex = remaining.contains { candidate in
+                    candidate != previous && candidate != current && candidate != next
+                        && pointInTriangle(
+                            points[candidate],
+                            a: points[previous],
+                            b: points[current],
+                            c: points[next],
+                            orientation: orientation
+                        )
+                }
+                guard !containsVertex else { continue }
+                triangles.append(loop[previous])
+                triangles.append(loop[current])
+                triangles.append(loop[next])
+                remaining.remove(at: position)
+                clipped = true
+                break
+            }
+            guard clipped else { return nil }
+        }
+        triangles.append(loop[remaining[0]])
+        triangles.append(loop[remaining[1]])
+        triangles.append(loop[remaining[2]])
+        return triangles
+    }
+
+    private static func projectedPoints(loop: [UInt32], vertices: [Float]) -> [Point2D] {
+        var normal = (x: Float(0), y: Float(0), z: Float(0))
+        for index in loop.indices {
+            let current = Int(loop[index]) * 3
+            let next = Int(loop[(index + 1) % loop.count]) * 3
+            normal.x += (vertices[current + 1] - vertices[next + 1])
+                * (vertices[current + 2] + vertices[next + 2])
+            normal.y += (vertices[current + 2] - vertices[next + 2])
+                * (vertices[current] + vertices[next])
+            normal.z += (vertices[current] - vertices[next])
+                * (vertices[current + 1] + vertices[next + 1])
+        }
+        let axis = [abs(normal.x), abs(normal.y), abs(normal.z)]
+            .enumerated()
+            .max { $0.element < $1.element }?.offset ?? 2
+        return loop.map { vertex in
+            let base = Int(vertex) * 3
+            switch axis {
+            case 0: return Point2D(x: vertices[base + 1], y: vertices[base + 2])
+            case 1: return Point2D(x: vertices[base], y: vertices[base + 2])
+            default: return Point2D(x: vertices[base], y: vertices[base + 1])
+            }
+        }
+    }
+
+    private static func area(_ points: [Point2D]) -> Float {
+        var result: Float = 0
+        for index in points.indices {
+            let next = points[(index + 1) % points.count]
+            result += points[index].x * next.y - next.x * points[index].y
+        }
+        return result * 0.5
+    }
+
+    private static func cross(_ a: Point2D, _ b: Point2D, _ c: Point2D) -> Float {
+        (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+    }
+
+    private static func pointInTriangle(
+        _ point: Point2D,
+        a: Point2D,
+        b: Point2D,
+        c: Point2D,
+        orientation: Float
+    ) -> Bool {
+        orientation * cross(a, b, point) >= -1e-10
+            && orientation * cross(b, c, point) >= -1e-10
+            && orientation * cross(c, a, point) >= -1e-10
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2Resources.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Resources.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+public struct Trellis2Checkpoint: Hashable, Sendable {
+    public let modelID: String
+    public let rootURL: URL
+    public let sparseStructureFlowURL: URL
+    public let sparseStructureDecoderURL: URL
+    public let shapeFlowURL: URL
+    public let shapeDecoderURL: URL
+    public let textureFlowURL: URL
+    public let textureDecoderURL: URL
+    public let dinoV3URL: URL
+
+    public init(rootURL: URL) throws {
+        let root = rootURL.standardizedFileURL
+        let validation = Trellis2Resources.validationMessages(in: root)
+        guard validation.isEmpty else {
+            throw Trellis2ResourceError.invalidCheckpoint(validation.joined(separator: "; "))
+        }
+        self.init(verifiedRootURL: root)
+    }
+
+    /// Tests and already-verified managed-resolution paths can construct the
+    /// value without re-hashing eleven gigabytes. This remains module-internal
+    /// so public callers cannot bypass checkpoint admission.
+    init(verifiedRootURL rootURL: URL) {
+        let root = rootURL.standardizedFileURL
+        self.modelID = Trellis2Resources.defaultModelID
+        self.rootURL = root
+        self.sparseStructureFlowURL = root.appendingPathComponent(
+            "ckpts/ss_flow_img_dit_1_3B_64_bf16.safetensors"
+        )
+        self.shapeFlowURL = root.appendingPathComponent(
+            "ckpts/slat_flow_img2shape_dit_1_3B_512_bf16.safetensors"
+        )
+        self.textureFlowURL = root.appendingPathComponent(
+            "ckpts/slat_flow_imgshape2tex_dit_1_3B_512_bf16.safetensors"
+        )
+        self.shapeDecoderURL = root.appendingPathComponent(
+            "ckpts/shape_dec_next_dc_f16c32_fp16.safetensors"
+        )
+        self.textureDecoderURL = root.appendingPathComponent(
+            "ckpts/tex_dec_next_dc_f16c32_fp16.safetensors"
+        )
+        self.sparseStructureDecoderURL = root.appendingPathComponent(
+            "dependencies/trellis-image-large/ckpts/ss_dec_conv3d_16l8_fp16.safetensors"
+        )
+        self.dinoV3URL = root.appendingPathComponent("dependencies/dinov3/model.safetensors")
+    }
+}
+
+public enum Trellis2ResourceError: Error, Equatable, LocalizedError, Sendable {
+    case unsupportedModel(String)
+    case checkpointNotFound(String)
+    case invalidCheckpoint(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedModel(let model):
+            "Unsupported TRELLIS.2 model '\(model)'. Only \(Trellis2Resources.defaultModelID) is permitted."
+        case .checkpointNotFound(let path):
+            "TRELLIS.2 checkpoint directory was not found: \(path)"
+        case .invalidCheckpoint(let detail):
+            "Invalid TRELLIS.2 checkpoint: \(detail)"
+        }
+    }
+}
+
+public enum Trellis2Resources {
+    public static let defaultModelID = ModelResolver.ModelID.image3DTrellis2.rawValue
+    public static let repository = "microsoft/TRELLIS.2-4B"
+    public static let revision = "af44b45f2e35a493886929c6d786e563ec68364d"
+    public static let sparseStructureRepository = "microsoft/TRELLIS-image-large"
+    public static let sparseStructureRevision = "25e0d31ffbebe4b5a97464dd851910efc3002d96"
+    public static let dinoV3Repository = "facebook/dinov3-vitl16-pretrain-lvd1689m"
+    public static let dinoV3Revision = "ea8dc2863c51be0a264bab82070e3e8836b02d51"
+    public static let primaryWeightsSHA256 =
+        "ca01377c485bec418076d38ee80166d32dc776d744f2553b835cba1e97a7abf6"
+
+    public static let primaryHubFallback = HubFallbackConfig(
+        repoId: repository,
+        revision: revision,
+        patterns: [
+            "README.md",
+            "pipeline.json",
+            "ckpts/ss_flow_img_dit_1_3B_64_bf16.json",
+            "ckpts/ss_flow_img_dit_1_3B_64_bf16.safetensors",
+            "ckpts/slat_flow_img2shape_dit_1_3B_512_bf16.json",
+            "ckpts/slat_flow_img2shape_dit_1_3B_512_bf16.safetensors",
+            "ckpts/slat_flow_imgshape2tex_dit_1_3B_512_bf16.json",
+            "ckpts/slat_flow_imgshape2tex_dit_1_3B_512_bf16.safetensors",
+            "ckpts/shape_dec_next_dc_f16c32_fp16.json",
+            "ckpts/shape_dec_next_dc_f16c32_fp16.safetensors",
+            "ckpts/tex_dec_next_dc_f16c32_fp16.json",
+            "ckpts/tex_dec_next_dc_f16c32_fp16.safetensors",
+        ]
+    )
+
+    public static let mountedHubFallbacks = [
+        MountedHubFallbackConfig(
+            destinationPath: "dependencies/trellis-image-large",
+            hubFallback: HubFallbackConfig(
+                repoId: sparseStructureRepository,
+                revision: sparseStructureRevision,
+                patterns: [
+                    "README.md",
+                    "ckpts/ss_dec_conv3d_16l8_fp16.json",
+                    "ckpts/ss_dec_conv3d_16l8_fp16.safetensors",
+                ]
+            )
+        ),
+        MountedHubFallbackConfig(
+            destinationPath: "dependencies/dinov3",
+            hubFallback: HubFallbackConfig(
+                repoId: dinoV3Repository,
+                revision: dinoV3Revision,
+                patterns: [
+                    "LICENSE.md",
+                    "README.md",
+                    "config.json",
+                    "preprocessor_config.json",
+                    "model.safetensors",
+                ]
+            )
+        ),
+    ]
+
+    static let artifactPins = [
+        ModelArtifactPin(
+            filename: "ckpts/ss_flow_img_dit_1_3B_64_bf16.safetensors",
+            byteCount: 2_584_426_920,
+            sha256: "ca01377c485bec418076d38ee80166d32dc776d744f2553b835cba1e97a7abf6"
+        ),
+        ModelArtifactPin(
+            filename: "ckpts/slat_flow_img2shape_dit_1_3B_512_bf16.safetensors",
+            byteCount: 2_584_574_424,
+            sha256: "ec5e0917ef9b7e25ad51dffc7d19687a42019871f94239f2fa7f86264c55b70f"
+        ),
+        ModelArtifactPin(
+            filename: "ckpts/slat_flow_imgshape2tex_dit_1_3B_512_bf16.safetensors",
+            byteCount: 2_584_672_728,
+            sha256: "8371aa1c5d13be79dcd5ddfd2cf3835e902e204dc34427169a1c702828e1a94d"
+        ),
+        ModelArtifactPin(
+            filename: "ckpts/shape_dec_next_dc_f16c32_fp16.safetensors",
+            byteCount: 948_490_494,
+            sha256: "e3b718d3e43e4f8780e9a24ac6fff231811a67e3b058e336e10fe654c911d581"
+        ),
+        ModelArtifactPin(
+            filename: "ckpts/tex_dec_next_dc_f16c32_fp16.safetensors",
+            byteCount: 948_458_812,
+            sha256: "97ea69addea2ecd9312910f5f548234665eef51c088386180b7cd5b258645e3c"
+        ),
+        ModelArtifactPin(
+            filename: "dependencies/trellis-image-large/ckpts/ss_dec_conv3d_16l8_fp16.safetensors",
+            byteCount: 147_591_972,
+            sha256: "1c76d4a40519aa2d711cc263a8404105231ac26db31d946bed48b84fee79009a"
+        ),
+        ModelArtifactPin(
+            filename: "dependencies/dinov3/model.safetensors",
+            byteCount: 1_212_559_808,
+            sha256: "dcb2e45127cccbf1601e5f42fef165eea275c8e5213197e8dcf3f48822718179"
+        ),
+    ]
+
+    public static let checkpointComponentManifests: [Trellis2CheckpointComponentManifest] = [
+        .init(name: "sparse-structure-flow", repository: repository, revision: revision,
+              relativePath: artifactPins[0].filename, byteCount: artifactPins[0].byteCount,
+              sha256: artifactPins[0].sha256, license: "MIT"),
+        .init(name: "shape-flow-512", repository: repository, revision: revision,
+              relativePath: artifactPins[1].filename, byteCount: artifactPins[1].byteCount,
+              sha256: artifactPins[1].sha256, license: "MIT"),
+        .init(name: "texture-flow-512", repository: repository, revision: revision,
+              relativePath: artifactPins[2].filename, byteCount: artifactPins[2].byteCount,
+              sha256: artifactPins[2].sha256, license: "MIT"),
+        .init(name: "shape-decoder", repository: repository, revision: revision,
+              relativePath: artifactPins[3].filename, byteCount: artifactPins[3].byteCount,
+              sha256: artifactPins[3].sha256, license: "MIT"),
+        .init(name: "texture-decoder", repository: repository, revision: revision,
+              relativePath: artifactPins[4].filename, byteCount: artifactPins[4].byteCount,
+              sha256: artifactPins[4].sha256, license: "MIT"),
+        .init(name: "sparse-structure-decoder", repository: sparseStructureRepository,
+              revision: sparseStructureRevision, relativePath: artifactPins[5].filename,
+              byteCount: artifactPins[5].byteCount, sha256: artifactPins[5].sha256, license: "MIT"),
+        .init(name: "dinov3-vitl16", repository: dinoV3Repository, revision: dinoV3Revision,
+              relativePath: artifactPins[6].filename, byteCount: artifactPins[6].byteCount,
+              sha256: artifactPins[6].sha256, license: "DINOv3 License"),
+    ]
+
+    private static let requiredRelativePaths = [
+        "README.md",
+        "pipeline.json",
+        "ckpts/ss_flow_img_dit_1_3B_64_bf16.json",
+        "ckpts/slat_flow_img2shape_dit_1_3B_512_bf16.json",
+        "ckpts/slat_flow_imgshape2tex_dit_1_3B_512_bf16.json",
+        "ckpts/shape_dec_next_dc_f16c32_fp16.json",
+        "ckpts/tex_dec_next_dc_f16c32_fp16.json",
+        "dependencies/trellis-image-large/ckpts/ss_dec_conv3d_16l8_fp16.json",
+        "dependencies/dinov3/LICENSE.md",
+        "dependencies/dinov3/config.json",
+    ]
+
+    public static func resolve(requestedModel: String?) async throws -> Trellis2Checkpoint {
+        let requested = requestedModel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !requested.isEmpty {
+            let explicit = URL(fileURLWithPath: requested).standardizedFileURL
+            if FileManager.default.fileExists(atPath: explicit.path) {
+                return try Trellis2Checkpoint(rootURL: explicit)
+            }
+            if requested.contains("/") || requested.hasPrefix(".") || requested.hasPrefix("~") {
+                throw Trellis2ResourceError.checkpointNotFound(explicit.path)
+            }
+        }
+        let modelID = requested.isEmpty ? defaultModelID : requested.lowercased()
+        guard modelID == defaultModelID else {
+            throw Trellis2ResourceError.unsupportedModel(modelID)
+        }
+        let resolution = try await ManagedModelResolver.resolveForRuntime(
+            requestedModel: modelID,
+            defaultModelID: defaultModelID,
+            allowAutoDownload: false
+        )
+        // Managed resolution has already run the checksum-backed TRELLIS.2
+        // validator. Avoid reading eleven gigabytes a second time at startup.
+        return Trellis2Checkpoint(verifiedRootURL: resolution.url)
+    }
+
+    public static func validate(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        var invalid = requiredRelativePaths
+            .map { rootURL.appendingPathComponent($0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+        for pin in artifactPins {
+            do {
+                _ = try pin.verify(in: rootURL, fileManager: fileManager)
+            } catch {
+                invalid.append(rootURL.appendingPathComponent(pin.filename))
+            }
+        }
+        return invalid
+    }
+
+    public static func validationMessages(
+        in rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        validate(rootURL: rootURL, fileManager: fileManager).map {
+            "Missing or mismatched TRELLIS.2 artifact: \($0.path)"
+        }
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2SparseDecoder.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2SparseDecoder.swift
@@ -1,0 +1,223 @@
+import Foundation
+@preconcurrency import MLX
+import MLXFast
+import MLXNN
+
+struct Trellis2SparseDecoderOutput {
+    let tensor: Trellis2SparseTensor
+    let subdivisions: [Trellis2Subdivision]
+}
+
+/// Functional MLX port of TRELLIS.2's sparse ConvNeXt decoder. Both shape and
+/// PBR decoders use this graph; the shape checkpoint predicts its subdivision
+/// tree and the texture checkpoint follows that same tree.
+struct Trellis2SparseDecoder {
+    enum Kind {
+        case shape
+        case texture
+
+        var outputChannels: Int {
+            switch self {
+            case .shape: 7
+            case .texture: 6
+            }
+        }
+
+        var predictsSubdivisions: Bool { self == .shape }
+    }
+
+    private static let modelChannels = [1_024, 512, 256, 128, 64]
+    private static let blockCounts = [4, 16, 8, 4, 0]
+
+    let kind: Kind
+    private let weights: Trellis2WeightStore
+
+    init(kind: Kind, checkpointURL: URL) throws {
+        self.kind = kind
+        self.weights = try Trellis2WeightStore(url: checkpointURL)
+        try validateWeights()
+    }
+
+    init(kind: Kind, weights: [String: MLXArray]) throws {
+        self.kind = kind
+        self.weights = Trellis2WeightStore(values: weights)
+        try validateWeights()
+    }
+
+    private func validateWeights() throws {
+        _ = try weights.checkedTensor("from_latent.weight", shape: [1_024, 32])
+        _ = try weights.checkedTensor(
+            "output_layer.weight",
+            shape: [kind.outputChannels, 64]
+        )
+        for level in 0..<Self.blockCounts.count {
+            let channels = Self.modelChannels[level]
+            for block in 0..<Self.blockCounts[level] {
+                let prefix = "blocks.\(level).\(block)"
+                _ = try weights.checkedTensor(
+                    "\(prefix).conv.weight",
+                    shape: [channels, 3, 3, 3, channels]
+                )
+                _ = try weights.checkedTensor(
+                    "\(prefix).mlp.0.weight",
+                    shape: [4 * channels, channels]
+                )
+                _ = try weights.checkedTensor(
+                    "\(prefix).mlp.2.weight",
+                    shape: [channels, 4 * channels]
+                )
+            }
+            if level < Self.modelChannels.count - 1 {
+                let prefix = "blocks.\(level).\(Self.blockCounts[level])"
+                _ = try weights.checkedTensor(
+                    "\(prefix).conv1.weight",
+                    shape: [8 * Self.modelChannels[level + 1], 3, 3, 3, channels]
+                )
+                _ = try weights.checkedTensor(
+                    "\(prefix).conv2.weight",
+                    shape: [Self.modelChannels[level + 1], 3, 3, 3, Self.modelChannels[level + 1]]
+                )
+                if kind.predictsSubdivisions {
+                    _ = try weights.checkedTensor(
+                        "\(prefix).to_subdiv.weight",
+                        shape: [8, channels]
+                    )
+                }
+            }
+        }
+    }
+
+    func decode(
+        _ latent: Trellis2SparseTensor,
+        guideSubdivisions: [Trellis2Subdivision]? = nil,
+        maximumTokens: Int
+    ) throws -> Trellis2SparseDecoderOutput {
+        guard latent.channels == 32 else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[tokens, 32] structured latent",
+                actual: latent.features.shape
+            )
+        }
+        if kind == .texture, guideSubdivisions?.count != 4 {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "four shape subdivision guides",
+                actual: [guideSubdivisions?.count ?? 0]
+            )
+        }
+
+        var hidden = try latent.replacing(features: weights.linear(
+            latent.features,
+            prefix: "from_latent"
+        ))
+        var subdivisions = [Trellis2Subdivision]()
+        subdivisions.reserveCapacity(4)
+
+        for level in 0..<Self.modelChannels.count {
+            for block in 0..<Self.blockCounts[level] {
+                hidden = try convNeXtBlock(hidden, prefix: "blocks.\(level).\(block)")
+                MLX.eval(hidden.features)
+                Memory.clearCache()
+            }
+            if level < Self.modelChannels.count - 1 {
+                let prefix = "blocks.\(level).\(Self.blockCounts[level])"
+                let guide: Trellis2Subdivision
+                if kind.predictsSubdivisions {
+                    let logits = try weights.linear(hidden.features, prefix: "\(prefix).to_subdiv")
+                    guide = try Trellis2Subdivision(logits: logits, topology: hidden.topology)
+                    subdivisions.append(guide)
+                } else {
+                    guide = guideSubdivisions![level]
+                }
+                hidden = try channelToSpatialBlock(
+                    hidden,
+                    subdivision: guide,
+                    prefix: prefix,
+                    outputChannels: Self.modelChannels[level + 1],
+                    maximumTokens: maximumTokens
+                )
+                MLX.eval(hidden.features)
+                Memory.clearCache()
+            }
+        }
+
+        let normalized = MLXFast.layerNorm(hidden.features.asType(.float32), eps: 1e-6)
+            .asType(hidden.features.dtype)
+        let output = try hidden.replacing(features: weights.linear(
+            normalized,
+            prefix: "output_layer"
+        ))
+        return Trellis2SparseDecoderOutput(tensor: output, subdivisions: subdivisions)
+    }
+
+    private func convNeXtBlock(
+        _ input: Trellis2SparseTensor,
+        prefix: String
+    ) throws -> Trellis2SparseTensor {
+        var hidden = try Trellis2SparseOperations.convolution(
+            input,
+            weights: weights,
+            prefix: "\(prefix).conv"
+        )
+        hidden = try hidden.replacing(features: affineLayerNorm(
+            hidden.features,
+            prefix: "\(prefix).norm"
+        ))
+        var features = try weights.linear(hidden.features, prefix: "\(prefix).mlp.0")
+        features = silu(features)
+        features = try weights.linear(features, prefix: "\(prefix).mlp.2")
+        return try input.replacing(features: input.features + features)
+    }
+
+    private func channelToSpatialBlock(
+        _ input: Trellis2SparseTensor,
+        subdivision: Trellis2Subdivision,
+        prefix: String,
+        outputChannels: Int,
+        maximumTokens: Int
+    ) throws -> Trellis2SparseTensor {
+        let normalized = affineLayerNorm(input.features, prefix: "\(prefix).norm1")
+        var hidden = try input.replacing(features: silu(normalized))
+        hidden = try Trellis2SparseOperations.convolution(
+            hidden,
+            weights: weights,
+            prefix: "\(prefix).conv1"
+        )
+        hidden = try Trellis2SparseOperations.channelToSpatial(
+            hidden,
+            subdivision: subdivision,
+            maximumTokens: maximumTokens
+        )
+
+        var residual = try Trellis2SparseOperations.channelToSpatial(
+            input,
+            subdivision: subdivision,
+            maximumTokens: maximumTokens
+        )
+        let repeatCount = outputChannels / residual.channels
+        residual = try residual.replacing(features: MLX.repeated(
+            residual.features,
+            count: repeatCount,
+            axis: 1
+        ))
+
+        var features = MLXFast.layerNorm(hidden.features.asType(.float32), eps: 1e-6)
+            .asType(hidden.features.dtype)
+        features = silu(features)
+        hidden = try hidden.replacing(features: features)
+        hidden = try Trellis2SparseOperations.convolution(
+            hidden,
+            weights: weights,
+            prefix: "\(prefix).conv2"
+        )
+        return try hidden.replacing(features: hidden.features + residual.features)
+    }
+
+    private func affineLayerNorm(_ input: MLXArray, prefix: String) -> MLXArray {
+        MLXFast.layerNorm(
+            input.asType(.float32),
+            weight: weights.values["\(prefix).weight"]!.asType(.float32),
+            bias: weights.values["\(prefix).bias"]!.asType(.float32),
+            eps: 1e-6
+        ).asType(input.dtype)
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2SparseTensor.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2SparseTensor.swift
@@ -1,0 +1,219 @@
+import Foundation
+@preconcurrency import MLX
+
+/// CPU-side coordinate topology paired with Metal-resident feature rows.
+/// TRELLIS.2 uses submanifold convolutions, so every convolution at a given
+/// level shares this exact neighbor map.
+final class Trellis2SparseTopology {
+    let coordinates: [Trellis2VoxelCoordinate]
+    private let coordinateIndices: [Trellis2VoxelCoordinate: Int]
+    private var cachedNeighbors: [Trellis2SparseNeighborPairs]?
+
+    init(coordinates: [Trellis2VoxelCoordinate]) {
+        self.coordinates = coordinates
+        self.coordinateIndices = Dictionary(
+            uniqueKeysWithValues: coordinates.enumerated().map { ($1, $0) }
+        )
+    }
+
+    var count: Int { coordinates.count }
+
+    /// Source/destination pairs for twenty-seven kernels in checkpoint order:
+    /// x, then y, then z. Missing neighbors are omitted so sparse convolution
+    /// does not spend a dense matmul on zero rows.
+    func convolutionNeighbors() -> [Trellis2SparseNeighborPairs] {
+        if let cachedNeighbors { return cachedNeighbors }
+
+        var result = [Trellis2SparseNeighborPairs]()
+        result.reserveCapacity(27)
+        for kernelX in 0..<3 {
+            for kernelY in 0..<3 {
+                for kernelZ in 0..<3 {
+                    let deltaX = Int32(kernelX - 1)
+                    let deltaY = Int32(kernelY - 1)
+                    let deltaZ = Int32(kernelZ - 1)
+                    var sources = [Int32]()
+                    var destinations = [Int32]()
+                    sources.reserveCapacity(coordinates.count)
+                    destinations.reserveCapacity(coordinates.count)
+                    for (destination, coordinate) in coordinates.enumerated() {
+                        guard let source = coordinateIndices[
+                            coordinate.offset(x: deltaX, y: deltaY, z: deltaZ)
+                        ] else { continue }
+                        sources.append(Int32(source))
+                        destinations.append(Int32(destination))
+                    }
+                    result.append(Trellis2SparseNeighborPairs(
+                        sources: sources,
+                        destinations: destinations
+                    ))
+                }
+            }
+        }
+        cachedNeighbors = result
+        return result
+    }
+}
+
+struct Trellis2SparseNeighborPairs {
+    let sources: [Int32]
+    let destinations: [Int32]
+}
+
+struct Trellis2SparseTensor {
+    let features: MLXArray
+    let topology: Trellis2SparseTopology
+
+    init(features: MLXArray, coordinates: [Trellis2VoxelCoordinate]) throws {
+        guard features.ndim == 2, features.dim(0) == coordinates.count else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[\(coordinates.count), channels] sparse features",
+                actual: features.shape
+            )
+        }
+        self.features = features
+        self.topology = Trellis2SparseTopology(coordinates: coordinates)
+    }
+
+    init(features: MLXArray, topology: Trellis2SparseTopology) throws {
+        guard features.ndim == 2, features.dim(0) == topology.count else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[\(topology.count), channels] sparse features",
+                actual: features.shape
+            )
+        }
+        self.features = features
+        self.topology = topology
+    }
+
+    var coordinates: [Trellis2VoxelCoordinate] { topology.coordinates }
+    var count: Int { topology.count }
+    var channels: Int { features.dim(1) }
+
+    func replacing(features: MLXArray) throws -> Trellis2SparseTensor {
+        try Trellis2SparseTensor(features: features, topology: topology)
+    }
+}
+
+struct Trellis2Subdivision {
+    let parentCoordinates: [Trellis2VoxelCoordinate]
+    let activeChildren: [[Bool]]
+
+    init(logits: MLXArray, topology: Trellis2SparseTopology) throws {
+        guard logits.shape == [topology.count, 8] else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[\(topology.count), 8] subdivision logits",
+                actual: logits.shape
+            )
+        }
+        MLX.eval(logits)
+        let values = logits.asType(.float32).asArray(Float.self)
+        self.parentCoordinates = topology.coordinates
+        self.activeChildren = (0..<topology.count).map { parent in
+            (0..<8).map { child in values[parent * 8 + child] > 0 }
+        }
+    }
+}
+
+enum Trellis2SparseOperations {
+    static func linear(
+        _ input: MLXArray,
+        weights: Trellis2WeightStore,
+        prefix: String
+    ) throws -> MLXArray {
+        try weights.linear(input, prefix: prefix)
+    }
+
+    static func convolution(
+        _ input: Trellis2SparseTensor,
+        weights: Trellis2WeightStore,
+        prefix: String
+    ) throws -> Trellis2SparseTensor {
+        let weight = try weights.tensor("\(prefix).weight")
+        guard weight.ndim == 5,
+              weight.dim(1) == 3,
+              weight.dim(2) == 3,
+              weight.dim(3) == 3,
+              weight.dim(4) == input.channels else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[output, 3, 3, 3, \(input.channels)] sparse convolution weight",
+                actual: weight.shape
+            )
+        }
+
+        let typedFeatures = input.features.asType(weight.dtype)
+        let neighbors = input.topology.convolutionNeighbors()
+        var output = MLX.zeros([input.count, weight.dim(0)], dtype: weight.dtype)
+        var kernelIndex = 0
+        for kernelX in 0..<3 {
+            for kernelY in 0..<3 {
+                for kernelZ in 0..<3 {
+                    let pairs = neighbors[kernelIndex]
+                    guard !pairs.sources.isEmpty else {
+                        kernelIndex += 1
+                        continue
+                    }
+                    let gathered = MLX.take(
+                        typedFeatures,
+                        MLXArray(pairs.sources),
+                        axis: 0
+                    )
+                    let kernel = weight[0..., kernelX, kernelY, kernelZ, 0...]
+                    let updates = MLX.matmul(gathered, kernel.transposed())
+                    output = output.at[MLXArray(pairs.destinations)].add(updates)
+                    kernelIndex += 1
+                }
+            }
+        }
+        if let bias = weights.values["\(prefix).bias"] {
+            output = output + bias
+        }
+        return try input.replacing(features: output)
+    }
+
+    static func channelToSpatial(
+        _ input: Trellis2SparseTensor,
+        subdivision: Trellis2Subdivision,
+        maximumTokens: Int
+    ) throws -> Trellis2SparseTensor {
+        guard subdivision.parentCoordinates == input.coordinates else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "subdivision coordinates matching sparse features",
+                actual: [subdivision.parentCoordinates.count, input.count]
+            )
+        }
+        guard input.channels.isMultiple(of: 8) else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "sparse channel count divisible by 8",
+                actual: input.features.shape
+            )
+        }
+
+        var coordinates = [Trellis2VoxelCoordinate]()
+        var featureRows = [Int32]()
+        coordinates.reserveCapacity(min(input.count * 8, maximumTokens))
+        featureRows.reserveCapacity(min(input.count * 8, maximumTokens))
+        for parentIndex in 0..<input.count {
+            let parent = input.coordinates[parentIndex]
+            for child in 0..<8 where subdivision.activeChildren[parentIndex][child] {
+                coordinates.append(Trellis2VoxelCoordinate(
+                    x: parent.x * 2 + Int32(child & 1),
+                    y: parent.y * 2 + Int32((child >> 1) & 1),
+                    z: parent.z * 2 + Int32((child >> 2) & 1)
+                ))
+                featureRows.append(Int32(parentIndex * 8 + child))
+            }
+        }
+        guard !coordinates.isEmpty else { throw Trellis2ModelError.emptySparseStructure }
+        guard coordinates.count <= maximumTokens else {
+            throw Trellis2ModelError.excessiveSparseStructure(
+                actual: coordinates.count,
+                maximum: maximumTokens
+            )
+        }
+
+        let reshaped = input.features.reshaped(input.count * 8, input.channels / 8)
+        let selected = MLX.take(reshaped, MLXArray(featureRows), axis: 0)
+        return try Trellis2SparseTensor(features: selected, coordinates: coordinates)
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2StructureDecoder.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2StructureDecoder.swift
@@ -1,0 +1,167 @@
+import Foundation
+@preconcurrency import MLX
+import MLXFast
+import MLXNN
+
+/// Native MLX port of the dense 16-latent TRELLIS sparse-structure decoder.
+/// The official dependency checkpoint is stored as PyTorch NCDHW kernels;
+/// kernels are transposed at use time into MLX's NDHWC layout.
+struct Trellis2StructureDecoder {
+    private let weights: Trellis2WeightStore
+
+    init(checkpointURL: URL) throws {
+        self.weights = try Trellis2WeightStore(url: checkpointURL)
+        try validateWeights()
+    }
+
+    init(weights: [String: MLXArray]) throws {
+        self.weights = Trellis2WeightStore(values: weights)
+        try validateWeights()
+    }
+
+    private func validateWeights() throws {
+        _ = try weights.checkedTensor("input_layer.weight", shape: [512, 8, 3, 3, 3])
+        _ = try weights.checkedTensor("out_layer.2.weight", shape: [1, 32, 3, 3, 3])
+        let residuals: [(String, Int)] = [
+            ("middle_block.0", 512),
+            ("middle_block.1", 512),
+            ("blocks.0", 512),
+            ("blocks.1", 512),
+            ("blocks.3", 128),
+            ("blocks.4", 128),
+            ("blocks.6", 32),
+            ("blocks.7", 32),
+        ]
+        for (prefix, channels) in residuals {
+            _ = try weights.checkedTensor(
+                "\(prefix).conv1.weight",
+                shape: [channels, channels, 3, 3, 3]
+            )
+            _ = try weights.checkedTensor(
+                "\(prefix).conv2.weight",
+                shape: [channels, channels, 3, 3, 3]
+            )
+        }
+        _ = try weights.checkedTensor("blocks.2.conv.weight", shape: [1_024, 512, 3, 3, 3])
+        _ = try weights.checkedTensor("blocks.5.conv.weight", shape: [256, 128, 3, 3, 3])
+    }
+
+    func decode(
+        latentTokens: MLXArray,
+        outputResolution: Int = 32,
+        maximumTokens: Int
+    ) throws -> [Trellis2VoxelCoordinate] {
+        guard latentTokens.shape == [1, 4_096, 8] else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "[1, 4096, 8] sparse-structure latent",
+                actual: latentTokens.shape
+            )
+        }
+        guard outputResolution == 32 || outputResolution == 64 else {
+            throw Trellis2ModelError.unsupportedCheckpoint(
+                "the native structure decoder supports 32 or 64 output coordinates"
+            )
+        }
+
+        var hidden = latentTokens.reshaped(1, 16, 16, 16, 8)
+        hidden = try convolution(hidden, prefix: "input_layer").asType(.float16)
+        hidden = try residualBlock(hidden, prefix: "middle_block.0")
+        hidden = try residualBlock(hidden, prefix: "middle_block.1")
+        hidden = try residualBlock(hidden, prefix: "blocks.0")
+        hidden = try residualBlock(hidden, prefix: "blocks.1")
+        hidden = try pixelShuffle3D(convolution(hidden, prefix: "blocks.2.conv"))
+        hidden = try residualBlock(hidden, prefix: "blocks.3")
+        hidden = try residualBlock(hidden, prefix: "blocks.4")
+        hidden = try pixelShuffle3D(convolution(hidden, prefix: "blocks.5.conv"))
+        hidden = affineLayerNorm(hidden, prefix: "out_layer.0")
+        hidden = silu(hidden)
+        hidden = try convolution(hidden.asType(.float32), prefix: "out_layer.2")
+        MLX.eval(hidden)
+
+        let occupied = (hidden[0, 0..., 0..., 0..., 0] .> 0)
+            .asType(.int32)
+            .asArray(Int32.self)
+        var coordinates = Set<Trellis2VoxelCoordinate>()
+        coordinates.reserveCapacity(min(maximumTokens, 49_152))
+        for x in 0..<64 {
+            for y in 0..<64 {
+                for z in 0..<64 where occupied[(x * 64 + y) * 64 + z] != 0 {
+                    let divisor = Int32(64 / outputResolution)
+                    coordinates.insert(Trellis2VoxelCoordinate(
+                        x: Int32(x) / divisor,
+                        y: Int32(y) / divisor,
+                        z: Int32(z) / divisor
+                    ))
+                }
+            }
+        }
+        guard !coordinates.isEmpty else { throw Trellis2ModelError.emptySparseStructure }
+        guard coordinates.count <= maximumTokens else {
+            throw Trellis2ModelError.excessiveSparseStructure(
+                actual: coordinates.count,
+                maximum: maximumTokens
+            )
+        }
+        return coordinates.sorted {
+            ($0.x, $0.y, $0.z) < ($1.x, $1.y, $1.z)
+        }
+    }
+
+    private func residualBlock(_ input: MLXArray, prefix: String) throws -> MLXArray {
+        var hidden = affineLayerNorm(input, prefix: "\(prefix).norm1")
+        hidden = silu(hidden)
+        hidden = try convolution(hidden, prefix: "\(prefix).conv1")
+        hidden = affineLayerNorm(hidden, prefix: "\(prefix).norm2")
+        hidden = silu(hidden)
+        hidden = try convolution(hidden, prefix: "\(prefix).conv2")
+        return hidden + input
+    }
+
+    private func affineLayerNorm(_ input: MLXArray, prefix: String) -> MLXArray {
+        MLXFast.layerNorm(
+            input.asType(.float32),
+            weight: weights.values["\(prefix).weight"]!.asType(.float32),
+            bias: weights.values["\(prefix).bias"]!.asType(.float32),
+            eps: 1e-6
+        ).asType(input.dtype)
+    }
+
+    private func convolution(_ input: MLXArray, prefix: String) throws -> MLXArray {
+        let pytorchWeight = try weights.tensor("\(prefix).weight")
+        guard pytorchWeight.ndim == 5, pytorchWeight.dim(1) == input.dim(4) else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "PyTorch [output, \(input.dim(4)), depth, height, width] kernel",
+                actual: pytorchWeight.shape
+            )
+        }
+        let weight = pytorchWeight.transposed(0, 2, 3, 4, 1)
+        var output = MLX.conv3d(
+            input.asType(weight.dtype),
+            weight,
+            stride: 1,
+            padding: 1
+        )
+        if let bias = weights.values["\(prefix).bias"] {
+            output = output + bias
+        }
+        return output
+    }
+
+    private func pixelShuffle3D(_ input: MLXArray) throws -> MLXArray {
+        guard input.ndim == 5, input.dim(4).isMultiple(of: 8) else {
+            throw Trellis2ModelError.invalidInputShape(
+                expected: "NDHWC tensor with channels divisible by 8",
+                actual: input.shape
+            )
+        }
+        let batch = input.dim(0)
+        let depth = input.dim(1)
+        let height = input.dim(2)
+        let width = input.dim(3)
+        let channels = input.dim(4) / 8
+        return input
+            .reshaped(batch, depth, height, width, channels, 2, 2, 2)
+            .transposed(0, 1, 5, 2, 6, 3, 7, 4)
+            .reshaped(batch, depth * 2, height * 2, width * 2, channels)
+    }
+}

--- a/Sources/MereRunCore/ZImageI2L/Model/DINOv3Encoder.swift
+++ b/Sources/MereRunCore/ZImageI2L/Model/DINOv3Encoder.swift
@@ -119,10 +119,10 @@ final class DINOv3Attention: Module {
         self.scale = 1.0 / sqrt(Float(headDim))
 
         let hiddenSize = config.hiddenSize
-        self._qProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: false)
-        self._kProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: false)
-        self._vProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: false)
-        self._oProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._qProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: config.queryBias)
+        self._kProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: config.keyBias)
+        self._vProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: config.valueBias)
+        self._oProj.wrappedValue = Linear(hiddenSize, hiddenSize, bias: config.projectionBias)
     }
 
     func callAsFunction(
@@ -208,25 +208,28 @@ final class DINOv3Attention: Module {
     }
 }
 
-// MARK: - DINOv3 MLP (SwiGLU)
+// MARK: - DINOv3 MLP
 
 final class DINOv3MLP: Module {
-    @ModuleInfo(key: "gate_proj") private var gateProj: Linear
+    @ModuleInfo(key: "gate_proj") private var gateProj: Linear?
     @ModuleInfo(key: "up_proj") private var upProj: Linear
     @ModuleInfo(key: "down_proj") private var downProj: Linear
 
     init(config: DINOv3Config) {
-        // SwiGLU: gate and up project to intermediate, down projects back
-        // intermediate is 8192 for 7B model (2x hidden)
-        let intermediateSize = config.hiddenSize * 2  // 4096 * 2 = 8192
-        self._gateProj.wrappedValue = Linear(config.hiddenSize, intermediateSize, bias: true)
-        self._upProj.wrappedValue = Linear(config.hiddenSize, intermediateSize, bias: true)
-        self._downProj.wrappedValue = Linear(intermediateSize, config.hiddenSize, bias: true)
+        let intermediateSize = config.intermediateSize
+        self._gateProj.wrappedValue = config.useGatedMLP
+            ? Linear(config.hiddenSize, intermediateSize, bias: config.mlpBias)
+            : nil
+        self._upProj.wrappedValue = Linear(config.hiddenSize, intermediateSize, bias: config.mlpBias)
+        self._downProj.wrappedValue = Linear(intermediateSize, config.hiddenSize, bias: config.mlpBias)
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        // SwiGLU activation: silu(gate) * up, then down
-        return downProj(silu(gateProj(x)) * upProj(x))
+        let up = upProj(x)
+        if let gateProj {
+            return downProj(silu(gateProj(x)) * up)
+        }
+        return downProj(gelu(up))
     }
 }
 
@@ -356,8 +359,7 @@ public final class DINOv3VisionModel: Module {
         self._norm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEps)
     }
 
-    /// Forward pass returning CLS token and patch embeddings
-    public func callAsFunction(_ pixelValues: MLXArray) -> (cls: MLXArray, patches: MLXArray) {
+    private func transformerHiddenStates(_ pixelValues: MLXArray) -> (hidden: MLXArray, prefixTokens: Int) {
         // Embed patches and prepend special tokens
         let (embeds, numPrefixTokens, gridH, gridW) = embeddings(pixelValues)
 
@@ -373,10 +375,34 @@ public final class DINOv3VisionModel: Module {
                 rotarySin: rotarySin,
                 numPrefixTokens: numPrefixTokens
             )
+            MLX.eval(hiddenStates)
+            Memory.clearCache()
         }
 
-        // Final layer norm
-        hiddenStates = norm(hiddenStates)
+        return (hiddenStates, numPrefixTokens)
+    }
+
+    /// Return every CLS, register, and patch token after the model's learned
+    /// final norm. This is useful to consumers that need the complete token
+    /// sequence rather than the pooled CLS representation.
+    public func normalizedTokens(_ pixelValues: MLXArray) -> MLXArray {
+        let states = transformerHiddenStates(pixelValues)
+        return norm(states.hidden)
+    }
+
+    /// Return every token after an affine-free layer norm. Microsoft's
+    /// TRELLIS.2 feature extractor consumes DINOv3's pre-norm hidden states in
+    /// exactly this form instead of applying the checkpoint's final norm.
+    public func preNormalizedTokens(_ pixelValues: MLXArray) -> MLXArray {
+        let states = transformerHiddenStates(pixelValues)
+        return MLXFast.layerNorm(states.hidden, eps: config.layerNormEps)
+    }
+
+    /// Forward pass returning CLS token and patch embeddings.
+    public func callAsFunction(_ pixelValues: MLXArray) -> (cls: MLXArray, patches: MLXArray) {
+        let states = transformerHiddenStates(pixelValues)
+        let hiddenStates = norm(states.hidden)
+        let numPrefixTokens = states.prefixTokens
 
         // Extract CLS token and patches
         let cls = hiddenStates[0..., 0, 0...]  // [batch, hidden]

--- a/Sources/MereRunCore/ZImageI2L/ZImageI2LConfigs.swift
+++ b/Sources/MereRunCore/ZImageI2L/ZImageI2LConfigs.swift
@@ -32,6 +32,15 @@ public struct DINOv3Config: Sendable {
     public var numRegisterTokens: Int = 4
     public var useRoPE: Bool = true
     public var ropeTheta: Float = 100.0
+    /// The original Z-Image-i2L checkpoint uses a gated SwiGLU MLP. Standard
+    /// DINOv3 ViT checkpoints, including the ViT-L/16 encoder used by
+    /// TRELLIS.2, use a single GELU projection instead.
+    public var useGatedMLP: Bool = true
+    public var queryBias: Bool = false
+    public var keyBias: Bool = false
+    public var valueBias: Bool = false
+    public var projectionBias: Bool = true
+    public var mlpBias: Bool = true
 
     public var headDim: Int { hiddenSize / numAttentionHeads }
 

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -90,6 +90,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
         XCTAssertEqual(visionNames, Set([
             "caption", "inspect", "ground", "segment", "track", "track-live", "pose", "flow", "ocr",
             "depth-video", "geometry", "geometry-multiview", "image-to-3d", "image-to-3d-multiview",
+            "image-to-3d-trellis2",
         ]))
 
         let videoNames = Set(Video.configuration.subcommands.map { $0.configuration.commandName })

--- a/Tests/MereRunCLITests/Trellis2CommandTests.swift
+++ b/Tests/MereRunCLITests/Trellis2CommandTests.swift
@@ -34,7 +34,7 @@ final class Trellis2CommandTests: XCTestCase {
     func testImageCommandUsesMatchingDefaults() throws {
         let command = try ImageReconstruct3DTrellis2.parse(["/tmp/chair.png"])
         XCTAssertEqual(command.seed, 42)
-        XCTAssertEqual(command.maxTokens, 1_048_576)
+        XCTAssertEqual(command.maxTokens, 2_097_152)
         XCTAssertFalse(command.alreadyFramed)
         XCTAssertFalse(command.dryRun)
     }

--- a/Tests/MereRunCLITests/Trellis2CommandTests.swift
+++ b/Tests/MereRunCLITests/Trellis2CommandTests.swift
@@ -1,0 +1,49 @@
+import MereRunCore
+import XCTest
+@testable import MereRunCLI
+
+final class Trellis2CommandTests: XCTestCase {
+    func testBothPublicCommandPathsRegister() {
+        let imageCommands = Set(Image.configuration.subcommands.map { $0.configuration.commandName })
+        let visionCommands = Set(Vision.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(imageCommands.contains("reconstruct-3d-trellis2"))
+        XCTAssertTrue(visionCommands.contains("image-to-3d-trellis2"))
+    }
+
+    func testVisionCommandParsesNativeProductionControls() throws {
+        let command = try VisionImageTo3DTrellis2.parse([
+            "/tmp/chair.png",
+            "--output", "/tmp/chair-trellis2",
+            "--model", "image-3d-trellis2-4b",
+            "--seed", "1234",
+            "--max-tokens", "65536",
+            "--already-framed",
+            "--dry-run",
+            "--json",
+        ])
+        XCTAssertEqual(command.input, "/tmp/chair.png")
+        XCTAssertEqual(command.output, "/tmp/chair-trellis2")
+        XCTAssertEqual(command.model, "image-3d-trellis2-4b")
+        XCTAssertEqual(command.seed, 1_234)
+        XCTAssertEqual(command.maxTokens, 65_536)
+        XCTAssertTrue(command.alreadyFramed)
+        XCTAssertTrue(command.dryRun)
+        XCTAssertTrue(command.json)
+    }
+
+    func testImageCommandUsesMatchingDefaults() throws {
+        let command = try ImageReconstruct3DTrellis2.parse(["/tmp/chair.png"])
+        XCTAssertEqual(command.seed, 42)
+        XCTAssertEqual(command.maxTokens, 1_048_576)
+        XCTAssertFalse(command.alreadyFramed)
+        XCTAssertFalse(command.dryRun)
+    }
+
+    func testDefaultOutputUsesTrellis2SpecificDirectory() {
+        let input = URL(fileURLWithPath: "/tmp/chair.asset.png")
+        XCTAssertEqual(
+            VisionImageTo3DTrellis2.resolveOutputURL(nil, inputURL: input).path,
+            "/tmp/chair.asset-trellis2-3d"
+        )
+    }
+}

--- a/Tests/MereRunCLITests/VisionSegmentCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/VisionSegmentCommandParsingTests.swift
@@ -363,6 +363,7 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
         XCTAssertEqual(visionNames, Set([
             "caption", "inspect", "segment", "ground", "track", "track-live", "pose", "flow", "ocr",
             "depth-video", "geometry", "geometry-multiview", "image-to-3d", "image-to-3d-multiview",
+            "image-to-3d-trellis2",
         ]))
     }
 

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -1,0 +1,204 @@
+import MediaIO
+import MLX
+@testable import MereRunCore
+import XCTest
+
+final class Trellis2CoreTests: MereRunCoreTestCase {
+    func testProductionConfigurationsMatchPinned512Pipeline() {
+        XCTAssertEqual(Trellis2FlowConfiguration.sparseStructure512.resolution, 16)
+        XCTAssertEqual(Trellis2FlowConfiguration.sparseStructure512.inputChannels, 8)
+        XCTAssertEqual(Trellis2FlowConfiguration.shape512.inputChannels, 32)
+        XCTAssertEqual(Trellis2FlowConfiguration.texture512.inputChannels, 64)
+        XCTAssertEqual(Trellis2FlowConfiguration.texture512.outputChannels, 32)
+        XCTAssertEqual(Trellis2FlowConfiguration.texture512.modelChannels, 1_536)
+        XCTAssertEqual(Trellis2FlowConfiguration.texture512.blockCount, 30)
+        XCTAssertEqual(Trellis2FlowConfiguration.texture512.headCount, 12)
+        XCTAssertEqual(Trellis2FlowConfiguration.texture512.mlpChannels, 8_192)
+        XCTAssertEqual(Trellis2SamplerConfiguration.sparseStructure.steps, 12)
+        XCTAssertEqual(Trellis2SamplerConfiguration.shape.steps, 12)
+        XCTAssertEqual(Trellis2SamplerConfiguration.texture.steps, 12)
+        XCTAssertEqual(Trellis2SamplerConfiguration.shape.timesteps.count, 13)
+        XCTAssertEqual(Trellis2SamplerConfiguration.shape.timesteps.first, 1)
+        XCTAssertEqual(Trellis2SamplerConfiguration.shape.timesteps.last, 0)
+        XCTAssertEqual(Trellis2Normalization.shapeMean.count, 32)
+        XCTAssertEqual(Trellis2Normalization.textureStandardDeviation.count, 32)
+    }
+
+    func testDenseCoordinateOrderMatchesTorchMeshgridFlattening() {
+        let coordinates = Trellis2Generator.denseCoordinates(resolution: 2)
+        XCTAssertEqual(coordinates.count, 8)
+        XCTAssertEqual(coordinates[0], .init(x: 0, y: 0, z: 0))
+        XCTAssertEqual(coordinates[1], .init(x: 0, y: 0, z: 1))
+        XCTAssertEqual(coordinates[2], .init(x: 0, y: 1, z: 0))
+        XCTAssertEqual(coordinates[4], .init(x: 1, y: 0, z: 0))
+        XCTAssertEqual(coordinates[7], .init(x: 1, y: 1, z: 1))
+    }
+
+    func testSubmanifoldConvolutionPreservesCenterFeatures() throws {
+        let coordinates = [
+            Trellis2VoxelCoordinate(x: 0, y: 0, z: 0),
+            Trellis2VoxelCoordinate(x: 1, y: 0, z: 0),
+        ]
+        let sparse = try Trellis2SparseTensor(
+            features: MLXArray([Float(2), 3]).reshaped(2, 1),
+            coordinates: coordinates
+        )
+        var kernel = [Float](repeating: 0, count: 27)
+        kernel[13] = 1
+        let weights = Trellis2WeightStore(values: [
+            "conv.weight": MLXArray(kernel).reshaped(1, 3, 3, 3, 1),
+        ])
+        let output = try Trellis2SparseOperations.convolution(
+            sparse,
+            weights: weights,
+            prefix: "conv"
+        )
+        MLX.eval(output.features)
+        XCTAssertEqual(output.coordinates, coordinates)
+        XCTAssertEqual(output.features.asArray(Float.self), [2, 3])
+    }
+
+    func testSubmanifoldConvolutionAccumulatesOnlyExistingNeighbors() throws {
+        let coordinates = [
+            Trellis2VoxelCoordinate(x: 0, y: 0, z: 0),
+            Trellis2VoxelCoordinate(x: 1, y: 0, z: 0),
+        ]
+        let sparse = try Trellis2SparseTensor(
+            features: MLXArray([Float(2), 3]).reshaped(2, 1),
+            coordinates: coordinates
+        )
+        var kernel = [Float](repeating: 0, count: 27)
+        kernel[4] = 10
+        kernel[22] = 100
+        let weights = Trellis2WeightStore(values: [
+            "conv.weight": MLXArray(kernel).reshaped(1, 3, 3, 3, 1),
+        ])
+        let output = try Trellis2SparseOperations.convolution(
+            sparse,
+            weights: weights,
+            prefix: "conv"
+        )
+        MLX.eval(output.features)
+        XCTAssertEqual(output.features.asArray(Float.self), [300, 20])
+    }
+
+    func testChannelToSpatialUsesPredictedChildMaskAndFeatureRows() throws {
+        let coordinate = Trellis2VoxelCoordinate(x: 3, y: 4, z: 5)
+        let sparse = try Trellis2SparseTensor(
+            features: MLXArray((0..<8).map(Float.init)).reshaped(1, 8),
+            coordinates: [coordinate]
+        )
+        let subdivision = try Trellis2Subdivision(
+            logits: MLXArray([Float(1), -1, -1, -1, -1, -1, -1, 1]).reshaped(1, 8),
+            topology: sparse.topology
+        )
+        let output = try Trellis2SparseOperations.channelToSpatial(
+            sparse,
+            subdivision: subdivision,
+            maximumTokens: 8
+        )
+        MLX.eval(output.features)
+        XCTAssertEqual(output.coordinates, [
+            .init(x: 6, y: 8, z: 10),
+            .init(x: 7, y: 9, z: 11),
+        ])
+        XCTAssertEqual(output.features.asArray(Float.self), [0, 7])
+    }
+
+    func testDecoderResidualUsesPyTorchRepeatInterleaveChannelOrder() {
+        let source = MLXArray([Float(1), 2, 3]).reshaped(1, 3)
+        let repeated = MLX.repeated(source, count: 2, axis: 1)
+        MLX.eval(repeated)
+        XCTAssertEqual(repeated.asArray(Float.self), [1, 1, 2, 2, 3, 3])
+    }
+
+    func testFlexibleDualGridProducesIndexedVertexColoredMeshAndPBRField() throws {
+        var coordinates = [Trellis2VoxelCoordinate]()
+        for x in 0..<2 {
+            for y in 0..<2 {
+                for z in 0..<2 {
+                    coordinates.append(.init(x: Int32(x), y: Int32(y), z: Int32(z)))
+                }
+            }
+        }
+        let shapeRow: [Float] = [0, 0, 0, 1, 1, 1, 0]
+        let textureRow: [Float] = [1, -1, -1, 0, 0, 1]
+        let shape = try Trellis2SparseTensor(
+            features: MLXArray(Array(repeating: shapeRow, count: 8).flatMap { $0 }).reshaped(8, 7),
+            coordinates: coordinates
+        )
+        let texture = try Trellis2SparseTensor(
+            features: MLXArray(Array(repeating: textureRow, count: 8).flatMap { $0 }).reshaped(8, 6),
+            coordinates: coordinates
+        )
+
+        let decoded = try Trellis2FlexibleDualGrid.decode(
+            shape: shape,
+            texture: texture,
+            resolution: 2
+        )
+        XCTAssertEqual(decoded.mesh.vertexCount, 8)
+        XCTAssertGreaterThan(decoded.mesh.triangleCount, 0)
+        XCTAssertEqual(decoded.mesh.colorsRGBA8?.count, 32)
+        XCTAssertEqual(decoded.pbrVoxels.coordinates, coordinates)
+        XCTAssertEqual(decoded.pbrVoxels.attributes.count, 48)
+        XCTAssertEqual(decoded.pbrVoxels.attributes[0], 1, accuracy: 1e-6)
+        XCTAssertEqual(decoded.pbrVoxels.attributes[1], 0, accuracy: 1e-6)
+        XCTAssertEqual(decoded.pbrVoxels.attributes[3], 0.5, accuracy: 1e-6)
+        XCTAssertEqual(decoded.pbrVoxels.attributes[5], 1, accuracy: 1e-6)
+    }
+
+    func testSmallHoleFillerCapsReferenceThresholdBoundaryWithoutAddingVertices() throws {
+        let side: Float = 0.005
+        let mesh = try MeshAsset(
+            vertices: [
+                0, 0, 0,
+                side, 0, 0,
+                0, side, 0,
+                0, 0, side,
+            ],
+            indices: [
+                0, 2, 1,
+                0, 1, 3,
+                0, 3, 2,
+            ],
+            inferredUnseenGeometry: true
+        )
+        let repaired = try Trellis2MeshHoleFiller.fillSmallHoles(in: mesh)
+        XCTAssertEqual(repaired.vertexCount, 4)
+        XCTAssertEqual(repaired.triangleCount, 4)
+    }
+
+    func testPreprocessorRequiresAlphaUnlessFramingIsExplicit() throws {
+        let opaque = try MediaImage(width: 1, height: 1, rgba8: [255, 64, 0, 255])
+        XCTAssertThrowsError(try Trellis2Preprocessor.prepare(image: opaque, size: 2)) {
+            XCTAssertEqual($0 as? Trellis2PreprocessingError, .backgroundRemovalRequired)
+        }
+        let prepared = try Trellis2Preprocessor.prepare(
+            image: opaque,
+            size: 2,
+            foregroundPolicy: .alreadyFramed
+        )
+        XCTAssertEqual(prepared.conditionInput.shape, [1, 3, 2, 2])
+        XCTAssertFalse(prepared.croppedTransparentForeground)
+        XCTAssertEqual(prepared.sourceWidth, 1)
+        XCTAssertEqual(prepared.sourceHeight, 1)
+    }
+
+    func testGeneratorRejectsMissingInputBeforeResolvingGatedDependencies() async {
+        let missing = URL(fileURLWithPath: "/tmp/mere-run-trellis2-missing-\(UUID().uuidString).png")
+        let generator = Trellis2Generator()
+        do {
+            _ = try await generator.generate(
+                imageURL: missing,
+                outputDirectory: URL(fileURLWithPath: "/tmp/unused")
+            )
+            XCTFail("Expected missing input failure")
+        } catch {
+            XCTAssertEqual(
+                error as? Trellis2GeneratorError,
+                .inputImageNotFound(missing.path)
+            )
+        }
+    }
+}

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -139,6 +139,7 @@ final class Trellis2CoreTests: MereRunCoreTestCase {
         )
         XCTAssertEqual(decoded.mesh.vertexCount, 8)
         XCTAssertGreaterThan(decoded.mesh.triangleCount, 0)
+        XCTAssertEqual(Array(decoded.mesh.vertices.prefix(3)), [-0.25, -0.25, 0.25])
         XCTAssertEqual(decoded.mesh.colorsRGBA8?.count, 32)
         XCTAssertEqual(decoded.pbrVoxels.coordinates, coordinates)
         XCTAssertEqual(decoded.pbrVoxels.attributes.count, 48)

--- a/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+@testable import MereRunCore
+import XCTest
+
+final class Trellis2ResourcesAndManifestTests: XCTestCase {
+    func testCatalogPinsOfficialRepositoriesAndEveryRequiredCheckpoint() {
+        XCTAssertEqual(Trellis2Resources.defaultModelID, "image-3d-trellis2-4b")
+        XCTAssertEqual(Trellis2Resources.repository, "microsoft/TRELLIS.2-4B")
+        XCTAssertEqual(Trellis2Resources.revision.count, 40)
+        XCTAssertEqual(Trellis2Resources.dinoV3Repository, "facebook/dinov3-vitl16-pretrain-lvd1689m")
+        XCTAssertEqual(Trellis2Resources.checkpointComponentManifests.count, 7)
+        XCTAssertEqual(
+            Trellis2Resources.checkpointComponentManifests.reduce(Int64(0)) { $0 + $1.byteCount },
+            11_010_775_158
+        )
+        XCTAssertTrue(Trellis2Resources.checkpointComponentManifests.allSatisfy {
+            $0.revision.count == 40 && $0.sha256.count == 64 && $0.byteCount > 0
+        })
+        XCTAssertEqual(
+            Trellis2Resources.checkpointComponentManifests.last?.license,
+            "DINOv3 License"
+        )
+
+        let spec = ManagedModelCatalog.spec(for: Trellis2Resources.defaultModelID)
+        XCTAssertEqual(spec?.category, .image3D)
+        XCTAssertEqual(spec?.installShape, .structuredRoot)
+        XCTAssertEqual(spec?.estimatedDownloadBytes, 11_010_775_158)
+        XCTAssertEqual(spec?.mountedHubFallbacks.count, 2)
+        XCTAssertEqual(Set(spec?.defaultCLICommands ?? []), [
+            "image reconstruct-3d-trellis2",
+            "vision image-to-3d-trellis2",
+        ])
+    }
+
+    func testManifestTemplateDeclaresNativeTrellis2Capabilities() {
+        let manifest = MereRunModelManifest.template(for: .image3DTrellis2)
+        XCTAssertEqual(manifest.engine, .trellis2)
+        XCTAssertEqual(manifest.family, .threeD)
+        XCTAssertEqual(manifest.tier, .max)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(Set(manifest.supports ?? []), [.imageTo3D, .meshGeneration])
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "microsoft/TRELLIS.2-4B@af44b45f2e35a493886929c6d786e563ec68364d"
+        )
+    }
+
+    func testPBRWriterAndRunManifestPreserveAllMaterialChannelsAndHashes() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "trellis2-run-manifest-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let inputURL = root.appendingPathComponent("chair.png")
+        let inputData = Data("stable input bytes".utf8)
+        try inputData.write(to: inputURL)
+        let mesh = try MeshAsset(
+            vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+            indices: [0, 1, 2],
+            colorsRGBA8: [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255],
+            inferredUnseenGeometry: true
+        )
+        let coordinates = [Trellis2VoxelCoordinate(x: 1, y: 2, z: 3)]
+        let grid = try Trellis2PBRVoxelGrid(
+            resolution: 512,
+            coordinates: coordinates,
+            attributes: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+        )
+        let asset = Trellis2DecodedAsset(
+            mesh: mesh,
+            pbrVoxels: grid,
+            metallic: [0.4, 0.4, 0.4],
+            roughness: [0.5, 0.5, 0.5]
+        )
+        let checkpoint = Trellis2Checkpoint(verifiedRootURL: root)
+        let inputRecord = MeshInputRecord(
+            path: inputURL.path,
+            byteCount: Int64(inputData.count),
+            sha256: try ModelArtifactPin.fileSHA256(inputURL)
+        )
+        let exported = try Trellis2ArtifactExporter.export(
+            asset: asset,
+            checkpoint: checkpoint,
+            inputURL: inputURL,
+            inputRecord: inputRecord,
+            outputDirectory: root,
+            stem: "chair",
+            sourceWidth: 640,
+            sourceHeight: 480,
+            foregroundPolicy: "transparent-alpha",
+            croppedTransparentForeground: true,
+            seed: 42,
+            maximumSparseTokens: 49_152,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(exported.pbr.byteCount, 60)
+        XCTAssertEqual(exported.pbr.sha256.count, 64)
+        XCTAssertEqual(exported.run.manifest.input.sha256, inputRecord.sha256)
+        XCTAssertEqual(exported.run.manifest.generation.pipelineResolution, 512)
+        XCTAssertEqual(exported.run.manifest.generation.seed, 42)
+        XCTAssertEqual(exported.run.manifest.mesh.pbrVoxelCount, 1)
+        XCTAssertTrue(exported.run.manifest.mesh.includesMetallicRoughnessSidecar)
+        XCTAssertEqual(
+            Set(exported.run.manifest.artifacts.map(\.kind)),
+            ["obj", "ply", "glb", "pbr-voxels", "mesh-manifest"]
+        )
+        XCTAssertTrue(exported.run.manifest.artifacts.allSatisfy {
+            $0.byteCount > 0 && $0.sha256.count == 64
+        })
+
+        let pbrURL = root.appendingPathComponent(exported.pbr.relativePath)
+        XCTAssertEqual(String(decoding: try Data(contentsOf: pbrURL).prefix(8), as: UTF8.self), "MRPBRV01")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            Trellis2RunManifest.self,
+            from: Data(contentsOf: exported.run.manifestURL)
+        )
+        XCTAssertEqual(decoded, exported.run.manifest)
+    }
+}

--- a/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
@@ -45,6 +45,22 @@ final class Trellis2ResourcesAndManifestTests: XCTestCase {
         )
     }
 
+    func testManifestTemplateDoesNotRequireDiffusersComponents() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "trellis2-manifest-validation-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: .image3DTrellis2).write(to: root)
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: Trellis2Resources.defaultModelID
+        )
+        XCTAssertFalse(report.errors.contains("Manifest missing components."))
+    }
+
     func testPBRWriterAndRunManifestPreserveAllMaterialChannelsAndHashes() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(
             "trellis2-run-manifest-\(UUID().uuidString)",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,18 @@ Segmentation and tracking runtime:
   - `Sources/MereRunCore/SAM3/SAM31VideoTracker.swift`
   - `Sources/MereRunCore/SAM3/SAM31CameraCapture.swift`
 
+Native object reconstruction:
+
+- CLI:
+  - `Sources/MereRunCLI/Commands/VisionImageTo3DCommand.swift`
+  - `Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift`
+  - `Sources/MereRunCLI/Commands/ImageReconstruct3DMultiviewCommand.swift`
+- Shared mesh contract: `Sources/MereRunCore/Asset3D`
+- Native runtimes:
+  - `Sources/MereRunCore/TripoSR/TripoSRGenerator.swift`
+  - `Sources/MereRunCore/Trellis2/Trellis2Generator.swift`
+  - `Sources/MereRunCore/InstantMesh/InstantMeshGenerator.swift`
+
 ## Music, SFX, and video
 
 Music generation:

--- a/docs/architecture/vfx-geometry-model-report.md
+++ b/docs/architecture/vfx-geometry-model-report.md
@@ -1,13 +1,14 @@
 # OSS depth and 3D models for native VFX workflows
 
-Research snapshot: 2026-07-11.
+Research snapshot: 2026-07-13.
 
-This report records the five permissively licensed model lanes selected for
-native Swift/MLX execution in `mere.run`. It separates what each neural model
-actually predicts from downstream files that `mere.run` derives, and it makes
-the InstantMesh licensing boundary explicit. The exact artifact identities in
-this document come from `GeometryModelPins`; upstream capability and license
-claims link to the corresponding Hugging Face model card or source repository.
+This report records five permissively licensed model lanes plus the separately
+license-gated DINOv3 dependency used by TRELLIS.2, all selected for native
+Swift/MLX execution in `mere.run`. It separates what each neural model actually
+predicts from downstream files that `mere.run` derives, and it makes the
+InstantMesh and DINOv3 licensing boundaries explicit. Exact TRELLIS.2 artifact
+identities live in `Trellis2Resources`; the other geometry identities live in
+`GeometryModelPins`.
 
 ## Recommendation at a glance
 
@@ -17,10 +18,12 @@ claims link to the corresponding Hugging Face model card or source repository.
 | Stable depth through a shot | Video Depth Anything Small | A decoded video sequence | Temporally aligned relative or metric depth frames | Depth mattes, rack-focus/DOF, fog, occlusion, depth-aware grading |
 | Geometry and cameras from views | Depth Anything 3 Small | One or more RGB views; cameras optional | Relative depth, confidence, camera intrinsics/extrinsics, colored points | Camera/point-cloud bootstrap, set reconstruction, 3DGS/Nerfstudio initialization |
 | Fast object proxy from one image | TripoSR | One isolated object image | Normalized colored object mesh | Prop proxy, previz asset, collision/holdout mesh, rendered turntable |
+| PBR object proxy from one image | TRELLIS.2-4B 512 | One isolated object image with alpha or explicit framing | Normalized colored object mesh plus sparse base-color/metallic/roughness/alpha O-Voxels | Material-aware prop proxy, look-development handoff, previz asset |
 | Better object proxy from supplied views | InstantMesh Base, reconstruction only | Exactly 4 or 6 ordered object views; cameras optional | Normalized colored object mesh | Turntable-to-mesh, multi-view prop reconstruction, set dressing and occluders |
 
 Use MoGe for a single scene image, VDA for a temporal plate, DA3 for a
-multi-view scene, TripoSR for a single isolated object, and InstantMesh when
+multi-view scene, TripoSR for a fast single-image proxy, TRELLIS.2 when a
+single-image result needs a retained PBR O-Voxel field, and InstantMesh when
 four or six licensed object views already exist. These models complement one
 another; they are not interchangeable depth checkpoints.
 
@@ -92,6 +95,21 @@ Metric variant:
 - License boundary: Apache-2.0 reconstruction checkpoint only. The runtime
   excludes view synthesis and NVIDIA's proprietary FlexiCubes implementation.
 
+### TRELLIS.2-4B 512
+
+- Managed ID: `image-3d-trellis2-4b`
+- Pinned model: [`microsoft/TRELLIS.2-4B@af44b45`](https://huggingface.co/microsoft/TRELLIS.2-4B/tree/af44b45f2e35a493886929c6d786e563ec68364d)
+- Pinned source: [`microsoft/TRELLIS.2`](https://github.com/microsoft/TRELLIS.2)
+- Pinned sparse-structure dependency:
+  [`microsoft/TRELLIS-image-large@25e0d31`](https://huggingface.co/microsoft/TRELLIS-image-large/tree/25e0d31ffbebe4b5a97464dd851910efc3002d96)
+- Pinned conditioner:
+  [`facebook/dinov3-vitl16-pretrain-lvd1689m@ea8dc28`](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m/tree/ea8dc2863c51be0a264bab82070e3e8836b02d51)
+- Seven pinned safetensors total 11,010,775,158 bytes; each byte count and
+  SHA-256 is enforced by `Trellis2Resources`.
+- License boundary: TRELLIS.2 code and weights are MIT. DINOv3 has separate
+  terms and a gated model repository; users must accept those terms and
+  authenticate before installation.
+
 ## Native conversion and runtime status
 
 | Model | Published format | Native admission path | Offline conversion status |
@@ -101,6 +119,7 @@ Metric variant:
 | DA3-S | Safetensors | Exact pinned safetensors and config are checksum-verified and loaded directly | No conversion required |
 | TripoSR | Lightning/PyTorch CKPT | Exact CKPT is accepted by the restricted state-dict grammar; verified converted safetensors is also accepted | Deterministic conversion proven byte-identical twice |
 | InstantMesh Base | Lightning CKPT | Runtime accepts only the verified reconstruction-only safetensors package | Deterministic conversion proven byte-identical twice; view-generation tensors are never accepted |
+| TRELLIS.2-4B 512 | Safetensors | Official BF16/FP16 files are checksum-verified and loaded directly into native dense/sparse MLX graphs | No conversion required |
 
 Every inference path is native Swift/MLX. Python appears only in audited
 release conversion and upstream-reference fixture generation, never as a
@@ -246,11 +265,38 @@ isosurface chunking for Apple Silicon. The benchmark ledger now includes native
 six-view grid-16 and grid-24 runs through the verified converted package; the
 measured figures are summarized below.
 
+### 6. TRELLIS.2-4B 512
+
+Microsoft describes TRELLIS.2 as an image-to-3D system built around a sparse
+O-Voxel representation. The native 512 pipeline uses DINOv3 ViT-L/16 image
+tokens, a dense sparse-structure flow and decoder, separate sparse shape and
+texture flows, adaptive sparse ConvNeXt decoders, and flexible-dual-grid mesh
+extraction. The three flow stages use the pinned 30-block, 1,536-channel graph
+and official 12-step Euler schedules.
+
+Official BF16 and FP16 safetensors load directly into MLX. Stages are loaded
+and released independently rather than retaining the roughly 11 GB checkpoint
+set at once. The result includes normalized colored OBJ, PLY, and GLB meshes.
+A deterministic `.pbrvox` sidecar preserves base color RGB, metallic,
+roughness, and alpha for every decoded sparse voxel; the current canonical GLB
+writer does not claim a synthesized texture-atlas representation.
+
+The native public surface deliberately starts with 512. It does not claim the
+1024/1536 cascade, real-world scale, or byte-identical face ordering with the
+CUDA reference implementation. Transparent alpha is required by default;
+opaque input needs explicit already-framed consent, and no hidden background
+removal service is invoked.
+
 ## License and commercial-use boundary
 
 The selected MoGe, VDA, DA3, TripoSR, and InstantMesh reconstruction artifacts
 have permissive MIT or Apache-2.0 lanes. That does not make every file mentioned
 by an upstream project safe to ship. The engineering boundary is:
+
+- **DINOv3 is separately gated.** TRELLIS.2 is MIT, but its DINOv3 ViT-L/16
+  conditioner has separate terms and a gated Hugging Face repository. Model
+  installation must surface license acceptance/authentication instead of
+  mirroring or silently substituting that dependency.
 
 - **Zero123++ is excluded.** The official Zero123++ repository states that its
   code is Apache-2.0 but its weights are CC-BY-NC-4.0 and cannot be used in a
@@ -352,6 +398,9 @@ Keep model truth explicit in plugin outputs:
   as initialization only. Never imply learned Gaussians or a triangle mesh.
 - Label TripoSR and InstantMesh meshes as normalized object space unless a
   separate scale/alignment operation establishes world units.
+- Label TRELLIS.2 meshes as normalized object space and keep the `.pbrvox`
+  sidecar attached when metallic, roughness, or alpha must survive handoff;
+  vertex-colored GLB alone is not full PBR parity.
 - For InstantMesh, reject inputs other than four or six views and expose that
   view generation is absent. Do not offer Zero123++ as an automatic fallback.
 - Record the native polygonizer and state plainly that TripoSR and InstantMesh

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -79,6 +79,7 @@ from the runtime catalog used by `mere.run model list`,
 | `vision-geometry` | `vision-geometry-da3-small` |
 | `image-3d` | `image-3d-triposr` |
 | `image-3d` | `image-3d-instantmesh-base` |
+| `image-3d` | `image-3d-trellis2-4b` |
 | `music` | `music-acestep` |
 | `music` | `music-acestep-xl-turbo` |
 | `music` | `music-acestep-xl-turbo-lm4b` |

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -75,6 +75,8 @@ Key subdirectories:
 - `Gemma4/`, `Q35/`, `LFM2/`, `Psi/`, `MeBot/`: text/chat model families
 - `Embeddings/`: embedding-generation support
 - `LightOnOCR/`: OCR runtime
+- `Asset3D/`, `TripoSR/`, `InstantMesh/`, `Trellis2/`: canonical mesh export
+  plus native single-view and multiview object reconstruction
 - `VLM/`: vision-language model helpers
 - `ACEStep/`: music generation pipeline
 - `Woosh/`: sound-effect generation pipeline

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -1,6 +1,7 @@
 # Vision Runtime
 
-This page covers captioning, inspection, grounding, segmentation, tracking, pose extraction, optical flow, and OCR.
+This page covers captioning, inspection, grounding, segmentation, tracking,
+pose extraction, optical flow, image-to-3D reconstruction, and OCR.
 
 ## Public surface
 
@@ -12,6 +13,9 @@ This page covers captioning, inspection, grounding, segmentation, tracking, pose
 - `mere.run vision track-live`
 - `mere.run vision pose`
 - `mere.run vision flow`
+- `mere.run vision image-to-3d`
+- `mere.run vision image-to-3d-trellis2`
+- `mere.run vision image-to-3d-multiview`
 - `mere.run vision ocr`
 
 ## Model family
@@ -19,6 +23,9 @@ This page covers captioning, inspection, grounding, segmentation, tracking, pose
 - `vision-ocr-lighton`
 - `vision-ground-falcon-perception`
 - `vision-segment-sam31`
+- `image-3d-triposr`
+- `image-3d-trellis2-4b`
+- `image-3d-instantmesh-base`
 
 Captioning and inspect flows also depend on vision-language support code in
 `MereRunCore`.
@@ -135,6 +142,23 @@ swift run mere.run vision flow ./frame-001.png ./frame-002.png \
 The two images must have equal dimensions. Output vectors use the Middlebury
 `.flo` format and preserve full-resolution 32-bit horizontal and vertical
 motion components.
+
+### Reconstruct a PBR object with TRELLIS.2
+
+Accept the DINOv3 checkpoint license on Hugging Face before the first pull,
+then run the native 512-resolution pipeline:
+
+```bash
+swift run mere.run model pull image-3d-trellis2-4b
+swift run mere.run vision image-to-3d-trellis2 ./object.png \
+  --output ./object-trellis2 \
+  --seed 42
+```
+
+Transparent alpha is required by default. `--already-framed` explicitly opts
+an opaque, isolated object into black-background conditioning. The result
+contains canonical colored OBJ/PLY/GLB meshes and a hashed `.pbrvox` sidecar
+that preserves base color, metallic, roughness, and alpha.
 
 ## Output artifacts
 


### PR DESCRIPTION
## Summary

- add a native Swift/MLX implementation of Microsoft's TRELLIS.2-4B 512px image-to-3D pipeline, including DINOv3 conditioning, three sparse flow stages, native O-Voxel decoding, flexible dual-grid extraction, and small-hole filling
- add `image-3d-trellis2-4b` to the managed catalog with pinned revisions, SHA-256 digests, byte counts, gated DINOv3 authentication, and direct safetensors loading
- expose `mere.run vision image-to-3d-trellis2` and the equivalent `mere.run image reconstruct-3d-trellis2` command
- export deterministic OBJ, PLY, GLB, mesh-manifest, run-manifest, and six-channel `.pbrvox` artifacts with canonical Y-up mesh coordinates and complete provenance
- document the runtime, model sources, command contract, output formats, and the intentionally unsupported 1024/1536 cascade

## Why

mere.run already owns native Apple-Silicon inference and geometry export. TRELLIS.2 belongs on that same boundary: no Python sidecar, PyTorch process, CUDA dependency, or converted checkpoint copy. This change makes the released 512 pipeline installable and runnable through the existing managed-model and CLI surfaces.

Live checkpoint validation found and fixed three integration issues before publication: TRELLIS.2 manifests must bypass Diffusers-component validation, real decoder output can exceed the original sparse-token ceiling, and O-Voxel geometry must be rotated from its native Z-up basis into the shared Y-up mesh contract.

## User impact

```bash
mere.run model pull image-3d-trellis2-4b
mere.run vision image-to-3d-trellis2 ./object.png --output ./object-3d
```

The model pull requires prior acceptance of the gated DINOv3 license and an authenticated Hugging Face token. Transparent foreground input is the default contract; callers can opt into already-framed opaque input explicitly.

## Validation

- [x] `./scripts/check.sh`
- [x] focused TRELLIS.2 tests
- [x] docs updated for public CLI and runtime behavior
- [x] official Microsoft sample completed through the native MLX backend
- [x] generated GLB imported and rendered upright in Blender for visual QA
- [x] 1,713 tests passed with 0 failures and 115 asset-gated skips
- [x] `THIRD_PARTY_NOTICES.md` not required; no vendored artifacts or package pins changed

The live sample produced 1,436,622 colored vertices, 2,965,272 triangles, and complete hashed OBJ/PLY/GLB/PBR provenance at the pinned `microsoft/TRELLIS.2-4B` revision.
