### PR TITLE
Fix TRELLIS.2 Linux MLX scalar typing

### DIFF
--- a/Sources/MereRunCore/Trellis2/Trellis2FlowModel.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2FlowModel.swift
@@ -321,7 +321,8 @@ struct Trellis2FlowModel {
         let gamma = try weights.tensor("\(prefix).gamma").asType(.float32)
         let squaredNorm = MLX.sum(input.asType(.float32) * input.asType(.float32), axis: -1, keepDims: true)
         let normalized = input.asType(.float32) * MLX.rsqrt(MLX.maximum(squaredNorm, MLXArray(1e-24)))
-        return (normalized * gamma * sqrt(Float(configuration.headDimension))).asType(input.dtype)
+        let scale = MLXArray(sqrt(Float(configuration.headDimension)))
+        return (normalized * gamma * scale).asType(input.dtype)
     }
 
     private func attention(query: MLXArray, key: MLXArray, value: MLXArray) -> MLXArray {


### PR DESCRIPTION
## Summary

- make TRELLIS.2 multi-head RMSNorm scaling unambiguous under Swift 6.0 on Linux
- preserve identical rank-zero MLX multiplication semantics on macOS

## Root cause

Swift 6.0 Linux could not resolve the chained `MLXArray * MLXArray * Float` overload in `Trellis2FlowModel.swift`. Wrapping the scalar scale as an `MLXArray` removes the cross-platform overload ambiguity without changing inference math.

## Validation

- [x] exact Swift 6.0 Jammy Linux container `./scripts/check-linux.sh`
- [x] `./scripts/check.sh`
- [x] `swift test --filter Trellis2` (18 tests)
