### PR TITLE
Fix DreamX camera-control magnitude

### DIFF
--- a/Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift
+++ b/Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift
@@ -226,19 +226,25 @@ public enum Wan2DreamXARTrajectory {
         precondition(pixelFrameCount > 0)
         let translation = control.translationMeters.map(abs).max() ?? 0
         let rotation = control.rotationDegrees.map(abs).max() ?? 0
+        let travelSteps = alignedTravelSteps(pixelFrameCount: pixelFrameCount)
         switch control.motion {
         case .hold:
             return 1.5
         case .forward, .backward, .strafeLeft, .strafeRight:
-            return max(translation / (0.05 * Float(pixelFrameCount)), 0.001)
+            return max(translation / (0.05 * travelSteps), 0.001)
         case .yawLeft, .yawRight:
-            return max(rotation / Float(pixelFrameCount), 0.001)
+            return max(rotation / travelSteps, 0.001)
         case .custom:
             return max(
-                max(translation / (0.05 * Float(pixelFrameCount)), rotation / Float(pixelFrameCount)),
+                max(translation / (0.05 * travelSteps), rotation / travelSteps),
                 0.001
             )
         }
+    }
+
+    private static func alignedTravelSteps(pixelFrameCount: Int) -> Float {
+        let alignedIndices = [0] + Array(stride(from: 1, to: pixelFrameCount, by: 4))
+        return Float(max((alignedIndices.last ?? 0) - (alignedIndices.first ?? 0), 1))
     }
 
     public static func compile(

--- a/Tests/MereRunCoreTests/Wan2WorldSessionTests.swift
+++ b/Tests/MereRunCoreTests/Wan2WorldSessionTests.swift
@@ -37,6 +37,23 @@ final class Wan2WorldSessionTests: MereRunCoreTestCase {
         XCTAssertNotEqual(near.viewMatrices, far.viewMatrices)
     }
 
+    func testCausalCameraControlReachesRequestedMagnitudeAtLastAlignedView() {
+        let yaw = Wan2DreamXARTrajectory.compile(
+            control: .yawLeft(degrees: 30),
+            pixelFrameCount: 9
+        )
+        let yawLast = Array(yaw.viewMatrices.suffix(16))
+        XCTAssertEqual(yawLast[0], cos(.pi / 6), accuracy: 1e-5)
+        XCTAssertEqual(abs(yawLast[2]), sin(.pi / 6), accuracy: 1e-5)
+
+        let forward = Wan2DreamXARTrajectory.compile(
+            control: .forward(meters: 0.25),
+            pixelFrameCount: 9
+        )
+        let forwardLast = Array(forward.viewMatrices.suffix(16))
+        XCTAssertEqual(abs(forwardLast[11]), 0.25, accuracy: 1e-5)
+    }
+
     func testColdSessionCanResetToAnExplicitWorldFrame() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("wan-session-model-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary
- scale DreamX AR camera speed across the actual aligned PRoPE travel span
- preserve the explicit upstream speed path
- add exact yaw and forward-magnitude coverage

## Test
- `swift test --filter Wan2WorldSessionTests` (7 passed)
- exercised from Local Recon Lab with a native 60-degree station yaw and exact inverse playback