### PR TITLE
Linearize GLB vertex colors per glTF COLOR_0 spec

### DIFF
--- a/Sources/MereRunCore/Asset3D/MeshAsset.swift
+++ b/Sources/MereRunCore/Asset3D/MeshAsset.swift
@@ -44,6 +44,7 @@ public struct MeshAsset: Sendable {
     public let vertices: [Float]
     public let indices: [UInt32]
     public let normals: [Float]?
+    /// sRGB-encoded RGB with linear alpha coverage; see `VertexColorTransfer`.
     public let colorsRGBA8: [UInt8]?
     public let textureCoordinates: [Float]?
     public let coordinateSystem: MeshCoordinateSystem

--- a/Sources/MereRunCore/Asset3D/MeshGLBWriter.swift
+++ b/Sources/MereRunCore/Asset3D/MeshGLBWriter.swift
@@ -44,10 +44,12 @@ public enum MeshGLBWriter {
 
         var colorAccessor: Int?
         if let colors = mesh.colorsRGBA8 {
-            let view = appendView(Data(colors), target: 34_962)
+            // glTF defines COLOR_0 as linear; colorsRGBA8 is sRGB-encoded.
+            let linear = VertexColorTransfer.linearRGBA16(fromSRGBA8: colors)
+            let view = appendView(uint16Data(linear), target: 34_962)
             accessors.append([
                 "bufferView": view,
-                "componentType": 5_121,
+                "componentType": 5_123,
                 "normalized": true,
                 "count": mesh.vertexCount,
                 "type": "VEC4",
@@ -140,6 +142,16 @@ public enum MeshGLBWriter {
         var data = Data()
         data.reserveCapacity(values.count * 4)
         for value in values { appendUInt32(value.bitPattern, to: &data) }
+        return data
+    }
+
+    private static func uint16Data(_ values: [UInt16]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 2)
+        for value in values {
+            var value = value.littleEndian
+            withUnsafeBytes(of: &value) { data.append(contentsOf: $0) }
+        }
         return data
     }
 

--- a/Sources/MereRunCore/Asset3D/README.md
+++ b/Sources/MereRunCore/Asset3D/README.md
@@ -14,6 +14,14 @@ PLY, and binary glTF writers used by native reconstruction runtimes.
 - `MeshGLBWriter` builds glTF's heterogeneous JSON object at the serialization
   boundary, which is why it is listed in the repository's dynamic-JSON
   inventory. No untyped JSON escapes this writer.
+- Vertex colors are sRGB-encoded bytes (`colorsRGBA8`) because reconstruction
+  models regress display-referred pixel values. OBJ and PLY write those bytes
+  verbatim per the display-referred de-facto convention of both formats.
+  glTF 2.0 defines `COLOR_0` as linear, so `MeshGLBWriter` decodes RGB through
+  the exact sRGB EOTF (`VertexColorTransfer`) and stores 16-bit normalized
+  values to keep decoded darks from banding. Alpha is linear coverage in every
+  format. Standards-compliant viewers (three.js, Blender) therefore display
+  identical colors for all three artifacts.
 
 Model-specific inference and provenance belong in `TripoSR`, `InstantMesh`, and
 `Trellis2`. TRELLIS.2 additionally writes its six-channel sparse PBR field as a

--- a/Sources/MereRunCore/Asset3D/VertexColorTransfer.swift
+++ b/Sources/MereRunCore/Asset3D/VertexColorTransfer.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// sRGB transfer functions for vertex-color interchange.
+///
+/// Native reconstruction models regress display-referred pixel values, so
+/// `colorsRGBA8` carries sRGB-encoded bytes. glTF 2.0 defines `COLOR_0` as
+/// linear, so the GLB writers decode RGB through the exact piecewise sRGB
+/// EOTF (IEC 61966-2-1) at export and widen to 16 bits because 8-bit linear
+/// values band in the darks. OBJ and PLY keep the sRGB bytes verbatim: those
+/// formats carry display-referred color by de-facto convention. Alpha is
+/// linear coverage everywhere and is never transfer-coded.
+public enum VertexColorTransfer {
+    /// Exact piecewise sRGB EOTF, encoded [0, 1] to linear [0, 1].
+    public static func linear(fromSRGB encoded: Float) -> Float {
+        encoded <= 0.04045 ? encoded / 12.92 : pow((encoded + 0.055) / 1.055, 2.4)
+    }
+
+    /// Linear 16-bit normalized RGBA from sRGB-encoded RGBA8 vertex colors.
+    /// RGB decodes through the sRGB EOTF; alpha rescales linearly.
+    public static func linearRGBA16(fromSRGBA8 colors: [UInt8]) -> [UInt16] {
+        var output = [UInt16](repeating: 0, count: colors.count)
+        for index in colors.indices {
+            let value = colors[index]
+            output[index] = index % 4 == 3
+                ? UInt16((Float(value) / 255 * 65535).rounded())
+                : linearRGB16[Int(value)]
+        }
+        return output
+    }
+
+    private static let linearRGB16: [UInt16] = (0...255).map { value in
+        UInt16((linear(fromSRGB: Float(value) / 255) * 65535).rounded())
+    }
+}

--- a/Sources/MereRunCore/Geometry/PointCloudAsset.swift
+++ b/Sources/MereRunCore/Geometry/PointCloudAsset.swift
@@ -17,6 +17,7 @@ public enum PointCloudAssetError: Error, Equatable, LocalizedError, Sendable {
 /// Canonical colored point cloud for native multi-view geometry handoffs.
 public struct PointCloudAsset: Sendable {
     public let positions: [Float]
+    /// sRGB-encoded RGB with linear alpha coverage; see `VertexColorTransfer`.
     public let colorsRGBA8: [UInt8]?
     public let confidence: [Float]?
     public let viewIndices: [UInt32]?

--- a/Sources/MereRunCore/Geometry/PointCloudGLBWriter.swift
+++ b/Sources/MereRunCore/Geometry/PointCloudGLBWriter.swift
@@ -32,10 +32,12 @@ public enum PointCloudGLBWriter {
         ])
         var attributes: [String: Any] = ["POSITION": accessors.count - 1]
         if let colors = cloud.colorsRGBA8 {
-            let view = appendView(Data(colors))
+            // glTF defines COLOR_0 as linear; colorsRGBA8 is sRGB-encoded.
+            let linear = VertexColorTransfer.linearRGBA16(fromSRGBA8: colors)
+            let view = appendView(uint16Data(linear))
             accessors.append([
                 "bufferView": view,
-                "componentType": 5_121,
+                "componentType": 5_123,
                 "normalized": true,
                 "count": cloud.pointCount,
                 "type": "VEC4",
@@ -102,6 +104,16 @@ public enum PointCloudGLBWriter {
         var data = Data()
         data.reserveCapacity(values.count * 4)
         for value in values { appendUInt32(value.bitPattern, to: &data) }
+        return data
+    }
+
+    private static func uint16Data(_ values: [UInt16]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 2)
+        for value in values {
+            var littleEndian = value.littleEndian
+            withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+        }
         return data
     }
 

--- a/Tests/MereRunCoreTests/VertexColorParityTests.swift
+++ b/Tests/MereRunCoreTests/VertexColorParityTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import MereRunCore
+import XCTest
+
+/// Vertex-color round-trip parity across the OBJ, PLY, and GLB writers.
+///
+/// glTF 2.0 defines `COLOR_0` as linear, so a standards-compliant viewer
+/// (three.js, Blender) applies the linear-to-sRGB transfer before display.
+/// These tests emulate that viewer convention with an independent transfer
+/// implementation and require the displayed bytes to equal the authored
+/// sRGB bytes exactly, while OBJ and PLY keep the authored bytes verbatim.
+final class VertexColorParityTests: XCTestCase {
+    /// Authored sRGB vertex colors covering the empirical mustard-yellow
+    /// regression, both sides of the piecewise sRGB knee (10 and 11), the
+    /// darkest nonzero step, both extremes, and non-opaque alpha.
+    private let authoredSRGBA8: [UInt8] = [
+        196, 158, 44, 255,
+        1, 10, 11, 128,
+        0, 128, 255, 0,
+    ]
+
+    func testGLBColorsDisplayAsAuthoredSRGBUnderViewerConvention() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("mesh.glb")
+        try MeshGLBWriter.write(try triangleMesh(), to: url)
+        let color = try GLBColorProbe.readColor0(try Data(contentsOf: url))
+
+        XCTAssertEqual(color.componentType, 5_123, "COLOR_0 should be 16-bit to avoid banding after linearization")
+        XCTAssertTrue(color.normalized)
+        XCTAssertEqual(color.type, "VEC4")
+        XCTAssertEqual(color.values.count, authoredSRGBA8.count)
+
+        for vertex in 0..<(authoredSRGBA8.count / 4) {
+            for channel in 0..<3 {
+                let index = vertex * 4 + channel
+                let linear = Float(color.values[index]) / 65535
+                XCTAssertEqual(
+                    displayedSRGBByte(fromLinear: linear),
+                    authoredSRGBA8[index],
+                    "vertex \(vertex) channel \(channel) should display as authored"
+                )
+            }
+            let alphaIndex = vertex * 4 + 3
+            XCTAssertEqual(
+                UInt8((Float(color.values[alphaIndex]) / 65535 * 255).rounded()),
+                authoredSRGBA8[alphaIndex],
+                "alpha is linear coverage and must rescale without a transfer"
+            )
+        }
+    }
+
+    func testOBJAndPLYKeepAuthoredDisplayReferredBytes() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mesh = try triangleMesh()
+
+        let objURL = root.appendingPathComponent("mesh.obj")
+        try MeshOBJWriter.write(mesh, to: objURL)
+        let vertexLines = String(decoding: try Data(contentsOf: objURL), as: UTF8.self)
+            .split(separator: "\n")
+            .filter { $0.hasPrefix("v ") }
+        XCTAssertEqual(vertexLines.count, 3)
+        for (vertex, line) in vertexLines.enumerated() {
+            let fields = line.split(separator: " ").dropFirst(4).compactMap { Float($0) }
+            XCTAssertEqual(fields.count, 3, "vertex line should carry r g b")
+            for channel in 0..<3 {
+                XCTAssertEqual(
+                    fields[channel],
+                    Float(authoredSRGBA8[vertex * 4 + channel]) / 255,
+                    accuracy: 1e-6
+                )
+            }
+        }
+
+        let plyURL = root.appendingPathComponent("mesh.ply")
+        try MeshPLYWriter.write(mesh, to: plyURL)
+        let ply = try Data(contentsOf: plyURL)
+        let headerEnd = try XCTUnwrap(ply.range(of: Data("end_header\n".utf8))).upperBound
+        let vertexStride = 6 * 4 + 4
+        for vertex in 0..<3 {
+            let colorOffset = headerEnd + vertex * vertexStride + 6 * 4
+            XCTAssertEqual(
+                Array(ply[colorOffset..<(colorOffset + 4)]),
+                Array(authoredSRGBA8[(vertex * 4)..<(vertex * 4 + 4)])
+            )
+        }
+    }
+
+    func testPointCloudGLBEncodesColorsIdenticallyToMeshGLB() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let meshURL = root.appendingPathComponent("mesh.glb")
+        let cloudURL = root.appendingPathComponent("cloud.glb")
+        try MeshGLBWriter.write(try triangleMesh(), to: meshURL)
+        try PointCloudGLBWriter.write(
+            try PointCloudAsset(
+                positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+                colorsRGBA8: authoredSRGBA8
+            ),
+            to: cloudURL
+        )
+        let meshColor = try GLBColorProbe.readColor0(try Data(contentsOf: meshURL))
+        let cloudColor = try GLBColorProbe.readColor0(try Data(contentsOf: cloudURL))
+        XCTAssertEqual(cloudColor.componentType, meshColor.componentType)
+        XCTAssertEqual(cloudColor.normalized, meshColor.normalized)
+        XCTAssertEqual(cloudColor.type, meshColor.type)
+        XCTAssertEqual(cloudColor.values, meshColor.values)
+    }
+
+    private func triangleMesh() throws -> MeshAsset {
+        try MeshAsset(
+            vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+            indices: [0, 1, 2],
+            colorsRGBA8: authoredSRGBA8,
+            inferredUnseenGeometry: true
+        )
+    }
+
+    /// Independent linear-to-sRGB OETF (IEC 61966-2-1) emulating what a
+    /// compliant viewer applies to COLOR_0 before display. Deliberately not
+    /// implemented via `VertexColorTransfer` so an encoder bug cannot cancel
+    /// itself out in the round trip.
+    private func displayedSRGBByte(fromLinear linear: Float) -> UInt8 {
+        let encoded = linear <= 0.0031308
+            ? linear * 12.92
+            : 1.055 * pow(linear, 1 / 2.4) - 0.055
+        return UInt8((min(1, max(0, encoded)) * 255).rounded())
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vertex-color-parity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
+/// Minimal GLB reader for the COLOR_0 accessor of the first primitive.
+enum GLBColorProbe {
+    struct Color0 {
+        let componentType: Int
+        let normalized: Bool
+        let type: String
+        let values: [UInt16]
+    }
+
+    static func readColor0(_ data: Data) throws -> Color0 {
+        let jsonLength = Int(readUInt32(data, offset: 12))
+        let document = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data.subdata(in: 20..<(20 + jsonLength)))
+                as? [String: Any]
+        )
+        let meshes = try XCTUnwrap(document["meshes"] as? [[String: Any]])
+        let primitive = try XCTUnwrap((meshes[0]["primitives"] as? [[String: Any]])?.first)
+        let attributes = try XCTUnwrap(primitive["attributes"] as? [String: Any])
+        let accessorIndex = try XCTUnwrap(attributes["COLOR_0"] as? Int)
+        let accessor = try XCTUnwrap(document["accessors"] as? [[String: Any]])[accessorIndex]
+        let viewIndex = try XCTUnwrap(accessor["bufferView"] as? Int)
+        let view = try XCTUnwrap(document["bufferViews"] as? [[String: Any]])[viewIndex]
+        let count = try XCTUnwrap(accessor["count"] as? Int)
+
+        let binaryStart = 20 + jsonLength + 8
+        let byteOffset = binaryStart + (view["byteOffset"] as? Int ?? 0)
+        let values = (0..<(count * 4)).map { element in
+            UInt16(data[byteOffset + element * 2]) | (UInt16(data[byteOffset + element * 2 + 1]) << 8)
+        }
+        return Color0(
+            componentType: try XCTUnwrap(accessor["componentType"] as? Int),
+            normalized: accessor["normalized"] as? Bool ?? false,
+            type: try XCTUnwrap(accessor["type"] as? String),
+            values: values
+        )
+    }
+
+    private static func readUInt32(_ data: Data, offset: Int) -> UInt32 {
+        data[offset..<(offset + 4)].enumerated().reduce(0) { result, item in
+            result | (UInt32(item.element) << UInt32(item.offset * 8))
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The native Asset3D GLB exporter (used by `mere.run vision image-to-3d` and the other reconstruction commands) wrote `colorsRGBA8` bytes directly into `COLOR_0`. Those bytes are sRGB-encoded — reconstruction models regress display-referred pixel values — but glTF 2.0 defines `COLOR_0` as linear. Standards-compliant viewers (three.js, Blender) therefore applied a second linear→sRGB transform on display and colors rendered washed out: a mustard-yellow slicker came out pale cream.

Confirmed empirically on `showcase-shotkit/mesh-pass/native-triposr/fox-studio-cutout.glb`: `COLOR_0` held raw sRGB bytes as normalized `UNSIGNED_BYTE` (slicker vertices `(213, 170, 59)`).

## Fix

- `colorsRGBA8` stays sRGB by contract (documented on `MeshAsset`, `PointCloudAsset`, and the Asset3D README) — it is what every producer emits and the perceptually efficient 8-bit storage.
- `MeshGLBWriter` and `PointCloudGLBWriter` decode RGB through the exact piecewise sRGB EOTF (new `VertexColorTransfer`) at write time and store **16-bit normalized** values, because 8-bit linear bands in the darks (same choice as Blender's glTF exporter). Alpha is coverage and rescales linearly.
- OBJ and PLY intentionally keep the sRGB bytes verbatim: both formats carry display-referred color by de-facto convention (MeshLab/CloudCompare display bytes directly; Blender types PLY `uchar` colors as sRGB byte-color attributes). All three artifacts now display identically in compliant viewers.

Covers all producers in one place: TripoSR, InstantMesh, TRELLIS.2 meshes, and multiview point clouds.

## Verification

- New `VertexColorParityTests` parse the emitted GLB binary and emulate the viewer convention with an **independently implemented** linear→sRGB transfer (so an encoder bug cannot cancel itself out): displayed bytes must equal authored bytes exactly, including values straddling the piecewise knee (10/11), the darkest nonzero step, and non-opaque alpha. Also pins OBJ/PLY bytes and mesh↔point-cloud GLB encoding parity.
- End-to-end: re-ran `mere.run vision image-to-3d` on the original fox image; viewer-convention decode of the produced GLB matches the PLY's sRGB bytes on all 45,580 vertices (245 distinct byte values, zero mismatches).
- Loaded old vs. new GLB in stock three.js r183 with unlit vertex-color materials: old renders pale cream, new renders the authored mustard palette matching the source photo.
- Suites passing: VertexColorParity, MeshAsset, PointCloudAsset, GeometryExporters, MultiViewGeometryExporter, TripoSRIsosurface, TripoSRRunManifest, Trellis2Core, InstantMeshCommand, InstantMeshAPIContract, VisionImageTo3DCommand, APIServeCommand.

Note: GLBs already on disk were written with the old encoding and stay washed out until re-exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)