### PR TITLE
TRELLIS.2 appearance and topology: normalized sampling, PBR factors, baked atlas, watertight remesh

### DIFF
--- a/Sources/MediaIO/AppleMediaImageIO.swift
+++ b/Sources/MediaIO/AppleMediaImageIO.swift
@@ -55,6 +55,13 @@ enum AppleMediaImageIO {
     static func mediaImage(from image: CGImage) throws -> MediaImage {
         let width = image.width
         let height = image.height
+        if let rgba = straightRGBA8Bytes(of: image) {
+            return try MediaImage(width: width, height: height, rgba8: rgba)
+        }
+
+        // CGContext cannot target straight alpha, so convert other formats by
+        // drawing premultiplied and un-premultiplying afterwards. Lossless for
+        // opaque pixels; semi-transparent RGB rounds through premultiplication.
         let bytesPerRow = width * 4
         var rgba = [UInt8](repeating: 0, count: width * height * 4)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
@@ -80,14 +87,72 @@ enum AppleMediaImageIO {
         guard succeeded else {
             throw MediaIOError.imageDecodeFailed(URL(fileURLWithPath: "<memory>"))
         }
+        unpremultiplyInPlace(&rgba)
         return try MediaImage(width: width, height: height, rgba8: rgba)
+    }
+
+    /// Copies samples directly when the image already uses MediaImage's 8-bit
+    /// RGBA layout. ImageIO decodes RGBA PNGs this way, and the direct copy is
+    /// the only path that keeps straight alpha byte-exact — the premultiplied
+    /// draw fallback rounds RGB wherever alpha < 255 and zeroes it at alpha 0.
+    /// Like the FFmpeg backend, this performs no color management.
+    private static func straightRGBA8Bytes(of image: CGImage) -> [UInt8]? {
+        let alphaInfo = image.alphaInfo
+        guard alphaInfo == .last || alphaInfo == .noneSkipLast,
+              image.bitsPerComponent == 8,
+              image.bitsPerPixel == 32,
+              image.colorSpace?.model == .rgb else {
+            return nil
+        }
+        let byteOrder = image.bitmapInfo.intersection(.byteOrderMask)
+        guard byteOrder == CGBitmapInfo() || byteOrder == .byteOrder32Big,
+              let data = image.dataProvider?.data as Data? else {
+            return nil
+        }
+        let width = image.width
+        let height = image.height
+        let sourceBytesPerRow = image.bytesPerRow
+        let rowBytes = width * 4
+        guard sourceBytesPerRow >= rowBytes,
+              data.count >= (height - 1) * sourceBytesPerRow + rowBytes else {
+            return nil
+        }
+        var rgba = [UInt8]()
+        rgba.reserveCapacity(height * rowBytes)
+        for row in 0..<height {
+            let start = data.startIndex + row * sourceBytesPerRow
+            rgba.append(contentsOf: data[start..<(start + rowBytes)])
+        }
+        if alphaInfo == .noneSkipLast {
+            for pixel in stride(from: 3, to: rgba.count, by: 4) {
+                rgba[pixel] = 255
+            }
+        }
+        return rgba
+    }
+
+    /// Converts premultiplied RGBA to straight alpha in place, rounding to the
+    /// nearest 8-bit value. Fully transparent pixels stay transparent black:
+    /// premultiplication already discarded their RGB.
+    private static func unpremultiplyInPlace(_ rgba: inout [UInt8]) {
+        for pixelStart in stride(from: 0, to: rgba.count, by: 4) {
+            let alpha = Int(rgba[pixelStart + 3])
+            guard alpha > 0, alpha < 255 else { continue }
+            for channel in pixelStart..<(pixelStart + 3) {
+                let value = ((Int(rgba[channel]) * 255) + (alpha / 2)) / alpha
+                rgba[channel] = UInt8(min(255, value))
+            }
+        }
     }
 
     static func cgImage(from image: MediaImage) throws -> CGImage {
         guard let provider = CGDataProvider(data: Data(image.rgba8) as CFData) else {
             throw MediaIOError.invalidBufferSize(expected: image.width * image.height * 4, actual: image.rgba8.count)
         }
-        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        // MediaImage.rgba8 is straight alpha. Declaring it premultiplied makes
+        // ImageIO un-premultiply on PNG encode, brightening RGB wherever
+        // alpha < 255; CGImage (unlike CGContext) supports straight alpha.
+        let bitmapInfo = CGImageAlphaInfo.last.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
         guard let cgImage = CGImage(
             width: image.width,
             height: image.height,

--- a/Sources/MediaIO/MediaIO.swift
+++ b/Sources/MediaIO/MediaIO.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// An 8-bit RGBA raster whose `rgba8` samples use straight (un-premultiplied)
+/// alpha, matching PNG storage and FFmpeg's `rgba` pixel format. Backends
+/// convert premultiplied sources on decode and must declare straight alpha on
+/// encode so semi-transparent RGB survives round trips byte-exactly.
 public struct MediaImage: Sendable, Hashable {
     public let width: Int
     public let height: Int

--- a/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
+++ b/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
@@ -21,6 +21,9 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
     @Option(name: [.long], help: "Deterministic MLX random seed.")
     var seed: UInt64 = 42
 
+    @Option(name: [.long], help: "Re-roll only the texture flow with this seed, keeping the geometry of --seed. Searches palette without touching a good reconstruction.")
+    var textureSeed: UInt64?
+
     @Option(name: [.long], help: "Safety limit for decoded 512-resolution O-Voxels.")
     var maxTokens: Int = Trellis2Generator.defaultMaximumSparseTokens
 
@@ -48,6 +51,7 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
             output: output,
             model: model,
             seed: seed,
+            textureSeed: textureSeed,
             maxTokens: maxTokens,
             alreadyFramed: alreadyFramed,
             noRemesh: noRemesh,
@@ -63,6 +67,7 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
         output: String?,
         model: String?,
         seed: UInt64,
+        textureSeed: UInt64? = nil,
         maxTokens: Int,
         alreadyFramed: Bool,
         noRemesh: Bool = false,
@@ -117,6 +122,7 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
                 model: model,
                 foregroundPolicy: policy,
                 seed: seed,
+                textureSeed: textureSeed,
                 maximumSparseTokens: maxTokens,
                 remesh: noRemesh
                     ? nil

--- a/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
+++ b/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
@@ -33,6 +33,9 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
     @Option(name: [.long], help: "Narrow-band half-width in voxels for the watertight remesh; crust tears narrower than roughly twice this seal shut.")
     var remeshBand: Float = 1
 
+    @Option(name: [.long], help: "Morphological-closing radius in voxels; occluded cavities with mouths narrower than roughly twice this are sealed with a membrane. 0 disables.")
+    var sealRadius: Int = 12
+
     @Flag(name: [.long], help: "Verify inputs and checkpoints, then print the execution plan without loading weights.")
     var dryRun = false
 
@@ -49,6 +52,7 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
             alreadyFramed: alreadyFramed,
             noRemesh: noRemesh,
             remeshBand: remeshBand,
+            sealRadius: sealRadius,
             dryRun: dryRun,
             json: json
         )
@@ -63,11 +67,15 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
         alreadyFramed: Bool,
         noRemesh: Bool = false,
         remeshBand: Float = 1,
+        sealRadius: Int = 12,
         dryRun: Bool,
         json: Bool
     ) async throws {
         guard remeshBand > 0, remeshBand <= 8 else {
             throw ValidationError("--remesh-band must be in (0, 8]")
+        }
+        guard sealRadius >= 0, sealRadius <= 32 else {
+            throw ValidationError("--seal-radius must be in [0, 32]")
         }
         guard maxTokens >= 4_096 else {
             throw ValidationError("--max-tokens must be at least 4096")
@@ -110,7 +118,9 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
                 foregroundPolicy: policy,
                 seed: seed,
                 maximumSparseTokens: maxTokens,
-                remesh: noRemesh ? nil : Trellis2RemeshConfiguration(band: remeshBand),
+                remesh: noRemesh
+                    ? nil
+                    : Trellis2RemeshConfiguration(band: remeshBand, sealRadius: sealRadius),
                 progress: { event in
                     CLIStderr.write("[image-to-3d-trellis2] \(event.message)\n")
                 }

--- a/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
+++ b/Sources/MereRunCLI/Commands/VisionImageTo3DTrellis2Command.swift
@@ -27,6 +27,12 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
     @Flag(name: [.long], help: "Preserve framing and composite alpha over black without foreground cropping.")
     var alreadyFramed = false
 
+    @Flag(name: [.long], help: "Export the raw porous dual-grid crust instead of the watertight narrow-band remesh.")
+    var noRemesh = false
+
+    @Option(name: [.long], help: "Narrow-band half-width in voxels for the watertight remesh; crust tears narrower than roughly twice this seal shut.")
+    var remeshBand: Float = 1
+
     @Flag(name: [.long], help: "Verify inputs and checkpoints, then print the execution plan without loading weights.")
     var dryRun = false
 
@@ -41,6 +47,8 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
             seed: seed,
             maxTokens: maxTokens,
             alreadyFramed: alreadyFramed,
+            noRemesh: noRemesh,
+            remeshBand: remeshBand,
             dryRun: dryRun,
             json: json
         )
@@ -53,9 +61,14 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
         seed: UInt64,
         maxTokens: Int,
         alreadyFramed: Bool,
+        noRemesh: Bool = false,
+        remeshBand: Float = 1,
         dryRun: Bool,
         json: Bool
     ) async throws {
+        guard remeshBand > 0, remeshBand <= 8 else {
+            throw ValidationError("--remesh-band must be in (0, 8]")
+        }
         guard maxTokens >= 4_096 else {
             throw ValidationError("--max-tokens must be at least 4096")
         }
@@ -97,6 +110,7 @@ struct VisionImageTo3DTrellis2: AsyncParsableCommand {
                 foregroundPolicy: policy,
                 seed: seed,
                 maximumSparseTokens: maxTokens,
+                remesh: noRemesh ? nil : Trellis2RemeshConfiguration(band: remeshBand),
                 progress: { event in
                     CLIStderr.write("[image-to-3d-trellis2] \(event.message)\n")
                 }

--- a/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
+++ b/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
@@ -29,6 +29,10 @@ Raising it can materially increase unified-memory use. This is deliberately
 separate from Microsoft's 49,152-token cascade-resolution budget, which does
 not cap the direct 512 decoder. The three flow stages use the official 12-step
 Euler schedules. `--seed` controls deterministic MLX noise and defaults to 42.
+`--texture-seed` re-rolls only the texture flow while structure and shape
+replay bit-identically from `--seed`: when a seed produces good geometry with
+a drifted palette, search texture seeds without touching the reconstruction.
+Both seeds are recorded in the run manifest.
 
 Use `--dry-run` to validate the input, checksum every pinned component, and
 print the plan without loading a neural graph:

--- a/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
+++ b/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
@@ -37,12 +37,24 @@ print the plan without loading a neural graph:
 mere.run image reconstruct-3d-trellis2 ./chair.png --dry-run --already-framed
 ```
 
+The exported mesh is, by default, the watertight narrow-band dual-contour
+envelope of the raw crust (band 1 voxel, no projection), mirroring upstream's
+shipped `to_glb` remesh: the flexible dual grid's open seams and pinholes are
+sealed and the material renders single-sided. Crust tears wider than roughly
+twice the band survive as tunnels; for fuzzy or furry subjects raise
+`--remesh-band` to 2 or 3 (each unit inflates the surface by one voxel,
+about 0.2% of the object). Colors are always sampled at the closest point on
+the original crust, so wider bands do not wash out or darken the appearance.
+Pass `--no-remesh` to export the raw porous dual-grid crust instead
+(double-sided, upstream's non-remesh topology).
+
 The output directory contains OBJ, binary PLY, and GLB files with sampled RGBA
-vertex color; a shared mesh manifest; a `.pbrvox` sparse material field; and an
-authoritative TRELLIS.2 run manifest. `.pbrvox` preserves base color RGB,
-metallic, roughness, and alpha for every decoded O-Voxel because the canonical
-mesh formats currently do not author a texture atlas. All artifacts and all
-seven checkpoint components are named, pinned, and hashed in provenance.
+vertex color; a `-textured.glb` whose per-quad atlas bakes the field into
+standard glTF PBR textures; a shared mesh manifest; a `.pbrvox` sparse material
+field; and an authoritative TRELLIS.2 run manifest. `.pbrvox` preserves base
+color RGB, metallic, roughness, and alpha for every decoded O-Voxel. All
+artifacts and all seven checkpoint components are named, pinned, and hashed in
+provenance.
 
 Coordinates are normalized object space with X right, Y up, and Z forward.
 They are not meters, and unseen geometry is inferred from the single image.

--- a/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
+++ b/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
@@ -40,13 +40,17 @@ mere.run image reconstruct-3d-trellis2 ./chair.png --dry-run --already-framed
 The exported mesh is, by default, the watertight narrow-band dual-contour
 envelope of the raw crust (band 1 voxel, no projection), mirroring upstream's
 shipped `to_glb` remesh: the flexible dual grid's open seams and pinholes are
-sealed and the material renders single-sided. Crust tears wider than roughly
-twice the band survive as tunnels; for fuzzy or furry subjects raise
-`--remesh-band` to 2 or 3 (each unit inflates the surface by one voxel,
-about 0.2% of the object). Colors are always sampled at the closest point on
-the original crust, so wider bands do not wash out or darken the appearance.
-Pass `--no-remesh` to export the raw porous dual-grid crust instead
-(double-sided, upstream's non-remesh topology).
+sealed and the material renders single-sided. Two additional sealing stages
+close what the envelope alone cannot: large clean boundary rims are capped
+before remeshing, and a morphological-closing classification of the occupancy
+(dilate, flood the exterior, erode) spans membranes across occluded cavities
+whose mouths are narrower than roughly twice `--seal-radius` (default 12
+voxels; 0 disables). Membrane and lid colors are sampled at the closest point
+on the original crust, so sealed regions blend into the surrounding fur
+rather than going dark. Raise `--remesh-band` for extra tear tolerance (each
+unit inflates the surface by one voxel, about 0.2% of the object); pass
+`--no-remesh` to export the raw porous dual-grid crust instead (double-sided,
+upstream's non-remesh topology).
 
 The output directory contains OBJ, binary PLY, and GLB files with sampled RGBA
 vertex color; a `-textured.glb` whose per-quad atlas bakes the field into

--- a/Sources/MereRunCore/Asset3D/MeshArtifactExporter.swift
+++ b/Sources/MereRunCore/Asset3D/MeshArtifactExporter.swift
@@ -122,6 +122,7 @@ public enum MeshArtifactExporter {
         stem: String = "asset",
         provenance: GeometryModelProvenance,
         inputRecords admittedInputRecords: [MeshInputRecord]? = nil,
+        material: MeshPBRMaterialFactors? = nil,
         createdAt: Date = Date()
     ) throws -> MeshExportResult {
         let root = outputDirectory.standardizedFileURL
@@ -156,7 +157,7 @@ public enum MeshArtifactExporter {
         let outputs: [(MeshArtifactKind, String, String, (MeshAsset, URL) throws -> Void)] = [
             (.obj, "obj", "model/obj", MeshOBJWriter.write),
             (.ply, "ply", "application/ply", MeshPLYWriter.write),
-            (.glb, "glb", "model/gltf-binary", MeshGLBWriter.write),
+            (.glb, "glb", "model/gltf-binary", { try MeshGLBWriter.write($0, to: $1, material: material) }),
         ]
         var artifacts: [MeshArtifactRecord] = []
         for (kind, extensionName, mediaType, writer) in outputs {

--- a/Sources/MereRunCore/Asset3D/MeshAsset.swift
+++ b/Sources/MereRunCore/Asset3D/MeshAsset.swift
@@ -45,10 +45,14 @@ public struct MeshBounds: Codable, Equatable, Sendable {
 public struct MeshPBRMaterialFactors: Codable, Equatable, Sendable {
     public let metallicFactor: Float
     public let roughnessFactor: Float
+    /// Watertight meshes with consistent outward orientation render
+    /// single-sided; the porous default stays double-sided.
+    public let doubleSided: Bool
 
-    public init(metallicFactor: Float, roughnessFactor: Float) {
+    public init(metallicFactor: Float, roughnessFactor: Float, doubleSided: Bool = true) {
         self.metallicFactor = min(max(metallicFactor, 0), 1)
         self.roughnessFactor = min(max(roughnessFactor, 0), 1)
+        self.doubleSided = doubleSided
     }
 }
 

--- a/Sources/MereRunCore/Asset3D/MeshAsset.swift
+++ b/Sources/MereRunCore/Asset3D/MeshAsset.swift
@@ -39,6 +39,19 @@ public struct MeshBounds: Codable, Equatable, Sendable {
     }
 }
 
+/// Uniform PBR scalars for an exported material. glTF viewers multiply these
+/// with per-vertex color, so they carry the field-level metallic/roughness
+/// that the vertex-color mesh contract cannot express per vertex.
+public struct MeshPBRMaterialFactors: Codable, Equatable, Sendable {
+    public let metallicFactor: Float
+    public let roughnessFactor: Float
+
+    public init(metallicFactor: Float, roughnessFactor: Float) {
+        self.metallicFactor = min(max(metallicFactor, 0), 1)
+        self.roughnessFactor = min(max(roughnessFactor, 0), 1)
+    }
+}
+
 /// Canonical indexed triangle mesh used by native object reconstruction.
 public struct MeshAsset: Sendable {
     public let vertices: [Float]

--- a/Sources/MereRunCore/Asset3D/MeshGLBWriter.swift
+++ b/Sources/MereRunCore/Asset3D/MeshGLBWriter.swift
@@ -105,7 +105,7 @@ public enum MeshGLBWriter {
             ]],
             "materials": [[
                 "name": "Vertex Colors",
-                "doubleSided": true,
+                "doubleSided": material?.doubleSided ?? true,
                 "pbrMetallicRoughness": [
                     "baseColorFactor": [1, 1, 1, 1],
                     "metallicFactor": material?.metallicFactor ?? 0,

--- a/Sources/MereRunCore/Asset3D/MeshGLBWriter.swift
+++ b/Sources/MereRunCore/Asset3D/MeshGLBWriter.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// Dependency-free glTF 2.0 binary writer for indexed, vertex-colored meshes.
 public enum MeshGLBWriter {
-    public static func write(_ source: MeshAsset, to url: URL) throws {
+    public static func write(
+        _ source: MeshAsset,
+        to url: URL,
+        material: MeshPBRMaterialFactors? = nil
+    ) throws {
         let mesh = source.normals == nil ? try source.withGeneratedNormals() : source
         var binary = Data()
         var bufferViews: [[String: Any]] = []
@@ -104,8 +108,8 @@ public enum MeshGLBWriter {
                 "doubleSided": true,
                 "pbrMetallicRoughness": [
                     "baseColorFactor": [1, 1, 1, 1],
-                    "metallicFactor": 0,
-                    "roughnessFactor": 1,
+                    "metallicFactor": material?.metallicFactor ?? 0,
+                    "roughnessFactor": material?.roughnessFactor ?? 1,
                 ],
             ]],
             "buffers": [["byteLength": binary.count]],

--- a/Sources/MereRunCore/Asset3D/README.md
+++ b/Sources/MereRunCore/Asset3D/README.md
@@ -23,7 +23,12 @@ PLY, and binary glTF writers used by native reconstruction runtimes.
   format. Standards-compliant viewers (three.js, Blender) therefore display
   identical colors for all three artifacts.
 
+- Exporters may pass uniform `MeshPBRMaterialFactors` (metallic, roughness);
+  `MeshGLBWriter` writes them as core glTF material factors and defaults to a
+  fully rough dielectric when absent.
+
 Model-specific inference and provenance belong in `TripoSR`, `InstantMesh`, and
 `Trellis2`. TRELLIS.2 additionally writes its six-channel sparse PBR field as a
 model-specific `.pbrvox` sidecar because the canonical mesh contract currently
-stores vertex color, not a generated texture atlas.
+stores vertex color, not a generated texture atlas; its field-median metallic
+and roughness ride along as the GLB's uniform material factors.

--- a/Sources/MereRunCore/Asset3D/README.md
+++ b/Sources/MereRunCore/Asset3D/README.md
@@ -29,6 +29,7 @@ PLY, and binary glTF writers used by native reconstruction runtimes.
 
 Model-specific inference and provenance belong in `TripoSR`, `InstantMesh`, and
 `Trellis2`. TRELLIS.2 additionally writes its six-channel sparse PBR field as a
-model-specific `.pbrvox` sidecar because the canonical mesh contract currently
-stores vertex color, not a generated texture atlas; its field-median metallic
-and roughness ride along as the GLB's uniform material factors.
+model-specific `.pbrvox` sidecar because the canonical mesh contract stores
+vertex color, not a texture atlas; its field-median metallic and roughness
+ride along as the canonical GLB's uniform material factors, and a separate
+model-specific `-textured.glb` bakes the field into real glTF PBR textures.

--- a/Sources/MereRunCore/Trellis2/README.md
+++ b/Sources/MereRunCore/Trellis2/README.md
@@ -23,8 +23,10 @@ does not launch Python, PyTorch, or CUDA.
 6. `Trellis2NarrowBandRemesher.swift` (default) replaces the porous crust with
    its watertight narrow-band dual-contour envelope — the native port of
    CuMesh's `remesh_narrow_band_dc` as upstream's `to_glb` invokes it (band 1,
-   no projection) — and re-samples vertex color and material scalars from the
-   field at the new vertices.
+   no projection) — unioned with `Trellis2SealedClassification`'s
+   morphological-closing solid so membranes span occluded cavities that no
+   band or rim capping can close, and re-samples vertex color and material
+   scalars from the field at each vertex's closest crust point.
 7. `Trellis2ArtifactExporter.swift` writes canonical OBJ, PLY, and GLB meshes,
    a deterministic `.pbrvox` sidecar that preserves all six PBR channels, and
    a self-contained `-textured.glb` whose per-quad atlas blocks

--- a/Sources/MereRunCore/Trellis2/README.md
+++ b/Sources/MereRunCore/Trellis2/README.md
@@ -20,7 +20,12 @@ does not launch Python, PyTorch, or CUDA.
    O-Voxel's Z-up basis into the canonical Y-up mesh contract, fills small
    boundary loops at the reference threshold, and samples RGBA, metallic, and
    roughness at its vertices.
-6. `Trellis2ArtifactExporter.swift` writes canonical OBJ, PLY, and GLB meshes,
+6. `Trellis2NarrowBandRemesher.swift` (default) replaces the porous crust with
+   its watertight narrow-band dual-contour envelope — the native port of
+   CuMesh's `remesh_narrow_band_dc` as upstream's `to_glb` invokes it (band 1,
+   no projection) — and re-samples vertex color and material scalars from the
+   field at the new vertices.
+7. `Trellis2ArtifactExporter.swift` writes canonical OBJ, PLY, and GLB meshes,
    a deterministic `.pbrvox` sidecar that preserves all six PBR channels, and
    a self-contained `-textured.glb` whose per-quad atlas blocks
    (`Trellis2TextureAtlasBaker`) bake the field into an sRGB baseColorTexture

--- a/Sources/MereRunCore/Trellis2/README.md
+++ b/Sources/MereRunCore/Trellis2/README.md
@@ -21,7 +21,10 @@ does not launch Python, PyTorch, or CUDA.
    boundary loops at the reference threshold, and samples RGBA, metallic, and
    roughness at its vertices.
 6. `Trellis2ArtifactExporter.swift` writes canonical OBJ, PLY, and GLB meshes,
-   plus a deterministic `.pbrvox` sidecar that preserves all six PBR channels.
+   a deterministic `.pbrvox` sidecar that preserves all six PBR channels, and
+   a self-contained `-textured.glb` whose per-quad atlas blocks
+   (`Trellis2TextureAtlasBaker`) bake the field into an sRGB baseColorTexture
+   and a linear metallicRoughnessTexture.
 
 Every large stage is loaded and released separately so the three 1.3B flow
 checkpoints and two sparse decoders are not resident together.
@@ -40,8 +43,11 @@ rejected unless the caller explicitly passes `--already-framed`; the runtime
 does not hide a background-removal service or model behind this command.
 
 The initial native surface is the official 512 pipeline. The 1024/1536 cascade
-checkpoints and texture-atlas conversion are not represented as supported.
-GLB/PLY/OBJ carry sampled vertex RGBA. Metallic, roughness, alpha, and base
+checkpoints are not represented as supported. GLB/PLY/OBJ carry sampled vertex
+RGBA; the additional `-textured.glb` artifact bakes the field into standard
+glTF PBR textures over a per-quad block atlas (dual-grid quads recovered from
+consecutive triangle pairs; blocks Morton-ordered by quad centroid so mip
+levels blend surface-local colors). Metallic, roughness, alpha, and base
 color remain losslessly available in the hashed `.pbrvox` sidecar and run
 manifest. Mesh artifacts use the canonical X-right, Y-up, Z-forward basis;
 `.pbrvox` coordinates remain integer O-Voxel indices in the model's native

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -91,6 +91,7 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
     public let remeshBand: Float?
     public let remeshProjectBack: Float?
     public let remeshCapBoundaryLoopPerimeter: Float?
+    public let remeshSealRadius: Int?
 
     public init(
         seed: UInt64,
@@ -103,7 +104,8 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
         pbrRepresentation: String,
         remeshBand: Float? = nil,
         remeshProjectBack: Float? = nil,
-        remeshCapBoundaryLoopPerimeter: Float? = nil
+        remeshCapBoundaryLoopPerimeter: Float? = nil,
+        remeshSealRadius: Int? = nil
     ) {
         self.seed = seed
         self.pipelineResolution = pipelineResolution
@@ -116,6 +118,7 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
         self.remeshBand = remeshBand
         self.remeshProjectBack = remeshProjectBack
         self.remeshCapBoundaryLoopPerimeter = remeshCapBoundaryLoopPerimeter
+        self.remeshSealRadius = remeshSealRadius
     }
 }
 
@@ -213,7 +216,8 @@ public enum Trellis2ArtifactExporter {
                 mesh: sealedCrust,
                 resolution: asset.pbrVoxels.resolution,
                 configuration: remesh,
-                bvh: sealedBVH
+                bvh: sealedBVH,
+                fieldCoordinates: asset.pbrVoxels.coordinates
             )
             // Envelope vertices sit up to `band` voxels off the crust, where
             // the sparse field has no data. Match upstream's to_glb: sample
@@ -365,7 +369,8 @@ public enum Trellis2ArtifactExporter {
                 pbrRepresentation: pbrRepresentation,
                 remeshBand: remesh?.band,
                 remeshProjectBack: remesh?.projectBack,
-                remeshCapBoundaryLoopPerimeter: remesh?.capBoundaryLoopPerimeter
+                remeshCapBoundaryLoopPerimeter: remesh?.capBoundaryLoopPerimeter,
+                remeshSealRadius: remesh?.sealRadius
             ),
             mesh: Trellis2MeshManifest(
                 coordinateSystem: mesh.manifest.coordinateSystem,

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -164,6 +164,10 @@ public enum Trellis2ArtifactExporter {
                 weightsSHA256: Trellis2Resources.primaryWeightsSHA256
             ),
             inputRecords: [inputRecord],
+            material: medianMaterialFactors(
+                metallic: asset.metallic,
+                roughness: asset.roughness
+            ),
             createdAt: createdAt
         )
         let cleanStem = mesh.manifestURL.lastPathComponent
@@ -247,6 +251,30 @@ public enum Trellis2ArtifactExporter {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
         return (mesh, pbr, Trellis2RunManifestExport(manifest: manifest, manifestURL: manifestURL))
+    }
+
+    /// Field-median metallic and roughness as uniform glTF material factors.
+    /// The per-vertex values stay in the `.pbrvox` sidecar; the median keeps
+    /// the GLB material honest for viewers that only read core glTF.
+    static func medianMaterialFactors(
+        metallic: [Float],
+        roughness: [Float]
+    ) -> MeshPBRMaterialFactors? {
+        guard let metallicMedian = median(of: metallic),
+              let roughnessMedian = median(of: roughness) else { return nil }
+        return MeshPBRMaterialFactors(
+            metallicFactor: metallicMedian,
+            roughnessFactor: roughnessMedian
+        )
+    }
+
+    private static func median(of values: [Float]) -> Float? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        return sorted.count.isMultiple(of: 2)
+            ? (sorted[middle - 1] + sorted[middle]) / 2
+            : sorted[middle]
     }
 
     private static func artifact(kind: String, url: URL, mediaType: String) throws -> Trellis2RunArtifact {

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -88,6 +88,32 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
     public let textureSteps: Int
     public let extractionAlgorithm: String
     public let pbrRepresentation: String
+    public let remeshBand: Float?
+    public let remeshProjectBack: Float?
+
+    public init(
+        seed: UInt64,
+        pipelineResolution: Int,
+        maximumSparseTokens: Int,
+        sparseStructureSteps: Int,
+        shapeSteps: Int,
+        textureSteps: Int,
+        extractionAlgorithm: String,
+        pbrRepresentation: String,
+        remeshBand: Float? = nil,
+        remeshProjectBack: Float? = nil
+    ) {
+        self.seed = seed
+        self.pipelineResolution = pipelineResolution
+        self.maximumSparseTokens = maximumSparseTokens
+        self.sparseStructureSteps = sparseStructureSteps
+        self.shapeSteps = shapeSteps
+        self.textureSteps = textureSteps
+        self.extractionAlgorithm = extractionAlgorithm
+        self.pbrRepresentation = pbrRepresentation
+        self.remeshBand = remeshBand
+        self.remeshProjectBack = remeshProjectBack
+    }
 }
 
 public struct Trellis2MeshManifest: Codable, Equatable, Sendable {
@@ -133,6 +159,8 @@ public struct Trellis2RunManifestExport: Equatable, Sendable {
 
 public enum Trellis2ArtifactExporter {
     public static let extractionAlgorithm = "native-ovoxel-flexible-dual-grid-small-hole-fill"
+    public static let remeshExtractionAlgorithm =
+        "native-ovoxel-flexible-dual-grid-small-hole-fill-narrow-band-dc-remesh"
     public static let pbrRepresentation = "vertex-rgba-plus-sparse-pbrvox-plus-baked-atlas"
 
     public static func export(
@@ -148,11 +176,81 @@ public enum Trellis2ArtifactExporter {
         croppedTransparentForeground: Bool,
         seed: UInt64,
         maximumSparseTokens: Int,
+        remesh: Trellis2RemeshConfiguration? = Trellis2RemeshConfiguration(),
         createdAt: Date = Date()
     ) throws -> (mesh: MeshExportResult, pbr: Trellis2PBRVoxelExport, run: Trellis2RunManifestExport) {
         let root = outputDirectory.standardizedFileURL
+
+        // The narrow-band remesh replaces the porous crust with its closed
+        // envelope; colors and material scalars are re-sampled from the field
+        // at the new vertices. The watertight envelope has a consistent
+        // outward orientation, so its materials are single-sided, matching
+        // upstream's to_glb.
+        let exportMesh: MeshAsset
+        let metallic: [Float]
+        let roughness: [Float]
+        let algorithm: String
+        let doubleSided: Bool
+        var crustSurface: Trellis2TriangleBVH?
+        if let remesh {
+            let bvh = Trellis2TriangleBVH(vertices: asset.mesh.vertices, indices: asset.mesh.indices)
+            let remeshed = try Trellis2NarrowBandRemesher.remesh(
+                mesh: asset.mesh,
+                resolution: asset.pbrVoxels.resolution,
+                configuration: remesh,
+                bvh: bvh
+            )
+            // Envelope vertices sit up to `band` voxels off the crust, where
+            // the sparse field has no data. Match upstream's to_glb: sample
+            // at each vertex's closest point on the original crust.
+            var sampledPositions = [Float](repeating: 0, count: remeshed.vertices.count)
+            sampledPositions.withUnsafeMutableBufferPointer { output in
+                remeshed.vertices.withUnsafeBufferPointer { input in
+                    Trellis2Parallel.chunks(remeshed.vertexCount) { range in
+                        for vertex in range {
+                            let closest = bvh.closestPoint(
+                                x: input[vertex * 3],
+                                y: input[vertex * 3 + 1],
+                                z: input[vertex * 3 + 2]
+                            )
+                            output[vertex * 3] = closest.x
+                            output[vertex * 3 + 1] = closest.y
+                            output[vertex * 3 + 2] = closest.z
+                        }
+                    }
+                }
+            }
+            let sampler = Trellis2SparseFieldSampler(
+                coordinates: asset.pbrVoxels.coordinates,
+                attributes: asset.pbrVoxels.attributes
+            )
+            let attributes = sampler.meshVertexAttributes(
+                vertices: sampledPositions,
+                resolution: asset.pbrVoxels.resolution
+            )
+            exportMesh = try MeshAsset(
+                vertices: remeshed.vertices,
+                indices: remeshed.indices,
+                colorsRGBA8: attributes.colorsRGBA8,
+                coordinateSystem: remeshed.coordinateSystem,
+                units: remeshed.units,
+                inferredUnseenGeometry: remeshed.inferredUnseenGeometry
+            )
+            metallic = attributes.metallic
+            roughness = attributes.roughness
+            algorithm = Self.remeshExtractionAlgorithm
+            doubleSided = false
+            crustSurface = bvh
+        } else {
+            exportMesh = asset.mesh
+            metallic = asset.metallic
+            roughness = asset.roughness
+            algorithm = Self.extractionAlgorithm
+            doubleSided = true
+        }
+
         let mesh = try MeshArtifactExporter.export(
-            mesh: asset.mesh,
+            mesh: exportMesh,
             inputURLs: [inputURL.standardizedFileURL],
             outputDirectory: root,
             stem: stem,
@@ -165,8 +263,9 @@ public enum Trellis2ArtifactExporter {
             ),
             inputRecords: [inputRecord],
             material: medianMaterialFactors(
-                metallic: asset.metallic,
-                roughness: asset.roughness
+                metallic: metallic,
+                roughness: roughness,
+                doubleSided: doubleSided
             ),
             createdAt: createdAt
         )
@@ -178,10 +277,15 @@ public enum Trellis2ArtifactExporter {
         )
         let texturedURL = root.appendingPathComponent("\(cleanStem)-textured.glb")
         try Trellis2TexturedGLBWriter.write(
-            Trellis2TextureAtlasBaker.bake(mesh: asset.mesh, field: asset.pbrVoxels),
-            coordinateSystem: asset.mesh.coordinateSystem,
-            units: asset.mesh.units,
-            inferredUnseenGeometry: asset.mesh.inferredUnseenGeometry,
+            Trellis2TextureAtlasBaker.bake(
+                mesh: exportMesh,
+                field: asset.pbrVoxels,
+                projectionSurface: crustSurface
+            ),
+            coordinateSystem: exportMesh.coordinateSystem,
+            units: exportMesh.units,
+            inferredUnseenGeometry: exportMesh.inferredUnseenGeometry,
+            doubleSided: doubleSided,
             to: texturedURL
         )
         let input = try mesh.manifest.inputRecord(for: inputURL)
@@ -242,8 +346,10 @@ public enum Trellis2ArtifactExporter {
                 sparseStructureSteps: Trellis2SamplerConfiguration.sparseStructure.steps,
                 shapeSteps: Trellis2SamplerConfiguration.shape.steps,
                 textureSteps: Trellis2SamplerConfiguration.texture.steps,
-                extractionAlgorithm: extractionAlgorithm,
-                pbrRepresentation: pbrRepresentation
+                extractionAlgorithm: algorithm,
+                pbrRepresentation: pbrRepresentation,
+                remeshBand: remesh?.band,
+                remeshProjectBack: remesh?.projectBack
             ),
             mesh: Trellis2MeshManifest(
                 coordinateSystem: mesh.manifest.coordinateSystem,
@@ -271,13 +377,15 @@ public enum Trellis2ArtifactExporter {
     /// the GLB material honest for viewers that only read core glTF.
     static func medianMaterialFactors(
         metallic: [Float],
-        roughness: [Float]
+        roughness: [Float],
+        doubleSided: Bool = true
     ) -> MeshPBRMaterialFactors? {
         guard let metallicMedian = median(of: metallic),
               let roughnessMedian = median(of: roughness) else { return nil }
         return MeshPBRMaterialFactors(
             metallicFactor: metallicMedian,
-            roughnessFactor: roughnessMedian
+            roughnessFactor: roughnessMedian,
+            doubleSided: doubleSided
         )
     }
 

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -81,6 +81,7 @@ public struct Trellis2InputManifest: Codable, Equatable, Sendable {
 
 public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
     public let seed: UInt64
+    public let textureSeed: UInt64?
     public let pipelineResolution: Int
     public let maximumSparseTokens: Int
     public let sparseStructureSteps: Int
@@ -95,6 +96,7 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
 
     public init(
         seed: UInt64,
+        textureSeed: UInt64? = nil,
         pipelineResolution: Int,
         maximumSparseTokens: Int,
         sparseStructureSteps: Int,
@@ -108,6 +110,7 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
         remeshSealRadius: Int? = nil
     ) {
         self.seed = seed
+        self.textureSeed = textureSeed
         self.pipelineResolution = pipelineResolution
         self.maximumSparseTokens = maximumSparseTokens
         self.sparseStructureSteps = sparseStructureSteps
@@ -181,6 +184,7 @@ public enum Trellis2ArtifactExporter {
         foregroundPolicy: String,
         croppedTransparentForeground: Bool,
         seed: UInt64,
+        textureSeed: UInt64? = nil,
         maximumSparseTokens: Int,
         remesh: Trellis2RemeshConfiguration? = Trellis2RemeshConfiguration(),
         createdAt: Date = Date()
@@ -360,6 +364,7 @@ public enum Trellis2ArtifactExporter {
             ),
             generation: Trellis2GenerationManifest(
                 seed: seed,
+                textureSeed: textureSeed,
                 pipelineResolution: 512,
                 maximumSparseTokens: maximumSparseTokens,
                 sparseStructureSteps: Trellis2SamplerConfiguration.sparseStructure.steps,

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -90,6 +90,7 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
     public let pbrRepresentation: String
     public let remeshBand: Float?
     public let remeshProjectBack: Float?
+    public let remeshCapBoundaryLoopPerimeter: Float?
 
     public init(
         seed: UInt64,
@@ -101,7 +102,8 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
         extractionAlgorithm: String,
         pbrRepresentation: String,
         remeshBand: Float? = nil,
-        remeshProjectBack: Float? = nil
+        remeshProjectBack: Float? = nil,
+        remeshCapBoundaryLoopPerimeter: Float? = nil
     ) {
         self.seed = seed
         self.pipelineResolution = pipelineResolution
@@ -113,6 +115,7 @@ public struct Trellis2GenerationManifest: Codable, Equatable, Sendable {
         self.pbrRepresentation = pbrRepresentation
         self.remeshBand = remeshBand
         self.remeshProjectBack = remeshProjectBack
+        self.remeshCapBoundaryLoopPerimeter = remeshCapBoundaryLoopPerimeter
     }
 }
 
@@ -194,11 +197,23 @@ public enum Trellis2ArtifactExporter {
         var crustSurface: Trellis2TriangleBVH?
         if let remesh {
             let bvh = Trellis2TriangleBVH(vertices: asset.mesh.vertices, indices: asset.mesh.indices)
+            // Cap large closed rims so occluded pockets seal instead of
+            // surviving as tunnels; the band field sees the capped crust,
+            // while colors keep projecting onto the real (uncapped) crust.
+            let sealedCrust = remesh.capBoundaryLoopPerimeter > 0
+                ? try Trellis2MeshHoleFiller.fillSmallHoles(
+                    in: asset.mesh,
+                    maximumPerimeter: remesh.capBoundaryLoopPerimeter
+                )
+                : asset.mesh
+            let sealedBVH = sealedCrust.indices.count == asset.mesh.indices.count
+                ? bvh
+                : Trellis2TriangleBVH(vertices: sealedCrust.vertices, indices: sealedCrust.indices)
             let remeshed = try Trellis2NarrowBandRemesher.remesh(
-                mesh: asset.mesh,
+                mesh: sealedCrust,
                 resolution: asset.pbrVoxels.resolution,
                 configuration: remesh,
-                bvh: bvh
+                bvh: sealedBVH
             )
             // Envelope vertices sit up to `band` voxels off the crust, where
             // the sparse field has no data. Match upstream's to_glb: sample
@@ -349,7 +364,8 @@ public enum Trellis2ArtifactExporter {
                 extractionAlgorithm: algorithm,
                 pbrRepresentation: pbrRepresentation,
                 remeshBand: remesh?.band,
-                remeshProjectBack: remesh?.projectBack
+                remeshProjectBack: remesh?.projectBack,
+                remeshCapBoundaryLoopPerimeter: remesh?.capBoundaryLoopPerimeter
             ),
             mesh: Trellis2MeshManifest(
                 coordinateSystem: mesh.manifest.coordinateSystem,

--- a/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2ArtifactExporter.swift
@@ -133,7 +133,7 @@ public struct Trellis2RunManifestExport: Equatable, Sendable {
 
 public enum Trellis2ArtifactExporter {
     public static let extractionAlgorithm = "native-ovoxel-flexible-dual-grid-small-hole-fill"
-    public static let pbrRepresentation = "vertex-rgba-plus-sparse-pbrvox"
+    public static let pbrRepresentation = "vertex-rgba-plus-sparse-pbrvox-plus-baked-atlas"
 
     public static func export(
         asset: Trellis2DecodedAsset,
@@ -176,6 +176,14 @@ public enum Trellis2ArtifactExporter {
             asset.pbrVoxels,
             to: root.appendingPathComponent("\(cleanStem).pbrvox")
         )
+        let texturedURL = root.appendingPathComponent("\(cleanStem)-textured.glb")
+        try Trellis2TexturedGLBWriter.write(
+            Trellis2TextureAtlasBaker.bake(mesh: asset.mesh, field: asset.pbrVoxels),
+            coordinateSystem: asset.mesh.coordinateSystem,
+            units: asset.mesh.units,
+            inferredUnseenGeometry: asset.mesh.inferredUnseenGeometry,
+            to: texturedURL
+        )
         let input = try mesh.manifest.inputRecord(for: inputURL)
         var artifacts = mesh.manifest.artifacts.map {
             Trellis2RunArtifact(
@@ -192,6 +200,11 @@ public enum Trellis2ArtifactExporter {
             mediaType: pbr.mediaType,
             byteCount: pbr.byteCount,
             sha256: pbr.sha256
+        ))
+        artifacts.append(try artifact(
+            kind: "glb-textured",
+            url: texturedURL,
+            mediaType: "model/gltf-binary"
         ))
         artifacts.append(try artifact(
             kind: "mesh-manifest",

--- a/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
@@ -168,7 +168,12 @@ enum Trellis2FlexibleDualGrid {
         )
     }
 
-    private static func sampleTextureAttributes(
+    /// Trilinear sampling of the sparse texture field at each dual vertex.
+    /// The interpolation cell straddles the occupied shell, so weights are
+    /// renormalized over the corners that exist; dropping them unnormalized
+    /// darkens every channel (including alpha) by the missing weight. A
+    /// vertex whose cell has no occupied corner falls back to its own voxel.
+    static func sampleTextureAttributes(
         coordinates: [Trellis2VoxelCoordinate],
         attributes: [Float],
         coordinateIndices: [Trellis2VoxelCoordinate: Int],
@@ -184,6 +189,7 @@ enum Trellis2FlexibleDualGrid {
             ]
             let base = sample.map { Int32(floor($0)) }
             let fraction = zip(sample, base).map { $0 - Float($1) }
+            var occupiedWeight: Float = 0
             for corner in 0..<8 {
                 let x = Int32(corner & 1)
                 let y = Int32((corner >> 1) & 1)
@@ -197,8 +203,18 @@ enum Trellis2FlexibleDualGrid {
                     z: base[2] + z
                 )
                 guard let source = coordinateIndices[neighbor] else { continue }
+                occupiedWeight += weight
                 for channel in 0..<6 {
                     result[vertex * 6 + channel] += attributes[source * 6 + channel] * weight
+                }
+            }
+            if occupiedWeight > 1e-6 {
+                for channel in 0..<6 {
+                    result[vertex * 6 + channel] /= occupiedWeight
+                }
+            } else {
+                for channel in 0..<6 {
+                    result[vertex * 6 + channel] = attributes[vertex * 6 + channel]
                 }
             }
         }

--- a/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2FlexibleDualGrid.swift
@@ -179,43 +179,21 @@ enum Trellis2FlexibleDualGrid {
         coordinateIndices: [Trellis2VoxelCoordinate: Int],
         dualOffsets: [Float]
     ) -> [Float] {
+        let sampler = Trellis2SparseFieldSampler(
+            attributes: attributes,
+            coordinateIndices: coordinateIndices
+        )
         var result = [Float](repeating: 0, count: coordinates.count * 6)
         for vertex in 0..<coordinates.count {
             let coordinate = coordinates[vertex]
-            let sample = [
-                Float(coordinate.x) + dualOffsets[vertex * 3],
-                Float(coordinate.y) + dualOffsets[vertex * 3 + 1],
-                Float(coordinate.z) + dualOffsets[vertex * 3 + 2],
-            ]
-            let base = sample.map { Int32(floor($0)) }
-            let fraction = zip(sample, base).map { $0 - Float($1) }
-            var occupiedWeight: Float = 0
-            for corner in 0..<8 {
-                let x = Int32(corner & 1)
-                let y = Int32((corner >> 1) & 1)
-                let z = Int32((corner >> 2) & 1)
-                let weight = (x == 0 ? 1 - fraction[0] : fraction[0])
-                    * (y == 0 ? 1 - fraction[1] : fraction[1])
-                    * (z == 0 ? 1 - fraction[2] : fraction[2])
-                let neighbor = Trellis2VoxelCoordinate(
-                    x: base[0] + x,
-                    y: base[1] + y,
-                    z: base[2] + z
-                )
-                guard let source = coordinateIndices[neighbor] else { continue }
-                occupiedWeight += weight
-                for channel in 0..<6 {
-                    result[vertex * 6 + channel] += attributes[source * 6 + channel] * weight
-                }
-            }
-            if occupiedWeight > 1e-6 {
-                for channel in 0..<6 {
-                    result[vertex * 6 + channel] /= occupiedWeight
-                }
-            } else {
-                for channel in 0..<6 {
-                    result[vertex * 6 + channel] = attributes[vertex * 6 + channel]
-                }
+            let values = sampler.trilinear(
+                x: Float(coordinate.x) + dualOffsets[vertex * 3],
+                y: Float(coordinate.y) + dualOffsets[vertex * 3 + 1],
+                z: Float(coordinate.z) + dualOffsets[vertex * 3 + 2]
+            )
+            for channel in 0..<6 {
+                result[vertex * 6 + channel] = values?[channel]
+                    ?? attributes[vertex * 6 + channel]
             }
         }
         return result

--- a/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
@@ -115,6 +115,7 @@ public actor Trellis2Generator {
         model requestedModel: String? = nil,
         foregroundPolicy: Trellis2ForegroundPolicy = .transparentAlpha,
         seed: UInt64 = 42,
+        textureSeed: UInt64? = nil,
         maximumSparseTokens: Int = defaultMaximumSparseTokens,
         remesh: Trellis2RemeshConfiguration? = Trellis2RemeshConfiguration(),
         progress: (@Sendable (Trellis2Progress) -> Void)? = nil
@@ -181,6 +182,12 @@ public actor Trellis2Generator {
             checkpointURL: checkpoint.shapeFlowURL,
             progress: progress
         )
+        // An explicit texture seed re-rolls only the appearance: structure
+        // and shape stay bit-identical to the base seed's geometry, letting
+        // palette drift be searched without touching a good reconstruction.
+        if let textureSeed {
+            MLXRandom.seed(textureSeed)
+        }
         let textureLatent = try sampleTexture(
             coordinates: coordinates,
             normalizedShape: shapeLatents.normalized,
@@ -233,6 +240,7 @@ public actor Trellis2Generator {
             foregroundPolicy: policyName,
             croppedTransparentForeground: prepared.croppedTransparentForeground,
             seed: seed,
+            textureSeed: textureSeed,
             maximumSparseTokens: maximumSparseTokens,
             remesh: remesh
         )

--- a/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Generator.swift
@@ -15,6 +15,7 @@ public enum Trellis2Progress: Equatable, Sendable {
     case decodingShape
     case decodingTexture
     case extractingMesh
+    case remeshingMesh
     case exportingAssets
 
     public var message: String {
@@ -41,6 +42,8 @@ public enum Trellis2Progress: Equatable, Sendable {
             "Decoding six-channel PBR O-Voxels"
         case .extractingMesh:
             "Extracting flexible-dual-grid mesh and filling small boundary holes"
+        case .remeshingMesh:
+            "Remeshing to the watertight narrow-band dual-contour envelope"
         case .exportingAssets:
             "Writing OBJ, PLY, GLB, PBR voxels, and manifests"
         }
@@ -113,6 +116,7 @@ public actor Trellis2Generator {
         foregroundPolicy: Trellis2ForegroundPolicy = .transparentAlpha,
         seed: UInt64 = 42,
         maximumSparseTokens: Int = defaultMaximumSparseTokens,
+        remesh: Trellis2RemeshConfiguration? = Trellis2RemeshConfiguration(),
         progress: (@Sendable (Trellis2Progress) -> Void)? = nil
     ) async throws -> Trellis2RunResult {
         let inputURL = imageURL.standardizedFileURL
@@ -210,6 +214,9 @@ public actor Trellis2Generator {
         )
         MLX.Memory.clearCache()
 
+        if remesh != nil {
+            progress?(.remeshingMesh)
+        }
         progress?(.exportingAssets)
         let policyName = foregroundPolicy == .alreadyFramed
             ? "already-framed"
@@ -226,7 +233,8 @@ public actor Trellis2Generator {
             foregroundPolicy: policyName,
             croppedTransparentForeground: prepared.croppedTransparentForeground,
             seed: seed,
-            maximumSparseTokens: maximumSparseTokens
+            maximumSparseTokens: maximumSparseTokens,
+            remesh: remesh
         )
         MLX.Memory.clearCache()
         return Trellis2RunResult(

--- a/Sources/MereRunCore/Trellis2/Trellis2NarrowBandRemesher.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2NarrowBandRemesher.swift
@@ -12,15 +12,23 @@ public struct Trellis2RemeshConfiguration: Equatable, Sendable {
     /// tunnels through the envelope. Zero disables; colors never sample the
     /// synthetic lids because projection targets the uncapped crust.
     public let capBoundaryLoopPerimeter: Float
+    /// Morphological-closing radius in voxels for the sealed inside/outside
+    /// classification. Cavities whose every mouth is narrower than roughly
+    /// twice this radius are classified interior even when their rims are
+    /// tangled open chains no loop capping can close, and the remesh spans a
+    /// membrane across the opening. Zero disables.
+    public let sealRadius: Int
 
     public init(
         band: Float = 1,
         projectBack: Float = 0,
-        capBoundaryLoopPerimeter: Float = 0.2
+        capBoundaryLoopPerimeter: Float = 0.2,
+        sealRadius: Int = 12
     ) {
         self.band = band
         self.projectBack = projectBack
         self.capBoundaryLoopPerimeter = capBoundaryLoopPerimeter
+        self.sealRadius = sealRadius
     }
 }
 
@@ -37,7 +45,8 @@ enum Trellis2NarrowBandRemesher {
         mesh: MeshAsset,
         resolution: Int,
         configuration: Trellis2RemeshConfiguration = Trellis2RemeshConfiguration(),
-        bvh providedBVH: Trellis2TriangleBVH? = nil
+        bvh providedBVH: Trellis2TriangleBVH? = nil,
+        fieldCoordinates: [Trellis2VoxelCoordinate]? = nil
     ) throws -> MeshAsset {
         let bvh = providedBVH ?? Trellis2TriangleBVH(vertices: mesh.vertices, indices: mesh.indices)
         // Upstream inflates the domain so the band never clips the grid:
@@ -45,6 +54,35 @@ enum Trellis2NarrowBandRemesher {
         // object cube, centered at the origin.
         let scale = (Float(resolution) + 3 * configuration.band) / Float(resolution)
         let eps = configuration.band * scale / Float(resolution)
+
+        // Sealed inside/outside classification on this grid. The occupancy
+        // arrives in the field's Z-up grid over the unscaled object cube;
+        // convert each voxel center into a remesh-grid cell. The surface of
+        // the union of the band envelope and the sealed solid spans
+        // membranes across openings whose mouths are narrower than roughly
+        // twice the seal radius.
+        var classification: Trellis2SealedClassification?
+        if let fieldCoordinates, configuration.sealRadius > 0 {
+            var cells = [Int32]()
+            cells.reserveCapacity(fieldCoordinates.count * 3)
+            let fieldResolution = Float(resolution)
+            for coordinate in fieldCoordinates {
+                let rawX = (Float(coordinate.x) + 0.5) / fieldResolution - 0.5
+                let rawY = (Float(coordinate.y) + 0.5) / fieldResolution - 0.5
+                let rawZ = (Float(coordinate.z) + 0.5) / fieldResolution - 0.5
+                // Z-up field to Y-up mesh, then into the inflated grid.
+                let meshX = rawX, meshY = rawZ, meshZ = -rawY
+                cells.append(Int32(((meshX / scale + 0.5) * Float(resolution)).rounded(.down)))
+                cells.append(Int32(((meshY / scale + 0.5) * Float(resolution)).rounded(.down)))
+                cells.append(Int32(((meshZ / scale + 0.5) * Float(resolution)).rounded(.down)))
+            }
+            classification = Trellis2SealedClassification(
+                resolution: resolution,
+                occupiedCells: cells,
+                radius: configuration.sealRadius
+            )
+        }
+        let sealMagnitude = Float(max(configuration.sealRadius, 1)) * scale / Float(resolution)
 
         // --- Sparse octree refinement toward the band isosurface ---
         var levelResolution = resolution
@@ -73,12 +111,19 @@ enum Trellis2NarrowBandRemesher {
                 coordinates.withUnsafeBufferPointer { input in
                     concurrentChunks(voxelCount) { range in
                         for voxel in range {
-                            let x = (Float(input[voxel * 3]) + 0.5) * inverseResolution - 0.5
-                            let y = (Float(input[voxel * 3 + 1]) + 0.5) * inverseResolution - 0.5
-                            let z = (Float(input[voxel * 3 + 2]) + 0.5) * inverseResolution - 0.5
+                            let cx = input[voxel * 3]
+                            let cy = input[voxel * 3 + 1]
+                            let cz = input[voxel * 3 + 2]
+                            let x = (Float(cx) + 0.5) * inverseResolution - 0.5
+                            let y = (Float(cy) + 0.5) * inverseResolution - 0.5
+                            let z = (Float(cz) + 0.5) * inverseResolution - 0.5
                             let distance = bvh.unsignedDistance(x: x * scale, y: y * scale, z: z * scale) - eps
                             // 0.87 ~ sqrt(3)/2 covers the voxel's diagonal radius.
                             output[voxel] = abs(distance) < 0.87 * cellSize
+                                || classification?.straddlesBoundary(
+                                    x: cx, y: cy, z: cz,
+                                    levelResolution: levelResolution
+                                ) == true
                         }
                     }
                 }
@@ -143,10 +188,23 @@ enum Trellis2NarrowBandRemesher {
             cornerCoordinates.withUnsafeBufferPointer { input in
                 concurrentChunks(cornerCount) { range in
                     for corner in range {
-                        let x = (Float(input[corner * 3]) * inverseResolution - 0.5) * scale
-                        let y = (Float(input[corner * 3 + 1]) * inverseResolution - 0.5) * scale
-                        let z = (Float(input[corner * 3 + 2]) * inverseResolution - 0.5) * scale
-                        output[corner] = bvh.unsignedDistance(x: x, y: y, z: z) - eps
+                        let gx = input[corner * 3]
+                        let gy = input[corner * 3 + 1]
+                        let gz = input[corner * 3 + 2]
+                        let x = (Float(gx) * inverseResolution - 0.5) * scale
+                        let y = (Float(gy) * inverseResolution - 0.5) * scale
+                        let z = (Float(gz) * inverseResolution - 0.5) * scale
+                        let envelope = bvh.unsignedDistance(x: x, y: y, z: z) - eps
+                        // Union of the band envelope and the sealed solid:
+                        // interior corners go negative, exterior corners keep
+                        // the (clamped) envelope value.
+                        if let classification {
+                            output[corner] = classification.isInterior(x: gx, y: gy, z: gz)
+                                ? -sealMagnitude
+                                : min(envelope, sealMagnitude)
+                        } else {
+                            output[corner] = envelope
+                        }
                     }
                 }
             }

--- a/Sources/MereRunCore/Trellis2/Trellis2NarrowBandRemesher.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2NarrowBandRemesher.swift
@@ -6,10 +6,21 @@ public struct Trellis2RemeshConfiguration: Equatable, Sendable {
     /// Fraction to move dual vertices toward the closest crust point;
     /// upstream's shipped app uses 0 (surface stays on the band envelope).
     public let projectBack: Float
+    /// Closed crust boundary loops up to this normalized perimeter are
+    /// capped before the band field is built, so large clean rims (an
+    /// occluded cheek pocket, for example) become sealed surface instead of
+    /// tunnels through the envelope. Zero disables; colors never sample the
+    /// synthetic lids because projection targets the uncapped crust.
+    public let capBoundaryLoopPerimeter: Float
 
-    public init(band: Float = 1, projectBack: Float = 0) {
+    public init(
+        band: Float = 1,
+        projectBack: Float = 0,
+        capBoundaryLoopPerimeter: Float = 0.2
+    ) {
         self.band = band
         self.projectBack = projectBack
+        self.capBoundaryLoopPerimeter = capBoundaryLoopPerimeter
     }
 }
 

--- a/Sources/MereRunCore/Trellis2/Trellis2NarrowBandRemesher.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2NarrowBandRemesher.swift
@@ -1,0 +1,339 @@
+import Foundation
+
+public struct Trellis2RemeshConfiguration: Equatable, Sendable {
+    /// Narrow-band half-width in voxel units; upstream's shipped app uses 1.
+    public let band: Float
+    /// Fraction to move dual vertices toward the closest crust point;
+    /// upstream's shipped app uses 0 (surface stays on the band envelope).
+    public let projectBack: Float
+
+    public init(band: Float = 1, projectBack: Float = 0) {
+        self.band = band
+        self.projectBack = projectBack
+    }
+}
+
+/// Native port of CuMesh's `remesh_narrow_band_dc` as invoked by upstream
+/// TRELLIS.2's `to_glb`: the isosurface of `UDF(crust) - band` is extracted
+/// with simple dual contouring (dual vertex = mean of edge crossings) over a
+/// sparse octree-refined grid. The result is the closed envelope of the
+/// porous crust — watertight by construction, sealing gaps narrower than
+/// roughly twice the band — with quads emitted around sign-crossing grid
+/// edges exactly like the flexible dual grid, so the atlas baker's quad
+/// recovery applies unchanged.
+enum Trellis2NarrowBandRemesher {
+    static func remesh(
+        mesh: MeshAsset,
+        resolution: Int,
+        configuration: Trellis2RemeshConfiguration = Trellis2RemeshConfiguration(),
+        bvh providedBVH: Trellis2TriangleBVH? = nil
+    ) throws -> MeshAsset {
+        let bvh = providedBVH ?? Trellis2TriangleBVH(vertices: mesh.vertices, indices: mesh.indices)
+        // Upstream inflates the domain so the band never clips the grid:
+        // scale = (resolution + 3 * band) / resolution over the [-0.5, 0.5]
+        // object cube, centered at the origin.
+        let scale = (Float(resolution) + 3 * configuration.band) / Float(resolution)
+        let eps = configuration.band * scale / Float(resolution)
+
+        // --- Sparse octree refinement toward the band isosurface ---
+        var levelResolution = resolution
+        while levelResolution > 32 {
+            precondition(levelResolution.isMultiple(of: 2), "resolution must halve down to 32")
+            levelResolution /= 2
+        }
+        var coordinates = [Int32]()
+        coordinates.reserveCapacity(levelResolution * levelResolution * levelResolution * 3)
+        for x in 0..<levelResolution {
+            for y in 0..<levelResolution {
+                for z in 0..<levelResolution {
+                    coordinates.append(Int32(x))
+                    coordinates.append(Int32(y))
+                    coordinates.append(Int32(z))
+                }
+            }
+        }
+
+        while true {
+            let cellSize = scale / Float(levelResolution)
+            let voxelCount = coordinates.count / 3
+            let inverseResolution = 1 / Float(levelResolution)
+            var keep = [Bool](repeating: false, count: voxelCount)
+            keep.withUnsafeMutableBufferPointer { output in
+                coordinates.withUnsafeBufferPointer { input in
+                    concurrentChunks(voxelCount) { range in
+                        for voxel in range {
+                            let x = (Float(input[voxel * 3]) + 0.5) * inverseResolution - 0.5
+                            let y = (Float(input[voxel * 3 + 1]) + 0.5) * inverseResolution - 0.5
+                            let z = (Float(input[voxel * 3 + 2]) + 0.5) * inverseResolution - 0.5
+                            let distance = bvh.unsignedDistance(x: x * scale, y: y * scale, z: z * scale) - eps
+                            // 0.87 ~ sqrt(3)/2 covers the voxel's diagonal radius.
+                            output[voxel] = abs(distance) < 0.87 * cellSize
+                        }
+                    }
+                }
+            }
+            var kept = [Int32]()
+            kept.reserveCapacity(coordinates.count)
+            for voxel in 0..<voxelCount where keep[voxel] {
+                kept.append(coordinates[voxel * 3])
+                kept.append(coordinates[voxel * 3 + 1])
+                kept.append(coordinates[voxel * 3 + 2])
+            }
+            coordinates = kept
+            if levelResolution >= resolution { break }
+            levelResolution *= 2
+            var children = [Int32]()
+            children.reserveCapacity(coordinates.count * 8)
+            for voxel in 0..<(coordinates.count / 3) {
+                let x = coordinates[voxel * 3] * 2
+                let y = coordinates[voxel * 3 + 1] * 2
+                let z = coordinates[voxel * 3 + 2] * 2
+                for corner in 0..<8 {
+                    children.append(x + Int32(corner & 1))
+                    children.append(y + Int32((corner >> 1) & 1))
+                    children.append(z + Int32((corner >> 2) & 1))
+                }
+            }
+            coordinates = children
+        }
+        let voxelCount = coordinates.count / 3
+        guard voxelCount > 0 else { throw Trellis2ModelError.emptyExtractedMesh }
+
+        // --- Grid corner values (UDF - eps) ---
+        let cornerStride = Int64(resolution + 1)
+        func cornerKey(_ x: Int32, _ y: Int32, _ z: Int32) -> Int64 {
+            (Int64(x) * cornerStride + Int64(y)) * cornerStride + Int64(z)
+        }
+        var cornerIndices = [Int64: Int32]()
+        cornerIndices.reserveCapacity(voxelCount * 2)
+        var cornerCoordinates = [Int32]()
+        cornerCoordinates.reserveCapacity(voxelCount * 6)
+        for voxel in 0..<voxelCount {
+            let x = coordinates[voxel * 3]
+            let y = coordinates[voxel * 3 + 1]
+            let z = coordinates[voxel * 3 + 2]
+            for corner in 0..<8 {
+                let cx = x + Int32(corner & 1)
+                let cy = y + Int32((corner >> 1) & 1)
+                let cz = z + Int32((corner >> 2) & 1)
+                let key = cornerKey(cx, cy, cz)
+                if cornerIndices[key] == nil {
+                    cornerIndices[key] = Int32(cornerCoordinates.count / 3)
+                    cornerCoordinates.append(cx)
+                    cornerCoordinates.append(cy)
+                    cornerCoordinates.append(cz)
+                }
+            }
+        }
+        let cornerCount = cornerCoordinates.count / 3
+        var cornerValues = [Float](repeating: 0, count: cornerCount)
+        let inverseResolution = 1 / Float(resolution)
+        cornerValues.withUnsafeMutableBufferPointer { output in
+            cornerCoordinates.withUnsafeBufferPointer { input in
+                concurrentChunks(cornerCount) { range in
+                    for corner in range {
+                        let x = (Float(input[corner * 3]) * inverseResolution - 0.5) * scale
+                        let y = (Float(input[corner * 3 + 1]) * inverseResolution - 0.5) * scale
+                        let z = (Float(input[corner * 3 + 2]) * inverseResolution - 0.5) * scale
+                        output[corner] = bvh.unsignedDistance(x: x, y: y, z: z) - eps
+                    }
+                }
+            }
+        }
+
+        // --- Simple dual contouring: mean of edge crossings per voxel ---
+        // Edges as corner-index pairs in (x | y<<1 | z<<2) encoding, grouped
+        // by axis; the fourth edge of each axis group (the far edge) drives
+        // the crossing flag used for quad topology, matching the kernel.
+        let edgesByAxis: [[(Int, Int)]] = [
+            [(0b000, 0b001), (0b100, 0b101), (0b010, 0b011), (0b110, 0b111)],
+            [(0b000, 0b010), (0b001, 0b011), (0b100, 0b110), (0b101, 0b111)],
+            [(0b000, 0b100), (0b010, 0b110), (0b001, 0b101), (0b011, 0b111)],
+        ]
+        var dualVertices = [Float](repeating: 0, count: voxelCount * 3)
+        var crossings = [Int8](repeating: 0, count: voxelCount * 3)
+        dualVertices.withUnsafeMutableBufferPointer { dualOut in
+            crossings.withUnsafeMutableBufferPointer { crossingOut in
+                concurrentChunks(voxelCount) { range in
+                    var values = [Float](repeating: 0, count: 8)
+                    for voxel in range {
+                        let x = coordinates[voxel * 3]
+                        let y = coordinates[voxel * 3 + 1]
+                        let z = coordinates[voxel * 3 + 2]
+                        for corner in 0..<8 {
+                            let key = cornerKey(
+                                x + Int32(corner & 1),
+                                y + Int32((corner >> 1) & 1),
+                                z + Int32((corner >> 2) & 1)
+                            )
+                            values[corner] = cornerValues[Int(cornerIndices[key]!)]
+                        }
+                        var sumX: Float = 0, sumY: Float = 0, sumZ: Float = 0
+                        var count = 0
+                        for axis in 0..<3 {
+                            for (edgeIndex, edge) in edgesByAxis[axis].enumerated() {
+                                let value1 = values[edge.0]
+                                let value2 = values[edge.1]
+                                let crosses = (value1 < 0 && value2 >= 0) || (value1 >= 0 && value2 < 0)
+                                if crosses {
+                                    let t = -value1 / (value2 - value1)
+                                    var px = Float(x) + Float(edge.0 & 1)
+                                    var py = Float(y) + Float((edge.0 >> 1) & 1)
+                                    var pz = Float(z) + Float((edge.0 >> 2) & 1)
+                                    switch axis {
+                                    case 0: px += t
+                                    case 1: py += t
+                                    default: pz += t
+                                    }
+                                    sumX += px; sumY += py; sumZ += pz
+                                    count += 1
+                                }
+                                if edgeIndex == 3 {
+                                    crossingOut[voxel * 3 + axis] = !crosses
+                                        ? 0
+                                        : (value1 < 0 ? 1 : -1)
+                                }
+                            }
+                        }
+                        if count > 0 {
+                            dualOut[voxel * 3] = sumX / Float(count)
+                            dualOut[voxel * 3 + 1] = sumY / Float(count)
+                            dualOut[voxel * 3 + 2] = sumZ / Float(count)
+                        } else {
+                            dualOut[voxel * 3] = Float(x) + 0.5
+                            dualOut[voxel * 3 + 1] = Float(y) + 0.5
+                            dualOut[voxel * 3 + 2] = Float(z) + 0.5
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Quad topology around crossing far edges ---
+        let voxelStride = Int64(resolution)
+        func voxelKey(_ x: Int32, _ y: Int32, _ z: Int32) -> Int64 {
+            (Int64(x) * voxelStride + Int64(y)) * voxelStride + Int64(z)
+        }
+        var voxelIndices = [Int64: Int32]()
+        voxelIndices.reserveCapacity(voxelCount * 2)
+        for voxel in 0..<voxelCount {
+            voxelIndices[voxelKey(
+                coordinates[voxel * 3],
+                coordinates[voxel * 3 + 1],
+                coordinates[voxel * 3 + 2]
+            )] = Int32(voxel)
+        }
+        let neighborOffsets: [[(Int32, Int32, Int32)]] = [
+            [(0, 0, 0), (0, 0, 1), (0, 1, 1), (0, 1, 0)],
+            [(0, 0, 0), (1, 0, 0), (1, 0, 1), (0, 0, 1)],
+            [(0, 0, 0), (0, 1, 0), (1, 1, 0), (1, 0, 0)],
+        ]
+        // Upstream's split tables: `p` variants flip winding for positive
+        // crossings; the alignment test below is ported literally.
+        let splitOneNegative = [0, 1, 2, 0, 2, 3], splitOnePositive = [0, 2, 1, 0, 3, 2]
+        let splitTwoNegative = [0, 1, 3, 3, 1, 2], splitTwoPositive = [0, 3, 1, 3, 2, 1]
+
+        func position(_ vertex: Int32) -> (Float, Float, Float) {
+            (dualVertices[Int(vertex) * 3], dualVertices[Int(vertex) * 3 + 1], dualVertices[Int(vertex) * 3 + 2])
+        }
+        func alignment(_ table: [Int], _ quad: [Int32]) -> Float {
+            let t0 = position(quad[table[0]])
+            let t1 = position(quad[table[1]])
+            let t2 = position(quad[table[2]])
+            let t3 = position(quad[table[3]])
+            let n0 = cross(subtract(t1, t0), subtract(t2, t0))
+            let n1 = cross(subtract(t2, t1), subtract(t3, t1))
+            return abs(n0.0 * n1.0 + n0.1 * n1.1 + n0.2 * n1.2)
+        }
+
+        var indices = [UInt32]()
+        indices.reserveCapacity(voxelCount * 3)
+        for voxel in 0..<voxelCount {
+            let x = coordinates[voxel * 3]
+            let y = coordinates[voxel * 3 + 1]
+            let z = coordinates[voxel * 3 + 2]
+            for axis in 0..<3 {
+                let sign = crossings[voxel * 3 + axis]
+                guard sign != 0 else { continue }
+                var quad = [Int32]()
+                quad.reserveCapacity(4)
+                for offset in neighborOffsets[axis] {
+                    guard let neighbor = voxelIndices[voxelKey(x + offset.0, y + offset.1, z + offset.2)] else { break }
+                    quad.append(neighbor)
+                }
+                guard quad.count == 4 else { continue }
+                let one = sign > 0 ? splitOnePositive : splitOneNegative
+                let two = sign > 0 ? splitTwoPositive : splitTwoNegative
+                let chosen = alignment(one, quad) > alignment(two, quad) ? one : two
+                for slot in chosen {
+                    indices.append(UInt32(quad[slot]))
+                }
+            }
+        }
+        guard !indices.isEmpty else { throw Trellis2ModelError.emptyExtractedMesh }
+
+        // --- Object-space vertices, optional projection onto the crust ---
+        var vertices = [Float](repeating: 0, count: dualVertices.count)
+        let projectFraction = configuration.projectBack
+        vertices.withUnsafeMutableBufferPointer { output in
+            dualVertices.withUnsafeBufferPointer { input in
+                concurrentChunks(voxelCount) { range in
+                    for voxel in range {
+                        var x = (input[voxel * 3] * inverseResolution - 0.5) * scale
+                        var y = (input[voxel * 3 + 1] * inverseResolution - 0.5) * scale
+                        var z = (input[voxel * 3 + 2] * inverseResolution - 0.5) * scale
+                        if projectFraction > 0 {
+                            let closest = bvh.closestPoint(x: x, y: y, z: z)
+                            x -= projectFraction * (x - closest.x)
+                            y -= projectFraction * (y - closest.y)
+                            z -= projectFraction * (z - closest.z)
+                        }
+                        output[voxel * 3] = x
+                        output[voxel * 3 + 1] = y
+                        output[voxel * 3 + 2] = z
+                    }
+                }
+            }
+        }
+
+        // Drop dual vertices never referenced by a quad.
+        var remap = [UInt32](repeating: UInt32.max, count: voxelCount)
+        var compactVertices = [Float]()
+        compactVertices.reserveCapacity(vertices.count)
+        var compactIndices = [UInt32]()
+        compactIndices.reserveCapacity(indices.count)
+        for index in indices {
+            if remap[Int(index)] == UInt32.max {
+                remap[Int(index)] = UInt32(compactVertices.count / 3)
+                compactVertices.append(contentsOf: vertices[(Int(index) * 3)..<(Int(index) * 3 + 3)])
+            }
+            compactIndices.append(remap[Int(index)])
+        }
+
+        return try MeshAsset(
+            vertices: compactVertices,
+            indices: compactIndices,
+            coordinateSystem: mesh.coordinateSystem,
+            units: mesh.units,
+            inferredUnseenGeometry: mesh.inferredUnseenGeometry
+        )
+    }
+
+    private static func concurrentChunks(_ count: Int, _ body: (Range<Int>) -> Void) {
+        Trellis2Parallel.chunks(count, body)
+    }
+
+    private static func subtract(
+        _ a: (Float, Float, Float),
+        _ b: (Float, Float, Float)
+    ) -> (Float, Float, Float) {
+        (a.0 - b.0, a.1 - b.1, a.2 - b.2)
+    }
+
+    private static func cross(
+        _ a: (Float, Float, Float),
+        _ b: (Float, Float, Float)
+    ) -> (Float, Float, Float) {
+        (a.1 * b.2 - a.2 * b.1, a.2 * b.0 - a.0 * b.2, a.0 * b.1 - a.1 * b.0)
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2Parallel.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Parallel.swift
@@ -4,15 +4,26 @@ import Foundation
 /// receive disjoint index ranges; callers hand out disjoint output regions
 /// via unsafe buffer pointers.
 enum Trellis2Parallel {
+    /// Linux's swift-corelibs-dispatch declares `concurrentPerform`'s closure
+    /// `@Sendable` (Darwin's SDK does not), so the non-Sendable body must be
+    /// smuggled across in a box. Sound because chunk ranges are disjoint and
+    /// `concurrentPerform` returns only after every iteration completes.
+    private struct UncheckedSendableBody: @unchecked Sendable {
+        let call: (Range<Int>) -> Void
+    }
+
     static func chunks(_ count: Int, chunk: Int = 4_096, _ body: (Range<Int>) -> Void) {
         let chunkCount = (count + chunk - 1) / chunk
         if chunkCount <= 1 {
             body(0..<count)
             return
         }
-        DispatchQueue.concurrentPerform(iterations: chunkCount) { chunkIndex in
-            let start = chunkIndex * chunk
-            body(start..<min(start + chunk, count))
+        withoutActuallyEscaping(body) { body in
+            let boxed = UncheckedSendableBody(call: body)
+            DispatchQueue.concurrentPerform(iterations: chunkCount) { chunkIndex in
+                let start = chunkIndex * chunk
+                boxed.call(start..<min(start + chunk, count))
+            }
         }
     }
 }

--- a/Sources/MereRunCore/Trellis2/Trellis2Parallel.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2Parallel.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Chunked concurrent iteration for the remesher and atlas baker. Bodies
+/// receive disjoint index ranges; callers hand out disjoint output regions
+/// via unsafe buffer pointers.
+enum Trellis2Parallel {
+    static func chunks(_ count: Int, chunk: Int = 4_096, _ body: (Range<Int>) -> Void) {
+        let chunkCount = (count + chunk - 1) / chunk
+        if chunkCount <= 1 {
+            body(0..<count)
+            return
+        }
+        DispatchQueue.concurrentPerform(iterations: chunkCount) { chunkIndex in
+            let start = chunkIndex * chunk
+            body(start..<min(start + chunk, count))
+        }
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2SealedClassification.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2SealedClassification.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+/// Sealed inside/outside classification of the O-Voxel occupancy grid via
+/// morphological closing: dilate the occupied crust by `radius`, flood-fill
+/// the exterior from the grid boundary, then erode by the same radius.
+/// Any cavity whose every mouth is narrower than roughly `2 * radius`
+/// voxels is classified interior even when the crust around it is torn, so
+/// the remesher can span a membrane across openings that no boundary-loop
+/// capping can close. Thin sheets are unaffected: they are handled by the
+/// narrow-band envelope, not the classification.
+struct Trellis2SealedClassification {
+    let resolution: Int
+    /// Cells that are neither exterior nor within `radius` of it.
+    private let interiorBits: [UInt64]
+    /// Per-level mixed-occupancy pyramid; level 0 is the full grid, each
+    /// higher level halves the resolution. A set bit means the block
+    /// contains both interior and non-interior cells, so an octree cell
+    /// overlapping it straddles the classification boundary.
+    private let mixedPyramid: [[UInt64]]
+
+    /// `occupiedCells` are flat (x, y, z) triples in this grid's own space.
+    init(
+        resolution: Int,
+        occupiedCells: [Int32],
+        radius: Int
+    ) {
+        self.resolution = resolution
+        let volume = resolution * resolution * resolution
+        let words = (volume + 63) / 64
+
+        func index(_ x: Int, _ y: Int, _ z: Int) -> Int {
+            (x * resolution + y) * resolution + z
+        }
+        func get(_ bits: [UInt64], _ cell: Int) -> Bool {
+            bits[cell >> 6] & (1 << UInt64(cell & 63)) != 0
+        }
+        func set(_ bits: inout [UInt64], _ cell: Int) {
+            bits[cell >> 6] |= 1 << UInt64(cell & 63)
+        }
+
+        // Multi-source BFS expansion by `rounds` through cells not blocked.
+        func expand(
+            from seeds: inout [Int32],
+            marked: inout [UInt64],
+            rounds: Int,
+            blocked: [UInt64]?
+        ) {
+            var frontier = seeds
+            for _ in 0..<rounds {
+                var next = [Int32]()
+                next.reserveCapacity(frontier.count)
+                for cell in frontier {
+                    let c = Int(cell)
+                    let z = c % resolution
+                    let y = (c / resolution) % resolution
+                    let x = c / (resolution * resolution)
+                    for (dx, dy, dz) in [(-1, 0, 0), (1, 0, 0), (0, -1, 0), (0, 1, 0), (0, 0, -1), (0, 0, 1)] {
+                        let nx = x + dx, ny = y + dy, nz = z + dz
+                        guard nx >= 0, nx < resolution, ny >= 0, ny < resolution, nz >= 0, nz < resolution else { continue }
+                        let n = index(nx, ny, nz)
+                        if get(marked, n) { continue }
+                        if let blocked, get(blocked, n) { continue }
+                        set(&marked, n)
+                        next.append(Int32(n))
+                    }
+                }
+                frontier = next
+                if frontier.isEmpty { break }
+            }
+            seeds = frontier
+        }
+
+        // 1. Occupancy.
+        var occupancy = [UInt64](repeating: 0, count: words)
+        for triple in stride(from: 0, to: occupiedCells.count, by: 3) {
+            let x = Int(occupiedCells[triple])
+            let y = Int(occupiedCells[triple + 1])
+            let z = Int(occupiedCells[triple + 2])
+            guard x >= 0, x < resolution, y >= 0, y < resolution, z >= 0, z < resolution else { continue }
+            set(&occupancy, index(x, y, z))
+        }
+
+        // 2. Dilate by `radius`.
+        var dilated = occupancy
+        var seeds = [Int32]()
+        for x in 0..<resolution {
+            for y in 0..<resolution {
+                for z in 0..<resolution where get(occupancy, index(x, y, z)) {
+                    seeds.append(Int32(index(x, y, z)))
+                }
+            }
+        }
+        expand(from: &seeds, marked: &dilated, rounds: radius, blocked: nil)
+
+        // 3. Exterior flood from the grid boundary through non-dilated cells.
+        var exterior = [UInt64](repeating: 0, count: words)
+        var boundarySeeds = [Int32]()
+        for a in 0..<resolution {
+            for b in 0..<resolution {
+                for cell in [
+                    index(0, a, b), index(resolution - 1, a, b),
+                    index(a, 0, b), index(a, resolution - 1, b),
+                    index(a, b, 0), index(a, b, resolution - 1),
+                ] where !get(dilated, cell) && !get(exterior, cell) {
+                    set(&exterior, cell)
+                    boundarySeeds.append(Int32(cell))
+                }
+            }
+        }
+        expand(from: &boundarySeeds, marked: &exterior, rounds: volume, blocked: dilated)
+
+        // 4. Erode: anything within `radius` of the exterior is surface skin,
+        // not sealed interior. The void beyond the grid is exterior too, so
+        // every wall cell seeds the erosion regardless of dilation — without
+        // this, occupancy dilated against a domain wall pinches off pockets
+        // that classify interior and clip the membrane at the grid edge.
+        var nearExterior = exterior
+        var exteriorSeeds = [Int32]()
+        for x in 0..<resolution {
+            for y in 0..<resolution {
+                for z in 0..<resolution {
+                    let cell = index(x, y, z)
+                    let wall = x == 0 || x == resolution - 1
+                        || y == 0 || y == resolution - 1
+                        || z == 0 || z == resolution - 1
+                    if get(exterior, cell) || (wall && !get(nearExterior, cell)) {
+                        if wall && !get(nearExterior, cell) { set(&nearExterior, cell) }
+                        exteriorSeeds.append(Int32(cell))
+                    }
+                }
+            }
+        }
+        expand(from: &exteriorSeeds, marked: &nearExterior, rounds: radius, blocked: nil)
+
+        var interior = [UInt64](repeating: 0, count: words)
+        for word in 0..<words {
+            interior[word] = ~nearExterior[word]
+        }
+        // Mask tail bits beyond the volume.
+        let tail = volume & 63
+        if tail != 0 {
+            interior[words - 1] &= (1 << UInt64(tail)) - 1
+        }
+        self.interiorBits = interior
+
+        // 5. Mixed pyramid for octree refinement: a level-k block is mixed
+        // when its eight children disagree or any child is mixed.
+        var pyramid: [[UInt64]] = []
+        var levelResolution = resolution
+        var levelAll = interior
+        var levelAny = interior
+        while levelResolution > 1 {
+            let half = levelResolution / 2
+            let halfVolume = half * half * half
+            let halfWords = (halfVolume + 63) / 64
+            var nextAll = [UInt64](repeating: 0, count: halfWords)
+            var nextAny = [UInt64](repeating: 0, count: halfWords)
+            var mixed = [UInt64](repeating: 0, count: halfWords)
+            func levelIndex(_ x: Int, _ y: Int, _ z: Int, _ r: Int) -> Int {
+                (x * r + y) * r + z
+            }
+            for x in 0..<half {
+                for y in 0..<half {
+                    for z in 0..<half {
+                        var all = true
+                        var any = false
+                        for corner in 0..<8 {
+                            let child = levelIndex(
+                                x * 2 + (corner & 1),
+                                y * 2 + ((corner >> 1) & 1),
+                                z * 2 + ((corner >> 2) & 1),
+                                levelResolution
+                            )
+                            let bit = levelAll[child >> 6] & (1 << UInt64(child & 63)) != 0
+                            let anyBit = levelAny[child >> 6] & (1 << UInt64(child & 63)) != 0
+                            all = all && bit
+                            any = any || anyBit
+                        }
+                        let cell = levelIndex(x, y, z, half)
+                        if all { nextAll[cell >> 6] |= 1 << UInt64(cell & 63) }
+                        if any { nextAny[cell >> 6] |= 1 << UInt64(cell & 63) }
+                        if any != all { mixed[cell >> 6] |= 1 << UInt64(cell & 63) }
+                    }
+                }
+            }
+            pyramid.append(mixed)
+            levelAll = nextAll
+            levelAny = nextAny
+            levelResolution = half
+        }
+        self.mixedPyramid = pyramid
+    }
+
+    /// Whether the cell at full-grid coordinates is sealed interior.
+    func isInterior(x: Int32, y: Int32, z: Int32) -> Bool {
+        let cx = min(max(Int(x), 0), resolution - 1)
+        let cy = min(max(Int(y), 0), resolution - 1)
+        let cz = min(max(Int(z), 0), resolution - 1)
+        let cell = (cx * resolution + cy) * resolution + cz
+        return interiorBits[cell >> 6] & (1 << UInt64(cell & 63)) != 0
+    }
+
+    /// Whether a voxel at `levelResolution` granularity straddles the
+    /// classification boundary (so octree refinement must descend into it).
+    /// The full-resolution test asks whether the cell's eight corner grid
+    /// points see mixed interior-ness — exactly the condition under which
+    /// dual contouring emits crossings on the cell's edges — so every cell
+    /// participating in a membrane quad stays active. Coarse levels widen
+    /// the pyramid's mixed bit to the 26-neighborhood, since a boundary can
+    /// sit exactly on a block seam.
+    func straddlesBoundary(x: Int32, y: Int32, z: Int32, levelResolution: Int) -> Bool {
+        guard levelResolution < resolution else {
+            let first = isInterior(x: x, y: y, z: z)
+            for corner in 1..<8 {
+                let mixed = isInterior(
+                    x: x + Int32(corner & 1),
+                    y: y + Int32((corner >> 1) & 1),
+                    z: z + Int32((corner >> 2) & 1)
+                ) != first
+                if mixed { return true }
+            }
+            return false
+        }
+        var level = 0
+        var r = resolution
+        while r / 2 > levelResolution {
+            r /= 2
+            level += 1
+        }
+        // pyramid[level] has resolution `resolution >> (level + 1)`.
+        let half = resolution >> (level + 1)
+        guard half == levelResolution else { return true }
+        let bits = mixedPyramid[level]
+        for dx in Int32(-1)...1 {
+            for dy in Int32(-1)...1 {
+                for dz in Int32(-1)...1 {
+                    let cx = min(max(Int(x + dx), 0), half - 1)
+                    let cy = min(max(Int(y + dy), 0), half - 1)
+                    let cz = min(max(Int(z + dz), 0), half - 1)
+                    let cell = (cx * half + cy) * half + cz
+                    if bits[cell >> 6] & (1 << UInt64(cell & 63)) != 0 { return true }
+                }
+            }
+        }
+        return false
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2SparseFieldSampler.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2SparseFieldSampler.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Normalized trilinear sampler over TRELLIS.2's sparse six-channel PBR
+/// field. Points are continuous voxel-space coordinates (voxel index plus
+/// fractional offset). Weights renormalize over the occupied corners of the
+/// containing cell so shell-boundary samples keep full magnitude; a point
+/// whose cell has no occupied corner falls back to the nearest occupied
+/// voxel in its 3x3x3 neighborhood.
+struct Trellis2SparseFieldSampler {
+    let attributes: [Float]
+    let coordinateIndices: [Trellis2VoxelCoordinate: Int]
+
+    init(coordinates: [Trellis2VoxelCoordinate], attributes: [Float]) {
+        self.attributes = attributes
+        self.coordinateIndices = Dictionary(
+            uniqueKeysWithValues: coordinates.enumerated().map { ($1, $0) }
+        )
+    }
+
+    init(attributes: [Float], coordinateIndices: [Trellis2VoxelCoordinate: Int]) {
+        self.attributes = attributes
+        self.coordinateIndices = coordinateIndices
+    }
+
+    /// Six channels at the point, or nil when no corner of the containing
+    /// interpolation cell is occupied.
+    func trilinear(x: Float, y: Float, z: Float) -> [Float]? {
+        let baseX = Int32(floor(x)), baseY = Int32(floor(y)), baseZ = Int32(floor(z))
+        let fractionX = x - Float(baseX), fractionY = y - Float(baseY), fractionZ = z - Float(baseZ)
+        var values = [Float](repeating: 0, count: 6)
+        var occupiedWeight: Float = 0
+        for corner in 0..<8 {
+            let dx = Int32(corner & 1)
+            let dy = Int32((corner >> 1) & 1)
+            let dz = Int32((corner >> 2) & 1)
+            let weight = (dx == 0 ? 1 - fractionX : fractionX)
+                * (dy == 0 ? 1 - fractionY : fractionY)
+                * (dz == 0 ? 1 - fractionZ : fractionZ)
+            guard let source = coordinateIndices[
+                Trellis2VoxelCoordinate(x: baseX + dx, y: baseY + dy, z: baseZ + dz)
+            ] else { continue }
+            occupiedWeight += weight
+            for channel in 0..<6 {
+                values[channel] += attributes[source * 6 + channel] * weight
+            }
+        }
+        guard occupiedWeight > 1e-6 else { return nil }
+        for channel in 0..<6 { values[channel] /= occupiedWeight }
+        return values
+    }
+
+    /// Trilinear sample with a nearest-occupied-neighbor fallback; zeros when
+    /// nothing in the 3x3x3 neighborhood is occupied.
+    func sample(x: Float, y: Float, z: Float) -> [Float] {
+        if let values = trilinear(x: x, y: y, z: z) { return values }
+        let nearestX = Int32(x.rounded()), nearestY = Int32(y.rounded()), nearestZ = Int32(z.rounded())
+        var best: (distance: Float, index: Int)?
+        for dx in Int32(-1)...1 {
+            for dy in Int32(-1)...1 {
+                for dz in Int32(-1)...1 {
+                    let coordinate = Trellis2VoxelCoordinate(
+                        x: nearestX + dx,
+                        y: nearestY + dy,
+                        z: nearestZ + dz
+                    )
+                    guard let index = coordinateIndices[coordinate] else { continue }
+                    let deltaX = Float(coordinate.x) - x
+                    let deltaY = Float(coordinate.y) - y
+                    let deltaZ = Float(coordinate.z) - z
+                    let distance = deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ
+                    if best == nil || distance < best!.distance {
+                        best = (distance, index)
+                    }
+                }
+            }
+        }
+        guard let best else { return [Float](repeating: 0, count: 6) }
+        return (0..<6).map { attributes[best.index * 6 + $0] }
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2SparseFieldSampler.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2SparseFieldSampler.swift
@@ -49,6 +49,38 @@ struct Trellis2SparseFieldSampler {
         return values
     }
 
+    /// Per-vertex color and material attributes for a mesh in the canonical
+    /// Y-up object space (inverting the dual grid's Z-up rotation), for
+    /// meshes whose vertices were not produced by the dual grid itself —
+    /// e.g. the narrow-band remesh.
+    func meshVertexAttributes(
+        vertices: [Float],
+        resolution: Int
+    ) -> (colorsRGBA8: [UInt8], metallic: [Float], roughness: [Float]) {
+        let vertexCount = vertices.count / 3
+        var colors = [UInt8](repeating: 255, count: vertexCount * 4)
+        var metallic = [Float](repeating: 0, count: vertexCount)
+        var roughness = [Float](repeating: 0, count: vertexCount)
+        for vertex in 0..<vertexCount {
+            let values = sample(
+                x: (vertices[vertex * 3] + 0.5) * Float(resolution),
+                y: (-vertices[vertex * 3 + 2] + 0.5) * Float(resolution),
+                z: (vertices[vertex * 3 + 1] + 0.5) * Float(resolution)
+            )
+            colors[vertex * 4] = byte(values[0])
+            colors[vertex * 4 + 1] = byte(values[1])
+            colors[vertex * 4 + 2] = byte(values[2])
+            colors[vertex * 4 + 3] = byte(values[5])
+            metallic[vertex] = min(max(values[3], 0), 1)
+            roughness[vertex] = min(max(values[4], 0), 1)
+        }
+        return (colors, metallic, roughness)
+    }
+
+    private func byte(_ value: Float) -> UInt8 {
+        UInt8((255 * min(max(value, 0), 1)).rounded())
+    }
+
     /// Trilinear sample with a nearest-occupied-neighbor fallback; zeros when
     /// nothing in the 3x3x3 neighborhood is occupied.
     func sample(x: Float, y: Float, z: Float) -> [Float] {

--- a/Sources/MereRunCore/Trellis2/Trellis2TextureAtlasBaker.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2TextureAtlasBaker.swift
@@ -45,7 +45,16 @@ enum Trellis2TextureAtlasBaker {
         let triangles: [[UInt32]]
     }
 
-    static func bake(mesh: MeshAsset, field: Trellis2PBRVoxelGrid) -> Trellis2BakedTexturedMesh {
+    /// `projectionSurface` mirrors upstream's `to_glb` texel handling: every
+    /// sample position is snapped to its closest point on the original crust
+    /// before sampling the field, so remeshed envelopes (whose surface sits
+    /// up to `band` voxels off the crust) sample where the field actually
+    /// lives instead of falling off the occupied shell.
+    static func bake(
+        mesh: MeshAsset,
+        field: Trellis2PBRVoxelGrid,
+        projectionSurface: Trellis2TriangleBVH? = nil
+    ) -> Trellis2BakedTexturedMesh {
         let normals = mesh.normals ?? MeshNormals.generate(vertices: mesh.vertices, indices: mesh.indices)
         // Mip levels average neighboring atlas blocks, so blocks must be
         // spatially coherent in BOTH atlas axes or minified views converge
@@ -88,11 +97,6 @@ enum Trellis2TextureAtlasBaker {
             let (blockX, blockY) = morton2D(cellIndex)
             let cellX = blockX * block
             let cellY = blockY * block
-            let corners = cell.corners.map { index -> (Float, Float, Float) in
-                let base = Int(index) * 3
-                return (mesh.vertices[base], mesh.vertices[base + 1], mesh.vertices[base + 2])
-            }
-
             let firstSplit = UInt32(positions.count / 3)
             for (slot, original) in cell.corners.enumerated() {
                 let base = Int(original) * 3
@@ -108,27 +112,58 @@ enum Trellis2TextureAtlasBaker {
                     indices.append(firstSplit + UInt32(slot))
                 }
             }
+        }
 
+        baseColor.withUnsafeMutableBufferPointer { basePixels in
+            metallicRoughness.withUnsafeMutableBufferPointer { mrPixels in
+                Trellis2Parallel.chunks(cells.count, chunk: 1_024) { range in
+                    for cellIndex in range {
+                        let cell = cells[cellIndex]
+                        let (blockX, blockY) = morton2D(cellIndex)
+                        let cellX = blockX * block
+                        let cellY = blockY * block
+                        let corners = cell.corners.map { index -> (Float, Float, Float) in
+                            let base = Int(index) * 3
+                            return (mesh.vertices[base], mesh.vertices[base + 1], mesh.vertices[base + 2])
+                        }
+                        for texelY in 0..<block {
+                            let t = min(1, max(0, (Float(texelY) - Float(gutterTexels)) / span))
+                            for texelX in 0..<block {
+                                let s = min(1, max(0, (Float(texelX) - Float(gutterTexels)) / span))
+                                var point = interpolate(corners: corners, s: s, t: t)
+                                if let projectionSurface {
+                                    let closest = projectionSurface.closestPoint(
+                                        x: point.0, y: point.1, z: point.2
+                                    )
+                                    point = (closest.x, closest.y, closest.z)
+                                }
+                                // Mesh space is the Z-up field rotated to
+                                // Y-up; invert the rotation, then shift into
+                                // continuous voxel space.
+                                let voxelX = (point.0 + 0.5) * Float(field.resolution)
+                                let voxelY = (-point.2 + 0.5) * Float(field.resolution)
+                                let voxelZ = (point.1 + 0.5) * Float(field.resolution)
+                                let values = sampler.sample(x: voxelX, y: voxelY, z: voxelZ)
+                                let pixel = ((cellY + texelY) * width + cellX + texelX) * 4
+                                basePixels[pixel] = byte(values[0])
+                                basePixels[pixel + 1] = byte(values[1])
+                                basePixels[pixel + 2] = byte(values[2])
+                                basePixels[pixel + 3] = 255
+                                mrPixels[pixel] = 255
+                                mrPixels[pixel + 1] = byte(values[4])
+                                mrPixels[pixel + 2] = byte(values[3])
+                                mrPixels[pixel + 3] = 255
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for cellIndex in 0..<cells.count {
+            let (blockX, blockY) = morton2D(cellIndex)
             for texelY in 0..<block {
-                let t = min(1, max(0, (Float(texelY) - Float(gutterTexels)) / span))
                 for texelX in 0..<block {
-                    let s = min(1, max(0, (Float(texelX) - Float(gutterTexels)) / span))
-                    let point = interpolate(corners: corners, s: s, t: t)
-                    // Mesh space is the Z-up field rotated to Y-up; invert
-                    // the rotation, then shift into continuous voxel space.
-                    let voxelX = (point.0 + 0.5) * Float(field.resolution)
-                    let voxelY = (-point.2 + 0.5) * Float(field.resolution)
-                    let voxelZ = (point.1 + 0.5) * Float(field.resolution)
-                    let values = sampler.sample(x: voxelX, y: voxelY, z: voxelZ)
-                    let pixel = ((cellY + texelY) * width + cellX + texelX) * 4
-                    baseColor[pixel] = byte(values[0])
-                    baseColor[pixel + 1] = byte(values[1])
-                    baseColor[pixel + 2] = byte(values[2])
-                    baseColor[pixel + 3] = 255
-                    metallicRoughness[pixel] = 255
-                    metallicRoughness[pixel + 1] = byte(values[4])
-                    metallicRoughness[pixel + 2] = byte(values[3])
-                    metallicRoughness[pixel + 3] = 255
+                    let pixel = ((blockY * block + texelY) * width + blockX * block + texelX) * 4
                     colorSums[0] += Double(baseColor[pixel])
                     colorSums[1] += Double(baseColor[pixel + 1])
                     colorSums[2] += Double(baseColor[pixel + 2])

--- a/Sources/MereRunCore/Trellis2/Trellis2TextureAtlasBaker.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2TextureAtlasBaker.swift
@@ -10,10 +10,8 @@ struct Trellis2BakedTexturedMesh {
     let atlasWidth: Int
     let atlasHeight: Int
     /// sRGB-encoded base color, matching glTF's baseColorTexture transfer
-    /// expectations. Alpha is constant 255: the material renders opaque, the
-    /// field's alpha channel stays in the `.pbrvox` sidecar, and straight
-    /// alpha below 255 would be corrupted by the premultiplied-alpha PNG
-    /// encode path (ImageIO divides RGB by alpha on write).
+    /// expectations. Alpha is constant 255: the material renders opaque and
+    /// the field's alpha channel stays in the `.pbrvox` sidecar.
     let baseColorRGBA8: [UInt8]
     /// Linear-encoded occupancy/roughness/metallic per the glTF
     /// metallicRoughnessTexture channel layout (G = roughness, B = metallic).

--- a/Sources/MereRunCore/Trellis2/Trellis2TextureAtlasBaker.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2TextureAtlasBaker.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+/// A vertex-split mesh with per-corner UVs and baked PBR atlases, ready for
+/// the textured GLB writer.
+struct Trellis2BakedTexturedMesh {
+    let positions: [Float]
+    let normals: [Float]
+    let uvs: [Float]
+    let indices: [UInt32]
+    let atlasWidth: Int
+    let atlasHeight: Int
+    /// sRGB-encoded base color, matching glTF's baseColorTexture transfer
+    /// expectations. Alpha is constant 255: the material renders opaque, the
+    /// field's alpha channel stays in the `.pbrvox` sidecar, and straight
+    /// alpha below 255 would be corrupted by the premultiplied-alpha PNG
+    /// encode path (ImageIO divides RGB by alpha on write).
+    let baseColorRGBA8: [UInt8]
+    /// Linear-encoded occupancy/roughness/metallic per the glTF
+    /// metallicRoughnessTexture channel layout (G = roughness, B = metallic).
+    let metallicRoughnessRGBA8: [UInt8]
+
+    var vertexCount: Int { positions.count / 3 }
+}
+
+/// Bakes TRELLIS.2's sparse PBR voxel field into per-quad atlas blocks.
+///
+/// The dual-grid extractor emits two triangles per grid-edge quad, so the
+/// mesh partitions into quads (plus a handful of hole-fill caps). Every quad
+/// gets a uniform texel block in the atlas — deterministic packing with no
+/// unwrapping, injective by construction, gutters against filter bleed. Block
+/// texels sample the field over the quad's bilinear patch, capturing the
+/// sub-voxel gradients that per-vertex color flattens.
+enum Trellis2TextureAtlasBaker {
+    /// Interior texels per block edge; corners map to the centers of the
+    /// interior corner texels so bilinear filtering never leaves the block.
+    static let interiorTexels = 4
+    static let gutterTexels = 1
+    static var blockTexels: Int { interiorTexels + 2 * gutterTexels }
+
+    private struct Cell {
+        /// Original vertex indices at the block corners: 4 in cycle order
+        /// (unique, shared, unique, shared) for a quad, 3 for a solo cap.
+        let corners: [UInt32]
+        /// Original index triples, re-emitted against the split corners.
+        let triangles: [[UInt32]]
+    }
+
+    static func bake(mesh: MeshAsset, field: Trellis2PBRVoxelGrid) -> Trellis2BakedTexturedMesh {
+        let normals = mesh.normals ?? MeshNormals.generate(vertices: mesh.vertices, indices: mesh.indices)
+        // Mip levels average neighboring atlas blocks, so blocks must be
+        // spatially coherent in BOTH atlas axes or minified views converge
+        // to the global average color. Order cells by the 3D Morton code of
+        // their centroid and place them along the 2D Morton curve of the
+        // block grid; mip blending then approximates a surface-local
+        // low-pass instead of mixing unrelated quads.
+        let cells = mortonOrdered(partition(indices: mesh.indices), vertices: mesh.vertices, bounds: mesh.bounds)
+        let sampler = Trellis2SparseFieldSampler(
+            coordinates: field.coordinates,
+            attributes: field.attributes
+        )
+
+        let block = blockTexels
+        var blocksPerSide = 1
+        while blocksPerSide * blocksPerSide < cells.count { blocksPerSide *= 2 }
+        let width = blocksPerSide * block
+        let height = blocksPerSide * block
+        let span = Float(max(1, interiorTexels - 1))
+
+        var positions = [Float]()
+        var splitNormals = [Float]()
+        var uvs = [Float]()
+        var indices = [UInt32]()
+        positions.reserveCapacity(cells.count * 4 * 3)
+        splitNormals.reserveCapacity(cells.count * 4 * 3)
+        uvs.reserveCapacity(cells.count * 4 * 2)
+        indices.reserveCapacity(mesh.indices.count)
+        var baseColor = [UInt8](repeating: 0, count: width * height * 4)
+        var metallicRoughness = [UInt8](repeating: 0, count: width * height * 4)
+        var colorSums: [Double] = [0, 0, 0]
+        var metallicRoughnessSums: [Double] = [0, 0]
+        var bakedTexels: Double = 0
+
+        let cornerUV: [[(Float, Float)]] = [
+            [(0, 0), (1, 0), (0, 1)],
+            [(0, 0), (1, 0), (1, 1), (0, 1)],
+        ]
+        for (cellIndex, cell) in cells.enumerated() {
+            let (blockX, blockY) = morton2D(cellIndex)
+            let cellX = blockX * block
+            let cellY = blockY * block
+            let corners = cell.corners.map { index -> (Float, Float, Float) in
+                let base = Int(index) * 3
+                return (mesh.vertices[base], mesh.vertices[base + 1], mesh.vertices[base + 2])
+            }
+
+            let firstSplit = UInt32(positions.count / 3)
+            for (slot, original) in cell.corners.enumerated() {
+                let base = Int(original) * 3
+                positions.append(contentsOf: mesh.vertices[base..<(base + 3)])
+                splitNormals.append(contentsOf: normals[base..<(base + 3)])
+                let (i, j) = cornerUV[cell.corners.count - 3][slot]
+                uvs.append((Float(cellX + gutterTexels) + i * span + 0.5) / Float(width))
+                uvs.append((Float(cellY + gutterTexels) + j * span + 0.5) / Float(height))
+            }
+            for triangle in cell.triangles {
+                for original in triangle {
+                    let slot = cell.corners.firstIndex(of: original)!
+                    indices.append(firstSplit + UInt32(slot))
+                }
+            }
+
+            for texelY in 0..<block {
+                let t = min(1, max(0, (Float(texelY) - Float(gutterTexels)) / span))
+                for texelX in 0..<block {
+                    let s = min(1, max(0, (Float(texelX) - Float(gutterTexels)) / span))
+                    let point = interpolate(corners: corners, s: s, t: t)
+                    // Mesh space is the Z-up field rotated to Y-up; invert
+                    // the rotation, then shift into continuous voxel space.
+                    let voxelX = (point.0 + 0.5) * Float(field.resolution)
+                    let voxelY = (-point.2 + 0.5) * Float(field.resolution)
+                    let voxelZ = (point.1 + 0.5) * Float(field.resolution)
+                    let values = sampler.sample(x: voxelX, y: voxelY, z: voxelZ)
+                    let pixel = ((cellY + texelY) * width + cellX + texelX) * 4
+                    baseColor[pixel] = byte(values[0])
+                    baseColor[pixel + 1] = byte(values[1])
+                    baseColor[pixel + 2] = byte(values[2])
+                    baseColor[pixel + 3] = 255
+                    metallicRoughness[pixel] = 255
+                    metallicRoughness[pixel + 1] = byte(values[4])
+                    metallicRoughness[pixel + 2] = byte(values[3])
+                    metallicRoughness[pixel + 3] = 255
+                    colorSums[0] += Double(baseColor[pixel])
+                    colorSums[1] += Double(baseColor[pixel + 1])
+                    colorSums[2] += Double(baseColor[pixel + 2])
+                    metallicRoughnessSums[0] += Double(metallicRoughness[pixel + 1])
+                    metallicRoughnessSums[1] += Double(metallicRoughness[pixel + 2])
+                    bakedTexels += 1
+                }
+            }
+        }
+
+        // Unused blocks in the power-of-two grid take the mean baked color so
+        // deep mip levels near the occupied boundary do not pull toward black.
+        if cells.count < blocksPerSide * blocksPerSide, bakedTexels > 0 {
+            let meanColor = colorSums.map { UInt8(($0 / bakedTexels).rounded()) }
+            let meanRoughness = UInt8((metallicRoughnessSums[0] / bakedTexels).rounded())
+            let meanMetallic = UInt8((metallicRoughnessSums[1] / bakedTexels).rounded())
+            for blockIndex in cells.count..<(blocksPerSide * blocksPerSide) {
+                let (blockX, blockY) = morton2D(blockIndex)
+                for texelY in 0..<block {
+                    for texelX in 0..<block {
+                        let pixel = ((blockY * block + texelY) * width + blockX * block + texelX) * 4
+                        baseColor[pixel] = meanColor[0]
+                        baseColor[pixel + 1] = meanColor[1]
+                        baseColor[pixel + 2] = meanColor[2]
+                        baseColor[pixel + 3] = 255
+                        metallicRoughness[pixel] = 255
+                        metallicRoughness[pixel + 1] = meanRoughness
+                        metallicRoughness[pixel + 2] = meanMetallic
+                        metallicRoughness[pixel + 3] = 255
+                    }
+                }
+            }
+        }
+
+        return Trellis2BakedTexturedMesh(
+            positions: positions,
+            normals: splitNormals,
+            uvs: uvs,
+            indices: indices,
+            atlasWidth: width,
+            atlasHeight: height,
+            baseColorRGBA8: baseColor,
+            metallicRoughnessRGBA8: metallicRoughness
+        )
+    }
+
+    /// Splits the index buffer into quads (consecutive triangles sharing an
+    /// edge — the dual-grid emission order) and solo hole-fill caps.
+    private static func partition(indices: [UInt32]) -> [Cell] {
+        var cells = [Cell]()
+        var triangle = 0
+        let triangleCount = indices.count / 3
+        while triangle < triangleCount {
+            let first = Array(indices[(triangle * 3)..<(triangle * 3 + 3)])
+            if triangle + 1 < triangleCount {
+                let second = Array(indices[(triangle * 3 + 3)..<(triangle * 3 + 6)])
+                let shared = Set(first).intersection(Set(second))
+                if shared.count == 2, Set(first).union(Set(second)).count == 4 {
+                    let uniqueFirst = first.first { !shared.contains($0) }!
+                    let uniqueSecond = second.first { !shared.contains($0) }!
+                    let sharedPair = Array(shared).sorted()
+                    cells.append(Cell(
+                        corners: [uniqueFirst, sharedPair[0], uniqueSecond, sharedPair[1]],
+                        triangles: [first, second]
+                    ))
+                    triangle += 2
+                    continue
+                }
+            }
+            cells.append(Cell(corners: first, triangles: [first]))
+            triangle += 1
+        }
+        return cells
+    }
+
+    /// Cells sorted by the interleaved 3D Morton code of their centroid so
+    /// consecutive cells are spatially adjacent on the surface.
+    private static func mortonOrdered(
+        _ cells: [Cell],
+        vertices: [Float],
+        bounds: MeshBounds
+    ) -> [Cell] {
+        let extent = (0..<3).map { max(bounds.maximum[$0] - bounds.minimum[$0], 1e-6) }
+        func key(_ cell: Cell) -> UInt64 {
+            var centroid: [Float] = [0, 0, 0]
+            for corner in cell.corners {
+                for axis in 0..<3 {
+                    centroid[axis] += vertices[Int(corner) * 3 + axis]
+                }
+            }
+            var code: UInt64 = 0
+            for axis in 0..<3 {
+                let normalized = (centroid[axis] / Float(cell.corners.count) - bounds.minimum[axis]) / extent[axis]
+                let quantized = UInt64(min(1023, max(0, Int(normalized * 1023))))
+                for bit in 0..<10 {
+                    code |= ((quantized >> bit) & 1) << (bit * 3 + axis)
+                }
+            }
+            return code
+        }
+        return cells
+            .map { (key($0), $0) }
+            .sorted { $0.0 < $1.0 }
+            .map(\.1)
+    }
+
+    /// Deinterleaves a cell rank into 2D Morton block coordinates.
+    private static func morton2D(_ rank: Int) -> (Int, Int) {
+        var x = 0, y = 0
+        for bit in 0..<16 {
+            x |= ((rank >> (bit * 2)) & 1) << bit
+            y |= ((rank >> (bit * 2 + 1)) & 1) << bit
+        }
+        return (x, y)
+    }
+
+    private static func interpolate(
+        corners: [(Float, Float, Float)],
+        s: Float,
+        t: Float
+    ) -> (Float, Float, Float) {
+        if corners.count == 4 {
+            let bottom = mix(corners[0], corners[1], s)
+            let top = mix(corners[3], corners[2], s)
+            return mix(bottom, top, t)
+        }
+        return (
+            corners[0].0 + s * (corners[1].0 - corners[0].0) + t * (corners[2].0 - corners[0].0),
+            corners[0].1 + s * (corners[1].1 - corners[0].1) + t * (corners[2].1 - corners[0].1),
+            corners[0].2 + s * (corners[1].2 - corners[0].2) + t * (corners[2].2 - corners[0].2)
+        )
+    }
+
+    private static func mix(
+        _ a: (Float, Float, Float),
+        _ b: (Float, Float, Float),
+        _ fraction: Float
+    ) -> (Float, Float, Float) {
+        (
+            a.0 + (b.0 - a.0) * fraction,
+            a.1 + (b.1 - a.1) * fraction,
+            a.2 + (b.2 - a.2) * fraction
+        )
+    }
+
+    private static func byte(_ value: Float) -> UInt8 {
+        UInt8((255 * min(max(value, 0), 1)).rounded())
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2TexturedGLBWriter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2TexturedGLBWriter.swift
@@ -1,0 +1,182 @@
+import Foundation
+import MediaIO
+
+/// Dependency-free glTF 2.0 binary writer for the baked-atlas TRELLIS.2 mesh:
+/// split vertices with UVs, an sRGB baseColorTexture (with field alpha), and
+/// a linear metallicRoughnessTexture, both embedded as PNG.
+enum Trellis2TexturedGLBWriter {
+    static func write(
+        _ baked: Trellis2BakedTexturedMesh,
+        coordinateSystem: MeshCoordinateSystem,
+        units: MeshUnits,
+        inferredUnseenGeometry: Bool,
+        to url: URL
+    ) throws {
+        let basePNG = try MediaImageIO.pngData(from: MediaImage(
+            width: baked.atlasWidth,
+            height: baked.atlasHeight,
+            rgba8: baked.baseColorRGBA8
+        ))
+        let metallicRoughnessPNG = try MediaImageIO.pngData(from: MediaImage(
+            width: baked.atlasWidth,
+            height: baked.atlasHeight,
+            rgba8: baked.metallicRoughnessRGBA8
+        ))
+
+        var binary = Data()
+        var bufferViews: [[String: Any]] = []
+
+        func appendView(_ data: Data, target: Int?) -> Int {
+            while !binary.count.isMultiple(of: 4) { binary.append(0) }
+            let offset = binary.count
+            binary.append(data)
+            let index = bufferViews.count
+            var view: [String: Any] = [
+                "buffer": 0,
+                "byteOffset": offset,
+                "byteLength": data.count,
+            ]
+            if let target { view["target"] = target }
+            bufferViews.append(view)
+            return index
+        }
+
+        var minimum = [Float](repeating: .infinity, count: 3)
+        var maximum = [Float](repeating: -.infinity, count: 3)
+        for vertex in 0..<baked.vertexCount {
+            for axis in 0..<3 {
+                let value = baked.positions[vertex * 3 + axis]
+                minimum[axis] = min(minimum[axis], value)
+                maximum[axis] = max(maximum[axis], value)
+            }
+        }
+
+        let positionView = appendView(floatData(baked.positions), target: 34_962)
+        let normalView = appendView(floatData(baked.normals), target: 34_962)
+        let uvView = appendView(floatData(baked.uvs), target: 34_962)
+        let indexView = appendView(uint32Data(baked.indices), target: 34_963)
+        let baseImageView = appendView(basePNG, target: nil)
+        let metallicRoughnessImageView = appendView(metallicRoughnessPNG, target: nil)
+
+        let accessors: [[String: Any]] = [
+            [
+                "bufferView": positionView,
+                "componentType": 5_126,
+                "count": baked.vertexCount,
+                "type": "VEC3",
+                "min": minimum,
+                "max": maximum,
+            ],
+            [
+                "bufferView": normalView,
+                "componentType": 5_126,
+                "count": baked.vertexCount,
+                "type": "VEC3",
+            ],
+            [
+                "bufferView": uvView,
+                "componentType": 5_126,
+                "count": baked.vertexCount,
+                "type": "VEC2",
+            ],
+            [
+                "bufferView": indexView,
+                "componentType": 5_125,
+                "count": baked.indices.count,
+                "type": "SCALAR",
+            ],
+        ]
+
+        let json: [String: Any] = [
+            "asset": ["version": "2.0", "generator": "mere.run native TRELLIS.2 baked atlas"],
+            "scene": 0,
+            "scenes": [["nodes": [0]]],
+            "nodes": [["mesh": 0, "name": "Reconstructed Asset"]],
+            "meshes": [[
+                "name": "Baked PBR Mesh",
+                "primitives": [[
+                    "attributes": [
+                        "POSITION": 0,
+                        "NORMAL": 1,
+                        "TEXCOORD_0": 2,
+                    ],
+                    "indices": 3,
+                    "material": 0,
+                    "mode": 4,
+                ]],
+            ]],
+            "materials": [[
+                "name": "Baked PBR",
+                "doubleSided": true,
+                "pbrMetallicRoughness": [
+                    "baseColorTexture": ["index": 0],
+                    "metallicRoughnessTexture": ["index": 1],
+                ],
+            ]],
+            "textures": [
+                ["sampler": 0, "source": 0],
+                ["sampler": 0, "source": 1],
+            ],
+            // Mipmapped minification: consecutive cells are spatially
+            // coherent (decode order follows the voxel scan), so mip blends
+            // average nearby surface colors instead of aliasing across
+            // unrelated blocks.
+            "samplers": [[
+                "magFilter": 9_729,
+                "minFilter": 9_987,
+                "wrapS": 33_071,
+                "wrapT": 33_071,
+            ]],
+            "images": [
+                ["bufferView": baseImageView, "mimeType": "image/png"],
+                ["bufferView": metallicRoughnessImageView, "mimeType": "image/png"],
+            ],
+            "buffers": [["byteLength": binary.count]],
+            "bufferViews": bufferViews,
+            "accessors": accessors,
+            "extras": [
+                "coordinateSystem": coordinateSystem.rawValue,
+                "units": units.rawValue,
+                "inferredUnseenGeometry": inferredUnseenGeometry,
+            ],
+        ]
+
+        var jsonData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+        while !jsonData.count.isMultiple(of: 4) { jsonData.append(0x20) }
+        while !binary.count.isMultiple(of: 4) { binary.append(0) }
+
+        let totalLength = 12 + 8 + jsonData.count + 8 + binary.count
+        var glb = Data()
+        appendUInt32(0x4654_6C67, to: &glb)
+        appendUInt32(2, to: &glb)
+        appendUInt32(UInt32(totalLength), to: &glb)
+        appendUInt32(UInt32(jsonData.count), to: &glb)
+        appendUInt32(0x4E4F_534A, to: &glb)
+        glb.append(jsonData)
+        appendUInt32(UInt32(binary.count), to: &glb)
+        appendUInt32(0x004E_4942, to: &glb)
+        glb.append(binary)
+
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try glb.write(to: url, options: .atomic)
+    }
+
+    private static func floatData(_ values: [Float]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 4)
+        for value in values { appendUInt32(value.bitPattern, to: &data) }
+        return data
+    }
+
+    private static func uint32Data(_ values: [UInt32]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 4)
+        for value in values { appendUInt32(value, to: &data) }
+        return data
+    }
+
+    private static func appendUInt32(_ value: UInt32, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+}

--- a/Sources/MereRunCore/Trellis2/Trellis2TexturedGLBWriter.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2TexturedGLBWriter.swift
@@ -10,6 +10,7 @@ enum Trellis2TexturedGLBWriter {
         coordinateSystem: MeshCoordinateSystem,
         units: MeshUnits,
         inferredUnseenGeometry: Bool,
+        doubleSided: Bool = true,
         to url: URL
     ) throws {
         let basePNG = try MediaImageIO.pngData(from: MediaImage(
@@ -107,7 +108,7 @@ enum Trellis2TexturedGLBWriter {
             ]],
             "materials": [[
                 "name": "Baked PBR",
-                "doubleSided": true,
+                "doubleSided": doubleSided,
                 "pbrMetallicRoughness": [
                     "baseColorTexture": ["index": 0],
                     "metallicRoughnessTexture": ["index": 1],

--- a/Sources/MereRunCore/Trellis2/Trellis2TriangleBVH.swift
+++ b/Sources/MereRunCore/Trellis2/Trellis2TriangleBVH.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+/// Median-split AABB tree over an indexed triangle mesh for closest-point
+/// queries. Mirrors the role of CuMesh's cuBVH in the narrow-band remesher:
+/// unsigned distance for the band field and closest points for projection.
+struct Trellis2TriangleBVH {
+    private struct Node {
+        var minX: Float, minY: Float, minZ: Float
+        var maxX: Float, maxY: Float, maxZ: Float
+        /// Leaf when `count > 0`: triangles [start, start + count) in `order`.
+        var start: Int32
+        var count: Int32
+        /// Internal node children; right = left + 1 is not guaranteed.
+        var left: Int32
+        var right: Int32
+    }
+
+    private let nodes: [Node]
+    /// Triangle indices permuted during the build.
+    private let order: [Int32]
+    private let vertices: [Float]
+    private let indices: [UInt32]
+
+    init(vertices: [Float], indices: [UInt32]) {
+        self.vertices = vertices
+        self.indices = indices
+        let triangleCount = indices.count / 3
+
+        var centroids = [Float](repeating: 0, count: triangleCount * 3)
+        for triangle in 0..<triangleCount {
+            for corner in 0..<3 {
+                let base = Int(indices[triangle * 3 + corner]) * 3
+                centroids[triangle * 3] += vertices[base] / 3
+                centroids[triangle * 3 + 1] += vertices[base + 1] / 3
+                centroids[triangle * 3 + 2] += vertices[base + 2] / 3
+            }
+        }
+
+        var order = (0..<triangleCount).map(Int32.init)
+        var nodes = [Node]()
+        nodes.reserveCapacity(triangleCount / 4)
+
+        func bounds(_ start: Int, _ count: Int) -> (Float, Float, Float, Float, Float, Float) {
+            var minX = Float.infinity, minY = Float.infinity, minZ = Float.infinity
+            var maxX = -Float.infinity, maxY = -Float.infinity, maxZ = -Float.infinity
+            for slot in start..<(start + count) {
+                let triangle = Int(order[slot])
+                for corner in 0..<3 {
+                    let base = Int(indices[triangle * 3 + corner]) * 3
+                    minX = min(minX, vertices[base]); maxX = max(maxX, vertices[base])
+                    minY = min(minY, vertices[base + 1]); maxY = max(maxY, vertices[base + 1])
+                    minZ = min(minZ, vertices[base + 2]); maxZ = max(maxZ, vertices[base + 2])
+                }
+            }
+            return (minX, minY, minZ, maxX, maxY, maxZ)
+        }
+
+        func build(_ start: Int, _ count: Int) -> Int32 {
+            let (minX, minY, minZ, maxX, maxY, maxZ) = bounds(start, count)
+            let nodeIndex = Int32(nodes.count)
+            nodes.append(Node(
+                minX: minX, minY: minY, minZ: minZ,
+                maxX: maxX, maxY: maxY, maxZ: maxZ,
+                start: Int32(start), count: Int32(count), left: -1, right: -1
+            ))
+            if count <= 8 { return nodeIndex }
+
+            var centroidMin = [Float.infinity, .infinity, .infinity]
+            var centroidMax = [-Float.infinity, -.infinity, -.infinity]
+            for slot in start..<(start + count) {
+                let triangle = Int(order[slot])
+                for axis in 0..<3 {
+                    centroidMin[axis] = min(centroidMin[axis], centroids[triangle * 3 + axis])
+                    centroidMax[axis] = max(centroidMax[axis], centroids[triangle * 3 + axis])
+                }
+            }
+            var axis = 0
+            for candidate in 1..<3
+                where centroidMax[candidate] - centroidMin[candidate] > centroidMax[axis] - centroidMin[axis] {
+                axis = candidate
+            }
+            guard centroidMax[axis] - centroidMin[axis] > Float.ulpOfOne else { return nodeIndex }
+
+            let middle = start + count / 2
+            order[start..<(start + count)].sort {
+                centroids[Int($0) * 3 + axis] < centroids[Int($1) * 3 + axis]
+            }
+            let left = build(start, middle - start)
+            let right = build(middle, start + count - middle)
+            nodes[Int(nodeIndex)].count = 0
+            nodes[Int(nodeIndex)].left = left
+            nodes[Int(nodeIndex)].right = right
+            return nodeIndex
+        }
+
+        _ = build(0, triangleCount)
+        self.order = order
+        self.nodes = nodes
+    }
+
+    /// Closest surface point and squared distance from the query point.
+    func closestPoint(x: Float, y: Float, z: Float) -> (distanceSquared: Float, x: Float, y: Float, z: Float) {
+        var best = Float.infinity
+        var bestPoint: (Float, Float, Float) = (x, y, z)
+        var stack = [Int32]()
+        stack.reserveCapacity(64)
+        stack.append(0)
+
+        while let nodeIndex = stack.popLast() {
+            let node = nodes[Int(nodeIndex)]
+            guard boxDistanceSquared(node, x, y, z) < best else { continue }
+            if node.count > 0 {
+                for slot in Int(node.start)..<Int(node.start + node.count) {
+                    let triangle = Int(order[slot])
+                    let candidate = closestPointOnTriangle(triangle, x, y, z)
+                    let dx = candidate.0 - x, dy = candidate.1 - y, dz = candidate.2 - z
+                    let distance = dx * dx + dy * dy + dz * dz
+                    if distance < best {
+                        best = distance
+                        bestPoint = candidate
+                    }
+                }
+            } else {
+                // Visit the nearer child last so it is popped first.
+                let leftDistance = boxDistanceSquared(nodes[Int(node.left)], x, y, z)
+                let rightDistance = boxDistanceSquared(nodes[Int(node.right)], x, y, z)
+                if leftDistance < rightDistance {
+                    stack.append(node.right)
+                    stack.append(node.left)
+                } else {
+                    stack.append(node.left)
+                    stack.append(node.right)
+                }
+            }
+        }
+        return (best, bestPoint.0, bestPoint.1, bestPoint.2)
+    }
+
+    func unsignedDistance(x: Float, y: Float, z: Float) -> Float {
+        closestPoint(x: x, y: y, z: z).distanceSquared.squareRoot()
+    }
+
+    private func boxDistanceSquared(_ node: Node, _ x: Float, _ y: Float, _ z: Float) -> Float {
+        let dx = max(node.minX - x, 0, x - node.maxX)
+        let dy = max(node.minY - y, 0, y - node.maxY)
+        let dz = max(node.minZ - z, 0, z - node.maxZ)
+        return dx * dx + dy * dy + dz * dz
+    }
+
+    /// Ericson's closest-point-on-triangle, returning the surface point.
+    private func closestPointOnTriangle(_ triangle: Int, _ px: Float, _ py: Float, _ pz: Float) -> (Float, Float, Float) {
+        let baseA = Int(indices[triangle * 3]) * 3
+        let baseB = Int(indices[triangle * 3 + 1]) * 3
+        let baseC = Int(indices[triangle * 3 + 2]) * 3
+        let ax = vertices[baseA], ay = vertices[baseA + 1], az = vertices[baseA + 2]
+        let bx = vertices[baseB], by = vertices[baseB + 1], bz = vertices[baseB + 2]
+        let cx = vertices[baseC], cy = vertices[baseC + 1], cz = vertices[baseC + 2]
+
+        let abx = bx - ax, aby = by - ay, abz = bz - az
+        let acx = cx - ax, acy = cy - ay, acz = cz - az
+        let apx = px - ax, apy = py - ay, apz = pz - az
+
+        let d1 = abx * apx + aby * apy + abz * apz
+        let d2 = acx * apx + acy * apy + acz * apz
+        if d1 <= 0 && d2 <= 0 { return (ax, ay, az) }
+
+        let bpx = px - bx, bpy = py - by, bpz = pz - bz
+        let d3 = abx * bpx + aby * bpy + abz * bpz
+        let d4 = acx * bpx + acy * bpy + acz * bpz
+        if d3 >= 0 && d4 <= d3 { return (bx, by, bz) }
+
+        let vc = d1 * d4 - d3 * d2
+        if vc <= 0 && d1 >= 0 && d3 <= 0 {
+            let t = d1 / (d1 - d3)
+            return (ax + t * abx, ay + t * aby, az + t * abz)
+        }
+
+        let cpx = px - cx, cpy = py - cy, cpz = pz - cz
+        let d5 = abx * cpx + aby * cpy + abz * cpz
+        let d6 = acx * cpx + acy * cpy + acz * cpz
+        if d6 >= 0 && d5 <= d6 { return (cx, cy, cz) }
+
+        let vb = d5 * d2 - d1 * d6
+        if vb <= 0 && d2 >= 0 && d6 <= 0 {
+            let t = d2 / (d2 - d6)
+            return (ax + t * acx, ay + t * acy, az + t * acz)
+        }
+
+        let va = d3 * d6 - d5 * d4
+        if va <= 0 && (d4 - d3) >= 0 && (d5 - d6) >= 0 {
+            let t = (d4 - d3) / ((d4 - d3) + (d5 - d6))
+            return (bx + t * (cx - bx), by + t * (cy - by), bz + t * (cz - bz))
+        }
+
+        let denominator = 1 / (va + vb + vc)
+        let v = vb * denominator
+        let w = vc * denominator
+        return (ax + abx * v + acx * w, ay + aby * v + acy * w, az + abz * v + acz * w)
+    }
+}

--- a/Tests/MereRunCoreTests/MediaIOTests.swift
+++ b/Tests/MereRunCoreTests/MediaIOTests.swift
@@ -3,6 +3,10 @@ import Foundation
 @testable import MediaIO
 import XCTest
 
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
+
 final class MediaIOTests: XCTestCase {
     private enum ExtractionRejection: Error, Equatable {
         case rejected
@@ -109,6 +113,69 @@ final class MediaIOTests: XCTestCase {
         XCTAssertEqual(cropped.height, 1)
         XCTAssertEqual(cropped.rgba8.count, 4)
     }
+
+    func testPNGRoundTripPreservesStraightAlphaBytes() throws {
+        #if !canImport(CoreGraphics)
+        guard isExecutableAvailable(MediaTool.ffmpegPath),
+              isExecutableAvailable(MediaTool.ffprobePath) else {
+            throw XCTSkip("ffmpeg and ffprobe are required")
+        }
+        #endif
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mediaio-alpha-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Straight-alpha samples, including RGB under partial and zero alpha.
+        // A premultiplied encode or decode step corrupts every non-opaque one.
+        let image = try MediaImage(
+            width: 2,
+            height: 2,
+            rgba8: [
+                200, 200, 200, 128,
+                200, 0, 0, 64,
+                0, 200, 0, 255,
+                50, 60, 70, 0,
+            ]
+        )
+        let url = tempDir.appendingPathComponent("straight-alpha.png")
+        try MediaImageIO.writePNG(image, to: url)
+
+        let decoded = try MediaImageIO.decode(url)
+        XCTAssertEqual(decoded.width, image.width)
+        XCTAssertEqual(decoded.height, image.height)
+        XCTAssertEqual(decoded.rgba8, image.rgba8)
+
+        let decodedFromData = try MediaImageIO.decode(data: Data(contentsOf: url))
+        XCTAssertEqual(decodedFromData.rgba8, image.rgba8)
+    }
+
+    #if canImport(CoreGraphics)
+    func testCGImageDecodeUnpremultipliesNonDirectFormats() throws {
+        // Premultiplied (100, 100, 100, 128) has no direct-copy path, so the
+        // draw fallback must un-premultiply back to straight ≈ (199, 199, 199).
+        let provider = try XCTUnwrap(CGDataProvider(data: Data([100, 100, 100, 128]) as CFData))
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        let premultiplied = try XCTUnwrap(CGImage(
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ))
+
+        let decoded = try AppleMediaImageIO.mediaImage(from: premultiplied)
+        XCTAssertEqual(decoded.rgba8[3], 128)
+        for channel in 0..<3 {
+            XCTAssertEqual(Int(decoded.rgba8[channel]), 199, accuracy: 1)
+        }
+    }
+    #endif
 
     func testFloatWAVWriterProducesPortableHeader() throws {
         let tempURL = FileManager.default.temporaryDirectory

--- a/Tests/MereRunCoreTests/MeshAssetTests.swift
+++ b/Tests/MereRunCoreTests/MeshAssetTests.swift
@@ -76,6 +76,39 @@ final class MeshAssetTests: XCTestCase {
         XCTAssertNil(legacy.inputs)
     }
 
+    func testGLBMaterialFactorsDefaultAndOverride() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mesh = try triangleMesh(normals: true)
+
+        let plain = root.appendingPathComponent("plain.glb")
+        try MeshGLBWriter.write(mesh, to: plain)
+        var material = try glbMaterial(at: plain)
+        XCTAssertEqual(material["metallicFactor"] as? Double, 0)
+        XCTAssertEqual(material["roughnessFactor"] as? Double, 1)
+
+        let pbr = root.appendingPathComponent("pbr.glb")
+        try MeshGLBWriter.write(
+            mesh,
+            to: pbr,
+            material: MeshPBRMaterialFactors(metallicFactor: 0.25, roughnessFactor: 0.625)
+        )
+        material = try glbMaterial(at: pbr)
+        XCTAssertEqual(try XCTUnwrap(material["metallicFactor"] as? Double), 0.25, accuracy: 1e-6)
+        XCTAssertEqual(try XCTUnwrap(material["roughnessFactor"] as? Double), 0.625, accuracy: 1e-6)
+    }
+
+    private func glbMaterial(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        let jsonLength = Int(readUInt32(data, offset: 12))
+        let document = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data.subdata(in: 20..<(20 + jsonLength)))
+                as? [String: Any]
+        )
+        let materials = try XCTUnwrap(document["materials"] as? [[String: Any]])
+        return try XCTUnwrap(materials[0]["pbrMetallicRoughness"] as? [String: Any])
+    }
+
     private func triangleMesh(normals: Bool) throws -> MeshAsset {
         try MeshAsset(
             vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -197,6 +197,133 @@ final class Trellis2CoreTests: MereRunCoreTestCase {
         XCTAssertNil(Trellis2ArtifactExporter.medianMaterialFactors(metallic: [], roughness: []))
     }
 
+    func testAtlasBakeMatchesVertexSamplesThroughUVLookup() throws {
+        // Distinct red per voxel; the baked atlas texel under each split
+        // corner's UV must equal the per-vertex sample of the same field.
+        var coordinates = [Trellis2VoxelCoordinate]()
+        for x in 0..<2 {
+            for y in 0..<2 {
+                for z in 0..<2 {
+                    coordinates.append(.init(x: Int32(x), y: Int32(y), z: Int32(z)))
+                }
+            }
+        }
+        let shapeRow: [Float] = [0, 0, 0, 1, 1, 1, 0]
+        let textureRows = (0..<8).map { [Float(-1) + 2 * Float($0) / 7, -1, 1, 0, 0, 1] }
+        let decoded = try Trellis2FlexibleDualGrid.decode(
+            shape: try Trellis2SparseTensor(
+                features: MLXArray(Array(repeating: shapeRow, count: 8).flatMap { $0 }).reshaped(8, 7),
+                coordinates: coordinates
+            ),
+            texture: try Trellis2SparseTensor(
+                features: MLXArray(textureRows.flatMap { $0 }).reshaped(8, 6),
+                coordinates: coordinates
+            ),
+            resolution: 2
+        )
+        let baked = Trellis2TextureAtlasBaker.bake(mesh: decoded.mesh, field: decoded.pbrVoxels)
+
+        XCTAssertEqual(baked.indices.count, decoded.mesh.indices.count)
+        XCTAssertEqual(baked.uvs.count, baked.vertexCount * 2)
+        XCTAssertEqual(baked.normals.count, baked.positions.count)
+        XCTAssertEqual(
+            baked.baseColorRGBA8.count,
+            baked.atlasWidth * baked.atlasHeight * 4
+        )
+
+        var originalByPosition = [[UInt32]: Int]()
+        for vertex in 0..<decoded.mesh.vertexCount {
+            let key = (0..<3).map { decoded.mesh.vertices[vertex * 3 + $0].bitPattern }
+            originalByPosition[key] = vertex
+        }
+        let colors = try XCTUnwrap(decoded.mesh.colorsRGBA8)
+        for vertex in 0..<baked.vertexCount {
+            let key = (0..<3).map { baked.positions[vertex * 3 + $0].bitPattern }
+            let original = try XCTUnwrap(originalByPosition[key], "split corner must be an original vertex")
+            let texelX = Int((baked.uvs[vertex * 2] * Float(baked.atlasWidth) - 0.5).rounded())
+            let texelY = Int((baked.uvs[vertex * 2 + 1] * Float(baked.atlasHeight) - 0.5).rounded())
+            let pixel = (texelY * baked.atlasWidth + texelX) * 4
+            for channel in 0..<4 {
+                XCTAssertEqual(
+                    Int(baked.baseColorRGBA8[pixel + channel]),
+                    Int(colors[original * 4 + channel]),
+                    accuracy: 1,
+                    "vertex \(vertex) channel \(channel)"
+                )
+            }
+            XCTAssertEqual(baked.metallicRoughnessRGBA8[pixel], 255)
+            XCTAssertEqual(Int(baked.metallicRoughnessRGBA8[pixel + 1]), 128, accuracy: 1)
+            XCTAssertEqual(Int(baked.metallicRoughnessRGBA8[pixel + 2]), 128, accuracy: 1)
+        }
+    }
+
+    func testTexturedGLBEmbedsAtlasTexturesAndUVs() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "trellis2-textured-glb-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        var coordinates = [Trellis2VoxelCoordinate]()
+        for x in 0..<2 {
+            for y in 0..<2 {
+                for z in 0..<2 {
+                    coordinates.append(.init(x: Int32(x), y: Int32(y), z: Int32(z)))
+                }
+            }
+        }
+        let shapeRow: [Float] = [0, 0, 0, 1, 1, 1, 0]
+        let textureRow: [Float] = [1, -1, -1, 0, 0, 1]
+        let decoded = try Trellis2FlexibleDualGrid.decode(
+            shape: try Trellis2SparseTensor(
+                features: MLXArray(Array(repeating: shapeRow, count: 8).flatMap { $0 }).reshaped(8, 7),
+                coordinates: coordinates
+            ),
+            texture: try Trellis2SparseTensor(
+                features: MLXArray(Array(repeating: textureRow, count: 8).flatMap { $0 }).reshaped(8, 6),
+                coordinates: coordinates
+            ),
+            resolution: 2
+        )
+        let baked = Trellis2TextureAtlasBaker.bake(mesh: decoded.mesh, field: decoded.pbrVoxels)
+        let url = root.appendingPathComponent("baked.glb")
+        try Trellis2TexturedGLBWriter.write(
+            baked,
+            coordinateSystem: decoded.mesh.coordinateSystem,
+            units: decoded.mesh.units,
+            inferredUnseenGeometry: decoded.mesh.inferredUnseenGeometry,
+            to: url
+        )
+
+        let data = try Data(contentsOf: url)
+        let jsonLength = Int(data[12]) | (Int(data[13]) << 8) | (Int(data[14]) << 16) | (Int(data[15]) << 24)
+        let document = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data.subdata(in: 20..<(20 + jsonLength))) as? [String: Any]
+        )
+        let primitive = try XCTUnwrap(
+            ((document["meshes"] as? [[String: Any]])?.first?["primitives"] as? [[String: Any]])?.first
+        )
+        let attributes = try XCTUnwrap(primitive["attributes"] as? [String: Any])
+        XCTAssertNotNil(attributes["TEXCOORD_0"])
+        XCTAssertNil(attributes["COLOR_0"], "textured GLB must not double-apply color")
+        let material = try XCTUnwrap((document["materials"] as? [[String: Any]])?.first)
+        let pbr = try XCTUnwrap(material["pbrMetallicRoughness"] as? [String: Any])
+        XCTAssertNotNil(pbr["baseColorTexture"])
+        XCTAssertNotNil(pbr["metallicRoughnessTexture"])
+        let images = try XCTUnwrap(document["images"] as? [[String: Any]])
+        XCTAssertEqual(images.count, 2)
+
+        let binaryStart = 20 + jsonLength + 8
+        let views = try XCTUnwrap(document["bufferViews"] as? [[String: Any]])
+        let imageView = views[try XCTUnwrap(images[0]["bufferView"] as? Int)]
+        let offset = binaryStart + (imageView["byteOffset"] as? Int ?? 0)
+        let length = try XCTUnwrap(imageView["byteLength"] as? Int)
+        let png = data.subdata(in: offset..<(offset + length))
+        XCTAssertEqual(Array(png.prefix(4)), [0x89, 0x50, 0x4E, 0x47])
+        let image = try MediaImageIO.decode(data: png)
+        XCTAssertEqual(image.width, baked.atlasWidth)
+        XCTAssertEqual(image.height, baked.atlasHeight)
+    }
+
     func testSmallHoleFillerCapsReferenceThresholdBoundaryWithoutAddingVertices() throws {
         let side: Float = 0.005
         let mesh = try MeshAsset(

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -410,6 +410,23 @@ final class Trellis2CoreTests: MereRunCoreTestCase {
         return Set((0..<mesh.vertexCount).map(find)).count
     }
 
+    func testHoleFillerCapsLargeClosedRimOnlyAtRaisedThreshold() throws {
+        // The open face's edges are all side*sqrt(2) diagonals, so the rim
+        // perimeter is ~0.17: beyond the 0.03 reference threshold, within
+        // the remesh pipeline's 0.2 rim-capping threshold.
+        let side: Float = 0.04
+        let mesh = try MeshAsset(
+            vertices: [0, 0, 0, side, 0, 0, 0, side, 0, 0, 0, side],
+            indices: [0, 2, 1, 0, 1, 3, 0, 3, 2],
+            inferredUnseenGeometry: true
+        )
+        let reference = try Trellis2MeshHoleFiller.fillSmallHoles(in: mesh)
+        XCTAssertEqual(reference.triangleCount, 3, "reference threshold must leave the large rim open")
+        let capped = try Trellis2MeshHoleFiller.fillSmallHoles(in: mesh, maximumPerimeter: 0.2)
+        XCTAssertEqual(capped.triangleCount, 4, "raised threshold must cap the rim")
+        XCTAssertEqual(capped.vertexCount, 4)
+    }
+
     func testSmallHoleFillerCapsReferenceThresholdBoundaryWithoutAddingVertices() throws {
         let side: Float = 0.005
         let mesh = try MeshAsset(

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -324,6 +324,92 @@ final class Trellis2CoreTests: MereRunCoreTestCase {
         XCTAssertEqual(image.height, baked.atlasHeight)
     }
 
+    func testTriangleBVHReturnsExactDistances() {
+        let bvh = Trellis2TriangleBVH(
+            vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+            indices: [0, 1, 2]
+        )
+        XCTAssertEqual(bvh.unsignedDistance(x: 0.25, y: 0.25, z: 0.7), 0.7, accuracy: 1e-5)
+        XCTAssertEqual(bvh.unsignedDistance(x: -1, y: -1, z: 0), Float(2).squareRoot(), accuracy: 1e-5)
+        XCTAssertEqual(bvh.unsignedDistance(x: 2, y: 0, z: 0), 1, accuracy: 1e-5)
+        XCTAssertEqual(bvh.unsignedDistance(x: 0.5, y: -0.5, z: 0), 0.5, accuracy: 1e-5)
+        let closest = bvh.closestPoint(x: 0.25, y: 0.25, z: 0.7)
+        XCTAssertEqual(closest.x, 0.25, accuracy: 1e-5)
+        XCTAssertEqual(closest.y, 0.25, accuracy: 1e-5)
+        XCTAssertEqual(closest.z, 0, accuracy: 1e-5)
+    }
+
+    func testNarrowBandRemeshClosesFullyOpenSurface() throws {
+        // A lone triangle is the extreme torn crust: every edge is a
+        // boundary. Its band envelope must come back watertight.
+        let crust = try MeshAsset(
+            vertices: [-0.2, -0.2, 0, 0.2, -0.2, 0, 0, 0.2, 0],
+            indices: [0, 1, 2],
+            inferredUnseenGeometry: true
+        )
+        let remeshed = try Trellis2NarrowBandRemesher.remesh(mesh: crust, resolution: 64)
+        XCTAssertGreaterThan(remeshed.triangleCount, 0)
+        XCTAssertEqual(boundaryEdgeCount(of: remeshed), 0, "envelope must be closed")
+    }
+
+    func testNarrowBandRemeshSealsSubBandGapsAndConnectsSheets() throws {
+        // Two coplanar sheets separated by ~1.5 voxels at resolution 64.
+        // The band envelopes overlap across the gap, so the result must be
+        // one connected watertight surface.
+        let gap: Float = 0.012
+        let crust = try MeshAsset(
+            vertices: [
+                -0.3, -0.3, 0, -gap, -0.3, 0, -gap, 0.3, 0, -0.3, 0.3, 0,
+                gap, -0.3, 0, 0.3, -0.3, 0, 0.3, 0.3, 0, gap, 0.3, 0,
+            ],
+            indices: [0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7],
+            inferredUnseenGeometry: true
+        )
+        let remeshed = try Trellis2NarrowBandRemesher.remesh(mesh: crust, resolution: 64)
+        XCTAssertEqual(boundaryEdgeCount(of: remeshed), 0, "envelope must be closed")
+        XCTAssertEqual(connectedComponentCount(of: remeshed), 1, "gap must be sealed")
+    }
+
+    private func boundaryEdgeCount(of mesh: MeshAsset) -> Int {
+        var counts = [UInt64: Int]()
+        for triangle in stride(from: 0, to: mesh.indices.count, by: 3) {
+            let corners = [
+                mesh.indices[triangle],
+                mesh.indices[triangle + 1],
+                mesh.indices[triangle + 2],
+            ]
+            for edge in 0..<3 {
+                let a = UInt64(min(corners[edge], corners[(edge + 1) % 3]))
+                let b = UInt64(max(corners[edge], corners[(edge + 1) % 3]))
+                counts[(a << 32) | b, default: 0] += 1
+            }
+        }
+        return counts.values.filter { $0 == 1 }.count
+    }
+
+    private func connectedComponentCount(of mesh: MeshAsset) -> Int {
+        var parent = Array(0..<mesh.vertexCount)
+        func find(_ vertex: Int) -> Int {
+            var root = vertex
+            while parent[root] != root { root = parent[root] }
+            var current = vertex
+            while parent[current] != root {
+                let next = parent[current]
+                parent[current] = root
+                current = next
+            }
+            return root
+        }
+        for triangle in stride(from: 0, to: mesh.indices.count, by: 3) {
+            let a = find(Int(mesh.indices[triangle]))
+            let b = find(Int(mesh.indices[triangle + 1]))
+            let c = find(Int(mesh.indices[triangle + 2]))
+            parent[b] = a
+            parent[c] = a
+        }
+        return Set((0..<mesh.vertexCount).map(find)).count
+    }
+
     func testSmallHoleFillerCapsReferenceThresholdBoundaryWithoutAddingVertices() throws {
         let side: Float = 0.005
         let mesh = try MeshAsset(

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -149,6 +149,54 @@ final class Trellis2CoreTests: MereRunCoreTestCase {
         XCTAssertEqual(decoded.pbrVoxels.attributes[5], 1, accuracy: 1e-6)
     }
 
+    func testDualGridSamplingIsUniformAcrossTheSparseShell() throws {
+        // Every voxel carries the same texture row, so every dual vertex must
+        // sample the identical full-magnitude value. Corner voxels of the 2^3
+        // grid interpolate over cells whose other corners are unoccupied;
+        // unnormalized weights would darken them (and their alpha) eightfold.
+        var coordinates = [Trellis2VoxelCoordinate]()
+        for x in 0..<2 {
+            for y in 0..<2 {
+                for z in 0..<2 {
+                    coordinates.append(.init(x: Int32(x), y: Int32(y), z: Int32(z)))
+                }
+            }
+        }
+        let shapeRow: [Float] = [0, 0, 0, 1, 1, 1, 0]
+        let textureRow: [Float] = [1, -1, -1, 0, 0, 1]
+        let decoded = try Trellis2FlexibleDualGrid.decode(
+            shape: try Trellis2SparseTensor(
+                features: MLXArray(Array(repeating: shapeRow, count: 8).flatMap { $0 }).reshaped(8, 7),
+                coordinates: coordinates
+            ),
+            texture: try Trellis2SparseTensor(
+                features: MLXArray(Array(repeating: textureRow, count: 8).flatMap { $0 }).reshaped(8, 6),
+                coordinates: coordinates
+            ),
+            resolution: 2
+        )
+        let colors = try XCTUnwrap(decoded.mesh.colorsRGBA8)
+        for vertex in 0..<decoded.mesh.vertexCount {
+            XCTAssertEqual(
+                Array(colors[(vertex * 4)..<(vertex * 4 + 4)]),
+                [255, 0, 0, 255],
+                "vertex \(vertex) should carry the uniform field value at full magnitude"
+            )
+        }
+        XCTAssertEqual(decoded.metallic, [Float](repeating: 0.5, count: 8))
+        XCTAssertEqual(decoded.roughness, [Float](repeating: 0.5, count: 8))
+    }
+
+    func testMedianMaterialFactors() throws {
+        let factors = try XCTUnwrap(Trellis2ArtifactExporter.medianMaterialFactors(
+            metallic: [0.1, 0.9, 0.2],
+            roughness: [0.3, 0.7, 0.5, 0.6]
+        ))
+        XCTAssertEqual(factors.metallicFactor, 0.2)
+        XCTAssertEqual(factors.roughnessFactor, 0.55, accuracy: 1e-6)
+        XCTAssertNil(Trellis2ArtifactExporter.medianMaterialFactors(metallic: [], roughness: []))
+    }
+
     func testSmallHoleFillerCapsReferenceThresholdBoundaryWithoutAddingVertices() throws {
         let side: Float = 0.005
         let mesh = try MeshAsset(

--- a/Tests/MereRunCoreTests/Trellis2CoreTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2CoreTests.swift
@@ -410,6 +410,107 @@ final class Trellis2CoreTests: MereRunCoreTestCase {
         return Set((0..<mesh.vertexCount).map(find)).count
     }
 
+    func testSealedClassificationClosesTornCavityOnlyWithSufficientRadius() {
+        // A hollow 12-cube shell centered in a 32-grid, with a 4-cell hole
+        // punched through one face. Closing with radius >= 2 must classify
+        // the cavity interior; radius 0 must let the flood leak through.
+        var occupied = [Int32]()
+        let low: Int32 = 10, high: Int32 = 21
+        for x in low...high {
+            for y in low...high {
+                for z in low...high {
+                    let shell = x == low || x == high || y == low || y == high || z == low || z == high
+                    guard shell else { continue }
+                    let inHole = x == high && (14...17).contains(y) && (14...17).contains(z)
+                    if !inHole {
+                        occupied.append(contentsOf: [x, y, z])
+                    }
+                }
+            }
+        }
+        let sealed = Trellis2SealedClassification(resolution: 32, occupiedCells: occupied, radius: 3)
+        XCTAssertTrue(sealed.isInterior(x: 15, y: 15, z: 15), "cavity center must seal at radius 3")
+        XCTAssertFalse(sealed.isInterior(x: 2, y: 2, z: 2), "far corner must stay exterior")
+        XCTAssertFalse(sealed.isInterior(x: 29, y: 15, z: 15), "outside the holed face must stay exterior")
+        let leaky = Trellis2SealedClassification(resolution: 32, occupiedCells: occupied, radius: 0)
+        XCTAssertFalse(leaky.isInterior(x: 15, y: 15, z: 15), "radius 0 must leak through the hole")
+    }
+
+    func testRemeshMembraneSpansTornCavity() throws {
+        // The same torn shell as a crust mesh: without sealing, the envelope
+        // has a tunnel; with sealing, a membrane spans the hole. Compare
+        // enclosed volumes via the divergence theorem.
+        var vertices = [Float]()
+        var indices = [UInt32]()
+        // Build shell quads from occupied-face voxels directly: a coarse
+        // axis-aligned box surface with a hole, in mesh object space.
+        func addQuad(_ a: [Float], _ b: [Float], _ c: [Float], _ d: [Float]) {
+            let base = UInt32(vertices.count / 3)
+            vertices.append(contentsOf: a + b + c + d)
+            indices.append(contentsOf: [base, base + 1, base + 2, base, base + 2, base + 3])
+        }
+        let half: Float = 0.2
+        let step: Float = 0.05
+        var tiles = 0
+        for u in stride(from: -half, to: half, by: step) {
+            for v in stride(from: -half, to: half, by: step) {
+                let u2 = u + step, v2 = v + step
+                addQuad([u, v, -half], [u2, v, -half], [u2, v2, -half], [u, v2, -half])
+                let hole = abs(u + step / 2) < 0.05 && abs(v + step / 2) < 0.05
+                if !hole {
+                    addQuad([u, v, half], [u, v2, half], [u2, v2, half], [u2, v, half])
+                }
+                addQuad([u, -half, v], [u2, -half, v], [u2, -half, v2], [u, -half, v2])
+                addQuad([u, half, v], [u, half, v2], [u2, half, v2], [u2, half, v])
+                addQuad([-half, u, v], [-half, u, v2], [-half, u2, v2], [-half, u2, v])
+                addQuad([half, u, v], [half, u2, v], [half, u2, v2], [half, u, v2])
+                tiles += 1
+            }
+        }
+        let crust = try MeshAsset(vertices: vertices, indices: indices, inferredUnseenGeometry: true)
+        // Occupancy for the classification: voxelize the shell tiles into the
+        // field's Z-up grid (mesh (x,y,z) -> field (x, -z, y)).
+        var field = [Trellis2VoxelCoordinate]()
+        let resolution = 64
+        for triple in stride(from: 0, to: vertices.count, by: 9) {
+            let x = vertices[triple], y = vertices[triple + 1], z = vertices[triple + 2]
+            let fx = Int32((x + 0.5) * Float(resolution))
+            let fy = Int32((-z + 0.5) * Float(resolution))
+            let fz = Int32((y + 0.5) * Float(resolution))
+            field.append(.init(x: fx, y: fy, z: fz))
+        }
+
+        func enclosedVolume(_ mesh: MeshAsset) -> Float {
+            var volume: Float = 0
+            for triangle in stride(from: 0, to: mesh.indices.count, by: 3) {
+                let a = Int(mesh.indices[triangle]) * 3
+                let b = Int(mesh.indices[triangle + 1]) * 3
+                let c = Int(mesh.indices[triangle + 2]) * 3
+                let ax = mesh.vertices[a], ay = mesh.vertices[a + 1], az = mesh.vertices[a + 2]
+                let bx = mesh.vertices[b], by = mesh.vertices[b + 1], bz = mesh.vertices[b + 2]
+                let cx = mesh.vertices[c], cy = mesh.vertices[c + 1], cz = mesh.vertices[c + 2]
+                volume += (ax * (by * cz - bz * cy) + ay * (bz * cx - bx * cz) + az * (bx * cy - by * cx)) / 6
+            }
+            return abs(volume)
+        }
+
+        let unsealed = try Trellis2NarrowBandRemesher.remesh(
+            mesh: crust,
+            resolution: resolution,
+            configuration: Trellis2RemeshConfiguration(band: 1, sealRadius: 0)
+        )
+        let sealedMesh = try Trellis2NarrowBandRemesher.remesh(
+            mesh: crust,
+            resolution: resolution,
+            configuration: Trellis2RemeshConfiguration(band: 1, sealRadius: 6),
+            fieldCoordinates: field
+        )
+        let boxVolume: Float = 0.4 * 0.4 * 0.4
+        XCTAssertLessThan(enclosedVolume(unsealed), boxVolume * 0.5, "tunnel envelope must not enclose the cavity")
+        XCTAssertGreaterThan(enclosedVolume(sealedMesh), boxVolume * 0.7, "sealed remesh must enclose the cavity")
+        XCTAssertEqual(boundaryEdgeCount(of: sealedMesh), 0)
+    }
+
     func testHoleFillerCapsLargeClosedRimOnlyAtRaisedThreshold() throws {
         // The open face's edges are all side*sqrt(2) diagonals, so the rim
         // perimeter is ~0.17: beyond the 0.03 reference threshold, within

--- a/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
@@ -120,7 +120,7 @@ final class Trellis2ResourcesAndManifestTests: XCTestCase {
         XCTAssertTrue(exported.run.manifest.mesh.includesMetallicRoughnessSidecar)
         XCTAssertEqual(
             Set(exported.run.manifest.artifacts.map(\.kind)),
-            ["obj", "ply", "glb", "pbr-voxels", "mesh-manifest"]
+            ["obj", "ply", "glb", "glb-textured", "pbr-voxels", "mesh-manifest"]
         )
         XCTAssertTrue(exported.run.manifest.artifacts.allSatisfy {
             $0.byteCount > 0 && $0.sha256.count == 64

--- a/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
+++ b/Tests/MereRunCoreTests/Trellis2ResourcesAndManifestTests.swift
@@ -77,9 +77,10 @@ final class Trellis2ResourcesAndManifestTests: XCTestCase {
             colorsRGBA8: [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255],
             inferredUnseenGeometry: true
         )
+        // Resolution 64 keeps the narrow-band remesh cheap in debug builds.
         let coordinates = [Trellis2VoxelCoordinate(x: 1, y: 2, z: 3)]
         let grid = try Trellis2PBRVoxelGrid(
-            resolution: 512,
+            resolution: 64,
             coordinates: coordinates,
             attributes: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
         )
@@ -116,6 +117,12 @@ final class Trellis2ResourcesAndManifestTests: XCTestCase {
         XCTAssertEqual(exported.run.manifest.input.sha256, inputRecord.sha256)
         XCTAssertEqual(exported.run.manifest.generation.pipelineResolution, 512)
         XCTAssertEqual(exported.run.manifest.generation.seed, 42)
+        XCTAssertEqual(
+            exported.run.manifest.generation.extractionAlgorithm,
+            Trellis2ArtifactExporter.remeshExtractionAlgorithm
+        )
+        XCTAssertEqual(exported.run.manifest.generation.remeshBand, 1)
+        XCTAssertEqual(exported.run.manifest.generation.remeshProjectBack, 0)
         XCTAssertEqual(exported.run.manifest.mesh.pbrVoxelCount, 1)
         XCTAssertTrue(exported.run.manifest.mesh.includesMetallicRoughnessSidecar)
         XCTAssertEqual(

--- a/scripts/agent_readiness_check.sh
+++ b/scripts/agent_readiness_check.sh
@@ -111,6 +111,7 @@ dynamic_boundary_files=(
   "Sources/MereRunCore/QwenImageEdit/Tokenizer/Qwen25VLTokenizer.swift"
   "Sources/MereRunCore/SAM3/SAM31Tokenizer.swift"
   "Sources/MereRunCore/SAM3/SAM31VideoIO.swift"
+  "Sources/MereRunCore/Trellis2/Trellis2TexturedGLBWriter.swift"
   "Sources/MereRunCore/VLM/Qwen3VLAutoCaptioner.swift"
   "Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/QwenGeneration.swift"
   "Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift"


### PR DESCRIPTION
Stacked on #167 (base: `fix/glb-vertex-color-linearization`); GitHub will retarget to `main` when that merges.

Three commits: sparse-sampling/material-factors fix, texture-atlas bake, watertight narrow-band remesh.

## 1. Normalize sparse sampling + export material factors (`7bbd410`)

`sampleTextureAttributes` dropped unoccupied trilinear corners without renormalizing — at surface vertices the interpolation cell straddles the occupied shell by definition, so every channel darkened by the missing weight (94% of vertices carried alpha < 255; the fox rendered as speckled dust). Weights now renormalize over occupied corners. `MeshArtifactExporter`/`MeshGLBWriter` also accept optional uniform `MeshPBRMaterialFactors` written as core glTF factors (default unchanged), and the TRELLIS.2 exporter passes its field medians.

## 2. Bake the field into a textured GLB (`1d3a0a2`)

The dual-grid mesh partitions into quads (two consecutive triangles per grid edge), so the field bakes into a **per-quad block atlas with no UV unwrapping** — deterministic, injective, guttered. Blocks are Morton-ordered by quad centroid and placed on the 2D Morton curve so mip levels blend surface-local colors. Emits `<stem>-textured.glb` with sRGB `baseColorTexture` + linear `metallicRoughnessTexture`, `TEXCOORD_0`, no `COLOR_0`. Two rendering-quality findings: straight-alpha PNGs are corrupted by the premultiplied encode path (atlas stores alpha 255; MediaIO bug flagged separately), and row-major block layout washes out under mipmapping (fixed by the Morton layout).

## 3. Watertight narrow-band DC remesh (`8f9f8d5`)

The raw crust is porous — on the showcase fox, **113,480 boundary edges** across ~59k open/tangled chains that no loop-capping can close (green-screen renders show straight through the flank). Research consensus and upstream itself point at re-extraction: TRELLIS.2's shipped `to_glb` runs CuMesh's `remesh_narrow_band_dc` (`remesh=True, band=1, project=0` in the app).

This is a native port of that algorithm: isosurface of `UDF(crust) − band·voxel` via simple dual contouring (dual vertex = mean of edge crossings, voxel-center fallback) over a sparse octree-refined grid, quads around sign-crossing far edges with upstream's exact neighbor tables and literal split-alignment selection, optional projection back to the crust. Watertight by construction; seals tears narrower than ~2× the band. A median-split triangle BVH serves distance/closest-point queries; all hot loops run in parallel chunks. Remeshing is the **default** for TRELLIS.2 exports (`--no-remesh` opts out, `--remesh-band` widens sealing for fuzzy subjects — each unit ≈ 0.2% surface inflation).

Two correctness details beyond the port:
- **Color sampling projects to the crust** (as upstream's texture bake does): envelope vertices/texels sit up to `band` voxels off the occupied shell, where naive sampling black-speckles. Vertex colors and atlas texels sample at each position's closest crust point, so wider bands cost nothing in appearance.
- **Single-sided material** when remeshed (consistent outward orientation), matching upstream; manifests record algorithm, band, and projection.

## Verification

- Unit: BVH exact distances; envelope closure of a fully open surface (lone triangle); sub-band gap sealing into one connected watertight component; UV-driven atlas parity; sampler uniform-field regression; manifest remesh fields. 27 suites green.
- Showcase fox (seed 42, deterministic): raw crust 113,480 boundary edges → **0** at every band; green-background renders go from colander → solid at band 3 (a handful of tunnel flecks remain at band 1, upstream-equivalent). Runs are byte-deterministic across invocations; full pipeline ~2 min per run (+~25 s over non-remesh).
- Atlas texels verified byte-exact against ground truth via pure-Python PNG decode earlier in the stack; projection sampling re-verified visually (band-2 black stipple eliminated).

Note: upstream's remesh branch also simplifies to a 1M-face target; native decimation is not ported (fox envelope ships at 2.8M triangles). Flagged as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)