### PR TITLE
Prepare 0.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,38 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.21.0 - 2026-07-14
+
 ### Added
 
 - added native Swift/MLX Microsoft TRELLIS.2-4B image-to-3D reconstruction at
   512 resolution, including direct official safetensors loading, pinned DINOv3
   ViT-L/16 conditioning, three 12-step flow stages, sparse ConvNeXt O-Voxel
   shape/PBR decoding, flexible-dual-grid mesh extraction, managed model pull,
-  reference-threshold small-hole repair, separate image/vision CLI commands,
-  and hashed OBJ/PLY/GLB plus six-channel `.pbrvox` material artifacts. The DINOv3 dependency remains separately
+  separate image/vision CLI commands, and hashed OBJ/PLY/GLB plus six-channel
+  `.pbrvox` material artifacts. The DINOv3 dependency remains separately
   license-gated and requires user acceptance/authentication.
+- added native Apple-platform VFX primitives through `vision pose` and
+  `vision flow`, with body/hand/face landmark JSON and dense Middlebury `.flo`
+  optical-flow output from the system Vision framework.
+- added native Swift/MLX geometry and depth workflows: MoGe-2 single-image
+  metric geometry, Video Depth Anything temporal depth, and Depth Anything 3
+  multi-view camera solving and point geometry. The commands emit bounded,
+  provenance-rich depth, confidence, camera, EXR, PLY, GLB, preview, and
+  3DGS-initialization artifacts as appropriate to each model.
+- added native TripoSR single-image and InstantMesh four/six-view object
+  reconstruction, with managed converted checkpoints, deterministic input
+  admission, native isosurface extraction, and hashed OBJ/PLY/GLB run
+  artifacts. InstantMesh intentionally does not bundle or invoke Zero123++.
+- added native Swift/MLX Wan 2.2 TI2V-5B image-to-video generation and reusable
+  warm world sessions with first-frame conditioning, camera controls, terminal
+  latent chaining, managed checkpoint verification, and MP4/PNG artifacts.
+- added the native DreamX causal world runtime and `world` CLI, including the
+  converted AR transformer, persistent block-causal and cross-attention caches,
+  PRoPE camera conditioning, multi-transition session state, and a loopback
+  `world serve` API with asynchronous jobs, progress, cancellation, reset, and
+  unload. The converted causal checkpoint remains a local-only managed artifact
+  because the public FP32 file is not the streamed BF16 MLX layout.
 - added native MMAudio large 44.1 kHz text-to-audio and video-to-audio SFX
   generation, including managed pinned assets, DFN5B CLIP and Synchformer video
   conditioning, the joint/fused MMDiT flow model, magnitude-preserving VAE,
@@ -39,9 +62,18 @@ The format is based on Keep a Changelog.
   beat phase, meter, and key detection with per-field confidence, reviewable
   beat-position JSON, and standard MIDI tempo/time/key meta events without
   quantizing source-relative note timing.
+- added catalog-backed managed-model download size estimates so model listings,
+  capabilities, Studio readiness, and pull preflights can show the expected
+  local storage commitment before a checkpoint download begins.
 
 ### Changed
 
+- upgraded TRELLIS.2 appearance and geometry export with glTF-spec linearized
+  vertex colors, material-factor normalization, deterministic PBR texture-atlas
+  baking into self-contained textured GLB, a watertight narrow-band remesh,
+  closed-rim capping, morphological cavity sealing, and closest-surface color
+  projection. `--texture-seed` can now re-roll appearance independently while
+  preserving structure and shape from the base seed.
 - polished the macOS Studio app: narrow windows keep an icon rail for mode
   navigation instead of hiding the sidebar; image generation shows a
   determinate per-step progress bar (parsing both the human `Generating (N/M)`
@@ -52,6 +84,8 @@ The format is based on Keep a Changelog.
   clipboard holds an image; results cap to a readable width on wide windows;
   Listen uses a mic-badged waveform icon; sidebar footer controls use themed
   styling.
+- overhauled the public docs theme with bundled typography, refreshed code
+  presentation, and upgraded local search styling.
 - reduced autoregressive prefill and decode work across shared Qwen, ACE-Step,
   ASR, TTS, OCR, VLM, MuScriptor, and Falcon paths with final-position output
   projection, pipelined GPU sampling, compact grouped-query caches, and true
@@ -152,6 +186,21 @@ The format is based on Keep a Changelog.
 - gated default CUDA `.deb` metadata on a linked CUDA 13 `libcudart` SONAME;
   other or unknown toolkit majors now fail closed unless a maintainer supplies
   the complete `MERERUN_PACKAGE_LINUX_DEPS` override. Tar packaging is unchanged.
+- changed the default code-benchmark model set to the models supported and
+  recommended for the current machine instead of a fixed cross-machine trio.
+
+### Fixed
+
+- fixed explicit `--models-root` and `MERERUN_MODELS_DIR` overrides so model
+  pull preflight reports and follow-up actions keep the requested path even
+  before that model-store directory exists.
+- fixed DreamX camera compilation so the final aligned view reaches the
+  requested translation or rotation magnitude instead of scaling motion by the
+  full pixel-frame count.
+- fixed Linux Swift 6 build compatibility across package manifests and the new
+  MMAudio and TRELLIS.2 runtime paths.
+- fixed repeat Linux packaging in an existing output directory so the
+  regenerated checksum manifest does not include and invalidate its previous copy.
 
 ## 0.20.0 - 2026-07-07
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ during NVRTC JIT compilation:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.20.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
 ```
 
 Current CUDA validation should be treated as limited to the exact hosts that
@@ -140,7 +140,7 @@ swift run mere.run --help
 To build Linux release packages from a Linux x86_64 Swift toolchain host:
 
 ```bash
-scripts/package-linux.sh --version 0.20.0
+scripts/package-linux.sh --version 0.21.0
 ls dist/linux/
 ```
 
@@ -149,14 +149,14 @@ builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.20.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
 On Linux arm64, use a CUDA-provisioned host:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.20.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.21.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.20.0"
+    static let current = "0.21.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.20.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.21.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -100,7 +100,7 @@ artifacts. Build package artifacts locally on the Linux host class you intend to
 validate:
 
 ```bash
-scripts/package-linux.sh --version 0.20.0
+scripts/package-linux.sh --version 0.21.0
 ls dist/linux/
 ```
 
@@ -113,7 +113,7 @@ CUDA variants use a suffix so they can ship beside the CPU artifacts:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.20.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
 ```
 
 That writes artifacts such as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ commands, package checks, and CUDA validation limits, see
 [Linux QuickStart](./linux-quickstart.md).
 
 ```bash
-scripts/package-linux.sh --version 0.20.0
+scripts/package-linux.sh --version 0.21.0
 ls dist/linux/
 ```
 

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -31,7 +31,7 @@ Use this path on Debian or Ubuntu-style systems after building a matching
 `.deb`, or when a matching `.deb` is attached to a release:
 
 ```bash
-version=0.20.0
+version=0.21.0
 case "$(uname -m)" in
   x86_64|amd64) deb_arch=amd64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -51,7 +51,7 @@ Use this path after building a matching tarball, or when a matching tarball is
 attached to a release:
 
 ```bash
-version=0.20.0
+version=0.21.0
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -79,7 +79,7 @@ hosts after building it, or when a matching CUDA tarball is attached to a
 release:
 
 ```bash
-version=0.20.0
+version=0.21.0
 tar -xzf "./dist/linux/mere-run-${version}-linux-x86_64-cuda.tar.gz"
 cd "mere-run-${version}-linux-x86_64-cuda"
 ./install.sh
@@ -130,7 +130,7 @@ x86_64 CUDA development host:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.20.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
@@ -144,7 +144,7 @@ MERERUN_LINUX_ACCEL=cuda \
 MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
 MERERUN_NATIVE_BUILD_JOBS=14 \
 MERERUN_CUDA_ARCHITECTURES="86-real;90-virtual" \
-  scripts/package-linux.sh --version 0.20.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
 ```
 
 Run a real GPU smoke on the target runtime class before widening support claims.
@@ -161,7 +161,7 @@ repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.20.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.21.0
 ls dist/linux/
 ```
 
@@ -255,7 +255,7 @@ When a Linux release includes `SHA256SUMS`, place it beside the matching
 tarball or `.deb` before checking it:
 
 ```bash
-tag=v0.20.0
+tag=v0.21.0
 
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/SHA256SUMS" -o SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,7 +96,7 @@ CUDA validation on a host that has not run the path.
 Linux release packaging has its own artifact check:
 
 ```bash
-scripts/package-linux.sh --version 0.20.0
+scripts/package-linux.sh --version 0.21.0
 test -s dist/linux/SHA256SUMS
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
@@ -109,7 +109,7 @@ Linux builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.20.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
 tar -tzf dist/linux/mere-run-*-linux-x86_64-cuda.tar.gz | grep '/.mererun-linux-cuda$'
 dpkg-deb --info dist/linux/mere-run-cuda_*_amd64.deb
 ```
@@ -125,7 +125,7 @@ major gate.
 On Linux arm64, use CUDA for the package check:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.20.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.21.0
 ```
 
 Run Linux package and manifest checks on the affected Linux host class. CUDA

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.20.0"
+default_version="0.21.0"
 if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -599,6 +599,7 @@ fi
 
 (
   cd "$output_root"
+  rm -f SHA256SUMS
   sha256sum ./* | sed 's#  \./#  #' >SHA256SUMS
 )
 echo "[package-linux] wrote $output_dir/SHA256SUMS"

--- a/scripts/test-package-linux.sh
+++ b/scripts/test-package-linux.sh
@@ -35,6 +35,8 @@ case "$(uname -m)" in
 esac
 
 output_dir="$fixture_root/output"
+mkdir -p "$output_dir"
+printf 'stale checksum manifest\n' >"$output_dir/SHA256SUMS"
 
 cat >"$fake_build/mere.run" <<'CLI'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- bump the CLI and macOS app release surface to 0.21.0
- publish the 0.21.0 changelog covering the new 3D, world, VFX, MMAudio, MuScriptor, runtime, performance, and Studio work
- align getting-started, development, testing, and Linux packaging documentation with the new release
- update version-sensitive tests and packaging checks

## Why

The changes since 0.20.0 are large enough to require a new minor release. This prepares the source tree and public documentation before building and publishing the platform artifacts.

## Validation

- `./scripts/check.sh`
- 1,730 tests executed, 115 fixture-dependent tests skipped, 0 failures
- strict SwiftLint, build, CLI help sweep, and hygiene scans passed