### PR TITLE
Add public adapter catalog and pull support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added a checksum-pinned public adapter catalog and `mere.run adapter list`
+  / `mere.run adapter pull` commands, beginning with the promoted Mere Platform
+  Assistant v22 release for Gemma 4 12B 4-bit. Text chat and API serving now
+  accept the catalog id `mere-platform-assistant` anywhere `--lora` accepts a
+  local adapter path.
+
 ## 0.21.0 - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The public OSS repo currently supports:
 - local speech synthesis, transcription, and voice-profile management
 - local vision captioning, inspection, grounding, segmentation, tracking, live camera tracking, and OCR
 - native ACEStep music generation, Woosh sound-effect generation, and LTX video generation
-- Hugging Face-backed model pulls that resolve into a shared local model store
+- Hugging Face-backed model pulls plus checksum-pinned public adapter pulls
+  that resolve into shared local model and adapter stores
 - offline command cookbooks through `mere.run guide`
 - a local OpenAI-compatible API surface for chat, embeddings, image generation,
   TTS, and STT
@@ -212,6 +213,14 @@ swift run mere.run model pull text-chat-lfm25-a1b-8bit
 swift run mere.run model pull text-code-north-mini
 swift run mere.run model pull text-agent-ornith-35b
 # text-agent-ornith-35b-mlx is local-only until a converted MLX snapshot is published
+
+# Pull and apply the promoted Mere Platform Assistant adapter
+swift run mere.run model pull text-chat-gemma4-12b-4bit
+swift run mere.run adapter pull mere-platform-assistant
+swift run mere.run text chat \
+  --model text-chat-gemma4-12b-4bit \
+  --lora mere-platform-assistant \
+  --prompt "What can you help me with in Mere?"
 
 # Generate an image
 swift run mere.run image generate \
@@ -679,7 +688,9 @@ The public OSS build keeps local-first behavior by default and requires explicit
   model
 - `mere.run api serve` can bind to loopback without auth, but non-loopback hosts require `--api-key` or `MERERUN_API_KEY`
 - the OpenAI-compatible chat and embedding routes require `Content-Type: application/json`, support `--rate-limit-per-minute` for basic abuse control, decode the common OpenAI request shapes, and reject unsupported high-impact fields before generation
-- API LoRA adapters are operator-controlled with `--lora`; per-request LoRA paths are rejected
+- API LoRA adapters are operator-controlled with `--lora`; it accepts a
+  verified installed adapter catalog id or a local path, while per-request LoRA
+  paths are rejected
 - tool-loop execution in `mere.run text chat` requires interactive approval unless `--auto-approve-tools` is passed for non-shell tools
 - `shell_exec` is disabled unless `--allow-shell-exec` is set, and still requires interactive approval when enabled
 - `write_file` stays inside the sandbox unless `--allow-absolute-tool-paths` is set

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -142,7 +142,7 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-lfm2, or text-chat-deepseek-v4-flash.")
     var engine: APIEngine = .textChatQ36
 
-    @Option(name: [.long], help: "Default LoRA adapter path for all requests.")
+    @Option(name: [.long], help: "Default cataloged adapter id or local LoRA path for all requests.")
     var lora: String?
 
     @Option(name: [.long], help: "Bearer token required by API endpoints. Also read from MERERUN_API_KEY.")
@@ -199,12 +199,14 @@ struct APIServe: AsyncParsableCommand {
         let resolvedAPIKey = resolveAPIKey()
         try validateServerSecurity(apiKey: resolvedAPIKey)
         let resolvedModelPath = try resolveModelPath()
+        let defaultModelID = defaultRuntimeModelID(modelPath: resolvedModelPath)
+        let resolvedLoraPath = try resolveLoraPath(modelPath: resolvedModelPath)
         let gemma4KVCacheQuantization = try resolveGemma4KVCacheQuantization()
         let memoryPressurePolicy = try resolveMemoryPressurePolicy()
         let server = try await CodeGenServer(
-            defaultModelID: defaultRuntimeModelID(modelPath: resolvedModelPath),
+            defaultModelID: defaultModelID,
             modelPath: resolvedModelPath,
-            fallbackLoraPath: lora,
+            fallbackLoraPath: resolvedLoraPath,
             apiKey: resolvedAPIKey,
             rateLimitPerMinute: rateLimitPerMinute,
             maxActiveRequests: maxActiveRequests,
@@ -239,6 +241,17 @@ struct APIServe: AsyncParsableCommand {
         case .textChatDeepseekV4Flash:
             return DeepseekV4FlashResources.defaultModelId
         }
+    }
+
+    func resolveLoraPath(
+        modelPath: String?,
+        fileManager: FileManager = .default
+    ) throws -> String? {
+        try ManagedAdapterArgumentResolver.resolve(
+            lora,
+            baseModelID: defaultRuntimeModelID(modelPath: modelPath),
+            fileManager: fileManager
+        )
     }
 
     func resolveModelPath() throws -> String? {

--- a/Sources/MereRunCLI/Commands/AdapterCommand.swift
+++ b/Sources/MereRunCLI/Commands/AdapterCommand.swift
@@ -1,0 +1,12 @@
+import ArgumentParser
+
+struct Adapter: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "adapter",
+        abstract: "List and pull verified LoRA adapters.",
+        subcommands: [
+            AdapterList.self,
+            AdapterPull.self,
+        ]
+    )
+}

--- a/Sources/MereRunCLI/Commands/AdapterListCommand.swift
+++ b/Sources/MereRunCLI/Commands/AdapterListCommand.swift
@@ -1,0 +1,73 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct AdapterList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List cataloged LoRA adapters and their install state."
+    )
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        let output = ManagedAdapterListOutput(
+            schemaVersion: 1,
+            adapterStore: MereRunModelPaths.adaptersDir.path,
+            adapters: ManagedAdapterCatalog.allSpecs.map(ManagedAdapterListItem.init)
+        )
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            print(String(decoding: try encoder.encode(output), as: UTF8.self))
+            return
+        }
+
+        for adapter in output.adapters {
+            let state = adapter.installed ? "installed" : "not installed"
+            print("\(adapter.id)\t\(adapter.version)\t\(adapter.baseModelID)\t\(state)")
+        }
+    }
+}
+
+struct ManagedAdapterListOutput: Codable, Equatable {
+    let schemaVersion: Int
+    let adapterStore: String
+    let adapters: [ManagedAdapterListItem]
+}
+
+struct ManagedAdapterListItem: Codable, Equatable {
+    let id: String
+    let title: String
+    let version: String
+    let summary: String
+    let baseModelID: String
+    let format: String
+    let license: String
+    let releaseManifestURL: String
+    let downloadURL: String
+    let filename: String
+    let byteCount: Int64
+    let sha256: String
+    let installed: Bool
+    let path: String?
+
+    init(_ spec: ManagedAdapterSpec) {
+        let installed = spec.isInstalled()
+        self.id = spec.id
+        self.title = spec.title
+        self.version = spec.version
+        self.summary = spec.summary
+        self.baseModelID = spec.baseModelID
+        self.format = spec.format
+        self.license = spec.license
+        self.releaseManifestURL = spec.releaseManifestURL.absoluteString
+        self.downloadURL = spec.downloadURL.absoluteString
+        self.filename = spec.artifact.filename
+        self.byteCount = spec.artifact.byteCount
+        self.sha256 = spec.artifact.sha256
+        self.installed = installed
+        self.path = installed ? spec.installedFileURL().path : nil
+    }
+}

--- a/Sources/MereRunCLI/Commands/AdapterPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/AdapterPullCommand.swift
@@ -1,0 +1,122 @@
+import ArgumentParser
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import MereRunCore
+
+struct AdapterPull: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "pull",
+        abstract: "Download and verify a cataloged LoRA adapter."
+    )
+
+    @Argument(help: "Canonical adapter id (for example: mere-platform-assistant).")
+    var target: String
+
+    @Flag(name: [.long], help: "Re-download even if the adapter is already installed and verified.")
+    var force: Bool = false
+
+    @Flag(name: [.short, .long], help: "Suppress progress output.")
+    var quiet: Bool = false
+
+    func run() async throws {
+        guard let spec = ManagedAdapterCatalog.spec(for: target) else {
+            throw ValidationError("Unknown canonical adapter id: \(target)")
+        }
+        let destination = spec.installedFileURL()
+        let fileManager = FileManager.default
+
+        if fileManager.fileExists(atPath: destination.path), !force {
+            do {
+                let verified = try spec.verifiedInstalledFileURL()
+                if !quiet {
+                    stderr("[\(spec.id)] already installed and verified (use --force to re-download)")
+                }
+                print(verified.path)
+                return
+            } catch {
+                throw ValidationError(
+                    "Existing adapter \(spec.id) failed verification: \(error.localizedDescription) Use --force to replace it."
+                )
+            }
+        }
+
+        let directory = spec.installDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let partial = directory.appendingPathComponent(
+            ".\(spec.artifact.filename).partial.\(UUID().uuidString)",
+            isDirectory: false
+        )
+        defer { try? fileManager.removeItem(at: partial) }
+
+        if !quiet {
+            stderr("[\(spec.id)] downloading \(spec.downloadURL.absoluteString)")
+        }
+        var request = URLRequest(url: spec.downloadURL)
+        request.httpMethod = "GET"
+        let temporary = try await downloadWithTransientRetries(request, adapterID: spec.id)
+        try fileManager.moveItem(at: temporary, to: partial)
+
+        let partialPin = ModelArtifactPin(
+            filename: partial.lastPathComponent,
+            byteCount: spec.artifact.byteCount,
+            sha256: spec.artifact.sha256
+        )
+        do {
+            _ = try partialPin.verify(in: directory)
+        } catch {
+            throw ValidationError("Downloaded adapter failed verification: \(error.localizedDescription)")
+        }
+
+        if fileManager.fileExists(atPath: destination.path) {
+            _ = try fileManager.replaceItemAt(destination, withItemAt: partial)
+        } else {
+            try fileManager.moveItem(at: partial, to: destination)
+        }
+        let verified = try spec.verifiedInstalledFileURL()
+        if !quiet {
+            stderr("[\(spec.id)] verified SHA-256 \(spec.artifact.sha256)")
+        }
+        print(verified.path)
+    }
+
+    private func stderr(_ message: String) {
+        CLIStderr.write(message + "\n")
+    }
+
+    private func downloadWithTransientRetries(
+        _ request: URLRequest,
+        adapterID: String
+    ) async throws -> URL {
+        let maximumAttempts = 3
+        for attempt in 1...maximumAttempts {
+            let temporary: URL
+            let response: URLResponse
+            do {
+                (temporary, response) = try await URLSession.shared.download(for: request)
+            } catch {
+                guard attempt < maximumAttempts else { throw error }
+                if !quiet {
+                    stderr("[\(adapterID)] transient download error; retrying (\(attempt + 1)/\(maximumAttempts))")
+                }
+                try await Task.sleep(nanoseconds: UInt64(attempt) * 250_000_000)
+                continue
+            }
+
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if status == 200 {
+                return temporary
+            }
+            try? FileManager.default.removeItem(at: temporary)
+            guard (500...599).contains(status), attempt < maximumAttempts else {
+                throw ValidationError("Adapter download failed (HTTP \(status)).")
+            }
+            if !quiet {
+                stderr("[\(adapterID)] server returned HTTP \(status); retrying (\(attempt + 1)/\(maximumAttempts))")
+            }
+            try await Task.sleep(nanoseconds: UInt64(attempt) * 250_000_000)
+        }
+        throw ValidationError("Adapter download failed after \(maximumAttempts) attempts.")
+    }
+}

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -118,7 +118,7 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-q36-nano, text-agent-ornith-9b, text-agent-ornith-35b-mlx, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
-    @Option(name: [.customLong("lora")], help: "Optional local LoRA adapter .safetensors path for supported chat models.")
+    @Option(name: [.customLong("lora")], help: "Optional cataloged adapter id or local LoRA .safetensors path for supported chat models.")
     var loraPath: String?
 
     @Option(name: [.customLong("lora-scale")], help: "LoRA adapter scale.")
@@ -193,7 +193,11 @@ struct TextChat: AsyncParsableCommand {
 
         let lora: LoRA?
         if let loraPath, !loraPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            lora = .local(path: URL(fileURLWithPath: loraPath).standardizedFileURL.path, scale: loraScale)
+            let resolved = try ManagedAdapterArgumentResolver.resolve(
+                loraPath,
+                baseModelID: model
+            )
+            lora = resolved.map { .local(path: $0, scale: loraScale) }
         } else {
             lora = nil
         }

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -28,6 +28,7 @@ struct MereRunCLI: AsyncParsableCommand {
             World.self,
             Run.self,
             Model.self,
+            Adapter.self,
             Status.self,
             Gate.self,
             Config.self,

--- a/Sources/MereRunCLI/Support/APIServePreflight.swift
+++ b/Sources/MereRunCLI/Support/APIServePreflight.swift
@@ -222,7 +222,11 @@ struct APIServePreflightAnalyzer {
         let resolvedModelPath = resolvedModelPath(diagnostics: &diagnostics)
         let kvQuantization = kvQuantization(diagnostics: &diagnostics)
         let memoryPolicy = memoryPolicy(diagnostics: &diagnostics)
-        appendStaticDiagnostics(apiKey: apiKey, diagnostics: &diagnostics)
+        appendStaticDiagnostics(
+            apiKey: apiKey,
+            resolvedModelPath: resolvedModelPath,
+            diagnostics: &diagnostics
+        )
 
         let server = serverSummary(apiKey: apiKey)
         let model = modelSummary(
@@ -540,6 +544,7 @@ struct APIServePreflightAnalyzer {
 
     private func appendStaticDiagnostics(
         apiKey: APIKeyPresence,
+        resolvedModelPath: String?,
         diagnostics: inout [PreflightDiagnostic]
     ) {
         if command.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -634,9 +639,15 @@ struct APIServePreflightAnalyzer {
                 )
             )
         }
-        if let lora = command.lora {
-            let url = URL(fileURLWithPath: lora).standardizedFileURL
-            if !fileManager.fileExists(atPath: url.path) {
+        if command.lora != nil {
+            do {
+                let resolved = try command.resolveLoraPath(
+                    modelPath: resolvedModelPath,
+                    fileManager: fileManager
+                )
+                guard let resolved else { return }
+                let url = URL(fileURLWithPath: resolved).standardizedFileURL
+                if fileManager.fileExists(atPath: url.path) { return }
                 diagnostics.append(
                     PreflightDiagnostic(
                         id: "lora_missing",
@@ -644,6 +655,15 @@ struct APIServePreflightAnalyzer {
                         title: "LoRA file missing",
                         message: "LoRA file not found: \(url.path).",
                         locations: [.init(kind: "file", path: url.path)]
+                    )
+                )
+            } catch {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "lora_missing",
+                        severity: .blocker,
+                        title: "LoRA adapter unavailable",
+                        message: error.localizedDescription
                     )
                 )
             }

--- a/Sources/MereRunCLI/Support/ManagedAdapterArgumentResolver.swift
+++ b/Sources/MereRunCLI/Support/ManagedAdapterArgumentResolver.swift
@@ -1,0 +1,25 @@
+import Foundation
+import MereRunCore
+
+enum ManagedAdapterArgumentResolver {
+    static func resolve(
+        _ reference: String?,
+        baseModelID: String,
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir,
+        fileManager: FileManager = .default
+    ) throws -> String? {
+        guard let reference = reference?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !reference.isEmpty else {
+            return nil
+        }
+        if let installed = try ManagedAdapterCatalog.resolveInstalledReference(
+            reference,
+            baseModelID: baseModelID,
+            adaptersRoot: adaptersRoot,
+            fileManager: fileManager
+        ) {
+            return installed.path
+        }
+        return URL(fileURLWithPath: reference).standardizedFileURL.path
+    }
+}

--- a/Sources/MereRunCore/ManagedAdapterCatalog.swift
+++ b/Sources/MereRunCore/ManagedAdapterCatalog.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+public struct ManagedAdapterSpec: Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let version: String
+    public let summary: String
+    public let baseModelID: String
+    public let format: String
+    public let license: String
+    public let releaseManifestURL: URL
+    public let downloadURL: URL
+    public let artifact: ModelArtifactPin
+
+    public init(
+        id: String,
+        title: String,
+        version: String,
+        summary: String,
+        baseModelID: String,
+        format: String,
+        license: String,
+        releaseManifestURL: URL,
+        downloadURL: URL,
+        artifact: ModelArtifactPin
+    ) {
+        self.id = id
+        self.title = title
+        self.version = version
+        self.summary = summary
+        self.baseModelID = baseModelID
+        self.format = format
+        self.license = license
+        self.releaseManifestURL = releaseManifestURL
+        self.downloadURL = downloadURL
+        self.artifact = artifact
+    }
+
+    public func installDirectory(
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir
+    ) -> URL {
+        adaptersRoot
+            .appendingPathComponent(id, isDirectory: true)
+            .appendingPathComponent(version, isDirectory: true)
+    }
+
+    public func installedFileURL(
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir
+    ) -> URL {
+        installDirectory(adaptersRoot: adaptersRoot)
+            .appendingPathComponent(artifact.filename, isDirectory: false)
+    }
+
+    public func verifiedInstalledFileURL(
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try artifact.verify(
+            in: installDirectory(adaptersRoot: adaptersRoot),
+            fileManager: fileManager
+        )
+    }
+
+    public func isInstalled(
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        (try? verifiedInstalledFileURL(
+            adaptersRoot: adaptersRoot,
+            fileManager: fileManager
+        )) != nil
+    }
+}
+
+public enum ManagedAdapterCatalog {
+    public static let merePlatformAssistantID = "mere-platform-assistant"
+
+    public static let allSpecs: [ManagedAdapterSpec] = [
+        ManagedAdapterSpec(
+            id: merePlatformAssistantID,
+            title: "Mere Platform Assistant",
+            version: "22",
+            summary: "Promoted Mere platform assistant for Gemma 4 12B 4-bit.",
+            baseModelID: Gemma4Resources.twelveB4BitModelId,
+            format: TextLoRATrainingManifest.format,
+            license: "Apache-2.0",
+            releaseManifestURL: URL(
+                string: "https://releases.merekit.com/mere-run/adapters/mere-platform-assistant/v22/release.json"
+            )!,
+            downloadURL: URL(
+                string: "https://releases.merekit.com/mere-run/adapters/mere-platform-assistant/v22/mere-platform-assistant-v22.safetensors"
+            )!,
+            artifact: ModelArtifactPin(
+                filename: "mere-platform-assistant-v22.safetensors",
+                byteCount: 128_131_022,
+                sha256: "c4fec5979631b4031196c1e21c0b990437a26c5ebc52aec32f89338d64063290"
+            )
+        ),
+    ]
+
+    public static func spec(for id: String) -> ManagedAdapterSpec? {
+        let normalized = id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return allSpecs.first { $0.id == normalized }
+    }
+
+    /// Resolves a catalog id to its verified installed file. Returns `nil`
+    /// when the reference is not a catalog id so callers can preserve local
+    /// path behavior.
+    public static func resolveInstalledReference(
+        _ reference: String,
+        baseModelID: String,
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir,
+        fileManager: FileManager = .default
+    ) throws -> URL? {
+        guard let spec = spec(for: reference) else { return nil }
+        guard spec.baseModelID == baseModelID else {
+            throw ManagedAdapterResolutionError.incompatibleBaseModel(
+                adapterID: spec.id,
+                expected: spec.baseModelID,
+                actual: baseModelID
+            )
+        }
+        do {
+            return try spec.verifiedInstalledFileURL(
+                adaptersRoot: adaptersRoot,
+                fileManager: fileManager
+            )
+        } catch let error as ModelArtifactVerificationError {
+            throw ManagedAdapterResolutionError.notInstalled(
+                adapterID: spec.id,
+                path: spec.installedFileURL(adaptersRoot: adaptersRoot).path,
+                detail: error.localizedDescription
+            )
+        }
+    }
+}
+
+public enum ManagedAdapterResolutionError: Error, Equatable, LocalizedError, Sendable {
+    case incompatibleBaseModel(adapterID: String, expected: String, actual: String)
+    case notInstalled(adapterID: String, path: String, detail: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .incompatibleBaseModel(let adapterID, let expected, let actual):
+            "Adapter \(adapterID) requires base model \(expected), not \(actual)."
+        case .notInstalled(let adapterID, let path, let detail):
+            "Adapter \(adapterID) is not installed and verified at \(path). Run `mere.run adapter pull \(adapterID)`. \(detail)"
+        }
+    }
+}

--- a/Sources/MereRunCore/MereRunModelPaths.swift
+++ b/Sources/MereRunCore/MereRunModelPaths.swift
@@ -83,6 +83,11 @@ public enum MereRunModelPaths {
         applicationSupportBase.appendingPathComponent("downloads", isDirectory: true)
     }
 
+    /// `~/Library/Application Support/MereRun/adapters`
+    public static var adaptersDir: URL {
+        applicationSupportBase.appendingPathComponent("adapters", isDirectory: true)
+    }
+
     public static var outputDir: URL {
         applicationSupportBase.appendingPathComponent("output", isDirectory: true)
     }

--- a/Tests/MereRunCLITests/AdapterCommandTests.swift
+++ b/Tests/MereRunCLITests/AdapterCommandTests.swift
@@ -1,0 +1,43 @@
+import ArgumentParser
+import Foundation
+import Testing
+@testable import MereRunCLI
+@testable import MereRunCore
+
+@Suite("Adapter commands")
+struct AdapterCommandTests {
+    @Test("Adapter pull parses the canonical id")
+    func parsesPull() throws {
+        let command = try AdapterPull.parse([
+            ManagedAdapterCatalog.merePlatformAssistantID,
+            "--force",
+            "--quiet",
+        ])
+        #expect(command.target == ManagedAdapterCatalog.merePlatformAssistantID)
+        #expect(command.force)
+        #expect(command.quiet)
+    }
+
+    @Test("Local LoRA paths remain supported")
+    func resolvesLocalPath() throws {
+        let relative = "fixtures/local-adapter.safetensors"
+        let resolved = try ManagedAdapterArgumentResolver.resolve(
+            relative,
+            baseModelID: Gemma4Resources.twelveB4BitModelId
+        )
+        #expect(resolved == URL(fileURLWithPath: relative).standardizedFileURL.path)
+    }
+
+    @Test("Catalog id requires a verified pull")
+    func catalogIDRequiresInstall() {
+        let emptyRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-adapter-test-\(UUID().uuidString)", isDirectory: true)
+        #expect(throws: ManagedAdapterResolutionError.self) {
+            _ = try ManagedAdapterArgumentResolver.resolve(
+                ManagedAdapterCatalog.merePlatformAssistantID,
+                baseModelID: Gemma4Resources.twelveB4BitModelId,
+                adaptersRoot: emptyRoot
+            )
+        }
+    }
+}

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -73,6 +73,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "world",
             "run",
             "model",
+            "adapter",
             "status",
             "gate",
             "api",

--- a/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import MereRunCore
+
+@Suite("Managed adapter catalog")
+struct ManagedAdapterCatalogTests {
+    @Test("Mere platform assistant release is pinned")
+    func releaseIsPinned() throws {
+        let spec = try #require(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.merePlatformAssistantID)
+        )
+        #expect(spec.version == "22")
+        #expect(spec.baseModelID == Gemma4Resources.twelveB4BitModelId)
+        #expect(spec.format == TextLoRATrainingManifest.format)
+        #expect(spec.artifact.filename == "mere-platform-assistant-v22.safetensors")
+        #expect(spec.artifact.byteCount == 128_131_022)
+        #expect(spec.artifact.sha256 == "c4fec5979631b4031196c1e21c0b990437a26c5ebc52aec32f89338d64063290")
+        #expect(spec.downloadURL.scheme == "https")
+        #expect(spec.downloadURL.host == "releases.merekit.com")
+    }
+
+    @Test("Catalog ids resolve case-insensitively")
+    func normalizedLookup() {
+        #expect(ManagedAdapterCatalog.spec(for: " MERE-PLATFORM-ASSISTANT ")?.version == "22")
+    }
+
+    @Test("Resolver enforces the base model before checking disk")
+    func rejectsWrongBaseModel() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        #expect(throws: ManagedAdapterResolutionError.self) {
+            _ = try ManagedAdapterCatalog.resolveInstalledReference(
+                ManagedAdapterCatalog.merePlatformAssistantID,
+                baseModelID: Gemma4Resources.nanoModelId,
+                adaptersRoot: root
+            )
+        }
+    }
+
+    @Test("Resolver reports the exact missing install path")
+    func reportsMissingInstall() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        do {
+            _ = try ManagedAdapterCatalog.resolveInstalledReference(
+                ManagedAdapterCatalog.merePlatformAssistantID,
+                baseModelID: Gemma4Resources.twelveB4BitModelId,
+                adaptersRoot: root
+            )
+            Issue.record("missing adapter should fail")
+        } catch let error as ManagedAdapterResolutionError {
+            #expect(error.localizedDescription.contains("mere.run adapter pull mere-platform-assistant"))
+            #expect(error.localizedDescription.contains("mere-platform-assistant-v22.safetensors"))
+        }
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -220,6 +220,17 @@ swift run mere.run plugin doctor mere-runpod
 
 Model installation in the OSS repo is explicit. `mere.run model pull` uses cataloged Hugging Face snapshots only; local-path-only models must be supplied with command-specific `--model` or `--model-root` options. See [`configuration.md`](./configuration.md) and [`model-sources.md`](./model-sources.md).
 
+Public LoRA releases use the separate checksum-pinned adapter catalog:
+
+```bash
+mere.run adapter list
+mere.run adapter pull mere-platform-assistant
+mere.run text chat \
+  --model text-chat-gemma4-12b-4bit \
+  --lora mere-platform-assistant \
+  --prompt "Summarize the current Mere workspace."
+```
+
 ### `mere.run plugin`
 
 Discover and install official companion plugins from the live plugin catalog.
@@ -1597,6 +1608,21 @@ download starts. The report includes `pull-model` or `pull-models` actions and
 exits nonzero after printing JSON when hard blockers are present.
 
 Use `--allow-unsupported` only when you intentionally accept the runtime risk.
+
+### `mere.run adapter list` and `mere.run adapter pull`
+
+List the built-in public adapter catalog or install one immutable release:
+
+```bash
+mere.run adapter list
+mere.run adapter list --json
+mere.run adapter pull mere-platform-assistant
+```
+
+The pull verifies the cataloged byte count and SHA-256 before atomically
+installing the adapter. Stdout contains only the installed path; progress and
+verification diagnostics go to stderr. Use the adapter id directly with
+`text chat --lora` or `api serve --lora`.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 sections below are the command reference for each benchmark lane.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,18 @@ swift run mere.run model pull image-zimage-nano
 Managed pulls use cataloged Hugging Face repos only. Private archive hosts and
 R2 credential flows are not part of the public distribution.
 
+## Adapter store
+
+Checksum-pinned public adapter releases install under:
+
+```text
+~/Library/Application Support/MereRun/adapters
+```
+
+`mere.run adapter pull` uses public HTTPS release URLs and never requires or
+accepts R2 credentials. Catalog ids resolve from this verified local store when
+passed to `text chat --lora` or `api serve --lora`.
+
 ## Specialized model roots
 
 ### `MERERUN_VIDEO_LTX_MODEL_ROOT`

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -11,6 +11,8 @@ the model-management commands.
 - `mere.run model pull`
 - `mere.run model remove`
 - `mere.run model repair-manifests`
+- `mere.run adapter list`
+- `mere.run adapter pull`
 - `mere.run status`
 - `mere.run setup`
 
@@ -84,6 +86,32 @@ Downloads a managed model from its cataloged Hugging Face source. Pulls are
 checked against the managed capability catalog before download so low-memory
 machines do not fetch models they cannot run. Pass `--allow-unsupported` only
 when you intentionally accept that risk or are using external hardware.
+
+### `mere.run adapter list` and `mere.run adapter pull`
+
+Adapters use a separate checksum-pinned catalog and install under:
+
+```text
+~/Library/Application Support/MereRun/adapters/<adapter-id>/<version>/
+```
+
+The first public entry is the promoted Mere Platform Assistant v22 for the
+`text-chat-gemma4-12b-4bit` base model:
+
+```bash
+mere.run model pull text-chat-gemma4-12b-4bit
+mere.run adapter list
+mere.run adapter pull mere-platform-assistant
+mere.run text chat \
+  --model text-chat-gemma4-12b-4bit \
+  --lora mere-platform-assistant \
+  --prompt "What can you help me with in Mere?"
+```
+
+`adapter pull` downloads the immutable public release, verifies its exact byte
+count and SHA-256, and prints the installed adapter path on stdout. Catalog ids
+are accepted by `text chat --lora` and `api serve --lora`; local paths remain
+supported.
 
 ### `mere.run setup`
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -59,6 +59,9 @@ fi
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null
 "$mere_run_bin" model --help >/dev/null
+"$mere_run_bin" adapter --help >/dev/null
+"$mere_run_bin" adapter list --help >/dev/null
+"$mere_run_bin" adapter pull --help >/dev/null
 "$mere_run_bin" model runtime --help >/dev/null
 "$mere_run_bin" model runtime get --help >/dev/null
 "$mere_run_bin" model runtime set --help >/dev/null


### PR DESCRIPTION
## Summary

- add a pinned public adapter catalog with Mere Platform Assistant v22 as the first release
- add `mere.run adapter list` and `mere.run adapter pull`
- verify artifact size and SHA-256 before atomic installation, with bounded retry and force-replacement behavior
- allow catalog adapter IDs in text chat and API serving through `--lora`
- document adapter storage, catalog metadata, and CLI usage

## Why

Promoted LoRA adapters were public artifacts, but users had no first-class discovery or installation path. They also had to translate release metadata into local file paths manually before serving a model.

This gives adapters the same product-level distribution contract as models: a stable catalog identity, verified pull, deterministic local storage, and direct runtime resolution.

## User impact

Users can now run:

```sh
mere.run adapter pull mere-platform-assistant
mere.run text chat --model text-chat-gemma4-12b-4bit --lora mere-platform-assistant
```

The v22 artifact is pinned to its public R2 release, byte size, SHA-256 digest, base model, format, and Apache-2.0 license.

## Validation

- full `./scripts/check.sh` passed
- 1,730 Swift tests passed, with 115 intentional skips
- adapter catalog and CLI test suites passed
- public pull, checksum verification, installed-state reporting, and force replacement were exercised
- exact Gemma4 12B 4-bit + v22 API serving and live inference succeeded
