### PR TITLE
Ship provider-aware portable graph runtime 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## Unreleased
+## 0.22.0 - 2026-07-15
 
 ### Added
 
@@ -19,6 +19,13 @@ The format is based on Keep a Changelog.
   content-addressed job bundles; local and resumable graph execution; the
   public graph worker protocol; SSH and direct relay executors; and unified
   inspect, watch, fetch, cancel, retry, and remote-list commands.
+- added provider-qualified graph nodes backed by a versioned plugin process
+  contract, exact provider catalog pinning, typed scalar/JSON/directory/
+  collection ports, structured NDJSON node events, and provider capability
+  reporting through local, SSH, and relay workers.
+- added dependency-scoped node fingerprints, exact model/adapter/provider
+  provenance, verified resume admission, typed artifact manifests, and stable
+  canonical hashes for portable execution and reproducible retries.
 - added durable mere.world relay sign-in with automatic refresh-token rotation,
   relay fleet inspection and node inventory refresh, typed no-eligible-node
   diagnostics, resumable artifact transfers, and per-job execution telemetry.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ during NVRTC JIT compilation:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.22.0 --artifact-suffix cuda
 ```
 
 Current CUDA validation should be treated as limited to the exact hosts that
@@ -196,7 +196,7 @@ swift run mere.run --help
 To build Linux release packages from a Linux x86_64 Swift toolchain host:
 
 ```bash
-scripts/package-linux.sh --version 0.21.0
+scripts/package-linux.sh --version 0.22.0
 ls dist/linux/
 ```
 
@@ -205,14 +205,14 @@ builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.22.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
 On Linux arm64, use a CUDA-provisioned host:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.21.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.22.0
 ```
 
 Do not use the app bundle commands on Linux. `mere.run.app`, SwiftUI studio

--- a/Sources/MereRunCLI/Commands/ExecutorCommand.swift
+++ b/Sources/MereRunCLI/Commands/ExecutorCommand.swift
@@ -150,6 +150,7 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
     let availableDiskBytes: Int64?
     let nodeKinds: [String]
     let installedModelIDs: [String]
+    let providers: [WorkflowGraphProviderRequirement]
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
@@ -162,6 +163,51 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
         case availableDiskBytes = "available_disk_bytes"
         case nodeKinds = "node_kinds"
         case installedModelIDs = "installed_model_ids"
+        case providers
+    }
+
+    init(
+        schemaVersion: Int,
+        workerVersion: String,
+        contractVersions: [String],
+        platform: String,
+        architecture: String,
+        acceleratorBackend: String,
+        memoryBytes: UInt64,
+        availableDiskBytes: Int64?,
+        nodeKinds: [String],
+        installedModelIDs: [String],
+        providers: [WorkflowGraphProviderRequirement] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.workerVersion = workerVersion
+        self.contractVersions = contractVersions
+        self.platform = platform
+        self.architecture = architecture
+        self.acceleratorBackend = acceleratorBackend
+        self.memoryBytes = memoryBytes
+        self.availableDiskBytes = availableDiskBytes
+        self.nodeKinds = nodeKinds
+        self.installedModelIDs = installedModelIDs
+        self.providers = providers
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        workerVersion = try container.decode(String.self, forKey: .workerVersion)
+        contractVersions = try container.decode([String].self, forKey: .contractVersions)
+        platform = try container.decode(String.self, forKey: .platform)
+        architecture = try container.decode(String.self, forKey: .architecture)
+        acceleratorBackend = try container.decode(String.self, forKey: .acceleratorBackend)
+        memoryBytes = try container.decode(UInt64.self, forKey: .memoryBytes)
+        availableDiskBytes = try container.decodeIfPresent(Int64.self, forKey: .availableDiskBytes)
+        nodeKinds = try container.decode([String].self, forKey: .nodeKinds)
+        installedModelIDs = try container.decode([String].self, forKey: .installedModelIDs)
+        providers = try container.decodeIfPresent(
+            [WorkflowGraphProviderRequirement].self,
+            forKey: .providers
+        ) ?? []
     }
 
     var summary: String {
@@ -191,6 +237,7 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
             forPath: MereRunModelPaths.applicationSupportBase.path
         )
         let disk = (fileSystemAttributes?[.systemFreeSize] as? NSNumber)?.int64Value
+        let graphProviders = WorkflowGraphProviderRegistry.discoveredCatalog().providers
         return WorkflowExecutorProbe(
             schemaVersion: 1,
             workerVersion: MereRunCLIVersion.current,
@@ -200,8 +247,11 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
             acceleratorBackend: backend,
             memoryBytes: memoryBytes,
             availableDiskBytes: disk ?? nil,
-            nodeKinds: WorkflowNodeRegistry.entries.map(\.kind).sorted(),
-            installedModelIDs: ModelInventory.rows(fileManager: fileManager).filter(\.isInstalled).map(\.id).sorted()
+            nodeKinds: Array(Set(
+                WorkflowNodeRegistry.entries.map(\.kind) + graphProviders.flatMap { $0.nodes.map(\.kind) }
+            )).sorted(),
+            installedModelIDs: ModelInventory.rows(fileManager: fileManager).filter(\.isInstalled).map(\.id).sorted(),
+            providers: graphProviders.map(\.requirement)
         )
     }
 

--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -29,12 +29,14 @@ struct GraphCatalogResult: Codable, Equatable {
     let graphSchemaVersion: Int
     let graphKind: String
     let jobContractVersion: String
+    let providers: [WorkflowGraphProviderRequirement]
     let nodes: [WorkflowNodeCatalogEntry]
 
     enum CodingKeys: String, CodingKey {
         case graphSchemaVersion = "graph_schema_version"
         case graphKind = "graph_kind"
         case jobContractVersion = "job_contract_version"
+        case providers
         case nodes
     }
 }
@@ -49,11 +51,20 @@ struct GraphCatalog: ParsableCommand {
     var json = false
 
     func run() throws {
+        let pluginCatalog = WorkflowGraphProviderRegistry.discoveredCatalog()
+        let pluginProviders = pluginCatalog.providers.map(\.requirement)
+        let builtIn = WorkflowGraphProviderRequirement(
+            id: WorkflowNodeProviderIdentity.builtInID,
+            version: WorkflowNodeRegistry.builtInProvider.version,
+            catalogSHA256: WorkflowNodeRegistry.builtInProvider.catalogSHA256,
+            nodeKinds: WorkflowNodeRegistry.entries.map(\.kind).sorted()
+        )
         let result = GraphCatalogResult(
             graphSchemaVersion: WorkflowGraphDocument.schemaVersion,
             graphKind: WorkflowGraphDocument.kind,
             jobContractVersion: WorkflowJobManifest.contractVersion,
-            nodes: WorkflowNodeRegistry.entries
+            providers: [builtIn] + pluginProviders,
+            nodes: WorkflowNodeRegistry.catalogEntries(pluginNodes: pluginCatalog.nodes)
         )
         if json {
             print(try StructuredRunOutput.encode(result))
@@ -155,6 +166,8 @@ struct GraphPreflightResult: Codable, Equatable {
     let requiredNodeKinds: [String]
     let requiredModelIDs: [String]
     let installedModelIDs: [String]
+    let requiredProviders: [WorkflowGraphProviderRequirement]
+    let availableProviders: [WorkflowGraphProviderRequirement]
     let executor: String
 
     enum CodingKeys: String, CodingKey {
@@ -163,6 +176,8 @@ struct GraphPreflightResult: Codable, Equatable {
         case requiredNodeKinds = "required_node_kinds"
         case requiredModelIDs = "required_model_ids"
         case installedModelIDs = "installed_model_ids"
+        case requiredProviders = "required_providers"
+        case availableProviders = "available_providers"
         case executor
     }
 }
@@ -212,12 +227,12 @@ struct GraphPreflight: AsyncParsableCommand {
                 message: "Executor '\(executor)' does not support \(WorkflowJobManifest.contractVersion)."
             ))
         }
-        if !["cuda", "metal"].contains(probe.acceleratorBackend), probe.acceleratorBackend != "mixed" {
+        if !requirements.acceleratorBackends.contains(probe.acceleratorBackend), probe.acceleratorBackend != "mixed" {
             diagnostics.append(.init(
                 id: "executor_accelerator_unsupported",
                 severity: .blocker,
                 title: "Executor accelerator is unsupported",
-                message: "Executor '\(executor)' reports accelerator backend '\(probe.acceleratorBackend)'."
+                message: "Executor '\(executor)' reports accelerator backend '\(probe.acceleratorBackend)'; this graph accepts \(requirements.acceleratorBackends.joined(separator: ", "))."
             ))
         }
         for kind in requirements.nodeKinds where !probe.nodeKinds.contains(kind) {
@@ -227,6 +242,17 @@ struct GraphPreflight: AsyncParsableCommand {
                 title: "Executor does not support workflow node",
                 message: "Executor '\(executor)' does not support node kind '\(kind)'."
             ))
+        }
+        for provider in requirements.providers {
+            guard probe.providers.contains(provider) else {
+                diagnostics.append(.init(
+                    id: "executor_provider_missing_\(provider.id)",
+                    severity: .blocker,
+                    title: "Executor graph provider is missing or incompatible",
+                    message: "Executor '\(executor)' requires provider '\(provider.id)' at version \(provider.version) with catalog \(provider.catalogSHA256)."
+                ))
+                continue
+            }
         }
         for modelID in requirements.modelIDs where !probe.installedModelIDs.contains(modelID) {
             diagnostics.append(.init(
@@ -272,6 +298,8 @@ struct GraphPreflight: AsyncParsableCommand {
                 requiredNodeKinds: requirements.nodeKinds,
                 requiredModelIDs: requirements.modelIDs,
                 installedModelIDs: probe.installedModelIDs,
+                requiredProviders: requirements.providers,
+                availableProviders: probe.providers,
                 executor: executor
             ),
             diagnostics: diagnostics,
@@ -645,9 +673,11 @@ struct GraphCancellationResult: Codable, Equatable {
 struct WorkflowGraphRequirements: Equatable {
     let nodeKinds: [String]
     let modelIDs: [String]
+    let providers: [WorkflowGraphProviderRequirement]
+    let acceleratorBackends: [String]
 
     static func resolve(graph: WorkflowGraphDocument, inputs: WorkflowInputsDocument) -> WorkflowGraphRequirements {
-        let modelIDs = graph.nodes.compactMap { node -> String? in
+        var modelIDs = graph.nodes.compactMap { node -> String? in
             if let model = node.arguments["model"] {
                 if case .string(let value) = model { return value }
                 if case .reference(let rawReference) = model,
@@ -663,9 +693,22 @@ struct WorkflowGraphRequirements: Equatable {
             default: return nil
             }
         }
+        for node in graph.nodes {
+            modelIDs.append(contentsOf: WorkflowNodeRegistry.entry(for: node)?.requirements.modelIDs ?? [])
+        }
+        var acceleratorBackends = Set(["cpu", "metal", "cuda", "rocm"])
+        for node in graph.nodes {
+            let accepted = WorkflowNodeRegistry.entry(for: node)?.requirements.acceleratorBackends ?? []
+            if !accepted.isEmpty { acceleratorBackends.formIntersection(accepted) }
+        }
         return .init(
             nodeKinds: Array(Set(graph.nodes.map(\.kind))).sorted(),
-            modelIDs: Array(Set(modelIDs)).sorted()
+            modelIDs: Array(Set(modelIDs)).sorted(),
+            providers: Array(Set(graph.nodes.compactMap { node -> WorkflowGraphProviderRequirement? in
+                guard node.resolvedProviderID != WorkflowNodeProviderIdentity.builtInID else { return nil }
+                return WorkflowGraphProviderRegistry.discoveredCatalog().provider(id: node.resolvedProviderID)?.requirement
+            })).sorted { $0.id < $1.id },
+            acceleratorBackends: acceleratorBackends.sorted()
         )
     }
 }
@@ -780,11 +823,11 @@ private func assetDiagnostics(
         )
     }
     for node in graph.nodes {
-        guard let catalog = WorkflowNodeRegistry.entry(for: node.kind) else { continue }
+        guard let catalog = WorkflowNodeRegistry.entry(for: node) else { continue }
         for field in catalog.inputs {
             guard let value = node.arguments[field.name] else { continue }
             let values: [WorkflowValue]
-            if field.type == .assetArray, case .array(let nested) = value {
+            if field.type == .assetArray || field.type == .assetCollection, case .array(let nested) = value {
                 values = nested
             } else if field.type == .asset || field.type == .assetDirectory {
                 values = [value]

--- a/Sources/MereRunCLI/Commands/PluginCommand.swift
+++ b/Sources/MereRunCLI/Commands/PluginCommand.swift
@@ -136,6 +136,9 @@ struct PluginInstall: ParsableCommand {
                 "Installed plugin manifest name mismatch: expected \(plugin.id), got \(manifest.name)"
             )
         }
+        if manifest.graphProvider != nil {
+            try WorkflowGraphProviderRegistry.register(entrypoint: plugin.entrypoint)
+        }
         print("Installed \(plugin.id) with \(install.manager).")
         print("Verified \(plugin.entrypoint) manifest version \(manifest.version).")
     }
@@ -222,6 +225,18 @@ struct PluginManifest: Decodable {
     let contractVersion: String
     let name: String
     let version: String
+    let graphProvider: PluginGraphProviderDeclaration?
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion
+        case name
+        case version
+        case graphProvider
+    }
+}
+
+struct PluginGraphProviderDeclaration: Decodable {
+    let contractVersion: String
 }
 
 enum PluginCatalogClient {
@@ -385,6 +400,11 @@ enum PluginVerifier {
 
 enum PluginProcess {
     static func which(_ name: String) -> URL? {
+        if name.contains("/") {
+            let url = URL(fileURLWithPath: NSString(string: name).expandingTildeInPath).standardizedFileURL
+            guard FileManager.default.isExecutableFile(atPath: url.path) else { return nil }
+            return url
+        }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
         process.arguments = [name]

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.21.0"
+    static let current = "0.22.0"
 }

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -1,15 +1,22 @@
 import ArgumentParser
 import Foundation
 
-enum WorkflowInputType: String, Codable, Equatable, Sendable {
+enum WorkflowPortType: String, Codable, Equatable, Sendable {
     case string
     case integer
     case number
     case boolean
     case enumeration = "enum"
+    case json
     case asset
     case assetDirectory = "asset_directory"
+    case assetCollection = "asset_collection"
+    // Decodes catalogs produced before asset_collection became the portable name.
+    case assetArray = "asset_array"
 }
+
+typealias WorkflowInputType = WorkflowPortType
+typealias WorkflowFieldType = WorkflowPortType
 
 indirect enum WorkflowValue: Codable, Equatable, Sendable {
     case null
@@ -123,14 +130,34 @@ struct WorkflowInputDefinition: Codable, Equatable, Sendable {
 struct WorkflowNode: Codable, Equatable, Sendable {
     let id: String
     let kind: String
+    let provider: String?
     let arguments: [String: WorkflowValue]
     let dependsOn: [String]?
 
     enum CodingKeys: String, CodingKey {
         case id
         case kind
+        case provider
         case arguments
         case dependsOn = "depends_on"
+    }
+
+    init(
+        id: String,
+        kind: String,
+        provider: String? = nil,
+        arguments: [String: WorkflowValue],
+        dependsOn: [String]?
+    ) {
+        self.id = id
+        self.kind = kind
+        self.provider = provider
+        self.arguments = arguments
+        self.dependsOn = dependsOn
+    }
+
+    var resolvedProviderID: String {
+        provider ?? WorkflowNodeProviderIdentity.builtInID
     }
 }
 
@@ -184,60 +211,206 @@ struct WorkflowInputsDocument: Codable, Equatable, Sendable {
     }
 }
 
-enum WorkflowFieldType: String, Codable, Equatable, Sendable {
-    case string
-    case integer
-    case number
-    case boolean
-    case asset
-    case assetDirectory = "asset_directory"
-    case assetArray = "asset_array"
-}
-
 struct WorkflowNodeField: Codable, Equatable, Sendable {
     let name: String
     let type: WorkflowFieldType
     let required: Bool
+    let description: String?
+    let defaultValue: WorkflowValue?
+    let values: [String]?
     let acceptedContentTypes: [String]?
+    let minimum: Double?
+    let maximum: Double?
+    let step: Double?
+    let multiline: Bool?
+    let secret: Bool?
+    let advanced: Bool?
 
     enum CodingKeys: String, CodingKey {
         case name
         case type
         case required
-        case acceptedContentTypes = "accepted_content_types"
+        case description
+        case defaultValue = "default"
+        case values
+        case acceptedContentTypes = "content_types"
+        case minimum
+        case maximum
+        case step
+        case multiline
+        case secret
+        case advanced
     }
 
     init(
         name: String,
         type: WorkflowFieldType,
         required: Bool,
-        acceptedContentTypes: [String]? = nil
+        description: String? = nil,
+        defaultValue: WorkflowValue? = nil,
+        values: [String]? = nil,
+        acceptedContentTypes: [String]? = nil,
+        minimum: Double? = nil,
+        maximum: Double? = nil,
+        step: Double? = nil,
+        multiline: Bool? = nil,
+        secret: Bool? = nil,
+        advanced: Bool? = nil
     ) {
         self.name = name
         self.type = type
         self.required = required
+        self.description = description
+        self.defaultValue = defaultValue
+        self.values = values
         self.acceptedContentTypes = acceptedContentTypes
+        self.minimum = minimum
+        self.maximum = maximum
+        self.step = step
+        self.multiline = multiline
+        self.secret = secret
+        self.advanced = advanced
     }
 }
 
 struct WorkflowNodeOutput: Codable, Equatable, Sendable {
     let name: String
     let type: WorkflowFieldType
+    let optional: Bool
+    let description: String?
     let contentTypes: [String]
 
     enum CodingKeys: String, CodingKey {
         case name
         case type
+        case optional
+        case description
         case contentTypes = "content_types"
+    }
+
+    init(
+        name: String,
+        type: WorkflowFieldType,
+        optional: Bool = false,
+        description: String? = nil,
+        contentTypes: [String] = []
+    ) {
+        self.name = name
+        self.type = type
+        self.optional = optional
+        self.description = description
+        self.contentTypes = contentTypes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        type = try container.decode(WorkflowFieldType.self, forKey: .type)
+        optional = try container.decode(Bool.self, forKey: .optional)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        contentTypes = try container.decodeIfPresent([String].self, forKey: .contentTypes) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(type, forKey: .type)
+        try container.encode(optional, forKey: .optional)
+        try container.encodeIfPresent(description, forKey: .description)
+        if !contentTypes.isEmpty {
+            try container.encode(contentTypes, forKey: .contentTypes)
+        }
+    }
+}
+
+struct WorkflowNodeRequirements: Codable, Equatable, Sendable {
+    let modelIDs: [String]
+    let acceleratorBackends: [String]
+    let minimumAcceleratorMemoryBytes: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case modelIDs = "model_ids"
+        case acceleratorBackends = "accelerator_backends"
+        case minimumAcceleratorMemoryBytes = "minimum_accelerator_memory_bytes"
+    }
+
+    static let none = WorkflowNodeRequirements(
+        modelIDs: [],
+        acceleratorBackends: [],
+        minimumAcceleratorMemoryBytes: nil
+    )
+}
+
+struct WorkflowNodeTraits: Codable, Equatable, Sendable {
+    let deterministic: Bool
+    let cacheable: Bool
+    let sideEffects: String
+    let supportsProgress: Bool
+    let supportsPreviews: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case deterministic
+        case cacheable
+        case sideEffects = "side_effects"
+        case supportsProgress = "supports_progress"
+        case supportsPreviews = "supports_previews"
+    }
+
+    static let core = WorkflowNodeTraits(
+        deterministic: false,
+        cacheable: true,
+        sideEffects: "local",
+        supportsProgress: false,
+        supportsPreviews: false
+    )
+}
+
+struct WorkflowNodeProviderIdentity: Codable, Equatable, Hashable, Sendable {
+    static let builtInID = "mere.run"
+
+    let id: String
+    let version: String
+    let catalogSHA256: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case version
+        case catalogSHA256 = "catalog_sha256"
     }
 }
 
 struct WorkflowNodeCatalogEntry: Codable, Equatable, Sendable {
     let kind: String
     let title: String
+    let description: String
     let category: String
     let inputs: [WorkflowNodeField]
     let outputs: [WorkflowNodeOutput]
+    let requirements: WorkflowNodeRequirements
+    let traits: WorkflowNodeTraits
+    let provider: WorkflowNodeProviderIdentity?
+
+    init(
+        kind: String,
+        title: String,
+        description: String = "",
+        category: String,
+        inputs: [WorkflowNodeField],
+        outputs: [WorkflowNodeOutput],
+        requirements: WorkflowNodeRequirements = .none,
+        traits: WorkflowNodeTraits = .core,
+        provider: WorkflowNodeProviderIdentity? = nil
+    ) {
+        self.kind = kind
+        self.title = title
+        self.description = description
+        self.category = category
+        self.inputs = inputs
+        self.outputs = outputs
+        self.requirements = requirements
+        self.traits = traits
+        self.provider = provider
+    }
 }
 
 enum WorkflowNodeRegistry {
@@ -260,7 +433,12 @@ enum WorkflowNodeRegistry {
                 .init(name: "base_quantization_bits", type: .integer, required: false),
                 .init(name: "sample_prompt", type: .string, required: false),
             ],
-            outputs: [.init(name: "adapter", type: .asset, contentTypes: ["application/x-safetensors"])]
+            outputs: [.init(name: "adapter", type: .asset, contentTypes: ["application/x-safetensors"])],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            )
         ),
         WorkflowNodeCatalogEntry(
             kind: "image.generate",
@@ -282,7 +460,12 @@ enum WorkflowNodeRegistry {
                 .init(name: "strength", type: .number, required: false),
                 .init(name: "krea_base_quantization_bits", type: .integer, required: false),
             ],
-            outputs: [.init(name: "image", type: .asset, contentTypes: ["image/png"])]
+            outputs: [.init(name: "image", type: .asset, contentTypes: ["image/png"])],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            )
         ),
         WorkflowNodeCatalogEntry(
             kind: "video.generate",
@@ -301,7 +484,12 @@ enum WorkflowNodeRegistry {
                 .init(name: "image", type: .asset, required: false, acceptedContentTypes: ["image/png", "image/jpeg", "image/webp"]),
                 .init(name: "end_image", type: .asset, required: false, acceptedContentTypes: ["image/png", "image/jpeg", "image/webp"]),
             ],
-            outputs: [.init(name: "video", type: .asset, contentTypes: ["video/mp4"])]
+            outputs: [.init(name: "video", type: .asset, contentTypes: ["video/mp4"])],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            )
         ),
     ]
 
@@ -309,8 +497,55 @@ enum WorkflowNodeRegistry {
         entries.first { $0.kind == kind }
     }
 
-    static func output(nodeKind: String, name: String) -> WorkflowNodeOutput? {
-        entry(for: nodeKind)?.outputs.first { $0.name == name }
+    static var builtInProvider: WorkflowNodeProviderIdentity {
+        WorkflowNodeProviderIdentity(
+            id: WorkflowNodeProviderIdentity.builtInID,
+            version: MereRunCLIVersion.current,
+            catalogSHA256: (try? WorkflowBundleCodec.hash(entries)) ?? ""
+        )
+    }
+
+    static var catalogEntries: [WorkflowNodeCatalogEntry] {
+        catalogEntries(pluginNodes: WorkflowGraphProviderRegistry.discoveredCatalog().nodes)
+    }
+
+    static func catalogEntries(pluginNodes: [WorkflowNodeCatalogEntry]) -> [WorkflowNodeCatalogEntry] {
+        let builtIn = entries.map { entry in
+            WorkflowNodeCatalogEntry(
+                kind: entry.kind,
+                title: entry.title,
+                description: entry.description,
+                category: entry.category,
+                inputs: entry.inputs,
+                outputs: entry.outputs,
+                requirements: entry.requirements,
+                traits: entry.traits,
+                provider: builtInProvider
+            )
+        }
+        return (builtIn + pluginNodes).sorted {
+            ($0.provider?.id ?? "", $0.kind) < ($1.provider?.id ?? "", $1.kind)
+        }
+    }
+
+    static func entry(for node: WorkflowNode) -> WorkflowNodeCatalogEntry? {
+        if node.resolvedProviderID == WorkflowNodeProviderIdentity.builtInID {
+            return entry(for: node.kind)
+        }
+        return WorkflowGraphProviderRegistry.discoveredCatalog().nodes.first {
+            $0.kind == node.kind && $0.provider?.id == node.resolvedProviderID
+        }
+    }
+
+    static func output(node: WorkflowNode, name: String) -> WorkflowNodeOutput? {
+        entry(for: node)?.outputs.first { $0.name == name }
+    }
+
+    static func provider(for node: WorkflowNode) -> WorkflowNodeProviderIdentity? {
+        if node.resolvedProviderID == WorkflowNodeProviderIdentity.builtInID {
+            return builtInProvider
+        }
+        return WorkflowGraphProviderRegistry.discoveredCatalog().provider(id: node.resolvedProviderID)?.identity
     }
 }
 
@@ -495,12 +730,12 @@ enum WorkflowGraphValidator {
         nodesByID: [String: WorkflowNode],
         diagnostics: inout [PreflightDiagnostic]
     ) {
-        guard let entry = WorkflowNodeRegistry.entry(for: node.kind) else {
+        guard let entry = WorkflowNodeRegistry.entry(for: node) else {
             diagnostics.append(.init(
                 id: "workflow_node_kind_unsupported_\(node.id)",
                 severity: .blocker,
                 title: "Unsupported workflow node",
-                message: "Node '\(node.id)' uses unregistered kind '\(node.kind)'."
+                message: "Node '\(node.id)' uses unregistered kind '\(node.kind)' from provider '\(node.resolvedProviderID)'."
             ))
             return
         }
@@ -527,6 +762,7 @@ enum WorkflowGraphValidator {
             validateValue(
                 value,
                 expected: field.type,
+                enumValues: field.values,
                 acceptedContentTypes: field.acceptedContentTypes,
                 nodeID: node.id,
                 field: field.name,
@@ -548,6 +784,7 @@ enum WorkflowGraphValidator {
     private static func validateValue(
         _ value: WorkflowValue,
         expected: WorkflowFieldType,
+        enumValues: [String]?,
         acceptedContentTypes: [String]?,
         nodeID: String,
         field: String,
@@ -576,7 +813,7 @@ enum WorkflowGraphValidator {
                 }
             case .nodeOutput(let sourceNodeID, let outputName):
                 guard let sourceNode = nodesByID[sourceNodeID],
-                      let output = WorkflowNodeRegistry.output(nodeKind: sourceNode.kind, name: outputName) else {
+                      let output = WorkflowNodeRegistry.output(node: sourceNode, name: outputName) else {
                     diagnostics.append(invalidReference(rawReference, nodeID: nodeID))
                     return
                 }
@@ -591,11 +828,12 @@ enum WorkflowGraphValidator {
             }
             return
         }
-        if expected == .assetArray, case .array(let values) = value {
+        if expected == .assetArray || expected == .assetCollection, case .array(let values) = value {
             for nested in values {
                 validateValue(
                     nested,
                     expected: .asset,
+                    enumValues: nil,
                     acceptedContentTypes: acceptedContentTypes,
                     nodeID: nodeID,
                     field: field,
@@ -606,7 +844,42 @@ enum WorkflowGraphValidator {
             }
             return
         }
-        if !matches(value, fieldType: expected) {
+        if expected == .json {
+            switch value {
+            case .array(let values):
+                for nested in values {
+                    validateValue(
+                        nested,
+                        expected: .json,
+                        enumValues: nil,
+                        acceptedContentTypes: nil,
+                        nodeID: nodeID,
+                        field: field,
+                        graph: graph,
+                        nodesByID: nodesByID,
+                        diagnostics: &diagnostics
+                    )
+                }
+            case .object(let values):
+                for nested in values.values {
+                    validateValue(
+                        nested,
+                        expected: .json,
+                        enumValues: nil,
+                        acceptedContentTypes: nil,
+                        nodeID: nodeID,
+                        field: field,
+                        graph: graph,
+                        nodesByID: nodesByID,
+                        diagnostics: &diagnostics
+                    )
+                }
+            default:
+                break
+            }
+            return
+        }
+        if !matches(value, fieldType: expected, enumValues: enumValues) {
             diagnostics.append(.init(
                 id: "workflow_node_argument_type_\(nodeID)_\(field)",
                 severity: .blocker,
@@ -626,7 +899,7 @@ enum WorkflowGraphValidator {
                   let reference = try? WorkflowReference(rawReference),
                   case .nodeOutput(let nodeID, let outputName) = reference.source,
                   let node = nodesByID[nodeID],
-                  WorkflowNodeRegistry.output(nodeKind: node.kind, name: outputName) != nil else {
+                  WorkflowNodeRegistry.output(node: node, name: outputName) != nil else {
                 diagnostics.append(.init(
                     id: "workflow_output_invalid_\(name)",
                     severity: .blocker,
@@ -678,20 +951,37 @@ enum WorkflowGraphValidator {
         case .enumeration:
             guard let string = value.stringValue else { return false }
             return enumValues?.contains(string) ?? true
+        case .json:
+            return true
+        case .assetCollection, .assetArray:
+            if case .array = value { return true }
+            return false
         }
     }
 
-    private static func matches(_ value: WorkflowValue, fieldType: WorkflowFieldType) -> Bool {
-        switch fieldType {
+    private static func matches(
+        _ value: WorkflowValue,
+        fieldType: WorkflowFieldType,
+        enumValues: [String]?
+    ) -> Bool {
+        return switch fieldType {
         case .string, .asset, .assetDirectory:
             value.stringValue != nil
+        case .enumeration:
+            if let string = value.stringValue {
+                enumValues?.contains(string) ?? true
+            } else {
+                false
+            }
         case .integer:
             value.integerValue != nil
         case .number:
             value.numberValue != nil
         case .boolean:
             value.booleanValue != nil
-        case .assetArray:
+        case .json:
+            true
+        case .assetCollection, .assetArray:
             if case .array = value { true } else { false }
         }
     }
@@ -699,8 +989,13 @@ enum WorkflowGraphValidator {
     private static func compatible(inputType: WorkflowInputType, fieldType: WorkflowFieldType) -> Bool {
         switch (inputType, fieldType) {
         case (.string, .string), (.integer, .integer), (.number, .number), (.integer, .number),
-             (.boolean, .boolean), (.enumeration, .string), (.asset, .asset),
-             (.assetDirectory, .assetDirectory):
+             (.boolean, .boolean), (.enumeration, .string), (.enumeration, .enumeration),
+             (.json, .json), (.asset, .asset), (.assetDirectory, .assetDirectory),
+             (.assetCollection, .assetCollection), (.assetArray, .assetArray),
+             (.assetCollection, .assetArray), (.assetArray, .assetCollection):
+            true
+        case (.string, .json), (.integer, .json), (.number, .json), (.boolean, .json),
+             (.enumeration, .json):
             true
         default:
             false
@@ -708,7 +1003,9 @@ enum WorkflowGraphValidator {
     }
 
     private static func compatible(outputType: WorkflowFieldType, fieldType: WorkflowFieldType) -> Bool {
-        outputType == fieldType || (outputType == .integer && fieldType == .number)
+        outputType == fieldType
+            || (outputType == .integer && fieldType == .number)
+            || (fieldType == .json && [.string, .integer, .number, .boolean, .enumeration, .json].contains(outputType))
     }
 
     private static func contentTypesAreCompatible(produced: [String]?, accepted: [String]?) -> Bool {

--- a/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
@@ -1,0 +1,243 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct WorkflowPluginGraphProviderDocument: Codable, Equatable, Sendable {
+    static let contractVersion = "mere.run/plugin-graph-provider.v1"
+
+    let contractVersion: String
+    let providerID: String
+    let providerVersion: String
+    let nodes: [WorkflowNodeCatalogEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case providerID = "provider_id"
+        case providerVersion = "provider_version"
+        case nodes
+    }
+}
+
+struct WorkflowGraphProviderRequirement: Codable, Equatable, Hashable, Sendable {
+    let id: String
+    let version: String
+    let catalogSHA256: String
+    let nodeKinds: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case version
+        case catalogSHA256 = "catalog_sha256"
+        case nodeKinds = "node_kinds"
+    }
+}
+
+struct WorkflowDiscoveredGraphProvider: Equatable, Sendable {
+    let identity: WorkflowNodeProviderIdentity
+    let executable: String
+    let nodes: [WorkflowNodeCatalogEntry]
+
+    var requirement: WorkflowGraphProviderRequirement {
+        .init(
+            id: identity.id,
+            version: identity.version,
+            catalogSHA256: identity.catalogSHA256,
+            nodeKinds: nodes.map(\.kind).sorted()
+        )
+    }
+}
+
+struct WorkflowDiscoveredGraphCatalog: Equatable, Sendable {
+    let providers: [WorkflowDiscoveredGraphProvider]
+
+    var nodes: [WorkflowNodeCatalogEntry] {
+        providers.flatMap(\.nodes).sorted {
+            ($0.provider?.id ?? "", $0.kind) < ($1.provider?.id ?? "", $1.kind)
+        }
+    }
+
+    func provider(id: String) -> WorkflowDiscoveredGraphProvider? {
+        providers.first { $0.identity.id == id }
+    }
+}
+
+struct WorkflowGraphProviderInstallRegistry: Codable, Equatable, Sendable {
+    static let filename = "graph-providers.json"
+
+    var entrypoints: [String]
+}
+
+enum WorkflowGraphProviderRegistry {
+    static let environmentKey = "MERERUN_GRAPH_PROVIDERS"
+    static let knownOfficialEntrypoints = ["mere-dataset-tools"]
+    private static let processCatalog = discover(
+        environment: ProcessInfo.processInfo.environment,
+        fileManager: .default
+    )
+
+    static var registryURL: URL {
+        MereRunModelPaths.applicationSupportBase.appendingPathComponent(
+            WorkflowGraphProviderInstallRegistry.filename,
+            isDirectory: false
+        )
+    }
+
+    static func register(entrypoint: String, fileManager: FileManager = .default) throws {
+        var registry = loadInstallRegistry(fileManager: fileManager)
+        if !registry.entrypoints.contains(entrypoint) {
+            registry.entrypoints.append(entrypoint)
+            registry.entrypoints.sort()
+        }
+        try fileManager.createDirectory(
+            at: registryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try WorkflowBundleCodec.encoder().encode(registry).write(to: registryURL, options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: registryURL.path)
+    }
+
+    static func discoveredCatalog(
+        environment: [String: String]? = nil,
+        fileManager: FileManager = .default
+    ) -> WorkflowDiscoveredGraphCatalog {
+        guard let environment else { return processCatalog }
+        return discover(environment: environment, fileManager: fileManager)
+    }
+
+    private static func discover(
+        environment: [String: String],
+        fileManager: FileManager
+    ) -> WorkflowDiscoveredGraphCatalog {
+        let providers = candidateEntrypoints(environment: environment, fileManager: fileManager).compactMap { entrypoint in
+            try? loadProvider(entrypoint: entrypoint)
+        }
+        var byID: [String: WorkflowDiscoveredGraphProvider] = [:]
+        for provider in providers.sorted(by: { $0.executable < $1.executable }) {
+            if byID[provider.identity.id] == nil {
+                byID[provider.identity.id] = provider
+            }
+        }
+        return WorkflowDiscoveredGraphCatalog(providers: byID.values.sorted { $0.identity.id < $1.identity.id })
+    }
+
+    static func requireProvider(id: String) throws -> WorkflowDiscoveredGraphProvider {
+        guard let provider = discoveredCatalog().provider(id: id) else {
+            throw ValidationError(
+                "Graph provider '\(id)' is not installed. Install its companion plugin or set \(environmentKey)."
+            )
+        }
+        return provider
+    }
+
+    static func loadProvider(entrypoint: String) throws -> WorkflowDiscoveredGraphProvider {
+        let manifest = try PluginVerifier.verify(entrypoint: entrypoint)
+        guard manifest.graphProvider?.contractVersion == WorkflowPluginGraphProviderDocument.contractVersion else {
+            throw ValidationError("Plugin '\(manifest.name)' does not expose a graph node provider.")
+        }
+        let data = try PluginProcess.captureExecutable(
+            entrypoint,
+            arguments: ["graph", "catalog", "--json"]
+        )
+        let document = try WorkflowBundleCodec.decoder().decode(
+            WorkflowPluginGraphProviderDocument.self,
+            from: data
+        )
+        guard document.contractVersion == WorkflowPluginGraphProviderDocument.contractVersion else {
+            throw ValidationError("Unsupported graph provider contract: \(document.contractVersion)")
+        }
+        guard document.providerID == manifest.name, document.providerVersion == manifest.version else {
+            throw ValidationError("Graph provider catalog identity does not match its plugin manifest.")
+        }
+        guard document.providerID.range(
+            of: "^mere-[a-z0-9-]+$",
+            options: .regularExpression
+        ) != nil else {
+            throw ValidationError("Graph provider id is invalid: \(document.providerID)")
+        }
+        guard !document.nodes.isEmpty else {
+            throw ValidationError("Graph provider '\(document.providerID)' has no nodes.")
+        }
+        let identity = WorkflowNodeProviderIdentity(
+            id: document.providerID,
+            version: document.providerVersion,
+            catalogSHA256: try WorkflowBundleCodec.hash(document)
+        )
+        let nodes = document.nodes.map { node in
+            WorkflowNodeCatalogEntry(
+                kind: node.kind,
+                title: node.title,
+                description: node.description,
+                category: node.category,
+                inputs: node.inputs,
+                outputs: node.outputs,
+                requirements: node.requirements,
+                traits: node.traits,
+                provider: identity
+            )
+        }
+        let duplicateKinds = Dictionary(grouping: nodes, by: \.kind).filter { $0.value.count > 1 }.keys
+        guard duplicateKinds.isEmpty else {
+            throw ValidationError(
+                "Graph provider '\(document.providerID)' declares duplicate node kinds: \(duplicateKinds.sorted().joined(separator: ", "))."
+            )
+        }
+        for node in nodes {
+            guard node.kind.range(
+                of: "^[a-z][a-z0-9-]{0,63}(\\.[a-z][a-z0-9-]{0,63})+$",
+                options: .regularExpression
+            ) != nil else {
+                throw ValidationError("Graph provider '\(document.providerID)' declares invalid kind '\(node.kind)'.")
+            }
+            let duplicateInputs = Dictionary(grouping: node.inputs, by: \.name).filter { $0.value.count > 1 }.keys
+            let duplicateOutputs = Dictionary(grouping: node.outputs, by: \.name).filter { $0.value.count > 1 }.keys
+            guard duplicateInputs.isEmpty, duplicateOutputs.isEmpty else {
+                throw ValidationError("Graph provider '\(document.providerID)' declares duplicate ports for '\(node.kind)'.")
+            }
+            for input in node.inputs {
+                let rangeIsValid = if let minimum = input.minimum, let maximum = input.maximum {
+                    minimum <= maximum
+                } else {
+                    true
+                }
+                guard input.name.range(of: "^[a-z][a-z0-9_]{0,63}$", options: .regularExpression) != nil,
+                      rangeIsValid,
+                      input.step.map({ $0 > 0 }) ?? true else {
+                    throw ValidationError("Graph provider '\(document.providerID)' has an invalid input on '\(node.kind)'.")
+                }
+            }
+            for output in node.outputs where output.name.range(
+                of: "^[a-z][a-z0-9_]{0,63}$",
+                options: .regularExpression
+            ) == nil {
+                throw ValidationError("Graph provider '\(document.providerID)' has an invalid output on '\(node.kind)'.")
+            }
+        }
+        return WorkflowDiscoveredGraphProvider(identity: identity, executable: entrypoint, nodes: nodes)
+    }
+
+    private static func candidateEntrypoints(
+        environment: [String: String],
+        fileManager: FileManager
+    ) -> [String] {
+        let configured = environment[environmentKey]?
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init) ?? []
+        let persisted = loadInstallRegistry(fileManager: fileManager).entrypoints
+        let knownInstalled = knownOfficialEntrypoints.filter { PluginProcess.which($0) != nil }
+        var seen = Set<String>()
+        return (configured + persisted + knownInstalled).filter { seen.insert($0).inserted }
+    }
+
+    private static func loadInstallRegistry(fileManager: FileManager) -> WorkflowGraphProviderInstallRegistry {
+        guard fileManager.fileExists(atPath: registryURL.path),
+              let data = try? Data(contentsOf: registryURL),
+              let registry = try? WorkflowBundleCodec.decoder().decode(
+                  WorkflowGraphProviderInstallRegistry.self,
+                  from: data
+              ) else {
+            return WorkflowGraphProviderInstallRegistry(entrypoints: [])
+        }
+        return registry
+    }
+}

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -44,6 +44,8 @@ struct WorkflowJobRequirements: Codable, Equatable, Sendable {
     let minimumMereRunVersion: String
     let nodeKinds: [String]
     let modelIDs: [String]
+    let models: [WorkflowModelProvenance]
+    let providers: [WorkflowGraphProviderRequirement]
     let acceleratorBackends: [String]
     let minimumAcceleratorMemoryBytes: Int64?
 
@@ -51,8 +53,75 @@ struct WorkflowJobRequirements: Codable, Equatable, Sendable {
         case minimumMereRunVersion = "minimum_mere_run_version"
         case nodeKinds = "node_kinds"
         case modelIDs = "model_ids"
+        case models
+        case providers
         case acceleratorBackends = "accelerator_backends"
         case minimumAcceleratorMemoryBytes = "minimum_accelerator_memory_bytes"
+    }
+
+    init(
+        minimumMereRunVersion: String,
+        nodeKinds: [String],
+        modelIDs: [String],
+        models: [WorkflowModelProvenance] = [],
+        providers: [WorkflowGraphProviderRequirement] = [],
+        acceleratorBackends: [String],
+        minimumAcceleratorMemoryBytes: Int64?
+    ) {
+        self.minimumMereRunVersion = minimumMereRunVersion
+        self.nodeKinds = nodeKinds
+        self.modelIDs = modelIDs
+        self.models = models
+        self.providers = providers
+        self.acceleratorBackends = acceleratorBackends
+        self.minimumAcceleratorMemoryBytes = minimumAcceleratorMemoryBytes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        minimumMereRunVersion = try container.decode(String.self, forKey: .minimumMereRunVersion)
+        nodeKinds = try container.decode([String].self, forKey: .nodeKinds)
+        modelIDs = try container.decode([String].self, forKey: .modelIDs)
+        models = try container.decodeIfPresent([WorkflowModelProvenance].self, forKey: .models) ?? []
+        providers = try container.decodeIfPresent(
+            [WorkflowGraphProviderRequirement].self,
+            forKey: .providers
+        ) ?? []
+        acceleratorBackends = try container.decode([String].self, forKey: .acceleratorBackends)
+        minimumAcceleratorMemoryBytes = try container.decodeIfPresent(
+            Int64.self,
+            forKey: .minimumAcceleratorMemoryBytes
+        )
+    }
+}
+
+struct WorkflowModelProvenance: Codable, Equatable, Hashable, Sendable {
+    let id: String
+    let repository: String?
+    let revision: String?
+    let catalogSHA256: String
+    let installManifestSHA256: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case repository
+        case revision
+        case catalogSHA256 = "catalog_sha256"
+        case installManifestSHA256 = "install_manifest_sha256"
+    }
+
+    init(
+        id: String,
+        repository: String?,
+        revision: String?,
+        catalogSHA256: String,
+        installManifestSHA256: String? = nil
+    ) {
+        self.id = id
+        self.repository = repository
+        self.revision = revision
+        self.catalogSHA256 = catalogSHA256
+        self.installManifestSHA256 = installManifestSHA256
     }
 }
 
@@ -232,13 +301,21 @@ struct WorkflowBundleMaterializer {
 
     private func resolveSeeds() -> WorkflowGraphDocument {
         let nodes = graph.nodes.map { node -> WorkflowNode in
-            guard WorkflowNodeRegistry.entry(for: node.kind)?.inputs.contains(where: { $0.name == "seed" }) == true,
-                  node.arguments["seed"] == nil else {
-                return node
-            }
+            guard let catalog = WorkflowNodeRegistry.entry(for: node) else { return node }
             var arguments = node.arguments
-            arguments["seed"] = .integer(seed())
-            return WorkflowNode(id: node.id, kind: node.kind, arguments: arguments, dependsOn: node.dependsOn)
+            for field in catalog.inputs where arguments[field.name] == nil {
+                arguments[field.name] = field.defaultValue
+            }
+            if catalog.inputs.contains(where: { $0.name == "seed" }), arguments["seed"] == nil {
+                arguments["seed"] = .integer(seed())
+            }
+            return WorkflowNode(
+                id: node.id,
+                kind: node.kind,
+                provider: node.provider,
+                arguments: arguments,
+                dependsOn: node.dependsOn
+            )
         }
         return WorkflowGraphDocument(
             schemaVersion: graph.schemaVersion,
@@ -294,7 +371,7 @@ struct WorkflowBundleMaterializer {
         groups: inout [WorkflowAssetGroup]
     ) throws -> WorkflowGraphDocument {
         let nodes = try graph.nodes.map { node -> WorkflowNode in
-            guard let catalog = WorkflowNodeRegistry.entry(for: node.kind) else { return node }
+            guard let catalog = WorkflowNodeRegistry.entry(for: node) else { return node }
             var arguments = node.arguments
             for field in catalog.inputs {
                 guard let value = arguments[field.name] else { continue }
@@ -315,7 +392,7 @@ struct WorkflowBundleMaterializer {
                         assetsDirectory: assetsDirectory,
                         groups: &groups
                     )
-                case .assetArray:
+                case .assetArray, .assetCollection:
                     guard case .array(let values) = value else { continue }
                     arguments[field.name] = .array(try values.enumerated().map { index, nested in
                         try portableNodeAsset(
@@ -330,7 +407,13 @@ struct WorkflowBundleMaterializer {
                     break
                 }
             }
-            return WorkflowNode(id: node.id, kind: node.kind, arguments: arguments, dependsOn: node.dependsOn)
+            return WorkflowNode(
+                id: node.id,
+                kind: node.kind,
+                provider: node.provider,
+                arguments: arguments,
+                dependsOn: node.dependsOn
+            )
         }
         return WorkflowGraphDocument(
             schemaVersion: graph.schemaVersion,
@@ -418,7 +501,7 @@ struct WorkflowBundleMaterializer {
         graph: WorkflowGraphDocument,
         resolvedInputs: WorkflowInputsDocument
     ) -> WorkflowJobRequirements {
-        let modelIDs = Set(graph.nodes.compactMap { node -> String? in
+        var modelIDs = Set(graph.nodes.compactMap { node -> String? in
             if let value = node.arguments["model"] {
                 if let resolved = resolveStatic(value, inputs: resolvedInputs.values)?.stringValue {
                     return resolved
@@ -432,12 +515,47 @@ struct WorkflowBundleMaterializer {
             default: return nil
             }
         })
+        for node in graph.nodes {
+            modelIDs.formUnion(WorkflowNodeRegistry.entry(for: node)?.requirements.modelIDs ?? [])
+        }
+        let modelProvenance = modelIDs.sorted().map { modelID -> WorkflowModelProvenance in
+            let spec = ManagedModelCatalog.spec(for: modelID)
+            let catalogIdentity = WorkflowManagedModelIdentity(
+                id: modelID,
+                repository: spec?.upstreamRepoId,
+                revision: spec?.upstreamRevision
+            )
+            return WorkflowModelProvenance(
+                id: modelID,
+                repository: spec?.upstreamRepoId,
+                revision: spec?.upstreamRevision,
+                catalogSHA256: (try? WorkflowBundleCodec.hash(catalogIdentity)) ?? "",
+                installManifestSHA256: nil
+            )
+        }
+        let providers = Array(Set(graph.nodes.compactMap { node -> WorkflowGraphProviderRequirement? in
+            guard node.resolvedProviderID != WorkflowNodeProviderIdentity.builtInID else { return nil }
+            return WorkflowGraphProviderRegistry.discoveredCatalog().provider(id: node.resolvedProviderID)?.requirement
+        })).sorted { $0.id < $1.id }
+        var acceptedBackends = Set(["cpu", "metal", "cuda", "rocm"])
+        var minimumMemory: Int64?
+        for node in graph.nodes {
+            guard let requirements = WorkflowNodeRegistry.entry(for: node)?.requirements else { continue }
+            if !requirements.acceleratorBackends.isEmpty {
+                acceptedBackends.formIntersection(requirements.acceleratorBackends)
+            }
+            if let nodeMinimum = requirements.minimumAcceleratorMemoryBytes {
+                minimumMemory = max(minimumMemory ?? 0, nodeMinimum)
+            }
+        }
         return WorkflowJobRequirements(
             minimumMereRunVersion: MereRunCLIVersion.current,
             nodeKinds: Array(Set(graph.nodes.map(\.kind))).sorted(),
             modelIDs: modelIDs.sorted(),
-            acceleratorBackends: ["cuda", "metal"],
-            minimumAcceleratorMemoryBytes: nil
+            models: modelProvenance,
+            providers: providers,
+            acceleratorBackends: acceptedBackends.sorted(),
+            minimumAcceleratorMemoryBytes: minimumMemory
         )
     }
 
@@ -463,6 +581,12 @@ struct WorkflowBundleMaterializer {
         default: "application/octet-stream"
         }
     }
+}
+
+private struct WorkflowManagedModelIdentity: Codable {
+    let id: String
+    let repository: String?
+    let revision: String?
 }
 
 struct WorkflowPortableInputFingerprint: Codable {
@@ -499,6 +623,26 @@ struct GraphRunArtifact: Codable, Equatable, Sendable {
     }
 }
 
+struct GraphRunNodeOutput: Codable, Equatable, Sendable {
+    let name: String
+    let type: WorkflowPortType
+    let value: WorkflowValue?
+    let path: String?
+    let contentType: String?
+    let sizeBytes: Int64?
+    let sha256: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case value
+        case path
+        case contentType = "content_type"
+        case sizeBytes = "size_bytes"
+        case sha256
+    }
+}
+
 struct GraphRunNodeRecord: Codable, Equatable, Sendable {
     let id: String
     let kind: String
@@ -507,7 +651,10 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
     var completedAt: Date?
     var exitStatus: Int32?
     var fingerprint: String
+    var provider: WorkflowNodeProviderIdentity?
+    var models: [WorkflowModelProvenance]
     var artifacts: [GraphRunArtifact]
+    var outputs: [GraphRunNodeOutput]
     var error: String?
 
     enum CodingKeys: String, CodingKey {
@@ -518,8 +665,55 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
         case completedAt = "completed_at"
         case exitStatus = "exit_status"
         case fingerprint
+        case provider
+        case models
         case artifacts
+        case outputs
         case error
+    }
+
+    init(
+        id: String,
+        kind: String,
+        state: GraphRunState,
+        startedAt: Date?,
+        completedAt: Date?,
+        exitStatus: Int32?,
+        fingerprint: String,
+        provider: WorkflowNodeProviderIdentity? = nil,
+        models: [WorkflowModelProvenance] = [],
+        artifacts: [GraphRunArtifact],
+        outputs: [GraphRunNodeOutput] = [],
+        error: String?
+    ) {
+        self.id = id
+        self.kind = kind
+        self.state = state
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.exitStatus = exitStatus
+        self.fingerprint = fingerprint
+        self.provider = provider
+        self.models = models
+        self.artifacts = artifacts
+        self.outputs = outputs
+        self.error = error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        kind = try container.decode(String.self, forKey: .kind)
+        state = try container.decode(GraphRunState.self, forKey: .state)
+        startedAt = try container.decodeIfPresent(Date.self, forKey: .startedAt)
+        completedAt = try container.decodeIfPresent(Date.self, forKey: .completedAt)
+        exitStatus = try container.decodeIfPresent(Int32.self, forKey: .exitStatus)
+        fingerprint = try container.decode(String.self, forKey: .fingerprint)
+        provider = try container.decodeIfPresent(WorkflowNodeProviderIdentity.self, forKey: .provider)
+        models = try container.decodeIfPresent([WorkflowModelProvenance].self, forKey: .models) ?? []
+        artifacts = try container.decode([GraphRunArtifact].self, forKey: .artifacts)
+        outputs = try container.decodeIfPresent([GraphRunNodeOutput].self, forKey: .outputs) ?? []
+        error = try container.decodeIfPresent(String.self, forKey: .error)
     }
 }
 
@@ -575,6 +769,10 @@ struct GraphRunEvent: Codable, Equatable, Sendable {
     let state: GraphRunState
     let nodeID: String?
     let message: String?
+    let progress: GraphRunProgress?
+    let artifact: GraphRunEventArtifact?
+    let diagnostic: GraphRunEventDiagnostic?
+    let metric: GraphRunMetric?
 
     enum CodingKeys: String, CodingKey {
         case sequence
@@ -583,22 +781,128 @@ struct GraphRunEvent: Codable, Equatable, Sendable {
         case state
         case nodeID = "node_id"
         case message
+        case progress
+        case artifact
+        case diagnostic
+        case metric
+    }
+
+    init(
+        sequence: Int,
+        createdAt: Date,
+        type: String,
+        state: GraphRunState,
+        nodeID: String?,
+        message: String?,
+        progress: GraphRunProgress? = nil,
+        artifact: GraphRunEventArtifact? = nil,
+        diagnostic: GraphRunEventDiagnostic? = nil,
+        metric: GraphRunMetric? = nil
+    ) {
+        self.sequence = sequence
+        self.createdAt = createdAt
+        self.type = type
+        self.state = state
+        self.nodeID = nodeID
+        self.message = message
+        self.progress = progress
+        self.artifact = artifact
+        self.diagnostic = diagnostic
+        self.metric = metric
+    }
+}
+
+struct GraphRunProgress: Codable, Equatable, Sendable {
+    let phase: String?
+    let current: Double?
+    let total: Double?
+    let fraction: Double?
+    let unit: String?
+}
+
+struct GraphRunEventArtifact: Codable, Equatable, Sendable {
+    let name: String
+    let path: String
+    let contentType: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case path
+        case contentType = "content_type"
+    }
+}
+
+struct GraphRunEventDiagnostic: Codable, Equatable, Sendable {
+    let id: String
+    let severity: String
+    let title: String
+    let message: String
+}
+
+struct GraphRunMetric: Codable, Equatable, Sendable {
+    let name: String
+    let value: Double
+    let unit: String?
+}
+
+struct WorkflowInvocationOutput: Codable, Equatable, Sendable {
+    let type: WorkflowPortType
+    let path: String?
+    let optional: Bool
+    let contentTypes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case path
+        case optional
+        case contentTypes = "content_types"
+    }
+}
+
+struct WorkflowPluginNodeInvocationDocument: Codable, Equatable, Sendable {
+    static let contractVersion = "mere.run/plugin-graph-invocation.v1"
+
+    let contractVersion: String
+    let jobID: String
+    let nodeID: String
+    let kind: String
+    let arguments: [String: WorkflowValue]
+    let outputs: [String: WorkflowInvocationOutput]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case jobID = "job_id"
+        case nodeID = "node_id"
+        case kind
+        case arguments
+        case outputs
     }
 }
 
 struct WorkflowNodeInvocation: Equatable {
     let command: [String]
+    let executable: URL
     let preflightArguments: [String]
     let runArguments: [String]
-    let outputs: [String: URL]
+    let outputs: [String: WorkflowInvocationOutput]
+    let streamsEvents: Bool
 }
 
 enum WorkflowNodeCommandBuilder {
     static func invocation(
         node: WorkflowNode,
         arguments: [String: WorkflowValue],
-        nodeDirectory: URL
+        nodeDirectory: URL,
+        jobID: String = UUID().uuidString.lowercased()
     ) throws -> WorkflowNodeInvocation {
+        if node.resolvedProviderID != WorkflowNodeProviderIdentity.builtInID {
+            return try pluginInvocation(
+                node: node,
+                arguments: arguments,
+                nodeDirectory: nodeDirectory,
+                jobID: jobID
+            )
+        }
         let artifacts = nodeDirectory.appendingPathComponent("artifacts", isDirectory: true)
         switch node.kind {
         case "image.train-lora":
@@ -622,9 +926,11 @@ enum WorkflowNodeCommandBuilder {
             appendString("sample_prompt", flag: "--sample-prompt", from: arguments, to: &args)
             return .init(
                 command: ["image", "train-lora"],
+                executable: CurrentExecutable.url(),
                 preflightArguments: args + ["--preflight", "--json"],
                 runArguments: args + ["--quiet"],
-                outputs: ["adapter": output]
+                outputs: ["adapter": fileOutput(output, contentTypes: ["application/x-safetensors"])],
+                streamsEvents: false
             )
         case "image.generate":
             let output = artifacts.appendingPathComponent("image.png")
@@ -656,9 +962,11 @@ enum WorkflowNodeCommandBuilder {
             }
             return .init(
                 command: ["image", "generate"],
+                executable: CurrentExecutable.url(),
                 preflightArguments: args + ["--preflight", "--json"],
                 runArguments: args + ["--quiet"],
-                outputs: ["image": output]
+                outputs: ["image": fileOutput(output, contentTypes: ["image/png"])],
+                streamsEvents: false
             )
         case "video.generate":
             let output = artifacts.appendingPathComponent("video.mp4")
@@ -675,12 +983,93 @@ enum WorkflowNodeCommandBuilder {
             appendString("end_image", flag: "--end-image", from: arguments, to: &args)
             return .init(
                 command: ["video", "generate"],
+                executable: CurrentExecutable.url(),
                 preflightArguments: args + ["--preflight", "--json"],
                 runArguments: args + ["--quiet"],
-                outputs: ["video": output]
+                outputs: ["video": fileOutput(output, contentTypes: ["video/mp4"])],
+                streamsEvents: false
             )
         default:
             throw ValidationError("Unsupported workflow node kind '\(node.kind)'.")
+        }
+    }
+
+    private static func pluginInvocation(
+        node: WorkflowNode,
+        arguments: [String: WorkflowValue],
+        nodeDirectory: URL,
+        jobID: String
+    ) throws -> WorkflowNodeInvocation {
+        let provider = try WorkflowGraphProviderRegistry.requireProvider(id: node.resolvedProviderID)
+        guard let catalog = provider.nodes.first(where: { $0.kind == node.kind }),
+              let executable = PluginProcess.which(provider.executable) else {
+            throw ValidationError(
+                "Graph provider '\(node.resolvedProviderID)' does not expose node kind '\(node.kind)'."
+            )
+        }
+        var outputs: [String: WorkflowInvocationOutput] = [:]
+        for output in catalog.outputs {
+            outputs[output.name] = WorkflowInvocationOutput(
+                type: output.type,
+                path: outputPath(for: output),
+                optional: output.optional,
+                contentTypes: output.contentTypes
+            )
+        }
+        let request = WorkflowPluginNodeInvocationDocument(
+            contractVersion: WorkflowPluginNodeInvocationDocument.contractVersion,
+            jobID: jobID,
+            nodeID: node.id,
+            kind: node.kind,
+            arguments: arguments,
+            outputs: outputs
+        )
+        let requestURL = nodeDirectory.appendingPathComponent("invocation.json")
+        try WorkflowBundleCodec.write(request, to: requestURL)
+        let shared = ["--request", requestURL.path, "--run-dir", nodeDirectory.path]
+        return WorkflowNodeInvocation(
+            command: [provider.executable, "graph", "execute"],
+            executable: executable,
+            preflightArguments: ["graph", "preflight"] + shared + ["--json"],
+            runArguments: ["graph", "execute"] + shared + ["--json-stream"],
+            outputs: outputs,
+            streamsEvents: true
+        )
+    }
+
+    private static func fileOutput(_ url: URL, contentTypes: [String]) -> WorkflowInvocationOutput {
+        WorkflowInvocationOutput(
+            type: .asset,
+            path: url.path,
+            optional: false,
+            contentTypes: contentTypes
+        )
+    }
+
+    private static func outputPath(for output: WorkflowNodeOutput) -> String? {
+        switch output.type {
+        case .asset:
+            let pathExtension = outputExtension(contentTypes: output.contentTypes)
+            return "artifacts/\(output.name)\(pathExtension)"
+        case .assetDirectory:
+            return "artifacts/\(output.name)"
+        case .assetCollection, .assetArray:
+            return "artifacts/\(output.name).json"
+        default:
+            return nil
+        }
+    }
+
+    private static func outputExtension(contentTypes: [String]) -> String {
+        switch contentTypes.first {
+        case "image/png": ".png"
+        case "image/jpeg": ".jpg"
+        case "image/webp": ".webp"
+        case "video/mp4": ".mp4"
+        case "audio/wav": ".wav"
+        case "application/json": ".json"
+        case "application/x-safetensors": ".safetensors"
+        default: ""
         }
     }
 

--- a/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
@@ -420,7 +420,8 @@ struct RelayWorkflowExecutor {
                 path: "/api/graph-jobs/\(created.jobID)/assets/\(digest)",
                 method: "PUT",
                 contentType: "application/octet-stream",
-                body: data
+                body: data,
+                transientRetryAttempts: 3
             )
         }
         let commitData = try await request(
@@ -529,28 +530,33 @@ struct RelayWorkflowExecutor {
         method: String,
         contentType: String = "application/json",
         body: Data? = nil,
-        authorize: Bool = true
+        authorize: Bool = true,
+        transientRetryAttempts: Int = 1
     ) async throws -> Data {
         guard let baseURL = profile.url, let url = URL(string: "\(baseURL)\(path)") else {
             throw ValidationError("Relay executor profile has an invalid URL.")
         }
         let credential = authorize ? try await RelayAuthentication.resolveCredential(profile: profile) : nil
-        var result = try await performRequest(
-            url: url,
-            method: method,
-            contentType: contentType,
-            body: body,
-            credential: credential
-        )
-        if result.response.statusCode == 401, credential?.refreshable == true {
-            let refreshed = try await RelayAuthentication.resolveCredential(profile: profile, forceRefresh: true)
-            result = try await performRequest(
+        var result = try await Self.performWithTransientRetries(maximumAttempts: transientRetryAttempts) {
+            try await performRequest(
                 url: url,
                 method: method,
                 contentType: contentType,
                 body: body,
-                credential: refreshed
+                credential: credential
             )
+        }
+        if result.response.statusCode == 401, credential?.refreshable == true {
+            let refreshed = try await RelayAuthentication.resolveCredential(profile: profile, forceRefresh: true)
+            result = try await Self.performWithTransientRetries(maximumAttempts: transientRetryAttempts) {
+                try await performRequest(
+                    url: url,
+                    method: method,
+                    contentType: contentType,
+                    body: body,
+                    credential: refreshed
+                )
+            }
         }
         guard (200..<300).contains(result.response.statusCode) else {
             let status = result.response.statusCode
@@ -559,6 +565,30 @@ struct RelayWorkflowExecutor {
             throw ValidationError("Relay request failed with HTTP \(status): \(detail)")
         }
         return result.data
+    }
+
+    static func performWithTransientRetries(
+        maximumAttempts: Int,
+        delayNanoseconds: UInt64 = 250_000_000,
+        operation: () async throws -> (data: Data, response: HTTPURLResponse)
+    ) async throws -> (data: Data, response: HTTPURLResponse) {
+        precondition(maximumAttempts > 0)
+        for attempt in 1...maximumAttempts {
+            do {
+                let result = try await operation()
+                guard isTransientHTTPStatus(result.response.statusCode), attempt < maximumAttempts else {
+                    return result
+                }
+            } catch let error as URLError {
+                guard attempt < maximumAttempts else { throw error }
+            }
+            try await Task.sleep(nanoseconds: UInt64(attempt) * delayNanoseconds)
+        }
+        preconditionFailure("Transient request retry loop exhausted without returning.")
+    }
+
+    private static func isTransientHTTPStatus(_ statusCode: Int) -> Bool {
+        statusCode == 408 || statusCode == 429 || (500...599).contains(statusCode)
     }
 
     private func performRequest(

--- a/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
@@ -759,6 +759,13 @@ func validateWorker(
     guard missingKinds.isEmpty else {
         throw ValidationError("Executor '\(executor)' is missing node kinds: \(missingKinds.joined(separator: ", ")).")
     }
+    let missingProviders = job.requirements.providers.filter { !worker.providers.contains($0) }
+    guard missingProviders.isEmpty else {
+        let descriptions = missingProviders.map { "\($0.id)@\($0.version) [\($0.catalogSHA256)]" }
+        throw ValidationError(
+            "Executor '\(executor)' is missing exact graph providers: \(descriptions.joined(separator: ", "))."
+        )
+    }
     let missingModels = job.requirements.modelIDs.filter { !worker.installedModelIDs.contains($0) }
     guard missingModels.isEmpty else {
         throw ValidationError("Executor '\(executor)' is missing models: \(missingModels.joined(separator: ", ")).")

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -30,26 +30,43 @@ protocol WorkflowProcessRunning {
     func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult
 }
 
-struct WorkflowProcessRunner: WorkflowProcessRunning {
+protocol WorkflowStreamingProcessRunning {
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> WorkflowProcessResult
+}
+
+struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRunning {
     static func stdoutCaptureURL(in directory: URL) -> URL {
         directory.appendingPathComponent(".workflow-stdout-\(UUID().uuidString)")
     }
 
     func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
+        try run(
+            executable: CurrentExecutable.url(),
+            arguments: arguments,
+            currentDirectory: currentDirectory,
+            stdoutLineHandler: nil
+        )
+    }
+
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
         let process = Process()
-        process.executableURL = CurrentExecutable.url()
+        process.executableURL = executable
         process.arguments = arguments
         process.currentDirectoryURL = currentDirectory
-        let stdoutURL = Self.stdoutCaptureURL(in: currentDirectory)
-        guard FileManager.default.createFile(atPath: stdoutURL.path, contents: nil) else {
-            throw ValidationError("Could not create workflow child stdout capture.")
-        }
-        let stdout = try FileHandle(forWritingTo: stdoutURL)
+        let stdout = Pipe()
         let runDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
         let processIDURL = runDirectory.appendingPathComponent("worker-child.pid")
         defer {
-            try? stdout.close()
-            try? FileManager.default.removeItem(at: stdoutURL)
             try? FileManager.default.removeItem(at: processIDURL)
         }
         process.standardInput = FileHandle.nullDevice
@@ -57,15 +74,34 @@ struct WorkflowProcessRunner: WorkflowProcessRunning {
         process.standardError = FileHandle.standardError
         try process.run()
         try Data(String(process.processIdentifier).utf8).write(to: processIDURL, options: .atomic)
+        var captured = Data()
+        var pending = Data()
+        while true {
+            let data = stdout.fileHandleForReading.availableData
+            if data.isEmpty { break }
+            captured.append(data)
+            guard stdoutLineHandler != nil else { continue }
+            pending.append(data)
+            while let newline = pending.firstIndex(of: 0x0A) {
+                let lineData = pending.prefix(upTo: newline)
+                pending.removeSubrange(...newline)
+                let line = String(decoding: lineData, as: UTF8.self)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !line.isEmpty { try stdoutLineHandler?(line) }
+            }
+        }
         process.waitUntilExit()
-        try stdout.close()
-        let data = try Data(contentsOf: stdoutURL)
+        if !pending.isEmpty {
+            let line = String(decoding: pending, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !line.isEmpty { try stdoutLineHandler?(line) }
+        }
         if FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
             throw WorkflowCancellationError()
         }
         return WorkflowProcessResult(
             status: process.terminationStatus,
-            stdout: String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            stdout: String(decoding: captured, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
         )
     }
 }
@@ -128,6 +164,13 @@ struct WorkflowRunner {
                 "Workflow requires mere.run \(job.requirements.minimumMereRunVersion) or newer; this worker is \(MereRunCLIVersion.current)."
             )
         }
+        let availableProviders = WorkflowGraphProviderRegistry.discoveredCatalog().providers.map(\.requirement)
+        let missingProviders = job.requirements.providers.filter { !availableProviders.contains($0) }
+        guard missingProviders.isEmpty else {
+            throw ValidationError(
+                "Worker is missing exact graph providers: \(missingProviders.map { "\($0.id)@\($0.version)" }.joined(separator: ", "))."
+            )
+        }
 
         let validation = WorkflowGraphValidator.validate(graph: graph, inputs: inputs)
         guard validation.status != .blocked else {
@@ -174,12 +217,26 @@ struct WorkflowRunner {
                     inputs: localizedInputs.values,
                     nodeOutputs: nodeOutputs
                 )
+                let referencedNodeIDs = Set(node.arguments.values.flatMap(\.references).compactMap { reference -> String? in
+                    guard let parsed = try? WorkflowReference(reference),
+                          case .nodeOutput(let sourceNodeID, _) = parsed.source else { return nil }
+                    return sourceNodeID
+                })
+                let upstreamOutputs = manifest.nodes
+                    .filter { referencedNodeIDs.contains($0.id) }
+                    .flatMap(\.outputs)
+                    .map(WorkflowNodeOutputFingerprint.init)
+                    .sorted { ($0.sourceName, $0.sha256 ?? "") < ($1.sourceName, $1.sha256 ?? "") }
+                guard let providerIdentity = WorkflowNodeRegistry.provider(for: node) else {
+                    throw ValidationError("Workflow provider '\(node.resolvedProviderID)' is unavailable.")
+                }
+                let nodeModels = modelProvenance(for: node, arguments: resolvedArguments, job: job)
                 let fingerprint = try WorkflowBundleCodec.hash(WorkflowNodeFingerprint(
-                    nodeID: node.id,
                     kind: node.kind,
+                    provider: providerIdentity,
                     arguments: resolvedArguments,
-                    inputFingerprint: job.inputFingerprint,
-                    upstreamArtifacts: manifest.nodes.prefix(nodeIndex).flatMap(\.artifacts)
+                    models: nodeModels,
+                    upstreamOutputs: upstreamOutputs
                 ))
                 if try shouldResume(
                     manifest.nodes[nodeIndex],
@@ -200,9 +257,12 @@ struct WorkflowRunner {
                 let invocation = try WorkflowNodeCommandBuilder.invocation(
                     node: node,
                     arguments: resolvedArguments,
-                    nodeDirectory: nodeDirectory
+                    nodeDirectory: nodeDirectory,
+                    jobID: job.jobID
                 )
                 manifest.nodes[nodeIndex].fingerprint = fingerprint
+                manifest.nodes[nodeIndex].provider = providerIdentity
+                manifest.nodes[nodeIndex].models = nodeModels
                 manifest.nodes[nodeIndex].state = .preflighting
                 manifest.nodes[nodeIndex].startedAt = now()
                 manifest.updatedAt = now()
@@ -217,9 +277,11 @@ struct WorkflowRunner {
                 ))
                 sequence += 1
 
-                let preflight = try processRunner.run(
+                let preflight = try runProcess(
+                    executable: invocation.executable,
                     arguments: invocation.preflightArguments,
-                    currentDirectory: nodeDirectory
+                    currentDirectory: nodeDirectory,
+                    stdoutLineHandler: nil
                 )
                 try throwIfCancellationRequested()
                 try Data(preflight.stdout.utf8).write(
@@ -228,6 +290,18 @@ struct WorkflowRunner {
                 )
                 guard preflight.status == 0 else {
                     throw ValidationError("Node '\(nodeID)' preflight failed with status \(preflight.status).")
+                }
+                if invocation.streamsEvents {
+                    let report = try WorkflowBundleCodec.decoder().decode(
+                        WorkflowPluginNodePreflight.self,
+                        from: Data(preflight.stdout.utf8)
+                    )
+                    guard report.contractVersion == WorkflowPluginNodePreflight.contractVersion,
+                          report.status != "blocked" else {
+                        throw ValidationError(
+                            report.diagnostics.map(\.message).joined(separator: " ")
+                        )
+                    }
                 }
 
                 manifest.nodes[nodeIndex].state = .running
@@ -243,9 +317,47 @@ struct WorkflowRunner {
                 ))
                 sequence += 1
 
-                let result = try processRunner.run(
+                var providerOutputs: [String: WorkflowValue]?
+                var providerSequence = -1
+                let result = try runProcess(
+                    executable: invocation.executable,
                     arguments: invocation.runArguments,
-                    currentDirectory: nodeDirectory
+                    currentDirectory: nodeDirectory,
+                    stdoutLineHandler: invocation.streamsEvents ? { line in
+                        let event = try WorkflowBundleCodec.decoder().decode(
+                            WorkflowPluginNodeEvent.self,
+                            from: Data(line.utf8)
+                        )
+                        guard event.contractVersion == WorkflowPluginNodeEvent.contractVersion,
+                              event.sequence == providerSequence + 1 else {
+                            throw ValidationError("Graph provider emitted an invalid event sequence for node '\(nodeID)'.")
+                        }
+                        providerSequence = event.sequence
+                        if event.type == "node_result" {
+                            providerOutputs = event.outputs
+                        } else {
+                            let runArtifact: GraphRunEventArtifact?
+                            if let eventArtifact = event.artifact {
+                                let artifactURL = try invocationOutputURL(
+                                    eventArtifact.path,
+                                    nodeDirectory: nodeDirectory
+                                )
+                                runArtifact = GraphRunEventArtifact(
+                                    name: eventArtifact.name,
+                                    path: try portableArtifactPath(for: artifactURL),
+                                    contentType: eventArtifact.contentType
+                                )
+                            } else {
+                                runArtifact = nil
+                            }
+                            try record(event.runEvent(
+                                sequence: sequence,
+                                nodeID: nodeID,
+                                artifact: runArtifact
+                            ))
+                            sequence += 1
+                        }
+                    } : nil
                 )
                 try throwIfCancellationRequested()
                 try Data(result.stdout.utf8).write(
@@ -257,18 +369,15 @@ struct WorkflowRunner {
                     throw ValidationError("Node '\(nodeID)' failed with status \(result.status).")
                 }
 
-                var artifacts: [GraphRunArtifact] = []
-                var outputs: [String: WorkflowValue] = [:]
-                for name in invocation.outputs.keys.sorted() {
-                    guard let url = invocation.outputs[name], fileManager.fileExists(atPath: url.path) else {
-                        throw ValidationError("Node '\(nodeID)' did not produce declared output '\(name)'.")
-                    }
-                    let artifact = try artifact(name: name, nodeKind: node.kind, url: url)
-                    artifacts.append(artifact)
-                    outputs[name] = .string(url.path)
-                }
-                nodeOutputs[nodeID] = outputs
-                manifest.nodes[nodeIndex].artifacts = artifacts
+                let verified = try verifyOutputs(
+                    invocation.outputs,
+                    providerValues: providerOutputs,
+                    node: node,
+                    nodeDirectory: nodeDirectory
+                )
+                nodeOutputs[nodeID] = verified.values
+                manifest.nodes[nodeIndex].artifacts = verified.artifacts
+                manifest.nodes[nodeIndex].outputs = verified.outputs
                 manifest.nodes[nodeIndex].state = .finished
                 manifest.nodes[nodeIndex].completedAt = now()
                 manifest.updatedAt = now()
@@ -336,6 +445,223 @@ struct WorkflowRunner {
             state: manifest.state,
             outputs: manifest.outputs
         )
+    }
+
+    private func runProcess(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
+        if let streamingRunner = processRunner as? any WorkflowStreamingProcessRunning {
+            return try streamingRunner.run(
+                executable: executable,
+                arguments: arguments,
+                currentDirectory: currentDirectory,
+                stdoutLineHandler: stdoutLineHandler
+            )
+        }
+        guard executable.standardizedFileURL == CurrentExecutable.url().standardizedFileURL else {
+            throw ValidationError("Injected workflow process runner cannot execute companion providers.")
+        }
+        let result = try processRunner.run(arguments: arguments, currentDirectory: currentDirectory)
+        if let stdoutLineHandler {
+            for line in result.stdout.split(whereSeparator: \Character.isNewline) {
+                try stdoutLineHandler(String(line))
+            }
+        }
+        return result
+    }
+
+    private func verifyOutputs(
+        _ descriptors: [String: WorkflowInvocationOutput],
+        providerValues: [String: WorkflowValue]?,
+        node: WorkflowNode,
+        nodeDirectory: URL
+    ) throws -> WorkflowVerifiedNodeOutputs {
+        var artifacts: [GraphRunArtifact] = []
+        var records: [GraphRunNodeOutput] = []
+        var values: [String: WorkflowValue] = [:]
+        for name in descriptors.keys.sorted() {
+            guard let descriptor = descriptors[name] else { continue }
+            let providerValue = providerValues?[name]
+            switch descriptor.type {
+            case .asset, .assetCollection, .assetArray:
+                guard let path = descriptor.path else {
+                    throw ValidationError("Node '\(node.id)' output '\(name)' has no declared path.")
+                }
+                let url = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
+                if providerValue == .null || !fileManager.fileExists(atPath: url.path) {
+                    if descriptor.optional { continue }
+                    throw ValidationError("Node '\(node.id)' did not produce declared output '\(name)'.")
+                }
+                if let providerPath = providerValue?.stringValue {
+                    let reported = try invocationOutputURL(providerPath, nodeDirectory: nodeDirectory)
+                    guard reported.standardizedFileURL == url.standardizedFileURL else {
+                        throw ValidationError("Node '\(node.id)' reported an unexpected path for output '\(name)'.")
+                    }
+                }
+                let outputArtifact = try artifact(
+                    name: name,
+                    nodeKind: node.kind,
+                    url: url,
+                    contentType: descriptor.contentTypes.first
+                )
+                artifacts.append(outputArtifact)
+                records.append(.init(
+                    name: name,
+                    type: descriptor.type,
+                    value: nil,
+                    path: outputArtifact.path,
+                    contentType: outputArtifact.contentType,
+                    sizeBytes: outputArtifact.sizeBytes,
+                    sha256: outputArtifact.sha256
+                ))
+                values[name] = .string(url.path)
+            case .assetDirectory:
+                guard let path = descriptor.path else {
+                    throw ValidationError("Node '\(node.id)' directory output '\(name)' has no declared path.")
+                }
+                let url = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
+                var isDirectory: ObjCBool = false
+                if providerValue == .null || !fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+                    if descriptor.optional { continue }
+                    throw ValidationError("Node '\(node.id)' did not produce declared directory output '\(name)'.")
+                }
+                guard isDirectory.boolValue else {
+                    throw ValidationError("Node '\(node.id)' output '\(name)' is not a directory.")
+                }
+                if let providerPath = providerValue?.stringValue {
+                    let reported = try invocationOutputURL(providerPath, nodeDirectory: nodeDirectory)
+                    guard reported.standardizedFileURL == url.standardizedFileURL else {
+                        throw ValidationError("Node '\(node.id)' reported an unexpected path for output '\(name)'.")
+                    }
+                }
+                let directory = try directoryIdentity(url)
+                let manifestURL = nodeDirectory
+                    .appendingPathComponent("artifacts", isDirectory: true)
+                    .appendingPathComponent("\(name).manifest.json")
+                try WorkflowBundleCodec.write(directory.manifest, to: manifestURL)
+                let manifestArtifact = try artifact(
+                    name: "\(name)_manifest",
+                    nodeKind: node.kind,
+                    url: manifestURL,
+                    contentType: "application/json"
+                )
+                artifacts.append(manifestArtifact)
+                records.append(.init(
+                    name: name,
+                    type: .assetDirectory,
+                    value: nil,
+                    path: try portableArtifactPath(for: url),
+                    contentType: descriptor.contentTypes.first,
+                    sizeBytes: directory.sizeBytes,
+                    sha256: directory.sha256
+                ))
+                values[name] = .string(url.path)
+            case .string, .integer, .number, .boolean, .enumeration, .json:
+                guard let providerValue, providerValue != .null else {
+                    if descriptor.optional { continue }
+                    throw ValidationError("Node '\(node.id)' did not report declared value output '\(name)'.")
+                }
+                guard workflowValue(providerValue, matches: descriptor.type) else {
+                    throw ValidationError("Node '\(node.id)' output '\(name)' has the wrong value type.")
+                }
+                records.append(.init(
+                    name: name,
+                    type: descriptor.type,
+                    value: providerValue,
+                    path: nil,
+                    contentType: nil,
+                    sizeBytes: nil,
+                    sha256: try WorkflowBundleCodec.hash(providerValue)
+                ))
+                values[name] = providerValue
+            }
+        }
+        if let providerValues {
+            let undeclared = Set(providerValues.keys).subtracting(descriptors.keys)
+            guard undeclared.isEmpty else {
+                throw ValidationError(
+                    "Node '\(node.id)' reported undeclared outputs: \(undeclared.sorted().joined(separator: ", "))."
+                )
+            }
+        }
+        return WorkflowVerifiedNodeOutputs(artifacts: artifacts, outputs: records, values: values)
+    }
+
+    private func invocationOutputURL(_ path: String, nodeDirectory: URL) throws -> URL {
+        let candidate: URL
+        if path.hasPrefix("/") {
+            candidate = URL(fileURLWithPath: path).standardizedFileURL
+        } else {
+            guard isConfinedRelativeWorkflowPath(path) else {
+                throw ValidationError("Workflow provider output path is not confined: \(path)")
+            }
+            candidate = nodeDirectory.appendingPathComponent(path).standardizedFileURL
+        }
+        let root = nodeDirectory.standardizedFileURL.path
+        guard candidate.path.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow provider output path escapes the node directory: \(path)")
+        }
+        return candidate
+    }
+
+    private func directoryIdentity(_ directory: URL) throws -> WorkflowDirectoryIdentity {
+        let root = directory.resolvingSymlinksInPath()
+        var entries: [WorkflowAssetEntry] = []
+        for path in try fileManager.subpathsOfDirectory(atPath: root.path).sorted() {
+            let url = root.appendingPathComponent(path)
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            if values.isSymbolicLink == true {
+                throw ValidationError("Workflow output directories cannot contain symbolic links: \(url.path)")
+            }
+            guard values.isRegularFile == true else { continue }
+            entries.append(WorkflowAssetEntry(
+                path: path,
+                digest: try ModelArtifactPin.fileSHA256(url),
+                sizeBytes: try ModelArtifactPin.fileByteCount(url),
+                contentType: contentType(for: url)
+            ))
+        }
+        let manifest = WorkflowOutputDirectoryManifest(contractVersion: "mere.run/output-directory.v1", entries: entries)
+        return WorkflowDirectoryIdentity(
+            manifest: manifest,
+            sizeBytes: entries.reduce(0) { $0 + $1.sizeBytes },
+            sha256: try WorkflowBundleCodec.hash(manifest)
+        )
+    }
+
+    private func modelProvenance(
+        for node: WorkflowNode,
+        arguments: [String: WorkflowValue],
+        job: WorkflowJobManifest
+    ) -> [WorkflowModelProvenance] {
+        var modelIDs = Set(WorkflowNodeRegistry.entry(for: node)?.requirements.modelIDs ?? [])
+        if let modelID = arguments["model"]?.stringValue {
+            modelIDs.insert(modelID)
+        } else {
+            switch node.kind {
+            case "image.train-lora": modelIDs.insert(ImageTrainLoRA.defaultManagedModelID.rawValue)
+            case "image.generate": modelIDs.insert(ImageGenerate.defaultManagedModelID.rawValue)
+            case "video.generate": modelIDs.insert(ModelResolver.ModelID.ltxVideo23AVMLX.rawValue)
+            default: break
+            }
+        }
+        return job.requirements.models.filter { modelIDs.contains($0.id) }.map { provenance in
+            let manifestURL = MereRunModelPaths.modelDir(provenance.id)
+                .appendingPathComponent(MereRunModelManifest.filename)
+            let manifestDigest = fileManager.fileExists(atPath: manifestURL.path)
+                ? try? ModelArtifactPin.fileSHA256(manifestURL)
+                : nil
+            return WorkflowModelProvenance(
+                id: provenance.id,
+                repository: provenance.repository,
+                revision: provenance.revision,
+                catalogSHA256: provenance.catalogSHA256,
+                installManifestSHA256: manifestDigest
+            )
+        }.sorted { $0.id < $1.id }
     }
 
     private func prepareRunDirectory() throws {
@@ -545,16 +871,39 @@ struct WorkflowRunner {
         guard resume,
               node.state == .finished,
               node.fingerprint == expectedFingerprint,
-              !node.artifacts.isEmpty else { return false }
+              !node.outputs.isEmpty || !node.artifacts.isEmpty else { return false }
         var outputs: [String: WorkflowValue] = [:]
-        for artifact in node.artifacts {
-            let url = try artifactURL(for: artifact.path)
-            guard fileManager.fileExists(atPath: url.path),
-                  try ModelArtifactPin.fileByteCount(url) == artifact.sizeBytes,
-                  try ModelArtifactPin.fileSHA256(url) == artifact.sha256 else {
-                return false
+        if !node.outputs.isEmpty {
+            for output in node.outputs {
+                if let value = output.value {
+                    guard try WorkflowBundleCodec.hash(value) == output.sha256 else { return false }
+                    outputs[output.name] = value
+                    continue
+                }
+                guard let path = output.path else { return false }
+                let url = try artifactURL(for: path)
+                if output.type == .assetDirectory {
+                    var isDirectory: ObjCBool = false
+                    guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                          isDirectory.boolValue,
+                          try directoryIdentity(url).sha256 == output.sha256 else { return false }
+                } else {
+                    guard fileManager.fileExists(atPath: url.path),
+                          try ModelArtifactPin.fileByteCount(url) == output.sizeBytes,
+                          try ModelArtifactPin.fileSHA256(url) == output.sha256 else { return false }
+                }
+                outputs[output.name] = .string(url.path)
             }
-            outputs[artifact.name] = .string(url.path)
+        } else {
+            for artifact in node.artifacts {
+                let url = try artifactURL(for: artifact.path)
+                guard fileManager.fileExists(atPath: url.path),
+                      try ModelArtifactPin.fileByteCount(url) == artifact.sizeBytes,
+                      try ModelArtifactPin.fileSHA256(url) == artifact.sha256 else {
+                    return false
+                }
+                outputs[artifact.name] = .string(url.path)
+            }
         }
         nodeOutputs[node.id] = outputs
         return true
@@ -570,11 +919,28 @@ struct WorkflowRunner {
             guard case .reference(let rawReference)? = graph.outputs[name] else { continue }
             let reference = try WorkflowReference(rawReference)
             guard case .nodeOutput(let nodeID, let output) = reference.source,
-                  let sourcePath = nodeOutputs[nodeID]?[output]?.stringValue else {
+                  let sourceValue = nodeOutputs[nodeID]?[output],
+                  let node = graph.nodes.first(where: { $0.id == nodeID }),
+                  let outputContract = WorkflowNodeRegistry.output(node: node, name: output) else {
                 throw ValidationError("Workflow output '\(name)' was not produced.")
             }
+            if outputContract.type != .asset && outputContract.type != .assetCollection && outputContract.type != .assetArray {
+                let destination = outputsRoot.appendingPathComponent("\(name).json")
+                try WorkflowBundleCodec.encoder().encode(sourceValue).write(to: destination, options: .atomic)
+                artifacts.append(try artifact(
+                    name: name,
+                    nodeKind: "graph.output",
+                    url: destination,
+                    contentType: "application/json"
+                ))
+                continue
+            }
+            guard let sourcePath = sourceValue.stringValue else {
+                throw ValidationError("Workflow output '\(name)' did not resolve to an artifact path.")
+            }
             let source = URL(fileURLWithPath: sourcePath)
-            let destination = outputsRoot.appendingPathComponent("\(name).\(source.pathExtension)")
+            let suffix = source.pathExtension.isEmpty ? "" : ".\(source.pathExtension)"
+            let destination = outputsRoot.appendingPathComponent("\(name)\(suffix)")
             if fileManager.fileExists(atPath: destination.path) {
                 try fileManager.removeItem(at: destination)
             }
@@ -588,12 +954,17 @@ struct WorkflowRunner {
         return artifacts
     }
 
-    private func artifact(name: String, nodeKind: String, url: URL) throws -> GraphRunArtifact {
+    private func artifact(
+        name: String,
+        nodeKind: String,
+        url: URL,
+        contentType explicitContentType: String? = nil
+    ) throws -> GraphRunArtifact {
         GraphRunArtifact(
             name: name,
             kind: nodeKind,
             path: try portableArtifactPath(for: url),
-            contentType: contentType(for: url),
+            contentType: explicitContentType ?? contentType(for: url),
             sizeBytes: try ModelArtifactPin.fileByteCount(url),
             sha256: try ModelArtifactPin.fileSHA256(url)
         )
@@ -628,7 +999,12 @@ struct WorkflowRunner {
     private func contentType(for url: URL) -> String {
         switch url.pathExtension.lowercased() {
         case "png": "image/png"
+        case "jpg", "jpeg": "image/jpeg"
+        case "webp": "image/webp"
         case "mp4": "video/mp4"
+        case "wav": "audio/wav"
+        case "json": "application/json"
+        case "txt": "text/plain"
         case "safetensors": "application/x-safetensors"
         default: "application/octet-stream"
         }
@@ -660,18 +1036,149 @@ struct WorkflowRunner {
 }
 
 private struct WorkflowNodeFingerprint: Codable {
-    let nodeID: String
     let kind: String
+    let provider: WorkflowNodeProviderIdentity
     let arguments: [String: WorkflowValue]
-    let inputFingerprint: String
-    let upstreamArtifacts: [GraphRunArtifact]
+    let models: [WorkflowModelProvenance]
+    let upstreamOutputs: [WorkflowNodeOutputFingerprint]
 
     enum CodingKeys: String, CodingKey {
-        case nodeID = "node_id"
         case kind
+        case provider
         case arguments
-        case inputFingerprint = "input_fingerprint"
-        case upstreamArtifacts = "upstream_artifacts"
+        case models
+        case upstreamOutputs = "upstream_outputs"
+    }
+}
+
+private struct WorkflowNodeOutputFingerprint: Codable {
+    let sourceName: String
+    let type: WorkflowPortType
+    let value: WorkflowValue?
+    let sha256: String?
+
+    init(_ output: GraphRunNodeOutput) {
+        sourceName = output.name
+        type = output.type
+        value = output.value
+        sha256 = output.sha256
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sourceName = "source_name"
+        case type
+        case value
+        case sha256
+    }
+}
+
+private struct WorkflowVerifiedNodeOutputs {
+    let artifacts: [GraphRunArtifact]
+    let outputs: [GraphRunNodeOutput]
+    let values: [String: WorkflowValue]
+}
+
+private struct WorkflowOutputDirectoryManifest: Codable {
+    let contractVersion: String
+    let entries: [WorkflowAssetEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case entries
+    }
+}
+
+private struct WorkflowDirectoryIdentity {
+    let manifest: WorkflowOutputDirectoryManifest
+    let sizeBytes: Int64
+    let sha256: String
+}
+
+private struct WorkflowPluginNodePreflight: Codable {
+    static let contractVersion = "mere.run/plugin-graph-preflight.v1"
+
+    let contractVersion: String
+    let status: String
+    let diagnostics: [GraphRunEventDiagnostic]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case status
+        case diagnostics
+    }
+}
+
+private struct WorkflowPluginNodeEvent: Codable {
+    static let contractVersion = "mere.run/plugin-graph-event.v1"
+
+    let contractVersion: String
+    let sequence: Int
+    let createdAt: String
+    let type: String
+    let message: String?
+    let progress: GraphRunProgress?
+    let artifact: GraphRunEventArtifact?
+    let diagnostic: GraphRunEventDiagnostic?
+    let metric: GraphRunMetric?
+    let outputs: [String: WorkflowValue]?
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case sequence
+        case createdAt = "created_at"
+        case type
+        case message
+        case progress
+        case artifact
+        case diagnostic
+        case metric
+        case outputs
+    }
+
+    func runEvent(
+        sequence runSequence: Int,
+        nodeID: String,
+        artifact runArtifact: GraphRunEventArtifact?
+    ) -> GraphRunEvent {
+        GraphRunEvent(
+            sequence: runSequence,
+            createdAt: Date(),
+            type: runEventType,
+            state: .running,
+            nodeID: nodeID,
+            message: message,
+            progress: progress,
+            artifact: runArtifact,
+            diagnostic: diagnostic,
+            metric: metric
+        )
+    }
+
+    private var runEventType: String {
+        switch type {
+        case "progress": "node_progress"
+        case "diagnostic": "node_diagnostic"
+        case "metric": "node_metric"
+        case "heartbeat": "node_heartbeat"
+        default: type
+        }
+    }
+}
+
+private func workflowValue(_ value: WorkflowValue, matches type: WorkflowPortType) -> Bool {
+    switch type {
+    case .string, .enumeration, .asset, .assetDirectory:
+        value.stringValue != nil
+    case .integer:
+        value.integerValue != nil
+    case .number:
+        value.numberValue != nil
+    case .boolean:
+        value.booleanValue != nil
+    case .json:
+        true
+    case .assetCollection, .assetArray:
+        if case .array = value { true } else { false }
     }
 }
 

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.21.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.22.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/PluginCommandTests.swift
+++ b/Tests/MereRunCLITests/PluginCommandTests.swift
@@ -94,6 +94,26 @@ final class PluginCommandTests: XCTestCase {
         }
     }
 
+    func testGraphProviderCatalogIsPinnedToVerifiedPluginIdentity() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PluginGraphProviderTests.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let executable = directory.appendingPathComponent("mere-fixture-tools")
+        try fixtureGraphProviderScript.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let provider = try WorkflowGraphProviderRegistry.loadProvider(entrypoint: executable.path)
+
+        XCTAssertEqual(provider.identity.id, "mere-fixture-tools")
+        XCTAssertEqual(provider.identity.version, "1.2.3")
+        XCTAssertEqual(provider.identity.catalogSHA256.count, 64)
+        XCTAssertEqual(provider.nodes.map(\.kind), ["fixture.prepare"])
+        XCTAssertEqual(provider.nodes[0].outputs.map(\.type), [.assetDirectory, .json])
+        XCTAssertTrue(provider.nodes[0].traits.deterministic)
+        XCTAssertEqual(provider.requirement.nodeKinds, ["fixture.prepare"])
+    }
+
     private func writeCatalog() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("PluginCommandTests.\(UUID().uuidString)", isDirectory: true)
@@ -106,6 +126,19 @@ final class PluginCommandTests: XCTestCase {
         return catalogURL
     }
 }
+
+private let fixtureGraphProviderScript = #"""
+#!/bin/sh
+if [ "$1" = "manifest" ]; then
+  printf '%s\n' '{"contractVersion":"mere.run/plugin.v1","name":"mere-fixture-tools","version":"1.2.3","graphProvider":{"contractVersion":"mere.run/plugin-graph-provider.v1"}}'
+  exit 0
+fi
+if [ "$1" = "graph" ] && [ "$2" = "catalog" ]; then
+  printf '%s\n' '{"contract_version":"mere.run/plugin-graph-provider.v1","provider_id":"mere-fixture-tools","provider_version":"1.2.3","nodes":[{"kind":"fixture.prepare","title":"Prepare fixture","description":"Prepare deterministic fixture data.","category":"fixture","inputs":[{"name":"data","type":"asset_directory","required":true}],"outputs":[{"name":"dataset","type":"asset_directory","optional":false,"content_types":["application/vnd.mere.dataset"]},{"name":"stats","type":"json","optional":false}],"requirements":{"model_ids":[],"accelerator_backends":["cpu"],"minimum_accelerator_memory_bytes":null},"traits":{"deterministic":true,"cacheable":true,"side_effects":"none","supports_progress":true,"supports_previews":false}}]}'
+  exit 0
+fi
+exit 2
+"""#
 
 private let catalogJSON = """
 {

--- a/Tests/MereRunCLITests/WorkflowRelayExecutorTests.swift
+++ b/Tests/MereRunCLITests/WorkflowRelayExecutorTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+final class WorkflowRelayExecutorTests: XCTestCase {
+    func testTransientServerFailuresRetryUntilSuccess() async throws {
+        var attempts = 0
+        let result = try await RelayWorkflowExecutor.performWithTransientRetries(
+            maximumAttempts: 3,
+            delayNanoseconds: 0
+        ) {
+            attempts += 1
+            return (Data(), response(statusCode: attempts < 3 ? 500 : 200))
+        }
+
+        XCTAssertEqual(attempts, 3)
+        XCTAssertEqual(result.response.statusCode, 200)
+    }
+
+    func testClientFailureDoesNotRetry() async throws {
+        var attempts = 0
+        let result = try await RelayWorkflowExecutor.performWithTransientRetries(
+            maximumAttempts: 3,
+            delayNanoseconds: 0
+        ) {
+            attempts += 1
+            return (Data(), response(statusCode: 409))
+        }
+
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(result.response.statusCode, 409)
+    }
+
+    func testTransientTransportFailureRetries() async throws {
+        var attempts = 0
+        let result = try await RelayWorkflowExecutor.performWithTransientRetries(
+            maximumAttempts: 2,
+            delayNanoseconds: 0
+        ) {
+            attempts += 1
+            if attempts == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+            return (Data(), response(statusCode: 200))
+        }
+
+        XCTAssertEqual(attempts, 2)
+        XCTAssertEqual(result.response.statusCode, 200)
+    }
+
+    private func response(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://relay.example.test")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -100,7 +100,7 @@ artifacts. Build package artifacts locally on the Linux host class you intend to
 validate:
 
 ```bash
-scripts/package-linux.sh --version 0.21.0
+scripts/package-linux.sh --version 0.22.0
 ls dist/linux/
 ```
 
@@ -113,7 +113,7 @@ CUDA variants use a suffix so they can ship beside the CPU artifacts:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.22.0 --artifact-suffix cuda
 ```
 
 That writes artifacts such as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ commands, package checks, and CUDA validation limits, see
 [Linux QuickStart](./linux-quickstart.md).
 
 ```bash
-scripts/package-linux.sh --version 0.21.0
+scripts/package-linux.sh --version 0.22.0
 ls dist/linux/
 ```
 

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -31,7 +31,7 @@ Use this path on Debian or Ubuntu-style systems after building a matching
 `.deb`, or when a matching `.deb` is attached to a release:
 
 ```bash
-version=0.21.0
+version=0.22.0
 case "$(uname -m)" in
   x86_64|amd64) deb_arch=amd64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -51,7 +51,7 @@ Use this path after building a matching tarball, or when a matching tarball is
 attached to a release:
 
 ```bash
-version=0.21.0
+version=0.22.0
 case "$(uname -m)" in
   x86_64|amd64) linux_arch=x86_64 ;;
   *) echo "use the arm64 CUDA package path for Linux arm64" >&2; exit 1 ;;
@@ -79,7 +79,7 @@ hosts after building it, or when a matching CUDA tarball is attached to a
 release:
 
 ```bash
-version=0.21.0
+version=0.22.0
 tar -xzf "./dist/linux/mere-run-${version}-linux-x86_64-cuda.tar.gz"
 cd "mere-run-${version}-linux-x86_64-cuda"
 ./install.sh
@@ -130,7 +130,7 @@ x86_64 CUDA development host:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.22.0 --artifact-suffix cuda
 ls dist/linux/
 ```
 
@@ -144,7 +144,7 @@ MERERUN_LINUX_ACCEL=cuda \
 MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
 MERERUN_NATIVE_BUILD_JOBS=14 \
 MERERUN_CUDA_ARCHITECTURES="86-real;90-virtual" \
-  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.22.0 --artifact-suffix cuda
 ```
 
 Run a real GPU smoke on the target runtime class before widening support claims.
@@ -161,7 +161,7 @@ repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.21.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.22.0
 ls dist/linux/
 ```
 
@@ -255,7 +255,7 @@ When a Linux release includes `SHA256SUMS`, place it beside the matching
 tarball or `.deb` before checking it:
 
 ```bash
-tag=v0.21.0
+tag=v0.22.0
 
 curl -L "https://github.com/sawfwair/mere-run/releases/download/${tag}/SHA256SUMS" -o SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/docs/public/schemas/graph-event-v1.schema.json
+++ b/docs/public/schemas/graph-event-v1.schema.json
@@ -13,6 +13,12 @@
         "run_started",
         "node_preflight_started",
         "node_started",
+        "node_progress",
+        "preview_ready",
+        "artifact_ready",
+        "node_diagnostic",
+        "node_metric",
+        "node_heartbeat",
         "node_resumed",
         "node_finished",
         "run_finished",
@@ -27,6 +33,48 @@
       "type": ["string", "null"],
       "pattern": "^[a-z][a-z0-9-]{0,63}$"
     },
-    "message": { "type": ["string", "null"] }
+    "message": { "type": ["string", "null"] },
+    "progress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "phase": { "type": "string" },
+        "current": { "type": "number", "minimum": 0 },
+        "total": { "type": "number", "exclusiveMinimum": 0 },
+        "fraction": { "type": "number", "minimum": 0, "maximum": 1 },
+        "unit": { "type": "string" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path", "content_type"],
+      "properties": {
+        "name": { "type": "string" },
+        "path": { "type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$" },
+        "content_type": { "type": "string", "minLength": 1 }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "severity", "title", "message"],
+      "properties": {
+        "id": { "type": "string" },
+        "severity": { "enum": ["info", "warning", "blocker"] },
+        "title": { "type": "string" },
+        "message": { "type": "string" }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": { "type": "string" },
+        "value": { "type": "number" },
+        "unit": { "type": "string" }
+      }
+    }
   }
 }

--- a/docs/public/schemas/graph-node-event.v1.schema.json
+++ b/docs/public/schemas/graph-node-event.v1.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mere.run/contracts/graph-node-event.v1.schema.json",
+  "title": "mere.run Plugin Graph Node Event v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "sequence", "created_at", "type"],
+  "properties": {
+    "contract_version": {"const": "mere.run/plugin-graph-event.v1"},
+    "sequence": {"type": "integer", "minimum": 0},
+    "created_at": {"type": "string", "format": "date-time"},
+    "type": {"enum": ["progress", "preview_ready", "artifact_ready", "diagnostic", "metric", "heartbeat", "node_result"]},
+    "message": {"type": "string"},
+    "progress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "phase": {"type": "string"},
+        "current": {"type": "number", "minimum": 0},
+        "total": {"type": "number", "exclusiveMinimum": 0},
+        "fraction": {"type": "number", "minimum": 0, "maximum": 1},
+        "unit": {"type": "string"}
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path", "content_type"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+        "path": {"type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"},
+        "content_type": {"type": "string", "minLength": 1}
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "severity", "title", "message"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z][a-z0-9_-]{0,127}$"},
+        "severity": {"enum": ["info", "warning", "blocker"]},
+        "title": {"type": "string"},
+        "message": {"type": "string"}
+      }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "value": {"type": "number"},
+        "unit": {"type": "string"}
+      }
+    },
+    "outputs": {"type": "object", "additionalProperties": {"$ref": "#/$defs/value"}}
+  },
+  "$defs": {
+    "value": {
+      "anyOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "array", "items": {"$ref": "#/$defs/value"}},
+        {"type": "object", "additionalProperties": {"$ref": "#/$defs/value"}}
+      ]
+    }
+  }
+}

--- a/docs/public/schemas/graph-node-invocation.v1.schema.json
+++ b/docs/public/schemas/graph-node-invocation.v1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mere.run/contracts/graph-node-invocation.v1.schema.json",
+  "title": "mere.run Plugin Graph Node Invocation v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "job_id", "node_id", "kind", "arguments", "outputs"],
+  "properties": {
+    "contract_version": {"const": "mere.run/plugin-graph-invocation.v1"},
+    "job_id": {"type": "string", "format": "uuid"},
+    "node_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$"},
+    "kind": {"type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}(\\.[a-z][a-z0-9-]{0,63})+$"},
+    "arguments": {"type": "object", "additionalProperties": {"$ref": "#/$defs/value"}},
+    "outputs": {
+      "type": "object",
+      "propertyNames": {"pattern": "^[a-z][a-z0-9_]{0,63}$"},
+      "additionalProperties": {"$ref": "#/$defs/output"}
+    }
+  },
+  "$defs": {
+    "value": {
+      "anyOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "array", "items": {"$ref": "#/$defs/value"}},
+        {"type": "object", "additionalProperties": {"$ref": "#/$defs/value"}}
+      ]
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {"enum": ["string", "integer", "number", "boolean", "enum", "json", "asset", "asset_directory", "asset_collection"]},
+        "path": {"type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"},
+        "optional": {"type": "boolean"},
+        "content_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    }
+  }
+}

--- a/docs/public/schemas/graph-node-preflight.v1.schema.json
+++ b/docs/public/schemas/graph-node-preflight.v1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mere.run/contracts/graph-node-preflight.v1.schema.json",
+  "title": "mere.run Plugin Graph Node Preflight v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "status", "diagnostics", "requirements"],
+  "properties": {
+    "contract_version": {"const": "mere.run/plugin-graph-preflight.v1"},
+    "status": {"enum": ["ok", "warning", "blocked"]},
+    "diagnostics": {"type": "array", "items": {"$ref": "#/$defs/diagnostic"}},
+    "requirements": {"$ref": "#/$defs/requirements"}
+  },
+  "$defs": {
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "severity", "title", "message"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z][a-z0-9_-]{0,127}$"},
+        "severity": {"enum": ["info", "warning", "blocker"]},
+        "title": {"type": "string", "minLength": 1},
+        "message": {"type": "string", "minLength": 1},
+        "suggested_action_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model_ids", "accelerator_backends"],
+      "properties": {
+        "model_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "accelerator_backends": {"type": "array", "uniqueItems": true, "items": {"enum": ["metal", "cuda", "rocm", "cpu"]}},
+        "minimum_accelerator_memory_bytes": {"type": ["integer", "null"], "minimum": 0}
+      }
+    }
+  }
+}

--- a/docs/public/schemas/graph-node-provider.v1.schema.json
+++ b/docs/public/schemas/graph-node-provider.v1.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mere.run/contracts/graph-node-provider.v1.schema.json",
+  "title": "mere.run Plugin Graph Node Provider v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "provider_id", "provider_version", "nodes"],
+  "properties": {
+    "contract_version": {"const": "mere.run/plugin-graph-provider.v1"},
+    "provider_id": {"$ref": "#/$defs/provider_id"},
+    "provider_version": {"$ref": "#/$defs/version"},
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/node"}
+    }
+  },
+  "$defs": {
+    "provider_id": {"type": "string", "pattern": "^mere-[a-z0-9-]+$"},
+    "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+([.-][A-Za-z0-9.-]+)?$"},
+    "id": {"type": "string", "pattern": "^[a-z][a-z0-9_]{0,63}$"},
+    "node_kind": {"type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}(\\.[a-z][a-z0-9-]{0,63})+$"},
+    "value": {
+      "anyOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "array", "items": {"$ref": "#/$defs/value"}},
+        {"type": "object", "additionalProperties": {"$ref": "#/$defs/value"}}
+      ]
+    },
+    "port_type": {
+      "enum": ["string", "integer", "number", "boolean", "enum", "json", "asset", "asset_directory", "asset_collection"]
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "required"],
+      "properties": {
+        "name": {"$ref": "#/$defs/id"},
+        "type": {"$ref": "#/$defs/port_type"},
+        "required": {"type": "boolean"},
+        "description": {"type": "string"},
+        "default": {"$ref": "#/$defs/value"},
+        "values": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "content_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "minimum": {"type": "number"},
+        "maximum": {"type": "number"},
+        "step": {"type": "number", "exclusiveMinimum": 0},
+        "multiline": {"type": "boolean"},
+        "secret": {"type": "boolean"},
+        "advanced": {"type": "boolean"}
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "optional"],
+      "properties": {
+        "name": {"$ref": "#/$defs/id"},
+        "type": {"$ref": "#/$defs/port_type"},
+        "optional": {"type": "boolean"},
+        "description": {"type": "string"},
+        "content_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model_ids", "accelerator_backends"],
+      "properties": {
+        "model_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "accelerator_backends": {"type": "array", "uniqueItems": true, "items": {"enum": ["metal", "cuda", "rocm", "cpu"]}},
+        "minimum_accelerator_memory_bytes": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "traits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deterministic", "cacheable", "side_effects", "supports_progress", "supports_previews"],
+      "properties": {
+        "deterministic": {"type": "boolean"},
+        "cacheable": {"type": "boolean"},
+        "side_effects": {"enum": ["none", "local", "external"]},
+        "supports_progress": {"type": "boolean"},
+        "supports_previews": {"type": "boolean"}
+      }
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "title", "description", "category", "inputs", "outputs", "requirements", "traits"],
+      "properties": {
+        "kind": {"$ref": "#/$defs/node_kind"},
+        "title": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "category": {"type": "string", "minLength": 1},
+        "inputs": {"type": "array", "items": {"$ref": "#/$defs/input"}},
+        "outputs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/output"}},
+        "requirements": {"$ref": "#/$defs/requirements"},
+        "traits": {"$ref": "#/$defs/traits"}
+      }
+    }
+  }
+}

--- a/docs/public/schemas/graph-run-v1.schema.json
+++ b/docs/public/schemas/graph-run-v1.schema.json
@@ -40,9 +40,53 @@
         "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
       }
     },
+    "provider": {
+      "type": "object",
+      "required": ["id", "version", "catalog_sha256"],
+      "properties": {
+        "id": { "type": "string" },
+        "version": { "type": "string" },
+        "catalog_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["id", "catalog_sha256"],
+      "properties": {
+        "id": { "type": "string" },
+        "repository": { "type": "string" },
+        "revision": { "type": "string" },
+        "catalog_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "install_manifest_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
+    "value": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "string" },
+        { "type": "integer" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "array", "items": { "$ref": "#/$defs/value" } },
+        { "type": "object", "additionalProperties": { "$ref": "#/$defs/value" } }
+      ]
+    },
+    "node_output": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": { "type": "string" },
+        "type": { "enum": ["string", "integer", "number", "boolean", "enum", "json", "asset", "asset_directory", "asset_collection", "asset_array"] },
+        "value": { "$ref": "#/$defs/value" },
+        "path": { "type": "string" },
+        "content_type": { "type": "string" },
+        "size_bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    },
     "node": {
       "type": "object",
-      "required": ["id", "kind", "state", "fingerprint", "artifacts"],
+      "required": ["id", "kind", "state", "fingerprint", "models", "artifacts", "outputs"],
       "properties": {
         "id": { "type": "string" },
         "kind": { "type": "string" },
@@ -51,7 +95,10 @@
         "completed_at": { "type": ["string", "null"], "format": "date-time" },
         "exit_status": { "type": ["integer", "null"] },
         "fingerprint": { "type": "string" },
+        "provider": { "$ref": "#/$defs/provider" },
+        "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },
         "artifacts": { "type": "array", "items": { "$ref": "#/$defs/artifact" } },
+        "outputs": { "type": "array", "items": { "$ref": "#/$defs/node_output" } },
         "error": { "type": ["string", "null"] }
       }
     }

--- a/docs/public/schemas/job-bundle-v1.schema.json
+++ b/docs/public/schemas/job-bundle-v1.schema.json
@@ -14,11 +14,13 @@
     "requirements": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["minimum_mere_run_version", "node_kinds", "model_ids", "accelerator_backends"],
+      "required": ["minimum_mere_run_version", "node_kinds", "model_ids", "models", "providers", "accelerator_backends"],
       "properties": {
         "minimum_mere_run_version": { "type": "string", "minLength": 1 },
         "node_kinds": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "model_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },
+        "providers": { "type": "array", "items": { "$ref": "#/$defs/provider" } },
         "accelerator_backends": { "type": "array", "items": { "enum": ["metal", "cuda", "rocm", "cpu"] }, "uniqueItems": true },
         "minimum_accelerator_memory_bytes": { "type": ["integer", "null"], "minimum": 0 }
       }
@@ -33,6 +35,32 @@
           "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
           "reference": { "type": "string", "pattern": "^nodes\\.[a-z][a-z0-9-]{0,63}\\.outputs\\.[a-z][a-z0-9-]{0,63}$" }
         }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "catalog_sha256"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string" },
+        "revision": { "type": "string" },
+        "catalog_sha256": { "$ref": "#/$defs/sha256" },
+        "install_manifest_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "catalog_sha256", "node_kinds"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^mere-[a-z0-9-]+$" },
+        "version": { "type": "string", "minLength": 1 },
+        "catalog_sha256": { "$ref": "#/$defs/sha256" },
+        "node_kinds": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
       }
     }
   }

--- a/docs/public/schemas/worker-probe-v1.schema.json
+++ b/docs/public/schemas/worker-probe-v1.schema.json
@@ -4,7 +4,7 @@
   "title": "mere.run Graph Worker Probe V1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "worker_version", "contract_versions", "platform", "architecture", "accelerator_backend", "memory_bytes", "node_kinds", "installed_model_ids"],
+  "required": ["schema_version", "worker_version", "contract_versions", "platform", "architecture", "accelerator_backend", "memory_bytes", "node_kinds", "installed_model_ids", "providers"],
   "properties": {
     "schema_version": { "const": 1 },
     "worker_version": { "type": "string" },
@@ -15,6 +15,20 @@
     "memory_bytes": { "type": "integer", "minimum": 0 },
     "available_disk_bytes": { "type": ["integer", "null"], "minimum": 0 },
     "node_kinds": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
-    "installed_model_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+    "installed_model_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "providers": { "type": "array", "items": { "$ref": "#/$defs/provider" } }
+  },
+  "$defs": {
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "catalog_sha256", "node_kinds"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^mere-[a-z0-9-]+$" },
+        "version": { "type": "string", "minLength": 1 },
+        "catalog_sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "node_kinds": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    }
   }
 }

--- a/docs/public/schemas/workflow-graph-v1.schema.json
+++ b/docs/public/schemas/workflow-graph-v1.schema.json
@@ -59,7 +59,7 @@
       "additionalProperties": false,
       "required": ["type"],
       "properties": {
-        "type": { "enum": ["string", "integer", "number", "boolean", "enum", "asset", "asset_directory"] },
+        "type": { "$ref": "#/$defs/port_type" },
         "required": { "type": "boolean" },
         "default": { "$ref": "#/$defs/value" },
         "values": { "type": "array", "items": { "type": "string" }, "minItems": 1, "uniqueItems": true },
@@ -72,10 +72,14 @@
       "required": ["id", "kind", "arguments"],
       "properties": {
         "id": { "$ref": "#/$defs/id" },
-        "kind": { "enum": ["image.train-lora", "image.generate", "video.generate"] },
+        "kind": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}(\\.[a-z][a-z0-9-]{0,63})+$" },
+        "provider": { "type": "string", "pattern": "^(mere\\.run|mere-[a-z0-9-]+)$" },
         "arguments": { "type": "object", "additionalProperties": { "$ref": "#/$defs/value" } },
         "depends_on": { "type": "array", "items": { "$ref": "#/$defs/id" }, "uniqueItems": true }
       }
+    },
+    "port_type": {
+      "enum": ["string", "integer", "number", "boolean", "enum", "json", "asset", "asset_directory", "asset_collection", "asset_array"]
     }
   }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,7 +96,7 @@ CUDA validation on a host that has not run the path.
 Linux release packaging has its own artifact check:
 
 ```bash
-scripts/package-linux.sh --version 0.21.0
+scripts/package-linux.sh --version 0.22.0
 test -s dist/linux/SHA256SUMS
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/mere.run$'
 tar -tzf dist/linux/mere-run-*-linux-*.tar.gz | grep '/install.sh$'
@@ -109,7 +109,7 @@ Linux builder with CUDA development packages:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
-  scripts/package-linux.sh --version 0.21.0 --artifact-suffix cuda
+  scripts/package-linux.sh --version 0.22.0 --artifact-suffix cuda
 tar -tzf dist/linux/mere-run-*-linux-x86_64-cuda.tar.gz | grep '/.mererun-linux-cuda$'
 dpkg-deb --info dist/linux/mere-run-cuda_*_amd64.deb
 ```
@@ -125,7 +125,7 @@ major gate.
 On Linux arm64, use CUDA for the package check:
 
 ```bash
-MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.21.0
+MERERUN_LINUX_ACCEL=cuda scripts/package-linux.sh --version 0.22.0
 ```
 
 Run Linux package and manifest checks on the affected Linux host class. CUDA

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -29,6 +29,35 @@ The V1 node catalog contains:
 - `image.generate`
 - `video.generate`
 
+Companion plugins may add typed nodes without adding arbitrary command or
+Python execution to the graph ABI. Plugin nodes name their provider explicitly:
+
+```json
+{
+  "id": "prepare",
+  "kind": "dataset.prepare",
+  "provider": "mere-dataset-tools",
+  "arguments": {
+    "data": {"$ref": "inputs.data"}
+  }
+}
+```
+
+Providers use one fixed machine protocol:
+
+```bash
+PLUGIN graph catalog --json
+PLUGIN graph preflight --request invocation.json --run-dir PATH --json
+PLUGIN graph execute --request invocation.json --run-dir PATH --json-stream
+```
+
+The catalog describes `string`, `integer`, `number`, `boolean`, `enum`,
+`json`, `asset`, `asset_directory`, and `asset_collection` ports, including
+defaults, ranges, content types, model and accelerator requirements, progress,
+preview, determinism, caching, and side-effect traits. `mere.run` validates the
+catalog and invokes only these fixed verbs. A plugin manifest cannot inject a
+command template.
+
 Inspect the exact typed fields and output descriptors with:
 
 ```bash
@@ -56,8 +85,9 @@ mere.run graph preflight workflow.json --inputs-json inputs.json --executor rela
 
 Validation is executor-independent. Preflight combines graph diagnostics with a
 worker capability probe, including contract version, node kinds, installed
-models, accelerator backend, memory, and available disk. Missing models produce
-declarative pull actions; V1 never pulls models automatically on a worker.
+models, exact provider versions and catalog digests, accelerator backend,
+memory, and available disk. Missing models produce declarative pull actions; V1
+never pulls models automatically on a worker.
 
 ## Portable job bundles
 
@@ -86,6 +116,12 @@ assets.json
 assets/sha256/<digest>
 ```
 
+The job pins each companion provider by ID, semantic version, catalog SHA-256,
+and node kinds. It also records managed model repository, revision, and catalog
+identity. At execution time the run record adds the installed model manifest
+digest when one is available. Adapter and other asset inputs retain their full
+content digests.
+
 The bundle contains relative paths only. Directory entries are ordered and
 content-addressed. Symlinks, device files, path traversal, and files escaping a
 declared directory root are rejected. Executor profiles, tokens, URLs, and
@@ -112,8 +148,11 @@ adapted to deterministic public CLI arguments and launched as an isolated
 diagnostic stderr, records exit status, verifies every declared artifact, and
 honors a cooperative cancellation marker.
 
-`--resume` reuses a finished node only when its fingerprint and every artifact
-size and SHA-256 still match.
+`--resume` reuses a finished node only when its provider pin, normalized
+arguments, exact model provenance, directly referenced upstream outputs, and
+every output digest still match. Unrelated branches do not invalidate each
+other. File, directory, collection, scalar, and JSON outputs retain their typed
+identity in the node run record.
 
 ## Run directories
 
@@ -151,8 +190,10 @@ mere.run graph worker inspect --run-dir PATH --json
 mere.run graph worker cancel --run-dir PATH --json
 ```
 
-`execute --json-stream` emits the run event model as NDJSON on stdout. Progress
-and diagnostics stay on stderr.
+`execute --json-stream` emits the run event model as NDJSON on stdout. It
+preserves node progress, preview, artifact, diagnostic, metric, heartbeat, and
+lifecycle events. Diagnostics produced outside the machine protocol stay on
+stderr.
 
 The versioned contracts are published under `docs/public/schemas`, including the
 [Graph Event V1 schema](./public/schemas/graph-event-v1.schema.json), workflow
@@ -266,3 +307,7 @@ node kind or model, accelerator backend or memory, and available disk.
 - [Job Bundle V1](/schemas/job-bundle-v1.schema.json)
 - [Graph Run V1](/schemas/graph-run-v1.schema.json)
 - [Worker Probe V1](/schemas/worker-probe-v1.schema.json)
+- [Plugin Graph Provider V1](/schemas/graph-node-provider.v1.schema.json)
+- [Plugin Graph Invocation V1](/schemas/graph-node-invocation.v1.schema.json)
+- [Plugin Graph Preflight V1](/schemas/graph-node-preflight.v1.schema.json)
+- [Plugin Graph Event V1](/schemas/graph-node-event.v1.schema.json)

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.21.0"
+default_version="0.22.0"
 if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary
- add provider-qualified portable graph nodes with typed ports, exact provider version/catalog pins, discovery, preflight, worker capabilities, and structured NDJSON events
- add dependency-scoped fingerprints plus exact model, adapter, and provider provenance for verified resume and deterministic retry
- harden relay asset uploads with bounded transient retry and publish the 0.22.0 release metadata and contracts

## Verification
- `./scripts/check.sh`
  - 923 Swift files linted with zero violations
  - 1,784 XCTest cases passed, 116 model-gated skips, zero failures
  - 10 Swift Testing cases passed
  - build, CLI help sweep, and hygiene scans passed
- `swift build -c release --product mere.run`
- release binary reports `0.22.0`, SHA-256 `a7164d5339ab861ba1099c9c3691faf2d3ed048a664e21ec72e7d41d6f1b0e08`
- mixed `dataset.prepare -> image.train-lora -> image.generate` graph completed locally and through authenticated production relay using `/Users/nerd/projects/animatic/data`; fetched artifact hashes matched
- SSH graph execution completed on `book.local` and CUDA `tensor.local`
- exact `mere-dataset-tools@0.2.0` provider/catalog capability was advertised by local, SSH, and relay workers

## Scope
No visual editor, arbitrary command/Python graph nodes, provider-specific executor, automatic model pulling, cross-machine node scattering, or tensor/latent public edges.