### PR TITLE
Fix graph preflight process diagnostics

### DIFF
--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -610,7 +610,10 @@ struct ImageGenerationPreflightAnalyzer {
         return ImageGenerationStructuredPromptPreflightSummary(
             enabled: input.structuredPrompt,
             model: input.structuredPromptModel,
-            backend: StructuredImagePromptAdapter.backendDescription(for: input.structuredPromptModel),
+            backend: StructuredImagePromptAdapter.backendDescription(
+                for: input.structuredPromptModel,
+                includeDefaultDevice: false
+            ),
             modelRoot: modelRoot,
             maxTokens: input.structuredPromptMaxTokens,
             output: output,

--- a/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
+++ b/Sources/MereRunCLI/Support/StructuredImagePromptAdapter.swift
@@ -23,7 +23,7 @@ enum StructuredImagePromptAdapter {
     static let defaultMaxTokens = 2_048
     static let recommendedImagePromptTokens = 2_048
 
-    static func backendDescription(for modelID: String) -> String {
+    static func backendDescription(for modelID: String, includeDefaultDevice: Bool = true) -> String {
         let normalizedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if normalizedModelID == "text-agent-deepseek-v4-flash" {
             return "external DeepSeek V4 Flash bridge"
@@ -31,7 +31,9 @@ enum StructuredImagePromptAdapter {
         if ManagedModelCatalog.spec(for: normalizedModelID)?.validationKind == .codegenGGUF {
             return "llama.cpp/GGUF"
         }
-        return NativeMLXRuntime.backendDescription
+        return includeDefaultDevice
+            ? NativeMLXRuntime.backendDescription
+            : NativeMLXRuntime.backendFamilyDescription
     }
 
     static func expand(

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -24,6 +24,74 @@ struct WorkflowRunOutcome: Codable, Equatable {
 struct WorkflowProcessResult: Equatable {
     let status: Int32
     let stdout: String
+    let stderr: String
+    let terminationReason: WorkflowProcessTerminationReason
+
+    init(
+        status: Int32,
+        stdout: String,
+        stderr: String = "",
+        terminationReason: WorkflowProcessTerminationReason = .exit
+    ) {
+        self.status = status
+        self.stdout = stdout
+        self.stderr = stderr
+        self.terminationReason = terminationReason
+    }
+
+    var failureSummary: String {
+        var summary = terminationReason == .uncaughtSignal
+            ? "terminated by signal \(status)"
+            : "exited with status \(status)"
+        if !stderr.isEmpty {
+            summary += ". stderr: \(stderr)"
+        } else if !stdout.isEmpty {
+            summary += ". stdout: \(stdout.suffix(16 * 1_024))"
+        }
+        return summary
+    }
+}
+
+enum WorkflowProcessTerminationReason: String, Equatable {
+    case exit
+    case uncaughtSignal = "uncaught_signal"
+
+    init(_ reason: Process.TerminationReason) {
+        switch reason {
+        case .exit:
+            self = .exit
+        case .uncaughtSignal:
+            self = .uncaughtSignal
+        @unknown default:
+            self = .exit
+        }
+    }
+}
+
+private final class WorkflowProcessStderrTail: @unchecked Sendable {
+    private static let maximumBytes = 16 * 1_024
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ newData: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        if newData.count >= Self.maximumBytes {
+            data = Data(newData.suffix(Self.maximumBytes))
+            return
+        }
+        data.append(newData)
+        if data.count > Self.maximumBytes {
+            data.removeFirst(data.count - Self.maximumBytes)
+        }
+    }
+
+    var string: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }
 
 protocol WorkflowProcessRunning {
@@ -64,6 +132,8 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         process.arguments = arguments
         process.currentDirectoryURL = currentDirectory
         let stdout = Pipe()
+        let stderr = Pipe()
+        let stderrTail = WorkflowProcessStderrTail()
         let runDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
         let processIDURL = runDirectory.appendingPathComponent("worker-child.pid")
         defer {
@@ -71,7 +141,13 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         }
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = stdout
-        process.standardError = FileHandle.standardError
+        process.standardError = stderr
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            stderrTail.append(data)
+            try? FileHandle.standardError.write(contentsOf: data)
+        }
         try process.run()
         try Data(String(process.processIdentifier).utf8).write(to: processIDURL, options: .atomic)
         var captured = Data()
@@ -91,6 +167,12 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
             }
         }
         process.waitUntilExit()
+        stderr.fileHandleForReading.readabilityHandler = nil
+        let remainingStderr = stderr.fileHandleForReading.readDataToEndOfFile()
+        if !remainingStderr.isEmpty {
+            stderrTail.append(remainingStderr)
+            try? FileHandle.standardError.write(contentsOf: remainingStderr)
+        }
         if !pending.isEmpty {
             let line = String(decoding: pending, as: UTF8.self)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -101,7 +183,9 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         }
         return WorkflowProcessResult(
             status: process.terminationStatus,
-            stdout: String(decoding: captured, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            stdout: String(decoding: captured, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines),
+            stderr: stderrTail.string,
+            terminationReason: WorkflowProcessTerminationReason(process.terminationReason)
         )
     }
 }
@@ -289,7 +373,7 @@ struct WorkflowRunner {
                     options: .atomic
                 )
                 guard preflight.status == 0 else {
-                    throw ValidationError("Node '\(nodeID)' preflight failed with status \(preflight.status).")
+                    throw ValidationError("Node '\(nodeID)' preflight \(preflight.failureSummary).")
                 }
                 if invocation.streamsEvents {
                     let report = try WorkflowBundleCodec.decoder().decode(

--- a/Sources/MereRunCore/Support/NativeMLXRuntime.swift
+++ b/Sources/MereRunCore/Support/NativeMLXRuntime.swift
@@ -2,6 +2,14 @@ import Foundation
 import MLX
 
 public enum NativeMLXRuntime {
+    public static var backendFamilyDescription: String {
+        #if os(macOS) || os(iOS)
+        return "native MLX/Metal"
+        #else
+        return "native MLX"
+        #endif
+    }
+
     public static var defaultDeviceType: String {
         Device.defaultDevice().deviceType?.rawValue ?? "unknown"
     }

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -276,6 +276,7 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         let decoded = try decoder.decode(ImageGenerationPreflightEnvelope.self, from: Data(encoded.utf8))
         XCTAssertEqual(decoded.status, .ok)
         XCTAssertEqual(decoded.result.model.family, "zimage")
+        XCTAssertFalse(decoded.result.structuredPrompt.backend.contains("default device"))
 
         let encodedPlan = try StructuredRunOutput.encode(envelope.result.runPlan)
         let planURL = temp.appendingPathComponent("generate.plan.json")

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -254,6 +254,25 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertFalse(first.lastPathComponent.contains("UUID()"))
     }
 
+    func testWorkflowChildCapturesStderrAndTerminationReason() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let nodeDirectory = root.appendingPathComponent("run/nodes/000-fixture", isDirectory: true)
+        try FileManager.default.createDirectory(at: nodeDirectory, withIntermediateDirectories: true)
+
+        let result = try WorkflowProcessRunner().run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf 'fixture failure' >&2; exit 7"],
+            currentDirectory: nodeDirectory,
+            stdoutLineHandler: nil
+        )
+
+        XCTAssertEqual(result.status, 7)
+        XCTAssertEqual(result.stderr, "fixture failure")
+        XCTAssertEqual(result.terminationReason, .exit)
+        XCTAssertEqual(result.failureSummary, "exited with status 7. stderr: fixture failure")
+    }
+
     func testMaterializationFreezesSeedAndCanonicalFingerprints() throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -448,6 +467,34 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertTrue(process.arguments[1].contains("--quiet"))
         XCTAssertEqual(outcome.outputs.count, 1)
         XCTAssertEqual(outcome.outputs[0].contentType, "image/png")
+    }
+
+    func testRunnerPersistsPreflightOutputInFailureDiagnostic() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bundle = try WorkflowBundleMaterializer(
+            graph: singleImageGraph(),
+            suppliedInputs: .init(values: ["prompt": .string("a lighthouse")]),
+            destination: root.appendingPathComponent("bundle"),
+            seed: { 99 }
+        ).materialize()
+        let runDirectory = root.appendingPathComponent("run")
+
+        let outcome = try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: runDirectory,
+            processRunner: FailingPreflightWorkflowProcessRunner()
+        ).execute()
+        let manifest = try WorkflowBundleCodec.decoder().decode(
+            GraphRunManifest.self,
+            from: Data(contentsOf: runDirectory.appendingPathComponent(GraphRunManifest.filename))
+        )
+
+        XCTAssertEqual(outcome.state, .failed)
+        XCTAssertEqual(
+            manifest.error,
+            "Node 'generate' preflight exited with status 255. stdout: fixture model failure."
+        )
     }
 
     func testResumeRequiresMatchingNodeFingerprintAndArtifactDigests() throws {
@@ -729,5 +776,11 @@ private final class FixtureWorkflowProcessRunner: WorkflowProcessRunning {
         try FileManager.default.createDirectory(at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data([0x89, 0x50, 0x4e, 0x47]).write(to: output)
         return WorkflowProcessResult(status: 0, stdout: "ok")
+    }
+}
+
+private struct FailingPreflightWorkflowProcessRunner: WorkflowProcessRunning {
+    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
+        WorkflowProcessResult(status: 255, stdout: "fixture model failure")
     }
 }


### PR DESCRIPTION
## Summary

- keep image-generation preflight declarative by describing the native MLX backend without initializing a Metal device
- capture a bounded child-process stderr tail while preserving live diagnostics
- report termination reason and stderr/stdout details in failed graph-node preflights

## Root cause

The signed relay node exposed an image preflight that exited 255 when its selected release CLI had no adjacent MLX metallib. Preflight was only describing the structured-prompt backend, but that description called `Device.defaultDevice()`, which initialized MLX before execution's existing metallib validation and self-heal could run. The workflow runner then reduced the native fatal message to only `status 255`.

Preflight now uses non-initializing backend-family metadata. Actual execution still validates the stamped metallib before loading MLX.

## Validation

- `./scripts/check.sh`
  - 923 Swift files linted with zero violations
  - 1,786 XCTest cases passed, 116 expected asset-gated skips
  - 10 Swift Testing cases passed
  - CLI help and hygiene sweeps passed
- isolated preflight with no metallib, arbitrary `/tmp` cwd, and inherited XPC app identity exits 0 with structured JSON
- production relay retry through the signed node completed, fetched all artifacts, and every advertised SHA-256 matched
