### PR TITLE
Add native face analysis models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           bundle="$(swift build --show-bin-path)/MereRun.app"
           test -x "${bundle}/Contents/MacOS/mere.run.app"
           test -x "${bundle}/Contents/Helpers/mere.run"
+          find "${bundle}/Contents/Helpers" -maxdepth 1 -name 'libonnxruntime*.dylib' -print -quit | grep -q .
+          test -f "${bundle}/Contents/Resources/ThirdPartyLicenses/THIRD_PARTY_NOTICES.md"
           "${bundle}/Contents/Helpers/mere.run" --version
           # Executable code must not live under Contents/Resources (notarization rule).
           if find "${bundle}/Contents/Resources" -type f -perm -111 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added managed Buffalo-L face analysis through `vision face detect`, `embed`,
+  `compare`, and warm-session `batch`, including RetinaFace-style boxes and five-point landmarks,
+  normalized 512-dimensional ArcFace embeddings, CPU/CoreML execution-provider
+  controls, machine-readable JSON, and exact checkpoint validation.
+
 - added constrained `json_object` generation for native MLX Gemma and
   Qwen-family chat models through OpenAI `response_format` and the new
   `text chat --response-format json_object` option. The runtime now enforces a

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "eb31f3ceacb915ec386e829e26d2390d5eb31b6c1ffbf48e1a6d8370d59c02e0",
+  "originHash" : "733d36da47174bd4d6075608a2611d1f7b8231e07fb2228196af4818630e4ac5",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -233,6 +233,15 @@
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-onnxruntime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/readdle/swift-onnxruntime.git",
+      "state" : {
+        "revision" : "f5c95540cc857b797c0d61cc62e398ad8688e5de",
+        "version" : "1.20.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -149,6 +149,18 @@ mereRunCoreDependencies.append(contentsOf: mlxDependency("MLXRandom"))
 mereRunCoreDependencies.append("AudioCodecs")
 mereRunCoreDependencies.append(.product(name: "Crypto", package: "swift-crypto"))
 mereRunCoreDependencies.append(.product(name: "Transformers", package: "swift-transformers"))
+if !isLinuxPackage {
+  mereRunCoreDependencies.append(
+    .product(
+      name: "CONNXRuntime",
+      package: "swift-onnxruntime",
+      condition: .when(platforms: [.macOS])
+    )
+  )
+  mereRunCoreDependencies.append(
+    .target(name: "COnnxRuntimeCoreML", condition: .when(platforms: [.macOS]))
+  )
+}
 
 if hasMediaIOTarget {
   products.append(.library(name: "MediaIO", targets: ["MediaIO"]))
@@ -206,6 +218,22 @@ if hasMagentaRT2Binary {
     )
   )
   mereRunCoreDependencies.append(.target(name: "magentart"))
+}
+if !isLinuxPackage {
+  targets.append(
+    .target(
+      name: "COnnxRuntimeCoreML",
+      dependencies: [
+        .product(
+          name: "CONNXRuntime",
+          package: "swift-onnxruntime",
+          condition: .when(platforms: [.macOS])
+        )
+      ],
+      path: "Sources/COnnxRuntimeCoreML",
+      publicHeadersPath: "include"
+    )
+  )
 }
 
 let linuxNativeLlamaLibraryPath = packagePath(".build/native/linux-\(hostArch)/llama/lib").path
@@ -282,6 +310,7 @@ targets.append(contentsOf: [
       "Decode/README.md",
       "DeepseekV4Flash/README.md",
       "DepthAnything3/README.md",
+      "FaceAnalysis/README.md",
       "FalconPerception/README.md",
       "Flux2Klein/README.md",
       "Flux2Klein/Model/Transformer/README.md",
@@ -431,7 +460,7 @@ if !isLinuxPackage {
   )
 }
 
-let packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
+var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.0")
 ]) + [
   .package(
@@ -442,6 +471,11 @@ let packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")
 ]
+if !isLinuxPackage {
+  packageDependencies.append(
+    .package(url: "https://github.com/readdle/swift-onnxruntime.git", exact: "1.20.1")
+  )
+}
 
 let package = Package(
   name: "MereRun",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mere.run guide --list
 For a small first image workflow:
 
 ```bash
-mere.run model pull image-zimage-nano
+mere.run model pull image-zimage-nano --accept-model-license
 mere.run image generate \
   --model image-zimage-nano \
   --prompt "a ceramic mug in soft morning light" \
@@ -262,9 +262,9 @@ swift run mere.run model capabilities --recommended
 swift run mere.run setup
 
 # Pull a Hugging Face-backed model into the local model store
-swift run mere.run model pull image-zimage-nano
-swift run mere.run model pull image-zimage-nano --preflight --json
-swift run mere.run model pull text-chat-lfm25-a1b-8bit
+swift run mere.run model pull image-zimage-nano --accept-model-license
+swift run mere.run model pull image-zimage-nano --accept-model-license --preflight --json
+swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 swift run mere.run model pull text-code-north-mini
 swift run mere.run model pull text-agent-ornith-35b
 # text-agent-ornith-35b-mlx is local-only until a converted MLX snapshot is published
@@ -394,7 +394,7 @@ curl http://127.0.0.1:8080/v1/audio/transcriptions \
 
 # Optional Open WebUI companion smoke
 swift run mere.run open-webui quickstart --dry-run
-swift run mere.run open-webui quickstart --pull
+swift run mere.run open-webui quickstart --pull --accept-model-license
 swift run mere.run guide open-webui
 scripts/smoke-open-webui.sh print-env
 scripts/smoke-open-webui.sh live-smoke
@@ -501,7 +501,7 @@ swift run mere.run vision face detect ./group.jpg --json
 swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
 
 # Segment an image
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision segment ./image.png --prompt "a person"
 
 # Track prompted objects through a video
@@ -541,7 +541,7 @@ swift run mere.run music analyze ./song.mp3 \
   > ./song-analysis.json
 
 # Transcribe a full mix into instrument-separated MIDI with MuScriptor
-swift run mere.run model pull music-muscriptor-medium
+swift run mere.run model pull music-muscriptor-medium --accept-model-license
 swift run mere.run music transcribe ./song.mp3 \
   --output ./song.mid \
   --context-output ./song-context.json
@@ -582,8 +582,8 @@ swift run mere.run music realtime \
   --midi-cc 2=drums:0:2
 
 # Generate a Foley / sound-effect WAV with Woosh or MMAudio
-swift run mere.run model pull sfx-woosh-dflow
-swift run mere.run model pull sfx-woosh-flow
+swift run mere.run model pull sfx-woosh-dflow --accept-model-license
+swift run mere.run model pull sfx-woosh-flow --accept-model-license
 swift run mere.run sfx generate \
   "metal wrench dropping onto concrete, bright clang and brief ring" \
   --model sfx-woosh-dflow \
@@ -594,8 +594,8 @@ swift run mere.run sfx ae decode ./wrench-clang-latents.npy -o ./wrench-clang-ro
 swift run mere.run sfx clap score \
   "metal wrench dropping onto concrete" \
   ./wrench-clang.wav
-swift run mere.run model pull sfx-woosh-dvflow-8s
-swift run mere.run model pull sfx-woosh-synchformer
+swift run mere.run model pull sfx-woosh-dvflow-8s --accept-model-license
+swift run mere.run model pull sfx-woosh-synchformer --accept-model-license
 swift run mere.run sfx video generate \
   "footsteps echoing in a hallway" \
   ./silent-hallway.mp4 \
@@ -608,7 +608,7 @@ swift run mere.run sfx video generate \
   --output ./hallway-footsteps.wav \
   --preflight \
   --json
-swift run mere.run model pull sfx-mmaudio-large-44k-v2
+swift run mere.run model pull sfx-mmaudio-large-44k-v2 --accept-model-license
 swift run mere.run sfx generate \
   "ocean waves striking a stone breakwater" \
   --negative-prompt "speech, music" \
@@ -649,7 +649,7 @@ swift run mere.run video generate \
   --output ./clip-directed.mp4
 
 # Generate synchronized LTX 2.3 audio/video
-swift run mere.run model pull video-ltx23-av-mlx
+swift run mere.run model pull video-ltx23-av-mlx --accept-model-license
 swift run mere.run video generate \
   "dialogue with clean background music and subtle city ambience" \
   --variant unified-av \

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ swift run mere.run model pull vision-ground-falcon-perception
 swift run mere.run vision ground ./image.png --query "a person"
 
 # Detect and compare faces locally
-swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run model pull vision-face-buffalo-l --accept-model-license
 swift run mere.run vision face detect ./group.jpg --json
 swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ current flags.
 | --- | --- | --- |
 | Images and LoRAs | `image generate`, `image train-lora`, `adapter list`, `adapter pull` | Klein, ZImage, HiDream O1, Krea 2, Ideogram 4, and Bonsai; text-to-image, edits, multiple references, structured prompts, local Krea/Klein training, and checksum-pinned public adapters |
 | Text, code, and agents | `text chat`, `text code`, `text embed`, `text anonymize`, `text train-lora`, `agent` | Local chat and tool use, code generation, embeddings, PII redaction, text LoRA training, and guided local-agent setup |
-| Vision understanding | `vision caption`, `inspect`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
+| Vision understanding | `vision caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
 | Video and worlds | `video generate`, `video export-latents`, `world serve` | LTX video, synchronized LTX 2.3 audio/video, Wan 2.2 TI2V, and a warm DreamX causal world session with camera-conditioned transitions |
 | Music and sound | `music analyze`, `generate`, `realtime`, `transcribe`; `sfx generate`, `sfx video generate` | ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
@@ -494,6 +494,11 @@ swift run mere.run vision inspect ./image.png "Describe this image."
 # Ground objects in an image
 swift run mere.run model pull vision-ground-falcon-perception
 swift run mere.run vision ground ./image.png --query "a person"
+
+# Detect and compare faces locally
+swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run vision face detect ./group.jpg --json
+swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
 
 # Segment an image
 swift run mere.run model pull vision-segment-sam31

--- a/Sources/COnnxRuntimeCoreML/COnnxRuntimeCoreML.c
+++ b/Sources/COnnxRuntimeCoreML/COnnxRuntimeCoreML.c
@@ -1,0 +1,6 @@
+#include "COnnxRuntimeCoreML.h"
+#include <coreml_provider_factory.h>
+
+OrtStatus *MereRunOrtAppendCoreML(OrtSessionOptions *options, uint32_t flags) {
+    return OrtSessionOptionsAppendExecutionProvider_CoreML(options, flags);
+}

--- a/Sources/COnnxRuntimeCoreML/include/COnnxRuntimeCoreML.h
+++ b/Sources/COnnxRuntimeCoreML/include/COnnxRuntimeCoreML.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <CONNXRuntime.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+OrtStatus *MereRunOrtAppendCoreML(OrtSessionOptions *options, uint32_t flags);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -224,6 +224,7 @@ struct CommandDraft: Equatable {
     var quiet = false
     var force = false
     var all = false
+    var acceptModelLicense = false
     var json = false
     var stream = false
     var extraArguments = ""
@@ -391,6 +392,7 @@ struct CommandTemplate: Identifiable, Equatable {
         case .agentOnboard:
             args = ["agent", "onboard"]
             if draft.force { args.append("--pull-recommended") }
+            if draft.acceptModelLicense { args.append("--accept-model-license") }
             if draft.all { args.append("--install-pi") }
             if draft.stream { args.append("--configure-pi") }
             if !draft.model.isBlank { args += ["--model", draft.model] }
@@ -427,6 +429,7 @@ struct CommandTemplate: Identifiable, Equatable {
             if draft.force { args.append("--force") }
             if draft.stream { args.append("--allow-unsupported") }
             if draft.quiet { args.append("--quiet") }
+            if draft.acceptModelLicense { args.append("--accept-model-license") }
 
         case .modelInfo:
             args = ["model", "info", draft.model]

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -1146,6 +1146,8 @@ private struct AgentOptions: View {
                     Toggle("Install Pi", isOn: $controller.draft.all)
                     Toggle("Configure Pi", isOn: $controller.draft.stream)
                 }
+                Toggle("Acknowledge third-party model terms", isOn: $controller.draft.acceptModelLicense)
+                    .toggleStyle(.checkbox)
                 AdaptiveControlRow {
                     TextField("Host", text: $controller.draft.host)
                         .textFieldStyle(.plain)
@@ -1163,11 +1165,18 @@ private struct ModelPullOptions: View {
 
     var body: some View {
         EditorSection("Download") {
-            AdaptiveControlRow {
-                Toggle("All", isOn: $controller.draft.all)
-                Toggle("Force", isOn: $controller.draft.force)
-                Toggle("Allow unsupported", isOn: $controller.draft.stream)
-                Toggle("Quiet", isOn: $controller.draft.quiet)
+            VStack(alignment: .leading, spacing: 10) {
+                AdaptiveControlRow {
+                    Toggle("All", isOn: $controller.draft.all)
+                    Toggle("Force", isOn: $controller.draft.force)
+                    Toggle("Allow unsupported", isOn: $controller.draft.stream)
+                    Toggle("Quiet", isOn: $controller.draft.quiet)
+                }
+                Toggle("Acknowledge third-party model terms", isOn: $controller.draft.acceptModelLicense)
+                    .toggleStyle(.checkbox)
+                Text("Required for new downloads whose owners publish non-commercial, research-only, gated, revenue-limited, or custom acceptable-use terms. The command output lists the exact model/component terms. Mere does not determine whether your intended use is permitted; you are responsible for compliance.")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
             }
         }
     }

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -1,11 +1,17 @@
 import AppKit
 import SwiftUI
 
+struct StudioModelUsageTerms: Equatable {
+    let summary: String
+    let links: [URL]
+}
+
 struct StudioModelInventoryRow: Identifiable, Equatable {
     let id: String
     let category: String
     let status: String
     let size: String
+    let usageTerms: StudioModelUsageTerms?
 
     var isInstalled: Bool {
         status.lowercased() == "installed"
@@ -57,14 +63,16 @@ struct StudioRuntimeSettings: Codable, Equatable {
 
 enum StudioModelInventoryParser {
     static func rows(from output: String) -> [StudioModelInventoryRow] {
-        output
+        let usageTerms = usageTermsByID(from: output)
+        return output
             .components(separatedBy: .newlines)
             .compactMap { line -> StudioModelInventoryRow? in
                 let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty,
                       !trimmed.hasPrefix("-"),
                       !trimmed.hasPrefix("ID "),
-                      !trimmed.hasPrefix("Usage restriction:") else {
+                      !trimmed.hasPrefix("Usage restriction:"),
+                      !trimmed.hasPrefix("Usage terms:") else {
                     return nil
                 }
 
@@ -74,9 +82,32 @@ enum StudioModelInventoryParser {
                     id: fields[0],
                     category: fields[1],
                     status: fields[2],
-                    size: fields.dropFirst(3).joined(separator: " ")
+                    size: fields.dropFirst(3).joined(separator: " "),
+                    usageTerms: usageTerms[fields[0]]
                 )
             }
+    }
+
+    static func usageTermsByID(from output: String) -> [String: StudioModelUsageTerms] {
+        var result: [String: StudioModelUsageTerms] = [:]
+        for line in output.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            let marker = "Usage terms: "
+            guard trimmed.hasPrefix(marker) else { continue }
+            let payload = String(trimmed.dropFirst(marker.count))
+            guard let separator = payload.range(of: " - ") else { continue }
+            let id = String(payload[..<separator.lowerBound])
+            let summary = String(payload[separator.upperBound...])
+            let links = summary
+                .split(whereSeparator: \.isWhitespace)
+                .compactMap { token -> URL? in
+                    let candidate = token.trimmingCharacters(in: CharacterSet(charactersIn: "[];"))
+                    guard candidate.hasPrefix("https://") else { return nil }
+                    return URL(string: candidate)
+                }
+            result[id] = StudioModelUsageTerms(summary: summary, links: links)
+        }
+        return result
     }
 
     static func modelRoot(from output: String) -> URL? {
@@ -353,6 +384,20 @@ struct StudioModelsSheet: View {
                     Text("\(row.category) · \(row.status) · \(row.size)")
                         .font(MereRunTheme.captionFont)
                         .foregroundStyle(MereRunTheme.textMuted)
+                    if let usageTerms = row.usageTerms {
+                        Text("Third-party usage terms · acknowledgement required for new downloads")
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.yellow)
+                        Text(usageTerms.summary)
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                        HStack(spacing: 8) {
+                            ForEach(Array(usageTerms.links.enumerated()), id: \.offset) { index, url in
+                                Link("Review terms \(index + 1)", destination: url)
+                                    .font(MereRunTheme.captionFont)
+                            }
+                        }
+                    }
                 }
 
                 Spacer()
@@ -754,6 +799,10 @@ private struct StudioModelListRow: View {
                         .truncationMode(.middle)
                     HStack(spacing: 6) {
                         Text(row.category)
+                        if row.usageTerms != nil {
+                            Label("terms", systemImage: "doc.text")
+                                .labelStyle(.titleAndIcon)
+                        }
                         if !row.isInstalled {
                             Text("·")
                             Text(row.status)

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -63,7 +63,8 @@ enum StudioModelInventoryParser {
                 let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty,
                       !trimmed.hasPrefix("-"),
-                      !trimmed.hasPrefix("ID ") else {
+                      !trimmed.hasPrefix("ID "),
+                      !trimmed.hasPrefix("Usage restriction:") else {
                     return nil
                 }
 

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -24,9 +24,11 @@ struct StudioRootView: View {
     /// not-yet-sent conversation (so the library has no empty row until the first message).
     @State private var activeConversationID: UUID?
     @State private var pendingPullRefresh: StudioReadinessRefresh?
+    @State private var pendingRestrictedPull: StudioRunRequest?
     @State private var studioError: String?
     /// Locally installed models feeding the composer's quick-picker.
     @State private var installedModels: [StudioModelInventoryRow] = []
+    @State private var modelUsageTermsByID: [String: StudioModelUsageTerms] = [:]
     @AppStorage("mererun.app.hasCompletedWelcome") private var hasCompletedWelcome = false
     @State private var showWelcome = false
     @FocusState private var promptFocused: Bool
@@ -449,6 +451,27 @@ struct StudioRootView: View {
                 }
                 .frame(width: 1_260, height: 780)
                 .environmentObject(controller)
+            }
+            .alert(
+                "Acknowledge third-party model terms",
+                isPresented: Binding(
+                    get: { pendingRestrictedPull != nil },
+                    set: { if !$0 { pendingRestrictedPull = nil } }
+                ),
+                presenting: pendingRestrictedPull
+            ) { request in
+                Button("Cancel", role: .cancel) {
+                    pendingRestrictedPull = nil
+                }
+                Button("Acknowledge & Download") {
+                    pendingRestrictedPull = nil
+                    startPull(request, acknowledgingUsageTerms: true)
+                }
+            } message: { request in
+                let usageTerms = modelUsageTermsByID[request.draft.model]
+                Text(
+                    "\(usageTerms?.summary ?? "This model has third-party usage terms.")\n\nMere does not determine whether your intended use is permitted. You are responsible for compliance."
+                )
             }
             .focusedSceneValue(\.showLibrary, visibleLibraryBinding)
             .focusedSceneValue(\.showAdvanced, $showAdvanced)
@@ -952,16 +975,38 @@ struct StudioRootView: View {
                 studioError = "This mode does not need a managed model."
                 return
             }
-            pendingPullRefresh = StudioReadinessRefresh(mode: mode, draft: draft)
-            controller.readinessByMode[mode] = .checking
-            // The canvas running overlay shows pull progress (bytes, speed, cancel) in place,
-            // so the Advanced console no longer needs to open for a pull.
-            if !controller.run(studio: request) {
-                pendingPullRefresh = nil
-                refreshReadiness()
+            if modelUsageTermsByID[request.draft.model] != nil {
+                pendingRestrictedPull = request
+            } else {
+                startPull(request)
             }
         } catch {
             studioError = error.localizedDescription
+        }
+    }
+
+    private func startPull(
+        _ request: StudioRunRequest,
+        acknowledgingUsageTerms: Bool = false
+    ) {
+        var commandDraft = request.draft
+        commandDraft.acceptModelLicense = acknowledgingUsageTerms
+        let effectiveRequest = StudioRunRequest(
+            id: request.id,
+            mode: request.mode,
+            templateID: request.templateID,
+            template: request.template,
+            draft: commandDraft,
+            createdAt: request.createdAt,
+            conversationID: request.conversationID
+        )
+        pendingPullRefresh = StudioReadinessRefresh(mode: request.mode, draft: draft)
+        controller.readinessByMode[request.mode] = .checking
+        // The canvas running overlay shows pull progress (bytes, speed, cancel) in place,
+        // so the Advanced console no longer needs to open for a pull.
+        if !controller.run(studio: effectiveRequest) {
+            pendingPullRefresh = nil
+            refreshReadiness()
         }
     }
 
@@ -974,7 +1019,13 @@ struct StudioRootView: View {
         Task {
             let result = await controller.utilityCommandResult(args: ["model", "list"])
             guard result.exitCode == 0 else { return }
-            installedModels = StudioModelInventoryParser.rows(from: result.stdout).filter(\.isInstalled)
+            let rows = StudioModelInventoryParser.rows(from: result.stdout)
+            installedModels = rows.filter(\.isInstalled)
+            modelUsageTermsByID = Dictionary(
+                uniqueKeysWithValues: rows.compactMap { row in
+                    row.usageTerms.map { (row.id, $0) }
+                }
+            )
         }
     }
 

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -4473,7 +4473,7 @@ actor CodeGenServer {
                 modelPath: resolved.rootURL.path,
                 request: request
             )
-        case .gemma, .liquid, .qwen, .sam, .falcon, .geometry, .depth, .threeD,
+        case .gemma, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
              .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek, nil:
             throw APIRequestValidationError.invalidField(
                 "model",

--- a/Sources/MereRunCLI/Commands/AgentCommand.swift
+++ b/Sources/MereRunCLI/Commands/AgentCommand.swift
@@ -24,6 +24,12 @@ struct AgentOnboard: AsyncParsableCommand {
     @Flag(name: [.long], help: "Pull the supported first-setup model package.")
     var pullRecommended: Bool = false
 
+    @Flag(
+        name: [.customLong("accept-model-license")],
+        help: "Acknowledge listed third-party model/component terms before downloading restricted recommended models."
+    )
+    var acceptModelLicense: Bool = false
+
     @Flag(name: [.long], help: "Install the latest Pi coding-agent release from GitHub.")
     var installPi: Bool = false
 
@@ -88,7 +94,7 @@ struct AgentOnboard: AsyncParsableCommand {
         if let codeReport = reports.first(where: { $0.spec.id == CodeGenResources.defaultModelId }) {
             if codeReport.isSupported {
                 print("  Qwen3-Coder Next is also supported for comparison or coding-specific sessions.")
-                print("  Pull it with: \(CLICommandDisplay.command("model pull \(CodeGenResources.defaultModelId)"))")
+                print("  Pull it with: \(CLICommandDisplay.modelPullCommand(for: CodeGenResources.defaultModelId))")
             } else {
                 print("  Qwen3-Coder Next is not supported here: \(codeReport.reasons.joined(separator: " "))")
             }
@@ -130,12 +136,33 @@ struct AgentOnboard: AsyncParsableCommand {
     private func pullRecommendedModels(_ reports: [ManagedModelSupportReport]) async throws {
         for report in reports {
             guard report.spec.hasAnyManagedDownloadSource() else { continue }
+            let isInstalled = ManagedModelResolver.isManagedInstallComplete(
+                spec: report.spec,
+                at: report.spec.managedInstallRootURL()
+            )
+            if let restriction = report.spec.usageRestriction,
+               !isInstalled,
+               !acceptModelLicense {
+                CLIStderr.write(
+                    "[\(report.spec.id)] skipping restricted model: \(restriction.summary) "
+                    + "Review \(restriction.terms.map(\.licenseURL).joined(separator: ", ")) and pass --accept-model-license.\n"
+                )
+                continue
+            }
+            if let restriction = report.spec.usageRestriction, !isInstalled, !quiet {
+                CLIStderr.write("[\(report.spec.id)] third-party usage terms: \(restriction.summary)\n")
+                for term in restriction.terms {
+                    CLIStderr.write("  \(term.component): \(term.license) \(term.licenseURL)\n")
+                }
+                CLIStderr.write("  You are responsible for determining whether your use complies.\n")
+            }
             if !quiet {
                 CLIStderr.write("[\(report.spec.id)] installing recommended model\n")
             }
             _ = try await ManagedModelResolver.installManagedModel(
                 id: report.spec.id,
                 force: false,
+                usageTermsAcknowledged: acceptModelLicense,
                 progress: { progress in
                     guard !quiet else { return }
                     switch progress {
@@ -247,7 +274,7 @@ struct AgentStart: AsyncParsableCommand {
             modelURL = existing
         } else if noBootstrap {
             throw ValidationError(
-                "Model \(spec.id) is not installed. Run `mere.run model pull \(spec.id)` "
+                "Model \(spec.id) is not installed. Run `\(CLICommandDisplay.modelPullCommand(for: spec.id))` "
                 + "or drop --no-bootstrap to auto-pull."
             )
         } else {

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -343,7 +343,7 @@ struct ImageGenerate: AsyncParsableCommand {
                 let generator = Ideogram4Generator()
                 defer { generator.unload() }
                 result = try await generator.generate(request, progressHandler: progressHandler)
-            case .gemma, .liquid, .qwen, .sam, .falcon, .geometry, .depth, .threeD,
+            case .gemma, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
                  .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek, nil:
                 throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")
             }

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -182,7 +182,7 @@ struct ImageGenerate: AsyncParsableCommand {
                     resolvedModel = try resolver.resolve(id).rootURL.path
                 } catch {
                     throw ValidationError(
-                        "Model \(id.rawValue) not found. Pull it with `mere.run model pull \(id.rawValue)` or point --model at a local path."
+                        "Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point --model at a local path."
                     )
                 }
             } else {
@@ -196,7 +196,7 @@ struct ImageGenerate: AsyncParsableCommand {
             } catch {
                 let modelID = Self.defaultManagedModelID.rawValue
                 throw ValidationError(
-                    "Image model \(modelID) not found. Pull it with `mere.run model pull \(modelID)` or point --model at a local path."
+                    "Image model \(modelID) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelID))` or point --model at a local path."
                 )
             }
         }

--- a/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
@@ -1179,7 +1179,7 @@ struct ImageTrainLoRA: AsyncParsableCommand {
                 return try ModelResolver().resolve(id).rootURL.path
             } catch {
                 throw ValidationError(
-                    "Sample model \(id.rawValue) not found. Pull it with `mere.run model pull \(id.rawValue)` or pass --sample-model."
+                    "Sample model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or pass --sample-model."
                 )
             }
         }
@@ -1221,7 +1221,7 @@ struct ImageTrainLoRA: AsyncParsableCommand {
             } catch {
                 let modelID = Self.defaultManagedModelID.rawValue
                 throw ValidationError(
-                    "Krea 2 Raw model \(modelID) not found. Pull it with `mere.run model pull \(modelID)` or point --model at a local Raw model path."
+                    "Krea 2 Raw model \(modelID) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelID))` or point --model at a local Raw model path."
                 )
             }
         }
@@ -1235,7 +1235,7 @@ struct ImageTrainLoRA: AsyncParsableCommand {
                 return try resolver.resolve(id).rootURL
             } catch {
                 throw ValidationError(
-                    "Model \(id.rawValue) not found. Pull it with `mere.run model pull \(id.rawValue)` or point --model at a local path."
+                    "Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point --model at a local path."
                 )
             }
         }

--- a/Sources/MereRunCLI/Commands/ImageValidateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageValidateCommand.swift
@@ -97,7 +97,7 @@ struct ImageValidate: AsyncParsableCommand {
         do {
             resolved = try ModelResolver().resolve(modelId)
         } catch {
-            throw ValidationError("Model \(modelId.rawValue) not found. Pull it with `mere.run model pull \(modelId.rawValue)` before running validation.")
+            throw ValidationError("Model \(modelId.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelId.rawValue))` before running validation.")
         }
 
         let report = MereRunModelValidator.validate(modelRoot: resolved.rootURL, expectedModelID: modelId.rawValue)
@@ -127,7 +127,7 @@ struct ImageValidate: AsyncParsableCommand {
                 print("    - \(error)")
             }
             throw ImageValidateRuntimeError(
-                "Model directory is incomplete. Repair the manifest or pull the model again with `mere.run model pull \(modelId.rawValue)`."
+                "Model directory is incomplete. Repair the manifest or pull the model again with `\(CLICommandDisplay.modelPullCommand(for: modelId.rawValue))`."
             )
         }
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkChatCommand.swift
@@ -147,7 +147,7 @@ struct ModelBenchmarkChat: AsyncParsableCommand {
         guard let installedURL = ManagedModelResolver.resolveInstalledModel(id: modelID) else {
             return ChatBenchmarkModelResult.missing(
                 model: modelID,
-                reason: "Model is not installed. Run `mere.run model pull \(modelID)` first."
+                reason: "Model is not installed. Run `\(CLICommandDisplay.modelPullCommand(for: modelID))` first."
             )
         }
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -177,7 +177,7 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
         guard let installedURL = ManagedModelResolver.resolveInstalledModel(id: modelID) else {
             return CodeBenchmarkModelResult.missing(
                 model: modelID,
-                reason: "Model is not installed. Run `mere.run model pull \(modelID)` first."
+                reason: "Model is not installed. Run `\(CLICommandDisplay.modelPullCommand(for: modelID))` first."
             )
         }
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkToolCallsCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkToolCallsCommand.swift
@@ -132,7 +132,7 @@ struct ModelBenchmarkToolCalls: AsyncParsableCommand {
         guard let installedURL = ManagedModelResolver.resolveInstalledModel(id: modelID) else {
             return ToolBenchmarkModelResult.missing(
                 model: modelID,
-                reason: "Model is not installed. Run `mere.run model pull \(modelID)` first."
+                reason: "Model is not installed. Run `\(CLICommandDisplay.modelPullCommand(for: modelID))` first."
             )
         }
 

--- a/Sources/MereRunCLI/Commands/ModelCapabilitiesCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCapabilitiesCommand.swift
@@ -77,7 +77,7 @@ struct ModelCapabilities: ParsableCommand {
 
         if let recommendedCodeReport {
             print("\nRecommended code model")
-            print("  \(CLICommandDisplay.command("model pull \(recommendedCodeReport.spec.id)"))")
+            print("  \(CLICommandDisplay.modelPullCommand(for: recommendedCodeReport.spec.id))")
             print("  \(recommendedCodeReport.descriptor.title): \(recommendedCodeReport.descriptor.summary)")
         }
 
@@ -94,7 +94,7 @@ struct ModelCapabilities: ParsableCommand {
             print("\nRecommended setup coverage (downloadable from Hugging Face)")
             print("  note: cross-modality starter set; lower-memory agent alternatives are not ranked upgrades.")
             for report in recommendedReports {
-                print("  mere.run model pull \(report.spec.id)")
+                print("  \(CLICommandDisplay.modelPullCommand(for: report.spec.id))")
             }
         }
         if !unavailableRecommended.isEmpty {

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -39,7 +39,7 @@ struct ModelInfo: ParsableCommand {
                 if id == .gemma4 {
                     throw ValidationError("Model \(id.rawValue) is not installed in the local model store. Gemma4 resolves through the native Hugging Face snapshot path on first use, or you can point info at a local model path.")
                 }
-                throw ValidationError("Model \(id.rawValue) not found. Pull it with `mere.run model pull \(id.rawValue)` or point info at a local model path.")
+                throw ValidationError("Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point info at a local model path.")
             }
         } else {
             throw ValidationError("Not a path and not a known model id: \(target)")
@@ -129,6 +129,25 @@ struct ModelInfo: ParsableCommand {
 
             if let upstream = manifest.upstreamRepoId {
                 print("  upstreamRepoId: \(upstream)")
+            }
+
+            if let sources = manifest.sources, !sources.isEmpty {
+                print("  sources:")
+                for source in sources {
+                    let destination = source.destinationPath.map { " -> \($0)" } ?? ""
+                    print("    - \(source.role): \(source.repository)@\(source.revision)\(destination)")
+                }
+            }
+
+            if let terms = manifest.usageTerms, !terms.isEmpty {
+                print("  usageTermsAcknowledged: \(manifest.usageTermsAcknowledged == true)")
+                print("  usageTerms:")
+                for term in terms {
+                    print("    - \(term.component): \(term.license)")
+                    print("      source: \(term.sourceRepoId)@\(term.sourceRevision)")
+                    print("      summary: \(term.summary)")
+                    print("      url: \(term.licenseURL)")
+                }
             }
 
             if let createdAt = manifest.createdAt {

--- a/Sources/MereRunCLI/Commands/ModelListCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelListCommand.swift
@@ -37,7 +37,10 @@ struct ModelList: ParsableCommand {
     ) -> [String] {
         specs.compactMap { spec in
             guard let restriction = spec.usageRestriction else { return nil }
-            return "Usage restriction: \(spec.id) - \(restriction.summary) \(restriction.licenseURL)"
+            let terms = restriction.terms
+                .map { "\($0.component): \($0.license) \($0.licenseURL)" }
+                .joined(separator: "; ")
+            return "Usage terms: \(spec.id) - \(restriction.summary) [\(terms)]"
         }
     }
 

--- a/Sources/MereRunCLI/Commands/ModelListCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelListCommand.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import MereRunCore
 
 struct ModelList: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -16,6 +17,9 @@ struct ModelList: ParsableCommand {
         for row in rows {
             printRow(row.id, row.category, row.status, row.size, widths: widths)
         }
+        for line in Self.usageRestrictionLines() {
+            print("\n\(line)")
+        }
     }
 
     private func printRow(_ id: String, _ category: String, _ status: String, _ size: String, widths: ModelListColumnWidths) {
@@ -26,6 +30,15 @@ struct ModelList: ParsableCommand {
             size
         ].joined(separator: "  ")
         print(row)
+    }
+
+    static func usageRestrictionLines(
+        specs: [ManagedModelSpec] = ManagedModelCatalog.allSpecs
+    ) -> [String] {
+        specs.compactMap { spec in
+            guard let restriction = spec.usageRestriction else { return nil }
+            return "Usage restriction: \(spec.id) - \(restriction.summary) \(restriction.licenseURL)"
+        }
     }
 
 }

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -23,6 +23,12 @@ struct ModelPull: AsyncParsableCommand {
     @Flag(name: [.long], help: "Bypass the Apple Silicon and unified-memory support check.")
     var allowUnsupported: Bool = false
 
+    @Flag(
+        name: [.customLong("accept-model-license")],
+        help: "Acknowledge the upstream usage restriction before downloading a restricted model."
+    )
+    var acceptModelLicense: Bool = false
+
     @Flag(name: [.customLong("preflight")], help: "Inspect support, source, disk, and install state without downloading.")
     var preflight: Bool = false
 
@@ -59,6 +65,12 @@ struct ModelPull: AsyncParsableCommand {
                 if !spec.hasAnyManagedDownloadSource() {
                     if !quiet {
                         stderr("[\(spec.id)] skipping (no Hugging Face source in this public build)")
+                    }
+                    continue
+                }
+                if spec.usageRestriction != nil, !acceptModelLicense {
+                    if !quiet {
+                        stderr("[\(spec.id)] skipping (pass --accept-model-license to acknowledge its upstream usage restriction)")
                     }
                     continue
                 }
@@ -121,6 +133,13 @@ struct ModelPull: AsyncParsableCommand {
                 }
             }
             return
+        }
+        if let message = licenseAcceptanceMessage(for: spec) {
+            throw ValidationError(message)
+        }
+        if let restriction = spec.usageRestriction, !quiet {
+            stderr("[\(spec.id)] usage restriction: \(restriction.summary)")
+            stderr("  license: \(restriction.licenseURL)")
         }
         try ModelPullDiskPreflight.check(spec: spec, modelDir: modelDir) { warning in
             guard !quiet else { return }
@@ -197,6 +216,17 @@ struct ModelPull: AsyncParsableCommand {
         CLIStderr.write(message)
     }
 
+    func licenseAcceptanceMessage(for spec: ManagedModelSpec) -> String? {
+        guard let restriction = spec.usageRestriction, !acceptModelLicense else {
+            return nil
+        }
+        return """
+        Model \(spec.id) has an upstream usage restriction: \(restriction.summary)
+        Review: \(restriction.licenseURL)
+        Re-run with --accept-model-license to acknowledge the restriction before download.
+        """
+    }
+
     func makePreflightEnvelope(
         fileManager: FileManager = .default,
         hubCacheURL: URL? = nil,
@@ -252,6 +282,9 @@ struct ModelPull: AsyncParsableCommand {
         }
         if allowUnsupported {
             args.append("--allow-unsupported")
+        }
+        if acceptModelLicense {
+            args.append("--accept-model-license")
         }
         return args
     }

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -25,7 +25,7 @@ struct ModelPull: AsyncParsableCommand {
 
     @Flag(
         name: [.customLong("accept-model-license")],
-        help: "Acknowledge the upstream usage restriction before downloading a restricted model."
+        help: "Acknowledge all listed third-party model/component terms before downloading a restricted model."
     )
     var acceptModelLicense: Bool = false
 
@@ -68,9 +68,14 @@ struct ModelPull: AsyncParsableCommand {
                     }
                     continue
                 }
-                if spec.usageRestriction != nil, !acceptModelLicense {
+                let requiresUsageTermsAcknowledgement = spec.usageRestriction != nil
+                    && (force || !ManagedModelResolver.isManagedInstallComplete(
+                        spec: spec,
+                        at: spec.managedInstallRootURL()
+                    ))
+                if requiresUsageTermsAcknowledgement, !acceptModelLicense {
                     if !quiet {
-                        stderr("[\(spec.id)] skipping (pass --accept-model-license to acknowledge its upstream usage restriction)")
+                        stderr("[\(spec.id)] skipping (pass --accept-model-license to acknowledge its third-party model/component terms)")
                     }
                     continue
                 }
@@ -138,8 +143,13 @@ struct ModelPull: AsyncParsableCommand {
             throw ValidationError(message)
         }
         if let restriction = spec.usageRestriction, !quiet {
-            stderr("[\(spec.id)] usage restriction: \(restriction.summary)")
-            stderr("  license: \(restriction.licenseURL)")
+            stderr("[\(spec.id)] third-party usage terms: \(restriction.summary)")
+            for term in restriction.terms {
+                stderr("  \(term.component): \(term.license)")
+                stderr("    source: \(term.sourceRepoId)@\(term.sourceRevision)")
+                stderr("    terms: \(term.licenseURL)")
+            }
+            stderr("  You are responsible for determining whether your use complies with these terms.")
         }
         try ModelPullDiskPreflight.check(spec: spec, modelDir: modelDir) { warning in
             guard !quiet else { return }
@@ -152,6 +162,7 @@ struct ModelPull: AsyncParsableCommand {
             result = try await ManagedModelResolver.installManagedModel(
                 id: spec.id,
                 force: force,
+                usageTermsAcknowledged: acceptModelLicense,
                 progress: { progress in
                     guard !quiet else { return }
                     stderrRaw("\r\(progressPrinter.render(progress))          ")
@@ -221,9 +232,10 @@ struct ModelPull: AsyncParsableCommand {
             return nil
         }
         return """
-        Model \(spec.id) has an upstream usage restriction: \(restriction.summary)
-        Review: \(restriction.licenseURL)
-        Re-run with --accept-model-license to acknowledge the restriction before download.
+        Model \(spec.id) has third-party usage terms: \(restriction.summary)
+        \(restriction.terms.map { "- \($0.component): \($0.license)\n  \($0.licenseURL)" }.joined(separator: "\n"))
+        Mere does not decide whether your intended use is permitted. You are responsible for compliance.
+        Re-run with --accept-model-license to acknowledge these terms before download.
         """
     }
 
@@ -239,6 +251,7 @@ struct ModelPull: AsyncParsableCommand {
             all: all,
             force: force,
             allowUnsupported: allowUnsupported,
+            acceptUsageTerms: acceptModelLicense,
             pullArgv: pullActionArguments(),
             cwd: fileManager.currentDirectoryPath
         )
@@ -302,7 +315,7 @@ struct ModelPullInstallError: LocalizedError, Sendable {
         lines.append(contentsOf: details.map { "- \($0)" })
         lines.append("")
         lines.append("Model store: \(modelDir.path)")
-        lines.append("Retry with: mere.run model pull \(modelID)")
+        lines.append("Retry with: \(CLICommandDisplay.modelPullCommand(for: modelID))")
         lines.append("Use --force only if you intentionally want to replace a complete install.")
         if let hubRepoID,
            let hubCache = try? HubSnapshot.resolvedDownloadBase() {

--- a/Sources/MereRunCLI/Commands/MusicTranscribeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicTranscribeCommand.swift
@@ -19,7 +19,7 @@ struct MusicTranscribe: ParsableCommand {
         and licensed CC BY-NC 4.0; accept the terms on Hugging Face before pulling.
 
         Examples:
-          mere.run model pull music-muscriptor-medium
+          mere.run model pull music-muscriptor-medium --accept-model-license
           mere.run music transcribe ./song.mp3 --output ./song.mid
           mere.run music transcribe ./song.wav --instruments voice,drums,bass
           mere.run music transcribe ./song.wav --format jsonl --output -

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -84,6 +84,12 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
     @Flag(name: [.long], help: "Pull the configured managed models before starting.")
     var pull: Bool = false
 
+    @Flag(
+        name: [.customLong("accept-model-license")],
+        help: "Acknowledge listed third-party model/component terms before downloading restricted configured models."
+    )
+    var acceptModelLicense: Bool = false
+
     @Flag(name: [.long], help: "Use an already-running mere.run API server.")
     var skipServer: Bool = false
 
@@ -244,6 +250,9 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
     }
 
     private func pullConfiguredModels() async throws {
+        if let message = unacknowledgedUsageTermsMessage() {
+            throw ValidationError(message)
+        }
         for modelID in uniqueModelIDs([textModel, visionModel, embeddingModel, imageModel, ttsModel, sttModel]) {
             guard let spec = ManagedModelCatalog.spec(for: modelID) else {
                 CLIStderr.write("[open-webui] Skipping pull for custom model \(modelID)\n")
@@ -259,6 +268,7 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
             _ = try await ManagedModelResolver.installManagedModel(
                 id: modelID,
                 force: false,
+                usageTermsAcknowledged: acceptModelLicense,
                 progress: { progress in
                     guard !quiet else { return }
                     switch progress {
@@ -289,6 +299,36 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
                 CLIStderr.write("\n")
             }
         }
+    }
+
+    func unacknowledgedUsageTermsMessage(fileManager: FileManager = .default) -> String? {
+        guard !acceptModelLicense else { return nil }
+        let restricted = uniqueModelIDs([textModel, visionModel, embeddingModel, imageModel, ttsModel, sttModel])
+            .compactMap(ManagedModelCatalog.spec(for:))
+            .filter { spec in
+                spec.usageRestriction != nil
+                    && spec.hasAnyManagedDownloadSource()
+                    && !ManagedModelResolver.isManagedInstallComplete(
+                        spec: spec,
+                        at: spec.managedInstallRootURL(),
+                        fileManager: fileManager
+                    )
+            }
+        guard !restricted.isEmpty else { return nil }
+
+        let details = restricted.map { spec in
+            let restriction = spec.usageRestriction!
+            let terms = restriction.terms
+                .map { "  - \($0.component): \($0.license) \($0.licenseURL)" }
+                .joined(separator: "\n")
+            return "- \(spec.id): \(restriction.summary)\n\(terms)"
+        }.joined(separator: "\n")
+        return """
+        Open WebUI --pull includes configured models with third-party usage terms:
+        \(details)
+        Mere does not determine whether your intended use is permitted. You are responsible for compliance.
+        Review the terms and re-run with --accept-model-license, or pre-install a different model.
+        """
     }
 
     private func startAPIServer(apiKey: String) throws -> (process: Process, logURL: URL) {

--- a/Sources/MereRunCLI/Commands/SetupCommand.swift
+++ b/Sources/MereRunCLI/Commands/SetupCommand.swift
@@ -161,7 +161,7 @@ struct Setup: AsyncParsableCommand {
             printNumberedCommand(
                 index: 1,
                 title: "Pull the model",
-                command: CLICommandDisplay.command("model pull \(recommendation.id)"),
+                command: CLICommandDisplay.modelPullCommand(for: recommendation.id),
                 trailingBlankLine: true
             )
             printNumberedCommand(
@@ -376,7 +376,7 @@ struct Setup: AsyncParsableCommand {
             printNumberedCommand(
                 index: 2,
                 title: "Pull the setup agent model",
-                command: CLICommandDisplay.command("model pull \(recommendation.id)"),
+                command: CLICommandDisplay.modelPullCommand(for: recommendation.id),
                 trailingBlankLine: true
             )
             printNumberedCommand(

--- a/Sources/MereRunCLI/Commands/VisionCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionCommand.swift
@@ -3,10 +3,11 @@ import ArgumentParser
 struct Vision: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "vision",
-        abstract: "Caption, inspect, segment, track, pose, depth, geometry, optical flow, and OCR visual media.",
+        abstract: "Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media.",
         subcommands: [
             VisionCaption.self,
             VisionInspect.self,
+            VisionFace.self,
             VisionGround.self,
             VisionSegment.self,
             VisionTrack.self,

--- a/Sources/MereRunCLI/Commands/VisionFaceCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionFaceCommand.swift
@@ -1,0 +1,419 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct VisionFace: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "face",
+        abstract: "Detect faces, create identity embeddings, and compare faces locally.",
+        discussion: """
+        Uses the managed Buffalo-L detector and ArcFace recognizer. Raw inference belongs here;
+        library indexing, search, clustering, and review workflows live in mere-run-plugins.
+        """,
+        subcommands: [
+            VisionFaceDetect.self,
+            VisionFaceEmbed.self,
+            VisionFaceCompare.self,
+            VisionFaceBatch.self,
+        ]
+    )
+}
+
+struct FaceModelOptions: ParsableArguments {
+    @Option(name: [.customShort("m"), .long], help: "Managed model id or local Buffalo-L model root.")
+    var model: String?
+
+    @Option(name: [.customLong("score-threshold")], help: "Minimum face detector score in [0, 1].")
+    var scoreThreshold = 0.65
+
+    @Option(name: [.customLong("execution-provider")], help: "Execution provider: auto, coreml, or cpu.")
+    var executionProvider = "auto"
+
+    func validate() throws {
+        guard (0...1).contains(scoreThreshold) else {
+            throw ValidationError("--score-threshold must be between 0 and 1.")
+        }
+        guard FaceExecutionProvider(rawValue: executionProvider.lowercased()) != nil else {
+            throw ValidationError("--execution-provider must be auto, coreml, or cpu.")
+        }
+    }
+
+    var resolvedExecutionProvider: FaceExecutionProvider {
+        FaceExecutionProvider(rawValue: executionProvider.lowercased()) ?? .auto
+    }
+}
+
+struct VisionFaceDetect: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "detect",
+        abstract: "Detect faces and five-point landmarks in an image."
+    )
+
+    @Argument(help: "Image file path.")
+    var image: String
+
+    @OptionGroup var modelOptions: FaceModelOptions
+
+    @Option(name: [.customLong("max-faces")], help: "Maximum detections to return after NMS.")
+    var maxFaces: Int?
+
+    @Flag(name: [.customLong("include-embeddings")], help: "Also compute normalized 512-dimensional ArcFace embeddings.")
+    var includeEmbeddings = false
+
+    @Option(name: [.customLong("json-output")], help: "Optional JSON output file.")
+    var jsonOutput: String?
+
+    @Flag(name: [.long], help: "Print JSON on stdout.")
+    var json = false
+
+    func validate() throws {
+        try modelOptions.validate()
+        if let maxFaces, maxFaces <= 0 {
+            throw ValidationError("--max-faces must be greater than zero.")
+        }
+    }
+
+    func run() throws {
+        let imageURL = try FaceCLI.resolveImage(image)
+        let modelRoot = try FaceCLI.resolveModelRoot(modelOptions.model)
+        let analyzer = try FaceAnalyzer(
+            modelRootURL: modelRoot,
+            includeRecognizer: includeEmbeddings,
+            executionProvider: modelOptions.resolvedExecutionProvider
+        )
+        let result = try analyzer.analyze(
+            imageURL: imageURL,
+            options: .init(
+                scoreThreshold: Float(modelOptions.scoreThreshold),
+                maxFaces: maxFaces,
+                includeEmbeddings: includeEmbeddings
+            )
+        )
+        try FaceCLI.emit(result, jsonOutput: jsonOutput, printJSON: json) {
+            print("Faces: \(result.faces.count)")
+            if let jsonOutput { print("JSON: \(URL(fileURLWithPath: jsonOutput).standardizedFileURL.path)") }
+        }
+    }
+}
+
+struct VisionFaceEmbed: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "embed",
+        abstract: "Create a normalized ArcFace embedding for one face in an image."
+    )
+
+    @Argument(help: "Image file path.")
+    var image: String
+
+    @OptionGroup var modelOptions: FaceModelOptions
+
+    @Option(name: [.customLong("face-index")], help: "Zero-based detected face index. Defaults to the largest face.")
+    var faceIndex: Int?
+
+    @Option(name: [.customLong("json-output")], help: "Optional JSON output file.")
+    var jsonOutput: String?
+
+    @Flag(name: [.long], help: "Print JSON on stdout.")
+    var json = false
+
+    func validate() throws {
+        try modelOptions.validate()
+        if let faceIndex, faceIndex < 0 {
+            throw ValidationError("--face-index must be zero or greater.")
+        }
+    }
+
+    func run() throws {
+        let imageURL = try FaceCLI.resolveImage(image)
+        let modelRoot = try FaceCLI.resolveModelRoot(modelOptions.model)
+        let analyzer = try FaceAnalyzer(
+            modelRootURL: modelRoot,
+            executionProvider: modelOptions.resolvedExecutionProvider
+        )
+        let face = try analyzer.embedding(
+            imageURL: imageURL,
+            scoreThreshold: Float(modelOptions.scoreThreshold),
+            selection: faceIndex
+        )
+        let result = FaceEmbeddingOutput(
+            image: imageURL.path,
+            modelID: FaceAnalysisResources.modelID,
+            face: face
+        )
+        try FaceCLI.emit(result, jsonOutput: jsonOutput, printJSON: json) {
+            print("Face: \(face.index)")
+            print("Dimensions: \(face.embedding?.count ?? 0)")
+            if let jsonOutput { print("JSON: \(URL(fileURLWithPath: jsonOutput).standardizedFileURL.path)") }
+        }
+    }
+}
+
+struct VisionFaceCompare: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "compare",
+        abstract: "Compare one face from each of two images with cosine similarity."
+    )
+
+    @Argument(help: "Reference image file path.")
+    var reference: String
+
+    @Argument(help: "Candidate image file path.")
+    var candidate: String
+
+    @OptionGroup var modelOptions: FaceModelOptions
+
+    @Option(name: [.customLong("reference-face-index")], help: "Reference face index. Defaults to largest face.")
+    var referenceFaceIndex: Int?
+
+    @Option(name: [.customLong("candidate-face-index")], help: "Candidate face index. Defaults to largest face.")
+    var candidateFaceIndex: Int?
+
+    @Option(name: [.customLong("json-output")], help: "Optional JSON output file.")
+    var jsonOutput: String?
+
+    @Flag(name: [.long], help: "Print JSON on stdout.")
+    var json = false
+
+    func validate() throws {
+        try modelOptions.validate()
+        if let referenceFaceIndex, referenceFaceIndex < 0 {
+            throw ValidationError("--reference-face-index must be zero or greater.")
+        }
+        if let candidateFaceIndex, candidateFaceIndex < 0 {
+            throw ValidationError("--candidate-face-index must be zero or greater.")
+        }
+    }
+
+    func run() throws {
+        let referenceURL = try FaceCLI.resolveImage(reference)
+        let candidateURL = try FaceCLI.resolveImage(candidate)
+        let analyzer = try FaceAnalyzer(
+            modelRootURL: FaceCLI.resolveModelRoot(modelOptions.model),
+            executionProvider: modelOptions.resolvedExecutionProvider
+        )
+        let referenceFace = try analyzer.embedding(
+            imageURL: referenceURL,
+            scoreThreshold: Float(modelOptions.scoreThreshold),
+            selection: referenceFaceIndex
+        )
+        let candidateFace = try analyzer.embedding(
+            imageURL: candidateURL,
+            scoreThreshold: Float(modelOptions.scoreThreshold),
+            selection: candidateFaceIndex
+        )
+        guard let lhs = referenceFace.embedding,
+              let rhs = candidateFace.embedding,
+              let similarity = FaceAnalysisMath.cosineSimilarity(lhs, rhs) else {
+            throw FaceAnalysisError.invalidModelOutput("could not compare face embeddings")
+        }
+        let result = FaceComparisonOutput(
+            modelID: FaceAnalysisResources.modelID,
+            referenceImage: referenceURL.path,
+            referenceFaceIndex: referenceFace.index,
+            candidateImage: candidateURL.path,
+            candidateFaceIndex: candidateFace.index,
+            cosineSimilarity: similarity
+        )
+        try FaceCLI.emit(result, jsonOutput: jsonOutput, printJSON: json) {
+            print(String(format: "%.6f", similarity))
+        }
+    }
+}
+
+struct VisionFaceBatch: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "batch",
+        abstract: "Analyze many images with one warm detector/recognizer session and emit JSONL."
+    )
+
+    @Argument(help: "One or more image file paths.")
+    var images: [String] = []
+
+    @Option(name: [.customLong("input-list")], help: "UTF-8 file containing one image path per line.")
+    var inputList: String?
+
+    @OptionGroup var modelOptions: FaceModelOptions
+
+    @Option(name: [.customLong("max-faces")], help: "Maximum detections per image after NMS.")
+    var maxFaces: Int?
+
+    @Flag(name: [.customLong("include-embeddings")], help: "Include normalized 512-dimensional embeddings.")
+    var includeEmbeddings = false
+
+    @Option(name: [.customLong("jsonl-output")], help: "Optional JSONL output file. Defaults to stdout.")
+    var jsonlOutput: String?
+
+    @Flag(name: [.customLong("fail-fast")], help: "Stop at the first unreadable or invalid image.")
+    var failFast = false
+
+    func validate() throws {
+        try modelOptions.validate()
+        guard !images.isEmpty || inputList != nil else {
+            throw ValidationError("Provide image paths or --input-list PATH.")
+        }
+        if let maxFaces, maxFaces <= 0 {
+            throw ValidationError("--max-faces must be greater than zero.")
+        }
+    }
+
+    func run() throws {
+        let paths = try resolvePaths()
+        guard !paths.isEmpty else {
+            throw ValidationError("No non-empty image paths were supplied.")
+        }
+        let analyzer = try FaceAnalyzer(
+            modelRootURL: FaceCLI.resolveModelRoot(modelOptions.model),
+            includeRecognizer: includeEmbeddings,
+            executionProvider: modelOptions.resolvedExecutionProvider
+        )
+        let writer = try FaceJSONLWriter(outputPath: jsonlOutput)
+        for path in paths {
+            let url = URL(fileURLWithPath: path).standardizedFileURL
+            do {
+                let result = try analyzer.analyze(
+                    imageURL: url,
+                    options: .init(
+                        scoreThreshold: Float(modelOptions.scoreThreshold),
+                        maxFaces: maxFaces,
+                        includeEmbeddings: includeEmbeddings
+                    )
+                )
+                try writer.write(FaceBatchOutput(ok: true, image: url.path, result: result, error: nil))
+            } catch {
+                try writer.write(FaceBatchOutput(
+                    ok: false,
+                    image: url.path,
+                    result: nil,
+                    error: error.localizedDescription
+                ))
+                if failFast { throw error }
+            }
+        }
+    }
+
+    private func resolvePaths() throws -> [String] {
+        var paths = images
+        if let inputList {
+            let listURL = URL(fileURLWithPath: inputList).standardizedFileURL
+            let contents = try String(contentsOf: listURL, encoding: .utf8)
+            paths.append(contentsOf: contents.split(whereSeparator: { $0.isNewline }).map(String.init))
+        }
+        return paths.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
+    }
+}
+
+private struct FaceEmbeddingOutput: Codable {
+    let image: String
+    let modelID: String
+    let face: FaceRecord
+}
+
+private struct FaceComparisonOutput: Codable {
+    let modelID: String
+    let referenceImage: String
+    let referenceFaceIndex: Int
+    let candidateImage: String
+    let candidateFaceIndex: Int
+    let cosineSimilarity: Double
+}
+
+private struct FaceBatchOutput: Codable {
+    let ok: Bool
+    let image: String
+    let result: FaceAnalysisResult?
+    let error: String?
+}
+
+private final class FaceJSONLWriter {
+    private let encoder = JSONEncoder()
+    private let handle: FileHandle?
+
+    init(outputPath: String?) throws {
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let outputPath else {
+            handle = nil
+            return
+        }
+        let url = URL(fileURLWithPath: outputPath).standardizedFileURL
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = FileManager.default.createFile(atPath: url.path, contents: nil)
+        let outputHandle = try FileHandle(forWritingTo: url)
+        try outputHandle.truncate(atOffset: 0)
+        handle = outputHandle
+    }
+
+    deinit { try? handle?.close() }
+
+    func write<T: Encodable>(_ value: T) throws {
+        var data = try encoder.encode(value)
+        data.append(0x0A)
+        if let handle {
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+        } else {
+            FileHandle.standardOutput.write(data)
+        }
+    }
+}
+
+private enum FaceCLI {
+    static func resolveImage(_ path: String) throws -> URL {
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ValidationError("Image not found: \(url.path)")
+        }
+        return url
+    }
+
+    static func resolveModelRoot(_ rawModel: String?) throws -> URL {
+        if let rawModel, !rawModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let path = URL(fileURLWithPath: rawModel).standardizedFileURL
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(atPath: path.path, isDirectory: &isDirectory) {
+                guard isDirectory.boolValue else {
+                    throw ValidationError("Model path must be a directory: \(path.path)")
+                }
+                return path
+            }
+            guard rawModel == FaceAnalysisResources.modelID else {
+                throw ValidationError(
+                    "Unknown face model \(rawModel). Pass a local model root or \(FaceAnalysisResources.modelID)."
+                )
+            }
+        }
+        do {
+            return try ModelResolver().resolve(.visionFaceBuffaloL).rootURL
+        } catch {
+            throw ValidationError(
+                "Model \(FaceAnalysisResources.modelID) not found. Pull it with `mere.run model pull \(FaceAnalysisResources.modelID)` or pass --model PATH."
+            )
+        }
+    }
+
+    static func emit<T: Encodable>(
+        _ value: T,
+        jsonOutput: String?,
+        printJSON: Bool,
+        humanOutput: () -> Void
+    ) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        if let jsonOutput {
+            let url = URL(fileURLWithPath: jsonOutput).standardizedFileURL
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+        }
+        if printJSON {
+            print(String(decoding: data, as: UTF8.self))
+        } else {
+            humanOutput()
+        }
+    }
+}

--- a/Sources/MereRunCLI/Commands/VisionFaceCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionFaceCommand.swift
@@ -388,7 +388,7 @@ private enum FaceCLI {
             return try ModelResolver().resolve(.visionFaceBuffaloL).rootURL
         } catch {
             throw ValidationError(
-                "Model \(FaceAnalysisResources.modelID) not found. Pull it with `mere.run model pull \(FaceAnalysisResources.modelID)` or pass --model PATH."
+                "Model \(FaceAnalysisResources.modelID) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: FaceAnalysisResources.modelID))` or pass --model PATH."
             )
         }
     }

--- a/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
@@ -106,7 +106,7 @@ struct VisionGround: AsyncParsableCommand {
                     return ResolvedModel(modelID: modelID.rawValue, rootURL: resolved.rootURL, isManaged: true)
                 } catch {
                     throw ValidationError(
-                        "Model \(modelID.rawValue) not found. Pull it with `mere.run model pull \(modelID.rawValue)` or point --model at a local path."
+                        "Model \(modelID.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelID.rawValue))` or point --model at a local path."
                     )
                 }
             }
@@ -119,7 +119,7 @@ struct VisionGround: AsyncParsableCommand {
             return ResolvedModel(modelID: defaultManagedModelID.rawValue, rootURL: resolved.rootURL, isManaged: true)
         } catch {
             throw ValidationError(
-                "Model \(defaultManagedModelID.rawValue) not found. Pull it with `mere.run model pull \(defaultManagedModelID.rawValue)` or point --model at a local path."
+                "Model \(defaultManagedModelID.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: defaultManagedModelID.rawValue))` or point --model at a local path."
             )
         }
     }

--- a/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
@@ -150,7 +150,7 @@ struct VisionSegment: AsyncParsableCommand {
                     )
                 } catch {
                     throw ValidationError(
-                        "Model \(modelID.rawValue) not found. Pull it with `mere.run model pull \(modelID.rawValue)` or point --model at a local path."
+                        "Model \(modelID.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelID.rawValue))` or point --model at a local path."
                     )
                 }
             }
@@ -167,7 +167,7 @@ struct VisionSegment: AsyncParsableCommand {
             )
         } catch {
             throw ValidationError(
-                "Model \(defaultManagedModelID.rawValue) not found. Pull it with `mere.run model pull \(defaultManagedModelID.rawValue)` or point --model at a local path."
+                "Model \(defaultManagedModelID.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: defaultManagedModelID.rawValue))` or point --model at a local path."
             )
         }
     }

--- a/Sources/MereRunCLI/Guides/agent-onboard.md
+++ b/Sources/MereRunCLI/Guides/agent-onboard.md
@@ -25,6 +25,7 @@ mere.run agent onboard --help
 ## Parameters
 
 - `--pull-recommended`: pull supported first-setup model packages.
+- `--accept-model-license`: acknowledge listed third-party terms before restricted recommended-model downloads.
 - `--install-pi`: install the latest Pi coding-agent release.
 - `--configure-pi`: write a Pi extension for the local mere.run API provider.
 - `--host`: local API host for the provider extension.

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -33,7 +33,7 @@ Supported engines:
 ```bash
 mere.run model capabilities
 mere.run model pull text-agent-deepseek-v4-flash
-mere.run model pull image-zimage-nano
+mere.run model pull image-zimage-nano --accept-model-license
 mere.run model pull speech-tts-qwen3-nano
 mere.run model pull speech-asr-parakeet
 mere.run model runtime get text-chat-gemma4
@@ -267,7 +267,7 @@ mere.run api serve --engine text-chat-gemma4 --model vision-chat-gemma4-12b --po
 ```
 
 ```bash
-mere.run model pull text-chat-lfm25-a1b-8bit
+mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 mere.run api serve --engine text-chat-lfm2 --port 11434
 ```
 

--- a/Sources/MereRunCLI/Guides/image-generate.md
+++ b/Sources/MereRunCLI/Guides/image-generate.md
@@ -19,10 +19,10 @@ Use one installed image model:
 
 ```bash
 mere.run model capabilities
-mere.run model pull image-zimage-nano
+mere.run model pull image-zimage-nano --accept-model-license
 mere.run model pull image-bonsai-binary
 mere.run model pull image-bonsai-ternary
-mere.run model pull image-krea2-turbo
+mere.run model pull image-krea2-turbo --accept-model-license
 mere.run image generate --help
 mere.run guide image generate --model image-zimage-nano
 ```

--- a/Sources/MereRunCLI/Guides/image-train-lora.md
+++ b/Sources/MereRunCLI/Guides/image-train-lora.md
@@ -19,9 +19,9 @@ and caption dataset and want an adapter that can be loaded with
 ## Install And Check
 
 ```bash
-mere.run model pull image-krea2-raw
-mere.run model pull image-krea2-turbo
-mere.run model pull image-klein-base-9b
+mere.run model pull image-krea2-raw --accept-model-license
+mere.run model pull image-krea2-turbo --accept-model-license
+mere.run model pull image-klein-base-9b --accept-model-license
 mere.run image train-lora --help
 ```
 
@@ -289,7 +289,7 @@ mere.run image generate \
 
 ## Troubleshooting
 
-- Missing Raw model: run `mere.run model pull image-krea2-raw`.
+- Missing Raw model: run `mere.run model pull image-krea2-raw --accept-model-license`.
 - LoRA has no visible effect: confirm you are generating with the exact `--lora`
   path and that the prompt includes the trained trigger token. For Klein LoRAs,
   train on `image-klein-base-9b` and run on distilled `image-klein-9b`, but

--- a/Sources/MereRunCLI/Guides/image-validate.md
+++ b/Sources/MereRunCLI/Guides/image-validate.md
@@ -14,7 +14,7 @@ Use an installed image family:
 ## Install And Check
 
 ```bash
-mere.run model pull image-zimage-nano
+mere.run model pull image-zimage-nano --accept-model-license
 mere.run image validate --family zimage --test all
 mere.run image validate --help
 ```

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -12,7 +12,7 @@ No model is required before running pull, but the target id must exist in the ma
 
 ```bash
 mere.run model capabilities
-mere.run model pull image-zimage-nano
+mere.run model pull image-zimage-nano --accept-model-license
 mere.run status
 mere.run model list
 ```
@@ -39,12 +39,12 @@ mere.run model list
 ## Examples
 
 ```bash
-mere.run model pull image-zimage-nano --preflight --json
+mere.run model pull image-zimage-nano --accept-model-license --preflight --json
 ```
 
 ```bash
 mere.run model pull text-chat-gemma4-nano
-mere.run model pull text-chat-lfm25-a1b-8bit
+mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 ```
 
 ```bash
@@ -53,9 +53,9 @@ MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
 MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
   mere.run model pull music-magenta-rt2-small
 MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
-  mere.run model pull sfx-woosh-dflow
+  mere.run model pull sfx-woosh-dflow --accept-model-license
 MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
-  mere.run model pull sfx-woosh-flow
+  mere.run model pull sfx-woosh-flow --accept-model-license
 ```
 
 ## Iteration Tips

--- a/Sources/MereRunCLI/Guides/music-transcribe.md
+++ b/Sources/MereRunCLI/Guides/music-transcribe.md
@@ -12,7 +12,7 @@ the terms for the chosen repository, then configure your token and pull it:
 
 ```bash
 mere.run config set hf-token "$HF_TOKEN"
-mere.run model pull music-muscriptor-medium
+mere.run model pull music-muscriptor-medium --accept-model-license
 ```
 
 `small` is the lightest checkpoint, `medium` is the default quality/speed

--- a/Sources/MereRunCLI/Guides/open-webui.md
+++ b/Sources/MereRunCLI/Guides/open-webui.md
@@ -25,7 +25,7 @@ to text and vision chat models, and keep image/TTS/STT/RAG sidecars in their
 own Open WebUI settings.
 
 ```bash
-mere.run open-webui quickstart --pull
+mere.run open-webui quickstart --pull --accept-model-license
 ```
 
 The default chat pair is `text-chat-gemma4-12b` and
@@ -67,7 +67,7 @@ Pull the models you want Open WebUI to see:
 mere.run model pull text-chat-gemma4-12b
 mere.run model pull vision-chat-gemma4-12b
 mere.run model pull text-embed-qwen3-0.6b
-mere.run model pull image-zimage-nano
+mere.run model pull image-zimage-nano --accept-model-license
 mere.run model pull speech-tts-qwen3-nano
 mere.run model pull speech-asr-parakeet
 mere.run model list

--- a/Sources/MereRunCLI/Guides/sfx-generate.md
+++ b/Sources/MereRunCLI/Guides/sfx-generate.md
@@ -24,9 +24,9 @@ checkpoint stack.
 ## Commands
 
 ```bash
-mere.run model pull sfx-woosh-dflow
-mere.run model pull sfx-woosh-flow
-mere.run model pull sfx-woosh-synchformer
+mere.run model pull sfx-woosh-dflow --accept-model-license
+mere.run model pull sfx-woosh-flow --accept-model-license
+mere.run model pull sfx-woosh-synchformer --accept-model-license
 mere.run sfx generate --help
 mere.run sfx clap score --help
 mere.run sfx video generate --help

--- a/Sources/MereRunCLI/Guides/video-export-latents.md
+++ b/Sources/MereRunCLI/Guides/video-export-latents.md
@@ -11,7 +11,7 @@ Managed id: `video-ltx-av`, or a local distilled LTX model root with the expecte
 ## Install And Check
 
 ```bash
-mere.run model pull video-ltx-av
+mere.run model pull video-ltx-av --accept-model-license
 mere.run video export-latents --help
 ```
 

--- a/Sources/MereRunCLI/Guides/video-generate.md
+++ b/Sources/MereRunCLI/Guides/video-generate.md
@@ -18,7 +18,7 @@ You can also pass a local LTX model root with `--model-root`.
 ## Install And Check
 
 ```bash
-mere.run model pull video-ltx23-av-mlx
+mere.run model pull video-ltx23-av-mlx --accept-model-license
 mere.run video generate --help
 ```
 

--- a/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
+++ b/Sources/MereRunCLI/Guides/vision-image-to-3d-trellis2.md
@@ -12,7 +12,7 @@ First accept the DINOv3 license on Hugging Face and authenticate the local Hub
 client. Then install the pinned model graph and run reconstruction:
 
 ```bash
-mere.run model pull image-3d-trellis2-4b
+mere.run model pull image-3d-trellis2-4b --accept-model-license
 mere.run vision image-to-3d-trellis2 ./chair.png \
   --output ./chair-trellis2 \
   --seed 42 \

--- a/Sources/MereRunCLI/Guides/vision-segment.md
+++ b/Sources/MereRunCLI/Guides/vision-segment.md
@@ -11,7 +11,7 @@ Managed id: `vision-segment-sam31`, or a local SAM 3.1 model root.
 ## Install And Check
 
 ```bash
-mere.run model pull vision-segment-sam31
+mere.run model pull vision-segment-sam31 --accept-model-license
 mere.run vision segment --help
 ```
 

--- a/Sources/MereRunCLI/Guides/vision-track-live.md
+++ b/Sources/MereRunCLI/Guides/vision-track-live.md
@@ -11,7 +11,7 @@ Managed id: `vision-segment-sam31`, or a local SAM 3.1 model root.
 ## Install And Check
 
 ```bash
-mere.run model pull vision-segment-sam31
+mere.run model pull vision-segment-sam31 --accept-model-license
 mere.run vision track-live --help
 ```
 

--- a/Sources/MereRunCLI/Guides/vision-track.md
+++ b/Sources/MereRunCLI/Guides/vision-track.md
@@ -11,7 +11,7 @@ Managed id: `vision-segment-sam31`, or a local SAM 3.1 model root.
 ## Install And Check
 
 ```bash
-mere.run model pull vision-segment-sam31
+mere.run model pull vision-segment-sam31 --accept-model-license
 mere.run vision track --help
 ```
 

--- a/Sources/MereRunCLI/Support/CLICommandDisplay.swift
+++ b/Sources/MereRunCLI/Support/CLICommandDisplay.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MereRunCore
 
 enum CLICommandDisplay {
     static var executable: String {
@@ -13,5 +14,12 @@ enum CLICommandDisplay {
 
     static func command(_ arguments: String) -> String {
         "\(executable) \(arguments)"
+    }
+
+    static func modelPullCommand(for modelID: String) -> String {
+        let acknowledgement = ManagedModelCatalog.spec(for: modelID)?.usageRestriction == nil
+            ? ""
+            : " --accept-model-license"
+        return command("model pull \(modelID)\(acknowledgement)")
     }
 }

--- a/Sources/MereRunCLI/Support/ModelPullPreflight.swift
+++ b/Sources/MereRunCLI/Support/ModelPullPreflight.swift
@@ -6,6 +6,7 @@ struct ModelPullPreflightInput {
     let all: Bool
     let force: Bool
     let allowUnsupported: Bool
+    let acceptUsageTerms: Bool
     let pullArgv: [String]
     let cwd: String
 }
@@ -15,12 +16,14 @@ struct ModelPullPreflightRequest: Codable, Equatable {
     let all: Bool
     let force: Bool
     let allowUnsupported: Bool
+    let acceptUsageTerms: Bool
 
     enum CodingKeys: String, CodingKey {
         case target
         case all
         case force
         case allowUnsupported = "allow_unsupported"
+        case acceptUsageTerms = "accept_usage_terms"
     }
 }
 
@@ -81,6 +84,8 @@ struct ModelPullModelPreflightSummary: Codable, Equatable {
     let estimatedDownloadBytes: Int64?
     let estimatedRequiredBytes: Int64?
     let companionModelIDs: [String]
+    let usageTerms: [ManagedModelUsageTerm]
+    let usageTermsAcknowledged: Bool
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -103,6 +108,8 @@ struct ModelPullModelPreflightSummary: Codable, Equatable {
         case estimatedDownloadBytes = "estimated_download_bytes"
         case estimatedRequiredBytes = "estimated_required_bytes"
         case companionModelIDs = "companion_model_ids"
+        case usageTerms = "usage_terms"
+        case usageTermsAcknowledged = "usage_terms_acknowledged"
     }
 }
 
@@ -165,7 +172,8 @@ struct ModelPullPreflightAnalyzer {
                 target: input.target,
                 all: input.all,
                 force: input.force,
-                allowUnsupported: input.allowUnsupported
+                allowUnsupported: input.allowUnsupported,
+                acceptUsageTerms: input.acceptUsageTerms
             ),
             result: result,
             diagnostics: diagnostics,
@@ -236,7 +244,13 @@ struct ModelPullPreflightAnalyzer {
         let selected = input.all || spec.id == input.target
         let blockedBySupport = !input.allowUnsupported && !support.isSupported
         let blockedBySource = !hasSource
-        let willDownload = selected && hasSource && !blockedBySupport && (input.force || !installed)
+        let requiresUsageTermsAcknowledgement = spec.usageRestriction != nil && (input.force || !installed)
+        let blockedByUsageTerms = requiresUsageTermsAcknowledgement && !input.acceptUsageTerms
+        let installedUsageTermsAcknowledged = (try? MereRunModelManifest.loadIfPresent(
+            from: installPath,
+            fileManager: fileManager
+        ))?.usageTermsAcknowledged == true
+        let willDownload = selected && hasSource && !blockedBySupport && !blockedByUsageTerms && (input.force || !installed)
         let status = Self.modelStatus(
             selected: selected,
             installed: installed,
@@ -244,7 +258,8 @@ struct ModelPullPreflightAnalyzer {
             willDownload: willDownload,
             blockedBySupport: blockedBySupport,
             blockedBySource: blockedBySource,
-            all: input.all
+            all: input.all,
+            blockedByUsageTerms: blockedByUsageTerms
         )
 
         if !input.all, blockedBySupport {
@@ -265,6 +280,16 @@ struct ModelPullPreflightAnalyzer {
                     severity: .blocker,
                     title: "Model has no public download source",
                     message: ManagedModelCatalog.missingHubSourceMessage(for: spec.id)
+                )
+            )
+        }
+        if !input.all, blockedByUsageTerms, let restriction = spec.usageRestriction {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "model_usage_terms_unacknowledged",
+                    severity: .blocker,
+                    title: "Third-party model terms require acknowledgement",
+                    message: "\(restriction.summary) Review the listed terms and pass --accept-model-license to acknowledge them before download."
                 )
             )
         }
@@ -301,7 +326,10 @@ struct ModelPullPreflightAnalyzer {
             hubRepoIDs: hubRepoIDs(for: spec),
             estimatedDownloadBytes: spec.estimatedDownloadBytes,
             estimatedRequiredBytes: ModelPullDiskPreflight.requiredBytes(estimatedDownloadBytes: spec.estimatedDownloadBytes),
-            companionModelIDs: spec.companionModelIDs
+            companionModelIDs: spec.companionModelIDs,
+            usageTerms: spec.usageRestriction?.terms ?? [],
+            usageTermsAcknowledged: spec.usageRestriction != nil
+                && (input.acceptUsageTerms || installedUsageTermsAcknowledged)
         )
     }
 
@@ -312,11 +340,13 @@ struct ModelPullPreflightAnalyzer {
         willDownload: Bool,
         blockedBySupport: Bool,
         blockedBySource: Bool,
-        all: Bool
+        all: Bool,
+        blockedByUsageTerms: Bool = false
     ) -> String {
         if !selected { return "not_selected" }
         if blockedBySupport { return all ? "skipped_unsupported" : "blocked_unsupported" }
         if blockedBySource { return all ? "skipped_no_source" : "blocked_no_source" }
+        if blockedByUsageTerms { return all ? "skipped_usage_terms" : "blocked_usage_terms" }
         if willDownload { return "will_download" }
         if conversionRequired { return "conversion_required" }
         if installed { return "installed" }

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -827,7 +827,7 @@ enum RuntimeModelPoolError: LocalizedError, Equatable {
         case .unsupportedModel(let id):
             return "Model '\(id)' is not supported by `mere.run api serve`."
         case .modelNotInstalled(let id):
-            return "Model '\(id)' is not installed. Run `mere.run model pull \(id)` first."
+            return "Model '\(id)' is not installed. Run `\(CLICommandDisplay.modelPullCommand(for: id))` first."
         case .incompatibleEngine(let detail):
             return detail
         case .unloadConflict(let id, let activeRequests):

--- a/Sources/MereRunCore/FaceAnalysis/FaceAnalysisResources.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceAnalysisResources.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct FaceAnalysisResources: Sendable {
+    public static let modelID = "vision-face-buffalo-l"
+    public static let detectorRelativePath = "buffalo_l/det_10g.onnx"
+    public static let recognizerRelativePath = "buffalo_l/w600k_r50.onnx"
+    public static let detectorByteCount: Int64 = 16_923_827
+    public static let recognizerByteCount: Int64 = 174_383_860
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var detectorURL: URL {
+        rootURL.appendingPathComponent(Self.detectorRelativePath)
+    }
+
+    public var recognizerURL: URL {
+        rootURL.appendingPathComponent(Self.recognizerRelativePath)
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        [
+            (detectorURL, Self.detectorByteCount),
+            (recognizerURL, Self.recognizerByteCount),
+        ].compactMap { url, expectedBytes in
+            guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+                  let byteCount = (attributes[.size] as? NSNumber)?.int64Value,
+                  byteCount == expectedBytes else {
+                return url
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/MereRunCore/FaceAnalysis/FaceAnalysisTypes.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceAnalysisTypes.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+public enum FaceExecutionProvider: String, Codable, CaseIterable, Hashable, Sendable {
+    case auto
+    case coreML = "coreml"
+    case cpu
+}
+
+public struct FacePoint: Codable, Hashable, Sendable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct FaceBoundingBox: Codable, Hashable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    public var area: Double { max(0, width) * max(0, height) }
+}
+
+public struct FaceDetection: Codable, Hashable, Sendable {
+    public let score: Double
+    public let boundingBox: FaceBoundingBox
+    public let landmarks: [FacePoint]
+
+    public init(score: Double, boundingBox: FaceBoundingBox, landmarks: [FacePoint]) {
+        self.score = score
+        self.boundingBox = boundingBox
+        self.landmarks = landmarks
+    }
+}
+
+public struct FaceRecord: Codable, Hashable, Sendable {
+    public let index: Int
+    public let detection: FaceDetection
+    public let embedding: [Float]?
+
+    public init(index: Int, detection: FaceDetection, embedding: [Float]? = nil) {
+        self.index = index
+        self.detection = detection
+        self.embedding = embedding
+    }
+}
+
+public struct FaceAnalysisResult: Codable, Hashable, Sendable {
+    public let image: String
+    public let width: Int
+    public let height: Int
+    public let modelID: String
+    public let faces: [FaceRecord]
+    public let elapsedMilliseconds: Double
+
+    public init(
+        image: String,
+        width: Int,
+        height: Int,
+        modelID: String,
+        faces: [FaceRecord],
+        elapsedMilliseconds: Double
+    ) {
+        self.image = image
+        self.width = width
+        self.height = height
+        self.modelID = modelID
+        self.faces = faces
+        self.elapsedMilliseconds = elapsedMilliseconds
+    }
+}
+
+public enum FaceAnalysisMath {
+    public static func l2Normalized(_ values: [Float]) -> [Float] {
+        let squaredNorm = values.reduce(Float.zero) { $0 + ($1 * $1) }
+        let norm = sqrt(squaredNorm)
+        guard norm > 0 else { return values }
+        return values.map { $0 / norm }
+    }
+
+    public static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Double? {
+        guard !lhs.isEmpty, lhs.count == rhs.count else { return nil }
+        var dot = Float.zero
+        var lhsNorm = Float.zero
+        var rhsNorm = Float.zero
+        for index in lhs.indices {
+            dot += lhs[index] * rhs[index]
+            lhsNorm += lhs[index] * lhs[index]
+            rhsNorm += rhs[index] * rhs[index]
+        }
+        let denominator = sqrt(lhsNorm) * sqrt(rhsNorm)
+        guard denominator > 0 else { return nil }
+        return Double(dot / denominator)
+    }
+}
+
+public enum FaceAnalysisError: LocalizedError, Sendable {
+    case unavailableRuntime(String)
+    case missingModelFiles([URL])
+    case invalidModelOutput(String)
+    case noFaceDetected(URL)
+    case invalidLandmarks
+    case runtimeFailure(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unavailableRuntime(let details):
+            return details
+        case .missingModelFiles(let urls):
+            return "Face model is incomplete. Missing or invalid: \(urls.map(\.path).joined(separator: ", "))"
+        case .invalidModelOutput(let details):
+            return "Invalid face model output: \(details)"
+        case .noFaceDetected(let url):
+            return "No face detected in \(url.path)."
+        case .invalidLandmarks:
+            return "Expected five valid facial landmarks for alignment."
+        case .runtimeFailure(let details):
+            return "Face runtime failed: \(details)"
+        }
+    }
+}

--- a/Sources/MereRunCore/FaceAnalysis/FaceAnalyzer.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceAnalyzer.swift
@@ -1,0 +1,109 @@
+import Foundation
+import MediaIO
+
+public final class FaceAnalyzer {
+    public struct Options: Hashable, Sendable {
+        public var scoreThreshold: Float
+        public var nmsThreshold: Double
+        public var maxFaces: Int?
+        public var includeEmbeddings: Bool
+
+        public init(
+            scoreThreshold: Float = 0.65,
+            nmsThreshold: Double = 0.4,
+            maxFaces: Int? = nil,
+            includeEmbeddings: Bool = false
+        ) {
+            self.scoreThreshold = scoreThreshold
+            self.nmsThreshold = nmsThreshold
+            self.maxFaces = maxFaces
+            self.includeEmbeddings = includeEmbeddings
+        }
+    }
+
+    private let detector: FaceDetector
+    private let embedder: FaceEmbedder?
+
+    public init(
+        modelRootURL: URL,
+        includeRecognizer: Bool = true,
+        executionProvider: FaceExecutionProvider = .auto,
+        fileManager: FileManager = .default
+    ) throws {
+        let resources = FaceAnalysisResources(rootURL: modelRootURL)
+        let missing = resources.validate(fileManager: fileManager)
+        guard missing.isEmpty else { throw FaceAnalysisError.missingModelFiles(missing) }
+        detector = try FaceDetector(modelURL: resources.detectorURL, executionProvider: executionProvider)
+        embedder = includeRecognizer
+            ? try FaceEmbedder(modelURL: resources.recognizerURL, executionProvider: executionProvider)
+            : nil
+    }
+
+    public func analyze(imageURL: URL, options: Options = Options()) throws -> FaceAnalysisResult {
+        let started = ContinuousClock.now
+        let image = try MediaImageIO.decode(imageURL)
+        let detections = try detector.detect(
+            image: image,
+            scoreThreshold: options.scoreThreshold,
+            nmsThreshold: options.nmsThreshold,
+            maxFaces: options.maxFaces
+        )
+        let faces = try detections.enumerated().map { index, detection in
+            FaceRecord(
+                index: index,
+                detection: detection,
+                embedding: options.includeEmbeddings ? try requireEmbedder().embed(
+                    image: image,
+                    landmarks: detection.landmarks
+                ) : nil
+            )
+        }
+        let duration = started.duration(to: .now)
+        return FaceAnalysisResult(
+            image: imageURL.standardizedFileURL.path,
+            width: image.width,
+            height: image.height,
+            modelID: FaceAnalysisResources.modelID,
+            faces: faces,
+            elapsedMilliseconds: duration.seconds * 1_000
+        )
+    }
+
+    public func embedding(
+        imageURL: URL,
+        scoreThreshold: Float = 0.65,
+        selection: Int? = nil
+    ) throws -> FaceRecord {
+        let result = try analyze(
+            imageURL: imageURL,
+            options: Options(
+                scoreThreshold: scoreThreshold,
+                includeEmbeddings: true
+            )
+        )
+        guard !result.faces.isEmpty else { throw FaceAnalysisError.noFaceDetected(imageURL) }
+        if let selection {
+            guard result.faces.indices.contains(selection) else {
+                throw FaceAnalysisError.invalidModelOutput(
+                    "face index \(selection) is outside 0..<\(result.faces.count)"
+                )
+            }
+            return result.faces[selection]
+        }
+        return result.faces.max { $0.detection.boundingBox.area < $1.detection.boundingBox.area }!
+    }
+
+    private func requireEmbedder() throws -> FaceEmbedder {
+        guard let embedder else {
+            throw FaceAnalysisError.runtimeFailure("recognizer session was not loaded")
+        }
+        return embedder
+    }
+}
+
+private extension Duration {
+    var seconds: Double {
+        let components = self.components
+        return Double(components.seconds) + (Double(components.attoseconds) / 1e18)
+    }
+}

--- a/Sources/MereRunCore/FaceAnalysis/FaceDetector.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceDetector.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MediaIO
+
+struct FaceDetector {
+    private static let strides = [8, 16, 32]
+    private static let anchorsPerCell = 2
+    private static let outputNames = ["448", "471", "494", "451", "474", "497", "454", "477", "500"]
+
+    let session: FaceONNXSession
+
+    init(modelURL: URL, executionProvider: FaceExecutionProvider) throws {
+        session = try FaceONNXSession(modelURL: modelURL, executionProvider: executionProvider)
+    }
+
+    func detect(
+        image: MediaImage,
+        scoreThreshold: Float,
+        nmsThreshold: Double,
+        maxFaces: Int?
+    ) throws -> [FaceDetection] {
+        let input = try FaceImageProcessing.detectorInput(from: image)
+        let outputs = try session.run(
+            input: input.values,
+            shape: [1, 3, 640, 640],
+            inputName: "input.1",
+            outputNames: Self.outputNames
+        )
+        guard outputs.count == Self.outputNames.count else {
+            throw FaceAnalysisError.invalidModelOutput("detector returned \(outputs.count) tensors")
+        }
+
+        var candidates: [FaceDetection] = []
+        for level in Self.strides.indices {
+            let stride = Self.strides[level]
+            let scores = outputs[level]
+            let boxes = outputs[level + 3]
+            let landmarks = outputs[level + 6]
+            let grid = 640 / stride
+            let anchorCount = grid * grid * Self.anchorsPerCell
+            guard scores.count == anchorCount,
+                  boxes.count == anchorCount * 4,
+                  landmarks.count == anchorCount * 10 else {
+                throw FaceAnalysisError.invalidModelOutput(
+                    "unexpected detector shapes at stride \(stride): scores=\(scores.count) boxes=\(boxes.count) landmarks=\(landmarks.count)"
+                )
+            }
+
+            for anchor in 0..<anchorCount where scores[anchor] >= scoreThreshold {
+                let cell = anchor / Self.anchorsPerCell
+                let centerX = Float(cell % grid) * Float(stride)
+                let centerY = Float(cell / grid) * Float(stride)
+                let boxOffset = anchor * 4
+                let x1 = Double(centerX - boxes[boxOffset] * Float(stride)) / input.scale
+                let y1 = Double(centerY - boxes[boxOffset + 1] * Float(stride)) / input.scale
+                let x2 = Double(centerX + boxes[boxOffset + 2] * Float(stride)) / input.scale
+                let y2 = Double(centerY + boxes[boxOffset + 3] * Float(stride)) / input.scale
+                let clippedX1 = min(max(0, x1), Double(image.width))
+                let clippedY1 = min(max(0, y1), Double(image.height))
+                let clippedX2 = min(max(0, x2), Double(image.width))
+                let clippedY2 = min(max(0, y2), Double(image.height))
+
+                var points: [FacePoint] = []
+                let landmarkOffset = anchor * 10
+                for point in 0..<5 {
+                    points.append(FacePoint(
+                        x: Double(centerX + landmarks[landmarkOffset + (point * 2)] * Float(stride)) / input.scale,
+                        y: Double(centerY + landmarks[landmarkOffset + (point * 2) + 1] * Float(stride)) / input.scale
+                    ))
+                }
+                candidates.append(FaceDetection(
+                    score: Double(scores[anchor]),
+                    boundingBox: FaceBoundingBox(
+                        x: clippedX1,
+                        y: clippedY1,
+                        width: max(0, clippedX2 - clippedX1),
+                        height: max(0, clippedY2 - clippedY1)
+                    ),
+                    landmarks: points
+                ))
+            }
+        }
+
+        let selected = nonMaximumSuppression(candidates, threshold: nmsThreshold)
+        if let maxFaces { return Array(selected.prefix(max(0, maxFaces))) }
+        return selected
+    }
+
+    private func nonMaximumSuppression(_ detections: [FaceDetection], threshold: Double) -> [FaceDetection] {
+        var remaining = detections.sorted { $0.score > $1.score }
+        var selected: [FaceDetection] = []
+        while let best = remaining.first {
+            selected.append(best)
+            remaining.removeFirst()
+            remaining.removeAll { intersectionOverUnion(best.boundingBox, $0.boundingBox) > threshold }
+        }
+        return selected
+    }
+
+    private func intersectionOverUnion(_ lhs: FaceBoundingBox, _ rhs: FaceBoundingBox) -> Double {
+        let x1 = max(lhs.x, rhs.x)
+        let y1 = max(lhs.y, rhs.y)
+        let x2 = min(lhs.x + lhs.width, rhs.x + rhs.width)
+        let y2 = min(lhs.y + lhs.height, rhs.y + rhs.height)
+        let intersection = max(0, x2 - x1) * max(0, y2 - y1)
+        let union = lhs.area + rhs.area - intersection
+        return union > 0 ? intersection / union : 0
+    }
+}

--- a/Sources/MereRunCore/FaceAnalysis/FaceEmbedder.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceEmbedder.swift
@@ -1,0 +1,26 @@
+import Foundation
+import MediaIO
+
+struct FaceEmbedder {
+    let session: FaceONNXSession
+
+    init(modelURL: URL, executionProvider: FaceExecutionProvider) throws {
+        session = try FaceONNXSession(modelURL: modelURL, executionProvider: executionProvider)
+    }
+
+    func embed(image: MediaImage, landmarks: [FacePoint]) throws -> [Float] {
+        let aligned = try FaceImageProcessing.alignedFace(from: image, landmarks: landmarks)
+        let outputs = try session.run(
+            input: FaceImageProcessing.recognizerInput(from: aligned),
+            shape: [1, 3, 112, 112],
+            inputName: "input.1",
+            outputNames: ["683"]
+        )
+        guard let values = outputs.first, values.count == 512 else {
+            throw FaceAnalysisError.invalidModelOutput(
+                "recognizer returned \(outputs.first?.count ?? 0) values; expected 512"
+            )
+        }
+        return FaceAnalysisMath.l2Normalized(values)
+    }
+}

--- a/Sources/MereRunCore/FaceAnalysis/FaceImageProcessing.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceImageProcessing.swift
@@ -1,0 +1,187 @@
+import Foundation
+import MediaIO
+
+struct FaceDetectorInput {
+    let values: [Float]
+    let scale: Double
+}
+
+enum FaceImageProcessing {
+    static let detectorSize = 640
+    static let recognizerSize = 112
+    static let arcFaceTemplate = [
+        FacePoint(x: 38.2946, y: 51.6963),
+        FacePoint(x: 73.5318, y: 51.5014),
+        FacePoint(x: 56.0252, y: 71.7366),
+        FacePoint(x: 41.5493, y: 92.3655),
+        FacePoint(x: 70.7299, y: 92.2041),
+    ]
+
+    static func detectorInput(from image: MediaImage) throws -> FaceDetectorInput {
+        let scale = min(
+            Double(detectorSize) / Double(image.width),
+            Double(detectorSize) / Double(image.height)
+        )
+        let resizedWidth = max(1, Int((Double(image.width) * scale).rounded()))
+        let resizedHeight = max(1, Int((Double(image.height) * scale).rounded()))
+        let resized = try resizedBilinear(image, width: resizedWidth, height: resizedHeight)
+        var canvas = try MediaImage(
+            width: detectorSize,
+            height: detectorSize,
+            rgba8: [UInt8](repeating: 0, count: detectorSize * detectorSize * 4)
+        )
+        for pixel in 0..<(detectorSize * detectorSize) {
+            canvas.rgba8[(pixel * 4) + 3] = 255
+        }
+        for y in 0..<resizedHeight {
+            for x in 0..<resizedWidth {
+                let source = ((y * resizedWidth) + x) * 4
+                let destination = ((y * detectorSize) + x) * 4
+                canvas.rgba8[destination..<(destination + 4)] = resized.rgba8[source..<(source + 4)]
+            }
+        }
+        return FaceDetectorInput(values: normalizedCHW(canvas, scale: 128), scale: scale)
+    }
+
+    static func alignedFace(from image: MediaImage, landmarks: [FacePoint]) throws -> MediaImage {
+        guard landmarks.count == arcFaceTemplate.count,
+              let transform = similarityTransform(from: landmarks, to: arcFaceTemplate) else {
+            throw FaceAnalysisError.invalidLandmarks
+        }
+        return try warpedBilinear(
+            image,
+            width: recognizerSize,
+            height: recognizerSize,
+            sourceToDestination: transform
+        )
+    }
+
+    static func recognizerInput(from alignedFace: MediaImage) -> [Float] {
+        normalizedCHW(alignedFace, scale: 127.5)
+    }
+
+    private static func normalizedCHW(_ image: MediaImage, scale: Float) -> [Float] {
+        let pixelCount = image.width * image.height
+        var values = [Float](repeating: 0, count: pixelCount * 3)
+        for pixel in 0..<pixelCount {
+            let source = pixel * 4
+            values[pixel] = (Float(image.rgba8[source]) - 127.5) / scale
+            values[pixel + pixelCount] = (Float(image.rgba8[source + 1]) - 127.5) / scale
+            values[pixel + (2 * pixelCount)] = (Float(image.rgba8[source + 2]) - 127.5) / scale
+        }
+        return values
+    }
+
+    private static func resizedBilinear(_ image: MediaImage, width: Int, height: Int) throws -> MediaImage {
+        var output = [UInt8](repeating: 0, count: width * height * 4)
+        let xScale = Double(image.width) / Double(width)
+        let yScale = Double(image.height) / Double(height)
+        for y in 0..<height {
+            let sourceY = min(
+                Double(image.height - 1),
+                max(0, ((Double(y) + 0.5) * yScale) - 0.5)
+            )
+            for x in 0..<width {
+                let sourceX = min(
+                    Double(image.width - 1),
+                    max(0, ((Double(x) + 0.5) * xScale) - 0.5)
+                )
+                sampleBilinear(image, x: sourceX, y: sourceY, into: &output, at: ((y * width) + x) * 4)
+            }
+        }
+        return try MediaImage(width: width, height: height, rgba8: output)
+    }
+
+    private static func warpedBilinear(
+        _ image: MediaImage,
+        width: Int,
+        height: Int,
+        sourceToDestination transform: [Double]
+    ) throws -> MediaImage {
+        let a = transform[0]
+        let b = transform[1]
+        let tx = transform[2]
+        let ty = transform[3]
+        let determinant = (a * a) + (b * b)
+        guard determinant > 1e-12 else { throw FaceAnalysisError.invalidLandmarks }
+        var output = [UInt8](repeating: 0, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                let dx = Double(x) - tx
+                let dy = Double(y) - ty
+                let sourceX = ((a * dx) + (b * dy)) / determinant
+                let sourceY = ((-b * dx) + (a * dy)) / determinant
+                sampleBilinear(image, x: sourceX, y: sourceY, into: &output, at: ((y * width) + x) * 4)
+            }
+        }
+        return try MediaImage(width: width, height: height, rgba8: output)
+    }
+
+    private static func sampleBilinear(
+        _ image: MediaImage,
+        x: Double,
+        y: Double,
+        into output: inout [UInt8],
+        at destination: Int
+    ) {
+        guard x >= 0, y >= 0, x <= Double(image.width - 1), y <= Double(image.height - 1) else {
+            output[destination + 3] = 255
+            return
+        }
+        let x0 = Int(floor(x))
+        let y0 = Int(floor(y))
+        let x1 = min(image.width - 1, x0 + 1)
+        let y1 = min(image.height - 1, y0 + 1)
+        let fx = x - Double(x0)
+        let fy = y - Double(y0)
+        for channel in 0..<4 {
+            let topLeft = Double(image.rgba8[((y0 * image.width) + x0) * 4 + channel])
+            let topRight = Double(image.rgba8[((y0 * image.width) + x1) * 4 + channel])
+            let bottomLeft = Double(image.rgba8[((y1 * image.width) + x0) * 4 + channel])
+            let bottomRight = Double(image.rgba8[((y1 * image.width) + x1) * 4 + channel])
+            let top = topLeft + ((topRight - topLeft) * fx)
+            let bottom = bottomLeft + ((bottomRight - bottomLeft) * fx)
+            output[destination + channel] = UInt8(clamping: Int((top + ((bottom - top) * fy)).rounded()))
+        }
+    }
+
+    private static func similarityTransform(from source: [FacePoint], to destination: [FacePoint]) -> [Double]? {
+        guard source.count == destination.count, source.count >= 2 else { return nil }
+        var normal = Array(repeating: Array(repeating: 0.0, count: 4), count: 4)
+        var target = Array(repeating: 0.0, count: 4)
+
+        func accumulate(_ row: [Double], value: Double) {
+            for i in 0..<4 {
+                target[i] += row[i] * value
+                for j in 0..<4 {
+                    normal[i][j] += row[i] * row[j]
+                }
+            }
+        }
+
+        for index in source.indices {
+            let x = source[index].x
+            let y = source[index].y
+            accumulate([x, -y, 1, 0], value: destination[index].x)
+            accumulate([y, x, 0, 1], value: destination[index].y)
+        }
+        return solveLinearSystem(normal, target)
+    }
+
+    private static func solveLinearSystem(_ matrix: [[Double]], _ vector: [Double]) -> [Double]? {
+        var augmented = zip(matrix, vector).map { $0 + [$1] }
+        for column in 0..<4 {
+            guard let pivot = (column..<4).max(by: {
+                abs(augmented[$0][column]) < abs(augmented[$1][column])
+            }), abs(augmented[pivot][column]) > 1e-12 else { return nil }
+            augmented.swapAt(column, pivot)
+            let divisor = augmented[column][column]
+            for index in column...4 { augmented[column][index] /= divisor }
+            for row in 0..<4 where row != column {
+                let factor = augmented[row][column]
+                for index in column...4 { augmented[row][index] -= factor * augmented[column][index] }
+            }
+        }
+        return augmented.map { $0[4] }
+    }
+}

--- a/Sources/MereRunCore/FaceAnalysis/FaceONNXSession.swift
+++ b/Sources/MereRunCore/FaceAnalysis/FaceONNXSession.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+#if canImport(CONNXRuntime) && os(macOS)
+import CONNXRuntime
+import COnnxRuntimeCoreML
+import Darwin
+
+final class FaceONNXSession {
+    private let api: UnsafePointer<OrtApi>
+    private var environment: OpaquePointer?
+    private var session: OpaquePointer?
+    private var memoryInfo: OpaquePointer?
+
+    init(modelURL: URL, executionProvider: FaceExecutionProvider) throws {
+        guard let api = OrtGetApiBase()?.pointee.GetApi(UInt32(ORT_API_VERSION)) else {
+            throw FaceAnalysisError.runtimeFailure("could not load ONNX Runtime API")
+        }
+        self.api = api
+
+        try checked(api.pointee.CreateEnv(ORT_LOGGING_LEVEL_WARNING, "mere.run.face", &environment))
+        var options: OpaquePointer?
+        try checked(api.pointee.CreateSessionOptions(&options))
+        defer { api.pointee.ReleaseSessionOptions(options) }
+        try checked(api.pointee.SetSessionGraphOptimizationLevel(options, ORT_ENABLE_ALL))
+        let savedStandardOutput: Int32 = executionProvider == .coreML ? Self.redirectStandardOutputToStandardError() : -1
+        defer { Self.restoreStandardOutput(savedStandardOutput) }
+        if executionProvider == .coreML {
+            let status = MereRunOrtAppendCoreML(options, 0x010)
+            try checked(status)
+        }
+        let createStatus = modelURL.path.withCString { path in
+            api.pointee.CreateSession(environment, path, options, &session)
+        }
+        try checked(createStatus)
+        try checked(api.pointee.CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &memoryInfo))
+    }
+
+    deinit {
+        api.pointee.ReleaseMemoryInfo(memoryInfo)
+        api.pointee.ReleaseSession(session)
+        api.pointee.ReleaseEnv(environment)
+    }
+
+    func run(input: [Float], shape: [Int64], inputName: String, outputNames: [String]) throws -> [[Float]] {
+        guard let memoryInfo, let session else {
+            throw FaceAnalysisError.runtimeFailure("ONNX session is not initialized")
+        }
+        var mutableInput = input
+        var inputValue: OpaquePointer?
+        try mutableInput.withUnsafeMutableBytes { buffer in
+            try shape.withUnsafeBufferPointer { shapeBuffer in
+                try checked(api.pointee.CreateTensorWithDataAsOrtValue(
+                    memoryInfo,
+                    buffer.baseAddress,
+                    buffer.count,
+                    shapeBuffer.baseAddress,
+                    shapeBuffer.count,
+                    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+                    &inputValue
+                ))
+            }
+        }
+        defer { api.pointee.ReleaseValue(inputValue) }
+
+        let inputCString = strdup(inputName)
+        let outputCStrings = outputNames.map { strdup($0) }
+        defer {
+            free(inputCString)
+            outputCStrings.forEach { free($0) }
+        }
+        let inputNamePointers: [UnsafePointer<CChar>?] = [
+            inputCString.map { UnsafePointer<CChar>($0) },
+        ]
+        let outputNamePointers: [UnsafePointer<CChar>?] = outputCStrings.map {
+            $0.map { UnsafePointer<CChar>($0) }
+        }
+        var outputs = [OpaquePointer?](repeating: nil, count: outputNames.count)
+
+        try inputNamePointers.withUnsafeBufferPointer { inputNamesBuffer in
+            try outputNamePointers.withUnsafeBufferPointer { outputNamesBuffer in
+                try outputs.withUnsafeMutableBufferPointer { outputBuffer in
+                    let inputValues: [OpaquePointer?] = [inputValue]
+                    try inputValues.withUnsafeBufferPointer { inputValuesBuffer in
+                        try checked(api.pointee.Run(
+                            session,
+                            nil,
+                            inputNamesBuffer.baseAddress,
+                            inputValuesBuffer.baseAddress,
+                            1,
+                            outputNamesBuffer.baseAddress,
+                            outputNamesBuffer.count,
+                            outputBuffer.baseAddress
+                        ))
+                    }
+                }
+            }
+        }
+        defer { outputs.forEach { api.pointee.ReleaseValue($0) } }
+        return try outputs.map(readFloatTensor)
+    }
+
+    private func readFloatTensor(_ value: OpaquePointer?) throws -> [Float] {
+        guard let value else { throw FaceAnalysisError.invalidModelOutput("missing output tensor") }
+        var typeAndShape: OpaquePointer?
+        try checked(api.pointee.GetTensorTypeAndShape(value, &typeAndShape))
+        defer { api.pointee.ReleaseTensorTypeAndShapeInfo(typeAndShape) }
+        var count = 0
+        try checked(api.pointee.GetTensorShapeElementCount(typeAndShape, &count))
+        var data: UnsafeMutableRawPointer?
+        try checked(api.pointee.GetTensorMutableData(value, &data))
+        guard let floats = data?.assumingMemoryBound(to: Float.self) else {
+            throw FaceAnalysisError.invalidModelOutput("output tensor has no data")
+        }
+        return Array(UnsafeBufferPointer(start: floats, count: count))
+    }
+
+    private func checked(_ status: OpaquePointer?) throws {
+        guard let status else { return }
+        defer { api.pointee.ReleaseStatus(status) }
+        let message = api.pointee.GetErrorMessage(status).map(String.init(cString:)) ?? "unknown ONNX Runtime error"
+        throw FaceAnalysisError.runtimeFailure(message)
+    }
+
+    private static func redirectStandardOutputToStandardError() -> Int32 {
+        fflush(stdout)
+        let saved = dup(STDOUT_FILENO)
+        if saved >= 0 { _ = dup2(STDERR_FILENO, STDOUT_FILENO) }
+        return saved
+    }
+
+    private static func restoreStandardOutput(_ saved: Int32) {
+        guard saved >= 0 else { return }
+        fflush(stdout)
+        _ = dup2(saved, STDOUT_FILENO)
+        close(saved)
+    }
+}
+#else
+final class FaceONNXSession {
+    init(modelURL: URL, executionProvider: FaceExecutionProvider) throws {
+        throw FaceAnalysisError.unavailableRuntime(
+            "Face analysis currently requires the macOS ONNX Runtime build; model: \(modelURL.path)"
+        )
+    }
+
+    func run(input: [Float], shape: [Int64], inputName: String, outputNames: [String]) throws -> [[Float]] {
+        throw FaceAnalysisError.unavailableRuntime("Face analysis ONNX Runtime is unavailable on this platform.")
+    }
+}
+#endif

--- a/Sources/MereRunCore/FaceAnalysis/README.md
+++ b/Sources/MereRunCore/FaceAnalysis/README.md
@@ -1,0 +1,34 @@
+# FaceAnalysis
+
+This module owns deterministic local inference for the managed
+`vision-face-buffalo-l` model. It intentionally stops at raw, reusable face
+primitives; library traversal, databases, identity labels, clustering, and
+review/export workflows belong in `mere-run-plugins`.
+
+## Data flow
+
+1. `FaceAnalysisResources` validates the pinned detector and recognizer files.
+2. `FaceImageProcessing` converts `MediaImage` pixels into InsightFace detector
+   input and aligns a selected face from five landmarks for ArcFace.
+3. `FaceDetector` decodes the pinned SCRFD/RetinaFace-style ONNX outputs and
+   applies non-maximum suppression.
+4. `FaceEmbedder` returns an L2-normalized 512-dimensional identity embedding.
+5. `FaceAnalyzer` exposes detection and selected-face embedding as typed,
+   codable results.
+
+`FaceONNXSession` is the only ONNX Runtime boundary. The macOS implementation
+supports CPU and explicit Core ML execution providers; `auto` currently uses
+CPU because the pinned Buffalo-L graphs benchmark faster there on Apple
+Silicon. Unsupported package platforms fail with a typed runtime error while
+the rest of core remains buildable.
+
+## Model contract
+
+The implementation is coupled to the exact pinned input/output names, shapes,
+preprocessing constants, and file sizes in `FaceAnalysisResources`. A different
+InsightFace export needs a new managed model contract rather than silent shape
+guessing.
+
+These models provide face boxes, five-point landmarks, alignment, and identity
+similarity. They do not infer emotion, demographics, liveness, deepfakes, or
+general visual semantics.

--- a/Sources/MereRunCore/FaceAnalysis/README.md
+++ b/Sources/MereRunCore/FaceAnalysis/README.md
@@ -32,3 +32,11 @@ guessing.
 These models provide face boxes, five-point landmarks, alignment, and identity
 similarity. They do not infer emotion, demographics, liveness, deepfakes, or
 general visual semantics.
+
+## Model license
+
+The ONNX Runtime dependency is MIT-licensed and is bundled with its complete
+notice. Buffalo-L model weights are downloaded separately and remain limited
+by InsightFace to non-commercial research use. `model pull` requires an
+explicit `--accept-model-license` acknowledgment and prints the upstream
+license URL before downloading them.

--- a/Sources/MereRunCore/Ideogram4/Ideogram4Resources.swift
+++ b/Sources/MereRunCore/Ideogram4/Ideogram4Resources.swift
@@ -3,10 +3,12 @@ import Foundation
 public struct Ideogram4Resources: Sendable, Hashable {
     public static let modelId = "image-ideogram4-sdnq-uint4"
     public static let upstreamRepoId = "WaveCut/ideogram-4-sdnq-uint4"
-    public static let upstreamRevision = "main"
+    public static let upstreamRevision = "ea2e67436478a97ad6c414c5f947d6d76aa8457d"
     public static let estimatedDownloadBytes: Int64 = 16 * 1_073_741_824
 
     public static let snapshotPatterns = [
+        "LICENSE*",
+        "README.md",
         "ideogram4_sdnq_pipeline.py",
         "model_index.json",
         "quantization_manifest.json",

--- a/Sources/MereRunCore/Krea2/Krea2RawResources.swift
+++ b/Sources/MereRunCore/Krea2/Krea2RawResources.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum Krea2RawResources {
     public static let modelId = "image-krea2-raw"
     public static let upstreamRepoId = "krea/Krea-2-Raw"
-    public static let upstreamRevision = "main"
+    public static let upstreamRevision = "4ad9f4b627a647fad78b3dfeebb09f2654aeb494"
     public static let estimatedDownloadBytes: Int64 = 36 * 1_073_741_824
 
     /// Raw ships both a root-level `raw.safetensors` file for Krea's official

--- a/Sources/MereRunCore/Krea2/Krea2Resources.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Resources.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct Krea2Resources: Sendable, Hashable {
     public static let modelId = "image-krea2-turbo"
     public static let upstreamRepoId = "krea/Krea-2-Turbo"
-    public static let upstreamRevision = "main"
+    public static let upstreamRevision = "1161245028ef398cd0a951101b2bbf486464f841"
     public static let estimatedDownloadBytes: Int64 = 36 * 1_073_741_824
 
     /// Krea publishes both split Diffusers component weights and a root-level

--- a/Sources/MereRunCore/LFM2/LFM2Resources.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Resources.swift
@@ -8,6 +8,8 @@ public struct LFM2Resources: Sendable, Hashable {
     public static let defaultContextLength = 32_768
 
     public static let snapshotPatterns = [
+        "LICENSE*",
+        "README.md",
         "config.json",
         "generation_config.json",
         "tokenizer.json",

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -2920,7 +2920,7 @@ public enum LTXUnifiedAVGeneratorError: LocalizedError {
         case .ltx23TextEncoderMissing(let id):
             return """
             LTX 2.3 requires the companion Gemma 3 text encoder `\(id)`. Install it with \
-            `mere.run model pull video-ltx23-av-mlx`, or set MERERUN_VIDEO_LTX_TEXT_ENCODER_ROOT to a local \
+            `mere.run model pull video-ltx23-av-mlx --accept-model-license`, or set MERERUN_VIDEO_LTX_TEXT_ENCODER_ROOT to a local \
             mlx-community/gemma-3-12b-it-4bit checkout.
             """
         case .generatorNotLoaded:

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -82,6 +82,16 @@ public enum ManagedModelAliasKind: String, Hashable, Sendable {
     case codegenGGUF
 }
 
+public struct ManagedModelUsageRestriction: Hashable, Sendable {
+    public let summary: String
+    public let licenseURL: String
+
+    public init(summary: String, licenseURL: String) {
+        self.summary = summary
+        self.licenseURL = licenseURL
+    }
+}
+
 public struct ManagedModelSpec: Hashable, Sendable {
     public let id: String
     public let category: ManagedModelCategory
@@ -90,6 +100,7 @@ public struct ManagedModelSpec: Hashable, Sendable {
     public let mountedHubFallbacks: [MountedHubFallbackConfig]
     public let upstreamRepoId: String?
     public let upstreamRevision: String?
+    public let usageRestriction: ManagedModelUsageRestriction?
     public let validationKind: ManagedModelValidationKind
     public let normalizationKind: ManagedModelNormalizationKind
     public let aliasKind: ManagedModelAliasKind
@@ -107,6 +118,7 @@ public struct ManagedModelSpec: Hashable, Sendable {
         mountedHubFallbacks: [MountedHubFallbackConfig] = [],
         upstreamRepoId: String? = nil,
         upstreamRevision: String? = nil,
+        usageRestriction: ManagedModelUsageRestriction? = nil,
         validationKind: ManagedModelValidationKind,
         normalizationKind: ManagedModelNormalizationKind = .none,
         aliasKind: ManagedModelAliasKind = .none,
@@ -123,6 +135,7 @@ public struct ManagedModelSpec: Hashable, Sendable {
         self.mountedHubFallbacks = mountedHubFallbacks
         self.upstreamRepoId = upstreamRepoId
         self.upstreamRevision = upstreamRevision
+        self.usageRestriction = usageRestriction
         self.validationKind = validationKind
         self.normalizationKind = normalizationKind
         self.aliasKind = aliasKind
@@ -1114,6 +1127,10 @@ public enum ManagedModelCatalog {
             ),
             upstreamRepoId: "deepghs/insightface",
             upstreamRevision: "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
+            usageRestriction: ManagedModelUsageRestriction(
+                summary: "InsightFace Buffalo-L pretrained weights are limited to non-commercial research use.",
+                licenseURL: "https://github.com/deepinsight/insightface#license"
+            ),
             validationKind: .insightFaceBuffaloL,
             estimatedDownloadBytes: FaceAnalysisResources.detectorByteCount
                 + FaceAnalysisResources.recognizerByteCount,

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -82,13 +82,51 @@ public enum ManagedModelAliasKind: String, Hashable, Sendable {
     case codegenGGUF
 }
 
-public struct ManagedModelUsageRestriction: Hashable, Sendable {
+public struct ManagedModelUsageTerm: Codable, Hashable, Sendable {
+    public let component: String
+    public let license: String
     public let summary: String
+    public let sourceRepoId: String
+    public let sourceRevision: String
     public let licenseURL: String
 
-    public init(summary: String, licenseURL: String) {
+    public init(
+        component: String,
+        license: String,
+        summary: String,
+        sourceRepoId: String,
+        sourceRevision: String,
+        licenseURL: String
+    ) {
+        self.component = component
+        self.license = license
         self.summary = summary
+        self.sourceRepoId = sourceRepoId
+        self.sourceRevision = sourceRevision
         self.licenseURL = licenseURL
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case component
+        case license
+        case summary
+        case sourceRepoId = "source_repo_id"
+        case sourceRevision = "source_revision"
+        case licenseURL = "license_url"
+    }
+}
+
+public struct ManagedModelUsageRestriction: Hashable, Sendable {
+    public let summary: String
+    public let terms: [ManagedModelUsageTerm]
+
+    public var licenseURL: String {
+        terms.first?.licenseURL ?? ""
+    }
+
+    public init(summary: String, terms: [ManagedModelUsageTerm]) {
+        self.summary = summary
+        self.terms = terms
     }
 }
 
@@ -149,6 +187,8 @@ public struct ManagedModelSpec: Hashable, Sendable {
 
 public enum ManagedModelCatalog {
     private static let diffusersImageSnapshotPatterns = [
+        "LICENSE*",
+        "README.md",
         "model_index.json",
         "tokenizer/*",
         "text_encoder/*",
@@ -178,6 +218,8 @@ public enum ManagedModelCatalog {
         "vae/diffusion_pytorch_model.safetensors",
     ]
     private static let zImageNanoSnapshotPatterns = [
+        "LICENSE*",
+        "README.md",
         "text_encoder/0.safetensors",
         "text_encoder/1.safetensors",
         "text_encoder/model.safetensors.index.json",
@@ -196,6 +238,14 @@ public enum ManagedModelCatalog {
     ]
 
     private static let zImageNanoUpstreamRepoId = "filipstrand/Z-Image-Turbo-mflux-4bit"
+    private static let zImageNanoUpstreamRevision = "b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b"
+    private static let klein9BUpstreamRevision = "b0f0826a36667ec7c58253e50557ba76f8c0255e"
+    private static let kleinBase9BUpstreamRevision = "32773329fbe7e81a90ef971740e8ba4b0364ecf3"
+    private static let sam31MLXRevision = "a992e302ea9b0f03f41dfd93414a4fd0e818f65b"
+    private static let sam31TokenizerRevision = "694239a1479aab8fd1317c87c433c58acd7c6eab"
+    private static let wooshWeightsRevision = "f7b524db359f95b2b0bdc4afce12120b72e68bff"
+    private static let ltx2DistilledRevision = "c38acc2729229140f083c3a834041e8735ee5260"
+    private static let ltx23MLXRevision = "baa5f235ea04fd9c95899d751295c4fd825ee4e2"
     private static let kleinNanoUpstreamRepoId = "stereovoid/flux2-klein-4b-4bit"
     private static let bonsaiBinaryUpstreamRepoId = "prism-ml/bonsai-image-binary-4B-mlx-1bit"
     private static let bonsaiTernaryUpstreamRepoId = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
@@ -275,6 +325,8 @@ public enum ManagedModelCatalog {
     ]
     private static let ltx23MLXUpstreamRepoId = "dgrauet/ltx-2.3-mlx"
     private static let ltx23MLXSnapshotPatterns = [
+        "LICENSE*",
+        "README.md",
         "config.json",
         "embedded_config.json",
         "split_model.json",
@@ -302,6 +354,150 @@ public enum ManagedModelCatalog {
         "special_tokens_map.json",
         "generation_config.json",
     ]
+
+    private static func usageRestriction(
+        summary: String,
+        component: String = "model",
+        license: String,
+        termSummary: String? = nil,
+        sourceRepoId: String,
+        sourceRevision: String,
+        licenseURL: String
+    ) -> ManagedModelUsageRestriction {
+        ManagedModelUsageRestriction(
+            summary: summary,
+            terms: [
+                ManagedModelUsageTerm(
+                    component: component,
+                    license: license,
+                    summary: termSummary ?? summary,
+                    sourceRepoId: sourceRepoId,
+                    sourceRevision: sourceRevision,
+                    licenseURL: licenseURL
+                ),
+            ]
+        )
+    }
+
+    private static func flux9BUsageRestriction(
+        sourceRepoId: String,
+        sourceRevision: String,
+        component: String = "model",
+        additionalTerms: [ManagedModelUsageTerm] = []
+    ) -> ManagedModelUsageRestriction {
+        let summary = "FLUX.2 Klein 9B weights are licensed only for non-commercial, non-production use."
+        let term = ManagedModelUsageTerm(
+            component: component,
+            license: "FLUX Non-Commercial License v2.1",
+            summary: summary,
+            sourceRepoId: sourceRepoId,
+            sourceRevision: sourceRevision,
+            licenseURL: "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B/blob/main/LICENSE.md"
+        )
+        return ManagedModelUsageRestriction(
+            summary: summary,
+            terms: [term] + additionalTerms
+        )
+    }
+
+    private static func krea2UsageRestriction(
+        sourceRepoId: String,
+        sourceRevision: String
+    ) -> ManagedModelUsageRestriction {
+        usageRestriction(
+            summary: "Krea 2 uses a custom community license; commercial use is limited to entities below USD 1M in trailing annual revenue and remains subject to its use and distribution conditions.",
+            license: "Krea 2 Community License Agreement",
+            sourceRepoId: sourceRepoId,
+            sourceRevision: sourceRevision,
+            licenseURL: "https://huggingface.co/\(sourceRepoId)/blob/\(sourceRevision)/LICENSE.pdf"
+        )
+    }
+
+    private static func muScriptorUsageRestriction(
+        sourceRepoId: String,
+        sourceRevision: String
+    ) -> ManagedModelUsageRestriction {
+        usageRestriction(
+            summary: "MuScriptor weights are licensed CC BY-NC 4.0 for non-commercial use.",
+            license: "CC BY-NC 4.0",
+            sourceRepoId: sourceRepoId,
+            sourceRevision: sourceRevision,
+            licenseURL: "https://creativecommons.org/licenses/by-nc/4.0/legalcode.en"
+        )
+    }
+
+    private static let wooshUsageRestriction = usageRestriction(
+        summary: "Woosh model weights are licensed CC BY-NC 4.0 for non-commercial use.",
+        license: "CC BY-NC 4.0",
+        sourceRepoId: WooshResources.huggingFaceMirrorRepoId,
+        sourceRevision: wooshWeightsRevision,
+        licenseURL: "https://github.com/SonyResearch/Woosh/blob/v1.0.0/LICENSE"
+    )
+
+    private static let wooshSynchformerUsageRestriction = usageRestriction(
+        summary: "The MMAudio Synchformer checkpoint used by Woosh is licensed CC BY-NC 4.0 for non-commercial use.",
+        component: "synchformer",
+        license: "CC BY-NC 4.0",
+        sourceRepoId: WooshResources.synchformerRepoId,
+        sourceRevision: MMAudioResources.convertedWeightsRevision,
+        licenseURL: "https://github.com/hkchengrex/MMAudio#pre-trained-weights"
+    )
+
+    private static let mmaudioUsageRestriction = ManagedModelUsageRestriction(
+        summary: "MMAudio combines non-commercial checkpoint terms with an Apple research-only visual encoder; each component's terms apply independently.",
+        terms: [
+            ManagedModelUsageTerm(
+                component: "MMAudio checkpoints",
+                license: "CC BY-NC 4.0",
+                summary: "Published MMAudio checkpoints are limited to non-commercial use.",
+                sourceRepoId: MMAudioResources.convertedWeightsRepoID,
+                sourceRevision: MMAudioResources.convertedWeightsRevision,
+                licenseURL: "https://github.com/hkchengrex/MMAudio#pre-trained-weights"
+            ),
+            ManagedModelUsageTerm(
+                component: "Apple DFN5B CLIP visual encoder",
+                license: "Apple Machine Learning Research Model License Agreement",
+                summary: "Apple licenses this component exclusively for non-commercial scientific research and academic development.",
+                sourceRepoId: MMAudioResources.clipRepoID,
+                sourceRevision: MMAudioResources.clipRevision,
+                licenseURL: "https://huggingface.co/apple/DFN5B-CLIP-ViT-H-14-378/blob/main/LICENSE"
+            ),
+        ]
+    )
+
+    private static func ltxUsageRestriction(
+        sourceRepoId: String,
+        sourceRevision: String,
+        additionalTerms: [ManagedModelUsageTerm] = []
+    ) -> ManagedModelUsageRestriction {
+        let summary = "LTX-2 uses a custom community license; entities with at least USD 10M annual revenue need a paid commercial license, and acceptable-use conditions apply."
+        let ltxTerm = ManagedModelUsageTerm(
+            component: "model",
+            license: "LTX-2 Community License Agreement",
+            summary: summary,
+            sourceRepoId: sourceRepoId,
+            sourceRevision: sourceRevision,
+            licenseURL: "https://github.com/Lightricks/LTX-2/blob/main/LICENSE"
+        )
+        return ManagedModelUsageRestriction(
+            summary: summary,
+            terms: [ltxTerm] + additionalTerms
+        )
+    }
+
+    private static let ltxGemmaTextEncoderUsageTerm = ManagedModelUsageTerm(
+        component: "Gemma 3 text encoder",
+        license: "Gemma Terms of Use",
+        summary: "The LTX 2.3 text-encoder companion is distributed under the Gemma Terms of Use and Gemma Prohibited Use Policy.",
+        sourceRepoId: ltxGemma3TextEncoderRepoId,
+        sourceRevision: ltxGemma3TextEncoderRevision,
+        licenseURL: "https://ai.google.dev/gemma/terms"
+    )
+
+    private static let ltxGemmaTextEncoderUsageRestriction = ManagedModelUsageRestriction(
+        summary: "The LTX 2.3 Gemma text-encoder companion uses Google's custom Gemma Terms of Use and Prohibited Use Policy.",
+        terms: [ltxGemmaTextEncoderUsageTerm]
+    )
 
     public static let allSpecs: [ManagedModelSpec] = [
         ManagedModelSpec(
@@ -343,9 +539,15 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "mlx-community/FLUX.2-klein-9B",
+                revision: klein9BUpstreamRevision,
                 patterns: diffusersImageSnapshotPatterns
             ),
             upstreamRepoId: "mlx-community/FLUX.2-klein-9B",
+            upstreamRevision: klein9BUpstreamRevision,
+            usageRestriction: flux9BUsageRestriction(
+                sourceRepoId: "mlx-community/FLUX.2-klein-9B",
+                sourceRevision: klein9BUpstreamRevision
+            ),
             validationKind: .flux2Klein,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 34_722_771_551,
@@ -376,6 +578,7 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "black-forest-labs/FLUX.2-klein-base-9B",
+                revision: kleinBase9BUpstreamRevision,
                 patterns: kleinBase9BTransformerSnapshotPatterns
             ),
             mountedHubFallbacks: [
@@ -383,6 +586,7 @@ public enum ManagedModelCatalog {
                     destinationPath: "text_encoder",
                     hubFallback: HubFallbackConfig(
                         repoId: "mlx-community/FLUX.2-klein-9B",
+                        revision: klein9BUpstreamRevision,
                         patterns: ["text_encoder/*"]
                     )
                 ),
@@ -390,6 +594,7 @@ public enum ManagedModelCatalog {
                     destinationPath: "tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: "mlx-community/FLUX.2-klein-9B",
+                        revision: klein9BUpstreamRevision,
                         patterns: ["tokenizer/*"]
                     )
                 ),
@@ -397,6 +602,7 @@ public enum ManagedModelCatalog {
                     destinationPath: "vae",
                     hubFallback: HubFallbackConfig(
                         repoId: "mlx-community/FLUX.2-klein-9B",
+                        revision: klein9BUpstreamRevision,
                         patterns: ["vae/*"]
                     )
                 ),
@@ -404,11 +610,28 @@ public enum ManagedModelCatalog {
                     destinationPath: "scheduler",
                     hubFallback: HubFallbackConfig(
                         repoId: "mlx-community/FLUX.2-klein-9B",
+                        revision: klein9BUpstreamRevision,
                         patterns: ["scheduler/*"]
                     )
                 ),
             ],
             upstreamRepoId: "black-forest-labs/FLUX.2-klein-base-9B",
+            upstreamRevision: kleinBase9BUpstreamRevision,
+            usageRestriction: flux9BUsageRestriction(
+                sourceRepoId: "black-forest-labs/FLUX.2-klein-base-9B",
+                sourceRevision: kleinBase9BUpstreamRevision,
+                component: "Base 9B transformer",
+                additionalTerms: [
+                    ManagedModelUsageTerm(
+                        component: "shared 9B text encoder, tokenizer, VAE, and scheduler",
+                        license: "FLUX Non-Commercial License v2.1",
+                        summary: "The shared FLUX.2 Klein 9B components are licensed only for non-commercial, non-production use.",
+                        sourceRepoId: "mlx-community/FLUX.2-klein-9B",
+                        sourceRevision: klein9BUpstreamRevision,
+                        licenseURL: "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B/blob/main/LICENSE.md"
+                    ),
+                ]
+            ),
             validationKind: .flux2Klein,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 48 * 1_073_741_824,
@@ -473,11 +696,18 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
                 repoId: zImageNanoUpstreamRepoId,
-                revision: "main",
+                revision: zImageNanoUpstreamRevision,
                 patterns: zImageNanoSnapshotPatterns
             ),
             upstreamRepoId: zImageNanoUpstreamRepoId,
-            upstreamRevision: "main",
+            upstreamRevision: zImageNanoUpstreamRevision,
+            usageRestriction: usageRestriction(
+                summary: "This quantized mirror declares the Tongyi Qianwen license even though its Z-Image-Turbo base model is Apache 2.0; review the mirror's declared terms before use.",
+                license: "Tongyi Qianwen License (mirror declaration)",
+                sourceRepoId: zImageNanoUpstreamRepoId,
+                sourceRevision: zImageNanoUpstreamRevision,
+                licenseURL: "https://huggingface.co/filipstrand/Z-Image-Turbo-mflux-4bit#license"
+            ),
             validationKind: .zimageTurbo,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 20_538_488_559,
@@ -584,6 +814,10 @@ public enum ManagedModelCatalog {
             ),
             upstreamRepoId: Krea2RawResources.upstreamRepoId,
             upstreamRevision: Krea2RawResources.upstreamRevision,
+            usageRestriction: krea2UsageRestriction(
+                sourceRepoId: Krea2RawResources.upstreamRepoId,
+                sourceRevision: Krea2RawResources.upstreamRevision
+            ),
             validationKind: .krea2,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: Krea2RawResources.estimatedDownloadBytes,
@@ -600,6 +834,10 @@ public enum ManagedModelCatalog {
             ),
             upstreamRepoId: Krea2Resources.upstreamRepoId,
             upstreamRevision: Krea2Resources.upstreamRevision,
+            usageRestriction: krea2UsageRestriction(
+                sourceRepoId: Krea2Resources.upstreamRepoId,
+                sourceRevision: Krea2Resources.upstreamRevision
+            ),
             validationKind: .krea2,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: Krea2Resources.estimatedDownloadBytes,
@@ -616,6 +854,13 @@ public enum ManagedModelCatalog {
             ),
             upstreamRepoId: Ideogram4Resources.upstreamRepoId,
             upstreamRevision: Ideogram4Resources.upstreamRevision,
+            usageRestriction: usageRestriction(
+                summary: "Ideogram 4 weights are licensed only for non-commercial purposes.",
+                license: "Ideogram Non-Commercial Model Agreement",
+                sourceRepoId: Ideogram4Resources.upstreamRepoId,
+                sourceRevision: Ideogram4Resources.upstreamRevision,
+                licenseURL: "https://huggingface.co/ideogram-ai/ideogram-4-fp8/blob/main/LICENSE.md"
+            ),
             validationKind: .ideogram4SDNQ,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: Ideogram4Resources.estimatedDownloadBytes,
@@ -840,7 +1085,15 @@ public enum ManagedModelCatalog {
             ),
             upstreamRepoId: LFM2Resources.upstreamRepoId,
             upstreamRevision: LFM2Resources.upstreamRevision,
+            usageRestriction: usageRestriction(
+                summary: "LFM uses a custom open license; commercial use by entities with at least USD 10M annual revenue is not licensed under its community terms.",
+                license: "LFM Open License v1.0",
+                sourceRepoId: LFM2Resources.upstreamRepoId,
+                sourceRevision: LFM2Resources.upstreamRevision,
+                licenseURL: "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B-MLX-8bit/blob/\(LFM2Resources.upstreamRevision)/LICENSE"
+            ),
             validationKind: .lfm2,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 10 * 1_073_741_824,
             defaultCLICommands: ["text chat", "api serve"]
         ),
@@ -852,6 +1105,8 @@ public enum ManagedModelCatalog {
                 repoId: "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
                 revision: "main",
                 patterns: [
+                    "LICENSE*",
+                    "README.md",
                     "config.json",
                     "generation_config.json",
                     "merges.txt",
@@ -1057,8 +1312,10 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "mlx-community/sam3.1-bf16",
-                revision: "main",
+                revision: sam31MLXRevision,
                 patterns: [
+                    "LICENSE*",
+                    "README.md",
                     "config.json",
                     "model.safetensors",
                     "model.safetensors.index.json",
@@ -1070,8 +1327,10 @@ public enum ManagedModelCatalog {
                     destinationPath: "tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: "AEmotionStudio/sam3.1",
-                        revision: "main",
+                        revision: sam31TokenizerRevision,
                         patterns: [
+                            "LICENSE*",
+                            "README.md",
                             "tokenizer.json",
                             "tokenizer_config.json",
                             "vocab.json",
@@ -1082,7 +1341,14 @@ public enum ManagedModelCatalog {
                 ),
             ],
             upstreamRepoId: "mlx-community/sam3.1-bf16",
-            upstreamRevision: "main",
+            upstreamRevision: sam31MLXRevision,
+            usageRestriction: usageRestriction(
+                summary: "SAM 3.1 uses Meta's custom SAM License, including trade-control, prohibited-use, redistribution, and research-attribution conditions.",
+                license: "SAM License",
+                sourceRepoId: "mlx-community/sam3.1-bf16",
+                sourceRevision: sam31MLXRevision,
+                licenseURL: "https://huggingface.co/facebook/sam3.1/blob/main/LICENSE"
+            ),
             validationKind: .sam31,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 3_498_072_777,
@@ -1121,17 +1387,23 @@ public enum ManagedModelCatalog {
                 repoId: "deepghs/insightface",
                 revision: "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
                 patterns: [
+                    "LICENSE*",
+                    "README.md",
                     FaceAnalysisResources.detectorRelativePath,
                     FaceAnalysisResources.recognizerRelativePath,
                 ]
             ),
             upstreamRepoId: "deepghs/insightface",
             upstreamRevision: "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
-            usageRestriction: ManagedModelUsageRestriction(
+            usageRestriction: usageRestriction(
                 summary: "InsightFace Buffalo-L pretrained weights are limited to non-commercial research use.",
+                license: "InsightFace pretrained model non-commercial research terms",
+                sourceRepoId: "deepghs/insightface",
+                sourceRevision: "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
                 licenseURL: "https://github.com/deepinsight/insightface#license"
             ),
             validationKind: .insightFaceBuffaloL,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: FaceAnalysisResources.detectorByteCount
                 + FaceAnalysisResources.recognizerByteCount,
             defaultCLICommands: [
@@ -1246,6 +1518,14 @@ public enum ManagedModelCatalog {
             mountedHubFallbacks: Trellis2Resources.mountedHubFallbacks,
             upstreamRepoId: Trellis2Resources.repository,
             upstreamRevision: Trellis2Resources.revision,
+            usageRestriction: usageRestriction(
+                summary: "TRELLIS.2 downloads a manually gated DINOv3 component governed by Meta's custom DINOv3 License.",
+                component: "DINOv3 image encoder",
+                license: "DINOv3 License",
+                sourceRepoId: Trellis2Resources.dinoV3Repository,
+                sourceRevision: Trellis2Resources.dinoV3Revision,
+                licenseURL: "https://ai.meta.com/resources/models-and-libraries/dinov3-license/"
+            ),
             validationKind: .trellis2,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 11_010_775_158,
@@ -1405,11 +1685,16 @@ public enum ManagedModelCatalog {
             hubFallback: HubFallbackConfig(
                 repoId: "MuScriptor/muscriptor-small",
                 revision: "8c127f603b807520fa465c838e9bfee8a91ada4e",
-                patterns: ["config.json", "model.safetensors"]
+                patterns: ["LICENSE*", "README.md", "config.json", "model.safetensors"]
             ),
             upstreamRepoId: "MuScriptor/muscriptor-small",
             upstreamRevision: "8c127f603b807520fa465c838e9bfee8a91ada4e",
+            usageRestriction: muScriptorUsageRestriction(
+                sourceRepoId: "MuScriptor/muscriptor-small",
+                sourceRevision: "8c127f603b807520fa465c838e9bfee8a91ada4e"
+            ),
             validationKind: .muScriptor,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 412_000_000,
             defaultCLICommands: ["music transcribe"]
         ),
@@ -1420,11 +1705,16 @@ public enum ManagedModelCatalog {
             hubFallback: HubFallbackConfig(
                 repoId: "MuScriptor/muscriptor-medium",
                 revision: "f32236969308476e01fd3aae67357de5feb05a2d",
-                patterns: ["config.json", "model.safetensors"]
+                patterns: ["LICENSE*", "README.md", "config.json", "model.safetensors"]
             ),
             upstreamRepoId: "MuScriptor/muscriptor-medium",
             upstreamRevision: "f32236969308476e01fd3aae67357de5feb05a2d",
+            usageRestriction: muScriptorUsageRestriction(
+                sourceRepoId: "MuScriptor/muscriptor-medium",
+                sourceRevision: "f32236969308476e01fd3aae67357de5feb05a2d"
+            ),
             validationKind: .muScriptor,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 1_230_000_000,
             defaultCLICommands: ["music transcribe"]
         ),
@@ -1435,11 +1725,16 @@ public enum ManagedModelCatalog {
             hubFallback: HubFallbackConfig(
                 repoId: "MuScriptor/muscriptor-large",
                 revision: "8809fdfbed2affa7ade94a7059e746e3880720e7",
-                patterns: ["config.json", "model.safetensors"]
+                patterns: ["LICENSE*", "README.md", "config.json", "model.safetensors"]
             ),
             upstreamRepoId: "MuScriptor/muscriptor-large",
             upstreamRevision: "8809fdfbed2affa7ade94a7059e746e3880720e7",
+            usageRestriction: muScriptorUsageRestriction(
+                sourceRepoId: "MuScriptor/muscriptor-large",
+                sourceRevision: "8809fdfbed2affa7ade94a7059e746e3880720e7"
+            ),
             validationKind: .muScriptor,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 5_620_000_000,
             defaultCLICommands: ["music transcribe"]
         ),
@@ -1449,7 +1744,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: WooshResources.huggingFaceMirrorRepoId,
-                revision: "main",
+                revision: wooshWeightsRevision,
                 patterns: wooshDFlowSnapshotPatterns
             ),
             mountedHubFallbacks: [
@@ -1457,14 +1752,16 @@ public enum ManagedModelCatalog {
                     destinationPath: "checkpoints/TextConditionerA/tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: WooshResources.robertaTokenizerRepoId,
-                        revision: "main",
+                        revision: WooshResources.robertaTokenizerRevision,
                         patterns: wooshRobertaTokenizerPatterns
                     )
                 ),
             ],
             upstreamRepoId: "\(WooshResources.upstreamRepoId)@\(WooshResources.upstreamRelease)",
             upstreamRevision: WooshResources.upstreamRelease,
+            usageRestriction: wooshUsageRestriction,
             validationKind: .woosh,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 5 * 1_073_741_824,
             defaultCLICommands: ["sfx generate"]
         ),
@@ -1474,7 +1771,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: WooshResources.huggingFaceMirrorRepoId,
-                revision: "main",
+                revision: wooshWeightsRevision,
                 patterns: wooshFlowSnapshotPatterns
             ),
             mountedHubFallbacks: [
@@ -1482,14 +1779,16 @@ public enum ManagedModelCatalog {
                     destinationPath: "checkpoints/TextConditionerA/tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: WooshResources.robertaTokenizerRepoId,
-                        revision: "main",
+                        revision: WooshResources.robertaTokenizerRevision,
                         patterns: wooshRobertaTokenizerPatterns
                     )
                 ),
             ],
             upstreamRepoId: "\(WooshResources.upstreamRepoId)@\(WooshResources.upstreamRelease)",
             upstreamRevision: WooshResources.upstreamRelease,
+            usageRestriction: wooshUsageRestriction,
             validationKind: .woosh,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 5 * 1_073_741_824,
             defaultCLICommands: ["sfx generate"]
         ),
@@ -1499,7 +1798,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: WooshResources.huggingFaceMirrorRepoId,
-                revision: "main",
+                revision: wooshWeightsRevision,
                 patterns: wooshCLAPSnapshotPatterns
             ),
             mountedHubFallbacks: [
@@ -1507,14 +1806,16 @@ public enum ManagedModelCatalog {
                     destinationPath: "checkpoints/Woosh-CLAP/tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: WooshResources.robertaTokenizerRepoId,
-                        revision: "main",
+                        revision: WooshResources.robertaTokenizerRevision,
                         patterns: wooshRobertaTokenizerPatterns
                     )
                 ),
             ],
             upstreamRepoId: "\(WooshResources.upstreamRepoId)@\(WooshResources.upstreamRelease)",
             upstreamRevision: WooshResources.upstreamRelease,
+            usageRestriction: wooshUsageRestriction,
             validationKind: .wooshClap,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 2 * 1_073_741_824,
             defaultCLICommands: ["sfx clap"]
         ),
@@ -1524,12 +1825,14 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: WooshResources.synchformerRepoId,
-                revision: "main",
+                revision: MMAudioResources.convertedWeightsRevision,
                 patterns: wooshSynchformerSnapshotPatterns
             ),
             upstreamRepoId: WooshResources.synchformerRepoId,
-            upstreamRevision: "main",
+            upstreamRevision: MMAudioResources.convertedWeightsRevision,
+            usageRestriction: wooshSynchformerUsageRestriction,
             validationKind: .wooshSynchformer,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 475 * 1_048_576,
             defaultCLICommands: ["sfx video generate"]
         ),
@@ -1539,7 +1842,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: WooshResources.huggingFaceMirrorRepoId,
-                revision: "main",
+                revision: wooshWeightsRevision,
                 patterns: wooshVFlow8sSnapshotPatterns
             ),
             mountedHubFallbacks: [
@@ -1547,14 +1850,16 @@ public enum ManagedModelCatalog {
                     destinationPath: "checkpoints/TextConditionerV/tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: WooshResources.robertaTokenizerRepoId,
-                        revision: "main",
+                        revision: WooshResources.robertaTokenizerRevision,
                         patterns: wooshRobertaTokenizerPatterns
                     )
                 ),
             ],
             upstreamRepoId: "\(WooshResources.upstreamRepoId)@\(WooshResources.upstreamRelease)",
             upstreamRevision: WooshResources.upstreamRelease,
+            usageRestriction: wooshUsageRestriction,
             validationKind: .woosh,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 6 * 1_073_741_824,
             defaultCLICommands: ["sfx video generate"]
         ),
@@ -1564,7 +1869,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: WooshResources.huggingFaceMirrorRepoId,
-                revision: "main",
+                revision: wooshWeightsRevision,
                 patterns: wooshDVFlow8sSnapshotPatterns
             ),
             mountedHubFallbacks: [
@@ -1572,14 +1877,16 @@ public enum ManagedModelCatalog {
                     destinationPath: "checkpoints/TextConditionerV/tokenizer",
                     hubFallback: HubFallbackConfig(
                         repoId: WooshResources.robertaTokenizerRepoId,
-                        revision: "main",
+                        revision: WooshResources.robertaTokenizerRevision,
                         patterns: wooshRobertaTokenizerPatterns
                     )
                 ),
             ],
             upstreamRepoId: "\(WooshResources.upstreamRepoId)@\(WooshResources.upstreamRelease)",
             upstreamRevision: WooshResources.upstreamRelease,
+            usageRestriction: wooshUsageRestriction,
             validationKind: .woosh,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 6 * 1_073_741_824,
             defaultCLICommands: ["sfx video generate"]
         ),
@@ -1612,7 +1919,9 @@ public enum ManagedModelCatalog {
             ],
             upstreamRepoId: "\(MMAudioResources.upstreamRepoID)@\(MMAudioResources.upstreamRevision)",
             upstreamRevision: MMAudioResources.upstreamRevision,
+            usageRestriction: mmaudioUsageRestriction,
             validationKind: .mmaudio,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 5_700_000_000,
             defaultCLICommands: ["sfx generate", "sfx video generate"]
         ),
@@ -1622,8 +1931,10 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "mlx-community/LTX-2-distilled-bf16",
-                revision: "main",
+                revision: ltx2DistilledRevision,
                 patterns: [
+                    "LICENSE*",
+                    "README.md",
                     "ltx-2-19b-distilled.safetensors",
                     "ltx-2-spatial-upscaler-x2-1.0.safetensors",
                     "text_encoder/*",
@@ -1631,8 +1942,13 @@ public enum ManagedModelCatalog {
                 ]
             ),
             upstreamRepoId: "mlx-community/LTX-2-distilled-bf16",
-            upstreamRevision: "main",
+            upstreamRevision: ltx2DistilledRevision,
+            usageRestriction: ltxUsageRestriction(
+                sourceRepoId: "mlx-community/LTX-2-distilled-bf16",
+                sourceRevision: ltx2DistilledRevision
+            ),
             validationKind: .ltxVideo,
+            runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 93_069_609_104,
             defaultCLICommands: ["video generate"]
         ),
@@ -1642,11 +1958,16 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: ltx23MLXUpstreamRepoId,
-                revision: "main",
+                revision: ltx23MLXRevision,
                 patterns: ltx23MLXSnapshotPatterns
             ),
             upstreamRepoId: ltx23MLXUpstreamRepoId,
-            upstreamRevision: "main",
+            upstreamRevision: ltx23MLXRevision,
+            usageRestriction: ltxUsageRestriction(
+                sourceRepoId: ltx23MLXUpstreamRepoId,
+                sourceRevision: ltx23MLXRevision,
+                additionalTerms: [ltxGemmaTextEncoderUsageTerm]
+            ),
             validationKind: .ltxVideo23MLX,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 120 * 1_073_741_824,
@@ -1730,6 +2051,7 @@ private extension ManagedModelCatalog {
                 ),
                 upstreamRepoId: ltxGemma3TextEncoderRepoId,
                 upstreamRevision: ltxGemma3TextEncoderRevision,
+                usageRestriction: ltxGemmaTextEncoderUsageRestriction,
                 validationKind: .hfTextChat,
                 runtimeAutoDownloadAllowed: false,
                 estimatedDownloadBytes: 8 * 1_073_741_824

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -12,6 +12,7 @@ public enum ManagedModelCategory: String, CaseIterable, Hashable, Sendable {
     case visionChat = "vision-chat"
     case visionSegment = "vision-segment"
     case visionGround = "vision-ground"
+    case visionFace = "vision-face"
     case visionGeometry = "vision-geometry"
     case visionDepth = "vision-depth"
     case image3D = "image-3d"
@@ -48,6 +49,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case lightOnOCR
     case sam31
     case falconPerception
+    case insightFaceBuffaloL
     case moge2
     case videoDepthAnything
     case depthAnything3
@@ -1099,6 +1101,30 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["vision ground"]
         ),
         ManagedModelSpec(
+            id: FaceAnalysisResources.modelID,
+            category: .visionFace,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "deepghs/insightface",
+                revision: "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
+                patterns: [
+                    FaceAnalysisResources.detectorRelativePath,
+                    FaceAnalysisResources.recognizerRelativePath,
+                ]
+            ),
+            upstreamRepoId: "deepghs/insightface",
+            upstreamRevision: "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
+            validationKind: .insightFaceBuffaloL,
+            estimatedDownloadBytes: FaceAnalysisResources.detectorByteCount
+                + FaceAnalysisResources.recognizerByteCount,
+            defaultCLICommands: [
+                "vision face detect",
+                "vision face embed",
+                "vision face compare",
+                "vision face batch",
+            ]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue,
             category: .visionGeometry,
             installShape: .directoryRoot,
@@ -1794,6 +1820,8 @@ public extension ManagedModelSpec {
             return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:
             return FalconPerceptionResources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .insightFaceBuffaloL:
+            return FaceAnalysisResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .moge2, .videoDepthAnything, .depthAnything3, .tripoSR:
             guard let pin = GeometryModelPins.pin(for: id) else { return [rootURL] }
             return Self.invalidPinnedArtifacts(pin.runtimeArtifacts, in: rootURL, fileManager: fileManager)

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -49,6 +49,7 @@ public enum ManagedModelResolver {
         case invalidModelPath(String)
         case modelNotInstalled(String)
         case autoDownloadDisabled(String)
+        case usageTermsNotAcknowledged(String)
         case unsupportedInstallShape(String)
         case downloadFailed(String)
         case invalidInstalledModel(String)
@@ -63,6 +64,8 @@ public enum ManagedModelResolver {
                 return "Model \(id) is not installed."
             case .autoDownloadDisabled(let id):
                 return "Model \(id) is not installed and does not support auto-download in this command."
+            case .usageTermsNotAcknowledged(let id):
+                return "Model \(id) has third-party usage terms that must be acknowledged before download."
             case .unsupportedInstallShape(let id):
                 return "Managed install shape is not supported for \(id)."
             case .downloadFailed(let message):
@@ -215,6 +218,7 @@ public enum ManagedModelResolver {
     public static func installManagedModel(
         id: String,
         force: Bool = false,
+        usageTermsAcknowledged: Bool = false,
         fileManager: FileManager = .default,
         progress: (@Sendable (InstallProgress) -> Void)? = nil
     ) async throws -> InstallResult {
@@ -224,6 +228,10 @@ public enum ManagedModelResolver {
         if !force, isManagedInstallComplete(spec: spec, at: modelDir, fileManager: fileManager) {
             let manifest = try? MereRunModelManifest.loadIfPresent(from: modelDir, fileManager: fileManager)
             return InstallResult(spec: spec, installURL: modelDir, manifest: manifest, wasAlreadyInstalled: true)
+        }
+
+        if spec.usageRestriction != nil, !usageTermsAcknowledged {
+            throw ResolverError.usageTermsNotAcknowledged(spec.id)
         }
 
         if fileManager.fileExists(atPath: modelDir.path) {
@@ -251,6 +259,7 @@ public enum ManagedModelResolver {
             snapshotURL: snapshotURL,
             mountedSnapshots: mountedSnapshots,
             modelDir: modelDir,
+            usageTermsAcknowledged: usageTermsAcknowledged,
             fileManager: fileManager
         )
         try installManagedAliasesIfNeeded(for: spec, rootURL: modelDir, fileManager: fileManager)
@@ -407,6 +416,7 @@ public enum ManagedModelResolver {
         snapshotURL: URL,
         mountedSnapshots: [(MountedHubFallbackConfig, URL)] = [],
         modelDir: URL,
+        usageTermsAcknowledged: Bool = false,
         fileManager: FileManager
     ) throws -> MereRunModelManifest? {
         try fileManager.createDirectory(at: modelDir, withIntermediateDirectories: true)
@@ -437,7 +447,11 @@ public enum ManagedModelResolver {
             fileManager: fileManager
         )
 
-        return try MereRunModelManifest.writeTemplateIfKnown(modelId: spec.id, to: modelDir)
+        return try MereRunModelManifest.writeTemplateIfKnown(
+            modelId: spec.id,
+            to: modelDir,
+            usageTermsAcknowledged: usageTermsAcknowledged
+        )
     }
 
     private static func mountedSnapshotSourceURL(

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -534,6 +534,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 24
             ),
             descriptor(
+                FaceAnalysisResources.modelID,
+                "Face analysis",
+                "Detects faces and landmarks, creates identity embeddings, and compares people locally.",
+                minimum: 8,
+                recommended: 16
+            ),
+            descriptor(
                 ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue,
                 "Metric image geometry",
                 "Predicts metric depth, point maps, normals, masks, and camera intrinsics with MoGe-2 Small.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -34,6 +34,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case samSegmentation = "sam-segmentation"
         /// Falcon Perception grounded detection and segmentation family.
         case falconPerception = "falcon-perception"
+        /// InsightFace Buffalo-L face detection and identity-embedding family.
+        case insightFace = "insightface"
         /// MoGe-2 metric monocular geometry family.
         case moge2 = "moge-2"
         /// Video Depth Anything temporal depth family.
@@ -93,6 +95,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case qwen
         case sam
         case falcon
+        case face
         case geometry
         case depth
         case threeD = "3d"
@@ -160,6 +163,10 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case visionTracking = "vision_tracking"
         case visionGrounding = "vision_grounding"
         case visionDetection = "vision_detection"
+        case faceDetection = "face_detection"
+        case faceLandmarks = "face_landmarks"
+        case faceEmbedding = "face_embedding"
+        case faceVerification = "face_verification"
         case soundEffectGeneration = "sound_effect_generation"
         case soundEffectEmbedding = "sound_effect_embedding"
         case videoToAudioGeneration = "video_to_audio_generation"
@@ -1143,6 +1150,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.visionGrounding, .visionDetection, .visionSegmentation],
                 components: falconPerceptionComponents,
                 upstreamRepoId: "tiiuae/Falcon-Perception",
+                createdAt: createdAt
+            )
+        case .visionFaceBuffaloL:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .insightFace,
+                family: .face,
+                tier: .latest,
+                variant: .standard,
+                precision: .fp32,
+                defaults: nil,
+                supports: [.faceDetection, .faceLandmarks, .faceEmbedding, .faceVerification],
+                components: nil,
+                upstreamRepoId: "deepghs/insightface@4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb",
                 createdAt: createdAt
             )
         case .visionGeometryMoGe2Small:

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -10,7 +10,7 @@ import Foundation
 /// As of Phase 11 (strict mode), the manifest is required for all local model roots used by mere.run's
 /// image pipelines. This eliminates silent guessing (variant/precision/quantization/components).
 public struct MereRunModelManifest: Codable, Hashable, Sendable {
-    public static let currentSchemaVersion: Int = 2
+    public static let currentSchemaVersion: Int = 3
     public static let filename: String = "mererun_model.json"
 
     public enum Engine: String, Codable, CaseIterable, Hashable, Sendable {
@@ -333,6 +333,32 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         }
     }
 
+    public struct SourceProvenance: Codable, Hashable, Sendable {
+        public var role: String
+        public var repository: String
+        public var revision: String
+        public var destinationPath: String?
+
+        public init(
+            role: String,
+            repository: String,
+            revision: String,
+            destinationPath: String? = nil
+        ) {
+            self.role = role
+            self.repository = repository
+            self.revision = revision
+            self.destinationPath = destinationPath
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case role
+            case repository
+            case revision
+            case destinationPath = "destination_path"
+        }
+    }
+
     public var schemaVersion: Int
     public var id: String
 
@@ -352,6 +378,15 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     /// Upstream identifier for the source repository or registry record.
     public var upstreamRepoId: String?
 
+    /// Exact repositories and requested revisions materialized into this managed install.
+    public var sources: [SourceProvenance]?
+
+    /// Third-party model/component terms that required explicit acknowledgement before download.
+    public var usageTerms: [ManagedModelUsageTerm]?
+
+    /// True only when the managed installer was invoked with explicit acknowledgement.
+    public var usageTermsAcknowledged: Bool?
+
     /// ISO8601 timestamp; informational only.
     public var createdAt: Date?
 
@@ -368,6 +403,9 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         supports: [Capability]? = nil,
         components: Components? = nil,
         upstreamRepoId: String? = nil,
+        sources: [SourceProvenance]? = nil,
+        usageTerms: [ManagedModelUsageTerm]? = nil,
+        usageTermsAcknowledged: Bool? = nil,
         createdAt: Date? = nil
     ) {
         self.schemaVersion = schemaVersion
@@ -382,6 +420,9 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         self.supports = supports
         self.components = components
         self.upstreamRepoId = upstreamRepoId
+        self.sources = sources
+        self.usageTerms = usageTerms
+        self.usageTermsAcknowledged = usageTermsAcknowledged
         self.createdAt = createdAt
     }
 
@@ -439,6 +480,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     public static func writeTemplateIfKnown(
         modelId: String,
         to modelRoot: URL,
+        usageTermsAcknowledged: Bool = false,
         createdAt: Date = Date()
     ) throws -> MereRunModelManifest? {
         guard let known = ModelResolver.ModelID(rawValue: modelId) else {
@@ -452,7 +494,10 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
             // Ignore decode errors and overwrite with a fresh template below.
         }
 
-        let manifest = template(for: known, createdAt: createdAt)
+        var manifest = template(for: known, createdAt: createdAt)
+        if manifest.usageTerms?.isEmpty == false {
+            manifest.usageTermsAcknowledged = usageTermsAcknowledged
+        }
         try manifest.write(to: modelRoot)
         return manifest
     }
@@ -461,6 +506,48 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     ///
     /// This is used by the app to write manifests after managed downloads, and by the CLI for validation.
     public static func template(for modelID: ModelResolver.ModelID, createdAt: Date = Date()) -> MereRunModelManifest {
+        var manifest = baseTemplate(for: modelID, createdAt: createdAt)
+        guard let spec = ManagedModelCatalog.spec(for: modelID.rawValue) else {
+            return manifest
+        }
+        manifest.sources = sourceProvenance(for: spec)
+        manifest.usageTerms = spec.usageRestriction?.terms
+        return manifest
+    }
+
+    private static func sourceProvenance(for spec: ManagedModelSpec) -> [SourceProvenance]? {
+        var sources: [SourceProvenance] = []
+        if let primary = spec.hubFallback {
+            sources.append(
+                SourceProvenance(
+                    role: "primary",
+                    repository: primary.repoId,
+                    revision: primary.revision
+                )
+            )
+        }
+        sources.append(contentsOf: spec.mountedHubFallbacks.map { mounted in
+            SourceProvenance(
+                role: "component",
+                repository: mounted.hubFallback.repoId,
+                revision: mounted.hubFallback.revision,
+                destinationPath: mounted.destinationPath
+            )
+        })
+        if let upstreamRepoId = spec.upstreamRepoId,
+           !sources.contains(where: { $0.repository == upstreamRepoId }) {
+            sources.append(
+                SourceProvenance(
+                    role: "upstream_reference",
+                    repository: upstreamRepoId,
+                    revision: spec.upstreamRevision ?? "unspecified"
+                )
+            )
+        }
+        return sources.isEmpty ? nil : sources
+    }
+
+    private static func baseTemplate(for modelID: ModelResolver.ModelID, createdAt: Date) -> MereRunModelManifest {
         let defaultComponents = Components(
             tokenizer: .local(path: "tokenizer"),
             textEncoder: .local(path: "text_encoder"),
@@ -987,7 +1074,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 defaults: Defaults(steps: 4, cfg: 1.0),
                 supports: [.txt2img, .img2img, .loraInference],
                 components: defaultComponents,
-                upstreamRepoId: "filipstrand/Z-Image-Turbo-mflux-4bit@main",
+                upstreamRepoId: "filipstrand/Z-Image-Turbo-mflux-4bit@b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b",
                 createdAt: createdAt
             )
         case .zetaMax:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -108,6 +108,7 @@ public enum MereRunModelValidator {
                     && spec.validationKind != .wooshClap
                     && spec.validationKind != .wooshSynchformer
                     && spec.validationKind != .mmaudio
+                    && spec.validationKind != .insightFaceBuffaloL
                     && spec.validationKind != .moge2
                     && spec.validationKind != .videoDepthAnything
                     && spec.validationKind != .depthAnything3
@@ -150,6 +151,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .mmaudio
             || spec?.validationKind == .ltxVideo
             || spec?.validationKind == .ltxVideo23MLX
+            || spec?.validationKind == .insightFaceBuffaloL
             || spec?.validationKind == .moge2
             || spec?.validationKind == .videoDepthAnything
             || spec?.validationKind == .depthAnything3
@@ -375,6 +377,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=sam expects sam-segmentation.")
             case .falcon where engine != .falconPerception:
                 warnings.append("Manifest engine mismatch: family=falcon expects falcon-perception.")
+            case .face where engine != .insightFace:
+                warnings.append("Manifest engine mismatch: family=face expects insightface.")
             case .tts where engine != .qwen3TTS:
                 warnings.append("Manifest engine mismatch: family=tts expects qwen3-tts.")
             case .asr where engine != .qwen3ASR && engine != .parakeetASR:
@@ -466,7 +470,8 @@ public enum MereRunModelValidator {
             }
             switch manifest.engine {
             case .qwen3Coder?, .northMiniCode?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .mmaudio?, .ltxVideo?,
-                 .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?:
+                 .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?,
+                 .insightFace?:
                 return true
             default:
                 return false
@@ -515,6 +520,7 @@ public enum MereRunModelValidator {
         if modelId.hasPrefix("image-ideogram4-") { return .ideogram }
         if modelId.hasPrefix("vision-segment-") { return .sam }
         if modelId.hasPrefix("vision-ground-") { return .falcon }
+        if modelId.hasPrefix("vision-face-") { return .face }
         if modelId.hasPrefix("vision-geometry-") { return .geometry }
         if modelId.hasPrefix("vision-depth-") { return .depth }
         if modelId.hasPrefix("image-3d-") { return .threeD }

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -58,6 +58,7 @@ public struct ModelResolver {
         case infinityParser2ProInt8 = "vision-ocr-infinity-pro-int8"
         case visionSegmentSAM31 = "vision-segment-sam31"
         case visionGroundFalconPerception = "vision-ground-falcon-perception"
+        case visionFaceBuffaloL = "vision-face-buffalo-l"
         case visionGeometryMoGe2Small = "vision-geometry-moge2-small"
         case visionDepthVDASmall = "vision-depth-vda-small"
         case visionDepthVDASmallMetric = "vision-depth-vda-small-metric"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -55,6 +55,7 @@ public enum QuantizedModelManifestWriter {
             case .qwen35HybridMoE: return .qwen
             case .samSegmentation: return .sam
             case .falconPerception: return .falcon
+            case .insightFace: return .face
             case .moge2, .depthAnything3: return .geometry
             case .videoDepthAnything: return .depth
             case .tripoSR, .instantMesh, .trellis2: return .threeD
@@ -115,6 +116,8 @@ public enum QuantizedModelManifestWriter {
                     return [.visionSegmentation, .visionTracking]
                 case .falconPerception:
                     return [.visionGrounding, .visionDetection, .visionSegmentation]
+                case .insightFace:
+                    return [.faceDetection, .faceLandmarks, .faceEmbedding, .faceVerification]
                 case .moge2:
                     return [.metricDepth, .surfaceNormals, .pointMap, .cameraIntrinsics, .pointCloud]
                 case .videoDepthAnything:
@@ -217,7 +220,7 @@ public enum QuantizedModelManifestWriter {
                 break
             case .qwen35HybridMoE:
                 break
-            case .samSegmentation, .falconPerception, .moge2, .videoDepthAnything, .depthAnything3,
+            case .samSegmentation, .falconPerception, .insightFace, .moge2, .videoDepthAnything, .depthAnything3,
                  .tripoSR, .instantMesh, .trellis2:
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .qwen3Embedding, .openAIPrivacyFilter,

--- a/Sources/MereRunCore/Trellis2/README.md
+++ b/Sources/MereRunCore/Trellis2/README.md
@@ -39,7 +39,7 @@ checkpoints and two sparse decoders are not resident together.
 ## Public boundary
 
 ```bash
-mere.run model pull image-3d-trellis2-4b
+mere.run model pull image-3d-trellis2-4b --accept-model-license
 mere.run vision image-to-3d-trellis2 ./object.png --output ./object-3d
 # Equivalent catalog-oriented spelling:
 mere.run image reconstruct-3d-trellis2 ./object.png --output ./object-3d

--- a/Sources/MereRunCore/Woosh/WooshResources.swift
+++ b/Sources/MereRunCore/Woosh/WooshResources.swift
@@ -16,6 +16,7 @@ public enum WooshResources {
     public static let synchformerRepoId = "Kijai/MMAudio_safetensors"
     public static let synchformerFilename = "mmaudio_synchformer_fp16.safetensors"
     public static let robertaTokenizerRepoId = "FacebookAI/roberta-large"
+    public static let robertaTokenizerRevision = "722cf37b1afa9454edce342e7895e588b6ff1d59"
     public static let sampleRate = 48_000
     public static let latentChannels = 128
     public static let latentFrames5s = 501

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,6 +12,21 @@ code; those source-derived implementations are noted below as well.
 When any vendored artifact changes, update this file in the same pull request
 with the new upstream source, version or commit when known, and license data.
 
+## Binary package runtime dependencies
+
+### ONNX Runtime for macOS face analysis
+
+- purpose: executes the managed Buffalo-L detector and ArcFace recognizer
+- Swift package: [`readdle/swift-onnxruntime`](https://github.com/readdle/swift-onnxruntime),
+  version `1.20.1`, revision `f5c95540cc857b797c0d61cc62e398ad8688e5de`; MIT
+- binary runtime: [Microsoft ONNX Runtime](https://github.com/microsoft/onnxruntime),
+  version `1.20.1`; MIT
+- package artifact checksum:
+  `31017531ebb064f1903a73ca5d55597ac49b6ae32360eb2482fb2f435342fdad`
+
+Face model weights are downloaded separately by `mere.run model pull` and are
+not vendored in this repository.
+
 ## Evaluation fixtures
 
 ### HumanEval slice

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -27,6 +27,58 @@ with the new upstream source, version or commit when known, and license data.
 Face model weights are downloaded separately by `mere.run model pull` and are
 not vendored in this repository.
 
+#### Microsoft ONNX Runtime license
+
+```text
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+#### Readdle swift-onnxruntime license
+
+```text
+MIT License
+
+Copyright (c) 2024 Readdle Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ## Evaluation fixtures
 
 ### HumanEval slice

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -27,6 +27,16 @@ with the new upstream source, version or commit when known, and license data.
 Face model weights are downloaded separately by `mere.run model pull` and are
 not vendored in this repository.
 
+The same separation applies to every managed model: mere.run ships model
+runtime code and source-level notices, not model weights. Managed models with
+non-commercial, research-only, gated, revenue-limited, or custom acceptable-
+use terms require explicit user acknowledgement before a new download. Their
+exact source revisions and component-level license URLs are preserved in the
+installed `mererun_model.json`; the authoritative inventory is in
+[`docs/model-sources.md`](./docs/model-sources.md#restricted-model-downloads).
+These third-party terms are separate from mere.run's source license, and the
+user is responsible for determining whether an intended use complies.
+
 #### Microsoft ONNX Runtime license
 
 ```text

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -524,6 +524,7 @@ final class StudioTypesTests: XCTestCase {
         image-zimage-nano          image           installed  4.2 GB
         text-chat-gemma4           text-chat       missing    —
         vision-segment-sam31       vision-segment  installed  950 MB
+        Usage restriction: vision-face-buffalo-l - non-commercial research use only
         """
 
         let rows = StudioModelInventoryParser.rows(from: output)

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -537,6 +537,37 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertFalse(rows[1].isInstalled)
     }
 
+    func testModelPullTemplatePropagatesUsageTermsAcceptance() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .modelPull))
+        var draft = template.defaultDraft()
+        draft.model = "vision-face-buffalo-l"
+        draft.acceptModelLicense = true
+
+        XCTAssertTrue(template.arguments(from: draft).contains("--accept-model-license"))
+    }
+
+    func testAgentOnboardTemplatePropagatesUsageTermsAcceptance() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .agentOnboard))
+        var draft = template.defaultDraft()
+        draft.force = true
+        draft.acceptModelLicense = true
+
+        let arguments = template.arguments(from: draft)
+        XCTAssertTrue(arguments.contains("--pull-recommended"))
+        XCTAssertTrue(arguments.contains("--accept-model-license"))
+    }
+
+    func testStudioModelInventoryMarksRestrictedModels() {
+        let output = """
+        vision-face-buffalo-l vision-face missing 287 MB
+        Usage terms: vision-face-buffalo-l - InsightFace weights are non-commercial. [model: research terms https://github.com/deepinsight/insightface#license]
+        """
+        let row = StudioModelInventoryParser.rows(from: output).first
+
+        XCTAssertNotNil(row?.usageTerms)
+        XCTAssertTrue(row?.usageTerms?.summary.contains("deepinsight/insightface#license") == true)
+    }
+
     func testStudioModelInventoryParserFindsModelRoot() throws {
         let output = """
         Model Root: /Users/example/Library/Application Support/MereRun/models/image-zimage-nano

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -28,14 +28,52 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertNil(accepted.licenseAcceptanceMessage(for: restricted))
     }
 
-    func testModelListReportsBuffaloLUsageRestriction() {
+    func testModelListReportsBuffaloLUsageTerms() {
         let lines = ModelList.usageRestrictionLines()
 
         XCTAssertTrue(lines.contains { line in
             line.contains(FaceAnalysisResources.modelID)
                 && line.contains("non-commercial research use")
+                && line.contains("Usage terms:")
                 && line.contains("deepinsight/insightface#license")
         })
+    }
+
+    func testRestrictedModelPreflightRequiresAndPropagatesAcceptance() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let modelStore = temp.appendingPathComponent("models", isDirectory: true)
+        let hubCache = temp.appendingPathComponent("hub", isDirectory: true)
+
+        let blocked = try ModelPull.parse([
+            FaceAnalysisResources.modelID,
+            "--allow-unsupported",
+            "--preflight",
+            "--json",
+        ]).makePreflightEnvelope(
+            hubCacheURL: hubCache,
+            modelStoreURL: modelStore,
+            diskAvailableBytes: { _ in 100 * ModelPullDiskPreflight.bytesPerGiB }
+        )
+        XCTAssertEqual(blocked.status, .blocked)
+        XCTAssertEqual(blocked.result.models.first?.status, "blocked_usage_terms")
+        XCTAssertEqual(blocked.result.models.first?.usageTermsAcknowledged, false)
+
+        let accepted = try ModelPull.parse([
+            FaceAnalysisResources.modelID,
+            "--allow-unsupported",
+            "--accept-model-license",
+            "--preflight",
+            "--json",
+        ]).makePreflightEnvelope(
+            hubCacheURL: hubCache,
+            modelStoreURL: modelStore,
+            diskAvailableBytes: { _ in 100 * ModelPullDiskPreflight.bytesPerGiB }
+        )
+        XCTAssertNotEqual(accepted.status, .blocked)
+        XCTAssertEqual(accepted.result.models.first?.status, "will_download")
+        XCTAssertEqual(accepted.result.models.first?.usageTermsAcknowledged, true)
+        XCTAssertTrue(accepted.actions.first { $0.id == "pull-model" }?.command?.argv.contains("--accept-model-license") == true)
     }
 
     func testModelPullParsesPreflightJSONOptions() throws {
@@ -50,6 +88,21 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.json)
     }
 
+    func testDisplayedPullGuidanceAddsAcknowledgementOnlyForRestrictedModels() {
+        XCTAssertTrue(
+            CLICommandDisplay.modelPullCommand(for: FaceAnalysisResources.modelID)
+                .hasSuffix("model pull vision-face-buffalo-l --accept-model-license")
+        )
+        XCTAssertTrue(
+            CLICommandDisplay.modelPullCommand(for: "image-klein-nano")
+                .hasSuffix("model pull image-klein-nano")
+        )
+        XCTAssertFalse(
+            CLICommandDisplay.modelPullCommand(for: "image-klein-nano")
+                .contains("--accept-model-license")
+        )
+    }
+
     func testModelPullPreflightReportsPullableModel() throws {
         let temp = try makeTemporaryDirectory()
         defer {
@@ -59,7 +112,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
         let hubCache = temp.appendingPathComponent("hub", isDirectory: true)
 
         let cmd = try ModelPull.parse([
-            "image-zimage-nano",
+            "image-klein-nano",
             "--allow-unsupported",
             "--preflight",
             "--json",
@@ -75,7 +128,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertEqual(envelope.command, ["model", "pull"])
         XCTAssertEqual(envelope.result.mode, "single")
         XCTAssertEqual(envelope.result.models.count, 1)
-        XCTAssertEqual(envelope.result.models.first?.id, "image-zimage-nano")
+        XCTAssertEqual(envelope.result.models.first?.id, "image-klein-nano")
         XCTAssertEqual(envelope.result.models.first?.status, "will_download")
         XCTAssertEqual(envelope.result.models.first?.hasDownloadSource, true)
         XCTAssertEqual(envelope.result.models.first?.installed, false)
@@ -91,7 +144,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
             "mere.run",
             "model",
             "pull",
-            "image-zimage-nano",
+            "image-klein-nano",
             "--allow-unsupported",
         ])
 
@@ -99,7 +152,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let decoded = try decoder.decode(ModelPullPreflightEnvelope.self, from: Data(encoded.utf8))
-        XCTAssertEqual(decoded.result.models.first?.id, "image-zimage-nano")
+        XCTAssertEqual(decoded.result.models.first?.id, "image-klein-nano")
         XCTAssertEqual(decoded.result.models.first?.runtimeReady, false)
         XCTAssertEqual(decoded.result.models.first?.conversionRequired, false)
     }
@@ -133,7 +186,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
         MereRunModelPaths.setProcessModelsDirOverride(missingModelStore)
 
         let cmd = try ModelPull.parse([
-            "image-zimage-nano",
+            "image-klein-nano",
             "--allow-unsupported",
             "--preflight",
             "--json",
@@ -149,7 +202,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertEqual(
             envelope.result.models.first?.installPath,
             missingModelStore
-                .appendingPathComponent("image-zimage-nano", isDirectory: true)
+                .appendingPathComponent("image-klein-nano", isDirectory: true)
                 .standardizedFileURL
                 .path
         )

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -13,6 +13,31 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.allowUnsupported)
     }
 
+    func testBuffaloLPullRequiresExplicitLicenseAcceptance() throws {
+        let restricted = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: FaceAnalysisResources.modelID)
+        )
+        let blocked = try ModelPull.parse([FaceAnalysisResources.modelID])
+        let accepted = try ModelPull.parse([
+            FaceAnalysisResources.modelID,
+            "--accept-model-license",
+        ])
+
+        XCTAssertNotNil(restricted.usageRestriction)
+        XCTAssertNotNil(blocked.licenseAcceptanceMessage(for: restricted))
+        XCTAssertNil(accepted.licenseAcceptanceMessage(for: restricted))
+    }
+
+    func testModelListReportsBuffaloLUsageRestriction() {
+        let lines = ModelList.usageRestrictionLines()
+
+        XCTAssertTrue(lines.contains { line in
+            line.contains(FaceAnalysisResources.modelID)
+                && line.contains("non-commercial research use")
+                && line.contains("deepinsight/insightface#license")
+        })
+    }
+
     func testModelPullParsesPreflightJSONOptions() throws {
         let cmd = try ModelPull.parse([
             "image-zimage-nano",

--- a/Tests/MereRunCLITests/OpenWebUICommandTests.swift
+++ b/Tests/MereRunCLITests/OpenWebUICommandTests.swift
@@ -31,6 +31,7 @@ final class OpenWebUICommandTests: XCTestCase {
         XCTAssertEqual(command.sttModel, ParakeetResources.defaultModelId)
         XCTAssertEqual(command.ttsFormat, "wav")
         XCTAssertFalse(command.pull)
+        XCTAssertFalse(command.acceptModelLicense)
         XCTAssertFalse(command.skipServer)
         XCTAssertFalse(command.skipDocker)
         XCTAssertFalse(command.skipConfigure)
@@ -60,6 +61,7 @@ final class OpenWebUICommandTests: XCTestCase {
             "--admin-password", "password",
             "--wait-seconds", "30",
             "--pull",
+            "--accept-model-license",
             "--skip-server",
             "--skip-docker",
             "--skip-configure",
@@ -86,12 +88,31 @@ final class OpenWebUICommandTests: XCTestCase {
         XCTAssertEqual(command.adminPassword, "password")
         XCTAssertEqual(command.waitSeconds, 30)
         XCTAssertTrue(command.pull)
+        XCTAssertTrue(command.acceptModelLicense)
         XCTAssertTrue(command.skipServer)
         XCTAssertTrue(command.skipDocker)
         XCTAssertTrue(command.skipConfigure)
         XCTAssertTrue(command.reset)
         XCTAssertTrue(command.dryRun)
         XCTAssertTrue(command.quiet)
+    }
+
+    func testQuickstartRequiresTermsAcknowledgementBeforeItsDefaultRestrictedImagePull() throws {
+        let modelsRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-open-webui-terms-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? FileManager.default.removeItem(at: modelsRoot)
+        }
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        let blocked = try OpenWebUIQuickstart.parse(["--pull"])
+        let message = try XCTUnwrap(blocked.unacknowledgedUsageTermsMessage())
+        XCTAssertTrue(message.contains("image-zimage-nano"))
+        XCTAssertTrue(message.contains("--accept-model-license"))
+
+        let accepted = try OpenWebUIQuickstart.parse(["--pull", "--accept-model-license"])
+        XCTAssertNil(accepted.unacknowledgedUsageTermsMessage())
     }
 
     func testQuickstartDryRunPlanUsesDockerBridgeAndChatFilter() throws {

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -91,7 +91,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
 
         let visionNames = Set(Vision.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertEqual(visionNames, Set([
-            "caption", "inspect", "ground", "segment", "track", "track-live", "pose", "flow", "ocr",
+            "caption", "inspect", "ground", "segment", "face", "track", "track-live", "pose", "flow", "ocr",
             "depth-video", "geometry", "geometry-multiview", "image-to-3d", "image-to-3d-multiview",
             "image-to-3d-trellis2",
         ]))

--- a/Tests/MereRunCLITests/VisionFaceCommandTests.swift
+++ b/Tests/MereRunCLITests/VisionFaceCommandTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import MereRunCLI
+
+final class VisionFaceCommandTests: XCTestCase {
+    func testParsesWarmBatchOptions() throws {
+        let command = try VisionFaceBatch.parse([
+            "--input-list", "/tmp/photos.txt",
+            "--include-embeddings",
+            "--model", "/tmp/buffalo_l",
+            "--execution-provider", "cpu",
+            "--score-threshold", "0.7",
+            "--max-faces", "3",
+            "--jsonl-output", "/tmp/faces.jsonl",
+            "--fail-fast",
+        ])
+
+        XCTAssertEqual(command.inputList, "/tmp/photos.txt")
+        XCTAssertTrue(command.includeEmbeddings)
+        XCTAssertEqual(command.modelOptions.model, "/tmp/buffalo_l")
+        XCTAssertEqual(command.modelOptions.executionProvider, "cpu")
+        XCTAssertEqual(command.modelOptions.scoreThreshold, 0.7)
+        XCTAssertEqual(command.maxFaces, 3)
+        XCTAssertEqual(command.jsonlOutput, "/tmp/faces.jsonl")
+        XCTAssertTrue(command.failFast)
+    }
+
+    func testBatchRequiresImagesOrInputList() throws {
+        XCTAssertThrowsError(try VisionFaceBatch.parse([]))
+    }
+
+    func testRejectsInvalidExecutionProvider() throws {
+        XCTAssertThrowsError(try VisionFaceDetect.parse([
+            "/tmp/face.jpg", "--execution-provider", "cuda",
+        ]))
+    }
+}

--- a/Tests/MereRunCLITests/VisionSegmentCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/VisionSegmentCommandParsingTests.swift
@@ -361,7 +361,7 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
     func testVisionSubcommandsIncludeSegment() {
         let visionNames = Set(Vision.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertEqual(visionNames, Set([
-            "caption", "inspect", "segment", "ground", "track", "track-live", "pose", "flow", "ocr",
+            "caption", "inspect", "segment", "face", "ground", "track", "track-live", "pose", "flow", "ocr",
             "depth-video", "geometry", "geometry-multiview", "image-to-3d", "image-to-3d-multiview",
             "image-to-3d-trellis2",
         ]))

--- a/Tests/MereRunCoreTests/FaceAnalysisTests.swift
+++ b/Tests/MereRunCoreTests/FaceAnalysisTests.swift
@@ -12,7 +12,12 @@ final class FaceAnalysisTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.revision, "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb")
         XCTAssertEqual(
             Set(spec.hubFallback?.patterns ?? []),
-            [FaceAnalysisResources.detectorRelativePath, FaceAnalysisResources.recognizerRelativePath]
+            [
+                FaceAnalysisResources.detectorRelativePath,
+                FaceAnalysisResources.recognizerRelativePath,
+                "LICENSE*",
+                "README.md",
+            ]
         )
         XCTAssertEqual(
             spec.estimatedDownloadBytes,

--- a/Tests/MereRunCoreTests/FaceAnalysisTests.swift
+++ b/Tests/MereRunCoreTests/FaceAnalysisTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCore
+
+final class FaceAnalysisTests: XCTestCase {
+    func testManagedBuffaloLModelUsesPinnedDetectorAndRecognizer() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: FaceAnalysisResources.modelID))
+        XCTAssertEqual(spec.category, .visionFace)
+        XCTAssertEqual(spec.validationKind, .insightFaceBuffaloL)
+        XCTAssertEqual(spec.hubFallback?.repoId, "deepghs/insightface")
+        XCTAssertEqual(spec.hubFallback?.revision, "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb")
+        XCTAssertEqual(
+            Set(spec.hubFallback?.patterns ?? []),
+            [FaceAnalysisResources.detectorRelativePath, FaceAnalysisResources.recognizerRelativePath]
+        )
+        XCTAssertEqual(
+            spec.estimatedDownloadBytes,
+            FaceAnalysisResources.detectorByteCount + FaceAnalysisResources.recognizerByteCount
+        )
+    }
+
+    func testResourcesRequireBothExactCheckpointSizes() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-face-resources-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resources = FaceAnalysisResources(rootURL: root)
+        try createSparseFile(resources.detectorURL, byteCount: FaceAnalysisResources.detectorByteCount)
+        XCTAssertEqual(resources.validate(), [resources.recognizerURL])
+        try createSparseFile(resources.recognizerURL, byteCount: FaceAnalysisResources.recognizerByteCount)
+        XCTAssertTrue(resources.validate().isEmpty)
+
+        let handle = try FileHandle(forWritingTo: resources.detectorURL)
+        try handle.truncate(atOffset: UInt64(FaceAnalysisResources.detectorByteCount - 1))
+        try handle.close()
+        XCTAssertEqual(resources.validate(), [resources.detectorURL])
+    }
+
+    func testEmbeddingNormalizationAndCosineSimilarity() throws {
+        let normalized = FaceAnalysisMath.l2Normalized([3, 4])
+        XCTAssertEqual(normalized[0], 0.6, accuracy: 0.000_001)
+        XCTAssertEqual(normalized[1], 0.8, accuracy: 0.000_001)
+        XCTAssertEqual(
+            try XCTUnwrap(FaceAnalysisMath.cosineSimilarity(normalized, normalized)),
+            1,
+            accuracy: 0.000_001
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(FaceAnalysisMath.cosineSimilarity([1, 0], [0, 1])),
+            0,
+            accuracy: 0.000_001
+        )
+        XCTAssertNil(FaceAnalysisMath.cosineSimilarity([1], [1, 2]))
+    }
+
+    func testDetectorInputUsesAspectFitAndInsightFaceNormalization() throws {
+        let image = try MediaImage(
+            width: 2,
+            height: 1,
+            rgba8: [255, 127, 0, 255, 255, 127, 0, 255]
+        )
+        let input = try FaceImageProcessing.detectorInput(from: image)
+        XCTAssertEqual(input.scale, 320, accuracy: 0.000_001)
+        XCTAssertEqual(input.values.count, 1 * 3 * 640 * 640)
+        XCTAssertEqual(input.values[0], (255 - 127.5) / 128, accuracy: 0.000_001)
+        XCTAssertEqual(input.values[640 * 640], (127 - 127.5) / 128, accuracy: 0.000_001)
+        XCTAssertEqual(input.values[2 * 640 * 640], (0 - 127.5) / 128, accuracy: 0.000_001)
+    }
+
+    private func createSparseFile(_ url: URL, byteCount: Int64) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: url)
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: UInt64(byteCount))
+        try handle.close()
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -51,6 +51,86 @@ final class ManagedModelCatalogTests: XCTestCase {
         }
     }
 
+    func testRestrictedModelInventoryIsCompleteAndCannotAutoDownload() throws {
+        let expected = Set([
+            "image-klein-9b",
+            "image-klein-base-9b",
+            "image-zimage-nano",
+            "image-krea2-raw",
+            "image-krea2-turbo",
+            "image-ideogram4-sdnq-uint4",
+            "text-chat-lfm25-a1b-8bit",
+            "vision-segment-sam31",
+            "vision-face-buffalo-l",
+            "image-3d-trellis2-4b",
+            "music-muscriptor-small",
+            "music-muscriptor-medium",
+            "music-muscriptor-large",
+            "sfx-woosh-dflow",
+            "sfx-woosh-flow",
+            "sfx-woosh-clap",
+            "sfx-woosh-synchformer",
+            "sfx-woosh-vflow-8s",
+            "sfx-woosh-dvflow-8s",
+            "sfx-mmaudio-large-44k-v2",
+            "video-ltx-av",
+            "video-ltx23-av-mlx",
+        ])
+        let visibleAndCompanionSpecs = ManagedModelCatalog.allSpecs
+            + ManagedModelCatalog.allSpecs
+                .flatMap(\.companionModelIDs)
+                .compactMap { ManagedModelCatalog.spec(for: $0) }
+        let restricted = Set(
+            visibleAndCompanionSpecs
+                .filter { $0.usageRestriction != nil }
+                .map(\.id)
+        )
+        let expectedWithCompanions = expected.union([
+            ModelResolver.ModelID.ltxGemma3TwelveB4Bit.rawValue,
+        ])
+
+        XCTAssertEqual(restricted, expectedWithCompanions)
+        for spec in visibleAndCompanionSpecs where spec.usageRestriction != nil {
+            XCTAssertFalse(spec.runtimeAutoDownloadAllowed, "Restricted model \(spec.id) must never auto-download.")
+            let terms = try XCTUnwrap(spec.usageRestriction?.terms)
+            XCTAssertFalse(terms.isEmpty)
+            for term in terms {
+                XCTAssertFalse(term.component.isEmpty)
+                XCTAssertFalse(term.license.isEmpty)
+                XCTAssertFalse(term.sourceRepoId.isEmpty)
+                XCTAssertTrue(
+                    term.sourceRevision.range(of: "^[0-9a-f]{40}$", options: .regularExpression) != nil,
+                    "Restricted source \(term.sourceRepoId) must use an immutable revision, not \(term.sourceRevision)."
+                )
+                XCTAssertNotNil(URL(string: term.licenseURL))
+            }
+
+            let downloadSources = [spec.hubFallback].compactMap { $0 }
+                + spec.mountedHubFallbacks.map(\.hubFallback)
+                + spec.companionModelIDs.compactMap { ManagedModelCatalog.spec(for: $0)?.hubFallback }
+            for source in downloadSources {
+                XCTAssertTrue(
+                    source.revision.range(of: "^[0-9a-f]{40}$", options: .regularExpression) != nil,
+                    "Restricted download source \(source.repoId) must use an immutable revision, not \(source.revision)."
+                )
+            }
+        }
+    }
+
+    func testRestrictedManifestCarriesSourceTermsWithoutClaimingAcceptance() throws {
+        let modelID = try XCTUnwrap(ModelResolver.ModelID(rawValue: FaceAnalysisResources.modelID))
+        let manifest = MereRunModelManifest.template(for: modelID, createdAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(manifest.schemaVersion, 3)
+        XCTAssertEqual(manifest.sources?.first?.repository, "deepghs/insightface")
+        XCTAssertEqual(
+            manifest.sources?.first?.revision,
+            "4e1f33d3fe0e50a0945f3a53ab94ae8977ae7ddb"
+        )
+        XCTAssertEqual(manifest.usageTerms?.first?.license, "InsightFace pretrained model non-commercial research terms")
+        XCTAssertNil(manifest.usageTermsAcknowledged)
+    }
+
     func testManagedDownloadSourcesAreHuggingFaceOnly() {
         for spec in ManagedModelCatalog.allSpecs where spec.hasAnyManagedDownloadSource() {
             XCTAssertNotNil(spec.hubFallback, "Managed model \(spec.id) should download from Hugging Face.")
@@ -110,8 +190,9 @@ final class ManagedModelCatalogTests: XCTestCase {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-zimage-nano"))
 
         XCTAssertEqual(spec.hubFallback?.repoId, "filipstrand/Z-Image-Turbo-mflux-4bit")
+        XCTAssertEqual(spec.hubFallback?.revision, "b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b")
         XCTAssertEqual(spec.upstreamRepoId, "filipstrand/Z-Image-Turbo-mflux-4bit")
-        XCTAssertEqual(spec.upstreamRevision, "main")
+        XCTAssertEqual(spec.upstreamRevision, "b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b")
         XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/added_tokens.json"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("transformer/model.safetensors.index.json"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("tokenizer/*"), false)
@@ -286,6 +367,9 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns, ["model_index.json", "transformer/*"])
         XCTAssertEqual(spec.upstreamRepoId, "black-forest-labs/FLUX.2-klein-base-9B")
         XCTAssertEqual(spec.defaultCLICommands, ["image generate", "image train-lora"])
+        XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
+        XCTAssertTrue(spec.usageRestriction?.terms.contains { $0.component == "Base 9B transformer" } == true)
+        XCTAssertTrue(spec.usageRestriction?.terms.contains { $0.component.hasPrefix("shared 9B") } == true)
 
         let mounted = Dictionary(uniqueKeysWithValues: spec.mountedHubFallbacks.map {
             ($0.destinationPath, $0.hubFallback.repoId)
@@ -337,9 +421,9 @@ final class ManagedModelCatalogTests: XCTestCase {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Ideogram4Resources.modelId))
 
         XCTAssertEqual(spec.hubFallback?.repoId, "WaveCut/ideogram-4-sdnq-uint4")
-        XCTAssertEqual(spec.hubFallback?.revision, "main")
+        XCTAssertEqual(spec.hubFallback?.revision, "ea2e67436478a97ad6c414c5f947d6d76aa8457d")
         XCTAssertEqual(spec.upstreamRepoId, "WaveCut/ideogram-4-sdnq-uint4")
-        XCTAssertEqual(spec.upstreamRevision, "main")
+        XCTAssertEqual(spec.upstreamRevision, "ea2e67436478a97ad6c414c5f947d6d76aa8457d")
         XCTAssertEqual(spec.validationKind, .ideogram4SDNQ)
         XCTAssertEqual(spec.estimatedDownloadBytes, 16 * 1_073_741_824)
         XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
@@ -647,7 +731,10 @@ final class ManagedModelCatalogTests: XCTestCase {
     func testZImageNanoAcceptsMFluxLayoutWithoutDiffusersConfigs() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
-        try writeMinimalMFluxZImageNano(at: root, upstreamRepoId: "filipstrand/Z-Image-Turbo-mflux-4bit@main")
+        try writeMinimalMFluxZImageNano(
+            at: root,
+            upstreamRepoId: "filipstrand/Z-Image-Turbo-mflux-4bit@b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b"
+        )
 
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-zimage-nano"))
         XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
@@ -868,7 +955,10 @@ final class ManagedModelCatalogTests: XCTestCase {
             XCTAssertEqual(spec.category, .music)
             XCTAssertEqual(spec.hubFallback?.repoId, repoID)
             XCTAssertEqual(spec.hubFallback?.revision, revision)
-            XCTAssertEqual(spec.hubFallback?.patterns, ["config.json", "model.safetensors"])
+            XCTAssertEqual(spec.hubFallback?.patterns.contains("config.json"), true)
+            XCTAssertEqual(spec.hubFallback?.patterns.contains("model.safetensors"), true)
+            XCTAssertEqual(spec.hubFallback?.patterns.contains("LICENSE*"), true)
+            XCTAssertEqual(spec.hubFallback?.patterns.contains("README.md"), true)
             XCTAssertEqual(spec.validationKind, .muScriptor)
             XCTAssertEqual(spec.defaultCLICommands, ["music transcribe"])
         }
@@ -895,6 +985,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(spec.hubFallback?.patterns.contains("checkpoints/Woosh-VFlow-8s/*") == false)
         XCTAssertEqual(spec.mountedHubFallbacks.first?.destinationPath, "checkpoints/TextConditionerA/tokenizer")
         XCTAssertEqual(spec.mountedHubFallbacks.first?.hubFallback.repoId, WooshResources.robertaTokenizerRepoId)
+        XCTAssertEqual(spec.mountedHubFallbacks.first?.hubFallback.revision, WooshResources.robertaTokenizerRevision)
     }
 
     func testWooshFlowSpecUsesOriginalFlowCheckpointLayout() throws {
@@ -1039,11 +1130,14 @@ final class ManagedModelCatalogTests: XCTestCase {
 
         XCTAssertEqual(spec.category, .video)
         XCTAssertEqual(spec.hubFallback?.repoId, "dgrauet/ltx-2.3-mlx")
-        XCTAssertEqual(spec.hubFallback?.revision, "main")
+        XCTAssertEqual(spec.hubFallback?.revision, "baa5f235ea04fd9c95899d751295c4fd825ee4e2")
         XCTAssertEqual(spec.upstreamRepoId, "dgrauet/ltx-2.3-mlx")
+        XCTAssertEqual(spec.upstreamRevision, "baa5f235ea04fd9c95899d751295c4fd825ee4e2")
         XCTAssertEqual(spec.validationKind, .ltxVideo23MLX)
         XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
         XCTAssertEqual(spec.companionModelIDs, [ModelResolver.ModelID.ltxGemma3TwelveB4Bit.rawValue])
+        XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
+        XCTAssertTrue(spec.usageRestriction?.terms.contains { $0.license == "Gemma Terms of Use" } == true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("embedded_config.json"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("vocoder.safetensors"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("transformer-dev.safetensors"), false)
@@ -1060,6 +1154,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.upstreamRevision, "14d891e009084901c434304fe93a86fd9013e84c")
         XCTAssertEqual(spec.validationKind, .hfTextChat)
         XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
+        XCTAssertEqual(spec.usageRestriction?.terms.first?.license, "Gemma Terms of Use")
     }
 
     func testHFTextRootValidationRequiresShardsNamedByIndex() throws {

--- a/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
@@ -2,6 +2,29 @@ import XCTest
 @testable import MereRunCore
 
 final class ManagedModelResolverTests: XCTestCase {
+    func testRestrictedInstallRequiresCoreAcknowledgementBeforeDownload() async throws {
+        let modelsRoot = try makeTemporaryDirectory()
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? FileManager.default.removeItem(at: modelsRoot)
+        }
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        do {
+            _ = try await ManagedModelResolver.installManagedModel(id: FaceAnalysisResources.modelID)
+            XCTFail("Restricted install should fail before contacting its download source.")
+        } catch let error as ManagedModelResolver.ResolverError {
+            guard case .usageTermsNotAcknowledged(let modelID) = error else {
+                return XCTFail("Unexpected resolver error: \(error)")
+            }
+            XCTAssertEqual(modelID, FaceAnalysisResources.modelID)
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: modelsRoot.appendingPathComponent(FaceAnalysisResources.modelID).path
+        ))
+    }
+
     func testMaterializedGeometryInstallsExactBundledLicenseEvidence() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -187,10 +210,12 @@ final class ManagedModelResolverTests: XCTestCase {
             snapshotURL: baseSnapshot,
             mountedSnapshots: mountedSnapshots,
             modelDir: install,
+            usageTermsAcknowledged: true,
             fileManager: .default
         )
 
         XCTAssertEqual(manifest?.id, "image-klein-base-9b")
+        XCTAssertEqual(manifest?.usageTermsAcknowledged, true)
         let mountedTextConfig = install.appendingPathComponent("text_encoder/config.json")
         XCTAssertEqual(
             URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: mountedTextConfig.path))

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -53,7 +53,10 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.engine, .zimageTurbo)
         XCTAssertEqual(manifest.precision, .int4)
         XCTAssertEqual(manifest.quantization?.bits, 4)
-        XCTAssertEqual(manifest.upstreamRepoId, "filipstrand/Z-Image-Turbo-mflux-4bit@main")
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "filipstrand/Z-Image-Turbo-mflux-4bit@b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b"
+        )
     }
 
     func testBonsaiTernaryTemplateHasExpectedNativeLayout() throws {
@@ -308,7 +311,10 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(Set(manifest.supports ?? []), Set([.txt2img]))
         XCTAssertEqual(manifest.components?.transformer, .local(path: "transformer"))
         XCTAssertEqual(manifest.components?.unconditionalTransformer, .local(path: "unconditional_transformer"))
-        XCTAssertEqual(manifest.upstreamRepoId, "WaveCut/ideogram-4-sdnq-uint4@main")
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "WaveCut/ideogram-4-sdnq-uint4@\(Ideogram4Resources.upstreamRevision)"
+        )
     }
 
     func testPrivacyFilterTemplateHasExpectedMetadata() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,7 +96,7 @@ swift run mere.run model list
 swift run mere.run status
 swift run mere.run model capabilities
 swift run mere.run model runtime get text-chat-gemma4
-swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull image-zimage-nano --accept-model-license
 swift run mere.run model info image-zimage-nano
 ```
 
@@ -164,7 +164,7 @@ swift run mere.run music realtime \
 ### Generate sound effects
 
 ```bash
-swift run mere.run model pull sfx-woosh-dflow
+swift run mere.run model pull sfx-woosh-dflow --accept-model-license
 swift run mere.run sfx generate \
   "metal wrench dropping onto concrete, bright clang and brief ring" \
   --model sfx-woosh-dflow \
@@ -328,8 +328,8 @@ FLUX.2 Klein LoRAs are trained on a Klein base model selected with `--model`
 and can be used with Klein generation via `image generate --lora`.
 
 ```bash
-swift run mere.run model pull image-krea2-raw
-swift run mere.run model pull image-krea2-turbo
+swift run mere.run model pull image-krea2-raw --accept-model-license
+swift run mere.run model pull image-krea2-turbo --accept-model-license
 swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-krea2.safetensors \
@@ -356,8 +356,8 @@ max side `512`, the fast Klein target surface, disk-backed latent caching,
 compiled-step disablement, and 250-step checkpoints:
 
 ```bash
-swift run mere.run model pull image-klein-base-9b
-swift run mere.run model pull image-klein-9b
+swift run mere.run model pull image-klein-base-9b --accept-model-license
+swift run mere.run model pull image-klein-9b --accept-model-license
 swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-klein.safetensors \
@@ -833,7 +833,7 @@ swift run mere.run vision inspect ./diagram.png "What does this diagram show?"
 Segment prompted objects in an image using the native SAM 3.1 runtime.
 
 ```bash
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision segment ./photo.jpg --prompt "a cat"
 ```
 
@@ -877,7 +877,7 @@ swift run mere.run vision segment ./photo.jpg --prompt "a dog" --output ./photo-
 Track prompted objects through a video with the native SAM 3.1 runtime.
 
 ```bash
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision track ./clip.mp4 --prompt "a dog"
 ```
 
@@ -1192,7 +1192,7 @@ The model repositories are gated and the weights are CC BY-NC 4.0. Accept the
 upstream Hugging Face terms before pulling.
 
 ```bash
-swift run mere.run model pull music-muscriptor-medium
+swift run mere.run model pull music-muscriptor-medium --accept-model-license
 swift run mere.run music transcribe ./song.mp3 --output ./song.mid
 swift run mere.run music transcribe ./song.mp3 \
   --output ./song.mid --context-output ./song-context.json
@@ -1379,7 +1379,7 @@ Synchformer video features. `.npy` feature inputs must have shape
 video so it can compute both CLIP and Synchformer conditioning.
 
 ```bash
-swift run mere.run model pull sfx-woosh-synchformer
+swift run mere.run model pull sfx-woosh-synchformer --accept-model-license
 swift run mere.run sfx video generate \
   "footsteps echoing in a hallway" \
   ./silent-hallway.mp4 \
@@ -1620,8 +1620,8 @@ the model capability catalog and available disk space before downloading so unsu
 machines do not pull models they cannot run and tight disks fail with a useful cache path.
 
 ```bash
-swift run mere.run model pull image-zimage-nano
-swift run mere.run model pull image-zimage-nano --preflight --json
+swift run mere.run model pull image-zimage-nano --accept-model-license
+swift run mere.run model pull image-zimage-nano --accept-model-license --preflight --json
 swift run mere.run model pull --all
 ```
 
@@ -1631,6 +1631,15 @@ download starts. The report includes `pull-model` or `pull-models` actions and
 exits nonzero after printing JSON when hard blockers are present.
 
 Use `--allow-unsupported` only when you intentionally accept the runtime risk.
+
+Models with non-commercial, research-only, gated, revenue-limited, or custom
+acceptable-use terms require `--accept-model-license` before a new download.
+The preflight reports the exact component terms and blocks without
+acknowledgement; `--all` skips restricted entries unless the flag is present.
+mere.run records the immutable source revisions and acknowledged term URLs in
+the installed `mererun_model.json`, but the user remains responsible for
+deciding whether their intended use complies. See
+[`model-sources.md`](./model-sources.md#restricted-model-downloads).
 
 ### `mere.run adapter list` and `mere.run adapter pull`
 
@@ -2169,7 +2178,7 @@ extension that points at `mere.run api serve`.
 
 ```bash
 swift run mere.run agent onboard
-swift run mere.run agent onboard --pull-recommended
+swift run mere.run agent onboard --pull-recommended --accept-model-license
 swift run mere.run agent onboard --install-pi --configure-pi
 swift run mere.run agent onboard --configure-pi --model text-agent-deepseek-v4-flash
 swift run mere.run agent onboard --configure-pi --model text-code-north-mini --port 8080

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -955,7 +955,7 @@ Notes:
 Run local Buffalo-L face detection and ArcFace identity embeddings.
 
 ```bash
-swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run model pull vision-face-buffalo-l --accept-model-license
 swift run mere.run vision face detect ./group.jpg --json
 swift run mere.run vision face detect ./group.jpg --include-embeddings --json-output ./faces.json
 swift run mere.run vision face embed ./reference.jpg --face-index 0 --json
@@ -969,6 +969,10 @@ face unless an explicit zero-based face index is supplied.
 `batch` keeps one detector/recognizer session warm across a path list and writes
 one success-or-error record per image, making it the high-throughput library
 indexing surface.
+
+Buffalo-L weights are restricted to non-commercial research use by their
+upstream provider. `model pull` requires `--accept-model-license`, prints the
+license URL before download, and stores the weights outside the application.
 
 ### `mere.run vision pose`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,7 @@ are:
   `vision-ocr-infinity-pro-int8`, `vision-ocr-infinity-pro`
 - Vision segmentation / tracking: `vision-segment-sam31`
 - Vision grounding: `vision-ground-falcon-perception`
+- Face detection and identity embeddings: `vision-face-buffalo-l`
 - Music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - SFX: `sfx-woosh-dflow`, `sfx-woosh-flow`
 - Video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-wan22-ti2v-5b-mlx`
@@ -948,6 +949,26 @@ Notes:
 - live tracking searches a short warm-up window after the init frame so startup exposure or motion blur does not silently produce an unsegmented output
 - live mode accepts text prompts only in the current implementation
 - `--output` is required; `--json-output` is optional
+
+### `mere.run vision face`
+
+Run local Buffalo-L face detection and ArcFace identity embeddings.
+
+```bash
+swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run vision face detect ./group.jpg --json
+swift run mere.run vision face detect ./group.jpg --include-embeddings --json-output ./faces.json
+swift run mere.run vision face embed ./reference.jpg --face-index 0 --json
+swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
+swift run mere.run vision face batch --input-list ./photos.txt --include-embeddings --jsonl-output ./faces.jsonl
+```
+
+Common options include `--model`, `--score-threshold`, and
+`--execution-provider auto|cpu|coreml`. `embed` and `compare` select the largest
+face unless an explicit zero-based face index is supplied.
+`batch` keeps one detector/recognizer session warm across a path list and writes
+one success-or-error record per image, making it the high-throughput library
+indexing surface.
 
 ### `mere.run vision pose`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ Overrides the Hugging Face snapshot cache used by managed model pulls.
 
 ```bash
 export MERERUN_HUB_CACHE=/Volumes/Models/huggingface
-swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull image-zimage-nano --accept-model-license
 ```
 
 Managed pulls use cataloged Hugging Face repos only. Private archive hosts and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -255,6 +255,14 @@ swift run mere.run model pull vision-ground-falcon-perception
 swift run mere.run vision ground ./image.png --query "a person"
 ```
 
+### Face analysis
+
+```bash
+swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run vision face detect ./group.jpg --json
+swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
+```
+
 ### Vision segment
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -184,7 +184,7 @@ Example:
 
 ```bash
 swift run mere.run model capabilities
-swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull image-zimage-nano --accept-model-license
 # Optional compact FLUX.2 Klein path:
 swift run mere.run model pull image-bonsai-binary
 ```
@@ -266,7 +266,7 @@ swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
 ### Vision segment
 
 ```bash
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision segment ./image.png --prompt "a person"
 swift run mere.run vision track ./clip.mp4 --prompt "a person"
 swift run mere.run vision track-live --output ./live.mp4 --prompt "a person"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -258,7 +258,7 @@ swift run mere.run vision ground ./image.png --query "a person"
 ### Face analysis
 
 ```bash
-swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run model pull vision-face-buffalo-l --accept-model-license
 swift run mere.run vision face detect ./group.jpg --json
 swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
 ```

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -102,6 +102,14 @@ from the runtime catalog used by `mere.run model list`,
 | `video` | `video-dreamx-world-5b-ar-mlx` |
 <!-- managed-model-catalog:end -->
 
+### Restricted model downloads
+
+`vision-face-buffalo-l` uses InsightFace pretrained weights. InsightFace limits
+those weights to non-commercial research use and directs commercial users to
+obtain separate licensing. mere.run does not bundle the weights. An explicit
+`--accept-model-license` acknowledgment is required before `model pull`
+downloads them, and `model list` reports the restriction and upstream URL.
+
 Most catalog IDs have managed Hugging Face sources and can be installed with
 `mere.run model pull`. A small number of legacy/local catalog IDs remain so
 existing installs and explicit local paths keep working:

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -104,11 +104,48 @@ from the runtime catalog used by `mere.run model list`,
 
 ### Restricted model downloads
 
-`vision-face-buffalo-l` uses InsightFace pretrained weights. InsightFace limits
-those weights to non-commercial research use and directs commercial users to
-obtain separate licensing. mere.run does not bundle the weights. An explicit
-`--accept-model-license` acknowledgment is required before `model pull`
-downloads them, and `model list` reports the restriction and upstream URL.
+mere.run is free and open source, but model and component licenses remain the
+terms of their respective owners. mere.run does not bundle these weights,
+decide whether a user's intended use qualifies, or police use after install.
+For every new download with non-commercial, research-only, gated, revenue-
+limited, or custom acceptable-use terms, the user must review the listed terms
+and pass `--accept-model-license`:
+
+```bash
+mere.run model pull vision-face-buffalo-l --accept-model-license
+mere.run model pull --all --accept-model-license
+```
+
+Without that flag, a single-model pull and its preflight are blocked; `--all`
+skips restricted models. Restricted models never auto-download from an
+inference command. The macOS app presents the same acknowledgement before a
+download and exposes the term links in its Models and Advanced views.
+Batch downloads through `agent onboard --pull-recommended` skip restricted
+entries without acknowledgement, while `open-webui quickstart --pull`
+validates all configured models before downloading any; both accept the same
+`--accept-model-license` flag.
+
+| Models | Upstream terms that require acknowledgement |
+| --- | --- |
+| `image-klein-9b`, `image-klein-base-9b` | FLUX Non-Commercial License v2.1; non-commercial, non-production use |
+| `image-zimage-nano` | the quantized mirror declares the Tongyi Qianwen License; the official Z-Image-Turbo base is Apache 2.0 |
+| `image-krea2-raw`, `image-krea2-turbo` | Krea 2 Community License; commercial use is limited to entities below USD 1M trailing annual revenue, plus use/distribution conditions |
+| `image-ideogram4-sdnq-uint4` | Ideogram Non-Commercial Model Agreement |
+| `text-chat-lfm25-a1b-8bit` | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
+| `vision-segment-sam31` | Meta SAM License custom use, trade-control, attribution, and redistribution conditions |
+| `vision-face-buffalo-l` | InsightFace pretrained weights; non-commercial research use |
+| `image-3d-trellis2-4b` | the mounted DINOv3 encoder is gated under Meta's custom DINOv3 License |
+| `music-muscriptor-{small,medium,large}` | CC BY-NC 4.0 model weights |
+| `sfx-woosh-*` | CC BY-NC 4.0 Woosh or MMAudio Synchformer weights |
+| `sfx-mmaudio-large-44k-v2` | CC BY-NC 4.0 MMAudio checkpoints plus Apple's research-only DFN5B encoder terms |
+| `video-ltx-av`, `video-ltx23-av-mlx` | LTX-2 Community License; entities at or above USD 10M annual revenue need a paid commercial license, plus acceptable-use conditions. The 2.3 MLX path also installs a hidden Gemma 3 text encoder under Google's Gemma Terms and Prohibited Use Policy. |
+
+The catalog pins every restricted download source to an immutable commit. New
+managed installs write those repository revisions, every applicable
+model/component license and URL, and the acknowledgement result into schema 3
+of `mererun_model.json`. `mere.run model info MODEL` displays the same record.
+Pre-existing installs remain usable and are not retroactively treated as an
+acknowledgement.
 
 Most catalog IDs have managed Hugging Face sources and can be installed with
 `mere.run model pull`. A small number of legacy/local catalog IDs remain so
@@ -359,7 +396,7 @@ when you want large models on an external disk:
 
 ```bash
 export MERERUN_HUB_CACHE=/Volumes/Models/huggingface
-swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull image-zimage-nano --accept-model-license
 ```
 
 Model pulls are resumable at the file level through the Hugging Face snapshot
@@ -395,11 +432,11 @@ Examples:
 
 ```bash
 # Pull into the default model store
-swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull image-zimage-nano --accept-model-license
 
 # Pull into a custom SSD-backed store
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-q36-nano
-MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25-a1b-8bit
+MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 
 # Inspect what is currently installed
 swift run mere.run status

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -73,6 +73,7 @@ from the runtime catalog used by `mere.run model list`,
 | `vision-ocr` | `vision-ocr-lighton` |
 | `vision-segment` | `vision-segment-sam31` |
 | `vision-ground` | `vision-ground-falcon-perception` |
+| `vision-face` | `vision-face-buffalo-l` |
 | `vision-geometry` | `vision-geometry-moge2-small` |
 | `vision-depth` | `vision-depth-vda-small` |
 | `vision-depth` | `vision-depth-vda-small-metric` |

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -60,7 +60,7 @@ swift run mere.run api serve \
 For the LiquidAI LFM2.5 MLX 8-bit model:
 
 ```bash
-swift run mere.run model pull text-chat-lfm25-a1b-8bit
+swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 swift run mere.run api serve --engine text-chat-lfm2
 ```
 
@@ -86,7 +86,7 @@ curl http://127.0.0.1:8080/v1/embeddings \
 Image generation and editing return base64 PNG JSON by default:
 
 ```bash
-swift run mere.run model pull image-zimage-nano
+swift run mere.run model pull image-zimage-nano --accept-model-license
 curl http://127.0.0.1:8080/v1/images/generations \
   -H "Content-Type: application/json" \
   --data '{
@@ -474,7 +474,7 @@ pip install, then configure Open WebUI with the mere.run `/v1` base URL.
 One-command Docker quickstart:
 
 ```bash
-mere.run open-webui quickstart --pull
+mere.run open-webui quickstart --pull --accept-model-license
 ```
 
 That starts `api serve`, runs the official Open WebUI container, configures the

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -98,8 +98,8 @@ comparison that trains every transformer Linear/QuantizedLinear layer instead
 of the default suffix allowlist.
 
 ```bash
-swift run mere.run model pull image-klein-base-9b
-swift run mere.run model pull image-klein-9b
+swift run mere.run model pull image-klein-base-9b --accept-model-license
+swift run mere.run model pull image-klein-9b --accept-model-license
 swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-klein.safetensors \
@@ -282,8 +282,8 @@ transformer files.
 Train adapters on Raw, then preview or run them on Turbo:
 
 ```bash
-swift run mere.run model pull image-krea2-raw
-swift run mere.run model pull image-krea2-turbo
+swift run mere.run model pull image-krea2-raw --accept-model-license
+swift run mere.run model pull image-krea2-turbo --accept-model-license
 swift run mere.run image train-lora \
   --data ./style-dataset \
   --output ./style-krea2.safetensors \

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -87,6 +87,14 @@ checked against the managed capability catalog before download so low-memory
 machines do not fetch models they cannot run. Pass `--allow-unsupported` only
 when you intentionally accept that risk or are using external hardware.
 
+Restricted or custom-terms models require `--accept-model-license` for new
+downloads and never auto-download at runtime. The CLI and macOS app show the
+applicable model/component terms before acceptance; schema 3 of the installed
+`mererun_model.json` records the immutable source revisions, term URLs, and
+acknowledgement. mere.run does not determine whether a user's intended use is
+permitted. The complete inventory is in
+[`model-sources.md`](../model-sources.md#restricted-model-downloads).
+
 ### `mere.run adapter list` and `mere.run adapter pull`
 
 Adapters use a separate checksum-pinned catalog and install under:

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -88,7 +88,7 @@ swift run mere.run music realtime \
   --output ./live.wav \
   --no-play
 
-swift run mere.run model pull music-muscriptor-medium
+swift run mere.run model pull music-muscriptor-medium --accept-model-license
 swift run mere.run music transcribe ./song.mp3 --output ./song.mid
 ```
 

--- a/docs/runtime/sfx.md
+++ b/docs/runtime/sfx.md
@@ -30,7 +30,7 @@ mere.run guide sfx generate --model sfx-woosh-dflow
 ## Typical workflow
 
 ```bash
-swift run mere.run model pull sfx-woosh-dflow
+swift run mere.run model pull sfx-woosh-dflow --accept-model-license
 swift run mere.run sfx generate \
   "metal wrench dropping onto concrete, bright clang and brief ring" \
   --model sfx-woosh-dflow \
@@ -41,7 +41,7 @@ swift run mere.run sfx generate \
 ```
 
 ```bash
-swift run mere.run model pull sfx-woosh-flow
+swift run mere.run model pull sfx-woosh-flow --accept-model-license
 swift run mere.run sfx generate \
   "dry branch snapping under a boot" \
   --model sfx-woosh-flow \
@@ -70,15 +70,15 @@ swift run mere.run sfx condition text \
 ```
 
 ```bash
-swift run mere.run model pull sfx-woosh-clap
+swift run mere.run model pull sfx-woosh-clap --accept-model-license
 swift run mere.run sfx clap score \
   "ceramic mug shattering on a tile floor" \
   ./ceramic-shatter.wav
 ```
 
 ```bash
-swift run mere.run model pull sfx-woosh-dvflow-8s
-swift run mere.run model pull sfx-woosh-synchformer
+swift run mere.run model pull sfx-woosh-dvflow-8s --accept-model-license
+swift run mere.run model pull sfx-woosh-synchformer --accept-model-license
 swift run mere.run sfx video generate \
   "footsteps echoing down a concrete hallway" \
   ./silent-hallway.mp4 \
@@ -91,7 +91,7 @@ MMAudio provides a second, native 44.1 kHz path for both text-to-audio and
 video-to-audio generation:
 
 ```bash
-swift run mere.run model pull sfx-mmaudio-large-44k-v2
+swift run mere.run model pull sfx-mmaudio-large-44k-v2 --accept-model-license
 swift run mere.run sfx generate \
   "ocean waves striking a stone breakwater, close and detailed" \
   --negative-prompt "speech, music" \

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -57,7 +57,7 @@ For LTX 2.3 audio/video, pull the managed model id and let it install its Gemma
 3 companion:
 
 ```bash
-swift run mere.run model pull video-ltx23-av-mlx
+swift run mere.run model pull video-ltx23-av-mlx --accept-model-license
 swift run mere.run video generate \
   "dialogue with clean background music" \
   --variant unified-av \

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -132,7 +132,7 @@ download starts. The weights are not bundled with mere.run.
 ### Segment an image with SAM 3.1
 
 ```bash
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision segment ./image.png --prompt "a person"
 ```
 
@@ -146,7 +146,7 @@ swift run mere.run vision ground ./image.png --query "a person"
 ### Track objects through a video
 
 ```bash
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision track ./clip.mp4 --prompt "a dog" --init-frame 12
 ```
 
@@ -186,7 +186,7 @@ Accept the DINOv3 checkpoint license on Hugging Face before the first pull,
 then run the native 512-resolution pipeline:
 
 ```bash
-swift run mere.run model pull image-3d-trellis2-4b
+swift run mere.run model pull image-3d-trellis2-4b --accept-model-license
 swift run mere.run vision image-to-3d-trellis2 ./object.png \
   --output ./object-trellis2 \
   --seed 42

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -1,12 +1,15 @@
 # Vision Runtime
 
-This page covers captioning, inspection, grounding, segmentation, tracking,
+This page covers captioning, inspection, face analysis, grounding, segmentation, tracking,
 pose extraction, optical flow, image-to-3D reconstruction, and OCR.
 
 ## Public surface
 
 - `mere.run vision caption`
 - `mere.run vision inspect`
+- `mere.run vision face detect`
+- `mere.run vision face embed`
+- `mere.run vision face compare`
 - `mere.run vision ground`
 - `mere.run vision segment`
 - `mere.run vision track`
@@ -22,6 +25,7 @@ pose extraction, optical flow, image-to-3D reconstruction, and OCR.
 
 - `vision-ocr-lighton`
 - `vision-ground-falcon-perception`
+- `vision-face-buffalo-l`
 - `vision-segment-sam31`
 - `image-3d-triposr`
 - `image-3d-trellis2-4b`
@@ -35,6 +39,19 @@ Grounding runs natively through the Swift/MLX Falcon Perception stack in
 
 Segmentation and tracking run natively through the Swift/MLX SAM 3.1 stack in
 `MereRunCore`.
+
+Face analysis runs the Buffalo-L detector and ArcFace R50 recognizer locally
+through ONNX Runtime. The default `auto` provider uses CPU for this model based
+on the repository's Apple Silicon parity run; `--execution-provider coreml`
+and `--execution-provider cpu` remain explicit controls.
+
+The detector is useful beyond identity search: it provides face boxes and
+five-point landmarks for alignment, crops, counts, redaction, face-aware
+reframing, thumbnail selection, and dataset quality gates. The embedding model
+also supports verification, unnamed-person clustering, similarity search,
+representative prototype selection, and identity-outlier review. Neither model
+claims emotion, demographic attributes, liveness, deepfake detection, or
+general image understanding.
 
 ## Current SAM 3.1 scope
 
@@ -91,6 +108,21 @@ swift run mere.run vision caption ./cards/*.jpg \
 ```bash
 swift run mere.run vision inspect ./image.png "What objects are visible?"
 ```
+
+### Detect, embed, and compare faces
+
+```bash
+swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run vision face detect ./group.jpg --json
+swift run mere.run vision face embed ./reference.jpg --json
+swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
+```
+
+`detect --include-embeddings` emits one normalized 512-dimensional embedding
+per detected face. `embed` selects the largest face by default or accepts
+`--face-index`; `compare` returns cosine similarity. Use the companion
+`mere-face-tools` plugin for resumable folder indexing, SQLite search, and
+review/export workflows.
 
 ### Segment an image with SAM 3.1
 
@@ -174,6 +206,17 @@ The JSON includes:
 - model and input/output paths
 - query list
 - detections with `query`, normalized `xy`, normalized `hw`, derived `box`, optional `score`, and optional `maskPath`
+
+### `vision face`
+
+- `detect` emits image dimensions, elapsed inference time, face scores, pixel
+  boxes, and five landmarks; `--include-embeddings` adds identity vectors
+- `embed` emits one selected face and its normalized 512-value embedding
+- `compare` emits the selected face indexes and cosine similarity
+- `batch` keeps the sessions warm and emits one durable JSONL result per image;
+  `--include-embeddings` enables recognition/search vectors
+- `--json` keeps stdout machine-readable; `--json-output` writes the same
+  sorted payload atomically
 
 ### `vision segment`
 

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -112,7 +112,7 @@ swift run mere.run vision inspect ./image.png "What objects are visible?"
 ### Detect, embed, and compare faces
 
 ```bash
-swift run mere.run model pull vision-face-buffalo-l
+swift run mere.run model pull vision-face-buffalo-l --accept-model-license
 swift run mere.run vision face detect ./group.jpg --json
 swift run mere.run vision face embed ./reference.jpg --json
 swift run mere.run vision face compare ./reference.jpg ./candidate.jpg --json
@@ -123,6 +123,11 @@ per detected face. `embed` selects the largest face by default or accepts
 `--face-index`; `compare` returns cosine similarity. Use the companion
 `mere-face-tools` plugin for resumable folder indexing, SQLite search, and
 review/export workflows.
+
+Buffalo-L pretrained weights are provided by InsightFace for non-commercial
+research use. The pull command requires `--accept-model-license` to acknowledge
+the upstream restriction and prints the authoritative license URL before the
+download starts. The weights are not bundled with mere.run.
 
 ### Segment an image with SAM 3.1
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -248,7 +248,7 @@ MERERUN_RUN_E2E=core ./scripts/check.sh
 If you touched the SAM runtime, also run at least one real local smoke like:
 
 ```bash
-swift run mere.run model pull vision-segment-sam31
+swift run mere.run model pull vision-segment-sam31 --accept-model-license
 swift run mere.run vision segment ./image.png --prompt "a person"
 swift run mere.run vision track ./clip.mp4 --prompt "a person"
 ```

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -90,12 +90,19 @@ fi
 for asset in \
   "${build_dir}/llama.framework" \
   "${build_dir}/magentart.framework" \
-  "${build_dir}/Resources"
+  "${build_dir}/Resources" \
+  "${build_dir}"/*.dylib
 do
   if [[ -e "$asset" ]]; then
     cp -R "$asset" "$cli_payload/"
   fi
 done
+
+# Ship the complete third-party notices with the app so licenses for loose
+# runtime libraries remain available after the source checkout is gone.
+third_party_licenses="${resources}/ThirdPartyLicenses"
+mkdir -p "$third_party_licenses"
+cp "${repo_root}/THIRD_PARTY_NOTICES.md" "${third_party_licenses}/THIRD_PARTY_NOTICES.md"
 
 # Bundle the vendored DeepSeek V4 Flash inference binaries + Metal shaders.
 # The premier agent tier spawns vendor/ds4/ds4-server as a subprocess.
@@ -163,6 +170,14 @@ while IFS= read -r -d '' asset; do
   fi
   sign "" "$asset"
 done < <(find "$helpers" \( -name '*.framework' -o -name '*.bundle' \) -prune -print0)
+
+# Loose SwiftPM runtime libraries also need their own signatures before the
+# enclosing app is sealed. ONNX Runtime is one such co-located dylib.
+while IFS= read -r -d '' asset; do
+  if file -b "$asset" | grep -q 'Mach-O'; then
+    sign "" "$asset"
+  fi
+done < <(find "$helpers" -maxdepth 1 -type f -name '*.dylib' -print0)
 
 # 2. The bundled CLI and every vendored Mach-O under Helpers — CLI entitlements. (The .metal
 #    shader sources sit beside the ds4 executables; the file-type test skips them.)


### PR DESCRIPTION
## Summary

- add the managed `vision-face-buffalo-l` face detector, landmark pipeline, and ArcFace recognizer with pinned Hugging Face sources and exact ONNX artifact validation
- add face detection, embedding, comparison, and warm JSONL batch commands with CPU and Core ML execution on macOS while keeping the Linux manifest buildable
- unify third-party usage-term handling for every managed model or component with non-commercial, research-only, gated, revenue-limited, or custom terms
- pin every restricted model, mounted component, and hidden companion source to an immutable revision; record source, component license, terms URL, and acknowledgement in schema 3 manifests
- require `--accept-model-license` before new or forced restricted downloads in core, CLI, Open WebUI quickstart, agent onboarding, and macOS flows; keep complete existing installs usable and do not police post-install use
- prevent silent runtime auto-downloads of restricted models and surface their exact terms through `model list`, `model info`, `model preflight`, and the macOS Models and Studio views
- preserve applicable LICENSE and README files in model installs and ship `THIRD_PARTY_NOTICES.md` in macOS and Linux packages
- deliberately exclude all evaluation photos, contact sheets, databases, generated results, model weights, and other binary artifacts

## Policy boundary

mere.run is free and open source. Third-party model and component terms still apply. Mere presents the exact terms and requires acknowledgement before it downloads restricted artifacts; users remain responsible for deciding whether their intended use complies. Mere does not retroactively treat existing installs as acknowledgement and does not police how installed models are used.

## Why

This puts reusable face inference in mere.run core while leaving photo-library traversal, indexing, identity search, and review artifacts to the companion plugin. It also makes restricted-model handling consistent across every current download surface instead of special-casing Buffalo-L.

## Validation

- `./scripts/check.sh`
  - SwiftLint: 933 files, 0 violations
  - agent readiness and build passed
  - XCTest: 1,804 passed, 116 skipped, 0 failures
- focused restricted-model, core, CLI, and macOS suite: 178 tests, 1 skipped, 0 failures
- managed Buffalo-L pull and local reference inference passed
- all 12 hosted checks completed successfully, with only the expected docs deploy skip
- staged and committed audits found no images, evaluation outputs, databases, PDFs, model weights, or binary diff entries
