### PR TITLE
release: finalize 0.22.0 and harden Bonsai CUDA fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ The format is based on Keep a Changelog.
   through a CPU-compatible base manifest while retaining the Swift 6.3
   CUDA/CGen package graph, and corrected literal quant-mode reporting in the
   DGX Spark e2e sweep.
+- keeps CUDA quant-kernel capability decisions isolated by bit width, group
+  size, and quantization mode, and dequantizes tied 1-bit/2-bit output
+  embeddings when the native CUDA matrix kernel cannot execute them.
 
 ## 0.21.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,10 @@ The format is based on Keep a Changelog.
   through a CPU-compatible base manifest while retaining the Swift 6.3
   CUDA/CGen package graph, and corrected literal quant-mode reporting in the
   DGX Spark e2e sweep.
-- keeps CUDA quant-kernel capability decisions isolated by bit width, group
-  size, and quantization mode, and dequantizes tied 1-bit/2-bit output
-  embeddings when the native CUDA matrix kernel cannot execute them.
+- kept CUDA quant-kernel capability decisions isolated by bit width, group
+  size, and quantization mode, and routed fused projections plus tied 1-bit/
+  2-bit output embeddings through the dense fallback when the native CUDA
+  matrix kernel cannot execute them.
 
 ## 0.21.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@ The format is based on Keep a Changelog.
   app bundle.
 - preserved Swift 6.0 Linux CLI compatibility for the pinned MLX Swift fork
   through a CPU-compatible base manifest while retaining the Swift 6.3
-  CUDA/CGen package graph.
+  CUDA/CGen package graph, and corrected literal quant-mode reporting in the
+  DGX Spark e2e sweep.
 
 ## 0.21.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## 0.22.0 - 2026-07-15
+## 0.22.0 - 2026-07-16
 
 ### Added
 
@@ -47,11 +47,36 @@ The format is based on Keep a Changelog.
   accept the catalog id `mere-platform-assistant` anywhere `--lora` accepts a
   local adapter path.
 
+### Changed
+
+- upgraded the shared Prism packed binary and ternary kernel stack used by the
+  new Bonsai 27B text models and the existing `image-bonsai-binary` and
+  `image-bonsai-ternary` generators. Matched M4 Max release runs measured 67.80
+  and 45.04 decode tokens/s for the 1-bit and 2-bit text models, plus 9.91 and
+  14.04 seconds for four-step 512x512 binary and ternary image generation.
+- enabled Krea 2 LoRA-training and adapter-backed image graph stages on
+  constrained CUDA workers through 4-bit bases, shape-scoped quantized
+  fallbacks, sequential model phases, and Linux-package CUDA discovery.
+- standardized restricted-model usage terms and explicit acceptance across
+  model listing, information, pull, preflight, setup, Studio, and related
+  command guidance while retaining upstream license and notice artifacts.
+- refreshed the README capability map and CLI documentation around the current
+  modality-first command surface, Relay/Nodes, portable workflows, adapters,
+  and the official plugin ecosystem.
+
 ### Fixed
 
 - updated the official plugin catalog default and bundled plugin guide to use
   the live `sawfwair/mere-run-plugins` repository after the old catalog path
   was retired.
+- kept image-generation graph preflight declarative so it no longer initializes
+  Metal merely to describe the selected backend, and included bounded stderr,
+  stdout, and termination details when a child preflight fails.
+- packaged the ONNX/CoreML face-analysis runtime correctly in the signed macOS
+  app bundle.
+- preserved Swift 6.0 Linux CLI compatibility for the pinned MLX Swift fork
+  through a CPU-compatible base manifest while retaining the Swift 6.3
+  CUDA/CGen package graph.
 
 ## 0.21.0 - 2026-07-14
 

--- a/Sources/MereRunCore/Gemma4/Gemma4FusedProjections.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4FusedProjections.swift
@@ -62,12 +62,7 @@ struct Gemma4CompiledSegment {
 /// source-module identity so any module replacement (e.g. LoRA wrapping) makes
 /// the caller drop the fusion and fall back to the unfused path.
 final class Gemma4FusedQuantizedProjection {
-    private let weight: MLXArray
-    private let scales: MLXArray
-    private let biases: MLXArray?
-    private let groupSize: Int
-    private let bits: Int
-    private let mode: QuantizationMode
+    private let projection: PortableQuantizedLinear
     private let splitIndices: [Int]
     private let sourceIDs: [ObjectIdentifier]
 
@@ -81,12 +76,15 @@ final class Gemma4FusedQuantizedProjection {
         splitIndices: [Int],
         sourceIDs: [ObjectIdentifier]
     ) {
-        self.weight = weight
-        self.scales = scales
-        self.biases = biases
-        self.groupSize = groupSize
-        self.bits = bits
-        self.mode = mode
+        self.projection = PortableQuantizedLinear(
+            weight: weight,
+            bias: nil,
+            scales: scales,
+            biases: biases,
+            groupSize: groupSize,
+            bits: bits,
+            mode: mode
+        )
         self.splitIndices = splitIndices
         self.sourceIDs = sourceIDs
     }
@@ -182,16 +180,7 @@ final class Gemma4FusedQuantizedProjection {
     /// The fused quantized matmul without the split — for consumers (fused
     /// decode kernels) that index the concatenated row directly.
     func callFused(_ x: MLXArray) -> MLXArray {
-        quantizedMM(
-            x,
-            weight,
-            scales: scales,
-            biases: biases,
-            transpose: true,
-            groupSize: groupSize,
-            bits: bits,
-            mode: mode
-        )
+        projection(x)
     }
 }
 

--- a/Sources/MereRunCore/Quantization/PortableQuantizedMatmul.swift
+++ b/Sources/MereRunCore/Quantization/PortableQuantizedMatmul.swift
@@ -3,9 +3,9 @@ import MLX
 import MLXNN
 
 /// Selects Linux/CUDA quantized matrix multiplication. Automatic mode probes
-/// each native MLX operation once, promotes it when evaluation succeeds, and
-/// permanently falls back to dense compatibility when that operation is not
-/// present in the linked CUDA runtime.
+/// each native MLX operation and packed layout once, promotes it when
+/// evaluation succeeds, and permanently falls back to dense compatibility
+/// when that combination is not present in the linked CUDA runtime.
 public enum MLXCUDAQuant {
     public enum Mode: String, Sendable {
         case automatic
@@ -24,6 +24,25 @@ public enum MLXCUDAQuant {
         case dense
     }
 
+    struct CapabilityKey: Hashable {
+        let operation: Operation
+        let bits: Int
+        let groupSize: Int
+        let quantizationMode: String
+
+        init(
+            operation: Operation,
+            bits: Int,
+            groupSize: Int,
+            quantizationMode: QuantizationMode
+        ) {
+            self.operation = operation
+            self.bits = bits
+            self.groupSize = groupSize
+            self.quantizationMode = quantizationMode.rawValue
+        }
+    }
+
     private enum Capability {
         case unknown
         case probing
@@ -32,7 +51,7 @@ public enum MLXCUDAQuant {
     }
 
     private static let stateLock = NSLock()
-    private nonisolated(unsafe) static var capabilities: [Operation: Capability] = [:]
+    private nonisolated(unsafe) static var capabilities: [CapabilityKey: Capability] = [:]
     private nonisolated(unsafe) static var loggedSelections: Set<String> = []
 
     public static let mode = parseMode(
@@ -58,19 +77,30 @@ public enum MLXCUDAQuant {
         }
     }
 
-    static func nativeDecision(for operation: Operation) -> NativeDecision {
+    static func nativeDecision(
+        for operation: Operation,
+        bits: Int,
+        groupSize: Int,
+        quantizationMode: QuantizationMode
+    ) -> NativeDecision {
+        let key = CapabilityKey(
+            operation: operation,
+            bits: bits,
+            groupSize: groupSize,
+            quantizationMode: quantizationMode
+        )
         switch mode {
         case .native:
-            logSelection(operation: operation, mode: .native, backend: "native")
+            logSelection(key: key, mode: .native, backend: "native")
             return .native
         case .dense:
-            logSelection(operation: operation, mode: .dense, backend: "dense")
+            logSelection(key: key, mode: .dense, backend: "dense")
             return .dense
         case .automatic:
             return stateLock.withLock {
-                switch capabilities[operation] ?? .unknown {
+                switch capabilities[key] ?? .unknown {
                 case .unknown:
-                    capabilities[operation] = .probing
+                    capabilities[key] = .probing
                     return .probe
                 case .probing:
                     return .dense
@@ -83,22 +113,45 @@ public enum MLXCUDAQuant {
         }
     }
 
-    static func completeProbe(operation: Operation, supported: Bool) {
+    static func completeProbe(
+        operation: Operation,
+        bits: Int,
+        groupSize: Int,
+        quantizationMode: QuantizationMode,
+        supported: Bool
+    ) {
+        let key = CapabilityKey(
+            operation: operation,
+            bits: bits,
+            groupSize: groupSize,
+            quantizationMode: quantizationMode
+        )
         stateLock.withLock {
-            capabilities[operation] = supported ? .supported : .unsupported
+            capabilities[key] = supported ? .supported : .unsupported
         }
         logSelection(
-            operation: operation,
+            key: key,
             mode: .automatic,
             backend: supported ? "native" : "dense"
         )
     }
 
-    private static func logSelection(operation: Operation, mode: Mode, backend: String) {
-        let key = "\(operation.rawValue):\(mode.rawValue):\(backend)"
-        let shouldLog = stateLock.withLock { loggedSelections.insert(key).inserted }
+    private static func logSelection(key: CapabilityKey, mode: Mode, backend: String) {
+        let selectionKey = [
+            key.operation.rawValue,
+            String(key.bits),
+            String(key.groupSize),
+            key.quantizationMode,
+            mode.rawValue,
+            backend,
+        ].joined(separator: ":")
+        let shouldLog = stateLock.withLock { loggedSelections.insert(selectionKey).inserted }
         guard shouldLog else { return }
-        let message = "[mere.run] mlx_cuda_quant operation=\(operation.rawValue) mode=\(mode.rawValue) backend=\(backend)\n"
+        let message = """
+        [mere.run] mlx_cuda_quant operation=\(key.operation.rawValue) \
+        mode=\(mode.rawValue) backend=\(backend) bits=\(key.bits) \
+        group_size=\(key.groupSize) quantization_mode=\(key.quantizationMode)\n
+        """
         FileHandle.standardError.write(Data(message.utf8))
     }
 }
@@ -117,7 +170,12 @@ public final class PortableQuantizedLinear: QuantizedLinear {
             if useUncachedDenseFallback {
                 return denseOutput(x, cacheWeight: false)
             }
-            switch MLXCUDAQuant.nativeDecision(for: .quantizedMM) {
+            switch MLXCUDAQuant.nativeDecision(
+                for: .quantizedMM,
+                bits: bits,
+                groupSize: groupSize,
+                quantizationMode: mode
+            ) {
             case .native:
                 return super.callAsFunction(x)
             case .dense:
@@ -126,10 +184,22 @@ public final class PortableQuantizedLinear: QuantizedLinear {
                 let output = super.callAsFunction(x)
                 do {
                     try MLX.checkedEval(output)
-                    MLXCUDAQuant.completeProbe(operation: .quantizedMM, supported: true)
+                    MLXCUDAQuant.completeProbe(
+                        operation: .quantizedMM,
+                        bits: bits,
+                        groupSize: groupSize,
+                        quantizationMode: mode,
+                        supported: true
+                    )
                     return output
                 } catch {
-                    MLXCUDAQuant.completeProbe(operation: .quantizedMM, supported: false)
+                    MLXCUDAQuant.completeProbe(
+                        operation: .quantizedMM,
+                        bits: bits,
+                        groupSize: groupSize,
+                        quantizationMode: mode,
+                        supported: false
+                    )
                     return denseOutput(x, cacheWeight: true)
                 }
             }
@@ -208,7 +278,12 @@ func portableGatherQuantizedMM(
 
     #if os(Linux)
     if Device.defaultDevice().deviceType == .gpu {
-        switch MLXCUDAQuant.nativeDecision(for: .gatherQMM) {
+        switch MLXCUDAQuant.nativeDecision(
+            for: .gatherQMM,
+            bits: bits,
+            groupSize: groupSize,
+            quantizationMode: mode
+        ) {
         case .native:
             break
         case .dense:
@@ -238,10 +313,22 @@ func portableGatherQuantizedMM(
             )
             do {
                 try MLX.checkedEval(output)
-                MLXCUDAQuant.completeProbe(operation: .gatherQMM, supported: true)
+                MLXCUDAQuant.completeProbe(
+                    operation: .gatherQMM,
+                    bits: bits,
+                    groupSize: groupSize,
+                    quantizationMode: mode,
+                    supported: true
+                )
                 return output
             } catch {
-                MLXCUDAQuant.completeProbe(operation: .gatherQMM, supported: false)
+                MLXCUDAQuant.completeProbe(
+                    operation: .gatherQMM,
+                    bits: bits,
+                    groupSize: groupSize,
+                    quantizationMode: mode,
+                    supported: false
+                )
                 return dequantizedGatherQuantizedMM(
                     x,
                     weight,

--- a/Sources/MereRunCore/QwenImageEdit/Model/DenseLayer.swift
+++ b/Sources/MereRunCore/QwenImageEdit/Model/DenseLayer.swift
@@ -153,6 +153,8 @@ public final class PreQuantizedEmbedding: Embedding, Quantized {
 
     public let scales: MLXArray
     public let biases: MLXArray?
+    private var cachedLinearWeight: MLXArray?
+    private var cachedLinearWeightDType: DType?
 
     public init(
         weight: MLXArray,
@@ -187,6 +189,48 @@ public final class PreQuantizedEmbedding: Embedding, Quantized {
     }
 
     public override func asLinear(_ x: MLXArray) -> MLXArray {
+        #if os(Linux)
+        if Device.defaultDevice().deviceType == .gpu, mode == .affine {
+            switch MLXCUDAQuant.nativeDecision(
+                for: .quantizedMM,
+                bits: bits,
+                groupSize: groupSize,
+                quantizationMode: mode
+            ) {
+            case .native:
+                return nativeLinear(x)
+            case .dense:
+                return denseLinear(x)
+            case .probe:
+                let output = nativeLinear(x)
+                do {
+                    try MLX.checkedEval(output)
+                    MLXCUDAQuant.completeProbe(
+                        operation: .quantizedMM,
+                        bits: bits,
+                        groupSize: groupSize,
+                        quantizationMode: mode,
+                        supported: true
+                    )
+                    return output
+                } catch {
+                    MLXCUDAQuant.completeProbe(
+                        operation: .quantizedMM,
+                        bits: bits,
+                        groupSize: groupSize,
+                        quantizationMode: mode,
+                        supported: false
+                    )
+                    return denseLinear(x)
+                }
+            }
+        }
+        #endif
+
+        return nativeLinear(x)
+    }
+
+    private func nativeLinear(_ x: MLXArray) -> MLXArray {
         quantizedMM(
             x,
             weight,
@@ -197,6 +241,27 @@ public final class PreQuantizedEmbedding: Embedding, Quantized {
             bits: bits,
             mode: mode
         )
+    }
+
+    func denseLinear(_ x: MLXArray) -> MLXArray {
+        let fullWeight: MLXArray
+        if let cachedLinearWeight, cachedLinearWeightDType == x.dtype {
+            fullWeight = cachedLinearWeight
+        } else {
+            fullWeight = dequantized(
+                weight,
+                scales: scales,
+                biases: biases,
+                groupSize: groupSize,
+                bits: bits,
+                mode: mode,
+                dtype: x.dtype
+            )
+            eval(fullWeight)
+            cachedLinearWeight = fullWeight
+            cachedLinearWeightDType = x.dtype
+        }
+        return matmul(x, fullWeight.T)
     }
 }
 

--- a/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
+++ b/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
@@ -24,6 +24,31 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
         )
     }
 
+    func testCUDAQuantCapabilitiesAreScopedByPackedLayout() {
+        let binary = MLXCUDAQuant.CapabilityKey(
+            operation: .quantizedMM,
+            bits: 1,
+            groupSize: 32,
+            quantizationMode: .affine
+        )
+        let ternary = MLXCUDAQuant.CapabilityKey(
+            operation: .quantizedMM,
+            bits: 2,
+            groupSize: 32,
+            quantizationMode: .affine
+        )
+        let fourBit = MLXCUDAQuant.CapabilityKey(
+            operation: .quantizedMM,
+            bits: 4,
+            groupSize: 64,
+            quantizationMode: .affine
+        )
+
+        XCTAssertNotEqual(binary, ternary)
+        XCTAssertNotEqual(binary, fourBit)
+        XCTAssertNotEqual(ternary, fourBit)
+    }
+
     func testQ35SwitchLinearDenseExpertPathTransposesWeights() throws {
         let weight = MLXArray([
             1.0, 2.0, 3.0,

--- a/Tests/MereRunCoreTests/PrismBinaryQuantizedLinearTests.swift
+++ b/Tests/MereRunCoreTests/PrismBinaryQuantizedLinearTests.swift
@@ -20,6 +20,24 @@ final class PrismLowBitQuantizationTests: XCTestCase {
         XCTAssertEqual(output[1, 0].item(Float.self), -1, accuracy: 0.001)
     }
 
+    func testOneBitPreQuantizedEmbeddingDenseLinearUnpacksFullWeight() {
+        let embedding = PreQuantizedEmbedding(
+            weight: MLXArray([UInt32.max, UInt32(0)], [2, 1]),
+            scales: MLXArray([Float(2), Float(2)], [2, 1]),
+            biases: MLXArray([Float(-1), Float(-1)], [2, 1]),
+            groupSize: 32,
+            bits: 1
+        )
+        let input = MLXArray(Array(repeating: Float(1), count: 32), [1, 32])
+
+        let output = embedding.denseLinear(input)
+        eval(output)
+
+        XCTAssertEqual(output.shape, [1, 2])
+        XCTAssertEqual(output[0, 0].item(Float.self), 32, accuracy: 0.001)
+        XCTAssertEqual(output[0, 1].item(Float.self), -32, accuracy: 0.001)
+    }
+
     func testNativeBinaryAffineLinearUnpacksOneBitWeights() {
         let layer = PortableQuantizedLinear(
             weight: MLXArray([UInt32.max, UInt32(0)], [2, 1]),

--- a/scripts/e2e_gb10.sh
+++ b/scripts/e2e_gb10.sh
@@ -249,7 +249,7 @@ want video && run_case video video-ltx-av file "$ASSETS/video.mp4" 1200 \
   echo
   echo "Binary: \`$BIN\` — $("$BIN" --version 2>/dev/null | head -1)"
   echo "Host: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1), $(uname -m), $(. /etc/os-release 2>/dev/null; echo "${PRETTY_NAME:-unknown}")"
-  echo "CUDA quant mode: `$QUANT_MODE`"
+  echo "CUDA quant mode: \`$QUANT_MODE\`"
   echo
   echo "| Category | Model | Status | Seconds | decode_tps | GPU peak | Detail |"
   echo "| --- | --- | --- | --- | --- | --- | --- |"


### PR DESCRIPTION
## What changed

- reconciles the full `v0.21.0..main` delta against the 0.22.0 changelog
- documents Bonsai 1-bit/2-bit text support and the shared Prism kernel gains for existing Bonsai image generators
- adds constrained-CUDA Krea workflow coverage, restricted-model terms, graph preflight diagnostics, signed face-runtime packaging, README/CLI refresh, and Swift 6.0 Linux compatibility
- corrects the DGX Spark quant-mode report
- scopes MLX CUDA quant-kernel capability decisions by operation, bit width, group size, and quantization mode
- routes fused projections and tied output embeddings through the CUDA fallback when a packed layout is unsupported
- dates the release entry for 2026-07-16

## Why

The implementation PRs are merged and the source already reports 0.22.0, but the release notes did not yet represent every public change that will ship in the tag. Real Bonsai inference on the DGX Spark also exposed Linux CUDA crashes in the 1-bit fused-QKV and tied-output projections, plus a shared capability cache that could affect unrelated packed layouts.

## Impact

The release changelog and GitHub release notes now describe all 21 commits since v0.21.0, including Linux ARM64/CUDA and existing Prism image-generator implications. Unsupported packed layouts fall back independently, so a 1-bit probe cannot poison native support for 2-bit or 4-bit models.

## Validation

- `git diff --check`
- `./scripts/check.sh`
- 932 Swift files linted with zero violations
- 1,822 XCTest cases passed, 116 checkpoint-gated cases skipped, zero failures
- 10 Swift Testing cases passed
- focused Prism low-bit, portable quantized-matmul, and fused-projection suites passed
- complete first-parent and non-merge commit audit for `v0.21.0..origin/main`
- exact-commit ARM64 CUDA tar/deb package build on NVIDIA GB10
- real `text-chat-bonsai-27b-1bit` default fused run: 4.55 decode tok/s via isolated dense fallback
- real `text-chat-bonsai-27b-2bit` default fused run: 15.11 decode tok/s via native CUDA kernel
