### PR TITLE
Correct 0.22.0 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,27 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## 0.22.0 - 2026-07-16
+## 0.22.0 - 2026-07-17
 
 ### Added
 
 - added native LTX phase timing reports and a typed JSONL `video session`
-  worker that keeps the standalone distilled LTX 2.3 model resident across
-  serial synchronized-AV generations while explicitly rejecting the mutable
-  full dev + distilled-LoRA lifecycle.
+  worker for resident standalone-distilled and full dev + distilled-LoRA
+  inference. Full sessions keep the transformer resident and install all 1,660
+  official mixed-rank LoRA targets as reversible runtime layers, preserving
+  the base weights for dev stage one and enabling the adapter only for
+  distilled stage two. On an M4 Max, matched resident requests reduced
+  end-to-end time from 103.447 to 29.947 seconds (3.45x) for the standalone
+  lane and from 347.040 to 235.862 seconds (1.47x) for the full lane.
 
 - added fully native LTX 2.3 source-audio-to-video generation through
   `video generate --audio`, including exact 16 kHz stereo mel conditioning,
   the audio VAE encoder, frozen-audio multimodal guidance, full/dev stage one,
   streaming distilled-LoRA stage two, the shared managed
   `video-ltx23-full-mlx` bundle for both unified AV and A2Vid, compatibility
-  resolution for the former `video-ltx23-a2vid-mlx` ID, structured preflight reporting, and
-  original source-segment MP4 muxing without a soundtrack-only fallback.
+  resolution for the former `video-ltx23-a2vid-mlx` ID, structured preflight
+  reporting, and original source-segment MP4 muxing without a soundtrack-only
+  fallback.
 
 - added managed `text-chat-bonsai-27b-1bit` and
   `text-chat-bonsai-27b-2bit` support for Prism ML's packed binary and ternary


### PR DESCRIPTION
## What changed

- correct the 0.22.0 release date to July 17, when the final LTX merge landed
- replace the stale statement that `video session` rejects the full dev + distilled-LoRA lifecycle
- document resident standalone and full sessions, reversible 1,660-target LoRA layers, and the measured M4 Max wall-time improvements
- wrap the A2Vid release note consistently

## Why

The changelog included native LTX A2Vid and the Bonsai CUDA QMV, but its session entry described an intermediate implementation. PR #181 ultimately made the full transformer safely reusable by enabling the official LoRA only for distilled stage two and disabling it after success or error. The release notes should describe the merged runtime rather than the earlier limitation.

## Release audit

- audited `v0.21.0...main`: 33 commits, 223 files
- mapped merged PRs #170 and #172 through #181 to the 0.22.0 Added, Changed, and Fixed sections
- confirmed native LTX full AV/A2Vid/session support and native 1-bit CUDA QMV are represented
- confirmed the only open PR is the unrelated Dependabot setup-node update
- confirmed the old untracked LTX end-keyframe worktree is a July 13 branch hundreds of commits behind main, not part of the completed 0.22.0 surface

## Validation

- `./scripts/check.sh`
  - SwiftLint strict passed
  - build passed
  - 1,861 XCTest cases passed with 116 expected asset-dependent skips and zero failures
  - all Swift Testing suites passed
  - CLI help and hygiene sweeps passed

The existing v0.22.0 tag and draft release still need to be rebuilt after this lands; the draft release body must be regenerated from the corrected changelog.
