### PR TITLE
Add the post-0.22 portable graph runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on Keep a Changelog.
 - added repeatable `run fetch --artifact <name>` selection with verified reuse
   of already-downloaded artifacts, allowing interrupted and partial remote
   result retrieval without transferring the complete artifact set again.
+- added `graph run-job` and `graph submit-job` so one verified immutable export
+  can execute unchanged through local, SSH, and Relay while mutable run state
+  remains in a separate directory.
 
 ## 0.22.0 - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on Keep a Changelog.
   secret contracts, reusable plugin-side composition, and stricter executor
   compatibility checks. These additions establish `0.23.0` as the minimum
   worker version for newly materialized graph jobs.
+- added repeatable `run fetch --artifact <name>` selection with verified reuse
+  of already-downloaded artifacts, allowing interrupted and partial remote
+  result retrieval without transferring the complete artifact set again.
 
 ## 0.22.0 - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## Unreleased
+
+### Added
+
+- expanded portable workflow graphs with deterministic parallel scheduling,
+  bounded retries and timeouts, verified cross-run caching, resource and named
+  secret contracts, reusable plugin-side composition, and stricter executor
+  compatibility checks. These additions establish `0.23.0` as the minimum
+  worker version for newly materialized graph jobs.
+
 ## 0.22.0 - 2026-07-17
 
 ### Added

--- a/Sources/MereRunCLI/Commands/ExecutorCommand.swift
+++ b/Sources/MereRunCLI/Commands/ExecutorCommand.swift
@@ -147,9 +147,13 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
     let architecture: String
     let acceleratorBackend: String
     let memoryBytes: UInt64
+    let systemMemoryBytes: UInt64
+    let logicalCPUCores: Int
     let availableDiskBytes: Int64?
+    let networkAccess: Bool
     let nodeKinds: [String]
     let installedModelIDs: [String]
+    let availableSecretNames: [String]
     let providers: [WorkflowGraphProviderRequirement]
 
     enum CodingKeys: String, CodingKey {
@@ -160,9 +164,13 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
         case architecture
         case acceleratorBackend = "accelerator_backend"
         case memoryBytes = "memory_bytes"
+        case systemMemoryBytes = "system_memory_bytes"
+        case logicalCPUCores = "logical_cpu_cores"
         case availableDiskBytes = "available_disk_bytes"
+        case networkAccess = "network_access"
         case nodeKinds = "node_kinds"
         case installedModelIDs = "installed_model_ids"
+        case availableSecretNames = "available_secret_names"
         case providers
     }
 
@@ -174,9 +182,13 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
         architecture: String,
         acceleratorBackend: String,
         memoryBytes: UInt64,
+        systemMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
+        logicalCPUCores: Int = ProcessInfo.processInfo.processorCount,
         availableDiskBytes: Int64?,
+        networkAccess: Bool = true,
         nodeKinds: [String],
         installedModelIDs: [String],
+        availableSecretNames: [String] = [],
         providers: [WorkflowGraphProviderRequirement] = []
     ) {
         self.schemaVersion = schemaVersion
@@ -186,9 +198,13 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
         self.architecture = architecture
         self.acceleratorBackend = acceleratorBackend
         self.memoryBytes = memoryBytes
+        self.systemMemoryBytes = systemMemoryBytes
+        self.logicalCPUCores = logicalCPUCores
         self.availableDiskBytes = availableDiskBytes
+        self.networkAccess = networkAccess
         self.nodeKinds = nodeKinds
         self.installedModelIDs = installedModelIDs
+        self.availableSecretNames = availableSecretNames
         self.providers = providers
     }
 
@@ -201,9 +217,15 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
         architecture = try container.decode(String.self, forKey: .architecture)
         acceleratorBackend = try container.decode(String.self, forKey: .acceleratorBackend)
         memoryBytes = try container.decode(UInt64.self, forKey: .memoryBytes)
+        systemMemoryBytes = try container.decodeIfPresent(UInt64.self, forKey: .systemMemoryBytes)
+            ?? 0
+        logicalCPUCores = try container.decodeIfPresent(Int.self, forKey: .logicalCPUCores)
+            ?? 0
         availableDiskBytes = try container.decodeIfPresent(Int64.self, forKey: .availableDiskBytes)
+        networkAccess = try container.decodeIfPresent(Bool.self, forKey: .networkAccess) ?? false
         nodeKinds = try container.decode([String].self, forKey: .nodeKinds)
         installedModelIDs = try container.decode([String].self, forKey: .installedModelIDs)
+        availableSecretNames = try container.decodeIfPresent([String].self, forKey: .availableSecretNames) ?? []
         providers = try container.decodeIfPresent(
             [WorkflowGraphProviderRequirement].self,
             forKey: .providers
@@ -246,13 +268,27 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
             architecture: architecture,
             acceleratorBackend: backend,
             memoryBytes: memoryBytes,
+            systemMemoryBytes: ProcessInfo.processInfo.physicalMemory,
+            logicalCPUCores: ProcessInfo.processInfo.processorCount,
             availableDiskBytes: disk ?? nil,
+            networkAccess: true,
             nodeKinds: Array(Set(
                 WorkflowNodeRegistry.entries.map(\.kind) + graphProviders.flatMap { $0.nodes.map(\.kind) }
             )).sorted(),
             installedModelIDs: ModelInventory.rows(fileManager: fileManager).filter(\.isInstalled).map(\.id).sorted(),
+            availableSecretNames: availableWorkflowSecretNames(),
             providers: graphProviders.map(\.requirement)
         )
+    }
+
+    private static func availableWorkflowSecretNames(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String] {
+        let prefix = "MERERUN_SECRET_"
+        return environment.keys.compactMap { key -> String? in
+            guard key.hasPrefix(prefix), environment[key]?.isEmpty == false else { return nil }
+            return key.dropFirst(prefix.count).lowercased().replacingOccurrences(of: "_", with: "-")
+        }.sorted()
     }
 
     #if os(Linux)

--- a/Sources/MereRunCLI/Commands/ExecutorCommand.swift
+++ b/Sources/MereRunCLI/Commands/ExecutorCommand.swift
@@ -995,7 +995,8 @@ enum WorkflowRemoteJobController {
     static func fetch(
         _ reference: WorkflowRemoteReference,
         into destination: URL,
-        allArtifacts: Bool
+        allArtifacts: Bool,
+        artifactNames: Set<String> = []
     ) async throws -> WorkflowRemoteJob {
         let profile = try WorkflowExecutorProfileStore.require(reference.executorReference)
         switch reference.kind {
@@ -1003,13 +1004,15 @@ enum WorkflowRemoteJobController {
             return try SSHWorkflowExecutor(profile: profile).fetch(
                 jobID: reference.jobID,
                 into: destination,
-                allArtifacts: allArtifacts
+                allArtifacts: allArtifacts,
+                artifactNames: artifactNames
             )
         case .relay:
             return try await RelayWorkflowExecutor(profile: profile).fetch(
                 jobID: reference.jobID,
                 into: destination,
-                allArtifacts: allArtifacts
+                allArtifacts: allArtifacts,
+                artifactNames: artifactNames
             )
         }
     }

--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -911,12 +911,7 @@ struct GraphWorkerCancel: ParsableCommand {
     func run() throws {
         let url = URL(fileURLWithPath: runDirectory).appendingPathComponent("cancel.request")
         try Data(Date().ISO8601Format().utf8).write(to: url, options: .atomic)
-        let processIDURL = url.deletingLastPathComponent().appendingPathComponent("worker-child.pid")
-        if let rawProcessID = try? String(contentsOf: processIDURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           let processID = Int32(rawProcessID), processID > 1 {
-            _ = kill(processID, SIGTERM)
-        }
+        WorkflowChildProcessRegistry.terminateAll(in: url.deletingLastPathComponent())
         let result = GraphCancellationResult(cancelled: true, runDirectory: url.deletingLastPathComponent().path)
         if json { print(try StructuredRunOutput.encode(result)) } else { print("Cancellation requested.") }
     }

--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -19,7 +19,9 @@ struct Graph: AsyncParsableCommand {
             GraphMaterialize.self,
             GraphExportJob.self,
             GraphRun.self,
+            GraphRunJob.self,
             GraphSubmit.self,
+            GraphSubmitJob.self,
             GraphWorker.self,
         ]
     )
@@ -599,6 +601,170 @@ struct GraphSubmitRequest: Codable, Equatable {
         case inputsPath = "inputs_path"
         case runDirectory = "run_directory"
         case executor
+    }
+}
+
+struct GraphRunJobRequest: Codable, Equatable {
+    let bundlePath: String
+    let runDirectory: String
+    let resume: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case bundlePath = "bundle_path"
+        case runDirectory = "run_directory"
+        case resume
+    }
+}
+
+typealias GraphRunJobEnvelope = StructuredRunEnvelope<GraphRunJobRequest, WorkflowRunOutcome>
+
+struct GraphRunJob: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "run-job",
+        abstract: "Run an existing immutable workflow job bundle locally."
+    )
+
+    @Option(name: [.long], help: "Portable job bundle directory.")
+    var bundle: String
+
+    @Option(name: [.customLong("run-dir")], help: "Durable run directory, separate from the immutable bundle.")
+    var runDirectory: String
+
+    @Flag(name: [.long], help: "Reuse verified outputs from a prior interrupted run.")
+    var resume = false
+
+    @Flag(name: [.long], help: "Emit one final structured run report.")
+    var json = false
+
+    @Flag(name: [.customLong("json-stream")], help: "Emit run events as newline-delimited JSON.")
+    var jsonStream = false
+
+    func run() async throws {
+        guard !(json && jsonStream) else {
+            throw ValidationError("--json and --json-stream are mutually exclusive.")
+        }
+        let eventHandler: ((GraphRunEvent) -> Void)? = jsonStream ? { event in
+            emitGraphStreamEvent(event)
+        } : nil
+        let envelope: GraphRunJobEnvelope = try makeEnvelope(eventHandler: eventHandler)
+        if json { print(try StructuredRunOutput.encode(envelope)) }
+        if !json && !jsonStream { print(envelope.summary) }
+        if envelope.result.state == .failed || envelope.result.state == .cancelled { throw ExitCode.failure }
+    }
+
+    func makeEnvelope(
+        now: @escaping () -> Date = Date.init,
+        eventHandler: ((GraphRunEvent) -> Void)? = nil,
+        processRunner: WorkflowProcessRunning = WorkflowProcessRunner()
+    ) throws -> GraphRunJobEnvelope {
+        let bundleURL = URL(fileURLWithPath: bundle).standardizedFileURL
+        let runURL = URL(fileURLWithPath: runDirectory).standardizedFileURL
+        try requireSeparateWorkflowDirectories(bundle: bundleURL, run: runURL)
+        _ = try verifiedPortableWorkflowBundle(at: bundleURL)
+        let outcome = try WorkflowRunner(
+            bundleDirectory: bundleURL,
+            runDirectory: runURL,
+            resume: resume,
+            processRunner: processRunner,
+            eventHandler: eventHandler
+        ).execute()
+        return GraphRunJobEnvelope(
+            schemaVersion: 1,
+            mereRunVersion: MereRunCLIVersion.current,
+            command: ["graph", "run-job"],
+            mode: .run,
+            status: structuredStatus(outcome.state),
+            createdAt: now(),
+            cwd: FileManager.default.currentDirectoryPath,
+            summary: "Workflow \(outcome.state.rawValue): \(outcome.jobID)",
+            request: .init(
+                bundlePath: bundleURL.path,
+                runDirectory: runURL.path,
+                resume: resume
+            ),
+            result: outcome,
+            diagnostics: outcome.state == .failed ? [.init(
+                id: "workflow_run_failed",
+                severity: .blocker,
+                title: "Workflow run failed",
+                message: "Inspect \(runURL.appendingPathComponent(GraphRunManifest.filename).path) for node details."
+            )] : [],
+            actions: []
+        )
+    }
+}
+
+struct GraphSubmitJobRequest: Codable, Equatable {
+    let bundlePath: String
+    let runDirectory: String
+    let executor: String
+
+    enum CodingKeys: String, CodingKey {
+        case bundlePath = "bundle_path"
+        case runDirectory = "run_directory"
+        case executor
+    }
+}
+
+typealias GraphSubmitJobEnvelope = StructuredRunEnvelope<GraphSubmitJobRequest, WorkflowRemoteJob>
+
+struct GraphSubmitJob: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "submit-job",
+        abstract: "Submit an existing immutable workflow job bundle to SSH or Relay."
+    )
+
+    @Option(name: [.long], help: "Portable job bundle directory.")
+    var bundle: String
+
+    @Option(name: [.long], help: "Remote executor reference: ssh:<profile> or relay:<profile>.")
+    var executor: String
+
+    @Option(name: [.customLong("run-dir")], help: "Local durable run directory, separate from the immutable bundle.")
+    var runDirectory: String
+
+    @Flag(name: [.long], help: "Emit a structured submission report.")
+    var json = false
+
+    func run() async throws {
+        let envelope = try await makeEnvelope()
+        if json { print(try StructuredRunOutput.encode(envelope)) } else { print(envelope.result.jobReference) }
+    }
+
+    func makeEnvelope(
+        now: @escaping () -> Date = Date.init,
+        submitter: (String, URL, URL) async throws -> WorkflowRemoteJob = { reference, bundle, run in
+            try await WorkflowExecutorController.submit(
+                reference: reference,
+                bundleDirectory: bundle,
+                localRunDirectory: run
+            )
+        }
+    ) async throws -> GraphSubmitJobEnvelope {
+        let bundleURL = URL(fileURLWithPath: bundle).standardizedFileURL
+        let runURL = URL(fileURLWithPath: runDirectory).standardizedFileURL
+        try requireSeparateWorkflowDirectories(bundle: bundleURL, run: runURL)
+        let verified = try verifiedPortableWorkflowBundle(at: bundleURL)
+        try copyPortableWorkflowBundle(verified, to: runURL)
+        let remoteJob = try await submitter(executor, runURL, runURL)
+        return GraphSubmitJobEnvelope(
+            schemaVersion: 1,
+            mereRunVersion: MereRunCLIVersion.current,
+            command: ["graph", "submit-job"],
+            mode: .run,
+            status: structuredStatus(remoteJob.state),
+            createdAt: now(),
+            cwd: FileManager.default.currentDirectoryPath,
+            summary: "Submitted workflow job \(remoteJob.jobID) to \(executor).",
+            request: .init(
+                bundlePath: bundleURL.path,
+                runDirectory: runURL.path,
+                executor: executor
+            ),
+            result: remoteJob,
+            diagnostics: [],
+            actions: []
+        )
     }
 }
 

--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -168,6 +168,18 @@ struct GraphPreflightResult: Codable, Equatable {
     let installedModelIDs: [String]
     let requiredProviders: [WorkflowGraphProviderRequirement]
     let availableProviders: [WorkflowGraphProviderRequirement]
+    let requiredSecretNames: [String]
+    let availableSecretNames: [String]
+    let minimumAcceleratorMemoryBytes: Int64?
+    let acceleratorMemoryBytes: UInt64
+    let minimumSystemMemoryBytes: Int64?
+    let systemMemoryBytes: UInt64
+    let minimumDiskBytes: Int64?
+    let availableDiskBytes: Int64?
+    let minimumCPUCores: Int?
+    let logicalCPUCores: Int
+    let networkAccessRequired: Bool
+    let networkAccessAvailable: Bool
     let executor: String
 
     enum CodingKeys: String, CodingKey {
@@ -178,6 +190,18 @@ struct GraphPreflightResult: Codable, Equatable {
         case installedModelIDs = "installed_model_ids"
         case requiredProviders = "required_providers"
         case availableProviders = "available_providers"
+        case requiredSecretNames = "required_secret_names"
+        case availableSecretNames = "available_secret_names"
+        case minimumAcceleratorMemoryBytes = "minimum_accelerator_memory_bytes"
+        case acceleratorMemoryBytes = "accelerator_memory_bytes"
+        case minimumSystemMemoryBytes = "minimum_system_memory_bytes"
+        case systemMemoryBytes = "system_memory_bytes"
+        case minimumDiskBytes = "minimum_disk_bytes"
+        case availableDiskBytes = "available_disk_bytes"
+        case minimumCPUCores = "minimum_cpu_cores"
+        case logicalCPUCores = "logical_cpu_cores"
+        case networkAccessRequired = "network_access_required"
+        case networkAccessAvailable = "network_access_available"
         case executor
     }
 }
@@ -227,6 +251,14 @@ struct GraphPreflight: AsyncParsableCommand {
                 message: "Executor '\(executor)' does not support \(WorkflowJobManifest.contractVersion)."
             ))
         }
+        if !workflowVersion(probe.workerVersion, satisfiesMinimum: MereRunCLIVersion.current) {
+            diagnostics.append(.init(
+                id: "executor_worker_version_too_old",
+                severity: .blocker,
+                title: "Executor worker is too old",
+                message: "Executor '\(executor)' reports mere.run \(probe.workerVersion); this graph requires \(MereRunCLIVersion.current) or newer."
+            ))
+        }
         if !requirements.acceleratorBackends.contains(probe.acceleratorBackend), probe.acceleratorBackend != "mixed" {
             diagnostics.append(.init(
                 id: "executor_accelerator_unsupported",
@@ -261,6 +293,58 @@ struct GraphPreflight: AsyncParsableCommand {
                 title: "Executor model is missing",
                 message: "Executor '\(executor)' does not have model '\(modelID)' installed.",
                 suggestedActionIDs: ["pull-model-\(modelID)"]
+            ))
+        }
+        for secretName in requirements.secretNames where !probe.availableSecretNames.contains(secretName) {
+            diagnostics.append(.init(
+                id: "executor_secret_missing_\(secretName)",
+                severity: .blocker,
+                title: "Executor secret is missing",
+                message: "Executor '\(executor)' does not expose configured secret '\(secretName)'. Configure \(workflowSecretEnvironmentKey(secretName)) on that worker."
+            ))
+        }
+        if let minimum = requirements.minimumAcceleratorMemoryBytes,
+           probe.memoryBytes < UInt64(minimum) {
+            diagnostics.append(.init(
+                id: "executor_accelerator_memory_insufficient",
+                severity: .blocker,
+                title: "Executor accelerator memory is insufficient",
+                message: "Executor '\(executor)' reports \(probe.memoryBytes) accelerator-memory bytes; this graph requires at least \(minimum)."
+            ))
+        }
+        if let minimum = requirements.minimumSystemMemoryBytes,
+           probe.systemMemoryBytes < UInt64(minimum) {
+            diagnostics.append(.init(
+                id: "executor_system_memory_insufficient",
+                severity: .blocker,
+                title: "Executor system memory is insufficient",
+                message: "Executor '\(executor)' reports \(probe.systemMemoryBytes) system-memory bytes; this graph requires at least \(minimum)."
+            ))
+        }
+        if let minimum = requirements.minimumDiskBytes,
+           probe.availableDiskBytes.map({ $0 < minimum }) != false {
+            diagnostics.append(.init(
+                id: "executor_disk_insufficient",
+                severity: .blocker,
+                title: "Executor disk space is insufficient",
+                message: "Executor '\(executor)' does not report at least \(minimum) free disk bytes."
+            ))
+        }
+        if let minimum = requirements.minimumCPUCores,
+           probe.logicalCPUCores < minimum {
+            diagnostics.append(.init(
+                id: "executor_cpu_insufficient",
+                severity: .blocker,
+                title: "Executor CPU capacity is insufficient",
+                message: "Executor '\(executor)' reports \(probe.logicalCPUCores) logical CPU cores; this graph requires at least \(minimum)."
+            ))
+        }
+        if requirements.networkAccess, !probe.networkAccess {
+            diagnostics.append(.init(
+                id: "executor_network_unavailable",
+                severity: .blocker,
+                title: "Executor network access is unavailable",
+                message: "Executor '\(executor)' does not allow network access required by this graph."
             ))
         }
         diagnostics.append(contentsOf: assetDiagnostics(graph: loaded.graph, inputs: loaded.inputs))
@@ -300,6 +384,18 @@ struct GraphPreflight: AsyncParsableCommand {
                 installedModelIDs: probe.installedModelIDs,
                 requiredProviders: requirements.providers,
                 availableProviders: probe.providers,
+                requiredSecretNames: requirements.secretNames,
+                availableSecretNames: probe.availableSecretNames,
+                minimumAcceleratorMemoryBytes: requirements.minimumAcceleratorMemoryBytes,
+                acceleratorMemoryBytes: probe.memoryBytes,
+                minimumSystemMemoryBytes: requirements.minimumSystemMemoryBytes,
+                systemMemoryBytes: probe.systemMemoryBytes,
+                minimumDiskBytes: requirements.minimumDiskBytes,
+                availableDiskBytes: probe.availableDiskBytes,
+                minimumCPUCores: requirements.minimumCPUCores,
+                logicalCPUCores: probe.logicalCPUCores,
+                networkAccessRequired: requirements.networkAccess,
+                networkAccessAvailable: probe.networkAccess,
                 executor: executor
             ),
             diagnostics: diagnostics,
@@ -674,7 +770,13 @@ struct WorkflowGraphRequirements: Equatable {
     let nodeKinds: [String]
     let modelIDs: [String]
     let providers: [WorkflowGraphProviderRequirement]
+    let secretNames: [String]
     let acceleratorBackends: [String]
+    let minimumAcceleratorMemoryBytes: Int64?
+    let minimumSystemMemoryBytes: Int64?
+    let minimumDiskBytes: Int64?
+    let minimumCPUCores: Int?
+    let networkAccess: Bool
 
     static func resolve(graph: WorkflowGraphDocument, inputs: WorkflowInputsDocument) -> WorkflowGraphRequirements {
         var modelIDs = graph.nodes.compactMap { node -> String? in
@@ -697,9 +799,28 @@ struct WorkflowGraphRequirements: Equatable {
             modelIDs.append(contentsOf: WorkflowNodeRegistry.entry(for: node)?.requirements.modelIDs ?? [])
         }
         var acceleratorBackends = Set(["cpu", "metal", "cuda", "rocm"])
+        var minimumAcceleratorMemoryBytes: Int64?
+        var minimumSystemMemoryBytes: Int64?
+        var minimumDiskBytes: Int64?
+        var minimumCPUCores: Int?
+        var networkAccess = false
         for node in graph.nodes {
-            let accepted = WorkflowNodeRegistry.entry(for: node)?.requirements.acceleratorBackends ?? []
+            guard let nodeRequirements = WorkflowNodeRegistry.entry(for: node)?.requirements else { continue }
+            let accepted = nodeRequirements.acceleratorBackends
             if !accepted.isEmpty { acceleratorBackends.formIntersection(accepted) }
+            if let minimum = nodeRequirements.minimumAcceleratorMemoryBytes {
+                minimumAcceleratorMemoryBytes = max(minimumAcceleratorMemoryBytes ?? 0, minimum)
+            }
+            if let minimum = nodeRequirements.minimumSystemMemoryBytes {
+                minimumSystemMemoryBytes = max(minimumSystemMemoryBytes ?? 0, minimum)
+            }
+            if let minimum = nodeRequirements.minimumDiskBytes {
+                minimumDiskBytes = max(minimumDiskBytes ?? 0, minimum)
+            }
+            if let minimum = nodeRequirements.minimumCPUCores {
+                minimumCPUCores = max(minimumCPUCores ?? 0, minimum)
+            }
+            networkAccess = networkAccess || nodeRequirements.networkAccess == true
         }
         return .init(
             nodeKinds: Array(Set(graph.nodes.map(\.kind))).sorted(),
@@ -708,7 +829,15 @@ struct WorkflowGraphRequirements: Equatable {
                 guard node.resolvedProviderID != WorkflowNodeProviderIdentity.builtInID else { return nil }
                 return WorkflowGraphProviderRegistry.discoveredCatalog().provider(id: node.resolvedProviderID)?.requirement
             })).sorted { $0.id < $1.id },
-            acceleratorBackends: acceleratorBackends.sorted()
+            secretNames: Array(Set(graph.nodes.flatMap { node in
+                node.arguments.values.flatMap(\.secretNames)
+            })).sorted(),
+            acceleratorBackends: acceleratorBackends.sorted(),
+            minimumAcceleratorMemoryBytes: minimumAcceleratorMemoryBytes,
+            minimumSystemMemoryBytes: minimumSystemMemoryBytes,
+            minimumDiskBytes: minimumDiskBytes,
+            minimumCPUCores: minimumCPUCores,
+            networkAccess: networkAccess
         )
     }
 }

--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -855,9 +855,9 @@ private func emitDiagnostics(_ diagnostics: [PreflightDiagnostic]) {
 }
 
 func emitGraphStreamEvent(_ event: GraphRunEvent, to handle: FileHandle = .standardOutput) {
-    guard let encoded = try? StructuredRunOutput.encode(event) else { return }
-    let line = encoded.replacingOccurrences(of: "\n", with: "") + "\n"
-    handle.write(Data(line.utf8))
+    guard let encoded = try? WorkflowBundleCodec.lineEncoder().encode(event) else { return }
+    handle.write(encoded)
+    handle.write(Data("\n".utf8))
 }
 
 private func structuredStatus(_ state: GraphRunState) -> StructuredRunStatus {

--- a/Sources/MereRunCLI/Commands/RunCommand.swift
+++ b/Sources/MereRunCLI/Commands/RunCommand.swift
@@ -232,14 +232,24 @@ struct RunFetch: AsyncParsableCommand {
     @Option(name: [.customLong("into")], help: "Destination run directory.") var into: String
     @Flag(name: [.customLong("all-artifacts")], help: "Fetch intermediate artifacts as well as final outputs and reports.")
     var allArtifacts = false
+    @Option(
+        name: [.customLong("artifact")],
+        parsing: .unconditionalSingleValue,
+        help: "Fetch a named artifact. Repeat to fetch multiple artifacts."
+    )
+    var artifacts: [String] = []
     @Flag(name: [.customLong("json")], help: "Emit the fetched job as JSON.") var json = false
 
     func run() async throws {
+        if allArtifacts && !artifacts.isEmpty {
+            throw ValidationError("--artifact and --all-artifacts are mutually exclusive.")
+        }
         let destination = URL(fileURLWithPath: into).standardizedFileURL
         let job = try await WorkflowRemoteJobController.fetch(
             WorkflowRemoteReference(reference),
             into: destination,
-            allArtifacts: allArtifacts
+            allArtifacts: allArtifacts,
+            artifactNames: Set(artifacts)
         )
         if json { print(try StructuredRunOutput.encode(job)) } else { print(job.runDirectory ?? destination.path) }
     }

--- a/Sources/MereRunCLI/Commands/RunCommand.swift
+++ b/Sources/MereRunCLI/Commands/RunCommand.swift
@@ -272,7 +272,7 @@ struct RunCancel: AsyncParsableCommand {
         }
         let marker = runDirectory.appendingPathComponent("cancel.request")
         try Data().write(to: marker, options: .atomic)
-        terminateWorkflowChild(in: runDirectory)
+        WorkflowChildProcessRegistry.terminateAll(in: runDirectory)
         let result = LocalCancellationResult(runDirectory: runDirectory.path, cancellationRequested: true)
         if json { print(try StructuredRunOutput.encode(result)) } else { print("Cancellation requested: \(runDirectory.path)") }
     }
@@ -343,14 +343,4 @@ private func localGraphManifest(at path: String) throws -> GraphRunManifest? {
     guard FileManager.default.fileExists(atPath: manifestURL.path) else { return nil }
     let data = try Data(contentsOf: manifestURL)
     return try? WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: data)
-}
-
-private func terminateWorkflowChild(in runDirectory: URL) {
-    let processIDURL = runDirectory.appendingPathComponent("worker-child.pid")
-    guard let raw = try? String(contentsOf: processIDURL, encoding: .utf8)
-        .trimmingCharacters(in: .whitespacesAndNewlines),
-          let processID = Int32(raw), processID > 1 else {
-        return
-    }
-    _ = kill(processID, SIGTERM)
 }

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.22.0"
+    static let current = "0.23.0"
 }

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -27,6 +27,7 @@ indirect enum WorkflowValue: Codable, Equatable, Sendable {
     case array([WorkflowValue])
     case object([String: WorkflowValue])
     case reference(String)
+    case secretReference(String)
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -46,6 +47,8 @@ indirect enum WorkflowValue: Codable, Equatable, Sendable {
             let value = try container.decode([String: WorkflowValue].self)
             if value.count == 1, case .string(let reference)? = value["$ref"] {
                 self = .reference(reference)
+            } else if value.count == 1, case .string(let name)? = value["$secret"] {
+                self = .secretReference(name)
             } else {
                 self = .object(value)
             }
@@ -71,6 +74,8 @@ indirect enum WorkflowValue: Codable, Equatable, Sendable {
             try container.encode(value)
         case .reference(let value):
             try container.encode(["$ref": WorkflowValue.string(value)])
+        case .secretReference(let value):
+            try container.encode(["$secret": WorkflowValue.string(value)])
         }
     }
 
@@ -82,6 +87,19 @@ indirect enum WorkflowValue: Codable, Equatable, Sendable {
             values.flatMap(\.references)
         case .object(let values):
             values.keys.sorted().flatMap { values[$0]?.references ?? [] }
+        default:
+            []
+        }
+    }
+
+    var secretNames: [String] {
+        switch self {
+        case .secretReference(let value):
+            [value]
+        case .array(let values):
+            values.flatMap(\.secretNames)
+        case .object(let values):
+            values.keys.sorted().flatMap { values[$0]?.secretNames ?? [] }
         default:
             []
         }
@@ -151,6 +169,18 @@ struct WorkflowNodeExecutionPolicy: Codable, Equatable, Sendable {
     var resolvedCache: WorkflowNodeCachePolicy { cache ?? .automatic }
 }
 
+struct WorkflowGraphExecutionPolicy: Codable, Equatable, Sendable {
+    static let maximumParallelNodes = 32
+
+    let maxParallelNodes: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case maxParallelNodes = "max_parallel_nodes"
+    }
+
+    var resolvedMaxParallelNodes: Int { maxParallelNodes ?? 1 }
+}
+
 struct WorkflowNode: Codable, Equatable, Sendable {
     let id: String
     let kind: String
@@ -199,6 +229,7 @@ struct WorkflowGraphDocument: Codable, Equatable, Sendable {
     let inputs: [String: WorkflowInputDefinition]
     let nodes: [WorkflowNode]
     let outputs: [String: WorkflowValue]
+    let execution: WorkflowGraphExecutionPolicy?
     let metadata: [String: WorkflowValue]?
 
     enum CodingKeys: String, CodingKey {
@@ -208,7 +239,28 @@ struct WorkflowGraphDocument: Codable, Equatable, Sendable {
         case inputs
         case nodes
         case outputs
+        case execution
         case metadata
+    }
+
+    init(
+        schemaVersion: Int,
+        kind: String,
+        name: String,
+        inputs: [String: WorkflowInputDefinition],
+        nodes: [WorkflowNode],
+        outputs: [String: WorkflowValue],
+        execution: WorkflowGraphExecutionPolicy? = nil,
+        metadata: [String: WorkflowValue]?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.kind = kind
+        self.name = name
+        self.inputs = inputs
+        self.nodes = nodes
+        self.outputs = outputs
+        self.execution = execution
+        self.metadata = metadata
     }
 
     static func load(from url: URL) throws -> WorkflowGraphDocument {
@@ -355,17 +407,61 @@ struct WorkflowNodeRequirements: Codable, Equatable, Sendable {
     let modelIDs: [String]
     let acceleratorBackends: [String]
     let minimumAcceleratorMemoryBytes: Int64?
+    let minimumSystemMemoryBytes: Int64?
+    let minimumDiskBytes: Int64?
+    let minimumCPUCores: Int?
+    let networkAccess: Bool?
 
     enum CodingKeys: String, CodingKey {
         case modelIDs = "model_ids"
         case acceleratorBackends = "accelerator_backends"
         case minimumAcceleratorMemoryBytes = "minimum_accelerator_memory_bytes"
+        case minimumSystemMemoryBytes = "minimum_system_memory_bytes"
+        case minimumDiskBytes = "minimum_disk_bytes"
+        case minimumCPUCores = "minimum_cpu_cores"
+        case networkAccess = "network_access"
+    }
+
+    init(
+        modelIDs: [String],
+        acceleratorBackends: [String],
+        minimumAcceleratorMemoryBytes: Int64?,
+        minimumSystemMemoryBytes: Int64? = nil,
+        minimumDiskBytes: Int64? = nil,
+        minimumCPUCores: Int? = nil,
+        networkAccess: Bool? = nil
+    ) {
+        self.modelIDs = modelIDs
+        self.acceleratorBackends = acceleratorBackends
+        self.minimumAcceleratorMemoryBytes = minimumAcceleratorMemoryBytes
+        self.minimumSystemMemoryBytes = minimumSystemMemoryBytes
+        self.minimumDiskBytes = minimumDiskBytes
+        self.minimumCPUCores = minimumCPUCores
+        self.networkAccess = networkAccess
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelIDs = try container.decode([String].self, forKey: .modelIDs)
+        acceleratorBackends = try container.decode([String].self, forKey: .acceleratorBackends)
+        minimumAcceleratorMemoryBytes = try container.decodeIfPresent(
+            Int64.self,
+            forKey: .minimumAcceleratorMemoryBytes
+        )
+        minimumSystemMemoryBytes = try container.decodeIfPresent(Int64.self, forKey: .minimumSystemMemoryBytes)
+        minimumDiskBytes = try container.decodeIfPresent(Int64.self, forKey: .minimumDiskBytes)
+        minimumCPUCores = try container.decodeIfPresent(Int.self, forKey: .minimumCPUCores)
+        networkAccess = try container.decodeIfPresent(Bool.self, forKey: .networkAccess)
     }
 
     static let none = WorkflowNodeRequirements(
         modelIDs: [],
         acceleratorBackends: [],
-        minimumAcceleratorMemoryBytes: nil
+        minimumAcceleratorMemoryBytes: nil,
+        minimumSystemMemoryBytes: nil,
+        minimumDiskBytes: nil,
+        minimumCPUCores: nil,
+        networkAccess: nil
     )
 }
 
@@ -601,6 +697,10 @@ struct WorkflowReference: Equatable, Sendable {
     }
 }
 
+func workflowSecretEnvironmentKey(_ name: String) -> String {
+    "MERERUN_SECRET_\(name.uppercased().replacingOccurrences(of: "-", with: "_"))"
+}
+
 struct WorkflowGraphValidation: Equatable {
     let diagnostics: [PreflightDiagnostic]
     let order: [String]
@@ -690,6 +790,24 @@ enum WorkflowGraphValidator {
                 message: "Add at least one registered workflow node."
             ))
         }
+        if let maximum = graph.execution?.maxParallelNodes,
+           !(1...WorkflowGraphExecutionPolicy.maximumParallelNodes).contains(maximum) {
+            diagnostics.append(.init(
+                id: "workflow_parallelism_invalid",
+                severity: .blocker,
+                title: "Invalid graph parallelism",
+                message: "execution.max_parallel_nodes must be between 1 and \(WorkflowGraphExecutionPolicy.maximumParallelNodes)."
+            ))
+        }
+        if graph.outputs.values.contains(where: { !$0.secretNames.isEmpty })
+            || graph.metadata?.values.contains(where: { !$0.secretNames.isEmpty }) == true {
+            diagnostics.append(.init(
+                id: "workflow_secret_exposed",
+                severity: .blocker,
+                title: "Secret reference is exposed",
+                message: "Secret references may appear only in secret node arguments."
+            ))
+        }
     }
 
     private static func validateIDs(
@@ -727,6 +845,15 @@ enum WorkflowGraphValidator {
                 severity: .blocker,
                 title: "Unknown workflow input",
                 message: "Input '\(name)' is not declared by the workflow."
+            ))
+        }
+        for name in supplied.values.keys.sorted()
+        where !(supplied.values[name]?.secretNames.isEmpty ?? true) {
+            diagnostics.append(.init(
+                id: "workflow_input_secret_\(name)",
+                severity: .blocker,
+                title: "Secret supplied as graph input",
+                message: "Input '\(name)' cannot contain a secret reference; bind secrets on secret node fields."
             ))
         }
         for (name, definition) in graph.inputs {
@@ -768,6 +895,15 @@ enum WorkflowGraphValidator {
             return
         }
         validateExecutionPolicy(node, entry: entry, diagnostics: &diagnostics)
+        if node.arguments.values.contains(where: { !$0.secretNames.isEmpty }),
+           node.execution?.resolvedCache != .never {
+            diagnostics.append(.init(
+                id: "workflow_node_secret_cache_\(node.id)",
+                severity: .blocker,
+                title: "Secret-bound node cannot be cached",
+                message: "Node '\(node.id)' must set execution.cache to 'never' because its output depends on a secret."
+            ))
+        }
         for name in node.arguments.keys where !entry.inputs.contains(where: { $0.name == name }) {
             diagnostics.append(.init(
                 id: "workflow_node_argument_unknown_\(node.id)_\(name)",
@@ -786,6 +922,28 @@ enum WorkflowGraphValidator {
                         message: "Node '\(node.id)' requires argument '\(field.name)'."
                     ))
                 }
+                continue
+            }
+            if field.secret == true {
+                guard case .secretReference(let name) = value,
+                      isValidSecretName(name) else {
+                    diagnostics.append(.init(
+                        id: "workflow_node_secret_invalid_\(node.id)_\(field.name)",
+                        severity: .blocker,
+                        title: "Invalid secret binding",
+                        message: "Node '\(node.id)' argument '\(field.name)' must be a named {\"$secret\":\"name\"} reference."
+                    ))
+                    continue
+                }
+                continue
+            }
+            if !value.secretNames.isEmpty {
+                diagnostics.append(.init(
+                    id: "workflow_node_secret_unexpected_\(node.id)_\(field.name)",
+                    severity: .blocker,
+                    title: "Unexpected secret binding",
+                    message: "Node '\(node.id)' argument '\(field.name)' is not declared secret by its provider."
+                ))
                 continue
             }
             validateValue(
@@ -842,6 +1000,10 @@ enum WorkflowGraphValidator {
                 message: "Node '\(node.id)' must set execution.cache to 'never' because its provider marks it non-cacheable."
             ))
         }
+    }
+
+    private static func isValidSecretName(_ value: String) -> Bool {
+        value.range(of: "^[a-z][a-z0-9-]{0,63}$", options: .regularExpression) != nil
     }
 
     private static func validateValue(

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -127,12 +127,37 @@ struct WorkflowInputDefinition: Codable, Equatable, Sendable {
     }
 }
 
+enum WorkflowNodeCachePolicy: String, Codable, Equatable, Sendable {
+    case automatic = "auto"
+    case never
+    case refresh
+}
+
+struct WorkflowNodeExecutionPolicy: Codable, Equatable, Sendable {
+    static let maximumAttempts = 10
+    static let maximumTimeoutSeconds = 7 * 24 * 60 * 60
+
+    let maxAttempts: Int?
+    let timeoutSeconds: Int?
+    let cache: WorkflowNodeCachePolicy?
+
+    enum CodingKeys: String, CodingKey {
+        case maxAttempts = "max_attempts"
+        case timeoutSeconds = "timeout_seconds"
+        case cache
+    }
+
+    var resolvedMaxAttempts: Int { maxAttempts ?? 1 }
+    var resolvedCache: WorkflowNodeCachePolicy { cache ?? .automatic }
+}
+
 struct WorkflowNode: Codable, Equatable, Sendable {
     let id: String
     let kind: String
     let provider: String?
     let arguments: [String: WorkflowValue]
     let dependsOn: [String]?
+    let execution: WorkflowNodeExecutionPolicy?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -140,6 +165,7 @@ struct WorkflowNode: Codable, Equatable, Sendable {
         case provider
         case arguments
         case dependsOn = "depends_on"
+        case execution
     }
 
     init(
@@ -147,13 +173,15 @@ struct WorkflowNode: Codable, Equatable, Sendable {
         kind: String,
         provider: String? = nil,
         arguments: [String: WorkflowValue],
-        dependsOn: [String]?
+        dependsOn: [String]?,
+        execution: WorkflowNodeExecutionPolicy? = nil
     ) {
         self.id = id
         self.kind = kind
         self.provider = provider
         self.arguments = arguments
         self.dependsOn = dependsOn
+        self.execution = execution
     }
 
     var resolvedProviderID: String {
@@ -739,6 +767,7 @@ enum WorkflowGraphValidator {
             ))
             return
         }
+        validateExecutionPolicy(node, entry: entry, diagnostics: &diagnostics)
         for name in node.arguments.keys where !entry.inputs.contains(where: { $0.name == name }) {
             diagnostics.append(.init(
                 id: "workflow_node_argument_unknown_\(node.id)_\(name)",
@@ -777,6 +806,40 @@ enum WorkflowGraphValidator {
                 severity: .blocker,
                 title: "Workflow dependency is missing",
                 message: "Node '\(node.id)' depends on unknown node '\(dependency)'."
+            ))
+        }
+    }
+
+    private static func validateExecutionPolicy(
+        _ node: WorkflowNode,
+        entry: WorkflowNodeCatalogEntry,
+        diagnostics: inout [PreflightDiagnostic]
+    ) {
+        guard let policy = node.execution else { return }
+        if let attempts = policy.maxAttempts,
+           !(1...WorkflowNodeExecutionPolicy.maximumAttempts).contains(attempts) {
+            diagnostics.append(.init(
+                id: "workflow_node_attempts_invalid_\(node.id)",
+                severity: .blocker,
+                title: "Invalid node retry policy",
+                message: "Node '\(node.id)' max_attempts must be between 1 and \(WorkflowNodeExecutionPolicy.maximumAttempts)."
+            ))
+        }
+        if let timeout = policy.timeoutSeconds,
+           !(1...WorkflowNodeExecutionPolicy.maximumTimeoutSeconds).contains(timeout) {
+            diagnostics.append(.init(
+                id: "workflow_node_timeout_invalid_\(node.id)",
+                severity: .blocker,
+                title: "Invalid node timeout",
+                message: "Node '\(node.id)' timeout_seconds must be between 1 and \(WorkflowNodeExecutionPolicy.maximumTimeoutSeconds)."
+            ))
+        }
+        if policy.resolvedCache != .never, !entry.traits.cacheable {
+            diagnostics.append(.init(
+                id: "workflow_node_cache_unsupported_\(node.id)",
+                severity: .blocker,
+                title: "Node output cannot be cached",
+                message: "Node '\(node.id)' must set execution.cache to 'never' because its provider marks it non-cacheable."
             ))
         }
     }

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -305,6 +305,7 @@ struct WorkflowNodeField: Codable, Equatable, Sendable {
     let multiline: Bool?
     let secret: Bool?
     let advanced: Bool?
+    let valueSchema: WorkflowValue?
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -320,6 +321,7 @@ struct WorkflowNodeField: Codable, Equatable, Sendable {
         case multiline
         case secret
         case advanced
+        case valueSchema = "value_schema"
     }
 
     init(
@@ -335,7 +337,8 @@ struct WorkflowNodeField: Codable, Equatable, Sendable {
         step: Double? = nil,
         multiline: Bool? = nil,
         secret: Bool? = nil,
-        advanced: Bool? = nil
+        advanced: Bool? = nil,
+        valueSchema: WorkflowValue? = nil
     ) {
         self.name = name
         self.type = type
@@ -350,6 +353,7 @@ struct WorkflowNodeField: Codable, Equatable, Sendable {
         self.multiline = multiline
         self.secret = secret
         self.advanced = advanced
+        self.valueSchema = valueSchema
     }
 }
 

--- a/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
@@ -205,12 +205,26 @@ enum WorkflowGraphProviderRegistry {
                       input.step.map({ $0 > 0 }) ?? true else {
                     throw ValidationError("Graph provider '\(document.providerID)' has an invalid input on '\(node.kind)'.")
                 }
+                if input.secret == true, input.type != .string {
+                    throw ValidationError(
+                        "Graph provider '\(document.providerID)' secret input '\(input.name)' must use type string."
+                    )
+                }
             }
             for output in node.outputs where output.name.range(
                 of: "^[a-z][a-z0-9_]{0,63}$",
                 options: .regularExpression
             ) == nil {
                 throw ValidationError("Graph provider '\(document.providerID)' has an invalid output on '\(node.kind)'.")
+            }
+            let requirements = node.requirements
+            guard requirements.minimumAcceleratorMemoryBytes.map({ $0 > 0 }) ?? true,
+                  requirements.minimumSystemMemoryBytes.map({ $0 > 0 }) ?? true,
+                  requirements.minimumDiskBytes.map({ $0 > 0 }) ?? true,
+                  requirements.minimumCPUCores.map({ $0 > 0 }) ?? true else {
+                throw ValidationError(
+                    "Graph provider '\(document.providerID)' has invalid resource requirements on '\(node.kind)'."
+                )
             }
         }
         return WorkflowDiscoveredGraphProvider(identity: identity, executable: entrypoint, nodes: nodes)

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -214,6 +214,131 @@ enum WorkflowBundleCodec {
     }
 }
 
+func verifiedPortableWorkflowBundle(
+    at directory: URL,
+    fileManager: FileManager = .default
+) throws -> WorkflowBundleMaterialization {
+    let directory = directory.standardizedFileURL
+    for filename in [
+        WorkflowJobManifest.filename,
+        "graph.json",
+        "inputs.json",
+        WorkflowAssetManifest.filename,
+    ] {
+        let document = directory.appendingPathComponent(filename)
+        let values = try document.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard fileManager.fileExists(atPath: document.path),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            throw ValidationError("Workflow bundle document is missing or unsafe: \(filename)")
+        }
+    }
+    let graph = try WorkflowGraphDocument.load(from: directory.appendingPathComponent("graph.json"))
+    let inputs = try WorkflowInputsDocument.load(from: directory.appendingPathComponent("inputs.json"))
+    let assets = try WorkflowBundleCodec.decoder().decode(
+        WorkflowAssetManifest.self,
+        from: Data(contentsOf: directory.appendingPathComponent(WorkflowAssetManifest.filename))
+    )
+    let job = try WorkflowBundleCodec.decoder().decode(
+        WorkflowJobManifest.self,
+        from: Data(contentsOf: directory.appendingPathComponent(WorkflowJobManifest.filename))
+    )
+    guard job.contractVersion == WorkflowJobManifest.contractVersion else {
+        throw ValidationError("Unsupported workflow job contract '\(job.contractVersion)'.")
+    }
+    guard assets.schemaVersion == 1 else {
+        throw ValidationError("Unsupported workflow asset manifest version '\(assets.schemaVersion)'.")
+    }
+    guard try WorkflowBundleCodec.hash(graph) == job.graphFingerprint else {
+        throw ValidationError("Workflow graph fingerprint does not match job.json.")
+    }
+    let inputFingerprint = try WorkflowBundleCodec.hash(WorkflowPortableInputFingerprint(inputs: inputs, assets: assets))
+    guard inputFingerprint == job.inputFingerprint else {
+        throw ValidationError("Workflow input fingerprint does not match job.json.")
+    }
+    let validation = WorkflowGraphValidator.validate(graph: graph, inputs: inputs)
+    guard validation.status != .blocked else {
+        throw ValidationError(validation.diagnostics.map(\.message).joined(separator: " "))
+    }
+    let assetRoot = directory.appendingPathComponent("assets/sha256", isDirectory: true)
+    for entry in assets.groups.flatMap(\.entries) {
+        guard isPortableWorkflowPath(entry.path), isWorkflowSHA256(entry.digest) else {
+            throw ValidationError("Workflow asset manifest contains an invalid path or digest.")
+        }
+        let source = assetRoot.appendingPathComponent(entry.digest)
+        let values = try source.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              try ModelArtifactPin.fileByteCount(source) == entry.sizeBytes,
+              try ModelArtifactPin.fileSHA256(source) == entry.digest else {
+            throw ValidationError("Workflow asset digest verification failed for '\(entry.path)'.")
+        }
+    }
+    return WorkflowBundleMaterialization(
+        directory: directory,
+        graph: graph,
+        inputs: inputs,
+        assets: assets,
+        job: job
+    )
+}
+
+func copyPortableWorkflowBundle(
+    _ bundle: WorkflowBundleMaterialization,
+    to destination: URL,
+    fileManager: FileManager = .default
+) throws {
+    let destination = destination.standardizedFileURL
+    if fileManager.fileExists(atPath: destination.path),
+       !(try fileManager.contentsOfDirectory(atPath: destination.path)).isEmpty {
+        throw ValidationError("Workflow run directory must be empty before bundle submission.")
+    }
+    try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+    for filename in [
+        WorkflowJobManifest.filename,
+        "graph.json",
+        "inputs.json",
+        WorkflowAssetManifest.filename,
+    ] {
+        try fileManager.copyItem(
+            at: bundle.directory.appendingPathComponent(filename),
+            to: destination.appendingPathComponent(filename)
+        )
+    }
+    let destinationAssets = destination.appendingPathComponent("assets/sha256", isDirectory: true)
+    try fileManager.createDirectory(at: destinationAssets, withIntermediateDirectories: true)
+    for digest in Set(bundle.assets.groups.flatMap(\.entries).map(\.digest)).sorted() {
+        try fileManager.copyItem(
+            at: bundle.directory.appendingPathComponent("assets/sha256/\(digest)"),
+            to: destinationAssets.appendingPathComponent(digest)
+        )
+    }
+}
+
+func requireSeparateWorkflowDirectories(bundle: URL, run: URL) throws {
+    let bundle = bundle.standardizedFileURL.path
+    let run = run.standardizedFileURL.path
+    guard bundle != run,
+          !run.hasPrefix(bundle + "/"),
+          !bundle.hasPrefix(run + "/") else {
+        throw ValidationError("Immutable bundle and run directories must be separate and non-nested.")
+    }
+}
+
+private func isPortableWorkflowPath(_ path: String) -> Bool {
+    !path.isEmpty
+        && !path.hasPrefix("/")
+        && path.split(separator: "/", omittingEmptySubsequences: false).allSatisfy {
+            $0 != "." && $0 != ".." && !$0.isEmpty
+        }
+}
+
+private func isWorkflowSHA256(_ value: String) -> Bool {
+    value.count == 64 && value.utf8.allSatisfy { byte in
+        (byte >= 48 && byte <= 57) || (byte >= 97 && byte <= 102)
+    }
+}
+
 struct WorkflowBundleMaterializer {
     let graph: WorkflowGraphDocument
     let suppliedInputs: WorkflowInputsDocument

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -46,8 +46,13 @@ struct WorkflowJobRequirements: Codable, Equatable, Sendable {
     let modelIDs: [String]
     let models: [WorkflowModelProvenance]
     let providers: [WorkflowGraphProviderRequirement]
+    let secretNames: [String]
     let acceleratorBackends: [String]
     let minimumAcceleratorMemoryBytes: Int64?
+    let minimumSystemMemoryBytes: Int64?
+    let minimumDiskBytes: Int64?
+    let minimumCPUCores: Int?
+    let networkAccess: Bool
 
     enum CodingKeys: String, CodingKey {
         case minimumMereRunVersion = "minimum_mere_run_version"
@@ -55,8 +60,13 @@ struct WorkflowJobRequirements: Codable, Equatable, Sendable {
         case modelIDs = "model_ids"
         case models
         case providers
+        case secretNames = "secret_names"
         case acceleratorBackends = "accelerator_backends"
         case minimumAcceleratorMemoryBytes = "minimum_accelerator_memory_bytes"
+        case minimumSystemMemoryBytes = "minimum_system_memory_bytes"
+        case minimumDiskBytes = "minimum_disk_bytes"
+        case minimumCPUCores = "minimum_cpu_cores"
+        case networkAccess = "network_access"
     }
 
     init(
@@ -65,16 +75,26 @@ struct WorkflowJobRequirements: Codable, Equatable, Sendable {
         modelIDs: [String],
         models: [WorkflowModelProvenance] = [],
         providers: [WorkflowGraphProviderRequirement] = [],
+        secretNames: [String] = [],
         acceleratorBackends: [String],
-        minimumAcceleratorMemoryBytes: Int64?
+        minimumAcceleratorMemoryBytes: Int64?,
+        minimumSystemMemoryBytes: Int64? = nil,
+        minimumDiskBytes: Int64? = nil,
+        minimumCPUCores: Int? = nil,
+        networkAccess: Bool = false
     ) {
         self.minimumMereRunVersion = minimumMereRunVersion
         self.nodeKinds = nodeKinds
         self.modelIDs = modelIDs
         self.models = models
         self.providers = providers
+        self.secretNames = secretNames
         self.acceleratorBackends = acceleratorBackends
         self.minimumAcceleratorMemoryBytes = minimumAcceleratorMemoryBytes
+        self.minimumSystemMemoryBytes = minimumSystemMemoryBytes
+        self.minimumDiskBytes = minimumDiskBytes
+        self.minimumCPUCores = minimumCPUCores
+        self.networkAccess = networkAccess
     }
 
     init(from decoder: Decoder) throws {
@@ -87,11 +107,16 @@ struct WorkflowJobRequirements: Codable, Equatable, Sendable {
             [WorkflowGraphProviderRequirement].self,
             forKey: .providers
         ) ?? []
+        secretNames = try container.decodeIfPresent([String].self, forKey: .secretNames) ?? []
         acceleratorBackends = try container.decode([String].self, forKey: .acceleratorBackends)
         minimumAcceleratorMemoryBytes = try container.decodeIfPresent(
             Int64.self,
             forKey: .minimumAcceleratorMemoryBytes
         )
+        minimumSystemMemoryBytes = try container.decodeIfPresent(Int64.self, forKey: .minimumSystemMemoryBytes)
+        minimumDiskBytes = try container.decodeIfPresent(Int64.self, forKey: .minimumDiskBytes)
+        minimumCPUCores = try container.decodeIfPresent(Int.self, forKey: .minimumCPUCores)
+        networkAccess = try container.decodeIfPresent(Bool.self, forKey: .networkAccess) ?? false
     }
 }
 
@@ -332,6 +357,7 @@ struct WorkflowBundleMaterializer {
             inputs: graph.inputs,
             nodes: nodes,
             outputs: graph.outputs,
+            execution: graph.execution,
             metadata: graph.metadata
         )
     }
@@ -431,6 +457,7 @@ struct WorkflowBundleMaterializer {
             inputs: graph.inputs,
             nodes: nodes,
             outputs: graph.outputs,
+            execution: graph.execution,
             metadata: graph.metadata
         )
     }
@@ -548,6 +575,10 @@ struct WorkflowBundleMaterializer {
         })).sorted { $0.id < $1.id }
         var acceptedBackends = Set(["cpu", "metal", "cuda", "rocm"])
         var minimumMemory: Int64?
+        var minimumSystemMemory: Int64?
+        var minimumDisk: Int64?
+        var minimumCPUCores: Int?
+        var networkAccess = false
         for node in graph.nodes {
             guard let requirements = WorkflowNodeRegistry.entry(for: node)?.requirements else { continue }
             if !requirements.acceleratorBackends.isEmpty {
@@ -556,15 +587,33 @@ struct WorkflowBundleMaterializer {
             if let nodeMinimum = requirements.minimumAcceleratorMemoryBytes {
                 minimumMemory = max(minimumMemory ?? 0, nodeMinimum)
             }
+            if let nodeMinimum = requirements.minimumSystemMemoryBytes {
+                minimumSystemMemory = max(minimumSystemMemory ?? 0, nodeMinimum)
+            }
+            if let nodeMinimum = requirements.minimumDiskBytes {
+                minimumDisk = max(minimumDisk ?? 0, nodeMinimum)
+            }
+            if let nodeMinimum = requirements.minimumCPUCores {
+                minimumCPUCores = max(minimumCPUCores ?? 0, nodeMinimum)
+            }
+            networkAccess = networkAccess || requirements.networkAccess == true
         }
+        let secretNames = Array(Set(
+            graph.nodes.flatMap { $0.arguments.values.flatMap(\.secretNames) }
+        )).sorted()
         return WorkflowJobRequirements(
             minimumMereRunVersion: MereRunCLIVersion.current,
             nodeKinds: Array(Set(graph.nodes.map(\.kind))).sorted(),
             modelIDs: modelIDs.sorted(),
             models: modelProvenance,
             providers: providers,
+            secretNames: secretNames,
             acceleratorBackends: acceptedBackends.sorted(),
-            minimumAcceleratorMemoryBytes: minimumMemory
+            minimumAcceleratorMemoryBytes: minimumMemory,
+            minimumSystemMemoryBytes: minimumSystemMemory,
+            minimumDiskBytes: minimumDisk,
+            minimumCPUCores: minimumCPUCores,
+            networkAccess: networkAccess
         )
     }
 

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -170,6 +170,13 @@ enum WorkflowBundleCodec {
         return decoder
     }
 
+    static func lineEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
     static func write<T: Encodable>(_ value: T, to url: URL) throws {
         try encoder().encode(value).write(to: url, options: .atomic)
     }
@@ -314,7 +321,8 @@ struct WorkflowBundleMaterializer {
                 kind: node.kind,
                 provider: node.provider,
                 arguments: arguments,
-                dependsOn: node.dependsOn
+                dependsOn: node.dependsOn,
+                execution: node.execution
             )
         }
         return WorkflowGraphDocument(
@@ -412,7 +420,8 @@ struct WorkflowBundleMaterializer {
                 kind: node.kind,
                 provider: node.provider,
                 arguments: arguments,
-                dependsOn: node.dependsOn
+                dependsOn: node.dependsOn,
+                execution: node.execution
             )
         }
         return WorkflowGraphDocument(
@@ -650,6 +659,8 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
     var startedAt: Date?
     var completedAt: Date?
     var exitStatus: Int32?
+    var attempt: Int
+    var maxAttempts: Int
     var fingerprint: String
     var provider: WorkflowNodeProviderIdentity?
     var models: [WorkflowModelProvenance]
@@ -664,6 +675,8 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
         case startedAt = "started_at"
         case completedAt = "completed_at"
         case exitStatus = "exit_status"
+        case attempt
+        case maxAttempts = "max_attempts"
         case fingerprint
         case provider
         case models
@@ -679,6 +692,8 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
         startedAt: Date?,
         completedAt: Date?,
         exitStatus: Int32?,
+        attempt: Int = 0,
+        maxAttempts: Int = 1,
         fingerprint: String,
         provider: WorkflowNodeProviderIdentity? = nil,
         models: [WorkflowModelProvenance] = [],
@@ -692,6 +707,8 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
         self.startedAt = startedAt
         self.completedAt = completedAt
         self.exitStatus = exitStatus
+        self.attempt = attempt
+        self.maxAttempts = maxAttempts
         self.fingerprint = fingerprint
         self.provider = provider
         self.models = models
@@ -708,6 +725,8 @@ struct GraphRunNodeRecord: Codable, Equatable, Sendable {
         startedAt = try container.decodeIfPresent(Date.self, forKey: .startedAt)
         completedAt = try container.decodeIfPresent(Date.self, forKey: .completedAt)
         exitStatus = try container.decodeIfPresent(Int32.self, forKey: .exitStatus)
+        attempt = try container.decodeIfPresent(Int.self, forKey: .attempt) ?? 0
+        maxAttempts = try container.decodeIfPresent(Int.self, forKey: .maxAttempts) ?? 1
         fingerprint = try container.decode(String.self, forKey: .fingerprint)
         provider = try container.decodeIfPresent(WorkflowNodeProviderIdentity.self, forKey: .provider)
         models = try container.decodeIfPresent([WorkflowModelProvenance].self, forKey: .models) ?? []

--- a/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
@@ -190,18 +190,49 @@ struct SSHWorkflowExecutor {
         )
     }
 
-    func fetch(jobID: String, into destination: URL, allArtifacts: Bool) throws -> WorkflowRemoteJob {
+    func fetch(
+        jobID: String,
+        into destination: URL,
+        allArtifacts: Bool,
+        artifactNames: Set<String> = []
+    ) throws -> WorkflowRemoteJob {
         try prepareFetchDestination(destination, expectedJobID: jobID)
         let remotePath = try resolvedRemoteJobPath(jobID: jobID)
+        let existing = try inspect(jobID: jobID)
+        let selected = try selectedArtifacts(
+            existing.artifacts,
+            allArtifacts: allArtifacts,
+            artifactNames: artifactNames
+        )
         var arguments = sshCommonArguments(executable: "scp")
         arguments.append("-r")
-        arguments.append(contentsOf: Self.fetchRelativePaths(allArtifacts: allArtifacts).map {
+        arguments.append(contentsOf: Self.fetchRelativePaths(
+            allArtifacts: allArtifacts && artifactNames.isEmpty,
+            includeOutputs: artifactNames.isEmpty
+        ).map {
             scpRemotePath("\(remotePath)/\($0)")
         })
         arguments.append(destination.path)
         let result = try executableRunner(arguments, nil)
         guard result.status == 0 else {
             throw ValidationError("SSH workflow fetch failed with status \(result.status).")
+        }
+        if !artifactNames.isEmpty {
+            for artifact in selected {
+                let localURL = try confinedFetchURL(root: destination, relativePath: artifact.path)
+                if try verifiedExistingArtifact(artifact, at: localURL) { continue }
+                try FileManager.default.createDirectory(
+                    at: localURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                var artifactArguments = sshCommonArguments(executable: "scp")
+                artifactArguments.append(scpRemotePath("\(remotePath)/\(artifact.path)"))
+                artifactArguments.append(localURL.path)
+                let artifactResult = try executableRunner(artifactArguments, nil)
+                guard artifactResult.status == 0 else {
+                    throw ValidationError("SSH artifact fetch failed with status \(artifactResult.status): \(artifact.name)")
+                }
+            }
         }
         var manifest = try WorkflowBundleCodec.decoder().decode(
             GraphRunManifest.self,
@@ -213,7 +244,7 @@ struct SSHWorkflowExecutor {
             jobReference: "ssh://\(profile.name)/\(jobID)"
         )
         try WorkflowBundleCodec.write(manifest, to: destination.appendingPathComponent(GraphRunManifest.filename))
-        try verifyFetchedArtifacts(manifest.outputs, root: destination)
+        try verifyFetchedArtifacts(artifactNames.isEmpty ? manifest.outputs : selected, root: destination)
         return WorkflowRemoteJob(
             jobID: jobID,
             jobReference: "ssh://\(profile.name)/\(jobID)",
@@ -222,7 +253,7 @@ struct SSHWorkflowExecutor {
             runDirectory: destination.path,
             createdAt: manifest.createdAt,
             updatedAt: manifest.updatedAt,
-            artifacts: manifest.outputs,
+            artifacts: artifactNames.isEmpty ? manifest.outputs : selected,
             error: manifest.error,
             placement: nil,
             metrics: nil
@@ -327,7 +358,7 @@ struct SSHWorkflowExecutor {
         "\(profile.destination!):\(shellQuote(path))"
     }
 
-    static func fetchRelativePaths(allArtifacts: Bool) -> [String] {
+    static func fetchRelativePaths(allArtifacts: Bool, includeOutputs: Bool = true) -> [String] {
         var paths = [
             GraphRunManifest.filename,
             "graph.json",
@@ -335,8 +366,8 @@ struct SSHWorkflowExecutor {
             WorkflowJobManifest.filename,
             WorkflowAssetManifest.filename,
             "events.jsonl",
-            "outputs",
         ]
+        if includeOutputs { paths.append("outputs") }
         if allArtifacts {
             paths += ["actions.json", "nodes"]
         }
@@ -476,7 +507,12 @@ struct RelayWorkflowExecutor {
         return response.jobs.map { $0.remoteJob(profile: profile.name, localRunDirectory: nil) }
     }
 
-    func fetch(jobID: String, into destination: URL, allArtifacts: Bool) async throws -> WorkflowRemoteJob {
+    func fetch(
+        jobID: String,
+        into destination: URL,
+        allArtifacts: Bool,
+        artifactNames: Set<String> = []
+    ) async throws -> WorkflowRemoteJob {
         let job = try await inspect(jobID: jobID)
         guard job.state == .finished else {
             throw ValidationError("Relay job \(jobID) is not finished.")
@@ -492,8 +528,14 @@ struct RelayWorkflowExecutor {
             profile: profile.name,
             jobReference: "relay://\(profile.name)/\(jobID)"
         )
-        for artifact in job.artifacts where allArtifacts || artifact.kind == "graph.output"
-            || artifact.kind == "graph.report" || artifact.kind == "graph.manifest" {
+        let selected = try selectedArtifacts(
+            job.artifacts,
+            allArtifacts: allArtifacts,
+            artifactNames: artifactNames
+        )
+        for artifact in selected {
+            let url = try confinedFetchURL(root: destination, relativePath: artifact.path)
+            if try verifiedExistingArtifact(artifact, at: url) { continue }
             let encodedName = try encodedPathSegment(artifact.name)
             let data = try await request(
                 path: "/api/graph-jobs/\(jobID)/artifacts/\(encodedName)",
@@ -504,12 +546,14 @@ struct RelayWorkflowExecutor {
                   ModelArtifactPinDigest.sha256(data) == artifact.sha256 else {
                 throw ValidationError("Fetched relay artifact failed verification: \(artifact.name)")
             }
-            let url = try confinedFetchURL(root: destination, relativePath: artifact.path)
             try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             try data.write(to: url, options: .atomic)
         }
         try WorkflowBundleCodec.write(manifest, to: destination.appendingPathComponent(GraphRunManifest.filename))
-        try verifyFetchedArtifacts(manifest.outputs, root: destination)
+        let fetchedOutputs = manifest.outputs.filter { output in
+            selected.contains { $0.name == output.name }
+        }
+        try verifyFetchedArtifacts(fetchedOutputs, root: destination)
         return WorkflowRemoteJob(
             jobID: job.jobID,
             jobReference: job.jobReference,
@@ -518,7 +562,7 @@ struct RelayWorkflowExecutor {
             runDirectory: destination.path,
             createdAt: job.createdAt,
             updatedAt: job.updatedAt,
-            artifacts: job.artifacts,
+            artifacts: selected,
             error: job.error,
             placement: job.placement,
             metrics: job.metrics
@@ -776,6 +820,31 @@ private func verifyFetchedArtifacts(_ artifacts: [GraphRunArtifact], root: URL) 
             throw ValidationError("Fetched artifact failed verification: \(artifact.name)")
         }
     }
+}
+
+private func selectedArtifacts(
+    _ artifacts: [GraphRunArtifact],
+    allArtifacts: Bool,
+    artifactNames: Set<String>
+) throws -> [GraphRunArtifact] {
+    if artifactNames.isEmpty {
+        return artifacts.filter {
+            allArtifacts || $0.kind == "graph.output" || $0.kind == "graph.report" || $0.kind == "graph.manifest"
+        }
+    }
+    let selected = artifacts.filter { artifactNames.contains($0.name) }
+    let found = Set(selected.map(\.name))
+    let missing = artifactNames.subtracting(found).sorted()
+    guard missing.isEmpty else {
+        throw ValidationError("Remote run does not contain artifacts: \(missing.joined(separator: ", ")).")
+    }
+    return selected
+}
+
+private func verifiedExistingArtifact(_ artifact: GraphRunArtifact, at url: URL) throws -> Bool {
+    guard FileManager.default.fileExists(atPath: url.path) else { return false }
+    return try ModelArtifactPin.fileByteCount(url) == artifact.sizeBytes
+        && ModelArtifactPin.fileSHA256(url) == artifact.sha256
 }
 
 func validateWorker(

--- a/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
@@ -235,7 +235,7 @@ struct SSHWorkflowExecutor {
 
     private func createArchive(bundleDirectory: URL, destination: URL) throws {
         let result = try executableRunner([
-            "tar", "-czf", destination.path,
+            "tar", "--no-xattrs", "-czf", destination.path,
             "-C", bundleDirectory.path,
             "graph.json", "inputs.json", WorkflowAssetManifest.filename, WorkflowJobManifest.filename,
         ], nil)

--- a/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
@@ -752,6 +752,8 @@ private func initializeRemoteRunRecord(
                     startedAt: nil,
                     completedAt: nil,
                     exitStatus: nil,
+                    attempt: 0,
+                    maxAttempts: $0.execution?.resolvedMaxAttempts ?? 1,
                     fingerprint: "",
                     artifacts: [],
                     error: nil

--- a/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRemoteExecutors.swift
@@ -787,6 +787,11 @@ func validateWorker(
     guard worker.contractVersions.contains(job.contractVersion) else {
         throw ValidationError("Executor '\(executor)' does not support \(job.contractVersion).")
     }
+    guard workflowVersion(worker.workerVersion, satisfiesMinimum: job.requirements.minimumMereRunVersion) else {
+        throw ValidationError(
+            "Executor '\(executor)' reports mere.run \(worker.workerVersion); job requires \(job.requirements.minimumMereRunVersion) or newer."
+        )
+    }
     let missingKinds = job.requirements.nodeKinds.filter { !worker.nodeKinds.contains($0) }
     guard missingKinds.isEmpty else {
         throw ValidationError("Executor '\(executor)' is missing node kinds: \(missingKinds.joined(separator: ", ")).")
@@ -802,6 +807,12 @@ func validateWorker(
     guard missingModels.isEmpty else {
         throw ValidationError("Executor '\(executor)' is missing models: \(missingModels.joined(separator: ", ")).")
     }
+    let missingSecrets = job.requirements.secretNames.filter { !worker.availableSecretNames.contains($0) }
+    guard missingSecrets.isEmpty else {
+        throw ValidationError(
+            "Executor '\(executor)' is missing configured secrets: \(missingSecrets.joined(separator: ", "))."
+        )
+    }
     let backendAccepted = job.requirements.acceleratorBackends.contains(worker.acceleratorBackend)
         || (allowMixedBackend && worker.acceleratorBackend == "mixed")
     guard backendAccepted else {
@@ -812,6 +823,21 @@ func validateWorker(
     if let minimum = job.requirements.minimumAcceleratorMemoryBytes,
        worker.memoryBytes < UInt64(minimum) {
         throw ValidationError("Executor '\(executor)' does not have the required accelerator memory.")
+    }
+    if let minimum = job.requirements.minimumSystemMemoryBytes,
+       worker.systemMemoryBytes < UInt64(minimum) {
+        throw ValidationError("Executor '\(executor)' does not have the required system memory.")
+    }
+    if let minimum = job.requirements.minimumCPUCores,
+       worker.logicalCPUCores < minimum {
+        throw ValidationError("Executor '\(executor)' does not have the required CPU cores.")
+    }
+    if let minimum = job.requirements.minimumDiskBytes,
+       worker.availableDiskBytes.map({ $0 < minimum }) != false {
+        throw ValidationError("Executor '\(executor)' does not report the required free disk space.")
+    }
+    if job.requirements.networkAccess, !worker.networkAccess {
+        throw ValidationError("Executor '\(executor)' does not allow required network access.")
     }
 }
 

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -68,6 +68,31 @@ enum WorkflowProcessTerminationReason: String, Equatable {
     }
 }
 
+private struct WorkflowProcessTimeoutError: LocalizedError {
+    let seconds: Int
+
+    var errorDescription: String? {
+        "Process timed out after \(seconds) seconds."
+    }
+}
+
+private final class WorkflowProcessTimeoutState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var timedOut = false
+
+    func markTimedOut() {
+        lock.lock()
+        timedOut = true
+        lock.unlock()
+    }
+
+    var didTimeOut: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return timedOut
+    }
+}
+
 private final class WorkflowProcessStderrTail: @unchecked Sendable {
     private static let maximumBytes = 16 * 1_024
     private let lock = NSLock()
@@ -103,6 +128,7 @@ protocol WorkflowStreamingProcessRunning {
         executable: URL,
         arguments: [String],
         currentDirectory: URL,
+        timeoutSeconds: Int?,
         stdoutLineHandler: ((String) throws -> Void)?
     ) throws -> WorkflowProcessResult
 }
@@ -117,6 +143,7 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
             executable: CurrentExecutable.url(),
             arguments: arguments,
             currentDirectory: currentDirectory,
+            timeoutSeconds: nil,
             stdoutLineHandler: nil
         )
     }
@@ -125,6 +152,7 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         executable: URL,
         arguments: [String],
         currentDirectory: URL,
+        timeoutSeconds: Int?,
         stdoutLineHandler: ((String) throws -> Void)?
     ) throws -> WorkflowProcessResult {
         let process = Process()
@@ -150,6 +178,27 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         }
         try process.run()
         try Data(String(process.processIdentifier).utf8).write(to: processIDURL, options: .atomic)
+        let timeoutState = WorkflowProcessTimeoutState()
+        let timeoutWorkItem: DispatchWorkItem?
+        if let timeoutSeconds {
+            let workItem = DispatchWorkItem {
+                guard process.isRunning else { return }
+                timeoutState.markTimedOut()
+                process.terminate()
+                Thread.sleep(forTimeInterval: 2)
+                if process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                }
+            }
+            timeoutWorkItem = workItem
+            DispatchQueue.global(qos: .utility).asyncAfter(
+                deadline: .now() + .seconds(timeoutSeconds),
+                execute: workItem
+            )
+        } else {
+            timeoutWorkItem = nil
+        }
+        defer { timeoutWorkItem?.cancel() }
         var captured = Data()
         var pending = Data()
         while true {
@@ -181,6 +230,9 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         if FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
             throw WorkflowCancellationError()
         }
+        if timeoutState.didTimeOut, let timeoutSeconds {
+            throw WorkflowProcessTimeoutError(seconds: timeoutSeconds)
+        }
         return WorkflowProcessResult(
             status: process.terminationStatus,
             stdout: String(decoding: captured, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines),
@@ -197,6 +249,7 @@ struct WorkflowRunner {
     let executor: GraphRunExecutorRecord
     let fileManager: FileManager
     let processRunner: any WorkflowProcessRunning
+    let cacheDirectory: URL?
     let now: () -> Date
     let eventHandler: ((GraphRunEvent) -> Void)?
 
@@ -207,6 +260,7 @@ struct WorkflowRunner {
         executor: GraphRunExecutorRecord = .init(kind: "local", profile: nil, jobReference: nil),
         fileManager: FileManager = .default,
         processRunner: any WorkflowProcessRunning = WorkflowProcessRunner(),
+        cacheDirectory: URL? = nil,
         now: @escaping () -> Date = Date.init,
         eventHandler: ((GraphRunEvent) -> Void)? = nil
     ) {
@@ -216,6 +270,11 @@ struct WorkflowRunner {
         self.executor = executor
         self.fileManager = fileManager
         self.processRunner = processRunner
+        self.cacheDirectory = cacheDirectory?.standardizedFileURL
+            ?? (processRunner is WorkflowProcessRunner
+                ? MereRunModelPaths.applicationSupportBase
+                    .appendingPathComponent("graph-cache/v1/nodes", isDirectory: true)
+                : nil)
         self.now = now
         self.eventHandler = eventHandler
     }
@@ -347,6 +406,34 @@ struct WorkflowRunner {
                 manifest.nodes[nodeIndex].fingerprint = fingerprint
                 manifest.nodes[nodeIndex].provider = providerIdentity
                 manifest.nodes[nodeIndex].models = nodeModels
+                manifest.nodes[nodeIndex].maxAttempts = node.execution?.resolvedMaxAttempts ?? 1
+                if (node.execution?.resolvedCache ?? .automatic) == .automatic,
+                   let cached = try restoreCachedOutputs(
+                    fingerprint: fingerprint,
+                    invocation: invocation,
+                    node: node,
+                    nodeDirectory: nodeDirectory
+                   ) {
+                    nodeOutputs[nodeID] = cached.values
+                    manifest.nodes[nodeIndex].attempt = 0
+                    manifest.nodes[nodeIndex].artifacts = cached.artifacts
+                    manifest.nodes[nodeIndex].outputs = cached.outputs
+                    manifest.nodes[nodeIndex].state = .finished
+                    manifest.nodes[nodeIndex].startedAt = now()
+                    manifest.nodes[nodeIndex].completedAt = now()
+                    manifest.updatedAt = now()
+                    try persist(manifest)
+                    try record(.init(
+                        sequence: sequence,
+                        createdAt: now(),
+                        type: "node_cache_hit",
+                        state: .finished,
+                        nodeID: nodeID,
+                        message: "Restored verified outputs for node fingerprint \(fingerprint)."
+                    ))
+                    sequence += 1
+                    continue
+                }
                 manifest.nodes[nodeIndex].state = .preflighting
                 manifest.nodes[nodeIndex].startedAt = now()
                 manifest.updatedAt = now()
@@ -365,6 +452,7 @@ struct WorkflowRunner {
                     executable: invocation.executable,
                     arguments: invocation.preflightArguments,
                     currentDirectory: nodeDirectory,
+                    timeoutSeconds: nil,
                     stdoutLineHandler: nil
                 )
                 try throwIfCancellationRequested()
@@ -388,80 +476,145 @@ struct WorkflowRunner {
                     }
                 }
 
-                manifest.nodes[nodeIndex].state = .running
-                manifest.updatedAt = now()
-                try persist(manifest)
-                try record(.init(
-                    sequence: sequence,
-                    createdAt: now(),
-                    type: "node_started",
-                    state: .running,
-                    nodeID: nodeID,
-                    message: invocation.command.joined(separator: " ")
-                ))
-                sequence += 1
+                let maxAttempts = node.execution?.resolvedMaxAttempts ?? 1
+                manifest.nodes[nodeIndex].attempt = 0
+                manifest.nodes[nodeIndex].maxAttempts = maxAttempts
+                var verifiedOutputs: WorkflowVerifiedNodeOutputs?
+                while verifiedOutputs == nil {
+                    manifest.nodes[nodeIndex].attempt += 1
+                    let attempt = manifest.nodes[nodeIndex].attempt
+                    manifest.nodes[nodeIndex].state = .running
+                    manifest.nodes[nodeIndex].exitStatus = nil
+                    manifest.nodes[nodeIndex].error = nil
+                    manifest.updatedAt = now()
+                    try persist(manifest)
+                    try record(.init(
+                        sequence: sequence,
+                        createdAt: now(),
+                        type: "node_started",
+                        state: .running,
+                        nodeID: nodeID,
+                        message: "\(invocation.command.joined(separator: " ")) (attempt \(attempt)/\(maxAttempts))"
+                    ))
+                    sequence += 1
 
-                var providerOutputs: [String: WorkflowValue]?
-                var providerSequence = -1
-                let result = try runProcess(
-                    executable: invocation.executable,
-                    arguments: invocation.runArguments,
-                    currentDirectory: nodeDirectory,
-                    stdoutLineHandler: invocation.streamsEvents ? { line in
-                        let event = try WorkflowBundleCodec.decoder().decode(
-                            WorkflowPluginNodeEvent.self,
-                            from: Data(line.utf8)
+                    do {
+                        var providerOutputs: [String: WorkflowValue]?
+                        var providerSequence = -1
+                        let result = try runProcess(
+                            executable: invocation.executable,
+                            arguments: invocation.runArguments,
+                            currentDirectory: nodeDirectory,
+                            timeoutSeconds: node.execution?.timeoutSeconds,
+                            stdoutLineHandler: invocation.streamsEvents ? { line in
+                                let event = try WorkflowBundleCodec.decoder().decode(
+                                    WorkflowPluginNodeEvent.self,
+                                    from: Data(line.utf8)
+                                )
+                                guard event.contractVersion == WorkflowPluginNodeEvent.contractVersion,
+                                      event.sequence == providerSequence + 1 else {
+                                    throw ValidationError("Graph provider emitted an invalid event sequence for node '\(nodeID)'.")
+                                }
+                                providerSequence = event.sequence
+                                if event.type == "node_result" {
+                                    providerOutputs = event.outputs
+                                } else {
+                                    let runArtifact: GraphRunEventArtifact?
+                                    if let eventArtifact = event.artifact {
+                                        let artifactURL = try invocationOutputURL(
+                                            eventArtifact.path,
+                                            nodeDirectory: nodeDirectory
+                                        )
+                                        runArtifact = GraphRunEventArtifact(
+                                            name: eventArtifact.name,
+                                            path: try portableArtifactPath(for: artifactURL),
+                                            contentType: eventArtifact.contentType
+                                        )
+                                    } else {
+                                        runArtifact = nil
+                                    }
+                                    try record(event.runEvent(
+                                        sequence: sequence,
+                                        nodeID: nodeID,
+                                        artifact: runArtifact
+                                    ))
+                                    sequence += 1
+                                }
+                            } : nil
                         )
-                        guard event.contractVersion == WorkflowPluginNodeEvent.contractVersion,
-                              event.sequence == providerSequence + 1 else {
-                            throw ValidationError("Graph provider emitted an invalid event sequence for node '\(nodeID)'.")
+                        try throwIfCancellationRequested()
+                        try Data(result.stdout.utf8).write(
+                            to: nodeDirectory.appendingPathComponent("stdout.txt"),
+                            options: .atomic
+                        )
+                        manifest.nodes[nodeIndex].exitStatus = result.status
+                        guard result.status == 0 else {
+                            throw ValidationError("Node '\(nodeID)' \(result.failureSummary).")
                         }
-                        providerSequence = event.sequence
-                        if event.type == "node_result" {
-                            providerOutputs = event.outputs
-                        } else {
-                            let runArtifact: GraphRunEventArtifact?
-                            if let eventArtifact = event.artifact {
-                                let artifactURL = try invocationOutputURL(
-                                    eventArtifact.path,
-                                    nodeDirectory: nodeDirectory
-                                )
-                                runArtifact = GraphRunEventArtifact(
-                                    name: eventArtifact.name,
-                                    path: try portableArtifactPath(for: artifactURL),
-                                    contentType: eventArtifact.contentType
-                                )
-                            } else {
-                                runArtifact = nil
-                            }
-                            try record(event.runEvent(
-                                sequence: sequence,
-                                nodeID: nodeID,
-                                artifact: runArtifact
-                            ))
-                            sequence += 1
-                        }
-                    } : nil
-                )
-                try throwIfCancellationRequested()
-                try Data(result.stdout.utf8).write(
-                    to: nodeDirectory.appendingPathComponent("stdout.txt"),
-                    options: .atomic
-                )
-                manifest.nodes[nodeIndex].exitStatus = result.status
-                guard result.status == 0 else {
-                    throw ValidationError("Node '\(nodeID)' failed with status \(result.status).")
+                        verifiedOutputs = try verifyOutputs(
+                            invocation.outputs,
+                            providerValues: providerOutputs,
+                            node: node,
+                            nodeDirectory: nodeDirectory
+                        )
+                    } catch is WorkflowCancellationError {
+                        throw WorkflowCancellationError()
+                    } catch {
+                        let message = (error as? ValidationError)?.message ?? error.localizedDescription
+                        manifest.nodes[nodeIndex].error = message
+                        manifest.updatedAt = now()
+                        try persist(manifest)
+                        guard attempt < maxAttempts else { throw error }
+                        try record(.init(
+                            sequence: sequence,
+                            createdAt: now(),
+                            type: "node_retrying",
+                            state: .running,
+                            nodeID: nodeID,
+                            message: "Attempt \(attempt) failed: \(message)"
+                        ))
+                        sequence += 1
+                        try clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
+                    }
                 }
 
-                let verified = try verifyOutputs(
-                    invocation.outputs,
-                    providerValues: providerOutputs,
-                    node: node,
-                    nodeDirectory: nodeDirectory
-                )
+                guard let verified = verifiedOutputs else {
+                    throw ValidationError("Node '\(nodeID)' finished without verified outputs.")
+                }
                 nodeOutputs[nodeID] = verified.values
                 manifest.nodes[nodeIndex].artifacts = verified.artifacts
                 manifest.nodes[nodeIndex].outputs = verified.outputs
+                if node.execution?.resolvedCache != .never {
+                    do {
+                        try storeCachedOutputs(
+                            verified,
+                            fingerprint: fingerprint,
+                            policy: node.execution?.resolvedCache ?? .automatic,
+                            nodeDirectory: nodeDirectory
+                        )
+                        if cacheDirectory != nil {
+                            try record(.init(
+                                sequence: sequence,
+                                createdAt: now(),
+                                type: "node_cache_stored",
+                                state: .running,
+                                nodeID: nodeID,
+                                message: "Stored verified outputs for node fingerprint \(fingerprint)."
+                            ))
+                            sequence += 1
+                        }
+                    } catch {
+                        try record(.init(
+                            sequence: sequence,
+                            createdAt: now(),
+                            type: "node_cache_store_failed",
+                            state: .running,
+                            nodeID: nodeID,
+                            message: error.localizedDescription
+                        ))
+                        sequence += 1
+                    }
+                }
                 manifest.nodes[nodeIndex].state = .finished
                 manifest.nodes[nodeIndex].completedAt = now()
                 manifest.updatedAt = now()
@@ -535,6 +688,7 @@ struct WorkflowRunner {
         executable: URL,
         arguments: [String],
         currentDirectory: URL,
+        timeoutSeconds: Int?,
         stdoutLineHandler: ((String) throws -> Void)?
     ) throws -> WorkflowProcessResult {
         if let streamingRunner = processRunner as? any WorkflowStreamingProcessRunning {
@@ -542,8 +696,12 @@ struct WorkflowRunner {
                 executable: executable,
                 arguments: arguments,
                 currentDirectory: currentDirectory,
+                timeoutSeconds: timeoutSeconds,
                 stdoutLineHandler: stdoutLineHandler
             )
+        }
+        if timeoutSeconds != nil {
+            throw ValidationError("Injected workflow process runner does not support execution timeouts.")
         }
         guard executable.standardizedFileURL == CurrentExecutable.url().standardizedFileURL else {
             throw ValidationError("Injected workflow process runner cannot execute companion providers.")
@@ -555,6 +713,183 @@ struct WorkflowRunner {
             }
         }
         return result
+    }
+
+    private func restoreCachedOutputs(
+        fingerprint: String,
+        invocation: WorkflowNodeInvocation,
+        node: WorkflowNode,
+        nodeDirectory: URL
+    ) throws -> WorkflowVerifiedNodeOutputs? {
+        guard let cacheDirectory else { return nil }
+        let entry = cacheDirectory.appendingPathComponent(fingerprint, isDirectory: true)
+        let manifestURL = entry.appendingPathComponent(WorkflowNodeCacheManifest.filename)
+        guard fileManager.fileExists(atPath: manifestURL.path) else { return nil }
+        do {
+            let manifest = try WorkflowBundleCodec.decoder().decode(
+                WorkflowNodeCacheManifest.self,
+                from: Data(contentsOf: manifestURL)
+            )
+            guard manifest.contractVersion == WorkflowNodeCacheManifest.contractVersion,
+                  manifest.fingerprint == fingerprint else {
+                throw ValidationError("Node cache manifest does not match its fingerprint.")
+            }
+            try clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
+            var providerValues: [String: WorkflowValue] = [:]
+            let filesRoot = entry.appendingPathComponent("files", isDirectory: true)
+            for output in manifest.outputs {
+                guard let descriptor = invocation.outputs[output.name], descriptor.type == output.type else {
+                    throw ValidationError("Node cache output contract has changed for '\(output.name)'.")
+                }
+                if let relativePath = output.relativePath {
+                    guard let descriptorPath = descriptor.path else {
+                        throw ValidationError("Node cache output '\(output.name)' no longer has a path.")
+                    }
+                    let destination = try invocationOutputURL(descriptorPath, nodeDirectory: nodeDirectory)
+                    guard try nodeRelativePath(destination, nodeDirectory: nodeDirectory) == relativePath else {
+                        throw ValidationError("Node cache output path has changed for '\(output.name)'.")
+                    }
+                    let source = try confinedCacheURL(relativePath, root: filesRoot)
+                    try copyCacheItem(from: source, to: destination)
+                } else if let value = output.value {
+                    providerValues[output.name] = value
+                }
+            }
+            let verified = try verifyOutputs(
+                invocation.outputs,
+                providerValues: providerValues,
+                node: node,
+                nodeDirectory: nodeDirectory
+            )
+            let restoredRecords = try verified.outputs.map {
+                try cacheOutput($0, nodeDirectory: nodeDirectory)
+            }.sorted { $0.name < $1.name }
+            guard restoredRecords == manifest.outputs.sorted(by: { $0.name < $1.name }) else {
+                throw ValidationError("Node cache output hashes do not match its manifest.")
+            }
+            return verified
+        } catch {
+            try? clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
+            try? fileManager.removeItem(at: entry)
+            return nil
+        }
+    }
+
+    private func storeCachedOutputs(
+        _ verified: WorkflowVerifiedNodeOutputs,
+        fingerprint: String,
+        policy: WorkflowNodeCachePolicy,
+        nodeDirectory: URL
+    ) throws {
+        guard let cacheDirectory else { return }
+        try fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        let entry = cacheDirectory.appendingPathComponent(fingerprint, isDirectory: true)
+        if fileManager.fileExists(atPath: entry.path), policy == .automatic { return }
+        let staging = cacheDirectory.appendingPathComponent(".\(fingerprint).\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: staging) }
+        let filesRoot = staging.appendingPathComponent("files", isDirectory: true)
+        try fileManager.createDirectory(at: filesRoot, withIntermediateDirectories: true)
+        let outputs = try verified.outputs.map { output -> WorkflowNodeCacheOutput in
+            let record = try cacheOutput(output, nodeDirectory: nodeDirectory)
+            if let relativePath = record.relativePath {
+                let source = try invocationOutputURL(relativePath, nodeDirectory: nodeDirectory)
+                let destination = try confinedCacheURL(relativePath, root: filesRoot)
+                try copyCacheItem(from: source, to: destination)
+            }
+            return record
+        }.sorted { $0.name < $1.name }
+        try WorkflowBundleCodec.write(
+            WorkflowNodeCacheManifest(
+                contractVersion: WorkflowNodeCacheManifest.contractVersion,
+                fingerprint: fingerprint,
+                outputs: outputs
+            ),
+            to: staging.appendingPathComponent(WorkflowNodeCacheManifest.filename)
+        )
+        if fileManager.fileExists(atPath: entry.path) {
+            try fileManager.removeItem(at: entry)
+        }
+        try fileManager.moveItem(at: staging, to: entry)
+    }
+
+    private func cacheOutput(
+        _ output: GraphRunNodeOutput,
+        nodeDirectory: URL
+    ) throws -> WorkflowNodeCacheOutput {
+        guard let sha256 = output.sha256 else {
+            throw ValidationError("Workflow output '\(output.name)' has no cache fingerprint.")
+        }
+        let relativePath: String?
+        if let path = output.path {
+            relativePath = try nodeRelativePath(artifactURL(for: path), nodeDirectory: nodeDirectory)
+        } else {
+            relativePath = nil
+        }
+        return WorkflowNodeCacheOutput(
+            name: output.name,
+            type: output.type,
+            value: output.value,
+            relativePath: relativePath,
+            contentType: output.contentType,
+            sizeBytes: output.sizeBytes,
+            sha256: sha256
+        )
+    }
+
+    private func nodeRelativePath(_ url: URL, nodeDirectory: URL) throws -> String {
+        let candidate = url.standardizedFileURL.path
+        let root = nodeDirectory.standardizedFileURL.path
+        guard candidate.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow cache output escapes the node directory: \(candidate)")
+        }
+        return String(candidate.dropFirst(root.count + 1))
+    }
+
+    private func confinedCacheURL(_ path: String, root: URL) throws -> URL {
+        guard isConfinedRelativeWorkflowPath(path) else {
+            throw ValidationError("Workflow cache contains an unconfined path: \(path)")
+        }
+        let candidate = root.appendingPathComponent(path).standardizedFileURL
+        guard candidate.path.hasPrefix(root.standardizedFileURL.path + "/") else {
+            throw ValidationError("Workflow cache path escapes its entry: \(path)")
+        }
+        return candidate
+    }
+
+    private func copyCacheItem(from source: URL, to destination: URL) throws {
+        let values = try source.resourceValues(forKeys: [.isSymbolicLinkKey])
+        guard values.isSymbolicLink != true else {
+            throw ValidationError("Workflow cache items cannot be symbolic links: \(source.path)")
+        }
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.copyItem(at: source, to: destination)
+    }
+
+    private func clearAttemptOutputs(
+        _ outputs: [String: WorkflowInvocationOutput],
+        nodeDirectory: URL
+    ) throws {
+        for descriptor in outputs.values {
+            guard let path = descriptor.path else { continue }
+            let outputURL = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
+            if fileManager.fileExists(atPath: outputURL.path) {
+                try fileManager.removeItem(at: outputURL)
+            }
+        }
+        let artifacts = nodeDirectory.appendingPathComponent("artifacts", isDirectory: true)
+        if fileManager.fileExists(atPath: artifacts.path) {
+            try fileManager.removeItem(at: artifacts)
+        }
+        let stdout = nodeDirectory.appendingPathComponent("stdout.txt")
+        if fileManager.fileExists(atPath: stdout.path) {
+            try fileManager.removeItem(at: stdout)
+        }
     }
 
     private func verifyOutputs(
@@ -883,6 +1218,8 @@ struct WorkflowRunner {
                         startedAt: nil,
                         completedAt: nil,
                         exitStatus: nil,
+                        attempt: 0,
+                        maxAttempts: $0.execution?.resolvedMaxAttempts ?? 1,
                         fingerprint: "",
                         artifacts: [],
                         error: nil
@@ -1099,7 +1436,7 @@ struct WorkflowRunner {
     }
 
     private func record(_ event: GraphRunEvent) throws {
-        let data = try WorkflowBundleCodec.encoder().encode(event)
+        let data = try WorkflowBundleCodec.lineEncoder().encode(event)
         let url = runDirectory.appendingPathComponent("events.jsonl")
         if !fileManager.fileExists(atPath: url.path) {
             try Data().write(to: url)
@@ -1160,6 +1497,41 @@ private struct WorkflowVerifiedNodeOutputs {
     let artifacts: [GraphRunArtifact]
     let outputs: [GraphRunNodeOutput]
     let values: [String: WorkflowValue]
+}
+
+private struct WorkflowNodeCacheManifest: Codable {
+    static let contractVersion = "mere.run/node-cache.v1"
+    static let filename = "cache.json"
+
+    let contractVersion: String
+    let fingerprint: String
+    let outputs: [WorkflowNodeCacheOutput]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case fingerprint
+        case outputs
+    }
+}
+
+private struct WorkflowNodeCacheOutput: Codable, Equatable {
+    let name: String
+    let type: WorkflowPortType
+    let value: WorkflowValue?
+    let relativePath: String?
+    let contentType: String?
+    let sizeBytes: Int64?
+    let sha256: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case value
+        case relativePath = "relative_path"
+        case contentType = "content_type"
+        case sizeBytes = "size_bytes"
+        case sha256
+    }
 }
 
 private struct WorkflowOutputDirectoryManifest: Codable {

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -93,6 +93,117 @@ private final class WorkflowProcessTimeoutState: @unchecked Sendable {
     }
 }
 
+enum WorkflowChildProcessRegistry {
+    static let directoryName = "worker-child-pids"
+    static let legacyFilename = "worker-child.pid"
+    private static let lock = NSLock()
+
+    static func register(
+        _ processID: Int32,
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        let entry = directory.appendingPathComponent("\(processID).pid")
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data(String(processID).utf8).write(to: entry, options: .atomic)
+            try Data(String(processID).utf8).write(
+                to: runDirectory.appendingPathComponent(legacyFilename),
+                options: .atomic
+            )
+        } catch {
+            try? fileManager.removeItem(at: entry)
+            throw error
+        }
+    }
+
+    static func unregister(
+        _ processID: Int32,
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        let entry = runDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent("\(processID).pid")
+        try? fileManager.removeItem(at: entry)
+        let legacy = runDirectory.appendingPathComponent(legacyFilename)
+        if readProcessID(at: legacy, fileManager: fileManager) == processID {
+            try? fileManager.removeItem(at: legacy)
+        }
+    }
+
+    static func processIDs(
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [Int32] {
+        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey]
+        )) ?? []
+        var processIDs = Set(entries.compactMap { entry -> Int32? in
+            guard entry.pathExtension == "pid",
+                  let values = try? entry.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+                  values.isRegularFile == true,
+                  values.isSymbolicLink != true else {
+                return nil
+            }
+            return readProcessID(at: entry, fileManager: fileManager)
+        })
+        if let legacy = readProcessID(
+            at: runDirectory.appendingPathComponent(legacyFilename),
+            fileManager: fileManager
+        ) {
+            processIDs.insert(legacy)
+        }
+        return processIDs.sorted()
+    }
+
+    @discardableResult
+    static func terminateAll(
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [Int32] {
+        let processIDs = processIDs(in: runDirectory, fileManager: fileManager)
+        for processID in processIDs {
+            _ = kill(processID, SIGTERM)
+        }
+        return processIDs
+    }
+
+    static func clear(
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let legacy = runDirectory.appendingPathComponent(legacyFilename)
+        if fileManager.fileExists(atPath: legacy.path) {
+            try fileManager.removeItem(at: legacy)
+        }
+        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        if fileManager.fileExists(atPath: directory.path) {
+            try fileManager.removeItem(at: directory)
+        }
+    }
+
+    private static func readProcessID(at url: URL, fileManager: FileManager) -> Int32? {
+        guard fileManager.fileExists(atPath: url.path),
+              let raw = try? String(contentsOf: url, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              let processID = Int32(raw),
+              processID > 1 else {
+            return nil
+        }
+        return processID
+    }
+}
+
 private final class WorkflowProcessStderrTail: @unchecked Sendable {
     private static let maximumBytes = 16 * 1_024
     private let lock = NSLock()
@@ -206,10 +317,6 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         let stderr = Pipe()
         let stderrTail = WorkflowProcessStderrTail()
         let runDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
-        let processIDURL = runDirectory.appendingPathComponent("worker-child.pid")
-        defer {
-            try? FileManager.default.removeItem(at: processIDURL)
-        }
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = stdout
         process.standardError = stderr
@@ -220,7 +327,19 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
             try? FileHandle.standardError.write(contentsOf: data)
         }
         try process.run()
-        try Data(String(process.processIdentifier).utf8).write(to: processIDURL, options: .atomic)
+        do {
+            try WorkflowChildProcessRegistry.register(process.processIdentifier, in: runDirectory)
+        } catch {
+            process.terminate()
+            process.waitUntilExit()
+            throw error
+        }
+        defer {
+            WorkflowChildProcessRegistry.unregister(process.processIdentifier, in: runDirectory)
+        }
+        if FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
+            process.terminate()
+        }
         let timeoutState = WorkflowProcessTimeoutState()
         let timeoutWorkItem: DispatchWorkItem?
         if let timeoutSeconds {
@@ -444,7 +563,7 @@ struct WorkflowRunner: @unchecked Sendable {
                     models: nodeModels,
                     upstreamOutputs: upstreamOutputs
                 ))
-                if try shouldResume(
+                if workflowNodeAllowsResumeReuse(node), try shouldResume(
                     manifest.nodes[nodeIndex],
                     expectedFingerprint: fingerprint,
                     nodeOutputs: &nodeOutputs
@@ -808,7 +927,7 @@ struct WorkflowRunner: @unchecked Sendable {
                     models: models,
                     upstreamOutputs: upstreamOutputs
                 ))
-                if try shouldResume(
+                if workflowNodeAllowsResumeReuse(node), try shouldResume(
                     manifest.nodes[nodeIndex],
                     expectedFingerprint: fingerprint,
                     nodeOutputs: &nodeOutputs
@@ -1586,10 +1705,7 @@ struct WorkflowRunner: @unchecked Sendable {
         if fileManager.fileExists(atPath: cancellationURL.path) {
             try fileManager.removeItem(at: cancellationURL)
         }
-        let processIDURL = runDirectory.appendingPathComponent("worker-child.pid")
-        if fileManager.fileExists(atPath: processIDURL.path) {
-            try fileManager.removeItem(at: processIDURL)
-        }
+        try WorkflowChildProcessRegistry.clear(in: runDirectory, fileManager: fileManager)
         try fileManager.createDirectory(
             at: runDirectory.appendingPathComponent("outputs", isDirectory: true),
             withIntermediateDirectories: true
@@ -2123,6 +2239,10 @@ private func workflowValue(_ value: WorkflowValue, matches type: WorkflowPortTyp
     case .assetCollection, .assetArray:
         if case .array = value { true } else { false }
     }
+}
+
+func workflowNodeAllowsResumeReuse(_ node: WorkflowNode) -> Bool {
+    node.arguments.values.allSatisfy { $0.secretNames.isEmpty }
 }
 
 private func isConfinedRelativeWorkflowPath(_ path: String) -> Bool {

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -119,6 +119,49 @@ private final class WorkflowProcessStderrTail: @unchecked Sendable {
     }
 }
 
+private struct WorkflowPreparedParallelNode: @unchecked Sendable {
+    let node: WorkflowNode
+    let index: Int
+    let directory: URL
+    let invocation: WorkflowNodeInvocation
+    let fingerprint: String
+    let provider: WorkflowNodeProviderIdentity
+    let models: [WorkflowModelProvenance]
+    let maxAttempts: Int
+}
+
+private enum WorkflowParallelBufferedEvent {
+    case provider(WorkflowPluginNodeEvent)
+    case retrying(attempt: Int, message: String)
+    case started(attempt: Int)
+}
+
+private struct WorkflowParallelNodeOutcome {
+    let verified: WorkflowVerifiedNodeOutputs?
+    let attempt: Int
+    let exitStatus: Int32?
+    let events: [WorkflowParallelBufferedEvent]
+    let error: String?
+    let cancelled: Bool
+}
+
+private final class WorkflowParallelOutcomeBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: WorkflowParallelNodeOutcome?
+
+    func store(_ outcome: WorkflowParallelNodeOutcome) {
+        lock.lock()
+        stored = outcome
+        lock.unlock()
+    }
+
+    func load() -> WorkflowParallelNodeOutcome? {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+}
+
 protocol WorkflowProcessRunning {
     func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult
 }
@@ -242,7 +285,7 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
     }
 }
 
-struct WorkflowRunner {
+struct WorkflowRunner: @unchecked Sendable {
     let bundleDirectory: URL
     let runDirectory: URL
     let resume: Bool
@@ -314,6 +357,15 @@ struct WorkflowRunner {
                 "Worker is missing exact graph providers: \(missingProviders.map { "\($0.id)@\($0.version)" }.joined(separator: ", "))."
             )
         }
+        let environment = ProcessInfo.processInfo.environment
+        let missingSecrets = job.requirements.secretNames.filter {
+            environment[workflowSecretEnvironmentKey($0)]?.isEmpty != false
+        }
+        guard missingSecrets.isEmpty else {
+            throw ValidationError(
+                "Worker is missing configured secrets: \(missingSecrets.joined(separator: ", "))."
+            )
+        }
 
         let validation = WorkflowGraphValidator.validate(graph: graph, inputs: inputs)
         guard validation.status != .blocked else {
@@ -342,6 +394,17 @@ struct WorkflowRunner {
 
         var nodeOutputs: [String: [String: WorkflowValue]] = [:]
         do {
+            if graph.execution?.resolvedMaxParallelNodes ?? 1 > 1 {
+                try executeParallelNodes(
+                    graph: graph,
+                    job: job,
+                    validation: validation,
+                    localizedInputs: localizedInputs,
+                    manifest: &manifest,
+                    sequence: &sequence,
+                    nodeOutputs: &nodeOutputs
+                )
+            } else {
             for nodeID in validation.order {
                 guard let node = graph.nodes.first(where: { $0.id == nodeID }),
                       let nodeIndex = manifest.nodes.firstIndex(where: { $0.id == nodeID }) else {
@@ -629,6 +692,7 @@ struct WorkflowRunner {
                 ))
                 sequence += 1
             }
+            }
 
             manifest.outputs = try materializeGraphOutputs(graph: graph, nodeOutputs: nodeOutputs)
             manifest.state = .finished
@@ -681,6 +745,429 @@ struct WorkflowRunner {
             jobID: manifest.jobID,
             state: manifest.state,
             outputs: manifest.outputs
+        )
+    }
+
+    private func executeParallelNodes(
+        graph: WorkflowGraphDocument,
+        job: WorkflowJobManifest,
+        validation: WorkflowGraphValidation,
+        localizedInputs: WorkflowInputsDocument,
+        manifest: inout GraphRunManifest,
+        sequence: inout Int,
+        nodeOutputs: inout [String: [String: WorkflowValue]]
+    ) throws {
+        let maximumParallelNodes = graph.execution?.resolvedMaxParallelNodes ?? 1
+        var pending = validation.order
+        var completed = Set<String>()
+
+        while !pending.isEmpty {
+            try throwIfCancellationRequested()
+            let ready = pending.filter { nodeID in
+                validation.dependencies[nodeID, default: []].isSubset(of: completed)
+            }
+            guard !ready.isEmpty else {
+                throw ValidationError("Workflow scheduler could not find a ready node.")
+            }
+
+            var prepared: [WorkflowPreparedParallelNode] = []
+            for nodeID in ready.prefix(maximumParallelNodes) {
+                guard let node = graph.nodes.first(where: { $0.id == nodeID }),
+                      let nodeIndex = manifest.nodes.firstIndex(where: { $0.id == nodeID }) else {
+                    throw ValidationError("Workflow execution order referenced missing node '\(nodeID)'.")
+                }
+                let nodeDirectory = runDirectory
+                    .appendingPathComponent("nodes", isDirectory: true)
+                    .appendingPathComponent(String(format: "%03d-%@", nodeIndex, node.id), isDirectory: true)
+                try fileManager.createDirectory(at: nodeDirectory, withIntermediateDirectories: true)
+                let resolvedArguments = try resolve(
+                    node.arguments,
+                    inputs: localizedInputs.values,
+                    nodeOutputs: nodeOutputs
+                )
+                let referencedNodeIDs = Set(
+                    node.arguments.values.flatMap(\.references).compactMap { reference -> String? in
+                        guard let parsed = try? WorkflowReference(reference),
+                              case .nodeOutput(let sourceNodeID, _) = parsed.source else { return nil }
+                        return sourceNodeID
+                    }
+                )
+                let upstreamOutputs = manifest.nodes
+                    .filter { referencedNodeIDs.contains($0.id) }
+                    .flatMap(\.outputs)
+                    .map(WorkflowNodeOutputFingerprint.init)
+                    .sorted { ($0.sourceName, $0.sha256 ?? "") < ($1.sourceName, $1.sha256 ?? "") }
+                guard let provider = WorkflowNodeRegistry.provider(for: node) else {
+                    throw ValidationError("Workflow provider '\(node.resolvedProviderID)' is unavailable.")
+                }
+                let models = modelProvenance(for: node, arguments: resolvedArguments, job: job)
+                let fingerprint = try WorkflowBundleCodec.hash(WorkflowNodeFingerprint(
+                    kind: node.kind,
+                    provider: provider,
+                    arguments: resolvedArguments,
+                    models: models,
+                    upstreamOutputs: upstreamOutputs
+                ))
+                if try shouldResume(
+                    manifest.nodes[nodeIndex],
+                    expectedFingerprint: fingerprint,
+                    nodeOutputs: &nodeOutputs
+                ) {
+                    try record(.init(
+                        sequence: sequence,
+                        createdAt: now(),
+                        type: "node_resumed",
+                        state: .finished,
+                        nodeID: nodeID,
+                        message: "Reused verified node outputs."
+                    ))
+                    sequence += 1
+                    completed.insert(nodeID)
+                    pending.removeAll { $0 == nodeID }
+                    continue
+                }
+
+                let invocation = try WorkflowNodeCommandBuilder.invocation(
+                    node: node,
+                    arguments: resolvedArguments,
+                    nodeDirectory: nodeDirectory,
+                    jobID: job.jobID
+                )
+                manifest.nodes[nodeIndex].fingerprint = fingerprint
+                manifest.nodes[nodeIndex].provider = provider
+                manifest.nodes[nodeIndex].models = models
+                manifest.nodes[nodeIndex].maxAttempts = node.execution?.resolvedMaxAttempts ?? 1
+                if (node.execution?.resolvedCache ?? .automatic) == .automatic,
+                   let cached = try restoreCachedOutputs(
+                    fingerprint: fingerprint,
+                    invocation: invocation,
+                    node: node,
+                    nodeDirectory: nodeDirectory
+                   ) {
+                    nodeOutputs[nodeID] = cached.values
+                    manifest.nodes[nodeIndex].attempt = 0
+                    manifest.nodes[nodeIndex].artifacts = cached.artifacts
+                    manifest.nodes[nodeIndex].outputs = cached.outputs
+                    manifest.nodes[nodeIndex].state = .finished
+                    manifest.nodes[nodeIndex].startedAt = now()
+                    manifest.nodes[nodeIndex].completedAt = now()
+                    manifest.updatedAt = now()
+                    try persist(manifest)
+                    try record(.init(
+                        sequence: sequence,
+                        createdAt: now(),
+                        type: "node_cache_hit",
+                        state: .finished,
+                        nodeID: nodeID,
+                        message: "Restored verified outputs for node fingerprint \(fingerprint)."
+                    ))
+                    sequence += 1
+                    completed.insert(nodeID)
+                    pending.removeAll { $0 == nodeID }
+                    continue
+                }
+
+                manifest.nodes[nodeIndex].state = .preflighting
+                manifest.nodes[nodeIndex].startedAt = now()
+                manifest.updatedAt = now()
+                try persist(manifest)
+                try record(.init(
+                    sequence: sequence,
+                    createdAt: now(),
+                    type: "node_preflight_started",
+                    state: .preflighting,
+                    nodeID: nodeID,
+                    message: nil
+                ))
+                sequence += 1
+                let preflight = try runProcess(
+                    executable: invocation.executable,
+                    arguments: invocation.preflightArguments,
+                    currentDirectory: nodeDirectory,
+                    timeoutSeconds: nil,
+                    stdoutLineHandler: nil
+                )
+                try throwIfCancellationRequested()
+                try Data(preflight.stdout.utf8).write(
+                    to: nodeDirectory.appendingPathComponent("preflight.json"),
+                    options: .atomic
+                )
+                guard preflight.status == 0 else {
+                    throw ValidationError("Node '\(nodeID)' preflight \(preflight.failureSummary).")
+                }
+                if invocation.streamsEvents {
+                    let report = try WorkflowBundleCodec.decoder().decode(
+                        WorkflowPluginNodePreflight.self,
+                        from: Data(preflight.stdout.utf8)
+                    )
+                    guard report.contractVersion == WorkflowPluginNodePreflight.contractVersion,
+                          report.status != "blocked" else {
+                        throw ValidationError(report.diagnostics.map(\.message).joined(separator: " "))
+                    }
+                }
+                let maxAttempts = node.execution?.resolvedMaxAttempts ?? 1
+                manifest.nodes[nodeIndex].attempt = 1
+                manifest.nodes[nodeIndex].maxAttempts = maxAttempts
+                manifest.nodes[nodeIndex].state = .running
+                manifest.nodes[nodeIndex].error = nil
+                manifest.nodes[nodeIndex].exitStatus = nil
+                manifest.updatedAt = now()
+                try persist(manifest)
+                try record(.init(
+                    sequence: sequence,
+                    createdAt: now(),
+                    type: "node_started",
+                    state: .running,
+                    nodeID: nodeID,
+                    message: "\(invocation.command.joined(separator: " ")) (attempt 1/\(maxAttempts))"
+                ))
+                sequence += 1
+                prepared.append(.init(
+                    node: node,
+                    index: nodeIndex,
+                    directory: nodeDirectory,
+                    invocation: invocation,
+                    fingerprint: fingerprint,
+                    provider: provider,
+                    models: models,
+                    maxAttempts: maxAttempts
+                ))
+            }
+
+            guard !prepared.isEmpty else { continue }
+            let queue = OperationQueue()
+            queue.maxConcurrentOperationCount = maximumParallelNodes
+            let boxes = prepared.map { item -> WorkflowParallelOutcomeBox in
+                let box = WorkflowParallelOutcomeBox()
+                queue.addOperation {
+                    box.store(runParallelNode(item))
+                }
+                return box
+            }
+            queue.waitUntilAllOperationsAreFinished()
+
+            var firstFailure: String?
+            var wasCancelled = false
+            for (item, box) in zip(prepared, boxes) {
+                guard let outcome = box.load() else {
+                    throw ValidationError("Parallel node '\(item.node.id)' did not return an outcome.")
+                }
+                manifest.nodes[item.index].attempt = outcome.attempt
+                manifest.nodes[item.index].exitStatus = outcome.exitStatus
+                for event in outcome.events {
+                    switch event {
+                    case .provider(let providerEvent):
+                        let artifact: GraphRunEventArtifact?
+                        if let eventArtifact = providerEvent.artifact {
+                            let artifactURL = try invocationOutputURL(
+                                eventArtifact.path,
+                                nodeDirectory: item.directory
+                            )
+                            artifact = GraphRunEventArtifact(
+                                name: eventArtifact.name,
+                                path: try portableArtifactPath(for: artifactURL),
+                                contentType: eventArtifact.contentType
+                            )
+                        } else {
+                            artifact = nil
+                        }
+                        try record(providerEvent.runEvent(
+                            sequence: sequence,
+                            nodeID: item.node.id,
+                            artifact: artifact
+                        ))
+                    case .retrying(let attempt, let message):
+                        try record(.init(
+                            sequence: sequence,
+                            createdAt: now(),
+                            type: "node_retrying",
+                            state: .running,
+                            nodeID: item.node.id,
+                            message: "Attempt \(attempt) failed: \(message)"
+                        ))
+                    case .started(let attempt):
+                        try record(.init(
+                            sequence: sequence,
+                            createdAt: now(),
+                            type: "node_started",
+                            state: .running,
+                            nodeID: item.node.id,
+                            message: "\(item.invocation.command.joined(separator: " ")) (attempt \(attempt)/\(item.maxAttempts))"
+                        ))
+                    }
+                    sequence += 1
+                }
+
+                guard let verified = outcome.verified else {
+                    let message = outcome.error ?? "Node '\(item.node.id)' failed without a diagnostic."
+                    manifest.nodes[item.index].state = outcome.cancelled ? .cancelled : .failed
+                    manifest.nodes[item.index].error = message
+                    manifest.nodes[item.index].completedAt = now()
+                    firstFailure = firstFailure ?? message
+                    wasCancelled = wasCancelled || outcome.cancelled
+                    continue
+                }
+                nodeOutputs[item.node.id] = verified.values
+                manifest.nodes[item.index].artifacts = verified.artifacts
+                manifest.nodes[item.index].outputs = verified.outputs
+                if item.node.execution?.resolvedCache != .never {
+                    do {
+                        try storeCachedOutputs(
+                            verified,
+                            fingerprint: item.fingerprint,
+                            policy: item.node.execution?.resolvedCache ?? .automatic,
+                            nodeDirectory: item.directory
+                        )
+                        if cacheDirectory != nil {
+                            try record(.init(
+                                sequence: sequence,
+                                createdAt: now(),
+                                type: "node_cache_stored",
+                                state: .running,
+                                nodeID: item.node.id,
+                                message: "Stored verified outputs for node fingerprint \(item.fingerprint)."
+                            ))
+                            sequence += 1
+                        }
+                    } catch {
+                        try record(.init(
+                            sequence: sequence,
+                            createdAt: now(),
+                            type: "node_cache_store_failed",
+                            state: .running,
+                            nodeID: item.node.id,
+                            message: error.localizedDescription
+                        ))
+                        sequence += 1
+                    }
+                }
+                manifest.nodes[item.index].state = .finished
+                manifest.nodes[item.index].completedAt = now()
+                manifest.nodes[item.index].error = nil
+                completed.insert(item.node.id)
+                pending.removeAll { $0 == item.node.id }
+                try record(.init(
+                    sequence: sequence,
+                    createdAt: now(),
+                    type: "node_finished",
+                    state: .finished,
+                    nodeID: item.node.id,
+                    message: nil
+                ))
+                sequence += 1
+            }
+            manifest.updatedAt = now()
+            try persist(manifest)
+            if wasCancelled { throw WorkflowCancellationError() }
+            if let firstFailure { throw ValidationError(firstFailure) }
+        }
+    }
+
+    private func runParallelNode(
+        _ prepared: WorkflowPreparedParallelNode
+    ) -> WorkflowParallelNodeOutcome {
+        var attempt = 0
+        var exitStatus: Int32?
+        var events: [WorkflowParallelBufferedEvent] = []
+        while attempt < prepared.maxAttempts {
+            attempt += 1
+            do {
+                var providerOutputs: [String: WorkflowValue]?
+                var providerSequence = -1
+                let result = try runProcess(
+                    executable: prepared.invocation.executable,
+                    arguments: prepared.invocation.runArguments,
+                    currentDirectory: prepared.directory,
+                    timeoutSeconds: prepared.node.execution?.timeoutSeconds,
+                    stdoutLineHandler: prepared.invocation.streamsEvents ? { line in
+                        let event = try WorkflowBundleCodec.decoder().decode(
+                            WorkflowPluginNodeEvent.self,
+                            from: Data(line.utf8)
+                        )
+                        guard event.contractVersion == WorkflowPluginNodeEvent.contractVersion,
+                              event.sequence == providerSequence + 1 else {
+                            throw ValidationError(
+                                "Graph provider emitted an invalid event sequence for node '\(prepared.node.id)'."
+                            )
+                        }
+                        providerSequence = event.sequence
+                        if event.type == "node_result" {
+                            providerOutputs = event.outputs
+                        } else {
+                            events.append(.provider(event))
+                        }
+                    } : nil
+                )
+                try throwIfCancellationRequested()
+                try Data(result.stdout.utf8).write(
+                    to: prepared.directory.appendingPathComponent("stdout.txt"),
+                    options: .atomic
+                )
+                exitStatus = result.status
+                guard result.status == 0 else {
+                    throw ValidationError("Node '\(prepared.node.id)' \(result.failureSummary).")
+                }
+                let verified = try verifyOutputs(
+                    prepared.invocation.outputs,
+                    providerValues: providerOutputs,
+                    node: prepared.node,
+                    nodeDirectory: prepared.directory
+                )
+                return .init(
+                    verified: verified,
+                    attempt: attempt,
+                    exitStatus: exitStatus,
+                    events: events,
+                    error: nil,
+                    cancelled: false
+                )
+            } catch is WorkflowCancellationError {
+                return .init(
+                    verified: nil,
+                    attempt: attempt,
+                    exitStatus: exitStatus,
+                    events: events,
+                    error: "Workflow cancellation requested.",
+                    cancelled: true
+                )
+            } catch {
+                let message = (error as? ValidationError)?.message ?? error.localizedDescription
+                guard attempt < prepared.maxAttempts else {
+                    return .init(
+                        verified: nil,
+                        attempt: attempt,
+                        exitStatus: exitStatus,
+                        events: events,
+                        error: message,
+                        cancelled: false
+                    )
+                }
+                events.append(.retrying(attempt: attempt, message: message))
+                events.append(.started(attempt: attempt + 1))
+                do {
+                    try clearAttemptOutputs(
+                        prepared.invocation.outputs,
+                        nodeDirectory: prepared.directory
+                    )
+                } catch {
+                    return .init(
+                        verified: nil,
+                        attempt: attempt,
+                        exitStatus: exitStatus,
+                        events: events,
+                        error: error.localizedDescription,
+                        cancelled: false
+                    )
+                }
+            }
+        }
+        return .init(
+            verified: nil,
+            attempt: attempt,
+            exitStatus: exitStatus,
+            events: events,
+            error: "Node '\(prepared.node.id)' exhausted its retry policy.",
+            cancelled: false
         )
     }
 
@@ -1646,7 +2133,7 @@ private func isConfinedRelativeWorkflowPath(_ path: String) -> Bool {
         }
 }
 
-private func workflowVersion(_ current: String, satisfiesMinimum minimum: String) -> Bool {
+func workflowVersion(_ current: String, satisfiesMinimum minimum: String) -> Bool {
     func components(_ value: String) -> [Int] {
         value
             .split(separator: ".")

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.22.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.23.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/graph-compatibility.v1.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/graph-compatibility.v1.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "kind": "mere.run/graph-compatibility",
+  "contracts": {
+    "workflow_graph_schema_versions": [1],
+    "workflow_program_schema_versions": [1],
+    "workflow_module_schema_versions": [1],
+    "workflow_editor_sidecar_schema_versions": [1],
+    "job_bundle": "mere.run/job-bundle.v1",
+    "graph_run": "mere.run/graph-run.v1",
+    "plugin_provider": "mere.run/plugin-graph-provider.v1",
+    "plugin_invocation": "mere.run/plugin-graph-invocation.v1",
+    "plugin_preflight": "mere.run/plugin-graph-preflight.v1",
+    "plugin_event": "mere.run/plugin-graph-event.v1"
+  },
+  "components": [
+    { "id": "mere.run", "minimum_version": "0.23.0" },
+    { "id": "mere-workflow-tools", "minimum_version": "0.2.0" },
+    { "id": "mere-run-graph-studio", "minimum_version": "0.1.0" },
+    { "id": "mere.run-node", "minimum_version": "0.1.9" }
+  ],
+  "canonical_fixture": {
+    "id": "parallel-image-video-v1",
+    "graph": "parallel-image-video.workflow.json",
+    "inputs": "parallel-image-video.inputs.json",
+    "assets": "parallel-image-video.assets.json",
+    "graph_fingerprint": "83327833196a00799c19507aaf2b34b36450346fb543467a2d4edfe2465316bc",
+    "input_fingerprint": "5380b7fbbed8ce21bf5fa4b3e1426fb479d9a289a2da06d531366b3f9120f30d",
+    "execution_order": ["image-a", "image-b", "video"]
+  }
+}

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/parallel-image-video.assets.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/parallel-image-video.assets.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "groups": []
+}

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/parallel-image-video.inputs.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/parallel-image-video.inputs.json
@@ -1,0 +1,3 @@
+{
+  "prompt": "A cinematic rainy city street at night, practical neon reflections, production still"
+}

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/parallel-image-video.workflow.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/parallel-image-video.workflow.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "kind": "mere.run/workflow-graph",
+  "name": "parallel-image-video",
+  "inputs": {
+    "prompt": { "type": "string" }
+  },
+  "execution": {
+    "max_parallel_nodes": 2
+  },
+  "nodes": [
+    {
+      "id": "image-a",
+      "kind": "image.generate",
+      "arguments": {
+        "prompt": { "$ref": "inputs.prompt" },
+        "seed": 101
+      },
+      "execution": {
+        "max_attempts": 2,
+        "timeout_seconds": 300,
+        "cache": "auto"
+      }
+    },
+    {
+      "id": "image-b",
+      "kind": "image.generate",
+      "arguments": {
+        "prompt": { "$ref": "inputs.prompt" },
+        "seed": 102
+      },
+      "execution": {
+        "cache": "refresh"
+      }
+    },
+    {
+      "id": "video",
+      "kind": "video.generate",
+      "depends_on": ["image-a", "image-b"],
+      "arguments": {
+        "prompt": { "$ref": "inputs.prompt" },
+        "image": { "$ref": "nodes.image-a.outputs.image" },
+        "seed": 103
+      }
+    }
+  ],
+  "outputs": {
+    "primary-image": { "$ref": "nodes.image-a.outputs.image" },
+    "secondary-image": { "$ref": "nodes.image-b.outputs.image" },
+    "video": { "$ref": "nodes.video.outputs.video" }
+  }
+}

--- a/Tests/MereRunCLITests/RunCommandTests.swift
+++ b/Tests/MereRunCLITests/RunCommandTests.swift
@@ -12,6 +12,22 @@ final class RunCommandTests: XCTestCase {
         XCTAssertEqual(runNames, Set(["list", "inspect", "watch", "fetch", "cancel", "retry"]))
     }
 
+    func testRunFetchAcceptsRepeatableArtifactSelection() throws {
+        let command = try RunFetch.parse([
+            "relay://fleet/job-123",
+            "--into", "/tmp/job-123",
+            "--artifact", "sample",
+            "--artifact", "adapter",
+            "--json",
+        ])
+
+        XCTAssertEqual(command.reference, "relay://fleet/job-123")
+        XCTAssertEqual(command.into, "/tmp/job-123")
+        XCTAssertEqual(command.artifacts, ["sample", "adapter"])
+        XCTAssertFalse(command.allArtifacts)
+        XCTAssertTrue(command.json)
+    }
+
     func testRunListReportsWorkspaceArtifacts() throws {
         let temp = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -147,6 +147,38 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertTrue(result.diagnostics.contains { $0.id == "workflow_cycle" })
     }
 
+    func testCanonicalWorkflowFingerprintMatchesCrossRuntimeContract() throws {
+        let fixtures = try XCTUnwrap(Bundle.module.resourceURL)
+            .appendingPathComponent("Fixtures/WorkflowGraphV1", isDirectory: true)
+        let compatibility = try WorkflowBundleCodec.decoder().decode(
+            WorkflowCompatibilityFixture.self,
+            from: Data(contentsOf: fixtures.appendingPathComponent("graph-compatibility.v1.json"))
+        )
+        let graph = try WorkflowGraphDocument.load(
+            from: fixtures.appendingPathComponent(compatibility.canonicalFixture.graph)
+        )
+        let inputs = try WorkflowInputsDocument.load(
+            from: fixtures.appendingPathComponent(compatibility.canonicalFixture.inputs)
+        )
+        let assets = try WorkflowBundleCodec.decoder().decode(
+            WorkflowAssetManifest.self,
+            from: Data(contentsOf: fixtures.appendingPathComponent(compatibility.canonicalFixture.assets))
+        )
+        let validation = WorkflowGraphValidator.validate(graph: graph, inputs: inputs)
+
+        XCTAssertEqual(compatibility.kind, "mere.run/graph-compatibility")
+        XCTAssertEqual(compatibility.schemaVersion, 1)
+        XCTAssertEqual(validation.order, compatibility.canonicalFixture.executionOrder)
+        XCTAssertEqual(
+            try WorkflowBundleCodec.hash(graph),
+            compatibility.canonicalFixture.graphFingerprint
+        )
+        XCTAssertEqual(
+            try WorkflowBundleCodec.hash(WorkflowPortableInputFingerprint(inputs: inputs, assets: assets)),
+            compatibility.canonicalFixture.inputFingerprint
+        )
+    }
+
     func testValidGraphInfersStableDependencyOrder() throws {
         let graph = try decodeGraph("""
         {
@@ -1157,6 +1189,36 @@ final class WorkflowGraphTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+}
+
+private struct WorkflowCompatibilityFixture: Decodable {
+    let schemaVersion: Int
+    let kind: String
+    let canonicalFixture: CanonicalFixture
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case kind
+        case canonicalFixture = "canonical_fixture"
+    }
+
+    struct CanonicalFixture: Decodable {
+        let graph: String
+        let inputs: String
+        let assets: String
+        let graphFingerprint: String
+        let inputFingerprint: String
+        let executionOrder: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case graph
+            case inputs
+            case assets
+            case graphFingerprint = "graph_fingerprint"
+            case inputFingerprint = "input_fingerprint"
+            case executionOrder = "execution_order"
+        }
     }
 }
 

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -11,6 +11,89 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertNil(WorkflowExecutorProbe.parseNVIDIAMemoryBytes("not available\n"))
     }
 
+    func testLegacyWorkerProbeConservativelyDefaultsNewCapabilities() throws {
+        let probe = try WorkflowBundleCodec.decoder().decode(
+            WorkflowExecutorProbe.self,
+            from: Data("""
+            {
+              "schema_version": 1,
+              "worker_version": "0.22.0",
+              "contract_versions": ["mere.run/job-bundle.v1"],
+              "platform": "linux",
+              "architecture": "arm64",
+              "accelerator_backend": "cuda",
+              "memory_bytes": 1024,
+              "available_disk_bytes": null,
+              "node_kinds": [],
+              "installed_model_ids": [],
+              "providers": []
+            }
+            """.utf8)
+        )
+
+        XCTAssertEqual(probe.systemMemoryBytes, 0)
+        XCTAssertEqual(probe.logicalCPUCores, 0)
+        XCTAssertFalse(probe.networkAccess)
+        XCTAssertEqual(probe.availableSecretNames, [])
+    }
+
+    func testWorkerVersionCompatibilityBlocksBeforeSubmission() {
+        let probe = WorkflowExecutorProbe(
+            schemaVersion: 1,
+            workerVersion: "0.22.0",
+            contractVersions: [WorkflowJobManifest.contractVersion],
+            platform: "linux",
+            architecture: "x86_64",
+            acceleratorBackend: "cuda",
+            memoryBytes: 16_000,
+            availableDiskBytes: 100_000,
+            nodeKinds: ["image.generate"],
+            installedModelIDs: []
+        )
+        let requirements = WorkflowJobRequirements(
+            minimumMereRunVersion: "0.23.0",
+            nodeKinds: ["image.generate"],
+            modelIDs: [],
+            acceleratorBackends: ["cuda"],
+            minimumAcceleratorMemoryBytes: nil
+        )
+        let job = WorkflowJobManifest(
+            contractVersion: WorkflowJobManifest.contractVersion,
+            jobID: UUID().uuidString,
+            createdAt: Date(),
+            graphFingerprint: String(repeating: "a", count: 64),
+            inputFingerprint: String(repeating: "b", count: 64),
+            requirements: requirements,
+            outputs: []
+        )
+
+        XCTAssertFalse(workflowVersion(probe.workerVersion, satisfiesMinimum: requirements.minimumMereRunVersion))
+        XCTAssertThrowsError(try validateWorker(probe, for: job, executor: "ssh:legacy")) { error in
+            XCTAssertTrue(String(describing: error).contains("requires 0.23.0 or newer"))
+        }
+    }
+
+    func testJobRequirementsRoundTripNamedSecretsAndResourcesWithoutValues() throws {
+        let requirements = WorkflowJobRequirements(
+            minimumMereRunVersion: "0.23.0",
+            nodeKinds: ["private.publish"],
+            modelIDs: [],
+            secretNames: ["api-token"],
+            acceleratorBackends: ["cpu"],
+            minimumAcceleratorMemoryBytes: 1_024,
+            minimumSystemMemoryBytes: 2_048,
+            minimumDiskBytes: 4_096,
+            minimumCPUCores: 4,
+            networkAccess: true
+        )
+
+        let data = try WorkflowBundleCodec.encoder().encode(requirements)
+        let encoded = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(encoded.contains("api-token"))
+        XCTAssertFalse(encoded.contains("MERERUN_SECRET_API_TOKEN"))
+        XCTAssertEqual(try WorkflowBundleCodec.decoder().decode(WorkflowJobRequirements.self, from: data), requirements)
+    }
+
     func testDatasetDiscoveryRanksCompleteImageCaptionDirectories() throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -38,7 +121,11 @@ final class WorkflowGraphTests: XCTestCase {
     func testCanonicalWorkflowFixturesDecodeAndValidate() throws {
         let fixtures = try XCTUnwrap(Bundle.module.resourceURL)
             .appendingPathComponent("Fixtures/WorkflowGraphV1", isDirectory: true)
-        for name in ["lora-sample.workflow.json", "image-video.workflow.json"] {
+        for name in [
+            "lora-sample.workflow.json",
+            "image-video.workflow.json",
+            "parallel-image-video.workflow.json",
+        ] {
             let graph = try WorkflowGraphDocument.load(from: fixtures.appendingPathComponent(name))
             let inputs = WorkflowInputsDocument(values: graph.inputs.reduce(into: [:]) { values, input in
                 switch input.value.type {
@@ -94,6 +181,79 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(validation.status, .ok)
         XCTAssertEqual(validation.order, ["make-image", "make-video"])
         XCTAssertEqual(validation.dependencies["make-video"], ["make-image"])
+    }
+
+    func testParallelSchedulerOverlapsReadyNodesAndWaitsForDependencies() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = try decodeGraph("""
+        {
+          "schema_version": 1,
+          "kind": "mere.run/workflow-graph",
+          "name": "parallel-images",
+          "inputs": {},
+          "execution": {"max_parallel_nodes": 2},
+          "nodes": [
+            {"id": "image-a", "kind": "image.generate", "arguments": {"prompt": "first", "seed": 1}},
+            {"id": "image-b", "kind": "image.generate", "arguments": {"prompt": "second", "seed": 2}},
+            {
+              "id": "video",
+              "kind": "video.generate",
+              "depends_on": ["image-a", "image-b"],
+              "arguments": {"prompt": "finish", "image": {"$ref": "nodes.image-a.outputs.image"}, "seed": 3}
+            }
+          ],
+          "outputs": {"video": {"$ref": "nodes.video.outputs.video"}}
+        }
+        """)
+        let bundle = try WorkflowBundleMaterializer(
+            graph: graph,
+            suppliedInputs: .init(values: [:]),
+            destination: root.appendingPathComponent("bundle")
+        ).materialize()
+        let process = OverlapWorkflowProcessRunner()
+
+        let outcome = try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: root.appendingPathComponent("run"),
+            processRunner: process
+        ).execute()
+
+        XCTAssertEqual(outcome.state, .finished)
+        XCTAssertEqual(process.maximumActiveRuns, 2)
+        let firstWaveEnd = try XCTUnwrap([
+            process.interval(for: "image-a")?.end,
+            process.interval(for: "image-b")?.end,
+        ].compactMap { $0 }.max())
+        let dependentStart = try XCTUnwrap(process.interval(for: "video")?.start)
+        XCTAssertGreaterThanOrEqual(dependentStart, firstWaveEnd)
+    }
+
+    func testGraphParallelismAndSecretReferencesAreValidated() throws {
+        let invalid = try decodeGraph("""
+        {
+          "schema_version": 1,
+          "kind": "mere.run/workflow-graph",
+          "name": "invalid-parallelism",
+          "inputs": {},
+          "execution": {"max_parallel_nodes": 0},
+          "nodes": [{"id": "image", "kind": "image.generate", "arguments": {"prompt": "fixture"}}],
+          "outputs": {"image": {"$ref": "nodes.image.outputs.image"}}
+        }
+        """)
+        let validation = WorkflowGraphValidator.validate(graph: invalid, inputs: .init(values: [:]))
+        XCTAssertTrue(validation.diagnostics.contains { $0.id == "workflow_parallelism_invalid" })
+
+        let value = try JSONDecoder().decode(
+            WorkflowValue.self,
+            from: Data(#"{"$secret":"hugging-face-token"}"#.utf8)
+        )
+        XCTAssertEqual(value, .secretReference("hugging-face-token"))
+        XCTAssertEqual(value.secretNames, ["hugging-face-token"])
+        XCTAssertEqual(
+            workflowSecretEnvironmentKey("hugging-face-token"),
+            "MERERUN_SECRET_HUGGING_FACE_TOKEN"
+        )
     }
 
     func testReferenceAcceptsProviderOutputPortNamesWithUnderscores() throws {
@@ -1011,6 +1171,58 @@ private final class FixtureWorkflowProcessRunner: WorkflowProcessRunning {
         let output = URL(fileURLWithPath: arguments[outputIndex + 1])
         try FileManager.default.createDirectory(at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data([0x89, 0x50, 0x4e, 0x47]).write(to: output)
+        return WorkflowProcessResult(status: 0, stdout: "ok")
+    }
+}
+
+private final class OverlapWorkflowProcessRunner: WorkflowProcessRunning, @unchecked Sendable {
+    struct Interval {
+        let start: Date
+        let end: Date
+    }
+
+    private let lock = NSLock()
+    private var activeRuns = 0
+    private var maximumRuns = 0
+    private var intervals: [String: Interval] = [:]
+
+    var maximumActiveRuns: Int {
+        lock.withLock { maximumRuns }
+    }
+
+    func interval(for nodeID: String) -> Interval? {
+        lock.withLock { intervals[nodeID] }
+    }
+
+    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
+        if arguments.contains("--preflight") {
+            return WorkflowProcessResult(status: 0, stdout: "{}")
+        }
+        let nodeID = currentDirectory.lastPathComponent
+            .split(separator: "-", maxSplits: 1)
+            .last
+            .map(String.init) ?? currentDirectory.lastPathComponent
+        let start = Date()
+        lock.withLock {
+            activeRuns += 1
+            maximumRuns = max(maximumRuns, activeRuns)
+        }
+        Thread.sleep(forTimeInterval: 0.12)
+        guard let outputIndex = arguments.firstIndex(of: "--output"),
+              outputIndex + 1 < arguments.count else {
+            return WorkflowProcessResult(status: 2, stdout: "")
+        }
+        let output = URL(fileURLWithPath: arguments[outputIndex + 1])
+        try FileManager.default.createDirectory(
+            at: output.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data([0x01, 0x02, 0x03, 0x04]).write(to: output)
+        let end = Date()
+        lock.withLock {
+            activeRuns -= 1
+            intervals[nodeID] = Interval(start: start, end: end)
+        }
         return WorkflowProcessResult(status: 0, stdout: "ok")
     }
 }

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -3,6 +3,27 @@ import XCTest
 @testable import MereRunCLI
 
 final class WorkflowGraphTests: XCTestCase {
+    func testCatalogFieldRoundTripsStructuredValueSchema() throws {
+        let field = WorkflowNodeField(
+            name: "policy",
+            type: .json,
+            required: false,
+            valueSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "enabled": .object([
+                        "type": .string("boolean"),
+                        "default": .boolean(true),
+                    ]),
+                ]),
+            ])
+        )
+
+        let data = try WorkflowBundleCodec.encoder().encode(field)
+        XCTAssertTrue(String(decoding: data, as: UTF8.self).contains("value_schema"))
+        XCTAssertEqual(try WorkflowBundleCodec.decoder().decode(WorkflowNodeField.self, from: data), field)
+    }
+
     func testNVIDIAMemoryProbeParsesLargestGPU() {
         XCTAssertEqual(
             WorkflowExecutorProbe.parseNVIDIAMemoryBytes("8192\n16384 MiB\n"),

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -1173,6 +1173,134 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(job.placement?.nodes.first?.blockers.first?.code, "model_missing")
     }
 
+    func testRunJobExecutesTheVerifiedBundleWithoutMutatingIt() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bundle = try WorkflowBundleMaterializer(
+            graph: try singleImageGraph(),
+            suppliedInputs: .init(values: ["prompt": .string("fixture")]),
+            destination: root.appendingPathComponent("bundle"),
+            jobID: { UUID(uuidString: "00000000-0000-0000-0000-000000000123")! }
+        ).materialize()
+        let sourceDocuments = try portableBundleDocuments(at: bundle.directory)
+        let runDirectory = root.appendingPathComponent("local-run")
+        let command = try GraphRunJob.parse([
+            "--bundle", bundle.directory.path,
+            "--run-dir", runDirectory.path,
+        ])
+
+        let envelope = try command.makeEnvelope(processRunner: FixtureWorkflowProcessRunner())
+
+        XCTAssertEqual(envelope.command, ["graph", "run-job"])
+        XCTAssertEqual(envelope.result.state, .finished)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: bundle.directory.appendingPathComponent(GraphRunManifest.filename).path
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: runDirectory.appendingPathComponent(GraphRunManifest.filename).path
+        ))
+        XCTAssertEqual(try portableBundleDocuments(at: bundle.directory), sourceDocuments)
+        XCTAssertEqual(try portableBundleDocuments(at: runDirectory), sourceDocuments)
+    }
+
+    func testSubmitJobCopiesExactVerifiedBundleBytesBeforeTransport() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dataset = root.appendingPathComponent("dataset", isDirectory: true)
+        try FileManager.default.createDirectory(at: dataset, withIntermediateDirectories: true)
+        try Data([0x89, 0x50, 0x4e, 0x47]).write(to: dataset.appendingPathComponent("frame.png"))
+        try Data("caption".utf8).write(to: dataset.appendingPathComponent("frame.txt"))
+        let bundle = try WorkflowBundleMaterializer(
+            graph: try trainingGraph(),
+            suppliedInputs: .init(values: ["data": .string(dataset.path)]),
+            destination: root.appendingPathComponent("bundle"),
+            jobID: { UUID(uuidString: "00000000-0000-0000-0000-000000000456")! }
+        ).materialize()
+        let sourceDocuments = try portableBundleDocuments(at: bundle.directory)
+        let sourceAssets = try portableBundleAssets(at: bundle.directory)
+        let runDirectory = root.appendingPathComponent("remote-run")
+        let command = try GraphSubmitJob.parse([
+            "--bundle", bundle.directory.path,
+            "--executor", "relay:fixture",
+            "--run-dir", runDirectory.path,
+        ])
+        var submitted = false
+
+        let envelope = try await command.makeEnvelope(submitter: { reference, submittedBundle, submittedRun in
+            submitted = true
+            XCTAssertEqual(reference, "relay:fixture")
+            XCTAssertEqual(submittedBundle.path, runDirectory.standardizedFileURL.path)
+            XCTAssertEqual(submittedRun.path, runDirectory.standardizedFileURL.path)
+            XCTAssertEqual(try self.portableBundleDocuments(at: submittedBundle), sourceDocuments)
+            XCTAssertEqual(try self.portableBundleAssets(at: submittedBundle), sourceAssets)
+            return WorkflowRemoteJob(
+                jobID: bundle.job.jobID,
+                jobReference: "relay://fixture/\(bundle.job.jobID)",
+                state: .queued,
+                executor: reference,
+                runDirectory: submittedRun.path,
+                createdAt: bundle.job.createdAt,
+                updatedAt: bundle.job.createdAt,
+                artifacts: [],
+                error: nil,
+                placement: nil,
+                metrics: nil
+            )
+        })
+
+        XCTAssertTrue(submitted)
+        XCTAssertEqual(envelope.command, ["graph", "submit-job"])
+        XCTAssertEqual(envelope.result.jobReference, "relay://fixture/\(bundle.job.jobID)")
+        XCTAssertEqual(try portableBundleDocuments(at: bundle.directory), sourceDocuments)
+        XCTAssertEqual(try portableBundleDocuments(at: runDirectory), sourceDocuments)
+        XCTAssertEqual(try portableBundleAssets(at: bundle.directory), sourceAssets)
+        XCTAssertEqual(try portableBundleAssets(at: runDirectory), sourceAssets)
+    }
+
+    func testSubmitJobRejectsTamperedAndNestedBundlesBeforeTransport() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bundle = try WorkflowBundleMaterializer(
+            graph: try singleImageGraph(),
+            suppliedInputs: .init(values: ["prompt": .string("fixture")]),
+            destination: root.appendingPathComponent("bundle")
+        ).materialize()
+        var graph = try WorkflowGraphDocument.load(
+            from: bundle.directory.appendingPathComponent("graph.json")
+        )
+        graph = WorkflowGraphDocument(
+            schemaVersion: graph.schemaVersion,
+            kind: graph.kind,
+            name: "tampered",
+            inputs: graph.inputs,
+            nodes: graph.nodes,
+            outputs: graph.outputs,
+            metadata: graph.metadata
+        )
+        try WorkflowBundleCodec.write(graph, to: bundle.directory.appendingPathComponent("graph.json"))
+        var submitted = false
+        let command = try GraphSubmitJob.parse([
+            "--bundle", bundle.directory.path,
+            "--executor", "ssh:fixture",
+            "--run-dir", root.appendingPathComponent("run").path,
+        ])
+
+        do {
+            _ = try await command.makeEnvelope(submitter: { _, _, _ in
+                submitted = true
+                throw NSError(domain: "fixture", code: 1)
+            })
+            XCTFail("Expected tampered bundle validation to fail.")
+        } catch {
+            XCTAssertTrue(String(describing: error).contains("fingerprint"))
+        }
+        XCTAssertFalse(submitted)
+        XCTAssertThrowsError(try requireSeparateWorkflowDirectories(
+            bundle: bundle.directory,
+            run: bundle.directory.appendingPathComponent("run")
+        ))
+    }
+
     private func singleImageGraph() throws -> WorkflowGraphDocument {
         try decodeGraph("""
         {
@@ -1188,6 +1316,29 @@ final class WorkflowGraphTests: XCTestCase {
           "outputs": {"image": {"$ref": "nodes.generate.outputs.image"}}
         }
         """)
+    }
+
+    private func portableBundleDocuments(at directory: URL) throws -> [String: Data] {
+        try Dictionary(uniqueKeysWithValues: [
+            WorkflowJobManifest.filename,
+            "graph.json",
+            "inputs.json",
+            WorkflowAssetManifest.filename,
+        ].map { filename in
+            (filename, try Data(contentsOf: directory.appendingPathComponent(filename)))
+        })
+    }
+
+    private func portableBundleAssets(at directory: URL) throws -> [String: Data] {
+        let manifest = try WorkflowBundleCodec.decoder().decode(
+            WorkflowAssetManifest.self,
+            from: Data(contentsOf: directory.appendingPathComponent(WorkflowAssetManifest.filename))
+        )
+        return try Dictionary(uniqueKeysWithValues: Set(
+            manifest.groups.flatMap(\.entries).map(\.digest)
+        ).map { digest in
+            (digest, try Data(contentsOf: directory.appendingPathComponent("assets/sha256/\(digest)")))
+        })
     }
 
     private func trainingGraph() throws -> WorkflowGraphDocument {

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -309,6 +309,25 @@ final class WorkflowGraphTests: XCTestCase {
         )
     }
 
+    func testSecretBoundNodeDisablesResumeReuse() {
+        let secretBound = WorkflowNode(
+            id: "publish",
+            kind: "private.publish",
+            arguments: ["token": .secretReference("api-token")],
+            dependsOn: nil,
+            execution: .init(maxAttempts: nil, timeoutSeconds: nil, cache: .never)
+        )
+        let publicNode = WorkflowNode(
+            id: "publish",
+            kind: "private.publish",
+            arguments: ["message": .string("fixture")],
+            dependsOn: nil
+        )
+
+        XCTAssertFalse(workflowNodeAllowsResumeReuse(secretBound))
+        XCTAssertTrue(workflowNodeAllowsResumeReuse(publicNode))
+    }
+
     func testReferenceAcceptsProviderOutputPortNamesWithUnderscores() throws {
         let reference = try WorkflowReference("nodes.prepare-data.outputs.contact_sheet")
 
@@ -585,6 +604,57 @@ final class WorkflowGraphTests: XCTestCase {
                 atPath: root.appendingPathComponent("run/worker-child.pid").path
             )
         )
+    }
+
+    func testWorkflowChildRegistryCancelsAllParallelProcesses() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runDirectory = root.appendingPathComponent("run", isDirectory: true)
+        let nodeDirectories = ["000-first", "001-second"].map {
+            runDirectory.appendingPathComponent("nodes/\($0)", isDirectory: true)
+        }
+        for directory in nodeDirectories {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = nodeDirectories.count
+        let results = ParallelWorkflowProcessResults()
+        for directory in nodeDirectories {
+            queue.addOperation {
+                do {
+                    _ = try WorkflowProcessRunner().run(
+                        executable: URL(fileURLWithPath: "/bin/sleep"),
+                        arguments: ["30"],
+                        currentDirectory: directory,
+                        timeoutSeconds: 5,
+                        stdoutLineHandler: nil
+                    )
+                    results.record(failed: false)
+                } catch {
+                    results.record(failed: true)
+                }
+            }
+        }
+
+        let registrationDeadline = Date().addingTimeInterval(3)
+        while WorkflowChildProcessRegistry.processIDs(in: runDirectory).count < nodeDirectories.count,
+              Date() < registrationDeadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        let registered = WorkflowChildProcessRegistry.processIDs(in: runDirectory)
+        XCTAssertEqual(registered.count, nodeDirectories.count)
+
+        try Data().write(to: runDirectory.appendingPathComponent("cancel.request"), options: .atomic)
+        let terminated = WorkflowChildProcessRegistry.terminateAll(in: runDirectory)
+        queue.waitUntilAllOperationsAreFinished()
+
+        XCTAssertEqual(terminated, registered)
+        XCTAssertEqual(results.completionCount, nodeDirectories.count)
+        XCTAssertEqual(results.failureCount, nodeDirectories.count)
+        XCTAssertTrue(WorkflowChildProcessRegistry.processIDs(in: runDirectory).isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: runDirectory.appendingPathComponent(WorkflowChildProcessRegistry.legacyFilename).path
+        ))
     }
 
     func testMaterializationFreezesSeedAndCanonicalFingerprints() throws {
@@ -1466,6 +1536,27 @@ private final class OverlapWorkflowProcessRunner: WorkflowProcessRunning, @unche
             intervals[nodeID] = Interval(start: start, end: end)
         }
         return WorkflowProcessResult(status: 0, stdout: "ok")
+    }
+}
+
+private final class ParallelWorkflowProcessResults: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completions = 0
+    private var failures = 0
+
+    var completionCount: Int {
+        lock.withLock { completions }
+    }
+
+    var failureCount: Int {
+        lock.withLock { failures }
+    }
+
+    func record(failed: Bool) {
+        lock.withLock {
+            completions += 1
+            if failed { failures += 1 }
+        }
     }
 }
 

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -1089,12 +1089,17 @@ final class WorkflowGraphTests: XCTestCase {
     func testSSHFetchUsesExplicitRunDirectoryEntries() {
         let reports = SSHWorkflowExecutor.fetchRelativePaths(allArtifacts: false)
         let allArtifacts = SSHWorkflowExecutor.fetchRelativePaths(allArtifacts: true)
+        let selectedArtifactReports = SSHWorkflowExecutor.fetchRelativePaths(
+            allArtifacts: false,
+            includeOutputs: false
+        )
 
         XCTAssertTrue(reports.contains("outputs"))
         XCTAssertFalse(reports.contains("nodes"))
         XCTAssertTrue(allArtifacts.contains("nodes"))
         XCTAssertTrue(allArtifacts.contains("actions.json"))
         XCTAssertFalse(allArtifacts.contains("."))
+        XCTAssertFalse(selectedArtifactReports.contains("outputs"))
     }
 
     func testRemoteReferenceParsingIsStrict() throws {

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -96,6 +96,72 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(validation.dependencies["make-video"], ["make-image"])
     }
 
+    func testNodeExecutionPolicySurvivesPortableMaterialization() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = try singleImageGraph()
+        let sourceNode = try XCTUnwrap(source.nodes.first)
+        let graph = WorkflowGraphDocument(
+            schemaVersion: source.schemaVersion,
+            kind: source.kind,
+            name: source.name,
+            inputs: source.inputs,
+            nodes: [WorkflowNode(
+                id: sourceNode.id,
+                kind: sourceNode.kind,
+                provider: sourceNode.provider,
+                arguments: sourceNode.arguments,
+                dependsOn: sourceNode.dependsOn,
+                execution: .init(maxAttempts: 3, timeoutSeconds: 120, cache: .refresh)
+            )],
+            outputs: source.outputs,
+            metadata: source.metadata
+        )
+
+        let bundle = try WorkflowBundleMaterializer(
+            graph: graph,
+            suppliedInputs: .init(values: ["prompt": .string("fixture")]),
+            destination: root.appendingPathComponent("bundle"),
+            seed: { 77 }
+        ).materialize()
+
+        XCTAssertEqual(bundle.graph.nodes.first?.execution?.resolvedMaxAttempts, 3)
+        XCTAssertEqual(bundle.graph.nodes.first?.execution?.timeoutSeconds, 120)
+        XCTAssertEqual(bundle.graph.nodes.first?.execution?.resolvedCache, .refresh)
+        let roundTrip = try WorkflowGraphDocument.load(from: bundle.directory.appendingPathComponent("graph.json"))
+        XCTAssertEqual(roundTrip, bundle.graph)
+    }
+
+    func testInvalidNodeExecutionPolicyBlocksValidation() throws {
+        let source = try singleImageGraph()
+        let sourceNode = try XCTUnwrap(source.nodes.first)
+        let graph = WorkflowGraphDocument(
+            schemaVersion: source.schemaVersion,
+            kind: source.kind,
+            name: source.name,
+            inputs: source.inputs,
+            nodes: [WorkflowNode(
+                id: sourceNode.id,
+                kind: sourceNode.kind,
+                provider: sourceNode.provider,
+                arguments: sourceNode.arguments,
+                dependsOn: sourceNode.dependsOn,
+                execution: .init(maxAttempts: 0, timeoutSeconds: 0, cache: .automatic)
+            )],
+            outputs: source.outputs,
+            metadata: source.metadata
+        )
+
+        let validation = WorkflowGraphValidator.validate(
+            graph: graph,
+            inputs: .init(values: ["prompt": .string("fixture")])
+        )
+
+        XCTAssertEqual(validation.status, .blocked)
+        XCTAssertTrue(validation.diagnostics.contains { $0.id == "workflow_node_attempts_invalid_generate" })
+        XCTAssertTrue(validation.diagnostics.contains { $0.id == "workflow_node_timeout_invalid_generate" })
+    }
+
     func testDuplicateNodeIDsProduceDiagnosticsWithoutTrapping() throws {
         let graph = try decodeGraph("""
         {
@@ -264,6 +330,7 @@ final class WorkflowGraphTests: XCTestCase {
             executable: URL(fileURLWithPath: "/bin/sh"),
             arguments: ["-c", "printf 'fixture failure' >&2; exit 7"],
             currentDirectory: nodeDirectory,
+            timeoutSeconds: nil,
             stdoutLineHandler: nil
         )
 
@@ -271,6 +338,31 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(result.stderr, "fixture failure")
         XCTAssertEqual(result.terminationReason, .exit)
         XCTAssertEqual(result.failureSummary, "exited with status 7. stderr: fixture failure")
+    }
+
+    func testWorkflowChildEnforcesTimeout() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let nodeDirectory = root.appendingPathComponent("run/nodes/000-fixture", isDirectory: true)
+        try FileManager.default.createDirectory(at: nodeDirectory, withIntermediateDirectories: true)
+        let startedAt = Date()
+
+        XCTAssertThrowsError(try WorkflowProcessRunner().run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "sleep 30"],
+            currentDirectory: nodeDirectory,
+            timeoutSeconds: 1,
+            stdoutLineHandler: nil
+        )) { error in
+            XCTAssertEqual(error.localizedDescription, "Process timed out after 1 seconds.")
+        }
+
+        XCTAssertLessThan(Date().timeIntervalSince(startedAt), 5)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: root.appendingPathComponent("run/worker-child.pid").path
+            )
+        )
     }
 
     func testMaterializationFreezesSeedAndCanonicalFingerprints() throws {
@@ -495,6 +587,141 @@ final class WorkflowGraphTests: XCTestCase {
             manifest.error,
             "Node 'generate' preflight exited with status 255. stdout: fixture model failure."
         )
+    }
+
+    func testRunnerRetriesFailedNodeAndRecordsAttempt() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = try singleImageGraph()
+        let sourceNode = try XCTUnwrap(source.nodes.first)
+        let graph = WorkflowGraphDocument(
+            schemaVersion: source.schemaVersion,
+            kind: source.kind,
+            name: source.name,
+            inputs: source.inputs,
+            nodes: [WorkflowNode(
+                id: sourceNode.id,
+                kind: sourceNode.kind,
+                provider: sourceNode.provider,
+                arguments: sourceNode.arguments,
+                dependsOn: sourceNode.dependsOn,
+                execution: .init(maxAttempts: 2, timeoutSeconds: nil, cache: nil)
+            )],
+            outputs: source.outputs,
+            metadata: source.metadata
+        )
+        let bundle = try WorkflowBundleMaterializer(
+            graph: graph,
+            suppliedInputs: .init(values: ["prompt": .string("a lighthouse")]),
+            destination: root.appendingPathComponent("bundle"),
+            seed: { 99 }
+        ).materialize()
+        let runDirectory = root.appendingPathComponent("run")
+        let process = RetryingWorkflowProcessRunner()
+
+        let outcome = try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: runDirectory,
+            processRunner: process
+        ).execute()
+        let manifest = try WorkflowBundleCodec.decoder().decode(
+            GraphRunManifest.self,
+            from: Data(contentsOf: runDirectory.appendingPathComponent(GraphRunManifest.filename))
+        )
+        let events = try String(
+            contentsOf: runDirectory.appendingPathComponent("events.jsonl"),
+            encoding: .utf8
+        )
+        let eventRecords = try events.split(separator: "\n").map {
+            try WorkflowBundleCodec.decoder().decode(GraphRunEvent.self, from: Data($0.utf8))
+        }
+
+        XCTAssertEqual(outcome.state, .finished)
+        XCTAssertEqual(process.runCount, 2)
+        XCTAssertEqual(manifest.nodes.first?.attempt, 2)
+        XCTAssertEqual(manifest.nodes.first?.maxAttempts, 2)
+        XCTAssertEqual(manifest.nodes.first?.exitStatus, 0)
+        XCTAssertNil(manifest.nodes.first?.error)
+        XCTAssertTrue(eventRecords.contains { $0.type == "node_retrying" })
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: runDirectory
+                    .appendingPathComponent("nodes/000-generate/artifacts/partial.txt")
+                    .path
+            )
+        )
+    }
+
+    func testRunnerReusesVerifiedCrossRunCacheAndRepairsCorruption() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bundle = try WorkflowBundleMaterializer(
+            graph: singleImageGraph(),
+            suppliedInputs: .init(values: ["prompt": .string("a lighthouse")]),
+            destination: root.appendingPathComponent("bundle"),
+            seed: { 99 }
+        ).materialize()
+        let cacheDirectory = root.appendingPathComponent("cache", isDirectory: true)
+        let firstRun = root.appendingPathComponent("run-one", isDirectory: true)
+        let firstProcess = FixtureWorkflowProcessRunner()
+
+        XCTAssertEqual(try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: firstRun,
+            processRunner: firstProcess,
+            cacheDirectory: cacheDirectory
+        ).execute().state, .finished)
+        XCTAssertEqual(firstProcess.arguments.count, 2)
+        let firstManifest = try WorkflowBundleCodec.decoder().decode(
+            GraphRunManifest.self,
+            from: Data(contentsOf: firstRun.appendingPathComponent(GraphRunManifest.filename))
+        )
+        let fingerprint = try XCTUnwrap(firstManifest.nodes.first?.fingerprint)
+
+        let secondRun = root.appendingPathComponent("run-two", isDirectory: true)
+        let secondProcess = FixtureWorkflowProcessRunner()
+        XCTAssertEqual(try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: secondRun,
+            processRunner: secondProcess,
+            cacheDirectory: cacheDirectory
+        ).execute().state, .finished)
+        let secondManifest = try WorkflowBundleCodec.decoder().decode(
+            GraphRunManifest.self,
+            from: Data(contentsOf: secondRun.appendingPathComponent(GraphRunManifest.filename))
+        )
+        let secondEvents = try String(
+            contentsOf: secondRun.appendingPathComponent("events.jsonl"),
+            encoding: .utf8
+        ).split(separator: "\n").map {
+            try WorkflowBundleCodec.decoder().decode(GraphRunEvent.self, from: Data($0.utf8))
+        }
+
+        XCTAssertTrue(secondProcess.arguments.isEmpty)
+        XCTAssertEqual(secondManifest.nodes.first?.attempt, 0)
+        XCTAssertTrue(secondEvents.contains { $0.type == "node_cache_hit" })
+        XCTAssertEqual(secondManifest.outputs.first?.sha256, firstManifest.outputs.first?.sha256)
+
+        let cacheFiles = cacheDirectory
+            .appendingPathComponent(fingerprint, isDirectory: true)
+            .appendingPathComponent("files", isDirectory: true)
+        let cachedRelativePath = try XCTUnwrap(
+            FileManager.default.subpathsOfDirectory(atPath: cacheFiles.path).first { path in
+                (try? cacheFiles.appendingPathComponent(path).resourceValues(
+                    forKeys: [.isRegularFileKey]
+                ).isRegularFile) == true
+            }
+        )
+        try Data("corrupt".utf8).write(to: cacheFiles.appendingPathComponent(cachedRelativePath))
+
+        let repairedProcess = FixtureWorkflowProcessRunner()
+        XCTAssertEqual(try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: root.appendingPathComponent("run-three"),
+            processRunner: repairedProcess,
+            cacheDirectory: cacheDirectory
+        ).execute().state, .finished)
+        XCTAssertEqual(repairedProcess.arguments.count, 2)
     }
 
     func testResumeRequiresMatchingNodeFingerprintAndArtifactDigests() throws {
@@ -782,5 +1009,30 @@ private final class FixtureWorkflowProcessRunner: WorkflowProcessRunning {
 private struct FailingPreflightWorkflowProcessRunner: WorkflowProcessRunning {
     func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
         WorkflowProcessResult(status: 255, stdout: "fixture model failure")
+    }
+}
+
+private final class RetryingWorkflowProcessRunner: WorkflowProcessRunning {
+    private(set) var runCount = 0
+
+    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
+        if arguments.contains("--preflight") {
+            return WorkflowProcessResult(status: 0, stdout: "{}")
+        }
+        runCount += 1
+        guard let outputIndex = arguments.firstIndex(of: "--output"), outputIndex + 1 < arguments.count else {
+            return WorkflowProcessResult(status: 2, stdout: "")
+        }
+        let output = URL(fileURLWithPath: arguments[outputIndex + 1])
+        try FileManager.default.createDirectory(at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if runCount == 1 {
+            let artifacts = currentDirectory.appendingPathComponent("artifacts", isDirectory: true)
+            try FileManager.default.createDirectory(at: artifacts, withIntermediateDirectories: true)
+            try Data("partial".utf8).write(to: artifacts.appendingPathComponent("partial.txt"))
+            try Data("incomplete".utf8).write(to: output)
+            return WorkflowProcessResult(status: 75, stdout: "temporary failure")
+        }
+        try Data([0x89, 0x50, 0x4e, 0x47]).write(to: output)
+        return WorkflowProcessResult(status: 0, stdout: "ok")
     }
 }

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -974,7 +974,8 @@ final class WorkflowGraphTests: XCTestCase {
             invocations.append(arguments)
             switch arguments.first {
             case "tar":
-                try Data("archive".utf8).write(to: URL(fileURLWithPath: arguments[2]))
+                let archiveFlag = try XCTUnwrap(arguments.firstIndex(of: "-czf"))
+                try Data("archive".utf8).write(to: URL(fileURLWithPath: arguments[archiveFlag + 1]))
                 return .init(status: 0, stdout: "")
             case "scp":
                 return .init(status: 0, stdout: "")
@@ -1027,6 +1028,8 @@ final class WorkflowGraphTests: XCTestCase {
             $0.contains("BatchMode=yes") && $0.contains("-O") && $0.contains("-P")
         })
         XCTAssertTrue(scpCalls.contains { $0.contains(where: { $0.hasSuffix(asset.digest) }) })
+        let tarCall = try XCTUnwrap(invocations.first(where: { $0.first == "tar" }))
+        XCTAssertTrue(tarCall.contains("--no-xattrs"))
         XCTAssertEqual(shellQuote("a'b;$(touch nope)"), "'a'\\''b;$(touch nope)'")
     }
 

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -96,6 +96,15 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(validation.dependencies["make-video"], ["make-image"])
     }
 
+    func testReferenceAcceptsProviderOutputPortNamesWithUnderscores() throws {
+        let reference = try WorkflowReference("nodes.prepare-data.outputs.contact_sheet")
+
+        XCTAssertEqual(
+            reference.source,
+            .nodeOutput(nodeID: "prepare-data", output: "contact_sheet")
+        )
+    }
+
     func testNodeExecutionPolicySurvivesPortableMaterialization() throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/docs/public/schemas/graph-node-preflight.v1.schema.json
+++ b/docs/public/schemas/graph-node-preflight.v1.schema.json
@@ -31,7 +31,11 @@
       "properties": {
         "model_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
         "accelerator_backends": {"type": "array", "uniqueItems": true, "items": {"enum": ["metal", "cuda", "rocm", "cpu"]}},
-        "minimum_accelerator_memory_bytes": {"type": ["integer", "null"], "minimum": 0}
+        "minimum_accelerator_memory_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "minimum_system_memory_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "minimum_disk_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "minimum_cpu_cores": {"type": ["integer", "null"], "minimum": 1},
+        "network_access": {"type": ["boolean", "null"]}
       }
     }
   }

--- a/docs/public/schemas/graph-node-provider.v1.schema.json
+++ b/docs/public/schemas/graph-node-provider.v1.schema.json
@@ -34,6 +34,25 @@
     "port_type": {
       "enum": ["string", "integer", "number", "boolean", "enum", "json", "asset", "asset_directory", "asset_collection"]
     },
+    "value_schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {"enum": ["object", "array", "string", "integer", "number", "boolean", "enum"]},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "default": {"$ref": "#/$defs/value"},
+        "values": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}},
+        "properties": {"type": "object", "additionalProperties": {"$ref": "#/$defs/value_schema"}},
+        "required": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/id"}},
+        "items": {"$ref": "#/$defs/value_schema"},
+        "minimum": {"type": "number"},
+        "maximum": {"type": "number"},
+        "step": {"type": "number", "exclusiveMinimum": 0},
+        "multiline": {"type": "boolean"}
+      }
+    },
     "input": {
       "type": "object",
       "additionalProperties": false,
@@ -51,7 +70,8 @@
         "step": {"type": "number", "exclusiveMinimum": 0},
         "multiline": {"type": "boolean"},
         "secret": {"type": "boolean"},
-        "advanced": {"type": "boolean"}
+        "advanced": {"type": "boolean"},
+        "value_schema": {"$ref": "#/$defs/value_schema"}
       }
     },
     "output": {

--- a/docs/public/schemas/graph-node-provider.v1.schema.json
+++ b/docs/public/schemas/graph-node-provider.v1.schema.json
@@ -73,7 +73,11 @@
       "properties": {
         "model_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
         "accelerator_backends": {"type": "array", "uniqueItems": true, "items": {"enum": ["metal", "cuda", "rocm", "cpu"]}},
-        "minimum_accelerator_memory_bytes": {"type": ["integer", "null"], "minimum": 0}
+        "minimum_accelerator_memory_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "minimum_system_memory_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "minimum_disk_bytes": {"type": ["integer", "null"], "minimum": 0},
+        "minimum_cpu_cores": {"type": ["integer", "null"], "minimum": 1},
+        "network_access": {"type": ["boolean", "null"]}
       }
     },
     "traits": {

--- a/docs/public/schemas/graph-run-v1.schema.json
+++ b/docs/public/schemas/graph-run-v1.schema.json
@@ -94,6 +94,8 @@
         "started_at": { "type": ["string", "null"], "format": "date-time" },
         "completed_at": { "type": ["string", "null"], "format": "date-time" },
         "exit_status": { "type": ["integer", "null"] },
+        "attempt": { "type": "integer", "minimum": 0 },
+        "max_attempts": { "type": "integer", "minimum": 1, "maximum": 10 },
         "fingerprint": { "type": "string" },
         "provider": { "$ref": "#/$defs/provider" },
         "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },

--- a/docs/public/schemas/job-bundle-v1.schema.json
+++ b/docs/public/schemas/job-bundle-v1.schema.json
@@ -14,15 +14,20 @@
     "requirements": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["minimum_mere_run_version", "node_kinds", "model_ids", "models", "providers", "accelerator_backends"],
+      "required": ["minimum_mere_run_version", "node_kinds", "model_ids", "models", "providers", "secret_names", "accelerator_backends", "network_access"],
       "properties": {
         "minimum_mere_run_version": { "type": "string", "minLength": 1 },
         "node_kinds": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "model_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },
         "providers": { "type": "array", "items": { "$ref": "#/$defs/provider" } },
+        "secret_names": { "type": "array", "items": { "$ref": "#/$defs/id" }, "uniqueItems": true },
         "accelerator_backends": { "type": "array", "items": { "enum": ["metal", "cuda", "rocm", "cpu"] }, "uniqueItems": true },
-        "minimum_accelerator_memory_bytes": { "type": ["integer", "null"], "minimum": 0 }
+        "minimum_accelerator_memory_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "minimum_system_memory_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "minimum_disk_bytes": { "type": ["integer", "null"], "minimum": 0 },
+        "minimum_cpu_cores": { "type": ["integer", "null"], "minimum": 1 },
+        "network_access": { "type": "boolean" }
       }
     },
     "outputs": {
@@ -33,12 +38,13 @@
         "required": ["name", "reference"],
         "properties": {
           "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
-          "reference": { "type": "string", "pattern": "^nodes\\.[a-z][a-z0-9-]{0,63}\\.outputs\\.[a-z][a-z0-9-]{0,63}$" }
+          "reference": { "type": "string", "pattern": "^nodes\\.[a-z][a-z0-9-]{0,63}\\.outputs\\.[a-z][a-z0-9_]{0,63}$" }
         }
       }
     }
   },
   "$defs": {
+    "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
     "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "model": {
       "type": "object",

--- a/docs/public/schemas/worker-probe-v1.schema.json
+++ b/docs/public/schemas/worker-probe-v1.schema.json
@@ -13,9 +13,13 @@
     "architecture": { "type": "string" },
     "accelerator_backend": { "enum": ["metal", "cuda", "rocm", "cpu", "unknown", "mixed"] },
     "memory_bytes": { "type": "integer", "minimum": 0 },
+    "system_memory_bytes": { "type": "integer", "minimum": 0 },
+    "logical_cpu_cores": { "type": "integer", "minimum": 0 },
     "available_disk_bytes": { "type": ["integer", "null"], "minimum": 0 },
+    "network_access": { "type": "boolean" },
     "node_kinds": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
     "installed_model_ids": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+    "available_secret_names": { "type": "array", "items": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" }, "uniqueItems": true },
     "providers": { "type": "array", "items": { "$ref": "#/$defs/provider" } }
   },
   "$defs": {

--- a/docs/public/schemas/workflow-graph-v1.schema.json
+++ b/docs/public/schemas/workflow-graph-v1.schema.json
@@ -75,7 +75,17 @@
         "kind": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}(\\.[a-z][a-z0-9-]{0,63})+$" },
         "provider": { "type": "string", "pattern": "^(mere\\.run|mere-[a-z0-9-]+)$" },
         "arguments": { "type": "object", "additionalProperties": { "$ref": "#/$defs/value" } },
-        "depends_on": { "type": "array", "items": { "$ref": "#/$defs/id" }, "uniqueItems": true }
+        "depends_on": { "type": "array", "items": { "$ref": "#/$defs/id" }, "uniqueItems": true },
+        "execution": { "$ref": "#/$defs/execution" }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_attempts": { "type": "integer", "minimum": 1, "maximum": 10 },
+        "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 604800 },
+        "cache": { "enum": ["auto", "never", "refresh"] }
       }
     },
     "port_type": {

--- a/docs/public/schemas/workflow-graph-v1.schema.json
+++ b/docs/public/schemas/workflow-graph-v1.schema.json
@@ -24,6 +24,7 @@
       "propertyNames": { "$ref": "#/$defs/id" },
       "additionalProperties": { "$ref": "#/$defs/reference" }
     },
+    "execution": { "$ref": "#/$defs/graph_execution" },
     "metadata": {
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/value" }
@@ -42,6 +43,14 @@
         }
       }
     },
+    "secret_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["$secret"],
+      "properties": {
+        "$secret": { "$ref": "#/$defs/id" }
+      }
+    },
     "value": {
       "anyOf": [
         { "type": "null" },
@@ -51,6 +60,7 @@
         { "type": "boolean" },
         { "type": "array", "items": { "$ref": "#/$defs/value" } },
         { "$ref": "#/$defs/reference" },
+        { "$ref": "#/$defs/secret_reference" },
         { "type": "object", "additionalProperties": { "$ref": "#/$defs/value" } }
       ]
     },
@@ -86,6 +96,13 @@
         "max_attempts": { "type": "integer", "minimum": 1, "maximum": 10 },
         "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 604800 },
         "cache": { "enum": ["auto", "never", "refresh"] }
+      }
+    },
+    "graph_execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_parallel_nodes": { "type": "integer", "minimum": 1, "maximum": 32 }
       }
     },
     "port_type": {

--- a/docs/public/schemas/workflow-graph-v1.schema.json
+++ b/docs/public/schemas/workflow-graph-v1.schema.json
@@ -38,7 +38,7 @@
       "properties": {
         "$ref": {
           "type": "string",
-          "pattern": "^(inputs\\.[a-z][a-z0-9-]{0,63}|nodes\\.[a-z][a-z0-9-]{0,63}\\.outputs\\.[a-z][a-z0-9-]{0,63})$"
+          "pattern": "^(inputs\\.[a-z][a-z0-9-]{0,63}|nodes\\.[a-z][a-z0-9-]{0,63}\\.outputs\\.[a-z][a-z0-9_]{0,63})$"
         }
       }
     },

--- a/docs/public/schemas/workflow-graph-v1.schema.json
+++ b/docs/public/schemas/workflow-graph-v1.schema.json
@@ -47,9 +47,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["$secret"],
-      "properties": {
-        "$secret": { "$ref": "#/$defs/id" }
-      }
+      "properties": { "$secret": { "$ref": "#/$defs/id" } }
     },
     "value": {
       "anyOf": [

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -309,6 +309,7 @@ and reused bytes and parts.
 mere.run run inspect relay://fleet/<job-id> --json
 mere.run run watch relay://fleet/<job-id> --json-stream
 mere.run run fetch relay://fleet/<job-id> --into ./runs/job --json
+mere.run run fetch relay://fleet/<job-id> --into ./runs/job --artifact sample --artifact adapter --json
 mere.run run fetch relay://fleet/<job-id> --into ./runs/job --all-artifacts --json
 mere.run run cancel relay://fleet/<job-id> --json
 mere.run run retry relay://fleet/<job-id> --json
@@ -318,7 +319,10 @@ mere.run run list --executor relay:fleet --limit 50 --json
 Fetch verifies artifact size and SHA-256 and materializes the same local
 run-directory shape. The default fetch includes reports, manifests, and final
 outputs; `--all-artifacts` also includes node artifacts. Explicit relay retry
-uses the same immutable bundle and resolved seeds.
+uses the same immutable bundle and resolved seeds. Repeat `--artifact` to fetch
+only named artifacts; an already-present file with the declared size and
+SHA-256 is reused, so retrying an interrupted fetch continues from verified
+local results. `--artifact` and `--all-artifacts` are mutually exclusive.
 
 Queued relay jobs include a typed placement report in `run inspect --json`.
 It identifies every connected device and reports concrete blockers such as a

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -129,6 +129,34 @@ assets.json
 assets/sha256/<digest>
 ```
 
+An exported bundle can be executed directly without materializing the source
+graph again. The bundle remains immutable and the mutable run record must use a
+separate, non-nested directory:
+
+```bash
+mere.run graph run-job \
+  --bundle ./job-bundle \
+  --run-dir ./runs/local \
+  --json
+
+mere.run graph submit-job \
+  --bundle ./job-bundle \
+  --executor ssh:gpu-box \
+  --run-dir ./runs/ssh \
+  --json
+
+mere.run graph submit-job \
+  --bundle ./job-bundle \
+  --executor relay:fleet \
+  --run-dir ./runs/relay \
+  --json
+```
+
+All four portable documents and every content-addressed asset are verified
+before execution or transport. This is the acceptance path for proving that
+local, SSH, and Relay consume the same resolved seeds, fingerprints, manifests,
+and asset bytes.
+
 The job pins each companion provider by ID, semantic version, catalog SHA-256,
 and node kinds. It also records managed model repository, revision, and catalog
 identity. At execution time the run record adds the installed model manifest
@@ -152,6 +180,12 @@ execution, resource, and secret fields during canonical fingerprint checks.
 mere.run graph run workflow.json \
   --inputs-json inputs.json \
   --run-dir ./runs/job \
+  --json
+
+mere.run graph run-job \
+  --bundle ./job-bundle \
+  --run-dir ./runs/exported-job \
+  --resume \
   --json
 
 mere.run graph run workflow.json \
@@ -274,6 +308,12 @@ mere.run graph submit workflow.json \
   --executor ssh:gpu-box \
   --run-dir ./runs/job \
   --json
+
+mere.run graph submit-job \
+  --bundle ./job-bundle \
+  --executor ssh:gpu-box \
+  --run-dir ./runs/exported-ssh-job \
+  --json
 ```
 
 SSH uses the system `ssh` and `scp`, `BatchMode=yes`, and normal host-key
@@ -289,6 +329,12 @@ mere.run graph submit workflow.json \
   --inputs-json inputs.json \
   --executor relay:fleet \
   --run-dir ./runs/job \
+  --json
+
+mere.run graph submit-job \
+  --bundle ./job-bundle \
+  --executor relay:fleet \
+  --run-dir ./runs/exported-relay-job \
   --json
 ```
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -23,6 +23,11 @@ References add dependency edges automatically. `depends_on` adds ordering-only
 edges. Validation blocks cycles, duplicate IDs, missing references, unknown node
 kinds, type mismatches, and incompatible artifact content types.
 
+Independent ready nodes may run concurrently when the graph declares
+`execution.max_parallel_nodes` from 1 through 32. The default remains one, and
+all scheduling, event commits, and final outputs retain stable topological order.
+Each node may independently set retry, timeout, and cache policy.
+
 The V1 node catalog contains:
 
 - `image.train-lora`
@@ -58,6 +63,13 @@ preview, determinism, caching, and side-effect traits. `mere.run` validates the
 catalog and invokes only these fixed verbs. A plugin manifest cannot inject a
 command template.
 
+Providers may also declare minimum accelerator memory, system memory, free disk,
+CPU cores, and network access. Secret fields accept only a named binding such as
+`{"$secret":"hugging-face-token"}`. Values are resolved from
+`MERERUN_SECRET_HUGGING_FACE_TOKEN` only inside the executing worker process;
+secret values never enter graphs, bundles, fingerprints, reports, events, or
+Relay payloads. Secret-bound nodes must disable caching.
+
 Inspect the exact typed fields and output descriptors with:
 
 ```bash
@@ -86,7 +98,8 @@ mere.run graph preflight workflow.json --inputs-json inputs.json --executor rela
 Validation is executor-independent. Preflight combines graph diagnostics with a
 worker capability probe, including contract version, node kinds, installed
 models, exact provider versions and catalog digests, accelerator backend,
-memory, and available disk. Missing models produce declarative pull actions; V1
+accelerator and system memory, CPU capacity, available disk, network access, and
+named secret availability. Missing models produce declarative pull actions; V1
 never pulls models automatically on a worker.
 
 ## Portable job bundles
@@ -127,6 +140,12 @@ content-addressed. Symlinks, device files, path traversal, and files escaping a
 declared directory root are rejected. Executor profiles, tokens, URLs, and
 machine paths never enter the bundle.
 
+Bundles pin their minimum compatible `mere.run` worker version. Preflight and
+submission reject older SSH or Relay workers before transfer or queueing; the
+worker repeats the check before execution. Graphs materialized by this release
+require `mere.run` 0.23.0 or newer because older workers do not preserve the new
+execution, resource, and secret fields during canonical fingerprint checks.
+
 ## Local execution
 
 ```bash
@@ -142,11 +161,18 @@ mere.run graph run workflow.json \
   --json
 ```
 
-Nodes run sequentially in stable topological order and fail fast. Every node is
+Nodes run in stable topological order and fail fast. Graphs are sequential by
+default; an explicit graph parallelism limit allows independent ready nodes to
+overlap without changing dependency semantics. Every node is
 adapted to deterministic public CLI arguments and launched as an isolated
 `mere.run` child process. The runner captures structured stdout, preserves
 diagnostic stderr, records exit status, verifies every declared artifact, and
 honors a cooperative cancellation marker.
+
+Node execution policy supports bounded retries, hard subprocess timeouts, and a
+cross-run content-addressed cache. Cache keys include normalized arguments,
+provider identity, model provenance, and directly referenced artifact digests.
+`cache: refresh` recomputes and replaces an entry; `cache: never` bypasses it.
 
 `--resume` reuses a finished node only when its provider pin, normalized
 arguments, exact model provenance, directly referenced upstream outputs, and


### PR DESCRIPTION
## Summary

- add deterministic parallel DAG scheduling with stable event/output commit order
- add bounded node retries, timeouts, verified cross-run caching, and cache corruption repair
- add typed resource requirements and named secret bindings without persisting secret values
- extend worker probes and executor preflight with system memory, CPU, disk, network, and secret capabilities
- require the post-0.22 `mere.run` 0.23.0 worker before transfer or queueing
- publish updated schemas and a canonical cross-runtime parallel graph fixture
- suppress macOS archive metadata during SSH bundle transport

## Validation

- `./scripts/check.sh`
- 1,872 Swift tests passed; 116 model-dependent tests skipped
- all GitHub Swift, Linux CLI, macOS bundle, docs, dependency, and security checks passed
- local Metal graph job `3075c86a-3ea4-4ae7-b304-030e611669c4` ran under `mere.run 0.23.0` and produced SHA-256 `4b846579a8f5df077b0f23a587ae708948e65a70f931418c26c96e146916e509`
- live SSH CUDA worker probe reported `mere.run 0.23.0`, 16 GB accelerator memory, 64 GB system memory, 20 CPUs, and installed Krea models
- cold SSH job `ssh://tensor-v23/3046ff6d-29b8-44b0-bb19-6d9a9ff63989` completed real GPU inference and fetched a verified 92,740-byte PNG
- repeat SSH job `ssh://tensor-v23/249175aa-b3c0-43d8-a8f5-80dc2877ddb5` emitted `node_cache_hit`
- post-fix SSH job `ssh://tensor-v23/a1c4854d-c8fc-47dd-9a08-fc1c02e634c2` completed without extended-attribute tar warnings
- local and SSH runs report the same graph fingerprint `1319da6c74c3beb61d45d13e6f3ae9f87cdaf2122b62a3ff22ebece2f914323e`

## Boundaries

Provider infrastructure remains outside this OSS repository. Graph authoring, reusable composition, provider SDKs, and Comfy import live in `mere-run-plugins`; hosted scheduling remains in `relay-mere-run`.
