### PR TITLE
Fix legacy Z-Image install resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on Keep a Changelog.
   can execute unchanged through local, SSH, and Relay while mutable run state
   remains in a separate directory.
 
+### Fixed
+
+- fixed canonical `image-zimage-nano` resolution for valid managed installs
+  created from the current mflux mirror's legacy `@main` manifest.
+
 ## 0.22.0 - 2026-07-17
 
 ### Added

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2440,6 +2440,9 @@ public extension ManagedModelSpec {
            installedRepo == expectedWithRevision {
             return true
         }
+        if installedRepo == "\(expectedRepo)@\(ZImageTurboRepository.revision)" {
+            return true
+        }
         return false
     }
 

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -786,6 +786,30 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(report.warnings.isEmpty)
     }
 
+    func testZImageNanoResolvesLegacyMainManifestThroughManagedSymlink() throws {
+        let modelsRoot = try makeTemporaryDirectory()
+        let snapshotRoot = try makeTemporaryDirectory()
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? FileManager.default.removeItem(at: modelsRoot)
+            try? FileManager.default.removeItem(at: snapshotRoot)
+        }
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+        try writeMinimalMFluxZImageNano(
+            at: snapshotRoot,
+            upstreamRepoId: "filipstrand/Z-Image-Turbo-mflux-4bit@main"
+        )
+        try FileManager.default.createSymbolicLink(
+            at: modelsRoot.appendingPathComponent("image-zimage-nano", isDirectory: true),
+            withDestinationURL: snapshotRoot
+        )
+
+        let resolved = try XCTUnwrap(ModelResolver().resolveIfPresent(.zetaNano))
+        XCTAssertEqual(resolved.modelID, .zetaNano)
+        XCTAssertEqual(resolved.source, .localModelStore)
+        XCTAssertEqual(resolved.rootURL.resolvingSymlinksInPath(), snapshotRoot.resolvingSymlinksInPath())
+    }
+
     func testBonsaiTernaryAcceptsPrismMLPackedLayout() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary
- accept the current Z-Image mflux mirror legacy `@main` manifest alongside the pinned source
- preserve rejection of stale mirror manifests
- cover the canonical symlinked managed-model resolution path

## Verification
- `./scripts/check.sh` (1,881 tests passed, 116 fixture-dependent skips, 0 failures)
- rebuilt `mere.run model info image-zimage-nano --json` resolves the real installed model
- rebuilt canonical `image generate --model image-zimage-nano` completed against the installed 5.9 GB checkpoint on Metal