### PR TITLE
Add canonical Gemma 4 tool continuations and MLX release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ The format is based on Keep a Changelog.
   answers after one- and two-tool chains against real checkpoints.
 - added a pinned `mlx-vlm` conversion script for reproducing the current Gemma
   4 12B affine 4-bit MLX artifact directly from Google's verified dense
-  checkpoint without modifying an installed managed model.
+  checkpoint without modifying an installed managed model, published the
+  audited conversion as `Sawfwair/gemma-4-12B-it-MLX-4bit@v1.0.0`, and pinned
+  managed compact Gemma pulls to the exact hosted release commit.
 - expanded portable workflow graphs with deterministic parallel scheduling,
   bounded retries and timeouts, verified cross-run caching, resource and named
   secret contracts, reusable plugin-side composition, and stricter executor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added checksum-gated canonical Gemma 4 chat templates, typed assistant
+  tool-call and tool-response history, and a deterministic
+  `model benchmark tool-continuations` lane for validating grounded final
+  answers after one- and two-tool chains against real checkpoints.
+- added a pinned `mlx-vlm` conversion script for reproducing the current Gemma
+  4 12B affine 4-bit MLX artifact directly from Google's verified dense
+  checkpoint without modifying an installed managed model.
 - expanded portable workflow graphs with deterministic parallel scheduling,
   bounded retries and timeouts, verified cross-run caching, resource and named
   secret contracts, reusable plugin-side composition, and stricter executor

--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ swift run mere.run model benchmark chat --json
 # Small tool-call eval: synthetic Mere tools, parsed tool names/arguments only
 swift run mere.run model benchmark tool-calls --json
 
+# Gemma4 tool-result continuation: one- and two-tool chains against a real checkpoint
+swift run mere.run model benchmark tool-continuations --log-responses --json
+
 # Tiny synthetic VLM eval: Gemma4 12B vision chat vs existing Qwen3-VL inspect backend
 swift run mere.run model benchmark vlm --json
 

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -2341,11 +2341,52 @@ enum APIServerContract {
 
         let imageURL = try firstImageURL(from: msg, capabilities: capabilities)
         let content = renderMessageContent(msg)
+        let toolCalls = try chatMessageToolCalls(from: msg)
         return ChatMessage(
             role: role,
             content: content,
-            imageUrl: imageURL
+            imageUrl: imageURL,
+            reasoningContent: msg.reasoning_content,
+            name: msg.name,
+            toolCallID: msg.tool_call_id,
+            toolCalls: toolCalls
         )
+    }
+
+    private static func chatMessageToolCalls(
+        from message: OpenAIChatMessage
+    ) throws -> [ChatMessageToolCall]? {
+        guard message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "assistant",
+              let openAIToolCalls = message.tool_calls,
+              !openAIToolCalls.isEmpty else {
+            return nil
+        }
+
+        return try openAIToolCalls.compactMap { toolCall in
+            guard toolCall.type == "function", let function = toolCall.function else {
+                return nil
+            }
+            guard let data = function.arguments.data(using: .utf8) else {
+                throw APIRequestValidationError.invalidField(
+                    "messages.tool_calls.function.arguments",
+                    "must be a UTF-8 JSON object"
+                )
+            }
+            let arguments: [String: OpenAIJSONValue]
+            do {
+                arguments = try JSONDecoder().decode([String: OpenAIJSONValue].self, from: data)
+            } catch {
+                throw APIRequestValidationError.invalidField(
+                    "messages.tool_calls.function.arguments",
+                    "must be a JSON object"
+                )
+            }
+            return ChatMessageToolCall(
+                id: toolCall.id,
+                name: function.name,
+                arguments: arguments
+            )
+        }
     }
 
     private static func firstImageURL(

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -14,6 +14,7 @@ struct ModelBenchmark: ParsableCommand {
         subcommands: [
             ModelBenchmarkChat.self,
             ModelBenchmarkToolCalls.self,
+            ModelBenchmarkToolContinuations.self,
             ModelBenchmarkCode.self,
             ModelBenchmarkGemma4KV.self,
             ModelBenchmarkGemma4MTP.self,

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkToolContinuationsCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkToolContinuationsCommand.swift
@@ -1,0 +1,341 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ModelBenchmarkToolContinuations: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tool-continuations",
+        abstract: "Evaluate Gemma 4 continuation after completed tool calls."
+    )
+
+    @Option(name: [.long], help: "Managed Gemma 4 model id.")
+    var model: String = Gemma4Resources.twelveB4BitModelId
+
+    @Option(name: [.long], help: "Override the Gemma 4 model root.")
+    var modelRoot: String?
+
+    @Option(name: [.long], help: "Maximum generated tokens per case.")
+    var maxTokens: Int = 96
+
+    @Option(name: [.long], help: "Maximum context tokens passed to the runtime.")
+    var contextSize: Int?
+
+    @Flag(name: [.long], help: "Print the benchmark plan without loading the model.")
+    var dryRun: Bool = false
+
+    @Flag(name: [.long], help: "Include model responses in the report.")
+    var logResponses: Bool = false
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json: Bool = false
+
+    func validate() throws {
+        guard maxTokens > 0 else {
+            throw ValidationError("--max-tokens must be greater than zero.")
+        }
+        if let contextSize {
+            guard contextSize > 0 else {
+                throw ValidationError("--context-size must be greater than zero.")
+            }
+        }
+        guard Gemma4Resources.handles(modelSpec: model) else {
+            throw ValidationError("--model must identify a Gemma 4 model.")
+        }
+        if let modelRoot {
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: modelRoot, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                throw ValidationError("--model-root must be an existing directory.")
+            }
+        }
+    }
+
+    func run() async throws {
+        let plan = ToolContinuationBenchmarkPlan(
+            model: model,
+            modelRoot: modelRoot,
+            cases: ToolContinuationBenchmarkCase.cases.map(\.caseID),
+            maxTokens: maxTokens,
+            contextSize: contextSize
+        )
+        if dryRun {
+            try printReport(ToolContinuationBenchmarkReport(plan: plan, result: nil))
+            return
+        }
+
+        try MLXBundleSupport.ensureAvailable(quiet: json)
+        let resolvedRoot = try resolveModelRoot()
+        let generator = Gemma4Generator(modelId: model)
+        var caseResults: [ToolContinuationBenchmarkCaseResult] = []
+        for benchmarkCase in ToolContinuationBenchmarkCase.cases {
+            caseResults.append(
+                await runCase(
+                    benchmarkCase,
+                    modelPath: resolvedRoot.path,
+                    generator: generator
+                )
+            )
+        }
+        await generator.unload()
+
+        let result = ToolContinuationBenchmarkModelResult(
+            model: model,
+            modelPath: resolvedRoot.path,
+            cases: caseResults
+        )
+        try printReport(ToolContinuationBenchmarkReport(plan: plan, result: result))
+    }
+
+    private func resolveModelRoot() throws -> URL {
+        if let modelRoot {
+            return URL(fileURLWithPath: modelRoot, isDirectory: true).standardizedFileURL
+        }
+        guard let installed = ManagedModelResolver.resolveInstalledModel(id: model) else {
+            throw ValidationError(
+                "Model is not installed. Run `\(CLICommandDisplay.modelPullCommand(for: model))` first."
+            )
+        }
+        return installed
+    }
+
+    private func runCase(
+        _ benchmarkCase: ToolContinuationBenchmarkCase,
+        modelPath: String,
+        generator: Gemma4Generator
+    ) async -> ToolContinuationBenchmarkCaseResult {
+        let request = ChatRequest(
+            messages: benchmarkCase.messages,
+            maxTokens: maxTokens,
+            temperature: 0,
+            topP: 1,
+            showThinking: false,
+            stopOnEOS: true,
+            maxContextTokens: contextSize
+        )
+        let start = Date()
+        do {
+            let response = try await generator.chat(
+                request,
+                modelPath: modelPath,
+                progressHandler: nil
+            )
+            let elapsed = Date().timeIntervalSince(start)
+            let evaluation = benchmarkCase.evaluate(response)
+            return ToolContinuationBenchmarkCaseResult(
+                caseID: benchmarkCase.caseID,
+                passed: evaluation.failedChecks.isEmpty,
+                failedChecks: evaluation.failedChecks,
+                generationSeconds: elapsed,
+                promptTokens: response.promptTokens,
+                completionTokens: response.tokensGenerated,
+                response: logResponses ? response.response : nil,
+                error: nil
+            )
+        } catch {
+            return ToolContinuationBenchmarkCaseResult(
+                caseID: benchmarkCase.caseID,
+                passed: false,
+                failedChecks: ["generation failed"],
+                generationSeconds: Date().timeIntervalSince(start),
+                promptTokens: nil,
+                completionTokens: 0,
+                response: nil,
+                error: String(describing: error)
+            )
+        }
+    }
+
+    private func printReport(_ report: ToolContinuationBenchmarkReport) throws {
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            print(String(decoding: try encoder.encode(report), as: UTF8.self))
+        } else {
+            print(report.renderText())
+        }
+    }
+}
+
+private struct ToolContinuationBenchmarkCase {
+    let caseID: String
+    let messages: [ChatMessage]
+    let requiredFragments: [String]
+    let forbiddenFragments: [String]
+
+    func evaluate(_ response: ChatResponse) -> ToolContinuationBenchmarkEvaluation {
+        let normalized = response.response.lowercased()
+        var failures: [String] = []
+        for fragment in requiredFragments where !normalized.contains(fragment.lowercased()) {
+            failures.append("missing response fragment: \(fragment)")
+        }
+        for fragment in forbiddenFragments where normalized.contains(fragment.lowercased()) {
+            failures.append("forbidden response fragment: \(fragment)")
+        }
+        if response.toolCalls?.isEmpty == false {
+            failures.append("model called another tool after completed tool results")
+        }
+        return ToolContinuationBenchmarkEvaluation(failedChecks: failures)
+    }
+
+    static let cases = [
+        ToolContinuationBenchmarkCase(
+            caseID: "Gemma4ToolContinuation/0",
+            messages: [
+                ChatMessage(
+                    role: .system,
+                    content: "Use completed tool results as authoritative. Do not call another tool. Answer briefly."
+                ),
+                ChatMessage(role: .user, content: "Check order A-17 and tell me its status."),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    reasoningContent: "I need the order record.",
+                    toolCalls: [
+                        ChatMessageToolCall(
+                            id: "call_order",
+                            name: "lookup_order",
+                            arguments: [
+                                "order_id": .string("A-17"),
+                                "include_eta": .bool(false),
+                                "metadata": .object(["source": .null]),
+                            ]
+                        ),
+                    ]
+                ),
+                ChatMessage(
+                    role: .tool,
+                    content: #"{"order_id":"A-17","status":"ready for pickup"}"#,
+                    name: "lookup_order",
+                    toolCallID: "call_order"
+                ),
+            ],
+            requiredFragments: ["A-17", "ready for pickup"],
+            forbiddenFragments: ["shipped", "<|tool_call>"]
+        ),
+        ToolContinuationBenchmarkCase(
+            caseID: "Gemma4ToolContinuation/1",
+            messages: [
+                ChatMessage(
+                    role: .system,
+                    content: "Use completed tool results as authoritative. Do not call another tool. Answer briefly."
+                ),
+                ChatMessage(role: .user, content: "What is the Halifax weather in Fahrenheit?"),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    reasoningContent: "First I need current weather.",
+                    toolCalls: [
+                        ChatMessageToolCall(
+                            id: "call_weather",
+                            name: "get_weather",
+                            arguments: [
+                                "city": .string("Halifax"),
+                                "units": .string("celsius"),
+                            ]
+                        ),
+                    ]
+                ),
+                ChatMessage(
+                    role: .tool,
+                    content: #"{"temperature_c":10,"condition":"rainy"}"#,
+                    name: "get_weather",
+                    toolCallID: "call_weather"
+                ),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    reasoningContent: "Now convert 10 Celsius.",
+                    toolCalls: [
+                        ChatMessageToolCall(
+                            id: "call_convert",
+                            name: "convert_temperature",
+                            arguments: [
+                                "value": .number(10),
+                                "from": .string("celsius"),
+                                "to": .string("fahrenheit"),
+                            ]
+                        ),
+                    ]
+                ),
+                ChatMessage(
+                    role: .tool,
+                    content: #"{"value":50}"#,
+                    name: "convert_temperature",
+                    toolCallID: "call_convert"
+                ),
+            ],
+            requiredFragments: ["Halifax", "50", "rain"],
+            forbiddenFragments: ["<|tool_call>"]
+        ),
+    ]
+}
+
+private struct ToolContinuationBenchmarkEvaluation {
+    let failedChecks: [String]
+}
+
+private struct ToolContinuationBenchmarkPlan: Encodable {
+    let model: String
+    let modelRoot: String?
+    let cases: [String]
+    let maxTokens: Int
+    let contextSize: Int?
+}
+
+private struct ToolContinuationBenchmarkReport: Encodable {
+    let plan: ToolContinuationBenchmarkPlan
+    let result: ToolContinuationBenchmarkModelResult?
+
+    func renderText() -> String {
+        var lines = [
+            "Gemma 4 tool-continuation benchmark",
+            "model: \(plan.model)",
+            "cases: \(plan.cases.joined(separator: ", "))",
+        ]
+        guard let result else {
+            lines.append("dry run: no model loaded and no generations run")
+            return lines.joined(separator: "\n")
+        }
+        lines.append("result: \(result.passCount)/\(result.cases.count) cases passed")
+        for benchmarkCase in result.cases {
+            lines.append(benchmarkCase.renderText())
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+private struct ToolContinuationBenchmarkModelResult: Encodable {
+    let model: String
+    let modelPath: String
+    let cases: [ToolContinuationBenchmarkCaseResult]
+
+    var passCount: Int {
+        cases.filter(\.passed).count
+    }
+}
+
+private struct ToolContinuationBenchmarkCaseResult: Encodable {
+    let caseID: String
+    let passed: Bool
+    let failedChecks: [String]
+    let generationSeconds: Double
+    let promptTokens: Int?
+    let completionTokens: Int
+    let response: String?
+    let error: String?
+
+    func renderText() -> String {
+        let status = passed ? "pass" : "fail"
+        var line = "  \(status) \(caseID) gen=\(String(format: "%.2f", generationSeconds))s"
+        if !failedChecks.isEmpty {
+            line += " [\(failedChecks.joined(separator: "; "))]"
+        }
+        if let error {
+            line += " error=\(error)"
+        }
+        if let response {
+            line += " response=\(response.replacingOccurrences(of: "\n", with: " "))"
+        }
+        return line
+    }
+}

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -332,7 +332,11 @@ struct TextChat: AsyncParsableCommand {
                     CLIStderr.write(cleanResponse(textBeforeTools, showThinking: request.showThinking) + "\n")
                 }
 
-                loopMessages.append(ChatMessage(role: .assistant, content: result.response))
+                loopMessages.append(ChatMessage(
+                    role: .assistant,
+                    content: result.response,
+                    reasoningContent: result.reasoningContent
+                ))
 
                 for call in calls {
                     if !quiet { CLIStderr.write("[tool] \(call.name)(\(call.arguments.map { "\($0.key)=\($0.value.prefix(80))" }.joined(separator: ", ")))\n") }
@@ -353,7 +357,7 @@ struct TextChat: AsyncParsableCommand {
                         output = "Denied: tool execution was not approved."
                     }
                     if !quiet { CLIStderr.write("[tool] → \(output.prefix(200))\n") }
-                    loopMessages.append(ChatMessage(role: .tool, content: output))
+                    loopMessages.append(ChatMessage(role: .tool, content: output, name: call.name))
                 }
 
                 if !quiet { CLIStderr.write("[tool-loop] Iteration \(iteration + 1)/\(maxIterations)\n") }

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -102,6 +102,18 @@ mere.run model benchmark vlm \
   --json
 ```
 
+## Gemma4 Tool-Continuation Benchmark
+
+Validate grounded continuation after completed Gemma 4 tool calls:
+
+```bash
+mere.run model benchmark tool-continuations --log-responses
+```
+
+The cases cover typed nested/null arguments, reasoning preservation, tool-call
+ids, tool names, and a repeated two-tool chain. `--model-root` accepts a local
+converted Gemma 4 directory without changing the managed installation.
+
 ## Gemma4 KV Benchmark
 
 `model benchmark gemma4-kv` runs a fixed-token comparison for the selected

--- a/Sources/MereRunCore/Gemma4/Gemma4CanonicalChatTemplate.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4CanonicalChatTemplate.swift
@@ -1,0 +1,129 @@
+import Crypto
+import Foundation
+
+enum Gemma4CanonicalChatTemplate {
+    enum Variant: String, Sendable {
+        case e4b
+        case standard
+
+        var resourceName: String {
+            switch self {
+            case .e4b:
+                "chat_template_e4b_2026-07-15"
+            case .standard:
+                "chat_template_standard_2026-07-15"
+            }
+        }
+
+        var expectedSHA256: String {
+            switch self {
+            case .e4b:
+                "0a2c8073c878ab1da004bee933a998606537bbb62016310352c7285c3f01c5b5"
+            case .standard:
+                "ae53464bf3be25802b3a5b37def7fd89667067d7577049b3b2d74c4d8de4c6d4"
+            }
+        }
+    }
+
+    struct Selection: Sendable {
+        let variant: Variant
+        let template: String
+    }
+
+    private static let staleTemplateSHA256s = Set([
+        "36e3a42e5cf14cd0020e72d92e1fdd9970f59b82170e421f0cbe1bb42bead3f0",
+    ])
+
+    static func override(
+        for rootURL: URL,
+        fileManager: FileManager = .default,
+        recognizedStaleTemplateSHA256s: Set<String> = staleTemplateSHA256s
+    ) throws -> Selection? {
+        let templateURL = rootURL.appending(path: "chat_template.jinja")
+        guard fileManager.fileExists(atPath: templateURL.path) else {
+            return nil
+        }
+
+        let installedTemplate = try Data(contentsOf: templateURL)
+        guard recognizedStaleTemplateSHA256s.contains(sha256(installedTemplate)) else {
+            return nil
+        }
+
+        let configURL = rootURL.appending(path: "config.json")
+        let config = try JSONDecoder().decode(
+            Profile.self,
+            from: Data(contentsOf: configURL)
+        )
+        guard let variant = variant(for: config.textConfig) else {
+            return nil
+        }
+
+        let resourceURL = Bundle.module.url(
+            forResource: variant.resourceName,
+            withExtension: "jinja",
+            subdirectory: "Gemma4"
+        ) ?? Bundle.module.url(
+            forResource: variant.resourceName,
+            withExtension: "jinja"
+        )
+        guard let resourceURL else {
+            throw Error.missingBundledTemplate(variant)
+        }
+
+        let resourceData = try Data(contentsOf: resourceURL)
+        guard sha256(resourceData) == variant.expectedSHA256 else {
+            throw Error.invalidBundledTemplate(variant)
+        }
+        guard let template = String(data: resourceData, encoding: .utf8) else {
+            throw Error.invalidBundledTemplate(variant)
+        }
+        return Selection(variant: variant, template: template)
+    }
+
+    private static func variant(for config: Profile.TextConfig) -> Variant? {
+        switch (config.hiddenSize, config.numHiddenLayers) {
+        case (2_560, 42):
+            .e4b
+        case (2_816, 30), (3_840, 48), (5_376, 60):
+            .standard
+        default:
+            nil
+        }
+    }
+
+    private static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private struct Profile: Decodable {
+        let textConfig: TextConfig
+
+        private enum CodingKeys: String, CodingKey {
+            case textConfig = "text_config"
+        }
+
+        struct TextConfig: Decodable {
+            let hiddenSize: Int
+            let numHiddenLayers: Int
+
+            private enum CodingKeys: String, CodingKey {
+                case hiddenSize = "hidden_size"
+                case numHiddenLayers = "num_hidden_layers"
+            }
+        }
+    }
+
+    enum Error: LocalizedError {
+        case missingBundledTemplate(Variant)
+        case invalidBundledTemplate(Variant)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingBundledTemplate(let variant):
+                "Bundled canonical Gemma 4 chat template is missing for \(variant.rawValue)."
+            case .invalidBundledTemplate(let variant):
+                "Bundled canonical Gemma 4 chat template failed checksum or UTF-8 validation for \(variant.rawValue)."
+            }
+        }
+    }
+}

--- a/Sources/MereRunCore/Gemma4/Gemma4Resources.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Resources.swift
@@ -12,7 +12,8 @@ public struct Gemma4Resources: Sendable, Hashable {
     public static let maxUpstreamModelId = "google/gemma-4-31B-it"
     public static let turboUpstreamModelId = "mlx-community/gemma-4-26b-a4b-it-nvfp4"
     public static let twelveBUpstreamModelId = "google/gemma-4-12B-it"
-    public static let twelveB4BitUpstreamModelId = "mlx-community/gemma-4-12B-it-4bit"
+    public static let twelveB4BitUpstreamModelId = "Sawfwair/gemma-4-12B-it-MLX-4bit"
+    public static let twelveB4BitUpstreamRevision = "0d75fd929a55a29ea3d431b43b2ab5142a6566bf"
     public static let defaultUpstreamModelId = maxUpstreamModelId
     public static let defaultContextLength = 32_768
     public static let defaultKVGroupSize = 64
@@ -38,6 +39,7 @@ public struct Gemma4Resources: Sendable, Hashable {
         "video_preprocessor_config.json",
         "chat_template.jinja",
         "chat_template.json",
+        "MERERUN_CONVERSION.json",
         "model.safetensors",
         "model.safetensors.index.json",
         "*.safetensors",

--- a/Sources/MereRunCore/Gemma4/Gemma4TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TokenizerAndTemplate.swift
@@ -8,19 +8,44 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
     public let eosTokenId: Int?
     public let turnTokenId: Int?
     public let toolCallEndTokenId: Int?
+    let canonicalChatTemplateVariant: Gemma4CanonicalChatTemplate.Variant?
 
-    public init(
+    private let chatTemplateOverride: String?
+
+    public convenience init(
         tokenizer: any Tokenizer,
         maxLength: Int,
         eosTokenId: Int?,
         turnTokenId: Int?,
         toolCallEndTokenId: Int? = nil
     ) {
+        self.init(
+            tokenizer: tokenizer,
+            maxLength: maxLength,
+            eosTokenId: eosTokenId,
+            turnTokenId: turnTokenId,
+            toolCallEndTokenId: toolCallEndTokenId,
+            chatTemplateOverride: nil,
+            canonicalChatTemplateVariant: nil
+        )
+    }
+
+    private init(
+        tokenizer: any Tokenizer,
+        maxLength: Int,
+        eosTokenId: Int?,
+        turnTokenId: Int?,
+        toolCallEndTokenId: Int?,
+        chatTemplateOverride: String?,
+        canonicalChatTemplateVariant: Gemma4CanonicalChatTemplate.Variant?
+    ) {
         self.tokenizer = tokenizer
         self.maxLength = maxLength
         self.eosTokenId = eosTokenId
         self.turnTokenId = turnTokenId
         self.toolCallEndTokenId = toolCallEndTokenId
+        self.chatTemplateOverride = chatTemplateOverride
+        self.canonicalChatTemplateVariant = canonicalChatTemplateVariant
     }
 
     public static func load(
@@ -28,6 +53,7 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
         maxLengthOverride: Int? = nil,
         hubApi: HubApi = .shared
     ) async throws -> Gemma4TokenizerAndTemplate {
+        let canonicalTemplate = try Gemma4CanonicalChatTemplate.override(for: rootURL)
         let tokenizer = try await AutoTokenizer.from(modelFolder: rootURL, hubApi: hubApi)
         let tokenizerConfigURL = rootURL.appending(path: "tokenizer_config.json")
 
@@ -47,7 +73,9 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
             maxLength: maxLength,
             eosTokenId: tokenizer.eosTokenId,
             turnTokenId: tokenizer.convertTokenToId("<turn|>"),
-            toolCallEndTokenId: tokenizer.convertTokenToId("<tool_call|>")
+            toolCallEndTokenId: tokenizer.convertTokenToId("<tool_call|>"),
+            chatTemplateOverride: canonicalTemplate?.template,
+            canonicalChatTemplateVariant: canonicalTemplate?.variant
         )
     }
 
@@ -64,7 +92,7 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
 
         var encoded = try tokenizer.applyChatTemplate(
             messages: renderedMessages,
-            chatTemplate: nil,
+            chatTemplate: chatTemplateOverride.map { .literal($0) },
             addGenerationPrompt: addGenerationPrompt,
             truncation: false,
             maxLength: nil,
@@ -114,31 +142,54 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
 
         switch message.role {
         case .assistant:
-            let toolCalls = Gemma4ToolParser.parseToolCalls(message.content)
-            if !toolCalls.isEmpty {
+            if let toolCalls = message.toolCalls, !toolCalls.isEmpty {
                 let renderedToolCalls: [[String: any Sendable]] = toolCalls.map { call in
-                    [
+                    var renderedCall: [String: any Sendable] = [
                         "function": [
                             "name": call.name,
-                            "arguments": call.arguments,
+                            "arguments": renderArguments(call.arguments),
                         ] as [String: any Sendable],
                     ]
+                    if let id = call.id, !id.isEmpty {
+                        renderedCall["id"] = id
+                    }
+                    return renderedCall
                 }
                 rendered["tool_calls"] = renderedToolCalls
-
                 let content = stripToolCalls(from: message.content)
                 if !content.isEmpty {
                     rendered["content"] = content
                 }
             } else {
-                rendered["content"] = renderContent(for: message)
+                let parsedToolCalls = Gemma4ToolParser.parseToolCalls(message.content)
+                if !parsedToolCalls.isEmpty {
+                    rendered["tool_calls"] = parsedToolCalls.map { call in
+                        [
+                            "function": [
+                                "name": call.name,
+                                "arguments": call.arguments,
+                            ] as [String: any Sendable],
+                        ]
+                    }
+                    let content = stripToolCalls(from: message.content)
+                    if !content.isEmpty {
+                        rendered["content"] = content
+                    }
+                } else {
+                    rendered["content"] = renderContent(for: message)
+                }
+            }
+            if let reasoningContent = message.reasoningContent, !reasoningContent.isEmpty {
+                rendered["reasoning_content"] = reasoningContent
             }
         case .tool:
-            let toolResponses: [[String: any Sendable]] = [[
-                "name": "tool",
-                "response": message.content,
-            ]]
-            rendered["tool_responses"] = toolResponses
+            rendered["content"] = renderContent(for: message)
+            if let name = message.name, !name.isEmpty {
+                rendered["name"] = name
+            }
+            if let toolCallID = message.toolCallID, !toolCallID.isEmpty {
+                rendered["tool_call_id"] = toolCallID
+            }
         default:
             rendered["content"] = renderContent(for: message)
         }
@@ -164,6 +215,29 @@ public final class Gemma4TokenizerAndTemplate: @unchecked Sendable {
                 options: .regularExpression
             )
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func renderArguments(
+        _ arguments: [String: OpenAIJSONValue]
+    ) -> [String: any Sendable] {
+        arguments.mapValues(renderJSONValue)
+    }
+
+    private static func renderJSONValue(_ value: OpenAIJSONValue) -> any Sendable {
+        switch value {
+        case .string(let value):
+            value
+        case .number(let value):
+            value
+        case .bool(let value):
+            value
+        case .object(let value):
+            value.mapValues(renderJSONValue)
+        case .array(let value):
+            value.map(renderJSONValue)
+        case .null:
+            Optional<String>.none
+        }
     }
 }
 

--- a/Sources/MereRunCore/Gemma4/README.md
+++ b/Sources/MereRunCore/Gemma4/README.md
@@ -4,9 +4,16 @@ Gemma 4 chat model runtime and tokenizer/template support.
 
 - `Gemma4Config.swift`: typed text model configuration.
 - `Gemma4TokenizerAndTemplate.swift`: chat-template and tokenizer boundary.
+- `Gemma4CanonicalChatTemplate.swift`: checksum-gated canonical-template overlay
+  for known stale Google/MLX model packages. The E4B generation primer remains
+  separate from the shared 12B/26B/31B template.
 - `Gemma4Model.swift`: native model layers.
 - `Gemma4Generator.swift`: `ChatGenerator` integration.
 - `Gemma4ToolParser.swift`: tool-call parsing.
 
 Keep OpenAI-style tool/message adaptation typed before passing into tokenizer
 library boundaries.
+
+Canonical templates are applied only when the package template has the exact
+known-stale SHA-256 and the decoded model profile matches a released Gemma 4
+shape. Current or custom package templates remain authoritative.

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -143,6 +143,18 @@ public extension ImageGenerator {
 
 // MARK: - Chat Types
 
+public struct ChatMessageToolCall: Sendable, Hashable, Codable {
+    public var id: String?
+    public var name: String
+    public var arguments: [String: OpenAIJSONValue]
+
+    public init(id: String? = nil, name: String, arguments: [String: OpenAIJSONValue]) {
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+    }
+}
+
 public struct ChatMessage: Sendable, Hashable, Codable {
     public enum Role: String, Sendable, Hashable, Codable {
         case system
@@ -154,11 +166,27 @@ public struct ChatMessage: Sendable, Hashable, Codable {
     public var role: Role
     public var content: String
     public var imageUrl: String?
+    public var reasoningContent: String?
+    public var name: String?
+    public var toolCallID: String?
+    public var toolCalls: [ChatMessageToolCall]?
 
-    public init(role: Role, content: String, imageUrl: String? = nil) {
+    public init(
+        role: Role,
+        content: String,
+        imageUrl: String? = nil,
+        reasoningContent: String? = nil,
+        name: String? = nil,
+        toolCallID: String? = nil,
+        toolCalls: [ChatMessageToolCall]? = nil
+    ) {
         self.role = role
         self.content = content
         self.imageUrl = imageUrl
+        self.reasoningContent = reasoningContent
+        self.name = name
+        self.toolCallID = toolCallID
+        self.toolCalls = toolCalls
     }
 }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -949,11 +949,13 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
                 repoId: Gemma4Resources.twelveB4BitUpstreamModelId,
+                revision: Gemma4Resources.twelveB4BitUpstreamRevision,
                 patterns: Gemma4Resources.snapshotPatterns
             ),
             upstreamRepoId: Gemma4Resources.twelveB4BitUpstreamModelId,
+            upstreamRevision: Gemma4Resources.twelveB4BitUpstreamRevision,
             validationKind: .gemma4,
-            estimatedDownloadBytes: 12 * 1_073_741_824,
+            estimatedDownloadBytes: 6_773_374_762,
             defaultCLICommands: ["text chat", "api serve"],
             companionModelIDs: [Gemma4MTPResources.modelId]
         ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -843,7 +843,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 defaults: nil,
                 supports: [.chat, .codeGeneration],
                 components: gemma4TextComponents,
-                upstreamRepoId: Gemma4Resources.twelveB4BitUpstreamModelId,
+                upstreamRepoId: Gemma4Resources.twelveB4BitUpstreamModelId
+                    + "@\(Gemma4Resources.twelveB4BitUpstreamRevision)",
                 createdAt: createdAt
             )
         case .ltxGemma3TwelveB4Bit:

--- a/Sources/MereRunCore/Resources/Gemma4/chat_template_e4b_2026-07-15.jinja
+++ b/Sources/MereRunCore/Resources/Gemma4/chat_template_e4b_2026-07-15.jinja
@@ -1,0 +1,386 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/Sources/MereRunCore/Resources/Gemma4/chat_template_standard_2026-07-15.jinja
+++ b/Sources/MereRunCore/Resources/Gemma4/chat_template_standard_2026-07-15.jinja
@@ -1,0 +1,390 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,6 +6,17 @@ extra bootstrap step.
 
 It also includes small third-party evaluation fixtures where noted below.
 
+It includes Google's two canonical Gemma 4 chat-template variants published on
+2026-07-15. They are bundled as small runtime resources so known stale model
+packages can receive Google's tool-calling and turn-closure fixes without
+re-downloading unchanged weights. The E4B template comes from
+`google/gemma-4-E4B-it` at revision
+`fa62d88df2e6df5efa9d26ad6b3beaea2765f0cd`; the shared 12B/26B/31B template
+comes from `google/gemma-4-12B-it` at revision
+`12ace6d648d72bd41519e140f1185f34d38c7e3d`. Both upstream model repositories
+identify Google as the template author and publish the model artifacts under
+their accompanying Gemma terms.
+
 Some native runtime implementations are ports of upstream open-source model
 code; those source-derived implementations are noted below as well.
 

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -2054,6 +2054,95 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.messages[0].content, "Follow repo rules.")
     }
 
+    func testChatRequestPreservesReasoningAndToolCorrelationFields() throws {
+        let request = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [
+                OpenAIChatMessage(
+                    role: "assistant",
+                    content: "Working...",
+                    reasoning_content: "I should write the file.",
+                    tool_calls: [
+                        OpenAIChatToolCall(
+                            id: "call_123",
+                            function: OpenAIChatToolCallFunction(
+                                name: "write_file",
+                                arguments: #"{"path":"note.txt","overwrite":false}"#
+                            )
+                        ),
+                    ]
+                ),
+                OpenAIChatMessage(
+                    role: "tool",
+                    content: "Wrote 4 bytes.",
+                    name: "write_file",
+                    tool_call_id: "call_123"
+                ),
+            ]
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: RuntimeServingEngine.textChatGemma4.openAICompatibility
+        )
+
+        XCTAssertEqual(chatRequest.messages[0].reasoningContent, "I should write the file.")
+        XCTAssertEqual(
+            chatRequest.messages[0].toolCalls,
+            [
+                ChatMessageToolCall(
+                    id: "call_123",
+                    name: "write_file",
+                    arguments: [
+                        "path": .string("note.txt"),
+                        "overwrite": .bool(false),
+                    ]
+                ),
+            ]
+        )
+        XCTAssertEqual(chatRequest.messages[1].name, "write_file")
+        XCTAssertEqual(chatRequest.messages[1].toolCallID, "call_123")
+    }
+
+    func testChatRequestRejectsInvalidToolCallArguments() {
+        let request = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [
+                OpenAIChatMessage(
+                    role: "assistant",
+                    tool_calls: [
+                        OpenAIChatToolCall(
+                            id: "call_123",
+                            function: OpenAIChatToolCallFunction(
+                                name: "write_file",
+                                arguments: "not-json"
+                            )
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        XCTAssertThrowsError(
+            try APIServerContract.chatRequest(
+                from: request,
+                fallbackLoraPath: nil,
+                contextSize: 4_096,
+                capabilities: RuntimeServingEngine.textChatGemma4.openAICompatibility
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? APIRequestValidationError,
+                .invalidField(
+                    "messages.tool_calls.function.arguments",
+                    "must be a JSON object"
+                )
+            )
+        }
+    }
+
     func testChatRequestMapsSupportedStopSequences() throws {
         let single = OpenAIChatRequest(
             model: "mererun-test-model",

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -23,6 +23,11 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertTrue(commandNames.contains("tool-calls"))
     }
 
+    func testBenchmarkCommandExposesToolContinuationsSubcommand() {
+        let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("tool-continuations"))
+    }
+
     func testBenchmarkCommandExposesCodeSubcommand() {
         let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertTrue(commandNames.contains("code"))

--- a/Tests/MereRunCoreTests/Gemma4TokenizerAndTemplateTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4TokenizerAndTemplateTests.swift
@@ -2,28 +2,160 @@ import XCTest
 @testable import MereRunCore
 
 final class Gemma4TokenizerAndTemplateTests: MereRunCoreTestCase {
-    func testRenderMessagesEncodesToolResponsesForToolRole() {
+    private static let fixtureTemplateSHA256 =
+        "e5173c5f6afb445d9ff38060e6a2b15c3323fdbe20bb72552dcdfbf410c74a11"
+
+    func testChatMessageDecodesPayloadWithoutAgentMetadata() throws {
+        let data = Data(#"{"role":"user","content":"hello"}"#.utf8)
+        let message = try JSONDecoder().decode(ChatMessage.self, from: data)
+
+        XCTAssertEqual(message, ChatMessage(role: .user, content: "hello"))
+    }
+
+    func testUpdatedUpstreamTemplateRendersToolResponse() async throws {
+        guard let modelRoot = ProcessInfo.processInfo.environment["MERERUN_GEMMA4_TEMPLATE_TEST_ROOT"] else {
+            throw XCTSkip("Set MERERUN_GEMMA4_TEMPLATE_TEST_ROOT to a tokenizer-only Gemma 4 model root.")
+        }
+
+        let tokenizer = try await Gemma4TokenizerAndTemplate.load(
+            from: URL(fileURLWithPath: modelRoot, isDirectory: true)
+        )
         let messages = [
             ChatMessage(role: .user, content: "Write the file."),
-            ChatMessage(role: .tool, content: "Wrote 4 bytes to /tmp/note.txt"),
+            ChatMessage(
+                role: .assistant,
+                content: "Working...",
+                reasoningContent: "I should write the requested file.",
+                toolCalls: [
+                    ChatMessageToolCall(
+                        id: "call_123",
+                        name: "write_file",
+                        arguments: [
+                            "path": .string("note.txt"),
+                            "overwrite": .bool(false),
+                            "metadata": .object([
+                                "source": .null,
+                            ]),
+                            "tags": .array([
+                                .string("draft"),
+                            ]),
+                        ]
+                    ),
+                ]
+            ),
+            ChatMessage(
+                role: .tool,
+                content: "Wrote 4 bytes to note.txt",
+                name: "write_file",
+                toolCallID: "call_123"
+            ),
+        ]
+
+        let tokens = try tokenizer.encodeForGeneration(
+            messages: messages,
+            addGenerationPrompt: true,
+            includeThinking: true,
+            maxLength: 4_096
+        )
+        let rendered = tokenizer.decode(tokens: tokens)
+
+        XCTAssertTrue(rendered.contains("call:write_file"), rendered)
+        XCTAssertTrue(rendered.contains("note.txt"), rendered)
+        XCTAssertTrue(rendered.contains("overwrite"), rendered)
+        XCTAssertTrue(rendered.contains("false"), rendered)
+        XCTAssertTrue(rendered.contains("source"), rendered)
+        XCTAssertTrue(rendered.contains("null"), rendered)
+        XCTAssertTrue(rendered.contains("draft"), rendered)
+        XCTAssertTrue(rendered.contains("response:write_file"), rendered)
+        XCTAssertTrue(rendered.contains("Wrote 4 bytes to note.txt"), rendered)
+        XCTAssertFalse(rendered.contains("response:unknown{value:null}"), rendered)
+    }
+
+    func testCanonicalTemplateOverlaySelectsStandardVariantFor12B() throws {
+        let modelRoot = try makeTemplateModelRoot(hiddenSize: 3_840, numHiddenLayers: 48)
+        defer { try? FileManager.default.removeItem(at: modelRoot) }
+
+        let selection = try Gemma4CanonicalChatTemplate.override(
+            for: modelRoot,
+            recognizedStaleTemplateSHA256s: [Self.fixtureTemplateSHA256]
+        )
+
+        XCTAssertEqual(selection?.variant, .standard)
+        XCTAssertTrue(selection?.template.contains("Google Gemma 4 Canonical Chat Template") == true)
+        XCTAssertTrue(selection?.template.contains("tool_calls[].function.arguments") == true)
+        XCTAssertTrue(selection?.template.contains("JSON object (mapping)") == true)
+    }
+
+    func testCanonicalTemplateOverlayKeepsE4BGenerationPrimerSeparate() throws {
+        let modelRoot = try makeTemplateModelRoot(hiddenSize: 2_560, numHiddenLayers: 42)
+        defer { try? FileManager.default.removeItem(at: modelRoot) }
+
+        let selection = try Gemma4CanonicalChatTemplate.override(
+            for: modelRoot,
+            recognizedStaleTemplateSHA256s: [Self.fixtureTemplateSHA256]
+        )
+
+        XCTAssertEqual(selection?.variant, .e4b)
+        XCTAssertFalse(selection?.template.contains("<|channel>thought\n<channel|>") == true)
+    }
+
+    func testCanonicalTemplateOverlayPreservesCustomTemplate() throws {
+        let modelRoot = try makeTemplateModelRoot(hiddenSize: 3_840, numHiddenLayers: 48)
+        defer { try? FileManager.default.removeItem(at: modelRoot) }
+
+        let selection = try Gemma4CanonicalChatTemplate.override(for: modelRoot)
+
+        XCTAssertNil(selection)
+    }
+
+    func testCanonicalTemplateOverlayRejectsUnknownModelProfile() throws {
+        let modelRoot = try makeTemplateModelRoot(hiddenSize: 1_024, numHiddenLayers: 12)
+        defer { try? FileManager.default.removeItem(at: modelRoot) }
+
+        let selection = try Gemma4CanonicalChatTemplate.override(
+            for: modelRoot,
+            recognizedStaleTemplateSHA256s: [Self.fixtureTemplateSHA256]
+        )
+
+        XCTAssertNil(selection)
+    }
+
+    func testRenderMessagesPreservesOpenAIToolResponseFields() {
+        let messages = [
+            ChatMessage(role: .user, content: "Write the file."),
+            ChatMessage(
+                role: .tool,
+                content: "Wrote 4 bytes to /tmp/note.txt",
+                name: "write_file",
+                toolCallID: "call_123"
+            ),
         ]
 
         let rendered = Gemma4TokenizerAndTemplate.renderMessages(messages)
         let toolMessage = tryCastDictionary(rendered[1])
-        let responses = tryCastArray(toolMessage["tool_responses"])
-        let firstResponse = tryCastDictionary(responses[0])
 
         XCTAssertEqual(toolMessage["role"] as? String, "tool")
-        XCTAssertNil(toolMessage["content"])
-        XCTAssertEqual(firstResponse["name"] as? String, "tool")
-        XCTAssertEqual(firstResponse["response"] as? String, "Wrote 4 bytes to /tmp/note.txt")
+        XCTAssertEqual(toolMessage["content"] as? String, "Wrote 4 bytes to /tmp/note.txt")
+        XCTAssertEqual(toolMessage["name"] as? String, "write_file")
+        XCTAssertEqual(toolMessage["tool_call_id"] as? String, "call_123")
     }
 
     func testRenderMessagesExtractsAssistantToolCalls() {
         let messages = [
             ChatMessage(
                 role: .assistant,
-                content: "Working...\n<|tool_call>call:write_file{path:<|\"|>note.txt<|\"|>,content:<|\"|>BLUE<|\"|>}<tool_call|>"
+                content: "Working...\n<|tool_call>call:write_file{path:<|\"|>note.txt<|\"|>,content:<|\"|>BLUE<|\"|>}<tool_call|>",
+                reasoningContent: "I should write the requested file.",
+                toolCalls: [
+                    ChatMessageToolCall(
+                        id: "call_123",
+                        name: "write_file",
+                        arguments: [
+                            "path": .string("note.txt"),
+                            "content": .string("BLUE"),
+                        ]
+                    ),
+                ]
             ),
         ]
 
@@ -36,6 +168,8 @@ final class Gemma4TokenizerAndTemplateTests: MereRunCoreTestCase {
 
         XCTAssertEqual(assistantMessage["role"] as? String, "assistant")
         XCTAssertEqual(assistantMessage["content"] as? String, "Working...")
+        XCTAssertEqual(assistantMessage["reasoning_content"] as? String, "I should write the requested file.")
+        XCTAssertEqual(firstCall["id"] as? String, "call_123")
         XCTAssertEqual(function["name"] as? String, "write_file")
         XCTAssertEqual(arguments["path"] as? String, "note.txt")
         XCTAssertEqual(arguments["content"] as? String, "BLUE")
@@ -55,5 +189,22 @@ final class Gemma4TokenizerAndTemplateTests: MereRunCoreTestCase {
             return []
         }
         return array
+    }
+
+    private func makeTemplateModelRoot(hiddenSize: Int, numHiddenLayers: Int) throws -> URL {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gemma4-template-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let config = """
+        {
+          "text_config": {
+            "hidden_size": \(hiddenSize),
+            "num_hidden_layers": \(numHiddenLayers)
+          }
+        }
+        """
+        try Data(config.utf8).write(to: rootURL.appendingPathComponent("config.json"))
+        try Data("stale fixture\n".utf8).write(to: rootURL.appendingPathComponent("chat_template.jinja"))
+        return rootURL
     }
 }

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -522,7 +522,11 @@ final class ManagedModelCatalogTests: XCTestCase {
 
         XCTAssertEqual(spec.category, .textChat)
         XCTAssertEqual(spec.hubFallback?.repoId, Gemma4Resources.twelveB4BitUpstreamModelId)
+        XCTAssertEqual(spec.hubFallback?.revision, Gemma4Resources.twelveB4BitUpstreamRevision)
         XCTAssertEqual(spec.upstreamRepoId, Gemma4Resources.twelveB4BitUpstreamModelId)
+        XCTAssertEqual(spec.upstreamRevision, Gemma4Resources.twelveB4BitUpstreamRevision)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 6_773_374_762)
+        XCTAssertTrue(spec.hubFallback?.patterns.contains("MERERUN_CONVERSION.json") == true)
         XCTAssertEqual(spec.validationKind, .gemma4)
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatGemma4)
         XCTAssertEqual(spec.companionModelIDs, [Gemma4MTPResources.modelId])

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -4,6 +4,23 @@ import XCTest
 
 final class MereRunModelManifestTests: MereRunCoreTestCase {
 
+    func testGemma4TwelveB4BitTemplatePinsSawfwairConversion() throws {
+        let manifest = MereRunModelManifest.template(
+            for: .gemma4TwelveB4Bit,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, Gemma4Resources.twelveB4BitModelId)
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            Gemma4Resources.twelveB4BitUpstreamModelId
+                + "@\(Gemma4Resources.twelveB4BitUpstreamRevision)"
+        )
+    }
+
     func testTemplateRoundTrip() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -14,6 +14,7 @@ the decision guide for which benchmark to run and how to read the result.
 | --- | --- | --- |
 | Grounded assistant behavior | `model benchmark chat` | Answers over provided evidence, abstention, formats, concise summaries, and local-action boundaries |
 | Tool selection | `model benchmark tool-calls` | Parsed tool names and arguments for synthetic Mere-style tools |
+| Tool continuation | `model benchmark tool-continuations` | Grounded final answers after completed Gemma 4 tool calls and repeated tool chains |
 | Coding ability | `model benchmark code` | Generated Python against HumanEval tests in a local sandbox |
 | Vision-language behavior | `model benchmark vlm` | Synthetic image-question fixtures, or external `lmms-eval` datasets |
 | API serving throughput | `model benchmark api-workload` | End-to-end `/v1/chat/completions` request latency, TTFT, cache, and batching counters |
@@ -162,6 +163,21 @@ swift run mere.run model benchmark vlm \
 ```
 
 ## Runtime Benchmarks
+
+### Gemma 4 Tool Continuation
+
+`model benchmark tool-continuations` runs two deterministic real-checkpoint
+Gemma 4 histories: a typed tool call containing boolean, nested, and null JSON
+arguments followed by its result, and a two-tool chain with preserved reasoning
+and call ids. Both cases require a grounded final answer and reject another
+tool call after the completed results.
+
+```bash
+mere.run model benchmark tool-continuations --log-responses
+```
+
+Use `--model-root` to validate a locally converted Gemma 4 directory without
+installing or replacing the managed model.
 
 ### API Workload
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1767,6 +1767,26 @@ and the activation threshold; leaving them unset uses the runtime policy
 defaults. The default fixture is deterministic and intended for throughput
 comparison, not model-quality evaluation.
 
+### `mere.run model benchmark tool-continuations`
+
+Run two deterministic real-checkpoint Gemma 4 cases that continue after
+completed tool results. The cases exercise typed nested and null arguments,
+reasoning metadata, tool-call correlation fields, and a repeated two-tool chain.
+They require the final answer to use the authoritative results and reject a
+spurious additional tool call.
+
+```bash
+swift run mere.run model benchmark tool-continuations \
+  --model text-chat-gemma4-12b-4bit \
+  --log-responses \
+  --json
+```
+
+Use `--dry-run` to print the plan without loading a checkpoint. `--model-root`
+accepts a local converted Gemma 4 directory while leaving the managed install
+untouched. `--max-tokens` and `--context-size` override the per-case generation
+and context limits.
+
 ### `mere.run model benchmark q36-mtp`
 
 Run a requested-token real-checkpoint Qwen-family MTP comparison. The command

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -229,8 +229,11 @@ gated for larger machines. On 32 GB Apple Silicon Macs, use
 `text-chat-gemma4-turbo`, which installs the MLX NVFP4 Gemma 4 26B-A4B-it MoE
 snapshot and runs through the native Swift Gemma runtime. On smaller supported
 machines, `text-chat-gemma4-12b-4bit` installs the
-`mlx-community/gemma-4-12B-it-4bit` snapshot as the compact managed Gemma 12B
-chat tier.
+checksum-pinned `Sawfwair/gemma-4-12B-it-MLX-4bit` snapshot as the compact
+managed Gemma 12B chat tier. Sawfwair's package is independently converted
+from Google's verified dense checkpoint, includes `MERERUN_CONVERSION.json`
+with source and emitted artifact hashes, and is published as the user-facing
+`v1.0.0` release.
 
 `text-chat-lfm25-a1b-8bit` uses the public
 `LiquidAI/LFM2.5-8B-A1B-MLX-8bit` snapshot at the pinned catalog revision. It is

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -32,6 +32,12 @@ for producing an independently controlled MLX package; existing compatible
 weights can receive the checksum-gated canonical template overlay without
 being downloaded again.
 
+The verified output is published at
+[`Sawfwair/gemma-4-12B-it-MLX-4bit`](https://huggingface.co/Sawfwair/gemma-4-12B-it-MLX-4bit)
+as `v1.0.0`. Managed pulls pin Hub commit
+`0d75fd929a55a29ea3d431b43b2ab5142a6566bf`; the tag is the human-facing
+release name, while the commit pin makes resolution reproducible.
+
 The VDA-S, TripoSR, and InstantMesh converters have one frozen serialization
 environment: CPython 3.11.15 with the exact packages in
 `requirements-vfx.txt`. They fail closed on any other tool version and verify

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -3,6 +3,35 @@
 These scripts are audited release tools. They are never invoked by a
 `mere.run` inference command and never become a Python sidecar.
 
+## Gemma 4 12B MLX 4-bit
+
+`convert_gemma4_12b_mlx.py` verifies Google's exact 23,919,549,408-byte Gemma 4
+12B-it BF16 checkpoint at revision
+`12ace6d648d72bd41519e140f1185f34d38c7e3d`, stages the pinned July 15 config,
+generation, processor, tokenizer, and canonical chat-template metadata, and
+converts it to affine MLX 4-bit with group size 64. Its PEP 723 environment pins
+Python and every serialization dependency. The output includes
+`MERERUN_CONVERSION.json` with source, tool, metadata, and emitted artifact
+hashes. MLX-VLM currently rewrites processor and tokenizer configuration to its
+local defaults during conversion, so the script restores the verified pinned
+upstream bytes before final validation.
+
+Gemma 4 12B is a unified multimodal architecture, so this converter uses
+MLX-VLM's conversion path. Plain `mlx-lm.convert` rejects
+`gemma4_unified` and must not be worked around by relabeling the config or
+discarding the non-language tensors.
+
+```bash
+scripts/model-conversion/convert_gemma4_12b_mlx.py \
+  --source "/path/to/google/gemma-4-12B-it" \
+  --output "/path/to/gemma-4-12B-it-mlx-4bit"
+```
+
+The July update did not change the Google 12B weight blob. Conversion is useful
+for producing an independently controlled MLX package; existing compatible
+weights can receive the checksum-gated canonical template overlay without
+being downloaded again.
+
 The VDA-S, TripoSR, and InstantMesh converters have one frozen serialization
 environment: CPython 3.11.15 with the exact packages in
 `requirements-vfx.txt`. They fail closed on any other tool version and verify

--- a/scripts/model-conversion/convert_gemma4_12b_mlx.py
+++ b/scripts/model-conversion/convert_gemma4_12b_mlx.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "==3.14.4"
+# dependencies = [
+#   "huggingface-hub==1.24.0",
+#   "mlx==0.32.0",
+#   "mlx-lm==0.31.3",
+#   "mlx-vlm==0.6.5",
+#   "mlx-audio==0.4.4",
+#   "numpy==2.5.1",
+#   "safetensors==0.8.0",
+#   "transformers==5.14.1",
+# ]
+# ///
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+import urllib.request
+
+
+SOURCE_REPO = "google/gemma-4-12B-it"
+SOURCE_REVISION = "12ace6d648d72bd41519e140f1185f34d38c7e3d"
+SOURCE_WEIGHT = {
+    "filename": "model.safetensors",
+    "byte_count": 23_919_549_408,
+    "sha256": "5a84cb313260ac447237b890387116dfa8682e49a6b44bc585ae8353abbff18d",
+}
+PINNED_METADATA = {
+    "config.json": {
+        "byte_count": 4_423,
+        "sha256": "478c46e8d2c52d5c2d85bf67e3b3e8c90e7c9d91086cee27e3c267907e936bd9",
+    },
+    "chat_template.jinja": {
+        "byte_count": 18_683,
+        "sha256": "ae53464bf3be25802b3a5b37def7fd89667067d7577049b3b2d74c4d8de4c6d4",
+    },
+    "generation_config.json": {
+        "byte_count": 260,
+        "sha256": "a8349d9bd64cc5841297fcb5002f0fdc4749c473c8f1b10ea337f9ce4ee7014e",
+    },
+    "processor_config.json": {
+        "byte_count": 1_382,
+        "sha256": "6b938e76555b3e9946890770e1abcd442a4718f34041a58e8139dc8ad34545c9",
+    },
+    "tokenizer_config.json": {
+        "byte_count": 2_102,
+        "sha256": "09e6222fd7049dae603d0f61a8b10af5a813f22dca10e6cdc6918f76d7661104",
+    },
+    "tokenizer.json": {
+        "byte_count": 32_169_626,
+        "sha256": "cc8d3a0ce36466ccc1278bf987df5f71db1719b9ca6b4118264f45cb627bfe0f",
+    },
+}
+TOOL_VERSIONS = {
+    "huggingface-hub": "1.24.0",
+    "mlx": "0.32.0",
+    "mlx-lm": "0.31.3",
+    "mlx-vlm": "0.6.5",
+    "mlx-audio": "0.4.4",
+    "numpy": "2.5.1",
+    "safetensors": "0.8.0",
+    "transformers": "5.14.1",
+}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_file(path: Path, pin: dict[str, int | str]) -> None:
+    byte_count = path.stat().st_size
+    if byte_count != pin["byte_count"]:
+        raise ValueError(
+            f"{path} has {byte_count} bytes; expected {pin['byte_count']}"
+        )
+    actual_sha256 = sha256(path)
+    if actual_sha256 != pin["sha256"]:
+        raise ValueError(
+            f"{path} has SHA-256 {actual_sha256}; expected {pin['sha256']}"
+        )
+
+
+def verify_environment() -> None:
+    for package, expected in TOOL_VERSIONS.items():
+        actual = importlib.metadata.version(package)
+        if actual != expected:
+            raise RuntimeError(f"{package} {actual} is installed; expected {expected}")
+
+
+def download_pinned_metadata(destination: Path) -> None:
+    for filename, pin in PINNED_METADATA.items():
+        url = (
+            f"https://huggingface.co/{SOURCE_REPO}/resolve/"
+            f"{SOURCE_REVISION}/{filename}"
+        )
+        request = urllib.request.Request(url, headers={"User-Agent": "mere.run-converter/1"})
+        with urllib.request.urlopen(request) as response:
+            payload = response.read()
+        path = destination / filename
+        path.write_bytes(payload)
+        verify_file(path, pin)
+
+
+def stage_source(source: Path, destination: Path) -> None:
+    excluded = {".cache", "mererun_model.json", *PINNED_METADATA}
+    for path in source.iterdir():
+        if path.name in excluded:
+            continue
+        os.symlink(path.resolve(), destination / path.name)
+    download_pinned_metadata(destination)
+
+
+def restore_converted_metadata(source: Path, output: Path) -> None:
+    for filename in PINNED_METADATA:
+        if filename != "config.json":
+            shutil.copyfile(source / filename, output / filename)
+
+
+def verify_output(output: Path) -> list[dict[str, int | str]]:
+    for filename, pin in PINNED_METADATA.items():
+        if filename != "config.json":
+            verify_file(output / filename, pin)
+
+    config = json.loads((output / "config.json").read_text(encoding="utf-8"))
+    if config["text_config"]["max_position_embeddings"] != 262_144:
+        raise ValueError("Converted config lost the pinned 262144-token context")
+    quantization = config.get("quantization")
+    if quantization != {"group_size": 64, "bits": 4, "mode": "affine"}:
+        raise ValueError(f"Unexpected converted quantization metadata: {quantization}")
+
+    weights = sorted(output.glob("*.safetensors"))
+    if not weights:
+        raise ValueError("Conversion emitted no safetensors weights")
+    return [
+        {
+            "filename": path.name,
+            "byte_count": path.stat().st_size,
+            "sha256": sha256(path),
+        }
+        for path in weights
+    ]
+
+
+def write_provenance(output: Path, artifacts: list[dict[str, int | str]]) -> None:
+    provenance = {
+        "converter": "scripts/model-conversion/convert_gemma4_12b_mlx.py",
+        "converter_version": 1,
+        "source": {
+            "repository": SOURCE_REPO,
+            "revision": SOURCE_REVISION,
+            **SOURCE_WEIGHT,
+        },
+        "metadata": PINNED_METADATA,
+        "quantization": {
+            "bits": 4,
+            "group_size": 64,
+            "mode": "affine",
+            "dtype": "bfloat16",
+        },
+        "tools": TOOL_VERSIONS,
+        "artifacts": artifacts,
+    }
+    path = output / "MERERUN_CONVERSION.json"
+    path.write_text(
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert the pinned Google Gemma 4 12B-it checkpoint to MLX affine 4-bit."
+    )
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    if output.exists():
+        raise ValueError(f"Output path already exists: {output}")
+
+    verify_environment()
+    verify_file(source / SOURCE_WEIGHT["filename"], SOURCE_WEIGHT)
+
+    from mlx_vlm.convert import convert
+
+    with tempfile.TemporaryDirectory(prefix="mererun-gemma4-convert-") as temporary:
+        staged_source = Path(temporary) / "source"
+        staged_source.mkdir()
+        stage_source(source, staged_source)
+        convert(
+            hf_path=str(staged_source),
+            mlx_path=str(output),
+            quantize=True,
+            q_group_size=64,
+            q_bits=4,
+            q_mode="affine",
+            dtype="bfloat16",
+        )
+        restore_converted_metadata(staged_source, output)
+
+    artifacts = verify_output(output)
+    write_provenance(output, artifacts)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- preserve structured OpenAI assistant tool calls, reasoning content, tool names, and tool-call correlation IDs through the native chat request path
- render nested and null tool arguments plus completed tool results correctly for Gemma 4
- checksum-gate Google's July 2026 canonical Gemma 4 chat templates, with separate standard and E4B variants
- add `mere.run model benchmark tool-continuations` with deterministic one- and two-tool continuation cases
- add a reproducible, revision-pinned Gemma 4 12B MLX affine 4-bit conversion script with complete provenance
- publish the verified conversion as `Sawfwair/gemma-4-12B-it-MLX-4bit@v1.0.0`
- pin managed `text-chat-gemma4-12b-4bit` pulls to the exact Sawfwair Hub commit and retain `MERERUN_CONVERSION.json`
- document the benchmark, converter, bundled template attribution, hosted release, and managed model source

## Why

Google's updated Gemma 4 template fixes tool-loop, null, turn-closure, and reasoning-history behavior. The existing Mere API adapter flattened assistant tool calls and tool results into content, so template-only updates could not repair multi-turn continuations reliably.

The typed history path is the correctness fix. The canonical template overlay is checksum-gated so custom and already-current packages are left untouched. Hosting the independently converted MLX artifact under Sawfwair gives the managed runtime an auditable, organization-controlled release without mutating an installed model.

## Validation

The attributable two-case matrix produced:

| Adapter | Template | Result |
| --- | --- | --- |
| old | old | 0/2 |
| old | canonical | 0/2 |
| typed | old | 2/2 |
| typed | canonical | 2/2 |
| typed | canonical + self-converted MLX 4-bit | 2/2 |

Additional validation:

- installed `text-chat-gemma4-12b-4bit`: 2/2 tool-continuation cases
- independently converted Google Gemma 4 12B MLX 4-bit: 2/2
- output weight shards match the published `mlx-community` conversion byte-for-byte
- hosted Sawfwair LFS object sizes and SHA-256 values match the validated local artifact
- tagged metadata and provenance resolve byte-for-byte through `v1.0.0`
- managed-pull preflight resolves `Sawfwair/gemma-4-12B-it-MLX-4bit`
- `./scripts/check.sh`
  - 1,890 tests passed
  - 117 checkpoint/fixture-gated skips
  - 0 failures
  - 0 SwiftLint violations
  - CLI help and hygiene checks passed

## User impact

OpenAI-compatible clients and the CLI can continue reliably after completed Gemma 4 tool calls. Maintainers gain a repeatable real-checkpoint acceptance test and a pinned in-house MLX conversion path. Future managed compact Gemma pulls resolve to Sawfwair's exact hosted release commit with accurate 6.77 GB download accounting and machine-readable conversion provenance.
