### PR TITLE
Repair model storage accounting and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added byte-exact `model storage --json` accounting and dry-run-first
+  `model gc`, including shared-payload ownership, legacy-link preservation,
+  stale partial/snapshot/blob collection, and macOS Studio cleanup previews.
+- added revision-addressed Hub snapshots, ETag-addressed hard-linked blobs,
+  paginated tree discovery, cross-process storage locking, and zero-copy
+  adoption of matching legacy payloads.
 - added checksum-gated canonical Gemma 4 chat templates, typed assistant
   tool-call and tool-response history, and a deterministic
   `model benchmark tool-continuations` lane for validating grounded final
@@ -44,6 +50,12 @@ The format is based on Keep a Changelog.
 
 ### Fixed
 
+- fixed `model remove` so it reports referenced versus reclaimable bytes and
+  actually deletes unshared backing payloads by default while preserving
+  shared consumers; `--keep-cache` retains the prior link-only behavior.
+- fixed model-size reporting that double-counted shared symlink targets and
+  allowed repo-flat caches, obsolete revisions, and incomplete downloads to
+  accumulate indefinitely.
 - fixed graph cancellation, retry, timeout, and resume cleanup so every owned
   child process is terminated and reusable outputs remain digest-verified.
 - suppressed harmless SSH archive metadata warnings without hiding transfer or

--- a/README.md
+++ b/README.md
@@ -747,6 +747,20 @@ model store. It is a mere.run-local cache, not the default
 If you already pull from Hugging Face elsewhere and want to share cached weights,
 point `MERERUN_HUB_CACHE` at your existing `huggingface/hub` directory.
 
+Inspect physical usage and sharing before deleting anything:
+
+```bash
+mere.run model storage
+mere.run model gc          # read-only plan
+mere.run model gc --force  # recompute under lock, then delete
+```
+
+`model remove <id>` reclaims backing payloads only when no other current or
+legacy model link uses them; `--keep-cache` retains those bytes intentionally.
+New pulls are revision-addressed and hard-link matching content blobs, while
+existing legacy cache directories remain compatible and can be adopted without
+copying payload bytes.
+
 ## Security defaults
 
 The public OSS build keeps local-first behavior by default and requires explicit opt-in for higher-risk modes:

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -430,7 +430,7 @@ private struct CommandEditor: View {
         EditorSection("Runtime") {
             VStack(spacing: 10) {
                 PathField(path: $controller.cliPath, placeholder: "Auto-detect mere.run", mode: .openFile([.unixExecutable, .item]))
-                PathField(path: $controller.modelsRoot, placeholder: "Optional models root", mode: .openDirectory)
+                PathField(path: $controller.modelsRoot, placeholder: "Optional model links/local-files root", mode: .openDirectory)
                 PathField(path: $controller.workingDirectory, placeholder: "Working directory", mode: .openDirectory)
             }
         }
@@ -1277,8 +1277,8 @@ struct MereRunSettingsView: View {
             }
             VStack(spacing: 12) {
                 PathField(path: $controller.cliPath, placeholder: "Auto-detect executable", mode: .openFile([.unixExecutable, .item]))
-                PathField(path: $controller.modelsRoot, placeholder: "Optional models root", mode: .openDirectory)
-                PathField(path: $controller.hubCache, placeholder: "Optional Hugging Face hub cache", mode: .openDirectory)
+                PathField(path: $controller.modelsRoot, placeholder: "Optional model links/local-files root", mode: .openDirectory)
+                PathField(path: $controller.hubCache, placeholder: "Optional model payload storage", mode: .openDirectory)
                 PathField(path: $controller.workingDirectory, placeholder: "Working directory", mode: .openDirectory)
             }
             Text("The app uses a bundled `mere.run` first, then nearby SwiftPM build products, common install locations, and the current package checkout.")

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -12,10 +12,79 @@ struct StudioModelInventoryRow: Identifiable, Equatable {
     let status: String
     let size: String
     let usageTerms: StudioModelUsageTerms?
+    let referencedBytes: Int64?
+    let reclaimableBytes: Int64?
+    let sharedBytes: Int64?
+    let externalBytes: Int64?
+
+    init(
+        id: String,
+        category: String,
+        status: String,
+        size: String,
+        usageTerms: StudioModelUsageTerms?,
+        referencedBytes: Int64? = nil,
+        reclaimableBytes: Int64? = nil,
+        sharedBytes: Int64? = nil,
+        externalBytes: Int64? = nil
+    ) {
+        self.id = id
+        self.category = category
+        self.status = status
+        self.size = size
+        self.usageTerms = usageTerms
+        self.referencedBytes = referencedBytes
+        self.reclaimableBytes = reclaimableBytes
+        self.sharedBytes = sharedBytes
+        self.externalBytes = externalBytes
+    }
 
     var isInstalled: Bool {
         status.lowercased() == "installed"
     }
+}
+
+private enum StudioModelsAlert: Identifiable {
+    case removal(StudioModelInventoryRow)
+    case cleanup(StudioModelGarbagePlan)
+
+    var id: String {
+        switch self {
+        case .removal(let row): "removal:\(row.id)"
+        case .cleanup: "cleanup"
+        }
+    }
+}
+
+private struct StudioModelGarbageCollectOutput: Decodable {
+    let plan: StudioModelGarbagePlan
+    let result: StudioModelGarbageResult?
+}
+
+private struct StudioModelGarbagePlan: Decodable {
+    let reclaimableBytes: Int64
+    let items: [StudioModelGarbageItem]
+}
+
+private struct StudioModelGarbageItem: Decodable {}
+
+private struct StudioModelGarbageResult: Decodable {
+    let reclaimedBytes: Int64
+}
+
+private struct StudioModelStorageReport: Decodable {
+    let applicationSupportBytes: Int64
+    let garbageCollectableBytes: Int64
+    let models: [StudioModelStorageUsage]
+}
+
+private struct StudioModelStorageUsage: Decodable {
+    let id: String
+    let installed: Bool
+    let referencedBytes: Int64
+    let reclaimableBytes: Int64
+    let sharedBytes: Int64
+    let externalBytes: Int64
 }
 
 struct StudioRuntimeSettings: Codable, Equatable {
@@ -139,7 +208,9 @@ struct StudioModelsSheet: View {
     @State private var loadingInfoID: String?
     @State private var loadingRuntimeID: String?
     @State private var removingID: String?
-    @State private var pendingRemoval: StudioModelInventoryRow?
+    @State private var pendingAlert: StudioModelsAlert?
+    @State private var storageReport: StudioModelStorageReport?
+    @State private var isCleaningStorage = false
     @State private var runtimeSettingsByID: [String: StudioRuntimeSettings] = [:]
     @State private var runtimeAlias = ""
     @State private var runtimeTTL = ""
@@ -201,15 +272,30 @@ struct StudioModelsSheet: View {
             }
             select(first)
         }
-        .alert(item: $pendingRemoval) { row in
-            Alert(
-                title: Text("Purge \(row.id)?"),
-                message: Text("This deletes \(row.size) from the local model store."),
-                primaryButton: .destructive(Text("Purge")) {
-                    Task { await purge(row) }
-                },
-                secondaryButton: .cancel()
-            )
+        .alert(item: $pendingAlert) { pending in
+            switch pending {
+            case .removal(let row):
+                Alert(
+                    title: Text("Purge \(row.id)?"),
+                    message: Text(removalMessage(row)),
+                    primaryButton: .destructive(Text("Purge")) {
+                        Task { await purge(row) }
+                    },
+                    secondaryButton: .cancel()
+                )
+            case .cleanup(let plan):
+                Alert(
+                    title: Text("Clean up model storage?"),
+                    message: Text(
+                        "This deletes \(Self.bytes(plan.reclaimableBytes)) across \(plan.items.count) "
+                            + "unreferenced items. Installed and legacy-linked payloads are preserved."
+                    ),
+                    primaryButton: .destructive(Text("Clean Up")) {
+                        Task { await cleanStorage() }
+                    },
+                    secondaryButton: .cancel()
+                )
+            }
         }
     }
 
@@ -240,6 +326,15 @@ struct StudioModelsSheet: View {
             }
             .buttonStyle(.bordered)
             .help("Reveal the model store in Finder")
+
+            Button {
+                Task { await previewStorageCleanup() }
+            } label: {
+                Label("Clean Up", systemImage: "externaldrive.badge.minus")
+            }
+            .buttonStyle(.bordered)
+            .disabled(isRefreshing || isCleaningStorage)
+            .help("Preview unreferenced payloads and partial downloads before deleting them")
 
             Button {
                 Task { await refresh() }
@@ -381,7 +476,7 @@ struct StudioModelsSheet: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(row.id)
                         .font(.system(size: 18, weight: .semibold))
-                    Text("\(row.category) · \(row.status) · \(row.size)")
+                    Text("\(row.category) · \(row.status) · \(row.size) referenced")
                         .font(MereRunTheme.captionFont)
                         .foregroundStyle(MereRunTheme.textMuted)
                     if let usageTerms = row.usageTerms {
@@ -463,7 +558,7 @@ struct StudioModelsSheet: View {
                 .help("Reveal this model's source folder in Finder")
 
                 Button(role: .destructive) {
-                    pendingRemoval = row
+                    pendingAlert = .removal(row)
                 } label: {
                     Label("Purge", systemImage: "trash")
                 }
@@ -568,16 +663,24 @@ struct StudioModelsSheet: View {
         isRefreshing = true
         statusMessage = "Refreshing model inventory..."
         let result = await controller.utilityCommandResult(args: ["model", "list"])
-        isRefreshing = false
 
         guard result.exitCode == 0 else {
+            isRefreshing = false
             statusMessage = "Could not list models"
             detailText = result.outputText
             return
         }
 
         rows = StudioModelInventoryParser.rows(from: result.stdout)
-        statusMessage = "\(installedRows.count) downloaded · \(rows.count) known"
+        let storageResult = await controller.utilityCommandResult(args: ["model", "storage", "--json"])
+        if storageResult.exitCode == 0,
+           let data = storageResult.stdout.data(using: .utf8),
+           let report = try? JSONDecoder().decode(StudioModelStorageReport.self, from: data) {
+            storageReport = report
+            applyStorageUsage(report)
+        }
+        isRefreshing = false
+        updateStatusMessage()
         if let selectedID, visibleRows.contains(where: { $0.id == selectedID }) {
             return
         }
@@ -749,6 +852,90 @@ struct StudioModelsSheet: View {
         } else {
             statusMessage = "Could not purge \(row.id)"
         }
+    }
+
+    @MainActor
+    private func previewStorageCleanup() async {
+        isCleaningStorage = true
+        statusMessage = "Inspecting model storage..."
+        let command = await controller.utilityCommandResult(args: ["model", "gc", "--json"])
+        isCleaningStorage = false
+        guard command.exitCode == 0,
+              let data = command.stdout.data(using: .utf8),
+              let output = try? JSONDecoder().decode(StudioModelGarbageCollectOutput.self, from: data) else {
+            statusMessage = "Could not inspect model storage"
+            detailText = command.outputText
+            return
+        }
+        guard !output.plan.items.isEmpty else {
+            statusMessage = "Model storage is clean"
+            return
+        }
+        pendingAlert = .cleanup(output.plan)
+        statusMessage = "\(Self.bytes(output.plan.reclaimableBytes)) can be cleaned up"
+    }
+
+    @MainActor
+    private func cleanStorage() async {
+        isCleaningStorage = true
+        statusMessage = "Cleaning model storage..."
+        let command = await controller.utilityCommandResult(args: ["model", "gc", "--force", "--json"])
+        isCleaningStorage = false
+        guard command.exitCode == 0,
+              let data = command.stdout.data(using: .utf8),
+              let output = try? JSONDecoder().decode(StudioModelGarbageCollectOutput.self, from: data),
+              let result = output.result else {
+            statusMessage = "Could not clean model storage"
+            detailText = command.outputText
+            return
+        }
+        statusMessage = "Reclaimed \(Self.bytes(result.reclaimedBytes))"
+        await refresh()
+    }
+
+    private func applyStorageUsage(_ report: StudioModelStorageReport) {
+        let usageByID = Dictionary(uniqueKeysWithValues: report.models.map { ($0.id, $0) })
+        rows = rows.map { row in
+            guard let usage = usageByID[row.id], usage.installed else { return row }
+            return StudioModelInventoryRow(
+                id: row.id,
+                category: row.category,
+                status: row.status,
+                size: Self.bytes(usage.referencedBytes),
+                usageTerms: row.usageTerms,
+                referencedBytes: usage.referencedBytes,
+                reclaimableBytes: usage.reclaimableBytes,
+                sharedBytes: usage.sharedBytes,
+                externalBytes: usage.externalBytes
+            )
+        }
+    }
+
+    private func updateStatusMessage() {
+        if let storageReport {
+            statusMessage = "\(installedRows.count) downloaded · \(Self.bytes(storageReport.applicationSupportBytes)) used"
+                + " · \(Self.bytes(storageReport.garbageCollectableBytes)) cleanable"
+        } else {
+            statusMessage = "\(installedRows.count) downloaded · \(rows.count) known"
+        }
+    }
+
+    private func removalMessage(_ row: StudioModelInventoryRow) -> String {
+        guard let reclaimable = row.reclaimableBytes else {
+            return "This model references \(row.size). Shared payloads used by other models will be preserved."
+        }
+        var message = "This model references \(row.size) and will reclaim \(Self.bytes(reclaimable)) now."
+        if let shared = row.sharedBytes, shared > 0 {
+            message += " \(Self.bytes(shared)) shared with other models will be preserved."
+        }
+        if let external = row.externalBytes, external > 0 {
+            message += " \(Self.bytes(external)) stored outside MereRun will be preserved."
+        }
+        return message
+    }
+
+    private static func bytes(_ count: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: count, countStyle: .file)
     }
 
     private func revealStore() {

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -592,6 +592,13 @@ enum GuideRegistry {
             resourceName: "model-remove.md"
         ),
         GuideTopic(
+            topic: "model-storage",
+            title: "Model Storage",
+            commandPaths: [["model", "storage"], ["model", "gc"]],
+            models: [],
+            resourceName: "model-storage.md"
+        ),
+        GuideTopic(
             topic: "model-repair-manifests",
             title: "Model Repair Manifests",
             commandPaths: [["model", "repair-manifests"]],

--- a/Sources/MereRunCLI/Commands/ModelCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCommand.swift
@@ -3,11 +3,13 @@ import ArgumentParser
 struct Model: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "model",
-        abstract: "List, pull, remove, and inspect models.",
+        abstract: "List, pull, remove, inspect, and clean up models.",
         subcommands: [
             ModelList.self,
             ModelPull.self,
             ModelRemove.self,
+            ModelStorage.self,
+            ModelGarbageCollect.self,
             ModelInfo.self,
             ModelCapabilities.self,
             ModelRuntime.self,

--- a/Sources/MereRunCLI/Commands/ModelGarbageCollectCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelGarbageCollectCommand.swift
@@ -1,0 +1,65 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ModelGarbageCollect: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gc",
+        abstract: "Find or delete unreferenced model payloads and partial downloads.",
+        discussion: """
+        The default is a read-only dry run. Pass --force to delete exactly the
+        items in a freshly computed plan. Payloads referenced by any current or
+        legacy MereRun install are preserved.
+        """
+    )
+
+    @Flag(name: [.long], help: "Delete the planned garbage. Without this flag, only show the plan.")
+    var force: Bool = false
+
+    @Flag(name: [.long], help: "Emit a structured JSON plan and result.")
+    var json: Bool = false
+
+    func run() throws {
+        let manager = try ModelStorageManager()
+        let plan = try manager.garbageCollectionPlan()
+        let result = force ? try manager.execute(plan) : nil
+        let output = ModelGarbageCollectOutput(
+            mode: force ? "executed" : "dry-run",
+            plan: plan,
+            result: result
+        )
+
+        if json {
+            print(try ModelStorageCommandOutput.encode(output))
+        } else {
+            print(Self.text(output))
+        }
+    }
+
+    static func text(_ output: ModelGarbageCollectOutput) -> String {
+        var lines = [
+            output.mode == "executed" ? "Model storage cleanup complete" : "Model storage cleanup dry run",
+            "  Reclaimable: \(ModelStorageCommandOutput.bytes(output.plan.reclaimableBytes))",
+            "  Partial downloads: \(ModelStorageCommandOutput.bytes(output.plan.incompleteDownloadBytes))",
+            "  Items: \(output.plan.items.count)",
+        ]
+        for item in output.plan.items {
+            lines.append(
+                "  - \(item.kind.rawValue): \(ModelStorageCommandOutput.bytes(item.logicalBytes))  \(item.path)"
+            )
+        }
+        if let result = output.result {
+            lines.append("  Reclaimed: \(ModelStorageCommandOutput.bytes(result.reclaimedBytes))")
+        } else if !output.plan.items.isEmpty {
+            lines.append("")
+            lines.append("Run `mere.run model gc --force` to delete this plan after it is recomputed.")
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct ModelGarbageCollectOutput: Codable, Equatable {
+    let mode: String
+    let plan: ModelStorageGarbagePlan
+    let result: ModelStorageGarbageResult?
+}

--- a/Sources/MereRunCLI/Commands/ModelListCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelListCommand.swift
@@ -12,7 +12,7 @@ struct ModelList: ParsableCommand {
         let rows = ModelInventory.rows()
 
         let widths = ModelListColumnWidths(rows: rows)
-        printRow("ID", "Category", "Status", "Size", widths: widths)
+        printRow("ID", "Category", "Status", "Referenced", widths: widths)
         print(String(repeating: "-", count: widths.totalWidth))
         for row in rows {
             printRow(row.id, row.category, row.status, row.size, widths: widths)
@@ -58,6 +58,6 @@ private struct ModelListColumnWidths {
     }
 
     var totalWidth: Int {
-        id + category + status + "Size".count + 6
+        id + category + status + "Referenced".count + 6
     }
 }

--- a/Sources/MereRunCLI/Commands/ModelRemoveCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelRemoveCommand.swift
@@ -14,10 +14,19 @@ struct ModelRemove: ParsableCommand {
     @Flag(name: [.long], help: "Skip confirmation prompt.")
     var force: Bool = false
 
+    @Flag(name: [.long], help: "Remove model links but retain unshared Hub payloads.")
+    var keepCache: Bool = false
+
+    @Flag(name: [.long], help: "Emit a structured JSON removal result. Requires --force.")
+    var json: Bool = false
+
     func run() throws {
         let id = resolveID(target)
         guard let id else {
             throw ValidationError("Unknown canonical model id: \(target)")
+        }
+        if json && !force {
+            throw ValidationError("--json requires --force because confirmation text would make stdout invalid JSON.")
         }
 
         let resolver = ModelResolver()
@@ -38,13 +47,25 @@ struct ModelRemove: ParsableCommand {
             }
         }
 
-        let bytes = FileSystemHelper.directorySize(at: installURL)
-        let sizeStr = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+        let storageManager = try ModelStorageManager()
+        let storageUsage = try storageManager.report(modelIDs: [id]).models.first
+        let cacheUnits = try storageManager.cacheUnitsReferenced(by: id)
+        let referencedBytes = storageUsage?.referencedBytes ?? FileSystemHelper.directorySize(at: installURL)
+        let expectedReclaimableBytes = storageUsage?.reclaimableBytes ?? 0
+        let referencedSize = ModelStorageCommandOutput.bytes(referencedBytes)
+        let reclaimableSize = ModelStorageCommandOutput.bytes(expectedReclaimableBytes)
 
         if !force {
             print("Remove \(id)?")
             print("  Path: \(installURL.path)")
-            print("  Size: \(sizeStr)")
+            print("  Referenced: \(referencedSize)")
+            print("  Reclaimable now: \(keepCache ? "0 bytes (--keep-cache)" : reclaimableSize)")
+            if let sharedBytes = storageUsage?.sharedBytes, sharedBytes > 0 {
+                print("  Shared and preserved: \(ModelStorageCommandOutput.bytes(sharedBytes))")
+            }
+            if let externalBytes = storageUsage?.externalBytes, externalBytes > 0 {
+                print("  External and preserved: \(ModelStorageCommandOutput.bytes(externalBytes))")
+            }
             print("")
             print("Confirm? [y/N] ", terminator: "")
             guard let answer = readLine()?.lowercased(), answer == "y" || answer == "yes" else {
@@ -55,7 +76,42 @@ struct ModelRemove: ParsableCommand {
 
         try FileManager.default.removeItem(at: installURL)
         try removeManagedAliasesIfNeeded(for: id)
-        print("Removed \(id) (\(sizeStr))")
+        let garbagePlan = keepCache
+            ? ModelStorageGarbagePlan(
+                hubPath: storageManager.hubDirectory.path,
+                reclaimableBytes: 0,
+                incompleteDownloadBytes: 0,
+                items: []
+            )
+            : try storageManager.garbageCollectionPlan(limitingTo: cacheUnits)
+        let garbageResult = keepCache ? nil : try storageManager.execute(garbagePlan)
+        let reclaimedBytes = (garbageResult?.reclaimedBytes ?? 0) + (storageUsage?.localBytes ?? 0)
+        let result = ModelRemoveOutput(
+            id: id,
+            installPath: installURL.path,
+            referencedBytes: referencedBytes,
+            expectedReclaimableBytes: expectedReclaimableBytes,
+            reclaimedBytes: reclaimedBytes,
+            retainedSharedBytes: storageUsage?.sharedBytes ?? 0,
+            retainedExternalBytes: storageUsage?.externalBytes ?? 0,
+            cacheRetained: keepCache,
+            deletedCacheItemCount: garbageResult?.deletedItemCount ?? 0
+        )
+        if json {
+            print(try ModelStorageCommandOutput.encode(result))
+        } else {
+            var message = "Removed \(id); reclaimed \(ModelStorageCommandOutput.bytes(reclaimedBytes))"
+            if result.retainedSharedBytes > 0 {
+                message += "; preserved \(ModelStorageCommandOutput.bytes(result.retainedSharedBytes)) shared"
+            }
+            if result.retainedExternalBytes > 0 {
+                message += "; preserved \(ModelStorageCommandOutput.bytes(result.retainedExternalBytes)) external"
+            }
+            if keepCache {
+                message += "; Hub payload retained"
+            }
+            print(message)
+        }
     }
 
     /// Resolve a user-supplied string to a canonical model id.
@@ -97,9 +153,22 @@ struct ModelRemove: ParsableCommand {
                 CodeGenResources.managedRelativePath,
                 isDirectory: false
             )
-            if FileManager.default.fileExists(atPath: aliasURL.path) {
+            if FileManager.default.fileExists(atPath: aliasURL.path)
+                || (try? FileManager.default.destinationOfSymbolicLink(atPath: aliasURL.path)) != nil {
                 try? FileManager.default.removeItem(at: aliasURL)
             }
         }
     }
+}
+
+struct ModelRemoveOutput: Codable, Equatable {
+    let id: String
+    let installPath: String
+    let referencedBytes: Int64
+    let expectedReclaimableBytes: Int64
+    let reclaimedBytes: Int64
+    let retainedSharedBytes: Int64
+    let retainedExternalBytes: Int64
+    let cacheRetained: Bool
+    let deletedCacheItemCount: Int
 }

--- a/Sources/MereRunCLI/Commands/ModelStorageCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelStorageCommand.swift
@@ -1,0 +1,67 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ModelStorage: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "storage",
+        abstract: "Inspect physical model storage, sharing, and reclaimable space."
+    )
+
+    @Flag(name: [.long], help: "Emit a structured JSON storage report.")
+    var json: Bool = false
+
+    func run() throws {
+        let report = try ModelStorageManager().report()
+        if json {
+            print(try ModelStorageCommandOutput.encode(report))
+        } else {
+            print(ModelStorageCommandOutput.text(report))
+        }
+    }
+}
+
+enum ModelStorageCommandOutput {
+    static func encode<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        guard let output = String(data: data, encoding: .utf8) else {
+            throw ValidationError("Could not encode model storage output as UTF-8.")
+        }
+        return output
+    }
+
+    static func text(_ report: ModelStorageReport) -> String {
+        var lines = [
+            "Model storage",
+            "  Application support: \(bytes(report.applicationSupportBytes))  \(report.applicationSupportPath)",
+            "  Hub payloads:       \(bytes(report.hubBytes))  \(report.hubPath)",
+            "  Model links/local:  \(bytes(report.modelStoreBytes))  \(report.modelStorePath)",
+            "  Other app data:     \(bytes(report.otherApplicationSupportBytes))",
+            "  Safe to collect:    \(bytes(report.garbageCollectableBytes))",
+            "  Partial downloads:  \(bytes(report.incompleteDownloadBytes))",
+        ]
+        let installed = report.models.filter(\.installed)
+        if !installed.isEmpty {
+            lines.append("")
+            lines.append("Installed model references (do not add these values):")
+            for model in installed.sorted(by: { $0.id < $1.id }) {
+                var detail = "  \(model.id): \(bytes(model.referencedBytes)) referenced"
+                detail += " · \(bytes(model.reclaimableBytes)) reclaimable on removal"
+                if model.sharedBytes > 0 {
+                    detail += " · \(bytes(model.sharedBytes)) shared"
+                }
+                if model.externalBytes > 0 {
+                    detail += " · \(bytes(model.externalBytes)) external (not managed here)"
+                }
+                lines.append(detail)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func bytes(_ count: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: count, countStyle: .file)
+    }
+}

--- a/Sources/MereRunCLI/Guides/model-list.md
+++ b/Sources/MereRunCLI/Guides/model-list.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 Show all known managed model ids, categories, install status, and resolved local
-payload size. Use this before pulling or running models.
+referenced payload size. Use this before pulling or running models.
 Use `mere.run status` when you also need the active API server and currently
 served model.
 
@@ -44,8 +44,8 @@ MERERUN_MODELS_DIR=/Volumes/Models/mere.run mere.run model list
 ## Iteration Tips
 
 - Look for `missing` vs `installed`, not just whether the id exists.
-- The size follows symlinked payload files and directories in managed model
-  stores. If layout is confusing, inspect with `model info`.
+- Referenced sizes follow symlinked payloads and are not additive when models
+  share files. Use `model storage` for physical and reclaimable byte counts.
 - If validation looks wrong, inspect with `model info` or repair manifests.
 
 ## Troubleshooting

--- a/Sources/MereRunCLI/Guides/model-remove.md
+++ b/Sources/MereRunCLI/Guides/model-remove.md
@@ -20,10 +20,12 @@ mere.run status
 
 - positional target: canonical model id.
 - `--force`: skip confirmation.
+- `--keep-cache`: remove install links but retain backing Hub payloads.
+- `--json`: emit a structured result; requires `--force`.
 
 ## Usage Patterns
 
-- Run `model list` first to confirm status and size.
+- Run `model storage` first to distinguish referenced, shared, and reclaimable bytes.
 - Use interactive confirmation for manual cleanup.
 - Use `--force` only in scripts where the target id is known.
 
@@ -41,13 +43,14 @@ mere.run model remove text-chat-gemma4-nano --force
 
 - Remove large creative models before pulling a different family.
 - Re-run `status` or `model list` after deletion to confirm status.
-- Remember that hub caches may still consume disk outside the model store.
+- The default removes unshared Hub payloads and preserves anything still referenced.
+- Use `--keep-cache` only when retaining bytes for a future reinstall is intentional.
 
 ## Troubleshooting
 
 - Unknown id: run `model list`.
 - Not installed: no deletion is needed.
-- Disk still full: inspect `MERERUN_HUB_CACHE` or the Hugging Face cache.
+- Disk still full: run the read-only `mere.run model gc` preview.
 
 ## Sources
 

--- a/Sources/MereRunCLI/Guides/model-storage.md
+++ b/Sources/MereRunCLI/Guides/model-storage.md
@@ -1,0 +1,60 @@
+# Model Storage
+
+## Purpose
+
+Inspect physical model storage without double-counting shared payloads, then
+preview or remove cache data that no installed or legacy MereRun model links use.
+
+## Inspect
+
+```bash
+mere.run model storage
+mere.run model storage --json
+```
+
+The top section reports physical bytes for the application-support directory,
+Hub payload store, model links/local files, and other app data. Per-model
+`referenced` values describe what each model can read and must not be added
+together. `reclaimable on removal` accounts for sharing.
+
+## Clean Up
+
+```bash
+# Read-only dry run
+mere.run model gc
+mere.run model gc --json
+
+# Recompute the plan under the storage lock, then delete it
+mere.run model gc --force
+```
+
+Garbage collection preserves payloads referenced by the configured model store
+or legacy links under MereRun application support. It also coordinates with
+managed pulls, rechecks the ownership graph before deletion, and protects newly
+created unreferenced snapshots for one hour. Do not run cleanup while an
+unmanaged process is directly reading files from the Hub cache.
+
+## Layout Compatibility
+
+Existing `hub/models/<org>/<repo>` payloads remain valid. New pulls use
+revision-addressed `hub/snapshots/...` directories and ETag-addressed hard-linked
+blobs. A later pull can adopt matching legacy files without downloading or
+copying their payload bytes; cleanup removes an old layout only after its last
+link disappears.
+
+## Related Commands
+
+```bash
+mere.run model list
+mere.run model remove <id>
+mere.run model remove <id> --keep-cache
+```
+
+`model remove` now deletes unshared backing payloads by default and reports the
+bytes actually reclaimed. Use `--keep-cache` when you intentionally want a fast
+future reinstall.
+
+## Sources
+
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCore/ModelStorageManager.swift
+- https://github.com/sawfwair/mere-run/blob/main/docs/runtime/model-management.md

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -2,7 +2,25 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+import Crypto
 @preconcurrency import Hub
+
+public struct HubSnapshotReceipt: Codable, Equatable, Sendable {
+    public static let filename = ".mererun_snapshot.json"
+
+    public struct File: Codable, Equatable, Sendable {
+        public let path: String
+        public let size: Int64
+        public let commit: String
+        public let etag: String?
+    }
+
+    public let schemaVersion: Int
+    public let repository: String
+    public let requestedRevision: String
+    public let resolvedRevision: String
+    public let files: [File]
+}
 
 public struct HubSnapshotOptions: Sendable {
     public var repoId: String
@@ -98,8 +116,16 @@ public actor HubSnapshot {
             return cachedSnapshotURL
         }
 
-        if !options.offline, !options.patterns.isEmpty {
+        let storageLock = try ModelStorageFileLock.acquire(hubDirectory: downloadBase)
+        defer { storageLock.unlock() }
+
+        if !options.offline {
             let snapshotURL = try await prepareMaterializedSnapshot(progressHandler: progressHandler)
+            cachedSnapshotURL = snapshotURL
+            return snapshotURL
+        }
+
+        if let snapshotURL = offlineMaterializedSnapshotURL() {
             cachedSnapshotURL = snapshotURL
             return snapshotURL
         }
@@ -184,14 +210,29 @@ public actor HubSnapshot {
     }
 
     private func prepareMaterializedSnapshot(progressHandler: ProgressHandler?) async throws -> URL {
-        let entries = try await remoteTreeEntries()
+        let tree = try await remoteTreeEntries()
+        let entries = tree.entries
             .filter { $0.type == "file" && Self.matchesPath($0.path, patterns: options.patterns) }
             .sorted { $0.path < $1.path }
         guard !entries.isEmpty else {
             throw Hub.HubClientError.fileNotFound(options.patterns.joined(separator: ", "))
         }
 
-        let snapshotURL = materializedSnapshotURL()
+        var preResolvedFiles: [String: HubSnapshotRemoteFile] = [:]
+        let resolvedRevision: String
+        if let treeRevision = tree.resolvedRevision {
+            resolvedRevision = treeRevision
+        } else {
+            let firstEntry = entries[0]
+            let remote = try await resolveRemoteFile(
+                source: resolveURL(for: firstEntry.path),
+                relativePath: firstEntry.path
+            )
+            resolvedRevision = remote.commitHash
+            preResolvedFiles[firstEntry.path] = remote
+        }
+
+        let snapshotURL = materializedSnapshotURL(resolvedRevision: resolvedRevision)
         let metadataURL = snapshotURL
             .appending(path: ".cache")
             .appending(path: "huggingface")
@@ -202,6 +243,7 @@ public actor HubSnapshot {
             partial + max(entry.size ?? 0, 0)
         }, 1)
         var completedBytes: Int64 = 0
+        var receiptFiles: [HubSnapshotReceipt.File] = []
         progressHandler?(HubSnapshotProgress(completedUnitCount: completedBytes, totalUnitCount: totalBytes))
 
         for entry in entries {
@@ -209,8 +251,18 @@ public actor HubSnapshot {
             let expectedBytes = max(entry.size ?? 0, 0)
             let destination = snapshotURL.appending(path: entry.path)
             let metadataDestination = metadataURL.appending(path: entry.path + ".metadata")
-            if Self.fileExists(at: destination, expectedBytes: expectedBytes) {
+            if Self.fileExists(at: destination, expectedBytes: expectedBytes),
+               let metadata = Self.readDownloadMetadata(at: metadataDestination),
+               metadata.commitHash == resolvedRevision {
                 completedBytes += max(expectedBytes, Self.fileSize(at: destination))
+                receiptFiles.append(
+                    HubSnapshotReceipt.File(
+                        path: entry.path,
+                        size: Self.fileSize(at: destination),
+                        commit: metadata.commitHash,
+                        etag: metadata.etag
+                    )
+                )
                 progressHandler?(HubSnapshotProgress(
                     completedUnitCount: min(completedBytes, totalBytes),
                     totalUnitCount: totalBytes
@@ -218,8 +270,42 @@ public actor HubSnapshot {
                 continue
             }
 
-            let source = resolveURL(for: entry.path)
-            let remote = try await resolveRemoteFile(source: source, relativePath: entry.path)
+            if let legacy = try importLegacyPayload(
+                relativePath: entry.path,
+                expectedBytes: expectedBytes,
+                resolvedRevision: resolvedRevision,
+                destination: destination,
+                metadataDestination: metadataDestination
+            ) {
+                completedBytes += max(expectedBytes, Self.fileSize(at: destination))
+                receiptFiles.append(
+                    HubSnapshotReceipt.File(
+                        path: entry.path,
+                        size: Self.fileSize(at: destination),
+                        commit: legacy.commitHash,
+                        etag: legacy.etag
+                    )
+                )
+                progressHandler?(HubSnapshotProgress(
+                    completedUnitCount: min(completedBytes, totalBytes),
+                    totalUnitCount: totalBytes
+                ))
+                continue
+            }
+
+            let remote: HubSnapshotRemoteFile
+            if let preResolved = preResolvedFiles.removeValue(forKey: entry.path) {
+                remote = preResolved
+            } else {
+                let source = resolveURL(for: entry.path)
+                remote = try await resolveRemoteFile(source: source, relativePath: entry.path)
+            }
+            guard remote.commitHash == resolvedRevision else {
+                throw Hub.HubClientError.downloadError(
+                    "Repository revision changed while downloading \(options.repoId): "
+                        + "expected \(resolvedRevision), found \(remote.commitHash)"
+                )
+            }
             let startedAt = Date()
             let completedBeforeDownload = completedBytes
             let delegate = HubSnapshotDownloadDelegate { written, _, _ in
@@ -237,9 +323,17 @@ public actor HubSnapshot {
                 withIntermediateDirectories: true
             )
             try? FileManager.default.removeItem(at: destination)
-            try FileManager.default.moveItem(at: tempURL, to: destination)
+            try materializeDownloadedPayload(tempURL, remote: remote, destination: destination)
             try writeDownloadMetadata(remote, to: metadataDestination)
             completedBytes += max(expectedBytes, Self.fileSize(at: destination))
+            receiptFiles.append(
+                HubSnapshotReceipt.File(
+                    path: entry.path,
+                    size: Self.fileSize(at: destination),
+                    commit: remote.commitHash,
+                    etag: remote.etag
+                )
+            )
             progressHandler?(HubSnapshotProgress(
                 completedUnitCount: min(completedBytes, totalBytes),
                 totalUnitCount: totalBytes,
@@ -247,27 +341,56 @@ public actor HubSnapshot {
             ))
         }
 
+        try writeSnapshotReceipt(
+            HubSnapshotReceipt(
+                schemaVersion: 1,
+                repository: options.repoId,
+                requestedRevision: options.revision,
+                resolvedRevision: resolvedRevision,
+                files: receiptFiles
+            ),
+            to: snapshotURL
+        )
+        try writeRequestedRevisionReference(resolvedRevision: resolvedRevision)
         progressHandler?(HubSnapshotProgress(completedUnitCount: totalBytes, totalUnitCount: totalBytes))
         return snapshotURL
     }
 
-    private func remoteTreeEntries() async throws -> [HubSnapshotTreeEntry] {
-        var url = hostURL()
+    private func remoteTreeEntries() async throws -> HubSnapshotTree {
+        let initialURL = hostURL()
             .appending(path: "api")
             .appending(path: options.repoType.rawValue)
             .appending(path: options.repoId)
             .appending(path: "tree")
             .appending(component: options.revision)
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        var components = URLComponents(url: initialURL, resolvingAgainstBaseURL: false)
         components?.queryItems = [URLQueryItem(name: "recursive", value: "true")]
-        if let componentURL = components?.url {
-            url = componentURL
+        var nextURL: URL? = components?.url ?? initialURL
+
+        var entries: [HubSnapshotTreeEntry] = []
+        var resolvedRevision: String?
+        var pageCount = 0
+        while let pageURL = nextURL {
+            pageCount += 1
+            guard pageCount <= 1_000 else {
+                throw Hub.HubClientError.downloadError("Too many Hub tree pages for \(options.repoId)")
+            }
+            var request = authorizedRequest(url: pageURL)
+            request.httpMethod = "GET"
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let http = try Self.validateHTTPResponse(
+                response,
+                data: data,
+                context: "\(options.repoId)@\(options.revision)"
+            )
+            entries.append(contentsOf: try JSONDecoder().decode([HubSnapshotTreeEntry].self, from: data))
+            resolvedRevision = resolvedRevision ?? http.value(forHTTPHeaderField: "X-Repo-Commit")
+            nextURL = Self.nextPageURL(
+                from: http.value(forHTTPHeaderField: "Link"),
+                relativeTo: pageURL
+            )
         }
-        var request = authorizedRequest(url: url)
-        request.httpMethod = "GET"
-        let (data, response) = try await URLSession.shared.data(for: request)
-        try Self.validateHTTPResponse(response, data: data, context: "\(options.repoId)@\(options.revision)")
-        return try JSONDecoder().decode([HubSnapshotTreeEntry].self, from: data)
+        return HubSnapshotTree(entries: entries, resolvedRevision: resolvedRevision)
     }
 
     private func resolveRemoteFile(source: URL, relativePath: String) async throws -> HubSnapshotRemoteFile {
@@ -329,19 +452,158 @@ public actor HubSnapshot {
     }
 
     private func writeDownloadMetadata(_ remote: HubSnapshotRemoteFile, to metadataURL: URL) throws {
-        guard let etag = remote.etag, !etag.isEmpty else { return }
         try FileManager.default.createDirectory(
             at: metadataURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        let content = "\(remote.commitHash)\n\(etag)\n\(Date().timeIntervalSince1970)\n"
+        let content = "\(remote.commitHash)\n\(remote.etag ?? "")\n\(Date().timeIntervalSince1970)\n"
         try content.write(to: metadataURL, atomically: true, encoding: .utf8)
     }
 
-    private func materializedSnapshotURL() -> URL {
+    private func materializeDownloadedPayload(
+        _ temporaryURL: URL,
+        remote: HubSnapshotRemoteFile,
+        destination: URL
+    ) throws {
+        guard let etag = remote.etag, !etag.isEmpty else {
+            try FileManager.default.moveItem(at: temporaryURL, to: destination)
+            return
+        }
+
+        let blobURL = contentBlobURL(etag: etag)
+        try FileManager.default.createDirectory(
+            at: blobURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if !FileManager.default.fileExists(atPath: blobURL.path) {
+            do {
+                try FileManager.default.moveItem(at: temporaryURL, to: blobURL)
+            } catch {
+                if FileManager.default.fileExists(atPath: blobURL.path) {
+                    try? FileManager.default.removeItem(at: temporaryURL)
+                } else {
+                    throw error
+                }
+            }
+        } else {
+            guard Self.fileSize(at: blobURL) == Self.fileSize(at: temporaryURL) else {
+                try? FileManager.default.removeItem(at: temporaryURL)
+                throw Hub.HubClientError.downloadError(
+                    "Hub blob identity collision for \(remote.etag ?? "unknown ETag")"
+                )
+            }
+            try? FileManager.default.removeItem(at: temporaryURL)
+        }
+        try FileManager.default.linkItem(at: blobURL, to: destination)
+    }
+
+    private func importLegacyPayload(
+        relativePath: String,
+        expectedBytes: Int64,
+        resolvedRevision: String,
+        destination: URL,
+        metadataDestination: URL
+    ) throws -> HubSnapshotDownloadMetadata? {
+        let legacyRoot = legacySnapshotURL()
+        let legacyPayload = legacyRoot.appending(path: relativePath)
+        let legacyMetadata = legacyRoot
+            .appending(path: ".cache")
+            .appending(path: "huggingface")
+            .appending(path: "download")
+            .appending(path: relativePath + ".metadata")
+        guard Self.fileExists(at: legacyPayload, expectedBytes: expectedBytes),
+              let metadata = Self.readDownloadMetadata(at: legacyMetadata),
+              metadata.commitHash == resolvedRevision else {
+            return nil
+        }
+
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: destination)
+        if let etag = metadata.etag, !etag.isEmpty {
+            let blobURL = contentBlobURL(etag: etag)
+            try FileManager.default.createDirectory(
+                at: blobURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if !FileManager.default.fileExists(atPath: blobURL.path) {
+                try FileManager.default.linkItem(at: legacyPayload, to: blobURL)
+            }
+            try FileManager.default.linkItem(at: blobURL, to: destination)
+        } else {
+            try FileManager.default.linkItem(at: legacyPayload, to: destination)
+        }
+        try FileManager.default.createDirectory(
+            at: metadataDestination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: metadataDestination)
+        try FileManager.default.copyItem(at: legacyMetadata, to: metadataDestination)
+        return metadata
+    }
+
+    private func writeSnapshotReceipt(_ receipt: HubSnapshotReceipt, to snapshotURL: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(receipt)
+        try data.write(
+            to: snapshotURL.appendingPathComponent(HubSnapshotReceipt.filename, isDirectory: false),
+            options: .atomic
+        )
+    }
+
+    private func writeRequestedRevisionReference(resolvedRevision: String) throws {
+        let referenceURL = requestedRevisionReferenceURL()
+        try FileManager.default.createDirectory(
+            at: referenceURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(resolvedRevision.utf8).write(to: referenceURL, options: .atomic)
+    }
+
+    private func offlineMaterializedSnapshotURL() -> URL? {
+        if let data = try? Data(contentsOf: requestedRevisionReferenceURL()),
+           let resolved = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !resolved.isEmpty {
+            let snapshot = materializedSnapshotURL(resolvedRevision: resolved)
+            if FileManager.default.fileExists(atPath: snapshot.path) {
+                return snapshot
+            }
+        }
+        let requested = materializedSnapshotURL(resolvedRevision: options.revision)
+        return FileManager.default.fileExists(atPath: requested.path) ? requested : nil
+    }
+
+    private func materializedSnapshotURL(resolvedRevision: String) -> URL {
+        downloadBase
+            .appending(path: "snapshots")
+            .appending(path: options.repoType.rawValue)
+            .appending(path: options.repoId)
+            .appending(path: Self.revisionKey(resolvedRevision))
+    }
+
+    private func legacySnapshotURL() -> URL {
         downloadBase
             .appending(path: options.repoType.rawValue)
             .appending(path: options.repoId)
+    }
+
+    private func requestedRevisionReferenceURL() -> URL {
+        downloadBase
+            .appending(path: "refs")
+            .appending(path: options.repoType.rawValue)
+            .appending(path: options.repoId)
+            .appending(path: Self.revisionKey(options.revision) + ".ref")
+    }
+
+    private func contentBlobURL(etag: String) -> URL {
+        let key = Self.contentKey(etag)
+        return downloadBase
+            .appending(path: "blobs")
+            .appending(path: String(key.prefix(2)))
+            .appending(path: key)
     }
 
     private func resolveURL(for relativePath: String) -> URL {
@@ -403,6 +665,34 @@ public actor HubSnapshot {
         URL(string: location, relativeTo: source)?.absoluteURL
     }
 
+    static func nextPageURL(from linkHeader: String?, relativeTo source: URL) -> URL? {
+        guard let linkHeader else { return nil }
+        for entry in linkHeader.split(separator: ",") {
+            let parts = entry.split(separator: ";", omittingEmptySubsequences: true)
+            guard let first = parts.first,
+                  parts.dropFirst().contains(where: {
+                      $0.trimmingCharacters(in: .whitespacesAndNewlines) == "rel=\"next\""
+                  }) else {
+                continue
+            }
+            let value = first.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard value.hasPrefix("<"), value.hasSuffix(">") else { continue }
+            return URL(string: String(value.dropFirst().dropLast()), relativeTo: source)?.absoluteURL
+        }
+        return nil
+    }
+
+    static func revisionKey(_ revision: String) -> String {
+        SHA256.hash(data: Data(revision.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func contentKey(_ etag: String) -> String {
+        let safe = etag.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_.")).contains($0)
+        }
+        return safe && !etag.isEmpty ? etag : revisionKey(etag)
+    }
+
     private static func globRegex(_ pattern: String) -> NSRegularExpression? {
         var regex = "^"
         for scalar in pattern.unicodeScalars {
@@ -448,6 +738,14 @@ public actor HubSnapshot {
             etag = String(etag.dropFirst(2))
         }
         return etag.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+
+    private static func readDownloadMetadata(at url: URL) -> HubSnapshotDownloadMetadata? {
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        let lines = content.components(separatedBy: .newlines)
+        guard let commit = lines.first, !commit.isEmpty else { return nil }
+        let etag = lines.count > 1 && !lines[1].isEmpty ? lines[1] : nil
+        return HubSnapshotDownloadMetadata(commitHash: commit, etag: etag)
     }
 
     @discardableResult
@@ -499,10 +797,20 @@ public actor HubSnapshot {
     }
 }
 
+private struct HubSnapshotTree: Sendable {
+    let entries: [HubSnapshotTreeEntry]
+    let resolvedRevision: String?
+}
+
 private struct HubSnapshotTreeEntry: Decodable, Sendable {
     let path: String
     let type: String
     let size: Int64?
+}
+
+private struct HubSnapshotDownloadMetadata: Sendable {
+    let commitHash: String
+    let etag: String?
 }
 
 private struct HubSnapshotRemoteFile: Sendable {

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -252,6 +252,11 @@ public enum ManagedModelResolver {
             for: spec,
             progress: progress
         )
+        let storageLock = try ModelStorageFileLock.acquire(
+            hubDirectory: HubSnapshot.resolvedDownloadBase(fileManager: fileManager),
+            fileManager: fileManager
+        )
+        defer { storageLock.unlock() }
         try normalizeManagedLayoutIfNeeded(for: spec, in: snapshotURL, fileManager: fileManager)
         try fileManager.createDirectory(at: modelDir.deletingLastPathComponent(), withIntermediateDirectories: true)
         let manifest = try materializeManagedInstallRoot(
@@ -426,6 +431,7 @@ public enum ManagedModelResolver {
             from: snapshotURL,
             to: modelDir,
             fileManager: fileManager,
+            includedPatterns: spec.hubFallback?.patterns ?? [],
             materializedDirectoryPaths: mountedDirectories,
             excludedRelativePaths: mountedDestinationPaths
         )
@@ -438,7 +444,17 @@ public enum ManagedModelResolver {
                 fileManager: fileManager
             )
             try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
-            try materializeSnapshotEntries(from: sourceURL, to: destinationURL, fileManager: fileManager)
+            try materializeSnapshotEntries(
+                from: sourceURL,
+                to: destinationURL,
+                fileManager: fileManager,
+                includedPatterns: mountedPatterns(
+                    mounted.hubFallback.patterns,
+                    destinationPath: mounted.destinationPath,
+                    sourceURL: sourceURL,
+                    snapshotURL: mountedSnapshotURL
+                )
+            )
         }
 
         try installBundledGeometryLicenseIfNeeded(
@@ -472,6 +488,7 @@ public enum ManagedModelResolver {
         to destinationRoot: URL,
         fileManager: FileManager,
         relativePath: String = "",
+        includedPatterns: [String] = [],
         materializedDirectoryPaths: Set<String> = [],
         excludedRelativePaths: Set<String> = []
     ) throws {
@@ -490,6 +507,14 @@ public enum ManagedModelResolver {
 
             let linkURL = destinationRoot.appendingPathComponent(entry.lastPathComponent)
             let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            if isInternalSnapshotPath(entryRelativePath)
+                || !shouldIncludeSnapshotEntry(
+                    entryRelativePath,
+                    isDirectory: isDirectory,
+                    includedPatterns: includedPatterns
+                ) {
+                continue
+            }
             if isDirectory && shouldMaterializeDirectory(entryRelativePath, materializedDirectoryPaths: materializedDirectoryPaths) {
                 try fileManager.createDirectory(at: linkURL, withIntermediateDirectories: true)
                 try materializeSnapshotEntries(
@@ -497,6 +522,7 @@ public enum ManagedModelResolver {
                     to: linkURL,
                     fileManager: fileManager,
                     relativePath: entryRelativePath,
+                    includedPatterns: includedPatterns,
                     materializedDirectoryPaths: materializedDirectoryPaths,
                     excludedRelativePaths: excludedRelativePaths
                 )
@@ -508,6 +534,41 @@ public enum ManagedModelResolver {
             }
             try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: entry)
         }
+    }
+
+    private static func mountedPatterns(
+        _ patterns: [String],
+        destinationPath: String,
+        sourceURL: URL,
+        snapshotURL: URL
+    ) -> [String] {
+        guard sourceURL.standardizedFileURL.path != snapshotURL.standardizedFileURL.path else {
+            return patterns
+        }
+        let prefix = normalizedRelativePath(destinationPath) + "/"
+        return patterns.compactMap { pattern in
+            pattern.hasPrefix(prefix) ? String(pattern.dropFirst(prefix.count)) : nil
+        }
+    }
+
+    private static func isInternalSnapshotPath(_ relativePath: String) -> Bool {
+        let components = relativePath.split(separator: "/")
+        return components.contains(".cache")
+            || relativePath == HubSnapshotReceipt.filename
+    }
+
+    private static func shouldIncludeSnapshotEntry(
+        _ relativePath: String,
+        isDirectory: Bool,
+        includedPatterns: [String]
+    ) -> Bool {
+        guard !includedPatterns.isEmpty else { return true }
+        if HubSnapshot.matchesPath(relativePath, patterns: includedPatterns) {
+            return true
+        }
+        guard isDirectory else { return false }
+        let prefix = relativePath + "/"
+        return includedPatterns.contains { $0.hasPrefix(prefix) }
     }
 
     private static func materializedDirectories(for mountedDestinationPaths: [String]) -> Set<String> {

--- a/Sources/MereRunCore/ModelStorageFileLock.swift
+++ b/Sources/MereRunCore/ModelStorageFileLock.swift
@@ -1,0 +1,46 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Cross-process exclusion for operations that mutate the Hub payload store.
+public final class ModelStorageFileLock: @unchecked Sendable {
+    private var descriptor: Int32
+
+    private init(descriptor: Int32) {
+        self.descriptor = descriptor
+    }
+
+    deinit {
+        unlock()
+    }
+
+    public static func acquire(
+        hubDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws -> ModelStorageFileLock {
+        try fileManager.createDirectory(at: hubDirectory, withIntermediateDirectories: true)
+        let lockURL = hubDirectory.appendingPathComponent(".mererun-storage.lock", isDirectory: false)
+        let descriptor = lockURL.path.withCString {
+            open($0, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        }
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            let code = errno
+            close(descriptor)
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+        return ModelStorageFileLock(descriptor: descriptor)
+    }
+
+    public func unlock() {
+        guard descriptor >= 0 else { return }
+        _ = flock(descriptor, LOCK_UN)
+        close(descriptor)
+        descriptor = -1
+    }
+}

--- a/Sources/MereRunCore/ModelStorageManager.swift
+++ b/Sources/MereRunCore/ModelStorageManager.swift
@@ -1,0 +1,765 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+public struct ModelStorageModelUsage: Codable, Equatable, Sendable {
+    public let id: String
+    public let installPath: String
+    public let installed: Bool
+    public let referencedBytes: Int64
+    public let localBytes: Int64
+    public let reclaimableBytes: Int64
+    public let sharedBytes: Int64
+    public let externalBytes: Int64
+
+    public init(
+        id: String,
+        installPath: String,
+        installed: Bool,
+        referencedBytes: Int64,
+        localBytes: Int64,
+        reclaimableBytes: Int64,
+        sharedBytes: Int64,
+        externalBytes: Int64 = 0
+    ) {
+        self.id = id
+        self.installPath = installPath
+        self.installed = installed
+        self.referencedBytes = referencedBytes
+        self.localBytes = localBytes
+        self.reclaimableBytes = reclaimableBytes
+        self.sharedBytes = sharedBytes
+        self.externalBytes = externalBytes
+    }
+}
+
+public struct ModelStorageReport: Codable, Equatable, Sendable {
+    public let applicationSupportPath: String
+    public let modelStorePath: String
+    public let hubPath: String
+    public let applicationSupportBytes: Int64
+    public let modelStoreBytes: Int64
+    public let hubBytes: Int64
+    public let otherApplicationSupportBytes: Int64
+    public let garbageCollectableBytes: Int64
+    public let incompleteDownloadBytes: Int64
+    public let models: [ModelStorageModelUsage]
+
+    public init(
+        applicationSupportPath: String,
+        modelStorePath: String,
+        hubPath: String,
+        applicationSupportBytes: Int64,
+        modelStoreBytes: Int64,
+        hubBytes: Int64,
+        otherApplicationSupportBytes: Int64,
+        garbageCollectableBytes: Int64,
+        incompleteDownloadBytes: Int64,
+        models: [ModelStorageModelUsage]
+    ) {
+        self.applicationSupportPath = applicationSupportPath
+        self.modelStorePath = modelStorePath
+        self.hubPath = hubPath
+        self.applicationSupportBytes = applicationSupportBytes
+        self.modelStoreBytes = modelStoreBytes
+        self.hubBytes = hubBytes
+        self.otherApplicationSupportBytes = otherApplicationSupportBytes
+        self.garbageCollectableBytes = garbageCollectableBytes
+        self.incompleteDownloadBytes = incompleteDownloadBytes
+        self.models = models
+    }
+}
+
+public struct ModelStorageGarbageItem: Codable, Equatable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case cacheUnit = "cache_unit"
+        case payload
+        case metadata
+        case incompleteDownload = "incomplete_download"
+        case blob
+        case reference
+    }
+
+    public let kind: Kind
+    public let path: String
+    public let logicalBytes: Int64
+
+    public init(kind: Kind, path: String, logicalBytes: Int64) {
+        self.kind = kind
+        self.path = path
+        self.logicalBytes = logicalBytes
+    }
+}
+
+public struct ModelStorageGarbagePlan: Codable, Equatable, Sendable {
+    public let hubPath: String
+    public let reclaimableBytes: Int64
+    public let incompleteDownloadBytes: Int64
+    public let items: [ModelStorageGarbageItem]
+    public let scopeCacheUnitPaths: [String]?
+
+    public init(
+        hubPath: String,
+        reclaimableBytes: Int64,
+        incompleteDownloadBytes: Int64,
+        items: [ModelStorageGarbageItem],
+        scopeCacheUnitPaths: [String]? = nil
+    ) {
+        self.hubPath = hubPath
+        self.reclaimableBytes = reclaimableBytes
+        self.incompleteDownloadBytes = incompleteDownloadBytes
+        self.items = items
+        self.scopeCacheUnitPaths = scopeCacheUnitPaths
+    }
+}
+
+public struct ModelStorageGarbageResult: Codable, Equatable, Sendable {
+    public let plannedBytes: Int64
+    public let reclaimedBytes: Int64
+    public let deletedItemCount: Int
+
+    public init(plannedBytes: Int64, reclaimedBytes: Int64, deletedItemCount: Int) {
+        self.plannedBytes = plannedBytes
+        self.reclaimedBytes = reclaimedBytes
+        self.deletedItemCount = deletedItemCount
+    }
+}
+
+/// Builds a physical ownership graph for the model store and its Hub-backed payloads.
+///
+/// Model install roots may contain direct files, symlink individual payload files, or be
+/// symlinks themselves. Accounting therefore follows model links for referenced bytes,
+/// but counts file identities only once for physical and reclaimable bytes.
+public final class ModelStorageManager {
+    private struct FileIdentity: Hashable {
+        let device: UInt64
+        let inode: UInt64
+    }
+
+    private struct FileRecord {
+        let url: URL
+        let identity: FileIdentity
+        let size: Int64
+        let linkCount: Int
+    }
+
+    private struct Reference {
+        let owner: String
+        let target: URL
+        let targetIsDirectory: Bool
+        let cacheUnit: URL?
+    }
+
+    private let fileManager: FileManager
+    private let unreferencedGracePeriod: TimeInterval
+    private let now: () -> Date
+    public let modelsDirectory: URL
+    public let hubDirectory: URL
+    public let applicationSupportDirectory: URL
+
+    public init(
+        modelsDirectory: URL = MereRunModelPaths.modelsDir,
+        hubDirectory: URL? = nil,
+        applicationSupportDirectory: URL = MereRunModelPaths.applicationSupportBase,
+        fileManager: FileManager = .default,
+        unreferencedGracePeriod: TimeInterval = 3_600,
+        now: @escaping () -> Date = Date.init
+    ) throws {
+        self.fileManager = fileManager
+        self.unreferencedGracePeriod = max(0, unreferencedGracePeriod)
+        self.now = now
+        let resolvedHubDirectory = try hubDirectory ?? HubSnapshot.resolvedDownloadBase(fileManager: fileManager)
+        self.modelsDirectory = Self.canonicalFileURL(modelsDirectory)
+        self.hubDirectory = Self.canonicalFileURL(resolvedHubDirectory)
+        self.applicationSupportDirectory = Self.canonicalFileURL(applicationSupportDirectory)
+    }
+
+    public func report(
+        modelIDs: [String] = ManagedModelCatalog.allSpecs.map(\.id)
+    ) throws -> ModelStorageReport {
+        let references = try symlinkReferences()
+        let ownerFiles = try referencedFilesByOwner(references: references)
+        let externalOwnerFiles = try referencedFilesByOwner(
+            references: references.filter { !isDescendant($0.target, of: applicationSupportDirectory) },
+            includeLocalFiles: false
+        )
+        let identityOwners = ownersByIdentity(ownerFiles)
+        let garbagePlan = try garbageCollectionPlan(references: references, limitingTo: nil)
+
+        let models = try modelIDs.map { id in
+            try modelUsage(
+                id: id,
+                ownerFiles: ownerFiles,
+                externalOwnerFiles: externalOwnerFiles,
+                identityOwners: identityOwners
+            )
+        }
+        let applicationSupportBytes = uniqueBytes(fileRecords(at: applicationSupportDirectory))
+        let modelStoreBytes = uniqueBytes(fileRecords(at: modelsDirectory))
+        let hubBytes = uniqueBytes(fileRecords(at: hubDirectory))
+        let otherBytes = max(0, applicationSupportBytes - hubBytes - modelStoreBytes)
+
+        return ModelStorageReport(
+            applicationSupportPath: applicationSupportDirectory.path,
+            modelStorePath: modelsDirectory.path,
+            hubPath: hubDirectory.path,
+            applicationSupportBytes: applicationSupportBytes,
+            modelStoreBytes: modelStoreBytes,
+            hubBytes: hubBytes,
+            otherApplicationSupportBytes: otherBytes,
+            garbageCollectableBytes: garbagePlan.reclaimableBytes,
+            incompleteDownloadBytes: garbagePlan.incompleteDownloadBytes,
+            models: models
+        )
+    }
+
+    public func cacheUnitsReferenced(by owner: String) throws -> [URL] {
+        let units = try symlinkReferences()
+            .filter { $0.owner == owner }
+            .compactMap(\.cacheUnit)
+        return uniqueURLs(units)
+    }
+
+    public func garbageCollectionPlan(
+        limitingTo cacheUnits: [URL]? = nil
+    ) throws -> ModelStorageGarbagePlan {
+        try garbageCollectionPlan(
+            references: symlinkReferences(),
+            limitingTo: cacheUnits.map { Set($0.map(Self.pathKey)) }
+        )
+    }
+
+    public func execute(_ plan: ModelStorageGarbagePlan) throws -> ModelStorageGarbageResult {
+        let storageLock = try ModelStorageFileLock.acquire(hubDirectory: hubDirectory, fileManager: fileManager)
+        defer { storageLock.unlock() }
+        let hubBefore = uniqueBytes(fileRecords(at: hubDirectory))
+        let currentPlan = try garbageCollectionPlan(
+            references: symlinkReferences(),
+            limitingTo: plan.scopeCacheUnitPaths.map(Set.init)
+        )
+        let currentlySafePaths = Set(currentPlan.items.map(\.path))
+        var deletedCount = 0
+
+        for item in plan.items.filter({ currentlySafePaths.contains($0.path) }).sorted(by: Self.deletionOrder) {
+            let url = URL(fileURLWithPath: item.path).standardizedFileURL
+            guard isDescendant(url, of: hubDirectory), url.path != hubDirectory.path else {
+                throw CocoaError(.fileWriteInvalidFileName)
+            }
+            guard fileManager.fileExists(atPath: url.path) else { continue }
+            try fileManager.removeItem(at: url)
+            deletedCount += 1
+        }
+
+        removeEmptyCacheDirectories()
+        let hubAfter = uniqueBytes(fileRecords(at: hubDirectory))
+        return ModelStorageGarbageResult(
+            plannedBytes: plan.reclaimableBytes,
+            reclaimedBytes: max(0, hubBefore - hubAfter),
+            deletedItemCount: deletedCount
+        )
+    }
+
+    private func modelUsage(
+        id: String,
+        ownerFiles: [String: [FileIdentity: FileRecord]],
+        externalOwnerFiles: [String: [FileIdentity: FileRecord]],
+        identityOwners: [FileIdentity: Set<String>]
+    ) throws -> ModelStorageModelUsage {
+        let installURL = modelsDirectory.appendingPathComponent(id, isDirectory: true)
+        let installed = fileManager.fileExists(atPath: installURL.path)
+        guard installed else {
+            return ModelStorageModelUsage(
+                id: id,
+                installPath: installURL.path,
+                installed: false,
+                referencedBytes: 0,
+                localBytes: 0,
+                reclaimableBytes: 0,
+                sharedBytes: 0,
+                externalBytes: 0
+            )
+        }
+
+        let referenced = ownerFiles[id] ?? [:]
+        let localRecords = fileRecords(at: installURL)
+        let localIdentities = Set(localRecords.map(\.identity))
+        let localBytes = uniqueBytes(localRecords)
+        let externalRecords = externalOwnerFiles[id] ?? [:]
+        let externalIdentities = Set(externalRecords.keys)
+        let externalBytes = externalRecords.values.reduce(Int64(0)) { $0 + $1.size }
+        let referencedBytes = referenced.values.reduce(Int64(0)) { $0 + $1.size }
+        let exclusiveCacheBytes = referenced.reduce(Int64(0)) { partial, entry in
+            let (identity, record) = entry
+            guard !localIdentities.contains(identity),
+                  !externalIdentities.contains(identity),
+                  identityOwners[identity] == [id] else {
+                return partial
+            }
+            return partial + record.size
+        }
+        let reclaimable = localBytes + exclusiveCacheBytes
+
+        return ModelStorageModelUsage(
+            id: id,
+            installPath: installURL.path,
+            installed: true,
+            referencedBytes: referencedBytes,
+            localBytes: localBytes,
+            reclaimableBytes: reclaimable,
+            sharedBytes: max(0, referencedBytes - reclaimable - externalBytes),
+            externalBytes: externalBytes
+        )
+    }
+
+    private func garbageCollectionPlan(
+        references: [Reference],
+        limitingTo cacheUnitPaths: Set<String>?
+    ) throws -> ModelStorageGarbagePlan {
+        let cacheUnits = try cacheUnitURLs().filter { unit in
+            cacheUnitPaths == nil || cacheUnitPaths?.contains(Self.pathKey(unit)) == true
+        }
+        let allHubRecords = fileRecords(at: hubDirectory)
+        let hubRecordsByIdentity = Dictionary(grouping: allHubRecords, by: \.identity)
+        var items: [ModelStorageGarbageItem] = []
+        var plannedFilePaths = Set<String>()
+        var incompleteBytes: Int64 = 0
+
+        for unit in cacheUnits {
+            let unitRecords = payloadFileRecords(at: unit)
+            let unitReferences = references.filter {
+                guard let referencedUnit = $0.cacheUnit else { return false }
+                return Self.pathKey(referencedUnit) == Self.pathKey(unit)
+            }
+            if unitReferences.isEmpty {
+                if cacheUnitPaths == nil, cacheUnitIsWithinGracePeriod(unit) {
+                    continue
+                }
+                let bytes = uniqueBytes(fileRecords(at: unit))
+                items.append(ModelStorageGarbageItem(kind: .cacheUnit, path: unit.path, logicalBytes: bytes))
+                plannedFilePaths.formUnion(fileRecords(at: unit).map { $0.url.path })
+                incompleteBytes += incompleteDownloadBytes(at: unit)
+                continue
+            }
+
+            for record in unitRecords where !isLive(record.url, references: unitReferences) {
+                items.append(ModelStorageGarbageItem(kind: .payload, path: record.url.path, logicalBytes: record.size))
+                plannedFilePaths.insert(record.url.path)
+                if let metadata = metadataURL(for: record.url, in: unit),
+                   fileManager.fileExists(atPath: metadata.path) {
+                    let metadataBytes = fileRecord(at: metadata)?.size ?? 0
+                    items.append(ModelStorageGarbageItem(
+                        kind: .metadata,
+                        path: metadata.path,
+                        logicalBytes: metadataBytes
+                    ))
+                    plannedFilePaths.insert(metadata.path)
+                }
+            }
+
+            for incomplete in incompleteDownloadRecords(at: unit) {
+                items.append(ModelStorageGarbageItem(
+                    kind: .incompleteDownload,
+                    path: incomplete.url.path,
+                    logicalBytes: incomplete.size
+                ))
+                plannedFilePaths.insert(incomplete.url.path)
+                incompleteBytes += incomplete.size
+            }
+        }
+
+        let blobRoot = hubDirectory.appendingPathComponent("blobs", isDirectory: true)
+        for blob in fileRecords(at: blobRoot) {
+            let allLinks = hubRecordsByIdentity[blob.identity] ?? []
+            let plannedLinks = allLinks.filter { plannedFilePaths.contains($0.url.path) }.count
+            let canDeleteOrphan = cacheUnitPaths == nil && blob.linkCount == 1
+            if canDeleteOrphan || (plannedLinks > 0 && blob.linkCount <= plannedLinks + 1) {
+                items.append(ModelStorageGarbageItem(kind: .blob, path: blob.url.path, logicalBytes: blob.size))
+                plannedFilePaths.insert(blob.url.path)
+            }
+        }
+
+        let plannedCacheUnitKeys = Set(
+            items.filter { $0.kind == .cacheUnit }.map { Self.pathKey(URL(fileURLWithPath: $0.path)) }
+        )
+        let refsRoot = hubDirectory.appendingPathComponent("refs", isDirectory: true)
+        for reference in fileRecords(at: refsRoot) {
+            guard let snapshot = snapshotURL(forReference: reference.url, refsRoot: refsRoot) else { continue }
+            let snapshotKey = Self.pathKey(snapshot)
+            let snapshotWillBeDeleted = plannedCacheUnitKeys.contains(snapshotKey)
+            let snapshotIsMissing = !fileManager.fileExists(atPath: snapshot.path)
+            guard snapshotWillBeDeleted || (cacheUnitPaths == nil && snapshotIsMissing) else { continue }
+            items.append(
+                ModelStorageGarbageItem(
+                    kind: .reference,
+                    path: reference.url.path,
+                    logicalBytes: reference.size
+                )
+            )
+            plannedFilePaths.insert(reference.url.path)
+        }
+
+        let reclaimableBytes = hubRecordsByIdentity.reduce(Int64(0)) { partial, entry in
+            let (_, records) = entry
+            guard let first = records.first else { return partial }
+            let plannedLinks = records.filter { plannedFilePaths.contains($0.url.path) }.count
+            guard plannedLinks >= first.linkCount else { return partial }
+            return partial + first.size
+        }
+
+        return ModelStorageGarbagePlan(
+            hubPath: hubDirectory.path,
+            reclaimableBytes: reclaimableBytes,
+            incompleteDownloadBytes: incompleteBytes,
+            items: uniqueGarbageItems(items),
+            scopeCacheUnitPaths: cacheUnitPaths?.sorted()
+        )
+    }
+
+    private func symlinkReferences() throws -> [Reference] {
+        var references: [Reference] = []
+        for root in referenceRoots() where fileManager.fileExists(atPath: root.path) {
+            guard let enumerator = fileManager.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.isSymbolicLinkKey],
+                options: []
+            ) else { continue }
+
+            for case let url as URL in enumerator {
+                if url.standardizedFileURL.path == hubDirectory.path || isDescendant(url, of: hubDirectory) {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                guard isSymbolicLink(url) else { continue }
+                let target = Self.canonicalFileURL(url)
+                var isDirectory: ObjCBool = false
+                guard fileManager.fileExists(atPath: target.path, isDirectory: &isDirectory) else {
+                    continue
+                }
+                let targetIsInHub = isDescendant(target, of: hubDirectory)
+                guard targetIsInHub || isDescendant(url, of: modelsDirectory) else { continue }
+                guard url.lastPathComponent != ".cache",
+                      url.lastPathComponent != HubSnapshotReceipt.filename else { continue }
+                references.append(
+                    Reference(
+                        owner: ownerID(for: url),
+                        target: target,
+                        targetIsDirectory: isDirectory.boolValue,
+                        cacheUnit: targetIsInHub ? cacheUnit(containing: target) : nil
+                    )
+                )
+            }
+        }
+        return references
+    }
+
+    private func referencedFilesByOwner(
+        references: [Reference],
+        includeLocalFiles: Bool = true
+    ) throws -> [String: [FileIdentity: FileRecord]] {
+        var result: [String: [FileIdentity: FileRecord]] = [:]
+        for reference in references {
+            let records = reference.targetIsDirectory
+                ? payloadFileRecords(at: reference.target)
+                : [fileRecord(at: reference.target)].compactMap { $0 }
+            for record in records {
+                result[reference.owner, default: [:]][record.identity] = record
+            }
+        }
+
+        if includeLocalFiles {
+            for id in ManagedModelCatalog.allSpecs.map(\.id) {
+                let root = modelsDirectory.appendingPathComponent(id, isDirectory: true)
+                for record in fileRecords(at: root) {
+                    result[id, default: [:]][record.identity] = record
+                }
+            }
+        }
+        return result
+    }
+
+    private func ownersByIdentity(
+        _ ownerFiles: [String: [FileIdentity: FileRecord]]
+    ) -> [FileIdentity: Set<String>] {
+        var result: [FileIdentity: Set<String>] = [:]
+        for (owner, files) in ownerFiles {
+            for identity in files.keys {
+                result[identity, default: []].insert(owner)
+            }
+        }
+        return result
+    }
+
+    private func referenceRoots() -> [URL] {
+        uniqueURLs([applicationSupportDirectory, modelsDirectory])
+    }
+
+    private func ownerID(for link: URL) -> String {
+        if isDescendant(link, of: modelsDirectory) {
+            let linkPath = Self.pathKey(link)
+            let modelsPath = Self.pathKey(modelsDirectory)
+            let relative = String(linkPath.dropFirst(modelsPath.count + 1))
+            let first = relative.split(separator: "/").first.map(String.init) ?? relative
+            if first == CodeGenResources.managedRelativePath {
+                return ModelResolver.ModelID.qwen3Code.rawValue
+            }
+            return first
+        }
+        let linkPath = Self.pathKey(link)
+        let applicationSupportPath = Self.pathKey(applicationSupportDirectory)
+        let relative = isDescendant(link, of: applicationSupportDirectory)
+            ? String(linkPath.dropFirst(applicationSupportPath.count + 1))
+            : linkPath
+        return "legacy:\(relative.split(separator: "/").first.map(String.init) ?? relative)"
+    }
+
+    private func cacheUnit(containing target: URL) -> URL? {
+        let legacyRoot = hubDirectory.appendingPathComponent("models", isDirectory: true)
+        if isDescendant(target, of: legacyRoot) {
+            let relative = String(target.path.dropFirst(legacyRoot.path.count + 1))
+            let parts = relative.split(separator: "/")
+            guard parts.count >= 2 else { return nil }
+            return legacyRoot
+                .appendingPathComponent(String(parts[0]), isDirectory: true)
+                .appendingPathComponent(String(parts[1]), isDirectory: true)
+        }
+
+        let snapshotsRoot = hubDirectory.appendingPathComponent("snapshots/models", isDirectory: true)
+        if isDescendant(target, of: snapshotsRoot) {
+            let relative = String(target.path.dropFirst(snapshotsRoot.path.count + 1))
+            let parts = relative.split(separator: "/")
+            guard parts.count >= 3 else { return nil }
+            return snapshotsRoot
+                .appendingPathComponent(String(parts[0]), isDirectory: true)
+                .appendingPathComponent(String(parts[1]), isDirectory: true)
+                .appendingPathComponent(String(parts[2]), isDirectory: true)
+        }
+        return nil
+    }
+
+    private func cacheUnitURLs() throws -> [URL] {
+        var result: [URL] = []
+        let legacy = hubDirectory.appendingPathComponent("models", isDirectory: true)
+        for owner in directoryChildren(of: legacy) {
+            result.append(contentsOf: directoryChildren(of: owner))
+        }
+
+        let snapshots = hubDirectory.appendingPathComponent("snapshots/models", isDirectory: true)
+        for owner in directoryChildren(of: snapshots) {
+            for repository in directoryChildren(of: owner) {
+                result.append(contentsOf: directoryChildren(of: repository))
+            }
+        }
+        return result
+    }
+
+    private func directoryChildren(of root: URL) -> [URL] {
+        let urls = (try? fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return urls.filter {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+    }
+
+    private func payloadFileRecords(at root: URL) -> [FileRecord] {
+        fileRecords(at: root).filter { record in
+            let relative = relativePath(of: record.url, under: root)
+            let components = relative.split(separator: "/")
+            return !components.contains(".cache")
+                && record.url.lastPathComponent != HubSnapshotReceipt.filename
+                && record.url.lastPathComponent != ".mererun-storage.lock"
+                && !record.url.lastPathComponent.hasSuffix(".incomplete")
+        }
+    }
+
+    private func incompleteDownloadRecords(at root: URL) -> [FileRecord] {
+        fileRecords(at: root).filter { $0.url.lastPathComponent.hasSuffix(".incomplete") }
+    }
+
+    private func incompleteDownloadBytes(at root: URL) -> Int64 {
+        uniqueBytes(incompleteDownloadRecords(at: root))
+    }
+
+    private func isLive(_ payload: URL, references: [Reference]) -> Bool {
+        references.contains { reference in
+            Self.pathKey(reference.target) == Self.pathKey(payload)
+                || (reference.targetIsDirectory && isDescendant(payload, of: reference.target))
+        }
+    }
+
+    private func metadataURL(for payload: URL, in unit: URL) -> URL? {
+        guard isDescendant(payload, of: unit) else { return nil }
+        let relative = relativePath(of: payload, under: unit)
+        return unit
+            .appendingPathComponent(".cache/huggingface/download", isDirectory: true)
+            .appendingPathComponent(relative + ".metadata", isDirectory: false)
+    }
+
+    private func snapshotURL(forReference reference: URL, refsRoot: URL) -> URL? {
+        let parts = relativePath(of: reference, under: refsRoot).split(separator: "/").map(String.init)
+        guard parts.count == 4,
+              parts[3].hasSuffix(".ref"),
+              let data = try? Data(contentsOf: reference),
+              let resolved = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !resolved.isEmpty else {
+            return nil
+        }
+        return hubDirectory
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(parts[0], isDirectory: true)
+            .appendingPathComponent(parts[1], isDirectory: true)
+            .appendingPathComponent(parts[2], isDirectory: true)
+            .appendingPathComponent(HubSnapshot.revisionKey(resolved), isDirectory: true)
+    }
+
+    private func cacheUnitIsWithinGracePeriod(_ unit: URL) -> Bool {
+        guard unreferencedGracePeriod > 0,
+              let attributes = try? fileManager.attributesOfItem(atPath: unit.path),
+              let modified = attributes[.modificationDate] as? Date else {
+            return false
+        }
+        return now().timeIntervalSince(modified) < unreferencedGracePeriod
+    }
+
+    private func fileRecords(at root: URL) -> [FileRecord] {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: root.path, isDirectory: &isDirectory) else { return [] }
+        if isSymbolicLink(root) {
+            return []
+        }
+        if !isDirectory.boolValue {
+            return fileRecord(at: root).map { [$0] } ?? []
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: []
+        ) else { return [] }
+
+        var result: [FileRecord] = []
+        for case let url as URL in enumerator {
+            if isSymbolicLink(url) {
+                continue
+            }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            if values?.isRegularFile == true, let record = fileRecord(at: url) {
+                result.append(record)
+            }
+        }
+        return result
+    }
+
+    private func isSymbolicLink(_ url: URL) -> Bool {
+        (try? fileManager.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+
+    private func fileRecord(at url: URL) -> FileRecord? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let device = (attributes[.systemNumber] as? NSNumber)?.uint64Value,
+              let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value,
+              let size = (attributes[.size] as? NSNumber)?.int64Value else {
+            return nil
+        }
+        let links = (attributes[.referenceCount] as? NSNumber)?.intValue ?? 1
+        return FileRecord(
+            url: url.standardizedFileURL,
+            identity: FileIdentity(device: device, inode: inode),
+            size: size,
+            linkCount: max(1, links)
+        )
+    }
+
+    private func uniqueBytes(_ records: [FileRecord]) -> Int64 {
+        var seen = Set<FileIdentity>()
+        return records.reduce(Int64(0)) { partial, record in
+            guard seen.insert(record.identity).inserted else { return partial }
+            return partial + record.size
+        }
+    }
+
+    private func uniqueURLs(_ urls: [URL]) -> [URL] {
+        var seen = Set<String>()
+        return urls.filter { seen.insert(Self.pathKey($0)).inserted }
+    }
+
+    private func uniqueGarbageItems(_ items: [ModelStorageGarbageItem]) -> [ModelStorageGarbageItem] {
+        var seen = Set<String>()
+        return items.filter { seen.insert($0.path).inserted }
+    }
+
+    private func relativePath(of url: URL, under root: URL) -> String {
+        let path = Self.pathKey(url)
+        let rootPath = Self.pathKey(root)
+        return String(path.dropFirst(rootPath.count + 1))
+    }
+
+    private func isDescendant(_ url: URL, of root: URL) -> Bool {
+        let path = Self.pathKey(url)
+        let rootPath = Self.pathKey(root)
+        return path.hasPrefix(rootPath + "/")
+    }
+
+    private func removeEmptyCacheDirectories() {
+        let roots = [
+            hubDirectory.appendingPathComponent("models", isDirectory: true),
+            hubDirectory.appendingPathComponent("snapshots", isDirectory: true),
+            hubDirectory.appendingPathComponent("blobs", isDirectory: true),
+        ]
+        for root in roots {
+            guard let enumerator = fileManager.enumerator(at: root, includingPropertiesForKeys: nil) else { continue }
+            var directories: [URL] = []
+            for case let url as URL in enumerator {
+                var isDirectory: ObjCBool = false
+                if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue {
+                    directories.append(url)
+                }
+            }
+            for directory in directories.sorted(by: { $0.path.count > $1.path.count }) {
+                let contents = try? fileManager.contentsOfDirectory(atPath: directory.path)
+                if contents?.isEmpty == true {
+                    try? fileManager.removeItem(at: directory)
+                }
+            }
+        }
+    }
+
+    private static func deletionOrder(_ lhs: ModelStorageGarbageItem, _ rhs: ModelStorageGarbageItem) -> Bool {
+        if lhs.kind == .cacheUnit, rhs.kind != .cacheUnit { return true }
+        if rhs.kind == .cacheUnit, lhs.kind != .cacheUnit { return false }
+        return lhs.path.count > rhs.path.count
+    }
+
+    private static func canonicalFileURL(_ url: URL) -> URL {
+        let resolved = url.path.withCString { realpath($0, nil) }
+        guard let resolved else { return normalizedSystemAlias(url.resolvingSymlinksInPath().standardizedFileURL) }
+        defer { free(resolved) }
+        let canonical = URL(fileURLWithPath: String(cString: resolved)).standardizedFileURL
+        return normalizedSystemAlias(canonical)
+    }
+
+    private static func normalizedSystemAlias(_ url: URL) -> URL {
+        #if canImport(Darwin)
+        let path = url.path
+        if path == "/var" || path.hasPrefix("/var/") || path == "/tmp" || path.hasPrefix("/tmp/") {
+            return URL(fileURLWithPath: "/private" + path).standardizedFileURL
+        }
+        #endif
+        return url
+    }
+
+    private static func pathKey(_ url: URL) -> String {
+        let path = url.standardizedFileURL.path
+        #if canImport(Darwin)
+        if path == "/private/var" || path.hasPrefix("/private/var/")
+            || path == "/private/tmp" || path.hasPrefix("/private/tmp/") {
+            return String(path.dropFirst("/private".count))
+        }
+        #endif
+        return path
+    }
+}

--- a/Tests/MereRunCLITests/ModelStorageCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelStorageCommandTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import MereRunCore
+@testable import MereRunCLI
+
+final class ModelStorageCommandTests: XCTestCase {
+    func testModelCommandExposesStorageAndGarbageCollection() {
+        let names = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(names.contains("storage"))
+        XCTAssertTrue(names.contains("gc"))
+    }
+
+    func testStorageAndGarbageCollectionFlagsParse() throws {
+        XCTAssertTrue(try ModelStorage.parse(["--json"]).json)
+
+        let dryRun = try ModelGarbageCollect.parse([])
+        XCTAssertFalse(dryRun.force)
+        XCTAssertFalse(dryRun.json)
+
+        let apply = try ModelGarbageCollect.parse(["--force", "--json"])
+        XCTAssertTrue(apply.force)
+        XCTAssertTrue(apply.json)
+    }
+
+    func testRemoveParsesCacheRetentionAndJSON() throws {
+        let command = try ModelRemove.parse([
+            "image-klein-nano",
+            "--force",
+            "--keep-cache",
+            "--json",
+        ])
+        XCTAssertTrue(command.force)
+        XCTAssertTrue(command.keepCache)
+        XCTAssertTrue(command.json)
+    }
+
+    func testStorageTextSeparatesPhysicalAndReferencedBytes() {
+        let report = ModelStorageReport(
+            applicationSupportPath: "/store",
+            modelStorePath: "/store/models",
+            hubPath: "/store/hub",
+            applicationSupportBytes: 1_000,
+            modelStoreBytes: 20,
+            hubBytes: 900,
+            otherApplicationSupportBytes: 80,
+            garbageCollectableBytes: 100,
+            incompleteDownloadBytes: 25,
+            models: [
+                ModelStorageModelUsage(
+                    id: "model-a",
+                    installPath: "/store/models/model-a",
+                    installed: true,
+                    referencedBytes: 800,
+                    localBytes: 0,
+                    reclaimableBytes: 600,
+                    sharedBytes: 150,
+                    externalBytes: 50
+                ),
+            ]
+        )
+
+        let text = ModelStorageCommandOutput.text(report)
+        XCTAssertTrue(text.contains("Hub payloads:"))
+        XCTAssertTrue(text.contains("Safe to collect:"))
+        XCTAssertTrue(text.contains("do not add these values"))
+        XCTAssertTrue(text.contains("referenced"))
+        XCTAssertTrue(text.contains("reclaimable on removal"))
+        XCTAssertTrue(text.contains("shared"))
+        XCTAssertTrue(text.contains("external (not managed here)"))
+    }
+
+    func testGarbageCollectionJSONIncludesDryRunModeAndPlan() throws {
+        let output = ModelGarbageCollectOutput(
+            mode: "dry-run",
+            plan: ModelStorageGarbagePlan(
+                hubPath: "/store/hub",
+                reclaimableBytes: 42,
+                incompleteDownloadBytes: 42,
+                items: [
+                    ModelStorageGarbageItem(
+                        kind: .incompleteDownload,
+                        path: "/store/hub/model.bin.incomplete",
+                        logicalBytes: 42
+                    ),
+                ]
+            ),
+            result: nil
+        )
+        let encoded = try ModelStorageCommandOutput.encode(output)
+        let decoded = try JSONDecoder().decode(
+            ModelGarbageCollectOutput.self,
+            from: Data(encoded.utf8)
+        )
+
+        XCTAssertEqual(decoded, output)
+        XCTAssertTrue(ModelGarbageCollect.text(output).contains("dry run"))
+        XCTAssertTrue(ModelGarbageCollect.text(output).contains("--force"))
+    }
+}

--- a/Tests/MereRunCoreTests/HubSnapshotTests.swift
+++ b/Tests/MereRunCoreTests/HubSnapshotTests.swift
@@ -38,4 +38,19 @@ final class HubSnapshotTests: XCTestCase {
         XCTAssertTrue(redirected.absoluteString.contains("tokenizer%2Fadded_tokens.json"))
         XCTAssertFalse(redirected.absoluteString.contains("tokenizer%252Fadded_tokens.json"))
     }
+
+    func testRevisionKeysAreStableAndRevisionSpecific() {
+        XCTAssertEqual(HubSnapshot.revisionKey("main"), HubSnapshot.revisionKey("main"))
+        XCTAssertNotEqual(HubSnapshot.revisionKey("main"), HubSnapshot.revisionKey("feature"))
+        XCTAssertEqual(HubSnapshot.revisionKey("main").count, 64)
+    }
+
+    func testNextPageLinkResolution() throws {
+        let source = try XCTUnwrap(URL(string: "https://huggingface.co/api/models/org/repo/tree/main"))
+        let header = "<https://huggingface.co/api/models/org/repo/tree/main?cursor=abc>; rel=\"next\", <https://example.test/end>; rel=\"last\""
+        let next = HubSnapshot.nextPageURL(from: header, relativeTo: source)
+
+        XCTAssertEqual(next?.absoluteString, "https://huggingface.co/api/models/org/repo/tree/main?cursor=abc")
+        XCTAssertNil(HubSnapshot.nextPageURL(from: nil, relativeTo: source))
+    }
 }

--- a/Tests/MereRunCoreTests/ModelStorageManagerTests.swift
+++ b/Tests/MereRunCoreTests/ModelStorageManagerTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+@testable import MereRunCore
+
+final class ModelStorageManagerTests: XCTestCase {
+    private let fileManager = FileManager.default
+    private var temporaryRoot: URL!
+    private var applicationSupport: URL!
+    private var models: URL!
+    private var hub: URL!
+
+    override func setUpWithError() throws {
+        temporaryRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("mere-run-storage-tests-\(UUID().uuidString)", isDirectory: true)
+        applicationSupport = temporaryRoot.appendingPathComponent("MereRun", isDirectory: true)
+        models = applicationSupport.appendingPathComponent("models", isDirectory: true)
+        hub = applicationSupport.appendingPathComponent("hub", isDirectory: true)
+        try fileManager.createDirectory(at: models, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: hub, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryRoot, fileManager.fileExists(atPath: temporaryRoot.path) {
+            try fileManager.removeItem(at: temporaryRoot)
+        }
+    }
+
+    func testExclusiveLegacyPayloadIsReclaimableAfterRemovingInstallLink() throws {
+        let unit = legacyUnit(repository: "exclusive")
+        let payload = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 128)
+        try linkModel("model-a", to: payload)
+        let manager = try makeManager()
+
+        let usage = try XCTUnwrap(manager.report(modelIDs: ["model-a"]).models.first)
+        XCTAssertTrue(usage.installed)
+        XCTAssertEqual(usage.referencedBytes, 128)
+        XCTAssertEqual(usage.localBytes, 0)
+        XCTAssertEqual(usage.reclaimableBytes, 128)
+        XCTAssertEqual(usage.sharedBytes, 0)
+        XCTAssertTrue(try manager.garbageCollectionPlan().items.isEmpty)
+
+        try fileManager.removeItem(at: models.appendingPathComponent("model-a"))
+        let plan = try manager.garbageCollectionPlan(limitingTo: [unit])
+        XCTAssertEqual(plan.reclaimableBytes, 128)
+        XCTAssertEqual(plan.items.map(\.kind), [.cacheUnit])
+
+        let result = try manager.execute(plan)
+        XCTAssertEqual(result.reclaimedBytes, 128)
+        XCTAssertFalse(fileManager.fileExists(atPath: unit.path))
+    }
+
+    func testSharedPayloadRemainsWhenOneModelIsRemoved() throws {
+        let unit = legacyUnit(repository: "shared")
+        let payload = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 96)
+        try linkModel("model-a", to: payload)
+        try linkModel("model-b", to: payload)
+        let manager = try makeManager()
+
+        let report = try manager.report(modelIDs: ["model-a", "model-b"])
+        XCTAssertEqual(report.models.map(\.referencedBytes), [96, 96])
+        XCTAssertEqual(report.models.map(\.reclaimableBytes), [0, 0])
+        XCTAssertEqual(report.models.map(\.sharedBytes), [96, 96])
+
+        try fileManager.removeItem(at: models.appendingPathComponent("model-a"))
+        let plan = try manager.garbageCollectionPlan(limitingTo: [unit])
+        XCTAssertEqual(plan.reclaimableBytes, 0)
+        XCTAssertTrue(plan.items.isEmpty)
+        XCTAssertTrue(fileManager.fileExists(atPath: payload.path))
+    }
+
+    func testAllSiblingSymlinkFilesContributeToOwnership() throws {
+        let unit = legacyUnit(repository: "many-links")
+        let first = try writePayload(at: unit.appendingPathComponent("first.bin"), bytes: 41)
+        let second = try writePayload(at: unit.appendingPathComponent("second.bin"), bytes: 59)
+        let model = models.appendingPathComponent("model-a", isDirectory: true)
+        try fileManager.createDirectory(at: model, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: model.appendingPathComponent("first.bin"),
+            withDestinationURL: first
+        )
+        try fileManager.createSymbolicLink(
+            at: model.appendingPathComponent("second.bin"),
+            withDestinationURL: second
+        )
+
+        let manager = try makeManager()
+        let usage = try XCTUnwrap(manager.report(modelIDs: ["model-a"]).models.first)
+        XCTAssertEqual(usage.referencedBytes, 100)
+        XCTAssertEqual(usage.reclaimableBytes, 100)
+        XCTAssertEqual(try manager.cacheUnitsReferenced(by: "model-a"), [unit])
+    }
+
+    func testLegacyApplicationSupportReferenceKeepsPayloadLive() throws {
+        let unit = legacyUnit(repository: "legacy-consumer")
+        let payload = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 64)
+        let legacyRoot = applicationSupport.appendingPathComponent("legacy-runtime", isDirectory: true)
+        try fileManager.createDirectory(at: legacyRoot, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: legacyRoot.appendingPathComponent("model.bin"),
+            withDestinationURL: payload
+        )
+
+        let plan = try makeManager().garbageCollectionPlan()
+        XCTAssertEqual(plan.reclaimableBytes, 0)
+        XCTAssertTrue(plan.items.isEmpty)
+    }
+
+    func testExternalPayloadIsReferencedButNeverReportedAsReclaimable() throws {
+        let externalRoot = temporaryRoot.appendingPathComponent("external", isDirectory: true)
+        let payload = try writePayload(at: externalRoot.appendingPathComponent("model.bin"), bytes: 101)
+        try linkModel("model-a", to: payload)
+
+        let usage = try XCTUnwrap(makeManager().report(modelIDs: ["model-a"]).models.first)
+        XCTAssertEqual(usage.referencedBytes, 101)
+        XCTAssertEqual(usage.externalBytes, 101)
+        XCTAssertEqual(usage.reclaimableBytes, 0)
+        XCTAssertEqual(usage.sharedBytes, 0)
+    }
+
+    func testLiveUnitCollectsStaleIncompleteDownload() throws {
+        let unit = legacyUnit(repository: "partial")
+        let payload = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 80)
+        let incomplete = try writePayload(
+            at: unit.appendingPathComponent("weights.bin.incomplete"),
+            bytes: 32
+        )
+        try linkModel("model-a", to: payload)
+
+        let plan = try makeManager().garbageCollectionPlan()
+        XCTAssertEqual(plan.reclaimableBytes, 32)
+        XCTAssertEqual(plan.incompleteDownloadBytes, 32)
+        XCTAssertEqual(plan.items.count, 1)
+        XCTAssertEqual(plan.items.first?.kind, .incompleteDownload)
+        XCTAssertEqual(plan.items.first?.path, incomplete.path)
+    }
+
+    func testRevisionedSnapshotAndBlobAreCountedOnceAndCollectedTogether() throws {
+        let snapshot = hub
+            .appendingPathComponent("snapshots/models/org/revisioned", isDirectory: true)
+            .appendingPathComponent(HubSnapshot.revisionKey("commit"), isDirectory: true)
+        let blob = try writePayload(
+            at: hub.appendingPathComponent("blobs/aa/content", isDirectory: false),
+            bytes: 160
+        )
+        let payload = snapshot.appendingPathComponent("model.bin", isDirectory: false)
+        try fileManager.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try fileManager.linkItem(at: blob, to: payload)
+        let reference = hub
+            .appendingPathComponent("refs/models/org/revisioned", isDirectory: true)
+            .appendingPathComponent(HubSnapshot.revisionKey("main") + ".ref")
+        try fileManager.createDirectory(at: reference.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("commit".utf8).write(to: reference)
+        try linkModel("model-a", to: payload)
+        let manager = try makeManager()
+
+        let report = try manager.report(modelIDs: ["model-a"])
+        XCTAssertEqual(report.hubBytes, 166)
+        XCTAssertEqual(report.models.first?.referencedBytes, 160)
+        XCTAssertEqual(report.models.first?.reclaimableBytes, 160)
+
+        try fileManager.removeItem(at: models.appendingPathComponent("model-a"))
+        let plan = try manager.garbageCollectionPlan(limitingTo: [snapshot])
+        XCTAssertEqual(plan.reclaimableBytes, 166)
+        XCTAssertEqual(Set(plan.items.map(\.kind)), [.cacheUnit, .blob, .reference])
+
+        let result = try manager.execute(plan)
+        XCTAssertEqual(result.reclaimedBytes, 166)
+        XCTAssertFalse(fileManager.fileExists(atPath: snapshot.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: blob.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: reference.path))
+    }
+
+    func testModelRootSymlinkDoesNotCountHubPayloadAsLocalBytes() throws {
+        let unit = legacyUnit(repository: "directory-root")
+        _ = try writePayload(at: unit.appendingPathComponent("config.json"), bytes: 40)
+        try fileManager.createSymbolicLink(
+            at: models.appendingPathComponent("model-a"),
+            withDestinationURL: unit
+        )
+
+        let usage = try XCTUnwrap(makeManager().report(modelIDs: ["model-a"]).models.first)
+        XCTAssertEqual(usage.referencedBytes, 40)
+        XCTAssertEqual(usage.localBytes, 0)
+        XCTAssertEqual(usage.reclaimableBytes, 40)
+    }
+
+    func testGlobalCollectionProtectsRecentlyCreatedUnreferencedCacheUnits() throws {
+        let unit = legacyUnit(repository: "recent")
+        _ = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 72)
+
+        XCTAssertTrue(try makeManager().garbageCollectionPlan().items.isEmpty)
+
+        let noGraceManager = try ModelStorageManager(
+            modelsDirectory: models,
+            hubDirectory: hub,
+            applicationSupportDirectory: applicationSupport,
+            fileManager: fileManager,
+            unreferencedGracePeriod: 0
+        )
+        XCTAssertEqual(try noGraceManager.garbageCollectionPlan().reclaimableBytes, 72)
+    }
+
+    func testExecutionRechecksReferencesUnderStorageLock() throws {
+        let unit = legacyUnit(repository: "recheck")
+        let payload = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 88)
+        try linkModel("model-a", to: payload)
+        let manager = try makeManager()
+        try fileManager.removeItem(at: models.appendingPathComponent("model-a"))
+        let plan = try manager.garbageCollectionPlan(limitingTo: [unit])
+        XCTAssertEqual(plan.reclaimableBytes, 88)
+
+        try linkModel("model-b", to: payload)
+        let result = try manager.execute(plan)
+
+        XCTAssertEqual(result.reclaimedBytes, 0)
+        XCTAssertEqual(result.deletedItemCount, 0)
+        XCTAssertTrue(fileManager.fileExists(atPath: payload.path))
+    }
+
+    private func makeManager() throws -> ModelStorageManager {
+        try ModelStorageManager(
+            modelsDirectory: models,
+            hubDirectory: hub,
+            applicationSupportDirectory: applicationSupport,
+            fileManager: fileManager
+        )
+    }
+
+    private func legacyUnit(repository: String) -> URL {
+        hub
+            .appendingPathComponent("models/org", isDirectory: true)
+            .appendingPathComponent(repository, isDirectory: true)
+    }
+
+    @discardableResult
+    private func writePayload(at url: URL, bytes: Int) throws -> URL {
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(repeating: 1, count: bytes).write(to: url)
+        return url
+    }
+
+    private func linkModel(_ id: String, to payload: URL) throws {
+        let root = models.appendingPathComponent(id, isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: root.appendingPathComponent(payload.lastPathComponent),
+            withDestinationURL: payload
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1602,11 +1602,46 @@ swift run mere.run video export-latents \
 
 ### `mere.run model list`
 
-List all managed model IDs, whether they are installed, and their resolved
-payload size. Sizes follow symlinked payload directories in the model store.
+List all managed model IDs, whether they are installed, and their referenced
+payload size. Referenced sizes follow symlinks and are not additive when models
+share payloads.
 
 ```bash
 swift run mere.run model list
+```
+
+### `mere.run model storage` and `mere.run model gc`
+
+Inspect physical storage, sharing, and per-model removal impact without
+double-counting shared files:
+
+```bash
+mere.run model storage
+mere.run model storage --json
+```
+
+Preview unreferenced payload, stale snapshot, blob, revision-reference, and
+partial-download cleanup. The default is read-only; mutation requires `--force`:
+
+```bash
+mere.run model gc
+mere.run model gc --json
+mere.run model gc --force
+```
+
+Cleanup rechecks the ownership graph under the same lock used by managed pulls.
+Existing legacy cache layouts remain readable and are adopted into the
+revision-addressed layout without copying matching payload bytes on a later pull.
+
+### `mere.run model remove`
+
+Remove an install and reclaim backing payloads that no remaining managed or
+legacy link uses:
+
+```bash
+mere.run model remove image-zimage-nano
+mere.run model remove image-zimage-nano --force --json
+mere.run model remove image-zimage-nano --keep-cache
 ```
 
 ### `mere.run status`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,9 @@ These are the public runtime environment variables that matter in the OSS repo.
 
 ### `MERERUN_MODELS_DIR`
 
-Overrides the shared local model store.
+Overrides the model links and model-local-files store. Large managed Hub
+payloads normally live under `MERERUN_HUB_CACHE`, so moving only this directory
+does not move most downloaded bytes.
 
 ```bash
 export MERERUN_MODELS_DIR=/Volumes/Models/mere.run
@@ -23,7 +25,8 @@ Default:
 
 ### `MERERUN_HUB_CACHE`
 
-Overrides the Hugging Face snapshot cache used by managed model pulls.
+Overrides the physical payload store used by managed model pulls. This is the
+location to move when large downloaded weights need to live on another disk.
 
 ```bash
 export MERERUN_HUB_CACHE=/Volumes/Models/huggingface

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -10,6 +10,8 @@ the model-management commands.
 - `mere.run model info`
 - `mere.run model pull`
 - `mere.run model remove`
+- `mere.run model storage`
+- `mere.run model gc`
 - `mere.run model repair-manifests`
 - `mere.run adapter list`
 - `mere.run adapter pull`
@@ -61,7 +63,23 @@ the canonical names shown by `mere.run model list`.
 
 ### `mere.run model list`
 
-Shows the canonical managed model table and installed status.
+Shows the canonical managed model table, installed status, and referenced size.
+Referenced sizes are not additive because multiple models can share payload files.
+
+### `mere.run model storage`
+
+Reports physical application-support, Hub, model-store, and other bytes, plus
+safe-to-collect partial/orphaned data. Per-model rows distinguish referenced,
+reclaimable-on-removal, and shared bytes. Pass `--json` for byte-exact output.
+
+### `mere.run model gc`
+
+Builds a read-only cleanup plan by default. `--force` recomputes and validates
+that plan under the cross-process storage lock before deleting unreferenced
+cache units, stale payloads, partial downloads, dead revision references, and
+unlinked blobs. Newly created unreferenced snapshots have a one-hour grace
+period. Installed model links and legacy links under MereRun application support
+keep their backing payloads live.
 
 ### `mere.run status`
 
@@ -141,7 +159,10 @@ the native `text-code`/llama.cpp path.
 
 ### `mere.run model remove`
 
-Removes a managed install from the local store.
+Removes a managed install and its unshared backing payloads, while preserving
+files referenced by another managed or legacy consumer. Confirmation and output
+show referenced versus reclaimable bytes. Pass `--keep-cache` to remove only the
+install links, or `--force --json` for structured automation.
 
 ### `mere.run model repair-manifests`
 

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -188,11 +188,13 @@ fi
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null
 "$mere_run_bin" model --help >/dev/null
+"$mere_run_bin" model storage --help >/dev/null
+"$mere_run_bin" model gc --help >/dev/null
 "$mere_run_bin" status --help >/dev/null
 "$mere_run_bin" api serve --help >/dev/null
 
 model_list_output="$("$mere_run_bin" model list)"
-rg -q '^ID +Category +Status +Size$' <<<"$model_list_output"
+rg -q '^ID +Category +Status +Referenced$' <<<"$model_list_output"
 rg -q '^image-klein-max +image +' <<<"$model_list_output"
 
 status_output="$("$mere_run_bin" status --timeout-seconds 0.1)"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -59,6 +59,8 @@ fi
 "$mere_run_bin" video generate --help >/dev/null
 "$mere_run_bin" video export-latents --help >/dev/null
 "$mere_run_bin" model --help >/dev/null
+"$mere_run_bin" model storage --help >/dev/null
+"$mere_run_bin" model gc --help >/dev/null
 "$mere_run_bin" adapter --help >/dev/null
 "$mere_run_bin" adapter list --help >/dev/null
 "$mere_run_bin" adapter pull --help >/dev/null
@@ -69,7 +71,7 @@ fi
 "$mere_run_bin" api serve --help >/dev/null
 
 model_list_output="$("$mere_run_bin" model list)"
-rg -q '^ID +Category +Status +Size$' <<<"$model_list_output"
+rg -q '^ID +Category +Status +Referenced$' <<<"$model_list_output"
 rg -q '^image-klein-max +image +' <<<"$model_list_output"
 
 status_output="$("$mere_run_bin" status --timeout-seconds 0.1)"


### PR DESCRIPTION
## Summary

- add byte-exact, ownership-aware model storage reporting across the CLI and macOS Studio
- add dry-run-first garbage collection with cross-process locking and a final ownership recheck before deletion
- make `model remove` reclaim unshared backing payloads while preserving shared, external, and legacy-linked data
- store new Hub pulls in revision-addressed snapshots backed by ETag-addressed hard-linked blobs
- support paginated Hub trees and zero-copy adoption of matching legacy payloads
- document the storage layout, migration behavior, cleanup workflow, and public CLI changes

## Why

The previous storage surfaces mixed logical model references with physical bytes. Shared symlink targets were double-counted, removal generally deleted only install links, and repo-flat Hub caches accumulated obsolete revisions and incomplete downloads without a safe ownership-aware cleanup path.

## User impact

New commands:

- `mere.run model storage [--json]`
- `mere.run model gc [--json]` for a read-only plan
- `mere.run model gc --force [--json]` to recompute under lock and execute

Behavior change:

- `mere.run model remove <id>` now deletes unshared backing payloads by default
- `--keep-cache` retains the previous link-only behavior
- model list labels per-model usage as `Referenced` so those values are not mistaken for additive physical storage

## Validation

- `./scripts/check.sh`
- SwiftLint: 0 violations across 953 files
- Swift tests: 1,927 passed, 117 real-asset tests skipped as designed, 0 failures
- live read-only validation with `model storage --json` and `model gc --json`

A fresh network-backed full-checkpoint migration was not run because of checkpoint size. Revision, pagination, legacy adoption, sharing, locking, and garbage-collection behavior are covered by fixtures and regression tests.
