### PR TITLE
Add Parakeet live ASR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## Unreleased
+
+### Added
+
+- added resident Parakeet live transcription for raw PCM and streamed files,
+  preserving the V1 partial, commit, stats, final, cancellation, silence, and
+  bounded-backpressure contract already used by Qwen live ASR.
+- added discoverable live ASR backend capabilities to `mere.run status` so
+  remote schedulers can select Parakeet or Qwen deliberately.
+
+### Changed
+
+- changed live `--backend auto` policy to match batch ASR: transcription uses
+  fast Parakeet while translation uses quality-first Qwen.
+
 ## 0.23.0 - 2026-07-18
 
 ### Added

--- a/Sources/AudioSTT/Parakeet/ParakeetASRLiveSession.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetASRLiveSession.swift
@@ -1,0 +1,297 @@
+import Foundation
+import AudioCore
+
+/// Low-latency utterance coordinator for Parakeet using the live ASR V1 event contract.
+///
+/// Parakeet is not an autoregressive streaming model. This session keeps one model
+/// resident and re-decodes the bounded active utterance to produce partial revisions.
+public actor ParakeetASRLiveSession {
+    public nonisolated let events: AsyncThrowingStream<ASRLiveEvent, Error>
+
+    private let request: ASRStreamingRequest
+    private let configuration: ASRLiveConfiguration
+    private let transcribe: @Sendable ([Float], String?) async throws -> ASRResult
+    private let continuation: AsyncThrowingStream<ASRLiveEvent, Error>.Continuation
+
+    private var pendingSamples: [Float] = []
+    private var processingTask: Task<Void, Never>?
+    private var processingError: Error?
+    private var preRoll: [Float] = []
+    private var utteranceSamples: [Float] = []
+    private var totalSampleCount = 0
+    private var utteranceStartSample = 0
+    private var lastSpeechSample = 0
+    private var lastDecodeSampleCount = 0
+    private var lastDecodedResult: ASRResult?
+    private var lastPartialText = ""
+    private var decodeCount = 0
+    private var utteranceId = UUID().uuidString.lowercased()
+    private var revision = 0
+    private var noiseRMS: Float = 0.002
+    private var finished = false
+    private var cancelled = false
+    private var finalEmitted = false
+
+    public init(
+        generator: ParakeetGenerator,
+        request: ASRStreamingRequest,
+        configuration: ASRLiveConfiguration = ASRLiveConfiguration()
+    ) {
+        self.request = request
+        self.configuration = configuration
+        self.transcribe = { samples, language in
+            try await generator.transcribePrepared(samples: samples, language: language)
+        }
+        var captured: AsyncThrowingStream<ASRLiveEvent, Error>.Continuation?
+        self.events = AsyncThrowingStream { captured = $0 }
+        self.continuation = captured!
+    }
+
+    init(
+        request: ASRStreamingRequest,
+        configuration: ASRLiveConfiguration = ASRLiveConfiguration(),
+        transcribe: @escaping @Sendable ([Float], String?) async throws -> ASRResult
+    ) {
+        self.request = request
+        self.configuration = configuration
+        self.transcribe = transcribe
+        var captured: AsyncThrowingStream<ASRLiveEvent, Error>.Continuation?
+        self.events = AsyncThrowingStream { captured = $0 }
+        self.continuation = captured!
+    }
+
+    public func feed(samples: [Float]) async throws {
+        if let processingError { throw processingError }
+        guard !finished else {
+            throw ASRStreamingError.invalidState("Cannot feed live ASR after finish.")
+        }
+        guard !samples.isEmpty else { return }
+        let maximumPendingSamples = request.sampleRate * configuration.maxQueuedAudioMs / 1_000
+        guard pendingSamples.count + samples.count <= maximumPendingSamples else {
+            throw ASRStreamingError.invalidInput("backpressure_exceeded: live ASR input exceeded the bounded queue.")
+        }
+
+        pendingSamples.append(contentsOf: samples)
+        startPendingAudioProcessing()
+    }
+
+    public func finish(reason: ASRLiveFinishReason = .eof) async throws {
+        if let processingError { throw processingError }
+        guard !finished else { return }
+        finished = true
+        if let processingTask {
+            await processingTask.value
+        }
+        if let processingError { throw processingError }
+        if !utteranceSamples.isEmpty {
+            try await commitUtterance(endSample: totalSampleCount)
+        }
+        emitFinal(reason)
+        continuation.finish()
+    }
+
+    public func cancel() {
+        guard !finished else { return }
+        cancelled = true
+        finished = true
+        processingTask?.cancel()
+        pendingSamples.removeAll(keepingCapacity: false)
+        utteranceSamples.removeAll(keepingCapacity: false)
+        emitFinal(.cancelled)
+        continuation.finish()
+    }
+
+    private func startPendingAudioProcessing() {
+        guard processingTask == nil else { return }
+        processingTask = Task { [weak self] in
+            await self?.drainPendingAudio()
+        }
+    }
+
+    private func drainPendingAudio() async {
+        let analysisWindowSamples = max(1, request.sampleRate / 10)
+        do {
+            while !pendingSamples.isEmpty {
+                try Task.checkCancellation()
+                let count = min(pendingSamples.count, analysisWindowSamples)
+                let window = Array(pendingSamples.prefix(count))
+                pendingSamples.removeFirst(count)
+                try await feedAnalysisWindow(window)
+            }
+        } catch is CancellationError where cancelled {
+            // Cancellation intentionally discards the active utterance.
+        } catch {
+            processingError = error
+            finished = true
+            pendingSamples.removeAll(keepingCapacity: false)
+            utteranceSamples.removeAll(keepingCapacity: false)
+            continuation.finish(throwing: error)
+        }
+        processingTask = nil
+    }
+
+    private func feedAnalysisWindow(_ samples: [Float]) async throws {
+        totalSampleCount += samples.count
+        let rms = rootMeanSquare(samples)
+        let speechThreshold = max(Float(0.005), noiseRMS * Float(3.5))
+        let containsSpeech = rms >= speechThreshold
+
+        if !containsSpeech {
+            noiseRMS = (noiseRMS * Float(0.97)) + (rms * Float(0.03))
+        }
+
+        if utteranceSamples.isEmpty {
+            appendPreRoll(samples)
+            guard containsSpeech else { return }
+            utteranceSamples = preRoll
+            preRoll.removeAll(keepingCapacity: true)
+            utteranceStartSample = max(0, totalSampleCount - utteranceSamples.count)
+            lastSpeechSample = totalSampleCount
+            lastDecodeSampleCount = 0
+            lastDecodedResult = nil
+            lastPartialText = ""
+            decodeCount = 0
+            utteranceId = UUID().uuidString.lowercased()
+            revision = 0
+        } else {
+            utteranceSamples.append(contentsOf: samples)
+            if containsSpeech {
+                lastSpeechSample = totalSampleCount
+            }
+        }
+
+        let minimumSamples = request.sampleRate * configuration.minDecodeAudioMs / 1_000
+        let decodeIntervalSamples = request.sampleRate * configuration.decodeIntervalMs / 1_000
+        if decodeCount == 0,
+           utteranceSamples.count >= minimumSamples,
+           utteranceSamples.count - lastDecodeSampleCount >= decodeIntervalSamples {
+            try await decodePartial()
+        }
+
+        let silenceSamples = request.sampleRate * configuration.silenceMs / 1_000
+        let maximumSamples = request.sampleRate * configuration.maxUtteranceMs / 1_000
+        if !containsSpeech, totalSampleCount - lastSpeechSample >= silenceSamples {
+            try await commitUtterance(endSample: lastSpeechSample)
+        } else if utteranceSamples.count >= maximumSamples {
+            try await commitUtterance(endSample: totalSampleCount)
+        }
+    }
+
+    private func decodePartial() async throws {
+        let samples = utteranceSamples
+        let started = ContinuousClock.now
+        let result = try await transcribe(samples, request.language)
+        let latency = started.duration(to: .now)
+        lastDecodeSampleCount = samples.count
+        lastDecodedResult = result
+        decodeCount += 1
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty, text != lastPartialText {
+            revision += 1
+            lastPartialText = text
+            continuation.yield(.partial(ASRLiveTranscript(
+                utteranceId: utteranceId,
+                revision: revision,
+                text: text,
+                startMs: utteranceStartSample * 1_000 / request.sampleRate,
+                endMs: totalSampleCount * 1_000 / request.sampleRate
+            )))
+        }
+        continuation.yield(.stats(
+            ASRStreamingStats(
+                decodeCount: decodeCount,
+                totalAudioSeconds: Double(samples.count) / Double(request.sampleRate),
+                lastDecodeLatencyMs: milliseconds(latency),
+                tokensGenerated: text.split(whereSeparator: \.isWhitespace).count
+            ),
+            queuedAudioMs: pendingSamples.count * 1_000 / request.sampleRate
+        ))
+    }
+
+    private func commitUtterance(endSample: Int) async throws {
+        let requiredCount = max(0, min(utteranceSamples.count, endSample - utteranceStartSample))
+        let samples = Array(utteranceSamples.prefix(requiredCount))
+        let result: ASRResult
+        if requiredCount == lastDecodeSampleCount, let lastDecodedResult {
+            result = lastDecodedResult
+        } else if let lastDecodedResult, lastDecodeSampleCount > 0 {
+            let overlapSamples = request.sampleRate / 2
+            let tailStart = max(0, lastDecodeSampleCount - overlapSamples)
+            let tail = Array(samples.dropFirst(tailStart))
+            let tailResult = try await transcribe(tail, request.language)
+            if tailStart == 0 {
+                result = tailResult
+            } else {
+                result = ASRResult(
+                    text: mergeTranscripts(lastDecodedResult.text, tailResult.text),
+                    language: tailResult.language ?? lastDecodedResult.language,
+                    duration: Double(requiredCount) / Double(request.sampleRate)
+                )
+            }
+        } else {
+            result = try await transcribe(samples, request.language)
+        }
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty {
+            revision += 1
+            continuation.yield(.commit(ASRLiveTranscript(
+                utteranceId: utteranceId,
+                revision: revision,
+                text: text,
+                startMs: utteranceStartSample * 1_000 / request.sampleRate,
+                endMs: max(utteranceStartSample, endSample) * 1_000 / request.sampleRate
+            )))
+        }
+        utteranceSamples.removeAll(keepingCapacity: true)
+        preRoll.removeAll(keepingCapacity: true)
+        lastDecodeSampleCount = 0
+        lastDecodedResult = nil
+        lastPartialText = ""
+        decodeCount = 0
+    }
+
+    private func appendPreRoll(_ samples: [Float]) {
+        preRoll.append(contentsOf: samples)
+        let maximum = request.sampleRate * configuration.preRollMs / 1_000
+        if preRoll.count > maximum {
+            preRoll.removeFirst(preRoll.count - maximum)
+        }
+    }
+
+    private func emitFinal(_ reason: ASRLiveFinishReason) {
+        guard !finalEmitted else { return }
+        finalEmitted = true
+        continuation.yield(.final(reason))
+    }
+
+    private func rootMeanSquare(_ samples: [Float]) -> Float {
+        guard !samples.isEmpty else { return 0 }
+        let sum = samples.reduce(Float.zero) { $0 + ($1 * $1) }
+        return sqrt(sum / Float(samples.count))
+    }
+
+    private func milliseconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) * 1_000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+
+    private func mergeTranscripts(_ prefix: String, _ suffix: String) -> String {
+        let prefixWords = prefix.split(whereSeparator: \.isWhitespace).map(String.init)
+        let suffixWords = suffix.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !prefixWords.isEmpty else { return suffixWords.joined(separator: " ") }
+        guard !suffixWords.isEmpty else { return prefixWords.joined(separator: " ") }
+
+        let maximumOverlap = min(prefixWords.count, suffixWords.count)
+        let overlap = stride(from: maximumOverlap, through: 1, by: -1).first { count in
+            zip(prefixWords.suffix(count), suffixWords.prefix(count)).allSatisfy {
+                normalizedWord($0) == normalizedWord($1)
+            }
+        } ?? 0
+        return (prefixWords.dropLast(overlap) + suffixWords).joined(separator: " ")
+    }
+
+    private func normalizedWord(_ value: String) -> String {
+        String(value.lowercased().filter { $0.isLetter || $0.isNumber })
+    }
+}

--- a/Sources/AudioSTT/Parakeet/ParakeetGenerator.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetGenerator.swift
@@ -43,16 +43,73 @@ public actor ParakeetGenerator: ASRGenerator {
             try await loadModel(from: root, progressHandler: progressHandler)
         }
 
+        progressHandler?(ASRProgress(stage: .loadingAudio, message: "Loading audio..."))
+        let audio = try AudioReader.readAudio(from: request.audioURL)
+        return try transcribePrepared(
+            samples: audio,
+            language: request.language,
+            progressHandler: progressHandler
+        )
+    }
+
+    public func transcribe(
+        samples: [Float],
+        language: String? = nil,
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ASRProgress) -> Void)? = nil
+    ) async throws -> ASRResult {
+        let root = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+
+        if loadedModelPath != root.path {
+            progressHandler?(ASRProgress(stage: .loadingModel, message: "Loading Parakeet model..."))
+            try await loadModel(from: root, progressHandler: progressHandler)
+        }
+
         guard let model, let audioPreprocessor, let modelConfig else {
             throw ParakeetError.modelNotLoaded
         }
 
-        progressHandler?(ASRProgress(stage: .loadingAudio, message: "Loading audio..."))
-        let audio = try AudioReader.readAudio(from: request.audioURL)
-        let audioDuration = TimeInterval(audio.count) / TimeInterval(modelConfig.preprocessor.sampleRate)
+        return decode(
+            samples: samples,
+            language: language,
+            model: model,
+            audioPreprocessor: audioPreprocessor,
+            modelConfig: modelConfig,
+            progressHandler: progressHandler
+        )
+    }
+
+    public func transcribePrepared(
+        samples: [Float],
+        language: String? = nil,
+        progressHandler: (@Sendable (ASRProgress) -> Void)? = nil
+    ) throws -> ASRResult {
+        guard let model, let audioPreprocessor, let modelConfig else {
+            throw ParakeetError.modelNotLoaded
+        }
+
+        return decode(
+            samples: samples,
+            language: language,
+            model: model,
+            audioPreprocessor: audioPreprocessor,
+            modelConfig: modelConfig,
+            progressHandler: progressHandler
+        )
+    }
+
+    private func decode(
+        samples: [Float],
+        language: String?,
+        model: any ParakeetDecodingModel,
+        audioPreprocessor: ParakeetAudioPreprocessor,
+        modelConfig: ParakeetModelConfig,
+        progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) -> ASRResult {
+        let audioDuration = TimeInterval(samples.count) / TimeInterval(modelConfig.preprocessor.sampleRate)
 
         progressHandler?(ASRProgress(stage: .extractingFeatures, message: "Extracting log-mel features..."))
-        let mel = audioPreprocessor.logMelSpectrogram(from: audio)
+        let mel = audioPreprocessor.logMelSpectrogram(from: samples)
         MLX.eval(mel)
 
         if Self.debugEnabled {
@@ -85,7 +142,7 @@ public actor ParakeetGenerator: ASRGenerator {
 
         return ASRResult(
             text: first.text,
-            language: request.language,
+            language: language,
             duration: audioDuration,
             tokenAlignments: ParakeetAlignment.toASRTokenAlignments(flattened),
             sentenceAlignments: ParakeetAlignment.toASRSentenceAlignments(first.sentences)

--- a/Sources/AudioSTT/Qwen3ASR/Qwen3ASRLiveSession.swift
+++ b/Sources/AudioSTT/Qwen3ASR/Qwen3ASRLiveSession.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AudioCore
 
-public struct Qwen3ASRLiveConfiguration: Sendable, Hashable {
+public struct ASRLiveConfiguration: Sendable, Hashable {
     public var decodeIntervalMs: Int
     public var minDecodeAudioMs: Int
     public var silenceMs: Int
@@ -26,14 +26,14 @@ public struct Qwen3ASRLiveConfiguration: Sendable, Hashable {
     }
 }
 
-public enum Qwen3ASRLiveFinishReason: String, Sendable, Hashable, Codable {
+public enum ASRLiveFinishReason: String, Sendable, Hashable, Codable {
     case eof
     case stopped
     case cancelled
     case maxDuration = "max_duration"
 }
 
-public struct Qwen3ASRLiveTranscript: Sendable, Hashable, Codable {
+public struct ASRLiveTranscript: Sendable, Hashable, Codable {
     public let utteranceId: String
     public let revision: Int
     public let text: String
@@ -41,12 +41,17 @@ public struct Qwen3ASRLiveTranscript: Sendable, Hashable, Codable {
     public let endMs: Int
 }
 
-public enum Qwen3ASRLiveEvent: Sendable, Hashable {
-    case partial(Qwen3ASRLiveTranscript)
-    case commit(Qwen3ASRLiveTranscript)
+public enum ASRLiveEvent: Sendable, Hashable {
+    case partial(ASRLiveTranscript)
+    case commit(ASRLiveTranscript)
     case stats(ASRStreamingStats, queuedAudioMs: Int)
-    case final(Qwen3ASRLiveFinishReason)
+    case final(ASRLiveFinishReason)
 }
+
+public typealias Qwen3ASRLiveConfiguration = ASRLiveConfiguration
+public typealias Qwen3ASRLiveFinishReason = ASRLiveFinishReason
+public typealias Qwen3ASRLiveTranscript = ASRLiveTranscript
+public typealias Qwen3ASRLiveEvent = ASRLiveEvent
 
 /// Quality-oriented utterance coordinator for live Qwen ASR.
 ///

--- a/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
@@ -71,7 +71,7 @@ struct SpeechTranscribe: AsyncParsableCommand {
     @Option(name: [.long], help: "Maximum tokens to generate (default: 448).")
     var maxTokens: Int = 448
 
-    @Flag(name: [.long], help: "Enable streaming ASR mode (forces Qwen backend).")
+    @Flag(name: [.long], help: "Enable streaming ASR mode using the selected backend.")
     var stream: Bool = false
 
     @Option(name: [.customLong("stream-chunk-ms")], help: "Audio feed chunk size in ms for streaming mode.")
@@ -107,6 +107,9 @@ struct SpeechTranscribe: AsyncParsableCommand {
             }
             guard streamDecodeMs > 0 else {
                 throw ValidationError("--stream-decode-ms must be > 0.")
+            }
+            if task == .translate, backend == .parakeet {
+                throw ValidationError("Parakeet does not support translation; use --backend qwen or --backend auto.")
             }
         }
 
@@ -148,13 +151,8 @@ struct SpeechTranscribe: AsyncParsableCommand {
             throw ValidationError("Audio file not found: \(audioURL.path)")
         }
 
-        if stream && backend == .parakeet {
-            CLIStderr.write("Streaming mode forces Qwen backend; ignoring --backend parakeet.\n")
-        }
-
         if !quiet {
-            let backendLabel = stream ? SpeechBackendOption.qwen.rawValue : backend.rawValue
-            CLIStderr.write("Task=\(task.rawValue) backend=\(backendLabel)\n")
+            CLIStderr.write("Task=\(task.rawValue) backend=\(backend.rawValue)\n")
         }
 
         let progressHandler: (@Sendable (ASRProgress) -> Void)?
@@ -233,24 +231,11 @@ struct SpeechTranscribe: AsyncParsableCommand {
                 }
             }
         }
-        let generator = try await CLIQwenASRLoader.prepare(model: model, progressHandler: progressHandler)
-        let request = ASRStreamingRequest(
-            language: language,
-            task: task.task,
-            maxTokens: maxTokens,
-            sampleRate: 16_000,
-            decodeIntervalMs: streamDecodeMs,
-            minDecodeAudioMs: 1_600
-        )
-        let live = Qwen3ASRLiveSession(
-            generator: generator,
-            request: request,
-            configuration: Qwen3ASRLiveConfiguration(decodeIntervalMs: streamDecodeMs)
-        )
+        let live = try await makeLiveSession(progressHandler: progressHandler)
         if jsonl {
             try LiveASRCLIWriter.write(.ready())
         } else if !quiet {
-            CLIStderr.write("Ready: qwen live ASR (pcm-s16le/16000/mono).\n")
+            CLIStderr.write("Ready: \(live.backend.rawValue) live ASR (pcm-s16le/16000/mono).\n")
         }
         let eventTask = Task {
             try await LiveASRCLIWriter.consume(live.events, jsonl: jsonl, quiet: quiet)
@@ -261,11 +246,11 @@ struct SpeechTranscribe: AsyncParsableCommand {
             while let data = try FileHandle.standardInput.read(upToCount: 32_000), !data.isEmpty {
                 let samples = decoder.decode(data)
                 if !samples.isEmpty {
-                    try await live.feed(samples: samples)
+                    try await live.feed(samples)
                 }
             }
             try decoder.validateEOF()
-            try await live.finish(reason: .eof)
+            try await live.finish(.eof)
             try await eventTask.value
         } catch {
             eventTask.cancel()
@@ -285,68 +270,50 @@ struct SpeechTranscribe: AsyncParsableCommand {
         audioURL: URL,
         progressHandler: (@Sendable (ASRProgress) -> Void)?
     ) async throws {
-        let normalizedOverride = normalized(model)
-        let overridePath = existingPath(from: normalizedOverride)
-        let qwenModelId: String
-        if let normalizedOverride, overridePath == nil {
-            qwenModelId = normalizedOverride
-        } else {
-            qwenModelId = Qwen3ASRResources.defaultModelId
-        }
-
-        let generator = Qwen3ASRGenerator(modelId: qwenModelId)
-        if let modelPath = overridePath {
-            try await generator.prepare(modelPath: modelPath.path, progressHandler: progressHandler)
-        } else if let localModelRoot = localQwenModelRootIfAvailable() {
-            try await generator.prepare(modelPath: localModelRoot.path, progressHandler: progressHandler)
-        }
-
-        let streamRequest = ASRStreamingRequest(
-            language: request.language,
-            task: request.task,
-            maxTokens: request.maxTokens,
-            sampleRate: 16_000,
-            decodeIntervalMs: streamDecodeMs
-        )
-        let session = try await generator.makeStreamingSession(streamRequest)
-        let chunkSamples = max(1, (streamRequest.sampleRate * streamChunkMs) / 1_000)
+        let live = try await makeLiveSession(progressHandler: progressHandler)
+        let chunkSamples = max(1, (16_000 * streamChunkMs) / 1_000)
         let audioSamples = try AudioReader.readAudio(from: audioURL)
 
-        let eventTask = Task { () throws -> ASRResult in
-            var finalResult: ASRResult?
-            for try await event in session.events {
+        let eventTask = Task { () throws -> [String] in
+            var commits: [String] = []
+            for try await event in live.events {
                 switch event {
-                case .partial(let text):
+                case .partial(let transcript):
                     if !quiet {
-                        CLIStderr.write("[partial] \(text)\n")
+                        CLIStderr.write("[partial] \(transcript.text)\n")
                     }
+                case .commit(let transcript):
+                    commits.append(transcript.text)
                 case .stats:
                     break
-                case .final(let result):
-                    finalResult = result
+                case .final:
+                    break
                 }
             }
-            if let finalResult {
-                return finalResult
-            }
-            throw ASRStreamingError.invalidState("ASR stream ended without final result.")
+            return commits
         }
 
         do {
             var start = 0
             while start < audioSamples.count {
                 let end = min(audioSamples.count, start + chunkSamples)
-                try await session.feed(samples: Array(audioSamples[start..<end]))
+                try await live.feed(Array(audioSamples[start..<end]))
                 start = end
+                try await Task.sleep(for: .milliseconds(streamChunkMs))
             }
-            try await session.finish()
+            try await live.finish(.eof)
 
-            let result = try await eventTask.value
+            let text = try await eventTask.value.joined(separator: "\n")
+            let result = ASRResult(
+                text: text,
+                language: request.language,
+                duration: Double(audioSamples.count) / 16_000
+            )
             let outputText = renderOutput(result: result, includeTimestamps: timestamps)
 
             if !quiet {
                 let durationStr = String(format: "%.2f", result.duration)
-                CLIStderr.write("Resolved backend: qwen (streaming_forced_qwen_v1)\n")
+                CLIStderr.write("Resolved backend: \(live.backend.rawValue) (streaming_policy_v1)\n")
                 CLIStderr.write("Audio duration: \(durationStr)s\n")
                 if let lang = result.language {
                     CLIStderr.write("Language: \(lang)\n")
@@ -366,40 +333,75 @@ struct SpeechTranscribe: AsyncParsableCommand {
             print(outputText)
         } catch {
             eventTask.cancel()
-            await session.cancel()
+            await live.cancel()
             throw error
         }
     }
 
-    private func localQwenModelRootIfAvailable() -> URL? {
-        let fm = FileManager.default
-        let base = MereRunModelPaths.resolveModelDir(Qwen3ASRResources.defaultModelId) { root in
-            fm.fileExists(atPath: root.appendingPathComponent("config.json").path)
-                || fm.fileExists(atPath: root.appendingPathComponent("\(Qwen3ASRResources.defaultModelId)/config.json").path)
+    private func makeLiveSession(
+        progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> CLILiveASRSession {
+        let selected = try resolvedStreamingBackend()
+        let request = ASRStreamingRequest(
+            language: language,
+            task: task.task,
+            maxTokens: maxTokens,
+            sampleRate: 16_000,
+            decodeIntervalMs: streamDecodeMs,
+            minDecodeAudioMs: 1_600
+        )
+        let configuration = Qwen3ASRLiveConfiguration(decodeIntervalMs: streamDecodeMs)
+
+        switch selected {
+        case .parakeet:
+            var parakeetConfiguration = configuration
+            parakeetConfiguration.silenceMs = min(configuration.silenceMs, 600)
+            let generator = try await CLIParakeetASRLoader.prepare(
+                model: model,
+                progressHandler: progressHandler
+            )
+            let live = ParakeetASRLiveSession(
+                generator: generator,
+                request: request,
+                configuration: parakeetConfiguration
+            )
+            return CLILiveASRSession(
+                backend: .parakeet,
+                events: live.events,
+                feed: { try await live.feed(samples: $0) },
+                finish: { try await live.finish(reason: $0) },
+                cancel: { await live.cancel() }
+            )
+        case .qwen:
+            let generator = try await CLIQwenASRLoader.prepare(
+                model: model,
+                progressHandler: progressHandler
+            )
+            let live = Qwen3ASRLiveSession(
+                generator: generator,
+                request: request,
+                configuration: configuration
+            )
+            return CLILiveASRSession(
+                backend: .qwen,
+                events: live.events,
+                feed: { try await live.feed(samples: $0) },
+                finish: { try await live.finish(reason: $0) },
+                cancel: { await live.cancel() }
+            )
+        case .auto:
+            preconditionFailure("Streaming backend must resolve before session creation.")
         }
-        let nested = base.appendingPathComponent(Qwen3ASRResources.defaultModelId, isDirectory: true)
-        if fm.fileExists(atPath: nested.appendingPathComponent("config.json").path) {
-            return nested
-        }
-        if fm.fileExists(atPath: base.appendingPathComponent("config.json").path) {
-            return base
-        }
-        return nil
     }
 
-    private func existingPath(from value: String?) -> URL? {
-        guard let value else { return nil }
-        let url = URL(fileURLWithPath: value).standardizedFileURL
-        if FileManager.default.fileExists(atPath: url.path) {
-            return url
+    private func resolvedStreamingBackend() throws -> SpeechBackendOption {
+        if task == .translate {
+            guard backend != .parakeet else {
+                throw ValidationError("Parakeet does not support translation; use --backend qwen or --backend auto.")
+            }
+            return .qwen
         }
-        return nil
-    }
-
-    private func normalized(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        return backend == .auto ? .parakeet : backend
     }
 
     private func renderOutput(result: ASRResult, includeTimestamps: Bool) -> String {

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -85,10 +85,12 @@ struct StatusSnapshot: Codable, Equatable {
 struct StatusCapabilitiesSnapshot: Codable, Equatable {
     let asrStreamingProtocols: [Int]
     let asrStreamingInputFormats: [String]
+    let asrStreamingBackends: [String]
 
     static let current = StatusCapabilitiesSnapshot(
         asrStreamingProtocols: [1],
-        asrStreamingInputFormats: ["pcm-s16le/16000/mono"]
+        asrStreamingInputFormats: ["pcm-s16le/16000/mono"],
+        asrStreamingBackends: ["parakeet", "qwen"]
     )
 }
 

--- a/Sources/MereRunCLI/Guides/speech-transcribe.md
+++ b/Sources/MereRunCLI/Guides/speech-transcribe.md
@@ -7,7 +7,7 @@ Transcribe or translate speech from a WAV file using native ASR backends. Auto m
 ## Required Models
 
 - `speech-asr-parakeet` for fast transcription.
-- `speech-asr-qwen3` for Qwen ASR, translation, and streaming.
+- `speech-asr-qwen3` for quality-first transcription and translation.
 
 ## Install And Check
 
@@ -26,7 +26,7 @@ mere.run speech transcribe --help
 - `--task`: `transcribe` or `translate`.
 - `--language`: optional language hint.
 - `--max-tokens`: generation cap, default `448`.
-- `--stream`: streaming ASR mode, forces Qwen.
+- `--stream`: streaming ASR mode using the selected backend.
 - `--stream-chunk-ms`: audio feed chunk size for streaming.
 - `--stream-decode-ms`: decode interval for streaming.
 - `--timestamps`, `--no-timestamps`: include alignment lines when available.
@@ -36,6 +36,8 @@ mere.run speech transcribe --help
 
 - Start with `--backend auto`.
 - Use `--backend parakeet` for normal transcription where speed matters.
+- Live transcription follows the same policy: `auto` selects Parakeet for
+  transcription and Qwen for translation.
 - Use `--task translate --backend auto` for translation.
 - Use `--language en` or another language hint when the audio is short or ambiguous.
 
@@ -43,6 +45,15 @@ mere.run speech transcribe --help
 
 ```bash
 mere.run speech transcribe ./meeting.wav --backend auto --output ./meeting.txt
+```
+
+```bash
+cat ./audio.pcm | mere.run speech transcribe - \
+  --stream \
+  --backend parakeet \
+  --input-format pcm-s16le \
+  --sample-rate 16000 \
+  --jsonl
 ```
 
 ```bash
@@ -60,7 +71,8 @@ mere.run speech transcribe ./spanish.wav \
 
 ## Troubleshooting
 
-- Streaming says it is forcing Qwen: expected behavior.
+- Streaming backpressure errors: pace PCM input in real time and keep no more
+  than five seconds queued.
 - Bad transcript on noisy audio: preprocess audio or try the other backend.
 - Translation with Parakeet requested: use Qwen or `--backend auto`.
 

--- a/Sources/MereRunCLI/Guides/status.md
+++ b/Sources/MereRunCLI/Guides/status.md
@@ -41,6 +41,8 @@ mere.run guide status
 - Use it instead of separate `curl /health`, `curl /v1/models`, and `model list`
   checks when you only need the current local state.
 - Use `--json` in scripts, setup agents, or support tooling.
+- Inspect `capabilities.asrStreamingBackends` before routing a live ASR stream
+  to Parakeet or Qwen.
 - Use it after manual load/unload or runtime settings changes to confirm the
   server sees the same control-plane state.
 - During overlapping API traffic, check `request admission` to see how many

--- a/Sources/MereRunCLI/Support/LiveASRCLI.swift
+++ b/Sources/MereRunCLI/Support/LiveASRCLI.swift
@@ -3,6 +3,14 @@ import AudioCore
 import AudioSTT
 import MereRunCore
 
+struct CLILiveASRSession {
+    let backend: SpeechBackendOption
+    let events: AsyncThrowingStream<ASRLiveEvent, Error>
+    let feed: @Sendable ([Float]) async throws -> Void
+    let finish: @Sendable (ASRLiveFinishReason) async throws -> Void
+    let cancel: @Sendable () async -> Void
+}
+
 struct PCM16LittleEndianDecoder {
     private var trailingByte: UInt8?
 
@@ -81,7 +89,7 @@ struct LiveASRProtocolEvent: Encodable {
         return event
     }
 
-    static func transcript(type: String, value: Qwen3ASRLiveTranscript) -> Self {
+    static func transcript(type: String, value: ASRLiveTranscript) -> Self {
         var event = Self(type: type)
         event.utteranceId = value.utteranceId
         event.revision = value.revision
@@ -99,7 +107,7 @@ struct LiveASRProtocolEvent: Encodable {
         return event
     }
 
-    static func final(_ reason: Qwen3ASRLiveFinishReason) -> Self {
+    static func final(_ reason: ASRLiveFinishReason) -> Self {
         var event = Self(type: "final")
         event.reason = reason.rawValue
         return event
@@ -127,7 +135,7 @@ enum LiveASRCLIWriter {
     }
 
     static func consume(
-        _ events: AsyncThrowingStream<Qwen3ASRLiveEvent, Error>,
+        _ events: AsyncThrowingStream<ASRLiveEvent, Error>,
         jsonl: Bool,
         quiet: Bool
     ) async throws {
@@ -203,5 +211,24 @@ enum CLIQwenASRLoader {
         if fileManager.fileExists(atPath: nested.appendingPathComponent("config.json").path) { return nested }
         if fileManager.fileExists(atPath: base.appendingPathComponent("config.json").path) { return base }
         return nil
+    }
+}
+
+enum CLIParakeetASRLoader {
+    static func prepare(
+        model: String?,
+        progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> ParakeetGenerator {
+        let normalized = model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = normalized?.isEmpty == false ? normalized : nil
+        let explicitPath = value.map { URL(fileURLWithPath: $0).standardizedFileURL }
+            .flatMap { FileManager.default.fileExists(atPath: $0.path) ? $0 : nil }
+        let modelId = explicitPath == nil ? (value ?? ParakeetResources.defaultModelId) : ParakeetResources.defaultModelId
+        let generator = ParakeetGenerator(modelId: modelId)
+        try await generator.prepare(
+            modelPath: explicitPath?.path,
+            progressHandler: progressHandler
+        )
+        return generator
     }
 }

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -64,6 +64,22 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
         XCTAssertNoThrow(try cmd.validate())
     }
 
+    func testSpeechTranscribeAllowsParakeetRawPCMStreaming() throws {
+        let cmd = try SpeechTranscribe.parse([
+            "-", "--stream", "--input-format", "pcm-s16le", "--sample-rate", "16000",
+            "--backend", "parakeet", "--jsonl",
+        ])
+        XCTAssertEqual(cmd.backend, .parakeet)
+        XCTAssertNoThrow(try cmd.validate())
+    }
+
+    func testSpeechTranscribeRejectsParakeetStreamingTranslation() {
+        XCTAssertThrowsError(try SpeechTranscribe.parse([
+            "-", "--stream", "--input-format", "pcm-s16le", "--sample-rate", "16000",
+            "--backend", "parakeet", "--task", "translate", "--jsonl",
+        ]))
+    }
+
     func testSpeechTranscribeRejectsInvalidRawPCMContracts() throws {
         XCTAssertThrowsError(try SpeechTranscribe.parse(["-"]))
         XCTAssertThrowsError(try SpeechTranscribe.parse([

--- a/Tests/MereRunCLITests/StatusCommandTests.swift
+++ b/Tests/MereRunCLITests/StatusCommandTests.swift
@@ -36,6 +36,7 @@ final class StatusCommandTests: XCTestCase {
 
     func testStatusAdvertisesLiveASRProtocol() {
         XCTAssertEqual(StatusCapabilitiesSnapshot.current.asrStreamingProtocols, [1])
+        XCTAssertEqual(StatusCapabilitiesSnapshot.current.asrStreamingBackends, ["parakeet", "qwen"])
         XCTAssertEqual(StatusCapabilitiesSnapshot.current.asrStreamingInputFormats, ["pcm-s16le/16000/mono"])
     }
 

--- a/Tests/MereRunCoreTests/ParakeetASRLiveSessionTests.swift
+++ b/Tests/MereRunCoreTests/ParakeetASRLiveSessionTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+import AudioCore
+@testable import AudioSTT
+
+final class ParakeetASRLiveSessionTests: XCTestCase {
+    func testParakeetLiveEmitsPartialCommitStatsAndFinal() async throws {
+        let transcriber = FakeParakeetLiveTranscriber(results: ["fast transcript"])
+        let live = makeLive(transcriber: transcriber)
+        let reader = collect(live.events)
+
+        try await live.feed(samples: samples(count: 100, value: 0.1))
+        try await live.feed(samples: samples(count: 90, value: 0))
+        try await live.finish(reason: .eof)
+
+        let events = try await reader.value
+        let partials = events.compactMap { event -> Qwen3ASRLiveTranscript? in
+            guard case .partial(let value) = event else { return nil }
+            return value
+        }
+        let commits = events.compactMap { event -> Qwen3ASRLiveTranscript? in
+            guard case .commit(let value) = event else { return nil }
+            return value
+        }
+        XCTAssertEqual(partials.map(\.text), ["fast transcript"])
+        XCTAssertEqual(commits.map(\.text), ["fast transcript"])
+        XCTAssertEqual(partials.first?.revision, 1)
+        XCTAssertEqual(commits.first?.revision, 2)
+        XCTAssertTrue(events.contains { if case .stats = $0 { return true }; return false })
+        XCTAssertEqual(finalReasons(events), [.eof])
+        let callCount = await transcriber.callCount()
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testParakeetLiveFinalDecodeIncludesAudioAfterLastPartial() async throws {
+        let transcriber = FakeParakeetLiveTranscriber(results: ["draft", "complete"])
+        let live = makeLive(transcriber: transcriber)
+        let reader = collect(live.events)
+
+        try await live.feed(samples: samples(count: 100, value: 0.1))
+        try await live.feed(samples: samples(count: 50, value: 0.1))
+        try await live.finish(reason: .stopped)
+
+        let commits = try await reader.value.compactMap { event -> Qwen3ASRLiveTranscript? in
+            guard case .commit(let value) = event else { return nil }
+            return value
+        }
+        XCTAssertEqual(commits.map(\.text), ["complete"])
+        let sampleCounts = await transcriber.sampleCounts()
+        XCTAssertEqual(sampleCounts, [100, 150])
+    }
+
+    func testParakeetLiveCancelDiscardsActiveUtterance() async throws {
+        let transcriber = FakeParakeetLiveTranscriber(results: ["draft"])
+        let live = makeLive(transcriber: transcriber)
+        let reader = collect(live.events)
+
+        try await live.feed(samples: samples(count: 100, value: 0.1))
+        await live.cancel()
+
+        let events = try await reader.value
+        XCTAssertFalse(events.contains { if case .commit = $0 { return true }; return false })
+        XCTAssertEqual(finalReasons(events), [.cancelled])
+    }
+
+    func testParakeetLiveCommitDecodesOnlyOverlappedTailAfterPartial() async throws {
+        let transcriber = FakeParakeetLiveTranscriber(results: ["hello brave", "brave new world"])
+        let live = ParakeetASRLiveSession(
+            request: ASRStreamingRequest(
+                sampleRate: 1_000,
+                decodeIntervalMs: 1_000,
+                minDecodeAudioMs: 1_000,
+                maxQueuedAudioMs: 2_000
+            ),
+            configuration: Qwen3ASRLiveConfiguration(
+                decodeIntervalMs: 1_000,
+                minDecodeAudioMs: 1_000,
+                silenceMs: 900,
+                preRollMs: 300,
+                maxUtteranceMs: 30_000,
+                maxQueuedAudioMs: 2_000
+            ),
+            transcribe: { samples, language in
+                try await transcriber.transcribe(samples: samples, language: language)
+            }
+        )
+        let reader = collect(live.events)
+
+        try await live.feed(samples: samples(count: 1_000, value: 0.1))
+        try await live.feed(samples: samples(count: 600, value: 0.1))
+        try await live.finish(reason: .eof)
+
+        let commits = try await reader.value.compactMap { event -> Qwen3ASRLiveTranscript? in
+            guard case .commit(let value) = event else { return nil }
+            return value
+        }
+        XCTAssertEqual(commits.map(\.text), ["hello brave new world"])
+        let sampleCounts = await transcriber.sampleCounts()
+        XCTAssertEqual(sampleCounts, [1_000, 1_100])
+    }
+
+    private func makeLive(transcriber: FakeParakeetLiveTranscriber) -> ParakeetASRLiveSession {
+        ParakeetASRLiveSession(
+            request: ASRStreamingRequest(
+                sampleRate: 1_000,
+                decodeIntervalMs: 100,
+                minDecodeAudioMs: 100,
+                maxQueuedAudioMs: 500
+            ),
+            configuration: Qwen3ASRLiveConfiguration(
+                decodeIntervalMs: 100,
+                minDecodeAudioMs: 100,
+                silenceMs: 90,
+                preRollMs: 300,
+                maxUtteranceMs: 30_000,
+                maxQueuedAudioMs: 500
+            ),
+            transcribe: { samples, language in
+                try await transcriber.transcribe(samples: samples, language: language)
+            }
+        )
+    }
+
+    private func samples(count: Int, value: Float) -> [Float] {
+        Array(repeating: value, count: count)
+    }
+
+    private func finalReasons(_ events: [Qwen3ASRLiveEvent]) -> [Qwen3ASRLiveFinishReason] {
+        events.compactMap { event in
+            guard case .final(let reason) = event else { return nil }
+            return reason
+        }
+    }
+
+    private func collect(
+        _ stream: AsyncThrowingStream<Qwen3ASRLiveEvent, Error>
+    ) -> Task<[Qwen3ASRLiveEvent], Error> {
+        Task {
+            var events: [Qwen3ASRLiveEvent] = []
+            for try await event in stream {
+                events.append(event)
+            }
+            return events
+        }
+    }
+}
+
+private actor FakeParakeetLiveTranscriber {
+    private var results: [String]
+    private var counts: [Int] = []
+
+    init(results: [String]) {
+        self.results = results
+    }
+
+    func transcribe(samples: [Float], language: String?) throws -> ASRResult {
+        counts.append(samples.count)
+        let text = results.isEmpty ? "" : results.removeFirst()
+        return ASRResult(
+            text: text,
+            language: language,
+            duration: Double(samples.count) / 1_000
+        )
+    }
+
+    func callCount() -> Int {
+        counts.count
+    }
+
+    func sampleCounts() -> [Int] {
+        counts
+    }
+}


### PR DESCRIPTION
## Summary

- add resident Parakeet live transcription for raw PCM and streamed files using the existing V1 ready/partial/commit/stats/final contract
- make `--backend auto` choose Parakeet for transcription while preserving Qwen for translation and explicit quality-first use
- keep ingestion bounded while avoiding repeated full-utterance decoding through one early partial plus overlapped-tail commit decoding
- advertise supported live ASR backends through `mere.run status` and update public guides and changelog

## Validation

- [x] `./scripts/check.sh`
- [x] 1,916 Swift tests passed; 117 fixture-dependent tests skipped; 0 failures
- [x] focused Parakeet live and speech command tests passed
- [x] docs updated for the public behavior change
- [x] `THIRD_PARTY_NOTICES.md` unchanged because no vendored artifacts or package pins changed
- [x] real `book.local` Parakeet smoke: 100 ms PCM feed, first partial 3.812 s after ready, silence commit 1.676 s after the 900 ms acceptance threshold, exactly one commit/final, no protocol errors, complete sentence recovered
