### PR TITLE
Refresh docs and prevent CLI drift

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -42,5 +42,6 @@ mere.run is a Swift package, CLI, and optional macOS GUI for local-first inferen
 - Prefer typed decoding at config/tokenizer boundaries over `[String: Any]`
 - Keep stdout machine-readable and stderr diagnostic in CLI commands
 - Add or update the closest test file for command parsing, model resolution, or compatibility behavior
+- After changing the command tree or command abstracts, run `./scripts/update-docs-command-reference.sh`; the docs contract owns every top-level command and fails `swift test` on drift
 - Add a module README before a source directory grows past 500 direct Swift lines
 - If a change requires real checkpoint assets or GPU-only validation, stop after the local gate and report the remaining validation gap explicitly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 - Install SwiftLint and ripgrep (`brew install swiftlint ripgrep`) and run `./scripts/check.sh` before opening a PR.
 - Add or update tests when changing command parsing, model resolution, inference behavior, or security-sensitive defaults.
 - Update `README.md`, `docs/`, and `CHANGELOG.md` when you change public setup, behavior, or operator-facing flags.
+- Run `./scripts/update-docs-command-reference.sh` after adding, removing, renaming, or redescribing a CLI command; CI rejects command inventories, docs ownership, navigation, and examples that drift from the code.
 - If you touch vendored artifacts or third-party package pins, update [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md).
 - Do not add hosted-service, billing, or app-store-only surfaces back into this repo.
 

--- a/Tests/MereRunCLITests/DocumentationContractTests.swift
+++ b/Tests/MereRunCLITests/DocumentationContractTests.swift
@@ -1,0 +1,297 @@
+import ArgumentParser
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+final class DocumentationContractTests: XCTestCase {
+    private struct CommandNode {
+        let name: String
+        let abstract: String
+        let children: [CommandNode]
+    }
+
+    private struct CommandPage {
+        let command: String
+        let path: String
+    }
+
+    private static let topLevelStart = "<!-- BEGIN GENERATED: CLI TOP LEVEL -->"
+    private static let topLevelEnd = "<!-- END GENERATED: CLI TOP LEVEL -->"
+    private static let treeStart = "<!-- BEGIN GENERATED: CLI TREE -->"
+    private static let treeEnd = "<!-- END GENERATED: CLI TREE -->"
+
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    func testGeneratedCommandInventoriesMatchCLI() throws {
+        let commands = commandTree()
+        let pages = try commandPages()
+        let topLevel = renderTopLevel(commands: commands, pages: pages)
+        let tree = renderTree(commands: commands, pages: pages)
+        let indexURL = repositoryRoot.appendingPathComponent("docs/index.md")
+        let gettingStartedURL = repositoryRoot.appendingPathComponent("docs/getting-started.md")
+        let cliURL = repositoryRoot.appendingPathComponent("docs/cli.md")
+
+        if ProcessInfo.processInfo.environment["MERERUN_UPDATE_DOCS"] == "1" {
+            try replaceGeneratedBlock(
+                in: indexURL,
+                start: Self.topLevelStart,
+                end: Self.topLevelEnd,
+                with: topLevel
+            )
+            try replaceGeneratedBlock(
+                in: gettingStartedURL,
+                start: Self.topLevelStart,
+                end: Self.topLevelEnd,
+                with: topLevel
+            )
+            try replaceGeneratedBlock(
+                in: cliURL,
+                start: Self.treeStart,
+                end: Self.treeEnd,
+                with: tree
+            )
+        }
+
+        let updateMessage = "Run ./scripts/update-docs-command-reference.sh and commit the generated changes."
+        XCTAssertEqual(
+            try generatedBlock(in: indexURL, start: Self.topLevelStart, end: Self.topLevelEnd),
+            topLevel,
+            updateMessage
+        )
+        XCTAssertEqual(
+            try generatedBlock(in: gettingStartedURL, start: Self.topLevelStart, end: Self.topLevelEnd),
+            topLevel,
+            updateMessage
+        )
+        XCTAssertEqual(
+            try generatedBlock(in: cliURL, start: Self.treeStart, end: Self.treeEnd),
+            tree,
+            updateMessage
+        )
+    }
+
+    func testEveryPublicCommandHasNavigableDocumentation() throws {
+        let commands = commandTree()
+        let pages = try commandPages()
+        XCTAssertEqual(
+            pages.map(\.command),
+            commands.map(\.name),
+            "docs/.vitepress/command-pages.tsv must own every top-level CLI command in CLI order."
+        )
+
+        let navigation = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("docs/.vitepress/config.mts"),
+            encoding: .utf8
+        )
+        for page in pages {
+            let basePath = page.path.split(separator: "#", maxSplits: 1).first.map(String.init) ?? page.path
+            let relativePath = basePath == "/" ? "index.md" : "\(basePath.dropFirst()).md"
+            let pageURL = repositoryRoot.appendingPathComponent("docs/\(relativePath)")
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: pageURL.path),
+                "Documentation owner for mere.run \(page.command) does not exist: \(relativePath)"
+            )
+            XCTAssertTrue(
+                navigation.contains("link: '\(basePath)'"),
+                "The documentation owner for mere.run \(page.command) is missing from the sidebar: \(basePath)"
+            )
+        }
+
+        let runtimeDirectory = repositoryRoot.appendingPathComponent("docs/runtime")
+        let runtimePages = try FileManager.default.contentsOfDirectory(
+            at: runtimeDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "md" }
+        for pageURL in runtimePages {
+            let path = "/runtime/\(pageURL.deletingPathExtension().lastPathComponent)"
+            XCTAssertTrue(navigation.contains("link: '\(path)'"), "Runtime page is missing from the sidebar: \(path)")
+        }
+    }
+
+    func testDocumentedCommandInvocationsUseCurrentCommandTree() throws {
+        let commands = commandTree()
+        let docsRoot = repositoryRoot.appendingPathComponent("docs")
+        let markdownFiles = try FileManager.default.subpathsOfDirectory(atPath: docsRoot.path)
+            .filter { $0.hasSuffix(".md") }
+            .sorted()
+        var failures: [String] = []
+
+        for relativePath in markdownFiles {
+            let fileURL = docsRoot.appendingPathComponent(relativePath)
+            let contents = try String(contentsOf: fileURL, encoding: .utf8)
+            var inFence = false
+            for (offset, lineValue) in contents.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                let line = String(lineValue)
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("```") {
+                    inFence.toggle()
+                    continue
+                }
+
+                let candidates = inlineCommandCandidates(in: line) + (inFence ? fencedCommandCandidates(in: line) : [])
+                for candidate in candidates {
+                    if let invalid = invalidCommandPath(candidate, commands: commands) {
+                        failures.append("\(relativePath):\(offset + 1): \(invalid)")
+                    }
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            failures.isEmpty,
+            "Documented command paths must match the CLI command tree:\n\(failures.joined(separator: "\n"))"
+        )
+    }
+
+    private func commandTree() -> [CommandNode] {
+        nodes(from: MereRunCLI.configuration.subcommands)
+    }
+
+    private func nodes(from commandTypes: [ParsableCommand.Type]) -> [CommandNode] {
+        commandTypes.compactMap { commandType in
+            let configuration = commandType.configuration
+            guard configuration.shouldDisplay, let name = configuration.commandName else { return nil }
+            return CommandNode(
+                name: name,
+                abstract: normalized(configuration.abstract),
+                children: nodes(from: configuration.subcommands)
+            )
+        }
+    }
+
+    private func normalized(_ value: String) -> String {
+        value.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
+    private func commandPages() throws -> [CommandPage] {
+        let mapURL = repositoryRoot.appendingPathComponent("docs/.vitepress/command-pages.tsv")
+        let contents = try String(contentsOf: mapURL, encoding: .utf8)
+        return try contents.split(separator: "\n").compactMap { lineValue in
+            let line = String(lineValue)
+            guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
+            let columns = line.split(separator: "\t", omittingEmptySubsequences: false)
+            guard columns.count == 2, !columns[0].isEmpty, columns[1].hasPrefix("/") else {
+                throw NSError(
+                    domain: "DocumentationContractTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Invalid command-pages.tsv row: \(line)"]
+                )
+            }
+            return CommandPage(command: String(columns[0]), path: String(columns[1]))
+        }
+    }
+
+    private func renderTopLevel(commands: [CommandNode], pages: [CommandPage]) -> String {
+        let paths = Dictionary(uniqueKeysWithValues: pages.map { ($0.command, $0.path) })
+        var lines = ["| Command | Purpose |", "| --- | --- |"]
+        for command in commands {
+            let path = paths[command.name] ?? "/cli"
+            let abstract = command.abstract.replacingOccurrences(of: "|", with: "\\|")
+            lines.append("| [`mere.run \(command.name)`](\(path)) | \(abstract) |")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func renderTree(commands: [CommandNode], pages: [CommandPage]) -> String {
+        let paths = Dictionary(uniqueKeysWithValues: pages.map { ($0.command, $0.path) })
+        var lines: [String] = []
+        for command in commands {
+            let path = paths[command.name] ?? "/cli"
+            lines.append("- [`mere.run \(command.name)`](\(path)) — \(command.abstract)")
+            appendChildren(command.children, prefix: [command.name], depth: 1, to: &lines)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func appendChildren(
+        _ commands: [CommandNode],
+        prefix: [String],
+        depth: Int,
+        to lines: inout [String]
+    ) {
+        for command in commands {
+            let path = prefix + [command.name]
+            lines.append("\(String(repeating: "  ", count: depth))- `mere.run \(path.joined(separator: " "))` — \(command.abstract)")
+            appendChildren(command.children, prefix: path, depth: depth + 1, to: &lines)
+        }
+    }
+
+    private func generatedBlock(in url: URL, start: String, end: String) throws -> String {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let startToken = "\(start)\n"
+        let endToken = "\n\(end)"
+        guard let startRange = contents.range(of: startToken),
+              let endRange = contents.range(of: endToken, range: startRange.upperBound..<contents.endIndex) else {
+            throw NSError(
+                domain: "DocumentationContractTests",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Missing generated block markers in \(url.path)"]
+            )
+        }
+        return String(contents[startRange.upperBound..<endRange.lowerBound])
+    }
+
+    private func replaceGeneratedBlock(in url: URL, start: String, end: String, with replacement: String) throws {
+        var contents = try String(contentsOf: url, encoding: .utf8)
+        let startToken = "\(start)\n"
+        let endToken = "\n\(end)"
+        guard let startRange = contents.range(of: startToken),
+              let endRange = contents.range(of: endToken, range: startRange.upperBound..<contents.endIndex) else {
+            throw NSError(
+                domain: "DocumentationContractTests",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Missing generated block markers in \(url.path)"]
+            )
+        }
+        contents.replaceSubrange(startRange.upperBound..<endRange.lowerBound, with: replacement)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func inlineCommandCandidates(in line: String) -> [String] {
+        let pattern = #"`((?:swift run )?mere\.run(?: [a-z][a-z0-9-]*)+)`"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        return expression.matches(in: line, range: range).compactMap { match in
+            guard let candidateRange = Range(match.range(at: 1), in: line) else { return nil }
+            return String(line[candidateRange])
+        }
+    }
+
+    private func fencedCommandCandidates(in line: String) -> [String] {
+        var trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("$ ") || trimmed.hasPrefix("| ") {
+            trimmed.removeFirst(2)
+        }
+        guard trimmed.hasPrefix("mere.run ") || trimmed.hasPrefix("swift run mere.run ") else { return [] }
+        return [trimmed]
+    }
+
+    private func invalidCommandPath(_ candidate: String, commands: [CommandNode]) -> String? {
+        let normalizedCandidate = candidate.hasPrefix("swift run ")
+            ? String(candidate.dropFirst("swift run ".count))
+            : candidate
+        let tokens = normalizedCandidate.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard tokens.first == "mere.run", tokens.count > 1 else { return nil }
+        var siblings = commands
+        var path: [String] = []
+
+        for token in tokens.dropFirst() {
+            guard !token.hasPrefix("-"), token.range(of: #"^[a-z][a-z0-9-]*$"#, options: .regularExpression) != nil else {
+                return nil
+            }
+            guard !siblings.isEmpty else { return nil }
+            guard let command = siblings.first(where: { $0.name == token }) else {
+                let parent = path.isEmpty ? "mere.run" : "mere.run \(path.joined(separator: " "))"
+                return "`\(candidate)` uses unknown subcommand `\(token)` under `\(parent)`"
+            }
+            path.append(token)
+            siblings = command.children
+        }
+        return nil
+    }
+}

--- a/docs/.vitepress/command-pages.tsv
+++ b/docs/.vitepress/command-pages.tsv
@@ -1,0 +1,24 @@
+# Top-level CLI command to canonical public documentation page.
+# Keep rows in MereRunCLI command order. DocumentationContractTests enforces ownership and navigation.
+guide	/cookbooks
+image	/runtime/image
+text	/runtime/text
+speech	/runtime/speech
+vision	/runtime/vision
+music	/runtime/music
+sfx	/runtime/sfx
+video	/runtime/video
+world	/runtime/world
+graph	/workflows
+executor	/workflows#executor-profiles
+run	/workflows#run-directories
+model	/runtime/model-management
+adapter	/runtime/model-management
+status	/runtime/model-management
+gate	/gate
+config	/configuration
+api	/runtime/api-server
+open-webui	/runtime/api-server#open-webui-companion
+plugin	/plugins
+setup	/getting-started
+agent	/getting-started

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,7 +22,7 @@ function resolveBase(): string {
 
 export default defineConfig({
   title: 'mere.run',
-  description: 'Local-first inference on Apple Silicon with a public Swift package and CLI.',
+  description: 'Local multimodal inference, portable workflow graphs, and headless executors from one public Swift CLI.',
   base: resolveBase(),
   cleanUrls: true,
   lastUpdated: true,
@@ -36,10 +36,10 @@ export default defineConfig({
     nav: [
       { text: 'Getting Started', link: '/getting-started' },
       { text: 'CLI', link: '/cli' },
-      { text: 'Benchmarking', link: '/benchmarking' },
-      { text: 'Cookbooks', link: '/cookbooks' },
+      { text: 'Workflows', link: '/workflows' },
       { text: 'Runtime', link: '/runtime/image' },
-      { text: 'Internals', link: '/internals/cli-and-runtime' }
+      { text: 'Plugins', link: '/plugins' },
+      { text: 'Contribute', link: '/repository-tour' }
     ],
     sidebar: [
       {
@@ -47,12 +47,19 @@ export default defineConfig({
         items: [
           { text: 'Docs Home', link: '/' },
           { text: 'Getting Started', link: '/getting-started' },
+          { text: 'Linux QuickStart', link: '/linux-quickstart' },
           { text: 'CLI Reference', link: '/cli' },
-          { text: 'Cookbooks', link: '/cookbooks' },
+          { text: 'Offline Cookbooks', link: '/cookbooks' },
+        ]
+      },
+      {
+        text: 'Workflows and Operations',
+        items: [
           { text: 'Portable Workflows', link: '/workflows' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Quality Gate', link: '/gate' },
-          { text: 'Model Sources', link: '/model-sources' }
+          { text: 'Model Sources', link: '/model-sources' },
+          { text: 'Companion Plugins', link: '/plugins' }
         ]
       },
       {
@@ -78,7 +85,9 @@ export default defineConfig({
           { text: 'Speech Runtime', link: '/runtime/speech' },
           { text: 'Vision Runtime', link: '/runtime/vision' },
           { text: 'Music Runtime', link: '/runtime/music' },
+          { text: 'SFX Runtime', link: '/runtime/sfx' },
           { text: 'Video Runtime', link: '/runtime/video' },
+          { text: 'Persistent Worlds', link: '/runtime/world' },
           { text: 'Model Management', link: '/runtime/model-management' },
           { text: 'Local API Server', link: '/runtime/api-server' }
         ]

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,10 +5,13 @@ export default createMereProductDocsTheme({
   productDomain: 'docs.mere.run',
   docsUrl: 'https://docs.mere.run/',
   productHref: 'https://mere.run',
-  corePrefix: 'Local-first inference on Apple Silicon with public CLI and runtime docs.',
+  corePrefix: 'Multimodal inference, portable graphs, and persistent local runtimes.',
   guideHref: '/getting-started',
   architectureHref: '/architecture',
   operationsHref: '/development-workflow',
+  workflowsHref: '/workflows',
+  runtimeHref: '/runtime/image',
+  pluginsHref: '/plugins',
   referenceHref: '/cli',
   cliHref: '/cli'
 })

--- a/docs/.vitepress/theme/mere/index.ts
+++ b/docs/.vitepress/theme/mere/index.ts
@@ -26,6 +26,9 @@ export interface MereProductDocsThemeOptions {
   guideHref?: string
   architectureHref?: string
   operationsHref?: string
+  workflowsHref?: string
+  runtimeHref?: string
+  pluginsHref?: string
   referenceHref?: string
   cliHref?: string
 }
@@ -49,36 +52,39 @@ export function createMereProductDocsTheme(options: MereProductDocsThemeOptions)
   const guideHref = options.guideHref ?? '/'
   const architectureHref = options.architectureHref ?? guideHref
   const operationsHref = options.operationsHref ?? guideHref
+  const workflowsHref = options.workflowsHref ?? guideHref
+  const runtimeHref = options.runtimeHref ?? architectureHref
+  const pluginsHref = options.pluginsHref ?? referenceHref
   const referenceHref = options.referenceHref ?? guideHref
   const cliHref = options.cliHref ?? referenceHref
   const planes: MereAtlasPlane[] = [
     {
-      name: `${options.productName} guide`,
-      signal: 'Setup paths, product workflows, and common tasks',
-      href: guideHref,
+      name: `${options.productName} CLI`,
+      signal: 'Complete command tree, setup paths, and practical cookbooks',
+      href: referenceHref,
       accent: 'green',
-      items: ['Guide', 'Workflows', 'Setup'],
+      items: ['Commands', 'Cookbooks', 'Setup'],
     },
     {
-      name: 'Architecture',
-      signal: 'Boundaries, data flow, and integration contracts',
-      href: architectureHref,
+      name: 'Portable workflows',
+      signal: 'Immutable bundles across local, SSH, and relay executors',
+      href: workflowsHref,
       accent: 'blue',
-      items: ['Contracts', 'Runtime', 'Data'],
+      items: ['Graphs', 'Executors', 'Runs'],
     },
     {
-      name: 'Operations',
-      signal: 'Deploy, verify, release, and troubleshoot',
-      href: operationsHref,
+      name: 'Runtime families',
+      signal: 'Image, text, audio, vision, video, 3D, and persistent worlds',
+      href: runtimeHref,
       accent: 'plum',
-      items: ['Deploy', 'Testing', 'Runbooks'],
+      items: ['Multimodal', 'Resident', 'Local'],
     },
     {
-      name: 'Mere atlas',
-      signal: 'Cross-product docs and ecosystem inventory',
-      href: 'https://mere-docs.mere.world/',
+      name: 'Companion plugins',
+      signal: 'Verified external tools and typed graph providers',
+      href: pluginsHref,
       accent: 'copper',
-      items: ['Products', 'Matrix', 'Reference'],
+      items: ['Catalog', 'Doctor', 'Providers'],
     },
   ]
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,11 +36,13 @@ If you are new to the repo, read these in order:
 1. [Getting Started](./getting-started.md)
 2. [Linux QuickStart](./linux-quickstart.md), if you are installing the headless CLI on Linux
 3. [CLI Reference](./cli.md)
-4. [Benchmarking](./benchmarking.md)
-5. [Cookbooks](./cookbooks.md)
-6. [Configuration](./configuration.md)
-7. [Model Sources](./model-sources.md)
-8. [Repository Tour](./repository-tour.md)
+4. [Portable Workflows](./workflows.md), if you are automating local or remote jobs
+5. [Benchmarking](./benchmarking.md)
+6. [Cookbooks](./cookbooks.md)
+7. [Configuration](./configuration.md)
+8. [Model Sources](./model-sources.md)
+9. [Companion Plugins](./plugins.md)
+10. [Repository Tour](./repository-tour.md)
 
 ## Choose your path
 
@@ -51,8 +53,10 @@ If you are new to the repo, read these in order:
 - [CLI Reference](./cli.md)
 - [Benchmarking](./benchmarking.md)
 - [Cookbooks](./cookbooks.md)
+- [Portable Workflows](./workflows.md)
 - [Configuration](./configuration.md)
 - [Model Sources](./model-sources.md)
+- [Companion Plugins](./plugins.md)
 
 ### I want to contribute code
 
@@ -71,6 +75,7 @@ If you are new to the repo, read these in order:
 - [Music Runtime](./runtime/music.md)
 - [SFX Runtime](./runtime/sfx.md)
 - [Video Runtime](./runtime/video.md)
+- [Persistent World Runtime](./runtime/world.md)
 - [Model Management](./runtime/model-management.md)
 - [Local API Server](./runtime/api-server.md)
 
@@ -90,6 +95,10 @@ If you are new to the repo, read these in order:
   and local model-store behavior
 - [Benchmarking](./benchmarking.md): local quality evals, generated-code
   execution, VLM datasets, API workload, and runtime microbenchmarks
+- [Portable Workflows](./workflows.md): typed graphs, immutable job bundles,
+  local execution, SSH and relay executors, run artifacts, and remote lifecycle
+- [Companion Plugins](./plugins.md): public catalog discovery, safe installation,
+  doctor checks, and the typed graph-provider boundary
 
 ### Repository guides
 
@@ -111,8 +120,29 @@ If you are new to the repo, read these in order:
 - [Music Runtime](./runtime/music.md)
 - [SFX Runtime](./runtime/sfx.md)
 - [Video Runtime](./runtime/video.md)
+- [Persistent World Runtime](./runtime/world.md)
 - [Model Management](./runtime/model-management.md)
 - [Local API Server](./runtime/api-server.md)
+
+## Keep command docs synchronized
+
+The generated command inventories on the docs home, Getting Started, and CLI
+reference come directly from `MereRunCLI.configuration`. Every top-level command
+also has an explicit owner in `.vitepress/command-pages.tsv`.
+
+After adding, renaming, removing, or redescribing a command, run:
+
+```bash
+./scripts/update-docs-command-reference.sh
+```
+
+`DocumentationContractTests` fails the normal `swift test` and
+`./scripts/check.sh` gates when:
+
+- a generated command inventory differs from the CLI configuration
+- a top-level command lacks a canonical docs owner or sidebar entry
+- a runtime guide is absent from the sidebar
+- a command invocation in Markdown names a subcommand that no longer exists
 
 ### Internal implementation guides
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Benchmarking](./benchmarking.md)
 - [Cookbooks](./cookbooks.md)
 - [Portable Workflows](./workflows.md)
+- [Companion Plugins](./plugins.md)
 - [Configuration](./configuration.md)
 - [Quality Gate](./gate.md)
 - [Model Sources](./model-sources.md)
@@ -22,6 +23,7 @@
   - [Music Runtime](./runtime/music.md)
   - [SFX Runtime](./runtime/sfx.md)
   - [Video Runtime](./runtime/video.md)
+  - [Persistent World Runtime](./runtime/world.md)
   - [Model Management](./runtime/model-management.md)
   - [Local API Server](./runtime/api-server.md)
 - Internals

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,27 +15,162 @@ swift run mere.run --help
 
 Public tree:
 
-- `mere.run guide`
-- `mere.run image { dataset, generate, reconstruct-3d, reconstruct-3d-trellis2, reconstruct-3d-multiview, run-plan, train-lora, visualize-run, validate }`
-- `mere.run text { chat, code, embed, anonymize, train-lora }`
-- `mere.run speech { synthesize, transcribe }`
-- `mere.run speech profile { list, create, delete }`
-- `mere.run vision { caption, inspect, ground, segment, track, track-live, pose, flow, depth-video, geometry, geometry-multiview, image-to-3d, image-to-3d-trellis2, image-to-3d-multiview, ocr }`
-- `mere.run music { analyze, generate, realtime, transcribe }`
-- `mere.run sfx { ae, clap, condition, generate, video }`
-- `mere.run video { generate, export-latents }`
-- `mere.run world serve`
-- `mere.run run { list, inspect }`
-- `mere.run model { list, pull, remove, info, capabilities, runtime, benchmark, repair-manifests }`
-- `mere.run adapter { list, pull }`
-- `mere.run status`
-- `mere.run gate`
-- `mere.run config { set, get, unset, list, path }`
-- `mere.run api serve`
-- `mere.run open-webui quickstart`
-- `mere.run plugin { list, info, install, doctor }`
-- `mere.run setup`
-- `mere.run agent { onboard, install-pi, start }`
+<!-- BEGIN GENERATED: CLI TREE -->
+- [`mere.run guide`](/cookbooks) — Read offline mere.run command cookbooks.
+- [`mere.run image`](/runtime/image) — Generate and validate image models.
+  - `mere.run image dataset` — Inspect image training datasets.
+    - `mere.run image dataset discover` — Find image-caption dataset candidates under a root directory.
+  - `mere.run image generate` — Generate images with local image models.
+  - `mere.run image reconstruct-3d` — Reconstruct a colored object mesh from one image with native TripoSR.
+  - `mere.run image reconstruct-3d-trellis2` — Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2.
+  - `mere.run image reconstruct-3d-multiview` — Reconstruct a colored mesh from 4 or 6 user-supplied views with native InstantMesh.
+  - `mere.run image run-plan` — Run a saved image workflow plan.
+  - `mere.run image train-lora` — Train a local image LoRA adapter.
+  - `mere.run image visualize-run` — Open a local LoRA training run viewer.
+  - `mere.run image validate` — Run advanced deterministic validation for local image model families.
+- [`mere.run text`](/runtime/text) — Run local chat, code, embedding, and anonymization workflows.
+  - `mere.run text chat` — Run local chat with text chat models.
+  - `mere.run text code` — Run local code generation with GGUF models via llama.cpp.
+  - `mere.run text embed` — Generate text embeddings using native Qwen3-Embedding-0.6B.
+  - `mere.run text anonymize` — Detect and redact PII using OpenAI Privacy Filter.
+  - `mere.run text train-lora` — Train a native text LoRA adapter from chat-style SFT JSONL.
+- [`mere.run speech`](/runtime/speech) — Synthesize, transcribe, and manage voice profiles.
+  - `mere.run speech synthesize` — Generate speech from text using Qwen3-TTS.
+  - `mere.run speech transcribe` — Transcribe or translate speech to text using native ASR backends.
+  - `mere.run speech listen` — Transcribe a macOS microphone with live Qwen ASR.
+  - `mere.run speech profile` — Manage saved voice clone profiles.
+    - `mere.run speech profile list` — List saved speech voice profiles.
+    - `mere.run speech profile create` — Create a speech profile from reference audio.
+    - `mere.run speech profile delete` — Delete a speech profile by id.
+- [`mere.run vision`](/runtime/vision) — Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media.
+  - `mere.run vision caption` — Generate training-friendly captions for images.
+  - `mere.run vision inspect` — Describe or answer questions about an image using Qwen3-VL.
+  - `mere.run vision face` — Detect faces, create identity embeddings, and compare faces locally.
+    - `mere.run vision face detect` — Detect faces and five-point landmarks in an image.
+    - `mere.run vision face embed` — Create a normalized ArcFace embedding for one face in an image.
+    - `mere.run vision face compare` — Compare one face from each of two images with cosine similarity.
+    - `mere.run vision face batch` — Analyze many images with one warm detector/recognizer session and emit JSONL.
+  - `mere.run vision ground` — Ground text queries in an image with the native Falcon Perception runtime.
+  - `mere.run vision segment` — Segment prompted objects in an image with the native SAM 3.1 runtime.
+  - `mere.run vision track` — Track prompted objects through a video with the native SAM 3.1 runtime.
+  - `mere.run vision track-live` — Capture from a camera and track text-prompted objects with the native SAM 3.1 runtime.
+  - `mere.run vision pose` — Detect body, hand, and face landmarks in an image with the native platform runtime.
+  - `mere.run vision flow` — Generate dense optical flow between two equal-size images.
+  - `mere.run vision depth-video` — Generate temporally consistent relative or metric video depth with native VDA-S.
+  - `mere.run vision geometry` — Generate metric depth, normals, camera intrinsics, and a point cloud with native MoGe-2.
+  - `mere.run vision geometry-multiview` — Solve native DA3-Small multi-view relative geometry, confidence, and cameras.
+  - `mere.run vision image-to-3d` — Reconstruct a colored object mesh from one image with native TripoSR.
+  - `mere.run vision image-to-3d-trellis2` — Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2.
+  - `mere.run vision image-to-3d-multiview` — VFX alias for native 4/6-view InstantMesh reconstruction.
+  - `mere.run vision ocr` — Extract text from images using LightOnOCR, GLM-OCR, or Infinity-Parser2.
+- [`mere.run music`](/runtime/music) — Generate music locally.
+  - `mere.run music analyze` — Analyze source audio with ACE-Step audio understanding.
+  - `mere.run music generate` — Generate audio from a music prompt.
+  - `mere.run music realtime` — Run Magenta RealTime 2 music generation.
+  - `mere.run music transcribe` — Transcribe a full music mix into instrument-separated MIDI with MuScriptor.
+- [`mere.run sfx`](/runtime/sfx) — Generate sound effects locally.
+  - `mere.run sfx ae` — Encode or decode Woosh audio autoencoder latents.
+    - `mere.run sfx ae encode` — Encode audio into normalized Woosh-AE latents.
+    - `mere.run sfx ae decode` — Decode normalized Woosh-AE latents into audio.
+  - `mere.run sfx clap` — Embed and score sound effects with Woosh-CLAP.
+    - `mere.run sfx clap score` — Score a text prompt against an audio file.
+  - `mere.run sfx condition` — Export Woosh conditioning tensors.
+    - `mere.run sfx condition text` — Encode a prompt with the Woosh text conditioner.
+  - `mere.run sfx generate` — Generate a sound effect from a text prompt.
+  - `mere.run sfx video` — Generate sound effects from video conditioning.
+    - `mere.run sfx video generate` — Generate an 8-second sound effect from a video or Synchformer features.
+- [`mere.run video`](/runtime/video) — Generate videos with native Swift/MLX LTX pipelines.
+  - `mere.run video export-latents` — Run native Swift/MLX distilled LTX denoising and export final latents.
+  - `mere.run video generate` — Generate MP4 video with native Swift/MLX video models.
+  - `mere.run video session` — Keep an LTX 2.3 runtime resident for JSONL generation requests.
+- [`mere.run world`](/runtime/world) — Run persistent local conditioned-video world sessions.
+  - `mere.run world serve` — Serve one warm DreamX causal world session over loopback HTTP.
+- [`mere.run graph`](/workflows) — Validate, materialize, run, and submit portable workflow graphs.
+  - `mere.run graph catalog` — List registered workflow node contracts.
+  - `mere.run graph dataset` — Discover graph-ready datasets without loading model runtimes.
+    - `mere.run graph dataset discover` — Find and rank image-caption dataset directories under a root.
+  - `mere.run graph validate` — Validate a typed workflow graph without executing it.
+  - `mere.run graph preflight` — Preflight a workflow graph against an executor.
+  - `mere.run graph materialize` — Create an immutable workflow job bundle in a run directory.
+  - `mere.run graph export-job` — Export an immutable workflow job bundle for any executor.
+  - `mere.run graph run` — Run a workflow graph locally.
+  - `mere.run graph run-job` — Run an existing immutable workflow job bundle locally.
+  - `mere.run graph submit` — Submit a portable workflow job to an SSH or relay executor.
+  - `mere.run graph submit-job` — Submit an existing immutable workflow job bundle to SSH or Relay.
+  - `mere.run graph worker` — Run the portable workflow worker protocol.
+    - `mere.run graph worker probe` — Report worker capabilities.
+    - `mere.run graph worker execute` — Execute a materialized job bundle.
+    - `mere.run graph worker inspect` — Inspect a worker run manifest.
+    - `mere.run graph worker cancel` — Request cooperative worker cancellation.
+- [`mere.run executor`](/workflows#executor-profiles) — Manage local, SSH, and relay workflow executors.
+  - `mere.run executor add` — Add an executor profile.
+    - `mere.run executor add ssh` — Add an SSH executor.
+    - `mere.run executor add relay` — Add a relay executor.
+  - `mere.run executor list` — List executor profiles.
+  - `mere.run executor inspect` — Inspect an executor profile.
+  - `mere.run executor probe` — Probe executor capabilities.
+  - `mere.run executor login` — Sign in to a relay executor through its advertised device authorization flow.
+  - `mere.run executor auth-status` — Inspect relay authentication without printing credentials.
+  - `mere.run executor logout` — Remove the saved credential for a relay executor.
+  - `mere.run executor fleet` — Inspect relay node identity, eligibility, inventory, and recent work.
+  - `mere.run executor node-refresh` — Ask a connected relay node to rescan its capabilities and installed models.
+  - `mere.run executor node-configure` — Update relay scheduling policy for a fleet node.
+  - `mere.run executor remove` — Remove an executor profile.
+- [`mere.run run`](/workflows#run-directories) — Inspect durable mere.run workflow reports and run directories.
+  - `mere.run run list` — Find durable run directories, structured reports, and run plans under a root.
+  - `mere.run run inspect` — Inspect a run directory, structured report, or run plan.
+  - `mere.run run watch` — Watch the worker event stream for an SSH or relay graph job.
+  - `mere.run run fetch` — Fetch a remote graph run into the standard local run-directory format.
+  - `mere.run run cancel` — Cancel a graph run.
+  - `mere.run run retry` — Retry an immutable relay graph job.
+- [`mere.run model`](/runtime/model-management) — List, pull, remove, inspect, and clean up models.
+  - `mere.run model list` — List all known models with install status.
+  - `mere.run model pull` — Download a managed model into the local model store.
+  - `mere.run model remove` — Remove a model from the local model store.
+  - `mere.run model storage` — Inspect physical model storage, sharing, and reclaimable space.
+  - `mere.run model gc` — Find or delete unreferenced model payloads and partial downloads.
+  - `mere.run model info` — Print a model's manifest, validation status, and resolved component paths.
+  - `mere.run model capabilities` — Show which managed models this machine can run.
+  - `mere.run model runtime` — Read and update per-model API runtime settings.
+    - `mere.run model runtime get` — Print typed API runtime settings for a managed model.
+    - `mere.run model runtime set` — Update typed API runtime settings for a managed model.
+  - `mere.run model benchmark` — Run focused local model benchmarks.
+    - `mere.run model benchmark chat` — Run a small grounded-chat eval slice against local assistant models.
+    - `mere.run model benchmark tool-calls` — Run a small tool-call selection eval against local chat models.
+    - `mere.run model benchmark tool-continuations` — Evaluate Gemma 4 continuation after completed tool calls.
+    - `mere.run model benchmark code` — Run a real coding-eval slice against local coding models.
+    - `mere.run model benchmark gemma4-kv` — Compare Gemma4 default KV cache decode against packed PolarKV.
+    - `mere.run model benchmark gemma4-mtp` — Compare Gemma4 serial decode against verified MTP speculative decode.
+    - `mere.run model benchmark q36-mtp` — Compare Qwen3.6 serial decode against adaptive and forced MTP speculative decode.
+    - `mere.run model benchmark api-workload` — Replay a chat workload against a running API server and measure runtime cache counters.
+    - `mere.run model benchmark vlm` — Compare vision-language chat models on synthetic or lmms-eval datasets.
+  - `mere.run model repair-manifests` — Write missing mererun_model.json for known models in the local mere.run model store.
+- [`mere.run adapter`](/runtime/model-management) — List and pull verified LoRA adapters.
+  - `mere.run adapter list` — List cataloged LoRA adapters and their install state.
+  - `mere.run adapter pull` — Download and verify a cataloged LoRA adapter.
+- [`mere.run status`](/runtime/model-management) — Show local server, loaded model, and installed model status.
+- [`mere.run gate`](/gate) — Run the end-to-end quality gate against installed models.
+- [`mere.run config`](/configuration) — Get and set persisted mere.run configuration (e.g. Hugging Face token).
+  - `mere.run config set` — Set a config value.
+  - `mere.run config get` — Print a config value (secrets masked).
+  - `mere.run config unset` — Remove a config value.
+  - `mere.run config list` — Show all config values (secrets masked).
+  - `mere.run config path` — Print the config file path.
+- [`mere.run api`](/runtime/api-server) — Serve local models through API surfaces.
+  - `mere.run api serve` — Start an OpenAI-compatible API server for local chat and embedding models.
+- [`mere.run open-webui`](/runtime/api-server#open-webui-companion) — Start the optional Open WebUI companion against a local mere.run API.
+  - `mere.run open-webui quickstart` — Start mere.run, run the official Open WebUI Docker image, and configure the connection.
+- [`mere.run plugin`](/plugins) — Discover and install official mere.run companion plugins.
+  - `mere.run plugin list` — List official plugins from the live catalog.
+  - `mere.run plugin info` — Show one plugin's catalog entry and install command.
+  - `mere.run plugin install` — Install one official plugin using its catalog install command.
+  - `mere.run plugin doctor` — Run an installed plugin's doctor command.
+- [`mere.run setup`](/getting-started) — Choose a guided, BYOA, or manual mere.run setup path.
+- [`mere.run agent`](/getting-started) — Install and start the optional guided local setup agent.
+  - `mere.run agent onboard` — Summarize this machine's model capabilities and prepare the optional Pi agent.
+  - `mere.run agent install-pi` — Install the latest Pi coding-agent release for use with mere.run.
+  - `mere.run agent start` — Start Pi against a local mere.run setup-agent API server.
+<!-- END GENERATED: CLI TREE -->
 
 ## Global model-store override
 
@@ -125,6 +260,13 @@ swift run mere.run speech synthesize \
 swift run mere.run speech transcribe ./hello.wav --backend auto
 ```
 
+For live microphone transcription on macOS:
+
+```bash
+swift run mere.run speech listen --list-devices
+swift run mere.run speech listen --device <core-audio-uid>
+```
+
 ### Inspect, segment, track, and OCR
 
 ```bash
@@ -178,9 +320,34 @@ swift run mere.run sfx generate \
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
   --variant unified-av \
-  --model-root ~/Library/Application\ Support/MereRun/models/video-ltx23-av-mlx \
+  --model video-ltx23-full-mlx \
+  --duration 5 \
   --output ./clip.mp4
 ```
+
+### Run a portable workflow
+
+```bash
+mere.run graph validate workflow.json --inputs-json inputs.json --json
+mere.run graph preflight workflow.json --inputs-json inputs.json --executor local --json
+mere.run graph run workflow.json --inputs-json inputs.json --run-dir ./runs/local
+mere.run run inspect ./runs/local --json
+```
+
+The same immutable job bundle can run through configured SSH or relay
+executors. See [Portable Workflows](./workflows.md).
+
+### Start a persistent world session
+
+```bash
+mere.run world serve \
+  --base-model video-wan22-ti2v-5b-mlx \
+  --model video-dreamx-world-5b-ar-mlx \
+  --prepare
+```
+
+See [Persistent World Runtime](./runtime/world.md) for the HTTP lifecycle,
+camera controls, state artifacts, and authentication boundary.
 
 ### Serve a local API
 
@@ -201,6 +368,9 @@ swift run mere.run plugin install mere-runpod
 swift run mere.run plugin install mere-runpod --yes
 swift run mere.run plugin doctor mere-runpod
 ```
+
+See [Companion Plugins](./plugins.md) for installation verification and the
+typed graph-provider boundary.
 
 ## Command reference
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -54,9 +54,19 @@ for every tiny edit.
 This catches docs hygiene regressions and verifies the CLI help surface still
 matches the public tree.
 
+If the change adds, removes, renames, or redescribes a CLI command, first run:
+
+```bash
+./scripts/update-docs-command-reference.sh
+```
+
+The documentation contract also requires every top-level command to have a
+canonical page in `docs/.vitepress/command-pages.tsv` and a sidebar entry.
+
 ### Command parsing or CLI UX change
 
 ```bash
+./scripts/update-docs-command-reference.sh
 swift test
 ./scripts/check.sh
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,21 +120,36 @@ packages are local smoke artifacts, not useful release targets.
 
 ## Understand the command tree
 
-The public CLI is modality-first:
+The public CLI is modality-first, with separate operational families for
+portable graphs, executors, run artifacts, models, adapters, serving, and
+extensions. This inventory is generated from the CLI configuration:
 
-- `mere.run guide ...`
-- `mere.run image ...`
-- `mere.run text ...`
-- `mere.run speech ...`
-- `mere.run vision ...`
-- `mere.run music ...`
-- `mere.run sfx ...`
-- `mere.run video ...`
-- `mere.run model ...`
-- `mere.run status`
-- `mere.run api ...`
-- `mere.run setup ...`
-- `mere.run agent ...`
+<!-- BEGIN GENERATED: CLI TOP LEVEL -->
+| Command | Purpose |
+| --- | --- |
+| [`mere.run guide`](/cookbooks) | Read offline mere.run command cookbooks. |
+| [`mere.run image`](/runtime/image) | Generate and validate image models. |
+| [`mere.run text`](/runtime/text) | Run local chat, code, embedding, and anonymization workflows. |
+| [`mere.run speech`](/runtime/speech) | Synthesize, transcribe, and manage voice profiles. |
+| [`mere.run vision`](/runtime/vision) | Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media. |
+| [`mere.run music`](/runtime/music) | Generate music locally. |
+| [`mere.run sfx`](/runtime/sfx) | Generate sound effects locally. |
+| [`mere.run video`](/runtime/video) | Generate videos with native Swift/MLX LTX pipelines. |
+| [`mere.run world`](/runtime/world) | Run persistent local conditioned-video world sessions. |
+| [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
+| [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
+| [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
+| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, and clean up models. |
+| [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |
+| [`mere.run status`](/runtime/model-management) | Show local server, loaded model, and installed model status. |
+| [`mere.run gate`](/gate) | Run the end-to-end quality gate against installed models. |
+| [`mere.run config`](/configuration) | Get and set persisted mere.run configuration (e.g. Hugging Face token). |
+| [`mere.run api`](/runtime/api-server) | Serve local models through API surfaces. |
+| [`mere.run open-webui`](/runtime/api-server#open-webui-companion) | Start the optional Open WebUI companion against a local mere.run API. |
+| [`mere.run plugin`](/plugins) | Discover and install official mere.run companion plugins. |
+| [`mere.run setup`](/getting-started) | Choose a guided, BYOA, or manual mere.run setup path. |
+| [`mere.run agent`](/getting-started) | Install and start the optional guided local setup agent. |
+<!-- END GENERATED: CLI TOP LEVEL -->
 
 For the full reference, see [CLI Reference](./cli.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,50 +3,99 @@ layout: home
 
 hero:
   name: mere.run
-  text: Local-first inference on Apple Silicon
-  tagline: A public Swift package, CLI, and optional macOS studio for image, text, speech, vision, music, SFX, video, model management, status snapshots, and local API serving.
+  text: Local inference from one machine to a portable fleet
+  tagline: A public Swift package and CLI for multimodal inference, persistent worlds, typed workflow graphs, local APIs, an optional macOS studio, and headless Linux executors.
   actions:
     - theme: brand
       text: Get Started
       link: /getting-started
     - theme: alt
-      text: Linux QuickStart
-      link: /linux-quickstart
-    - theme: alt
       text: CLI Reference
       link: /cli
     - theme: alt
-      text: Benchmarking
-      link: /benchmarking
+      text: Portable Workflows
+      link: /workflows
     - theme: alt
-      text: Repository Tour
-      link: /repository-tour
+      text: Linux QuickStart
+      link: /linux-quickstart
 
 features:
-  - title: One CLI, clear modalities
-    details: The public surface is organized around image, text, speech, vision, music, SFX, video, model management, status snapshots, and local API serving.
-  - title: Native macOS studio
-    details: The optional SwiftUI app opens to a prompt-first canvas, local output library, guided readiness, and advanced CLI details.
-  - title: Headless Linux CLI packages
-    details: Linux package scripts produce CLI-only tarballs and Debian packages for Ubuntu-style hosts; CUDA packages require matching CUDA hardware for runtime validation.
-  - title: Canonical model system
-    details: Public model IDs, shared model-store rules, Hugging Face-backed pulls, and `mere.run status` make installs predictable and scriptable.
-  - title: Focused local benchmarks
-    details: Quality evals, generated-code execution, VLM fixtures, serving workload, and runtime microbenchmarks are documented as separate lanes.
-  - title: Readable runtime families
-    details: The repo is documented and decomposed so contributors can follow command -> runtime -> model loading -> generation without guesswork.
+  - title: Multimodal by design
+    details: Run image, text, speech, vision, 3D, music, sound-effect, video, and persistent-world workloads from one typed CLI.
+  - title: Portable workflow graphs
+    details: Validate once, materialize immutable job bundles, and run the same graph locally, over SSH, or through a relay executor.
+  - title: Live and resident runtimes
+    details: Stream microphone transcription, keep text and video models warm, and preserve causal world state across requests.
+  - title: Managed models and adapters
+    details: Inspect machine capabilities, pull pinned model snapshots and verified LoRAs, configure runtimes, and run deterministic quality gates.
+  - title: Local APIs and companions
+    details: Serve OpenAI-compatible chat, embeddings, images, speech, and transcription; connect Open WebUI or install official companion plugins.
+  - title: Mac-first, headless when needed
+    details: Use the native macOS studio on Apple Silicon or install CLI-only Linux packages for compatible CPU and CUDA hosts.
 ---
 
-## Documentation paths
+## Current public command surface
 
-### Use the CLI
+This inventory is generated from the CLI configuration. Each command links to
+the page that owns its public documentation.
+
+<!-- BEGIN GENERATED: CLI TOP LEVEL -->
+| Command | Purpose |
+| --- | --- |
+| [`mere.run guide`](/cookbooks) | Read offline mere.run command cookbooks. |
+| [`mere.run image`](/runtime/image) | Generate and validate image models. |
+| [`mere.run text`](/runtime/text) | Run local chat, code, embedding, and anonymization workflows. |
+| [`mere.run speech`](/runtime/speech) | Synthesize, transcribe, and manage voice profiles. |
+| [`mere.run vision`](/runtime/vision) | Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media. |
+| [`mere.run music`](/runtime/music) | Generate music locally. |
+| [`mere.run sfx`](/runtime/sfx) | Generate sound effects locally. |
+| [`mere.run video`](/runtime/video) | Generate videos with native Swift/MLX LTX pipelines. |
+| [`mere.run world`](/runtime/world) | Run persistent local conditioned-video world sessions. |
+| [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
+| [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
+| [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
+| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, and clean up models. |
+| [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |
+| [`mere.run status`](/runtime/model-management) | Show local server, loaded model, and installed model status. |
+| [`mere.run gate`](/gate) | Run the end-to-end quality gate against installed models. |
+| [`mere.run config`](/configuration) | Get and set persisted mere.run configuration (e.g. Hugging Face token). |
+| [`mere.run api`](/runtime/api-server) | Serve local models through API surfaces. |
+| [`mere.run open-webui`](/runtime/api-server#open-webui-companion) | Start the optional Open WebUI companion against a local mere.run API. |
+| [`mere.run plugin`](/plugins) | Discover and install official mere.run companion plugins. |
+| [`mere.run setup`](/getting-started) | Choose a guided, BYOA, or manual mere.run setup path. |
+| [`mere.run agent`](/getting-started) | Install and start the optional guided local setup agent. |
+<!-- END GENERATED: CLI TOP LEVEL -->
+
+## Choose a path
+
+### Install and run locally
 
 - [Getting Started](/getting-started)
 - [Linux QuickStart](/linux-quickstart)
 - [CLI Reference](/cli)
-- [Benchmarking](/benchmarking)
+- [Offline Cookbooks](/cookbooks)
 - [Configuration](/configuration)
 - [Model Sources](/model-sources)
+
+### Automate and operate
+
+- [Portable Workflows, Executors, and Run Artifacts](/workflows)
+- [Model and Adapter Management](/runtime/model-management)
+- [Local API Server and Open WebUI](/runtime/api-server)
+- [Official Companion Plugins](/plugins)
+- [Quality Gate](/gate)
+- [Benchmarking](/benchmarking)
+
+### Explore runtime families
+
+- [Image](/runtime/image)
+- [Text](/runtime/text)
+- [Speech](/runtime/speech)
+- [Vision and 3D](/runtime/vision)
+- [Music](/runtime/music)
+- [Sound Effects](/runtime/sfx)
+- [Video](/runtime/video)
+- [Persistent Worlds](/runtime/world)
 
 ### Contribute to the repo
 
@@ -54,20 +103,4 @@ features:
 - [Development Workflow](/development-workflow)
 - [Testing Guide](/testing)
 - [Architecture Reading Map](/architecture)
-
-### Understand the runtime families
-
-- [Image Runtime](/runtime/image)
-- [Text Runtime](/runtime/text)
-- [Speech Runtime](/runtime/speech)
-- [Vision Runtime](/runtime/vision)
-- [Music Runtime](/runtime/music)
-- [SFX Runtime](/runtime/sfx)
-- [Video Runtime](/runtime/video)
-- [Model Management](/runtime/model-management)
-- [Local API Server](/runtime/api-server)
-
-### Internal source maps
-
 - [CLI and Runtime Internals](/internals/cli-and-runtime)
-- [Source Layout Reference](/internals/source-layout)

--- a/docs/internals/structured-runs-preflight-actions.md
+++ b/docs/internals/structured-runs-preflight-actions.md
@@ -960,15 +960,11 @@ Viewer rule:
 - viewer buttons render declarative actions
 - viewer does not invent hidden command behavior
 
-Possible future commands:
-
-```bash
-mere.run run view ./runs/my-run
-mere.run image generate --visualize
-mere.run api serve --visualize
-```
-
-This is intentionally not part of the first implementation milestone.
+There is no generic run-view command. The current viewer entrypoint is
+`mere.run image visualize-run` for compatible local image-training runs. Other
+clients should build views from `mere.run run inspect --json` and the same
+reports, events, metrics, artifacts, and declarative actions that the CLI
+writes.
 
 ## Command adoption matrix
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -715,9 +715,13 @@ The native DreamX-World autoregressive checkpoint root is:
 .../models/video-dreamx-world-5b-ar-mlx
 ```
 
-`mere.run world prepare` converts the pinned `GD-ML/DreamX-World-5B`
-checkpoint into the MLX-native root. The runtime pairs it with
-`video-wan22-ti2v-5b-mlx` for the tokenizer, text encoder, and VAE resources.
-The checkpoint provides learned camera conditioning, block-causal attention,
+The public CLI does not convert this local-only checkpoint. Supply a previously
+converted `GD-ML/DreamX-World-5B` root at the managed path above or pass its
+directory to `mere.run world serve --model`. The runtime pairs it with
+`video-wan22-ti2v-5b-mlx` for tokenizer, text encoder, and VAE resources. The
+checkpoint provides learned camera conditioning, block-causal attention,
 persistent attention caches, and autoregressive forcing for long-lived local
-world sessions. It is not downloaded automatically at runtime.
+world sessions. It is never downloaded or converted automatically at runtime.
+
+See [Persistent World Runtime](./runtime/world.md) for the server and request
+lifecycle.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,65 @@
+# Companion Plugins
+
+Official mere.run plugins are separate executables distributed outside the
+Swift package. They can add operational integrations and typed workflow graph
+providers without loading third-party code into the `mere.run` process.
+
+## Discover plugins
+
+The CLI reads the public plugin catalog and can return either a human-readable
+list or machine-readable JSON:
+
+```bash
+mere.run plugin list
+mere.run plugin list --json
+mere.run plugin info mere-runpod
+```
+
+Use `--catalog-url` with a local JSON file when developing or reviewing a
+catalog change. The default catalog remains the public release source.
+
+## Install safely
+
+`plugin install` is a dry run unless `--yes` is present. Inspect the exact
+package-manager command first, then opt in to execution:
+
+```bash
+mere.run plugin install mere-runpod
+mere.run plugin install mere-runpod --yes
+```
+
+After installation, mere.run verifies the plugin manifest and entrypoint. A
+plugin that declares a graph provider is registered only after that manifest
+passes validation.
+
+Use `--channel` to select a non-default catalog channel and `--force` only when
+you intentionally want to forward a forced reinstall to the package manager.
+
+## Diagnose an installation
+
+```bash
+mere.run plugin doctor mere-runpod
+```
+
+The doctor command resolves the catalog entry, verifies that its executable is
+on `PATH`, and invokes the plugin's fixed `doctor` verb. Plugin stdout and exit
+status remain owned by that executable.
+
+## Workflow-provider boundary
+
+A graph-provider plugin exposes a versioned manifest and only three graph
+verbs: catalog, preflight, and execute. The core runtime validates typed
+requests and events; plugin manifests cannot inject arbitrary shell commands
+into workflow bundles.
+
+See [Portable Workflows](./workflows.md#graph-v1) for the graph ABI and
+[CLI Reference](./cli.md) for every plugin option.
+
+## Source boundary
+
+- The core repo owns catalog discovery, installation verification, and the
+  typed plugin protocol.
+- Plugin packages and their implementation dependencies live in the separate
+  `mere-run-plugins` repository.
+- Hosted-service, billing, and private deployment behavior do not belong in
+  this public package.

--- a/docs/runtime/speech.md
+++ b/docs/runtime/speech.md
@@ -39,15 +39,22 @@ swift run mere.run speech synthesize \
 swift run mere.run speech transcribe ./hello.wav --backend auto
 ```
 
-Batch transcription prefers Parakeet. Live transcription uses Qwen and accepts
-raw `pcm-s16le/16000/mono` on stdin:
+In automatic mode, transcription prefers Parakeet while translation routes to
+Qwen. Streaming transcription uses the selected backend and accepts raw
+`pcm-s16le/16000/mono` on stdin. Use `--backend parakeet` or `--backend qwen`
+to pin it explicitly:
 
 ```bash
 audio-source | swift run mere.run speech transcribe - \
   --stream --input-format pcm-s16le --sample-rate 16000 --jsonl
+audio-source | swift run mere.run speech transcribe - \
+  --stream --backend parakeet \
+  --input-format pcm-s16le --sample-rate 16000 --jsonl
 swift run mere.run speech listen --list-devices
 swift run mere.run speech listen --device <core-audio-uid>
 ```
+
+`speech listen` remains the Qwen-backed macOS microphone convenience command.
 
 ### Manage voice profiles
 
@@ -86,6 +93,7 @@ Tokenizer internals:
 - `Sources/AudioSTT/Qwen3ASR/Qwen3ASRGenerator.swift`
 - `Sources/AudioSTT/Qwen3ASR/Qwen3ASRLiveSession.swift`
 - `Sources/AudioSTT/Parakeet/ParakeetGenerator.swift`
+- `Sources/AudioSTT/Parakeet/ParakeetASRLiveSession.swift`
 
 ## How speech synthesis flows
 

--- a/docs/runtime/world.md
+++ b/docs/runtime/world.md
@@ -1,0 +1,122 @@
+# Persistent World Runtime
+
+`mere.run world` runs a long-lived, local conditioned-video session. The current
+public surface is a loopback-first HTTP server backed by Wan 2.2 TI2V resources
+and a converted DreamX causal checkpoint.
+
+## Public surface
+
+- `mere.run world serve`
+
+## Required models
+
+The session combines two managed roots:
+
+- `video-wan22-ti2v-5b-mlx` supplies the tokenizer, text encoder, VAE, and Wan
+  TI2V base resources.
+- `video-dreamx-world-5b-ar-mlx` supplies the converted DreamX causal weights
+  for learned camera conditioning, block-causal attention, and persistent
+  attention caches.
+
+Both roots must already be installed or supplied as local directories. The
+server never downloads model components while starting or serving requests.
+
+## Start a session
+
+```bash
+mere.run world serve \
+  --base-model video-wan22-ti2v-5b-mlx \
+  --model video-dreamx-world-5b-ar-mlx \
+  --state-directory ./world-state \
+  --prepare
+```
+
+The default listener is `127.0.0.1:8791`. `--prepare` loads and warms the
+models before the server accepts transitions. Without it, the runtime prepares
+on the first explicit prepare or transition request.
+
+The default state directory is:
+
+```text
+~/Library/Application Support/MereRun/world-sessions/default
+```
+
+Binding to a non-loopback address requires `--api-key`. Authenticated requests
+use `Authorization: Bearer <token>`.
+
+## HTTP lifecycle
+
+The server exposes:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/health` | Process health; does not load a model. |
+| `GET` | `/v1/world/session` | Read phase, transition count, state IDs, and retained-state flags. |
+| `POST` | `/v1/world/session/prepare` | Load and warm the session. |
+| `POST` | `/v1/world/session/transitions` | Queue one transition and return `202 Accepted`. |
+| `GET` | `/v1/world/jobs/{id}` | Poll job status, progress, receipt, or error. |
+| `DELETE` | `/v1/world/jobs/{id}` | Request cancellation of an active transition. |
+| `POST` | `/v1/world/session/reset` | Clear causal state, optionally seeding a new source image. |
+| `POST` | `/v1/world/session/unload` | Release the warm runtime. |
+
+Only one transition can be active in a session. A competing transition,
+prepare, reset, or unload request fails explicitly instead of racing the active
+generation.
+
+## Queue a transition
+
+The first transition requires `sourceImage`. Later transitions reuse the
+previous terminal state unless a new source is supplied.
+
+```bash
+curl -X POST http://127.0.0.1:8791/v1/world/session/transitions \
+  -H 'content-type: application/json' \
+  -d '{
+    "prompt": "continue forward through the same stone corridor",
+    "camera": {
+      "motion": "forward",
+      "translationMeters": [0, 0, 1],
+      "rotationDegrees": [0, 0, 0]
+    },
+    "sourceImage": "./corridor.png",
+    "output": "./world-state/forward.mp4",
+    "width": 512,
+    "height": 288,
+    "seed": 42,
+    "fps": 24
+  }'
+```
+
+Camera motion values are `hold`, `forward`, `backward`, `strafeLeft`,
+`strafeRight`, `yawLeft`, `yawRight`, and `custom`. Translation and rotation
+arrays are XYZ values in meters and degrees.
+
+A completed receipt includes the previous and new state IDs, transition index,
+MP4 output, terminal-frame image, camera request, conditioning mode, and seed.
+Persisted files are the public handoff; callers never receive mutable MLX
+tensors.
+
+## Reset or unload
+
+```bash
+curl -X POST http://127.0.0.1:8791/v1/world/session/reset \
+  -H 'content-type: application/json' \
+  -d '{"sourceImage":"./new-scene.png"}'
+
+curl -X POST http://127.0.0.1:8791/v1/world/session/unload
+```
+
+Reset preserves the server but clears the transition chain. Unload releases
+model resources and returns the session to a cold phase.
+
+## Runtime entrypoints
+
+### CLI and HTTP server
+
+- `Sources/MereRunCLI/Commands/WorldCommand.swift`
+
+### Runtime
+
+- `Sources/MereRunCore/Wan2/Wan2WorldSession.swift`
+- `Sources/MereRunCore/Wan2/Wan2CausalWorldGenerator.swift`
+- `Sources/MereRunCore/Wan2/Wan2CameraConditioning.swift`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,11 +38,28 @@ This script is the main gate for contributors. It runs:
 - `swift build`
 - `swift test`
 - help smoke for the public command tree
+- generated CLI documentation and command-owner synchronization
 - `mere.run model list` output sanity checks
 - `mere.run status` output sanity checks
 - docs and source hygiene sweeps
 
 Use this for almost every change before you stop.
+
+### CLI documentation contract
+
+`DocumentationContractTests` derives the complete public command tree from
+`MereRunCLI.configuration`. It compares that tree with the generated command
+inventories, verifies that every top-level command owns a navigable docs page,
+checks runtime-guide sidebar coverage, and rejects stale command paths in
+Markdown examples.
+
+When a command changes intentionally, regenerate the inventories before running
+the main gate:
+
+```bash
+./scripts/update-docs-command-reference.sh
+swift test --filter DocumentationContractTests
+```
 
 ## Linux CLI compatibility fixture
 

--- a/scripts/update-docs-command-reference.sh
+++ b/scripts/update-docs-command-reference.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+MERERUN_UPDATE_DOCS=1 swift test \
+  --filter DocumentationContractTests/testGeneratedCommandInventoriesMatchCLI
+
+echo "Updated the generated CLI inventories in docs/index.md, docs/getting-started.md, and docs/cli.md."


### PR DESCRIPTION
## What changed

- Refresh the docs homepage, getting-started flow, CLI reference, navigation, and custom home theme around the complete current product surface.
- Add dedicated plugin and persistent-world runtime guides.
- Document current model storage cleanup and Parakeet streaming ASR behavior from the latest main branch.
- Remove stale or never-shipped command examples.
- Add generated command inventories plus ownership and navigation contracts so CLI/docs drift fails the normal test gate.
- Add an explicit regeneration helper for intentional CLI changes.

## Why

The deployed site was built from current source, but its front door and information architecture still described an older, much smaller CLI. Important runtime families and workflow surfaces were hard to discover, and manually maintained command lists could silently fall behind.

## Impact

The public docs now cover all 22 top-level commands, current nested commands, plugins, persistent worlds, workflows, Linux, SFX, model storage, and live ASR. Future CLI or runtime-page additions must be documented and navigable before the repository gate passes.

## Validation

- `pnpm docs:build`
- Browser preview of the homepage, CLI reference, Plugins, and Persistent Worlds pages with no console errors.
- `./scripts/check.sh`
  - SwiftLint: 0 violations
  - 1,936 tests, 117 expected skips, 0 failures
  - CLI help sweep and hygiene checks passed
- `git diff --check`
