### PR TITLE
Document Graph v2 and Graph Studio

### DIFF
--- a/Tests/MereRunCLITests/DocumentationContractTests.swift
+++ b/Tests/MereRunCLITests/DocumentationContractTests.swift
@@ -148,6 +148,22 @@ final class DocumentationContractTests: XCTestCase {
         )
     }
 
+    func testGraphStudioDocumentationPreservesTheVersionBoundary() throws {
+        let studioURL = repositoryRoot.appendingPathComponent("docs/graph/studio.md")
+        let navigationURL = repositoryRoot.appendingPathComponent("docs/.vitepress/config.mts")
+        let workflowsURL = repositoryRoot.appendingPathComponent("docs/workflows.md")
+        let studio = try String(contentsOf: studioURL, encoding: .utf8)
+        let navigation = try String(contentsOf: navigationURL, encoding: .utf8)
+        let workflows = try String(contentsOf: workflowsURL, encoding: .utf8)
+
+        XCTAssertTrue(navigation.contains("link: '/graph/studio'"))
+        XCTAssertTrue(studio.contains("Graph v2"))
+        XCTAssertTrue(studio.contains("`schema_version: 1`"))
+        XCTAssertTrue(studio.contains("https://studio.mere.run/"))
+        XCTAssertTrue(workflows.contains("Graph v2 runtime and v1 contract"))
+        XCTAssertTrue(studio.contains("Do not change a workflow to `schema_version: 2`"))
+    }
+
     private func commandTree() -> [CommandNode] {
         nodes(from: MereRunCLI.configuration.subcommands)
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
         text: 'Workflows and Operations',
         items: [
           { text: 'Portable Workflows', link: '/workflows' },
+          { text: 'Graph Studio', link: '/graph/studio' },
           { text: 'Configuration', link: '/configuration' },
           { text: 'Quality Gate', link: '/gate' },
           { text: 'Model Sources', link: '/model-sources' },

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,12 +37,13 @@ If you are new to the repo, read these in order:
 2. [Linux QuickStart](./linux-quickstart.md), if you are installing the headless CLI on Linux
 3. [CLI Reference](./cli.md)
 4. [Portable Workflows](./workflows.md), if you are automating local or remote jobs
-5. [Benchmarking](./benchmarking.md)
-6. [Cookbooks](./cookbooks.md)
-7. [Configuration](./configuration.md)
-8. [Model Sources](./model-sources.md)
-9. [Companion Plugins](./plugins.md)
-10. [Repository Tour](./repository-tour.md)
+5. [Graph Studio](./graph/studio.md), if you want to author Graph v2 workflows visually
+6. [Benchmarking](./benchmarking.md)
+7. [Cookbooks](./cookbooks.md)
+8. [Configuration](./configuration.md)
+9. [Model Sources](./model-sources.md)
+10. [Companion Plugins](./plugins.md)
+11. [Repository Tour](./repository-tour.md)
 
 ## Choose your path
 
@@ -54,6 +55,7 @@ If you are new to the repo, read these in order:
 - [Benchmarking](./benchmarking.md)
 - [Cookbooks](./cookbooks.md)
 - [Portable Workflows](./workflows.md)
+- [Graph Studio](./graph/studio.md)
 - [Configuration](./configuration.md)
 - [Model Sources](./model-sources.md)
 - [Companion Plugins](./plugins.md)
@@ -97,6 +99,8 @@ If you are new to the repo, read these in order:
   execution, VLM datasets, API workload, and runtime microbenchmarks
 - [Portable Workflows](./workflows.md): typed graphs, immutable job bundles,
   local execution, SSH and relay executors, run artifacts, and remote lifecycle
+- [Graph Studio](./graph/studio.md): visual Graph v2 authoring in the browser or
+  a cross-platform Tauri desktop app, using the same version-1 workflow contract
 - [Companion Plugins](./plugins.md): public catalog discovery, safe installation,
   doctor checks, and the typed graph-provider boundary
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Benchmarking](./benchmarking.md)
 - [Cookbooks](./cookbooks.md)
 - [Portable Workflows](./workflows.md)
+- [Graph Studio](./graph/studio.md)
 - [Companion Plugins](./plugins.md)
 - [Configuration](./configuration.md)
 - [Quality Gate](./gate.md)

--- a/docs/graph/studio.md
+++ b/docs/graph/studio.md
@@ -1,0 +1,102 @@
+# Graph Studio
+
+Mere Graph Studio is the visual authoring and operations surface for the
+current `mere.run` Graph v2 runtime. Use the hosted app at
+[studio.mere.run](https://studio.mere.run/) or run the cross-platform Tauri 2
+desktop app on macOS, Windows, or Linux.
+
+Studio is a client of the portable graph system, not a separate workflow
+engine. It authors the same typed graph, inputs, and immutable job bundle that
+the CLI validates and executes locally, over SSH, or through Relay.
+
+## Graph v2 versus `schema_version: 1`
+
+Two version labels describe different layers:
+
+| Label | Meaning |
+| --- | --- |
+| Graph v2 | The current runtime generation: catalog-driven nodes, immutable bundles, preflight, parallel and resumable execution, providers, Relay placement, and typed artifacts. |
+| `schema_version: 1` | The stable serialized `mere.run/workflow-graph` ABI consumed by every current executor. |
+
+Do not change a workflow to `schema_version: 2`. Graph v2 intentionally keeps
+the version-1 document contract so the CLI, desktop Studio, hosted Studio,
+Relay, and paired Nodes execute the same bytes.
+
+## Choose a Studio surface
+
+### Hosted Studio
+
+[Open Graph Studio](https://studio.mere.run/app) in a modern browser and sign in
+with Mere World. Projects are private to the signed-in account. The site loads
+the live node catalog reported by the user's paired fleet, performs placement
+preflight, creates an immutable job, and submits it through Relay.
+
+The hosted site does not run models. Relay owns admission, scheduling, leases,
+retry state, and artifact delivery; the paired Node owns model execution. A
+stale worker cannot settle a newer attempt.
+
+Hosted execution currently accepts graphs whose inputs are JSON values. Use the
+desktop app for workflows that bind local files or directories; browser asset
+upload is a separate transport boundary and is not inferred from a machine-local
+path.
+
+### Desktop Studio
+
+The desktop app packages the React/XYFlow editor in a Rust and Tauri 2 shell.
+It is designed for:
+
+- macOS, Windows, and Linux native installation;
+- local file and directory inputs;
+- local, SSH, and Relay execution;
+- offline or loopback-only authoring;
+- native project and run workspaces.
+
+Desktop Studio requires a compatible `mere.run` executable for local execution.
+Optional workflow tools add templates, programs, and conservative ComfyUI
+prompt import; core graph authoring remains available without them.
+
+Native packaging is implemented for each platform. Public installer links are
+published from [studio.mere.run](https://studio.mere.run/) only after the
+matching platform artifact has passed its signing and package-verification
+gate; the hosted app remains available without a desktop install.
+
+## The project model
+
+Studio keeps editor state outside the executable graph:
+
+```text
+workflow graph   typed nodes, references, execution policy, outputs
+inputs           values supplied to declared graph inputs
+editor sidecar   node positions, groups, notes, selections, view state
+program          optional higher-level map and branch authoring document
+```
+
+Import and export use a `.meregraph.json` project package to carry those
+documents together. Execution still materializes the canonical
+`mere.run/job-bundle.v1` files described in [Portable Workflows](../workflows.md).
+
+## Run from the CLI
+
+A Studio-authored workflow remains a normal CLI workflow:
+
+```bash
+mere.run graph validate workflow.json --inputs-json inputs.json --json
+mere.run graph preflight workflow.json --inputs-json inputs.json --executor local --json
+mere.run graph run workflow.json --inputs-json inputs.json --run-dir ./runs/studio --json
+```
+
+For a paired fleet, select the Relay executor in Studio or submit the same
+materialized bundle with `mere.run graph submit-job`. Run reports, events, and
+artifact hashes use the same contract in either client.
+
+## Compatibility and drift prevention
+
+Studio does not keep a private hard-coded execution schema. Desktop Studio
+reads `mere.run graph catalog --json`; hosted Studio reads catalogs reported by
+connected Nodes through Relay. The catalog carries node fields, requirements,
+provider versions, and provider catalog digests, so an unavailable or outdated
+node is rejected during authoring or preflight instead of failing after queueing.
+
+The `mere.run` repository keeps its CLI and documentation synchronized through
+`DocumentationContractTests`. Graph Studio, Relay, and Node maintain shared
+contract fixtures and run their own local gates before release.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -4,7 +4,18 @@
 contract locally, over SSH, and through a relay-managed GPU fleet. A future
 canvas can author this document, but it does not own execution behavior.
 
-## Graph V1
+## Graph v2 runtime and v1 contract
+
+The current execution system is the second-generation graph runtime: immutable
+job bundles, typed provider catalogs, executor preflight, resumable runs,
+parallel scheduling, and one execution contract across local, SSH, and Relay.
+That product/runtime generation is called **Graph v2**.
+
+The serialized workflow ABI remains deliberately stable at version 1. Graph v2
+therefore still reads and writes `mere.run/workflow-graph` documents with
+`schema_version: 1`; the runtime name is not a request to emit a
+`schema_version: 2` document. See [Graph Studio](./graph/studio.md) for the
+visual authoring surfaces built on this contract.
 
 Every graph uses `schema_version: 1` and `kind: "mere.run/workflow-graph"`.
 Identifiers match `[a-z][a-z0-9-]{0,63}`. Supported graph input types are


### PR DESCRIPTION
## Summary
- explain that Graph v2 is the current runtime generation while the stable workflow ABI remains `schema_version: 1`
- add the public `/graph/studio` guide for hosted and cross-platform Tauri surfaces
- add the page to VitePress navigation and the documentation map
- extend the documentation contract test so the version boundary and Studio route cannot silently disappear

## Local validation
- `./scripts/check.sh` (1,936 tests passed, 117 skipped; CLI help and hygiene gates passed)
- `swiftlint lint --strict Tests/MereRunCLITests/DocumentationContractTests.swift`
- `swift test --filter DocumentationContractTests` (4 passed)
- `pnpm docs:build`
