### PR TITLE
Document Graph Studio authentication boundaries

### DIFF
--- a/Tests/MereRunCLITests/DocumentationContractTests.swift
+++ b/Tests/MereRunCLITests/DocumentationContractTests.swift
@@ -162,6 +162,11 @@ final class DocumentationContractTests: XCTestCase {
         XCTAssertTrue(studio.contains("https://studio.mere.run/"))
         XCTAssertTrue(workflows.contains("Graph v2 runtime and v1 contract"))
         XCTAssertTrue(studio.contains("Do not change a workflow to `schema_version: 2`"))
+        XCTAssertTrue(studio.contains("Local Studio never requires Mere World sign-in"))
+        XCTAssertTrue(studio.contains("Mere World OAuth Authorization Code with PKCE"))
+        XCTAssertTrue(studio.contains("OAuth device grant"))
+        XCTAssertTrue(studio.contains("does not open a browser callback or local web server"))
+        XCTAssertTrue(studio.contains("does not ship a Python"))
     }
 
     private func commandTree() -> [CommandNode] {

--- a/docs/graph/studio.md
+++ b/docs/graph/studio.md
@@ -48,17 +48,44 @@ It is designed for:
 - macOS, Windows, and Linux native installation;
 - local file and directory inputs;
 - local, SSH, and Relay execution;
-- offline or loopback-only authoring;
+- offline authoring and local execution;
 - native project and run workspaces.
 
 Desktop Studio requires a compatible `mere.run` executable for local execution.
 Optional workflow tools add templates, programs, and conservative ComfyUI
 prompt import; core graph authoring remains available without them.
 
+The desktop product has one native backend: the frontend invokes Rust through
+Tauri IPC, and Rust invokes the installed CLI. It does not ship a Python
+runtime, browser compatibility server, or loopback HTTP API.
+
 Native packaging is implemented for each platform. Public installer links are
 published from [studio.mere.run](https://studio.mere.run/) only after the
 matching platform artifact has passed its signing and package-verification
 gate; the hosted app remains available without a desktop install.
+
+## Authentication boundary
+
+Local Studio never requires Mere World sign-in. Launch, authoring, project
+save and load, catalog discovery, validation, preflight, and local execution
+remain available without an account or network connection when the required
+CLI and model assets are already installed.
+
+Identity is introduced only when Studio crosses an account or fleet boundary:
+
+| Surface | Authentication |
+| --- | --- |
+| Desktop local | None. Tauri IPC stays on the machine. |
+| Desktop SSH | The configured SSH credentials for that target. |
+| Desktop Relay | Relay credentials, requested only after Relay is selected. |
+| Hosted Studio | Mere World OAuth Authorization Code with PKCE. |
+| Mere Node joining Relay | OAuth device grant completed by the operator at `mere.world/device`. |
+
+The Node device flow does not open a browser callback or local web server. The
+Node requests a device code, shows the verification URL and user code, polls
+Relay for completion, stores the resulting rotating credentials in its
+platform configuration directory, and authenticates its Relay WebSocket with
+a bearer token. Desktop local mode does none of this.
 
 ## The project model
 
@@ -99,4 +126,6 @@ node is rejected during authoring or preflight instead of failing after queueing
 
 The `mere.run` repository keeps its CLI and documentation synchronized through
 `DocumentationContractTests`. Graph Studio, Relay, and Node maintain shared
-contract fixtures and run their own local gates before release.
+contract fixtures and run their own local gates before release. Studio's gate
+also rejects a returning Python host, browser proxy, or authentication
+dependency in the native runtime.


### PR DESCRIPTION
## Summary

- state that native Graph Studio uses Tauri IPC and Rust with no Python runtime, browser compatibility host, or loopback HTTP API
- make the no-auth/no-network local contract explicit for launch, authoring, persistence, catalog, validation, preflight, and local execution
- distinguish direct SSH credentials, opt-in Relay credentials, hosted Mere World Authorization Code + PKCE, and the Mere Node OAuth device grant
- document that Node device authorization has no browser callback or local web server
- extend the documentation contract test so these architecture promises cannot silently disappear

## Validation

- `pnpm docs:build`
- `swift test --filter DocumentationContractTests/testGraphStudioDocumentationPreservesTheVersionBoundary`
- `./scripts/check.sh`
  - strict SwiftLint: 0 violations across 956 files
  - Swift build
  - 1,937 XCTest cases passed, 117 expected checkpoint-dependent skips, 0 failures
  - 10 Swift Testing cases passed
  - CLI help sweep and hygiene scans
- rendered desktop check at 1440x900: no document overflow, authentication content present
- rendered mobile checks at 390x844: no document overflow; authentication table remains contained and readable
