### PR TITLE
Creative material nodes for workflow graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## Unreleased
+## 0.24.0 - 2026-07-19
 
 ### Added
 
+- added first-class creative material nodes for reusable text, numeric, boolean,
+  JSON, seed, choice, join, template, enhancement, and image-description
+  workflows, with native deterministic intrinsics, strict template validation,
+  explicit installed-model execution, recursive typed catalog schemas, frozen
+  seeds, and source-correlated run provenance.
 - added native Swift/MLX SCAIL-2 14B subject animation and replacement through
   `video animate`, including exact seven-color mask packing, mixed-stream RoPE,
   OpenCLIP and UMT5 conditioning, Wan 2.1 VAE support, 81/5 segmented clean

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -174,9 +174,31 @@ struct TextChat: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Suppress progress output.")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong("preflight")], help: "Inspect the chat request without loading or downloading a model.")
+    var preflight: Bool = false
+
+    @Flag(name: [.customLong("json")], help: "With --preflight, emit a structured JSON report.")
+    var json: Bool = false
+
+    @Flag(name: [.customLong("require-installed")], help: "Require an installed model and never download implicitly.")
+    var requireInstalled: Bool = false
+
     func run() async throws {
         let normalizedModelId = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         try Self.validate(responseFormat: responseFormat, modelID: normalizedModelId)
+        let installedModelPath = resolvedInstalledModelPath(modelID: normalizedModelId)
+        if preflight {
+            try emitPreflight(modelID: normalizedModelId, installedModelPath: installedModelPath)
+            return
+        }
+        if requireInstalled {
+            guard installedModelPath != nil else {
+                throw ValidationError(
+                    "Model '\(normalizedModelId)' is not installed. Run 'mere.run model pull \(normalizedModelId)' explicitly."
+                )
+            }
+        }
+        let runtimeModelRoot = requireInstalled ? installedModelPath : modelRoot
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
         let imageReference: String?
@@ -262,7 +284,7 @@ struct TextChat: AsyncParsableCommand {
         let chatOnce: (ChatRequest) async throws -> ChatResponse = { req in
             if normalizedModelId == Psi3ChatResources.defaultModelId {
                 let generator = Psi3ChatGenerator(modelId: Psi3ChatResources.defaultModelId)
-                return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
+                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
             } else if Gemma4Resources.handles(modelSpec: normalizedModelId) {
                 let effectiveModelId = normalizedModelId.isEmpty ? Gemma4Resources.defaultModelId : normalizedModelId
                 let kvQuantization = try self.resolveGemma4KVCacheQuantization(for: effectiveModelId)
@@ -270,7 +292,7 @@ struct TextChat: AsyncParsableCommand {
                     modelId: effectiveModelId,
                     kvCacheQuantization: kvQuantization
                 )
-                let response = try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
+                let response = try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
                 lastGemma4MTPStats = await generator.mtpStats()
                 return response
             } else if ManagedModelCatalog.spec(for: normalizedModelId)?.validationKind == .codegenGGUF {
@@ -278,15 +300,15 @@ struct TextChat: AsyncParsableCommand {
                 // `text code` uses). On Linux CUDA this is the GB10-optimized
                 // llama.cpp runtime, which has fast quantized-MoE kernels MLX lacks.
                 let generator = CodeGenGenerator(modelId: normalizedModelId)
-                return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
+                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
             } else if LFM2Resources.handles(modelSpec: normalizedModelId) {
                 let effectiveModelId = normalizedModelId.isEmpty ? LFM2Resources.defaultModelId : normalizedModelId
                 let generator = LFM2Generator(modelId: effectiveModelId)
-                return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
+                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
             } else {
                 let effectiveModelId = normalizedModelId.isEmpty ? Q35Resources.defaultModelId : normalizedModelId
                 let generator = Q35Generator(modelId: effectiveModelId)
-                return try await generator.chat(req, modelPath: self.modelRoot, progressHandler: progressHandler)
+                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
             }
         }
 
@@ -410,6 +432,59 @@ struct TextChat: AsyncParsableCommand {
         }
     }
 
+    private func resolvedInstalledModelPath(modelID: String) -> String? {
+        if let modelRoot, !modelRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let url = URL(fileURLWithPath: modelRoot).standardizedFileURL
+            return FileManager.default.fileExists(atPath: url.path) ? url.path : nil
+        }
+        return ManagedModelResolver.resolveInstalledModel(id: modelID)?.path
+    }
+
+    private func emitPreflight(modelID: String, installedModelPath: String?) throws {
+        var diagnostics: [PreflightDiagnostic] = []
+        if modelID.isEmpty || ManagedModelCatalog.spec(for: modelID) == nil {
+            diagnostics.append(.init(
+                id: "text_chat_model_unknown",
+                severity: .blocker,
+                title: "Unknown chat model",
+                message: "No managed model is cataloged as '\(modelID)'."
+            ))
+        }
+        if requireInstalled, installedModelPath == nil {
+            diagnostics.append(.init(
+                id: "text_chat_model_not_installed",
+                severity: .blocker,
+                title: "Chat model is not installed",
+                message: "Install '\(modelID)' explicitly before running this workflow node."
+            ))
+        }
+        if let image, !image.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !image.lowercased().hasPrefix("data:image/") {
+            let imageURL = URL(fileURLWithPath: image).standardizedFileURL
+            if !FileManager.default.fileExists(atPath: imageURL.path) {
+                diagnostics.append(.init(
+                    id: "text_chat_image_missing",
+                    severity: .blocker,
+                    title: "Chat image is missing",
+                    message: "Image file not found: \(imageURL.path)"
+                ))
+            }
+        }
+        let report = TextChatPreflightReport(
+            schemaVersion: 1,
+            status: StructuredRunOutput.status(for: diagnostics),
+            model: modelID,
+            installed: installedModelPath != nil,
+            modelPath: installedModelPath,
+            diagnostics: diagnostics
+        )
+        if json {
+            print(try StructuredRunOutput.encode(report))
+        } else {
+            print(report.summary)
+        }
+    }
+
     static func formatGemma4MTPStats(_ stats: Gemma4MTPStats) -> String {
         let state: String
         if stats.active {
@@ -522,6 +597,28 @@ struct TextChat: AsyncParsableCommand {
 
     private static func stdinIsInteractive() -> Bool {
         CLIStdin.isInteractive()
+    }
+}
+
+private struct TextChatPreflightReport: Codable, Equatable {
+    let schemaVersion: Int
+    let status: StructuredRunStatus
+    let model: String
+    let installed: Bool
+    let modelPath: String?
+    let diagnostics: [PreflightDiagnostic]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case status
+        case model
+        case installed
+        case modelPath = "model_path"
+        case diagnostics
+    }
+
+    var summary: String {
+        "\(status.rawValue): \(model) \(installed ? "is installed" : "is not installed")"
     }
 }
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.23.0"
+    static let current = "0.24.0"
 }

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -291,6 +291,95 @@ struct WorkflowInputsDocument: Codable, Equatable, Sendable {
     }
 }
 
+enum WorkflowValueSchemaType: String, Codable, Equatable, Sendable {
+    case string
+    case integer
+    case number
+    case boolean
+    case array
+    case object
+    case json
+    case enumeration = "enum"
+}
+
+final class WorkflowValueSchema: Codable, @unchecked Sendable, Equatable {
+    let type: WorkflowValueSchemaType
+    let title: String?
+    let description: String?
+    let defaultValue: WorkflowValue?
+    let values: [String]?
+    let properties: [String: WorkflowValueSchema]?
+    let required: [String]?
+    let items: WorkflowValueSchema?
+    let additionalProperties: WorkflowValueSchema?
+    let minimum: Double?
+    let maximum: Double?
+    let step: Double?
+    let multiline: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case title
+        case description
+        case defaultValue = "default"
+        case values
+        case properties
+        case required
+        case items
+        case additionalProperties = "additional_properties"
+        case minimum
+        case maximum
+        case step
+        case multiline
+    }
+
+    init(
+        type: WorkflowValueSchemaType,
+        title: String? = nil,
+        description: String? = nil,
+        defaultValue: WorkflowValue? = nil,
+        values: [String]? = nil,
+        properties: [String: WorkflowValueSchema]? = nil,
+        required: [String]? = nil,
+        items: WorkflowValueSchema? = nil,
+        additionalProperties: WorkflowValueSchema? = nil,
+        minimum: Double? = nil,
+        maximum: Double? = nil,
+        step: Double? = nil,
+        multiline: Bool? = nil
+    ) {
+        self.type = type
+        self.title = title
+        self.description = description
+        self.defaultValue = defaultValue
+        self.values = values
+        self.properties = properties
+        self.required = required
+        self.items = items
+        self.additionalProperties = additionalProperties
+        self.minimum = minimum
+        self.maximum = maximum
+        self.step = step
+        self.multiline = multiline
+    }
+
+    static func == (lhs: WorkflowValueSchema, rhs: WorkflowValueSchema) -> Bool {
+        lhs.type == rhs.type
+            && lhs.title == rhs.title
+            && lhs.description == rhs.description
+            && lhs.defaultValue == rhs.defaultValue
+            && lhs.values == rhs.values
+            && lhs.properties == rhs.properties
+            && lhs.required == rhs.required
+            && lhs.items == rhs.items
+            && lhs.additionalProperties == rhs.additionalProperties
+            && lhs.minimum == rhs.minimum
+            && lhs.maximum == rhs.maximum
+            && lhs.step == rhs.step
+            && lhs.multiline == rhs.multiline
+    }
+}
+
 struct WorkflowNodeField: Codable, Equatable, Sendable {
     let name: String
     let type: WorkflowFieldType
@@ -305,7 +394,7 @@ struct WorkflowNodeField: Codable, Equatable, Sendable {
     let multiline: Bool?
     let secret: Bool?
     let advanced: Bool?
-    let valueSchema: WorkflowValue?
+    let valueSchema: WorkflowValueSchema?
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -338,7 +427,7 @@ struct WorkflowNodeField: Codable, Equatable, Sendable {
         multiline: Bool? = nil,
         secret: Bool? = nil,
         advanced: Bool? = nil,
-        valueSchema: WorkflowValue? = nil
+        valueSchema: WorkflowValueSchema? = nil
     ) {
         self.name = name
         self.type = type
@@ -491,6 +580,14 @@ struct WorkflowNodeTraits: Codable, Equatable, Sendable {
         supportsProgress: false,
         supportsPreviews: false
     )
+
+    static let material = WorkflowNodeTraits(
+        deterministic: true,
+        cacheable: true,
+        sideEffects: "none",
+        supportsProgress: false,
+        supportsPreviews: true
+    )
 }
 
 struct WorkflowNodeProviderIdentity: Codable, Equatable, Hashable, Sendable {
@@ -507,6 +604,21 @@ struct WorkflowNodeProviderIdentity: Codable, Equatable, Hashable, Sendable {
     }
 }
 
+struct WorkflowNodePresentation: Codable, Equatable, Sendable {
+    let style: String
+    let primaryArgument: String?
+
+    enum CodingKeys: String, CodingKey {
+        case style
+        case primaryArgument = "primary_argument"
+    }
+
+    init(style: String, primaryArgument: String? = nil) {
+        self.style = style
+        self.primaryArgument = primaryArgument
+    }
+}
+
 struct WorkflowNodeCatalogEntry: Codable, Equatable, Sendable {
     let kind: String
     let title: String
@@ -516,6 +628,7 @@ struct WorkflowNodeCatalogEntry: Codable, Equatable, Sendable {
     let outputs: [WorkflowNodeOutput]
     let requirements: WorkflowNodeRequirements
     let traits: WorkflowNodeTraits
+    let presentation: WorkflowNodePresentation?
     let provider: WorkflowNodeProviderIdentity?
 
     init(
@@ -527,6 +640,7 @@ struct WorkflowNodeCatalogEntry: Codable, Equatable, Sendable {
         outputs: [WorkflowNodeOutput],
         requirements: WorkflowNodeRequirements = .none,
         traits: WorkflowNodeTraits = .core,
+        presentation: WorkflowNodePresentation? = nil,
         provider: WorkflowNodeProviderIdentity? = nil
     ) {
         self.kind = kind
@@ -537,12 +651,184 @@ struct WorkflowNodeCatalogEntry: Codable, Equatable, Sendable {
         self.outputs = outputs
         self.requirements = requirements
         self.traits = traits
+        self.presentation = presentation
         self.provider = provider
     }
 }
 
 enum WorkflowNodeRegistry {
     static let entries: [WorkflowNodeCatalogEntry] = [
+        WorkflowNodeCatalogEntry(
+            kind: "text.value",
+            title: "Text",
+            description: "A reusable text value.",
+            category: "values",
+            inputs: [
+                .init(name: "value", type: .string, required: true, multiline: true),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "value")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "integer.value",
+            title: "Integer",
+            description: "A reusable whole-number value.",
+            category: "values",
+            inputs: [
+                .init(name: "value", type: .integer, required: true),
+            ],
+            outputs: [.init(name: "value", type: .integer)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "value")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "number.value",
+            title: "Number",
+            description: "A reusable numeric value.",
+            category: "values",
+            inputs: [
+                .init(name: "value", type: .number, required: true),
+            ],
+            outputs: [.init(name: "value", type: .number)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "value")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "boolean.value",
+            title: "Boolean",
+            description: "A reusable true or false value.",
+            category: "values",
+            inputs: [
+                .init(name: "value", type: .boolean, required: true),
+            ],
+            outputs: [.init(name: "value", type: .boolean)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "value")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "json.value",
+            title: "JSON",
+            description: "A reusable structured JSON value.",
+            category: "values",
+            inputs: [
+                .init(name: "value", type: .json, required: true),
+            ],
+            outputs: [.init(name: "value", type: .json)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "value")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "seed.value",
+            title: "Seed",
+            description: "A reproducible seed, generated once when omitted.",
+            category: "values",
+            inputs: [
+                .init(name: "seed", type: .integer, required: false),
+            ],
+            outputs: [.init(name: "seed", type: .integer)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "seed")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "choice.value",
+            title: "Choice",
+            description: "A selected value from an explicit list of options.",
+            category: "values",
+            inputs: [
+                .init(
+                    name: "options",
+                    type: .json,
+                    required: true,
+                    valueSchema: .init(type: .array, items: .init(type: .string))
+                ),
+                .init(name: "selected", type: .string, required: true),
+            ],
+            outputs: [.init(name: "value", type: .string)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "selected")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "text.join",
+            title: "Join text",
+            description: "Join an ordered list of text values.",
+            category: "text",
+            inputs: [
+                .init(
+                    name: "parts",
+                    type: .json,
+                    required: true,
+                    valueSchema: .init(type: .array, items: .init(type: .string))
+                ),
+                .init(name: "separator", type: .string, required: false, defaultValue: .string("\n")),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "parts")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "text.template",
+            title: "Text template",
+            description: "Render {{name}} placeholders with named text variables.",
+            category: "text",
+            inputs: [
+                .init(name: "template", type: .string, required: true, multiline: true),
+                .init(
+                    name: "variables",
+                    type: .json,
+                    required: true,
+                    valueSchema: .init(type: .object, additionalProperties: .init(type: .string))
+                ),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            traits: .material,
+            presentation: .init(style: "material", primaryArgument: "template")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "text.enhance",
+            title: "Enhance text",
+            description: "Improve text with an explicitly selected installed chat model.",
+            category: "text",
+            inputs: [
+                .init(name: "text", type: .string, required: true, multiline: true),
+                .init(name: "instruction", type: .string, required: true, multiline: true),
+                .init(name: "model", type: .string, required: true),
+                .init(name: "max_tokens", type: .integer, required: false, defaultValue: .integer(512), minimum: 1),
+                .init(name: "temperature", type: .number, required: false, defaultValue: .number(0.3), minimum: 0),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            ),
+            presentation: .init(style: "material", primaryArgument: "text")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "image.describe",
+            title: "Describe image",
+            description: "Describe an image with an explicitly selected installed vision model.",
+            category: "text",
+            inputs: [
+                .init(
+                    name: "image",
+                    type: .asset,
+                    required: true,
+                    acceptedContentTypes: ["image/png", "image/jpeg", "image/webp"]
+                ),
+                .init(name: "instruction", type: .string, required: true, multiline: true),
+                .init(name: "model", type: .string, required: true),
+                .init(name: "max_tokens", type: .integer, required: false, defaultValue: .integer(256), minimum: 1),
+                .init(name: "temperature", type: .number, required: false, defaultValue: .number(0.2), minimum: 0),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            ),
+            presentation: .init(style: "material", primaryArgument: "image")
+        ),
         WorkflowNodeCatalogEntry(
             kind: "image.train-lora",
             title: "Train image LoRA",
@@ -648,6 +934,7 @@ enum WorkflowNodeRegistry {
                 outputs: entry.outputs,
                 requirements: entry.requirements,
                 traits: entry.traits,
+                presentation: entry.presentation,
                 provider: builtInProvider
             )
         }
@@ -955,12 +1242,26 @@ enum WorkflowGraphValidator {
                 expected: field.type,
                 enumValues: field.values,
                 acceptedContentTypes: field.acceptedContentTypes,
+                valueSchema: field.valueSchema,
                 nodeID: node.id,
                 field: field.name,
                 graph: graph,
                 nodesByID: nodesByID,
                 diagnostics: &diagnostics
             )
+        }
+        if node.kind == "choice.value",
+           case .array(let options)? = node.arguments["options"],
+           case .string(let selected)? = node.arguments["selected"] {
+            let optionStrings = options.compactMap(\.stringValue)
+            if optionStrings.count == options.count, !optionStrings.contains(selected) {
+                diagnostics.append(.init(
+                    id: "workflow_choice_selected_invalid_\(node.id)",
+                    severity: .blocker,
+                    title: "Choice selection is unavailable",
+                    message: "Node '\(node.id)' selected value must appear in its options."
+                ))
+            }
         }
         for dependency in node.dependsOn ?? [] where nodesByID[dependency] == nil {
             diagnostics.append(.init(
@@ -1015,6 +1316,7 @@ enum WorkflowGraphValidator {
         expected: WorkflowFieldType,
         enumValues: [String]?,
         acceptedContentTypes: [String]?,
+        valueSchema: WorkflowValueSchema? = nil,
         nodeID: String,
         field: String,
         graph: WorkflowGraphDocument,
@@ -1064,6 +1366,7 @@ enum WorkflowGraphValidator {
                     expected: .asset,
                     enumValues: nil,
                     acceptedContentTypes: acceptedContentTypes,
+                    valueSchema: nil,
                     nodeID: nodeID,
                     field: field,
                     graph: graph,
@@ -1082,6 +1385,7 @@ enum WorkflowGraphValidator {
                         expected: .json,
                         enumValues: nil,
                         acceptedContentTypes: nil,
+                        valueSchema: nil,
                         nodeID: nodeID,
                         field: field,
                         graph: graph,
@@ -1096,6 +1400,7 @@ enum WorkflowGraphValidator {
                         expected: .json,
                         enumValues: nil,
                         acceptedContentTypes: nil,
+                        valueSchema: nil,
                         nodeID: nodeID,
                         field: field,
                         graph: graph,
@@ -1106,6 +1411,17 @@ enum WorkflowGraphValidator {
             default:
                 break
             }
+            if let valueSchema {
+                validateValueSchema(
+                    value,
+                    schema: valueSchema,
+                    nodeID: nodeID,
+                    field: field,
+                    graph: graph,
+                    nodesByID: nodesByID,
+                    diagnostics: &diagnostics
+                )
+            }
             return
         }
         if !matches(value, fieldType: expected, enumValues: enumValues) {
@@ -1114,6 +1430,89 @@ enum WorkflowGraphValidator {
                 severity: .blocker,
                 title: "Node argument type mismatch",
                 message: "Node '\(nodeID)' argument '\(field)' must be '\(expected.rawValue)'."
+            ))
+        }
+    }
+
+    private static func validateValueSchema(
+        _ value: WorkflowValue,
+        schema: WorkflowValueSchema,
+        nodeID: String,
+        field: String,
+        graph: WorkflowGraphDocument,
+        nodesByID: [String: WorkflowNode],
+        diagnostics: inout [PreflightDiagnostic]
+    ) {
+        if case .reference = value {
+            let expected: WorkflowFieldType = switch schema.type {
+            case .string: .string
+            case .integer: .integer
+            case .number: .number
+            case .boolean: .boolean
+            case .enumeration: .string
+            case .array, .object, .json: .json
+            }
+            validateValue(
+                value,
+                expected: expected,
+                enumValues: nil,
+                acceptedContentTypes: nil,
+                valueSchema: nil,
+                nodeID: nodeID,
+                field: field,
+                graph: graph,
+                nodesByID: nodesByID,
+                diagnostics: &diagnostics
+            )
+            return
+        }
+
+        switch (schema.type, value) {
+        case (.string, .string), (.integer, .integer), (.number, .number),
+             (.number, .integer), (.boolean, .boolean), (.json, _):
+            return
+        case (.enumeration, .string(let selected)):
+            if let values = schema.values, !values.contains(selected) {
+                diagnostics.append(.init(
+                    id: "workflow_node_argument_schema_\(nodeID)_\(field.replacingOccurrences(of: "/", with: "_"))",
+                    severity: .blocker,
+                    title: "Node argument choice mismatch",
+                    message: "Node '\(nodeID)' argument '\(field)' is not an allowed value."
+                ))
+            }
+        case (.array, .array(let values)):
+            guard let items = schema.items else { return }
+            for (index, nested) in values.enumerated() {
+                validateValueSchema(
+                    nested,
+                    schema: items,
+                    nodeID: nodeID,
+                    field: "\(field)/\(index)",
+                    graph: graph,
+                    nodesByID: nodesByID,
+                    diagnostics: &diagnostics
+                )
+            }
+        case (.object, .object(let values)):
+            guard let additionalProperties = schema.additionalProperties else { return }
+            for key in values.keys.sorted() {
+                guard let nested = values[key] else { continue }
+                validateValueSchema(
+                    nested,
+                    schema: additionalProperties,
+                    nodeID: nodeID,
+                    field: "\(field)/\(key)",
+                    graph: graph,
+                    nodesByID: nodesByID,
+                    diagnostics: &diagnostics
+                )
+            }
+        default:
+            diagnostics.append(.init(
+                id: "workflow_node_argument_schema_\(nodeID)_\(field.replacingOccurrences(of: "/", with: "_"))",
+                severity: .blocker,
+                title: "Node argument structure mismatch",
+                message: "Node '\(nodeID)' argument '\(field)' does not match its declared value_schema."
             ))
         }
     }

--- a/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
@@ -173,6 +173,7 @@ enum WorkflowGraphProviderRegistry {
                 outputs: node.outputs,
                 requirements: node.requirements,
                 traits: node.traits,
+                presentation: node.presentation,
                 provider: identity
             )
         }

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -159,6 +159,8 @@ struct WorkflowJobManifest: Codable, Equatable, Sendable {
     let createdAt: Date
     let graphFingerprint: String
     let inputFingerprint: String
+    let sourceGraphFingerprint: String?
+    let sourceInputFingerprint: String?
     let requirements: WorkflowJobRequirements
     let outputs: [WorkflowJobOutput]
 
@@ -168,8 +170,32 @@ struct WorkflowJobManifest: Codable, Equatable, Sendable {
         case createdAt = "created_at"
         case graphFingerprint = "graph_fingerprint"
         case inputFingerprint = "input_fingerprint"
+        case sourceGraphFingerprint = "source_graph_fingerprint"
+        case sourceInputFingerprint = "source_input_fingerprint"
         case requirements
         case outputs
+    }
+
+    init(
+        contractVersion: String,
+        jobID: String,
+        createdAt: Date,
+        graphFingerprint: String,
+        inputFingerprint: String,
+        sourceGraphFingerprint: String? = nil,
+        sourceInputFingerprint: String? = nil,
+        requirements: WorkflowJobRequirements,
+        outputs: [WorkflowJobOutput]
+    ) {
+        self.contractVersion = contractVersion
+        self.jobID = jobID
+        self.createdAt = createdAt
+        self.graphFingerprint = graphFingerprint
+        self.inputFingerprint = inputFingerprint
+        self.sourceGraphFingerprint = sourceGraphFingerprint
+        self.sourceInputFingerprint = sourceInputFingerprint
+        self.requirements = requirements
+        self.outputs = outputs
     }
 }
 
@@ -374,6 +400,8 @@ struct WorkflowBundleMaterializer {
         }
         try prepareDestination()
 
+        let sourceGraphFingerprint = try WorkflowBundleCodec.hash(graph)
+        let sourceInputFingerprint = try WorkflowBundleCodec.hash(suppliedInputs)
         let resolvedInputs = resolveDefaults()
         let resolvedGraph = resolveSeeds()
         let assetsDirectory = destination
@@ -412,6 +440,8 @@ struct WorkflowBundleMaterializer {
             createdAt: now(),
             graphFingerprint: graphFingerprint,
             inputFingerprint: inputFingerprint,
+            sourceGraphFingerprint: sourceGraphFingerprint,
+            sourceInputFingerprint: sourceInputFingerprint,
             requirements: requirements(graph: portableGraph, resolvedInputs: resolvedInputs),
             outputs: portableGraph.outputs.keys.sorted().compactMap { name in
                 guard case .reference(let reference)? = portableGraph.outputs[name] else { return nil }
@@ -930,6 +960,8 @@ struct GraphRunManifest: Codable, Equatable, Sendable {
     let jobID: String
     let graphName: String
     let graphFingerprint: String
+    let sourceGraphFingerprint: String?
+    let sourceInputFingerprint: String?
     var state: GraphRunState
     let createdAt: Date
     var updatedAt: Date
@@ -944,6 +976,8 @@ struct GraphRunManifest: Codable, Equatable, Sendable {
         case jobID = "job_id"
         case graphName = "graph_name"
         case graphFingerprint = "graph_fingerprint"
+        case sourceGraphFingerprint = "source_graph_fingerprint"
+        case sourceInputFingerprint = "source_input_fingerprint"
         case state
         case createdAt = "created_at"
         case updatedAt = "updated_at"
@@ -952,6 +986,38 @@ struct GraphRunManifest: Codable, Equatable, Sendable {
         case nodes
         case outputs
         case error
+    }
+
+    init(
+        contractVersion: String,
+        jobID: String,
+        graphName: String,
+        graphFingerprint: String,
+        sourceGraphFingerprint: String? = nil,
+        sourceInputFingerprint: String? = nil,
+        state: GraphRunState,
+        createdAt: Date,
+        updatedAt: Date,
+        attempt: Int,
+        executor: GraphRunExecutorRecord,
+        nodes: [GraphRunNodeRecord],
+        outputs: [GraphRunArtifact],
+        error: String?
+    ) {
+        self.contractVersion = contractVersion
+        self.jobID = jobID
+        self.graphName = graphName
+        self.graphFingerprint = graphFingerprint
+        self.sourceGraphFingerprint = sourceGraphFingerprint
+        self.sourceInputFingerprint = sourceInputFingerprint
+        self.state = state
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.attempt = attempt
+        self.executor = executor
+        self.nodes = nodes
+        self.outputs = outputs
+        self.error = error
     }
 }
 
@@ -1079,6 +1145,107 @@ struct WorkflowNodeInvocation: Equatable {
     let runArguments: [String]
     let outputs: [String: WorkflowInvocationOutput]
     let streamsEvents: Bool
+    let intrinsic: WorkflowIntrinsicInvocation?
+    let stdoutOutputName: String?
+
+    init(
+        command: [String],
+        executable: URL,
+        preflightArguments: [String],
+        runArguments: [String],
+        outputs: [String: WorkflowInvocationOutput],
+        streamsEvents: Bool,
+        intrinsic: WorkflowIntrinsicInvocation? = nil,
+        stdoutOutputName: String? = nil
+    ) {
+        self.command = command
+        self.executable = executable
+        self.preflightArguments = preflightArguments
+        self.runArguments = runArguments
+        self.outputs = outputs
+        self.streamsEvents = streamsEvents
+        self.intrinsic = intrinsic
+        self.stdoutOutputName = stdoutOutputName
+    }
+}
+
+struct WorkflowIntrinsicInvocation: Equatable {
+    let kind: String
+    let arguments: [String: WorkflowValue]
+
+    func evaluate() throws -> [String: WorkflowValue] {
+        switch kind {
+        case "text.value":
+            return ["text": try required("value")]
+        case "integer.value", "number.value", "boolean.value", "json.value":
+            return ["value": try required("value")]
+        case "seed.value":
+            return ["seed": try required("seed")]
+        case "choice.value":
+            guard case .array(let options) = try required("options"),
+                  options.allSatisfy({ $0.stringValue != nil }),
+                  case .string(let selected) = try required("selected") else {
+                throw ValidationError("choice.value requires string options and a selected string.")
+            }
+            guard options.contains(.string(selected)) else {
+                throw ValidationError("choice.value selected value must appear in options.")
+            }
+            return ["value": .string(selected)]
+        case "text.join":
+            guard case .array(let parts) = try required("parts"),
+                  parts.allSatisfy({ $0.stringValue != nil }) else {
+                throw ValidationError("text.join parts must resolve to an array of strings.")
+            }
+            let separator = arguments["separator"]?.stringValue ?? "\n"
+            return ["text": .string(parts.compactMap(\.stringValue).joined(separator: separator))]
+        case "text.template":
+            guard case .string(let template) = try required("template"),
+                  case .object(let variables) = try required("variables"),
+                  variables.values.allSatisfy({ $0.stringValue != nil }) else {
+                throw ValidationError("text.template requires a string template and string variables.")
+            }
+            return ["text": .string(try renderTemplate(template, variables: variables))]
+        default:
+            throw ValidationError("Unsupported intrinsic workflow node kind '\(kind)'.")
+        }
+    }
+
+    private func required(_ name: String) throws -> WorkflowValue {
+        guard let value = arguments[name], value != .null else {
+            throw ValidationError("\(kind) requires argument '\(name)'.")
+        }
+        return value
+    }
+
+    private func renderTemplate(
+        _ template: String,
+        variables: [String: WorkflowValue]
+    ) throws -> String {
+        let expression = try NSRegularExpression(pattern: #"(?<!\\)\{\{([^{}]+)\}\}"#)
+        let source = template as NSString
+        let matches = expression.matches(
+            in: template,
+            range: NSRange(location: 0, length: source.length)
+        )
+        var rendered = template
+        for match in matches.reversed() {
+            let name = source.substring(with: match.range(at: 1))
+            guard name.range(
+                of: "^[a-z][a-z0-9_]{0,63}$",
+                options: .regularExpression
+            ) != nil else {
+                throw ValidationError("text.template placeholder '{{\(name)}}' is invalid.")
+            }
+            guard let replacement = variables[name]?.stringValue else {
+                throw ValidationError("text.template is missing variable '\(name)'.")
+            }
+            guard let range = Range(match.range, in: rendered) else {
+                throw ValidationError("text.template could not resolve placeholder '\(name)'.")
+            }
+            rendered.replaceSubrange(range, with: replacement)
+        }
+        return rendered.replacingOccurrences(of: #"\{{"#, with: "{{")
+    }
 }
 
 enum WorkflowNodeCommandBuilder {
@@ -1098,6 +1265,69 @@ enum WorkflowNodeCommandBuilder {
         }
         let artifacts = nodeDirectory.appendingPathComponent("artifacts", isDirectory: true)
         switch node.kind {
+        case "text.value", "integer.value", "number.value", "boolean.value",
+             "json.value", "seed.value", "choice.value", "text.join", "text.template":
+            guard let entry = WorkflowNodeRegistry.entry(for: node) else {
+                throw ValidationError("Unsupported workflow node kind '\(node.kind)'.")
+            }
+            return .init(
+                command: ["intrinsic", node.kind],
+                executable: CurrentExecutable.url(),
+                preflightArguments: [],
+                runArguments: [],
+                outputs: Dictionary(uniqueKeysWithValues: entry.outputs.map { output in
+                    (
+                        output.name,
+                        WorkflowInvocationOutput(
+                            type: output.type,
+                            path: nil,
+                            optional: output.optional,
+                            contentTypes: output.contentTypes
+                        )
+                    )
+                }),
+                streamsEvents: false,
+                intrinsic: WorkflowIntrinsicInvocation(kind: node.kind, arguments: arguments)
+            )
+        case "text.enhance":
+            let instruction = try requiredString("instruction", in: arguments)
+            let text = try requiredString("text", in: arguments)
+            var args = [
+                "text", "chat",
+                "--prompt", "\(instruction)\n\nText:\n\(text)",
+                "--model", try requiredString("model", in: arguments),
+            ]
+            appendInteger("max_tokens", flag: "--max-tokens", from: arguments, to: &args)
+            appendNumber("temperature", flag: "--temperature", from: arguments, to: &args)
+            args += ["--no-thinking", "--require-installed", "--quiet"]
+            return .init(
+                command: ["text", "chat"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args,
+                outputs: ["text": valueOutput(.string)],
+                streamsEvents: false,
+                stdoutOutputName: "text"
+            )
+        case "image.describe":
+            var args = [
+                "text", "chat",
+                "--prompt", try requiredString("instruction", in: arguments),
+                "--image", try requiredString("image", in: arguments),
+                "--model", try requiredString("model", in: arguments),
+            ]
+            appendInteger("max_tokens", flag: "--max-tokens", from: arguments, to: &args)
+            appendNumber("temperature", flag: "--temperature", from: arguments, to: &args)
+            args += ["--no-thinking", "--require-installed", "--quiet"]
+            return .init(
+                command: ["text", "chat"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args,
+                outputs: ["text": valueOutput(.string)],
+                streamsEvents: false,
+                stdoutOutputName: "text"
+            )
         case "image.train-lora":
             let output = artifacts.appendingPathComponent("adapter.safetensors")
             var args = ["image", "train-lora", "--data", try requiredString("data", in: arguments), "--output", output.path]
@@ -1236,6 +1466,15 @@ enum WorkflowNodeCommandBuilder {
             path: url.path,
             optional: false,
             contentTypes: contentTypes
+        )
+    }
+
+    private static func valueOutput(_ type: WorkflowPortType) -> WorkflowInvocationOutput {
+        WorkflowInvocationOutput(
+            type: type,
+            path: nil,
+            optional: false,
+            contentTypes: []
         )
     }
 

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -630,12 +630,10 @@ struct WorkflowRunner: @unchecked Sendable {
                 ))
                 sequence += 1
 
-                let preflight = try runProcess(
-                    executable: invocation.executable,
-                    arguments: invocation.preflightArguments,
+                let preflight = try preflightInvocation(
+                    invocation,
                     currentDirectory: nodeDirectory,
-                    timeoutSeconds: nil,
-                    stdoutLineHandler: nil
+                    nodeID: nodeID
                 )
                 try throwIfCancellationRequested()
                 try Data(preflight.stdout.utf8).write(
@@ -683,9 +681,8 @@ struct WorkflowRunner: @unchecked Sendable {
                     do {
                         var providerOutputs: [String: WorkflowValue]?
                         var providerSequence = -1
-                        let result = try runProcess(
-                            executable: invocation.executable,
-                            arguments: invocation.runArguments,
+                        let execution = try executeInvocation(
+                            invocation,
                             currentDirectory: nodeDirectory,
                             timeoutSeconds: node.execution?.timeoutSeconds,
                             stdoutLineHandler: invocation.streamsEvents ? { line in
@@ -724,6 +721,10 @@ struct WorkflowRunner: @unchecked Sendable {
                                 }
                             } : nil
                         )
+                        let result = execution.result
+                        if let intrinsicOutputs = execution.outputs {
+                            providerOutputs = intrinsicOutputs
+                        }
                         try throwIfCancellationRequested()
                         try Data(result.stdout.utf8).write(
                             to: nodeDirectory.appendingPathComponent("stdout.txt"),
@@ -999,12 +1000,10 @@ struct WorkflowRunner: @unchecked Sendable {
                     message: nil
                 ))
                 sequence += 1
-                let preflight = try runProcess(
-                    executable: invocation.executable,
-                    arguments: invocation.preflightArguments,
+                let preflight = try preflightInvocation(
+                    invocation,
                     currentDirectory: nodeDirectory,
-                    timeoutSeconds: nil,
-                    stdoutLineHandler: nil
+                    nodeID: nodeID
                 )
                 try throwIfCancellationRequested()
                 try Data(preflight.stdout.utf8).write(
@@ -1193,9 +1192,8 @@ struct WorkflowRunner: @unchecked Sendable {
             do {
                 var providerOutputs: [String: WorkflowValue]?
                 var providerSequence = -1
-                let result = try runProcess(
-                    executable: prepared.invocation.executable,
-                    arguments: prepared.invocation.runArguments,
+                let execution = try executeInvocation(
+                    prepared.invocation,
                     currentDirectory: prepared.directory,
                     timeoutSeconds: prepared.node.execution?.timeoutSeconds,
                     stdoutLineHandler: prepared.invocation.streamsEvents ? { line in
@@ -1217,6 +1215,10 @@ struct WorkflowRunner: @unchecked Sendable {
                         }
                     } : nil
                 )
+                let result = execution.result
+                if let intrinsicOutputs = execution.outputs {
+                    providerOutputs = intrinsicOutputs
+                }
                 try throwIfCancellationRequested()
                 try Data(result.stdout.utf8).write(
                     to: prepared.directory.appendingPathComponent("stdout.txt"),
@@ -1288,6 +1290,62 @@ struct WorkflowRunner: @unchecked Sendable {
             error: "Node '\(prepared.node.id)' exhausted its retry policy.",
             cancelled: false
         )
+    }
+
+    private func preflightInvocation(
+        _ invocation: WorkflowNodeInvocation,
+        currentDirectory: URL,
+        nodeID: String
+    ) throws -> WorkflowProcessResult {
+        if invocation.intrinsic != nil {
+            let report = ["node_id": nodeID, "status": "ready"]
+            let stdout = String(
+                decoding: try WorkflowBundleCodec.lineEncoder().encode(report),
+                as: UTF8.self
+            ) + "\n"
+            return WorkflowProcessResult(status: 0, stdout: stdout)
+        }
+        return try runProcess(
+            executable: invocation.executable,
+            arguments: invocation.preflightArguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: nil,
+            stdoutLineHandler: nil
+        )
+    }
+
+    private func executeInvocation(
+        _ invocation: WorkflowNodeInvocation,
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> (result: WorkflowProcessResult, outputs: [String: WorkflowValue]?) {
+        if let intrinsic = invocation.intrinsic {
+            try throwIfCancellationRequested()
+            let outputs = try intrinsic.evaluate()
+            let stdout = String(
+                decoding: try WorkflowBundleCodec.lineEncoder().encode(outputs),
+                as: UTF8.self
+            ) + "\n"
+            return (WorkflowProcessResult(status: 0, stdout: stdout), outputs)
+        }
+        let result = try runProcess(
+            executable: invocation.executable,
+            arguments: invocation.runArguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: timeoutSeconds,
+            stdoutLineHandler: stdoutLineHandler
+        )
+        guard result.status == 0, let outputName = invocation.stdoutOutputName else {
+            return (result, nil)
+        }
+        var scalar = result.stdout
+        if scalar.hasSuffix("\r\n") {
+            scalar.removeLast(2)
+        } else if scalar.hasSuffix("\n") {
+            scalar.removeLast()
+        }
+        return (result, [outputName: .string(scalar)])
     }
 
     private func runProcess(
@@ -1807,6 +1865,8 @@ struct WorkflowRunner: @unchecked Sendable {
             jobID: job.jobID,
             graphName: graph.name,
             graphFingerprint: job.graphFingerprint,
+            sourceGraphFingerprint: job.sourceGraphFingerprint,
+            sourceInputFingerprint: job.sourceInputFingerprint,
             state: .planned,
             createdAt: now(),
             updatedAt: now(),

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.23.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.24.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/creative-materials.assets.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/creative-materials.assets.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "groups": []
+}

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/creative-materials.inputs.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/creative-materials.inputs.json
@@ -1,0 +1,3 @@
+{
+  "subject": "luminous botanist"
+}

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/creative-materials.workflow.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/creative-materials.workflow.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "kind": "mere.run/workflow-graph",
+  "name": "creative-materials-fixture",
+  "inputs": {
+    "subject": {
+      "type": "string",
+      "default": "luminous botanist"
+    }
+  },
+  "nodes": [
+    {
+      "id": "subject",
+      "kind": "text.value",
+      "arguments": {"value": {"$ref": "inputs.subject"}}
+    },
+    {
+      "id": "style",
+      "kind": "text.value",
+      "arguments": {"value": "editorial portrait"}
+    },
+    {
+      "id": "parts",
+      "kind": "text.join",
+      "arguments": {
+        "parts": [
+          {"$ref": "nodes.subject.outputs.text"},
+          {"$ref": "nodes.style.outputs.text"}
+        ],
+        "separator": ", "
+      }
+    },
+    {
+      "id": "format",
+      "kind": "choice.value",
+      "arguments": {
+        "options": ["square", "portrait", "landscape"],
+        "selected": "portrait"
+      }
+    },
+    {
+      "id": "prompt",
+      "kind": "text.template",
+      "arguments": {
+        "template": "{{body}}; {{format}} composition",
+        "variables": {
+          "body": {"$ref": "nodes.parts.outputs.text"},
+          "format": {"$ref": "nodes.format.outputs.value"}
+        }
+      }
+    },
+    {
+      "id": "seed",
+      "kind": "seed.value",
+      "arguments": {"seed": 42}
+    }
+  ],
+  "outputs": {
+    "prompt": {"$ref": "nodes.prompt.outputs.text"},
+    "format": {"$ref": "nodes.format.outputs.value"},
+    "seed": {"$ref": "nodes.seed.outputs.seed"}
+  },
+  "execution": {"max_parallel_nodes": 2},
+  "metadata": {"fixture": "creative-materials-v1"}
+}

--- a/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/graph-compatibility.v1.json
+++ b/Tests/MereRunCLITests/Fixtures/WorkflowGraphV1/graph-compatibility.v1.json
@@ -14,9 +14,9 @@
     "plugin_event": "mere.run/plugin-graph-event.v1"
   },
   "components": [
-    { "id": "mere.run", "minimum_version": "0.23.0" },
-    { "id": "mere-workflow-tools", "minimum_version": "0.2.0" },
-    { "id": "mere-run-graph-studio", "minimum_version": "0.1.0" },
+    { "id": "mere.run", "minimum_version": "0.24.0" },
+    { "id": "mere-workflow-tools", "minimum_version": "0.3.0" },
+    { "id": "mere-run-graph-studio", "minimum_version": "0.3.0" },
     { "id": "mere.run-node", "minimum_version": "0.1.9" }
   ],
   "canonical_fixture": {
@@ -27,5 +27,14 @@
     "graph_fingerprint": "83327833196a00799c19507aaf2b34b36450346fb543467a2d4edfe2465316bc",
     "input_fingerprint": "5380b7fbbed8ce21bf5fa4b3e1426fb479d9a289a2da06d531366b3f9120f30d",
     "execution_order": ["image-a", "image-b", "video"]
+  },
+  "material_fixture": {
+    "id": "creative-materials-v1",
+    "graph": "creative-materials.workflow.json",
+    "inputs": "creative-materials.inputs.json",
+    "assets": "creative-materials.assets.json",
+    "graph_fingerprint": "1790e6ed75ab3b757501bc5ef331def1e57ae9622ae3b5752f95abaee14b2f91",
+    "input_fingerprint": "ba0aedb2359a8d03bbd4e364e5331ff09d0cd139a83eadb397c93dfea4254da2",
+    "execution_order": ["subject", "style", "parts", "format", "prompt", "seed"]
   }
 }

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -8,20 +8,198 @@ final class WorkflowGraphTests: XCTestCase {
             name: "policy",
             type: .json,
             required: false,
-            valueSchema: .object([
-                "type": .string("object"),
-                "properties": .object([
-                    "enabled": .object([
-                        "type": .string("boolean"),
-                        "default": .boolean(true),
-                    ]),
-                ]),
-            ])
+            valueSchema: .init(
+                type: .object,
+                properties: [
+                    "enabled": .init(type: .boolean, defaultValue: .boolean(true)),
+                ]
+            )
         )
 
         let data = try WorkflowBundleCodec.encoder().encode(field)
         XCTAssertTrue(String(decoding: data, as: UTF8.self).contains("value_schema"))
         XCTAssertEqual(try WorkflowBundleCodec.decoder().decode(WorkflowNodeField.self, from: data), field)
+    }
+
+    func testCreativeMaterialCatalogIsTypedAndPresented() throws {
+        let expectedKinds = [
+            "text.value", "integer.value", "number.value", "boolean.value", "json.value",
+            "seed.value", "choice.value", "text.join", "text.template", "text.enhance",
+            "image.describe",
+        ]
+        for kind in expectedKinds {
+            let entry = try XCTUnwrap(WorkflowNodeRegistry.entry(for: kind))
+            XCTAssertEqual(entry.presentation?.style, "material")
+        }
+        let join = try XCTUnwrap(WorkflowNodeRegistry.entry(for: "text.join"))
+        XCTAssertEqual(join.inputs.first(where: { $0.name == "parts" })?.valueSchema?.type, .array)
+        XCTAssertEqual(
+            join.inputs.first(where: { $0.name == "parts" })?.valueSchema?.items?.type,
+            .string
+        )
+        let template = try XCTUnwrap(WorkflowNodeRegistry.entry(for: "text.template"))
+        XCTAssertEqual(
+            template.inputs.first(where: { $0.name == "variables" })?
+                .valueSchema?.additionalProperties?.type,
+            .string
+        )
+    }
+
+    func testCreativeMaterialIntrinsicsHaveExactSemantics() throws {
+        XCTAssertEqual(
+            try WorkflowIntrinsicInvocation(
+                kind: "text.join",
+                arguments: ["parts": .array([]), "separator": .string("|")]
+            ).evaluate(),
+            ["text": .string("")]
+        )
+        XCTAssertEqual(
+            try WorkflowIntrinsicInvocation(
+                kind: "text.template",
+                arguments: [
+                    "template": .string(#"{{name}} + {{name}} + \{{literal}}"#),
+                    "variables": .object([
+                        "name": .string("Mere"),
+                        "extra": .string("retained"),
+                    ]),
+                ]
+            ).evaluate(),
+            ["text": .string("Mere + Mere + {{literal}}")]
+        )
+        XCTAssertThrowsError(try WorkflowIntrinsicInvocation(
+            kind: "choice.value",
+            arguments: [
+                "options": .array([.string("square")]),
+                "selected": .string("wide"),
+            ]
+        ).evaluate())
+        XCTAssertThrowsError(try WorkflowIntrinsicInvocation(
+            kind: "text.join",
+            arguments: ["parts": .array([.integer(1)])]
+        ).evaluate())
+        XCTAssertThrowsError(try WorkflowIntrinsicInvocation(
+            kind: "text.template",
+            arguments: [
+                "template": .string("{{missing}}"),
+                "variables": .object([:]),
+            ]
+        ).evaluate())
+    }
+
+    func testCreativeMaterialGraphRunsWithNestedReferencesAndFrozenSeed() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = try decodeGraph(#"""
+        {
+          "schema_version": 1,
+          "kind": "mere.run/workflow-graph",
+          "name": "creative-materials",
+          "inputs": {},
+          "execution": {"max_parallel_nodes": 3},
+          "nodes": [
+            {"id": "alpha", "kind": "text.value", "arguments": {"value": "alpha"}},
+            {"id": "beta", "kind": "text.value", "arguments": {"value": "beta"}},
+            {
+              "id": "joined",
+              "kind": "text.join",
+              "arguments": {
+                "parts": [
+                  {"$ref": "nodes.alpha.outputs.text"},
+                  {"$ref": "nodes.beta.outputs.text"}
+                ],
+                "separator": "|"
+              }
+            },
+            {
+              "id": "templated",
+              "kind": "text.template",
+              "arguments": {
+                "template": "Result: {{body}}",
+                "variables": {"body": {"$ref": "nodes.joined.outputs.text"}}
+              }
+            },
+            {
+              "id": "format",
+              "kind": "choice.value",
+              "arguments": {"options": ["square", "wide"], "selected": "wide"}
+            },
+            {"id": "seed", "kind": "seed.value", "arguments": {}}
+          ],
+          "outputs": {
+            "text": {"$ref": "nodes.templated.outputs.text"},
+            "format": {"$ref": "nodes.format.outputs.value"},
+            "seed": {"$ref": "nodes.seed.outputs.seed"}
+          }
+        }
+        """#)
+        let sourceGraphFingerprint = try WorkflowBundleCodec.hash(graph)
+        let sourceInputs = WorkflowInputsDocument(values: [:])
+        let bundle = try WorkflowBundleMaterializer(
+            graph: graph,
+            suppliedInputs: sourceInputs,
+            destination: root.appendingPathComponent("bundle"),
+            seed: { 42 }
+        ).materialize()
+
+        XCTAssertEqual(bundle.job.sourceGraphFingerprint, sourceGraphFingerprint)
+        XCTAssertEqual(bundle.job.sourceInputFingerprint, try WorkflowBundleCodec.hash(sourceInputs))
+        XCTAssertEqual(bundle.graph.nodes.first(where: { $0.id == "seed" })?.arguments["seed"], .integer(42))
+        XCTAssertNotEqual(bundle.job.sourceGraphFingerprint, bundle.job.graphFingerprint)
+
+        let runDirectory = root.appendingPathComponent("run")
+        let outcome = try WorkflowRunner(
+            bundleDirectory: bundle.directory,
+            runDirectory: runDirectory,
+            processRunner: FixtureWorkflowProcessRunner()
+        ).execute()
+        XCTAssertEqual(outcome.state, .finished)
+
+        let manifest = try WorkflowBundleCodec.decoder().decode(
+            GraphRunManifest.self,
+            from: Data(contentsOf: runDirectory.appendingPathComponent(GraphRunManifest.filename))
+        )
+        XCTAssertEqual(manifest.sourceGraphFingerprint, sourceGraphFingerprint)
+        XCTAssertEqual(
+            manifest.nodes.first(where: { $0.id == "templated" })?
+                .outputs.first(where: { $0.name == "text" })?.value,
+            .string("Result: alpha|beta")
+        )
+        XCTAssertEqual(
+            manifest.nodes.first(where: { $0.id == "format" })?
+                .outputs.first(where: { $0.name == "value" })?.value,
+            .string("wide")
+        )
+        XCTAssertEqual(
+            manifest.nodes.first(where: { $0.id == "seed" })?
+                .outputs.first(where: { $0.name == "seed" })?.value,
+            .integer(42)
+        )
+    }
+
+    func testModelBackedCreativeNodesRequireInstalledExplicitModels() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let enhance = WorkflowNode(
+            id: "enhance",
+            kind: "text.enhance",
+            arguments: [
+                "text": .string("draft"),
+                "instruction": .string("Make it vivid."),
+                "model": .string("text-chat-gemma4-12b-4bit"),
+                "max_tokens": .integer(512),
+                "temperature": .number(0.3),
+            ],
+            dependsOn: nil
+        )
+        let invocation = try WorkflowNodeCommandBuilder.invocation(
+            node: enhance,
+            arguments: enhance.arguments,
+            nodeDirectory: root
+        )
+        XCTAssertTrue(invocation.preflightArguments.suffix(2).elementsEqual(["--preflight", "--json"]))
+        XCTAssertTrue(invocation.runArguments.contains("--require-installed"))
+        XCTAssertTrue(invocation.runArguments.contains("--no-thinking"))
+        XCTAssertEqual(invocation.stdoutOutputName, "text")
     }
 
     func testNVIDIAMemoryProbeParsesLargestGPU() {
@@ -197,6 +375,32 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(
             try WorkflowBundleCodec.hash(WorkflowPortableInputFingerprint(inputs: inputs, assets: assets)),
             compatibility.canonicalFixture.inputFingerprint
+        )
+
+        let materialGraph = try WorkflowGraphDocument.load(
+            from: fixtures.appendingPathComponent(compatibility.materialFixture.graph)
+        )
+        let materialInputs = try WorkflowInputsDocument.load(
+            from: fixtures.appendingPathComponent(compatibility.materialFixture.inputs)
+        )
+        let materialAssets = try WorkflowBundleCodec.decoder().decode(
+            WorkflowAssetManifest.self,
+            from: Data(contentsOf: fixtures.appendingPathComponent(compatibility.materialFixture.assets))
+        )
+        let materialValidation = WorkflowGraphValidator.validate(
+            graph: materialGraph,
+            inputs: materialInputs
+        )
+        XCTAssertEqual(materialValidation.order, compatibility.materialFixture.executionOrder)
+        XCTAssertEqual(
+            try WorkflowBundleCodec.hash(materialGraph),
+            compatibility.materialFixture.graphFingerprint
+        )
+        XCTAssertEqual(
+            try WorkflowBundleCodec.hash(
+                WorkflowPortableInputFingerprint(inputs: materialInputs, assets: materialAssets)
+            ),
+            compatibility.materialFixture.inputFingerprint
         )
     }
 
@@ -1443,11 +1647,13 @@ private struct WorkflowCompatibilityFixture: Decodable {
     let schemaVersion: Int
     let kind: String
     let canonicalFixture: CanonicalFixture
+    let materialFixture: CanonicalFixture
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
         case kind
         case canonicalFixture = "canonical_fixture"
+        case materialFixture = "material_fixture"
     }
 
     struct CanonicalFixture: Decodable {

--- a/docs/public/schemas/graph-node-provider.v1.schema.json
+++ b/docs/public/schemas/graph-node-provider.v1.schema.json
@@ -39,7 +39,7 @@
       "additionalProperties": false,
       "required": ["type"],
       "properties": {
-        "type": {"enum": ["object", "array", "string", "integer", "number", "boolean", "enum"]},
+        "type": {"enum": ["object", "array", "string", "integer", "number", "boolean", "enum", "json"]},
         "title": {"type": "string"},
         "description": {"type": "string"},
         "default": {"$ref": "#/$defs/value"},
@@ -47,6 +47,7 @@
         "properties": {"type": "object", "additionalProperties": {"$ref": "#/$defs/value_schema"}},
         "required": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/id"}},
         "items": {"$ref": "#/$defs/value_schema"},
+        "additional_properties": {"$ref": "#/$defs/value_schema"},
         "minimum": {"type": "number"},
         "maximum": {"type": "number"},
         "step": {"type": "number", "exclusiveMinimum": 0},
@@ -112,6 +113,15 @@
         "supports_previews": {"type": "boolean"}
       }
     },
+    "presentation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["style"],
+      "properties": {
+        "style": {"const": "material"},
+        "primary_argument": {"$ref": "#/$defs/id"}
+      }
+    },
     "node": {
       "type": "object",
       "additionalProperties": false,
@@ -124,7 +134,8 @@
         "inputs": {"type": "array", "items": {"$ref": "#/$defs/input"}},
         "outputs": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/output"}},
         "requirements": {"$ref": "#/$defs/requirements"},
-        "traits": {"$ref": "#/$defs/traits"}
+        "traits": {"$ref": "#/$defs/traits"},
+        "presentation": {"$ref": "#/$defs/presentation"}
       }
     }
   }

--- a/docs/public/schemas/graph-run-v1.schema.json
+++ b/docs/public/schemas/graph-run-v1.schema.json
@@ -9,6 +9,8 @@
     "job_id": { "type": "string", "format": "uuid" },
     "graph_name": { "type": "string" },
     "graph_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "source_graph_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "source_input_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "state": { "$ref": "#/$defs/state" },
     "created_at": { "type": "string", "format": "date-time" },
     "updated_at": { "type": "string", "format": "date-time" },

--- a/docs/public/schemas/job-bundle-v1.schema.json
+++ b/docs/public/schemas/job-bundle-v1.schema.json
@@ -11,6 +11,8 @@
     "created_at": { "type": "string", "format": "date-time" },
     "graph_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "input_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "source_graph_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "source_input_fingerprint": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "requirements": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -41,9 +41,24 @@ Each node may independently set retry, timeout, and cache policy.
 
 The V1 node catalog contains:
 
+- `text.value`, `integer.value`, `number.value`, `boolean.value`, `json.value`
+- `seed.value`, `choice.value`
+- `text.join`, `text.template`
+- `text.enhance`, `image.describe`
 - `image.train-lora`
 - `image.generate`
 - `video.generate`
+
+The value and text nodes make authored creative material reusable without
+turning it into a runtime graph input. Literal values, seeds, joins, and
+templates execute as native deterministic intrinsics. `text.template` accepts
+strict `{{name}}` identifiers, preserves escaped `\{{name}}` text, and blocks
+missing variables. `text.enhance` and `image.describe` require an explicit
+installed model and never trigger a hidden pull.
+
+Catalog value schemas recursively describe array items, object properties, and
+additional properties. Editors may expose those nested slots as typed ports
+while the serialized graph continues to use ordinary nested JSON references.
 
 Companion plugins may add typed nodes without adding arbitrary command or
 Python execution to the graph ABI. Plugin nodes name their provider explicitly:
@@ -115,8 +130,11 @@ never pulls models automatically on a worker.
 
 ## Portable job bundles
 
-Materialization resolves defaults and random seeds, fingerprints the canonical
-graph and inputs, and copies declared file inputs into a content-addressed store.
+Materialization records source graph and input fingerprints, resolves defaults
+and random seeds, fingerprints the portable graph and inputs, and copies
+declared file inputs into a content-addressed store. The optional source
+fingerprints also flow into `run.json`, allowing authoring clients to display
+results only when they match the currently open source documents.
 
 ```bash
 mere.run graph materialize workflow.json \
@@ -181,9 +199,8 @@ machine paths never enter the bundle.
 
 Bundles pin their minimum compatible `mere.run` worker version. Preflight and
 submission reject older SSH or Relay workers before transfer or queueing; the
-worker repeats the check before execution. Graphs materialized by this release
-require `mere.run` 0.23.0 or newer because older workers do not preserve the new
-execution, resource, and secret fields during canonical fingerprint checks.
+worker repeats the check before execution. Graphs using creative material nodes
+require `mere.run` 0.24.0 or newer.
 
 ## Local execution
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.23.0"
+default_version="0.24.0"
 if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary
- add 11 typed creative material nodes with recursive value schemas and presentation metadata
- execute pure material intrinsics in-process and gate model-backed enhancement/description on explicit installed models
- persist source graph/input fingerprints and publish synchronized JSON contracts
- release mere.run 0.24.0 contract metadata

## Verification
- ./scripts/check.sh (1,987 tests; 125 checkpoint-dependent skips; 0 failures)
- built mere.run 0.24.0 and ran the creative-materials fixture end to end
- verified prompt, choice, seed outputs and both source fingerprints in run.json
- cross-repo schema and fixture byte parity