### PR TITLE
Native SCAIL-2 recast masks and fast profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## Unreleased
+
+### Changed
+
+- made the proven four-step SCAIL-2 adapter recipe the default for
+  `video animate`, including its 832x480 geometry, no-CFG Euler schedule, and
+  shift 5. The configurable 40-step UniPC recipe remains available through
+  explicit `--profile quality` selection.
+
 ## 0.24.0 - 2026-07-19
 
 This release contains the complete `v0.23.0..v0.24.0` delta: 22 commits

--- a/README.md
+++ b/README.md
@@ -681,12 +681,14 @@ swift run mere.run video generate \
 
 # Animate a masked reference subject from a driving video with native SCAIL-2
 swift run mere.run model pull video-scail2-14b-mlx
+swift run mere.run adapter pull scail2-lightx2v-4step
 swift run mere.run video animate \
   "a dancer in a red silk dress" \
-  --reference ./ref.png \
-  --reference-mask ./ref-mask.png \
+  --reference ./reference-dancer-prepared.png \
+  --reference-mask ./reference-dancer-mask.png \
   --driving-video ./pose.mp4 \
   --driving-mask ./pose-mask.mp4 \
+  --profile fast \
   --tail-policy pad-trim \
   --audio-source driving \
   --output ./animated.mp4

--- a/README.md
+++ b/README.md
@@ -688,7 +688,6 @@ swift run mere.run video animate \
   --reference-mask ./reference-dancer-mask.png \
   --driving-video ./pose.mp4 \
   --driving-mask ./pose-mask.mp4 \
-  --profile fast \
   --tail-policy pad-trim \
   --audio-source driving \
   --output ./animated.mp4

--- a/Sources/MereRunCLI/Commands/AdapterListCommand.swift
+++ b/Sources/MereRunCLI/Commands/AdapterListCommand.swift
@@ -45,6 +45,7 @@ struct ManagedAdapterListItem: Codable, Equatable {
     let baseModelID: String
     let format: String
     let license: String
+    let upstreamRevision: String?
     let releaseManifestURL: String
     let downloadURL: String
     let filename: String
@@ -62,6 +63,7 @@ struct ManagedAdapterListItem: Codable, Equatable {
         self.baseModelID = spec.baseModelID
         self.format = spec.format
         self.license = spec.license
+        self.upstreamRevision = spec.upstreamRevision
         self.releaseManifestURL = spec.releaseManifestURL.absoluteString
         self.downloadURL = spec.downloadURL.absoluteString
         self.filename = spec.artifact.filename

--- a/Sources/MereRunCLI/Commands/VideoAnimateCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoAnimateCommand.swift
@@ -32,6 +32,23 @@ enum SCAIL2CLIAudioSource: String, CaseIterable, ExpressibleByArgument {
     case driving
 }
 
+enum SCAIL2CLISampler: String, CaseIterable, ExpressibleByArgument {
+    case unipc
+    case euler
+
+    var runtimeSampler: SCAIL2Sampler {
+        switch self {
+        case .unipc: .unipc
+        case .euler: .euler
+        }
+    }
+}
+
+enum SCAIL2CLIProfile: String, CaseIterable, ExpressibleByArgument {
+    case quality
+    case fast
+}
+
 struct SCAIL2AnimationPreflightReport: Codable, Equatable {
     let status: String
     let model: String
@@ -41,11 +58,16 @@ struct SCAIL2AnimationPreflightReport: Codable, Equatable {
     let missingInputFiles: [String]
     let output: String
     let mode: String
+    let profile: String
     let width: Int
     let height: Int
     let steps: Int
     let guidanceScale: Float
     let shift: Float
+    let sampler: String
+    let denoisingSchedule: String
+    let distilledAdapter: String?
+    let distilledAdapterStrength: Float
     let fps: Int
     let segmentLength: Int
     let segmentOverlap: Int
@@ -62,11 +84,16 @@ struct SCAIL2AnimationPreflightReport: Codable, Equatable {
         case missingInputFiles = "missing_input_files"
         case output
         case mode
+        case profile
         case width
         case height
         case steps
         case guidanceScale = "guidance_scale"
         case shift
+        case sampler
+        case denoisingSchedule = "denoising_schedule"
+        case distilledAdapter = "distilled_adapter"
+        case distilledAdapterStrength = "distilled_adapter_strength"
         case fps
         case segmentLength = "segment_length"
         case segmentOverlap = "segment_overlap"
@@ -127,6 +154,9 @@ struct VideoAnimate: AsyncParsableCommand {
     @Option(name: [.long], help: "SCAIL-2 task mode: animation or replacement.")
     var mode: SCAIL2CLIMode = .animation
 
+    @Option(name: [.long], help: "Render recipe: quality (40-step UniPC by default) or fast (managed LightX2V 4-step adapter).")
+    var profile: SCAIL2CLIProfile = .quality
+
     @Option(name: [.long], help: "Target width; must be divisible by 32.")
     var width: Int = 896
 
@@ -141,6 +171,15 @@ struct VideoAnimate: AsyncParsableCommand {
 
     @Option(name: [.long], help: "Flow schedule shift; 3 is recommended at 480p.")
     var shift: Float = 3
+
+    @Option(name: [.long], help: "Denoising sampler: unipc or euler.")
+    var sampler: SCAIL2CLISampler = .unipc
+
+    @Option(name: [.customLong("distilled-adapter")], help: "Installed adapter catalog id or local distilled Wan 2.1 I2V safetensors path.")
+    var distilledAdapter: String?
+
+    @Option(name: [.customLong("distilled-adapter-strength")], help: "Distilled adapter multiplier.")
+    var distilledAdapterStrength: Float = 1
 
     @Option(name: [.long], help: "Random seed.")
     var seed: Int = 42
@@ -224,6 +263,10 @@ struct VideoAnimate: AsyncParsableCommand {
             CLIStderr.write("Engine: native Swift/MLX SCAIL-2\n")
             CLIStderr.write("Model root: \(runtimeRoot.path)\n")
             CLIStderr.write("Mode: \(mode.rawValue)\n")
+            CLIStderr.write("Profile: \(profile.rawValue)\n")
+            if let distilledAdapterURL = options.distilledAdapterURL {
+                CLIStderr.write("Distilled adapter: \(distilledAdapterURL.path)\n")
+            }
         }
         let reportsProgress = !quiet
         let result = try await SCAIL2Generator().generate(
@@ -263,7 +306,21 @@ struct VideoAnimate: AsyncParsableCommand {
     }
 
     func makeOptions(prompt: String, outputURL: URL) throws -> SCAIL2GenerationOptions {
-        try SCAIL2GenerationOptions(
+        let effectiveAdapterReference = profile == .fast
+            ? distilledAdapter ?? ManagedAdapterCatalog.scail2LightX2VFourStepID
+            : distilledAdapter
+        let resolvedDistilledAdapter = try ManagedAdapterArgumentResolver.resolve(
+            effectiveAdapterReference,
+            baseModelID: SCAIL2Resources.modelID
+        )
+        let effectiveSteps = profile == .fast ? 4 : steps
+        let effectiveGuidanceScale: Float = profile == .fast ? 1 : guidanceScale
+        let effectiveShift: Float = profile == .fast ? 5 : shift
+        let effectiveSampler: SCAIL2Sampler = profile == .fast ? .euler : sampler.runtimeSampler
+        let effectiveSchedule: SCAIL2DenoisingSchedule = profile == .fast
+            ? .lightX2VFourStep
+            : .standard
+        return try SCAIL2GenerationOptions(
             prompt: prompt,
             negativePrompt: negativePrompt,
             reference: SCAIL2ReferenceInput(
@@ -282,9 +339,15 @@ struct VideoAnimate: AsyncParsableCommand {
             mode: mode.runtimeMode,
             width: width,
             height: height,
-            steps: steps,
-            guidanceScale: guidanceScale,
-            shift: shift,
+            steps: effectiveSteps,
+            guidanceScale: effectiveGuidanceScale,
+            shift: effectiveShift,
+            sampler: effectiveSampler,
+            denoisingSchedule: effectiveSchedule,
+            distilledAdapterURL: resolvedDistilledAdapter.map {
+                URL(fileURLWithPath: $0).standardizedFileURL
+            },
+            distilledAdapterStrength: distilledAdapterStrength,
             seed: UInt64(bitPattern: Int64(seed)),
             fps: fps,
             segmentLength: segmentLength,
@@ -303,6 +366,7 @@ struct VideoAnimate: AsyncParsableCommand {
             options.drivingVideoURL,
             options.drivingMaskVideoURL,
         ] + options.additionalReferences.flatMap { [$0.imageURL, $0.maskURL] }
+            + (options.distilledAdapterURL.map { [$0] } ?? [])
         let missingInputs = inputs.filter { !FileManager.default.fileExists(atPath: $0.path) }
         let missingModels = modelRootURL.map { SCAIL2Resources(rootURL: $0).validate() } ?? []
         let installed = modelRootURL != nil && missingModels.isEmpty
@@ -319,11 +383,16 @@ struct VideoAnimate: AsyncParsableCommand {
                 defaultExtension: "mp4"
             ).path,
             mode: mode.rawValue,
+            profile: profile.rawValue,
             width: width,
             height: height,
-            steps: steps,
-            guidanceScale: guidanceScale,
-            shift: shift,
+            steps: options.steps,
+            guidanceScale: options.guidanceScale,
+            shift: options.shift,
+            sampler: options.sampler.rawValue,
+            denoisingSchedule: options.denoisingSchedule.rawValue,
+            distilledAdapter: options.distilledAdapterURL?.path,
+            distilledAdapterStrength: options.distilledAdapterStrength,
             fps: fps,
             segmentLength: segmentLength,
             segmentOverlap: segmentOverlap,

--- a/Sources/MereRunCLI/Commands/VideoAnimateCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoAnimateCommand.swift
@@ -154,26 +154,26 @@ struct VideoAnimate: AsyncParsableCommand {
     @Option(name: [.long], help: "SCAIL-2 task mode: animation or replacement.")
     var mode: SCAIL2CLIMode = .animation
 
-    @Option(name: [.long], help: "Render recipe: quality (40-step UniPC by default) or fast (managed LightX2V 4-step adapter).")
-    var profile: SCAIL2CLIProfile = .quality
+    @Option(name: [.long], help: "Render recipe: fast (default managed four-step adapter) or quality (40-step UniPC).")
+    var profile: SCAIL2CLIProfile = .fast
 
     @Option(name: [.long], help: "Target width; must be divisible by 32.")
-    var width: Int = 896
+    var width: Int = 832
 
     @Option(name: [.long], help: "Target height; must be divisible by 32.")
-    var height: Int = 512
+    var height: Int = 480
 
-    @Option(name: [.long], help: "UniPC denoising steps.")
-    var steps: Int = 40
+    @Option(name: [.long], help: "Quality-profile denoising steps (default 40; fast is fixed at 4).")
+    var steps: Int?
 
-    @Option(name: [.customLong("guidance-scale")], help: "Classifier-free guidance scale.")
-    var guidanceScale: Float = 5
+    @Option(name: [.customLong("guidance-scale")], help: "Quality-profile CFG scale (default 5; fast disables CFG).")
+    var guidanceScale: Float?
 
-    @Option(name: [.long], help: "Flow schedule shift; 3 is recommended at 480p.")
-    var shift: Float = 3
+    @Option(name: [.long], help: "Quality-profile flow shift (default 3; fast is fixed at 5).")
+    var shift: Float?
 
-    @Option(name: [.long], help: "Denoising sampler: unipc or euler.")
-    var sampler: SCAIL2CLISampler = .unipc
+    @Option(name: [.long], help: "Quality-profile sampler (default UniPC; fast is fixed to Euler).")
+    var sampler: SCAIL2CLISampler?
 
     @Option(name: [.customLong("distilled-adapter")], help: "Installed adapter catalog id or local distilled Wan 2.1 I2V safetensors path.")
     var distilledAdapter: String?
@@ -313,10 +313,10 @@ struct VideoAnimate: AsyncParsableCommand {
             effectiveAdapterReference,
             baseModelID: SCAIL2Resources.modelID
         )
-        let effectiveSteps = profile == .fast ? 4 : steps
-        let effectiveGuidanceScale: Float = profile == .fast ? 1 : guidanceScale
-        let effectiveShift: Float = profile == .fast ? 5 : shift
-        let effectiveSampler: SCAIL2Sampler = profile == .fast ? .euler : sampler.runtimeSampler
+        let effectiveSteps = profile == .fast ? 4 : (steps ?? 40)
+        let effectiveGuidanceScale: Float = profile == .fast ? 1 : (guidanceScale ?? 5)
+        let effectiveShift: Float = profile == .fast ? 5 : (shift ?? 3)
+        let effectiveSampler: SCAIL2Sampler = profile == .fast ? .euler : (sampler?.runtimeSampler ?? .unipc)
         let effectiveSchedule: SCAIL2DenoisingSchedule = profile == .fast
             ? .lightX2VFourStep
             : .standard

--- a/Sources/MereRunCore/ManagedAdapterCatalog.swift
+++ b/Sources/MereRunCore/ManagedAdapterCatalog.swift
@@ -8,6 +8,7 @@ public struct ManagedAdapterSpec: Equatable, Sendable {
     public let baseModelID: String
     public let format: String
     public let license: String
+    public let upstreamRevision: String?
     public let releaseManifestURL: URL
     public let downloadURL: URL
     public let artifact: ModelArtifactPin
@@ -20,6 +21,7 @@ public struct ManagedAdapterSpec: Equatable, Sendable {
         baseModelID: String,
         format: String,
         license: String,
+        upstreamRevision: String? = nil,
         releaseManifestURL: URL,
         downloadURL: URL,
         artifact: ModelArtifactPin
@@ -31,6 +33,7 @@ public struct ManagedAdapterSpec: Equatable, Sendable {
         self.baseModelID = baseModelID
         self.format = format
         self.license = license
+        self.upstreamRevision = upstreamRevision
         self.releaseManifestURL = releaseManifestURL
         self.downloadURL = downloadURL
         self.artifact = artifact
@@ -74,6 +77,8 @@ public struct ManagedAdapterSpec: Equatable, Sendable {
 
 public enum ManagedAdapterCatalog {
     public static let merePlatformAssistantID = "mere-platform-assistant"
+    public static let scail2LightX2VFourStepID = "scail2-lightx2v-4step"
+    public static let scail2LightX2VFourStepRevision = "27ae38da91014b947dd39cc3fa78b97cd7b386dd"
 
     public static let allSpecs: [ManagedAdapterSpec] = [
         ManagedAdapterSpec(
@@ -94,6 +99,27 @@ public enum ManagedAdapterCatalog {
                 filename: "mere-platform-assistant-v22.safetensors",
                 byteCount: 128_131_022,
                 sha256: "c4fec5979631b4031196c1e21c0b990437a26c5ebc52aec32f89338d64063290"
+            )
+        ),
+        ManagedAdapterSpec(
+            id: scail2LightX2VFourStepID,
+            title: "LightX2V Wan 2.1 I2V 4-step",
+            version: String(scail2LightX2VFourStepRevision.prefix(12)),
+            summary: "Apache-2.0 four-step distilled Wan 2.1 I2V adapter for native SCAIL-2.",
+            baseModelID: SCAIL2Resources.modelID,
+            format: SCAIL2DistilledAdapter.format,
+            license: "Apache-2.0",
+            upstreamRevision: scail2LightX2VFourStepRevision,
+            releaseManifestURL: URL(
+                string: "https://huggingface.co/lightx2v/Wan2.1-Distill-Loras/commit/\(scail2LightX2VFourStepRevision)"
+            )!,
+            downloadURL: URL(
+                string: "https://huggingface.co/lightx2v/Wan2.1-Distill-Loras/resolve/\(scail2LightX2VFourStepRevision)/wan2.1_i2v_lora_rank64_lightx2v_4step.safetensors?download=true"
+            )!,
+            artifact: ModelArtifactPin(
+                filename: "wan2.1_i2v_lora_rank64_lightx2v_4step.safetensors",
+                byteCount: 739_472_104,
+                sha256: "8833bd4fd7c8eabebf0bc8ee5cfaf47f4f310ce116928a02c1adf8941dd4b0f1"
             )
         ),
     ]

--- a/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
+++ b/Sources/MereRunCore/SAM3/SAM31ImageSegmenter.swift
@@ -471,6 +471,7 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
     private static func loadWeights(resources: SAM31Resources, into model: SAM31Model) throws {
         let targetParameters = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
         var anyMapped = false
+        var mappedKeys = Set<String>()
 
         func applyArrays(_ arrays: [String: MLXArray]) throws {
             var updates: [(String, MLXArray)] = []
@@ -481,6 +482,7 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
                 guard let target = targetParameters[resolvedKey] else { continue }
                 guard let adapted = adaptWeight(value, to: target) else { continue }
                 updates.append((resolvedKey, adapted))
+                mappedKeys.insert(resolvedKey)
             }
 
             if !updates.isEmpty {
@@ -509,6 +511,16 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
 
         guard anyMapped else {
             throw SegmenterError.failedToMapWeights
+        }
+        let missingTrackerKeys = targetParameters.keys
+            .filter { $0.hasPrefix("tracker_model.") && !mappedKeys.contains($0) }
+            .sorted()
+        guard missingTrackerKeys.isEmpty else {
+            let preview = missingTrackerKeys.prefix(12).joined(separator: ", ")
+            throw SegmenterError.failedToLoadWeights(
+                resources.modelRootURL,
+                reason: "Missing \(missingTrackerKeys.count) native tracker weights: \(preview)"
+            )
         }
     }
 
@@ -544,7 +556,16 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         return nil
     }
 
-    private static func mapCheckpointKey(_ key: String) -> String {
+    static func mapCheckpointKey(_ key: String) -> String {
+        if key.contains("tracker_model.interactive_sam_mask_decoder."),
+           key.contains(".output_hypernetworks_mlps.")
+            || key.contains(".iou_prediction_head.")
+            || key.contains(".pred_obj_score_head.") {
+            return key
+                .replacingOccurrences(of: ".proj_in.", with: ".layer1.")
+                .replacingOccurrences(of: ".layers.0.", with: ".layer2.")
+                .replacingOccurrences(of: ".proj_out.", with: ".layer3.")
+        }
         if key.contains(".scale_layers.0.") {
             return key.replacingOccurrences(of: ".scale_layers.0.", with: ".scale_layers.first.")
         }
@@ -622,9 +643,7 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
         let maskTensor: MLXArray?
         if let path = promptObject.maskPrompt?.path {
             let image = try MediaImageIO.decode(URL(fileURLWithPath: path).standardizedFileURL)
-            let values = stride(from: 0, to: image.rgba8.count, by: 4).map {
-                image.rgba8[$0] >= 128 ? Float(1) : Float(0)
-            }
+            let values = Self.binaryMaskPromptValues(from: image)
             maskTensor = MLXArray(values).reshaped(1, image.height, image.width, 1)
         } else {
             maskTensor = nil
@@ -670,6 +689,12 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
                 }
             }
             binaryMask = largestConnectedComponent(binaryMask: binaryMask, width: imageWidth, height: imageHeight)
+            binaryMask = fillSmallHoles(
+                binaryMask: binaryMask,
+                width: imageWidth,
+                height: imageHeight,
+                maximumArea: max(64, (imageWidth * imageHeight) / 200)
+            )
             area = binaryMask.reduce(0) { $0 + ($1 == 0 ? 0 : 1) }
             guard area > 0 else { continue }
 
@@ -821,6 +846,67 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             filtered[index] = 1
         }
         return filtered
+    }
+
+    static func fillSmallHoles(
+        binaryMask: [UInt8],
+        width: Int,
+        height: Int,
+        maximumArea: Int
+    ) -> [UInt8] {
+        guard width > 0,
+              height > 0,
+              binaryMask.count == width * height,
+              maximumArea > 0 else {
+            return binaryMask
+        }
+        var result = binaryMask
+        var visited = [UInt8](repeating: 0, count: binaryMask.count)
+        let neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+
+        for startIndex in binaryMask.indices
+        where binaryMask[startIndex] == 0 && visited[startIndex] == 0 {
+            var queue = [startIndex]
+            var cursor = 0
+            var component: [Int] = []
+            var touchesBorder = false
+            visited[startIndex] = 1
+
+            while cursor < queue.count {
+                let index = queue[cursor]
+                cursor += 1
+                component.append(index)
+                let x = index % width
+                let y = index / width
+                if x == 0 || y == 0 || x == width - 1 || y == height - 1 {
+                    touchesBorder = true
+                }
+                for (dx, dy) in neighbors {
+                    let nextX = x + dx
+                    let nextY = y + dy
+                    guard nextX >= 0,
+                          nextX < width,
+                          nextY >= 0,
+                          nextY < height else {
+                        continue
+                    }
+                    let nextIndex = (nextY * width) + nextX
+                    guard binaryMask[nextIndex] == 0,
+                          visited[nextIndex] == 0 else {
+                        continue
+                    }
+                    visited[nextIndex] = 1
+                    queue.append(nextIndex)
+                }
+            }
+
+            if !touchesBorder && component.count <= maximumArea {
+                for index in component {
+                    result[index] = 1
+                }
+            }
+        }
+        return result
     }
 
     private static func writeMaskArtifacts(
@@ -1567,6 +1653,16 @@ public final class SAM31ImageSegmenter: @unchecked Sendable {
             try data.write(to: url, options: [.atomic])
         } catch {
             throw SegmenterError.failedToEncodeMetadata(error.localizedDescription)
+        }
+    }
+
+    static func binaryMaskPromptValues(from image: MediaImage) -> [Float] {
+        stride(from: 0, to: image.rgba8.count, by: 4).map { offset in
+            let foreground = max(
+                image.rgba8[offset],
+                max(image.rgba8[offset + 1], image.rgba8[offset + 2])
+            )
+            return foreground >= 128 ? 1 : 0
         }
     }
 

--- a/Sources/MereRunCore/SAM3/SAM31InteractiveSAM.swift
+++ b/Sources/MereRunCore/SAM3/SAM31InteractiveSAM.swift
@@ -280,6 +280,7 @@ final class SAM31RandomPositionalEmbedding: Module {
 final class SAM31InteractivePromptEncoder: Module {
     let embedDim: Int
     let imageEmbeddingSize: (height: Int, width: Int)
+    let inputImageSize: (height: Int, width: Int)
 
     @ModuleInfo(key: "point_embed") var pointEmbed: Embedding
     @ModuleInfo(key: "not_a_point_embed") var notAPointEmbed: Embedding
@@ -290,6 +291,7 @@ final class SAM31InteractivePromptEncoder: Module {
     init(config: SAM31PromptEncoderConfig) {
         self.embedDim = config.hiddenSize
         self.imageEmbeddingSize = (config.imageSize / config.patchSize, config.imageSize / config.patchSize)
+        self.inputImageSize = (config.imageSize, config.imageSize)
         self._pointEmbed.wrappedValue = Embedding(embeddingCount: config.numPointEmbeddings, dimensions: config.hiddenSize)
         self._notAPointEmbed.wrappedValue = Embedding(embeddingCount: 1, dimensions: config.hiddenSize)
         self._maskEmbed.wrappedValue = SAM31MaskEmbedConvs(
@@ -338,6 +340,12 @@ final class SAM31InteractivePromptEncoder: Module {
         if let masks {
             batch = masks.dim(0)
             denseEmbeddings = maskEmbed(masks)
+            if sparseEmbeddings.dim(1) == 0 {
+                sparseEmbeddings = MLX.broadcast(
+                    notAPointEmbed.weight.reshaped(1, 1, embedDim),
+                    to: [batch, 1, embedDim]
+                )
+            }
         } else {
             let base = noMaskEmbed.weight.reshaped(1, 1, embedDim)
             denseEmbeddings = MLX.broadcast(base, to: [batch, targetHeight * targetWidth, embedDim])
@@ -352,7 +360,10 @@ final class SAM31InteractivePromptEncoder: Module {
 
     private func embedPoints(_ coords: MLXArray, labels: MLXArray, targetHeight: Int, targetWidth: Int) -> MLXArray {
         let shifted = coords + 0.5
-        let normalizer = MLXArray([Float(max(targetWidth, 1)), Float(max(targetHeight, 1))], [1, 1, 2]).asType(.float32)
+        let normalizer = MLXArray(
+            [Float(max(inputImageSize.width, 1)), Float(max(inputImageSize.height, 1))],
+            [1, 1, 2]
+        ).asType(.float32)
         var pointEmbeddings = sharedEmbedding.forwardWithCoords(shifted / normalizer)
 
         let count = labels.dim(labels.ndim - 1)
@@ -373,8 +384,11 @@ final class SAM31InteractivePromptEncoder: Module {
     }
 
     private func embedBoxes(_ boxes: MLXArray, targetHeight: Int, targetWidth: Int) -> MLXArray {
-        let reshaped = boxes.reshaped(boxes.dim(0), boxes.dim(1) * 2, 2)
-        let normalizer = MLXArray([Float(max(targetWidth, 1)), Float(max(targetHeight, 1))], [1, 1, 2]).asType(.float32)
+        let reshaped = (boxes + 0.5).reshaped(boxes.dim(0), boxes.dim(1) * 2, 2)
+        let normalizer = MLXArray(
+            [Float(max(inputImageSize.width, 1)), Float(max(inputImageSize.height, 1))],
+            [1, 1, 2]
+        ).asType(.float32)
         let cornerEmbeddings = sharedEmbedding.forwardWithCoords(reshaped / normalizer)
         let firstLabel = MLXArray([2], [1, 1]).asType(.int32)
         let secondLabel = MLXArray([3], [1, 1]).asType(.int32)

--- a/Sources/MereRunCore/SAM3/SAM31Model.swift
+++ b/Sources/MereRunCore/SAM3/SAM31Model.swift
@@ -1508,7 +1508,10 @@ final class SAM31TrackerModel: Module {
                     Float(maskHeight) / Float(maskPrompt.dim(1)),
                     Float(maskWidth) / Float(maskPrompt.dim(2)),
                 ])
-                resizedMaskPrompt = Upsample(scaleFactor: scale, mode: .nearest)(maskPrompt)
+                resizedMaskPrompt = Upsample(
+                    scaleFactor: scale,
+                    mode: .linear(alignCorners: false)
+                )(maskPrompt)
             }
         } else {
             resizedMaskPrompt = nil

--- a/Sources/MereRunCore/SAM3/SAM31VideoTracker.swift
+++ b/Sources/MereRunCore/SAM3/SAM31VideoTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 
 public final class SAM31VideoTracker: @unchecked Sendable {
     public enum TrackingError: LocalizedError, Sendable {
@@ -117,7 +118,18 @@ public final class SAM31VideoTracker: @unchecked Sendable {
         }
         annotatedFrameURLs[seedFrameIndex] = seedRun.annotatedImageURL
 
-        let seedDetections = bestDetectionsByObjectID(normalizeSeedDetections(seedRun.detections))
+        var seedDetections = bestDetectionsByObjectID(normalizeSeedDetections(seedRun.detections))
+        for promptObject in normalizedPrompts {
+            if let authoritative = try authoritativeMaskSeedDetection(
+                for: promptObject,
+                frameWidth: asset.frameWidth,
+                frameHeight: asset.frameHeight,
+                frameIndex: seedFrameIndex,
+                maskOutputDirectoryURL: maskOutputDirectoryURL
+            ) {
+                seedDetections[promptObject.objectID] = authoritative
+            }
+        }
         let trackingStates = normalizedPrompts.compactMap { promptObject -> TrackingState? in
             guard let detection = seedDetections[promptObject.objectID] else { return nil }
             let trackedObject = SAM31TrackedObject(
@@ -288,7 +300,7 @@ public final class SAM31VideoTracker: @unchecked Sendable {
                 resolution: resolution,
                 showBoxes: showBoxes,
                 showLabels: showLabels,
-                multimask: false,
+                multimask: true,
                 maskOutputDirectoryURL: maskDirectory
             )
             let stabilizedRun = try stabilizedRunIfNeeded(
@@ -307,7 +319,12 @@ public final class SAM31VideoTracker: @unchecked Sendable {
             )
             annotatedFrameURLs[frameIndex] = stabilizedRun.annotatedImageURL
 
-            let detectionsByObjectID = bestDetectionsByObjectID(stabilizedRun.detections)
+            let detectionsByObjectID = Self.trackingDetectionsByObjectID(
+                stabilizedRun.detections,
+                previousResultsByObject: previousResultsByObject,
+                seedResultsByObject: statesByObjectID.mapValues(\.seedResult),
+                threshold: threshold
+            )
 
             let frameResults = orderedStates.map { state -> SAM31TrackingObjectResult in
                 let object = state.trackedObject
@@ -437,11 +454,21 @@ public final class SAM31VideoTracker: @unchecked Sendable {
         maskOutputDirectoryURL: URL?,
         frameIndex: Int
     ) throws -> SAM31SegmentationRun {
-        let detectionsByObjectID = bestDetectionsByObjectID(initialRun.detections)
+        let seedResultsByObject = Dictionary(
+            uniqueKeysWithValues: trackingStates.map {
+                ($0.trackedObject.objectID, $0.seedResult)
+            }
+        )
+        let detectionsByObjectID = Self.trackingDetectionsByObjectID(
+            initialRun.detections,
+            previousResultsByObject: previousResultsByObject,
+            seedResultsByObject: seedResultsByObject,
+            threshold: threshold
+        )
         let fallbackPromptObjects = trackingStates.compactMap { state -> SAM31PromptObject? in
             let previousResult = previousResultsByObject[state.trackedObject.objectID] ?? state.seedResult
             let detection = detectionsByObjectID[state.trackedObject.objectID]
-            guard needsFallback(
+            guard Self.needsFallback(
                 detection: detection,
                 previousResult: previousResult,
                 seedResult: state.seedResult,
@@ -477,7 +504,7 @@ public final class SAM31VideoTracker: @unchecked Sendable {
             resolution: resolution,
             showBoxes: showBoxes,
             showLabels: showLabels,
-            multimask: false,
+            multimask: true,
             maskOutputDirectoryURL: rerunMaskDirectory
         )
     }
@@ -529,15 +556,88 @@ public final class SAM31VideoTracker: @unchecked Sendable {
             return SAM31PromptObject(
                 objectID: state.trackedObject.objectID,
                 label: state.trackedObject.label,
-                promptKind: .mask,
-                boxPrompt: state.seedPromptObject.boxPrompt,
+                promptKind: .box,
+                boxPrompt: SAM31PromptBox(
+                    x1: state.seedResult.box.x1,
+                    y1: state.seedResult.box.y1,
+                    x2: state.seedResult.box.x2,
+                    y2: state.seedResult.box.y2,
+                    label: state.trackedObject.objectID
+                ),
                 pointPrompts: state.seedPromptObject.pointPrompts,
-                maskPrompt: state.seedPromptObject.maskPrompt
+                maskPrompt: nil
             )
         }
     }
 
-    private func needsFallback(
+    private func authoritativeMaskSeedDetection(
+        for promptObject: SAM31PromptObject,
+        frameWidth: Int,
+        frameHeight: Int,
+        frameIndex: Int,
+        maskOutputDirectoryURL: URL?
+    ) throws -> SAM31SegmentationDetection? {
+        guard let maskPath = promptObject.maskPrompt?.path else { return nil }
+        let decoded = try MediaImageIO.decode(URL(fileURLWithPath: maskPath).standardizedFileURL)
+        let image = decoded.width == frameWidth && decoded.height == frameHeight
+            ? decoded
+            : try MediaImageIO.resized(decoded, width: frameWidth, height: frameHeight)
+
+        var area = 0
+        var minX = frameWidth
+        var minY = frameHeight
+        var maxX = -1
+        var maxY = -1
+        for pixelIndex in 0..<(frameWidth * frameHeight) {
+            let offset = pixelIndex * 4
+            let foreground = max(
+                image.rgba8[offset],
+                max(image.rgba8[offset + 1], image.rgba8[offset + 2])
+            )
+            guard foreground >= 128 else { continue }
+            let x = pixelIndex % frameWidth
+            let y = pixelIndex / frameWidth
+            area += 1
+            minX = min(minX, x)
+            minY = min(minY, y)
+            maxX = max(maxX, x)
+            maxY = max(maxY, y)
+        }
+        guard area > 0 else { return nil }
+
+        let persistedMaskPath: String
+        if let maskOutputDirectoryURL {
+            let directory = maskOutputDirectoryURL.appendingPathComponent(
+                String(format: "frame_%05d", frameIndex),
+                isDirectory: true
+            )
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            let url = directory
+                .appendingPathComponent("\(promptObject.objectID)_authoritative")
+                .appendingPathExtension("png")
+            try MediaImageIO.writePNG(image, to: url)
+            persistedMaskPath = url.path
+        } else {
+            persistedMaskPath = URL(fileURLWithPath: maskPath).standardizedFileURL.path
+        }
+
+        return SAM31SegmentationDetection(
+            objectID: promptObject.objectID,
+            label: promptObject.label,
+            promptKind: .mask,
+            score: 1,
+            box: SAM31SegmentationBox(
+                x1: Float(minX),
+                y1: Float(minY),
+                x2: Float(maxX + 1),
+                y2: Float(maxY + 1)
+            ),
+            maskAreaPixels: area,
+            maskPath: persistedMaskPath
+        )
+    }
+
+    static func needsFallback(
         detection: SAM31SegmentationDetection?,
         previousResult: SAM31TrackingObjectResult,
         seedResult: SAM31TrackingObjectResult,
@@ -558,12 +658,75 @@ public final class SAM31VideoTracker: @unchecked Sendable {
             return true
         }
         if previousResult.visible && previousResult.maskAreaPixels > 0 {
+            if candidateArea < Int(Float(previousArea) * 0.45) {
+                return true
+            }
             let overlap = SAM31ImageSegmenter.iou(detection.box, previousResult.box)
             if overlap < 0.05 {
                 return true
             }
         }
+        if candidateArea < Int(Float(seedArea) * 0.3) {
+            return true
+        }
         return false
+    }
+
+    static func preferredTrackingDetection(
+        _ detections: [SAM31SegmentationDetection],
+        previousResult: SAM31TrackingObjectResult,
+        seedResult: SAM31TrackingObjectResult,
+        threshold: Float
+    ) -> SAM31SegmentationDetection? {
+        guard !detections.isEmpty else { return nil }
+        let stable = detections.filter {
+            !needsFallback(
+                detection: $0,
+                previousResult: previousResult,
+                seedResult: seedResult,
+                threshold: threshold
+            )
+        }
+        return stable.min { lhs, rhs in
+            trackingCandidateCost(lhs, previousResult: previousResult)
+                < trackingCandidateCost(rhs, previousResult: previousResult)
+        }
+    }
+
+    private static func trackingCandidateCost(
+        _ detection: SAM31SegmentationDetection,
+        previousResult: SAM31TrackingObjectResult
+    ) -> Float {
+        let referenceArea = Float(max(previousResult.maskAreaPixels, 1))
+        let areaRatio = Float(max(detection.maskAreaPixels, 1)) / referenceArea
+        let areaCost = abs(log(areaRatio))
+        let overlap = SAM31ImageSegmenter.iou(detection.box, previousResult.box)
+        let candidatePenalty = Float(detection.candidateIndex ?? 0) * 0.25
+        return areaCost + ((1 - overlap) * 2) + candidatePenalty - (detection.score * 0.25)
+    }
+
+    static func trackingDetectionsByObjectID(
+        _ detections: [SAM31SegmentationDetection],
+        previousResultsByObject: [String: SAM31TrackingObjectResult],
+        seedResultsByObject: [String: SAM31TrackingObjectResult],
+        threshold: Float
+    ) -> [String: SAM31SegmentationDetection] {
+        let grouped = Dictionary(grouping: detections) { $0.objectID }
+        var selected: [String: SAM31SegmentationDetection] = [:]
+        for (objectID, objectDetections) in grouped {
+            guard let objectID,
+                  let seed = seedResultsByObject[objectID] else {
+                continue
+            }
+            let previous = previousResultsByObject[objectID] ?? seed
+            selected[objectID] = Self.preferredTrackingDetection(
+                objectDetections,
+                previousResult: previous,
+                seedResult: seed,
+                threshold: threshold
+            )
+        }
+        return selected
     }
 
     private func bestDetectionsByObjectID(

--- a/Sources/MereRunCore/SCAIL2/SCAIL2DistilledAdapter.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2DistilledAdapter.swift
@@ -1,0 +1,299 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum SCAIL2DistilledAdapter {
+    public static let format = "scail2-distilled-wan-i2v-lora-v1"
+
+    public struct ApplicationResult: Hashable, Sendable {
+        public let pairCount: Int
+        public let differenceCount: Int
+        public let skippedDifferenceCount: Int
+
+        public init(
+            pairCount: Int,
+            differenceCount: Int,
+            skippedDifferenceCount: Int = 0
+        ) {
+            self.pairCount = pairCount
+            self.differenceCount = differenceCount
+            self.skippedDifferenceCount = skippedDifferenceCount
+        }
+    }
+
+    public enum AdapterError: LocalizedError {
+        case noPairs(URL)
+        case unexpectedPairCount(expected: Int, actual: Int)
+        case unexpectedDifferenceCount(expected: Int, actual: Int)
+        case unsupportedTarget(String)
+        case missingTargetParameter(String)
+        case invalidPairShape(String, down: [Int], up: [Int])
+        case targetShapeMismatch(String, expected: [Int], actual: [Int])
+
+        public var errorDescription: String? {
+            switch self {
+            case .noPairs(let url):
+                return "No SCAIL-2 distilled adapter tensor pairs were found in \(url.path)."
+            case .unexpectedPairCount(let expected, let actual):
+                return "SCAIL-2 distilled adapter pair count mismatch: expected \(expected), found \(actual)."
+            case .unexpectedDifferenceCount(let expected, let actual):
+                return "SCAIL-2 distilled adapter difference count mismatch: expected \(expected), found \(actual)."
+            case .unsupportedTarget(let key):
+                return "Unsupported SCAIL-2 distilled adapter target: \(key)"
+            case .missingTargetParameter(let key):
+                return "SCAIL-2 distilled adapter target is missing from the transformer: \(key)"
+            case .invalidPairShape(let key, let down, let up):
+                return "Invalid SCAIL-2 distilled adapter pair for \(key): down=\(down), up=\(up)."
+            case .targetShapeMismatch(let key, let expected, let actual):
+                return "SCAIL-2 distilled adapter delta for \(key) has shape \(actual); expected \(expected)."
+            }
+        }
+    }
+
+    /// Applies a distilled Wan I2V adapter directly to the resident native
+    /// transformer. The checkpoint remains a separately pulled model artifact;
+    /// no adapter runtime or source code is imported.
+    @discardableResult
+    public static func apply(
+        url: URL,
+        to transformer: SCAIL2TransformerModel,
+        strength: Float = 1,
+        expectedPairCount: Int? = 487,
+        expectedDifferenceCount: Int? = 775
+    ) throws -> ApplicationResult {
+        var parameters = Dictionary(uniqueKeysWithValues: transformer.parameters().flattened())
+        let modulesByPath = Dictionary(uniqueKeysWithValues: transformer.leafModules().flattened())
+        var appliedPairs = 0
+
+        let pairCount = try SafetensorsStreamingLoader.forEachTensorPair(
+            url: url,
+            firstSuffix: ".lora_down.weight",
+            secondSuffix: ".lora_up.weight"
+        ) { sourceBaseKey, down, up in
+            guard let targetBaseKey = targetBaseKey(for: sourceBaseKey) else {
+                throw AdapterError.unsupportedTarget(sourceBaseKey)
+            }
+            let targetKey = targetBaseKey + ".weight"
+            guard let current = parameters[targetKey] else {
+                throw AdapterError.missingTargetParameter(targetKey)
+            }
+            let fused = try fusedWeight(
+                targetKey: targetKey,
+                currentWeight: current,
+                down: down,
+                up: up,
+                strength: strength
+            )
+            MLX.eval(fused)
+            try update(
+                targetKey: targetKey,
+                value: fused,
+                modulesByPath: modulesByPath
+            )
+            parameters[targetKey] = fused
+            appliedPairs += 1
+            if appliedPairs.isMultiple(of: 8) {
+                Memory.clearCache()
+            }
+        }
+
+        guard pairCount > 0 else {
+            throw AdapterError.noPairs(url)
+        }
+        if let expectedPairCount, pairCount != expectedPairCount {
+            throw AdapterError.unexpectedPairCount(expected: expectedPairCount, actual: pairCount)
+        }
+
+        let differences = try SafetensorsStreamingLoader.loadArrays(url: url) {
+            $0.hasSuffix(".diff") || $0.hasSuffix(".diff_b")
+        }
+        if let expectedDifferenceCount, differences.count != expectedDifferenceCount {
+            throw AdapterError.unexpectedDifferenceCount(
+                expected: expectedDifferenceCount,
+                actual: differences.count
+            )
+        }
+
+        var appliedDifferences = 0
+        var skippedDifferences = 0
+        for sourceKey in differences.keys.sorted() {
+            guard let difference = differences[sourceKey],
+                  let targetKey = differenceTargetKey(for: sourceKey) else {
+                throw AdapterError.unsupportedTarget(sourceKey)
+            }
+            guard let current = parameters[targetKey] else {
+                throw AdapterError.missingTargetParameter(targetKey)
+            }
+            if isTaskInputProjectionDifference(
+                sourceKey: sourceKey,
+                sourceShape: difference.shape,
+                targetShape: current.shape
+            ) {
+                skippedDifferences += 1
+                continue
+            }
+            guard current.shape == difference.shape else {
+                throw AdapterError.targetShapeMismatch(
+                    targetKey,
+                    expected: current.shape,
+                    actual: difference.shape
+                )
+            }
+            let fused = (
+                current.asType(.float32)
+                    + difference.asType(.float32) * MLXArray(strength)
+            ).asType(current.dtype)
+            MLX.eval(fused)
+            try update(
+                targetKey: targetKey,
+                value: fused,
+                modulesByPath: modulesByPath
+            )
+            parameters[targetKey] = fused
+            appliedDifferences += 1
+        }
+        Memory.clearCache()
+        return ApplicationResult(
+            pairCount: appliedPairs,
+            differenceCount: appliedDifferences,
+            skippedDifferenceCount: skippedDifferences
+        )
+    }
+
+    static func isTaskInputProjectionDifference(
+        sourceKey: String,
+        sourceShape: [Int],
+        targetShape: [Int]
+    ) -> Bool {
+        sourceKey == "diffusion_model.patch_embedding.diff"
+            && sourceShape == [5_120, 36, 1, 2, 2]
+            && targetShape == [5_120, 80]
+    }
+
+    static func fusedWeight(
+        targetKey: String,
+        currentWeight: MLXArray,
+        down: MLXArray,
+        up: MLXArray,
+        strength: Float
+    ) throws -> MLXArray {
+        guard down.ndim == 2,
+              up.ndim == 2,
+              up.dim(1) == down.dim(0) else {
+            throw AdapterError.invalidPairShape(
+                targetKey,
+                down: down.shape,
+                up: up.shape
+            )
+        }
+        var delta = MLX.matmul(
+            up.asType(.float32) * MLXArray(strength),
+            down.asType(.float32)
+        )
+        if delta.shape != currentWeight.shape,
+           delta.T.shape == currentWeight.shape {
+            delta = delta.T
+        }
+        guard delta.shape == currentWeight.shape else {
+            throw AdapterError.targetShapeMismatch(
+                targetKey,
+                expected: currentWeight.shape,
+                actual: delta.shape
+            )
+        }
+        return (currentWeight.asType(.float32) + delta)
+            .asType(currentWeight.dtype)
+    }
+
+    static func targetBaseKey(for sourceKey: String) -> String? {
+        let prefix = "diffusion_model."
+        guard sourceKey.hasPrefix(prefix) else { return nil }
+        var components = sourceKey
+            .dropFirst(prefix.count)
+            .split(separator: ".")
+            .map(String.init)
+        guard let first = components.first else { return nil }
+
+        switch first {
+        case "blocks":
+            guard components.count >= 3 else { return nil }
+            if components.count >= 4, components[2] == "ffn" {
+                switch components[3] {
+                case "0": components[3] = "fc1"
+                case "2": components[3] = "fc2"
+                default: return nil
+                }
+            }
+        case "img_emb":
+            guard components.count == 3,
+                  components[1] == "proj",
+                  ["0", "1", "3", "4"].contains(components[2]) else {
+                return nil
+            }
+            components = ["img_emb", "layer_\(components[2])"]
+        case "text_embedding":
+            guard components.count == 2 else { return nil }
+            switch components[1] {
+            case "0": components = ["text_embedding_0"]
+            case "2": components = ["text_embedding_1"]
+            default: return nil
+            }
+        case "time_embedding":
+            guard components.count == 2 else { return nil }
+            switch components[1] {
+            case "0": components = ["time_embedding_0"]
+            case "2": components = ["time_embedding_1"]
+            default: return nil
+            }
+        case "time_projection":
+            guard components == ["time_projection", "1"] else { return nil }
+            components = ["time_projection"]
+        case "patch_embedding":
+            guard components.count == 1 else { return nil }
+            components = ["patch_embedding_proj"]
+        case "head":
+            guard components == ["head", "head"] else { return nil }
+        default:
+            return nil
+        }
+        return components.joined(separator: ".")
+    }
+
+    static func differenceTargetKey(for sourceKey: String) -> String? {
+        let suffix: String
+        let parameter: String
+        if sourceKey.hasSuffix(".diff_b") {
+            suffix = ".diff_b"
+            parameter = ".bias"
+        } else if sourceKey.hasSuffix(".diff") {
+            suffix = ".diff"
+            parameter = ".weight"
+        } else {
+            return nil
+        }
+        let sourceBaseKey = String(sourceKey.dropLast(suffix.count))
+        return targetBaseKey(for: sourceBaseKey).map { $0 + parameter }
+    }
+
+    private static func update(
+        targetKey: String,
+        value: MLXArray,
+        modulesByPath: [String: Module]
+    ) throws {
+        let components = targetKey.split(separator: ".")
+        guard components.count >= 2,
+              let parameterName = components.last else {
+            throw AdapterError.unsupportedTarget(targetKey)
+        }
+        let modulePath = components.dropLast().joined(separator: ".")
+        guard let module = modulesByPath[modulePath] else {
+            throw AdapterError.missingTargetParameter(targetKey)
+        }
+        try module.update(
+            parameters: ModuleParameters.unflattened([
+                (String(parameterName), value),
+            ]),
+            verify: .none
+        )
+    }
+}

--- a/Sources/MereRunCore/SCAIL2/SCAIL2Generator.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2Generator.swift
@@ -9,6 +9,14 @@ public enum SCAIL2GenerationError: LocalizedError, Sendable {
     case invalidFrameRate(Int)
     case invalidGuidanceScale(Float)
     case invalidScheduleShift(Float)
+    case invalidAdapterStrength(Float)
+    case invalidDistilledSchedule(
+        schedule: SCAIL2DenoisingSchedule,
+        steps: Int,
+        sampler: SCAIL2Sampler,
+        hasAdapter: Bool,
+        guidanceScale: Float
+    )
     case invalidSegment(length: Int, overlap: Int)
     case inputNotFound(URL)
     case inputDecodeFailed(URL)
@@ -31,6 +39,16 @@ public enum SCAIL2GenerationError: LocalizedError, Sendable {
             return "SCAIL-2 guidance scale must be positive; received \(scale)."
         case .invalidScheduleShift(let shift):
             return "SCAIL-2 schedule shift must be positive; received \(shift)."
+        case .invalidAdapterStrength(let strength):
+            return "SCAIL-2 distilled adapter strength must be positive and finite; received \(strength)."
+        case .invalidDistilledSchedule(
+            let schedule,
+            let steps,
+            let sampler,
+            let hasAdapter,
+            let guidanceScale
+        ):
+            return "SCAIL-2 schedule \(schedule.rawValue) requires 4 steps, Euler, a distilled adapter, and guidance <= 1; received steps=\(steps), sampler=\(sampler.rawValue), adapter=\(hasAdapter), guidance=\(guidanceScale)."
         case .invalidSegment(let length, let overlap):
             return "SCAIL-2 segment length and overlap must equal 1 modulo 4, with 0 < overlap < length; received length=\(length), overlap=\(overlap)."
         case .inputNotFound(let url):
@@ -68,6 +86,16 @@ public enum SCAIL2TailPolicy: String, Codable, CaseIterable, Hashable, Sendable 
     case padTrim = "pad-trim"
 }
 
+public enum SCAIL2Sampler: String, Codable, CaseIterable, Hashable, Sendable {
+    case unipc
+    case euler
+}
+
+public enum SCAIL2DenoisingSchedule: String, Codable, CaseIterable, Hashable, Sendable {
+    case standard
+    case lightX2VFourStep = "lightx2v-4step"
+}
+
 public struct SCAIL2GenerationOptions: Hashable, Sendable {
     public let prompt: String
     public let negativePrompt: String
@@ -82,6 +110,10 @@ public struct SCAIL2GenerationOptions: Hashable, Sendable {
     public let steps: Int
     public let guidanceScale: Float
     public let shift: Float
+    public let sampler: SCAIL2Sampler
+    public let denoisingSchedule: SCAIL2DenoisingSchedule
+    public let distilledAdapterURL: URL?
+    public let distilledAdapterStrength: Float
     public let seed: UInt64
     public let fps: Int
     public let segmentLength: Int
@@ -102,6 +134,10 @@ public struct SCAIL2GenerationOptions: Hashable, Sendable {
         steps: Int = 40,
         guidanceScale: Float = 5,
         shift: Float = 3,
+        sampler: SCAIL2Sampler = .unipc,
+        denoisingSchedule: SCAIL2DenoisingSchedule = .standard,
+        distilledAdapterURL: URL? = nil,
+        distilledAdapterStrength: Float = 1,
         seed: UInt64 = 42,
         fps: Int = 16,
         segmentLength: Int = 81,
@@ -115,6 +151,22 @@ public struct SCAIL2GenerationOptions: Hashable, Sendable {
         guard fps > 0 else { throw SCAIL2GenerationError.invalidFrameRate(fps) }
         guard guidanceScale > 0 else { throw SCAIL2GenerationError.invalidGuidanceScale(guidanceScale) }
         guard shift > 0 else { throw SCAIL2GenerationError.invalidScheduleShift(shift) }
+        guard distilledAdapterStrength > 0, distilledAdapterStrength.isFinite else {
+            throw SCAIL2GenerationError.invalidAdapterStrength(distilledAdapterStrength)
+        }
+        if denoisingSchedule == .lightX2VFourStep,
+           steps != 4
+            || sampler != .euler
+            || distilledAdapterURL == nil
+            || guidanceScale > 1 {
+            throw SCAIL2GenerationError.invalidDistilledSchedule(
+                schedule: denoisingSchedule,
+                steps: steps,
+                sampler: sampler,
+                hasAdapter: distilledAdapterURL != nil,
+                guidanceScale: guidanceScale
+            )
+        }
         guard segmentLength > 0,
               segmentOverlap > 0,
               segmentOverlap < segmentLength,
@@ -135,6 +187,10 @@ public struct SCAIL2GenerationOptions: Hashable, Sendable {
         self.steps = steps
         self.guidanceScale = guidanceScale
         self.shift = shift
+        self.sampler = sampler
+        self.denoisingSchedule = denoisingSchedule
+        self.distilledAdapterURL = distilledAdapterURL
+        self.distilledAdapterStrength = distilledAdapterStrength
         self.seed = seed
         self.fps = fps
         self.segmentLength = segmentLength
@@ -157,7 +213,8 @@ public enum SCAIL2SegmentBuilder {
         frameCount: Int,
         segmentLength: Int,
         segmentOverlap: Int,
-        temporalStride: Int = 4
+        temporalStride: Int = 4,
+        includePartialFinalSegment: Bool = false
     ) -> [Range<Int>] {
         precondition(segmentLength > 0 && segmentOverlap > 0 && segmentOverlap < segmentLength)
         precondition(temporalStride > 0)
@@ -169,8 +226,19 @@ public enum SCAIL2SegmentBuilder {
         let stride = segmentLength - segmentOverlap
         var result: [Range<Int>] = []
         var start = 0
-        while start + segmentLength <= frameCount {
-            result.append(start..<(start + segmentLength))
+        while start < frameCount {
+            let available = min(segmentLength, frameCount - start)
+            let keep = ((available - 1) / temporalStride) * temporalStride + 1
+            if keep <= 0 || (!result.isEmpty && keep <= segmentOverlap) {
+                break
+            }
+            if keep < segmentLength && !includePartialFinalSegment {
+                break
+            }
+            result.append(start..<(start + keep))
+            if keep < segmentLength {
+                break
+            }
             start += stride
         }
         return result
@@ -182,11 +250,24 @@ public enum SCAIL2SegmentBuilder {
         segmentOverlap: Int
     ) -> Int {
         guard frameCount > 0 else { return 0 }
-        guard frameCount > segmentLength else { return segmentLength }
+        func nextLegalFrameCount(_ count: Int) -> Int {
+            ((count - 1 + 3) / 4) * 4 + 1
+        }
+        guard frameCount > segmentLength else {
+            return min(segmentLength, nextLegalFrameCount(frameCount))
+        }
         let stride = segmentLength - segmentOverlap
-        let remainder = frameCount - segmentLength
-        let additionalSegments = (remainder + stride - 1) / stride
-        return segmentLength + additionalSegments * stride
+        var lastFullStart = 0
+        while lastFullStart + segmentLength < frameCount {
+            let nextStart = lastFullStart + stride
+            if nextStart + segmentLength <= frameCount {
+                lastFullStart = nextStart
+                continue
+            }
+            let finalLength = nextLegalFrameCount(frameCount - nextStart)
+            return nextStart + min(segmentLength, finalLength)
+        }
+        return frameCount
     }
 }
 
@@ -281,7 +362,8 @@ public final class SCAIL2Generator: @unchecked Sendable {
         let segments = SCAIL2SegmentBuilder.build(
             frameCount: drivingFrameURLs.count,
             segmentLength: options.segmentLength,
-            segmentOverlap: options.segmentOverlap
+            segmentOverlap: options.segmentOverlap,
+            includePartialFinalSegment: options.tailPolicy == .padTrim
         )
         guard !segments.isEmpty else {
             throw SCAIL2GenerationError.noUsableSegment(
@@ -379,6 +461,23 @@ public final class SCAIL2Generator: @unchecked Sendable {
             resources: resources,
             configuration: configuration
         )
+        if let adapterURL = options.distilledAdapterURL {
+            progressHandler?(GenerationProgress(
+                stage: .loadingLoRA,
+                stepIndex: 0,
+                totalSteps: 1
+            ))
+            try SCAIL2DistilledAdapter.apply(
+                url: adapterURL,
+                to: transformer,
+                strength: options.distilledAdapterStrength
+            )
+            progressHandler?(GenerationProgress(
+                stage: .loadingLoRA,
+                stepIndex: 1,
+                totalSteps: 1
+            ))
+        }
         let prompt = text.prompt.expandedDimensions(axis: 0)
         let negativePrompt = text.negativePrompt.expandedDimensions(axis: 0)
         let positiveConditioning = transformer.prepareConditioning(
@@ -414,8 +513,17 @@ public final class SCAIL2Generator: @unchecked Sendable {
             ]).asType(.float32)
             var latent = Self.applyCleanHistory(noise, history: historyLatent)
             eval(latent)
-            var scheduler = Wan2UniPCScheduler(steps: options.steps, shift: options.shift)
-            for (stepIndex, timestep) in scheduler.timesteps.enumerated() {
+            var uniPCScheduler = Wan2UniPCScheduler(steps: options.steps, shift: options.shift)
+            var eulerScheduler = options.denoisingSchedule == .lightX2VFourStep
+                ? Wan2FlowMatchEulerScheduler(
+                    denoisingStepList: [1_000, 750, 500, 250],
+                    shift: options.shift
+                )
+                : Wan2FlowMatchEulerScheduler(steps: options.steps, shift: options.shift)
+            let timesteps = options.sampler == .unipc
+                ? uniPCScheduler.timesteps
+                : eulerScheduler.timesteps
+            for (stepIndex, timestep) in timesteps.enumerated() {
                 try Task.checkCancellation()
                 progressHandler?(GenerationProgress(
                     stage: .denoising,
@@ -437,16 +545,29 @@ public final class SCAIL2Generator: @unchecked Sendable {
                     timestep: MLXArray(timestep),
                     mode: options.mode
                 )
-                let conditional = transformer(modelInput, conditioning: positiveConditioning)
+                let conditional = transformer(
+                    modelInput,
+                    conditioning: positiveConditioning,
+                    evaluationBlockInterval: 1
+                )
                 eval(conditional)
                 let velocity: MLXArray
                 if options.guidanceScale <= 1 {
                     velocity = conditional
                 } else {
-                    let unconditional = transformer(modelInput, conditioning: negativeConditioning)
+                    let unconditional = transformer(
+                        modelInput,
+                        conditioning: negativeConditioning,
+                        evaluationBlockInterval: 1
+                    )
                     velocity = unconditional + options.guidanceScale * (conditional - unconditional)
                 }
-                latent = scheduler.step(modelOutput: velocity, sample: latent)
+                switch options.sampler {
+                case .unipc:
+                    latent = uniPCScheduler.step(modelOutput: velocity, sample: latent)
+                case .euler:
+                    latent = eulerScheduler.step(velocity: velocity, sample: latent)
+                }
                 latent = Self.applyCleanHistory(latent, history: historyLatent)
                 eval(latent)
                 Memory.clearCache()
@@ -549,12 +670,15 @@ public final class SCAIL2Generator: @unchecked Sendable {
         guard (1...6).contains(referenceCount) else {
             throw SCAIL2GenerationError.invalidReferenceCount(referenceCount)
         }
-        let urls = [
+        var urls = [
             options.reference.imageURL,
             options.reference.maskURL,
             options.drivingVideoURL,
             options.drivingMaskVideoURL,
         ] + options.additionalReferences.flatMap { [$0.imageURL, $0.maskURL] }
+        if let distilledAdapterURL = options.distilledAdapterURL {
+            urls.append(distilledAdapterURL)
+        }
         for url in urls where !FileManager.default.fileExists(atPath: url.path) {
             throw SCAIL2GenerationError.inputNotFound(url)
         }

--- a/Sources/MereRunCore/SCAIL2/SCAIL2MaskArtifacts.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2MaskArtifacts.swift
@@ -25,6 +25,7 @@ public struct SCAIL2MaskSubjectManifest: Codable, Hashable, Sendable {
     public let id: String
     public let color: SCAIL2SubjectColor
     public let referenceImagePath: String
+    public let preparedReferenceImagePath: String
     public let referenceMaskPath: String
     public let seedFrameIndex: Int?
     public let gapRanges: [ClosedRange<Int>]
@@ -33,6 +34,7 @@ public struct SCAIL2MaskSubjectManifest: Codable, Hashable, Sendable {
         case id
         case color
         case referenceImagePath = "reference_image_path"
+        case preparedReferenceImagePath = "prepared_reference_image_path"
         case referenceMaskPath = "reference_mask_path"
         case seedFrameIndex = "seed_frame_index"
         case gapRanges = "gap_ranges"
@@ -42,6 +44,7 @@ public struct SCAIL2MaskSubjectManifest: Codable, Hashable, Sendable {
         id: String,
         color: SCAIL2SubjectColor,
         referenceImagePath: String,
+        preparedReferenceImagePath: String,
         referenceMaskPath: String,
         seedFrameIndex: Int?,
         gapRanges: [ClosedRange<Int>]
@@ -49,6 +52,7 @@ public struct SCAIL2MaskSubjectManifest: Codable, Hashable, Sendable {
         self.id = id
         self.color = color
         self.referenceImagePath = referenceImagePath
+        self.preparedReferenceImagePath = preparedReferenceImagePath
         self.referenceMaskPath = referenceMaskPath
         self.seedFrameIndex = seedFrameIndex
         self.gapRanges = gapRanges
@@ -279,7 +283,23 @@ public struct SCAIL2MaskTrackingSubject: Codable, Hashable, Sendable {
         self.id = id
         self.color = color
         self.seedFrameIndex = seedFrameIndex
-        self.frames = frames
+        self.frames = frames.map { frame in
+            SAM31TrackingFrameResult(
+                frameIndex: frame.frameIndex,
+                timestampSeconds: frame.timestampSeconds,
+                detections: frame.detections.map { detection in
+                    SAM31TrackingObjectResult(
+                        objectID: detection.objectID,
+                        label: detection.label,
+                        score: detection.score,
+                        visible: detection.visible,
+                        box: detection.box,
+                        maskAreaPixels: detection.maskAreaPixels,
+                        maskPath: nil
+                    )
+                }
+            )
+        }
     }
 }
 

--- a/Sources/MereRunCore/SCAIL2/SCAIL2MaskPlan.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2MaskPlan.swift
@@ -253,6 +253,7 @@ public struct SCAIL2MaskPlan: Codable, Hashable, Sendable {
     }
 
     public let schemaVersion: Int
+    public let mode: SCAIL2Mode
     public let drivingVideo: String
     public let inSeconds: Double?
     public let outSeconds: Double?
@@ -268,6 +269,7 @@ public struct SCAIL2MaskPlan: Codable, Hashable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
+        case mode
         case drivingVideo = "driving_video"
         case inSeconds = "in_seconds"
         case outSeconds = "out_seconds"
@@ -284,6 +286,7 @@ public struct SCAIL2MaskPlan: Codable, Hashable, Sendable {
 
     public init(
         schemaVersion: Int = 1,
+        mode: SCAIL2Mode = .animation,
         drivingVideo: String,
         inSeconds: Double? = nil,
         outSeconds: Double? = nil,
@@ -298,6 +301,7 @@ public struct SCAIL2MaskPlan: Codable, Hashable, Sendable {
         paletteTolerance: UInt8 = SCAIL2Palette.codecTolerance
     ) {
         self.schemaVersion = schemaVersion
+        self.mode = mode
         self.drivingVideo = drivingVideo
         self.inSeconds = inSeconds
         self.outSeconds = outSeconds
@@ -315,6 +319,7 @@ public struct SCAIL2MaskPlan: Codable, Hashable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        mode = try container.decodeIfPresent(SCAIL2Mode.self, forKey: .mode) ?? .animation
         drivingVideo = try container.decode(String.self, forKey: .drivingVideo)
         inSeconds = try container.decodeIfPresent(Double.self, forKey: .inSeconds)
         outSeconds = try container.decodeIfPresent(Double.self, forKey: .outSeconds)
@@ -384,12 +389,15 @@ public struct SCAIL2MaskPlan: Codable, Hashable, Sendable {
     public func resolvingPaths(relativeTo planURL: URL) -> Self {
         let baseURL = planURL.deletingLastPathComponent()
         func resolve(_ path: String) -> String {
-            let url = URL(fileURLWithPath: path)
-            return (url.path.hasPrefix("/") ? url : baseURL.appendingPathComponent(path))
+            let url = path.hasPrefix("/")
+                ? URL(fileURLWithPath: path)
+                : baseURL.appendingPathComponent(path)
+            return url
                 .standardizedFileURL.path
         }
         return Self(
             schemaVersion: schemaVersion,
+            mode: mode,
             drivingVideo: resolve(drivingVideo),
             inSeconds: inSeconds,
             outSeconds: outSeconds,

--- a/Sources/MereRunCore/SCAIL2/SCAIL2MaskPreparer.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2MaskPreparer.swift
@@ -439,7 +439,7 @@ public final class SCAIL2MaskPreparer: @unchecked Sendable {
                     id: $0.subject.id,
                     color: $0.subject.color,
                     seedFrameIndex: $0.base.objects.first?.seedFrameIndex,
-                    frames: $0.base.frames
+                    frames: effectiveTrackingFrames(for: $0, frameCount: drivingFrames.count)
                 )
             }
         )
@@ -471,6 +471,7 @@ public final class SCAIL2MaskPreparer: @unchecked Sendable {
                 id: reference.id,
                 color: reference.color,
                 referenceImagePath: reference.referenceImagePath,
+                preparedReferenceImagePath: reference.preparedReferenceImagePath,
                 referenceMaskPath: reference.referenceMaskPath,
                 seedFrameIndex: seed,
                 gapRanges: contiguousRanges(gapsBySubject[reference.id] ?? [])
@@ -619,25 +620,38 @@ public final class SCAIL2MaskPreparer: @unchecked Sendable {
                 height: referenceImage.height,
                 allowEmpty: false
             )
-            let palette = try SCAIL2Palette.compose(
-                width: referenceImage.width,
-                height: referenceImage.height,
-                subjectMasks: [(subject.color, binary)]
-            ).image
+            let prepared = try Self.preparedReference(
+                image: referenceImage,
+                binaryMask: binary,
+                color: subject.color,
+                width: plan.width,
+                height: plan.height,
+                mode: plan.mode
+            )
+            let preparedImageURL = outputDirectoryURL
+                .appendingPathComponent("reference-\(subject.id)-prepared.png")
             let maskURL = outputDirectoryURL
                 .appendingPathComponent("reference-\(subject.id)-mask.png")
             let overlayURL = outputDirectoryURL
                 .appendingPathComponent("reference-\(subject.id)-overlay.png")
-            try MediaImageIO.writePNG(palette, to: maskURL)
-            let overlay = try SCAIL2Palette.overlay(image: referenceImage, paletteMask: palette)
+            try MediaImageIO.writePNG(prepared.image, to: preparedImageURL)
+            try MediaImageIO.writePNG(prepared.paletteMask, to: maskURL)
+            let overlay = try SCAIL2Palette.overlay(
+                image: prepared.image,
+                paletteMask: prepared.paletteMask
+            )
             try MediaImageIO.writePNG(overlay, to: overlayURL)
             overlays.append(overlay)
-            artifactURLs.append(contentsOf: [maskURL, overlayURL])
+            artifactURLs.append(contentsOf: [preparedImageURL, maskURL, overlayURL])
             manifests.append(
                 SCAIL2MaskSubjectManifest(
                     id: subject.id,
                     color: subject.color,
                     referenceImagePath: subject.referenceImage,
+                    preparedReferenceImagePath: relativePath(
+                        preparedImageURL,
+                        to: outputDirectoryURL
+                    ),
                     referenceMaskPath: relativePath(maskURL, to: outputDirectoryURL),
                     seedFrameIndex: nil,
                     gapRanges: []
@@ -645,6 +659,74 @@ public final class SCAIL2MaskPreparer: @unchecked Sendable {
             )
         }
         return (manifests, overlays, artifactURLs)
+    }
+
+    static func preparedReference(
+        image: MediaImage,
+        binaryMask: [UInt8],
+        color: SCAIL2SubjectColor,
+        width: Int,
+        height: Int,
+        mode: SCAIL2Mode
+    ) throws -> (image: MediaImage, paletteMask: MediaImage) {
+        guard binaryMask.count == image.width * image.height else {
+            throw SCAIL2PaletteError.dimensionMismatch(
+                expectedWidth: image.width,
+                expectedHeight: image.height,
+                actualWidth: binaryMask.count,
+                actualHeight: 1
+            )
+        }
+        let scale = min(
+            Double(width) / Double(image.width),
+            Double(height) / Double(image.height)
+        )
+        let scaledWidth = min(width, max(1, Int((Double(image.width) * scale).rounded())))
+        let scaledHeight = min(height, max(1, Int((Double(image.height) * scale).rounded())))
+        let originX = (width - scaledWidth) / 2
+        let originY = (height - scaledHeight) / 2
+        var preparedRGBA = [UInt8](repeating: 0, count: width * height * 4)
+        var paletteRGBA = [UInt8](repeating: 255, count: width * height * 4)
+        let subjectRGBA = color.rgba8
+
+        for pixelIndex in 0..<(width * height) {
+            preparedRGBA[(pixelIndex * 4) + 3] = 255
+            paletteRGBA[(pixelIndex * 4) + 3] = 255
+        }
+
+        for targetY in 0..<scaledHeight {
+            let sourceY = min(
+                image.height - 1,
+                Int((Double(targetY) + 0.5) * Double(image.height) / Double(scaledHeight))
+            )
+            for targetX in 0..<scaledWidth {
+                let sourceX = min(
+                    image.width - 1,
+                    Int((Double(targetX) + 0.5) * Double(image.width) / Double(scaledWidth))
+                )
+                let sourcePixel = (sourceY * image.width) + sourceX
+                let destinationPixel = ((targetY + originY) * width) + targetX + originX
+                let source = sourcePixel * 4
+                let destination = destinationPixel * 4
+                let selected = binaryMask[sourcePixel] != 0
+                if mode == .animation || selected {
+                    preparedRGBA[destination] = image.rgba8[source]
+                    preparedRGBA[destination + 1] = image.rgba8[source + 1]
+                    preparedRGBA[destination + 2] = image.rgba8[source + 2]
+                    preparedRGBA[destination + 3] = image.rgba8[source + 3]
+                }
+                if selected {
+                    paletteRGBA[destination] = subjectRGBA.0
+                    paletteRGBA[destination + 1] = subjectRGBA.1
+                    paletteRGBA[destination + 2] = subjectRGBA.2
+                    paletteRGBA[destination + 3] = subjectRGBA.3
+                }
+            }
+        }
+        return (
+            try MediaImage(width: width, height: height, rgba8: preparedRGBA),
+            try MediaImage(width: width, height: height, rgba8: paletteRGBA)
+        )
     }
 
     private func track(
@@ -781,6 +863,20 @@ public final class SCAIL2MaskPreparer: @unchecked Sendable {
             detection.score,
             maskGeometry(mask, width: width, height: height)
         )
+    }
+
+    private func effectiveTrackingFrames(
+        for track: SubjectTrack,
+        frameCount: Int
+    ) -> [SAM31TrackingFrameResult] {
+        (0..<frameCount).compactMap { frameIndex in
+            let correctionIndex = Self.correctionIndex(
+                for: frameIndex,
+                corrections: track.corrections.map(\.correction)
+            )
+            let run = correctionIndex.map { track.corrections[$0].run } ?? track.base
+            return run.frames.first { $0.frameIndex == frameIndex }
+        }
     }
 
     private func loadBinaryMask(

--- a/Sources/MereRunCore/SCAIL2/SCAIL2Palette.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2Palette.swift
@@ -134,13 +134,23 @@ public enum SCAIL2Palette {
                 rgba[offset + 3] = hiddenBackgroundRGBA.3
                 continue
             }
-            let distances = legal.map { entry -> Int in
+            var selected = 0
+            var minimum = Int.max
+            var nextMinimum = Int.max
+            for (index, entry) in legal.enumerated() {
                 let dr = Int(red) - Int(entry.rgba.0)
                 let dg = Int(green) - Int(entry.rgba.1)
                 let db = Int(blue) - Int(entry.rgba.2)
-                return max(abs(dr), max(abs(dg), abs(db)))
+                let distance = max(abs(dr), max(abs(dg), abs(db)))
+                if distance < minimum {
+                    nextMinimum = minimum
+                    minimum = distance
+                    selected = index
+                } else if distance < nextMinimum {
+                    nextMinimum = distance
+                }
             }
-            guard let minimum = distances.min(), minimum <= Int(tolerance) else {
+            guard minimum <= Int(tolerance) else {
                 throw SCAIL2PaletteError.colorOutsideTolerance(
                     red: red,
                     green: green,
@@ -148,13 +158,6 @@ public enum SCAIL2Palette {
                     tolerance: tolerance
                 )
             }
-            guard let selected = distances.firstIndex(of: minimum) else {
-                throw SCAIL2PaletteError.ambiguousColor(red: red, green: green, blue: blue)
-            }
-            let nextMinimum = distances.enumerated()
-                .filter { $0.offset != selected }
-                .map(\.element)
-                .min() ?? Int.max
             guard nextMinimum - minimum >= minimumPaletteSeparation else {
                 throw SCAIL2PaletteError.ambiguousColor(red: red, green: green, blue: blue)
             }

--- a/Sources/MereRunCore/SCAIL2/SCAIL2Transformer.swift
+++ b/Sources/MereRunCore/SCAIL2/SCAIL2Transformer.swift
@@ -277,6 +277,13 @@ enum SCAIL2RoPE {
 }
 
 final class SCAIL2SelfAttention: Module {
+    // An 81-frame 480p SCAIL window produces roughly 40k tokens. Evaluating
+    // that entire query axis in one Metal command can exceed the macOS GPU
+    // watchdog. Query slicing is exact because every slice still attends to
+    // the complete key/value sequence.
+    static let maximumQueryTokensPerKernel = 1_024
+    static let maximumKernelsPerEvaluation = 1
+
     let heads: Int
     let headDimension: Int
     let scale: Float
@@ -314,14 +321,62 @@ final class SCAIL2SelfAttention: Module {
         let v = value(typed).reshaped(batch, sequence, heads, headDimension).transposed(0, 2, 1, 3)
         q = SCAIL2RoPE.apply(q, cache: rope).transposed(0, 2, 1, 3)
         k = SCAIL2RoPE.apply(k, cache: rope).transposed(0, 2, 1, 3)
-        let attended = MLXFast.scaledDotProductAttention(
+        let attended = Self.scaledDotProductAttention(
             queries: q,
             keys: k,
             values: v,
             scale: scale,
-            mask: .none
+            maximumQueryTokens: Self.maximumQueryTokensPerKernel,
+            maximumKernelsPerEvaluation: Self.maximumKernelsPerEvaluation
         )
         return output(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, heads * headDimension))
+    }
+
+    static func scaledDotProductAttention(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        scale: Float,
+        maximumQueryTokens: Int?,
+        maximumKernelsPerEvaluation: Int = 1
+    ) -> MLXArray {
+        guard let maximumQueryTokens,
+              maximumQueryTokens > 0,
+              queries.dim(2) > maximumQueryTokens else {
+            return MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+        }
+
+        precondition(maximumKernelsPerEvaluation > 0)
+        var outputs: [MLXArray] = []
+        outputs.reserveCapacity((queries.dim(2) + maximumQueryTokens - 1) / maximumQueryTokens)
+        var pending: [MLXArray] = []
+        pending.reserveCapacity(maximumKernelsPerEvaluation)
+        for start in stride(from: 0, to: queries.dim(2), by: maximumQueryTokens) {
+            let end = min(start + maximumQueryTokens, queries.dim(2))
+            let output = MLXFast.scaledDotProductAttention(
+                queries: queries[0..., 0..., start..<end, 0...],
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+            outputs.append(output)
+            pending.append(output)
+            if pending.count == maximumKernelsPerEvaluation {
+                eval(pending)
+                pending.removeAll(keepingCapacity: true)
+            }
+        }
+        if !pending.isEmpty {
+            eval(pending)
+        }
+        return MLX.concatenated(outputs, axis: 2)
     }
 }
 
@@ -676,10 +731,12 @@ public final class SCAIL2TransformerModel: Module {
 
     public func callAsFunction(
         _ input: SCAIL2TransformerInput,
-        conditioning: SCAIL2PreparedConditioning
+        conditioning: SCAIL2PreparedConditioning,
+        evaluationBlockInterval: Int? = nil
     ) -> MLXArray {
         validate(input)
         precondition(conditioning.crossAttentionCaches.count == blocks.count)
+        precondition(evaluationBlockInterval.map { $0 > 0 } ?? true)
         let assembled = assembleTokens(input)
         var hidden = assembled.tokens
         let timestep = input.timestep.ndim == 0 ? input.timestep.reshaped(1) : input.timestep
@@ -696,7 +753,8 @@ public final class SCAIL2TransformerModel: Module {
             poseWidthShift: configuration.poseWidthShift,
             replacementReferenceHeightShift: configuration.replacementReferenceHeightShift
         )
-        for (block, crossCache) in zip(blocks, conditioning.crossAttentionCaches) {
+        for (index, pair) in zip(blocks, conditioning.crossAttentionCaches).enumerated() {
+            let (block, crossCache) = pair
             hidden = block(
                 hidden,
                 modulationInput: modulation,
@@ -705,6 +763,11 @@ public final class SCAIL2TransformerModel: Module {
                 rope: rope,
                 crossCache: crossCache
             )
+            if let evaluationBlockInterval,
+               (index + 1).isMultiple(of: evaluationBlockInterval) {
+                eval(hidden)
+                Memory.clearCache()
+            }
         }
         let patches = outputHead(hidden, timestepEmbedding: timestepEmbedding)
         return unpatchifyVideo(

--- a/Sources/MereRunCore/Wan2/Wan2Generation.swift
+++ b/Sources/MereRunCore/Wan2/Wan2Generation.swift
@@ -116,6 +116,27 @@ public struct Wan2FlowMatchEulerScheduler: Sendable {
         self.timesteps = shifted.dropLast().map { $0 * Float(trainTimesteps) }
     }
 
+    public init(
+        denoisingStepList: [Int],
+        shift: Float = 5,
+        trainTimesteps: Int = 1_000
+    ) {
+        precondition(!denoisingStepList.isEmpty)
+        precondition(trainTimesteps > 1)
+        precondition(shift > 0)
+        precondition(denoisingStepList.allSatisfy { (1...trainTimesteps).contains($0) })
+        precondition(zip(
+            denoisingStepList,
+            denoisingStepList.dropFirst()
+        ).allSatisfy { $0.0 > $0.1 })
+        let scheduled = denoisingStepList.map { trainingStep -> Float in
+            let sigma = Float(trainingStep) / Float(trainTimesteps)
+            return shift * sigma / (1 + (shift - 1) * sigma)
+        }
+        self.sigmas = scheduled + [0]
+        self.timesteps = scheduled.map { $0 * Float(trainTimesteps) }
+    }
+
     public mutating func step(velocity: MLXArray, sample: MLXArray) -> MLXArray {
         precondition(stepIndex < timesteps.count)
         let delta = sigmas[stepIndex + 1] - sigmas[stepIndex]

--- a/Tests/MereRunCLITests/AdapterCommandTests.swift
+++ b/Tests/MereRunCLITests/AdapterCommandTests.swift
@@ -18,6 +18,14 @@ struct AdapterCommandTests {
         #expect(command.quiet)
     }
 
+    @Test("SCAIL-2 distilled adapter pull parses its canonical id")
+    func parsesSCAIL2Pull() throws {
+        let command = try AdapterPull.parse([
+            ManagedAdapterCatalog.scail2LightX2VFourStepID,
+        ])
+        #expect(command.target == ManagedAdapterCatalog.scail2LightX2VFourStepID)
+    }
+
     @Test("Local LoRA paths remain supported")
     func resolvesLocalPath() throws {
         let relative = "fixtures/local-adapter.safetensors"

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -35,11 +35,15 @@ final class VideoCommandTests: XCTestCase {
 
         XCTAssertEqual(command.model, SCAIL2Resources.modelID)
         XCTAssertEqual(command.mode, .animation)
+        XCTAssertEqual(command.profile, .quality)
         XCTAssertEqual(command.width, 896)
         XCTAssertEqual(command.height, 512)
         XCTAssertEqual(command.steps, 40)
         XCTAssertEqual(command.guidanceScale, 5)
         XCTAssertEqual(command.shift, 3)
+        XCTAssertEqual(command.sampler, .unipc)
+        XCTAssertNil(command.distilledAdapter)
+        XCTAssertEqual(command.distilledAdapterStrength, 1)
         XCTAssertEqual(command.fps, 16)
         XCTAssertEqual(command.segmentLength, 81)
         XCTAssertEqual(command.segmentOverlap, 5)
@@ -62,6 +66,52 @@ final class VideoCommandTests: XCTestCase {
 
         XCTAssertEqual(command.tailPolicy, .padTrim)
         XCTAssertEqual(command.audioSource, .driving)
+    }
+
+    func testVideoAnimateParsesDistilledFastRecipe() throws {
+        let command = try VideoAnimate.parse([
+            "a dancer turns",
+            "--reference", "/tmp/ref.png",
+            "--reference-mask", "/tmp/ref-mask.png",
+            "--driving-video", "/tmp/pose.mp4",
+            "--driving-mask", "/tmp/pose-mask.mov",
+            "--steps", "6",
+            "--guidance-scale", "1",
+            "--shift", "5",
+            "--sampler", "euler",
+            "--distilled-adapter", "/tmp/lightx2v.safetensors",
+            "--distilled-adapter-strength", "0.8",
+        ])
+
+        XCTAssertEqual(command.steps, 6)
+        XCTAssertEqual(command.guidanceScale, 1)
+        XCTAssertEqual(command.shift, 5)
+        XCTAssertEqual(command.sampler, .euler)
+        XCTAssertEqual(command.distilledAdapter, "/tmp/lightx2v.safetensors")
+        XCTAssertEqual(command.distilledAdapterStrength, 0.8)
+    }
+
+    func testVideoAnimateFastProfileUsesPinnedManagedRecipe() throws {
+        let command = try VideoAnimate.parse([
+            "a dancer turns",
+            "--reference", "/tmp/ref.png",
+            "--reference-mask", "/tmp/ref-mask.png",
+            "--driving-video", "/tmp/pose.mp4",
+            "--driving-mask", "/tmp/pose-mask.mov",
+            "--profile", "fast",
+            "--distilled-adapter", "/tmp/lightx2v.safetensors",
+        ])
+
+        XCTAssertEqual(command.profile, .fast)
+        let options = try command.makeOptions(
+            prompt: command.prompt,
+            outputURL: URL(fileURLWithPath: "/tmp/result.mp4")
+        )
+        XCTAssertEqual(options.steps, 4)
+        XCTAssertEqual(options.guidanceScale, 1)
+        XCTAssertEqual(options.shift, 5)
+        XCTAssertEqual(options.sampler, .euler)
+        XCTAssertEqual(options.denoisingSchedule, .lightX2VFourStep)
     }
 
     func testVideoPrepareMasksParsesPreviewAndJSON() throws {

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -35,13 +35,13 @@ final class VideoCommandTests: XCTestCase {
 
         XCTAssertEqual(command.model, SCAIL2Resources.modelID)
         XCTAssertEqual(command.mode, .animation)
-        XCTAssertEqual(command.profile, .quality)
-        XCTAssertEqual(command.width, 896)
-        XCTAssertEqual(command.height, 512)
-        XCTAssertEqual(command.steps, 40)
-        XCTAssertEqual(command.guidanceScale, 5)
-        XCTAssertEqual(command.shift, 3)
-        XCTAssertEqual(command.sampler, .unipc)
+        XCTAssertEqual(command.profile, .fast)
+        XCTAssertEqual(command.width, 832)
+        XCTAssertEqual(command.height, 480)
+        XCTAssertNil(command.steps)
+        XCTAssertNil(command.guidanceScale)
+        XCTAssertNil(command.shift)
+        XCTAssertNil(command.sampler)
         XCTAssertNil(command.distilledAdapter)
         XCTAssertEqual(command.distilledAdapterStrength, 1)
         XCTAssertEqual(command.fps, 16)
@@ -51,6 +51,42 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(command.audioSource, .none)
         XCTAssertEqual(command.additionalReferences, ["/tmp/ref-2.png"])
         XCTAssertEqual(command.additionalReferenceMasks, ["/tmp/ref-mask-2.png"])
+
+        var effectiveCommand = command
+        effectiveCommand.distilledAdapter = "/tmp/lightx2v.safetensors"
+        let options = try effectiveCommand.makeOptions(
+            prompt: effectiveCommand.prompt,
+            outputURL: URL(fileURLWithPath: "/tmp/result.mp4")
+        )
+        XCTAssertEqual(options.steps, 4)
+        XCTAssertEqual(options.guidanceScale, 1)
+        XCTAssertEqual(options.shift, 5)
+        XCTAssertEqual(options.sampler, .euler)
+        XCTAssertEqual(options.denoisingSchedule, .lightX2VFourStep)
+        XCTAssertEqual(options.distilledAdapterURL?.path, "/tmp/lightx2v.safetensors")
+    }
+
+    func testVideoAnimateQualityProfileRemainsExplicitlyAvailable() throws {
+        let command = try VideoAnimate.parse([
+            "a dancer turns",
+            "--reference", "/tmp/ref.png",
+            "--reference-mask", "/tmp/ref-mask.png",
+            "--driving-video", "/tmp/pose.mp4",
+            "--driving-mask", "/tmp/pose-mask.mov",
+            "--profile", "quality",
+        ])
+
+        let options = try command.makeOptions(
+            prompt: command.prompt,
+            outputURL: URL(fileURLWithPath: "/tmp/result.mp4")
+        )
+        XCTAssertEqual(command.profile, .quality)
+        XCTAssertEqual(options.steps, 40)
+        XCTAssertEqual(options.guidanceScale, 5)
+        XCTAssertEqual(options.shift, 3)
+        XCTAssertEqual(options.sampler, .unipc)
+        XCTAssertEqual(options.denoisingSchedule, .standard)
+        XCTAssertNil(options.distilledAdapterURL)
     }
 
     func testVideoAnimateParsesPadTrimAndDrivingAudio() throws {

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -78,6 +78,160 @@ final class DiTShapeBenchTests: XCTestCase {
         return best
     }
 
+    /// Measures the fused SDPA dispatch used by a full upstream-equivalent
+    /// SCAIL-2 window. This is env-gated because the key/value tensors occupy
+    /// about 900 MB and the larger query sizes intentionally stress Metal's
+    /// command-buffer watchdog. Set
+    /// `MERERUN_SCAIL2_BENCH_QUERY_TOKENS=1024,2048` to isolate sizes during
+    /// watchdog qualification. `MERERUN_SCAIL2_BENCH_EVAL_BATCH=4` controls
+    /// how many kernels are submitted before each synchronization.
+    func testSCAIL2AttentionQueryChunkSizes() throws {
+        try benchGate()
+        let keyTokens = 42_510
+        let heads = 40
+        let headDimension = 128
+        let keys = MLXRandom.normal([1, heads, keyTokens, headDimension]).asType(.bfloat16)
+        let values = MLXRandom.normal([1, heads, keyTokens, headDimension]).asType(.bfloat16)
+        MLX.eval(keys, values)
+        let scale = Float(1.0 / Double(headDimension).squareRoot())
+        let configuredQueryTokens = ProcessInfo.processInfo.environment[
+            "MERERUN_SCAIL2_BENCH_QUERY_TOKENS"
+        ]?
+            .split(separator: ",")
+            .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+            .filter { $0 > 0 } ?? []
+        let queryTokenSizes = configuredQueryTokens.isEmpty
+            ? [1_024, 2_048, 4_096, 8_192]
+            : configuredQueryTokens
+        let evaluationBatchSize = max(
+            1,
+            Int(ProcessInfo.processInfo.environment["MERERUN_SCAIL2_BENCH_EVAL_BATCH"] ?? "") ?? 1
+        )
+        let clearCacheAfterChunk = ProcessInfo.processInfo.environment[
+            "MERERUN_SCAIL2_BENCH_CLEAR_CACHE"
+        ] == "1"
+
+        for queryTokens in queryTokenSizes {
+            let queries = MLXRandom.normal([1, heads, queryTokens, headDimension]).asType(.bfloat16)
+            MLX.eval(queries)
+            let start = CFAbsoluteTimeGetCurrent()
+            let output = MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+            MLX.eval(output)
+            print(
+                String(
+                    format: "[dit-bench] SCAIL-2 SDPA q=%d k=%d %.3f ms",
+                    queryTokens,
+                    keyTokens,
+                    (CFAbsoluteTimeGetCurrent() - start) * 1_000
+                )
+            )
+            Memory.clearCache()
+        }
+
+        let fullQueries = MLXRandom.normal([1, heads, keyTokens, headDimension]).asType(.bfloat16)
+        MLX.eval(fullQueries)
+        let fullStart = CFAbsoluteTimeGetCurrent()
+        let chunkSize = configuredQueryTokens.first ?? 2_048
+        let fullOutput: MLXArray
+        if clearCacheAfterChunk {
+            var chunks: [MLXArray] = []
+            for start in stride(from: 0, to: keyTokens, by: chunkSize) {
+                let end = min(start + chunkSize, keyTokens)
+                let chunk = MLXFast.scaledDotProductAttention(
+                    queries: fullQueries[0..., 0..., start..<end, 0...],
+                    keys: keys,
+                    values: values,
+                    scale: scale,
+                    mask: .none
+                )
+                MLX.eval(chunk)
+                Memory.clearCache()
+                chunks.append(chunk)
+            }
+            fullOutput = MLX.concatenated(chunks, axis: 2)
+        } else {
+            fullOutput = SCAIL2SelfAttention.scaledDotProductAttention(
+                queries: fullQueries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                maximumQueryTokens: chunkSize,
+                maximumKernelsPerEvaluation: evaluationBatchSize
+            )
+        }
+        MLX.eval(fullOutput)
+        print(
+            String(
+                format: "[dit-bench] SCAIL-2 full q=%d k=%d chunk=%d eval-batch=%d clear=%d %.3f ms",
+                keyTokens,
+                keyTokens,
+                chunkSize,
+                evaluationBatchSize,
+                clearCacheAfterChunk ? 1 : 0,
+                (CFAbsoluteTimeGetCurrent() - fullStart) * 1_000
+            )
+        )
+    }
+
+    /// Compares dense and affine 4-bit projection throughput at the exact
+    /// token and channel sizes of an 832x480 SCAIL-2 window.
+    func testSCAIL2ProjectionShapes() throws {
+        try benchGate()
+        let tokens = 42_510
+        let hidden = 5_120
+        let feedForward = 13_824
+        let input = MLXRandom.normal([1, tokens, hidden]).asType(.bfloat16)
+        MLX.eval(input)
+
+        func measure(_ label: String, _ body: () -> MLXArray) {
+            MLX.eval(body())
+            var best = Double.greatestFiniteMagnitude
+            for _ in 0..<3 {
+                let start = CFAbsoluteTimeGetCurrent()
+                MLX.eval(body())
+                best = min(best, CFAbsoluteTimeGetCurrent() - start)
+            }
+            print(String(format: "[dit-bench] SCAIL-2 %@ %.3f ms", label, best * 1_000))
+            Memory.clearCache()
+        }
+
+        let denseSquare = Linear(hidden, hidden, bias: true)
+        denseSquare.update(parameters: denseSquare.parameters().mapValues { $0.asType(.bfloat16) })
+        MLX.eval(denseSquare.parameters())
+        measure("bf16 \(hidden)->\(hidden)") { denseSquare(input) }
+
+        let quantizedSquare = QuantizedLinear(
+            hidden,
+            hidden,
+            bias: true,
+            groupSize: 64,
+            bits: 4
+        )
+        MLX.eval(quantizedSquare.parameters())
+        measure("q4-g64 \(hidden)->\(hidden)") { quantizedSquare(input) }
+
+        let denseUp = Linear(hidden, feedForward, bias: true)
+        denseUp.update(parameters: denseUp.parameters().mapValues { $0.asType(.bfloat16) })
+        MLX.eval(denseUp.parameters())
+        measure("bf16 \(hidden)->\(feedForward)") { denseUp(input) }
+
+        let quantizedUp = QuantizedLinear(
+            hidden,
+            feedForward,
+            bias: true,
+            groupSize: 64,
+            bits: 4
+        )
+        MLX.eval(quantizedUp.parameters())
+        measure("q4-g64 \(hidden)->\(feedForward)") { quantizedUp(input) }
+    }
+
     func testKleinNanoShapes() throws {
         try benchGate()
         // klein-nano: hidden 3072 (24 heads x 128), mlp_ratio 3, 5 double +

--- a/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
@@ -19,6 +19,24 @@ struct ManagedAdapterCatalogTests {
         #expect(spec.downloadURL.host == "releases.merekit.com")
     }
 
+    @Test("SCAIL-2 LightX2V release is an immutable remote-only pin")
+    func scail2LightX2VReleaseIsPinned() throws {
+        let spec = try #require(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.scail2LightX2VFourStepID)
+        )
+        #expect(spec.version == "27ae38da9101")
+        #expect(spec.baseModelID == SCAIL2Resources.modelID)
+        #expect(spec.format == SCAIL2DistilledAdapter.format)
+        #expect(spec.license == "Apache-2.0")
+        #expect(spec.upstreamRevision == "27ae38da91014b947dd39cc3fa78b97cd7b386dd")
+        #expect(spec.artifact.filename == "wan2.1_i2v_lora_rank64_lightx2v_4step.safetensors")
+        #expect(spec.artifact.byteCount == 739_472_104)
+        #expect(spec.artifact.sha256 == "8833bd4fd7c8eabebf0bc8ee5cfaf47f4f310ce116928a02c1adf8941dd4b0f1")
+        #expect(spec.downloadURL.scheme == "https")
+        #expect(spec.downloadURL.host == "huggingface.co")
+        #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
+    }
+
     @Test("Catalog ids resolve case-insensitively")
     func normalizedLookup() {
         #expect(ManagedAdapterCatalog.spec(for: " MERE-PLATFORM-ASSISTANT ")?.version == "22")

--- a/Tests/MereRunCoreTests/SAM31ImageSegmenterTests.swift
+++ b/Tests/MereRunCoreTests/SAM31ImageSegmenterTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MediaIO
 import MLX
 import XCTest
 @testable import MereRunCore
@@ -62,6 +63,80 @@ final class SAM31ImageSegmenterTests: MereRunCoreTestCase {
         XCTAssertEqual(detections[0].label, "a person")
         XCTAssertGreaterThan(detections[0].score, 0.5)
         XCTAssertGreaterThan(detections[0].maskAreaPixels, 0)
+    }
+
+    func testBinaryMaskPromptAcceptsEveryPaletteColor() throws {
+        let image = try MediaImage(
+            width: 4,
+            height: 1,
+            rgba8: [
+                0, 0, 255, 255,
+                255, 0, 0, 255,
+                0, 255, 0, 255,
+                0, 0, 0, 255,
+            ]
+        )
+
+        XCTAssertEqual(
+            SAM31ImageSegmenter.binaryMaskPromptValues(from: image),
+            [1, 1, 1, 0]
+        )
+    }
+
+    func testDenseMaskPromptIncludesTheUpstreamNotAPointToken() {
+        let encoder = SAM31InteractivePromptEncoder(
+            config: SAM31PromptEncoderConfig(
+                hiddenSize: 8,
+                imageSize: 8,
+                patchSize: 4,
+                maskInputChannels: 4
+            )
+        )
+        let output = encoder(
+            masks: MLX.ones([1, 8, 8, 1], dtype: .float32),
+            targetHeight: 2,
+            targetWidth: 2
+        )
+
+        XCTAssertEqual(output.sparseEmbeddings.shape, [1, 1, 8])
+        XCTAssertEqual(output.denseEmbeddings.shape, [1, 4, 8])
+    }
+
+    func testSmallEnclosedMaskHolesAreFilledWithoutClosingBackground() {
+        let mask: [UInt8] = [
+            0, 0, 0, 0, 0,
+            0, 1, 1, 1, 0,
+            0, 1, 0, 1, 0,
+            0, 1, 1, 1, 0,
+            0, 0, 0, 0, 0,
+        ]
+
+        let filled = SAM31ImageSegmenter.fillSmallHoles(
+            binaryMask: mask,
+            width: 5,
+            height: 5,
+            maximumArea: 1
+        )
+
+        XCTAssertEqual(filled[12], 1)
+        XCTAssertEqual(filled[0], 0)
+    }
+
+    func testInteractiveDecoderMLPCheckpointKeysMapToNativeLayers() {
+        let prefix = "tracker_model.interactive_sam_mask_decoder.output_hypernetworks_mlps.2"
+
+        XCTAssertEqual(
+            SAM31ImageSegmenter.mapCheckpointKey("\(prefix).proj_in.weight"),
+            "\(prefix).layer1.weight"
+        )
+        XCTAssertEqual(
+            SAM31ImageSegmenter.mapCheckpointKey("\(prefix).layers.0.bias"),
+            "\(prefix).layer2.bias"
+        )
+        XCTAssertEqual(
+            SAM31ImageSegmenter.mapCheckpointKey("\(prefix).proj_out.weight"),
+            "\(prefix).layer3.weight"
+        )
     }
 
     func testJSONMetadataEncodesExpectedShape() throws {

--- a/Tests/MereRunCoreTests/SAM31VideoTrackerTests.swift
+++ b/Tests/MereRunCoreTests/SAM31VideoTrackerTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import MereRunCore
+
+final class SAM31VideoTrackerTests: MereRunCoreTestCase {
+    func testFallbackRejectsCollapsedMaskArea() {
+        let box = SAM31SegmentationBox(x1: 100, y1: 50, x2: 500, y2: 450)
+        let seed = trackingResult(area: 60_000, box: box)
+        let previous = trackingResult(area: 45_000, box: box)
+        let collapsed = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 0.7,
+            box: SAM31SegmentationBox(x1: 450, y1: 100, x2: 500, y2: 430),
+            maskAreaPixels: 5_000
+        )
+
+        XCTAssertTrue(
+            SAM31VideoTracker.needsFallback(
+                detection: collapsed,
+                previousResult: previous,
+                seedResult: seed,
+                threshold: 0.05
+            )
+        )
+    }
+
+    func testFallbackAcceptsStableMaskArea() {
+        let box = SAM31SegmentationBox(x1: 100, y1: 50, x2: 500, y2: 450)
+        let seed = trackingResult(area: 60_000, box: box)
+        let previous = trackingResult(area: 50_000, box: box)
+        let stable = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 0.7,
+            box: SAM31SegmentationBox(x1: 105, y1: 55, x2: 505, y2: 455),
+            maskAreaPixels: 48_000
+        )
+
+        XCTAssertFalse(
+            SAM31VideoTracker.needsFallback(
+                detection: stable,
+                previousResult: previous,
+                seedResult: seed,
+                threshold: 0.05
+            )
+        )
+    }
+
+    func testTrackingCandidatePrefersGeometryOverBackgroundScore() throws {
+        let seedBox = SAM31SegmentationBox(x1: 286, y1: 100, x2: 646, y2: 480)
+        let seed = trackingResult(area: 59_000, box: seedBox)
+        let background = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 0.11,
+            box: SAM31SegmentationBox(x1: 0, y1: 0, x2: 832, y2: 480),
+            maskAreaPixels: 372_000,
+            candidateIndex: 0
+        )
+        let performer = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 0.10,
+            box: SAM31SegmentationBox(x1: 268, y1: 124, x2: 640, y2: 480),
+            maskAreaPixels: 61_779,
+            candidateIndex: 1
+        )
+
+        let selected = try XCTUnwrap(
+            SAM31VideoTracker.preferredTrackingDetection(
+                [background, performer],
+                previousResult: seed,
+                seedResult: seed,
+                threshold: 0.05
+            )
+        )
+
+        XCTAssertEqual(selected.candidateIndex, 1)
+    }
+
+    func testTrackingCandidatePrefersDefaultMaskWhenGeometryIsComparable() throws {
+        let box = SAM31SegmentationBox(x1: 270, y1: 90, x2: 640, y2: 480)
+        let previous = trackingResult(area: 61_000, box: box)
+        let defaultMask = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 1,
+            box: box,
+            maskAreaPixels: 62_000,
+            candidateIndex: 0
+        )
+        let alternate = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 1,
+            box: box,
+            maskAreaPixels: 61_000,
+            candidateIndex: 3
+        )
+
+        let selected = try XCTUnwrap(
+            SAM31VideoTracker.preferredTrackingDetection(
+                [alternate, defaultMask],
+                previousResult: previous,
+                seedResult: previous,
+                threshold: 0.05
+            )
+        )
+
+        XCTAssertEqual(selected.candidateIndex, 0)
+    }
+
+    func testTrackingCandidateRejectsCollapsedOnlyResultSoTheGapCanReanchor() {
+        let box = SAM31SegmentationBox(x1: 100, y1: 50, x2: 500, y2: 450)
+        let seed = trackingResult(area: 60_000, box: box)
+        let collapsed = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 0.7,
+            box: SAM31SegmentationBox(x1: 450, y1: 100, x2: 500, y2: 430),
+            maskAreaPixels: 5_000,
+            candidateIndex: 0
+        )
+
+        XCTAssertNil(
+            SAM31VideoTracker.preferredTrackingDetection(
+                [collapsed],
+                previousResult: seed,
+                seedResult: seed,
+                threshold: 0.05
+            )
+        )
+    }
+
+    func testReappearingObjectCanRecoverFromItsSeedAfterAVisibilityGap() {
+        let seedBox = SAM31SegmentationBox(x1: 100, y1: 50, x2: 300, y2: 450)
+        let seed = trackingResult(area: 48_000, box: seedBox)
+        let missing = SAM31TrackingObjectResult(
+            objectID: "performer",
+            label: "performer",
+            score: 0,
+            visible: false,
+            box: seedBox,
+            maskAreaPixels: 0
+        )
+        let reappeared = SAM31SegmentationDetection(
+            objectID: "performer",
+            label: "performer",
+            score: 0.72,
+            box: SAM31SegmentationBox(x1: 510, y1: 55, x2: 710, y2: 455),
+            maskAreaPixels: 46_000,
+            candidateIndex: 0
+        )
+
+        XCTAssertFalse(
+            SAM31VideoTracker.needsFallback(
+                detection: reappeared,
+                previousResult: missing,
+                seedResult: seed,
+                threshold: 0.05
+            )
+        )
+    }
+
+    func testMultiSubjectCandidateSelectionKeepsStableObjectIDs() throws {
+        let leftBox = SAM31SegmentationBox(x1: 40, y1: 60, x2: 260, y2: 450)
+        let rightBox = SAM31SegmentationBox(x1: 560, y1: 60, x2: 790, y2: 450)
+        let left = trackingResult(objectID: "lead", area: 52_000, box: leftBox)
+        let right = trackingResult(objectID: "partner", area: 54_000, box: rightBox)
+        let detections = [
+            SAM31SegmentationDetection(
+                objectID: "partner",
+                label: "partner",
+                score: 0.8,
+                box: rightBox,
+                maskAreaPixels: 53_000,
+                candidateIndex: 0
+            ),
+            SAM31SegmentationDetection(
+                objectID: "lead",
+                label: "lead",
+                score: 0.8,
+                box: leftBox,
+                maskAreaPixels: 51_000,
+                candidateIndex: 0
+            ),
+        ]
+
+        let selected = SAM31VideoTracker.trackingDetectionsByObjectID(
+            detections,
+            previousResultsByObject: ["lead": left, "partner": right],
+            seedResultsByObject: ["lead": left, "partner": right],
+            threshold: 0.05
+        )
+
+        XCTAssertEqual(try XCTUnwrap(selected["lead"]).objectID, "lead")
+        XCTAssertEqual(try XCTUnwrap(selected["lead"]).box, leftBox)
+        XCTAssertEqual(try XCTUnwrap(selected["partner"]).objectID, "partner")
+        XCTAssertEqual(try XCTUnwrap(selected["partner"]).box, rightBox)
+    }
+
+    private func trackingResult(
+        objectID: String = "performer",
+        area: Int,
+        box: SAM31SegmentationBox
+    ) -> SAM31TrackingObjectResult {
+        SAM31TrackingObjectResult(
+            objectID: objectID,
+            label: objectID,
+            score: 0.8,
+            visible: true,
+            box: box,
+            maskAreaPixels: area
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/SCAIL2GeneratorTests.swift
+++ b/Tests/MereRunCoreTests/SCAIL2GeneratorTests.swift
@@ -26,7 +26,15 @@ final class SCAIL2GeneratorTests: MereRunCoreTestCase {
                 segmentLength: 81,
                 segmentOverlap: 5
             ),
-            81
+            1
+        )
+        XCTAssertEqual(
+            SCAIL2SegmentBuilder.paddedFrameCount(
+                frameCount: 65,
+                segmentLength: 81,
+                segmentOverlap: 5
+            ),
+            65
         )
         XCTAssertEqual(
             SCAIL2SegmentBuilder.paddedFrameCount(
@@ -34,7 +42,7 @@ final class SCAIL2GeneratorTests: MereRunCoreTestCase {
                 segmentLength: 81,
                 segmentOverlap: 5
             ),
-            157
+            85
         )
         XCTAssertEqual(
             SCAIL2SegmentBuilder.paddedFrameCount(
@@ -43,6 +51,23 @@ final class SCAIL2GeneratorTests: MereRunCoreTestCase {
                 segmentOverlap: 5
             ),
             157
+        )
+        XCTAssertEqual(
+            SCAIL2SegmentBuilder.paddedFrameCount(
+                frameCount: 200,
+                segmentLength: 81,
+                segmentOverlap: 5
+            ),
+            201
+        )
+        XCTAssertEqual(
+            SCAIL2SegmentBuilder.build(
+                frameCount: 201,
+                segmentLength: 81,
+                segmentOverlap: 5,
+                includePartialFinalSegment: true
+            ),
+            [0..<81, 76..<157, 152..<201]
         )
     }
 

--- a/Tests/MereRunCoreTests/SCAIL2MaskPlanTests.swift
+++ b/Tests/MereRunCoreTests/SCAIL2MaskPlanTests.swift
@@ -31,12 +31,132 @@ final class SCAIL2MaskPlanTests: XCTestCase {
 
         try plan.validate()
         XCTAssertEqual(plan.schemaVersion, 1)
+        XCTAssertEqual(plan.mode, .animation)
         XCTAssertEqual(plan.subjects.count, 1)
         XCTAssertEqual(plan.subjects[0].color, .blue)
         XCTAssertEqual(plan.threshold, 0.05)
         XCTAssertEqual(plan.resolution, 1008)
         XCTAssertEqual(plan.seedFrameSearchLimit, 48)
         XCTAssertEqual(plan.paletteTolerance, SCAIL2Palette.codecTolerance)
+    }
+
+    func testDecodesReplacementPreparationMode() throws {
+        let data = Data(
+            """
+            {
+              "schema_version": 1,
+              "mode": "replacement",
+              "driving_video": "driver.mp4",
+              "width": 832,
+              "height": 480,
+              "fps": 16,
+              "subjects": [{
+                "id": "performer",
+                "color": "blue",
+                "reference_image": "reference.png",
+                "reference_selector": {"text": "the puppet"},
+                "driving_selector": {"text": "the dancer"}
+              }]
+            }
+            """.utf8
+        )
+
+        let plan = try JSONDecoder().decode(SCAIL2MaskPlan.self, from: data)
+
+        try plan.validate()
+        XCTAssertEqual(plan.mode, .replacement)
+        XCTAssertEqual(plan.width, 832)
+        XCTAssertEqual(plan.height, 480)
+    }
+
+    func testRelativeInputsResolveAgainstThePlanFile() throws {
+        let plan = SCAIL2MaskPlan(
+            mode: .replacement,
+            drivingVideo: "driver.mp4",
+            width: 832,
+            height: 480,
+            fps: 16,
+            subjects: [
+                SCAIL2MaskSubject(
+                    id: "performer",
+                    color: .blue,
+                    referenceImage: "refs/puppet.png",
+                    referenceSelector: SCAIL2MaskSelector(text: "the puppet"),
+                    drivingSelector: SCAIL2MaskSelector(text: "the dancer")
+                ),
+            ],
+            corrections: [
+                SCAIL2MaskCorrection(
+                    subjectID: "performer",
+                    frameIndex: 4,
+                    paintedBinaryCorrectionPNG: "corrections/frame-4.png"
+                ),
+            ]
+        )
+        let planURL = URL(fileURLWithPath: "/tmp/recast/request.json")
+
+        let resolved = plan.resolvingPaths(relativeTo: planURL)
+
+        XCTAssertEqual(resolved.drivingVideo, "/tmp/recast/driver.mp4")
+        XCTAssertEqual(resolved.subjects[0].referenceImage, "/tmp/recast/refs/puppet.png")
+        XCTAssertEqual(
+            resolved.corrections[0].paintedBinaryCorrectionPNG,
+            "/tmp/recast/corrections/frame-4.png"
+        )
+    }
+
+    func testReplacementReferenceIsAspectFitAndMattedToBlack() throws {
+        let source = try MediaImage(
+            width: 2,
+            height: 2,
+            rgba8: [
+                255, 0, 0, 255, 0, 255, 0, 255,
+                0, 0, 255, 255, 255, 255, 0, 255,
+            ]
+        )
+
+        let prepared = try SCAIL2MaskPreparer.preparedReference(
+            image: source,
+            binaryMask: [1, 0, 0, 1],
+            color: .blue,
+            width: 4,
+            height: 2,
+            mode: .replacement
+        )
+
+        XCTAssertEqual(prepared.image.width, 4)
+        XCTAssertEqual(prepared.image.height, 2)
+        XCTAssertEqual(pixel(prepared.image, x: 0, y: 0), [0, 0, 0, 255])
+        XCTAssertEqual(pixel(prepared.image, x: 1, y: 0), [255, 0, 0, 255])
+        XCTAssertEqual(pixel(prepared.image, x: 2, y: 0), [0, 0, 0, 255])
+        XCTAssertEqual(pixel(prepared.image, x: 2, y: 1), [255, 255, 0, 255])
+        XCTAssertEqual(pixel(prepared.paletteMask, x: 1, y: 0), [0, 0, 255, 255])
+        XCTAssertEqual(pixel(prepared.paletteMask, x: 2, y: 0), [255, 255, 255, 255])
+    }
+
+    func testAnimationReferencePreservesTheFittedScene() throws {
+        let source = try MediaImage(
+            width: 2,
+            height: 1,
+            rgba8: [
+                12, 34, 56, 255,
+                78, 90, 123, 255,
+            ]
+        )
+
+        let prepared = try SCAIL2MaskPreparer.preparedReference(
+            image: source,
+            binaryMask: [1, 0],
+            color: .red,
+            width: 2,
+            height: 1,
+            mode: .animation
+        )
+
+        XCTAssertEqual(pixel(prepared.image, x: 0, y: 0), [12, 34, 56, 255])
+        XCTAssertEqual(pixel(prepared.image, x: 1, y: 0), [78, 90, 123, 255])
+        XCTAssertEqual(pixel(prepared.paletteMask, x: 0, y: 0), [255, 0, 0, 255])
+        XCTAssertEqual(pixel(prepared.paletteMask, x: 1, y: 0), [255, 255, 255, 255])
     }
 
     func testRejectsMoreThanSixSubjects() {
@@ -63,6 +183,11 @@ final class SCAIL2MaskPlanTests: XCTestCase {
                 .invalidSubjectCount(7)
             )
         }
+    }
+
+    private func pixel(_ image: MediaImage, x: Int, y: Int) -> [UInt8] {
+        let offset = ((y * image.width) + x) * 4
+        return Array(image.rgba8[offset..<(offset + 4)])
     }
 
     func testCorrectionPropagationUsesNearestImmutableBoundary() {
@@ -215,6 +340,45 @@ final class SCAIL2MaskPlanTests: XCTestCase {
             object["model_revision"] as? String,
             "a992e302ea9b0f03f41dfd93414a4fd0e818f65b"
         )
+    }
+
+    func testDurableTrackingReportStripsTemporaryMaskPaths() throws {
+        let subject = SCAIL2MaskTrackingSubject(
+            id: "performer",
+            color: .blue,
+            seedFrameIndex: 0,
+            frames: [
+                SAM31TrackingFrameResult(
+                    frameIndex: 0,
+                    timestampSeconds: 0,
+                    detections: [
+                        SAM31TrackingObjectResult(
+                            objectID: "performer",
+                            label: "performer",
+                            score: 0.9,
+                            visible: true,
+                            box: SAM31SegmentationBox(x1: 1, y1: 2, x2: 3, y2: 4),
+                            maskAreaPixels: 42,
+                            maskPath: "/var/folders/temporary/mask.png"
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        let encoded = try JSONEncoder().encode(
+            SCAIL2MaskTrackingReport(
+                modelID: "vision-segment-sam31",
+                frameCount: 1,
+                fps: 16,
+                subjects: [subject]
+            )
+        )
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+
+        XCTAssertNil(subject.frames[0].detections[0].maskPath)
+        XCTAssertFalse(json.contains("/var/folders/temporary"))
+        XCTAssertFalse(json.contains("\"maskPath\""))
     }
 
     func testPaletteVideoRoundTripPreservesLegalLabels() throws {

--- a/Tests/MereRunCoreTests/SCAIL2TransformerTests.swift
+++ b/Tests/MereRunCoreTests/SCAIL2TransformerTests.swift
@@ -112,4 +112,181 @@ final class SCAIL2TransformerTests: MereRunCoreTestCase {
 
         XCTAssertEqual(direct.asArray(Float.self), cached.asArray(Float.self))
     }
+
+    func testBlockwiseEvaluationMatchesLazyForwardPath() {
+        let model = SCAIL2TransformerModel(configuration: configuration)
+        let input = SCAIL2TransformerInput(
+            videoLatent: MLX.zeros([16, 3, 8, 8]),
+            referenceLatent: MLX.zeros([16, 1, 8, 8]),
+            referenceMask: MLX.zeros([28, 1, 8, 8]),
+            drivingLatent: MLX.zeros([16, 3, 4, 4]),
+            drivingMask: MLX.zeros([28, 3, 4, 4]),
+            textEmbeddings: MLX.zeros([1, 4, 16]),
+            imageEmbeddings: MLX.zeros([1, 17, 8]),
+            timestep: MLXArray([500]),
+            mode: .replacement
+        )
+        let prepared = model.prepareConditioning(
+            textEmbeddings: input.textEmbeddings,
+            imageEmbeddings: input.imageEmbeddings
+        )
+        let lazy = model(input, conditioning: prepared)
+        eval(lazy)
+        let blockwise = model(
+            input,
+            conditioning: prepared,
+            evaluationBlockInterval: 1
+        )
+        eval(blockwise)
+
+        XCTAssertEqual(lazy.asArray(Float.self), blockwise.asArray(Float.self))
+    }
+
+    func testQueryChunkedAttentionMatchesFullAttention() {
+        let queries = MLXArray(
+            (0..<(1 * 2 * 6 * 4)).map { Float($0) / 100 },
+            [1, 2, 6, 4]
+        )
+        let keys = MLXArray(
+            (0..<(1 * 2 * 7 * 4)).map { Float($0) / 110 },
+            [1, 2, 7, 4]
+        )
+        let values = MLXArray(
+            (0..<(1 * 2 * 7 * 4)).map { Float($0) / 90 },
+            [1, 2, 7, 4]
+        )
+        let full = SCAIL2SelfAttention.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: 0.5,
+            maximumQueryTokens: nil
+        )
+        let chunked = SCAIL2SelfAttention.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: 0.5,
+            maximumQueryTokens: 2,
+            maximumKernelsPerEvaluation: 2
+        )
+        eval(full, chunked)
+
+        let fullValues = full.asArray(Float.self)
+        let chunkedValues = chunked.asArray(Float.self)
+        XCTAssertEqual(fullValues.count, chunkedValues.count)
+        XCTAssertLessThan(
+            zip(fullValues, chunkedValues).map { abs($0 - $1) }.max() ?? .infinity,
+            1e-5
+        )
+    }
+
+    func testDistilledAdapterMapsWanTargetsWithoutExternalRuntimeCode() {
+        XCTAssertEqual(
+            SCAIL2DistilledAdapter.targetBaseKey(
+                for: "diffusion_model.blocks.3.self_attn.q"
+            ),
+            "blocks.3.self_attn.q"
+        )
+        XCTAssertEqual(
+            SCAIL2DistilledAdapter.targetBaseKey(
+                for: "diffusion_model.blocks.7.ffn.2"
+            ),
+            "blocks.7.ffn.fc2"
+        )
+        XCTAssertEqual(
+            SCAIL2DistilledAdapter.targetBaseKey(
+                for: "diffusion_model.img_emb.proj.4"
+            ),
+            "img_emb.layer_4"
+        )
+        XCTAssertEqual(
+            SCAIL2DistilledAdapter.differenceTargetKey(
+                for: "diffusion_model.text_embedding.2.diff_b"
+            ),
+            "text_embedding_1.bias"
+        )
+        XCTAssertNil(
+            SCAIL2DistilledAdapter.targetBaseKey(
+                for: "foreign_runtime.blocks.0.self_attn.q"
+            )
+        )
+        XCTAssertTrue(
+            SCAIL2DistilledAdapter.isTaskInputProjectionDifference(
+                sourceKey: "diffusion_model.patch_embedding.diff",
+                sourceShape: [5_120, 36, 1, 2, 2],
+                targetShape: [5_120, 80]
+            )
+        )
+        XCTAssertFalse(
+            SCAIL2DistilledAdapter.isTaskInputProjectionDifference(
+                sourceKey: "diffusion_model.blocks.0.self_attn.q.diff",
+                sourceShape: [5_120, 5_120],
+                targetShape: [5_120, 5_120]
+            )
+        )
+    }
+
+    func testDistilledAdapterFusesPairsAndDifferenceParameters() throws {
+        let model = SCAIL2TransformerModel(configuration: configuration)
+        let query = model.blocks[0].selfAttention.query
+        let originalWeight = query.weight
+        let originalBias = try XCTUnwrap(query.bias)
+        eval(originalWeight, originalBias)
+        let originalWeightSnapshot = MLXArray(
+            originalWeight.asArray(Float.self),
+            originalWeight.shape
+        )
+        let originalBiasSnapshot = MLXArray(
+            originalBias.asArray(Float.self),
+            originalBias.shape
+        )
+
+        let adapterURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scail2-distilled-\(UUID().uuidString).safetensors")
+        defer { try? FileManager.default.removeItem(at: adapterURL) }
+        let down = MLX.full([2, configuration.hiddenSize], values: MLXArray(Float(0.25)))
+        let up = MLX.full([configuration.hiddenSize, 2], values: MLXArray(Float(0.5)))
+        let biasDifference = MLX.full(
+            [configuration.hiddenSize],
+            values: MLXArray(Float(0.75))
+        )
+        try MLX.save(
+            arrays: [
+                "diffusion_model.blocks.0.self_attn.q.lora_down.weight": down,
+                "diffusion_model.blocks.0.self_attn.q.lora_up.weight": up,
+                "diffusion_model.blocks.0.self_attn.q.diff_b": biasDifference,
+            ],
+            metadata: [:],
+            url: adapterURL
+        )
+
+        let result = try SCAIL2DistilledAdapter.apply(
+            url: adapterURL,
+            to: model,
+            strength: 0.5,
+            expectedPairCount: 1,
+            expectedDifferenceCount: 1
+        )
+        let fusedQuery = model.blocks[0].selfAttention.query
+        let expectedWeight = originalWeightSnapshot + MLX.full(
+            originalWeight.shape,
+            values: MLXArray(Float(0.125))
+        )
+        let expectedBias = originalBiasSnapshot + MLX.full(
+            originalBias.shape,
+            values: MLXArray(Float(0.375))
+        )
+        eval(fusedQuery.weight, fusedQuery.bias!, expectedWeight, expectedBias)
+
+        XCTAssertEqual(result, .init(pairCount: 1, differenceCount: 1))
+        XCTAssertLessThan(
+            MLX.max(MLX.abs(fusedQuery.weight - expectedWeight)).item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThan(
+            MLX.max(MLX.abs(fusedQuery.bias! - expectedBias)).item(Float.self),
+            1e-5
+        )
+    }
 }

--- a/Tests/MereRunCoreTests/Wan2GenerationTests.swift
+++ b/Tests/MereRunCoreTests/Wan2GenerationTests.swift
@@ -56,6 +56,20 @@ final class Wan2GenerationTests: MereRunCoreTestCase {
         XCTAssertEqual(scheduler.sigmas[0], 1, accuracy: 1e-6)
     }
 
+    func testLightX2VFourStepScheduleUsesPublishedTrainingIndices() {
+        let scheduler = Wan2FlowMatchEulerScheduler(
+            denoisingStepList: [1_000, 750, 500, 250],
+            shift: 5
+        )
+        XCTAssertEqual(scheduler.sigmas.count, 5)
+        XCTAssertEqual(scheduler.timesteps.count, 4)
+        XCTAssertEqual(scheduler.timesteps[0], 1_000, accuracy: 1e-5)
+        XCTAssertEqual(scheduler.timesteps[1], 937.5, accuracy: 1e-5)
+        XCTAssertEqual(scheduler.timesteps[2], 833.333_3, accuracy: 1e-4)
+        XCTAssertEqual(scheduler.timesteps[3], 625, accuracy: 1e-5)
+        XCTAssertEqual(scheduler.sigmas.last, 0)
+    }
+
     func testEulerStepUsesNextMinusCurrentSigma() {
         var scheduler = Wan2FlowMatchEulerScheduler(steps: 2, shift: 1)
         let sample = MLXArray([1, 2], [1, 2])

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1627,11 +1627,11 @@ options are `--mode animation|replacement`, `--model-root`, `--width`,
 `--segment-length`, `--segment-overlap`, and paired repeatable
 `--additional-reference` / `--additional-reference-mask`. `--tail-policy`
 accepts `drop` or `pad-trim`; `--audio-source` accepts `none` or `driving`.
-`--profile quality` is the compatibility default: 896x512, 40 UniPC steps,
-guidance 5, shift 3, 16 fps, 81-frame segments, and five clean-history overlap
-frames. `--profile fast` requires the separately pulled
-`scail2-lightx2v-4step` adapter and fixes the published no-CFG four-step Euler
-recipe with shift 5. Compatibility defaults are `drop` and `none`.
+`--profile fast` is the default: 832x480, the separately pulled
+`scail2-lightx2v-4step` adapter, and the published no-CFG four-step Euler
+recipe with shift 5. `--profile quality` explicitly selects the configurable
+40-step UniPC/CFG recipe. The segment defaults remain 81 frames with five
+clean-history overlap frames; compatibility defaults are `drop` and `none`.
 `pad-trim` preserves legal `1 mod 4` clip lengths and pads only the final
 incomplete temporal segment to the next legal length.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1627,10 +1627,13 @@ options are `--mode animation|replacement`, `--model-root`, `--width`,
 `--segment-length`, `--segment-overlap`, and paired repeatable
 `--additional-reference` / `--additional-reference-mask`. `--tail-policy`
 accepts `drop` or `pad-trim`; `--audio-source` accepts `none` or `driving`.
-Defaults match the
-official 480p recipe: 896x512, 40 UniPC steps, guidance 5, shift 3, 16 fps,
-81-frame segments, and five clean-history overlap frames. Compatibility
-defaults are `drop` and `none`.
+`--profile quality` is the compatibility default: 896x512, 40 UniPC steps,
+guidance 5, shift 3, 16 fps, 81-frame segments, and five clean-history overlap
+frames. `--profile fast` requires the separately pulled
+`scail2-lightx2v-4step` adapter and fixes the published no-CFG four-step Euler
+recipe with shift 5. Compatibility defaults are `drop` and `none`.
+`pad-trim` preserves legal `1 mod 4` clip lengths and pads only the final
+incomplete temporal segment to the next legal length.
 
 `--preflight --json` validates the MLX model root, input pairs, output, and
 execution plan without loading MLX or decoding video. The converted checkpoint
@@ -1649,14 +1652,17 @@ swift run mere.run video prepare-masks \
   [--preflight --json]
 ```
 
-Plans contain exact driver geometry/FPS/range, one to six stable subjects,
+Plans contain `mode` (`animation` or `replacement`), exact driver
+geometry/FPS/range, one to six stable subjects,
 unique legal palette colours, project-materialized reference images,
 text/box/positive/negative selectors, and optional point/box/dense painted-PNG
 keyframe corrections. Preview mode segments references plus one selected
-driving frame. Full mode tracks both directions, records gaps and quality
-warnings, and emits reference masks, a ProRes 4444 categorical driving mask,
-overlay MP4, contact sheet, tracking/quality JSON, normalized driver, and a
-canonical hashed manifest.
+driving frame. Reference preparation aspect-fits each image and its mask into
+the requested canvas; replacement mode mattes non-subject reference pixels to
+black. Full mode tracks both directions, records gaps and quality warnings, and
+emits prepared reference image/mask pairs, a ProRes 4444 categorical driving
+mask, overlay MP4, contact sheet, tracking/quality JSON, normalized driver, and
+a canonical hashed manifest.
 
 ### `mere.run video generate`
 
@@ -1986,12 +1992,15 @@ List the built-in public adapter catalog or install one immutable release:
 mere.run adapter list
 mere.run adapter list --json
 mere.run adapter pull mere-platform-assistant
+mere.run adapter pull scail2-lightx2v-4step
 ```
 
 The pull verifies the cataloged byte count and SHA-256 before atomically
 installing the adapter. Stdout contains only the installed path; progress and
 verification diagnostics go to stderr. Use the adapter id directly with
-`text chat --lora` or `api serve --lora`.
+`text chat --lora`, `api serve --lora`, or the matching SCAIL
+`video animate --distilled-adapter` option. `video animate --profile fast`
+selects `scail2-lightx2v-4step` and its fixed four-step schedule.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 sections below are the command reference for each benchmark lane.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -732,6 +732,16 @@ mere.run model pull video-scail2-14b-mlx
 An explicitly prepared compatible root can still be supplied with
 `--model-root`.
 
+The optional `scail2-lightx2v-4step` adapter is not part of that model package
+or this repository. `mere.run adapter pull` downloads only
+`wan2.1_i2v_lora_rank64_lightx2v_4step.safetensors` from
+`lightx2v/Wan2.1-Distill-Loras` at immutable revision
+`27ae38da91014b947dd39cc3fa78b97cd7b386dd`, verifies 739,472,104 bytes and
+SHA-256 `8833bd4fd7c8eabebf0bc8ee5cfaf47f4f310ce116928a02c1adf8941dd4b0f1`,
+and stores it outside git under the managed adapter directory. The upstream
+model card declares Apache-2.0. The Wan 2.2 adapters are deliberately rejected
+for SCAIL-2 because they target the incompatible Wan 2.2 MoE base.
+
 ### `video-dreamx-world-5b-ar-mlx`
 
 The native DreamX-World autoregressive checkpoint root is:

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -139,8 +139,8 @@ mere.run text chat \
 byte count and SHA-256, and prints the installed adapter path on stdout.
 Catalog ids are accepted by `text chat --lora`, `api serve --lora`, and the
 compatible SCAIL `video animate --distilled-adapter` surface; local paths
-remain supported. `video animate --profile fast` selects the SCAIL adapter ID
-and its published four-step schedule automatically.
+remain supported. The default `video animate --profile fast` selects the SCAIL
+adapter ID and its published four-step schedule automatically.
 
 ### `mere.run setup`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -121,23 +121,26 @@ Adapters use a separate checksum-pinned catalog and install under:
 ~/Library/Application Support/MereRun/adapters/<adapter-id>/<version>/
 ```
 
-The first public entry is the promoted Mere Platform Assistant v22 for the
-`text-chat-gemma4-12b-4bit` base model:
+Catalog entries include the promoted Mere Platform Assistant v22 and the
+remote-only Apache-2.0 LightX2V Wan 2.1 I2V four-step adapter:
 
 ```bash
 mere.run model pull text-chat-gemma4-12b-4bit
 mere.run adapter list
 mere.run adapter pull mere-platform-assistant
+mere.run adapter pull scail2-lightx2v-4step
 mere.run text chat \
   --model text-chat-gemma4-12b-4bit \
   --lora mere-platform-assistant \
   --prompt "What can you help me with in Mere?"
 ```
 
-`adapter pull` downloads the immutable public release, verifies its exact byte
-count and SHA-256, and prints the installed adapter path on stdout. Catalog ids
-are accepted by `text chat --lora` and `api serve --lora`; local paths remain
-supported.
+`adapter pull` downloads the immutable upstream artifact, verifies its exact
+byte count and SHA-256, and prints the installed adapter path on stdout.
+Catalog ids are accepted by `text chat --lora`, `api serve --lora`, and the
+compatible SCAIL `video animate --distilled-adapter` surface; local paths
+remain supported. `video animate --profile fast` selects the SCAIL adapter ID
+and its published four-step schedule automatically.
 
 ### `mere.run setup`
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -107,11 +107,11 @@ swift run mere.run video animate \
   --output ./animated.mp4
 ```
 
-Add `--profile fast` for the managed four-step path. It selects the pinned
+The default `--profile fast` managed four-step path selects the pinned
 `scail2-lightx2v-4step` adapter, disables classifier-free guidance, uses shift
 5, Euler updates, and the adapter's exact `1000, 750, 500, 250` training-step
-schedule. `--profile quality` remains the default and retains the configurable
-40-step UniPC/CFG recipe:
+schedule at 832x480. `--profile quality` remains available as an explicit
+opt-in to the configurable 40-step UniPC/CFG recipe:
 
 ```bash
 swift run mere.run video animate \
@@ -121,7 +121,6 @@ swift run mere.run video animate \
   --driving-video ./pose.mp4 \
   --driving-mask ./pose-mask.mp4 \
   --mode replacement \
-  --profile fast \
   --tail-policy pad-trim \
   --audio-source driving \
   --output ./recast-fast.mp4

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -37,6 +37,14 @@ swift run mere.run model pull video-scail2-14b-mlx
 swift run mere.run model pull vision-segment-sam31 --accept-model-license
 ```
 
+For interactive recast work, also pull the checksum-pinned Apache-2.0
+LightX2V Wan 2.1 I2V adapter. Adapter weights remain in the local adapter store
+and are not bundled with mere.run:
+
+```bash
+swift run mere.run adapter pull scail2-lightx2v-4step
+```
+
 Create a schema-version 1 mask plan, preview one target frame, and then prepare
 the immutable full mask revision:
 
@@ -54,11 +62,20 @@ swift run mere.run video prepare-masks \
 ```
 
 The full result contains an exact-geometry/FPS driving proxy, per-subject
-reference masks, a ProRes 4444 categorical mask video, overlay preview, contact
-sheet, tracking and quality reports, and a canonical SHA-256 manifest. The plan
+prepared reference images and masks, a ProRes 4444 categorical mask video,
+overlay preview, contact sheet, tracking and quality reports, and a canonical
+SHA-256 manifest. Set the plan's `mode` to `replacement` to aspect-fit every
+reference into the target canvas and matte all non-subject pixels to black;
+`animation` preserves the fitted reference scene. The plan
 supports one to six stable subjects, text/box/point selectors, and dense painted
 PNG corrections. White is background; legal subject colours are blue, red,
 green, magenta, cyan, and yellow.
+
+The native transformer preserves upstream global self-attention while splitting
+the query axis into independently evaluated Metal command buffers. Every query
+slice still attends to the complete key/value sequence; the split only keeps a
+full 81-frame window below the macOS GPU watchdog and does not introduce local
+or sliding-window attention.
 
 Prepared review artifacts always use white as the canonical background. During
 inference, `video animate` matches the official SCAIL-2 mask-role semantics:
@@ -72,16 +89,16 @@ After reviewing the mask artifacts, preflight and render natively:
 ```bash
 swift run mere.run video animate \
   "a dancer in a red silk dress" \
-  --reference ./ref.png \
-  --reference-mask ./ref-mask.png \
+  --reference ./reference-performer-prepared.png \
+  --reference-mask ./reference-performer-mask.png \
   --driving-video ./pose.mp4 \
   --driving-mask ./pose-mask.mp4 \
   --preflight --json
 
 swift run mere.run video animate \
   "a dancer in a red silk dress" \
-  --reference ./ref.png \
-  --reference-mask ./ref-mask.png \
+  --reference ./reference-performer-prepared.png \
+  --reference-mask ./reference-performer-mask.png \
   --driving-video ./pose.mp4 \
   --driving-mask ./pose-mask.mp4 \
   --mode animation \
@@ -90,13 +107,42 @@ swift run mere.run video animate \
   --output ./animated.mp4
 ```
 
+Add `--profile fast` for the managed four-step path. It selects the pinned
+`scail2-lightx2v-4step` adapter, disables classifier-free guidance, uses shift
+5, Euler updates, and the adapter's exact `1000, 750, 500, 250` training-step
+schedule. `--profile quality` remains the default and retains the configurable
+40-step UniPC/CFG recipe:
+
+```bash
+swift run mere.run video animate \
+  "a silver puppet follows the dancer" \
+  --reference ./reference-performer-prepared.png \
+  --reference-mask ./reference-performer-mask.png \
+  --driving-video ./pose.mp4 \
+  --driving-mask ./pose-mask.mp4 \
+  --mode replacement \
+  --profile fast \
+  --tail-policy pad-trim \
+  --audio-source driving \
+  --output ./recast-fast.mp4
+```
+
+SCAIL-2's unified motion interface has a task-specific 20-channel input
+projection, while the generic Wan 2.1 I2V adapter carries a 36-channel
+projection difference. The native fuser requires every shared transformer
+target to match exactly, applies the compatible 487 LoRA pairs and parameter
+differences, and explicitly leaves only that incompatible input-projection
+weight untouched. It does not use a general skip-mismatch mode.
+
 Decoded mask pixels are snapped to the nearest legal colour inside a strict
 tolerance, and ambiguous or out-of-tolerance pixels are rejected. The default
 long-video contract uses 81-frame segments with five decoded frames of clean
 overlap. Compatibility defaults remain `--tail-policy drop` and
-`--audio-source none`; `pad-trim` pads only the internal final window, trims the
-result to the exact requested frame count, and `driving` muxes source audio to
-that exact duration.
+`--audio-source none`; `pad-trim` keeps already legal `1 mod 4` temporal
+lengths unchanged, pads only an incomplete final segment to the next legal
+latent length, trims the result to the exact requested frame count, and
+`driving` muxes source audio to that exact duration. It never expands a legal
+65-frame clip to an unused 81-frame window.
 
 Use `--mode replacement` to place the reference subject into the driving
 scene. Pair repeatable `--additional-reference` and

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -101,6 +101,15 @@ then
   exit 1
 fi
 
+if rg -n -i -g '*.swift' \
+  -e 'python' \
+  -e 'Process *\(' \
+  Sources/MereRunCore/SCAIL2 Sources/MereRunCLI/Commands/VideoAnimateCommand.swift Sources/MereRunCLI/Commands/VideoPrepareMasksCommand.swift
+then
+  echo "Native SCAIL-2 Swift sources contain a prohibited sidecar runtime hook." >&2
+  exit 1
+fi
+
 if [[ "${MERERUN_RUN_E2E:-}" == "core" ]]; then
   ./scripts/e2e_smoke.sh --core
 elif [[ "${MERERUN_RUN_E2E:-}" == "installed" ]]; then


### PR DESCRIPTION
## Summary

- adds review-first native SAM 3.1 reference/driving mask preparation with dense correction prompts, stable tracking, palette validation, immutable manifests, previews, and quality reporting
- makes the proven native Swift/MLX four-step adapter recipe the default for `video animate`: 832x480, Euler, no CFG, shift 5, with the pinned published timestep schedule
- keeps the configurable 40-step UniPC recipe available through explicit `--profile quality`
- preserves exact pad-trim frame counts, driving audio, multi-reference ordering, and strict no-fallback behavior
- pins the optional Apache-2.0 adapter as a remote-only managed pull; no weights, upstream inference code, Python runtime, or conversion utility are committed

## Real acceptance

- official adapter revision: 27ae38da91014b947dd39cc3fa78b97cd7b386dd
- adapter SHA-256: 8833bd4fd7c8eabebf0bc8ee5cfaf47f4f310ce116928a02c1adf8941dd4b0f1
- completed native replacement render: 65 frames, 16 fps, 832x480, 4.0625 seconds, stereo driving audio
- render SHA-256: c2e30dd2d55084b3ad4529ce507c39828aaf216bb8783ac1321a5176097c97c0
- clean runtime: 1770.91 seconds, zero Metal recoveries
- matched reference/source/overlay/categorical-mask/result review confirms the puppet follows the dancer pose while preserving the scene and camera
- bare-command preflight resolves the fast profile, four-step schedule, pinned adapter, 832x480 geometry, and 81/5 window

## Validation

Completed locally on head 443be97:

- `./scripts/check.sh`
- 978 Swift files linted with zero violations
- 2,013 XCTest tests passed (127 opt-in tests skipped)
- 12 Swift Testing tests passed
- documentation contracts, CLI help sweep, agent readiness, hygiene, and provenance scans passed
