### PR TITLE
chore(release): prepare v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,71 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
-## Unreleased
+## 0.25.0 - 2026-07-21
+
+This release contains the complete `v0.24.0..v0.25.0` delta: 4 commits
+changing 78 files across native Cosmos3 Edge inference, persistent
+action-conditioned worlds, and the SCAIL-2 recast workflow.
+
+### Added
+
+- added a native Swift/MLX implementation of NVIDIA Cosmos3 Edge through
+  `video cosmos3`, covering text-to-image, image editing, text/image/video
+  generation, policy prediction, action-conditioned forward dynamics, inverse
+  dynamics, and image/video reasoning (#200).
+- added the managed `video-cosmos3-edge-mlx` model with an immutable official
+  snapshot pin, complete generation and understanding checkpoint validation,
+  published per-mode sampling defaults, and explicit OpenMDW-1.1 model-license
+  acceptance (#200).
+- added `world serve --backend cosmos3` with normalized `camera_pose`
+  trajectories, semantic camera controls, direct `model_space_actions`, warm
+  model reuse, autoregressive seed progression, pixel-stable public-frame
+  handoffs, and exact inverse traversal of cached navigation edges without
+  stochastic regeneration (#200).
+- added native Cosmos3 packed SigLIP2 vision, multimodal reasoner, tokenizer,
+  action packing for all 15 published domains, shifted-flow UniPC schedules,
+  Wan VAE loading, and generation/understanding mixture-of-transformers
+  execution (#200).
+- added independently generated Cosmos3 checkpoint inventories and numerical
+  parity fixtures against pinned NVIDIA sources. Runtime inference neither
+  vendors nor invokes upstream Python, PyTorch, or Diffusers code (#200).
+- added a checksum-pinned, remote-only Apache-2.0 LightX2V four-step adapter
+  to the managed adapter catalog for native SCAIL-2 rendering (#199).
+- added review-first SCAIL-2 recast preparation with dense painted-mask
+  corrections, replacement reference matting, stable multi-subject tracking,
+  palette validation, immutable manifests, previews, and quality reports
+  (#199).
 
 ### Changed
 
 - made the proven four-step SCAIL-2 adapter recipe the default for
   `video animate`, including its 832x480 geometry, no-CFG Euler schedule, and
   shift 5. The configurable 40-step UniPC recipe remains available through
-  explicit `--profile quality` selection.
+  explicit `--profile quality` selection (#199).
+- changed native SCAIL-2 attention execution to split the query axis across
+  independently evaluated Metal command buffers while preserving global
+  key/value attention, keeping full 81-frame windows below the macOS GPU
+  watchdog without introducing local or sliding-window attention (#199).
+- extended persistent-world session responses and transition receipts with an
+  explicit backend identity, action space/domain, and normalized model-space
+  trajectory. `raw_actions` remains a compatibility alias (#200).
+- documented the Cosmos3 model-license boundary, immutable NVIDIA source pins,
+  native implementation provenance, public CLI modes, and world-session
+  behavior in the model registry, guides, and third-party notices (#200).
+
+### Fixed
+
+- fixed SCAIL-2 reference and driving mask-role semantics for animation versus
+  replacement, including legal palette handling, dense correction encoding,
+  aspect-fit replacement references, and canonical white review backgrounds
+  (#199).
+- fixed SCAIL-2 tracking across collapsed masks and visibility gaps so objects
+  can re-anchor from their seeds without swapping stable multi-subject IDs
+  (#199).
+- fixed `video animate --preflight` on clean installations so the default
+  managed adapter is reported as a missing pinned input instead of throwing
+  before the preflight report; real renders still require checksum-verified
+  adapter installation (#200).
 
 ## 0.24.0 - 2026-07-19
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.24.0"
+    static let current = "0.25.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.24.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.25.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.24.0"
+default_version="0.25.0"
 if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- publish the complete changelog for the 4-commit, 78-file delta since v0.24.0
- document native Cosmos3 Edge inference, action-conditioned persistent worlds, and SCAIL-2 recast/runtime improvements
- bump the CLI, bundle fallback, and release-version assertion to 0.25.0
- retain 0.24.0 only where it is the intentional workflow compatibility floor

## Validation

- `./scripts/check.sh`
  - SwiftLint: 993 files, 0 violations
  - XCTest: 2,050 tests, 127 skipped, 0 failures
  - Swift Testing: 13 tests, 0 failures
- `./.build/debug/mere.run --version` -> `0.25.0`
- `git diff --check`