### PR TITLE
feat(video): separate LTX quality from output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog.
 
 ### Changed
 
+- separated LTX video checkpoint quality from output modality. `video generate`
+  now uses `--quality draft|final` and `--output-mode
+  video-only|audio-video`, defaults to fast draft video-only, and supports the
+  full dev + distilled-LoRA final pipeline without forcing an audio stream.
+  The former `--variant distilled|unified-av` selector remains compatible.
+- clarified the LTX product workflow around fast draft iteration and
+  higher-quality final renders: audio suppression controls the deliverable,
+  while checkpoint selection controls the meaningful speed/quality tradeoff.
 - refreshed the bundled DwarfStar runtime for the DeepSeek V4 Flash premier
   agent tier from upstream `be434773` to `efdadd41`, including the current
   Metal kernels, server request hardening, KV-cache fixes, and session/runtime
@@ -16,6 +24,10 @@ The format is based on Keep a Changelog.
 
 ### Fixed
 
+- fixed canonical `video-ltx23-full-mlx` inspection and validation when an
+  existing compatible install still carries the legacy
+  `video-ltx23-a2vid-mlx` manifest ID. Component reporting now uses the
+  requested full layout while retaining an explicit compatibility warning.
 - fixed bare and explicit `video generate --variant distilled` requests on
   LTX 2.3 split MLX roots. The CLI now routes those roots through the native V2
   standalone-distilled transformer, preserves the video-only MP4 contract,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ The format is based on Keep a Changelog.
   improvements while preserving the existing Mere launch and OpenAI-compatible
   API contract.
 
+### Fixed
+
+- fixed bare and explicit `video generate --variant distilled` requests on
+  LTX 2.3 split MLX roots. The CLI now routes those roots through the native V2
+  standalone-distilled transformer, preserves the video-only MP4 contract,
+  skips unnecessary audio VAE/vocoder loading and decoding, and exposes phase
+  timings without changing legacy merged distilled or unified-AV output.
+
 ## 0.25.0 - 2026-07-21
 
 This release contains every change merged since `v0.24.0` across native

--- a/README.md
+++ b/README.md
@@ -634,16 +634,12 @@ swift run mere.run sfx generate \
 # Generate a fast video-only draft
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --num-frames 65 \
   --output ./clip.mp4
 
 # Inspect the same render before loading MLX or writing an MP4
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --num-frames 65 \
   --output ./clip.mp4 \
   --preflight \
@@ -652,19 +648,25 @@ swift run mere.run video generate \
 # Anchor the first and last keyframes for directed image-to-video
 swift run mere.run video generate \
   "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --image ./car-start.png \
   --end-image ./car-end.png \
   --num-frames 65 \
   --output ./clip-directed.mp4
 
-# Generate synchronized LTX 2.3 audio/video
+# Generate final-quality video without an audio stream
+swift run mere.run model pull video-ltx23-full-mlx --accept-model-license
+swift run mere.run video generate \
+  "a red fox runs across a snowy clearing, detailed winter fur, natural motion" \
+  --quality final \
+  --duration 4 \
+  --output ./clip-final.mp4
+
+# Generate synchronized final-quality LTX 2.3 audio/video
 swift run mere.run model pull video-ltx23-full-mlx --accept-model-license
 swift run mere.run video generate \
   "dialogue with clean background music and subtle city ambience" \
-  --variant unified-av \
-  --model video-ltx23-full-mlx \
+  --quality final \
+  --output-mode audio-video \
   --duration 15 \
   --fps 24 \
   --output ./clip-av.mp4

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -238,25 +238,25 @@ struct ModelInfo: ParsableCommand {
     }
 
     static func usesLTX23SplitLayout(manifest: MereRunModelManifest?, expectedModelID: String?) -> Bool {
-        let id = manifest?.id ?? expectedModelID
+        let id = expectedModelID ?? manifest?.id
         guard let id else { return false }
         return ManagedModelCatalog.spec(for: id)?.validationKind == .ltxVideo23MLX
     }
 
     static func usesLTX23A2VidLayout(manifest: MereRunModelManifest?, expectedModelID: String?) -> Bool {
-        let id = manifest?.id ?? expectedModelID
+        let id = expectedModelID ?? manifest?.id
         guard let id else { return false }
         return ManagedModelCatalog.spec(for: id)?.validationKind == .ltxVideo23A2VMLX
     }
 
     static func usesLTX23FullLayout(manifest: MereRunModelManifest?, expectedModelID: String?) -> Bool {
-        let id = manifest?.id ?? expectedModelID
+        let id = expectedModelID ?? manifest?.id
         guard let id else { return false }
         return ManagedModelCatalog.spec(for: id)?.validationKind == .ltxVideo23FullMLX
     }
 
     static func usesLTXMergedLayout(manifest: MereRunModelManifest?, expectedModelID: String?) -> Bool {
-        let id = manifest?.id ?? expectedModelID
+        let id = expectedModelID ?? manifest?.id
         guard let id else { return false }
         return ManagedModelCatalog.spec(for: id)?.validationKind == .ltxVideo
     }

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -9,6 +9,35 @@ enum LTXVideoVariant: String, CaseIterable, ExpressibleByArgument {
     case distilled = "distilled"
 }
 
+enum LTXVideoGenerationRoute: String, Equatable {
+    case legacyDistilledVideo = "legacy-distilled-video"
+    case splitDistilledVideo = "split-distilled-video"
+    case unifiedAV = "unified-av"
+
+    var writesAudio: Bool {
+        self == .unifiedAV
+    }
+
+    var supportsPhaseTimings: Bool {
+        self != .legacyDistilledVideo
+    }
+}
+
+func resolveLTXVideoGenerationRoute(
+    variant: LTXVideoVariant,
+    modelRoot: URL,
+    fileManager: FileManager = .default
+) -> LTXVideoGenerationRoute {
+    switch variant {
+    case .unifiedAV:
+        return .unifiedAV
+    case .distilled:
+        return isLTX23SplitModelRoot(modelRoot, fileManager: fileManager)
+            ? .splitDistilledVideo
+            : .legacyDistilledVideo
+    }
+}
+
 struct Video: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "video",
@@ -235,10 +264,10 @@ struct VideoGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong("json")], help: "With --preflight, emit a structured JSON report.")
     var json: Bool = false
 
-    @Flag(name: [.customLong("timings")], help: "Print native LTX unified-AV/A2Vid phase timings to stderr.")
+    @Flag(name: [.customLong("timings")], help: "Print native LTX split-distilled/unified-AV/A2Vid phase timings to stderr.")
     var timings: Bool = false
 
-    @Option(name: [.customLong("timings-output")], help: "Write native LTX unified-AV/A2Vid phase timings as JSON.")
+    @Option(name: [.customLong("timings-output")], help: "Write native LTX split-distilled/unified-AV/A2Vid phase timings as JSON.")
     var timingsOutput: String?
 
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
@@ -271,13 +300,6 @@ struct VideoGenerate: AsyncParsableCommand {
         guard !trimmedPrompt.isEmpty else {
             throw ValidationError("Prompt cannot be empty.")
         }
-        let hasSourceAudio = audio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        if (timings || timingsOutput != nil), variant != .unifiedAV, !hasSourceAudio {
-            throw ValidationError(
-                "--timings and --timings-output require --variant unified-av or --audio."
-            )
-        }
-
         guard fps > 0 else {
             throw ValidationError("--fps must be >= 1")
         }
@@ -404,6 +426,11 @@ struct VideoGenerate: AsyncParsableCommand {
             return
         }
         if isWan2ModelRoot(resolvedRootURL) {
+            if timings || timingsOutput != nil {
+                throw ValidationError(
+                    "--timings and --timings-output are available for native LTX generation, not Wan2.2 TI2V."
+                )
+            }
             guard let sourceImageURL else {
                 throw ValidationError("Wan2.2 TI2V requires --image.")
             }
@@ -683,7 +710,13 @@ struct VideoGenerate: AsyncParsableCommand {
         outputURL: URL
     ) async throws {
         let rootURL = URL(fileURLWithPath: modelRoot).standardizedFileURL
-        if variant == .unifiedAV,
+        let route = resolveLTXVideoGenerationRoute(variant: variant, modelRoot: rootURL)
+        if (timings || timingsOutput != nil), !route.supportsPhaseTimings {
+            throw ValidationError(
+                "--timings and --timings-output require an LTX 2.3 split model, --variant unified-av, or --audio."
+            )
+        }
+        if route == .unifiedAV,
            isLTX23AudioToVideoModelRoot(rootURL),
            !isLTX23FullModelRoot(rootURL) {
             throw ValidationError(
@@ -696,12 +729,36 @@ struct VideoGenerate: AsyncParsableCommand {
         if !quiet {
             CLIStderr.write("Engine: native\n")
             CLIStderr.write("Variant: \(variant.rawValue)\n")
+            CLIStderr.write("Runtime lane: \(route.rawValue)\n")
             CLIStderr.write("Model root: \(rootURL.path)\n")
             CLIStderr.write("Mode: \(sourceImageURL == nil ? "text-to-video" : "image-to-video")\n")
         }
 
-        switch variant {
-        case .distilled:
+        let unifiedOptions = LTXUnifiedAVGenerationOptions(
+            prompt: prompt,
+            negativePrompt: negativePrompt ?? LTXUnifiedAVGenerationOptions.defaultNegativePrompt,
+            width: width,
+            height: height,
+            numFrames: numFrames,
+            fps: fps,
+            seed: seed,
+            inferenceSteps: inferenceSteps,
+            videoGuidance: LTXMultiModalGuidance(
+                classifierFreeScale: videoCFGGuidanceScale,
+                modalityScale: audioToVideoGuidanceScale
+            ),
+            audioGuidance: LTXMultiModalGuidance(
+                classifierFreeScale: audioCFGGuidanceScale,
+                modalityScale: videoToAudioGuidanceScale
+            ),
+            sourceImageURL: sourceImageURL,
+            imageStrength: imageStrength,
+            endImageURL: endImageURL,
+            endImageStrength: endImageStrength
+        )
+
+        switch route {
+        case .legacyDistilledVideo:
             if !quiet {
                 CLIStderr.write("Loading native distilled model...\n")
             }
@@ -746,6 +803,59 @@ struct VideoGenerate: AsyncParsableCommand {
                 throw error
             }
 
+        case .splitDistilledVideo:
+            let endToEndStart = videoMonotonicSeconds()
+            if !quiet {
+                CLIStderr.write("Loading native LTX 2.3 split distilled model for video-only output...\n")
+            }
+            let generator = LTXUnifiedAVGenerator()
+            do {
+                let loadTimings = try await generator.loadVideoOnly(modelRoot: rootURL)
+                if !quiet {
+                    CLIStderr.write(
+                        "Running standalone distilled joint denoising + video decode (audio output disabled)...\n"
+                    )
+                }
+                let result = try await generator.generateVideoOnly(options: unifiedOptions)
+                let unloadStart = videoMonotonicSeconds()
+                await generator.unload()
+                let unloadSeconds = videoMonotonicSeconds() - unloadStart
+
+                if let debugPrefix = ProcessInfo.processInfo.environment["MERERUN_VIDEO_LTX_DEBUG_SAVE_PREFIX"], !debugPrefix.isEmpty {
+                    let base = URL(fileURLWithPath: debugPrefix).standardizedFileURL
+                    let parent = base.deletingLastPathComponent()
+                    try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+                    let stem = base.lastPathComponent
+                    try MLX.save(array: result.frames, url: parent.appendingPathComponent("\(stem)_frames.npy"))
+                    try MLX.save(array: result.videoLatents, url: parent.appendingPathComponent("\(stem)_latents.npy"))
+                }
+
+                if !quiet {
+                    CLIStderr.write("Decoded frames shape: \(shapeString(result.frames.shape))\n")
+                    CLIStderr.write("Writing video-only MP4...\n")
+                }
+                let writeStart = videoMonotonicSeconds()
+                try LTXVideoMP4Writer.writeMP4(frames: result.frames, fps: fps, to: outputURL)
+                let mp4WriteSeconds = videoMonotonicSeconds() - writeStart
+                try emitLTXVideoTimingReport(
+                    LTXVideoTimingReport(
+                        mode: "standalone-distilled-video-only",
+                        modelRoot: rootURL.path,
+                        residentModelReused: false,
+                        load: loadTimings,
+                        generation: result.timings,
+                        unloadSeconds: unloadSeconds,
+                        mp4WriteSeconds: mp4WriteSeconds,
+                        totalSeconds: videoMonotonicSeconds() - endToEndStart
+                    ),
+                    printToStandardError: timings,
+                    outputPath: timingsOutput
+                )
+            } catch {
+                await generator.unload()
+                throw error
+            }
+
         case .unifiedAV:
             let endToEndStart = videoMonotonicSeconds()
             if !quiet {
@@ -765,31 +875,7 @@ struct VideoGenerate: AsyncParsableCommand {
                         : "standalone distilled two-stage"
                     CLIStderr.write("Running \(lane) unified AV denoising + decode...\n")
                 }
-                let result = try await generator.generate(
-                    options: LTXUnifiedAVGenerationOptions(
-                        prompt: prompt,
-                        negativePrompt: negativePrompt
-                            ?? LTXUnifiedAVGenerationOptions.defaultNegativePrompt,
-                        width: width,
-                        height: height,
-                        numFrames: numFrames,
-                        fps: fps,
-                        seed: seed,
-                        inferenceSteps: inferenceSteps,
-                        videoGuidance: LTXMultiModalGuidance(
-                            classifierFreeScale: videoCFGGuidanceScale,
-                            modalityScale: audioToVideoGuidanceScale
-                        ),
-                        audioGuidance: LTXMultiModalGuidance(
-                            classifierFreeScale: audioCFGGuidanceScale,
-                            modalityScale: videoToAudioGuidanceScale
-                        ),
-                        sourceImageURL: sourceImageURL,
-                        imageStrength: imageStrength,
-                        endImageURL: endImageURL,
-                        endImageStrength: endImageStrength
-                    )
-                )
+                let result = try await generator.generate(options: unifiedOptions)
                 let unloadStart = videoMonotonicSeconds()
                 await generator.unload()
                 let unloadSeconds = videoMonotonicSeconds() - unloadStart
@@ -871,6 +957,8 @@ struct VideoGenerate: AsyncParsableCommand {
             imageStrength: imageStrength,
             endImage: endImage,
             endImageStrength: endImageStrength,
+            timings: timings,
+            timingsOutput: timingsOutput,
             generationArgv: generationActionArguments(outputURL: outputURL),
             cwd: fileManager.currentDirectoryPath
         )

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -9,9 +9,28 @@ enum LTXVideoVariant: String, CaseIterable, ExpressibleByArgument {
     case distilled = "distilled"
 }
 
+enum LTXVideoQuality: String, CaseIterable, ExpressibleByArgument {
+    case draft
+    case final
+}
+
+enum LTXVideoOutputMode: String, CaseIterable, ExpressibleByArgument {
+    case videoOnly = "video-only"
+    case audioVideo = "audio-video"
+
+    var writesAudio: Bool {
+        self == .audioVideo
+    }
+
+    var compatibilityVariant: LTXVideoVariant {
+        writesAudio ? .unifiedAV : .distilled
+    }
+}
+
 enum LTXVideoGenerationRoute: String, Equatable {
     case legacyDistilledVideo = "legacy-distilled-video"
     case splitDistilledVideo = "split-distilled-video"
+    case fullQualityVideo = "full-quality-video"
     case unifiedAV = "unified-av"
 
     var writesAudio: Bool {
@@ -24,18 +43,33 @@ enum LTXVideoGenerationRoute: String, Equatable {
 }
 
 func resolveLTXVideoGenerationRoute(
-    variant: LTXVideoVariant,
+    outputMode: LTXVideoOutputMode,
     modelRoot: URL,
     fileManager: FileManager = .default
 ) -> LTXVideoGenerationRoute {
-    switch variant {
-    case .unifiedAV:
+    switch outputMode {
+    case .audioVideo:
         return .unifiedAV
-    case .distilled:
+    case .videoOnly:
+        if isLTX23AudioToVideoModelRoot(modelRoot, fileManager: fileManager) {
+            return .fullQualityVideo
+        }
         return isLTX23SplitModelRoot(modelRoot, fileManager: fileManager)
             ? .splitDistilledVideo
             : .legacyDistilledVideo
     }
+}
+
+func resolveLTXVideoGenerationRoute(
+    variant: LTXVideoVariant,
+    modelRoot: URL,
+    fileManager: FileManager = .default
+) -> LTXVideoGenerationRoute {
+    resolveLTXVideoGenerationRoute(
+        outputMode: variant == .unifiedAV ? .audioVideo : .videoOnly,
+        modelRoot: modelRoot,
+        fileManager: fileManager
+    )
 }
 
 struct Video: AsyncParsableCommand {
@@ -164,17 +198,22 @@ struct VideoGenerate: AsyncParsableCommand {
         Prints the output MP4 path to stdout.
         Progress and diagnostics are printed to stderr.
 
-        Use the default distilled variant for faster video-only drafts. Use
-        --variant unified-av for synchronized audio/video from the full LTX 2.3
-        dev + distilled-LoRA bundle. Supplying --audio uses that same full model
-        for native two-stage A2Vid and preserves the selected source segment as
-        the soundtrack.
+        Quality and output are separate choices. The default is a fast draft
+        checkpoint with video-only output. Use --quality final for the full LTX
+        2.3 dev + distilled-LoRA quality pipeline, and --output-mode audio-video
+        when synchronized generated audio is part of the deliverable. Supplying
+        --audio uses the full model for native two-stage A2Vid and preserves the
+        selected source segment as the soundtrack.
+
+        --variant distilled|unified-av remains available for compatibility. Do
+        not combine it with --quality or --output-mode.
 
         Examples:
           swift run mere.run video generate "a cinematic drone flythrough over snowy mountains" --num-frames 65
           swift run mere.run video generate "woman walking in neon rain" --image frame.png
           swift run mere.run video generate "a car drives from dawn into sunset" --image start.png --end-image end.png
-          swift run mere.run video generate "dialogue with clean background music" --variant unified-av --model video-ltx23-full-mlx --duration 15 --fps 24
+          swift run mere.run video generate "a cinematic final shot" --quality final --duration 4
+          swift run mere.run video generate "dialogue with clean background music" --quality final --output-mode audio-video --duration 15 --fps 24
           swift run mere.run video generate "a kinetic live performance" --audio song.wav --audio-start-time 30 --duration 5 --image performer.png
           swift run mere.run video generate "the camera walks forward" --model video-wan22-ti2v-5b-mlx --image frame.png --num-frames 41 --width 1280 --height 704
         """
@@ -189,8 +228,14 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.customShort("m"), .long], help: "Managed video model id or local model root. Defaults by operation.")
     var model: String = ""
 
-    @Option(name: [.customLong("variant")], help: "Native LTX lane: distilled for faster video-only drafts, unified-av for synchronized audio/video.")
-    var variant: LTXVideoVariant = .distilled
+    @Option(name: [.customLong("quality")], help: "LTX checkpoint quality: draft uses standalone distilled; final uses dev + distilled-LoRA.")
+    var quality: LTXVideoQuality?
+
+    @Option(name: [.customLong("output-mode")], help: "LTX deliverable: video-only or synchronized audio-video.")
+    var outputMode: LTXVideoOutputMode?
+
+    @Option(name: [.customLong("variant")], help: "Compatibility selector: distilled defaults to draft video-only; unified-av defaults to final audio-video.")
+    var legacyVariant: LTXVideoVariant?
 
     @Option(name: [.customLong("model-root")], help: "Local LTX model root. Takes precedence over --model.")
     var modelRoot: String?
@@ -273,13 +318,51 @@ struct VideoGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
+    var variant: LTXVideoVariant {
+        effectiveOutputMode.compatibilityVariant
+    }
+
+    var requestedQuality: LTXVideoQuality {
+        if audio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return .final
+        }
+        if let quality {
+            return quality
+        }
+        return legacyVariant == .unifiedAV ? .final : .draft
+    }
+
+    var effectiveOutputMode: LTXVideoOutputMode {
+        if audio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return .audioVideo
+        }
+        if let outputMode {
+            return outputMode
+        }
+        return legacyVariant == .unifiedAV ? .audioVideo : .videoOnly
+    }
+
+    var productSelectionValidationMessage: String? {
+        if legacyVariant != nil, quality != nil || outputMode != nil {
+            return "Use --quality/--output-mode or the compatibility --variant option, not both."
+        }
+        let hasSourceAudio = audio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        if hasSourceAudio, quality == .draft {
+            return "--audio requires --quality final because source-audio conditioning uses the dev + distilled-LoRA checkpoint."
+        }
+        if hasSourceAudio, outputMode == .videoOnly {
+            return "--audio preserves the selected soundtrack and requires --output-mode audio-video."
+        }
+        return nil
+    }
+
     var resolvedRequestedModel: String {
         let requested = model.trimmingCharacters(in: .whitespacesAndNewlines)
         if !requested.isEmpty {
             return requested
         }
         let hasAudio = audio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        if hasAudio || variant == .unifiedAV {
+        if hasAudio || requestedQuality == .final {
             return ModelResolver.ModelID.ltxVideo23FullMLX.rawValue
         }
         return ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
@@ -294,6 +377,10 @@ struct VideoGenerate: AsyncParsableCommand {
         if preflight {
             try runPreflight(outputURL: outputURL)
             return
+        }
+
+        if let productSelectionValidationMessage {
+            throw ValidationError(productSelectionValidationMessage)
         }
 
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -401,6 +488,7 @@ struct VideoGenerate: AsyncParsableCommand {
         ).path
 
         let resolvedRootURL = URL(fileURLWithPath: resolvedModelRoot).standardizedFileURL
+        try validateProductSelection(modelRoot: resolvedRootURL)
         if let sourceAudioURL {
             try validateNativeAudioToVideoModelRoot(resolvedRootURL)
             try await runNativeAudioToVideoGenerate(
@@ -498,7 +586,7 @@ struct VideoGenerate: AsyncParsableCommand {
             numFrames: resolvedNumFrames,
             fps: fps,
             seed: seed ?? 42,
-            variant: variant,
+            outputMode: effectiveOutputMode,
             negativePrompt: negativePrompt,
             inferenceSteps: a2vSteps,
             videoCFGGuidanceScale: videoCFGGuidanceScale,
@@ -512,6 +600,31 @@ struct VideoGenerate: AsyncParsableCommand {
             modelRoot: resolvedModelRoot,
             outputURL: outputURL
         )
+    }
+
+    private func validateProductSelection(modelRoot: URL) throws {
+        if isWan2ModelRoot(modelRoot) {
+            if quality != nil || outputMode != nil {
+                throw ValidationError("--quality and --output-mode currently select native LTX generation, not Wan2.2 TI2V.")
+            }
+            return
+        }
+        guard let quality else { return }
+        switch quality {
+        case .draft:
+            guard !isLTX23FullModelRoot(modelRoot), !isLTX23AudioToVideoModelRoot(modelRoot) else {
+                throw ValidationError(
+                    "--quality draft requires \(ModelResolver.ModelID.ltxVideo23AVMLX.rawValue), not the full dev checkpoint."
+                )
+            }
+        case .final:
+            let supportsRequestedFinalPath = isLTX23AudioToVideoModelRoot(modelRoot)
+            guard supportsRequestedFinalPath else {
+                throw ValidationError(
+                    "--quality final requires \(ModelResolver.ModelID.ltxVideo23FullMLX.rawValue)."
+                )
+            }
+        }
     }
 
     private func isWan2ModelRoot(_ rootURL: URL) -> Bool {
@@ -695,7 +808,7 @@ struct VideoGenerate: AsyncParsableCommand {
         numFrames: Int,
         fps: Int,
         seed: Int,
-        variant: LTXVideoVariant,
+        outputMode: LTXVideoOutputMode,
         negativePrompt: String?,
         inferenceSteps: Int,
         videoCFGGuidanceScale: Float,
@@ -710,10 +823,10 @@ struct VideoGenerate: AsyncParsableCommand {
         outputURL: URL
     ) async throws {
         let rootURL = URL(fileURLWithPath: modelRoot).standardizedFileURL
-        let route = resolveLTXVideoGenerationRoute(variant: variant, modelRoot: rootURL)
+        let route = resolveLTXVideoGenerationRoute(outputMode: outputMode, modelRoot: rootURL)
         if (timings || timingsOutput != nil), !route.supportsPhaseTimings {
             throw ValidationError(
-                "--timings and --timings-output require an LTX 2.3 split model, --variant unified-av, or --audio."
+                "--timings and --timings-output require an LTX 2.3 split model, --quality final, --output-mode audio-video, or --audio."
             )
         }
         if route == .unifiedAV,
@@ -728,7 +841,8 @@ struct VideoGenerate: AsyncParsableCommand {
 
         if !quiet {
             CLIStderr.write("Engine: native\n")
-            CLIStderr.write("Variant: \(variant.rawValue)\n")
+            CLIStderr.write("Quality: \(isLTX23AudioToVideoModelRoot(rootURL) ? LTXVideoQuality.final.rawValue : LTXVideoQuality.draft.rawValue)\n")
+            CLIStderr.write("Output mode: \(outputMode.rawValue)\n")
             CLIStderr.write("Runtime lane: \(route.rawValue)\n")
             CLIStderr.write("Model root: \(rootURL.path)\n")
             CLIStderr.write("Mode: \(sourceImageURL == nil ? "text-to-video" : "image-to-video")\n")
@@ -856,6 +970,59 @@ struct VideoGenerate: AsyncParsableCommand {
                 throw error
             }
 
+        case .fullQualityVideo:
+            let endToEndStart = videoMonotonicSeconds()
+            if !quiet {
+                CLIStderr.write("Loading native LTX 2.3 full-quality model for video-only output...\n")
+            }
+            let generator = LTXUnifiedAVGenerator()
+            do {
+                let loadTimings = try await generator.loadFullVideoOnly(modelRoot: rootURL)
+                if !quiet {
+                    CLIStderr.write(
+                        "Running guided dev stage 1 + distilled-LoRA stage 2 (audio output disabled)...\n"
+                    )
+                }
+                let result = try await generator.generateVideoOnly(options: unifiedOptions)
+                let unloadStart = videoMonotonicSeconds()
+                await generator.unload()
+                let unloadSeconds = videoMonotonicSeconds() - unloadStart
+
+                if let debugPrefix = ProcessInfo.processInfo.environment["MERERUN_VIDEO_LTX_DEBUG_SAVE_PREFIX"], !debugPrefix.isEmpty {
+                    let base = URL(fileURLWithPath: debugPrefix).standardizedFileURL
+                    let parent = base.deletingLastPathComponent()
+                    try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+                    let stem = base.lastPathComponent
+                    try MLX.save(array: result.frames, url: parent.appendingPathComponent("\(stem)_frames.npy"))
+                    try MLX.save(array: result.videoLatents, url: parent.appendingPathComponent("\(stem)_latents.npy"))
+                }
+
+                if !quiet {
+                    CLIStderr.write("Decoded frames shape: \(shapeString(result.frames.shape))\n")
+                    CLIStderr.write("Writing full-quality video-only MP4...\n")
+                }
+                let writeStart = videoMonotonicSeconds()
+                try LTXVideoMP4Writer.writeMP4(frames: result.frames, fps: fps, to: outputURL)
+                let mp4WriteSeconds = videoMonotonicSeconds() - writeStart
+                try emitLTXVideoTimingReport(
+                    LTXVideoTimingReport(
+                        mode: "full-video-only",
+                        modelRoot: rootURL.path,
+                        residentModelReused: false,
+                        load: loadTimings,
+                        generation: result.timings,
+                        unloadSeconds: unloadSeconds,
+                        mp4WriteSeconds: mp4WriteSeconds,
+                        totalSeconds: videoMonotonicSeconds() - endToEndStart
+                    ),
+                    printToStandardError: timings,
+                    outputPath: timingsOutput
+                )
+            } catch {
+                await generator.unload()
+                throw error
+            }
+
         case .unifiedAV:
             let endToEndStart = videoMonotonicSeconds()
             if !quiet {
@@ -938,6 +1105,10 @@ struct VideoGenerate: AsyncParsableCommand {
             outputURL: outputURL,
             model: resolvedRequestedModel,
             variant: variant,
+            quality: quality,
+            outputMode: outputMode,
+            legacyVariant: legacyVariant,
+            productSelectionValidationMessage: productSelectionValidationMessage,
             modelRoot: modelRoot,
             width: width,
             height: height,
@@ -994,8 +1165,6 @@ struct VideoGenerate: AsyncParsableCommand {
             outputURL.path,
             "--model",
             resolvedRequestedModel,
-            "--variant",
-            variant.rawValue,
             "--width",
             String(width),
             "--height",
@@ -1005,6 +1174,15 @@ struct VideoGenerate: AsyncParsableCommand {
             "--fps",
             String(fps),
         ]
+        if let quality {
+            args += ["--quality", quality.rawValue]
+        }
+        if let outputMode {
+            args += ["--output-mode", outputMode.rawValue]
+        }
+        if let legacyVariant {
+            args += ["--variant", legacyVariant.rawValue]
+        }
         if let duration {
             args += ["--duration", String(duration)]
         }
@@ -1014,7 +1192,7 @@ struct VideoGenerate: AsyncParsableCommand {
         if let negativePrompt {
             args += ["--negative-prompt", negativePrompt]
         }
-        if audio != nil || variant == .unifiedAV {
+        if audio != nil || requestedQuality == .final || effectiveOutputMode == .audioVideo {
             args += [
                 "--a2v-guidance-scale", String(a2vGuidanceScale),
                 "--video-cfg-guidance-scale", String(videoCFGGuidanceScale),
@@ -1061,7 +1239,7 @@ func validateNativeModelRoot(_ rootURL: URL) throws {
         return
     }
 
-    if isLTX23FullModelRoot(rootURL) || isLTX23SplitModelRoot(rootURL) {
+    if isLTX23AudioToVideoModelRoot(rootURL) || isLTX23SplitModelRoot(rootURL) {
         return
     }
 

--- a/Sources/MereRunCLI/Guides/video-generate.md
+++ b/Sources/MereRunCLI/Guides/video-generate.md
@@ -9,10 +9,9 @@ Generate an MP4 video from text, optionally anchored by a source image, with nat
 Managed ids:
 
 - `video-ltx23-av-mlx`: split-layout standalone distilled LTX 2.3 MLX root for
-  fast video-only drafts. The default `distilled` variant uses this model
-  directly and writes an MP4 without an audio stream.
+  fast drafts. The default `--quality draft` selection uses this checkpoint.
 - `video-ltx23-full-mlx`: dev checkpoint, official distilled LoRA, vocoder,
-  VAEs, and x2 upscaler for both high-quality synchronized `--variant unified-av`
+  VAEs, and x2 upscaler for `--quality final`, generated synchronized audio,
   and native source-audio-conditioned video.
 - `video-ltx23-a2vid-mlx`: compatibility ID for existing A2Vid installs.
 - `video-ltx-av`: legacy merged LTX root. Superseded by LTX 2.3; only still required by
@@ -33,9 +32,14 @@ mere.run video generate --help
 - positional prompt: video prompt.
 - `--output`, `-o`: MP4 path.
 - `--model`, `-m`: managed id or local model root.
-- `--variant`: `distilled` for faster video-only drafts from current LTX 2.3
-  split roots or legacy merged roots, or `unified-av` for synchronized
-  audio/video.
+- `--quality`: `draft` selects the fast standalone-distilled checkpoint;
+  `final` selects the full dev + distilled-LoRA quality pipeline. Default:
+  `draft`.
+- `--output-mode`: `video-only` writes no audio stream; `audio-video` generates
+  synchronized audio. Default: `video-only`.
+- `--variant`: compatibility selector. `distilled` defaults to draft
+  video-only; `unified-av` defaults to final audio-video. An explicit `--model`
+  still wins. Do not combine it with the canonical selectors.
 - `--model-root`: explicit local root, takes precedence over `--model`.
 - `--width`, `--height`: output size; snapped down to multiples of 64.
 - `--num-frames`: frame count; adjusted to `8n+1`.
@@ -71,8 +75,11 @@ mere.run video generate --help
 - For directed image-to-video, pass `--image` and `--end-image` so the first
   and last latent frames are both anchored.
 - Keep early drafts short: `--num-frames 65` at `24` fps is a fast test.
-- Use `video-ltx23-full-mlx --variant unified-av --fps 24` for representative
-  LTX 2.3 dialogue, score, and SFX checks.
+- Use `--quality final` for delivery renders even when the deliverable is
+  video-only. Add `--output-mode audio-video --fps 24` when dialogue, score,
+  or SFX is part of the output.
+- Suppressing audio is an output contract, not a meaningful speed lane. The
+  large speed/quality tradeoff comes from `--quality draft` versus `final`.
 - Split-layout distilled generation retains the model's joint audio/video
   denoising tokens because audio-to-video cross attention contributes to the
   video result, but skips loading the audio VAE/vocoder and never writes an
@@ -102,7 +109,6 @@ mere.run video generate \
 ```bash
 mere.run video generate \
   "slow cinematic dolly shot through a rainy neon alley, reflections on pavement, moody blue and magenta light" \
-  --variant distilled \
   --width 768 --height 512 \
   --num-frames 65 \
   --output ./alley.mp4 \
@@ -113,7 +119,6 @@ mere.run video generate \
 ```bash
 mere.run video generate \
   "slow cinematic dolly shot through a rainy neon alley, reflections on pavement, moody blue and magenta light" \
-  --variant distilled \
   --width 768 --height 512 \
   --num-frames 65 \
   --seed 9 \
@@ -122,9 +127,19 @@ mere.run video generate \
 
 ```bash
 mere.run video generate \
+  "a red fox runs across a snowy clearing, detailed winter fur, natural motion" \
+  --quality final \
+  --width 768 --height 512 \
+  --duration 4 \
+  --seed 23 \
+  --output ./fox-final.mp4
+```
+
+```bash
+mere.run video generate \
   "two actors talking beside a window while a restrained orchestral score and distant city sirens play underneath" \
-  --model video-ltx23-full-mlx \
-  --variant unified-av \
+  --quality final \
+  --output-mode audio-video \
   --duration 15 \
   --fps 24 \
   --width 1280 --height 720 \
@@ -174,7 +189,7 @@ into the dev transformer in place and must reload before another generation.
 
 - Lock seed after motion is promising.
 - If motion is weak, make verbs and camera movement more explicit.
-- For unified AV, prefer `--duration` so the CLI picks the nearest legal `8n+1`
+- For audio-video output, prefer `--duration` so the CLI picks the nearest legal `8n+1`
   frame count for the requested FPS.
 - If anatomy or objects distort, lower duration/frame count or anchor with `--image`.
 

--- a/Sources/MereRunCLI/Guides/video-generate.md
+++ b/Sources/MereRunCLI/Guides/video-generate.md
@@ -8,8 +8,9 @@ Generate an MP4 video from text, optionally anchored by a source image, with nat
 
 Managed ids:
 
-- `video-ltx23-av-mlx`: standalone distilled LTX 2.3 MLX root for fast
-  video-only drafts.
+- `video-ltx23-av-mlx`: split-layout standalone distilled LTX 2.3 MLX root for
+  fast video-only drafts. The default `distilled` variant uses this model
+  directly and writes an MP4 without an audio stream.
 - `video-ltx23-full-mlx`: dev checkpoint, official distilled LoRA, vocoder,
   VAEs, and x2 upscaler for both high-quality synchronized `--variant unified-av`
   and native source-audio-conditioned video.
@@ -32,8 +33,9 @@ mere.run video generate --help
 - positional prompt: video prompt.
 - `--output`, `-o`: MP4 path.
 - `--model`, `-m`: managed id or local model root.
-- `--variant`: `distilled` for faster video-only drafts, or `unified-av` for
-  synchronized audio/video.
+- `--variant`: `distilled` for faster video-only drafts from current LTX 2.3
+  split roots or legacy merged roots, or `unified-av` for synchronized
+  audio/video.
 - `--model-root`: explicit local root, takes precedence over `--model`.
 - `--width`, `--height`: output size; snapped down to multiples of 64.
 - `--num-frames`: frame count; adjusted to `8n+1`.
@@ -56,8 +58,9 @@ mere.run video generate --help
   writing an MP4.
 - `--json`: with `--preflight`, emit a structured report with diagnostics and
   declarative follow-up actions.
-- `--timings`: print native LTX 2.3 unified-AV/A2Vid load, generation, decode,
-  write, and end-to-end phase timings to stderr.
+- `--timings`: print native LTX 2.3 split-distilled, unified-AV, or A2Vid load,
+  generation, decode, write, and end-to-end phase timings to stderr. Legacy
+  merged distilled roots do not expose phase timings.
 - `--timings-output`: write those timings as JSON.
 - `--quiet`, `-q`: suppress diagnostics.
 
@@ -70,13 +73,18 @@ mere.run video generate --help
 - Keep early drafts short: `--num-frames 65` at `24` fps is a fast test.
 - Use `video-ltx23-full-mlx --variant unified-av --fps 24` for representative
   LTX 2.3 dialogue, score, and SFX checks.
+- Split-layout distilled generation retains the model's joint audio/video
+  denoising tokens because audio-to-video cross attention contributes to the
+  video result, but skips loading the audio VAE/vocoder and never writes an
+  audio track.
 - Use standard aspect ratios before custom sizes.
 - With `--audio`, the source latent stays frozen through the guided full/dev
   stage and distilled-LoRA refinement; the selected source segment is muxed as
   the soundtrack. Short audio and incompatible models fail without fallback.
 - Use `--preflight --json` before long renders to confirm model availability,
   keyframe paths, output overwrite risk, resolved dimensions, and resolved
-  frame count/duration.
+  frame count/duration. Preflight also rejects `--timings` for legacy merged
+  distilled roots and Wan2.2 before generation starts.
 
 ## Examples
 

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -26,6 +26,8 @@ struct VideoGenerationPreflightInput {
     let imageStrength: Float
     let endImage: String?
     let endImageStrength: Float
+    let timings: Bool
+    let timingsOutput: String?
     let generationArgv: [String]
     let cwd: String
 }
@@ -54,6 +56,8 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
     let imageStrength: Float
     let endImage: String?
     let endImageStrength: Float
+    let timings: Bool?
+    let timingsOutput: String?
 
     enum CodingKeys: String, CodingKey {
         case prompt
@@ -79,6 +83,8 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
         case imageStrength = "image_strength"
         case endImage = "end_image"
         case endImageStrength = "end_image_strength"
+        case timings
+        case timingsOutput = "timings_output"
     }
 }
 
@@ -240,9 +246,10 @@ struct VideoGenerationPreflightAnalyzer {
         var diagnostics: [PreflightDiagnostic] = []
         validateStaticOptions(diagnostics: &diagnostics)
         let model = modelSummary(diagnostics: &diagnostics)
+        validateTimingOptions(model: model, diagnostics: &diagnostics)
         let output = outputSummary(diagnostics: &diagnostics)
         let inputs = inputSummary(diagnostics: &diagnostics)
-        let plan = planSummary(inputs: inputs, diagnostics: &diagnostics)
+        let plan = planSummary(model: model, inputs: inputs, diagnostics: &diagnostics)
         let status = StructuredRunOutput.status(for: diagnostics)
 
         return VideoGenerationPreflightEnvelope(
@@ -290,8 +297,60 @@ struct VideoGenerationPreflightAnalyzer {
             image: input.image,
             imageStrength: input.imageStrength,
             endImage: input.endImage,
-            endImageStrength: input.endImageStrength
+            endImageStrength: input.endImageStrength,
+            timings: input.timings,
+            timingsOutput: input.timingsOutput
         )
+    }
+
+    private func validateTimingOptions(
+        model: VideoGenerationModelPreflightSummary,
+        diagnostics: inout [PreflightDiagnostic]
+    ) {
+        guard input.timings || input.timingsOutput != nil else { return }
+        guard !usesAudioConditioning else { return }
+        guard !usesWanGeometry else {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "timings_lane_unsupported",
+                    severity: .blocker,
+                    title: "Phase timings are unavailable for this lane",
+                    message: "--timings and --timings-output are available for native LTX generation, not Wan2.2 TI2V."
+                )
+            )
+            return
+        }
+
+        let route = resolvedLTXRoute(model: model)
+        if route?.supportsPhaseTimings == false {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "timings_lane_unsupported",
+                    severity: .blocker,
+                    title: "Phase timings are unavailable for this lane",
+                    message: "Use an LTX 2.3 split model, --variant unified-av, or --audio for phase timings."
+                )
+            )
+        }
+    }
+
+    private func resolvedLTXRoute(
+        model: VideoGenerationModelPreflightSummary
+    ) -> LTXVideoGenerationRoute? {
+        if let path = model.path {
+            return resolveLTXVideoGenerationRoute(
+                variant: input.variant,
+                modelRoot: URL(fileURLWithPath: path),
+                fileManager: fileManager
+            )
+        }
+        if input.variant == .unifiedAV {
+            return .unifiedAV
+        }
+        if input.model == ModelResolver.ModelID.ltxVideo23AVMLX.rawValue {
+            return .splitDistilledVideo
+        }
+        return nil
     }
 
     private func validateStaticOptions(diagnostics: inout [PreflightDiagnostic]) {
@@ -794,6 +853,7 @@ struct VideoGenerationPreflightAnalyzer {
     }
 
     private func planSummary(
+        model: VideoGenerationModelPreflightSummary,
         inputs: VideoGenerationInputPreflightSummary,
         diagnostics: inout [PreflightDiagnostic]
     ) -> VideoGenerationPlanPreflightSummary {
@@ -852,6 +912,8 @@ struct VideoGenerationPreflightAnalyzer {
             )
         }
 
+        let routeWritesAudio = resolvedLTXRoute(model: model)?.writesAudio
+            ?? (input.variant == .unifiedAV)
         return VideoGenerationPlanPreflightSummary(
             variant: usesWanGeometry
                 ? "wan22-ti2v"
@@ -867,7 +929,7 @@ struct VideoGenerationPreflightAnalyzer {
             resolvedNumFrames: resolvedFrames,
             resolvedDurationSeconds: input.fps > 0 ? Double(resolvedFrames) / Double(input.fps) : nil,
             seed: input.seed ?? 42,
-            writesAudio: usesAudioConditioning || (!usesWanGeometry && input.variant == .unifiedAV),
+            writesAudio: usesAudioConditioning || (!usesWanGeometry && routeWritesAudio),
             audioConditioning: usesAudioConditioning,
             preservesSourceAudio: usesAudioConditioning,
             resolvedAudioStartTime: usesAudioConditioning ? input.audioStartTime : nil

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -7,6 +7,10 @@ struct VideoGenerationPreflightInput {
     let outputURL: URL
     let model: String
     let variant: LTXVideoVariant
+    let quality: LTXVideoQuality?
+    let outputMode: LTXVideoOutputMode?
+    let legacyVariant: LTXVideoVariant?
+    let productSelectionValidationMessage: String?
     let modelRoot: String?
     let width: Int
     let height: Int
@@ -37,6 +41,8 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
     let output: String
     let model: String
     let variant: String
+    let quality: String?
+    let outputMode: String?
     let modelRoot: String?
     let width: Int
     let height: Int
@@ -64,6 +70,8 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
         case output
         case model
         case variant
+        case quality
+        case outputMode = "output_mode"
         case modelRoot = "model_root"
         case width
         case height
@@ -171,6 +179,8 @@ struct VideoGenerationPathPreflightSummary: Codable, Equatable {
 
 struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
     let variant: String
+    let quality: String?
+    let outputMode: String?
     let inputMode: String
     let requestedWidth: Int
     let requestedHeight: Int
@@ -189,6 +199,8 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case variant
+        case quality
+        case outputMode = "output_mode"
         case inputMode = "input_mode"
         case requestedWidth = "requested_width"
         case requestedHeight = "requested_height"
@@ -246,6 +258,7 @@ struct VideoGenerationPreflightAnalyzer {
         var diagnostics: [PreflightDiagnostic] = []
         validateStaticOptions(diagnostics: &diagnostics)
         let model = modelSummary(diagnostics: &diagnostics)
+        validateProductSelection(model: model, diagnostics: &diagnostics)
         validateTimingOptions(model: model, diagnostics: &diagnostics)
         let output = outputSummary(diagnostics: &diagnostics)
         let inputs = inputSummary(diagnostics: &diagnostics)
@@ -279,6 +292,8 @@ struct VideoGenerationPreflightAnalyzer {
             output: input.outputURL.path,
             model: input.model,
             variant: input.variant.rawValue,
+            quality: input.quality?.rawValue,
+            outputMode: input.outputMode?.rawValue,
             modelRoot: input.modelRoot,
             width: input.width,
             height: input.height,
@@ -328,7 +343,7 @@ struct VideoGenerationPreflightAnalyzer {
                     id: "timings_lane_unsupported",
                     severity: .blocker,
                     title: "Phase timings are unavailable for this lane",
-                    message: "Use an LTX 2.3 split model, --variant unified-av, or --audio for phase timings."
+                    message: "Use an LTX 2.3 split model, --quality final, --output-mode audio-video, or --audio for phase timings."
                 )
             )
         }
@@ -354,6 +369,26 @@ struct VideoGenerationPreflightAnalyzer {
     }
 
     private func validateStaticOptions(diagnostics: inout [PreflightDiagnostic]) {
+        if let message = input.productSelectionValidationMessage {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "video_product_selection_conflict",
+                    severity: .blocker,
+                    title: "Video product selection is ambiguous",
+                    message: message
+                )
+            )
+        }
+        if usesWanGeometry, input.quality != nil || input.outputMode != nil {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "ltx_product_selection_with_wan",
+                    severity: .blocker,
+                    title: "LTX product options do not apply to Wan",
+                    message: "--quality and --output-mode currently select native LTX generation, not Wan2.2 TI2V."
+                )
+            )
+        }
         if input.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             diagnostics.append(
                 PreflightDiagnostic(
@@ -502,6 +537,41 @@ struct VideoGenerationPreflightAnalyzer {
                     message: "LTX audio/video is trained around 24 fps; --fps \(input.fps) can make motion look time-stretched relative to audio."
                 )
             )
+        }
+    }
+
+    private func validateProductSelection(
+        model: VideoGenerationModelPreflightSummary,
+        diagnostics: inout [PreflightDiagnostic]
+    ) {
+        guard let requestedQuality = input.quality,
+              let actualQuality = resolvedQuality(model: model),
+              requestedQuality != actualQuality else {
+            return
+        }
+        let requiredModel = requestedQuality == .final
+            ? ModelResolver.ModelID.ltxVideo23FullMLX.rawValue
+            : ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
+        diagnostics.append(
+            PreflightDiagnostic(
+                id: "video_quality_model_mismatch",
+                severity: .blocker,
+                title: "Checkpoint does not match requested quality",
+                message: "--quality \(requestedQuality.rawValue) requires \(requiredModel)."
+            )
+        )
+    }
+
+    private func resolvedQuality(
+        model: VideoGenerationModelPreflightSummary
+    ) -> LTXVideoQuality? {
+        switch model.layout {
+        case "ltx23_full_split", "ltx23_a2vid_split":
+            return .final
+        case "ltx23_distilled_split", "ltx_merged":
+            return .draft
+        default:
+            return nil
         }
     }
 
@@ -914,10 +984,15 @@ struct VideoGenerationPreflightAnalyzer {
 
         let routeWritesAudio = resolvedLTXRoute(model: model)?.writesAudio
             ?? (input.variant == .unifiedAV)
+        let resolvedOutputMode: LTXVideoOutputMode? = usesWanGeometry
+            ? nil
+            : (usesAudioConditioning || input.variant == .unifiedAV ? .audioVideo : .videoOnly)
         return VideoGenerationPlanPreflightSummary(
             variant: usesWanGeometry
                 ? "wan22-ti2v"
                 : (usesAudioConditioning ? "audio-to-video" : input.variant.rawValue),
+            quality: resolvedQuality(model: model)?.rawValue,
+            outputMode: resolvedOutputMode?.rawValue,
             inputMode: inputs.mode,
             requestedWidth: input.width,
             requestedHeight: input.height,

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -92,9 +92,9 @@ public enum LTXDistilledLatentGeneratorError: LocalizedError {
             return "Missing LTX upsampler weights at \(url.path)"
         case .unsupportedLTX23SplitModel(let url):
             return """
-            Detected an LTX 2.3 split MLX model at \(url.path). This native loader still supports the older \
-            merged LTX layout; port the LTX 2.3 V2 connector, transformer, and split component loader before \
-            generation.
+            Detected an LTX 2.3 split MLX model at \(url.path). This legacy loader only supports the older \
+            merged LTX layout. Use `mere.run video generate --variant distilled` for video-only output from \
+            split models, or `--variant unified-av` for synchronized audio and video.
             """
         case .generatorNotLoaded:
             return "LTX distilled latent generator is not loaded."
@@ -2891,6 +2891,31 @@ public struct LTXUnifiedAVGenerationResult: @unchecked Sendable {
     }
 }
 
+public struct LTXUnifiedVideoGenerationResult: @unchecked Sendable {
+    public let frames: MLXArray
+    public let videoLatents: MLXArray
+    public let timings: LTXGenerationTimings
+
+    public init(
+        frames: MLXArray,
+        videoLatents: MLXArray,
+        timings: LTXGenerationTimings = LTXGenerationTimings()
+    ) {
+        self.frames = frames
+        self.videoLatents = videoLatents
+        self.timings = timings
+    }
+}
+
+private struct LTXUnifiedGenerationOutput {
+    let frames: MLXArray
+    let videoLatents: MLXArray
+    let audioLatents: MLXArray
+    let audioWaveform: MLXArray?
+    let audioSampleRate: Int?
+    let timings: LTXGenerationTimings
+}
+
 public struct LTXAudioToVideoGenerationOptions: Sendable {
     public static let defaultNegativePrompt = """
     blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, \
@@ -3029,9 +3054,9 @@ public enum LTXUnifiedAVGeneratorError: LocalizedError {
             return "Missing LTX upsampler weights at \(url.path)"
         case .unsupportedLTX23SplitModel(let url):
             return """
-            Detected an LTX 2.3 split MLX model at \(url.path). This native loader still supports the older \
-            merged LTX layout; port the LTX 2.3 V2 connector, transformer, and split component loader before \
-            generation.
+            Detected an LTX 2.3 split MLX model at \(url.path). Use \
+            `mere.run video generate --variant distilled` for video-only output, or \
+            `--variant unified-av` for synchronized audio and video.
             """
         case .ltx23TextEncoderMissing(let id):
             return """
@@ -3242,6 +3267,7 @@ public actor LTXUnifiedAVGenerator {
     private var loadedForAudioToVideo = false
     private var loadedForFullTwoStage = false
     private var loadedForReusableFullTwoStage = false
+    private var loadedForVideoOnlyOutput = false
     private var twoStageGenerationConsumed = false
 
     public init() {}
@@ -3402,6 +3428,36 @@ public actor LTXUnifiedAVGenerator {
         modelRoot: URL,
         dtype: DType = .bfloat16
     ) async throws -> LTXLoadTimings {
+        try await loadStandalone(
+            modelRoot: modelRoot,
+            dtype: dtype,
+            loadAudioOutput: true
+        )
+    }
+
+    /// Loads the standalone distilled transformer for video-only output.
+    ///
+    /// Audio latents remain part of the joint AV denoising contract because
+    /// audio-to-video cross attention influences every video block. This lane
+    /// skips only the audio VAE and vocoder, which are not needed when callers
+    /// do not request an audio waveform.
+    @discardableResult
+    public func loadVideoOnly(
+        modelRoot: URL,
+        dtype: DType = .bfloat16
+    ) async throws -> LTXLoadTimings {
+        try await loadStandalone(
+            modelRoot: modelRoot,
+            dtype: dtype,
+            loadAudioOutput: false
+        )
+    }
+
+    private func loadStandalone(
+        modelRoot: URL,
+        dtype: DType,
+        loadAudioOutput: Bool
+    ) async throws -> LTXLoadTimings {
         let totalStart = ltxMonotonicSeconds()
         await unload()
         let root = modelRoot.standardizedFileURL
@@ -3536,68 +3592,80 @@ public actor LTXUnifiedAVGenerator {
         )
         let upsamplerSeconds = ltxMonotonicSeconds() - upsamplerStart
 
-        let audioDecoderStart = ltxMonotonicSeconds()
-        let audioDecoder = LTXAudioDecoder()
-        let audioDecoderURL = isLTX23
-            ? root.appendingPathComponent("audio_vae.safetensors", isDirectory: false)
-            : transformerURL
-        try SafetensorsStreamingLoader.applyWeightsStreaming(
-            url: audioDecoderURL,
-            to: audioDecoder,
-            dtype: .float32,
-            verify: .none,
-            include: { key in
-                key.hasPrefix("audio_vae.decoder.")
-                    || key.hasPrefix("audio_vae.per_channel_statistics.")
-            },
-            mapper: { key, value in
-                mapAudioVaeDecoderWeight(key: key, value: value, dtype: .float32, sourceLayout: splitTensorLayout)
-            },
-            batchSize: 24
-        )
+        var loadedAudioDecoder: LTXAudioDecoder?
+        var loadedVocoder: LTXAudioVocoderBase?
+        var audioDecoderSeconds = 0.0
+        if loadAudioOutput {
+            let audioDecoderStart = ltxMonotonicSeconds()
+            let audioDecoder = LTXAudioDecoder()
+            let audioDecoderURL = isLTX23
+                ? root.appendingPathComponent("audio_vae.safetensors", isDirectory: false)
+                : transformerURL
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: audioDecoderURL,
+                to: audioDecoder,
+                dtype: .float32,
+                verify: .none,
+                include: { key in
+                    key.hasPrefix("audio_vae.decoder.")
+                        || key.hasPrefix("audio_vae.per_channel_statistics.")
+                },
+                mapper: { key, value in
+                    mapAudioVaeDecoderWeight(
+                        key: key,
+                        value: value,
+                        dtype: .float32,
+                        sourceLayout: splitTensorLayout
+                    )
+                },
+                batchSize: 24
+            )
 
-        let vocoderURL = isLTX23
-            ? root.appendingPathComponent("vocoder.safetensors", isDirectory: false)
-            : transformerURL
-        let vocoderMetadata = try SafetensorsStreamingLoader.metadata(url: vocoderURL)
-        let vocoderFlavor = detectLTXVocoderFlavor(keys: vocoderMetadata.keys)
-        let vocoder: LTXAudioVocoderBase = switch vocoderFlavor {
-        case .legacy:
-            LTXVocoder()
-        case .bandwidthExtension:
-            if let config = try loadLTXBWEVocoderConfig(modelRoot: root) {
-                LTXVocoderWithBWE(config: config)
-            } else {
-                throw LTXUnifiedAVGeneratorError.bweVocoderConfigMissing(root)
+            let vocoderURL = isLTX23
+                ? root.appendingPathComponent("vocoder.safetensors", isDirectory: false)
+                : transformerURL
+            let vocoderMetadata = try SafetensorsStreamingLoader.metadata(url: vocoderURL)
+            let vocoderFlavor = detectLTXVocoderFlavor(keys: vocoderMetadata.keys)
+            let vocoder: LTXAudioVocoderBase = switch vocoderFlavor {
+            case .legacy:
+                LTXVocoder()
+            case .bandwidthExtension:
+                if let config = try loadLTXBWEVocoderConfig(modelRoot: root) {
+                    LTXVocoderWithBWE(config: config)
+                } else {
+                    throw LTXUnifiedAVGeneratorError.bweVocoderConfigMissing(root)
+                }
             }
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: vocoderURL,
+                to: vocoder,
+                dtype: .float32,
+                verify: .none,
+                include: { key in
+                    key.hasPrefix("vocoder.")
+                },
+                mapper: { key, value in
+                    mapVocoderWeight(
+                        key: key,
+                        value: value,
+                        dtype: .float32,
+                        sourceLayout: isLTX23 ? .mlx : .pytorch,
+                        targetFlavor: vocoderFlavor
+                    )
+                },
+                batchSize: 24
+            )
+            loadedAudioDecoder = audioDecoder
+            loadedVocoder = vocoder
+            audioDecoderSeconds = ltxMonotonicSeconds() - audioDecoderStart
         }
-        try SafetensorsStreamingLoader.applyWeightsStreaming(
-            url: vocoderURL,
-            to: vocoder,
-            dtype: .float32,
-            verify: .none,
-            include: { key in
-                key.hasPrefix("vocoder.")
-            },
-            mapper: { key, value in
-                mapVocoderWeight(
-                    key: key,
-                    value: value,
-                    dtype: .float32,
-                    sourceLayout: isLTX23 ? .mlx : .pytorch,
-                    targetFlavor: vocoderFlavor
-                )
-            },
-            batchSize: 24
-        )
-        let audioDecoderSeconds = ltxMonotonicSeconds() - audioDecoderStart
 
         self.textEncoder = text
         self.transformer = model
         self.decoder = vaeDecoder
         self.upsampler = latentUpsampler
-        self.audioDecoder = audioDecoder
-        self.vocoder = vocoder
+        self.audioDecoder = loadedAudioDecoder
+        self.vocoder = loadedVocoder
         self.encoder = nil
         self.modelWeightsURL = transformerURL
         self.videoEncoderWeightsURL = isLTX23
@@ -3606,6 +3674,7 @@ public actor LTXUnifiedAVGenerator {
         self.videoVAEWeightLayout = splitTensorLayout
         self.loadedDType = dtype
         self.loadedRoot = root
+        self.loadedForVideoOnlyOutput = !loadAudioOutput
         return LTXLoadTimings(
             textEncoderSeconds: textEncoderSeconds,
             transformerSeconds: transformerSeconds,
@@ -3638,6 +3707,7 @@ public actor LTXUnifiedAVGenerator {
         loadedForAudioToVideo = false
         loadedForFullTwoStage = false
         loadedForReusableFullTwoStage = false
+        loadedForVideoOnlyOutput = false
         twoStageGenerationConsumed = false
         Memory.clearCache()
     }
@@ -4141,6 +4211,39 @@ public actor LTXUnifiedAVGenerator {
     public func generate(
         options: LTXUnifiedAVGenerationOptions
     ) async throws -> LTXUnifiedAVGenerationResult {
+        guard !loadedForVideoOnlyOutput else {
+            throw LTXUnifiedAVGeneratorError.audioDecoderNotLoaded
+        }
+        let output = try await generate(options: options, decodeAudio: true)
+        guard let audioWaveform = output.audioWaveform,
+              let audioSampleRate = output.audioSampleRate else {
+            throw LTXUnifiedAVGeneratorError.audioDecoderNotLoaded
+        }
+        return LTXUnifiedAVGenerationResult(
+            frames: output.frames,
+            videoLatents: output.videoLatents,
+            audioLatents: output.audioLatents,
+            audioWaveform: audioWaveform,
+            audioSampleRate: audioSampleRate,
+            timings: output.timings
+        )
+    }
+
+    public func generateVideoOnly(
+        options: LTXUnifiedAVGenerationOptions
+    ) async throws -> LTXUnifiedVideoGenerationResult {
+        let output = try await generate(options: options, decodeAudio: false)
+        return LTXUnifiedVideoGenerationResult(
+            frames: output.frames,
+            videoLatents: output.videoLatents,
+            timings: output.timings
+        )
+    }
+
+    private func generate(
+        options: LTXUnifiedAVGenerationOptions,
+        decodeAudio: Bool
+    ) async throws -> LTXUnifiedGenerationOutput {
         let totalStart = ltxMonotonicSeconds()
         var textEncodingSeconds = 0.0
         var textEncoderReloadSeconds = 0.0
@@ -4580,62 +4683,68 @@ public actor LTXUnifiedAVGenerator {
         }
 
         _ = decodedVideo
-        let audioDecodeStart = ltxMonotonicSeconds()
-        let activeAudioDecoder: LTXAudioDecoder
-        let activeVocoder: LTXAudioVocoderBase
-        if usesFullTwoStage {
-            guard let loadedRoot else {
-                throw LTXUnifiedAVGeneratorError.generatorNotLoaded
+        var audioWaveform: MLXArray?
+        var audioSampleRate: Int?
+        if decodeAudio {
+            let audioDecodeStart = ltxMonotonicSeconds()
+            let activeAudioDecoder: LTXAudioDecoder
+            let activeVocoder: LTXAudioVocoderBase
+            if usesFullTwoStage {
+                guard let loadedRoot else {
+                    throw LTXUnifiedAVGeneratorError.generatorNotLoaded
+                }
+                if !usesReusableFullTwoStage {
+                    self.transformer = nil
+                    self.upsampler = nil
+                    Memory.clearCache()
+                }
+                activeAudioDecoder = try loadLTX23AudioDecoder(modelRoot: loadedRoot)
+                activeVocoder = try loadLTX23Vocoder(modelRoot: loadedRoot)
+                if !usesReusableFullTwoStage {
+                    self.audioDecoder = activeAudioDecoder
+                    self.vocoder = activeVocoder
+                }
+            } else {
+                guard let audioDecoder else {
+                    throw LTXUnifiedAVGeneratorError.audioDecoderNotLoaded
+                }
+                guard let vocoder else {
+                    throw LTXUnifiedAVGeneratorError.vocoderNotLoaded
+                }
+                activeAudioDecoder = audioDecoder
+                activeVocoder = vocoder
             }
-            if !usesReusableFullTwoStage {
-                self.transformer = nil
-                self.upsampler = nil
-                Memory.clearCache()
-            }
-            activeAudioDecoder = try loadLTX23AudioDecoder(modelRoot: loadedRoot)
-            activeVocoder = try loadLTX23Vocoder(modelRoot: loadedRoot)
-            if !usesReusableFullTwoStage {
-                self.audioDecoder = activeAudioDecoder
-                self.vocoder = activeVocoder
-            }
-        } else {
-            guard let audioDecoder else {
-                throw LTXUnifiedAVGeneratorError.audioDecoderNotLoaded
-            }
-            guard let vocoder else {
-                throw LTXUnifiedAVGeneratorError.vocoderNotLoaded
-            }
-            activeAudioDecoder = audioDecoder
-            activeVocoder = vocoder
+            let mel = activeAudioDecoder.decode(latents: audioLatents.asType(.float32))
+            saveLTXAVDebugArray(mel, suffix: "audio_mel")
+            let vocodedAudio = activeVocoder(mel)
+            saveLTXAVDebugAudio(
+                vocodedAudio,
+                suffix: "audio_vocoded_raw",
+                sampleRate: activeVocoder.outputSamplingRate
+            )
+            let waveform = matchLTXAudioWaveformDuration(
+                vocodedAudio,
+                videoFrames: options.numFrames,
+                fps: options.fps,
+                sampleRate: activeVocoder.outputSamplingRate
+            )
+            MLX.eval(waveform)
+            audioDecodeSeconds = ltxMonotonicSeconds() - audioDecodeStart
+            saveLTXAVDebugAudio(
+                waveform,
+                suffix: "audio_waveform_matched",
+                sampleRate: activeVocoder.outputSamplingRate
+            )
+            audioWaveform = waveform
+            audioSampleRate = activeVocoder.outputSamplingRate
         }
-        let mel = activeAudioDecoder.decode(latents: audioLatents.asType(.float32))
-        saveLTXAVDebugArray(mel, suffix: "audio_mel")
-        let vocodedAudio = activeVocoder(mel)
-        saveLTXAVDebugAudio(
-            vocodedAudio,
-            suffix: "audio_vocoded_raw",
-            sampleRate: activeVocoder.outputSamplingRate
-        )
-        let audioWaveform = matchLTXAudioWaveformDuration(
-            vocodedAudio,
-            videoFrames: options.numFrames,
-            fps: options.fps,
-            sampleRate: activeVocoder.outputSamplingRate
-        )
-        MLX.eval(audioWaveform)
-        audioDecodeSeconds = ltxMonotonicSeconds() - audioDecodeStart
-        saveLTXAVDebugAudio(
-            audioWaveform,
-            suffix: "audio_waveform_matched",
-            sampleRate: activeVocoder.outputSamplingRate
-        )
 
-        return LTXUnifiedAVGenerationResult(
+        return LTXUnifiedGenerationOutput(
             frames: frames,
             videoLatents: videoLatents,
             audioLatents: audioLatents,
             audioWaveform: audioWaveform,
-            audioSampleRate: activeVocoder.outputSamplingRate,
+            audioSampleRate: audioSampleRate,
             timings: LTXGenerationTimings(
                 textEncodingSeconds: textEncodingSeconds,
                 preparationSeconds: preparationSeconds,

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -3287,6 +3287,24 @@ public actor LTXUnifiedAVGenerator {
         return timings
     }
 
+    /// Loads the full dev + distilled-LoRA quality pipeline without requiring
+    /// audio decoder or vocoder output components.
+    @discardableResult
+    public func loadFullVideoOnly(
+        modelRoot: URL,
+        dtype: DType = .bfloat16
+    ) async throws -> LTXLoadTimings {
+        let root = modelRoot.standardizedFileURL
+        guard isLTX23AudioToVideoModelRoot(root) else {
+            throw LTXUnifiedAVGeneratorError.fullGenerationRequiresLTX23(root)
+        }
+        let timings = try await loadAudioToVideo(modelRoot: root, dtype: dtype)
+        loadedForFullTwoStage = true
+        loadedForReusableFullTwoStage = false
+        loadedForVideoOnlyOutput = true
+        return timings
+    }
+
     /// Loads the full dev transformer once and installs the distilled adapter as
     /// a reversible runtime path. Stage 1 uses the untouched dev weights; Stage 2
     /// enables the adapter without permanently fusing into the base checkpoint.

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -718,14 +718,14 @@ public enum ManagedModelCapabilityCatalog {
             descriptor(
                 ModelResolver.ModelID.ltxVideo23AVMLX.rawValue,
                 "LTX 2.3 Distilled MLX",
-                "Installs the standalone distilled LTX 2.3 MLX checkpoint for fast video drafts.",
+                "Installs the standalone distilled LTX 2.3 MLX checkpoint for fast draft renders.",
                 minimum: 96,
                 recommended: 128
             ),
             descriptor(
                 ModelResolver.ModelID.ltxVideo23FullMLX.rawValue,
                 "LTX 2.3 Full MLX",
-                "Installs the dev transformer, distilled LoRA, and vocoder for unified AV and A2Vid.",
+                "Installs the final-quality dev transformer, distilled LoRA, and optional generated-audio components.",
                 minimum: 96,
                 recommended: 128
             ),

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -83,7 +83,8 @@ public enum MereRunModelValidator {
             errors.append("Missing \(MereRunModelManifest.filename). Manifests are required (no heuristic guessing).")
         }
 
-        let spec = manifest.flatMap { ManagedModelCatalog.spec(for: $0.id) }
+        let manifestSpec = manifest.flatMap { ManagedModelCatalog.spec(for: $0.id) }
+        let spec = expectedModelID.flatMap(ManagedModelCatalog.spec(for:)) ?? manifestSpec
         let usesMFluxZImage = spec?.validationKind == .zimageTurbo
             && ZImageTurboResources(rootURL: rootURL).hasMFluxWeights(fileManager: fileManager)
 
@@ -152,6 +153,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .ltxVideo
             || spec?.validationKind == .ltxVideo23MLX
             || spec?.validationKind == .ltxVideo23A2VMLX
+            || spec?.validationKind == .ltxVideo23FullMLX
             || spec?.validationKind == .insightFaceBuffaloL
             || spec?.validationKind == .moge2
             || spec?.validationKind == .videoDepthAnything
@@ -342,7 +344,11 @@ public enum MereRunModelValidator {
         errors: inout [String]
     ) {
         if let expectedModelID, manifest.id != expectedModelID {
-            errors.append("Manifest id mismatch: expected=\(expectedModelID) found=\(manifest.id)")
+            if manifestIDIsCompatible(expected: expectedModelID, actual: manifest.id) {
+                warnings.append("Resolved compatible manifest id: requested=\(expectedModelID) installed=\(manifest.id)")
+            } else {
+                errors.append("Manifest id mismatch: expected=\(expectedModelID) found=\(manifest.id)")
+            }
         }
 
         if manifest.schemaVersion > MereRunModelManifest.currentSchemaVersion {
@@ -502,6 +508,10 @@ public enum MereRunModelValidator {
         }
         if supportsImagePipeline && !usesUnifiedImageTransformer && components.vae == nil { errors.append("Manifest components missing vae.") }
         if supportsImagePipeline && !usesUnifiedImageTransformer && components.scheduler == nil { errors.append("Manifest components missing scheduler.") }
+    }
+
+    private static func manifestIDIsCompatible(expected: String, actual: String) -> Bool {
+        ManagedModelCatalog.spec(for: expected)?.resolutionFallbackIDs.contains(actual) == true
     }
 
     private static func manifestRequiresInlineQuantization(_ manifest: MereRunModelManifest) -> Bool {

--- a/Tests/MereRunCLITests/GuideCommandTests.swift
+++ b/Tests/MereRunCLITests/GuideCommandTests.swift
@@ -114,7 +114,7 @@ final class GuideCommandTests: XCTestCase {
         XCTAssertEqual(command.model, "image-zimage-max")
     }
 
-    func testGuideVideoGenerateCoversLTX23UnifiedAVModel() throws {
+    func testGuideVideoGenerateCoversLTX23QualityAndOutputContract() throws {
         let command = try GuideCommand.parse([
             "video",
             "generate",
@@ -127,7 +127,8 @@ final class GuideCommandTests: XCTestCase {
         XCTAssertEqual(entry.topic, "video-generate")
         XCTAssertEqual(command.model, ModelResolver.ModelID.ltxVideo23AVMLX.rawValue)
         XCTAssertTrue(rendered.contains("Model focus: `\(ModelResolver.ModelID.ltxVideo23AVMLX.rawValue)`"))
-        XCTAssertTrue(rendered.contains("--variant unified-av"))
+        XCTAssertTrue(rendered.contains("--quality final"))
+        XCTAssertTrue(rendered.contains("--output-mode audio-video"))
     }
 
     func testGuideOpenWebUIParsesAndRenders() throws {

--- a/Tests/MereRunCLITests/ModelInfoCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelInfoCommandTests.swift
@@ -90,6 +90,26 @@ final class ModelInfoCommandTests: XCTestCase {
         XCTAssertFalse(lines.contains { $0.contains("(missing)") })
     }
 
+    func testLTX23FullRequestedIDTakesPrecedenceOverCompatibleLegacyManifest() {
+        let legacyManifest = MereRunModelManifest.template(
+            for: .ltxVideo23A2VMLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertTrue(
+            ModelInfo.usesLTX23FullLayout(
+                manifest: legacyManifest,
+                expectedModelID: ModelResolver.ModelID.ltxVideo23FullMLX.rawValue
+            )
+        )
+        XCTAssertFalse(
+            ModelInfo.usesLTX23A2VidLayout(
+                manifest: legacyManifest,
+                expectedModelID: ModelResolver.ModelID.ltxVideo23FullMLX.rawValue
+            )
+        )
+    }
+
     func testLTXMergedComponentLinesShowMergedModelFiles() throws {
         let root = try makeTempDirectory()
         try FileManager.default.createDirectory(

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -274,6 +274,12 @@ final class VideoCommandTests: XCTestCase {
 
         XCTAssertEqual(cmd.prompt, "a cinematic drone flythrough")
         XCTAssertEqual(cmd.variant, .distilled)
+        XCTAssertNil(cmd.quality)
+        XCTAssertNil(cmd.outputMode)
+        XCTAssertNil(cmd.legacyVariant)
+        XCTAssertEqual(cmd.requestedQuality, .draft)
+        XCTAssertEqual(cmd.effectiveOutputMode, .videoOnly)
+        XCTAssertEqual(cmd.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23AVMLX.rawValue)
         XCTAssertEqual(cmd.width, 768)
         XCTAssertEqual(cmd.height, 512)
         XCTAssertEqual(cmd.numFrames, 65)
@@ -287,6 +293,54 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertFalse(cmd.json)
         XCTAssertFalse(cmd.timings)
         XCTAssertNil(cmd.timingsOutput)
+    }
+
+    func testVideoGenerateSeparatesCheckpointQualityFromOutputMode() throws {
+        let finalVideo = try VideoGenerate.parse([
+            "a cinematic final shot",
+            "--quality", "final",
+        ])
+        XCTAssertEqual(finalVideo.requestedQuality, .final)
+        XCTAssertEqual(finalVideo.effectiveOutputMode, .videoOnly)
+        XCTAssertEqual(finalVideo.variant, .distilled)
+        XCTAssertEqual(finalVideo.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23FullMLX.rawValue)
+
+        let draftAV = try VideoGenerate.parse([
+            "a fast synchronized draft",
+            "--quality", "draft",
+            "--output-mode", "audio-video",
+        ])
+        XCTAssertEqual(draftAV.requestedQuality, .draft)
+        XCTAssertEqual(draftAV.effectiveOutputMode, .audioVideo)
+        XCTAssertEqual(draftAV.variant, .unifiedAV)
+        XCTAssertEqual(draftAV.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23AVMLX.rawValue)
+
+        let finalAV = try VideoGenerate.parse([
+            "a final synchronized shot",
+            "--quality", "final",
+            "--output-mode", "audio-video",
+        ])
+        XCTAssertEqual(finalAV.requestedQuality, .final)
+        XCTAssertEqual(finalAV.effectiveOutputMode, .audioVideo)
+        XCTAssertEqual(finalAV.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23FullMLX.rawValue)
+    }
+
+    func testVideoGenerateLegacyVariantDefaultsRemainCompatible() throws {
+        let distilled = try VideoGenerate.parse([
+            "a draft",
+            "--variant", "distilled",
+        ])
+        XCTAssertEqual(distilled.requestedQuality, .draft)
+        XCTAssertEqual(distilled.effectiveOutputMode, .videoOnly)
+        XCTAssertEqual(distilled.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23AVMLX.rawValue)
+
+        let unified = try VideoGenerate.parse([
+            "a final synchronized shot",
+            "--variant", "unified-av",
+        ])
+        XCTAssertEqual(unified.requestedQuality, .final)
+        XCTAssertEqual(unified.effectiveOutputMode, .audioVideo)
+        XCTAssertEqual(unified.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23FullMLX.rawValue)
     }
 
     func testVideoGenerateParsesTimingOptions() throws {
@@ -319,6 +373,8 @@ final class VideoCommandTests: XCTestCase {
     func testLTXVideoGenerationRoutePreservesLayoutAndAudioContracts() throws {
         let legacyRoot = try makeValidLTXModelRoot()
         let splitRoot = try makeValidSplitDistilledModelRoot()
+        let a2vRoot = try makeValidA2VidModelRoot()
+        let fullRoot = try makeValidFullModelRoot()
 
         let legacy = resolveLTXVideoGenerationRoute(variant: .distilled, modelRoot: legacyRoot)
         XCTAssertEqual(legacy, .legacyDistilledVideo)
@@ -329,6 +385,15 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(split, .splitDistilledVideo)
         XCTAssertFalse(split.writesAudio)
         XCTAssertTrue(split.supportsPhaseTimings)
+
+        let fullVideo = resolveLTXVideoGenerationRoute(outputMode: .videoOnly, modelRoot: fullRoot)
+        XCTAssertEqual(fullVideo, .fullQualityVideo)
+        XCTAssertFalse(fullVideo.writesAudio)
+        XCTAssertTrue(fullVideo.supportsPhaseTimings)
+
+        let compatibleFullVideo = resolveLTXVideoGenerationRoute(outputMode: .videoOnly, modelRoot: a2vRoot)
+        XCTAssertEqual(compatibleFullVideo, .fullQualityVideo)
+        XCTAssertFalse(compatibleFullVideo.writesAudio)
 
         let unified = resolveLTXVideoGenerationRoute(variant: .unifiedAV, modelRoot: splitRoot)
         XCTAssertEqual(unified, .unifiedAV)
@@ -512,6 +577,106 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(envelope.result.model.layout, "ltx23_full_split")
         XCTAssertEqual(envelope.result.plan.variant, "unified-av")
         XCTAssertTrue(envelope.result.plan.writesAudio)
+    }
+
+    func testVideoGenerateFinalQualityDefaultsToVideoOnlyFullPipeline() throws {
+        let modelRoot = try makeValidFullModelRoot()
+        let output = makeTempOutput(name: "final.mp4")
+        let cmd = try VideoGenerate.parse([
+            "a cinematic final shot",
+            "--quality", "final",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.layout, "ltx23_full_split")
+        XCTAssertEqual(envelope.result.plan.quality, "final")
+        XCTAssertEqual(envelope.result.plan.outputMode, "video-only")
+        XCTAssertFalse(envelope.result.plan.writesAudio)
+        let action = try XCTUnwrap(envelope.actions.first { $0.id == "start-video-generation" })
+        XCTAssertTrue(action.command?.argv.contains("--quality") == true)
+        XCTAssertTrue(action.command?.argv.contains("final") == true)
+        XCTAssertFalse(action.command?.argv.contains("--variant") == true)
+    }
+
+    func testVideoGenerateDraftAudioVideoKeepsDistilledCheckpoint() throws {
+        let modelRoot = try makeValidSplitDistilledModelRoot()
+        let output = makeTempOutput(name: "draft-av.mp4")
+        let cmd = try VideoGenerate.parse([
+            "a synchronized draft",
+            "--quality", "draft",
+            "--output-mode", "audio-video",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.layout, "ltx23_distilled_split")
+        XCTAssertEqual(envelope.result.plan.quality, "draft")
+        XCTAssertEqual(envelope.result.plan.outputMode, "audio-video")
+        XCTAssertTrue(envelope.result.plan.writesAudio)
+    }
+
+    func testVideoGeneratePreflightBlocksAmbiguousLegacyAndProductSelectors() throws {
+        let modelRoot = try makeValidFullModelRoot()
+        let output = makeTempOutput(name: "ambiguous.mp4")
+        let cmd = try VideoGenerate.parse([
+            "an ambiguous request",
+            "--variant", "unified-av",
+            "--quality", "final",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "video_product_selection_conflict" })
+    }
+
+    func testVideoGeneratePreflightBlocksQualityModelMismatch() throws {
+        let modelRoot = try makeValidFullModelRoot()
+        let output = makeTempOutput(name: "mismatch.mp4")
+        let cmd = try VideoGenerate.parse([
+            "a mismatched request",
+            "--quality", "draft",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "video_quality_model_mismatch" })
     }
 
     func testVideoGenerateSplitDistilledPreflightReportsVideoOnlyContract() throws {
@@ -762,6 +927,10 @@ final class VideoCommandTests: XCTestCase {
 
     func testValidateNativeModelRootAcceptsFullLTX23Layout() throws {
         XCTAssertNoThrow(try validateNativeModelRoot(makeValidFullModelRoot()))
+    }
+
+    func testValidateNativeModelRootAcceptsCompatibleA2VidLayoutForFinalVideo() throws {
+        XCTAssertNoThrow(try validateNativeModelRoot(makeValidA2VidModelRoot()))
     }
 
     func testWanPreflightUsesNativeSpatialAndTemporalGeometry() throws {

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -301,17 +301,39 @@ final class VideoCommandTests: XCTestCase {
     }
 
     func testVideoGenerateRejectsTimingOptionsForUnsupportedLane() async throws {
+        let modelRoot = try makeValidLTXModelRoot()
         let cmd = try VideoGenerate.parse([
             "a cinematic drone flythrough",
             "--timings",
+            "--model-root", modelRoot.path,
         ])
 
         do {
             try await cmd.run()
-            XCTFail("Expected timing options without unified AV or A2Vid to fail validation.")
+            XCTFail("Expected timing options with the legacy distilled lane to fail validation.")
         } catch {
-            XCTAssertTrue(String(describing: error).contains("require --variant unified-av or --audio"))
+            XCTAssertTrue(String(describing: error).contains("require an LTX 2.3 split model"))
         }
+    }
+
+    func testLTXVideoGenerationRoutePreservesLayoutAndAudioContracts() throws {
+        let legacyRoot = try makeValidLTXModelRoot()
+        let splitRoot = try makeValidSplitDistilledModelRoot()
+
+        let legacy = resolveLTXVideoGenerationRoute(variant: .distilled, modelRoot: legacyRoot)
+        XCTAssertEqual(legacy, .legacyDistilledVideo)
+        XCTAssertFalse(legacy.writesAudio)
+        XCTAssertFalse(legacy.supportsPhaseTimings)
+
+        let split = resolveLTXVideoGenerationRoute(variant: .distilled, modelRoot: splitRoot)
+        XCTAssertEqual(split, .splitDistilledVideo)
+        XCTAssertFalse(split.writesAudio)
+        XCTAssertTrue(split.supportsPhaseTimings)
+
+        let unified = resolveLTXVideoGenerationRoute(variant: .unifiedAV, modelRoot: splitRoot)
+        XCTAssertEqual(unified, .unifiedAV)
+        XCTAssertTrue(unified.writesAudio)
+        XCTAssertTrue(unified.supportsPhaseTimings)
     }
 
     func testVideoSessionParsesDefaults() throws {
@@ -490,6 +512,57 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(envelope.result.model.layout, "ltx23_full_split")
         XCTAssertEqual(envelope.result.plan.variant, "unified-av")
         XCTAssertTrue(envelope.result.plan.writesAudio)
+    }
+
+    func testVideoGenerateSplitDistilledPreflightReportsVideoOnlyContract() throws {
+        let modelRoot = try makeValidSplitDistilledModelRoot()
+        let output = makeTempOutput(name: "draft.mp4")
+        let timingsOutput = makeTempOutput(name: "draft-timings.json")
+        let cmd = try VideoGenerate.parse([
+            "a fox runs across snow",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--timings",
+            "--timings-output", timingsOutput.path,
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.layout, "ltx23_distilled_split")
+        XCTAssertEqual(envelope.result.plan.variant, "distilled")
+        XCTAssertFalse(envelope.result.plan.writesAudio)
+        XCTAssertEqual(envelope.request.timings, true)
+        XCTAssertEqual(envelope.request.timingsOutput, timingsOutput.path)
+        XCTAssertFalse(envelope.diagnostics.contains { $0.id == "timings_lane_unsupported" })
+    }
+
+    func testVideoGenerateLegacyDistilledPreflightBlocksPhaseTimings() throws {
+        let modelRoot = try makeValidLTXModelRoot()
+        let output = makeTempOutput(name: "draft.mp4")
+        let cmd = try VideoGenerate.parse([
+            "a fox runs across snow",
+            "--model-root", modelRoot.path,
+            "--output", output.path,
+            "--timings",
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "timings_lane_unsupported" })
     }
 
     func testVideoGenerateA2VidPreflightBlocksIncompatibleManagedModel() throws {
@@ -767,6 +840,22 @@ final class VideoCommandTests: XCTestCase {
         ] {
             try createFile(rootURL.appendingPathComponent(name))
         }
+        return rootURL
+    }
+
+    private func makeValidSplitDistilledModelRoot() throws -> URL {
+        let rootURL = try makeTempDirectory()
+        for name in [
+            "split_model.json",
+            "transformer-distilled.safetensors",
+            "vae_decoder.safetensors",
+            "spatial_upscaler_x2_v1_1.safetensors",
+        ] {
+            try createFile(rootURL.appendingPathComponent(name))
+        }
+        try Data(#"{"model_version":"2.3"}"#.utf8).write(
+            to: rootURL.appendingPathComponent("config.json")
+        )
         return rootURL
     }
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -255,6 +255,40 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         }
     }
 
+    private func writeMinimalLTX23FullModel(
+        at root: URL,
+        manifestID: ModelResolver.ModelID,
+        includeVocoder: Bool
+    ) throws {
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(
+            for: manifestID,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+        var files = [
+            "config.json",
+            "embedded_config.json",
+            "split_model.json",
+            "connector.safetensors",
+            "transformer-dev.safetensors",
+            "ltx-2.3-22b-distilled-lora-384-1.1.safetensors",
+            "vae_decoder.safetensors",
+            "vae_encoder.safetensors",
+            "audio_vae.safetensors",
+            "spatial_upscaler_x2_v1_1.safetensors",
+            "spatial_upscaler_x2_v1_1_config.json",
+        ]
+        if includeVocoder {
+            files.append("vocoder.safetensors")
+        }
+        for file in files {
+            try TestFileSystem.writeFile(
+                root.appendingPathComponent(file),
+                contents: file.hasSuffix(".json") ? Data(#"{"model_version":"2.3.0"}"#.utf8) : Data()
+            )
+        }
+    }
+
     func testValidModelPasses() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }
@@ -397,6 +431,47 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(report.manifest?.engine, .ltxVideo)
         XCTAssertEqual(report.manifest?.family, .video)
         XCTAssertEqual(report.manifest?.upstreamRepoId, "dgrauet/ltx-2.3-mlx@main")
+    }
+
+    func testLTX23FullCanonicalIDAcceptsCompatibleLegacyManifest() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(ModelResolver.ModelID.ltxVideo23A2VMLX.rawValue)
+        try writeMinimalLTX23FullModel(
+            at: root,
+            manifestID: .ltxVideo23A2VMLX,
+            includeVocoder: true
+        )
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: ModelResolver.ModelID.ltxVideo23FullMLX.rawValue
+        )
+
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertTrue(report.warnings.contains { $0.contains("Resolved compatible manifest id") })
+    }
+
+    func testLTX23FullCanonicalIDStillRequiresFullBundleAssets() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(ModelResolver.ModelID.ltxVideo23A2VMLX.rawValue)
+        try writeMinimalLTX23FullModel(
+            at: root,
+            manifestID: .ltxVideo23A2VMLX,
+            includeVocoder: false
+        )
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: ModelResolver.ModelID.ltxVideo23FullMLX.rawValue
+        )
+
+        XCTAssertFalse(report.isValid)
+        XCTAssertTrue(report.errors.contains { $0.contains("vocoder.safetensors") })
     }
 
     func testMissingWeightsFails() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -322,8 +322,7 @@ swift run mere.run sfx generate \
 ```bash
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
-  --variant unified-av \
-  --model video-ltx23-full-mlx \
+  --quality final \
   --duration 5 \
   --output ./clip.mp4
 ```
@@ -1715,8 +1714,12 @@ swift run mere.run video generate "<prompt>" [options]
 
 Key options:
 
-- `--variant`: `distilled` for video-only output from current split or legacy
-  merged LTX roots, or `unified-av` for synchronized audio/video
+- `--quality`: `draft` selects the fast standalone-distilled checkpoint;
+  `final` selects the full dev + distilled-LoRA quality pipeline
+- `--output-mode`: `video-only` (default) or synchronized `audio-video`
+- `--variant`: compatibility selector; `distilled` defaults to draft
+  video-only and `unified-av` defaults to final audio-video; explicit `--model`
+  still wins
 - `--model-root`
 - `--output`
 - `--width`, `--height`
@@ -1752,13 +1755,15 @@ Environment:
   `mlx-community/gemma-3-12b-it-4bit` checkout used by `video-ltx23-av-mlx`,
   `video-ltx23-full-mlx`, and the legacy `video-ltx23-a2vid-mlx`
 
-For `--variant unified-av`, keep `--fps 24` unless you are deliberately making
+For `--output-mode audio-video`, keep `--fps 24` unless you are deliberately making
 a retimed clip. LTX 2.3 unified AV is trained around 24 fps; using 8 fps can
 make generated motion look slow while audio remains normal. Use `--duration`
 for clip length so the CLI can choose the nearest legal `8n+1` frame count.
-Use the default `distilled` lane for faster video-only drafts. Use
-`--variant unified-av --model video-ltx23-full-mlx` for the current high-quality
-synchronized audio/video lane.
+Use the default `--quality draft` lane for fast iterations. Use `--quality
+final` for the current high-quality two-stage checkpoint. Output is a separate
+choice: both qualities default to video-only, and `--output-mode audio-video`
+adds synchronized generated audio. Suppressing audio on the same checkpoint is
+an output contract, not the source of the draft lane's speed advantage.
 
 On `video-ltx23-av-mlx`, distilled generation uses the split-layout LTX 2.3
 transformer and preserves its joint audio/video denoising contract because
@@ -1797,18 +1802,20 @@ Examples:
 ```bash
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --num-frames 65
 
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --num-frames 65 \
   --output ./clip.mp4 \
   --preflight \
   --json
+
+swift run mere.run video generate \
+  "a red fox runs across a snowy clearing, detailed winter fur, natural motion" \
+  --quality final \
+  --duration 4 \
+  --output ./fox-final.mp4
 
 swift run mere.run video generate \
   "the first-person camera walks straight forward through the same corridor" \
@@ -1822,8 +1829,8 @@ swift run mere.run video generate \
 
 swift run mere.run video generate \
   "two actors talking beside a window while a restrained orchestral score and distant city sirens play underneath" \
-  --variant unified-av \
-  --model video-ltx23-full-mlx \
+  --quality final \
+  --output-mode audio-video \
   --duration 15 \
   --fps 24 \
   --output ./dialogue-score-sfx.mp4
@@ -1838,8 +1845,6 @@ swift run mere.run video generate \
 
 swift run mere.run video generate \
   "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --image ./car-start.png \
   --end-image ./car-end.png \
   --num-frames 65 \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1715,7 +1715,8 @@ swift run mere.run video generate "<prompt>" [options]
 
 Key options:
 
-- `--variant`: `distilled` or `unified-av`
+- `--variant`: `distilled` for video-only output from current split or legacy
+  merged LTX roots, or `unified-av` for synchronized audio/video
 - `--model-root`
 - `--output`
 - `--width`, `--height`
@@ -1739,7 +1740,8 @@ Key options:
 - `--end-image-strength`
 - `--preflight`
 - `--json`: only with `--preflight`
-- `--timings`: native LTX 2.3 unified-AV/A2Vid phase timings on stderr
+- `--timings`: native LTX 2.3 split-distilled, unified-AV, or A2Vid phase
+  timings on stderr; unavailable for legacy merged distilled roots
 - `--timings-output`: write those timings as JSON
 - `--quiet`
 
@@ -1757,6 +1759,11 @@ for clip length so the CLI can choose the nearest legal `8n+1` frame count.
 Use the default `distilled` lane for faster video-only drafts. Use
 `--variant unified-av --model video-ltx23-full-mlx` for the current high-quality
 synchronized audio/video lane.
+
+On `video-ltx23-av-mlx`, distilled generation uses the split-layout LTX 2.3
+transformer and preserves its joint audio/video denoising contract because
+audio-to-video cross attention contributes to the video result. It skips
+loading the audio VAE and vocoder, and the resulting MP4 has no audio stream.
 
 With `--audio`, the command resolves `video-ltx23-full-mlx` automatically.
 The full/dev transformer performs guided half-resolution denoising with frozen
@@ -1780,7 +1787,8 @@ Preflight mode:
   audio offset, seed, input mode, whether audio conditions generation, whether
   the source soundtrack is preserved, diagnostics, and declarative actions.
 - blockers such as a missing model root, missing image, invalid frame rate, or
-  `--end-image` without `--image` produce JSON and a nonzero exit.
+  `--end-image` without `--image` produce JSON and a nonzero exit. Requesting
+  phase timings on a legacy merged distilled root or Wan2.2 is also blocked.
 - notes such as dimension/frame snapping remain machine-readable so a UI can
   explain the exact render that will run.
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -624,9 +624,9 @@ The unified AV model root is:
 .../models/video-ltx-av
 ```
 
-`mere.run video generate --variant distilled --model video-ltx-av` is the
-faster video-only draft path. `mere.run video generate --variant unified-av
---model video-ltx-av` remains available for the older synchronized AV root.
+`mere.run video generate --quality draft --model video-ltx-av` is the faster
+video-only draft path. The legacy `--variant` selector remains available for
+older scripts using this root.
 `MERERUN_VIDEO_LTX_MODEL_ROOT` can still point at this layout explicitly.
 
 ### `video-ltx23-av-mlx`
@@ -646,11 +646,11 @@ conditioning. Set `MERERUN_VIDEO_LTX_TEXT_ENCODER_ROOT` only when pointing at an
 external `mlx-community/gemma-3-12b-it-4bit` checkout.
 
 The native Swift runtime uses this standalone distilled transformer for the
-fast video-only draft lane. That route retains the checkpoint's joint AV
-denoising tokens but does not load or decode the audio VAE/vocoder, and its MP4
-contains no audio stream. It can still run synchronized AV when explicitly
-selected with `--variant unified-av`, but the canonical two-stage quality path
-uses `video-ltx23-full-mlx`.
+fast `--quality draft` lane. The default `--output-mode video-only` route
+retains the checkpoint's joint AV denoising tokens but does not load or decode
+the audio VAE/vocoder, and its MP4 contains no audio stream. It can also emit
+synchronized AV with `--output-mode audio-video`, but the canonical final
+quality path uses `video-ltx23-full-mlx`.
 The Unsloth `LTX-2.3-GGUF` checkpoint family is a separate quantized GGUF lane
 and is not loaded by the native MLX video runtime.
 
@@ -670,11 +670,13 @@ temporal upscalers. Hugging Face cache objects are shared with
 `video-ltx23-av-mlx` when both models are installed. The hidden Gemma 3
 companion is shared as well.
 
-The same bundle drives both official two-stage contracts. Unified AV jointly
-denoises guided video and audio latents in stage one, then refines both after
-LoRA fusion. A2Vid encodes source audio and freezes those audio latents through
-both stages; the original decoded source segment—not VAE-decoded audio—is muxed
-into the MP4.
+The same bundle drives all official two-stage final-quality contracts. The
+default `--quality final --output-mode video-only` route runs the full video
+pipeline without requiring audio in the deliverable. With `--output-mode
+audio-video`, unified AV jointly denoises guided video and audio latents in
+stage one, then refines both after LoRA fusion. A2Vid encodes source audio and
+freezes those audio latents through both stages; the original decoded source
+segment—not VAE-decoded audio—is muxed into the MP4.
 
 ### `video-ltx23-a2vid-mlx`
 
@@ -684,10 +686,10 @@ This deprecated compatibility ID preserves existing A2Vid installs and scripts:
 .../models/video-ltx23-a2vid-mlx
 ```
 
-Its legacy narrow manifest omits the vocoder, so it can run source-audio A2Vid
-but not generated-audio unified AV. Requests for either the legacy ID or the
-new full ID resolve to an already-installed compatible root when possible. New
-pulls should use `video-ltx23-full-mlx`.
+Its legacy narrow manifest may omit the vocoder, so it can run final-quality
+video-only and source-audio A2Vid but not generated-audio output. Requests for
+either the legacy ID or the new full ID resolve to an already-installed
+compatible root when possible. New pulls should use `video-ltx23-full-mlx`.
 
 ### `video-wan22-ti2v-5b-mlx`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -646,7 +646,9 @@ conditioning. Set `MERERUN_VIDEO_LTX_TEXT_ENCODER_ROOT` only when pointing at an
 external `mlx-community/gemma-3-12b-it-4bit` checkout.
 
 The native Swift runtime uses this standalone distilled transformer for the
-fast video-only draft lane. It can still run synchronized AV when explicitly
+fast video-only draft lane. That route retains the checkpoint's joint AV
+denoising tokens but does not load or decode the audio VAE/vocoder, and its MP4
+contains no audio stream. It can still run synchronized AV when explicitly
 selected with `--variant unified-av`, but the canonical two-stage quality path
 uses `video-ltx23-full-mlx`.
 The Unsloth `LTX-2.3-GGUF` checkpoint family is a separate quantized GGUF lane

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -14,10 +14,10 @@ This page covers the native video-generation path exposed through `mere.run vide
 ## Model family
 
 - `video-ltx23-av-mlx`: standalone distilled LTX 2.3 MLX checkpoint for fast
-  video-only drafts.
+  drafts. This is the default `--quality draft` checkpoint.
 - `video-ltx23-full-mlx`: LTX 2.3 dev checkpoint, official distilled LoRA,
   vocoder, VAEs, and x2 upscaler. This is the shared quality bundle for both
-  `--variant unified-av` and source-audio A2Vid.
+  `--quality final`, generated synchronized audio, and source-audio A2Vid.
 - `video-ltx23-a2vid-mlx`: compatibility ID for existing A2Vid installs. New
   installs should use `video-ltx23-full-mlx`.
 - `video-ltx-av`: legacy merged LTX root, superseded by LTX 2.3. Only still required
@@ -181,8 +181,9 @@ and reference/mask ordering is preserved.
 
 ### Fast visual draft
 
-The default `distilled` lane is the speed path. It generates video-only MP4s
-and is the right first pass for prompt, camera, subject, and composition checks.
+The default `--quality draft` lane is the speed path. It generates video-only
+MP4s by default and is the right first pass for prompt, camera, subject, and
+composition checks.
 For the current split-layout LTX 2.3 model, it retains the joint AV denoising
 tokens that influence video through audio-to-video cross attention, but skips
 loading and decoding the audio VAE/vocoder and writes no audio stream.
@@ -190,8 +191,6 @@ loading and decoding the audio VAE/vocoder and writes no audio stream.
 ```bash
 swift run mere.run video generate \
   "a cinematic drone flythrough over snowy mountains" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --num-frames 65 \
   --output ./clip.mp4
 ```
@@ -204,8 +203,6 @@ should move toward a specific final keyframe.
 ```bash
 swift run mere.run video generate \
   "a car drives from a bright morning street into a warm sunset road, smooth forward motion" \
-  --variant distilled \
-  --model video-ltx23-av-mlx \
   --image ./car-start.png \
   --image-strength 0.9 \
   --end-image ./car-end.png \
@@ -217,7 +214,26 @@ swift run mere.run video generate \
 `--end-image` requires `--image`; the start conditioning wins if very short
 clips make the start and end latent conditioning windows overlap.
 
-### Synchronized AV quality render
+### Final-quality render
+
+Quality and output are independent choices. `--quality final` uses the full
+dev + distilled-LoRA two-stage pipeline and still writes a video-only MP4 by
+default:
+
+```bash
+swift run mere.run model pull video-ltx23-full-mlx --accept-model-license
+swift run mere.run video generate \
+  "a red fox runs across a snowy clearing, detailed winter fur, natural motion" \
+  --quality final \
+  --duration 4 \
+  --output ./fox-final.mp4
+```
+
+This is the final-quality checkpoint with audio components omitted from the
+deliverable. It is not a separate speed optimization; the meaningful speed
+change comes from selecting the draft checkpoint.
+
+### Synchronized AV final render
 
 For LTX 2.3 audio/video, pull the managed model id and let it install its Gemma
 3 companion:
@@ -226,8 +242,8 @@ For LTX 2.3 audio/video, pull the managed model id and let it install its Gemma
 swift run mere.run model pull video-ltx23-full-mlx --accept-model-license
 swift run mere.run video generate \
   "dialogue with clean background music" \
-  --variant unified-av \
-  --model video-ltx23-full-mlx \
+  --quality final \
+  --output-mode audio-video \
   --duration 15 \
   --fps 24 \
   --output ./ltx23.mp4
@@ -238,12 +254,12 @@ representative unified AV tests. LTX 2.3 expects 24 fps timing; for example,
 15 seconds resolves to 361 frames at 24 fps because LTX frame counts must
 satisfy `8n+1`.
 
-`video-ltx23-full-mlx --variant unified-av` runs the official two-stage quality
+`--quality final --output-mode audio-video` runs the official two-stage quality
 path: guided dev denoising for both audio and video at half resolution, followed
 by x2 latent upscaling and four-step refinement after fusing the distilled LoRA.
 The older `video-ltx-av` merged root is retained only for `video export-latents`.
 
-Add `--timings` to print phase timings for native LTX 2.3 unified-AV or A2Vid
+Add `--timings` to print phase timings for native LTX 2.3 draft, final, or A2Vid
 generation. `--timings-output <path>` writes the same typed report as JSON,
 including model-component loading, text encoding, each denoising stage, LoRA
 fusion where applicable, upsampling, video/audio decode, MP4 writing, unload,

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -183,6 +183,9 @@ and reference/mask ordering is preserved.
 
 The default `distilled` lane is the speed path. It generates video-only MP4s
 and is the right first pass for prompt, camera, subject, and composition checks.
+For the current split-layout LTX 2.3 model, it retains the joint AV denoising
+tokens that influence video through audio-to-video cross attention, but skips
+loading and decoding the audio VAE/vocoder and writes no audio stream.
 
 ```bash
 swift run mere.run video generate \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -195,11 +195,13 @@ Use it to separate waveform/vocoder problems from mux or AAC encoding
 differences.
 
 `video-ltx23-full-mlx` is the managed LTX 2.3 dev + distilled-LoRA checkpoint
-for the high-quality two-stage `unified-av` and A2Vid paths. The standalone
-`video-ltx23-av-mlx` distilled split remains the fast draft lane. Both can be
-scanned by the comparison script after generating a sample. The Unsloth LTX 2.3
-GGUF checkpoints are a separate quantized runner shape, not a drop-in native
-MLX model root.
+for the high-quality two-stage `--quality final` and A2Vid paths. Generated
+audio is independently selected with `--output-mode audio-video`; leaving it
+off does not turn the full checkpoint into the fast lane. The standalone
+`video-ltx23-av-mlx` distilled split remains the fast `--quality draft` lane.
+Both can be scanned by the comparison script after generating a sample. The
+Unsloth LTX 2.3 GGUF checkpoints are a separate quantized runner shape, not a
+drop-in native MLX model root.
 
 ## End-to-end smoke tests
 


### PR DESCRIPTION
## Summary

- route standalone LTX 2.3 distilled roots through the native split-distilled video-only path
- separate checkpoint choice with `--quality draft|final` from deliverable choice with `--output-mode video-only|audio-video`
- preserve `--variant distilled|unified-av` compatibility while blocking ambiguous mixed selectors
- support full dev plus distilled-LoRA final-quality generation without forcing an audio stream
- repair canonical `video-ltx23-full-mlx` inspection when an installed compatible root still uses the legacy A2Vid manifest ID
- update structured preflight, guides, README, runtime docs, model sources, testing docs, and changelog

## Product contract

- default: draft checkpoint plus video-only output
- `--quality final`: full two-stage dev plus distilled-LoRA video, still video-only by default
- `--output-mode audio-video`: generate synchronized audio independently of checkpoint choice
- `--audio`: select final quality A2Vid and preserve the selected source soundtrack

This keeps the distilled checkpoint as the fast iteration lane and the full checkpoint as the final-quality lane. Audio suppression controls the deliverable; it is not presented as a meaningful speed optimization for the same checkpoint.

## Validation

- `./scripts/check.sh`
  - strict lint passed
  - build passed
  - 2,065 XCTest cases passed with 127 fixture-gated skips
  - Swift Testing suites passed
  - CLI help sweep and hygiene scans passed
- `pnpm docs:build`
- installed-model structured preflight matrix passed for draft/video-only, final/video-only, draft/audio-video, final/audio-video, and legacy unified AV
- ambiguous legacy plus canonical selectors return a structured blocker
- real installed `--quality final` video-only smoke passed at 512x320, 33 frames, 24 fps, seed 20260717
  - output contains one H.264 stream and no audio stream
  - decoded-frame SHA-256 `439542d9baaf057516b54d5e7913fcc336d8269299d45c9b03b9fd475eef564d`
  - hash exactly matches the video stream from the corresponding full AV benchmark