### PR TITLE
feat(music): complete ACE-Step production workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## Unreleased
+
+### Added
+
+- added typed ACE-Step task and checkpoint capability routing for text-to-music,
+  repaint, cover, cover-nofsq, extract, lego, and complete. Invalid tasks now
+  fail during CLI parsing, and Base-only operations fail before checkpoint
+  weights load on Turbo/SFT models.
+- added native ACE-Step repaint ranges with upstream-compatible chunk masks,
+  source-silence conditioning, per-step clean-source injection, latent boundary
+  blending, and post-VAE original-waveform splicing. New controls expose edit
+  start/end, chunk-mask mode, preservation mode, and balanced-mode strength.
+- added immutable XL-SFT and XL-Base managed checkpoints, native continuous
+  non-Turbo inference with CFG/APG/ADG and Euler/Heun integration, adaptive
+  draft/song/final/edit presets, 4B LM planning, and automatic duration.
+- added warm resident music sessions and API batching, deterministic best-of-N
+  seed fanout, technical candidate scoring/ranking, retake interpolation, and
+  upstream-style semantic flow editing.
+- added full resident API control parity for inference, guidance, cover,
+  repaint, flow edit, reference audio, LM planning, VAE tiling, and task
+  instructions. Batch items keep independent best-of-N counts and responses
+  include their final effective conditioning metadata.
+- added native stacked PEFT LoRA and LyCORIS LoKr inference plus ACE-Step
+  flow-matching training through `music train-adapter`. Both formats were
+  train-save-reload tested against the installed XL-Turbo checkpoint.
+- added synchronized LRC, exact checkpoint/adapter recipe provenance, PCM16,
+  PCM24 and Float32 export, normalization/fade/dither controls, extracted
+  stems, and portable DAW/REAPER bundles.
+- added generation recipe schema 2 with the final effective BPM, duration,
+  key/scale, vocal language, and time signature after LM planning and explicit
+  overrides.
+
+### Changed
+
+- changed `--non-cover` into a compatibility alias for the explicit
+  `cover-nofsq` task instead of a boolean that could silently erase task
+  semantics.
+- source-conditioned ACE-Step tasks now inherit source duration and require
+  source audio explicitly. Non-Turbo checkpoints now use their native
+  guidance and continuous schedule rather than the distilled Turbo sampler.
+- ACE-Step LM vocal-language metadata now accepts only the exact supported
+  upstream language codes, normalizes valid codes to lowercase, and discards
+  malformed multi-value or non-vocal planner output.
+- resident music API requests now reject a model other than the loaded model,
+  reject unsupported response formats with actionable JSON errors, and honor
+  per-item candidate counts in heterogeneous batches.
+
+### Fixed
+
+- fixed ACE-Step prompt, unconditional, and automatic repaint chunk masks to
+  match upstream boolean-mask semantics. The runtime previously supplied
+  `2.0` where upstream converts that value to boolean `true` (`1.0`), causing
+  stationary broadband-noise output from otherwise parity-matched components.
+- fixed text-to-music LM conditioning so generated 5 Hz audio codes reach the
+  diffusion model, and made `--seed` cover both LM planning/code sampling and
+  diffusion for repeatable recipes.
+- strengthened best-of-N ranking and the listening regression with spectral
+  structure and tail-continuity metrics, so non-silent broadband noise and
+  prematurely dead endings no longer pass as high-quality candidates.
+
 ## 0.26.0 - 2026-07-22
 
 This release contains every change merged since `v0.25.0`: the LTX 2.3

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -412,6 +412,8 @@ enum GuideRegistry {
             commandPaths: [["music", "generate"]],
             models: [
                 "music-acestep",
+                "music-acestep-xl-base",
+                "music-acestep-xl-sft",
                 "music-acestep-xl-turbo",
                 "music-acestep-xl-turbo-lm4b",
                 "music-magenta-rt2-small",

--- a/Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift
@@ -27,7 +27,10 @@ struct MusicAnalyze: AsyncParsableCommand {
     @Option(name: [.customLong("checkpoints-root")], help: "Root directory containing ACE-Step checkpoint subdirectories. Auto-discovered if not set.")
     var checkpointsRoot: String?
 
-    @Option(name: [.customLong("turbo-subdirectory")], help: "Turbo decoder subdirectory under checkpoints root.")
+    @Option(
+        name: [.customLong("decoder-subdirectory"), .customLong("turbo-subdirectory")],
+        help: "ACE-Step decoder subdirectory under checkpoints root."
+    )
     var turboSubdirectory: String = "acestep-v15-turbo"
 
     @Option(name: [.customLong("vae-subdirectory")], help: "VAE subdirectory under checkpoints root.")

--- a/Sources/MereRunCLI/Commands/MusicCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicCommand.swift
@@ -8,6 +8,8 @@ struct Music: ParsableCommand {
             MusicAnalyze.self,
             MusicGenerate.self,
             MusicRealtime.self,
+            MusicServe.self,
+            MusicTrainAdapter.self,
             MusicTranscribe.self,
         ]
     )

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -41,8 +41,64 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("lyrics-file")], help: "Path to lyrics text file. Cannot be used with --lyrics.")
     var lyricsFile: String?
 
+    @Option(name: [.customLong("lrc-file")], help: "Synchronized LRC lyrics input. Cannot be combined with plain lyrics options.")
+    var lrcFile: String?
+
+    @Option(name: [.customLong("lrc-output")], help: "Write synchronized LRC; plain lyrics receive clearly marked approximate line timing.")
+    var lrcOutput: String?
+
     @Option(name: [.customShort("o"), .long], help: "Output WAV path (default: ./mererun-music-<timestamp>.wav).")
     var output: String?
+
+    @Option(name: [.customLong("export-format")], help: "WAV encoding: pcm16, pcm24, or float32.")
+    var exportFormat: ACEStepAudioFormat = .pcm24
+
+    @Option(name: [.customLong("normalize")], help: "Output normalization: none or peak.")
+    var normalization: ACEStepNormalizationMode = .peak
+
+    @Option(name: [.customLong("target-peak-db")], help: "Peak-normalization target in dBFS.")
+    var targetPeakDB: Float = -1
+
+    @Option(name: [.customLong("fade-in-ms")], help: "Output fade-in in milliseconds.")
+    var fadeInMilliseconds: Float = 5
+
+    @Option(name: [.customLong("fade-out-ms")], help: "Output fade-out in milliseconds.")
+    var fadeOutMilliseconds: Float = 20
+
+    @Flag(name: [.customLong("no-dither")], help: "Disable deterministic TPDF dither for integer PCM export.")
+    var noDither: Bool = false
+
+    @Option(name: [.customLong("recipe-output")], help: "Generation recipe JSON path (default: <output>.recipe.json).")
+    var recipeOutput: String?
+
+    @Flag(name: [.customLong("no-recipe")], help: "Do not write the reproducible generation recipe sidecar.")
+    var noRecipe: Bool = false
+
+    @Option(name: [.customLong("daw-bundle")], help: "Write a portable DAW bundle with WAVs, recipe, LRC markers, and a REAPER project.")
+    var dawBundle: String?
+
+    @Option(name: [.customLong("stems")], help: "Comma-separated stems to extract after generation (Base checkpoints only).")
+    var stems: String?
+
+    @Option(
+        name: [.customLong("adapter")],
+        parsing: .upToNextOption,
+        help: "PEFT LoRA or LyCORIS LoKr safetensors file(s) to stack on the ACE-Step decoder."
+    )
+    var adapters: [String] = []
+
+    @Option(
+        name: [.customLong("adapter-kind")],
+        help: "Adapter format: auto, lora, or lokr."
+    )
+    var adapterKind: ACEStepAdapterKind = .auto
+
+    @Option(
+        name: [.customLong("adapter-scale")],
+        parsing: .upToNextOption,
+        help: "Adapter scale(s): one value for all adapters, or one per --adapter path."
+    )
+    var adapterScales: [Float] = []
 
     @Option(name: [.customShort("m"), .long], help: "Managed model id or local path to the ACE-Step model root/checkpoints root.")
     var model: String = ModelResolver.ModelID.aceStep.rawValue
@@ -50,7 +106,10 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("checkpoints-root")], help: "Root directory containing ACE-Step checkpoint subdirectories. Auto-discovered if not set.")
     var checkpointsRoot: String?
 
-    @Option(name: [.customLong("turbo-subdirectory")], help: "Turbo decoder subdirectory under checkpoints root.")
+    @Option(
+        name: [.customLong("decoder-subdirectory"), .customLong("turbo-subdirectory")],
+        help: "ACE-Step decoder subdirectory under checkpoints root."
+    )
     var turboSubdirectory: String = "acestep-v15-turbo"
 
     @Option(name: [.customLong("vae-subdirectory")], help: "VAE subdirectory under checkpoints root.")
@@ -65,23 +124,65 @@ struct MusicGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong("use-lm")], help: "Use 5Hz LM constrained decoding for supported ACE-Step tasks.")
     var useLM: Bool = false
 
+    @Flag(name: [.customLong("no-lm")], help: "Disable ACE-Step LM planning and semantic-code generation selected by a quality preset.")
+    var noLM: Bool = false
+
     @Flag(
         name: [.customLong("analyze-source-audio")],
         help: "Use ACE-Step 5Hz LM audio understanding to fill missing cover metadata from --source-audio."
     )
     var analyzeSourceAudio: Bool = false
 
-    @Option(name: [.customLong("duration")], help: "Output duration in seconds.")
-    var durationSeconds: Float = 10.0
+    @Option(name: [.customLong("duration")], help: "Output duration in seconds (omitting it lets song/final quality plan duration).")
+    var durationSeconds: Float?
 
-    @Option(name: [.customShort("s"), .long], help: "Number of turbo denoise steps.")
-    var steps: Int = 8
+    @Option(name: [.customLong("quality")], help: "Adaptive ACE-Step quality: draft, song, final, or edit.")
+    var quality: ACEStepQualityPreset = .song
 
-    @Option(name: [.customLong("shift")], help: "Turbo scheduler shift.")
-    var shift: Float = Self.defaultACEStepShift
+    @Option(name: [.customShort("s"), .long], help: "Denoise steps (default: Turbo 8; Base/SFT 50).")
+    var steps: Int?
+
+    @Option(name: [.customLong("shift")], help: "Flow scheduler shift (default: Turbo 3; Base/SFT 1).")
+    var shift: Float?
+
+    @Option(name: [.customLong("infer-method")], help: "Diffusion method: ode or sde (default: ode).")
+    var inferMethod: ACEStepInferenceMethod?
+
+    @Option(name: [.customLong("sampler")], help: "ODE sampler: euler or heun (default: euler).")
+    var samplerMode: ACEStepSamplerMode?
+
+    @Option(name: [.customLong("guidance-scale")], help: "Base/SFT diffusion guidance (default: 7; Turbo always uses 1).")
+    var guidanceScale: Float?
+
+    @Option(name: [.customLong("guidance-mode")], help: "Base/SFT guidance: apg, adg, or cfg (default: apg).")
+    var guidanceMode: ACEStepGuidanceMode?
+
+    @Option(name: [.customLong("cfg-interval-start")], help: "Enable guidance at or above this timestep in [0, 1].")
+    var cfgIntervalStart: Float?
+
+    @Option(name: [.customLong("cfg-interval-end")], help: "Enable guidance at or below this timestep in [0, 1].")
+    var cfgIntervalEnd: Float?
+
+    @Option(name: [.customLong("velocity-norm-threshold")], help: "Clamp velocity norm relative to the latent norm (0 disables).")
+    var velocityNormThreshold: Float?
+
+    @Option(name: [.customLong("velocity-ema-factor")], help: "Blend each velocity with its predecessor in [0, 1) (0 disables).")
+    var velocityEMAFactor: Float?
 
     @Option(name: [.long], help: "Seed for deterministic generation.")
     var seed: UInt64?
+
+    @Option(
+        name: [.customLong("candidates"), .customLong("best-of")],
+        help: "Generate and rank this many warm-session candidates (preset default: draft 1, song/edit 2, final 4)."
+    )
+    var candidateCount: Int?
+
+    @Flag(
+        name: [.customLong("keep-candidates")],
+        help: "Save every ranked candidate next to the selected output."
+    )
+    var keepCandidates: Bool = false
 
     @Option(name: [.customLong("audio-cover-strength")], help: "Cover-conditioning strength in [0, 1].")
     var audioCoverStrength: Float = 1.0
@@ -89,16 +190,25 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("cover-noise-strength")], help: "Source-latent noise initialization strength in [0, 1] for ACE-Step covers.")
     var coverNoiseStrength: Float = 0.0
 
+    @Option(name: [.customLong("retake-seed")], help: "Independent seed used to vary a reproducible retake.")
+    var retakeSeed: UInt64?
+
+    @Option(name: [.customLong("retake-variance")], help: "Retake interpolation in [0, 1]; 0 keeps --seed and 1 uses --retake-seed.")
+    var retakeVariance: Float = 0
+
     @Option(name: [.customLong("vocal-language")], help: "Language tag used in lyric prompt formatting.")
     var vocalLanguage: String = "en"
 
     @Option(name: [.customLong("instruction")], help: "Caption instruction prefix.")
     var instruction: String = "Fill the audio semantic mask based on the given conditions:"
 
-    @Option(name: [.customLong("task-type"), .customLong("task")], help: "Task type: text2music, cover, repaint, extract, lego, complete.")
-    var taskType: String = "text2music"
+    @Option(
+        name: [.customLong("task-type"), .customLong("task")],
+        help: "ACE-Step task: text2music, repaint, cover, cover-nofsq, extract, lego, or complete."
+    )
+    var taskType: ACEStepTask = .textToMusic
 
-    @Option(name: [.customLong("source-audio")], help: "Source audio file for ACE-Step cover conditioning. Implies cover mode unless --non-cover is set.")
+    @Option(name: [.customLong("source-audio")], help: "Source audio for ACE-Step cover, repaint, extract, lego, or complete. With the default task, implies cover.")
     var sourceAudio: String?
 
     @Option(name: [.customLong("reference-audio")], parsing: .upToNextOption, help: "Optional reference audio file(s) for ACE-Step timbre conditioning.")
@@ -110,8 +220,41 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("complete-track-classes")], help: "Comma-separated track classes for complete task (e.g. Drums,Bass).")
     var completeTrackClasses: String?
 
-    @Flag(name: [.customLong("non-cover")], help: "Force non-cover conditioning for cover-style tasks.")
+    @Flag(name: [.customLong("non-cover")], help: "Compatibility alias that selects cover-nofsq instead of FSQ cover conditioning.")
     var nonCover: Bool = false
+
+    @Option(name: [.customLong("repaint-start")], help: "Repaint/lego range start in seconds.")
+    var repaintStartSeconds: Float = 0
+
+    @Option(name: [.customLong("repaint-end")], help: "Repaint/lego range end in seconds (-1 uses the source end).")
+    var repaintEndSeconds: Float = -1
+
+    @Option(name: [.customLong("chunk-mask-mode")], help: "Repaint chunk-mask mode: auto or explicit.")
+    var chunkMaskMode: ACEStepChunkMaskMode = .auto
+
+    @Option(name: [.customLong("repaint-mode")], help: "Source preservation: conservative, balanced, or aggressive.")
+    var repaintMode: ACEStepRepaintMode = .balanced
+
+    @Option(name: [.customLong("repaint-strength")], help: "Balanced repaint aggressiveness in [0, 1].")
+    var repaintStrength: Float = 0.5
+
+    @Flag(name: [.customLong("flow-edit")], help: "Morph --source-audio from its source caption/lyrics toward the target prompt.")
+    var flowEdit: Bool = false
+
+    @Option(name: [.customLong("source-caption")], help: "Caption describing --source-audio before flow edit.")
+    var sourceCaption: String?
+
+    @Option(name: [.customLong("source-lyrics")], help: "Original lyrics used by flow edit.")
+    var sourceLyrics: String = ""
+
+    @Option(name: [.customLong("flow-edit-n-min")], help: "Normalized flow-edit integration window start.")
+    var flowEditNMin: Float = 0
+
+    @Option(name: [.customLong("flow-edit-n-max")], help: "Normalized flow-edit integration window end.")
+    var flowEditNMax: Float = 1
+
+    @Option(name: [.customLong("flow-edit-n-average")], help: "Monte Carlo forward-noise draws per flow-edit step.")
+    var flowEditNAverage: Int = 1
 
     @Option(name: [.customLong("bpm")], help: "Optional BPM metadata for constrained LM / prompt metadata.")
     var bpm: Int?
@@ -182,17 +325,79 @@ struct MusicGenerate: AsyncParsableCommand {
     func run() async throws {
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
-        guard durationSeconds > 0 else {
+        if let durationSeconds, durationSeconds <= 0 {
             throw ValidationError("--duration must be > 0")
         }
-        guard steps > 0 else {
+        if useLM && noLM {
+            throw ValidationError("Pass either --use-lm or --no-lm, not both.")
+        }
+        if let steps, steps < 1 {
             throw ValidationError("--steps must be >= 1")
+        }
+        if let shift, shift <= 0 {
+            throw ValidationError("--shift must be > 0")
+        }
+        if let guidanceScale, guidanceScale < 1 {
+            throw ValidationError("--guidance-scale must be >= 1")
+        }
+        if let cfgIntervalStart, !(0...1).contains(cfgIntervalStart) {
+            throw ValidationError("--cfg-interval-start must be between 0 and 1")
+        }
+        if let cfgIntervalEnd, !(0...1).contains(cfgIntervalEnd) {
+            throw ValidationError("--cfg-interval-end must be between 0 and 1")
+        }
+        let resolvedCFGStart = cfgIntervalStart ?? 0
+        let resolvedCFGEnd = cfgIntervalEnd ?? 1
+        guard resolvedCFGStart <= resolvedCFGEnd else {
+            throw ValidationError("--cfg-interval-start must be <= --cfg-interval-end")
+        }
+        if let velocityNormThreshold, velocityNormThreshold < 0 {
+            throw ValidationError("--velocity-norm-threshold must be >= 0")
+        }
+        if let velocityEMAFactor, !(0..<1).contains(velocityEMAFactor) {
+            throw ValidationError("--velocity-ema-factor must be between 0 (inclusive) and 1 (exclusive)")
         }
         guard (0.0...1.0).contains(audioCoverStrength) else {
             throw ValidationError("--audio-cover-strength must be between 0.0 and 1.0")
         }
+        if let candidateCount, !(1...16).contains(candidateCount) {
+            throw ValidationError("--candidates must be between 1 and 16")
+        }
         guard (0.0...1.0).contains(coverNoiseStrength) else {
             throw ValidationError("--cover-noise-strength must be between 0.0 and 1.0")
+        }
+        guard (0.0...1.0).contains(retakeVariance) else {
+            throw ValidationError("--retake-variance must be between 0.0 and 1.0")
+        }
+        guard repaintStartSeconds >= 0 else {
+            throw ValidationError("--repaint-start must be >= 0")
+        }
+        guard repaintEndSeconds == -1 || repaintEndSeconds > repaintStartSeconds else {
+            throw ValidationError("--repaint-end must be -1 or greater than --repaint-start")
+        }
+        guard (0.0...1.0).contains(repaintStrength) else {
+            throw ValidationError("--repaint-strength must be between 0.0 and 1.0")
+        }
+        if flowEdit {
+            guard sourceAudio != nil else {
+                throw ValidationError("--flow-edit requires --source-audio")
+            }
+            guard sourceCaption?.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty == false else {
+                throw ValidationError("--flow-edit requires --source-caption")
+            }
+            guard 0 <= flowEditNMin,
+                  flowEditNMin <= flowEditNMax,
+                  flowEditNMax <= 1
+            else {
+                throw ValidationError(
+                    "--flow-edit requires 0 <= n-min <= n-max <= 1"
+                )
+            }
+            guard flowEditNAverage >= 1 else {
+                throw ValidationError("--flow-edit-n-average must be >= 1")
+            }
         }
         guard lmTopK >= 0 else {
             throw ValidationError("--lm-top-k must be >= 0")
@@ -209,66 +414,140 @@ struct MusicGenerate: AsyncParsableCommand {
         if lyricsFile != nil, !lyrics.isEmpty {
             throw ValidationError("Pass either --lyrics or --lyrics-file, not both.")
         }
+        if lrcFile != nil, lyricsFile != nil || !lyrics.isEmpty {
+            throw ValidationError(
+                "Pass --lrc-file or plain --lyrics/--lyrics-file, not both."
+            )
+        }
+        guard targetPeakDB <= 0 else {
+            throw ValidationError("--target-peak-db must be <= 0")
+        }
+        guard fadeInMilliseconds >= 0, fadeOutMilliseconds >= 0 else {
+            throw ValidationError("Output fades must be >= 0")
+        }
+        if dawBundle != nil, noRecipe {
+            throw ValidationError(
+                "--daw-bundle requires recipe metadata; remove --no-recipe"
+            )
+        }
 
         if isMagentaRT2Request {
             try await runMagentaRT2()
             return
         }
 
-        let isCover = resolvedACEStepIsCover
-        let effectiveTaskType = resolvedACEStepTaskType(isCover: isCover)
-        let effectiveUseLM = resolvedACEStepUsesLM(taskType: effectiveTaskType)
-        if analyzeSourceAudio && !isCover {
+        let effectiveTask = resolvedACEStepTask
+        var effectiveUseLM = flowEdit
+            ? false
+            : resolvedACEStepUsesLM(task: effectiveTask)
+        if analyzeSourceAudio && effectiveTask != .cover && effectiveTask != .coverNoFSQ {
             throw ValidationError("--analyze-source-audio requires ACE-Step cover mode with --source-audio.")
         }
-        let needsLMResources = effectiveUseLM || analyzeSourceAudio
+        let wantsLMResources = effectiveUseLM || analyzeSourceAudio
 
         let checkpointsRootURL = try await resolveACEStepCheckpointsRoot()
         let resolvedTurboSubdirectory = try resolveACEStepTurboSubdirectory(
             at: checkpointsRootURL,
             explicit: turboSubdirectory
         )
-        let resolvedLMSubdirectory = try needsLMResources
+        let checkpointVariant = try ACEStepCheckpointVariant.load(
+            modelRootURL: checkpointsRootURL.appendingPathComponent(
+                resolvedTurboSubdirectory,
+                isDirectory: true
+            )
+        )
+        do {
+            try checkpointVariant.validate(effectiveTask)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        let stemNames = parsedStemNames()
+        if !stemNames.isEmpty {
+            do {
+                try checkpointVariant.validate(.extract)
+            } catch {
+                throw ValidationError(
+                    "--stems requires an ACE-Step Base checkpoint: "
+                        + error.localizedDescription
+                )
+            }
+        }
+        let qualityDefaults = quality.defaults(
+            for: checkpointVariant,
+            task: effectiveTask
+        )
+        let resolvedLMSubdirectory = try wantsLMResources
             ? resolveACEStepLMSubdirectory(at: checkpointsRootURL, explicit: lmSubdirectory)
             : nil
         let resolvedTextSubdirectory = try resolveACEStepTextSubdirectory(
             at: checkpointsRootURL,
             explicit: textSubdirectory
         )
-        if needsLMResources && resolvedLMSubdirectory == nil {
-            throw ValidationError(
-                "--use-lm and --analyze-source-audio require --lm-subdirectory. "
-                    + "Set --lm-subdirectory or keep a default layout like 'acestep-5Hz-lm-1.7B'."
-            )
+        if wantsLMResources && resolvedLMSubdirectory == nil {
+            if useLM || analyzeSourceAudio || lmSubdirectory != nil {
+                throw ValidationError(
+                    "ACE-Step LM planning/generation and --analyze-source-audio require --lm-subdirectory. "
+                        + "Set --lm-subdirectory or use a managed model that includes a 5Hz LM."
+                )
+            }
+            effectiveUseLM = false
+            if !quiet {
+                CLIStderr.write(
+                    "No 5Hz LM is installed with this checkpoint; "
+                        + "continuing with direct DiT generation. Use --no-lm to make this choice explicit.\n"
+                )
+            }
         }
+        let needsLMResources = effectiveUseLM || analyzeSourceAudio
         if resolvedTextSubdirectory == nil {
             throw ValidationError("ACE-Step text encoder not found. Set --text-subdirectory or keep a default layout like 'Qwen3-Embedding-0.6B'.")
+        }
+        if quality == .final,
+           let resolvedLMSubdirectory,
+           !resolvedLMSubdirectory.lowercased().contains("4b"),
+           !quiet
+        {
+            CLIStderr.write(
+                "Final quality is using \(resolvedLMSubdirectory); "
+                    + "use music-acestep-xl-turbo-lm4b or --lm-subdirectory with the 4B LM for the strongest planning.\n"
+            )
         }
 
         let outputURL = CLIOutput.resolveOutputURL(output, defaultPrefix: "mererun-music", defaultExtension: "wav")
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-        let resolvedLyrics = try loadLyrics()
+        let inputLRC = try loadLRC()
+        let resolvedLyrics = try inputLRC?.lyrics ?? loadLyrics()
         let sourceAudio48kHz = try loadACEStepSourceAudio48kHz()
         let referenceAudio48kHz = try loadACEStepReferenceAudio48kHz()
-        if isCover && sourceAudio48kHz == nil {
-            throw ValidationError("--source-audio is required for ACE-Step cover mode.")
+        if effectiveTask.requiresSourceAudio && sourceAudio48kHz == nil {
+            throw ValidationError("--source-audio is required for ACE-Step \(effectiveTask.rawValue).")
         }
-        let effectiveDurationSeconds = resolvedACEStepDurationSeconds(
-            isCover: isCover,
-            sourceAudio48kHz: sourceAudio48kHz
+        var effectiveDurationSeconds = resolvedACEStepDurationSeconds(
+            task: effectiveTask,
+            sourceAudio48kHz: sourceAudio48kHz,
+            fallback: durationSeconds ?? qualityDefaults.fallbackDurationSeconds
         )
         let resolvedInstruction = resolveInstruction(
-            taskType: effectiveTaskType,
+            task: effectiveTask,
             explicitInstruction: instruction,
             trackName: trackName,
             completeTrackClasses: completeTrackClasses
         )
 
+        let shouldPlanDuration = effectiveUseLM
+            && durationSeconds == nil
+            && qualityDefaults.automaticDuration
+            && !effectiveTask.locksDurationToSource
+        var effectiveCaption = caption
         var userMetadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
             bpm: bpm.map(String.init),
             caption: caption,
-            duration: resolvedMetadataDuration(effectiveDurationSeconds: effectiveDurationSeconds),
+            duration: shouldPlanDuration
+                ? nil
+                : resolvedLMMetadataDuration(
+                    effectiveDurationSeconds: effectiveDurationSeconds
+                ),
             keyscale: keyscale,
             language: metadataLanguage,
             timesignature: timesignature
@@ -277,7 +556,7 @@ struct MusicGenerate: AsyncParsableCommand {
         if !quiet {
             CLIStderr.write("Loading ACE-Step checkpoints from \(checkpointsRootURL.path)\n")
             if useLM && !effectiveUseLM {
-                CLIStderr.write("Skipping 5Hz LM for ACE-Step \(effectiveTaskType) task; upstream uses direct DiT conditioning for this task.\n")
+                CLIStderr.write("Skipping 5Hz LM for ACE-Step \(effectiveTask.rawValue) task; upstream uses direct DiT conditioning for this task.\n")
             }
         }
 
@@ -295,6 +574,7 @@ struct MusicGenerate: AsyncParsableCommand {
             lmResources: resources.lmResources,
             textEncoderResources: resources.textEncoderResources
         )
+        let loadedAdapters = try loadAdapters(into: pipeline)
 
         if analyzeSourceAudio {
             guard let sourceAudio48kHz else {
@@ -321,69 +601,370 @@ struct MusicGenerate: AsyncParsableCommand {
             }
         }
 
+        if effectiveUseLM && qualityDefaults.plansMetadata {
+            if !quiet {
+                CLIStderr.write("Planning ACE-Step \(quality.rawValue) metadata with the 5Hz LM\n")
+            }
+            let planningMetadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
+                bpm: userMetadata.bpm,
+                caption: nil,
+                duration: shouldPlanDuration ? nil : userMetadata.duration,
+                keyscale: userMetadata.keyscale,
+                language: userMetadata.language,
+                timesignature: userMetadata.timesignature
+            )
+            let plan = try pipeline.planMusic(
+                caption: caption,
+                lyrics: resolvedLyrics,
+                instruction: resolvedInstruction,
+                userMetadata: planningMetadata,
+                lmConfig: .init(
+                    maxNewTokens: 1_024,
+                    temperature: 0.85,
+                    topK: lmTopK,
+                    topP: lmTopP,
+                    seed: seed
+                )
+            )
+            if let plannedCaption = nonEmpty(plan.metadata.caption) {
+                effectiveCaption = plannedCaption
+            }
+            if shouldPlanDuration, let plannedDuration = plan.metadata.durationSeconds {
+                effectiveDurationSeconds = clampedAutomaticDuration(plannedDuration)
+            }
+            userMetadata = mergePlanMetadata(
+                existing: userMetadata,
+                plan: plan.metadata,
+                caption: effectiveCaption,
+                durationSeconds: effectiveDurationSeconds
+            )
+            if !quiet {
+                CLIStderr.write(
+                    "ACE-Step plan: \(plan.metadata.understandingSummary); "
+                        + "duration=\(Int(effectiveDurationSeconds))s\n"
+                )
+            }
+        }
+
         let inference = ACEStepInferenceConfig(
             durationSeconds: effectiveDurationSeconds,
-            fixNFE: steps,
-            shift: shift,
+            fixNFE: steps ?? qualityDefaults.inferenceSteps,
+            shift: shift ?? qualityDefaults.shift,
             timesteps: nil,
             coverNoiseStrength: coverNoiseStrength,
-            inferMethod: .ode,
+            retakeSeed: retakeSeed,
+            retakeVariance: retakeVariance,
+            inferMethod: inferMethod ?? .ode,
+            samplerMode: samplerMode ?? qualityDefaults.samplerMode,
+            guidanceScale: guidanceScale ?? qualityDefaults.guidanceScale,
+            guidanceMode: guidanceMode ?? .apg,
+            cfgIntervalStart: resolvedCFGStart,
+            cfgIntervalEnd: resolvedCFGEnd,
+            velocityNormThreshold: velocityNormThreshold
+                ?? qualityDefaults.velocityNormThreshold,
+            velocityEMAFactor: velocityEMAFactor
+                ?? qualityDefaults.velocityEMAFactor,
             useTiledVaeDecode: !noTiledVAE,
             vaeChunkSize: vaeChunkSize,
             vaeOverlap: vaeOverlap,
             seed: seed
         )
-
-        let audio: MLXArray
-        if effectiveUseLM {
-            if !quiet {
-                CLIStderr.write("Running constrained 5Hz LM + diffusion\n")
-            }
-            let result = try pipeline.generatePromptToAudioWithLM(
-                caption: caption,
-                lyrics: resolvedLyrics,
-                config: inference,
-                lmConfig: .init(maxNewTokens: 4096, temperature: 0.85, topK: lmTopK, topP: lmTopP),
-                lmUserMetadata: userMetadata,
-                sourceLatents25Hz: nil,
-                sourceAudio48kHz: sourceAudio48kHz,
-                referenceTimbreLatents25Hz: nil,
-                referenceTimbreAudio48kHz: referenceAudio48kHz,
-                audioCoverStrength: audioCoverStrength,
-                vocalLanguage: vocalLanguage,
-                instruction: resolvedInstruction,
-                isCover: isCover
+        let repaintConfiguration = effectiveTask == .repaint || effectiveTask == .lego
+            ? ACEStepRepaintConfiguration(
+                startSeconds: repaintStartSeconds,
+                endSeconds: repaintEndSeconds,
+                chunkMaskMode: chunkMaskMode,
+                mode: repaintMode,
+                strength: repaintStrength
             )
-            if !quiet {
-                CLIStderr.write("Generated \(result.lmResult.audioCodeValues.count) audio code tokens\n")
-            }
-            audio = result.audio
-        } else {
-            if !quiet {
-                CLIStderr.write("Running direct prompt-to-audio diffusion\n")
-            }
-            audio = try pipeline.generatePromptToAudio(
-                caption: caption,
+            : nil
+        let flowEditConfiguration = flowEdit
+            ? ACEStepFlowEditConfiguration(
+                sourceCaption: sourceCaption ?? "",
+                sourceLyrics: sourceLyrics,
+                nMin: flowEditNMin,
+                nMax: flowEditNMax,
+                nAverage: flowEditNAverage,
+                retakeSeed: retakeSeed
+            )
+            : nil
+
+        let resolvedCandidateCount = candidateCount ?? qualityDefaults.candidateCount
+        if !quiet {
+            let mode = effectiveUseLM ? "constrained 5Hz LM + diffusion" : "direct prompt-to-audio diffusion"
+            CLIStderr.write(
+                "Running \(mode) in one warm session; candidates=\(resolvedCandidateCount)\n"
+            )
+        }
+        let session = ACEStepGenerationSession(pipeline: pipeline)
+        let ranked = try session.generateBest(
+            ACEStepSessionRequest(
+                caption: effectiveCaption,
                 lyrics: resolvedLyrics,
                 config: inference,
+                lmConfig: .init(
+                    maxNewTokens: 4_096,
+                    temperature: 0.85,
+                    topK: lmTopK,
+                    topP: lmTopP
+                ),
                 lmUserMetadata: userMetadata,
-                sourceLatents25Hz: nil,
                 sourceAudio48kHz: sourceAudio48kHz,
-                referenceTimbreLatents25Hz: nil,
                 referenceTimbreAudio48kHz: referenceAudio48kHz,
                 audioCoverStrength: audioCoverStrength,
                 vocalLanguage: vocalLanguage,
                 instruction: resolvedInstruction,
-                isCover: isCover
+                task: effectiveTask,
+                repaintConfiguration: repaintConfiguration,
+                flowEditConfiguration: flowEditConfiguration,
+                useLanguageModel: effectiveUseLM
+            ),
+            candidateCount: resolvedCandidateCount
+        )
+
+        let exportOptions = ACEStepAudioExportOptions(
+            format: exportFormat,
+            normalization: normalization,
+            targetPeakDB: targetPeakDB,
+            fadeInMilliseconds: fadeInMilliseconds,
+            fadeOutMilliseconds: fadeOutMilliseconds,
+            dither: !noDither
+        )
+        try ACEStepWAVWriter.writeWAV(
+            ranked.best.audio,
+            to: outputURL,
+            sampleRate: 48_000,
+            options: exportOptions
+        )
+        if keepCandidates {
+            for candidate in ranked.candidates {
+                let candidateURL = candidateOutputURL(
+                    selectedOutputURL: outputURL,
+                    rank: ranked.candidates.firstIndex { $0.index == candidate.index } ?? 0,
+                    candidate: candidate
+                )
+                try ACEStepWAVWriter.writeWAV(
+                    candidate.audio,
+                    to: candidateURL,
+                    sampleRate: 48_000,
+                    options: exportOptions
+                )
+            }
+        }
+
+        var stemTracks: [ACEStepDAWBundleWriter.Track] = []
+        for stemName in stemNames {
+            if !quiet {
+                CLIStderr.write("Extracting ACE-Step stem: \(stemName)\n")
+            }
+            var stemConfig = inference
+            stemConfig.seed = ranked.best.seed
+            let extracted = try session.generateBest(
+                ACEStepSessionRequest(
+                    caption: effectiveCaption,
+                    lyrics: "",
+                    config: stemConfig,
+                    lmUserMetadata: userMetadata,
+                    sourceAudio48kHz: ranked.best.audio,
+                    vocalLanguage: vocalLanguage,
+                    instruction: ACEStepTask.extract.instruction(
+                        trackName: stemName
+                    ),
+                    task: .extract,
+                    useLanguageModel: false
+                ),
+                candidateCount: 1
+            ).best
+            let stemURL = stemOutputURL(
+                selectedOutputURL: outputURL,
+                stemName: stemName
+            )
+            try ACEStepWAVWriter.writeWAV(
+                extracted.audio,
+                to: stemURL,
+                sampleRate: 48_000,
+                options: exportOptions
+            )
+            stemTracks.append(
+                ACEStepDAWBundleWriter.Track(
+                    name: stemName,
+                    audio: extracted.audio
+                )
             )
         }
 
-        try ACEStepWAVWriter.writeWAV(audio, to: outputURL, sampleRate: 48_000)
+        let synchronizedLyrics: ACEStepLRCDocument? = {
+            if let inputLRC {
+                return inputLRC
+            }
+            if lrcOutput != nil || dawBundle != nil, !resolvedLyrics.isEmpty {
+                return .approximate(
+                    lyrics: resolvedLyrics,
+                    durationSeconds: Double(effectiveDurationSeconds)
+                )
+            }
+            return nil
+        }()
+        let synchronizedLyricsURL: URL? = try {
+            guard let synchronizedLyrics else {
+                return nil
+            }
+            let url = lrcOutput.map(resolveUserPath)
+                ?? outputURL.deletingPathExtension().appendingPathExtension("lrc")
+            try synchronizedLyrics.rendered().write(
+                to: url,
+                atomically: true,
+                encoding: .utf8
+            )
+            return url
+        }()
+
+        let recipeURL: URL? = try {
+            guard !noRecipe else {
+                return nil
+            }
+            let url = recipeOutput.map(resolveUserPath)
+                ?? outputURL.deletingPathExtension()
+                    .appendingPathExtension("recipe.json")
+            let manifest = try MereRunModelManifest.loadIfPresent(
+                from: checkpointsRootURL
+            )
+            let sourceSHA256 = try sourceAudio.map {
+                try ModelArtifactPin.fileSHA256(resolveUserPath($0))
+            }
+            let recipe = ACEStepGenerationRecipe(
+                schemaVersion: ACEStepGenerationRecipe.currentSchemaVersion,
+                createdAt: Date(),
+                modelID: model,
+                checkpointVariant: checkpointVariant,
+                decoderSubdirectory: resolvedTurboSubdirectory,
+                checkpointSources:
+                    ACEStepGenerationRecipe.checkpointProvenance(
+                        modelID: model,
+                        manifest: manifest
+                    ),
+                languageModelSubdirectory: resolvedLMSubdirectory,
+                textEncoderSubdirectory: resolvedTextSubdirectory ?? "",
+                adapters: loadedAdapters,
+                task: effectiveTask,
+                quality: quality,
+                caption: effectiveCaption,
+                lyrics: resolvedLyrics,
+                instruction: resolvedInstruction,
+                conditioningMetadata:
+                    ACEStepRecipeConditioningMetadata(userMetadata),
+                inference: inference,
+                repaint: repaintConfiguration,
+                flowEdit: flowEditConfiguration,
+                languageModelUsed: effectiveUseLM,
+                candidates: ranked.candidates.enumerated().map {
+                    rank,
+                    candidate in
+                    ACEStepRecipeCandidate(
+                        rank: rank + 1,
+                        index: candidate.index,
+                        seed: candidate.seed,
+                        score: candidate.score,
+                        metrics: candidate.metrics,
+                        lmAudioCodeCount: candidate.lmAudioCodeCount,
+                        selected: candidate.index == ranked.best.index
+                    )
+                },
+                export: exportOptions,
+                sourceAudioSHA256: sourceSHA256,
+                outputFilename: outputURL.lastPathComponent,
+                outputSHA256: try ModelArtifactPin.fileSHA256(outputURL),
+                lrcFilename: synchronizedLyricsURL?.lastPathComponent,
+                lrcTimingIsApproximate:
+                    synchronizedLyrics?.timingIsApproximate
+            )
+            try recipe.write(to: url)
+            return url
+        }()
+
+        if let dawBundle {
+            guard let recipeURL else {
+                throw ValidationError("DAW bundle requires a recipe.")
+            }
+            let directory = resolveUserPath(dawBundle)
+            try ACEStepDAWBundleWriter.write(
+                directory: directory,
+                mixURL: outputURL,
+                recipeURL: recipeURL,
+                lrcURL: synchronizedLyricsURL,
+                candidates: ranked.candidates.enumerated().map {
+                    rank,
+                    candidate in
+                    ACEStepDAWBundleWriter.Track(
+                        name: "Candidate \(rank + 1) seed \(candidate.seed)",
+                        audio: candidate.audio
+                    )
+                },
+                stems: stemTracks,
+                lrc: synchronizedLyrics,
+                exportOptions: exportOptions
+            )
+            if !quiet {
+                CLIStderr.write("Saved DAW bundle: \(directory.path)\n")
+            }
+        }
 
         if !quiet {
+            for (rank, candidate) in ranked.candidates.enumerated() {
+                let selected = candidate.index == ranked.best.index ? " selected" : ""
+                CLIStderr.write(
+                    String(
+                        format: "Candidate %d: seed=%llu score=%.2f%@\n",
+                        rank + 1,
+                        candidate.seed,
+                        candidate.score,
+                        selected
+                    )
+                )
+            }
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+    }
+
+    private func loadAdapters(
+        into pipeline: ACEStepPipeline
+    ) throws -> [ACEStepAdapterDescriptor] {
+        guard !adapters.isEmpty else {
+            if !adapterScales.isEmpty {
+                throw ValidationError("--adapter-scale requires --adapter.")
+            }
+            return []
+        }
+        guard adapterScales.isEmpty
+            || adapterScales.count == 1
+            || adapterScales.count == adapters.count
+        else {
+            throw ValidationError(
+                "--adapter-scale accepts one value for every adapter or one value per adapter."
+            )
+        }
+
+        return try adapters.enumerated().map { index, path in
+            let scale = adapterScales.isEmpty
+                ? 1
+                : adapterScales.count == 1
+                    ? adapterScales[0]
+                    : adapterScales[index]
+            let report = try pipeline.loadAdapter(
+                from: resolveUserPath(path),
+                kind: adapterKind,
+                scale: scale
+            )
+            if !quiet {
+                CLIStderr.write(
+                    "Loaded ACE-Step \(report.kind.rawValue) adapter "
+                        + "\(report.filename) at scale \(report.scale) "
+                        + "on \(report.matchedLayerCount) layers\n"
+                )
+            }
+            return report
+        }
     }
 
     private var isMagentaRT2Request: Bool {
@@ -394,38 +975,43 @@ struct MusicGenerate: AsyncParsableCommand {
         return MagentaRT2Resources.looksLikeMagentaRT2Root(url)
     }
 
+    private func candidateOutputURL(
+        selectedOutputURL: URL,
+        rank: Int,
+        candidate: ACEStepGeneratedCandidate
+    ) -> URL {
+        let stem = selectedOutputURL.deletingPathExtension().lastPathComponent
+        let filename = "\(stem).candidate-\(rank + 1).seed-\(candidate.seed).wav"
+        return selectedOutputURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(filename)
+    }
+
+    var resolvedACEStepTask: ACEStepTask {
+        if flowEdit {
+            return .textToMusic
+        }
+        if nonCover && (taskType == .cover || taskType == .textToMusic) {
+            return .coverNoFSQ
+        }
+        if taskType == .textToMusic,
+           sourceAudio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        {
+            return .cover
+        }
+        return taskType
+    }
+
     var resolvedACEStepIsCover: Bool {
-        guard !nonCover else {
+        resolvedACEStepTask.usesFSQCoverHints
+    }
+
+    func resolvedACEStepUsesLM(task: ACEStepTask) -> Bool {
+        guard !noLM, !task.skipsLanguageModel else {
             return false
         }
-        if sourceAudio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-            return true
-        }
-        return taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "cover"
+        return useLM || quality.defaults(for: .turbo, task: task).usesLanguageModel
     }
-
-    func resolvedACEStepTaskType(isCover: Bool) -> String {
-        let normalized = taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if isCover && normalized == "text2music" {
-            return "cover"
-        }
-        return normalized
-    }
-
-    func resolvedACEStepUsesLM(taskType: String) -> Bool {
-        guard useLM else {
-            return false
-        }
-        let normalized = taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return !Self.aceStepTasksSkippingLM.contains(normalized)
-    }
-
-    private static let aceStepTasksSkippingLM: Set<String> = [
-        "cover",
-        "cover-nofsq",
-        "repaint",
-        "extract"
-    ]
 
     private func runMagentaRT2() async throws {
         try validateMagentaRT2Options()
@@ -453,7 +1039,7 @@ struct MusicGenerate: AsyncParsableCommand {
             MagentaRT2RenderRequest(
                 prompt: caption,
                 resources: resources,
-                durationSeconds: durationSeconds,
+                durationSeconds: durationSeconds ?? 10,
                 controls: controls
             ),
             progress: { frame, total in
@@ -481,7 +1067,10 @@ struct MusicGenerate: AsyncParsableCommand {
         if useLM {
             throw ValidationError("Magenta RT2 does not support --use-lm; that option is ACE-Step only.")
         }
-        if taskType != "text2music" {
+        if noLM {
+            throw ValidationError("Magenta RT2 does not support --no-lm; that option is ACE-Step only.")
+        }
+        if taskType != .textToMusic {
             throw ValidationError("Magenta RT2 does not support --task-type; that option is ACE-Step only.")
         }
         if trackName != nil
@@ -496,8 +1085,18 @@ struct MusicGenerate: AsyncParsableCommand {
         if seed != nil {
             throw ValidationError("Magenta RT2 uses --seed-rotation instead of --seed.")
         }
-        if steps != 8 || shift != Self.defaultACEStepShift {
-            throw ValidationError("Magenta RT2 does not use ACE-Step --steps or --shift.")
+        if steps != nil
+            || shift != nil
+            || inferMethod != nil
+            || samplerMode != nil
+            || guidanceScale != nil
+            || guidanceMode != nil
+            || cfgIntervalStart != nil
+            || cfgIntervalEnd != nil
+            || velocityNormThreshold != nil
+            || velocityEMAFactor != nil
+        {
+            throw ValidationError("Magenta RT2 does not use ACE-Step diffusion or guidance options.")
         }
         _ = try magentaControls()
     }
@@ -538,6 +1137,45 @@ struct MusicGenerate: AsyncParsableCommand {
         return lyrics
     }
 
+    private func loadLRC() throws -> ACEStepLRCDocument? {
+        guard let lrcFile else {
+            return nil
+        }
+        let url = resolveUserPath(lrcFile)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ValidationError("LRC file not found: \(url.path)")
+        }
+        do {
+            return try ACEStepLRCDocument.parse(
+                String(contentsOf: url, encoding: .utf8)
+            )
+        } catch {
+            throw ValidationError(
+                "Invalid LRC file \(url.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func parsedStemNames() -> [String] {
+        stems?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            ?? []
+    }
+
+    private func stemOutputURL(
+        selectedOutputURL: URL,
+        stemName: String
+    ) -> URL {
+        let safe = stemName.lowercased().map { character -> Character in
+            character.isLetter || character.isNumber ? character : "-"
+        }
+        let stem = selectedOutputURL.deletingPathExtension().lastPathComponent
+        return selectedOutputURL.deletingLastPathComponent()
+            .appendingPathComponent("\(stem).stem-\(String(safe)).wav")
+    }
+
     private func loadACEStepSourceAudio48kHz() throws -> MLXArray? {
         guard let sourceAudio,
               !sourceAudio.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -573,13 +1211,22 @@ struct MusicGenerate: AsyncParsableCommand {
         ACEStepCLIHelper.resolveUserPath(path)
     }
 
-    func resolvedACEStepDurationSeconds(isCover: Bool, sourceAudio48kHz: MLXArray?) -> Float {
-        guard isCover, let sourceAudio48kHz, sourceAudio48kHz.ndim >= 2 else {
-            return durationSeconds
+    func resolvedACEStepDurationSeconds(
+        task: ACEStepTask,
+        sourceAudio48kHz: MLXArray?,
+        fallback: Float? = nil
+    ) -> Float {
+        let requestedDuration = fallback ?? durationSeconds
+            ?? quality.defaults(for: .turbo, task: task).fallbackDurationSeconds
+        guard task.locksDurationToSource,
+              let sourceAudio48kHz,
+              sourceAudio48kHz.ndim >= 2
+        else {
+            return requestedDuration
         }
         let sourceFrames = sourceAudio48kHz.dim(1)
         guard sourceFrames > 0 else {
-            return durationSeconds
+            return requestedDuration
         }
         return Float(sourceFrames) / 48_000.0
     }
@@ -590,6 +1237,42 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         let seconds = max(1, Int(effectiveDurationSeconds))
         return "\(seconds) seconds"
+    }
+
+    func resolvedLMMetadataDuration(effectiveDurationSeconds: Float) -> String {
+        if let metadataDuration, !metadataDuration.isEmpty {
+            return metadataDuration
+        }
+        return String(max(1, Int(effectiveDurationSeconds)))
+    }
+
+    func clampedAutomaticDuration(_ duration: Float) -> Float {
+        let upperBound: Float = quality == .song ? 240 : 600
+        return min(max(duration, 10), upperBound)
+    }
+
+    private func mergePlanMetadata(
+        existing: ACEStep5HzLMConstrainedSampler.UserMetadata,
+        plan: ACEStepMusicUnderstandingMetadata,
+        caption: String,
+        durationSeconds: Float
+    ) -> ACEStep5HzLMConstrainedSampler.UserMetadata {
+        ACEStep5HzLMConstrainedSampler.UserMetadata(
+            bpm: nonEmpty(existing.bpm) ?? plan.bpm.map(String.init),
+            caption: caption,
+            duration: resolvedLMMetadataDuration(
+                effectiveDurationSeconds: durationSeconds
+            ),
+            keyscale: nonEmpty(existing.keyscale) ?? nonEmpty(plan.keyscale),
+            language: nonEmpty(existing.language) ?? nonEmpty(plan.language),
+            timesignature: nonEmpty(existing.timesignature)
+                ?? nonEmpty(plan.timesignature)
+        )
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     func mergedMetadataWithSourceAnalysis(
@@ -641,45 +1324,17 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     private func resolveInstruction(
-        taskType: String,
+        task: ACEStepTask,
         explicitInstruction: String,
         trackName: String?,
         completeTrackClasses: String?
     ) -> String {
         let defaultInstruction = "Fill the audio semantic mask based on the given conditions:"
         let trimmed = explicitInstruction.trimmingCharacters(in: .whitespacesAndNewlines)
-        let normalizedTask = taskType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-
-        let taskInstruction: String
-        switch normalizedTask {
-        case "text2music", "":
-            taskInstruction = "Fill the audio semantic mask based on the given conditions:"
-        case "repaint":
-            taskInstruction = "Repaint the mask area based on the given conditions:"
-        case "cover":
-            taskInstruction = "Generate audio semantic tokens based on the given conditions:"
-        case "extract":
-            if let trackName, !trackName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                taskInstruction = "Extract the \(trackName.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()) track from the audio:"
-            } else {
-                taskInstruction = "Extract the track from the audio:"
-            }
-        case "lego":
-            if let trackName, !trackName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                taskInstruction = "Generate the \(trackName.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()) track based on the audio context:"
-            } else {
-                taskInstruction = "Generate the track based on the audio context:"
-            }
-        case "complete":
-            let classes = parseCompleteTrackClasses(completeTrackClasses)
-            if !classes.isEmpty {
-                taskInstruction = "Complete the input track with \(classes.map { $0.uppercased() }.joined(separator: " | ")):"
-            } else {
-                taskInstruction = "Complete the input track:"
-            }
-        default:
-            taskInstruction = "Fill the audio semantic mask based on the given conditions:"
-        }
+        let taskInstruction = task.instruction(
+            trackName: trackName,
+            completeTrackClasses: parseCompleteTrackClasses(completeTrackClasses)
+        )
 
         let shouldAutoMapInstruction = trimmed.isEmpty || trimmed == defaultInstruction
         return shouldAutoMapInstruction ? taskInstruction : trimmed
@@ -718,120 +1373,5 @@ struct MusicGenerate: AsyncParsableCommand {
 
     private func resolveACEStepTurboSubdirectory(at root: URL, explicit: String) throws -> String {
         try ACEStepCLIHelper.resolveTurboSubdirectory(at: root, explicit: explicit)
-    }
-
-    private static let defaultACEStepShift: Float = 3.0
-}
-
-private enum ACEStepWAVWriter {
-    enum WriterError: LocalizedError {
-        case invalidShape([Int])
-        case invalidChannels(Int)
-
-        var errorDescription: String? {
-            switch self {
-            case .invalidShape(let shape):
-                return "Unsupported ACE-Step audio tensor shape: \(shape). Expected [1,S,C], [S,C], [1,S], or [S]."
-            case .invalidChannels(let channels):
-                return "Invalid channel count \(channels). Expected 1...8."
-            }
-        }
-    }
-
-    static func writeWAV(_ audio: MLXArray, to url: URL, sampleRate: Int) throws {
-        let (interleaved, channels) = try flattenToInterleaved(audio)
-        guard (1...8).contains(channels) else {
-            throw WriterError.invalidChannels(channels)
-        }
-
-        let int16Samples = peakNormalized(interleaved).map { sample -> Int16 in
-            let finiteSample = sample.isFinite ? sample : 0.0
-            let clamped = max(-1.0, min(1.0, finiteSample))
-            return Int16(clamped * 32767.0)
-        }
-
-        let dataSize = UInt32(int16Samples.count * MemoryLayout<Int16>.size)
-        let fileSize = UInt32(36) + dataSize
-        let channelsU16 = UInt16(channels)
-        let sampleRateU32 = UInt32(sampleRate)
-        let bitsPerSample = UInt16(16)
-        let blockAlign = UInt16(channels) * (bitsPerSample / 8)
-        let byteRate = sampleRateU32 * UInt32(blockAlign)
-
-        var data = Data()
-        data.append("RIFF".data(using: .utf8)!)
-        append(fileSize, to: &data)
-        data.append("WAVE".data(using: .utf8)!)
-
-        data.append("fmt ".data(using: .utf8)!)
-        append(UInt32(16), to: &data)  // PCM fmt chunk length
-        append(UInt16(1), to: &data)  // PCM format
-        append(channelsU16, to: &data)
-        append(sampleRateU32, to: &data)
-        append(byteRate, to: &data)
-        append(blockAlign, to: &data)
-        append(bitsPerSample, to: &data)
-
-        data.append("data".data(using: .utf8)!)
-        append(dataSize, to: &data)
-        for sample in int16Samples {
-            append(sample, to: &data)
-        }
-
-        try data.write(to: url)
-    }
-
-    private static func flattenToInterleaved(_ audio: MLXArray) throws -> ([Float], Int) {
-        let sampleChannel: MLXArray
-        if audio.ndim == 1 {
-            sampleChannel = audio.reshaped(audio.dim(0), 1)
-        } else if audio.ndim == 2 {
-            if audio.dim(1) <= 8 {
-                sampleChannel = audio
-            } else if audio.dim(0) <= 8 {
-                sampleChannel = audio.transposed(1, 0)
-            } else {
-                throw WriterError.invalidShape(audio.shape)
-            }
-        } else if audio.ndim == 3 {
-            guard audio.dim(0) == 1 else {
-                throw WriterError.invalidShape(audio.shape)
-            }
-            let squeezed = audio[0, 0..., 0...]
-            if squeezed.dim(1) <= 8 {
-                sampleChannel = squeezed
-            } else if squeezed.dim(0) <= 8 {
-                sampleChannel = squeezed.transposed(1, 0)
-            } else {
-                throw WriterError.invalidShape(audio.shape)
-            }
-        } else {
-            throw WriterError.invalidShape(audio.shape)
-        }
-
-        MLX.eval(sampleChannel)
-        let channels = sampleChannel.dim(1)
-        let interleaved = sampleChannel.asType(.float32).reshaped(-1).asArray(Float.self)
-        return (interleaved, channels)
-    }
-
-    private static func peakNormalized(_ samples: [Float]) -> [Float] {
-        var peak: Float = 0
-        for sample in samples where sample.isFinite {
-            peak = max(peak, abs(sample))
-        }
-        guard peak > 1 else {
-            return samples
-        }
-        return samples.map { sample in
-            sample.isFinite ? sample / peak : 0.0
-        }
-    }
-
-    private static func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
-        var littleEndian = value.littleEndian
-        withUnsafeBytes(of: &littleEndian) { bytes in
-            data.append(bytes.bindMemory(to: UInt8.self))
-        }
     }
 }

--- a/Sources/MereRunCLI/Commands/MusicServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicServeCommand.swift
@@ -1,0 +1,841 @@
+import ArgumentParser
+import Foundation
+import Hummingbird
+import MereRunCore
+import NIOCore
+
+struct MusicServe: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Start a warm resident ACE-Step music generation API."
+    )
+
+    @Option(name: [.long], help: "Host to bind to.")
+    var host: String = "127.0.0.1"
+
+    @Option(name: [.short, .long], help: "Port to listen on.")
+    var port: Int = 8081
+
+    @Option(name: [.customShort("m"), .long], help: "Managed ACE-Step model id or local checkpoint root.")
+    var model: String = ModelResolver.ModelID.aceStep.rawValue
+
+    @Option(name: [.customLong("checkpoints-root")], help: "Root containing ACE-Step checkpoint directories.")
+    var checkpointsRoot: String?
+
+    @Option(name: [.customLong("decoder-subdirectory")], help: "ACE-Step decoder subdirectory.")
+    var decoderSubdirectory: String = "acestep-v15-turbo"
+
+    @Option(name: [.customLong("vae-subdirectory")], help: "ACE-Step VAE subdirectory.")
+    var vaeSubdirectory: String = "vae"
+
+    @Option(name: [.customLong("lm-subdirectory")], help: "Optional 5Hz LM subdirectory; the 4B LM is preferred.")
+    var lmSubdirectory: String?
+
+    @Option(name: [.customLong("text-subdirectory")], help: "Optional text encoder subdirectory.")
+    var textSubdirectory: String?
+
+    @Option(
+        name: [.customLong("adapter")],
+        parsing: .upToNextOption,
+        help: "PEFT LoRA or LyCORIS LoKr safetensors file(s) to keep resident."
+    )
+    var adapters: [String] = []
+
+    @Option(name: [.customLong("adapter-kind")], help: "Adapter format: auto, lora, or lokr.")
+    var adapterKind: ACEStepAdapterKind = .auto
+
+    @Option(
+        name: [.customLong("adapter-scale")],
+        parsing: .upToNextOption,
+        help: "One adapter scale for all paths, or one scale per adapter."
+    )
+    var adapterScales: [Float] = []
+
+    @Option(name: [.customLong("api-key")], help: "Bearer token; also read from MERERUN_API_KEY.")
+    var apiKey: String?
+
+    func run() async throws {
+        guard (1...65_535).contains(port) else {
+            throw ValidationError("--port must be between 1 and 65535")
+        }
+        let resolvedAPIKey = apiKey
+            ?? ProcessInfo.processInfo.environment[APIServe.apiKeyEnvironmentKey]
+        if !Self.isLoopback(host), resolvedAPIKey?.isEmpty != false {
+            throw ValidationError(
+                "Non-loopback music API binds require --api-key or MERERUN_API_KEY."
+            )
+        }
+
+        let root = try await ACEStepCLIHelper.resolveCheckpointsRoot(
+            model: model,
+            checkpointsRoot: checkpointsRoot,
+            turboSubdirectory: decoderSubdirectory,
+            vaeSubdirectory: vaeSubdirectory,
+            lmSubdirectory: nil,
+            textSubdirectory: textSubdirectory
+        )
+        let decoder = try ACEStepCLIHelper.resolveTurboSubdirectory(
+            at: root,
+            explicit: decoderSubdirectory
+        )
+        guard let text = try ACEStepCLIHelper.resolveTextSubdirectory(
+            at: root,
+            explicit: textSubdirectory
+        ) else {
+            throw ValidationError("ACE-Step text encoder not found.")
+        }
+        let lm = try ACEStepCLIHelper.resolveLMSubdirectory(
+            at: root,
+            explicit: lmSubdirectory
+        )
+        let variant = try ACEStepCheckpointVariant.load(
+            modelRootURL: root.appendingPathComponent(decoder, isDirectory: true)
+        )
+        let container = ACEStepModelContainer(
+            checkpointsRootURL: root,
+            turboSubdirectory: decoder,
+            vaeSubdirectory: vaeSubdirectory,
+            lmSubdirectory: lm,
+            textEncoderSubdirectory: text
+        )
+        CLIStderr.write("Loading resident ACE-Step \(variant.rawValue) session\n")
+        let resources = try await container.resources()
+        let pipeline = try ACEStepPipeline(
+            decoderResources: resources.decoderResources,
+            vaeResources: resources.vaeResources,
+            lmResources: resources.lmResources,
+            textEncoderResources: resources.textEncoderResources
+        )
+        let loadedAdapters = try loadAdapters(into: pipeline)
+        let server = MusicAPIServer(
+            session: ACEStepGenerationSession(pipeline: pipeline),
+            pipeline: pipeline,
+            variant: variant,
+            modelID: model,
+            languageModelAvailable: lm != nil,
+            adapters: loadedAdapters,
+            apiKey: resolvedAPIKey
+        )
+        try await server.run(host: host, port: port)
+    }
+
+    private func loadAdapters(
+        into pipeline: ACEStepPipeline
+    ) throws -> [ACEStepAdapterDescriptor] {
+        guard !adapters.isEmpty else {
+            if !adapterScales.isEmpty {
+                throw ValidationError("--adapter-scale requires --adapter.")
+            }
+            return []
+        }
+        guard adapterScales.isEmpty
+            || adapterScales.count == 1
+            || adapterScales.count == adapters.count
+        else {
+            throw ValidationError(
+                "--adapter-scale accepts one value for all adapters or one per adapter."
+            )
+        }
+        return try adapters.enumerated().map { index, path in
+            let scale = adapterScales.isEmpty
+                ? 1
+                : adapterScales.count == 1
+                    ? adapterScales[0]
+                    : adapterScales[index]
+            let report = try pipeline.loadAdapter(
+                from: ACEStepCLIHelper.resolveUserPath(path),
+                kind: adapterKind,
+                scale: scale
+            )
+            CLIStderr.write(
+                "Loaded resident \(report.kind.rawValue) adapter "
+                    + "\(report.filename) on \(report.matchedLayerCount) layers\n"
+            )
+            return report
+        }
+    }
+
+    static func isLoopback(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized == "localhost"
+            || normalized == "127.0.0.1"
+            || normalized == "::1"
+    }
+
+    static func apiErrorMessage(_ error: Error) -> String {
+        if let validationError = error as? ValidationError {
+            return validationError.message
+        }
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription,
+           !description.isEmpty
+        {
+            return description
+        }
+        return error.localizedDescription
+    }
+}
+
+struct MusicAPIGenerationRequest: Codable, Sendable {
+    var model: String?
+    var prompt: String
+    var lyrics: String?
+    var instruction: String?
+    var durationSeconds: Float?
+    var quality: ACEStepQualityPreset?
+    var task: ACEStepTask?
+    var seed: UInt64?
+    var retakeSeed: UInt64?
+    var retakeVariance: Float?
+    var candidates: Int?
+    var steps: Int?
+    var shift: Float?
+    var inferMethod: ACEStepInferenceMethod?
+    var guidanceScale: Float?
+    var guidanceMode: ACEStepGuidanceMode?
+    var cfgIntervalStart: Float?
+    var cfgIntervalEnd: Float?
+    var velocityNormThreshold: Float?
+    var velocityEMAFactor: Float?
+    var sampler: ACEStepSamplerMode?
+    var useLanguageModel: Bool?
+    var lmTopK: Int?
+    var lmTopP: Float?
+    var bpm: Int?
+    var keyscale: String?
+    var metadataLanguage: String?
+    var timeSignature: String?
+    var vocalLanguage: String?
+    var sourceAudioPath: String?
+    var referenceAudioPaths: [String]?
+    var audioCoverStrength: Float?
+    var coverNoiseStrength: Float?
+    var sourceCaption: String?
+    var sourceLyrics: String?
+    var flowEditNMin: Float?
+    var flowEditNMax: Float?
+    var flowEditNAverage: Int?
+    var trackName: String?
+    var completeTrackClasses: [String]?
+    var repaintStartSeconds: Float?
+    var repaintEndSeconds: Float?
+    var chunkMaskMode: ACEStepChunkMaskMode?
+    var repaintMode: ACEStepRepaintMode?
+    var repaintStrength: Float?
+    var useTiledVAEDecode: Bool?
+    var vaeChunkSize: Int?
+    var vaeOverlap: Int?
+    var responseFormat: String?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case prompt
+        case lyrics
+        case instruction
+        case durationSeconds = "duration_seconds"
+        case quality
+        case task
+        case seed
+        case retakeSeed = "retake_seed"
+        case retakeVariance = "retake_variance"
+        case candidates
+        case steps
+        case shift
+        case inferMethod = "infer_method"
+        case guidanceScale = "guidance_scale"
+        case guidanceMode = "guidance_mode"
+        case cfgIntervalStart = "cfg_interval_start"
+        case cfgIntervalEnd = "cfg_interval_end"
+        case velocityNormThreshold = "velocity_norm_threshold"
+        case velocityEMAFactor = "velocity_ema_factor"
+        case sampler
+        case useLanguageModel = "use_lm"
+        case lmTopK = "lm_top_k"
+        case lmTopP = "lm_top_p"
+        case bpm
+        case keyscale
+        case metadataLanguage = "metadata_language"
+        case timeSignature = "time_signature"
+        case vocalLanguage = "vocal_language"
+        case sourceAudioPath = "source_audio_path"
+        case referenceAudioPaths = "reference_audio_paths"
+        case audioCoverStrength = "audio_cover_strength"
+        case coverNoiseStrength = "cover_noise_strength"
+        case sourceCaption = "source_caption"
+        case sourceLyrics = "source_lyrics"
+        case flowEditNMin = "flow_edit_n_min"
+        case flowEditNMax = "flow_edit_n_max"
+        case flowEditNAverage = "flow_edit_n_average"
+        case trackName = "track_name"
+        case completeTrackClasses = "complete_track_classes"
+        case repaintStartSeconds = "repaint_start_seconds"
+        case repaintEndSeconds = "repaint_end_seconds"
+        case chunkMaskMode = "chunk_mask_mode"
+        case repaintMode = "repaint_mode"
+        case repaintStrength = "repaint_strength"
+        case useTiledVAEDecode = "use_tiled_vae_decode"
+        case vaeChunkSize = "vae_chunk_size"
+        case vaeOverlap = "vae_overlap"
+        case responseFormat = "response_format"
+    }
+}
+
+struct MusicAPIBatchRequest: Codable, Sendable {
+    var requests: [MusicAPIGenerationRequest]
+}
+
+private struct MusicAPIHealthResponse: Codable {
+    var status: String
+    var model: String
+    var checkpointVariant: ACEStepCheckpointVariant
+    var resident: Bool
+    var languageModelAvailable: Bool
+    var adapters: [ACEStepAdapterDescriptor]
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case model
+        case checkpointVariant = "checkpoint_variant"
+        case resident
+        case languageModelAvailable = "language_model_available"
+        case adapters
+    }
+}
+
+private struct MusicAPICandidateResponse: Codable {
+    var rank: Int
+    var seed: UInt64
+    var score: Float
+    var metrics: ACEStepCandidateMetrics
+    var audioBase64: String
+    var format: String
+    var sampleRate: Int
+    var selected: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case rank
+        case seed
+        case score
+        case metrics
+        case audioBase64 = "audio_base64"
+        case format
+        case sampleRate = "sample_rate"
+        case selected
+    }
+}
+
+private struct MusicAPIGenerationResponse: Codable {
+    var model: String
+    var quality: ACEStepQualityPreset
+    var task: ACEStepTask
+    var conditioningMetadata: ACEStepRecipeConditioningMetadata
+    var candidates: [MusicAPICandidateResponse]
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case quality
+        case task
+        case conditioningMetadata = "conditioning_metadata"
+        case candidates
+    }
+}
+
+private struct MusicAPIBatchResponse: Codable {
+    var data: [MusicAPIGenerationResponse]
+}
+
+private struct PreparedMusicAPIRequest {
+    var request: ACEStepSessionRequest
+    var quality: ACEStepQualityPreset
+    var task: ACEStepTask
+    var candidateCount: Int
+    var conditioningMetadata: ACEStepRecipeConditioningMetadata
+}
+
+private final class MusicAPIServer: @unchecked Sendable {
+    let session: ACEStepGenerationSession
+    let pipeline: ACEStepPipeline
+    let variant: ACEStepCheckpointVariant
+    let modelID: String
+    let languageModelAvailable: Bool
+    let adapters: [ACEStepAdapterDescriptor]
+    let apiKey: String?
+
+    init(
+        session: ACEStepGenerationSession,
+        pipeline: ACEStepPipeline,
+        variant: ACEStepCheckpointVariant,
+        modelID: String,
+        languageModelAvailable: Bool,
+        adapters: [ACEStepAdapterDescriptor],
+        apiKey: String?
+    ) {
+        self.session = session
+        self.pipeline = pipeline
+        self.variant = variant
+        self.modelID = modelID
+        self.languageModelAvailable = languageModelAvailable
+        self.adapters = adapters
+        self.apiKey = apiKey
+    }
+
+    func run(host: String, port: Int) async throws {
+        let app = Application(
+            router: buildRouter(),
+            configuration: .init(address: .hostname(host, port: port))
+        )
+        CLIStderr.write("Resident music API: http://\(host):\(port)/v1/audio/music\n")
+        CLIStderr.write("Batch endpoint: http://\(host):\(port)/v1/audio/music/batches\n")
+        try await app.runService()
+    }
+
+    func buildRouter() -> Router<BasicRequestContext> {
+        let router = Router()
+        router.get("/health") { [self] request, _ in
+            guard isAuthorized(request) else {
+                return errorResponse(status: .unauthorized, message: "Invalid API key.")
+            }
+            return try jsonResponse(
+                MusicAPIHealthResponse(
+                    status: "ok",
+                    model: modelID,
+                    checkpointVariant: variant,
+                    resident: true,
+                    languageModelAvailable: languageModelAvailable,
+                    adapters: adapters
+                )
+            )
+        }
+        router.post("/v1/audio/music") { [self] request, _ in
+            await handleGeneration(request)
+        }
+        router.post("/v1/audio/music/batches") { [self] request, _ in
+            await handleBatch(request)
+        }
+        return router
+    }
+
+    private func handleGeneration(_ request: Request) async -> Response {
+        guard isAuthorized(request) else {
+            return errorResponse(status: .unauthorized, message: "Invalid API key.")
+        }
+        do {
+            let payload = try await decode(
+                MusicAPIGenerationRequest.self,
+                from: request
+            )
+            let prepared = try prepare(payload)
+            let ranked = try session.generateBest(
+                prepared.request,
+                candidateCount: prepared.candidateCount
+            )
+            if payload.responseFormat?.lowercased() == "wav" {
+                let data = try ACEStepWAVWriter.wavData(
+                    ranked.best.audio,
+                    sampleRate: 48_000
+                )
+                return Response(
+                    status: .ok,
+                    headers: [.contentType: "audio/wav"],
+                    body: .init(byteBuffer: ByteBuffer(bytes: data))
+                )
+            }
+            return try jsonResponse(
+                try response(for: ranked, prepared: prepared)
+            )
+        } catch {
+            return errorResponse(
+                status: .badRequest,
+                message: MusicServe.apiErrorMessage(error)
+            )
+        }
+    }
+
+    private func handleBatch(_ request: Request) async -> Response {
+        guard isAuthorized(request) else {
+            return errorResponse(status: .unauthorized, message: "Invalid API key.")
+        }
+        do {
+            let payload = try await decode(MusicAPIBatchRequest.self, from: request)
+            guard (1...32).contains(payload.requests.count) else {
+                throw ValidationError("Batch requests must contain 1...32 items.")
+            }
+            guard !payload.requests.contains(where: {
+                $0.responseFormat?.lowercased() == "wav"
+            }) else {
+                throw ValidationError(
+                    "Batch requests support response_format=json only."
+                )
+            }
+            let prepared = try payload.requests.map(prepare)
+            let ranked = try session.generateBatch(
+                prepared.map(\.request),
+                candidateCounts: prepared.map(\.candidateCount)
+            )
+            let responses = try zip(ranked, prepared).map {
+                try response(for: $0.0, prepared: $0.1)
+            }
+            return try jsonResponse(MusicAPIBatchResponse(data: responses))
+        } catch {
+            return errorResponse(
+                status: .badRequest,
+                message: MusicServe.apiErrorMessage(error)
+            )
+        }
+    }
+
+    private func prepare(
+        _ payload: MusicAPIGenerationRequest
+    ) throws -> PreparedMusicAPIRequest {
+        let prompt = payload.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw ValidationError("prompt must not be empty.")
+        }
+        if let requestedModel = payload.model,
+           requestedModel != modelID
+        {
+            throw ValidationError(
+                "Resident music API loaded '\(modelID)', not "
+                    + "'\(requestedModel)'."
+            )
+        }
+        let task = payload.task ?? .textToMusic
+        try variant.validate(task)
+        let quality = payload.quality ?? .song
+        let defaults = quality.defaults(for: variant, task: task)
+        let candidates = payload.candidates ?? defaults.candidateCount
+        guard (1...16).contains(candidates) else {
+            throw ValidationError("candidates must be between 1 and 16.")
+        }
+        let steps = payload.steps ?? defaults.inferenceSteps
+        guard steps >= 1 else {
+            throw ValidationError("steps must be at least 1.")
+        }
+        let shift = payload.shift ?? defaults.shift
+        guard shift > 0 else {
+            throw ValidationError("shift must be greater than 0.")
+        }
+        let guidanceScale = payload.guidanceScale ?? defaults.guidanceScale
+        guard guidanceScale >= 1 else {
+            throw ValidationError("guidance_scale must be at least 1.")
+        }
+        let cfgIntervalStart = payload.cfgIntervalStart ?? 0
+        let cfgIntervalEnd = payload.cfgIntervalEnd ?? 1
+        guard (0...1).contains(cfgIntervalStart),
+              (0...1).contains(cfgIntervalEnd),
+              cfgIntervalStart <= cfgIntervalEnd
+        else {
+            throw ValidationError(
+                "CFG intervals require 0 <= cfg_interval_start "
+                    + "<= cfg_interval_end <= 1."
+            )
+        }
+        let velocityNormThreshold = payload.velocityNormThreshold
+            ?? defaults.velocityNormThreshold
+        guard velocityNormThreshold >= 0 else {
+            throw ValidationError(
+                "velocity_norm_threshold must be nonnegative."
+            )
+        }
+        let velocityEMAFactor = payload.velocityEMAFactor
+            ?? defaults.velocityEMAFactor
+        guard (0..<1).contains(velocityEMAFactor) else {
+            throw ValidationError(
+                "velocity_ema_factor must be in [0, 1)."
+            )
+        }
+        let audioCoverStrength = payload.audioCoverStrength ?? 1
+        guard (0...1).contains(audioCoverStrength) else {
+            throw ValidationError(
+                "audio_cover_strength must be between 0 and 1."
+            )
+        }
+        let coverNoiseStrength = payload.coverNoiseStrength ?? 0
+        guard (0...1).contains(coverNoiseStrength) else {
+            throw ValidationError(
+                "cover_noise_strength must be between 0 and 1."
+            )
+        }
+        let retakeVariance = payload.retakeVariance ?? 0
+        guard (0...1).contains(retakeVariance) else {
+            throw ValidationError(
+                "retake_variance must be between 0 and 1."
+            )
+        }
+        let repaintStart = payload.repaintStartSeconds ?? 0
+        let repaintEnd = payload.repaintEndSeconds ?? -1
+        guard repaintStart >= 0,
+              repaintEnd == -1 || repaintEnd > repaintStart
+        else {
+            throw ValidationError(
+                "repaint range requires a nonnegative start and an end "
+                    + "greater than the start, or -1."
+            )
+        }
+        let repaintStrength = payload.repaintStrength ?? 0.5
+        guard (0...1).contains(repaintStrength) else {
+            throw ValidationError(
+                "repaint_strength must be between 0 and 1."
+            )
+        }
+        let lmTopK = payload.lmTopK ?? 0
+        let lmTopP = payload.lmTopP ?? 0.9
+        guard lmTopK >= 0, (0...1).contains(lmTopP) else {
+            throw ValidationError(
+                "LM sampling requires lm_top_k >= 0 and lm_top_p in [0, 1]."
+            )
+        }
+        let vaeChunkSize = payload.vaeChunkSize ?? 512
+        let vaeOverlap = payload.vaeOverlap ?? 64
+        guard vaeChunkSize > 0, vaeOverlap >= 0 else {
+            throw ValidationError(
+                "VAE tiling requires vae_chunk_size > 0 and vae_overlap >= 0."
+            )
+        }
+        let responseFormat = payload.responseFormat?.lowercased() ?? "json"
+        guard responseFormat == "json" || responseFormat == "wav" else {
+            throw ValidationError("response_format must be json or wav.")
+        }
+        let sourceAudio = try payload.sourceAudioPath.map {
+            try ACEStepCLIHelper.loadAudio48kHz($0, label: "Source audio")
+        }
+        let referenceAudio = try (payload.referenceAudioPaths ?? []).map {
+            try ACEStepCLIHelper.loadAudio48kHz(
+                $0,
+                label: "Reference audio"
+            )
+        }
+        let isFlowEdit = payload.sourceCaption != nil
+        if task.requiresSourceAudio, sourceAudio == nil {
+            throw ValidationError("source_audio_path is required for \(task.rawValue).")
+        }
+        if isFlowEdit, sourceAudio == nil {
+            throw ValidationError("source_audio_path is required with source_caption.")
+        }
+        var duration = task.locksDurationToSource || isFlowEdit
+            ? sourceAudio.map {
+                ACEStepCLIHelper.durationSeconds(
+                    of: $0,
+                    fallback: defaults.fallbackDurationSeconds
+                )
+            } ?? defaults.fallbackDurationSeconds
+            : payload.durationSeconds ?? defaults.fallbackDurationSeconds
+        guard (1...600).contains(duration) else {
+            throw ValidationError("duration_seconds must be between 1 and 600.")
+        }
+        let useLM = !isFlowEdit
+            && !task.skipsLanguageModel
+            && languageModelAvailable
+            && (payload.useLanguageModel ?? defaults.usesLanguageModel)
+        let instruction = Self.nonEmpty(payload.instruction)
+            ?? task.instruction(
+                trackName: payload.trackName,
+                completeTrackClasses: payload.completeTrackClasses ?? []
+            )
+        let shouldPlanDuration = useLM
+            && payload.durationSeconds == nil
+            && defaults.automaticDuration
+            && !task.locksDurationToSource
+            && !isFlowEdit
+        var effectivePrompt = prompt
+        var metadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
+            bpm: payload.bpm.map(String.init),
+            caption: prompt,
+            duration: shouldPlanDuration
+                ? nil
+                : String(max(1, Int(duration.rounded()))),
+            keyscale: Self.nonEmpty(payload.keyscale),
+            language: Self.nonEmpty(payload.metadataLanguage),
+            timesignature: Self.nonEmpty(payload.timeSignature)
+        )
+        if useLM && defaults.plansMetadata {
+            let plan = try session.planMusic(
+                caption: prompt,
+                lyrics: payload.lyrics ?? "",
+                instruction: instruction,
+                userMetadata: .init(
+                    bpm: metadata.bpm,
+                    duration: shouldPlanDuration
+                        ? nil
+                        : metadata.duration,
+                    keyscale: metadata.keyscale,
+                    language: metadata.language,
+                    timesignature: metadata.timesignature
+                ),
+                lmConfig: .init(
+                    maxNewTokens: 1_024,
+                    temperature: 0.85,
+                    topK: lmTopK,
+                    topP: lmTopP
+                )
+            )
+            effectivePrompt = Self.nonEmpty(plan.metadata.caption) ?? prompt
+            if shouldPlanDuration,
+               let plannedDuration = plan.metadata.durationSeconds
+            {
+                let upperBound: Float = quality == .song ? 240 : 600
+                duration = min(max(plannedDuration, 10), upperBound)
+            }
+            metadata = .init(
+                bpm: Self.nonEmpty(metadata.bpm)
+                    ?? plan.metadata.bpm.map(String.init),
+                caption: effectivePrompt,
+                duration: String(max(1, Int(duration.rounded()))),
+                keyscale: Self.nonEmpty(metadata.keyscale)
+                    ?? Self.nonEmpty(plan.metadata.keyscale),
+                language: Self.nonEmpty(metadata.language)
+                    ?? Self.nonEmpty(plan.metadata.language),
+                timesignature: Self.nonEmpty(metadata.timesignature)
+                    ?? Self.nonEmpty(plan.metadata.timesignature)
+            )
+        }
+        let config = ACEStepInferenceConfig(
+            durationSeconds: duration,
+            fixNFE: steps,
+            shift: shift,
+            coverNoiseStrength: coverNoiseStrength,
+            retakeSeed: payload.retakeSeed,
+            retakeVariance: retakeVariance,
+            inferMethod: payload.inferMethod ?? .ode,
+            samplerMode: payload.sampler ?? defaults.samplerMode,
+            guidanceScale: guidanceScale,
+            guidanceMode: payload.guidanceMode ?? .apg,
+            cfgIntervalStart: cfgIntervalStart,
+            cfgIntervalEnd: cfgIntervalEnd,
+            velocityNormThreshold: velocityNormThreshold,
+            velocityEMAFactor: velocityEMAFactor,
+            useTiledVaeDecode: payload.useTiledVAEDecode ?? true,
+            vaeChunkSize: vaeChunkSize,
+            vaeOverlap: vaeOverlap,
+            seed: payload.seed
+        )
+        let repaint = task == .repaint || task == .lego
+            ? ACEStepRepaintConfiguration(
+                startSeconds: repaintStart,
+                endSeconds: repaintEnd,
+                chunkMaskMode: payload.chunkMaskMode ?? .auto,
+                mode: payload.repaintMode ?? .balanced,
+                strength: repaintStrength
+            )
+            : nil
+        let flowEdit = payload.sourceCaption.map {
+            ACEStepFlowEditConfiguration(
+                sourceCaption: $0,
+                sourceLyrics: payload.sourceLyrics ?? "",
+                nMin: payload.flowEditNMin ?? 0,
+                nMax: payload.flowEditNMax ?? 1,
+                nAverage: payload.flowEditNAverage ?? 1,
+                retakeSeed: payload.retakeSeed
+            )
+        }
+        try flowEdit?.validate()
+        return PreparedMusicAPIRequest(
+            request: ACEStepSessionRequest(
+                caption: effectivePrompt,
+                lyrics: payload.lyrics ?? "",
+                config: config,
+                lmConfig: .init(
+                    maxNewTokens: 4_096,
+                    topK: lmTopK,
+                    topP: lmTopP
+                ),
+                lmUserMetadata: metadata,
+                sourceAudio48kHz: sourceAudio,
+                referenceTimbreAudio48kHz:
+                    referenceAudio.isEmpty ? nil : referenceAudio,
+                audioCoverStrength: audioCoverStrength,
+                vocalLanguage: Self.nonEmpty(payload.vocalLanguage)
+                    ?? Self.nonEmpty(metadata.language)
+                    ?? "en",
+                instruction: instruction,
+                task: task,
+                repaintConfiguration: repaint,
+                flowEditConfiguration: flowEdit,
+                useLanguageModel: useLM
+            ),
+            quality: quality,
+            task: task,
+            candidateCount: candidates,
+            conditioningMetadata: ACEStepRecipeConditioningMetadata(
+                metadata
+            )
+        )
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func response(
+        for ranked: ACEStepRankedGeneration,
+        prepared: PreparedMusicAPIRequest
+    ) throws -> MusicAPIGenerationResponse {
+        MusicAPIGenerationResponse(
+            model: modelID,
+            quality: prepared.quality,
+            task: prepared.task,
+            conditioningMetadata: prepared.conditioningMetadata,
+            candidates: try ranked.candidates.enumerated().map { rank, candidate in
+                MusicAPICandidateResponse(
+                    rank: rank + 1,
+                    seed: candidate.seed,
+                    score: candidate.score,
+                    metrics: candidate.metrics,
+                    audioBase64: try ACEStepWAVWriter.wavData(
+                        candidate.audio,
+                        sampleRate: 48_000
+                    ).base64EncodedString(),
+                    format: "wav",
+                    sampleRate: 48_000,
+                    selected: candidate.index == ranked.best.index
+                )
+            }
+        )
+    }
+
+    private func decode<T: Decodable>(
+        _ type: T.Type,
+        from request: Request
+    ) async throws -> T {
+        guard request.headers[.contentType]?.lowercased().contains("application/json") == true else {
+            throw ValidationError("Content-Type must be application/json.")
+        }
+        let body = try await request.body.collect(upTo: 4 * 1_024 * 1_024)
+        return try JSONDecoder().decode(T.self, from: Data(body.readableBytesView))
+    }
+
+    private func isAuthorized(_ request: Request) -> Bool {
+        guard let apiKey, !apiKey.isEmpty else {
+            return true
+        }
+        return request.headers[.authorization] == "Bearer \(apiKey)"
+    }
+
+    private func jsonResponse<T: Encodable>(_ value: T) throws -> Response {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+
+    private func errorResponse(
+        status: HTTPResponse.Status,
+        message: String
+    ) -> Response {
+        let data = (try? JSONEncoder().encode(["error": message]))
+            ?? Data("{\"error\":\"music API error\"}".utf8)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+}

--- a/Sources/MereRunCLI/Commands/MusicTrainAdapterCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicTrainAdapterCommand.swift
@@ -1,0 +1,250 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct MusicTrainAdapter: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "train-adapter",
+        abstract: "Train a native ACE-Step LoRA or LoKr adapter."
+    )
+
+    @Option(
+        name: [.customShort("m"), .long],
+        help: "Managed ACE-Step model id or local checkpoint root."
+    )
+    var model: String = ModelResolver.ModelID.aceStep.rawValue
+
+    @Option(name: [.long], help: "JSON or JSONL dataset manifest.")
+    var dataset: String
+
+    @Option(
+        name: [.customShort("o"), .long],
+        help: "Output .safetensors adapter path."
+    )
+    var output: String
+
+    @Option(name: [.customLong("kind")], help: "Adapter kind: lora or lokr.")
+    var kind: ACEStepAdapterKind = .lora
+
+    @Option(name: [.long], help: "Adapter rank.")
+    var rank: Int = 8
+
+    @Option(name: [.long], help: "Adapter alpha.")
+    var alpha: Float = 16
+
+    @Option(
+        name: [.long],
+        help: "LoKr factorization target; -1 chooses the closest balanced factors."
+    )
+    var factor: Int = -1
+
+    @Option(name: [.long], help: "Optimizer steps.")
+    var steps: Int = 1_000
+
+    @Option(name: [.customLong("learning-rate")], help: "AdamW learning rate.")
+    var learningRate: Float = 1e-4
+
+    @Option(name: [.customLong("weight-decay")], help: "AdamW weight decay.")
+    var weightDecay: Float = 1e-4
+
+    @Option(name: [.long], help: "Deterministic training seed.")
+    var seed: UInt64 = 42
+
+    @Option(
+        name: [.customLong("max-duration")],
+        help: "Crop every training example to this many seconds."
+    )
+    var maxDurationSeconds: Float = 30
+
+    @Option(name: [.customLong("checkpoints-root")], help: "ACE-Step checkpoint root.")
+    var checkpointsRoot: String?
+
+    @Option(name: [.customLong("decoder-subdirectory")], help: "Decoder subdirectory.")
+    var decoderSubdirectory: String = "acestep-v15-turbo"
+
+    @Option(name: [.customLong("vae-subdirectory")], help: "VAE subdirectory.")
+    var vaeSubdirectory: String = "vae"
+
+    @Option(name: [.customLong("text-subdirectory")], help: "Text encoder subdirectory.")
+    var textSubdirectory: String?
+
+    @Option(name: [.customLong("log-every")], help: "Progress interval.")
+    var logEvery: Int = 10
+
+    func run() async throws {
+        guard kind == .lora || kind == .lokr else {
+            throw ValidationError("--kind must be lora or lokr.")
+        }
+        guard maxDurationSeconds > 0, maxDurationSeconds <= 600 else {
+            throw ValidationError("--max-duration must be in (0, 600].")
+        }
+        guard logEvery > 0 else {
+            throw ValidationError("--log-every must be greater than zero.")
+        }
+
+        let manifestURL = ACEStepCLIHelper.resolveUserPath(dataset)
+        let records = try Self.loadManifest(from: manifestURL)
+        let examples = try records.enumerated().map { index, record in
+            let audioURL = Self.resolveAudioURL(
+                record.audio,
+                relativeTo: manifestURL.deletingLastPathComponent()
+            )
+            let decoded = try ACEStepCLIHelper.loadAudio48kHz(
+                audioURL.path,
+                label: "Dataset audio \(index + 1)"
+            )
+            let maxFrames = max(
+                1,
+                Int((maxDurationSeconds * 48_000).rounded())
+            )
+            let audio = decoded.dim(1) > maxFrames
+                ? decoded[0..., 0..<maxFrames, 0...]
+                : decoded
+            return ACEStepAdapterTrainingExample(
+                audio48kHz: audio,
+                caption: record.caption,
+                lyrics: record.lyrics ?? ""
+            )
+        }
+
+        let root = try await ACEStepCLIHelper.resolveCheckpointsRoot(
+            model: model,
+            checkpointsRoot: checkpointsRoot,
+            turboSubdirectory: decoderSubdirectory,
+            vaeSubdirectory: vaeSubdirectory,
+            lmSubdirectory: nil,
+            textSubdirectory: textSubdirectory
+        )
+        let decoder = try ACEStepCLIHelper.resolveTurboSubdirectory(
+            at: root,
+            explicit: decoderSubdirectory
+        )
+        guard let text = try ACEStepCLIHelper.resolveTextSubdirectory(
+            at: root,
+            explicit: textSubdirectory
+        ) else {
+            throw ValidationError("ACE-Step text encoder not found.")
+        }
+        let container = ACEStepModelContainer(
+            checkpointsRootURL: root,
+            turboSubdirectory: decoder,
+            vaeSubdirectory: vaeSubdirectory,
+            textEncoderSubdirectory: text
+        )
+        CLIStderr.write(
+            "Loading ACE-Step for \(kind.rawValue) training with "
+                + "\(examples.count) example(s)\n"
+        )
+        let resources = try await container.resources()
+        let pipeline = try ACEStepPipeline(
+            decoderResources: resources.decoderResources,
+            vaeResources: resources.vaeResources,
+            textEncoderResources: resources.textEncoderResources
+        )
+        let outputURL = ACEStepCLIHelper.resolveUserPath(output)
+        let report = try pipeline.trainAdapter(
+            examples: examples,
+            configuration: .init(
+                kind: kind,
+                rank: rank,
+                alpha: alpha,
+                factor: factor,
+                trainingSteps: steps,
+                learningRate: learningRate,
+                weightDecay: weightDecay,
+                seed: seed
+            ),
+            outputURL: outputURL
+        ) { progress in
+            if progress.step == 1
+                || progress.step == progress.totalSteps
+                || progress.step.isMultiple(of: logEvery)
+            {
+                CLIStderr.write(
+                    String(
+                        format: "ACE-Step adapter step %d/%d loss=%.6f\n",
+                        progress.step,
+                        progress.totalSteps,
+                        progress.loss
+                    )
+                )
+            }
+        }
+        CLIStderr.write(
+            String(
+                format: "Saved %d-layer %@ adapter; loss %.6f -> %.6f; sha256=%@\n",
+                report.layerCount,
+                report.kind.rawValue,
+                report.initialLoss,
+                report.finalLoss,
+                report.outputSHA256
+            )
+        )
+        print(outputURL.path)
+    }
+
+    struct ManifestRecord: Codable, Sendable {
+        var audio: String
+        var caption: String
+        var lyrics: String?
+    }
+
+    static func loadManifest(from url: URL) throws -> [ManifestRecord] {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ValidationError("Dataset manifest not found: \(url.path)")
+        }
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        let records: [ManifestRecord]
+        if let decoded = try? decoder.decode([ManifestRecord].self, from: data) {
+            records = decoded
+        } else {
+            let text = String(decoding: data, as: UTF8.self)
+            records = try text.split(whereSeparator: \.isNewline)
+                .enumerated()
+                .map { lineNumber, line in
+                    do {
+                        return try decoder.decode(
+                            ManifestRecord.self,
+                            from: Data(line.utf8)
+                        )
+                    } catch {
+                        throw ValidationError(
+                            "Invalid dataset JSONL line \(lineNumber + 1): "
+                                + error.localizedDescription
+                        )
+                    }
+                }
+        }
+        guard !records.isEmpty else {
+            throw ValidationError("Dataset manifest contains no examples.")
+        }
+        for (index, record) in records.enumerated() {
+            if record.audio.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty {
+                throw ValidationError(
+                    "Dataset record \(index + 1) has an empty audio path."
+                )
+            }
+            if record.caption.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty {
+                throw ValidationError(
+                    "Dataset record \(index + 1) has an empty caption."
+                )
+            }
+        }
+        return records
+    }
+
+    private static func resolveAudioURL(
+        _ path: String,
+        relativeTo directory: URL
+    ) -> URL {
+        if path.hasPrefix("/") || path.hasPrefix("~") {
+            return ACEStepCLIHelper.resolveUserPath(path)
+        }
+        return directory.appendingPathComponent(path).standardizedFileURL
+    }
+}

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -16,6 +16,10 @@ Managed ids:
   encoder.
 - `music-acestep-xl-turbo-lm4b`: ACE-Step 1.5 XL turbo plus the optional 4B
   5 Hz LM subdirectory.
+- `music-acestep-xl-sft`: ACE-Step 1.5 XL-SFT with full non-distilled
+  CFG/APG/ADG inference.
+- `music-acestep-xl-base`: ACE-Step 1.5 XL-Base, including extract, lego, and
+  complete tasks.
 - `music-magenta-rt2-small`: Magenta RealTime 2 small exported runtime assets.
 - `music-magenta-rt2-base`: Magenta RealTime 2 base exported runtime assets.
 
@@ -39,6 +43,21 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--lyrics`: inline lyrics.
 - `--lyrics-file`: lyrics file; cannot be used with `--lyrics`.
 - `--output`, `-o`: WAV path.
+- `--quality draft|song|final|edit`: model-aware steps, sampler, guidance, LM,
+  automatic-duration, and best-of-N policy.
+- `--candidates`, `--best-of`: warm-session candidate count; results are
+  technically scored and stably ranked.
+- `--retake-seed`, `--retake-variance`: reproducible spherical retake noise.
+- `--flow-edit`, `--source-caption`, `--source-lyrics`,
+  `--flow-edit-n-min`, `--flow-edit-n-max`, `--flow-edit-n-average`: semantic
+  source-to-target flow editing.
+- `--adapter`, `--adapter-kind`, `--adapter-scale`: stack PEFT LoRA and
+  LyCORIS LoKr adapters.
+- `--export-format pcm16|pcm24|float32`, `--normalize`, fades, and dither:
+  mastering/export controls.
+- `--recipe-output`, `--no-recipe`: exact reproducibility sidecar controls.
+- `--lrc-file`, `--lrc-output`: synchronized lyrics input/output.
+- `--daw-bundle`, `--stems`: portable DAW session and Base-only extraction.
 - `--model`, `-m`: managed id, model root, or checkpoints root.
 - `--checkpoints-root`: root containing ACE-Step subdirectories.
 - `--turbo-subdirectory`, `--vae-subdirectory`, `--lm-subdirectory`, `--text-subdirectory`: component layout overrides.
@@ -49,7 +68,8 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--steps`, `-s`: turbo denoise steps.
 - `--shift`: turbo scheduler shift; ACE-Step CLI default is `3.0`, matching upstream.
 - `--seed`: deterministic generation.
-- `--source-audio`: source song for ACE-Step cover conditioning; implies cover mode unless `--non-cover` is set.
+- `--source-audio`: source song for ACE-Step cover, repaint, extract, lego, or
+  complete conditioning. With the default task it implies `cover`.
 - `--analyze-source-audio`: run ACE-Step 5 Hz LM audio understanding before a
   cover and fill missing BPM, key/scale, language, and time signature metadata
   from the source audio. Explicit `--bpm`, `--keyscale`, `--timesignature`, and
@@ -61,10 +81,19 @@ mere.run guide music generate --model music-magenta-rt2-small
   start closer to the source song.
 - `--vocal-language`: language tag for lyric formatting.
 - `--instruction`: caption instruction prefix.
-- `--task-type`, `--task`: `text2music`, `cover`, `repaint`, `extract`, `lego`, or `complete`.
+- `--task-type`, `--task`: `text2music`, `repaint`, `cover`, `cover-nofsq`,
+  `extract`, `lego`, or `complete`. Unknown values are rejected during parsing.
 - `--track-name`: target track for extract/lego.
 - `--complete-track-classes`: comma-separated classes for complete.
-- `--non-cover`: set `isCover=false`.
+- `--non-cover`: compatibility alias for the explicit `cover-nofsq` task.
+- `--repaint-start`, `--repaint-end`: edit range in seconds; `-1` uses the
+  source end.
+- `--chunk-mask-mode auto|explicit`: use learned automatic masking or pass the
+  exact edit span into the DiT chunk-mask channels.
+- `--repaint-mode conservative|balanced|aggressive`: source-preservation
+  policy. Conservative injects the source throughout denoising and uses the
+  widest boundary fades; aggressive performs pure diffusion.
+- `--repaint-strength`: balanced-mode aggressiveness from `0` to `1`.
 - `--bpm`, `--keyscale`, `--timesignature`: musical metadata.
 - `--lm-top-k`, `--lm-top-p`: constrained LM sampling controls.
 - `--metadata-duration`, `--metadata-language`: metadata overrides for LM.
@@ -95,8 +124,38 @@ The default ACE-Step managed ID uses the smaller 1.5 turbo DiT. Use
 `music-acestep-xl-turbo` for the ACE-Step 1.5 XL turbo DiT on larger machines,
 or `music-acestep-xl-turbo-lm4b` with `--use-lm` and
 `--lm-subdirectory acestep-5Hz-lm-4B` when you want the optional 4B 5 Hz LM.
-ACE-Step cover/repaint/extract tasks skip the LM phase, matching upstream,
-because they use source-audio conditioning directly.
+ACE-Step cover, cover-nofsq, repaint, and extract tasks skip the LM phase,
+matching upstream. Turbo and SFT checkpoints support text-to-music, repaint,
+cover, and cover-nofsq. Extract, lego, and complete are Base-only; the CLI
+rejects those tasks on Turbo/SFT checkpoints before loading model weights.
+XL-SFT and XL-Base use native continuous scheduling, CFG/APG/ADG, velocity
+stabilization, and Euler or Heun integration.
+
+Use a warm resident server when generating repeatedly:
+
+```bash
+mere.run music serve \
+  --model music-acestep-xl-turbo-lm4b \
+  --adapter ./house-style.safetensors \
+  --port 8081
+
+curl http://127.0.0.1:8081/v1/audio/music \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"sleek nocturnal house","quality":"final","candidates":4}'
+```
+
+Train a directly reloadable adapter from a JSON/JSONL manifest containing
+`audio`, `caption`, and optional `lyrics`:
+
+```bash
+mere.run music train-adapter \
+  --model music-acestep-xl-turbo \
+  --dataset ./music-training.jsonl \
+  --kind lokr \
+  --rank 8 \
+  --alpha 16 \
+  --output ./my-style.safetensors
+```
 
 For realtime Magenta RT2 runs, use `mere.run music realtime`. It accepts the
 same Magenta controls plus `--play` or `--no-play` and optional `--output` WAV
@@ -118,9 +177,7 @@ mere.run guide music generate --model music-magenta-rt2-small
 ```
 
 For ACE-Step text-to-music, start with a direct caption and optional structured
-lyrics. Add `--use-lm` only when you want the 5 Hz LM planning phase for
-text-to-music; cover, repaint, extract, lego, and complete tasks use direct DiT
-conditioning instead.
+lyrics. Add `--use-lm` only when you want the 5 Hz LM planning phase.
 
 For ACE-Step covers, keep the source song in `--source-audio` and put the target
 arrangement in the caption. Add `--analyze-source-audio` when you want missing
@@ -131,6 +188,25 @@ For ACE-Step style-transfer covers or remixes, lower `--audio-cover-strength`
 so the caption can steer genre and arrangement. Start around `0.20`, keep
 `--cover-noise-strength 0.0`, and only raise source noise when the result needs
 more of the original song's contour.
+
+For a surgical edit, select `--task repaint`, pass the original song, and set
+the edit range. The runtime silences only that latent span for conditioning,
+re-injects appropriately noised clean source latents outside it during
+denoising, blends the latent boundaries, then restores the original pre-VAE
+waveform outside the range:
+
+```bash
+mere.run music generate \
+  "replace the bridge with a bigger live-drum chorus" \
+  --model music-acestep-xl-turbo \
+  --task repaint \
+  --source-audio ./song.wav \
+  --repaint-start 42.0 \
+  --repaint-end 58.5 \
+  --repaint-mode balanced \
+  --repaint-strength 0.4 \
+  --output ./song-repaint.wav
+```
 
 For analysis-first workflows, run `mere.run music analyze` separately, inspect
 the JSON, then pass explicit `--bpm`, `--keyscale`, `--timesignature`, or
@@ -267,7 +343,9 @@ mere.run music realtime \
 - `--lyrics` and `--lyrics-file` conflict: use only one.
 - Text encoder missing: set `--text-subdirectory` or keep the default layout.
 - `--use-lm` fails: ensure the LM subdirectory exists or pass `--lm-subdirectory`.
-  Cover/repaint/extract tasks skip LM even if the flag is present.
+  Cover, cover-nofsq, repaint, and extract skip LM even if the flag is present.
+- Base-only task rejected: extract, lego, and complete require
+  `music-acestep-xl-base`; Turbo and SFT intentionally reject them.
 - Audio decode memory pressure: keep tiled VAE enabled, reduce duration, or tune VAE chunk size.
 - Magenta RT2 unsupported runtime: build `vendor/magentart.xcframework` with
   `scripts/rebuild_magentart_xcframework.sh` on Apple Silicon macOS, then

--- a/Sources/MereRunCLI/Support/ACEStepAudioExporter.swift
+++ b/Sources/MereRunCLI/Support/ACEStepAudioExporter.swift
@@ -1,0 +1,258 @@
+import Foundation
+import MLX
+
+enum ACEStepAudioFormat: String, CaseIterable, Codable {
+    case pcm16
+    case pcm24
+    case float32
+
+    var bitsPerSample: UInt16 {
+        switch self {
+        case .pcm16:
+            16
+        case .pcm24:
+            24
+        case .float32:
+            32
+        }
+    }
+
+    var waveFormat: UInt16 {
+        self == .float32 ? 3 : 1
+    }
+}
+
+enum ACEStepNormalizationMode: String, CaseIterable, Codable {
+    case none
+    case peak
+}
+
+struct ACEStepAudioExportOptions: Codable {
+    var format: ACEStepAudioFormat = .pcm24
+    var normalization: ACEStepNormalizationMode = .peak
+    var targetPeakDB: Float = -1
+    var fadeInMilliseconds: Float = 5
+    var fadeOutMilliseconds: Float = 20
+    var dither: Bool = true
+}
+
+enum ACEStepWAVWriter {
+    enum WriterError: LocalizedError {
+        case invalidShape([Int])
+        case invalidChannels(Int)
+        case invalidSampleRate(Int)
+        case invalidPeak(Float)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidShape(let shape):
+                return "Unsupported ACE-Step audio tensor shape: \(shape). "
+                    + "Expected [1,S,C], [S,C], [1,S], or [S]."
+            case .invalidChannels(let channels):
+                return "Invalid channel count \(channels). Expected 1...8."
+            case .invalidSampleRate(let sampleRate):
+                return "Invalid sample rate \(sampleRate)."
+            case .invalidPeak(let peak):
+                return "Target peak must be at most 0 dBFS; got \(peak)."
+            }
+        }
+    }
+
+    static func writeWAV(
+        _ audio: MLXArray,
+        to url: URL,
+        sampleRate: Int,
+        options: ACEStepAudioExportOptions = .init()
+    ) throws {
+        try wavData(audio, sampleRate: sampleRate, options: options).write(
+            to: url,
+            options: .atomic
+        )
+    }
+
+    static func wavData(
+        _ audio: MLXArray,
+        sampleRate: Int,
+        options: ACEStepAudioExportOptions = .init()
+    ) throws -> Data {
+        guard sampleRate > 0 else {
+            throw WriterError.invalidSampleRate(sampleRate)
+        }
+        guard options.targetPeakDB <= 0 else {
+            throw WriterError.invalidPeak(options.targetPeakDB)
+        }
+        let (interleaved, channels) = try flattenToInterleaved(audio)
+        guard (1...8).contains(channels) else {
+            throw WriterError.invalidChannels(channels)
+        }
+
+        var samples = interleaved.map { $0.isFinite ? $0 : 0 }
+        applyFades(
+            to: &samples,
+            channels: channels,
+            sampleRate: sampleRate,
+            fadeInMilliseconds: options.fadeInMilliseconds,
+            fadeOutMilliseconds: options.fadeOutMilliseconds
+        )
+        normalize(
+            &samples,
+            mode: options.normalization,
+            targetPeakDB: options.targetPeakDB
+        )
+
+        let bytesPerSample = Int(options.format.bitsPerSample / 8)
+        let dataSize = UInt32(samples.count * bytesPerSample)
+        let blockAlign = UInt16(channels * bytesPerSample)
+        let byteRate = UInt32(sampleRate) * UInt32(blockAlign)
+
+        var data = Data()
+        data.append(Data("RIFF".utf8))
+        append(UInt32(36) + dataSize, to: &data)
+        data.append(Data("WAVE".utf8))
+        data.append(Data("fmt ".utf8))
+        append(UInt32(16), to: &data)
+        append(options.format.waveFormat, to: &data)
+        append(UInt16(channels), to: &data)
+        append(UInt32(sampleRate), to: &data)
+        append(byteRate, to: &data)
+        append(blockAlign, to: &data)
+        append(options.format.bitsPerSample, to: &data)
+        data.append(Data("data".utf8))
+        append(dataSize, to: &data)
+
+        for (index, sample) in samples.enumerated() {
+            let clamped = max(-1, min(1, sample))
+            switch options.format {
+            case .pcm16:
+                let dither = options.dither ? triangularDither(index: index) / 32_768 : 0
+                append(Int16(max(-1, min(1, clamped + dither)) * 32_767), to: &data)
+            case .pcm24:
+                let dither = options.dither ? triangularDither(index: index) / 8_388_608 : 0
+                let value = Int32(max(-1, min(1, clamped + dither)) * 8_388_607)
+                data.append(UInt8(truncatingIfNeeded: value))
+                data.append(UInt8(truncatingIfNeeded: value >> 8))
+                data.append(UInt8(truncatingIfNeeded: value >> 16))
+            case .float32:
+                appendFloat32(clamped, to: &data)
+            }
+        }
+        return data
+    }
+
+    static func flattenToInterleaved(_ audio: MLXArray) throws -> ([Float], Int) {
+        let sampleChannel: MLXArray
+        if audio.ndim == 1 {
+            sampleChannel = audio.reshaped(audio.dim(0), 1)
+        } else if audio.ndim == 2 {
+            if audio.dim(1) <= 8 {
+                sampleChannel = audio
+            } else if audio.dim(0) <= 8 {
+                sampleChannel = audio.transposed(1, 0)
+            } else {
+                throw WriterError.invalidShape(audio.shape)
+            }
+        } else if audio.ndim == 3 {
+            guard audio.dim(0) == 1 else {
+                throw WriterError.invalidShape(audio.shape)
+            }
+            let squeezed = audio[0, 0..., 0...]
+            if squeezed.dim(1) <= 8 {
+                sampleChannel = squeezed
+            } else if squeezed.dim(0) <= 8 {
+                sampleChannel = squeezed.transposed(1, 0)
+            } else {
+                throw WriterError.invalidShape(audio.shape)
+            }
+        } else {
+            throw WriterError.invalidShape(audio.shape)
+        }
+
+        MLX.eval(sampleChannel)
+        return (
+            sampleChannel.asType(.float32).reshaped(-1).asArray(Float.self),
+            sampleChannel.dim(1)
+        )
+    }
+
+    private static func normalize(
+        _ samples: inout [Float],
+        mode: ACEStepNormalizationMode,
+        targetPeakDB: Float
+    ) {
+        guard mode == .peak else {
+            return
+        }
+        let peak = samples.reduce(Float.zero) { max($0, abs($1)) }
+        guard peak > 0 else {
+            return
+        }
+        let target = pow(10, targetPeakDB / 20)
+        let gain = target / peak
+        for index in samples.indices {
+            samples[index] *= gain
+        }
+    }
+
+    private static func applyFades(
+        to samples: inout [Float],
+        channels: Int,
+        sampleRate: Int,
+        fadeInMilliseconds: Float,
+        fadeOutMilliseconds: Float
+    ) {
+        let frameCount = samples.count / channels
+        guard frameCount > 0 else {
+            return
+        }
+        let fadeInFrames = min(
+            frameCount,
+            max(0, Int(Float(sampleRate) * fadeInMilliseconds / 1_000))
+        )
+        let fadeOutFrames = min(
+            frameCount,
+            max(0, Int(Float(sampleRate) * fadeOutMilliseconds / 1_000))
+        )
+        for frame in 0..<fadeInFrames {
+            let gain = Float(frame) / Float(max(fadeInFrames - 1, 1))
+            for channel in 0..<channels {
+                samples[frame * channels + channel] *= gain
+            }
+        }
+        for offset in 0..<fadeOutFrames {
+            let frame = frameCount - fadeOutFrames + offset
+            let gain = Float(fadeOutFrames - offset - 1)
+                / Float(max(fadeOutFrames - 1, 1))
+            for channel in 0..<channels {
+                samples[frame * channels + channel] *= gain
+            }
+        }
+    }
+
+    private static func triangularDither(index: Int) -> Float {
+        let first = pseudoRandom(UInt64(index) &* 2)
+        let second = pseudoRandom(UInt64(index) &* 2 &+ 1)
+        return first - second
+    }
+
+    private static func pseudoRandom(_ seed: UInt64) -> Float {
+        var value = seed &+ 0x9E37_79B9_7F4A_7C15
+        value = (value ^ (value >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        value = (value ^ (value >> 27)) &* 0x94D0_49BB_1331_11EB
+        value ^= value >> 31
+        return Float(value & 0x00FF_FFFF) / Float(0x0100_0000)
+    }
+
+    private static func append<T: FixedWidthInteger>(
+        _ value: T,
+        to data: inout Data
+    ) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { bytes in
+            data.append(contentsOf: bytes)
+        }
+    }
+
+    private static func appendFloat32(_ value: Float, to data: inout Data) {
+        append(value.bitPattern, to: &data)
+    }
+}

--- a/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
+++ b/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
@@ -138,18 +138,26 @@ enum ACEStepCLIHelper {
         let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
         let upstreamDefault = "acestep-v15-turbo"
         let compatibilityDefault = "music-acestep-v15-turbo"
-        let xlTurboDefault = "acestep-v15-xl-turbo"
+        let decoderDefaults = [
+            upstreamDefault,
+            compatibilityDefault,
+            "acestep-v15-xl-turbo",
+            "acestep-v15-xl-sft",
+            "acestep-v15-xl-base",
+            "acestep-v15-sft",
+            "acestep-v15-base",
+        ]
         let candidates = trimmed == upstreamDefault
-            ? [upstreamDefault, compatibilityDefault, xlTurboDefault]
+            ? decoderDefaults
             : [trimmed]
 
-        for candidate in candidates where isUsableTurboDirectory(
+        for candidate in candidates where isUsableDecoderDirectory(
             root.appendingPathComponent(candidate, isDirectory: true),
             fileManager: fm
         ) {
             return candidate
         }
-        throw ValidationError("--turbo-subdirectory not found: \(trimmed)")
+        throw ValidationError("--decoder-subdirectory not found: \(trimmed)")
     }
 
     static func resolveLMSubdirectory(at root: URL, explicit: String?) throws -> String? {
@@ -165,16 +173,16 @@ enum ACEStepCLIHelper {
         }
 
         let preferredCandidates = [
-            "acestep-5Hz-lm-1.7B",
-            "acestep-5hz-lm-1.7b",
             "acestep-5Hz-lm-4B",
             "acestep-5hz-lm-4b",
+            "acestep-5Hz-lm-1.7B",
+            "acestep-5hz-lm-1.7b",
             "acestep-5Hz-lm",
             "acestep-5hz-lm",
-            "music-acestep-5hz-lm-1.7b",
-            "music-acestep-5Hz-lm-1.7B",
             "music-acestep-5hz-lm-4b",
             "music-acestep-5Hz-lm-4B",
+            "music-acestep-5hz-lm-1.7b",
+            "music-acestep-5Hz-lm-1.7B",
             "music-acestep-5hz-lm",
             "music-acestep-5Hz-lm",
             "lm",
@@ -309,10 +317,18 @@ enum ACEStepCLIHelper {
             return false
         }
         let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
-            ? ["acestep-v15-turbo", "music-acestep-v15-turbo", "acestep-v15-xl-turbo"]
+            ? [
+                "acestep-v15-turbo",
+                "music-acestep-v15-turbo",
+                "acestep-v15-xl-turbo",
+                "acestep-v15-xl-sft",
+                "acestep-v15-xl-base",
+                "acestep-v15-sft",
+                "acestep-v15-base",
+            ]
             : [turboSubdirectory]
         guard turboCandidates.contains(where: {
-            isUsableTurboDirectory(root.appendingPathComponent($0, isDirectory: true), fileManager: fm)
+            isUsableDecoderDirectory(root.appendingPathComponent($0, isDirectory: true), fileManager: fm)
         }) else {
             return false
         }
@@ -335,7 +351,7 @@ enum ACEStepCLIHelper {
         return true
     }
 
-    private static func isUsableTurboDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+    private static func isUsableDecoderDirectory(_ url: URL, fileManager: FileManager) -> Bool {
         isDirectory(url, fileManager: fileManager)
             && ACEStepResources(rootURL: url).validate(fileManager: fileManager).isEmpty
     }

--- a/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
@@ -1,0 +1,293 @@
+import Foundation
+import MLX
+import MereRunCore
+
+struct ACEStepRecipeCandidate: Codable {
+    var rank: Int
+    var index: Int
+    var seed: UInt64
+    var score: Float
+    var metrics: ACEStepCandidateMetrics
+    var lmAudioCodeCount: Int?
+    var selected: Bool
+}
+
+struct ACEStepRecipeConditioningMetadata: Codable, Equatable {
+    var bpm: String?
+    var duration: String?
+    var keyscale: String?
+    var language: String?
+    var timesignature: String?
+
+    init(_ metadata: ACEStep5HzLMConstrainedSampler.UserMetadata) {
+        bpm = metadata.bpm
+        duration = metadata.duration
+        keyscale = metadata.keyscale
+        language = metadata.language
+        timesignature = metadata.timesignature
+    }
+}
+
+struct ACEStepGenerationRecipe: Codable {
+    static let currentSchemaVersion = 2
+
+    var schemaVersion: Int
+    var createdAt: Date
+    var modelID: String
+    var checkpointVariant: ACEStepCheckpointVariant
+    var decoderSubdirectory: String
+    var checkpointSources: [MereRunModelManifest.SourceProvenance]
+    var languageModelSubdirectory: String?
+    var textEncoderSubdirectory: String
+    var adapters: [ACEStepAdapterDescriptor]
+    var task: ACEStepTask
+    var quality: ACEStepQualityPreset
+    var caption: String
+    var lyrics: String
+    var instruction: String
+    var conditioningMetadata: ACEStepRecipeConditioningMetadata
+    var inference: ACEStepInferenceConfig
+    var repaint: ACEStepRepaintConfiguration?
+    var flowEdit: ACEStepFlowEditConfiguration?
+    var languageModelUsed: Bool
+    var candidates: [ACEStepRecipeCandidate]
+    var export: ACEStepAudioExportOptions
+    var sourceAudioSHA256: String?
+    var outputFilename: String
+    var outputSHA256: String
+    var lrcFilename: String?
+    var lrcTimingIsApproximate: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case createdAt = "created_at"
+        case modelID = "model_id"
+        case checkpointVariant = "checkpoint_variant"
+        case decoderSubdirectory = "decoder_subdirectory"
+        case checkpointSources = "checkpoint_sources"
+        case languageModelSubdirectory = "language_model_subdirectory"
+        case textEncoderSubdirectory = "text_encoder_subdirectory"
+        case adapters
+        case task
+        case quality
+        case caption
+        case lyrics
+        case instruction
+        case conditioningMetadata = "conditioning_metadata"
+        case inference
+        case repaint
+        case flowEdit = "flow_edit"
+        case languageModelUsed = "language_model_used"
+        case candidates
+        case export
+        case sourceAudioSHA256 = "source_audio_sha256"
+        case outputFilename = "output_filename"
+        case outputSHA256 = "output_sha256"
+        case lrcFilename = "lrc_filename"
+        case lrcTimingIsApproximate = "lrc_timing_is_approximate"
+    }
+
+    func write(to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(self).write(to: url, options: .atomic)
+    }
+
+    static func checkpointProvenance(
+        modelID: String,
+        manifest: MereRunModelManifest?
+    ) -> [MereRunModelManifest.SourceProvenance] {
+        if let sources = manifest?.sources, !sources.isEmpty {
+            return sources
+        }
+        guard let spec = ManagedModelCatalog.spec(for: modelID) else {
+            return []
+        }
+        var sources: [MereRunModelManifest.SourceProvenance] = []
+        if let primary = spec.hubFallback {
+            sources.append(
+                .init(
+                    role: "primary",
+                    repository: primary.repoId,
+                    revision: primary.revision
+                )
+            )
+        }
+        sources.append(contentsOf: spec.mountedHubFallbacks.map {
+            .init(
+                role: "mounted",
+                repository: $0.hubFallback.repoId,
+                revision: $0.hubFallback.revision,
+                destinationPath: $0.destinationPath
+            )
+        })
+        if let repository = spec.upstreamRepoId,
+           !sources.contains(where: { $0.repository == repository })
+        {
+            sources.append(
+                .init(
+                    role: "upstream",
+                    repository: repository,
+                    revision: spec.upstreamRevision ?? "unspecified"
+                )
+            )
+        }
+        return sources
+    }
+}
+
+enum ACEStepDAWBundleWriter {
+    struct Track {
+        var name: String
+        var audio: MLXArray
+    }
+
+    static func write(
+        directory: URL,
+        mixURL: URL,
+        recipeURL: URL,
+        lrcURL: URL?,
+        candidates: [Track],
+        stems: [Track],
+        lrc: ACEStepLRCDocument?,
+        exportOptions: ACEStepAudioExportOptions
+    ) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let audioDirectory = directory.appendingPathComponent(
+            "audio",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: audioDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let mixDestination = audioDirectory.appendingPathComponent("mix.wav")
+        try Data(contentsOf: mixURL).write(to: mixDestination, options: .atomic)
+        var projectFiles: [(name: String, audioURL: URL)] = [
+            (name: "Mix", audioURL: mixDestination),
+        ]
+
+        for (prefix, tracks) in [("candidate", candidates), ("stem", stems)] {
+            for (index, track) in tracks.enumerated() {
+                let safeName = safeFilename(track.name)
+                let filename = "\(prefix)-\(index + 1)-\(safeName).wav"
+                let destination = audioDirectory.appendingPathComponent(filename)
+                try ACEStepWAVWriter.writeWAV(
+                    track.audio,
+                    to: destination,
+                    sampleRate: 48_000,
+                    options: exportOptions
+                )
+                projectFiles.append((track.name, destination))
+            }
+        }
+
+        let recipeDestination = directory.appendingPathComponent("recipe.json")
+        try Data(contentsOf: recipeURL).write(
+            to: recipeDestination,
+            options: .atomic
+        )
+        if let lrcURL {
+            try Data(contentsOf: lrcURL).write(
+                to: directory.appendingPathComponent("lyrics.lrc"),
+                options: .atomic
+            )
+        }
+        try markerCSV(lrc).write(
+            to: directory.appendingPathComponent("markers.csv"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try reaperProject(
+            tracks: projectFiles,
+            baseDirectory: directory
+        ).write(
+            to: directory.appendingPathComponent("mere-run-session.rpp"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try readme(trackCount: projectFiles.count).write(
+            to: directory.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private static func markerCSV(_ lrc: ACEStepLRCDocument?) -> String {
+        var rows = ["Name,Start,End,Length,Color"]
+        for (index, line) in (lrc?.lines ?? []).enumerated() {
+            let escaped = line.text.replacingOccurrences(of: "\"", with: "\"\"")
+            let next = lrc?.lines.dropFirst(index + 1).first?.timestampSeconds
+                ?? line.timestampSeconds
+            rows.append(
+                "\"\(escaped)\",\(line.timestampSeconds),\(next),"
+                    + "\(max(0, next - line.timestampSeconds)),"
+            )
+        }
+        return rows.joined(separator: "\n") + "\n"
+    }
+
+    private static func reaperProject(
+        tracks: [(name: String, audioURL: URL)],
+        baseDirectory: URL
+    ) -> String {
+        var lines = [
+            "<REAPER_PROJECT 0.1 \"7.0\" 0",
+            "  RIPPLE 0",
+            "  GROUPOVERRIDE 0 0 0",
+        ]
+        for track in tracks {
+            let relative = track.audioURL.path.replacingOccurrences(
+                of: baseDirectory.path + "/",
+                with: ""
+            )
+            lines.append(contentsOf: [
+                "  <TRACK",
+                "    NAME \"\(escapedProjectValue(track.name))\"",
+                "    <ITEM",
+                "      POSITION 0",
+                "      <SOURCE WAVE",
+                "        FILE \"\(escapedProjectValue(relative))\"",
+                "      >",
+                "    >",
+                "  >",
+            ])
+        }
+        lines.append(">")
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func readme(trackCount: Int) -> String {
+        """
+        # mere.run ACE-Step session
+
+        This portable bundle contains \(trackCount) 48 kHz WAV track(s), the
+        exact generation recipe and checkpoint revisions, synchronized lyric
+        markers, and a REAPER project. Open `mere-run-session.rpp` in REAPER or
+        import `audio/*.wav` and `markers.csv` into another DAW.
+        """
+            + "\n"
+    }
+
+    private static func safeFilename(_ value: String) -> String {
+        let mapped = value.lowercased().map { character -> Character in
+            character.isLetter || character.isNumber ? character : "-"
+        }
+        let collapsed = String(mapped)
+            .replacingOccurrences(of: "--", with: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return collapsed.isEmpty ? "track" : collapsed
+    }
+
+    private static func escapedProjectValue(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Sources/MereRunCLI/Support/ArgumentParserConformances.swift
+++ b/Sources/MereRunCLI/Support/ArgumentParserConformances.swift
@@ -1,6 +1,17 @@
 import ArgumentParser
 import MereRunCore
 
+extension ACEStepTask: ExpressibleByArgument {}
+extension ACEStepChunkMaskMode: ExpressibleByArgument {}
+extension ACEStepRepaintMode: ExpressibleByArgument {}
+extension ACEStepInferenceMethod: ExpressibleByArgument {}
+extension ACEStepSamplerMode: ExpressibleByArgument {}
+extension ACEStepGuidanceMode: ExpressibleByArgument {}
+extension ACEStepQualityPreset: ExpressibleByArgument {}
+extension ACEStepAudioFormat: ExpressibleByArgument {}
+extension ACEStepNormalizationMode: ExpressibleByArgument {}
+extension ACEStepAdapterKind: ExpressibleByArgument {}
+
 extension ModelResolver.ModelID: ExpressibleByArgument {
     public init?(argument: String) {
         self.init(rawValue: argument)

--- a/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MLX
 import MLXNN
+import MLXRandom
 
 public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
     public var maxNewTokens: Int
@@ -10,6 +11,7 @@ public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
     public var repetitionPenalty: Float?
     public var repetitionContextSize: Int
     public var stopTokenIds: Set<Int>
+    public var seed: UInt64?
 
     public init(
         maxNewTokens: Int = 4096,
@@ -18,7 +20,8 @@ public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
         topP: Float = 0.9,
         repetitionPenalty: Float? = nil,
         repetitionContextSize: Int = 64,
-        stopTokenIds: Set<Int> = []
+        stopTokenIds: Set<Int> = [],
+        seed: UInt64? = nil
     ) {
         self.maxNewTokens = maxNewTokens
         self.temperature = temperature
@@ -27,6 +30,7 @@ public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
         self.stopTokenIds = stopTokenIds
+        self.seed = seed
     }
 }
 
@@ -271,6 +275,9 @@ public final class ACEStep5HzLM {
             repetitionPenalty: config.repetitionPenalty,
             repetitionContextSize: config.repetitionContextSize
         )
+        if let seed = config.seed {
+            MLXRandom.seed(seed)
+        }
         let result = AutoregressiveDecodeEngine.decodeStateful(
             AutoregressiveDecodeRequest(
                 initialLogits: logits,

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapter.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapter.swift
@@ -1,0 +1,552 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum ACEStepAdapterKind: String, Codable, CaseIterable, Sendable {
+    case auto
+    case lora
+    case lokr
+}
+
+public struct ACEStepAdapterDescriptor: Codable, Hashable, Sendable {
+    public var kind: ACEStepAdapterKind
+    public var filename: String
+    public var sha256: String
+    public var scale: Float
+    public var matchedLayerCount: Int
+    public var matchedLayers: [String]
+
+    public init(
+        kind: ACEStepAdapterKind,
+        filename: String,
+        sha256: String,
+        scale: Float,
+        matchedLayers: [String]
+    ) {
+        self.kind = kind
+        self.filename = filename
+        self.sha256 = sha256
+        self.scale = scale
+        self.matchedLayerCount = matchedLayers.count
+        self.matchedLayers = matchedLayers
+    }
+}
+
+public enum ACEStepAdapterError: LocalizedError {
+    case fileNotFound(String)
+    case unsupportedFormat(String)
+    case noCompatibleLayers
+    case ambiguousLayer(String, [String])
+    case invalidTensor(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let path):
+            return "ACE-Step adapter file not found: \(path)"
+        case .unsupportedFormat(let reason):
+            return "Unsupported ACE-Step adapter: \(reason)"
+        case .noCompatibleLayers:
+            return "The adapter contains no weights compatible with ACE-Step decoder Linear layers."
+        case .ambiguousLayer(let key, let matches):
+            return "Adapter layer '\(key)' ambiguously matches: \(matches.joined(separator: ", "))."
+        case .invalidTensor(let reason):
+            return "Invalid ACE-Step adapter tensor: \(reason)"
+        }
+    }
+}
+
+extension ACEStepPipeline {
+    /// Loads a PEFT LoRA or LyCORIS LoKr adapter directly onto the resident
+    /// decoder. Repeated calls stack adapters without rebuilding the pipeline.
+    @discardableResult
+    public func loadAdapter(
+        from url: URL,
+        kind requestedKind: ACEStepAdapterKind = .auto,
+        scale: Float = 1
+    ) throws -> ACEStepAdapterDescriptor {
+        try ACEStepAdapterLoader.load(
+            from: url,
+            kind: requestedKind,
+            scale: scale,
+            into: decoder
+        )
+    }
+}
+
+private final class ACEStepAdapterLinear: Linear {
+    struct LoRAContribution {
+        var down: MLXArray
+        var up: MLXArray
+        var scale: Float
+    }
+
+    struct LoKRContribution {
+        var w1: MLXArray
+        var w2: MLXArray
+        var scale: Float
+    }
+
+    private let base: Linear
+    var loraContributions: [LoRAContribution] = []
+    var lokrContributions: [LoKRContribution] = []
+
+    init(base: Linear) {
+        self.base = base
+        super.init(weight: base.weight, bias: base.bias)
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var output = base(x)
+        let input = x.asType(.float32)
+        for contribution in loraContributions {
+            let projected = MLX.matmul(
+                MLX.matmul(input, contribution.down.T),
+                contribution.up.T
+            ) * MLXArray(contribution.scale)
+            output = output + projected.asType(output.dtype)
+        }
+        for contribution in lokrContributions {
+            let prefixShape = Array(input.shape.dropLast())
+            let grouped = input.reshaped(
+                prefixShape + [contribution.w1.dim(1), contribution.w2.dim(1)]
+            )
+            let projectedW2 = MLX.matmul(grouped, contribution.w2.T)
+            let swapped = projectedW2.swappedAxes(-1, -2)
+            let projectedW1 = MLX.matmul(swapped, contribution.w1.T)
+                .swappedAxes(-1, -2)
+                .reshaped(prefixShape + [contribution.w1.dim(0) * contribution.w2.dim(0)])
+            let projected = projectedW1 * MLXArray(contribution.scale)
+            output = output + projected.asType(output.dtype)
+        }
+        return output
+    }
+}
+
+enum ACEStepAdapterLoader {
+    private struct LoRAPair {
+        var key: String
+        var down: MLXArray
+        var up: MLXArray
+        var alpha: Float
+    }
+
+    private struct LoKRGroup {
+        var key: String
+        var tensors: [String: MLXArray]
+    }
+
+    private static let targetSuffixes = [
+        ".self_attn.q_proj",
+        ".self_attn.k_proj",
+        ".self_attn.v_proj",
+        ".self_attn.o_proj",
+        ".cross_attn.q_proj",
+        ".cross_attn.k_proj",
+        ".cross_attn.v_proj",
+        ".cross_attn.o_proj",
+    ]
+
+    static func load(
+        from url: URL,
+        kind requestedKind: ACEStepAdapterKind,
+        scale: Float,
+        into decoder: Module
+    ) throws -> ACEStepAdapterDescriptor {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ACEStepAdapterError.fileNotFound(url.path)
+        }
+        guard scale.isFinite else {
+            throw ACEStepAdapterError.invalidTensor("adapter scale must be finite.")
+        }
+
+        let (arrays, metadata) = try MLX.loadArraysAndMetadata(url: url)
+        let kind = try resolveKind(
+            requestedKind,
+            keys: Array(arrays.keys),
+            metadata: metadata
+        )
+        let matchedLayers: [String]
+        switch kind {
+        case .lora:
+            matchedLayers = try loadLoRA(
+                arrays: arrays,
+                metadata: metadata,
+                scale: scale,
+                into: decoder
+            )
+        case .lokr:
+            matchedLayers = try loadLoKR(
+                arrays: arrays,
+                metadata: metadata,
+                scale: scale,
+                into: decoder
+            )
+        case .auto:
+            preconditionFailure("Adapter kind must be resolved before loading.")
+        }
+        guard !matchedLayers.isEmpty else {
+            throw ACEStepAdapterError.noCompatibleLayers
+        }
+
+        return try ACEStepAdapterDescriptor(
+            kind: kind,
+            filename: url.lastPathComponent,
+            sha256: ModelArtifactPin.fileSHA256(url),
+            scale: scale,
+            matchedLayers: matchedLayers.sorted()
+        )
+    }
+
+    private static func resolveKind(
+        _ requested: ACEStepAdapterKind,
+        keys: [String],
+        metadata: [String: String]?
+    ) throws -> ACEStepAdapterKind {
+        if requested != .auto {
+            return requested
+        }
+        if keys.contains(where: { $0.contains(".lokr_w") })
+            || metadata?["algo"]?.lowercased() == "lokr"
+        {
+            return .lokr
+        }
+        if keys.contains(where: {
+            $0.contains(".lora_A")
+                || $0.contains(".lora_B")
+                || $0.contains(".lora_down")
+                || $0.contains(".lora_up")
+        }) {
+            return .lora
+        }
+        throw ACEStepAdapterError.unsupportedFormat(
+            "could not detect PEFT LoRA or LyCORIS LoKr keys."
+        )
+    }
+
+    private static func loadLoRA(
+        arrays: [String: MLXArray],
+        metadata: [String: String]?,
+        scale: Float,
+        into decoder: Module
+    ) throws -> [String] {
+        let pairs = try loraPairs(arrays: arrays, metadata: metadata)
+        let leaves = targetLeaves(in: decoder)
+        var replacements: [String: Module] = [:]
+        var matched: [String] = []
+
+        for pair in pairs {
+            let path = try matchPath(pair.key, among: Array(leaves.keys))
+            guard let path, let linear = leaves[path] else { continue }
+            guard pair.down.ndim == 2, pair.up.ndim == 2 else {
+                throw ACEStepAdapterError.invalidTensor(
+                    "\(pair.key) LoRA tensors must both be rank 2."
+                )
+            }
+            let rank = pair.down.dim(0)
+            let shape = linear.shape
+            guard pair.down.shape == [rank, shape.1],
+                  pair.up.shape == [shape.0, rank] else {
+                throw ACEStepAdapterError.invalidTensor(
+                    "\(pair.key) expects down [\(rank), \(shape.1)] and "
+                        + "up [\(shape.0), \(rank)], got "
+                        + "\(pair.down.shape) and \(pair.up.shape)."
+                )
+            }
+            let wrapper = adapterWrapper(
+                for: path,
+                linear: linear,
+                replacements: &replacements
+            )
+            wrapper.loraContributions.append(
+                .init(
+                    down: pair.down.asType(.float32),
+                    up: pair.up.asType(.float32),
+                    scale: (pair.alpha / Float(rank)) * scale
+                )
+            )
+            matched.append(path)
+        }
+
+        apply(replacements: replacements, to: decoder)
+        return matched
+    }
+
+    private static func loadLoKR(
+        arrays: [String: MLXArray],
+        metadata: [String: String]?,
+        scale: Float,
+        into decoder: Module
+    ) throws -> [String] {
+        let groups = lokrGroups(arrays: arrays)
+        let leaves = targetLeaves(in: decoder)
+        var replacements: [String: Module] = [:]
+        var matched: [String] = []
+
+        for group in groups {
+            let path = try matchPath(group.key, among: Array(leaves.keys))
+            guard let path, let linear = leaves[path] else { continue }
+            let (w1, w2, nativeScale) = try resolveLoKR(
+                group,
+                metadata: metadata
+            )
+            let deltaShape = [
+                w1.dim(0) * w2.dim(0),
+                w1.dim(1) * w2.dim(1),
+            ]
+            guard deltaShape == [linear.shape.0, linear.shape.1] else {
+                throw ACEStepAdapterError.invalidTensor(
+                    "\(group.key) LoKr delta has shape \(deltaShape); "
+                        + "expected [\(linear.shape.0), \(linear.shape.1)]."
+                )
+            }
+            let wrapper = adapterWrapper(
+                for: path,
+                linear: linear,
+                replacements: &replacements
+            )
+            wrapper.lokrContributions.append(
+                .init(
+                    w1: w1.asType(.float32),
+                    w2: w2.asType(.float32),
+                    scale: nativeScale * scale
+                )
+            )
+            matched.append(path)
+        }
+
+        apply(replacements: replacements, to: decoder)
+        return matched
+    }
+
+    private static func targetLeaves(in decoder: Module) -> [String: Linear] {
+        var result: [String: Linear] = [:]
+        for (path, module) in decoder.namedModules() {
+            guard targetSuffixes.contains(where: { path.hasSuffix($0) }),
+                  let linear = module as? Linear else {
+                continue
+            }
+            result[path] = linear
+        }
+        return result
+    }
+
+    private static func adapterWrapper(
+        for path: String,
+        linear: Linear,
+        replacements: inout [String: Module]
+    ) -> ACEStepAdapterLinear {
+        if let pending = replacements[path] as? ACEStepAdapterLinear {
+            return pending
+        }
+        if let existing = linear as? ACEStepAdapterLinear {
+            return existing
+        }
+        let wrapper = ACEStepAdapterLinear(base: linear)
+        replacements[path] = wrapper
+        return wrapper
+    }
+
+    private static func apply(
+        replacements: [String: Module],
+        to decoder: Module
+    ) {
+        guard !replacements.isEmpty else { return }
+        decoder.update(
+            modules: ModuleChildren.unflattened(
+                replacements.map { ($0.key, $0.value) }
+            )
+        )
+    }
+
+    private static func loraPairs(
+        arrays: [String: MLXArray],
+        metadata: [String: String]?
+    ) throws -> [LoRAPair] {
+        let patterns = [
+            (down: ".lora_A.default.weight", up: ".lora_B.default.weight"),
+            (down: ".lora_A.weight", up: ".lora_B.weight"),
+            (down: ".lora_down.weight", up: ".lora_up.weight"),
+            (down: ".lora_down", up: ".lora_up"),
+        ]
+        let fallbackAlpha = metadata.flatMap { values in
+            ["lora_alpha", "alpha", "network_alpha"]
+                .compactMap { key in values[key].flatMap(Float.init) }
+                .first
+        }
+        var pairs: [LoRAPair] = []
+        var seen = Set<String>()
+
+        for key in arrays.keys.sorted() {
+            for pattern in patterns where key.hasSuffix(pattern.down) {
+                let base = String(key.dropLast(pattern.down.count))
+                guard seen.insert(base).inserted else { continue }
+                let upKey = base + pattern.up
+                guard let down = arrays[key], let up = arrays[upKey] else {
+                    throw ACEStepAdapterError.invalidTensor(
+                        "missing pair for \(key)."
+                    )
+                }
+                let rank = down.ndim == 2 ? down.dim(0) : 0
+                let alpha = scalar(
+                    arrays[base + ".alpha"]
+                        ?? arrays[base + ".lora_alpha"]
+                ) ?? fallbackAlpha ?? Float(rank)
+                pairs.append(
+                    .init(key: base, down: down, up: up, alpha: alpha)
+                )
+            }
+        }
+        if pairs.isEmpty {
+            throw ACEStepAdapterError.unsupportedFormat(
+                "no complete LoRA A/B or down/up tensor pairs were found."
+            )
+        }
+        return pairs
+    }
+
+    private static func lokrGroups(
+        arrays: [String: MLXArray]
+    ) -> [LoKRGroup] {
+        let suffixes = [
+            ".lokr_w1",
+            ".lokr_w1_a",
+            ".lokr_w1_b",
+            ".lokr_w2",
+            ".lokr_w2_a",
+            ".lokr_w2_b",
+            ".lokr_t2",
+            ".alpha",
+        ]
+        var groups: [String: [String: MLXArray]] = [:]
+        for (key, array) in arrays {
+            guard let suffix = suffixes.first(where: { key.hasSuffix($0) }) else {
+                continue
+            }
+            let base = String(key.dropLast(suffix.count))
+            groups[base, default: [:]][String(suffix.dropFirst())] = array
+        }
+        return groups.keys.sorted().map {
+            LoKRGroup(key: $0, tensors: groups[$0]!)
+        }
+    }
+
+    private static func resolveLoKR(
+        _ group: LoKRGroup,
+        metadata: [String: String]?
+    ) throws -> (MLXArray, MLXArray, Float) {
+        if group.tensors["lokr_t2"] != nil {
+            throw ACEStepAdapterError.unsupportedFormat(
+                "\(group.key) uses Tucker-convolution LoKr weights; "
+                    + "ACE-Step attention projections are Linear and must not contain lokr_t2."
+            )
+        }
+        let w1 = try factor(
+            direct: group.tensors["lokr_w1"],
+            left: group.tensors["lokr_w1_a"],
+            right: group.tensors["lokr_w1_b"],
+            name: "\(group.key).lokr_w1"
+        )
+        let w2 = try factor(
+            direct: group.tensors["lokr_w2"],
+            left: group.tensors["lokr_w2_a"],
+            right: group.tensors["lokr_w2_b"],
+            name: "\(group.key).lokr_w2"
+        )
+        guard w1.ndim == 2, w2.ndim == 2 else {
+            throw ACEStepAdapterError.invalidTensor(
+                "\(group.key) LoKr factors must materialize to rank-2 matrices."
+            )
+        }
+
+        let rank = group.tensors["lokr_w1_a"]?.dim(1)
+            ?? group.tensors["lokr_w2_a"]?.dim(1)
+        let metadataAlpha = metadata.flatMap { values in
+            ["linear_alpha", "alpha"]
+                .compactMap { key in values[key].flatMap(Float.init) }
+                .first
+        }
+        let alpha = scalar(group.tensors["alpha"]) ?? metadataAlpha
+        let nativeScale: Float
+        if group.tensors["lokr_w1"] != nil,
+           group.tensors["lokr_w2"] != nil {
+            nativeScale = 1
+        } else if let rank, rank > 0 {
+            nativeScale = (alpha ?? Float(rank)) / Float(rank)
+        } else {
+            nativeScale = 1
+        }
+        return (w1, w2, nativeScale)
+    }
+
+    private static func factor(
+        direct: MLXArray?,
+        left: MLXArray?,
+        right: MLXArray?,
+        name: String
+    ) throws -> MLXArray {
+        if let direct {
+            return direct
+        }
+        guard let left, let right,
+              left.ndim == 2, right.ndim == 2,
+              left.dim(1) == right.dim(0) else {
+            throw ACEStepAdapterError.invalidTensor(
+                "\(name) requires a direct tensor or compatible _a/_b factors."
+            )
+        }
+        return MLX.matmul(left, right)
+    }
+
+    private static func scalar(_ array: MLXArray?) -> Float? {
+        guard let array, array.size == 1 else { return nil }
+        MLX.eval(array)
+        return array.item(Float.self)
+    }
+
+    private static func matchPath(
+        _ externalKey: String,
+        among paths: [String]
+    ) throws -> String? {
+        let normalized = normalize(externalKey)
+        let canonical = canonicalize(normalized)
+        let matches = paths.filter { path in
+            normalized == path
+                || normalized.hasSuffix("." + path)
+                || canonical == canonicalize(path)
+                || canonical.hasSuffix("_" + canonicalize(path))
+        }
+        if matches.count > 1 {
+            throw ACEStepAdapterError.ambiguousLayer(externalKey, matches)
+        }
+        return matches.first
+    }
+
+    private static func normalize(_ key: String) -> String {
+        var result = key
+        let prefixes = [
+            "base_model.model.",
+            "base_model.",
+            "model.model.",
+            "model.decoder.",
+            "diffusion_model.",
+            "transformer.",
+            "decoder.",
+            "module.",
+            "lycoris_",
+            "lora_unet_",
+        ]
+        var removed = true
+        while removed {
+            removed = false
+            for prefix in prefixes where result.hasPrefix(prefix) {
+                result.removeFirst(prefix.count)
+                removed = true
+            }
+        }
+        return result
+    }
+
+    private static func canonicalize(_ key: String) -> String {
+        key.replacingOccurrences(of: ".", with: "_")
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainer.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainer.swift
@@ -1,0 +1,598 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXOptimizers
+import MLXRandom
+
+public struct ACEStepAdapterTrainingExample: @unchecked Sendable {
+    public var audio48kHz: MLXArray
+    public var caption: String
+    public var lyrics: String
+
+    public init(
+        audio48kHz: MLXArray,
+        caption: String,
+        lyrics: String = ""
+    ) {
+        self.audio48kHz = audio48kHz
+        self.caption = caption
+        self.lyrics = lyrics
+    }
+}
+
+public struct ACEStepAdapterTrainingConfiguration: Sendable {
+    public var kind: ACEStepAdapterKind
+    public var rank: Int
+    public var alpha: Float
+    public var factor: Int
+    public var trainingSteps: Int
+    public var learningRate: Float
+    public var weightDecay: Float
+    public var seed: UInt64
+
+    public init(
+        kind: ACEStepAdapterKind = .lora,
+        rank: Int = 8,
+        alpha: Float = 16,
+        factor: Int = -1,
+        trainingSteps: Int = 1_000,
+        learningRate: Float = 1e-4,
+        weightDecay: Float = 1e-4,
+        seed: UInt64 = 42
+    ) {
+        self.kind = kind
+        self.rank = rank
+        self.alpha = alpha
+        self.factor = factor
+        self.trainingSteps = trainingSteps
+        self.learningRate = learningRate
+        self.weightDecay = weightDecay
+        self.seed = seed
+    }
+}
+
+public struct ACEStepAdapterTrainingProgress: Sendable {
+    public var step: Int
+    public var totalSteps: Int
+    public var loss: Float
+}
+
+public struct ACEStepAdapterTrainingReport: Codable, Sendable {
+    public var kind: ACEStepAdapterKind
+    public var layerCount: Int
+    public var trainingSteps: Int
+    public var initialLoss: Float
+    public var finalLoss: Float
+    public var outputSHA256: String
+}
+
+public enum ACEStepAdapterTrainingError: LocalizedError {
+    case invalidConfiguration(String)
+    case noExamples
+    case noTrainableLayers
+    case invalidAudio(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let reason):
+            return "Invalid ACE-Step adapter training configuration: \(reason)"
+        case .noExamples:
+            return "ACE-Step adapter training requires at least one audio example."
+        case .noTrainableLayers:
+            return "No ACE-Step attention projections were available for adapter training."
+        case .invalidAudio(let reason):
+            return "Invalid ACE-Step adapter training audio: \(reason)"
+        }
+    }
+}
+
+extension ACEStepPipeline {
+    /// Fine-tunes the resident decoder with the same flow-matching objective
+    /// used by upstream ACE-Step training and writes a directly loadable
+    /// PEFT LoRA or LyCORIS LoKr safetensors artifact.
+    public func trainAdapter(
+        examples: [ACEStepAdapterTrainingExample],
+        configuration: ACEStepAdapterTrainingConfiguration,
+        outputURL: URL,
+        progress: (@Sendable (ACEStepAdapterTrainingProgress) -> Void)? = nil
+    ) throws -> ACEStepAdapterTrainingReport {
+        try ACEStepAdapterTrainer.train(
+            pipeline: self,
+            examples: examples,
+            configuration: configuration,
+            outputURL: outputURL,
+            progress: progress
+        )
+    }
+}
+
+private final class ACEStepTrainableLoKRLinear: Linear {
+    private let base: Linear
+    let rank: Int
+    let alphaValue: Float
+
+    @ParameterInfo(key: "lokr_w1") var w1: MLXArray
+    @ParameterInfo(key: "lokr_w2_a") var w2A: MLXArray
+    @ParameterInfo(key: "lokr_w2_b") var w2B: MLXArray
+
+    init(
+        base: Linear,
+        rank: Int,
+        alpha: Float,
+        factor: Int
+    ) {
+        self.base = base
+        self.rank = rank
+        self.alphaValue = alpha
+        let (outSmall, outLarge) = ACEStepAdapterTrainer.factorization(
+            base.shape.0,
+            factor: factor
+        )
+        let (inSmall, inLarge) = ACEStepAdapterTrainer.factorization(
+            base.shape.1,
+            factor: factor
+        )
+        let w1Bound = 1 / sqrt(Float(max(1, inSmall)))
+        let w2Bound = 1 / sqrt(Float(max(1, inLarge)))
+        self._w1.wrappedValue = MLXRandom.uniform(
+            low: -w1Bound,
+            high: w1Bound,
+            [outSmall, inSmall]
+        ).asType(.float32)
+        self._w2A.wrappedValue = MLXRandom.uniform(
+            low: -w2Bound,
+            high: w2Bound,
+            [outLarge, rank]
+        ).asType(.float32)
+        self._w2B.wrappedValue = MLXArray.zeros(
+            [rank, inLarge],
+            dtype: .float32
+        )
+        super.init(weight: base.weight, bias: base.bias)
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let input = x.asType(.float32)
+        let w2 = MLX.matmul(w2A, w2B)
+        let prefixShape = Array(input.shape.dropLast())
+        let grouped = input.reshaped(
+            prefixShape + [w1.dim(1), w2.dim(1)]
+        )
+        let projectedW2 = MLX.matmul(grouped, w2.T)
+        let projectedW1 = MLX.matmul(
+            projectedW2.swappedAxes(-1, -2),
+            w1.T
+        )
+            .swappedAxes(-1, -2)
+            .reshaped(prefixShape + [w1.dim(0) * w2.dim(0)])
+        let contribution = projectedW1 * MLXArray(alphaValue / Float(rank))
+        return base(x) + contribution.asType(x.dtype)
+    }
+}
+
+enum ACEStepAdapterTrainer {
+    private struct PreparedExample {
+        var cleanLatents: MLXArray
+        var encoderHiddenStates: MLXArray
+        var encoderAttentionMask: MLXArray
+        var contextLatents: MLXArray
+    }
+
+    private static let targetSuffixes = [
+        ".self_attn.q_proj",
+        ".self_attn.k_proj",
+        ".self_attn.v_proj",
+        ".self_attn.o_proj",
+        ".cross_attn.q_proj",
+        ".cross_attn.k_proj",
+        ".cross_attn.v_proj",
+        ".cross_attn.o_proj",
+    ]
+
+    static func train(
+        pipeline: ACEStepPipeline,
+        examples: [ACEStepAdapterTrainingExample],
+        configuration: ACEStepAdapterTrainingConfiguration,
+        outputURL: URL,
+        progress: (@Sendable (ACEStepAdapterTrainingProgress) -> Void)?
+    ) throws -> ACEStepAdapterTrainingReport {
+        try validate(configuration, examples: examples)
+        MLXRandom.seed(configuration.seed)
+
+        let layerCount: Int
+        let loraLayers: [String: TrainableLoRALayer]
+        let lokrLayers: [String: ACEStepTrainableLoKRLinear]
+        switch configuration.kind {
+        case .lora:
+            loraLayers = try injectLoRA(
+                into: pipeline.decoder,
+                rank: configuration.rank,
+                alpha: configuration.alpha
+            )
+            lokrLayers = [:]
+            layerCount = loraLayers.count
+        case .lokr:
+            loraLayers = [:]
+            lokrLayers = try injectLoKR(
+                into: pipeline.decoder,
+                rank: configuration.rank,
+                alpha: configuration.alpha,
+                factor: configuration.factor
+            )
+            layerCount = lokrLayers.count
+        case .auto:
+            throw ACEStepAdapterTrainingError.invalidConfiguration(
+                "training kind must be lora or lokr, not auto."
+            )
+        }
+        guard layerCount > 0 else {
+            throw ACEStepAdapterTrainingError.noTrainableLayers
+        }
+
+        try pipeline.decoder.freeze(
+            recursive: true,
+            keys: nil,
+            strict: false
+        )
+        for layer in loraLayers.values {
+            guard let module = layer as? Module else { continue }
+            try module.unfreeze(
+                recursive: false,
+                keys: ["loraDown", "loraUp"],
+                strict: true
+            )
+        }
+        for layer in lokrLayers.values {
+            try layer.unfreeze(
+                recursive: false,
+                keys: ["lokr_w1", "lokr_w2_a", "lokr_w2_b"],
+                strict: true
+            )
+        }
+        guard !pipeline.decoder.trainableParameters().flattened().isEmpty else {
+            throw ACEStepAdapterTrainingError.noTrainableLayers
+        }
+
+        let prepared = try examples.map {
+            try prepare($0, pipeline: pipeline)
+        }
+        let optimizer = AdamW(
+            learningRate: configuration.learningRate,
+            weightDecay: configuration.weightDecay,
+            biasCorrection: true
+        )
+        let lossAndGrad = valueAndGrad(model: pipeline.decoder) {
+            model,
+            arrays in
+            let clean = arrays[0].asType(.float32)
+            let noise = arrays[1].asType(.float32)
+            let condition = arrays[2]
+            let conditionMask = arrays[3]
+            let context = arrays[4]
+            let timestep = arrays[5].asType(.float32)
+            let sample = flowMatchingSample(
+                clean: clean,
+                noise: noise,
+                timestep: timestep
+            )
+            let prediction = model(
+                hiddenStates: sample.noisy.asType(clean.dtype),
+                timestep: timestep,
+                timestepR: timestep,
+                encoderHiddenStates: condition,
+                encoderAttentionMask: conditionMask,
+                contextLatents: context
+            ).asType(.float32)
+            return [(prediction - sample.target).square().mean()]
+        }
+
+        var initialLoss: Float?
+        var finalLoss: Float = .nan
+        let schedule = pipeline.checkpointVariant.isTurbo
+            ? ACEStepTurboScheduler(fixNFE: 8, shift: 3).timesteps
+            : ACEStepContinuousScheduler(
+                inferenceSteps: max(8, min(100, configuration.trainingSteps)),
+                shift: 1
+            ).timesteps
+
+        for step in 0..<configuration.trainingSteps {
+            let example = prepared[step % prepared.count]
+            let noise = MLXRandom.normal(
+                example.cleanLatents.shape,
+                key: MLXRandom.key(
+                    configuration.seed &+ UInt64(step) &+ 1
+                )
+            ).asType(.float32)
+            let timestepValue = schedule[step % schedule.count]
+            let timestep = MLXArray([timestepValue]).asType(.float32)
+            let (values, gradients) = lossAndGrad(
+                pipeline.decoder,
+                [
+                    example.cleanLatents,
+                    noise,
+                    example.encoderHiddenStates,
+                    example.encoderAttentionMask,
+                    example.contextLatents,
+                    timestep,
+                ]
+            )
+            optimizer.update(model: pipeline.decoder, gradients: gradients)
+            MLX.eval(values[0], pipeline.decoder, optimizer)
+            let loss = values[0].item(Float.self)
+            initialLoss = initialLoss ?? loss
+            finalLoss = loss
+            progress?(
+                .init(
+                    step: step + 1,
+                    totalSteps: configuration.trainingSteps,
+                    loss: loss
+                )
+            )
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        switch configuration.kind {
+        case .lora:
+            try LoRASafetensorsWriter.save(
+                loraLayers: loraLayers,
+                to: outputURL,
+                metadata: trainingMetadata(configuration)
+            )
+        case .lokr:
+            try saveLoKR(
+                lokrLayers,
+                configuration: configuration,
+                to: outputURL
+            )
+        case .auto:
+            preconditionFailure("Adapter training kind was validated.")
+        }
+        return try ACEStepAdapterTrainingReport(
+            kind: configuration.kind,
+            layerCount: layerCount,
+            trainingSteps: configuration.trainingSteps,
+            initialLoss: initialLoss ?? .nan,
+            finalLoss: finalLoss,
+            outputSHA256: ModelArtifactPin.fileSHA256(outputURL)
+        )
+    }
+
+    static func factorization(
+        _ dimension: Int,
+        factor requestedFactor: Int
+    ) -> (Int, Int) {
+        if requestedFactor > 0, dimension.isMultiple(of: requestedFactor) {
+            return (
+                min(requestedFactor, dimension / requestedFactor),
+                max(requestedFactor, dimension / requestedFactor)
+            )
+        }
+        let limit = requestedFactor < 0 ? dimension : requestedFactor
+        var best = (1, dimension)
+        var candidate = 1
+        while candidate * candidate <= dimension {
+            if dimension.isMultiple(of: candidate),
+               candidate <= limit {
+                best = (candidate, dimension / candidate)
+            }
+            candidate += 1
+        }
+        return best
+    }
+
+    static func flowMatchingSample(
+        clean: MLXArray,
+        noise: MLXArray,
+        timestep: MLXArray
+    ) -> (noisy: MLXArray, target: MLXArray) {
+        let expandedTimestep = timestep.reshaped(
+            timestep.dim(0),
+            1,
+            1
+        )
+        return (
+            noisy: expandedTimestep * noise
+                + (MLXArray(Float(1)) - expandedTimestep) * clean,
+            target: noise - clean
+        )
+    }
+
+    private static func validate(
+        _ configuration: ACEStepAdapterTrainingConfiguration,
+        examples: [ACEStepAdapterTrainingExample]
+    ) throws {
+        guard !examples.isEmpty else {
+            throw ACEStepAdapterTrainingError.noExamples
+        }
+        guard configuration.rank > 0 else {
+            throw ACEStepAdapterTrainingError.invalidConfiguration(
+                "rank must be greater than zero."
+            )
+        }
+        guard configuration.alpha.isFinite, configuration.alpha > 0 else {
+            throw ACEStepAdapterTrainingError.invalidConfiguration(
+                "alpha must be finite and greater than zero."
+            )
+        }
+        guard configuration.trainingSteps > 0 else {
+            throw ACEStepAdapterTrainingError.invalidConfiguration(
+                "trainingSteps must be greater than zero."
+            )
+        }
+        guard configuration.learningRate.isFinite,
+              configuration.learningRate > 0 else {
+            throw ACEStepAdapterTrainingError.invalidConfiguration(
+                "learningRate must be finite and greater than zero."
+            )
+        }
+    }
+
+    private static func prepare(
+        _ example: ACEStepAdapterTrainingExample,
+        pipeline: ACEStepPipeline
+    ) throws -> PreparedExample {
+        guard example.audio48kHz.ndim == 3,
+              example.audio48kHz.dim(0) == 1,
+              example.audio48kHz.dim(1) > 0,
+              example.audio48kHz.dim(2) == pipeline.vaeConfig.audioChannels else {
+            throw ACEStepAdapterTrainingError.invalidAudio(
+                "expected [1, samples, \(pipeline.vaeConfig.audioChannels)]."
+            )
+        }
+        let clean = pipeline.vae.tiledEncode(
+            example.audio48kHz.asType(.float32),
+            sample: false
+        ).asType(.float32)
+        let source = pipeline.defaultSourceLatents(
+            targetFrames: clean.dim(1)
+        ).asType(.float32)
+        let metadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
+            caption: example.caption,
+            duration: String(
+                Int(
+                    (Float(example.audio48kHz.dim(1)) / 48_000)
+                        .rounded()
+                )
+            )
+        )
+        let inputs = try pipeline.preparePromptConditionInputs(
+            caption: example.caption,
+            lyrics: example.lyrics,
+            srcLatents: source,
+            chunkChannels: pipeline.chunkChannelsForPromptConditioning(),
+            lmUserMetadata: metadata,
+            vocalLanguage: "en",
+            instruction: ACEStepTask.textToMusic.instruction(),
+            task: .textToMusic
+        )
+        let prepared = pipeline.prepareCondition(
+            textHiddenStates: inputs.textHiddenStates,
+            textAttentionMask: inputs.textAttentionMask,
+            lyricHiddenStates: inputs.lyricHiddenStates,
+            lyricAttentionMask: inputs.lyricAttentionMask,
+            referAudioAcousticHiddenStatesPacked:
+                inputs.referAudioAcousticHiddenStatesPacked,
+            referAudioOrderMask: inputs.referAudioOrderMask,
+            hiddenStates: inputs.hiddenStates ?? source,
+            attentionMask: inputs.attentionMask
+                ?? MLXArray.ones([1, clean.dim(1)], dtype: .int32),
+            silenceLatent: inputs.silenceLatent,
+            srcLatents: inputs.srcLatents,
+            chunkMasks: inputs.chunkMasks,
+            isCovers: inputs.isCovers
+        )
+        MLX.eval(
+            clean,
+            prepared.encoderHiddenStates,
+            prepared.encoderAttentionMask,
+            prepared.contextLatents
+        )
+        return PreparedExample(
+            cleanLatents: clean,
+            encoderHiddenStates: prepared.encoderHiddenStates,
+            encoderAttentionMask: prepared.encoderAttentionMask,
+            contextLatents: prepared.contextLatents
+        )
+    }
+
+    private static func injectLoRA(
+        into decoder: Module,
+        rank: Int,
+        alpha: Float
+    ) throws -> [String: TrainableLoRALayer] {
+        var replacements: [String: Module] = [:]
+        var layers: [String: TrainableLoRALayer] = [:]
+        for (path, module) in decoder.namedModules() {
+            guard targetSuffixes.contains(where: { path.hasSuffix($0) }),
+                  let linear = module as? Linear else {
+                continue
+            }
+            let wrapper = LoRALinear(
+                base: linear,
+                rank: rank,
+                alpha: alpha,
+                zeroInitUp: true
+            )
+            replacements[path] = wrapper
+            layers[path] = wrapper
+        }
+        apply(replacements, to: decoder)
+        return layers
+    }
+
+    private static func injectLoKR(
+        into decoder: Module,
+        rank: Int,
+        alpha: Float,
+        factor: Int
+    ) throws -> [String: ACEStepTrainableLoKRLinear] {
+        var replacements: [String: Module] = [:]
+        var layers: [String: ACEStepTrainableLoKRLinear] = [:]
+        for (path, module) in decoder.namedModules() {
+            guard targetSuffixes.contains(where: { path.hasSuffix($0) }),
+                  let linear = module as? Linear else {
+                continue
+            }
+            let wrapper = ACEStepTrainableLoKRLinear(
+                base: linear,
+                rank: rank,
+                alpha: alpha,
+                factor: factor
+            )
+            replacements[path] = wrapper
+            layers[path] = wrapper
+        }
+        apply(replacements, to: decoder)
+        return layers
+    }
+
+    private static func apply(
+        _ replacements: [String: Module],
+        to decoder: Module
+    ) {
+        decoder.update(
+            modules: ModuleChildren.unflattened(
+                replacements.map { ($0.key, $0.value) }
+            )
+        )
+    }
+
+    private static func saveLoKR(
+        _ layers: [String: ACEStepTrainableLoKRLinear],
+        configuration: ACEStepAdapterTrainingConfiguration,
+        to url: URL
+    ) throws {
+        var arrays: [String: MLXArray] = [:]
+        for (path, layer) in layers {
+            let key = "lycoris_" + path.replacingOccurrences(of: ".", with: "_")
+            arrays["\(key).lokr_w1"] = layer.w1.asType(.float16)
+            arrays["\(key).lokr_w2_a"] = layer.w2A.asType(.float16)
+            arrays["\(key).lokr_w2_b"] = layer.w2B.asType(.float16)
+            arrays["\(key).alpha"] = MLXArray(configuration.alpha)
+        }
+        MLX.eval(Array(arrays.values))
+        var metadata = trainingMetadata(configuration)
+        metadata["algo"] = "lokr"
+        metadata["format"] = "lycoris"
+        metadata["linear_dim"] = String(configuration.rank)
+        metadata["linear_alpha"] = String(configuration.alpha)
+        try MLX.save(arrays: arrays, metadata: metadata, url: url)
+    }
+
+    private static func trainingMetadata(
+        _ configuration: ACEStepAdapterTrainingConfiguration
+    ) -> [String: String] {
+        [
+            "base_model": "ACE-Step-1.5",
+            "format": configuration.kind == .lora ? "peft" : "lycoris",
+            "lora_alpha": String(configuration.alpha),
+            "lora_rank": String(configuration.rank),
+            "mere_run_adapter_kind": configuration.kind.rawValue,
+            "mere_run_training_objective": "ace_step_flow_matching",
+            "training_steps": String(configuration.trainingSteps),
+        ]
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepContinuousScheduler.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepContinuousScheduler.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct ACEStepContinuousScheduler: Sendable, Hashable {
+    public let timesteps: [Float]
+
+    public init(
+        inferenceSteps: Int,
+        shift: Float = 1,
+        timesteps: [Float]? = nil
+    ) {
+        precondition(inferenceSteps > 0, "inferenceSteps must be positive.")
+        if var timesteps {
+            while timesteps.last == 0 {
+                timesteps.removeLast()
+            }
+            self.timesteps = timesteps.isEmpty
+                ? Self.makeTimesteps(inferenceSteps: inferenceSteps, shift: shift)
+                : Array(timesteps.prefix(20))
+        } else {
+            self.timesteps = Self.makeTimesteps(
+                inferenceSteps: inferenceSteps,
+                shift: shift
+            )
+        }
+    }
+
+    public static func makeTimesteps(
+        inferenceSteps: Int,
+        shift: Float
+    ) -> [Float] {
+        precondition(inferenceSteps > 0, "inferenceSteps must be positive.")
+        return (0..<inferenceSteps).map { index in
+            let timestep = Float(1 - Double(index) / Double(inferenceSteps))
+            guard shift != 1 else {
+                return timestep
+            }
+            return shift * timestep / (1 + (shift - 1) * timestep)
+        }
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepFlowEdit.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepFlowEdit.swift
@@ -1,0 +1,509 @@
+import Foundation
+import MLX
+
+public struct ACEStepFlowEditConfiguration: Codable, Hashable, Sendable {
+    public var sourceCaption: String
+    public var sourceLyrics: String
+    public var nMin: Float
+    public var nMax: Float
+    public var nAverage: Int
+    public var retakeSeed: UInt64?
+
+    public init(
+        sourceCaption: String,
+        sourceLyrics: String = "",
+        nMin: Float = 0,
+        nMax: Float = 1,
+        nAverage: Int = 1,
+        retakeSeed: UInt64? = nil
+    ) {
+        self.sourceCaption = sourceCaption
+        self.sourceLyrics = sourceLyrics
+        self.nMin = nMin
+        self.nMax = nMax
+        self.nAverage = nAverage
+        self.retakeSeed = retakeSeed
+    }
+
+    public func validate() throws {
+        guard !sourceCaption.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty else {
+            throw ACEStepFlowEditError.emptySourceCaption
+        }
+        guard 0 <= nMin, nMin <= nMax, nMax <= 1 else {
+            throw ACEStepFlowEditError.invalidWindow(nMin: nMin, nMax: nMax)
+        }
+        guard nAverage >= 1 else {
+            throw ACEStepFlowEditError.invalidAverageCount(nAverage)
+        }
+    }
+}
+
+public enum ACEStepFlowEditError: LocalizedError {
+    case emptySourceCaption
+    case invalidWindow(nMin: Float, nMax: Float)
+    case invalidAverageCount(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptySourceCaption:
+            return "Flow edit requires a non-empty source caption."
+        case .invalidWindow(let nMin, let nMax):
+            return "Flow edit requires 0 <= n-min <= n-max <= 1; "
+                + "got \(nMin), \(nMax)."
+        case .invalidAverageCount(let count):
+            return "Flow edit n-average must be at least 1; got \(count)."
+        }
+    }
+}
+
+public enum ACEStepFlowEdit {
+    public static func windowIndices(
+        stepCount: Int,
+        nMin: Float,
+        nMax: Float
+    ) -> (minimum: Int, maximum: Int) {
+        (
+            Int(Float(stepCount) * nMin),
+            Int(Float(stepCount) * nMax)
+        )
+    }
+
+    public static func integrateDelta(
+        editedLatents: MLXArray,
+        sourceVelocity: MLXArray,
+        targetVelocity: MLXArray,
+        currentTimestep: Float,
+        nextTimestep: Float
+    ) -> MLXArray {
+        editedLatents
+            + MLXArray(nextTimestep - currentTimestep)
+                .asType(editedLatents.dtype)
+                * (targetVelocity - sourceVelocity)
+    }
+}
+
+extension ACEStepPipeline {
+    public func generateFlowEdit(
+        targetCaption: String,
+        targetLyrics: String,
+        sourceLatents25Hz: MLXArray? = nil,
+        sourceAudio48kHz: MLXArray? = nil,
+        config: ACEStepInferenceConfig = .init(),
+        flowEdit: ACEStepFlowEditConfiguration,
+        lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        referenceTimbreLatents25Hz: [MLXArray]? = nil,
+        referenceTimbreAudio48kHz: [MLXArray]? = nil,
+        vocalLanguage: String = "en"
+    ) throws -> MLXArray {
+        try flowEdit.validate()
+        guard sourceLatents25Hz != nil || sourceAudio48kHz != nil else {
+            throw PipelineError.invalidConditioningInput(
+                "flow edit requires sourceLatents25Hz or sourceAudio48kHz."
+            )
+        }
+        let targetFrames = max(
+            1,
+            Int((Double(config.durationSeconds) * 25).rounded())
+        )
+        let sourceLatents = try normalizeSourceLatents(
+            sourceLatents25Hz,
+            sourceAudio48kHz: sourceAudio48kHz,
+            targetFrames: targetFrames
+        )
+        let chunkChannels = chunkChannelsForPromptConditioning()
+        let sourceInputs = try preparePromptConditionInputs(
+            caption: flowEdit.sourceCaption,
+            lyrics: flowEdit.sourceLyrics,
+            srcLatents: sourceLatents,
+            chunkChannels: chunkChannels,
+            lmUserMetadata: lmUserMetadata,
+            referenceTimbreLatents25Hz: referenceTimbreLatents25Hz,
+            referenceTimbreAudio48kHz: referenceTimbreAudio48kHz,
+            sourceAudio48kHz: sourceAudio48kHz,
+            vocalLanguage: vocalLanguage,
+            instruction: ACEStepTask.textToMusic.instruction(),
+            task: .textToMusic
+        )
+        let targetInputs = try preparePromptConditionInputs(
+            caption: targetCaption,
+            lyrics: targetLyrics,
+            srcLatents: sourceLatents,
+            chunkChannels: chunkChannels,
+            lmUserMetadata: lmUserMetadata,
+            referenceTimbreLatents25Hz: referenceTimbreLatents25Hz,
+            referenceTimbreAudio48kHz: referenceTimbreAudio48kHz,
+            sourceAudio48kHz: sourceAudio48kHz,
+            vocalLanguage: vocalLanguage,
+            instruction: ACEStepTask.textToMusic.instruction(),
+            task: .textToMusic
+        )
+        let contextSource = defaultSourceLatents(
+            targetFrames: targetFrames,
+            batchSize: sourceLatents.dim(0)
+        ).asType(sourceLatents.dtype)
+        let attentionMask = MLXArray.ones(
+            [sourceLatents.dim(0), targetFrames],
+            dtype: .int32
+        )
+        let sourceCondition = prepareFlowEditCondition(
+            sourceInputs,
+            contextSource: contextSource,
+            attentionMask: attentionMask
+        )
+        let targetCondition = prepareFlowEditCondition(
+            targetInputs,
+            contextSource: contextSource,
+            attentionMask: attentionMask
+        )
+        let targetLatents = flowEditSamplingLoop(
+            sourceLatents: sourceLatents,
+            sourceCondition: sourceCondition,
+            targetCondition: targetCondition,
+            config: config,
+            flowEdit: flowEdit
+        )
+        if config.useTiledVaeDecode {
+            return vae.tiledDecode(
+                targetLatents,
+                chunkSize: config.vaeChunkSize,
+                overlap: config.vaeOverlap
+            )
+        }
+        return vae.decode(targetLatents)
+    }
+
+    private func prepareFlowEditCondition(
+        _ inputs: ACEStepConditionInputs,
+        contextSource: MLXArray,
+        attentionMask: MLXArray
+    ) -> (
+        encoderHiddenStates: MLXArray,
+        encoderAttentionMask: MLXArray,
+        contextLatents: MLXArray
+    ) {
+        prepareCondition(
+            textHiddenStates: inputs.textHiddenStates,
+            textAttentionMask: inputs.textAttentionMask,
+            lyricHiddenStates: inputs.lyricHiddenStates,
+            lyricAttentionMask: inputs.lyricAttentionMask,
+            referAudioAcousticHiddenStatesPacked:
+                inputs.referAudioAcousticHiddenStatesPacked,
+            referAudioOrderMask: inputs.referAudioOrderMask,
+            hiddenStates: contextSource,
+            attentionMask: attentionMask,
+            silenceLatent: inputs.silenceLatent,
+            srcLatents: contextSource,
+            chunkMasks: inputs.chunkMasks,
+            isCovers: MLXArray.zeros(inputs.isCovers.shape, dtype: .int32)
+        )
+    }
+
+    private func flowEditSamplingLoop(
+        sourceLatents: MLXArray,
+        sourceCondition: (
+            encoderHiddenStates: MLXArray,
+            encoderAttentionMask: MLXArray,
+            contextLatents: MLXArray
+        ),
+        targetCondition: (
+            encoderHiddenStates: MLXArray,
+            encoderAttentionMask: MLXArray,
+            contextLatents: MLXArray
+        ),
+        config: ACEStepInferenceConfig,
+        flowEdit: ACEStepFlowEditConfiguration
+    ) -> MLXArray {
+        var timesteps = inferenceTimesteps(config)
+        if timesteps.last != 0 {
+            timesteps.append(0)
+        }
+        let stepCount = max(0, timesteps.count - 1)
+        let window = ACEStepFlowEdit.windowIndices(
+            stepCount: stepCount,
+            nMin: flowEdit.nMin,
+            nMax: flowEdit.nMax
+        )
+        let usesGuidance = !checkpointVariant.isTurbo
+            && config.guidanceScale > 1
+        let baseNoiseSeed = flowEdit.retakeSeed
+            ?? config.retakeSeed
+            ?? config.seed
+            ?? UInt64.random(in: UInt64.min...UInt64.max)
+        var drawIndex: UInt64 = 0
+        var editedLatents = sourceLatents
+        var targetTrajectory: MLXArray?
+        var sourceMomentum: MLXArray?
+        var targetMomentum: MLXArray?
+        var previousSourceVelocity: MLXArray?
+        var previousTargetVelocity: MLXArray?
+
+        func prediction(
+            latents: MLXArray,
+            timestep: Float,
+            condition: (
+                encoderHiddenStates: MLXArray,
+                encoderAttentionMask: MLXArray,
+                contextLatents: MLXArray
+            ),
+            momentum: inout MLXArray?
+        ) -> (velocity: MLXArray, guidanceDifference: MLXArray?) {
+            let modelLatents = usesGuidance
+                ? MLX.concatenated([latents, latents], axis: 0)
+                : latents
+            let modelTimestep = MLXArray(
+                Array(repeating: timestep, count: modelLatents.dim(0))
+            ).asType(.float32)
+            let hiddenStates: MLXArray
+            let attentionMask: MLXArray
+            let context: MLXArray
+            if usesGuidance {
+                hiddenStates = MLX.concatenated([
+                    condition.encoderHiddenStates,
+                    MLX.broadcast(
+                        nullConditionEmbedding.asType(
+                            condition.encoderHiddenStates.dtype
+                        ),
+                        to: condition.encoderHiddenStates.shape
+                    ),
+                ], axis: 0)
+                attentionMask = MLX.concatenated([
+                    condition.encoderAttentionMask,
+                    condition.encoderAttentionMask,
+                ], axis: 0)
+                context = MLX.concatenated([
+                    condition.contextLatents,
+                    condition.contextLatents,
+                ], axis: 0)
+            } else {
+                hiddenStates = condition.encoderHiddenStates
+                attentionMask = condition.encoderAttentionMask
+                context = condition.contextLatents
+            }
+            let raw = decoder(
+                hiddenStates: modelLatents,
+                timestep: modelTimestep,
+                timestepR: modelTimestep,
+                encoderHiddenStates: hiddenStates,
+                encoderAttentionMask: attentionMask,
+                contextLatents: context
+            )
+            guard usesGuidance else {
+                return (raw, nil)
+            }
+            let branches = MLX.split(raw, parts: 2, axis: 0)
+            let conditional = branches[0]
+            let unconditional = branches[1]
+            guard config.cfgIntervalStart <= timestep,
+                  timestep <= config.cfgIntervalEnd
+            else {
+                return (conditional, conditional - unconditional)
+            }
+            switch config.guidanceMode {
+            case .apg:
+                return (
+                    ACEStepGuidance.apg(
+                        conditional: conditional,
+                        unconditional: unconditional,
+                        scale: config.guidanceScale,
+                        runningAverage: &momentum
+                    ),
+                    conditional - unconditional
+                )
+            case .adg, .cfg:
+                return (
+                    ACEStepGuidance.cfg(
+                        conditional: conditional,
+                        unconditional: unconditional,
+                        scale: config.guidanceScale
+                    ),
+                    conditional - unconditional
+                )
+            }
+        }
+
+        func stabilize(
+            _ velocity: MLXArray,
+            latents: MLXArray,
+            previous: MLXArray?
+        ) -> MLXArray {
+            var result = velocity
+            if config.velocityNormThreshold > 0 {
+                let velocityNorm = MLX.sqrt(
+                    (result * result).sum(axes: [1, 2], keepDims: true)
+                )
+                let latentNorm = MLX.sqrt(
+                    (latents * latents).sum(axes: [1, 2], keepDims: true)
+                ) + MLXArray(Float(1e-10))
+                let factor = MLX.minimum(
+                    MLXArray.ones(velocityNorm.shape, dtype: velocityNorm.dtype),
+                    MLXArray(config.velocityNormThreshold)
+                        * latentNorm / (velocityNorm + MLXArray(Float(1e-10)))
+                )
+                result = result * factor
+            }
+            if config.velocityEMAFactor > 0, let previous {
+                result = MLXArray(Float(1 - config.velocityEMAFactor)) * result
+                    + MLXArray(config.velocityEMAFactor) * previous
+            }
+            return result
+        }
+
+        for step in 0..<stepCount {
+            guard step >= window.minimum else {
+                continue
+            }
+            let current = timesteps[step]
+            let next = timesteps[step + 1]
+            if step < window.maximum {
+                let sourceMomentumBefore = sourceMomentum
+                let targetMomentumBefore = targetMomentum
+                var sourceVelocitySum = MLXArray.zeros(
+                    sourceLatents.shape,
+                    dtype: sourceLatents.dtype
+                )
+                var targetVelocitySum = MLXArray.zeros(
+                    sourceLatents.shape,
+                    dtype: sourceLatents.dtype
+                )
+                var sourceDifferenceSum: MLXArray?
+                var targetDifferenceSum: MLXArray?
+
+                for _ in 0..<flowEdit.nAverage {
+                    sourceMomentum = sourceMomentumBefore
+                    targetMomentum = targetMomentumBefore
+                    let forwardNoise = MLXRandom.normal(
+                        sourceLatents.shape,
+                        key: MLXRandom.key(baseNoiseSeed &+ drawIndex)
+                    ).asType(sourceLatents.dtype)
+                    drawIndex &+= 1
+                    let noisedSource = MLXArray(Float(1 - current))
+                        * sourceLatents
+                        + MLXArray(current) * forwardNoise
+                    let noisedTarget = editedLatents
+                        + noisedSource - sourceLatents
+                    let source = prediction(
+                        latents: noisedSource,
+                        timestep: current,
+                        condition: sourceCondition,
+                        momentum: &sourceMomentum
+                    )
+                    let target = prediction(
+                        latents: noisedTarget,
+                        timestep: current,
+                        condition: targetCondition,
+                        momentum: &targetMomentum
+                    )
+                    sourceVelocitySum = sourceVelocitySum
+                        + stabilize(
+                            source.velocity,
+                            latents: noisedSource,
+                            previous: nil
+                        )
+                    targetVelocitySum = targetVelocitySum
+                        + stabilize(
+                            target.velocity,
+                            latents: noisedTarget,
+                            previous: nil
+                        )
+                    if let difference = source.guidanceDifference {
+                        sourceDifferenceSum = sourceDifferenceSum.map {
+                            $0 + difference
+                        } ?? difference
+                    }
+                    if let difference = target.guidanceDifference {
+                        targetDifferenceSum = targetDifferenceSum.map {
+                            $0 + difference
+                        } ?? difference
+                    }
+                }
+                let divisor = MLXArray(Float(flowEdit.nAverage))
+                if config.guidanceMode == .apg, usesGuidance {
+                    sourceMomentum = advancedFlowEditMomentum(
+                        previous: sourceMomentumBefore,
+                        differenceSum: sourceDifferenceSum,
+                        divisor: divisor
+                    )
+                    targetMomentum = advancedFlowEditMomentum(
+                        previous: targetMomentumBefore,
+                        differenceSum: targetDifferenceSum,
+                        divisor: divisor
+                    )
+                }
+                let sourceVelocity = stabilize(
+                    sourceVelocitySum / divisor,
+                    latents: sourceLatents,
+                    previous: previousSourceVelocity
+                )
+                let targetVelocity = stabilize(
+                    targetVelocitySum / divisor,
+                    latents: editedLatents,
+                    previous: previousTargetVelocity
+                )
+                previousSourceVelocity = sourceVelocity
+                previousTargetVelocity = targetVelocity
+                editedLatents = ACEStepFlowEdit.integrateDelta(
+                    editedLatents: editedLatents,
+                    sourceVelocity: sourceVelocity,
+                    targetVelocity: targetVelocity,
+                    currentTimestep: current,
+                    nextTimestep: next
+                )
+            } else {
+                if targetTrajectory == nil {
+                    let forwardNoise = MLXRandom.normal(
+                        sourceLatents.shape,
+                        key: MLXRandom.key(baseNoiseSeed &+ drawIndex)
+                    ).asType(sourceLatents.dtype)
+                    drawIndex &+= 1
+                    let noisedSource = MLXArray(Float(1 - current))
+                        * sourceLatents
+                        + MLXArray(current) * forwardNoise
+                    targetTrajectory = editedLatents
+                        + noisedSource - sourceLatents
+                }
+                var trajectory = targetTrajectory!
+                var target = prediction(
+                    latents: trajectory,
+                    timestep: current,
+                    condition: targetCondition,
+                    momentum: &targetMomentum
+                ).velocity
+                target = stabilize(
+                    target,
+                    latents: trajectory,
+                    previous: previousTargetVelocity
+                )
+                previousTargetVelocity = target
+                trajectory = trajectory
+                    + MLXArray(next - current) * target
+                targetTrajectory = trajectory
+            }
+            MLX.eval(editedLatents, targetTrajectory ?? editedLatents)
+        }
+        return targetTrajectory ?? editedLatents
+    }
+
+    private func advancedFlowEditMomentum(
+        previous: MLXArray?,
+        differenceSum: MLXArray?,
+        divisor: MLXArray
+    ) -> MLXArray? {
+        guard let differenceSum else {
+            return previous
+        }
+        var momentum = previous
+        let averageDifference = differenceSum / divisor
+        _ = ACEStepGuidance.apg(
+            conditional: averageDifference,
+            unconditional: MLXArray.zeros(
+                averageDifference.shape,
+                dtype: averageDifference.dtype
+            ),
+            scale: 1,
+            runningAverage: &momentum
+        )
+        return momentum
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift
@@ -1,0 +1,698 @@
+import Foundation
+import MLX
+
+public struct ACEStepSessionRequest {
+    public var caption: String
+    public var lyrics: String
+    public var config: ACEStepInferenceConfig
+    public var lmConfig: ACEStep5HzLMGenerationConfig
+    public var lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata
+    public var sourceLatents25Hz: MLXArray?
+    public var sourceAudio48kHz: MLXArray?
+    public var referenceTimbreLatents25Hz: [MLXArray]?
+    public var referenceTimbreAudio48kHz: [MLXArray]?
+    public var audioCoverStrength: Float
+    public var vocalLanguage: String
+    public var instruction: String?
+    public var task: ACEStepTask
+    public var repaintConfiguration: ACEStepRepaintConfiguration?
+    public var flowEditConfiguration: ACEStepFlowEditConfiguration?
+    public var useLanguageModel: Bool
+
+    public init(
+        caption: String,
+        lyrics: String = "",
+        config: ACEStepInferenceConfig = .init(),
+        lmConfig: ACEStep5HzLMGenerationConfig = .init(),
+        lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        sourceLatents25Hz: MLXArray? = nil,
+        sourceAudio48kHz: MLXArray? = nil,
+        referenceTimbreLatents25Hz: [MLXArray]? = nil,
+        referenceTimbreAudio48kHz: [MLXArray]? = nil,
+        audioCoverStrength: Float = 1,
+        vocalLanguage: String = "en",
+        instruction: String? = nil,
+        task: ACEStepTask = .textToMusic,
+        repaintConfiguration: ACEStepRepaintConfiguration? = nil,
+        flowEditConfiguration: ACEStepFlowEditConfiguration? = nil,
+        useLanguageModel: Bool = false
+    ) {
+        self.caption = caption
+        self.lyrics = lyrics
+        self.config = config
+        self.lmConfig = lmConfig
+        self.lmUserMetadata = lmUserMetadata
+        self.sourceLatents25Hz = sourceLatents25Hz
+        self.sourceAudio48kHz = sourceAudio48kHz
+        self.referenceTimbreLatents25Hz = referenceTimbreLatents25Hz
+        self.referenceTimbreAudio48kHz = referenceTimbreAudio48kHz
+        self.audioCoverStrength = audioCoverStrength
+        self.vocalLanguage = vocalLanguage
+        self.instruction = instruction
+        self.task = task
+        self.repaintConfiguration = repaintConfiguration
+        self.flowEditConfiguration = flowEditConfiguration
+        self.useLanguageModel = useLanguageModel
+    }
+}
+
+public struct ACEStepCandidateMetrics: Codable, Hashable, Sendable {
+    public var peak: Float
+    public var rms: Float
+    public var crestFactorDB: Float
+    public var silenceRatio: Float
+    public var clippingRatio: Float
+    public var dcOffset: Float
+    public var finiteRatio: Float
+    public var spectralFlatness: Float?
+    public var frameEnergyVariation: Float?
+    public var periodicity: Float?
+    public var temporalSpectralVariation: Float?
+    public var tailEnergyRatio: Float?
+
+    public init(
+        peak: Float,
+        rms: Float,
+        crestFactorDB: Float,
+        silenceRatio: Float,
+        clippingRatio: Float,
+        dcOffset: Float,
+        finiteRatio: Float,
+        spectralFlatness: Float? = nil,
+        frameEnergyVariation: Float? = nil,
+        periodicity: Float? = nil,
+        temporalSpectralVariation: Float? = nil,
+        tailEnergyRatio: Float? = nil
+    ) {
+        self.peak = peak
+        self.rms = rms
+        self.crestFactorDB = crestFactorDB
+        self.silenceRatio = silenceRatio
+        self.clippingRatio = clippingRatio
+        self.dcOffset = dcOffset
+        self.finiteRatio = finiteRatio
+        self.spectralFlatness = spectralFlatness
+        self.frameEnergyVariation = frameEnergyVariation
+        self.periodicity = periodicity
+        self.temporalSpectralVariation = temporalSpectralVariation
+        self.tailEnergyRatio = tailEnergyRatio
+    }
+}
+
+public struct ACEStepGeneratedCandidate {
+    public var index: Int
+    public var seed: UInt64
+    public var audio: MLXArray
+    public var score: Float
+    public var metrics: ACEStepCandidateMetrics
+    public var lmAudioCodeCount: Int?
+
+    public init(
+        index: Int,
+        seed: UInt64,
+        audio: MLXArray,
+        score: Float,
+        metrics: ACEStepCandidateMetrics,
+        lmAudioCodeCount: Int? = nil
+    ) {
+        self.index = index
+        self.seed = seed
+        self.audio = audio
+        self.score = score
+        self.metrics = metrics
+        self.lmAudioCodeCount = lmAudioCodeCount
+    }
+}
+
+public struct ACEStepRankedGeneration {
+    public var best: ACEStepGeneratedCandidate
+    public var candidates: [ACEStepGeneratedCandidate]
+
+    public init(
+        best: ACEStepGeneratedCandidate,
+        candidates: [ACEStepGeneratedCandidate]
+    ) {
+        self.best = best
+        self.candidates = candidates
+    }
+}
+
+/// A warm, reusable ACE-Step runtime with serialized generation and
+/// deterministic best-of-N candidate ranking.
+public final class ACEStepGenerationSession: @unchecked Sendable {
+    public enum SessionError: LocalizedError {
+        case invalidCandidateCount(Int)
+        case mismatchedBatchCandidateCounts(
+            requestCount: Int,
+            candidateCount: Int
+        )
+        case noCandidates
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidCandidateCount(let count):
+                return "ACE-Step candidate count must be positive; got \(count)."
+            case .mismatchedBatchCandidateCounts(
+                let requestCount,
+                let candidateCount
+            ):
+                return "ACE-Step batch has \(requestCount) requests but "
+                    + "\(candidateCount) candidate counts."
+            case .noCandidates:
+                return "ACE-Step generation returned no candidates."
+            }
+        }
+    }
+
+    public let pipeline: ACEStepPipeline
+    private let generationLock = NSLock()
+
+    public init(pipeline: ACEStepPipeline) {
+        self.pipeline = pipeline
+    }
+
+    public func generateBest(
+        _ request: ACEStepSessionRequest,
+        candidateCount: Int
+    ) throws -> ACEStepRankedGeneration {
+        guard candidateCount > 0 else {
+            throw SessionError.invalidCandidateCount(candidateCount)
+        }
+        generationLock.lock()
+        defer { generationLock.unlock() }
+
+        let baseSeed = request.config.seed ?? UInt64.random(in: UInt64.min...UInt64.max)
+        var candidates: [ACEStepGeneratedCandidate] = []
+        candidates.reserveCapacity(candidateCount)
+        for index in 0..<candidateCount {
+            let seed = baseSeed &+ UInt64(index)
+            var candidateRequest = request
+            candidateRequest.config.seed = seed
+            let generated = try generate(candidateRequest)
+            let evaluation = ACEStepCandidateScorer.evaluate(generated.audio)
+            candidates.append(
+                ACEStepGeneratedCandidate(
+                    index: index,
+                    seed: seed,
+                    audio: generated.audio,
+                    score: evaluation.score,
+                    metrics: evaluation.metrics,
+                    lmAudioCodeCount: generated.lmAudioCodeCount
+                )
+            )
+            Memory.clearCache()
+        }
+        guard let best = candidates.max(by: Self.candidateRanksBefore) else {
+            throw SessionError.noCandidates
+        }
+        return ACEStepRankedGeneration(
+            best: best,
+            candidates: ACEStepCandidateScorer.rank(candidates)
+        )
+    }
+
+    public func generateBatch(
+        _ requests: [ACEStepSessionRequest],
+        candidatesPerRequest: Int = 1
+    ) throws -> [ACEStepRankedGeneration] {
+        try requests.map {
+            try generateBest($0, candidateCount: candidatesPerRequest)
+        }
+    }
+
+    public func generateBatch(
+        _ requests: [ACEStepSessionRequest],
+        candidateCounts: [Int]
+    ) throws -> [ACEStepRankedGeneration] {
+        guard requests.count == candidateCounts.count else {
+            throw SessionError.mismatchedBatchCandidateCounts(
+                requestCount: requests.count,
+                candidateCount: candidateCounts.count
+            )
+        }
+        if let invalidCount = candidateCounts.first(where: { $0 <= 0 }) {
+            throw SessionError.invalidCandidateCount(invalidCount)
+        }
+        return try zip(requests, candidateCounts).map {
+            try generateBest($0.0, candidateCount: $0.1)
+        }
+    }
+
+    public func planMusic(
+        caption: String,
+        lyrics: String,
+        instruction: String,
+        userMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata,
+        lmConfig: ACEStep5HzLMGenerationConfig
+    ) throws -> ACEStepMusicPlan {
+        generationLock.lock()
+        defer { generationLock.unlock() }
+        return try pipeline.planMusic(
+            caption: caption,
+            lyrics: lyrics,
+            instruction: instruction,
+            userMetadata: userMetadata,
+            lmConfig: lmConfig
+        )
+    }
+
+    private func generate(
+        _ request: ACEStepSessionRequest
+    ) throws -> (audio: MLXArray, lmAudioCodeCount: Int?) {
+        if let flowEdit = request.flowEditConfiguration {
+            return (
+                try pipeline.generateFlowEdit(
+                    targetCaption: request.caption,
+                    targetLyrics: request.lyrics,
+                    sourceLatents25Hz: request.sourceLatents25Hz,
+                    sourceAudio48kHz: request.sourceAudio48kHz,
+                    config: request.config,
+                    flowEdit: flowEdit,
+                    lmUserMetadata: request.lmUserMetadata,
+                    referenceTimbreLatents25Hz:
+                        request.referenceTimbreLatents25Hz,
+                    referenceTimbreAudio48kHz:
+                        request.referenceTimbreAudio48kHz,
+                    vocalLanguage: request.vocalLanguage
+                ),
+                nil
+            )
+        }
+        if request.useLanguageModel {
+            let result = try pipeline.generatePromptToAudioWithLM(
+                caption: request.caption,
+                lyrics: request.lyrics,
+                config: request.config,
+                lmConfig: request.lmConfig,
+                lmUserMetadata: request.lmUserMetadata,
+                sourceLatents25Hz: request.sourceLatents25Hz,
+                sourceAudio48kHz: request.sourceAudio48kHz,
+                referenceTimbreLatents25Hz: request.referenceTimbreLatents25Hz,
+                referenceTimbreAudio48kHz: request.referenceTimbreAudio48kHz,
+                audioCoverStrength: request.audioCoverStrength,
+                vocalLanguage: request.vocalLanguage,
+                instruction: request.instruction,
+                task: request.task,
+                repaintConfiguration: request.repaintConfiguration
+            )
+            return (result.audio, result.lmResult.audioCodeValues.count)
+        }
+
+        return (
+            try pipeline.generatePromptToAudio(
+                caption: request.caption,
+                lyrics: request.lyrics,
+                config: request.config,
+                lmUserMetadata: request.lmUserMetadata,
+                sourceLatents25Hz: request.sourceLatents25Hz,
+                sourceAudio48kHz: request.sourceAudio48kHz,
+                referenceTimbreLatents25Hz: request.referenceTimbreLatents25Hz,
+                referenceTimbreAudio48kHz: request.referenceTimbreAudio48kHz,
+                audioCoverStrength: request.audioCoverStrength,
+                vocalLanguage: request.vocalLanguage,
+                instruction: request.instruction,
+                task: request.task,
+                repaintConfiguration: request.repaintConfiguration
+            ),
+            nil
+        )
+    }
+
+    private static func candidateRanksBefore(
+        _ lhs: ACEStepGeneratedCandidate,
+        _ rhs: ACEStepGeneratedCandidate
+    ) -> Bool {
+        if lhs.score == rhs.score {
+            return lhs.index > rhs.index
+        }
+        return lhs.score < rhs.score
+    }
+
+}
+
+public enum ACEStepCandidateScorer {
+    public static func rank(
+        _ candidates: [ACEStepGeneratedCandidate]
+    ) -> [ACEStepGeneratedCandidate] {
+        candidates.sorted { lhs, rhs in
+            if lhs.score == rhs.score {
+                return lhs.index < rhs.index
+            }
+            return lhs.score > rhs.score
+        }
+    }
+
+    public static func evaluate(
+        _ audio: MLXArray
+    ) -> (score: Float, metrics: ACEStepCandidateMetrics) {
+        let flattened = audio.asType(.float32).reshaped(-1)
+        MLX.eval(flattened)
+        let values = flattened.asArray(Float.self)
+        guard !values.isEmpty else {
+            let metrics = ACEStepCandidateMetrics(
+                peak: 0,
+                rms: 0,
+                crestFactorDB: 0,
+                silenceRatio: 1,
+                clippingRatio: 0,
+                dcOffset: 0,
+                finiteRatio: 0,
+                spectralFlatness: 1,
+                frameEnergyVariation: 0,
+                periodicity: 0,
+                temporalSpectralVariation: 0,
+                tailEnergyRatio: 0
+            )
+            return (0, metrics)
+        }
+
+        var finiteCount = 0
+        var silenceCount = 0
+        var clippingCount = 0
+        var peak: Float = 0
+        var sum: Double = 0
+        var sumSquares: Double = 0
+        for value in values where value.isFinite {
+            finiteCount += 1
+            let magnitude = abs(value)
+            peak = max(peak, magnitude)
+            sum += Double(value)
+            sumSquares += Double(value) * Double(value)
+            if magnitude < 0.000_1 {
+                silenceCount += 1
+            }
+            if magnitude >= 0.999 {
+                clippingCount += 1
+            }
+        }
+
+        let count = max(finiteCount, 1)
+        let rms = Float(sqrt(sumSquares / Double(count)))
+        let crestFactorDB = rms > 0
+            ? 20 * log10(max(peak / rms, 1))
+            : 0
+        let channelCount = audio.ndim >= 2 ? max(1, audio.dim(audio.ndim - 1)) : 1
+        let mono = monoSamples(values, channelCount: channelCount)
+        let spectralFlatness = estimateSpectralFlatness(mono)
+        let frameEnergyVariation = estimateFrameEnergyVariation(mono)
+        let periodicity = estimatePeriodicity(mono)
+        let temporalSpectralVariation = estimateTemporalSpectralVariation(mono)
+        let tailEnergyRatio = estimateTailEnergyRatio(mono)
+        let metrics = ACEStepCandidateMetrics(
+            peak: peak,
+            rms: rms,
+            crestFactorDB: crestFactorDB,
+            silenceRatio: Float(silenceCount) / Float(count),
+            clippingRatio: Float(clippingCount) / Float(count),
+            dcOffset: Float(abs(sum / Double(count))),
+            finiteRatio: Float(finiteCount) / Float(values.count),
+            spectralFlatness: spectralFlatness,
+            frameEnergyVariation: frameEnergyVariation,
+            periodicity: periodicity,
+            temporalSpectralVariation: temporalSpectralVariation,
+            tailEnergyRatio: tailEnergyRatio
+        )
+
+        let finiteScore = metrics.finiteRatio
+        let activityScore = 1 - min(max(metrics.silenceRatio, 0), 1)
+        let levelScore = min(max(rms / 0.02, 0), 1)
+        let crestDistance = abs(crestFactorDB - 10)
+        let crestScore = max(0, 1 - crestDistance / 18)
+        let clippingScore = max(0, 1 - metrics.clippingRatio * 100)
+        let dcScore = max(0, 1 - metrics.dcOffset * 20)
+        let flatnessScore = 1 - min(max((spectralFlatness - 0.15) / 0.7, 0), 1)
+        let variationScore = min(max(frameEnergyVariation / 0.35, 0), 1)
+        let periodicityScore = min(max((periodicity - 0.05) / 0.35, 0), 1)
+        let temporalStructureScore = min(
+            max((temporalSpectralVariation - 0.65) / 0.9, 0),
+            1
+        )
+        let tailContinuityScore = min(
+            max((tailEnergyRatio - 0.02) / 0.28, 0),
+            1
+        )
+        let structureScore =
+            0.15 * flatnessScore
+            + 0.10 * variationScore
+            + 0.10 * periodicityScore
+            + 0.45 * temporalStructureScore
+            + 0.20 * tailContinuityScore
+        let score = 100 * (
+            0.20 * finiteScore
+                + 0.10 * activityScore
+                + 0.10 * levelScore
+                + 0.10 * crestScore
+                + 0.10 * clippingScore
+                + 0.05 * dcScore
+                + 0.35 * structureScore
+        )
+        return (score.isFinite ? score : 0, metrics)
+    }
+
+    private static func monoSamples(
+        _ interleaved: [Float],
+        channelCount: Int
+    ) -> [Float] {
+        guard channelCount > 1 else {
+            return interleaved.map { $0.isFinite ? $0 : 0 }
+        }
+        let frameCount = interleaved.count / channelCount
+        return (0..<frameCount).map { frameIndex in
+            let start = frameIndex * channelCount
+            let sum = interleaved[start..<(start + channelCount)].reduce(0.0) {
+                $0 + Double($1.isFinite ? $1 : 0)
+            }
+            return Float(sum / Double(channelCount))
+        }
+    }
+
+    private static func estimateFrameEnergyVariation(_ samples: [Float]) -> Float {
+        let windowSize = min(2_048, samples.count)
+        guard windowSize >= 256 else {
+            return 0
+        }
+        let hopSize = max(1, windowSize / 2)
+        var energies: [Double] = []
+        var start = 0
+        while start + windowSize <= samples.count {
+            var sumSquares = 0.0
+            for sample in samples[start..<(start + windowSize)] {
+                sumSquares += Double(sample) * Double(sample)
+            }
+            energies.append(sqrt(sumSquares / Double(windowSize)))
+            start += hopSize
+        }
+        guard !energies.isEmpty else {
+            return 0
+        }
+        let mean = energies.reduce(0, +) / Double(energies.count)
+        guard mean > 1e-9 else {
+            return 0
+        }
+        let variance = energies.reduce(0) { partial, value in
+            partial + (value - mean) * (value - mean)
+        } / Double(energies.count)
+        return Float(sqrt(variance) / mean)
+    }
+
+    private static func estimateSpectralFlatness(_ samples: [Float]) -> Float {
+        let windowSize = min(1_024, samples.count)
+        guard windowSize >= 256 else {
+            return 1
+        }
+        let starts = analysisWindowStarts(
+            sampleCount: samples.count,
+            windowSize: windowSize,
+            maximumCount: 8
+        )
+        let binCount = min(128, (windowSize / 2) - 1)
+        var flatnessSum = 0.0
+        for start in starts {
+            var logPowerSum = 0.0
+            var powerSum = 0.0
+            for bin in 2..<(binCount + 2) {
+                let power = goertzelPower(
+                    samples,
+                    start: start,
+                    windowSize: windowSize,
+                    bin: bin
+                )
+                powerSum += power
+                logPowerSum += log(power)
+            }
+            let arithmeticMean = powerSum / Double(binCount)
+            let geometricMean = exp(logPowerSum / Double(binCount))
+            flatnessSum += min(max(geometricMean / max(arithmeticMean, 1e-20), 0), 1)
+        }
+        return Float(flatnessSum / Double(starts.count))
+    }
+
+    private static func estimatePeriodicity(_ samples: [Float]) -> Float {
+        let windowSize = min(4_096, samples.count)
+        guard windowSize >= 512 else {
+            return 0
+        }
+        let starts = analysisWindowStarts(
+            sampleCount: samples.count,
+            windowSize: windowSize,
+            maximumCount: 8
+        )
+        var periodicitySum = 0.0
+        for start in starts {
+            let window = samples[start..<(start + windowSize)]
+            let mean = window.reduce(0.0) { $0 + Double($1) } / Double(windowSize)
+            var best = 0.0
+            let maximumLag = min(1_200, windowSize / 2)
+            for lag in stride(from: 80, through: maximumLag, by: 8) {
+                var product = 0.0
+                var firstEnergy = 0.0
+                var secondEnergy = 0.0
+                for offset in 0..<(windowSize - lag) {
+                    let first = Double(samples[start + offset]) - mean
+                    let second = Double(samples[start + offset + lag]) - mean
+                    product += first * second
+                    firstEnergy += first * first
+                    secondEnergy += second * second
+                }
+                let correlation = product
+                    / sqrt(max(firstEnergy * secondEnergy, Double.leastNonzeroMagnitude))
+                best = max(best, correlation)
+            }
+            periodicitySum += best
+        }
+        return Float(periodicitySum / Double(starts.count))
+    }
+
+    private static func estimateTailEnergyRatio(_ samples: [Float]) -> Float {
+        guard samples.count >= 512 else {
+            return 0
+        }
+        let tailCount = max(256, samples.count / 8)
+        let bodyEnd = samples.count - tailCount
+        guard bodyEnd > 0 else {
+            return 0
+        }
+        let bodyRMS = rootMeanSquare(samples[0..<bodyEnd])
+        let tailRMS = rootMeanSquare(samples[bodyEnd..<samples.count])
+        guard bodyRMS > 1e-9 else {
+            return 0
+        }
+        return Float(tailRMS / bodyRMS)
+    }
+
+    private static func rootMeanSquare(
+        _ samples: ArraySlice<Float>
+    ) -> Double {
+        guard !samples.isEmpty else {
+            return 0
+        }
+        let sumSquares = samples.reduce(0.0) { partial, sample in
+            partial + Double(sample) * Double(sample)
+        }
+        return sqrt(sumSquares / Double(samples.count))
+    }
+
+    private static func estimateTemporalSpectralVariation(
+        _ samples: [Float]
+    ) -> Float {
+        let windowSize = min(1_024, samples.count)
+        guard windowSize >= 256 else {
+            return 0
+        }
+        let segmentSpan = min(8_192, samples.count)
+        let segmentStarts = analysisWindowStarts(
+            sampleCount: samples.count,
+            windowSize: segmentSpan,
+            maximumCount: 8
+        )
+        let subframeCount = min(4, max(1, segmentSpan / windowSize))
+        let maximumSubframeStart = max(0, segmentSpan - windowSize)
+        let subframeOffsets = (0..<subframeCount).map { index in
+            guard subframeCount > 1 else {
+                return 0
+            }
+            return Int(
+                (Double(maximumSubframeStart) * Double(index)
+                    / Double(subframeCount - 1)).rounded()
+            )
+        }
+        let binCount = min(64, (windowSize / 2) - 1)
+        var spectra: [[Double]] = []
+        spectra.reserveCapacity(segmentStarts.count)
+
+        for segmentStart in segmentStarts {
+            var spectrum: [Double] = []
+            spectrum.reserveCapacity(binCount)
+            for bin in 2..<(binCount + 2) {
+                let meanPower = subframeOffsets.reduce(0.0) { partial, offset in
+                    partial + goertzelPower(
+                        samples,
+                        start: segmentStart + offset,
+                        windowSize: windowSize,
+                        bin: bin
+                    )
+                } / Double(subframeCount)
+                spectrum.append(log(max(meanPower, 1e-20)))
+            }
+            let mean = spectrum.reduce(0, +) / Double(spectrum.count)
+            spectra.append(spectrum.map { $0 - mean })
+        }
+
+        var variationSum = 0.0
+        for bin in 0..<binCount {
+            let mean = spectra.reduce(0.0) {
+                $0 + $1[bin]
+            } / Double(spectra.count)
+            let variance = spectra.reduce(0.0) {
+                let difference = $1[bin] - mean
+                return $0 + difference * difference
+            } / Double(spectra.count)
+            variationSum += sqrt(variance)
+        }
+        return Float(variationSum / Double(binCount))
+    }
+
+    private static func goertzelPower(
+        _ samples: [Float],
+        start: Int,
+        windowSize: Int,
+        bin: Int
+    ) -> Double {
+        let omega = 2 * Double.pi * Double(bin) / Double(windowSize)
+        let coefficient = 2 * cos(omega)
+        var previous = 0.0
+        var previousPrevious = 0.0
+        for offset in 0..<windowSize {
+            let hann = 0.5 - 0.5
+                * cos(2 * Double.pi * Double(offset) / Double(windowSize - 1))
+            let current = Double(samples[start + offset]) * hann
+                + coefficient * previous
+                - previousPrevious
+            previousPrevious = previous
+            previous = current
+        }
+        return max(
+            previous * previous
+                + previousPrevious * previousPrevious
+                - coefficient * previous * previousPrevious,
+            1e-20
+        )
+    }
+
+    private static func analysisWindowStarts(
+        sampleCount: Int,
+        windowSize: Int,
+        maximumCount: Int
+    ) -> [Int] {
+        guard sampleCount > windowSize, maximumCount > 1 else {
+            return [0]
+        }
+        let lastStart = sampleCount - windowSize
+        return (0..<maximumCount).map { index in
+            Int(
+                (Double(lastStart) * Double(index) / Double(maximumCount - 1))
+                    .rounded()
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepGuidance.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepGuidance.swift
@@ -1,0 +1,114 @@
+import MLX
+
+enum ACEStepGuidance {
+    static func cfg(
+        conditional: MLXArray,
+        unconditional: MLXArray,
+        scale: Float
+    ) -> MLXArray {
+        unconditional + MLXArray(scale).asType(conditional.dtype)
+            * (conditional - unconditional)
+    }
+
+    static func apg(
+        conditional: MLXArray,
+        unconditional: MLXArray,
+        scale: Float,
+        runningAverage: inout MLXArray?,
+        momentum: Float = -0.75,
+        normThreshold: Float = 2.5
+    ) -> MLXArray {
+        var difference = conditional - unconditional
+        if let runningAverage {
+            difference = difference
+                + MLXArray(momentum).asType(difference.dtype) * runningAverage
+        }
+        runningAverage = difference
+
+        if normThreshold > 0 {
+            let norm = MLX.sqrt(
+                (difference * difference).sum(axis: 1, keepDims: true)
+            )
+            let scaleFactor = MLX.minimum(
+                MLXArray.ones(norm.shape, dtype: norm.dtype),
+                MLXArray(normThreshold).asType(norm.dtype)
+                    / (norm + MLXArray(Float(1e-8)).asType(norm.dtype))
+            )
+            difference = difference * scaleFactor
+        }
+
+        let conditionalNorm = MLX.sqrt(
+            (conditional * conditional).sum(axis: 1, keepDims: true)
+        )
+        let direction = conditional
+            / (conditionalNorm + MLXArray(Float(1e-8)).asType(conditional.dtype))
+        let parallel = (difference * direction).sum(axis: 1, keepDims: true)
+            * direction
+        let orthogonal = difference - parallel
+        return conditional
+            + MLXArray(scale - 1).asType(conditional.dtype) * orthogonal
+    }
+
+    static func adg(
+        latents: MLXArray,
+        conditional: MLXArray,
+        unconditional: MLXArray,
+        sigma: Float,
+        scale: Float,
+        angleClip: Float = Float.pi / 6
+    ) -> MLXArray {
+        guard sigma > 0 else {
+            return cfg(
+                conditional: conditional,
+                unconditional: unconditional,
+                scale: scale
+            )
+        }
+        precondition(latents.shape == conditional.shape)
+        precondition(latents.shape == unconditional.shape)
+
+        let dtype = conditional.dtype
+        let sigmaArray = MLXArray(sigma).asType(dtype)
+        let weight = max(scale - 1, 0) + 0.001
+        let conditionalClean = latents - sigmaArray * conditional
+        let unconditionalClean = latents - sigmaArray * unconditional
+        let difference = conditionalClean - unconditionalClean
+
+        let epsilon = MLXArray(Float(1e-8)).asType(dtype)
+        let conditionalNorm = MLX.sqrt(
+            (conditionalClean * conditionalClean).sum(axis: 2, keepDims: true)
+        )
+        let unconditionalNorm = MLX.sqrt(
+            (unconditionalClean * unconditionalClean).sum(axis: 2, keepDims: true)
+        )
+        let cosine = MLX.clip(
+            (conditionalClean * unconditionalClean).sum(axis: 2, keepDims: true)
+                / (conditionalNorm * unconditionalNorm + epsilon),
+            min: -1 + 1e-6,
+            max: 1 - 1e-6
+        )
+        let theta = MLX.acos(cosine)
+        let guidedTheta = MLX.clip(
+            theta * MLXArray(weight).asType(dtype),
+            min: -angleClip,
+            max: angleClip
+        )
+
+        let normSquared = (unconditionalClean * unconditionalClean)
+            .sum(axis: 2, keepDims: true)
+        let projection = (difference * unconditionalClean)
+            .sum(axis: 2, keepDims: true)
+            / (normSquared + epsilon)
+            * unconditionalClean
+        let perpendicular = difference - projection
+        let sinTheta = MLX.sin(theta)
+        let scaledPerpendicular = MLX.where(
+            sinTheta .> MLXArray(Float(1e-3)).asType(dtype),
+            perpendicular * MLX.sin(guidedTheta) / (sinTheta + epsilon),
+            perpendicular * MLXArray(weight).asType(dtype)
+        )
+        let guidedClean = MLX.cos(guidedTheta) * conditionalClean
+            + scaledPerpendicular
+        return (latents - guidedClean) / sigmaArray
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepInferenceConfig.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepInferenceConfig.swift
@@ -1,18 +1,29 @@
 import Foundation
 
-public enum ACEStepInferenceMethod: String, Sendable, Hashable {
+public enum ACEStepInferenceMethod: String, CaseIterable, Codable, Sendable, Hashable {
     case ode
     case sde
 }
 
-public enum ACEStepDCWMode: String, Sendable, Hashable {
+public enum ACEStepDCWMode: String, CaseIterable, Codable, Sendable, Hashable {
     case low
     case high
     case double
     case pix
 }
 
-public struct ACEStepInferenceConfig: Sendable, Hashable {
+public enum ACEStepSamplerMode: String, CaseIterable, Codable, Sendable, Hashable {
+    case euler
+    case heun
+}
+
+public enum ACEStepGuidanceMode: String, CaseIterable, Codable, Sendable, Hashable {
+    case apg
+    case adg
+    case cfg
+}
+
+public struct ACEStepInferenceConfig: Codable, Sendable, Hashable {
     /// Seconds of audio to synthesize.
     public var durationSeconds: Float
 
@@ -30,8 +41,24 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
     /// starts closest to the source latents at the nearest schedule step.
     public var coverNoiseStrength: Float
 
+    /// Optional second deterministic noise source for retakes. Variance uses
+    /// upstream spherical interpolation: 0 keeps the main seed, 1 uses only
+    /// the retake seed.
+    public var retakeSeed: UInt64?
+    public var retakeVariance: Float
+
     /// ODE is deterministic and matches the default turbo inference path.
     public var inferMethod: ACEStepInferenceMethod
+    public var samplerMode: ACEStepSamplerMode
+
+    /// Non-Turbo classifier-free guidance. Turbo checkpoints are distilled
+    /// and force this to 1 regardless of the configured value.
+    public var guidanceScale: Float
+    public var guidanceMode: ACEStepGuidanceMode
+    public var cfgIntervalStart: Float
+    public var cfgIntervalEnd: Float
+    public var velocityNormThreshold: Float
+    public var velocityEMAFactor: Float
 
     public var useTiledVaeDecode: Bool
     public var vaeChunkSize: Int
@@ -52,7 +79,16 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
         shift: Float = 1.0,
         timesteps: [Float]? = nil,
         coverNoiseStrength: Float = 0.0,
+        retakeSeed: UInt64? = nil,
+        retakeVariance: Float = 0.0,
         inferMethod: ACEStepInferenceMethod = .ode,
+        samplerMode: ACEStepSamplerMode = .euler,
+        guidanceScale: Float = 7.0,
+        guidanceMode: ACEStepGuidanceMode = .apg,
+        cfgIntervalStart: Float = 0.0,
+        cfgIntervalEnd: Float = 1.0,
+        velocityNormThreshold: Float = 0.0,
+        velocityEMAFactor: Float = 0.0,
         useTiledVaeDecode: Bool = true,
         vaeChunkSize: Int = 512,
         vaeOverlap: Int = 64,
@@ -67,7 +103,16 @@ public struct ACEStepInferenceConfig: Sendable, Hashable {
         self.shift = shift
         self.timesteps = timesteps
         self.coverNoiseStrength = coverNoiseStrength
+        self.retakeSeed = retakeSeed
+        self.retakeVariance = retakeVariance
         self.inferMethod = inferMethod
+        self.samplerMode = samplerMode
+        self.guidanceScale = guidanceScale
+        self.guidanceMode = guidanceMode
+        self.cfgIntervalStart = cfgIntervalStart
+        self.cfgIntervalEnd = cfgIntervalEnd
+        self.velocityNormThreshold = velocityNormThreshold
+        self.velocityEMAFactor = velocityEMAFactor
         self.useTiledVaeDecode = useTiledVaeDecode
         self.vaeChunkSize = vaeChunkSize
         self.vaeOverlap = vaeOverlap

--- a/Sources/MereRunCore/ACEStep/ACEStepLRC.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepLRC.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+public struct ACEStepLRCLine: Codable, Hashable, Sendable {
+    public var timestampSeconds: Double
+    public var text: String
+
+    public init(timestampSeconds: Double, text: String) {
+        self.timestampSeconds = timestampSeconds
+        self.text = text
+    }
+}
+
+public struct ACEStepLRCDocument: Codable, Hashable, Sendable {
+    public var metadata: [String: String]
+    public var lines: [ACEStepLRCLine]
+    public var timingIsApproximate: Bool
+
+    public init(
+        metadata: [String: String] = [:],
+        lines: [ACEStepLRCLine],
+        timingIsApproximate: Bool = false
+    ) {
+        self.metadata = metadata
+        self.lines = lines.sorted {
+            if $0.timestampSeconds == $1.timestampSeconds {
+                return $0.text < $1.text
+            }
+            return $0.timestampSeconds < $1.timestampSeconds
+        }
+        self.timingIsApproximate = timingIsApproximate
+    }
+
+    public var lyrics: String {
+        lines.map(\.text).joined(separator: "\n")
+    }
+
+    public func rendered() -> String {
+        var output = metadata.keys.sorted().map {
+            "[\($0):\(metadata[$0] ?? "")]"
+        }
+        if timingIsApproximate {
+            output.append("[re:mere.run approximate line timing]")
+        }
+        output.append(contentsOf: lines.map { line in
+            "[\(Self.timestamp(line.timestampSeconds))]\(line.text)"
+        })
+        return output.joined(separator: "\n") + "\n"
+    }
+
+    public static func parse(_ text: String) throws -> ACEStepLRCDocument {
+        var metadata: [String: String] = [:]
+        var parsedLines: [ACEStepLRCLine] = []
+        let timestampExpression = try NSRegularExpression(
+            pattern: #"\[(\d{1,3}):(\d{2})(?:[.:](\d{1,3}))?\]"#
+        )
+        let metadataExpression = try NSRegularExpression(
+            pattern: #"^\[([A-Za-z][A-Za-z0-9_-]*):(.*)\]$"#
+        )
+
+        for rawLine in text.components(separatedBy: .newlines) {
+            let range = NSRange(rawLine.startIndex..., in: rawLine)
+            let matches = timestampExpression.matches(
+                in: rawLine,
+                range: range
+            )
+            if matches.isEmpty {
+                if let match = metadataExpression.firstMatch(
+                    in: rawLine,
+                    range: range
+                ),
+                   let keyRange = Range(match.range(at: 1), in: rawLine),
+                   let valueRange = Range(match.range(at: 2), in: rawLine)
+                {
+                    metadata[String(rawLine[keyRange]).lowercased()] =
+                        String(rawLine[valueRange])
+                }
+                continue
+            }
+            let textStart = matches.last!.range.location
+                + matches.last!.range.length
+            let lyricRange = rawLine.index(
+                rawLine.startIndex,
+                offsetBy: textStart
+            )..<rawLine.endIndex
+            let lyric = String(rawLine[lyricRange])
+                .trimmingCharacters(in: .whitespaces)
+            for match in matches {
+                guard let minuteRange = Range(match.range(at: 1), in: rawLine),
+                      let secondRange = Range(match.range(at: 2), in: rawLine),
+                      let minutes = Double(rawLine[minuteRange]),
+                      let seconds = Double(rawLine[secondRange])
+                else {
+                    continue
+                }
+                var fraction = 0.0
+                if match.range(at: 3).location != NSNotFound,
+                   let fractionRange = Range(match.range(at: 3), in: rawLine)
+                {
+                    let digits = String(rawLine[fractionRange])
+                    fraction = (Double(digits) ?? 0)
+                        / pow(10, Double(digits.count))
+                }
+                parsedLines.append(
+                    ACEStepLRCLine(
+                        timestampSeconds: minutes * 60 + seconds + fraction,
+                        text: lyric
+                    )
+                )
+            }
+        }
+        guard !parsedLines.isEmpty else {
+            throw ACEStepLRCError.noTimedLines
+        }
+        return ACEStepLRCDocument(metadata: metadata, lines: parsedLines)
+    }
+
+    public static func approximate(
+        lyrics: String,
+        durationSeconds: Double
+    ) -> ACEStepLRCDocument {
+        let lyricLines = lyrics.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        let count = max(lyricLines.count, 1)
+        let usableDuration = max(0, durationSeconds)
+        return ACEStepLRCDocument(
+            lines: lyricLines.enumerated().map { index, text in
+                ACEStepLRCLine(
+                    timestampSeconds: usableDuration
+                        * Double(index) / Double(count),
+                    text: text
+                )
+            },
+            timingIsApproximate: true
+        )
+    }
+
+    private static func timestamp(_ seconds: Double) -> String {
+        let centiseconds = max(0, Int((seconds * 100).rounded()))
+        let minutes = centiseconds / 6_000
+        let remaining = centiseconds % 6_000
+        return String(
+            format: "%02d:%02d.%02d",
+            minutes,
+            remaining / 100,
+            remaining % 100
+        )
+    }
+}
+
+public enum ACEStepLRCError: LocalizedError {
+    case noTimedLines
+
+    public var errorDescription: String? {
+        "LRC input contains no [mm:ss.xx] timed lyric lines."
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
@@ -65,7 +65,56 @@ public struct ACEStepMusicUnderstandingResult: Sendable, Hashable {
     }
 }
 
+public struct ACEStepMusicPlan: Sendable, Hashable {
+    public var metadata: ACEStepMusicUnderstandingMetadata
+    public var lmResult: ACEStep5HzLMResult
+
+    public init(
+        metadata: ACEStepMusicUnderstandingMetadata,
+        lmResult: ACEStep5HzLMResult
+    ) {
+        self.metadata = metadata
+        self.lmResult = lmResult
+    }
+}
+
 extension ACEStepPipeline {
+    public func planMusic(
+        caption: String,
+        lyrics: String,
+        instruction: String = ACEStepLMInstructions.defaultInstruction,
+        userMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        lmConfig: ACEStep5HzLMGenerationConfig = .init(
+            maxNewTokens: 1_024,
+            temperature: 0.85,
+            topP: 0.9
+        )
+    ) throws -> ACEStepMusicPlan {
+        guard let lm else {
+            throw PipelineError.lmNotConfigured
+        }
+        let sampler = lm.makeConstrainedSampler(
+            enabled: true,
+            skipCaption: false,
+            skipLanguage: false,
+            stopAtReasoning: true,
+            generationPhase: .codes,
+            userMetadata: userMetadata
+        )
+        let result = lm.generateConstrained(
+            caption: caption,
+            lyrics: lyrics,
+            instruction: instruction,
+            systemInstruction: instruction,
+            config: lmConfig,
+            sampler: sampler
+        )
+        return ACEStepMusicPlan(
+            metadata: Self.parseUnderstandingOutput(result.generatedText),
+            lmResult: result
+        )
+    }
+
     public func audioCodeString(
         sourceAudio48kHz: MLXArray,
         durationSeconds: Float
@@ -152,7 +201,7 @@ extension ACEStepPipeline {
             case .keyscale:
                 metadata.keyscale = cleanMetadataString(value)
             case .language:
-                metadata.language = cleanMetadataString(value)
+                metadata.language = normalizedVocalLanguage(value)
             case .timesignature:
                 metadata.timesignature = cleanMetadataString(value)
             case .genres:
@@ -222,6 +271,22 @@ extension ACEStepPipeline {
         }
         return trimmed
     }
+
+    private static func normalizedVocalLanguage(_ value: String) -> String? {
+        guard let cleaned = cleanMetadataString(value) else {
+            return nil
+        }
+        let normalized = cleaned.lowercased()
+        return validVocalLanguages.contains(normalized) ? normalized : nil
+    }
+
+    private static let validVocalLanguages: Set<String> = [
+        "ar", "az", "bg", "bn", "ca", "cs", "da", "de", "el", "en",
+        "es", "fa", "fi", "fr", "he", "hi", "hr", "ht", "hu", "id",
+        "is", "it", "ja", "ko", "la", "lt", "ms", "ne", "nl", "no",
+        "pa", "pl", "pt", "ro", "ru", "sa", "sk", "sr", "sv", "sw",
+        "ta", "te", "th", "tl", "tr", "uk", "ur", "vi", "yue", "zh",
+    ]
 
     private static func parseInt(_ value: String) -> Int? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift
@@ -5,6 +5,82 @@ import MLX
 // ACEStepPipeline. Public entrypoints stay in the main pipeline file.
 
 extension ACEStepPipeline {
+    static func blendRetakeNoise(
+        primary: MLXArray,
+        retake: MLXArray,
+        variance: Float
+    ) -> MLXArray {
+        let clamped = min(max(variance, 0), 1)
+        if clamped == 0 {
+            return primary
+        }
+        if clamped == 1 {
+            return retake
+        }
+        let radians = clamped * .pi / 2
+        return MLXArray(cos(radians)).asType(primary.dtype) * primary
+            + MLXArray(sin(radians)).asType(primary.dtype) * retake
+    }
+
+    func prepareInitialNoise(
+        shape: [Int],
+        config: ACEStepInferenceConfig
+    ) -> MLXArray {
+        let primary: MLXArray
+        if let seed = config.seed {
+            primary = MLXRandom.normal(shape, key: MLXRandom.key(seed))
+                .asType(.float32)
+        } else {
+            primary = MLXRandom.normal(shape).asType(.float32)
+        }
+        guard config.retakeVariance > 0 else {
+            return primary
+        }
+        let retake: MLXArray
+        if let retakeSeed = config.retakeSeed {
+            retake = MLXRandom.normal(shape, key: MLXRandom.key(retakeSeed))
+                .asType(.float32)
+        } else {
+            retake = MLXRandom.normal(shape).asType(.float32)
+        }
+        return Self.blendRetakeNoise(
+            primary: primary,
+            retake: retake,
+            variance: config.retakeVariance
+        )
+    }
+
+    func decodeAndApplyRepaintSplice(
+        latents: MLXArray,
+        conditionInputs: ACEStepConditionInputs,
+        config: ACEStepInferenceConfig
+    ) throws -> MLXArray {
+        let decoded: MLXArray
+        if config.useTiledVaeDecode {
+            decoded = vae.tiledDecode(
+                latents,
+                chunkSize: config.vaeChunkSize,
+                overlap: config.vaeOverlap
+            )
+        } else {
+            decoded = vae.decode(latents)
+        }
+
+        guard let repaint = conditionInputs.repaintConfiguration,
+              let sourceAudio = conditionInputs.sourceAudio48kHz
+        else {
+            return decoded
+        }
+        let normalizedSource = try normalizeReferenceTimbreAudio(sourceAudio)
+        return ACEStepRepaint.spliceWaveform(
+            generatedAudio: decoded,
+            sourceAudio: normalizedSource,
+            startSeconds: repaint.startSeconds,
+            endSeconds: repaint.endSeconds,
+            crossfadeSeconds: repaint.waveformCrossfadeSeconds
+        )
+    }
+
     func generateAudioCodesWithFallback(
         lm: ACEStep5HzLM,
         caption: String,
@@ -121,6 +197,7 @@ extension ACEStepPipeline {
         noise: MLXArray,
         timesteps: [Float],
         inferMethod: ACEStepInferenceMethod,
+        samplerMode: ACEStepSamplerMode = .euler,
         encoderHiddenStates: MLXArray,
         encoderAttentionMask: MLXArray,
         contextLatents: MLXArray,
@@ -133,9 +210,20 @@ extension ACEStepPipeline {
         dcwEnabled: Bool = true,
         dcwMode: ACEStepDCWMode = .double,
         dcwScaler: Float = 0.05,
-        dcwHighScaler: Float = 0.02
+        dcwHighScaler: Float = 0.02,
+        guidanceScale: Float = 1,
+        guidanceMode: ACEStepGuidanceMode = .apg,
+        nullConditionEmbedding: MLXArray? = nil,
+        cfgIntervalStart: Float = 0,
+        cfgIntervalEnd: Float = 1,
+        velocityNormThreshold: Float = 0,
+        velocityEMAFactor: Float = 0,
+        repaintMask: MLXArray? = nil,
+        cleanSourceLatents: MLXArray? = nil,
+        repaintInjectionRatio: Float = 0.5,
+        repaintCrossfadeFrames: Int = 10
     ) -> MLXArray {
-        precondition(!timesteps.isEmpty, "Turbo timesteps must not be empty.")
+        precondition(!timesteps.isEmpty, "ACE-Step timesteps must not be empty.")
 
         let coverNoise = Self.prepareCoverNoiseSchedule(
             noise: noise,
@@ -145,7 +233,7 @@ extension ACEStepPipeline {
         )
         var xt = coverNoise.latents
         let activeTimesteps = coverNoise.timesteps
-        let B = xt.dim(0)
+        let usesGuidance = guidanceScale > 1 && nullConditionEmbedding != nil
         let hasNonCoverCondition =
             nonCoverEncoderHiddenStates != nil
             && nonCoverEncoderAttentionMask != nil
@@ -155,35 +243,149 @@ extension ACEStepPipeline {
         let dcwActive =
             dcwEnabled
             && (dcwScaler != 0 || (dcwMode == .double && dcwHighScaler != 0))
+        let hasRepaint =
+            repaintMask != nil
+            && cleanSourceLatents != nil
+        let repaintInjectionCutoff = Int(
+            (Double(min(max(repaintInjectionRatio, 0), 1)) * Double(activeTimesteps.count))
+                .rounded(.toNearestOrEven)
+        )
+        var guidanceRunningAverage: MLXArray?
+        var previousVelocity: MLXArray?
+
+        func decoderPrediction(
+            latents: MLXArray,
+            timestep: Float,
+            condition: MLXArray,
+            conditionMask: MLXArray,
+            context: MLXArray
+        ) -> MLXArray {
+            let modelLatents = usesGuidance
+                ? MLX.concatenated([latents, latents], axis: 0)
+                : latents
+            let modelTimestep = MLXArray(
+                Array(repeating: timestep, count: modelLatents.dim(0))
+            ).asType(.float32)
+            let modelCondition: MLXArray
+            let modelConditionMask: MLXArray
+            let modelContext: MLXArray
+            if usesGuidance {
+                let nullCondition = MLX.broadcast(
+                    nullConditionEmbedding!.asType(condition.dtype),
+                    to: condition.shape
+                )
+                modelCondition = MLX.concatenated(
+                    [condition, nullCondition],
+                    axis: 0
+                )
+                modelConditionMask = MLX.concatenated(
+                    [conditionMask, conditionMask],
+                    axis: 0
+                )
+                modelContext = MLX.concatenated([context, context], axis: 0)
+            } else {
+                modelCondition = condition
+                modelConditionMask = conditionMask
+                modelContext = context
+            }
+            return decoder(
+                hiddenStates: modelLatents,
+                timestep: modelTimestep,
+                timestepR: modelTimestep,
+                encoderHiddenStates: modelCondition,
+                encoderAttentionMask: modelConditionMask,
+                contextLatents: modelContext
+            )
+        }
+
+        func stabilize(
+            _ prediction: MLXArray,
+            latents: MLXArray,
+            previous: MLXArray?
+        ) -> MLXArray {
+            var result = prediction
+            if velocityNormThreshold > 0 {
+                let predictionNorm = MLX.sqrt(
+                    (result * result).sum(axes: [1, 2], keepDims: true)
+                )
+                let latentNorm = MLX.sqrt(
+                    (latents * latents).sum(axes: [1, 2], keepDims: true)
+                ) + MLXArray(Float(1e-10)).asType(latents.dtype)
+                let factor = MLX.minimum(
+                    MLXArray.ones(predictionNorm.shape, dtype: predictionNorm.dtype),
+                    MLXArray(velocityNormThreshold).asType(result.dtype)
+                        * latentNorm / (predictionNorm + MLXArray(Float(1e-10)))
+                )
+                result = result * factor
+            }
+            if velocityEMAFactor > 0, let previous {
+                result = MLXArray(Float(1 - velocityEMAFactor)).asType(result.dtype)
+                    * result
+                    + MLXArray(velocityEMAFactor).asType(result.dtype) * previous
+            }
+            return result
+        }
 
         for i in 0..<activeTimesteps.count {
             let t = activeTimesteps[i]
-            let tBatch = MLXArray((0..<B).map { _ in t }).asType(.float32)
             let useNonCoverCondition = hasNonCoverCondition && i >= coverSteps
             let currentEncoderHiddenStates = useNonCoverCondition ? nonCoverEncoderHiddenStates! : encoderHiddenStates
             let currentEncoderAttentionMask = useNonCoverCondition ? nonCoverEncoderAttentionMask! : encoderAttentionMask
             let currentContextLatents = useNonCoverCondition ? nonCoverContextLatents! : contextLatents
 
-            let vt = decoder(
-                hiddenStates: xt,
-                timestep: tBatch,
-                timestepR: tBatch,
-                encoderHiddenStates: currentEncoderHiddenStates,
-                encoderAttentionMask: currentEncoderAttentionMask,
-                contextLatents: currentContextLatents
+            var vt = decoderPrediction(
+                latents: xt,
+                timestep: t,
+                condition: currentEncoderHiddenStates,
+                conditionMask: currentEncoderAttentionMask,
+                context: currentContextLatents
             )
+            if usesGuidance {
+                let predictions = MLX.split(vt, parts: 2, axis: 0)
+                let conditional = predictions[0]
+                let unconditional = predictions[1]
+                if cfgIntervalStart <= t && t <= cfgIntervalEnd {
+                    switch guidanceMode {
+                    case .apg:
+                        vt = ACEStepGuidance.apg(
+                            conditional: conditional,
+                            unconditional: unconditional,
+                            scale: guidanceScale,
+                            runningAverage: &guidanceRunningAverage
+                        )
+                    case .adg:
+                        vt = ACEStepGuidance.adg(
+                            latents: xt,
+                            conditional: conditional,
+                            unconditional: unconditional,
+                            sigma: t,
+                            scale: guidanceScale
+                        )
+                    case .cfg:
+                        vt = ACEStepGuidance.cfg(
+                            conditional: conditional,
+                            unconditional: unconditional,
+                            scale: guidanceScale
+                        )
+                    }
+                } else {
+                    vt = conditional
+                }
+            }
+            vt = stabilize(vt, latents: xt, previous: previousVelocity)
 
             let xtBeforeStep = xt
             let vtForDenoise = vt
+            var velocityForNextStep = vt
 
             if i == activeTimesteps.count - 1 {
-                let tBroadcast = tBatch.asType(vt.dtype).reshaped(B, 1, 1)
+                let tBroadcast = MLXArray(t).asType(vt.dtype).reshaped(1, 1, 1)
                 xt = xt - vt * tBroadcast
                 MLX.eval(xt)
             } else {
                 switch inferMethod {
                 case .sde:
-                    let tBroadcast = tBatch.asType(vt.dtype).reshaped(B, 1, 1)
+                    let tBroadcast = MLXArray(t).asType(vt.dtype).reshaped(1, 1, 1)
                     let predClean = xt - vt * tBroadcast
                     let nextT = activeTimesteps[i + 1]
                     let newNoise = MLXRandom.normal(xt.shape).asType(xt.dtype)
@@ -192,13 +394,60 @@ extension ACEStepPipeline {
                     MLX.eval(xt)
                 case .ode:
                     let dt = t - activeTimesteps[i + 1]
-                    xt = xt - vt * MLXArray(dt).asType(vt.dtype)
+                    if samplerMode == .heun {
+                        let nextT = activeTimesteps[i + 1]
+                        let predictedLatents = xt
+                            - vt * MLXArray(dt).asType(vt.dtype)
+                        var corrector = decoderPrediction(
+                            latents: predictedLatents,
+                            timestep: nextT,
+                            condition: currentEncoderHiddenStates,
+                            conditionMask: currentEncoderAttentionMask,
+                            context: currentContextLatents
+                        )
+                        if usesGuidance {
+                            let predictions = MLX.split(corrector, parts: 2, axis: 0)
+                            let conditional = predictions[0]
+                            let unconditional = predictions[1]
+                            if cfgIntervalStart <= nextT && nextT <= cfgIntervalEnd {
+                                if guidanceMode == .adg, nextT > 0 {
+                                    corrector = ACEStepGuidance.adg(
+                                        latents: predictedLatents,
+                                        conditional: conditional,
+                                        unconditional: unconditional,
+                                        sigma: nextT,
+                                        scale: guidanceScale
+                                    )
+                                } else {
+                                    corrector = ACEStepGuidance.cfg(
+                                        conditional: conditional,
+                                        unconditional: unconditional,
+                                        scale: guidanceScale
+                                    )
+                                }
+                            } else {
+                                corrector = conditional
+                            }
+                        }
+                        corrector = stabilize(
+                            corrector,
+                            latents: predictedLatents,
+                            previous: vt
+                        )
+                        let average = MLXArray(Float(0.5)).asType(vt.dtype)
+                            * (vt + corrector)
+                        xt = xt - average * MLXArray(dt).asType(vt.dtype)
+                        velocityForNextStep = average
+                    } else {
+                        xt = xt - vt * MLXArray(dt).asType(vt.dtype)
+                    }
                     MLX.eval(xt)
                 }
             }
 
             if dcwActive {
-                let tBroadcast = tBatch.asType(vtForDenoise.dtype).reshaped(B, 1, 1)
+                let tBroadcast = MLXArray(t).asType(vtForDenoise.dtype)
+                    .reshaped(1, 1, 1)
                 let denoised = xtBeforeStep - vtForDenoise * tBroadcast
                 xt = ACEStepDCW.applyHaar(
                     xNext: xt,
@@ -212,7 +461,32 @@ extension ACEStepPipeline {
                 MLX.eval(xt)
             }
 
+            previousVelocity = velocityForNextStep
+            if hasRepaint, i < repaintInjectionCutoff {
+                let nextTimestep = i < activeTimesteps.count - 1
+                    ? activeTimesteps[i + 1]
+                    : 0
+                xt = ACEStepRepaint.injectPreservedSource(
+                    generatedLatents: xt,
+                    cleanSourceLatents: cleanSourceLatents!,
+                    repaintMask: repaintMask!,
+                    nextTimestep: nextTimestep,
+                    noise: noise
+                )
+                MLX.eval(xt)
+            }
+
             Memory.clearCache()
+        }
+
+        if hasRepaint, repaintCrossfadeFrames > 0 {
+            xt = ACEStepRepaint.blendLatentBoundaries(
+                generatedLatents: xt,
+                cleanSourceLatents: cleanSourceLatents!,
+                repaintMask: repaintMask!,
+                crossfadeFrames: repaintCrossfadeFrames
+            )
+            MLX.eval(xt)
         }
 
         return xt

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift
@@ -112,10 +112,12 @@ extension ACEStepPipeline {
         lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata,
         referenceTimbreLatents25Hz: [MLXArray]? = nil,
         referenceTimbreAudio48kHz: [MLXArray]? = nil,
+        sourceAudio48kHz: MLXArray? = nil,
         audioCoverStrength: Float = 1.0,
         vocalLanguage: String,
         instruction: String,
-        isCover: Bool
+        task: ACEStepTask,
+        repaintConfiguration: ACEStepRepaintConfiguration? = nil
     ) throws -> ACEStepConditionInputs {
         let B = srcLatents.dim(0)
         let T = srcLatents.dim(1)
@@ -210,22 +212,41 @@ extension ACEStepPipeline {
             referenceTimbreAudio48kHz: referenceTimbreAudio48kHz,
             fallbackLatents25Hz: srcLatents
         )
+        let repaintConditioning: ACEStepRepaint.Conditioning? = {
+            guard let repaintConfiguration else {
+                return nil
+            }
+            return ACEStepRepaint.prepareConditioning(
+                cleanSourceLatents: srcLatents,
+                silenceLatents: defaultSourceLatents(targetFrames: T, batchSize: B)
+                    .asType(srcLatents.dtype),
+                chunkChannels: chunkChannels,
+                configuration: repaintConfiguration,
+                task: task
+            )
+        }()
 
         return ACEStepConditionInputs(
+            task: task,
             textHiddenStates: textConditioning.textHiddenStates,
             textAttentionMask: textConditioning.textAttentionMask,
             lyricHiddenStates: textConditioning.lyricHiddenStates,
             lyricAttentionMask: textConditioning.lyricAttentionMask,
             referAudioAcousticHiddenStatesPacked: timbre.packed,
             referAudioOrderMask: timbre.orderMask,
-            srcLatents: srcLatents,
-            chunkMasks: MLXArray.ones([B, T, chunkChannels], dtype: .float32),
-            isCovers: MLXArray([isCover ? Int32(1) : Int32(0)]).asType(.int32),
+            srcLatents: repaintConditioning?.sourceLatents ?? srcLatents,
+            chunkMasks: repaintConditioning?.chunkMasks
+                ?? MLXArray.ones([B, T, chunkChannels], dtype: .float32),
+            isCovers: MLXArray([task.usesFSQCoverHints ? Int32(1) : Int32(0)]).asType(.int32),
             hiddenStates: srcLatents,
             attentionMask: MLXArray.ones([B, T], dtype: .int32),
             silenceLatent: silenceLatent,
             nonCoverTextHiddenStates: textConditioning.nonCoverTextHiddenStates,
-            nonCoverTextAttentionMask: textConditioning.nonCoverTextAttentionMask
+            nonCoverTextAttentionMask: textConditioning.nonCoverTextAttentionMask,
+            repaintMask: repaintConditioning?.repaintMask,
+            cleanSourceLatents: repaintConditioning == nil ? nil : srcLatents,
+            repaintConfiguration: repaintConfiguration,
+            sourceAudio48kHz: sourceAudio48kHz
         )
     }
 

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline.swift
@@ -8,6 +8,7 @@ import MLXRandom
 // main file reads in the same order callers use the pipeline.
 
 public struct ACEStepConditionInputs {
+    public var task: ACEStepTask
     public var textHiddenStates: MLXArray
     public var textAttentionMask: MLXArray
     public var lyricHiddenStates: MLXArray
@@ -22,8 +23,13 @@ public struct ACEStepConditionInputs {
     public var silenceLatent: MLXArray?
     public var nonCoverTextHiddenStates: MLXArray?
     public var nonCoverTextAttentionMask: MLXArray?
+    public var repaintMask: MLXArray?
+    public var cleanSourceLatents: MLXArray?
+    public var repaintConfiguration: ACEStepRepaintConfiguration?
+    public var sourceAudio48kHz: MLXArray?
 
     public init(
+        task: ACEStepTask = .textToMusic,
         textHiddenStates: MLXArray,
         textAttentionMask: MLXArray,
         lyricHiddenStates: MLXArray,
@@ -37,8 +43,13 @@ public struct ACEStepConditionInputs {
         attentionMask: MLXArray? = nil,
         silenceLatent: MLXArray? = nil,
         nonCoverTextHiddenStates: MLXArray? = nil,
-        nonCoverTextAttentionMask: MLXArray? = nil
+        nonCoverTextAttentionMask: MLXArray? = nil,
+        repaintMask: MLXArray? = nil,
+        cleanSourceLatents: MLXArray? = nil,
+        repaintConfiguration: ACEStepRepaintConfiguration? = nil,
+        sourceAudio48kHz: MLXArray? = nil
     ) {
+        self.task = task
         self.textHiddenStates = textHiddenStates
         self.textAttentionMask = textAttentionMask
         self.lyricHiddenStates = lyricHiddenStates
@@ -53,6 +64,10 @@ public struct ACEStepConditionInputs {
         self.silenceLatent = silenceLatent
         self.nonCoverTextHiddenStates = nonCoverTextHiddenStates
         self.nonCoverTextAttentionMask = nonCoverTextAttentionMask
+        self.repaintMask = repaintMask
+        self.cleanSourceLatents = cleanSourceLatents
+        self.repaintConfiguration = repaintConfiguration
+        self.sourceAudio48kHz = sourceAudio48kHz
     }
 }
 
@@ -90,6 +105,7 @@ public final class ACEStepPipeline {
     }
 
     let decoderConfig: ACEStepConfig
+    public let checkpointVariant: ACEStepCheckpointVariant
     let decoder: ACEStepDiT
     let encoder: ACEStepConditionEncoder
     let tokenizer: ACEStepAudioTokenizer
@@ -131,7 +147,15 @@ public final class ACEStepPipeline {
             }
         }
 
-        self.decoderConfig = try ACEStepCheckpointLoader.loadConfig(resources: decoderResources, fileManager: fileManager)
+        let decoderConfig = try ACEStepCheckpointLoader.loadConfig(
+            resources: decoderResources,
+            fileManager: fileManager
+        )
+        self.decoderConfig = decoderConfig
+        self.checkpointVariant = ACEStepCheckpointVariant.detect(
+            modelRootURL: decoderResources.modelRootURL,
+            config: decoderConfig
+        )
         let bundle = try ACEStepCheckpointLoader.loadTurboBundle(
             resources: decoderResources,
             dtype: dtype,
@@ -215,13 +239,10 @@ public final class ACEStepPipeline {
         let B = 1
         let T = max(1, Int((Double(config.durationSeconds) * 25.0).rounded()))
 
-        let noise: MLXArray
-        if let seed = config.seed {
-            let key = MLXRandom.key(seed)
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.float32)
-        } else {
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.float32)
-        }
+        let noise = prepareInitialNoise(
+            shape: [B, T, decoderConfig.audioAcousticHiddenDim],
+            config: config
+        )
 
         let encoderHiddenStates = MLX.broadcast(
             nullConditionEmbedding,
@@ -237,21 +258,24 @@ public final class ACEStepPipeline {
         let chunkChannels = contextChannels - srcChannels
         let srcLatents = defaultSourceLatents(targetFrames: T).asType(noise.dtype)
         precondition(srcLatents.dim(2) == srcChannels, "Expected source latent channels to match context layout.")
-        let chunkMask = MLXArray.ones([B, T, chunkChannels], dtype: noise.dtype) * MLXArray(Float(2.0)).asType(noise.dtype)
+        let chunkMask = MLXArray.ones([B, T, chunkChannels], dtype: noise.dtype)
         let contextLatents = MLX.concatenated([srcLatents, chunkMask], axis: -1)
 
-        let schedule = ACEStepTurboScheduler(fixNFE: config.fixNFE, shift: config.shift, timesteps: config.timesteps)
+        let timesteps = inferenceTimesteps(config)
         let latents = denoiseTurbo(
             noise: noise,
-            timesteps: schedule.timesteps,
+            timesteps: timesteps,
             inferMethod: config.inferMethod,
+            samplerMode: config.samplerMode,
             encoderHiddenStates: encoderHiddenStates,
             encoderAttentionMask: encoderAttentionMask,
             contextLatents: contextLatents,
             dcwEnabled: config.dcwEnabled,
             dcwMode: config.dcwMode,
             dcwScaler: config.dcwScaler,
-            dcwHighScaler: config.dcwHighScaler
+            dcwHighScaler: config.dcwHighScaler,
+            velocityNormThreshold: config.velocityNormThreshold,
+            velocityEMAFactor: config.velocityEMAFactor
         )
 
         if config.useTiledVaeDecode {
@@ -274,6 +298,7 @@ public final class ACEStepPipeline {
         guard let lm else {
             throw PipelineError.lmNotConfigured
         }
+        try checkpointVariant.validate(conditionInputs.task)
 
         let B = conditionInputs.srcLatents.dim(0)
         precondition(B == 1, "generateWithLM currently supports batch size 1.")
@@ -282,6 +307,8 @@ public final class ACEStepPipeline {
         let targetCodes = Int(ceil(Double(T) / Double(decoderConfig.poolWindowSize)))
         let targetDurationSeconds = Float(targetCodes) / 5.0
 
+        var effectiveLMConfig = lmConfig
+        effectiveLMConfig.seed = effectiveLMConfig.seed ?? config.seed
         let lmResult = try generateAudioCodesWithFallback(
             lm: lm,
             caption: caption,
@@ -290,7 +317,7 @@ public final class ACEStepPipeline {
             lmSystemInstruction: lmSystemInstruction,
             targetCodes: targetCodes,
             targetDurationSeconds: targetDurationSeconds,
-            lmConfig: lmConfig,
+            lmConfig: effectiveLMConfig,
             lmUserMetadata: lmUserMetadata
         )
 
@@ -322,24 +349,28 @@ public final class ACEStepPipeline {
             silenceLatent: conditionInputs.silenceLatent,
             srcLatents: conditionInputs.srcLatents,
             chunkMasks: conditionInputs.chunkMasks,
-            isCovers: conditionInputs.isCovers,
+            // Upstream promotes any request carrying semantic audio-code hints
+            // to cover conditioning. Otherwise the decoded 5 Hz LM plan is
+            // computed and then discarded for ordinary text-to-music requests.
+            isCovers: MLXArray.ones(
+                conditionInputs.isCovers.shape,
+                dtype: conditionInputs.isCovers.dtype
+            ),
             audioCodes: audioCodes
         )
         let nonCoverPrepared = prepareNonCoverConditionIfNeeded(conditionInputs: conditionInputs)
 
-        let noise: MLXArray
-        if let seed = config.seed {
-            let key = MLXRandom.key(seed)
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.float32)
-        } else {
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.float32)
-        }
+        let noise = prepareInitialNoise(
+            shape: [B, T, decoderConfig.audioAcousticHiddenDim],
+            config: config
+        )
 
-        let schedule = ACEStepTurboScheduler(fixNFE: config.fixNFE, shift: config.shift, timesteps: config.timesteps)
+        let timesteps = inferenceTimesteps(config)
         let latents = denoiseTurbo(
             noise: noise,
-            timesteps: schedule.timesteps,
+            timesteps: timesteps,
             inferMethod: config.inferMethod,
+            samplerMode: config.samplerMode,
             encoderHiddenStates: prepared.encoderHiddenStates.asType(noise.dtype),
             encoderAttentionMask: prepared.encoderAttentionMask,
             contextLatents: prepared.contextLatents.asType(noise.dtype),
@@ -352,15 +383,25 @@ public final class ACEStepPipeline {
             dcwEnabled: config.dcwEnabled,
             dcwMode: config.dcwMode,
             dcwScaler: config.dcwScaler,
-            dcwHighScaler: config.dcwHighScaler
+            dcwHighScaler: config.dcwHighScaler,
+            guidanceScale: checkpointVariant.isTurbo ? 1 : config.guidanceScale,
+            guidanceMode: config.guidanceMode,
+            nullConditionEmbedding: nullConditionEmbedding,
+            cfgIntervalStart: config.cfgIntervalStart,
+            cfgIntervalEnd: config.cfgIntervalEnd,
+            velocityNormThreshold: config.velocityNormThreshold,
+            velocityEMAFactor: config.velocityEMAFactor,
+            repaintMask: conditionInputs.repaintMask,
+            cleanSourceLatents: conditionInputs.cleanSourceLatents,
+            repaintInjectionRatio: conditionInputs.repaintConfiguration?.injectionRatio ?? 0,
+            repaintCrossfadeFrames: conditionInputs.repaintConfiguration?.latentCrossfadeFrames ?? 0
         )
 
-        let audio: MLXArray
-        if config.useTiledVaeDecode {
-            audio = vae.tiledDecode(latents, chunkSize: config.vaeChunkSize, overlap: config.vaeOverlap)
-        } else {
-            audio = vae.decode(latents)
-        }
+        let audio = try decodeAndApplyRepaintSplice(
+            latents: latents,
+            conditionInputs: conditionInputs,
+            config: config
+        )
 
         return (audio, lmResult)
     }
@@ -377,9 +418,23 @@ public final class ACEStepPipeline {
         referenceTimbreAudio48kHz: [MLXArray]? = nil,
         audioCoverStrength: Float = 1.0,
         vocalLanguage: String = "en",
-        instruction: String = "Fill the audio semantic mask based on the given conditions:",
-        isCover: Bool = false
+        instruction: String? = nil,
+        task: ACEStepTask = .textToMusic,
+        repaintConfiguration: ACEStepRepaintConfiguration? = nil
     ) throws -> MLXArray {
+        try checkpointVariant.validate(task)
+        if task.requiresSourceAudio,
+           sourceLatents25Hz == nil,
+           sourceAudio48kHz == nil
+        {
+            throw PipelineError.invalidConditioningInput(
+                "task '\(task.rawValue)' requires sourceLatents25Hz or sourceAudio48kHz."
+            )
+        }
+        let effectiveRepaintConfiguration = task == .repaint || task == .lego
+            ? repaintConfiguration ?? .init()
+            : nil
+        let effectiveInstruction = instruction ?? task.instruction()
         let T = max(1, Int((Double(config.durationSeconds) * 25.0).rounded()))
         let srcLatents = try normalizeSourceLatents(
             sourceLatents25Hz,
@@ -396,10 +451,12 @@ public final class ACEStepPipeline {
             lmUserMetadata: lmUserMetadata,
             referenceTimbreLatents25Hz: referenceTimbreLatents25Hz,
             referenceTimbreAudio48kHz: referenceTimbreAudio48kHz,
+            sourceAudio48kHz: sourceAudio48kHz,
             audioCoverStrength: audioCoverStrength,
             vocalLanguage: vocalLanguage,
-            instruction: instruction,
-            isCover: isCover
+            instruction: effectiveInstruction,
+            task: task,
+            repaintConfiguration: effectiveRepaintConfiguration
         )
 
         let B = conditionInputs.srcLatents.dim(0)
@@ -425,19 +482,17 @@ public final class ACEStepPipeline {
         )
         let nonCoverPrepared = prepareNonCoverConditionIfNeeded(conditionInputs: conditionInputs)
 
-        let noise: MLXArray
-        if let seed = config.seed {
-            let key = MLXRandom.key(seed)
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim], key: key).asType(.float32)
-        } else {
-            noise = MLXRandom.normal([B, T, decoderConfig.audioAcousticHiddenDim]).asType(.float32)
-        }
+        let noise = prepareInitialNoise(
+            shape: [B, T, decoderConfig.audioAcousticHiddenDim],
+            config: config
+        )
 
-        let schedule = ACEStepTurboScheduler(fixNFE: config.fixNFE, shift: config.shift, timesteps: config.timesteps)
+        let timesteps = inferenceTimesteps(config)
         let latents = denoiseTurbo(
             noise: noise,
-            timesteps: schedule.timesteps,
+            timesteps: timesteps,
             inferMethod: config.inferMethod,
+            samplerMode: config.samplerMode,
             encoderHiddenStates: prepared.encoderHiddenStates.asType(noise.dtype),
             encoderAttentionMask: prepared.encoderAttentionMask,
             contextLatents: prepared.contextLatents.asType(noise.dtype),
@@ -450,13 +505,25 @@ public final class ACEStepPipeline {
             dcwEnabled: config.dcwEnabled,
             dcwMode: config.dcwMode,
             dcwScaler: config.dcwScaler,
-            dcwHighScaler: config.dcwHighScaler
+            dcwHighScaler: config.dcwHighScaler,
+            guidanceScale: checkpointVariant.isTurbo ? 1 : config.guidanceScale,
+            guidanceMode: config.guidanceMode,
+            nullConditionEmbedding: nullConditionEmbedding,
+            cfgIntervalStart: config.cfgIntervalStart,
+            cfgIntervalEnd: config.cfgIntervalEnd,
+            velocityNormThreshold: config.velocityNormThreshold,
+            velocityEMAFactor: config.velocityEMAFactor,
+            repaintMask: conditionInputs.repaintMask,
+            cleanSourceLatents: conditionInputs.cleanSourceLatents,
+            repaintInjectionRatio: conditionInputs.repaintConfiguration?.injectionRatio ?? 0,
+            repaintCrossfadeFrames: conditionInputs.repaintConfiguration?.latentCrossfadeFrames ?? 0
         )
 
-        if config.useTiledVaeDecode {
-            return vae.tiledDecode(latents, chunkSize: config.vaeChunkSize, overlap: config.vaeOverlap)
-        }
-        return vae.decode(latents)
+        return try decodeAndApplyRepaintSplice(
+            latents: latents,
+            conditionInputs: conditionInputs,
+            config: config
+        )
     }
 
     public func generatePromptToAudioWithLM(
@@ -471,10 +538,24 @@ public final class ACEStepPipeline {
         referenceTimbreAudio48kHz: [MLXArray]? = nil,
         audioCoverStrength: Float = 1.0,
         vocalLanguage: String = "en",
-        instruction: String = "Fill the audio semantic mask based on the given conditions:",
+        instruction: String? = nil,
         lmSystemInstruction: String = ACEStepLMInstructions.defaultInstruction,
-        isCover: Bool = false
+        task: ACEStepTask = .textToMusic,
+        repaintConfiguration: ACEStepRepaintConfiguration? = nil
     ) throws -> (audio: MLXArray, lmResult: ACEStep5HzLMResult) {
+        try checkpointVariant.validate(task)
+        if task.requiresSourceAudio,
+           sourceLatents25Hz == nil,
+           sourceAudio48kHz == nil
+        {
+            throw PipelineError.invalidConditioningInput(
+                "task '\(task.rawValue)' requires sourceLatents25Hz or sourceAudio48kHz."
+            )
+        }
+        let effectiveRepaintConfiguration = task == .repaint || task == .lego
+            ? repaintConfiguration ?? .init()
+            : nil
+        let effectiveInstruction = instruction ?? task.instruction()
         let T = max(1, Int((Double(config.durationSeconds) * 25.0).rounded()))
         let srcLatents = try normalizeSourceLatents(
             sourceLatents25Hz,
@@ -492,10 +573,12 @@ public final class ACEStepPipeline {
             lmUserMetadata: lmUserMetadata,
             referenceTimbreLatents25Hz: referenceTimbreLatents25Hz,
             referenceTimbreAudio48kHz: referenceTimbreAudio48kHz,
+            sourceAudio48kHz: sourceAudio48kHz,
             audioCoverStrength: audioCoverStrength,
             vocalLanguage: vocalLanguage,
-            instruction: instruction,
-            isCover: isCover
+            instruction: effectiveInstruction,
+            task: task,
+            repaintConfiguration: effectiveRepaintConfiguration
         )
 
         return try generateWithLM(
@@ -504,11 +587,26 @@ public final class ACEStepPipeline {
             conditionInputs: conditionInputs,
             config: config,
             lmConfig: lmConfig,
-            instruction: instruction,
+            instruction: effectiveInstruction,
             lmUserMetadata: lmUserMetadata,
             lmSystemInstruction: lmSystemInstruction,
             audioCoverStrength: audioCoverStrength
         )
+    }
+
+    func inferenceTimesteps(_ config: ACEStepInferenceConfig) -> [Float] {
+        if checkpointVariant.isTurbo {
+            return ACEStepTurboScheduler(
+                fixNFE: config.fixNFE,
+                shift: config.shift,
+                timesteps: config.timesteps
+            ).timesteps
+        }
+        return ACEStepContinuousScheduler(
+            inferenceSteps: config.fixNFE,
+            shift: config.shift,
+            timesteps: config.timesteps
+        ).timesteps
     }
 
 }

--- a/Sources/MereRunCore/ACEStep/ACEStepQualityPreset.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepQualityPreset.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+public enum ACEStepQualityPreset: String, CaseIterable, Codable, Hashable, Sendable {
+    case draft
+    case song
+    case final
+    case edit
+
+    public func defaults(
+        for variant: ACEStepCheckpointVariant,
+        task: ACEStepTask
+    ) -> ACEStepQualityDefaults {
+        switch self {
+        case .draft:
+            return ACEStepQualityDefaults(
+                inferenceSteps: variant.isTurbo ? 4 : 20,
+                shift: variant.defaultShift,
+                guidanceScale: variant.defaultGuidanceScale,
+                samplerMode: .euler,
+                velocityNormThreshold: 0,
+                velocityEMAFactor: 0,
+                usesLanguageModel: false,
+                plansMetadata: false,
+                automaticDuration: false,
+                fallbackDurationSeconds: 10,
+                candidateCount: 1
+            )
+        case .song:
+            return ACEStepQualityDefaults(
+                inferenceSteps: variant.defaultInferenceSteps,
+                shift: variant.defaultShift,
+                guidanceScale: variant.defaultGuidanceScale,
+                samplerMode: .euler,
+                velocityNormThreshold: 0,
+                velocityEMAFactor: 0,
+                usesLanguageModel: !task.skipsLanguageModel,
+                plansMetadata: !task.skipsLanguageModel,
+                automaticDuration: task == .textToMusic || task == .complete,
+                fallbackDurationSeconds: 30,
+                candidateCount: 2
+            )
+        case .final:
+            return ACEStepQualityDefaults(
+                inferenceSteps: variant.defaultInferenceSteps,
+                shift: variant.defaultShift,
+                guidanceScale: variant.defaultGuidanceScale,
+                samplerMode: .heun,
+                velocityNormThreshold: 2,
+                velocityEMAFactor: 0.1,
+                usesLanguageModel: !task.skipsLanguageModel,
+                plansMetadata: !task.skipsLanguageModel,
+                automaticDuration: task == .textToMusic || task == .complete,
+                fallbackDurationSeconds: 60,
+                candidateCount: 4
+            )
+        case .edit:
+            return ACEStepQualityDefaults(
+                inferenceSteps: variant.defaultInferenceSteps,
+                shift: variant.defaultShift,
+                guidanceScale: variant.defaultGuidanceScale,
+                samplerMode: .heun,
+                velocityNormThreshold: 2,
+                velocityEMAFactor: 0.1,
+                usesLanguageModel: !task.skipsLanguageModel,
+                plansMetadata: !task.skipsLanguageModel,
+                automaticDuration: false,
+                fallbackDurationSeconds: 30,
+                candidateCount: 2
+            )
+        }
+    }
+}
+
+public struct ACEStepQualityDefaults: Hashable, Sendable {
+    public var inferenceSteps: Int
+    public var shift: Float
+    public var guidanceScale: Float
+    public var samplerMode: ACEStepSamplerMode
+    public var velocityNormThreshold: Float
+    public var velocityEMAFactor: Float
+    public var usesLanguageModel: Bool
+    public var plansMetadata: Bool
+    public var automaticDuration: Bool
+    public var fallbackDurationSeconds: Float
+    public var candidateCount: Int
+
+    public init(
+        inferenceSteps: Int,
+        shift: Float,
+        guidanceScale: Float,
+        samplerMode: ACEStepSamplerMode,
+        velocityNormThreshold: Float,
+        velocityEMAFactor: Float,
+        usesLanguageModel: Bool,
+        plansMetadata: Bool,
+        automaticDuration: Bool,
+        fallbackDurationSeconds: Float,
+        candidateCount: Int
+    ) {
+        self.inferenceSteps = inferenceSteps
+        self.shift = shift
+        self.guidanceScale = guidanceScale
+        self.samplerMode = samplerMode
+        self.velocityNormThreshold = velocityNormThreshold
+        self.velocityEMAFactor = velocityEMAFactor
+        self.usesLanguageModel = usesLanguageModel
+        self.plansMetadata = plansMetadata
+        self.automaticDuration = automaticDuration
+        self.fallbackDurationSeconds = fallbackDurationSeconds
+        self.candidateCount = candidateCount
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepRepaint.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepRepaint.swift
@@ -1,0 +1,212 @@
+import MLX
+
+enum ACEStepRepaint {
+    struct Conditioning {
+        var sourceLatents: MLXArray
+        var chunkMasks: MLXArray
+        var repaintMask: MLXArray
+        var latentRange: Range<Int>
+    }
+
+    static func prepareConditioning(
+        cleanSourceLatents: MLXArray,
+        silenceLatents: MLXArray,
+        chunkChannels: Int,
+        configuration: ACEStepRepaintConfiguration,
+        task: ACEStepTask
+    ) -> Conditioning {
+        precondition(cleanSourceLatents.ndim == 3, "cleanSourceLatents must be [B,T,D].")
+        precondition(
+            silenceLatents.shape == cleanSourceLatents.shape,
+            "silenceLatents must match cleanSourceLatents."
+        )
+        precondition(chunkChannels > 0, "chunkChannels must be positive.")
+
+        let batchSize = cleanSourceLatents.dim(0)
+        let totalFrames = cleanSourceLatents.dim(1)
+        let range = configuration.latentRange(totalFrames: totalFrames)
+        let maskValues = (0..<(batchSize * totalFrames)).map { index -> Float in
+            range.contains(index % totalFrames) ? 1 : 0
+        }
+        let repaintMask = MLXArray(maskValues, [batchSize, totalFrames]).asType(.bool)
+        let expandedMask = repaintMask.reshaped(batchSize, totalFrames, 1)
+
+        let sourceLatents: MLXArray
+        if task == .lego {
+            sourceLatents = cleanSourceLatents
+        } else {
+            sourceLatents = MLX.where(
+                expandedMask,
+                silenceLatents.asType(cleanSourceLatents.dtype),
+                cleanSourceLatents
+            )
+        }
+
+        let chunkMasks: MLXArray
+        switch configuration.chunkMaskMode {
+        case .auto:
+            chunkMasks = MLXArray.ones(
+                [batchSize, totalFrames, chunkChannels],
+                dtype: .float32
+            )
+        case .explicit:
+            chunkMasks = MLX.broadcast(
+                repaintMask.asType(.float32).reshaped(batchSize, totalFrames, 1),
+                to: [batchSize, totalFrames, chunkChannels]
+            )
+        }
+
+        return Conditioning(
+            sourceLatents: sourceLatents,
+            chunkMasks: chunkMasks,
+            repaintMask: repaintMask,
+            latentRange: range
+        )
+    }
+
+    static func injectPreservedSource(
+        generatedLatents: MLXArray,
+        cleanSourceLatents: MLXArray,
+        repaintMask: MLXArray,
+        nextTimestep: Float,
+        noise: MLXArray
+    ) -> MLXArray {
+        precondition(generatedLatents.shape == cleanSourceLatents.shape)
+        precondition(generatedLatents.shape == noise.shape)
+        let batchSize = generatedLatents.dim(0)
+        let totalFrames = generatedLatents.dim(1)
+        precondition(repaintMask.shape == [batchSize, totalFrames])
+
+        let t = MLXArray(nextTimestep).asType(generatedLatents.dtype)
+        let noisedSource = t * noise
+            + MLXArray(Float(1 - nextTimestep)).asType(generatedLatents.dtype)
+                * cleanSourceLatents.asType(generatedLatents.dtype)
+        return MLX.where(
+            repaintMask.reshaped(batchSize, totalFrames, 1),
+            generatedLatents,
+            noisedSource
+        )
+    }
+
+    static func blendLatentBoundaries(
+        generatedLatents: MLXArray,
+        cleanSourceLatents: MLXArray,
+        repaintMask: MLXArray,
+        crossfadeFrames: Int
+    ) -> MLXArray {
+        precondition(generatedLatents.shape == cleanSourceLatents.shape)
+        let batchSize = generatedLatents.dim(0)
+        let totalFrames = generatedLatents.dim(1)
+        precondition(repaintMask.shape == [batchSize, totalFrames])
+
+        MLX.eval(repaintMask)
+        let mask = repaintMask.asArray(Bool.self)
+        var soft = mask.map { $0 ? Float(1) : Float(0) }
+
+        if crossfadeFrames > 0 {
+            for batch in 0..<batchSize {
+                let offset = batch * totalFrames
+                let row = Array(mask[offset..<(offset + totalFrames)])
+                guard let left = row.firstIndex(of: true),
+                      let last = row.lastIndex(of: true)
+                else {
+                    continue
+                }
+                let right = last + 1
+                let fadeStart = max(left - crossfadeFrames, 0)
+                let leftLength = left - fadeStart
+                if leftLength > 0 {
+                    for index in 0..<leftLength {
+                        soft[offset + fadeStart + index] = Float(index + 1) / Float(leftLength + 1)
+                    }
+                }
+                let fadeEnd = min(right + crossfadeFrames, totalFrames)
+                let rightLength = fadeEnd - right
+                if rightLength > 0 {
+                    for index in 0..<rightLength {
+                        soft[offset + right + index] = Float(rightLength - index) / Float(rightLength + 1)
+                    }
+                }
+            }
+        }
+
+        let blend = MLXArray(soft, [batchSize, totalFrames, 1])
+            .asType(generatedLatents.dtype)
+        return blend * generatedLatents
+            + (MLXArray(Float(1)).asType(generatedLatents.dtype) - blend)
+                * cleanSourceLatents.asType(generatedLatents.dtype)
+    }
+
+    static func spliceWaveform(
+        generatedAudio: MLXArray,
+        sourceAudio: MLXArray,
+        startSeconds: Float,
+        endSeconds: Float,
+        crossfadeSeconds: Float,
+        sampleRate: Int = 48_000
+    ) -> MLXArray {
+        precondition(generatedAudio.ndim == 3, "generatedAudio must be [B,S,C].")
+        precondition(sourceAudio.ndim == 3, "sourceAudio must be [B,S,C].")
+        precondition(generatedAudio.dim(0) == sourceAudio.dim(0))
+        precondition(generatedAudio.dim(2) == sourceAudio.dim(2))
+
+        let batchSize = generatedAudio.dim(0)
+        let channels = generatedAudio.dim(2)
+        let generatedSamples = generatedAudio.dim(1)
+        let sourceSamples = sourceAudio.dim(1)
+        let commonSamples = min(generatedSamples, sourceSamples)
+        guard commonSamples > 0 else {
+            return generatedAudio
+        }
+
+        let start = max(0, min(Int(startSeconds * Float(sampleRate)), commonSamples))
+        let resolvedEndSeconds = endSeconds > startSeconds
+            ? endSeconds
+            : Float(commonSamples) / Float(sampleRate)
+        let end = max(start, min(Int(resolvedEndSeconds * Float(sampleRate)), commonSamples))
+        if start == 0 && end >= commonSamples {
+            return generatedAudio
+        }
+
+        let crossfadeSamples = max(0, Int(crossfadeSeconds * Float(sampleRate)))
+        var mask = Array(repeating: Float(0), count: commonSamples)
+        if start < end {
+            for sample in start..<end {
+                mask[sample] = 1
+            }
+        }
+
+        let fadeStart = max(start - crossfadeSamples, 0)
+        let leftLength = start - fadeStart
+        if leftLength > 0 {
+            for index in 0..<leftLength {
+                mask[fadeStart + index] = Float(index + 1) / Float(leftLength + 1)
+            }
+        }
+
+        let fadeEnd = min(end + crossfadeSamples, commonSamples)
+        let rightLength = fadeEnd - end
+        if rightLength > 0 {
+            for index in 0..<rightLength {
+                mask[end + index] = Float(rightLength - index) / Float(rightLength + 1)
+            }
+        }
+
+        let blend = MLX.broadcast(
+            MLXArray(mask, [1, commonSamples, 1]),
+            to: [batchSize, commonSamples, channels]
+        ).asType(generatedAudio.dtype)
+        let generatedHead = generatedAudio[0..., 0..<commonSamples, 0...]
+        let sourceHead = sourceAudio[0..., 0..<commonSamples, 0...].asType(generatedAudio.dtype)
+        let spliced = blend * generatedHead
+            + (MLXArray(Float(1)).asType(generatedAudio.dtype) - blend) * sourceHead
+
+        guard generatedSamples > commonSamples else {
+            return spliced
+        }
+        return MLX.concatenated(
+            [spliced, generatedAudio[0..., commonSamples..<generatedSamples, 0...]],
+            axis: 1
+        )
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepTask.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepTask.swift
@@ -1,0 +1,279 @@
+import Foundation
+
+public enum ACEStepTask: String, CaseIterable, Codable, Hashable, Sendable {
+    case textToMusic = "text2music"
+    case repaint
+    case cover
+    case coverNoFSQ = "cover-nofsq"
+    case extract
+    case lego
+    case complete
+
+    public var requiresSourceAudio: Bool {
+        self != .textToMusic
+    }
+
+    public var locksDurationToSource: Bool {
+        switch self {
+        case .cover, .coverNoFSQ, .repaint, .extract, .lego:
+            true
+        case .textToMusic, .complete:
+            false
+        }
+    }
+
+    public var usesFSQCoverHints: Bool {
+        self == .cover
+    }
+
+    public var skipsLanguageModel: Bool {
+        switch self {
+        case .cover, .coverNoFSQ, .repaint, .extract:
+            true
+        case .textToMusic, .lego, .complete:
+            false
+        }
+    }
+
+    public var requiresBaseCheckpoint: Bool {
+        switch self {
+        case .extract, .lego, .complete:
+            true
+        case .textToMusic, .repaint, .cover, .coverNoFSQ:
+            false
+        }
+    }
+
+    public func instruction(
+        trackName: String? = nil,
+        completeTrackClasses: [String] = []
+    ) -> String {
+        switch self {
+        case .textToMusic:
+            return "Fill the audio semantic mask based on the given conditions:"
+        case .repaint:
+            return "Repaint the mask area based on the given conditions:"
+        case .cover, .coverNoFSQ:
+            return "Generate audio semantic tokens based on the given conditions:"
+        case .extract:
+            if let trackName = Self.nonEmpty(trackName) {
+                return "Extract the \(trackName.uppercased()) track from the audio:"
+            } else {
+                return "Extract the track from the audio:"
+            }
+        case .lego:
+            if let trackName = Self.nonEmpty(trackName) {
+                return "Generate the \(trackName.uppercased()) track based on the audio context:"
+            } else {
+                return "Generate the track based on the audio context:"
+            }
+        case .complete:
+            let classes = completeTrackClasses
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            if classes.isEmpty {
+                return "Complete the input track:"
+            } else {
+                return "Complete the input track with \(classes.map { $0.uppercased() }.joined(separator: " | ")):"
+            }
+        }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+public enum ACEStepCheckpointVariant: String, CaseIterable, Codable, Hashable, Sendable {
+    case base
+    case sft
+    case turbo
+    case xlBase = "xl-base"
+    case xlSFT = "xl-sft"
+    case xlTurbo = "xl-turbo"
+
+    public var isXL: Bool {
+        switch self {
+        case .xlBase, .xlSFT, .xlTurbo:
+            true
+        case .base, .sft, .turbo:
+            false
+        }
+    }
+
+    public var isTurbo: Bool {
+        switch self {
+        case .turbo, .xlTurbo:
+            true
+        case .base, .sft, .xlBase, .xlSFT:
+            false
+        }
+    }
+
+    public var supportsBaseTasks: Bool {
+        switch self {
+        case .base, .xlBase:
+            true
+        case .sft, .turbo, .xlSFT, .xlTurbo:
+            false
+        }
+    }
+
+    /// Official upstream inference defaults for the distilled and
+    /// classifier-free-guidance checkpoint families.
+    public var defaultInferenceSteps: Int {
+        isTurbo ? 8 : 50
+    }
+
+    public var defaultShift: Float {
+        isTurbo ? 3 : 1
+    }
+
+    public var defaultGuidanceScale: Float {
+        isTurbo ? 1 : 7
+    }
+
+    public func supports(_ task: ACEStepTask) -> Bool {
+        !task.requiresBaseCheckpoint || supportsBaseTasks
+    }
+
+    public func validate(_ task: ACEStepTask) throws {
+        guard supports(task) else {
+            throw ACEStepCapabilityError.unsupportedTask(task: task, variant: self)
+        }
+    }
+
+    public static func detect(
+        modelRootURL: URL,
+        config: ACEStepConfig
+    ) -> ACEStepCheckpointVariant {
+        let name = modelRootURL.lastPathComponent.lowercased()
+        let isXL = name.contains("xl-")
+            || name.contains("-xl")
+            || config.hiddenSize > 2_048
+
+        if config.isTurbo || name.contains("turbo") {
+            return isXL ? .xlTurbo : .turbo
+        }
+        if name.contains("sft") {
+            return isXL ? .xlSFT : .sft
+        }
+        return isXL ? .xlBase : .base
+    }
+
+    public static func load(
+        modelRootURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> ACEStepCheckpointVariant {
+        let resources = ACEStepResources(rootURL: modelRootURL)
+        let missing = resources.validate(fileManager: fileManager)
+        if !missing.isEmpty {
+            throw ACEStepCapabilityError.missingCheckpointFiles(missing)
+        }
+        let config = try JSONDecoder().decode(
+            ACEStepConfig.self,
+            from: Data(contentsOf: resources.configURL)
+        )
+        return detect(modelRootURL: modelRootURL, config: config)
+    }
+}
+
+public enum ACEStepCapabilityError: LocalizedError {
+    case missingCheckpointFiles([URL])
+    case unsupportedTask(task: ACEStepTask, variant: ACEStepCheckpointVariant)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCheckpointFiles(let urls):
+            let list = urls.map(\.path).joined(separator: "\n")
+            return "Missing ACE-Step checkpoint resources:\n\(list)"
+        case .unsupportedTask(let task, let variant):
+            return "ACE-Step task '\(task.rawValue)' is not supported by \(variant.rawValue) checkpoints. "
+                + "Use an ACE-Step Base checkpoint for extract, lego, and complete."
+        }
+    }
+}
+
+public enum ACEStepChunkMaskMode: String, CaseIterable, Codable, Hashable, Sendable {
+    case auto
+    case explicit
+}
+
+public enum ACEStepRepaintMode: String, CaseIterable, Codable, Hashable, Sendable {
+    case conservative
+    case balanced
+    case aggressive
+}
+
+public struct ACEStepRepaintConfiguration: Codable, Hashable, Sendable {
+    public var startSeconds: Float
+    public var endSeconds: Float
+    public var chunkMaskMode: ACEStepChunkMaskMode
+    public var mode: ACEStepRepaintMode
+    public var strength: Float
+
+    public init(
+        startSeconds: Float = 0,
+        endSeconds: Float = -1,
+        chunkMaskMode: ACEStepChunkMaskMode = .auto,
+        mode: ACEStepRepaintMode = .balanced,
+        strength: Float = 0.5
+    ) {
+        self.startSeconds = startSeconds
+        self.endSeconds = endSeconds
+        self.chunkMaskMode = chunkMaskMode
+        self.mode = mode
+        self.strength = strength
+    }
+
+    public var injectionRatio: Float {
+        switch mode {
+        case .aggressive:
+            0
+        case .conservative:
+            1
+        case .balanced:
+            1 - clampedStrength
+        }
+    }
+
+    public var latentCrossfadeFrames: Int {
+        switch mode {
+        case .aggressive:
+            0
+        case .conservative:
+            25
+        case .balanced:
+            Int((25 * Double(1 - clampedStrength)).rounded(.toNearestOrEven))
+        }
+    }
+
+    public var waveformCrossfadeSeconds: Float {
+        switch mode {
+        case .aggressive:
+            0
+        case .conservative:
+            0.05
+        case .balanced:
+            0.05 * (1 - clampedStrength)
+        }
+    }
+
+    public func latentRange(
+        totalFrames: Int,
+        framesPerSecond: Float = 25
+    ) -> Range<Int> {
+        precondition(totalFrames > 0, "totalFrames must be positive.")
+        let start = max(0, min(Int(startSeconds * framesPerSecond), totalFrames - 1))
+        let resolvedEnd = endSeconds > startSeconds
+            ? endSeconds
+            : Float(totalFrames) / framesPerSecond
+        let end = max(start + 1, min(Int(resolvedEnd * framesPerSecond), totalFrames))
+        return start..<end
+    }
+
+    private var clampedStrength: Float {
+        min(max(strength, 0), 1)
+    }
+}

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -255,6 +255,11 @@ public enum ManagedModelCatalog {
     private static let bonsaiTernaryUpstreamRepoId = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
     private static let magentaRT2UpstreamRepoId = "google/magenta-realtime-2"
     private static let magentaRT2UpstreamRevision = "010aa0dcb0dfd27b24f0ad07b4dad63e8f9521cc"
+    private static let aceStepSharedRevision = "19671f406d603126926c1b7e2adc169acbcade22"
+    private static let aceStepXLBaseRevision = "220c1166efbdd9583eafcb12eb160594bbfcb241"
+    private static let aceStepXLSFTRevision = "d06de46b4622f781cf07f4a013a67d591ca52819"
+    private static let aceStepXLTurboRevision = "d4a0b288b83ebb7e25a8c0b32c573c22e134e8ee"
+    private static let aceStepLM4BRevision = "0a3ec94b557aea7d508da38b31cfe7341f6ff737"
     private static let magentaRT2ResourcePatterns = [
         "resources/musiccoca/audio_preprocessor.tflite",
         "resources/musiccoca/mapper.tflite",
@@ -1594,7 +1599,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "ACE-Step/Ace-Step1.5",
-                revision: "main",
+                revision: aceStepSharedRevision,
                 patterns: [
                     "config.json",
                     "acestep-v15-turbo/*",
@@ -1604,11 +1609,85 @@ public enum ManagedModelCatalog {
                 ]
             ),
             upstreamRepoId: "ACE-Step/Ace-Step1.5",
-            upstreamRevision: "main",
+            upstreamRevision: aceStepSharedRevision,
             validationKind: .aceStep,
             normalizationKind: .musicACEStep,
             estimatedDownloadBytes: 10_092_095_357,
             defaultCLICommands: ["music generate", "music analyze"]
+        ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.aceStepXLBase.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "ACE-Step/Ace-Step1.5",
+                revision: aceStepSharedRevision,
+                patterns: [
+                    "Qwen3-Embedding-0.6B/*",
+                    "vae/*",
+                ]
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "acestep-v15-xl-base",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "ACE-Step/acestep-v15-xl-base",
+                        revision: aceStepXLBaseRevision,
+                        patterns: [
+                            "apg_guidance.py",
+                            "config.json",
+                            "configuration_acestep_v15.py",
+                            "model*.safetensors",
+                            "model.safetensors.index.json",
+                            "modeling_acestep_v15_xl_base.py",
+                            "silence_latent.pt",
+                        ]
+                    )
+                ),
+            ],
+            upstreamRepoId: "ACE-Step/acestep-v15-xl-base",
+            upstreamRevision: aceStepXLBaseRevision,
+            validationKind: .aceStep,
+            normalizationKind: .musicACEStep,
+            estimatedDownloadBytes: 23 * 1_073_741_824,
+            defaultCLICommands: ["music generate"]
+        ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.aceStepXLSFT.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "ACE-Step/Ace-Step1.5",
+                revision: aceStepSharedRevision,
+                patterns: [
+                    "Qwen3-Embedding-0.6B/*",
+                    "vae/*",
+                ]
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "acestep-v15-xl-sft",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "ACE-Step/acestep-v15-xl-sft",
+                        revision: aceStepXLSFTRevision,
+                        patterns: [
+                            "apg_guidance.py",
+                            "config.json",
+                            "configuration_acestep_v15.py",
+                            "model*.safetensors",
+                            "model.safetensors.index.json",
+                            "modeling_acestep_v15_xl_base.py",
+                            "silence_latent.pt",
+                        ]
+                    )
+                ),
+            ],
+            upstreamRepoId: "ACE-Step/acestep-v15-xl-sft",
+            upstreamRevision: aceStepXLSFTRevision,
+            validationKind: .aceStep,
+            normalizationKind: .musicACEStep,
+            estimatedDownloadBytes: 23 * 1_073_741_824,
+            defaultCLICommands: ["music generate"]
         ),
         ManagedModelSpec(
             id: ModelResolver.ModelID.aceStepXLTurbo.rawValue,
@@ -1616,7 +1695,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "ACE-Step/Ace-Step1.5",
-                revision: "main",
+                revision: aceStepSharedRevision,
                 patterns: [
                     "Qwen3-Embedding-0.6B/*",
                     "vae/*",
@@ -1627,7 +1706,7 @@ public enum ManagedModelCatalog {
                     destinationPath: "acestep-v15-xl-turbo",
                     hubFallback: HubFallbackConfig(
                         repoId: "ACE-Step/acestep-v15-xl-turbo",
-                        revision: "main",
+                        revision: aceStepXLTurboRevision,
                         patterns: [
                             "config.json",
                             "configuration_acestep_v15.py",
@@ -1640,7 +1719,7 @@ public enum ManagedModelCatalog {
                 ),
             ],
             upstreamRepoId: "ACE-Step/acestep-v15-xl-turbo",
-            upstreamRevision: "main",
+            upstreamRevision: aceStepXLTurboRevision,
             validationKind: .aceStep,
             normalizationKind: .musicACEStep,
             estimatedDownloadBytes: 23 * 1_073_741_824,
@@ -1652,7 +1731,7 @@ public enum ManagedModelCatalog {
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
                 repoId: "ACE-Step/Ace-Step1.5",
-                revision: "main",
+                revision: aceStepSharedRevision,
                 patterns: [
                     "Qwen3-Embedding-0.6B/*",
                     "vae/*",
@@ -1663,7 +1742,7 @@ public enum ManagedModelCatalog {
                     destinationPath: "acestep-v15-xl-turbo",
                     hubFallback: HubFallbackConfig(
                         repoId: "ACE-Step/acestep-v15-xl-turbo",
-                        revision: "main",
+                        revision: aceStepXLTurboRevision,
                         patterns: [
                             "config.json",
                             "configuration_acestep_v15.py",
@@ -1678,7 +1757,7 @@ public enum ManagedModelCatalog {
                     destinationPath: "acestep-5Hz-lm-4B",
                     hubFallback: HubFallbackConfig(
                         repoId: "ACE-Step/acestep-5Hz-lm-4B",
-                        revision: "main",
+                        revision: aceStepLM4BRevision,
                         patterns: [
                             "*.json",
                             "*.safetensors",
@@ -1690,7 +1769,7 @@ public enum ManagedModelCatalog {
                 ),
             ],
             upstreamRepoId: "ACE-Step/acestep-v15-xl-turbo + ACE-Step/acestep-5Hz-lm-4B",
-            upstreamRevision: "main",
+            upstreamRevision: "\(aceStepXLTurboRevision)+\(aceStepLM4BRevision)",
             validationKind: .aceStep,
             normalizationKind: .musicACEStep,
             estimatedDownloadBytes: 32 * 1_073_741_824,
@@ -2809,15 +2888,23 @@ public extension ManagedModelSpec {
 
     private static func missingACEStepPaths(modelID: String, in rootURL: URL, fileManager: FileManager) -> [URL] {
         var missing: [URL] = []
-        let turboSubdirectories = modelID == ModelResolver.ModelID.aceStep.rawValue
-            ? ["acestep-v15-turbo", "music-acestep-v15-turbo"]
-            : ["acestep-v15-xl-turbo"]
+        let decoderSubdirectories: [String]
+        switch modelID {
+        case ModelResolver.ModelID.aceStep.rawValue:
+            decoderSubdirectories = ["acestep-v15-turbo", "music-acestep-v15-turbo"]
+        case ModelResolver.ModelID.aceStepXLBase.rawValue:
+            decoderSubdirectories = ["acestep-v15-xl-base"]
+        case ModelResolver.ModelID.aceStepXLSFT.rawValue:
+            decoderSubdirectories = ["acestep-v15-xl-sft"]
+        default:
+            decoderSubdirectories = ["acestep-v15-xl-turbo"]
+        }
         let vaeDir = rootURL.appendingPathComponent("vae", isDirectory: true)
         let textDir = rootURL.appendingPathComponent("Qwen3-Embedding-0.6B", isDirectory: true)
-        if !turboSubdirectories.contains(where: {
+        if !decoderSubdirectories.contains(where: {
             fileManager.fileExists(atPath: rootURL.appendingPathComponent($0, isDirectory: true).path)
         }) {
-            missing.append(rootURL.appendingPathComponent(turboSubdirectories[0], isDirectory: true))
+            missing.append(rootURL.appendingPathComponent(decoderSubdirectories[0], isDirectory: true))
         }
         if !fileManager.fileExists(atPath: vaeDir.path) { missing.append(vaeDir) }
         if !fileManager.fileExists(atPath: textDir.path) { missing.append(textDir) }

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -611,6 +611,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 32
             ),
             descriptor(
+                ModelResolver.ModelID.aceStepXLBase.rawValue,
+                "ACE-Step XL Base",
+                "Runs the full ACE-Step 1.5 XL Base DiT with CFG and advanced source-audio tasks.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
+                ModelResolver.ModelID.aceStepXLSFT.rawValue,
+                "ACE-Step XL SFT",
+                "Runs the full ACE-Step 1.5 XL supervised checkpoint with CFG for highest-fidelity standard generation.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
                 ModelResolver.ModelID.aceStepXLTurbo.rawValue,
                 "ACE-Step XL Turbo",
                 "Generates higher-quality music with the ACE-Step 1.5 XL turbo DiT.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1504,19 +1504,35 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "lightonai/LightOnOCR-2-1B",
                 createdAt: createdAt
             )
-        case .aceStep, .aceStepXLTurbo, .aceStepXLTurboLM4B:
-            let isXL = modelID == .aceStepXLTurbo || modelID == .aceStepXLTurboLM4B
+        case .aceStep, .aceStepXLBase, .aceStepXLSFT, .aceStepXLTurbo, .aceStepXLTurboLM4B:
+            let isBase = modelID == .aceStepXLBase
+            let isSFT = modelID == .aceStepXLSFT
+            let isXLTurbo = modelID == .aceStepXLTurbo || modelID == .aceStepXLTurboLM4B
+            let isXL = isBase || isSFT || isXLTurbo
+            let repoID: String
+            if isBase {
+                repoID = "ACE-Step/acestep-v15-xl-base"
+            } else if isSFT {
+                repoID = "ACE-Step/acestep-v15-xl-sft"
+            } else if isXLTurbo {
+                repoID = "ACE-Step/acestep-v15-xl-turbo"
+            } else {
+                repoID = "ACE-Step/Ace-Step1.5"
+            }
             return MereRunModelManifest(
                 id: modelID.rawValue,
                 engine: .aceStep,
                 family: .music,
-                tier: isXL ? .turbo : .latest,
-                variant: isXL ? .distilled : .standard,
+                tier: isXLTurbo ? .turbo : (isXL ? .max : .latest),
+                variant: isXLTurbo ? .distilled : .standard,
                 precision: .bf16,
-                defaults: Defaults(steps: 8, cfg: 1.0),
+                defaults: Defaults(
+                    steps: isXLTurbo || !isXL ? 8 : 50,
+                    cfg: isXLTurbo || !isXL ? 1.0 : 7.0
+                ),
                 supports: [.musicGeneration],
                 components: nil,
-                upstreamRepoId: isXL ? "ACE-Step/acestep-v15-xl-turbo" : "ACE-Step/Ace-Step1.5",
+                upstreamRepoId: repoID,
                 createdAt: createdAt
             )
         case .magentaRT2Small, .magentaRT2Base:

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -69,6 +69,8 @@ public struct ModelResolver {
         case image3DInstantMeshBase = "image-3d-instantmesh-base"
         case image3DTrellis2 = "image-3d-trellis2-4b"
         case aceStep = "music-acestep"
+        case aceStepXLBase = "music-acestep-xl-base"
+        case aceStepXLSFT = "music-acestep-xl-sft"
         case aceStepXLTurbo = "music-acestep-xl-turbo"
         case aceStepXLTurboLM4B = "music-acestep-xl-turbo-lm4b"
         case magentaRT2Small = "music-magenta-rt2-small"

--- a/Tests/MereRunCLITests/Fixtures/ACEStep/listening-regression.json
+++ b/Tests/MereRunCLITests/Fixtures/ACEStep/listening-regression.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "model": "music-acestep-xl-turbo-lm4b",
+  "duration_seconds": 12,
+  "quality": "song",
+  "candidates": 2,
+  "cases": [
+    {
+      "id": "transient-electronic",
+      "seed": 1101,
+      "caption": "tight electronic club groove, crisp kick and snare transients, elastic sub bass, polished stereo synth stabs, instrumental",
+      "listen_for": "clean transients, stable low end, no clipping, coherent four-bar motion"
+    },
+    {
+      "id": "acoustic-space",
+      "seed": 1102,
+      "caption": "intimate fingerpicked acoustic guitar and warm cello in a small wooden room, natural dynamics, instrumental",
+      "listen_for": "credible attacks, room continuity, low metallic fizz, stable instrument identity"
+    },
+    {
+      "id": "vocal-alignment",
+      "seed": 1103,
+      "caption": "dream-pop song with a clear close lead vocal, soft live drums, chiming guitars, uplifting chorus",
+      "lyrics": "[verse]\nCity lights are folding into blue\n[chorus]\nStay awake, I am coming home to you",
+      "listen_for": "intelligible words, section transition, phrasing aligned to the lyric structure"
+    },
+    {
+      "id": "dense-arrangement",
+      "seed": 1104,
+      "caption": "cinematic progressive metal with double-kick drums, wide rhythm guitars, orchestral brass, and a memorable lead theme, instrumental",
+      "listen_for": "separation under density, rhythmic stability, theme continuity, controlled high frequencies"
+    },
+    {
+      "id": "ambient-continuity",
+      "seed": 1105,
+      "caption": "slowly evolving ambient modular synthesizers, distant bowed glass, deep soft drones, no percussion, instrumental",
+      "listen_for": "continuous tails, no abrupt seams, evolving harmony, low noise-floor modulation"
+    }
+  ]
+}

--- a/Tests/MereRunCLITests/GuideCommandTests.swift
+++ b/Tests/MereRunCLITests/GuideCommandTests.swift
@@ -178,6 +178,8 @@ final class GuideCommandTests: XCTestCase {
             payload.models,
             [
                 "music-acestep",
+                ModelResolver.ModelID.aceStepXLBase.rawValue,
+                ModelResolver.ModelID.aceStepXLSFT.rawValue,
                 ModelResolver.ModelID.aceStepXLTurbo.rawValue,
                 ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue,
                 ModelResolver.ModelID.magentaRT2Small.rawValue,

--- a/Tests/MereRunCLITests/MusicAnalyzeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicAnalyzeCommandParsingTests.swift
@@ -87,6 +87,9 @@ final class MusicAnalyzeCommandParsingTests: XCTestCase {
 
     func testMusicCommandExposesAnalyze() {
         let commandNames = Set(Music.configuration.subcommands.map { $0.configuration.commandName })
-        XCTAssertEqual(commandNames, Set(["analyze", "generate", "realtime", "transcribe"]))
+        XCTAssertEqual(
+            commandNames,
+            Set(["analyze", "generate", "realtime", "serve", "train-adapter", "transcribe"])
+        )
     }
 }

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -4,6 +4,47 @@ import MLX
 @testable import MereRunCore
 
 final class MusicGenerateCommandParsingTests: XCTestCase {
+    func testMusicGenerateParsesStackedAdaptersAndScales() throws {
+        let command = try MusicGenerate.parse([
+            "cinematic synth anthem",
+            "--adapter", "/tmp/a.safetensors", "/tmp/b.safetensors",
+            "--adapter-kind", "auto",
+            "--adapter-scale", "0.75", "0.4",
+        ])
+
+        XCTAssertEqual(
+            command.adapters,
+            ["/tmp/a.safetensors", "/tmp/b.safetensors"]
+        )
+        XCTAssertEqual(command.adapterKind, .auto)
+        XCTAssertEqual(command.adapterScales, [0.75, 0.4])
+    }
+
+    func testMusicGenerateParsesRetakeAndFlowEditControls() throws {
+        let command = try MusicGenerate.parse([
+            "polished synthwave remix",
+            "--source-audio", "/tmp/source.wav",
+            "--flow-edit",
+            "--source-caption", "rough acoustic demo",
+            "--source-lyrics", "old words",
+            "--flow-edit-n-min", "0.1",
+            "--flow-edit-n-max", "0.9",
+            "--flow-edit-n-average", "4",
+            "--retake-seed", "99",
+            "--retake-variance", "0.35",
+        ])
+
+        XCTAssertTrue(command.flowEdit)
+        XCTAssertEqual(command.resolvedACEStepTask, .textToMusic)
+        XCTAssertEqual(command.sourceCaption, "rough acoustic demo")
+        XCTAssertEqual(command.sourceLyrics, "old words")
+        XCTAssertEqual(command.flowEditNMin, 0.1)
+        XCTAssertEqual(command.flowEditNMax, 0.9)
+        XCTAssertEqual(command.flowEditNAverage, 4)
+        XCTAssertEqual(command.retakeSeed, 99)
+        XCTAssertEqual(command.retakeVariance, 0.35)
+    }
+
     func testMusicGenerateParsesManagedDefaultModel() throws {
         let cmd = try MusicGenerate.parse([
             "warm synthwave groove",
@@ -15,8 +56,11 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.turboSubdirectory, "acestep-v15-turbo")
         XCTAssertEqual(cmd.vaeSubdirectory, "vae")
         XCTAssertFalse(cmd.useLM)
-        XCTAssertEqual(cmd.durationSeconds, 10.0, accuracy: 0.0001)
-        XCTAssertEqual(cmd.shift, 3.0, accuracy: 0.0001)
+        XCTAssertNil(cmd.durationSeconds)
+        XCTAssertEqual(cmd.quality, .song)
+        XCTAssertNil(cmd.steps)
+        XCTAssertNil(cmd.shift)
+        XCTAssertNil(cmd.guidanceScale)
         XCTAssertEqual(cmd.coverNoiseStrength, 0.0, accuracy: 0.0001)
         XCTAssertFalse(cmd.resolvedACEStepIsCover)
     }
@@ -33,6 +77,15 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--use-lm",
             "--duration", "18",
             "--steps", "12",
+            "--shift", "1.5",
+            "--infer-method", "ode",
+            "--sampler", "heun",
+            "--guidance-scale", "6.5",
+            "--guidance-mode", "adg",
+            "--cfg-interval-start", "0.1",
+            "--cfg-interval-end", "0.9",
+            "--velocity-norm-threshold", "2.5",
+            "--velocity-ema-factor", "0.1",
         ])
 
         XCTAssertEqual(cmd.model, "/tmp/acestep")
@@ -42,8 +95,17 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.lmSubdirectory, "custom-lm")
         XCTAssertEqual(cmd.textSubdirectory, "text-encoder")
         XCTAssertTrue(cmd.useLM)
-        XCTAssertEqual(cmd.durationSeconds, 18.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.durationSeconds, 18.0)
         XCTAssertEqual(cmd.steps, 12)
+        XCTAssertEqual(cmd.shift, 1.5)
+        XCTAssertEqual(cmd.inferMethod, .ode)
+        XCTAssertEqual(cmd.samplerMode, .heun)
+        XCTAssertEqual(cmd.guidanceScale, 6.5)
+        XCTAssertEqual(cmd.guidanceMode, .adg)
+        XCTAssertEqual(cmd.cfgIntervalStart, 0.1)
+        XCTAssertEqual(cmd.cfgIntervalEnd, 0.9)
+        XCTAssertEqual(cmd.velocityNormThreshold, 2.5)
+        XCTAssertEqual(cmd.velocityEMAFactor, 0.1)
     }
 
     func testMusicGenerateCheckpointCandidatesHonorRequestedManagedModel() throws {
@@ -72,6 +134,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--task-type", "cover",
         ])
         XCTAssertTrue(cover.resolvedACEStepIsCover)
+        XCTAssertEqual(cover.resolvedACEStepTask, .cover)
 
         let forcedNonCover = try MusicGenerate.parse([
             "cover this",
@@ -79,6 +142,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--non-cover",
         ])
         XCTAssertFalse(forcedNonCover.resolvedACEStepIsCover)
+        XCTAssertEqual(forcedNonCover.resolvedACEStepTask, .coverNoFSQ)
 
         let textToMusic = try MusicGenerate.parse([
             "new song",
@@ -103,7 +167,36 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.audioCoverStrength, 0.75, accuracy: 0.0001)
         XCTAssertEqual(cmd.coverNoiseStrength, 0.45, accuracy: 0.0001)
         XCTAssertTrue(cmd.resolvedACEStepIsCover)
-        XCTAssertEqual(cmd.resolvedACEStepTaskType(isCover: cmd.resolvedACEStepIsCover), "cover")
+        XCTAssertEqual(cmd.resolvedACEStepTask, .cover)
+    }
+
+    func testMusicGenerateParsesRepaintControls() throws {
+        let cmd = try MusicGenerate.parse([
+            "replace the bridge with a bigger chorus",
+            "--task", "repaint",
+            "--source-audio", "/tmp/source.wav",
+            "--repaint-start", "12.5",
+            "--repaint-end", "20",
+            "--chunk-mask-mode", "explicit",
+            "--repaint-mode", "conservative",
+            "--repaint-strength", "0.2",
+        ])
+
+        XCTAssertEqual(cmd.resolvedACEStepTask, .repaint)
+        XCTAssertEqual(cmd.repaintStartSeconds, 12.5)
+        XCTAssertEqual(cmd.repaintEndSeconds, 20)
+        XCTAssertEqual(cmd.chunkMaskMode, .explicit)
+        XCTAssertEqual(cmd.repaintMode, .conservative)
+        XCTAssertEqual(cmd.repaintStrength, 0.2)
+    }
+
+    func testMusicGenerateRejectsUnknownTaskDuringParsing() {
+        XCTAssertThrowsError(
+            try MusicGenerate.parse([
+                "bad task",
+                "--task", "remxi",
+            ])
+        )
     }
 
     func testMusicGenerateSkipsLMForCoverParity() throws {
@@ -113,10 +206,10 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--use-lm",
             "--lm-subdirectory", "acestep-5Hz-lm-4B",
         ])
-        let taskType = cover.resolvedACEStepTaskType(isCover: cover.resolvedACEStepIsCover)
+        let task = cover.resolvedACEStepTask
 
-        XCTAssertEqual(taskType, "cover")
-        XCTAssertFalse(cover.resolvedACEStepUsesLM(taskType: taskType))
+        XCTAssertEqual(task, .cover)
+        XCTAssertFalse(cover.resolvedACEStepUsesLM(task: task))
 
         let textToMusic = try MusicGenerate.parse([
             "fresh song",
@@ -124,7 +217,19 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--lm-subdirectory", "acestep-5Hz-lm-4B",
         ])
 
-        XCTAssertTrue(textToMusic.resolvedACEStepUsesLM(taskType: "text2music"))
+        XCTAssertTrue(textToMusic.resolvedACEStepUsesLM(task: .textToMusic))
+
+        let draft = try MusicGenerate.parse([
+            "fast idea",
+            "--quality", "draft",
+        ])
+        XCTAssertFalse(draft.resolvedACEStepUsesLM(task: .textToMusic))
+
+        let noLM = try MusicGenerate.parse([
+            "manual plan",
+            "--no-lm",
+        ])
+        XCTAssertFalse(noLM.resolvedACEStepUsesLM(task: .textToMusic))
     }
 
     func testMusicGenerateCoverDurationUsesSourceAudioLength() throws {
@@ -136,12 +241,34 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         let sourceAudio = MLXArray(Array(repeating: Float(0), count: 48_000 * 2 * 2), [1, 48_000 * 2, 2])
 
         let duration = cmd.resolvedACEStepDurationSeconds(
-            isCover: cmd.resolvedACEStepIsCover,
+            task: cmd.resolvedACEStepTask,
             sourceAudio48kHz: sourceAudio
         )
 
         XCTAssertEqual(duration, 2.0, accuracy: 0.0001)
         XCTAssertEqual(cmd.resolvedMetadataDuration(effectiveDurationSeconds: duration), "2 seconds")
+    }
+
+    func testMusicGenerateCompleteKeepsRequestedDuration() throws {
+        let cmd = try MusicGenerate.parse([
+            "finish this arrangement",
+            "--task", "complete",
+            "--source-audio", "/tmp/partial.wav",
+            "--duration", "30",
+        ])
+        let sourceAudio = MLXArray(
+            Array(repeating: Float(0), count: 48_000 * 2 * 2),
+            [1, 48_000 * 2, 2]
+        )
+
+        XCTAssertEqual(
+            cmd.resolvedACEStepDurationSeconds(
+                task: .complete,
+                sourceAudio48kHz: sourceAudio
+            ),
+            30,
+            accuracy: 0.0001
+        )
     }
 
     func testMusicGenerateSourceAnalysisFillsOnlyMissingMetadata() throws {
@@ -195,7 +322,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         ])
 
         XCTAssertEqual(cmd.model, ModelResolver.ModelID.magentaRT2Small.rawValue)
-        XCTAssertEqual(cmd.durationSeconds, 4.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.durationSeconds, 4.0)
         XCTAssertEqual(cmd.magentaStyleConditioning, .full)
         XCTAssertEqual(cmd.magentaTemperature, 0.8, accuracy: 0.0001)
         XCTAssertEqual(cmd.magentaTopK, 64)

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -1,0 +1,319 @@
+import ArgumentParser
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class MusicServeAndExportTests: XCTestCase {
+    func testMusicCommandExposesResidentServe() {
+        let names = Set(Music.configuration.subcommands.map {
+            $0.configuration.commandName
+        })
+        XCTAssertTrue(names.contains("serve"))
+        XCTAssertTrue(names.contains("train-adapter"))
+    }
+
+    func testMusicServeParsesResidentAdapters() throws {
+        let command = try MusicServe.parse([
+            "--adapter", "/tmp/style.safetensors", "/tmp/voice.safetensors",
+            "--adapter-kind", "lora",
+            "--adapter-scale", "0.8", "0.5",
+        ])
+
+        XCTAssertEqual(
+            command.adapters,
+            ["/tmp/style.safetensors", "/tmp/voice.safetensors"]
+        )
+        XCTAssertEqual(command.adapterKind, .lora)
+        XCTAssertEqual(command.adapterScales, [0.8, 0.5])
+    }
+
+    func testMusicTrainAdapterParsesAndLoadsJSONLManifest() throws {
+        let command = try MusicTrainAdapter.parse([
+            "--dataset", "/tmp/music.jsonl",
+            "--output", "/tmp/style.safetensors",
+            "--kind", "lokr",
+            "--rank", "16",
+            "--alpha", "32",
+            "--factor", "8",
+            "--steps", "25",
+            "--learning-rate", "0.0002",
+            "--max-duration", "12",
+        ])
+        XCTAssertEqual(command.kind, .lokr)
+        XCTAssertEqual(command.rank, 16)
+        XCTAssertEqual(command.alpha, 32)
+        XCTAssertEqual(command.factor, 8)
+        XCTAssertEqual(command.steps, 25)
+        XCTAssertEqual(command.learningRate, 0.0002)
+        XCTAssertEqual(command.maxDurationSeconds, 12)
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let manifestURL = directory.appendingPathComponent("music.jsonl")
+        try """
+        {"audio":"one.wav","caption":"glassy dream pop","lyrics":"hello"}
+        {"audio":"two.wav","caption":"heavy breakbeat"}
+        """.write(to: manifestURL, atomically: true, encoding: .utf8)
+
+        let records = try MusicTrainAdapter.loadManifest(from: manifestURL)
+        XCTAssertEqual(records.count, 2)
+        XCTAssertEqual(records[0].lyrics, "hello")
+        XCTAssertEqual(records[1].audio, "two.wav")
+    }
+
+    func testListeningRegressionFixturePinsDiverseCases() throws {
+        let fixtureURL = try XCTUnwrap(Bundle.module.resourceURL)
+            .appendingPathComponent(
+                "Fixtures/ACEStep/listening-regression.json"
+            )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Data(contentsOf: fixtureURL)
+            ) as? [String: Any]
+        )
+        XCTAssertEqual(object["schema_version"] as? Int, 1)
+        XCTAssertEqual(
+            object["model"] as? String,
+            "music-acestep-xl-turbo-lm4b"
+        )
+        let cases = try XCTUnwrap(object["cases"] as? [[String: Any]])
+        XCTAssertEqual(cases.count, 5)
+        XCTAssertEqual(Set(cases.compactMap { $0["seed"] as? Int }).count, 5)
+        XCTAssertTrue(
+            cases.allSatisfy {
+                ($0["listen_for"] as? String)?.isEmpty == false
+            }
+        )
+    }
+
+    func testRecipeSchemaPersistsEffectiveConditioningMetadata() throws {
+        let metadata = ACEStepRecipeConditioningMetadata(
+            .init(
+                bpm: "118",
+                caption: "not duplicated here",
+                duration: "12",
+                keyscale: "D major",
+                language: "en",
+                timesignature: "4"
+            )
+        )
+        let encoded = try JSONEncoder().encode(metadata)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: String]
+        )
+
+        XCTAssertEqual(ACEStepGenerationRecipe.currentSchemaVersion, 2)
+        XCTAssertEqual(object["bpm"], "118")
+        XCTAssertEqual(object["duration"], "12")
+        XCTAssertEqual(object["keyscale"], "D major")
+        XCTAssertEqual(object["language"], "en")
+        XCTAssertEqual(object["timesignature"], "4")
+        XCTAssertNil(object["caption"])
+    }
+
+    func testMusicServeParsesSecureRuntimeOptions() throws {
+        let command = try MusicServe.parse([
+            "--host", "0.0.0.0",
+            "--port", "8089",
+            "--model", "music-acestep-xl-sft",
+            "--api-key", "secret",
+        ])
+        XCTAssertEqual(command.host, "0.0.0.0")
+        XCTAssertEqual(command.port, 8_089)
+        XCTAssertEqual(command.model, "music-acestep-xl-sft")
+        XCTAssertEqual(command.apiKey, "secret")
+        XCTAssertTrue(MusicServe.isLoopback("127.0.0.1"))
+        XCTAssertTrue(MusicServe.isLoopback("::1"))
+        XCTAssertFalse(MusicServe.isLoopback("0.0.0.0"))
+        XCTAssertEqual(
+            MusicServe.apiErrorMessage(
+                ValidationError("resident model mismatch")
+            ),
+            "resident model mismatch"
+        )
+    }
+
+    func testMusicAPIRequestDecodesSnakeCaseAdvancedControls() throws {
+        let request = try JSONDecoder().decode(
+            MusicAPIGenerationRequest.self,
+            from: Data(
+                """
+                {
+                  "prompt": "glassy synth pop",
+                  "instruction": "custom semantic instruction",
+                  "duration_seconds": 12,
+                  "quality": "final",
+                  "task": "text2music",
+                  "seed": 42,
+                  "candidates": 3,
+                  "shift": 1.5,
+                  "infer_method": "sde",
+                  "guidance_scale": 6.5,
+                  "guidance_mode": "apg",
+                  "cfg_interval_start": 0.2,
+                  "cfg_interval_end": 0.8,
+                  "velocity_norm_threshold": 2.5,
+                  "velocity_ema_factor": 0.15,
+                  "sampler": "heun",
+                  "use_lm": true,
+                  "lm_top_k": 50,
+                  "lm_top_p": 0.85,
+                  "bpm": 118,
+                  "keyscale": "D major",
+                  "metadata_language": "en",
+                  "time_signature": "4",
+                  "vocal_language": "en",
+                  "reference_audio_paths": ["/tmp/ref.wav"],
+                  "audio_cover_strength": 0.75,
+                  "cover_noise_strength": 0.1,
+                  "complete_track_classes": ["Drums", "Bass"],
+                  "chunk_mask_mode": "explicit",
+                  "repaint_mode": "conservative",
+                  "repaint_strength": 0.25,
+                  "use_tiled_vae_decode": true,
+                  "vae_chunk_size": 256,
+                  "vae_overlap": 32,
+                  "response_format": "wav"
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(request.instruction, "custom semantic instruction")
+        XCTAssertEqual(request.durationSeconds, 12)
+        XCTAssertEqual(request.quality, .final)
+        XCTAssertEqual(request.task, .textToMusic)
+        XCTAssertEqual(request.seed, 42)
+        XCTAssertEqual(request.candidates, 3)
+        XCTAssertEqual(request.shift, 1.5)
+        XCTAssertEqual(request.inferMethod, .sde)
+        XCTAssertEqual(request.guidanceScale, 6.5)
+        XCTAssertEqual(request.guidanceMode, .apg)
+        XCTAssertEqual(request.cfgIntervalStart, 0.2)
+        XCTAssertEqual(request.cfgIntervalEnd, 0.8)
+        XCTAssertEqual(request.velocityNormThreshold, 2.5)
+        XCTAssertEqual(request.velocityEMAFactor, 0.15)
+        XCTAssertEqual(request.sampler, .heun)
+        XCTAssertEqual(request.useLanguageModel, true)
+        XCTAssertEqual(request.lmTopK, 50)
+        XCTAssertEqual(request.lmTopP, 0.85)
+        XCTAssertEqual(request.bpm, 118)
+        XCTAssertEqual(request.keyscale, "D major")
+        XCTAssertEqual(request.metadataLanguage, "en")
+        XCTAssertEqual(request.timeSignature, "4")
+        XCTAssertEqual(request.vocalLanguage, "en")
+        XCTAssertEqual(request.referenceAudioPaths, ["/tmp/ref.wav"])
+        XCTAssertEqual(request.audioCoverStrength, 0.75)
+        XCTAssertEqual(request.coverNoiseStrength, 0.1)
+        XCTAssertEqual(request.completeTrackClasses, ["Drums", "Bass"])
+        XCTAssertEqual(request.chunkMaskMode, .explicit)
+        XCTAssertEqual(request.repaintMode, .conservative)
+        XCTAssertEqual(request.repaintStrength, 0.25)
+        XCTAssertEqual(request.useTiledVAEDecode, true)
+        XCTAssertEqual(request.vaeChunkSize, 256)
+        XCTAssertEqual(request.vaeOverlap, 32)
+        XCTAssertEqual(request.responseFormat, "wav")
+    }
+
+    func testHighQualityWAVFormatsHaveTruthfulHeadersAndSizes() throws {
+        let audio = MLXArray([
+            Float(0.25), Float(-0.25),
+            Float(0.5), Float(-0.5),
+            Float(0.75), Float(-0.75),
+        ], [1, 3, 2])
+
+        for (format, bits, bytesPerSample) in [
+            (ACEStepAudioFormat.pcm16, UInt16(16), 2),
+            (.pcm24, UInt16(24), 3),
+            (.float32, UInt16(32), 4),
+        ] {
+            let data = try ACEStepWAVWriter.wavData(
+                audio,
+                sampleRate: 48_000,
+                options: .init(
+                    format: format,
+                    normalization: .none,
+                    targetPeakDB: -1,
+                    fadeInMilliseconds: 0,
+                    fadeOutMilliseconds: 0,
+                    dither: false
+                )
+            )
+            XCTAssertEqual(String(data: data[0..<4], encoding: .utf8), "RIFF")
+            XCTAssertEqual(readUInt16(data, offset: 34), bits)
+            XCTAssertEqual(data.count, 44 + 6 * bytesPerSample)
+        }
+    }
+
+    func testDAWBundleContainsPortableAudioRecipeMarkersAndProject() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        let mixURL = root.appendingPathComponent("source.wav")
+        let recipeURL = root.appendingPathComponent("source.recipe.json")
+        let lrcURL = root.appendingPathComponent("source.lrc")
+        let audio = MLXArray(
+            [Float](repeating: 0.1, count: 960),
+            [1, 480, 2]
+        )
+        try ACEStepWAVWriter.writeWAV(
+            audio,
+            to: mixURL,
+            sampleRate: 48_000
+        )
+        try Data("{}".utf8).write(to: recipeURL)
+        let lrc = ACEStepLRCDocument(
+            lines: [.init(timestampSeconds: 0, text: "hello")]
+        )
+        try lrc.rendered().write(
+            to: lrcURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        let bundleURL = root.appendingPathComponent("bundle", isDirectory: true)
+
+        try ACEStepDAWBundleWriter.write(
+            directory: bundleURL,
+            mixURL: mixURL,
+            recipeURL: recipeURL,
+            lrcURL: lrcURL,
+            candidates: [.init(name: "Candidate 1", audio: audio)],
+            stems: [.init(name: "Drums", audio: audio)],
+            lrc: lrc,
+            exportOptions: .init()
+        )
+
+        for path in [
+            "audio/mix.wav",
+            "audio/candidate-1-candidate-1.wav",
+            "audio/stem-1-drums.wav",
+            "recipe.json",
+            "lyrics.lrc",
+            "markers.csv",
+            "mere-run-session.rpp",
+            "README.md",
+        ] {
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: bundleURL.appendingPathComponent(path).path
+                ),
+                path
+            )
+        }
+    }
+
+    private func readUInt16(_ data: Data, offset: Int) -> UInt16 {
+        UInt16(data[offset]) | UInt16(data[offset + 1]) << 8
+    }
+}

--- a/Tests/MereRunCoreTests/ACEStepAdapterTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepAdapterTests.swift
@@ -1,0 +1,184 @@
+import MLX
+import MLXRandom
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepAdapterTests: MereRunCoreTestCase {
+    func testLoKrFactorizationMatchesLyCORISRules() {
+        XCTAssertEqual(
+            ACEStepAdapterTrainer.factorization(128, factor: -1).0,
+            8
+        )
+        XCTAssertEqual(
+            ACEStepAdapterTrainer.factorization(128, factor: -1).1,
+            16
+        )
+        XCTAssertEqual(
+            ACEStepAdapterTrainer.factorization(360, factor: 8).0,
+            8
+        )
+        XCTAssertEqual(
+            ACEStepAdapterTrainer.factorization(360, factor: 8).1,
+            45
+        )
+    }
+
+    func testTrainingFlowMatchingObjectiveMatchesUpstream() {
+        let clean = MLXArray([Float(2), Float(4)], [1, 1, 2])
+        let noise = MLXArray([Float(10), Float(20)], [1, 1, 2])
+        let sample = ACEStepAdapterTrainer.flowMatchingSample(
+            clean: clean,
+            noise: noise,
+            timestep: MLXArray([Float(0.25)])
+        )
+
+        MLX.eval(sample.noisy, sample.target)
+        XCTAssertEqual(sample.noisy.asArray(Float.self), [4, 8])
+        XCTAssertEqual(sample.target.asArray(Float.self), [8, 16])
+    }
+
+    func testPEFTLoRAChangesOnlyMatchedProjection() throws {
+        let directory = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        MLXRandom.seed(12)
+        let model = ACEStepDiT(config: tinyConfig)
+        let input = MLXRandom.normal([1, 3, 32]).asType(.float32)
+        let original = model.layers[0].selfAttn.qProj(input)
+        let down = MLXArray.ones([2, 32], dtype: .float32) * 0.02
+        let up = MLXArray.ones([32, 2], dtype: .float32) * 0.03
+        let adapterURL = directory
+            .appendingPathComponent("ace-lora.safetensors")
+        try MLX.save(
+            arrays: [
+                "base_model.model.decoder.layers.0.self_attn.q_proj.lora_A.default.weight": down,
+                "base_model.model.decoder.layers.0.self_attn.q_proj.lora_B.default.weight": up,
+            ],
+            metadata: ["lora_alpha": "4"],
+            url: adapterURL
+        )
+
+        let report = try ACEStepAdapterLoader.load(
+            from: adapterURL,
+            kind: .auto,
+            scale: 0.5,
+            into: model
+        )
+        let actual = model.layers[0].selfAttn.qProj(input)
+        let expected = original
+            + MLX.matmul(MLX.matmul(input, down.T), up.T)
+
+        MLX.eval(actual, expected)
+        XCTAssertEqual(report.kind, ACEStepAdapterKind.lora)
+        XCTAssertEqual(report.matchedLayers, ["layers.0.self_attn.q_proj"])
+        XCTAssertLessThan(
+            MLX.max(MLX.abs(actual - expected)).item(Float.self),
+            1e-6
+        )
+    }
+
+    func testLyCORISLoKRDecomposedFactorsAndAlpha() throws {
+        let directory = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        MLXRandom.seed(14)
+        let model = ACEStepDiT(config: tinyConfig)
+        let input = MLXRandom.normal([1, 2, 32]).asType(.float32)
+        let original = model.layers[0].crossAttn.vProj(input)
+        let w1 = MLXArray.ones([4, 4], dtype: .float32) * 0.01
+        let w2A = MLXArray.ones([8, 2], dtype: .float32) * 0.02
+        let w2B = MLXArray.ones([2, 8], dtype: .float32) * 0.03
+        let delta = MLX.kron(w1, MLX.matmul(w2A, w2B))
+        let adapterURL = directory
+            .appendingPathComponent("ace-lokr.safetensors")
+        let key = "lycoris_layers_0_cross_attn_v_proj"
+        try MLX.save(
+            arrays: [
+                "\(key).lokr_w1": w1,
+                "\(key).lokr_w2_a": w2A,
+                "\(key).lokr_w2_b": w2B,
+                "\(key).alpha": MLXArray(Float(4)),
+            ],
+            metadata: ["algo": "lokr", "format": "lycoris"],
+            url: adapterURL
+        )
+
+        let report = try ACEStepAdapterLoader.load(
+            from: adapterURL,
+            kind: .auto,
+            scale: 0.25,
+            into: model
+        )
+        let actual = model.layers[0].crossAttn.vProj(input)
+        let expected = original
+            + MLX.matmul(input, delta.T) * MLXArray(Float(0.5))
+
+        MLX.eval(actual, expected)
+        XCTAssertEqual(report.kind, ACEStepAdapterKind.lokr)
+        XCTAssertEqual(report.matchedLayers, ["layers.0.cross_attn.v_proj"])
+        XCTAssertLessThan(
+            MLX.max(MLX.abs(actual - expected)).item(Float.self),
+            1e-6
+        )
+    }
+
+    func testAdaptersStackOnOneProjection() throws {
+        let directory = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        MLXRandom.seed(16)
+        let model = ACEStepDiT(config: tinyConfig)
+        let input = MLXRandom.normal([1, 2, 32]).asType(.float32)
+        let original = model.layers[0].selfAttn.oProj(input)
+        let down = MLXArray.ones([1, 32], dtype: .float32) * 0.01
+        let up = MLXArray.ones([32, 1], dtype: .float32) * 0.02
+        let adapterURL = directory
+            .appendingPathComponent("stacked-lora.safetensors")
+        try MLX.save(
+            arrays: [
+                "layers.0.self_attn.o_proj.lora_down.weight": down,
+                "layers.0.self_attn.o_proj.lora_up.weight": up,
+            ],
+            url: adapterURL
+        )
+
+        _ = try ACEStepAdapterLoader.load(
+            from: adapterURL,
+            kind: .lora,
+            scale: 1,
+            into: model
+        )
+        _ = try ACEStepAdapterLoader.load(
+            from: adapterURL,
+            kind: .lora,
+            scale: 0.5,
+            into: model
+        )
+        let actual = model.layers[0].selfAttn.oProj(input)
+        let contribution = MLX.matmul(
+            MLX.matmul(input, down.T),
+            up.T
+        )
+        let expected = original + contribution * MLXArray(Float(1.5))
+
+        MLX.eval(actual, expected)
+        XCTAssertLessThan(
+            MLX.max(MLX.abs(actual - expected)).item(Float.self),
+            1e-6
+        )
+    }
+
+    private var tinyConfig: ACEStepConfig {
+        ACEStepConfig(
+            hiddenSize: 32,
+            intermediateSize: 64,
+            numHiddenLayers: 1,
+            numAttentionHeads: 4,
+            numKeyValueHeads: 4,
+            encoderHiddenSize: 32,
+            encoderIntermediateSize: 64,
+            encoderNumAttentionHeads: 4,
+            encoderNumKeyValueHeads: 4,
+            headDim: 8,
+            audioAcousticHiddenDim: 4,
+            inChannels: 12
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/ACEStepMusicUnderstandingTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepMusicUnderstandingTests.swift
@@ -60,4 +60,20 @@ final class ACEStepMusicUnderstandingTests: MereRunCoreTestCase {
         XCTAssertNil(metadata.language)
         XCTAssertNil(metadata.timesignature)
     }
+
+    func testParseUnderstandingOutputAcceptsOnlyOneUpstreamLanguageCode() {
+        let valid = ACEStepPipeline.parseUnderstandingOutput(
+            "<think>\nlanguage: EN\n</think>"
+        )
+        let multiple = ACEStepPipeline.parseUnderstandingOutput(
+            "<think>\nlanguage: en, ja, ko\n</think>"
+        )
+        let unsupported = ACEStepPipeline.parseUnderstandingOutput(
+            "<think>\nlanguage: zxx\n</think>"
+        )
+
+        XCTAssertEqual(valid.language, "en")
+        XCTAssertNil(multiple.language)
+        XCTAssertNil(unsupported.language)
+    }
 }

--- a/Tests/MereRunCoreTests/ACEStepParityDumpTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepParityDumpTests.swift
@@ -89,7 +89,7 @@ final class ACEStepParityDumpTests: MereRunCoreTestCase {
             audioCoverStrength: 0.85,
             vocalLanguage: ACEStepPipeline.defaultVocalLanguage,
             instruction: instruction,
-            isCover: true
+            task: .cover
         )
         try dumpTensor(inputs.textHiddenStates, name: "swift_condition_text_hidden_bld_f32", to: outputURL)
         try dumpTensor(inputs.textAttentionMask.asType(DType.float32), name: "swift_condition_text_mask_f32", to: outputURL)
@@ -285,6 +285,141 @@ final class ACEStepParityDumpTests: MereRunCoreTestCase {
         ).asType(.float32)
 
         try dumpTensor(output, name: "swift_dit_fixture_output_btc_f32", to: outputURL)
+    }
+
+    func testDumpConditionEncoderFixture() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let outputRoot = env["MERERUN_PARITY_DUMP_DIR"], !outputRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_PARITY_DUMP_DIR=/tmp/acestep-condition-parity.")
+        }
+        guard let decoderRoot = env["MERERUN_TEST_ACESTEP_DECODER_ROOT"], !decoderRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_DECODER_ROOT=/path/to/acestep-v15-turbo.")
+        }
+
+        let outputURL = URL(fileURLWithPath: outputRoot)
+        let textURL = outputURL.appendingPathComponent("condition_text_f32.raw")
+        let lyricsURL = outputURL.appendingPathComponent("condition_lyrics_f32.raw")
+        let referenceURL = outputURL.appendingPathComponent("condition_refer_f32.raw")
+        for fixtureURL in [textURL, lyricsURL, referenceURL] {
+            guard FileManager.default.fileExists(atPath: fixtureURL.path) else {
+                throw XCTSkip("Missing condition fixture: \(fixtureURL.path)")
+            }
+        }
+
+        let resources = ACEStepResources(rootURL: URL(fileURLWithPath: decoderRoot))
+        let config = try ACEStepCheckpointLoader.loadConfig(resources: resources)
+        let bundle = try ACEStepCheckpointLoader.loadTurboBundle(resources: resources, dtype: .float32)
+
+        let text = MLXArray(
+            try readFloats(from: textURL),
+            [1, 3, config.textHiddenDim]
+        ).asType(.float32)
+        let lyrics = MLXArray(
+            try readFloats(from: lyricsURL),
+            [1, 4, config.textHiddenDim]
+        ).asType(.float32)
+        let reference = MLXArray(
+            try readFloats(from: referenceURL),
+            [1, 5, config.timbreHiddenDim]
+        ).asType(.float32)
+
+        let result = bundle.encoder(
+            textHiddenStates: text,
+            textAttentionMask: MLXArray([Int32(1), 1, 0], [1, 3]),
+            lyricHiddenStates: lyrics,
+            lyricAttentionMask: MLXArray([Int32(1), 1, 1, 0], [1, 4]),
+            referAudioAcousticHiddenStatesPacked: reference,
+            referAudioOrderMask: MLXArray([Int32(0)])
+        )
+        try dumpTensor(result.hiddenStates, name: "swift_condition_hidden_f32", to: outputURL)
+        try writeInt32(
+            result.attentionMask.asType(.int32).reshaped(-1).asArray(Int32.self),
+            to: outputURL.appendingPathComponent("swift_condition_mask_i32.raw")
+        )
+    }
+
+    func testDumpQwenTextEncoderFixture() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let outputRoot = env["MERERUN_PARITY_DUMP_DIR"], !outputRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_PARITY_DUMP_DIR=/tmp/acestep-qwen-parity.")
+        }
+        guard let textRoot = env["MERERUN_TEST_ACESTEP_TEXT_ROOT"], !textRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_TEXT_ROOT=/path/to/Qwen3-Embedding-0.6B.")
+        }
+
+        let resources = ACEStep5HzLMResources(rootURL: URL(fileURLWithPath: textRoot))
+        let data = try Data(contentsOf: resources.configURL)
+        let textConfig = try JSONDecoder().decode(ACEStep5HzLMConfig.self, from: data)
+        let qwenConfig = QwenTextEncoderConfiguration(
+            vocabSize: textConfig.vocabSize,
+            hiddenSize: textConfig.hiddenSize,
+            numHiddenLayers: textConfig.numHiddenLayers,
+            numAttentionHeads: textConfig.numAttentionHeads,
+            numKeyValueHeads: textConfig.numKeyValueHeads,
+            intermediateSize: textConfig.intermediateSize,
+            ropeTheta: textConfig.ropeTheta,
+            maxPositionEmbeddings: textConfig.maxPositionEmbeddings,
+            rmsNormEps: textConfig.rmsNormEps,
+            promptDropIndex: 0,
+            headDim: textConfig.headDim,
+            mropeSection: nil,
+            mropeInterleaved: false,
+            useFloat32Activations: true
+        )
+        let encoder = QwenEncoder(configuration: qwenConfig)
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.weightsIndexURL,
+            singleURL: resources.weightsURL,
+            to: encoder,
+            dtype: .float32,
+            verify: .noUnusedKeys,
+            mapper: QwenEncoder.mapHFSafetensorWeight
+        )
+
+        let inputIDs = MLXArray(
+            [Int32(151_643), 9_707, 374, 264, 1_296, 13, 151_645, 151_643],
+            [1, 8]
+        )
+        let attentionMask = MLXArray(
+            [Int32(1), 1, 1, 1, 1, 1, 1, 0],
+            [1, 8]
+        )
+        let hidden = encoder.forward(
+            inputIds: inputIDs,
+            attentionMask: attentionMask
+        ).lastHiddenState
+        let embedding = encoder.embed(inputIds: inputIDs)
+        let outputURL = URL(fileURLWithPath: outputRoot)
+        try dumpTensor(hidden, name: "swift_qwen_hidden_f32", to: outputURL)
+        try dumpTensor(embedding, name: "swift_qwen_embed_f32", to: outputURL)
+    }
+
+    func testDumpFSQDetokenizerFixture() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let outputRoot = env["MERERUN_PARITY_DUMP_DIR"], !outputRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_PARITY_DUMP_DIR=/tmp/acestep-fsq-parity.")
+        }
+        guard let decoderRoot = env["MERERUN_TEST_ACESTEP_DECODER_ROOT"], !decoderRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_DECODER_ROOT=/path/to/acestep-v15-turbo.")
+        }
+
+        let resources = ACEStepResources(rootURL: URL(fileURLWithPath: decoderRoot))
+        let bundle = try ACEStepCheckpointLoader.loadTurboBundle(
+            resources: resources,
+            dtype: .float32
+        )
+        let codes = MLXArray(
+            [Int32(100), 1_234, 50_000, 63_999],
+            [1, 4, 1]
+        )
+        let quantized = bundle.tokenizer.quantizer.getOutputFromIndices(
+            codes,
+            dtype: .float32
+        )
+        let detokenized = bundle.detokenizer(quantized)
+        let outputURL = URL(fileURLWithPath: outputRoot)
+        try dumpTensor(quantized, name: "swift_fsq_quantized_f32", to: outputURL)
+        try dumpTensor(detokenized, name: "swift_fsq_detokenized_f32", to: outputURL)
     }
 
     func testDumpSourceAudioAndVAELatents() throws {

--- a/Tests/MereRunCoreTests/ACEStepPipelineIntegrationTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepPipelineIntegrationTests.swift
@@ -4,6 +4,168 @@ import XCTest
 @testable import MereRunCore
 
 final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
+    func testInstalledVAERoundTripPreservesStructuredAudio() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let vaeRoot = env["MERERUN_TEST_ACESTEP_VAE_ROOT"], !vaeRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_VAE_ROOT to run the real VAE round-trip test.")
+        }
+
+        let resources = OobleckVAEResources(rootURL: URL(fileURLWithPath: vaeRoot))
+        let config = try OobleckVAECheckpointLoader.loadConfig(resources: resources)
+        let hopLength = config.downsamplingRatios.reduce(1, *)
+        let sampleCount = config.samplingRate
+        XCTAssertEqual(sampleCount % hopLength, 0)
+
+        var sourceSamples: [Float] = []
+        sourceSamples.reserveCapacity(sampleCount * config.audioChannels)
+        for sampleIndex in 0..<sampleCount {
+            let time = Double(sampleIndex) / Double(config.samplingRate)
+            let envelope = min(1, time * 20) * min(1, (1 - time) * 20)
+            let pulse = (sampleIndex % (config.samplingRate / 8)) < 120 ? 0.12 : 0
+            let left = envelope * (
+                0.22 * sin(2 * Double.pi * 220 * time)
+                    + 0.12 * sin(2 * Double.pi * 440 * time)
+                    + pulse
+            )
+            let right = envelope * (
+                0.20 * sin(2 * Double.pi * 330 * time)
+                    + 0.10 * sin(2 * Double.pi * 660 * time)
+                    + pulse
+            )
+            sourceSamples.append(Float(left))
+            sourceSamples.append(Float(right))
+        }
+
+        let source = MLXArray(sourceSamples, [1, sampleCount, config.audioChannels]).asType(.float32)
+        let vae = try OobleckVAECheckpointLoader.loadVAE(resources: resources, dtype: .float32)
+        let latents = vae.encode(source, sample: false).asType(.float32)
+        let reconstructed = vae.decode(latents).asType(.float32)
+        MLX.eval(latents, reconstructed)
+
+        XCTAssertEqual(latents.shape, [1, sampleCount / hopLength, config.decoderInputChannels])
+        XCTAssertEqual(reconstructed.shape, source.shape)
+
+        let reconstructedSamples = reconstructed.asArray(Float.self)
+        let correlation = normalizedCorrelation(sourceSamples, reconstructedSamples)
+        let normalizedError = normalizedMeanSquaredError(sourceSamples, reconstructedSamples)
+
+        XCTAssertGreaterThan(
+            correlation,
+            0.2,
+            "VAE round-trip lost source structure: correlation=\(correlation), normalizedMSE=\(normalizedError)"
+        )
+        XCTAssertLessThan(
+            normalizedError,
+            4,
+            "VAE round-trip behaves like unrelated noise: correlation=\(correlation), normalizedMSE=\(normalizedError)"
+        )
+    }
+
+    func testNonTurboXLSFTEndToEndWithAPGAndHeun() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let decoderRoot = env["MERERUN_TEST_ACESTEP_XL_SFT_ROOT"],
+              !decoderRoot.isEmpty
+        else {
+            throw XCTSkip(
+                "Set MERERUN_TEST_ACESTEP_XL_SFT_ROOT to run the non-Turbo XL-SFT test."
+            )
+        }
+        guard let vaeRoot = env["MERERUN_TEST_ACESTEP_VAE_ROOT"], !vaeRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_VAE_ROOT to run this test.")
+        }
+
+        let pipeline = try ACEStepPipeline(
+            decoderResources: ACEStepResources(
+                rootURL: URL(fileURLWithPath: decoderRoot)
+            ),
+            vaeResources: OobleckVAEResources(
+                rootURL: URL(fileURLWithPath: vaeRoot)
+            )
+        )
+
+        XCTAssertEqual(pipeline.checkpointVariant, .xlSFT)
+        let audio = try pipeline.generatePromptToAudio(
+            caption: "tight electronic drum groove, instrumental",
+            lyrics: "",
+            config: .init(
+                durationSeconds: 0.4,
+                fixNFE: 2,
+                shift: 1,
+                samplerMode: .heun,
+                guidanceScale: 2,
+                guidanceMode: .apg,
+                velocityNormThreshold: 2,
+                velocityEMAFactor: 0.1,
+                useTiledVaeDecode: false,
+                seed: 42
+            )
+        )
+        MLX.eval(audio)
+
+        XCTAssertEqual(audio.shape, [1, 19_200, 2])
+        let maxAbs = MLX.max(MLX.abs(audio.asType(.float32))).item(Float.self)
+        XCTAssertTrue(maxAbs.isFinite)
+        XCTAssertGreaterThan(maxAbs, 0)
+    }
+
+    func testRepaintTurboPreservesSourceWaveformOutsideRequestedRange() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let turboRoot = env["MERERUN_TEST_ACESTEP_TURBO_ROOT"], !turboRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_TURBO_ROOT to run this test.")
+        }
+        guard let vaeRoot = env["MERERUN_TEST_ACESTEP_VAE_ROOT"], !vaeRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_VAE_ROOT to run this test.")
+        }
+        guard let textRoot = env["MERERUN_TEST_ACESTEP_TEXT_ROOT"], !textRoot.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_TEXT_ROOT to run this test.")
+        }
+
+        let pipeline = try ACEStepPipeline(
+            decoderResources: ACEStepResources(rootURL: URL(fileURLWithPath: turboRoot)),
+            vaeResources: OobleckVAEResources(rootURL: URL(fileURLWithPath: vaeRoot)),
+            textEncoderResources: ACEStep5HzLMResources(rootURL: URL(fileURLWithPath: textRoot))
+        )
+
+        let durationSeconds: Float = 0.4
+        let sampleCount = Int(durationSeconds * 48_000)
+        var samples: [Float] = []
+        samples.reserveCapacity(sampleCount * 2)
+        for sample in 0..<sampleCount {
+            let value = Float(sin(2 * Double.pi * 220 * Double(sample) / 48_000)) * 0.1
+            samples.append(value)
+            samples.append(value)
+        }
+        let source = MLXArray(samples, [1, sampleCount, 2])
+        let output = try pipeline.generatePromptToAudio(
+            caption: "replace the middle with a bright synth fill",
+            lyrics: "",
+            config: .init(
+                durationSeconds: durationSeconds,
+                fixNFE: 2,
+                useTiledVaeDecode: false,
+                seed: 404
+            ),
+            sourceAudio48kHz: source,
+            task: .repaint,
+            repaintConfiguration: .init(
+                startSeconds: 0.12,
+                endSeconds: 0.28,
+                mode: .conservative
+            )
+        )
+        MLX.eval(output)
+
+        XCTAssertEqual(output.shape, source.shape)
+        let outputValues = output.asArray(Float.self)
+        let preservedHeadSamples = Int(0.05 * 48_000) * 2
+        for index in 0..<preservedHeadSamples {
+            XCTAssertEqual(outputValues[index], samples[index], accuracy: 0.000_001)
+        }
+        let preservedTailStart = Int(0.35 * 48_000) * 2
+        for index in preservedTailStart..<samples.count {
+            XCTAssertEqual(outputValues[index], samples[index], accuracy: 0.000_001)
+        }
+    }
 
     func testUnconditionalTurboEndToEnd() throws {
         let env = ProcessInfo.processInfo.environment
@@ -64,8 +226,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             caption: "upbeat electronic groove.",
             lyrics: "[verse]\nla la la",
             config: .init(durationSeconds: durationSeconds, seed: 11),
-            lmUserMetadata: .init(bpm: "120", duration: "10", keyscale: "C major", timesignature: "4"),
-            isCover: false
+            lmUserMetadata: .init(bpm: "120", duration: "10", keyscale: "C major", timesignature: "4")
         )
 
         XCTAssertEqual(audio.dim(0), 1)
@@ -171,7 +332,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             lmUserMetadata: .init(bpm: "80", duration: "12", keyscale: "C minor", language: "en", timesignature: "4"),
             vocalLanguage: "en",
             instruction: "Fill the audio semantic mask based on the given conditions",
-            isCover: true
+            task: .cover
         )
 
         XCTAssertGreaterThan(inputs.textHiddenStates.dim(1), 1)
@@ -222,7 +383,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             audioCoverStrength: 1.0,
             vocalLanguage: "en",
             instruction: "Use this custom instruction for cover conditioning",
-            isCover: true
+            task: .cover
         )
         XCTAssertNil(fullCoverInputs.nonCoverTextHiddenStates)
         XCTAssertNil(fullCoverInputs.nonCoverTextAttentionMask)
@@ -236,7 +397,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             audioCoverStrength: 0.5,
             vocalLanguage: "en",
             instruction: "Use this custom instruction for cover conditioning",
-            isCover: true
+            task: .cover
         )
 
         guard
@@ -308,7 +469,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             referenceTimbreLatents25Hz: [referenceA, referenceB],
             vocalLanguage: "en",
             instruction: "Fill the audio semantic mask based on the given conditions",
-            isCover: true
+            task: .cover
         )
 
         XCTAssertEqual(inputs.referAudioAcousticHiddenStatesPacked.dim(0), 2)
@@ -361,7 +522,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             referenceTimbreAudio48kHz: [monoWave, channelFirstStereoWave],
             vocalLanguage: "en",
             instruction: "Fill the audio semantic mask based on the given conditions",
-            isCover: true
+            task: .cover
         )
 
         XCTAssertEqual(inputs.referAudioAcousticHiddenStatesPacked.dim(0), 2)
@@ -419,7 +580,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             audioCoverStrength: 0.5,
             vocalLanguage: "en",
             instruction: "Strong cover conditioning instruction",
-            isCover: true
+            task: .cover
         )
 
         XCTAssertEqual(audio.dim(0), 1)
@@ -470,7 +631,7 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
             config: .init(durationSeconds: durationSeconds, seed: 91),
             sourceAudio48kHz: sourceAudio,
             audioCoverStrength: 0.8,
-            isCover: true
+            task: .cover
         )
 
         XCTAssertEqual(audio.dim(0), 1)
@@ -481,5 +642,37 @@ final class ACEStepPipelineIntegrationTests: MereRunCoreTestCase {
         XCTAssertFalse(maxAbs.isNaN)
         XCTAssertFalse(maxAbs.isInfinite)
         XCTAssertGreaterThan(maxAbs, 0)
+    }
+
+    private func normalizedCorrelation(_ lhs: [Float], _ rhs: [Float]) -> Double {
+        precondition(lhs.count == rhs.count)
+        let count = Double(lhs.count)
+        let lhsMean = lhs.reduce(0) { $0 + Double($1) } / count
+        let rhsMean = rhs.reduce(0) { $0 + Double($1) } / count
+
+        var covariance = 0.0
+        var lhsVariance = 0.0
+        var rhsVariance = 0.0
+        for index in lhs.indices {
+            let lhsCentered = Double(lhs[index]) - lhsMean
+            let rhsCentered = Double(rhs[index]) - rhsMean
+            covariance += lhsCentered * rhsCentered
+            lhsVariance += lhsCentered * lhsCentered
+            rhsVariance += rhsCentered * rhsCentered
+        }
+        return covariance / sqrt(max(lhsVariance * rhsVariance, Double.leastNonzeroMagnitude))
+    }
+
+    private func normalizedMeanSquaredError(_ lhs: [Float], _ rhs: [Float]) -> Double {
+        precondition(lhs.count == rhs.count)
+        var squaredError = 0.0
+        var sourceEnergy = 0.0
+        for index in lhs.indices {
+            let source = Double(lhs[index])
+            let difference = source - Double(rhs[index])
+            squaredError += difference * difference
+            sourceEnergy += source * source
+        }
+        return squaredError / max(sourceEnergy, Double.leastNonzeroMagnitude)
     }
 }

--- a/Tests/MereRunCoreTests/ACEStepTaskAndRepaintTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepTaskAndRepaintTests.swift
@@ -1,0 +1,603 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepTaskAndRepaintTests: MereRunCoreTestCase {
+    func testCandidateScoringRejectsSilenceClippingAndNonFiniteAudio() {
+        let healthy = (0..<4_800).map { index in
+            Float(sin(Double(index) * 2 * .pi * 440 / 48_000)) * 0.2
+        }
+        let silent = [Float](repeating: 0, count: 4_800)
+        let clipped = [Float](repeating: 1, count: 4_800)
+        var nonFinite = healthy
+        nonFinite[0] = .nan
+        nonFinite[1] = .infinity
+
+        let healthyResult = ACEStepCandidateScorer.evaluate(MLXArray(healthy))
+        let silentResult = ACEStepCandidateScorer.evaluate(MLXArray(silent))
+        let clippedResult = ACEStepCandidateScorer.evaluate(MLXArray(clipped))
+        let nonFiniteResult = ACEStepCandidateScorer.evaluate(MLXArray(nonFinite))
+
+        XCTAssertGreaterThan(healthyResult.score, silentResult.score)
+        XCTAssertGreaterThan(healthyResult.score, clippedResult.score)
+        XCTAssertLessThan(nonFiniteResult.metrics.finiteRatio, 1)
+        XCTAssertTrue(healthyResult.score.isFinite)
+    }
+
+    func testCandidateScoringPenalizesStationaryBroadbandNoise() {
+        let sampleCount = 48_000
+        var state: UInt64 = 0x9e37_79b9_7f4a_7c15
+        var noise: [Float] = []
+        var structured: [Float] = []
+        noise.reserveCapacity(sampleCount)
+        structured.reserveCapacity(sampleCount)
+        for index in 0..<sampleCount {
+            state = state &* 6_364_136_223_846_793_005 &+ 1
+            let random = Float((state >> 40) & 0xFF_FFFF)
+                / Float(0xFF_FFFF)
+            noise.append((random * 2 - 1) * 0.2)
+
+            let time = Double(index) / 48_000
+            let noteIndex = Int(time * 8) % 4
+            let fundamental = [165.0, 220.0, 277.18, 330.0][noteIndex]
+            let beatEnvelope = 0.35 + 0.65
+                * max(0, sin(2 * Double.pi * 4 * time))
+            let tonal = 0.16 * sin(2 * Double.pi * fundamental * time)
+                + 0.08 * sin(2 * Double.pi * fundamental * 2 * time)
+            structured.append(Float(beatEnvelope * tonal))
+        }
+
+        let noiseResult = ACEStepCandidateScorer.evaluate(MLXArray(noise))
+        let structuredResult = ACEStepCandidateScorer.evaluate(
+            MLXArray(structured)
+        )
+        var truncated = structured
+        truncated.replaceSubrange(
+            (sampleCount * 3 / 4)..<sampleCount,
+            with: repeatElement(0, count: sampleCount / 4)
+        )
+        let truncatedResult = ACEStepCandidateScorer.evaluate(
+            MLXArray(truncated)
+        )
+
+        XCTAssertGreaterThan(structuredResult.score, noiseResult.score + 10)
+        XCTAssertGreaterThan(
+            structuredResult.score,
+            truncatedResult.score + 3
+        )
+        XCTAssertLessThan(
+            structuredResult.metrics.spectralFlatness ?? 1,
+            noiseResult.metrics.spectralFlatness ?? 0
+        )
+        XCTAssertGreaterThan(
+            structuredResult.metrics.periodicity ?? 0,
+            noiseResult.metrics.periodicity ?? 1
+        )
+        XCTAssertGreaterThan(
+            structuredResult.metrics.temporalSpectralVariation ?? 0,
+            noiseResult.metrics.temporalSpectralVariation ?? 1
+        )
+        XCTAssertGreaterThan(
+            structuredResult.metrics.tailEnergyRatio ?? 0,
+            0.5
+        )
+        XCTAssertLessThan(
+            truncatedResult.metrics.tailEnergyRatio ?? 1,
+            0.02
+        )
+    }
+
+    func testCandidateRankingIsScoreDescendingAndStableByIndex() {
+        let audio = MLXArray([Float](repeating: 0, count: 2))
+        let metrics = ACEStepCandidateScorer.evaluate(audio).metrics
+        let ranked = ACEStepCandidateScorer.rank([
+            .init(index: 2, seed: 12, audio: audio, score: 50, metrics: metrics),
+            .init(index: 1, seed: 11, audio: audio, score: 80, metrics: metrics),
+            .init(index: 0, seed: 10, audio: audio, score: 80, metrics: metrics),
+        ])
+
+        XCTAssertEqual(ranked.map(\.index), [0, 1, 2])
+    }
+
+    func testRetakeNoiseInterpolationMatchesUpstreamEndpointsAndMidpoint() {
+        let primary = MLXArray([Float(1), 0, -1])
+        let retake = MLXArray([Float(0), 1, 0.5])
+
+        XCTAssertEqual(
+            ACEStepPipeline.blendRetakeNoise(
+                primary: primary,
+                retake: retake,
+                variance: 0
+            ).asArray(Float.self),
+            primary.asArray(Float.self)
+        )
+        XCTAssertEqual(
+            ACEStepPipeline.blendRetakeNoise(
+                primary: primary,
+                retake: retake,
+                variance: 1
+            ).asArray(Float.self),
+            retake.asArray(Float.self)
+        )
+
+        let midpoint = ACEStepPipeline.blendRetakeNoise(
+            primary: primary,
+            retake: retake,
+            variance: 0.5
+        ).asArray(Float.self)
+        let scale = Float(sqrt(0.5))
+        XCTAssertEqual(midpoint[0], scale, accuracy: 0.000_001)
+        XCTAssertEqual(midpoint[1], scale, accuracy: 0.000_001)
+        XCTAssertEqual(midpoint[2], -0.5 * scale, accuracy: 0.000_001)
+    }
+
+    func testFlowEditWindowAndVelocityDeltaMatchUpstream() throws {
+        let configuration = ACEStepFlowEditConfiguration(
+            sourceCaption: "acoustic folk demo",
+            nMin: 0.2,
+            nMax: 0.8,
+            nAverage: 3,
+            retakeSeed: 99
+        )
+        XCTAssertNoThrow(try configuration.validate())
+        let window = ACEStepFlowEdit.windowIndices(
+            stepCount: 50,
+            nMin: configuration.nMin,
+            nMax: configuration.nMax
+        )
+        XCTAssertEqual(window.minimum, 10)
+        XCTAssertEqual(window.maximum, 40)
+
+        let edited = MLXArray([Float(1), 2, 3])
+        let sourceVelocity = MLXArray([Float(2), 4, 6])
+        let targetVelocity = MLXArray([Float(3), 2, 10])
+        let result = ACEStepFlowEdit.integrateDelta(
+            editedLatents: edited,
+            sourceVelocity: sourceVelocity,
+            targetVelocity: targetVelocity,
+            currentTimestep: 0.8,
+            nextTimestep: 0.6
+        ).asArray(Float.self)
+        XCTAssertEqual(result[0], 0.8, accuracy: 0.000_001)
+        XCTAssertEqual(result[1], 2.4, accuracy: 0.000_001)
+        XCTAssertEqual(result[2], 2.2, accuracy: 0.000_001)
+    }
+
+    func testFlowEditValidationRejectsInvalidWindowsAndAverages() {
+        XCTAssertThrowsError(
+            try ACEStepFlowEditConfiguration(
+                sourceCaption: "source",
+                nMin: 0.8,
+                nMax: 0.2
+            ).validate()
+        )
+        XCTAssertThrowsError(
+            try ACEStepFlowEditConfiguration(
+                sourceCaption: "source",
+                nAverage: 0
+            ).validate()
+        )
+    }
+
+    func testLRCParsingRenderingAndApproximateTiming() throws {
+        let document = try ACEStepLRCDocument.parse(
+            """
+            [ar:Test Artist]
+            [00:01.25]First line
+            [00:03.50][00:05.00]Repeat line
+            """
+        )
+        XCTAssertEqual(document.metadata["ar"], "Test Artist")
+        XCTAssertEqual(document.lines.count, 3)
+        XCTAssertEqual(document.lines[0].timestampSeconds, 1.25, accuracy: 0.001)
+        XCTAssertEqual(document.lyrics, "First line\nRepeat line\nRepeat line")
+        XCTAssertTrue(document.rendered().contains("[00:03.50]Repeat line"))
+
+        let approximate = ACEStepLRCDocument.approximate(
+            lyrics: "one\ntwo\nthree",
+            durationSeconds: 12
+        )
+        XCTAssertTrue(approximate.timingIsApproximate)
+        XCTAssertEqual(
+            approximate.lines.map(\.timestampSeconds),
+            [0, 4, 8]
+        )
+        XCTAssertTrue(approximate.rendered().contains("approximate line timing"))
+    }
+
+    func testContinuousSchedulerMatchesUpstreamBaseSchedule() {
+        XCTAssertEqual(
+            ACEStepContinuousScheduler(
+                inferenceSteps: 4,
+                shift: 1
+            ).timesteps,
+            [1, 0.75, 0.5, 0.25]
+        )
+
+        let shifted = ACEStepContinuousScheduler(
+            inferenceSteps: 4,
+            shift: 2
+        ).timesteps
+        XCTAssertEqual(shifted.count, 4)
+        XCTAssertEqual(shifted[0], 1, accuracy: 0.000_001)
+        XCTAssertEqual(shifted[1], 6.0 / 7.0, accuracy: 0.000_001)
+        XCTAssertEqual(shifted[2], 2.0 / 3.0, accuracy: 0.000_001)
+        XCTAssertEqual(shifted[3], 0.4, accuracy: 0.000_001)
+    }
+
+    func testContinuousSchedulerStripsTerminalZeroFromCustomTimesteps() {
+        XCTAssertEqual(
+            ACEStepContinuousScheduler(
+                inferenceSteps: 50,
+                shift: 1,
+                timesteps: [1, 0.5, 0]
+            ).timesteps,
+            [1, 0.5]
+        )
+    }
+
+    func testCFGMatchesUpstreamFormula() {
+        let conditional = MLXArray([Float(1), 3], [1, 1, 2])
+        let unconditional = MLXArray([Float(-1), 1], [1, 1, 2])
+        let guided = ACEStepGuidance.cfg(
+            conditional: conditional,
+            unconditional: unconditional,
+            scale: 2.5
+        )
+        MLX.eval(guided)
+
+        XCTAssertEqual(guided.asArray(Float.self), [4, 6])
+    }
+
+    func testAPGProjectionAndMomentumMatchUpstream() {
+        let conditional = MLXArray(
+            [
+                Float(1), 0,
+                0, 1,
+            ],
+            [1, 2, 2]
+        )
+        let unconditional = MLXArray(
+            [
+                Float(1), -1,
+                -1, 1,
+            ],
+            [1, 2, 2]
+        )
+        var runningAverage: MLXArray?
+
+        let first = ACEStepGuidance.apg(
+            conditional: conditional,
+            unconditional: unconditional,
+            scale: 2,
+            runningAverage: &runningAverage
+        )
+        let second = ACEStepGuidance.apg(
+            conditional: conditional,
+            unconditional: unconditional,
+            scale: 2,
+            runningAverage: &runningAverage
+        )
+        MLX.eval(first, second)
+
+        XCTAssertEqual(first.asArray(Float.self), [1, 1, 1, 1])
+        XCTAssertEqual(second.asArray(Float.self), [1, 0.25, 0.25, 1])
+    }
+
+    func testADGProducesFiniteVelocityWithUpstreamShape() {
+        let latents = MLXArray(
+            [
+                0.5, -0.5,
+                1.0, 0.25,
+            ],
+            [1, 2, 2]
+        )
+        let conditional = MLXArray(
+            [
+                0.1, 0.2,
+                -0.3, 0.4,
+            ],
+            [1, 2, 2]
+        )
+        let unconditional = MLXArray(
+            [
+                -0.2, 0.3,
+                0.2, -0.1,
+            ],
+            [1, 2, 2]
+        )
+        let guided = ACEStepGuidance.adg(
+            latents: latents,
+            conditional: conditional,
+            unconditional: unconditional,
+            sigma: 0.75,
+            scale: 7
+        )
+        MLX.eval(guided)
+
+        XCTAssertEqual(guided.shape, conditional.shape)
+        XCTAssertTrue(guided.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+
+    func testTaskCapabilityMatrixMatchesUpstream() throws {
+        for variant in [
+            ACEStepCheckpointVariant.turbo,
+            .sft,
+            .xlTurbo,
+            .xlSFT,
+        ] {
+            XCTAssertTrue(variant.supports(.textToMusic))
+            XCTAssertTrue(variant.supports(.repaint))
+            XCTAssertTrue(variant.supports(.cover))
+            XCTAssertTrue(variant.supports(.coverNoFSQ))
+            XCTAssertFalse(variant.supports(.extract))
+            XCTAssertFalse(variant.supports(.lego))
+            XCTAssertFalse(variant.supports(.complete))
+        }
+
+        for variant in [ACEStepCheckpointVariant.base, .xlBase] {
+            for task in ACEStepTask.allCases {
+                XCTAssertTrue(variant.supports(task), "\(variant) should support \(task)")
+            }
+        }
+
+        XCTAssertThrowsError(try ACEStepCheckpointVariant.xlTurbo.validate(.extract))
+        XCTAssertNoThrow(try ACEStepCheckpointVariant.xlBase.validate(.extract))
+    }
+
+    func testCheckpointInferenceDefaultsMatchOfficialModelFamilies() {
+        XCTAssertEqual(ACEStepCheckpointVariant.xlTurbo.defaultInferenceSteps, 8)
+        XCTAssertEqual(ACEStepCheckpointVariant.xlTurbo.defaultShift, 3)
+        XCTAssertEqual(ACEStepCheckpointVariant.xlTurbo.defaultGuidanceScale, 1)
+
+        XCTAssertEqual(ACEStepCheckpointVariant.xlSFT.defaultInferenceSteps, 50)
+        XCTAssertEqual(ACEStepCheckpointVariant.xlSFT.defaultShift, 1)
+        XCTAssertEqual(ACEStepCheckpointVariant.xlSFT.defaultGuidanceScale, 7)
+
+        XCTAssertEqual(ACEStepCheckpointVariant.xlBase.defaultInferenceSteps, 50)
+        XCTAssertEqual(ACEStepCheckpointVariant.xlBase.defaultShift, 1)
+        XCTAssertEqual(ACEStepCheckpointVariant.xlBase.defaultGuidanceScale, 7)
+    }
+
+    func testAdaptiveQualityPresetsScaleByCheckpointAndWorkflow() {
+        let turboDraft = ACEStepQualityPreset.draft.defaults(
+            for: .xlTurbo,
+            task: .textToMusic
+        )
+        XCTAssertEqual(turboDraft.inferenceSteps, 4)
+        XCTAssertFalse(turboDraft.usesLanguageModel)
+        XCTAssertEqual(turboDraft.candidateCount, 1)
+
+        let baseFinal = ACEStepQualityPreset.final.defaults(
+            for: .xlBase,
+            task: .textToMusic
+        )
+        XCTAssertEqual(baseFinal.inferenceSteps, 50)
+        XCTAssertEqual(baseFinal.guidanceScale, 7)
+        XCTAssertEqual(baseFinal.samplerMode, .heun)
+        XCTAssertEqual(baseFinal.velocityNormThreshold, 2)
+        XCTAssertEqual(baseFinal.velocityEMAFactor, 0.1)
+        XCTAssertTrue(baseFinal.automaticDuration)
+        XCTAssertEqual(baseFinal.candidateCount, 4)
+
+        let repaint = ACEStepQualityPreset.edit.defaults(
+            for: .xlTurbo,
+            task: .repaint
+        )
+        XCTAssertFalse(repaint.usesLanguageModel)
+        XCTAssertFalse(repaint.automaticDuration)
+    }
+
+    func testTaskInstructionsAndLMRoutingMatchUpstream() {
+        XCTAssertEqual(
+            ACEStepTask.coverNoFSQ.instruction(),
+            "Generate audio semantic tokens based on the given conditions:"
+        )
+        XCTAssertEqual(
+            ACEStepTask.extract.instruction(trackName: "drums"),
+            "Extract the DRUMS track from the audio:"
+        )
+        XCTAssertEqual(
+            ACEStepTask.complete.instruction(completeTrackClasses: ["Drums", "Bass"]),
+            "Complete the input track with DRUMS | BASS:"
+        )
+        XCTAssertTrue(ACEStepTask.repaint.skipsLanguageModel)
+        XCTAssertTrue(ACEStepTask.cover.usesFSQCoverHints)
+        XCTAssertFalse(ACEStepTask.coverNoFSQ.usesFSQCoverHints)
+        XCTAssertTrue(ACEStepTask.lego.locksDurationToSource)
+        XCTAssertFalse(ACEStepTask.complete.locksDurationToSource)
+    }
+
+    func testCheckpointVariantDetectionUsesNameAndConfig() {
+        let turbo = ACEStepConfig(isTurbo: true)
+        let xlNonTurbo = ACEStepConfig(hiddenSize: 2_560, isTurbo: false)
+
+        XCTAssertEqual(
+            ACEStepCheckpointVariant.detect(
+                modelRootURL: URL(fileURLWithPath: "/models/acestep-v15-xl-turbo"),
+                config: turbo
+            ),
+            .xlTurbo
+        )
+        XCTAssertEqual(
+            ACEStepCheckpointVariant.detect(
+                modelRootURL: URL(fileURLWithPath: "/models/acestep-v15-xl-sft"),
+                config: xlNonTurbo
+            ),
+            .xlSFT
+        )
+        XCTAssertEqual(
+            ACEStepCheckpointVariant.detect(
+                modelRootURL: URL(fileURLWithPath: "/models/acestep-v15-base"),
+                config: ACEStepConfig(isTurbo: false)
+            ),
+            .base
+        )
+    }
+
+    func testRepaintModeMappingMatchesUpstream() {
+        let conservative = ACEStepRepaintConfiguration(mode: .conservative)
+        XCTAssertEqual(conservative.injectionRatio, 1)
+        XCTAssertEqual(conservative.latentCrossfadeFrames, 25)
+        XCTAssertEqual(conservative.waveformCrossfadeSeconds, 0.05)
+
+        let balanced = ACEStepRepaintConfiguration(mode: .balanced, strength: 0.5)
+        XCTAssertEqual(balanced.injectionRatio, 0.5)
+        XCTAssertEqual(balanced.latentCrossfadeFrames, 12)
+        XCTAssertEqual(balanced.waveformCrossfadeSeconds, 0.025)
+
+        let aggressive = ACEStepRepaintConfiguration(mode: .aggressive)
+        XCTAssertEqual(aggressive.injectionRatio, 0)
+        XCTAssertEqual(aggressive.latentCrossfadeFrames, 0)
+        XCTAssertEqual(aggressive.waveformCrossfadeSeconds, 0)
+    }
+
+    func testRepaintConditioningMasksOnlyRequestedRange() {
+        let source = MLXArray(Array(repeating: Float(1), count: 6 * 2), [1, 6, 2])
+        let silence = MLXArray.zeros([1, 6, 2], dtype: .float32)
+        let configuration = ACEStepRepaintConfiguration(
+            startSeconds: 0.08,
+            endSeconds: 0.16,
+            chunkMaskMode: .explicit
+        )
+
+        let result = ACEStepRepaint.prepareConditioning(
+            cleanSourceLatents: source,
+            silenceLatents: silence,
+            chunkChannels: 2,
+            configuration: configuration,
+            task: .repaint
+        )
+        MLX.eval(result.sourceLatents, result.chunkMasks, result.repaintMask)
+
+        XCTAssertEqual(result.latentRange, 2..<4)
+        XCTAssertEqual(
+            result.repaintMask.asArray(Bool.self),
+            [false, false, true, true, false, false]
+        )
+        XCTAssertEqual(
+            result.sourceLatents.asArray(Float.self),
+            [
+                1, 1,
+                1, 1,
+                0, 0,
+                0, 0,
+                1, 1,
+                1, 1,
+            ]
+        )
+        XCTAssertEqual(
+            result.chunkMasks.asArray(Float.self),
+            [
+                0, 0,
+                0, 0,
+                1, 1,
+                1, 1,
+                0, 0,
+                0, 0,
+            ]
+        )
+    }
+
+    func testAutomaticChunkMaskMatchesUpstreamBooleanMaskValue() {
+        let source = MLXArray.ones([1, 6, 2], dtype: .float32)
+        let silence = MLXArray.zeros([1, 6, 2], dtype: .float32)
+        let configuration = ACEStepRepaintConfiguration(
+            startSeconds: 0.08,
+            endSeconds: 0.16,
+            chunkMaskMode: .auto
+        )
+
+        let result = ACEStepRepaint.prepareConditioning(
+            cleanSourceLatents: source,
+            silenceLatents: silence,
+            chunkChannels: 2,
+            configuration: configuration,
+            task: .repaint
+        )
+
+        XCTAssertEqual(
+            result.chunkMasks.asArray(Float.self),
+            Array(repeating: 1, count: 12)
+        )
+    }
+
+    func testRepaintStepInjectionAndBoundaryBlendMatchUpstream() {
+        let generated = MLXArray(Array(repeating: Float(10), count: 6), [1, 6, 1])
+        let source = MLXArray.zeros([1, 6, 1], dtype: .float32)
+        let noise = MLXArray(Array(repeating: Float(4), count: 6), [1, 6, 1])
+        let mask = MLXArray([0, 0, 1, 1, 0, 0], [1, 6]).asType(.bool)
+
+        let injected = ACEStepRepaint.injectPreservedSource(
+            generatedLatents: generated,
+            cleanSourceLatents: source,
+            repaintMask: mask,
+            nextTimestep: 0.5,
+            noise: noise
+        )
+        let blended = ACEStepRepaint.blendLatentBoundaries(
+            generatedLatents: generated,
+            cleanSourceLatents: source,
+            repaintMask: mask,
+            crossfadeFrames: 1
+        )
+        MLX.eval(injected, blended)
+
+        XCTAssertEqual(injected.asArray(Float.self), [2, 2, 10, 10, 2, 2])
+        XCTAssertEqual(blended.asArray(Float.self), [0, 5, 10, 10, 5, 0])
+    }
+
+    func testLegoRangePreservesSourceLatentsWhileMaskingGenerationRange() {
+        let source = MLXArray(Array(repeating: Float(2.5), count: 6 * 2), [1, 6, 2])
+        let silence = MLXArray.zeros([1, 6, 2], dtype: .float32)
+        let configuration = ACEStepRepaintConfiguration(
+            startSeconds: 0.08,
+            endSeconds: 0.16,
+            chunkMaskMode: .explicit
+        )
+
+        let result = ACEStepRepaint.prepareConditioning(
+            cleanSourceLatents: source,
+            silenceLatents: silence,
+            chunkChannels: 2,
+            configuration: configuration,
+            task: .lego
+        )
+        MLX.eval(result.sourceLatents, result.chunkMasks)
+
+        XCTAssertEqual(
+            result.sourceLatents.asArray(Float.self),
+            Array(repeating: 2.5, count: 12)
+        )
+        XCTAssertEqual(
+            result.chunkMasks.asArray(Float.self),
+            [
+                0, 0,
+                0, 0,
+                1, 1,
+                1, 1,
+                0, 0,
+                0, 0,
+            ]
+        )
+    }
+
+    func testWaveformSpliceRestoresOriginalOutsideRepaintRange() {
+        let generated = MLXArray(Array(repeating: Float(10), count: 10), [1, 10, 1])
+        let source = MLXArray.zeros([1, 10, 1], dtype: .float32)
+        let spliced = ACEStepRepaint.spliceWaveform(
+            generatedAudio: generated,
+            sourceAudio: source,
+            startSeconds: 0.2,
+            endSeconds: 0.6,
+            crossfadeSeconds: 0.1,
+            sampleRate: 10
+        )
+        MLX.eval(spliced)
+
+        XCTAssertEqual(
+            spliced.asArray(Float.self),
+            [0, 5, 10, 10, 10, 10, 5, 0, 0, 0]
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -943,8 +943,13 @@ final class ManagedModelCatalogTests: XCTestCase {
     func testACEStepXLTurboUsesMountedXLLayout() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.aceStepXLTurbo.rawValue))
         XCTAssertEqual(spec.hubFallback?.repoId, "ACE-Step/Ace-Step1.5")
+        XCTAssertEqual(spec.hubFallback?.revision, "19671f406d603126926c1b7e2adc169acbcade22")
         XCTAssertEqual(spec.mountedHubFallbacks.map(\.destinationPath), ["acestep-v15-xl-turbo"])
         XCTAssertEqual(spec.mountedHubFallbacks.first?.hubFallback.repoId, "ACE-Step/acestep-v15-xl-turbo")
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.first?.hubFallback.revision,
+            "d4a0b288b83ebb7e25a8c0b32c573c22e134e8ee"
+        )
 
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -957,6 +962,48 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertFalse(spec.isManagedRootComplete(standardRoot, fileManager: .default))
     }
 
+    func testACEStepXLBaseAndSFTUsePinnedMountedLayouts() throws {
+        let fixtures: [
+            (
+                modelID: ModelResolver.ModelID,
+                destination: String,
+                repoID: String,
+                revision: String
+            )
+        ] = [
+            (
+                .aceStepXLBase,
+                "acestep-v15-xl-base",
+                "ACE-Step/acestep-v15-xl-base",
+                "220c1166efbdd9583eafcb12eb160594bbfcb241"
+            ),
+            (
+                .aceStepXLSFT,
+                "acestep-v15-xl-sft",
+                "ACE-Step/acestep-v15-xl-sft",
+                "d06de46b4622f781cf07f4a013a67d591ca52819"
+            ),
+        ]
+
+        for fixture in fixtures {
+            let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: fixture.modelID.rawValue))
+            XCTAssertEqual(spec.hubFallback?.repoId, "ACE-Step/Ace-Step1.5")
+            XCTAssertEqual(spec.hubFallback?.revision, "19671f406d603126926c1b7e2adc169acbcade22")
+            XCTAssertEqual(spec.mountedHubFallbacks.map(\.destinationPath), [fixture.destination])
+            XCTAssertEqual(spec.mountedHubFallbacks.first?.hubFallback.repoId, fixture.repoID)
+            XCTAssertEqual(spec.mountedHubFallbacks.first?.hubFallback.revision, fixture.revision)
+            XCTAssertEqual(
+                spec.mountedHubFallbacks.first?.hubFallback.patterns.contains("apg_guidance.py"),
+                true
+            )
+
+            let root = try makeTemporaryDirectory()
+            defer { try? FileManager.default.removeItem(at: root) }
+            try writeMinimalACEStepRoot(at: root, turboSubdirectory: fixture.destination)
+            XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+        }
+    }
+
     func testACEStepXLTurboLM4BRequiresMountedLM() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue))
         XCTAssertEqual(
@@ -964,6 +1011,10 @@ final class ManagedModelCatalogTests: XCTestCase {
             ["acestep-v15-xl-turbo", "acestep-5Hz-lm-4B"]
         )
         XCTAssertEqual(spec.mountedHubFallbacks.last?.hubFallback.repoId, "ACE-Step/acestep-5Hz-lm-4B")
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.last?.hubFallback.revision,
+            "0a3ec94b557aea7d508da38b31cfe7341f6ff737"
+        )
 
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,6 +93,7 @@ export default defineConfig({
           { text: 'Speech Runtime', link: '/runtime/speech' },
           { text: 'Vision Runtime', link: '/runtime/vision' },
           { text: 'Music Runtime', link: '/runtime/music' },
+          { text: 'ACE-Step Validation', link: '/runtime/acestep-validation' },
           { text: 'SFX Runtime', link: '/runtime/sfx' },
           { text: 'Video Runtime', link: '/runtime/video' },
           { text: 'Persistent Worlds', link: '/runtime/world' },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,8 @@ Public tree:
   - `mere.run music analyze` — Analyze source audio with ACE-Step audio understanding.
   - `mere.run music generate` — Generate audio from a music prompt.
   - `mere.run music realtime` — Run Magenta RealTime 2 music generation.
+  - `mere.run music serve` — Start a warm resident ACE-Step music generation API.
+  - `mere.run music train-adapter` — Train a native ACE-Step LoRA or LoKr adapter.
   - `mere.run music transcribe` — Transcribe a full music mix into instrument-separated MIDI with MuScriptor.
 - [`mere.run sfx`](/runtime/sfx) — Generate sound effects locally.
   - `mere.run sfx ae` — Encode or decode Woosh audio autoencoder latents.
@@ -211,7 +213,7 @@ are:
 - Vision segmentation / tracking: `vision-segment-sam31`
 - Vision grounding: `vision-ground-falcon-perception`
 - Face detection and identity embeddings: `vision-face-buffalo-l`
-- Music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
+- Music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - SFX: `sfx-woosh-dflow`, `sfx-woosh-flow`
 - Video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -84,6 +84,8 @@ from the runtime catalog used by `mere.run model list`,
 | `image-3d` | `image-3d-instantmesh-base` |
 | `image-3d` | `image-3d-trellis2-4b` |
 | `music` | `music-acestep` |
+| `music` | `music-acestep-xl-base` |
+| `music` | `music-acestep-xl-sft` |
 | `music` | `music-acestep-xl-turbo` |
 | `music` | `music-acestep-xl-turbo-lm4b` |
 | `music` | `music-magenta-rt2-small` |
@@ -464,7 +466,7 @@ swift run mere.run model info image-klein-max
 
 Some retained surfaces have more structure than a flat model root.
 
-### `music-acestep`, `music-acestep-xl-turbo`, and `music-acestep-xl-turbo-lm4b`
+### ACE-Step 1.5 models
 
 The top-level model roots are:
 
@@ -472,12 +474,16 @@ The top-level model roots are:
 .../models/music-acestep
 .../models/music-acestep-xl-turbo
 .../models/music-acestep-xl-turbo-lm4b
+.../models/music-acestep-xl-sft
+.../models/music-acestep-xl-base
 ```
 
 Those roots may contain:
 
 - `acestep-v15-turbo/`
 - `acestep-v15-xl-turbo/`
+- `acestep-v15-xl-sft/`
+- `acestep-v15-xl-base/`
 - `acestep-5Hz-lm-1.7B/` or another supported LM subdirectory
 - `acestep-5Hz-lm-4B/`
 - `Qwen3-Embedding-0.6B/`
@@ -492,6 +498,11 @@ encoder components. `music-acestep-xl-turbo-lm4b` adds the optional
 `acestep-5Hz-lm-4B/` 5 Hz LM. The default ACE-Step LM component discovery
 continues to prefer the smaller `acestep-5Hz-lm-1.7B/` when both LM directories
 are present; pass `--lm-subdirectory acestep-5Hz-lm-4B` to force the 4B LM.
+`music-acestep-xl-sft` and `music-acestep-xl-base` install the non-distilled
+XL checkpoints and use continuous flow sampling with CFG, APG, or ADG. Base is
+also the checkpoint family for extract, lego, and complete tasks. Every
+component is downloaded at the immutable revision listed in
+[ACE-Step validation](./runtime/acestep-validation.md).
 
 `mere.run music generate` and `mere.run music analyze` auto-discover these
 layouts unless you override the root with `--checkpoints-root` or

--- a/docs/runtime/acestep-validation.md
+++ b/docs/runtime/acestep-validation.md
@@ -1,0 +1,165 @@
+# ACE-Step Validation
+
+This is the evidence contract for the native Swift/MLX ACE-Step 1.5 runtime.
+It separates source parity, local tests, installed-checkpoint execution,
+performance, and listening review.
+
+## Immutable sources
+
+The implementation was compared with ACE-Step upstream commit
+`6d467e4b5081ccb0abf1ec1bf4fdf9051a2d34b0`. Managed downloads use immutable
+Hugging Face revisions:
+
+| Component | Repository | Revision |
+| --- | --- | --- |
+| Shared VAE/text/Turbo assets | `ACE-Step/Ace-Step1.5` | `19671f406d603126926c1b7e2adc169acbcade22` |
+| XL-Turbo | `ACE-Step/acestep-v15-xl-turbo` | `d4a0b288b83ebb7e25a8c0b32c573c22e134e8ee` |
+| 4B planner | `ACE-Step/acestep-5Hz-lm-4B` | `0a3ec94b557aea7d508da38b31cfe7341f6ff737` |
+| XL-SFT | `ACE-Step/acestep-v15-xl-sft` | `d06de46b4622f781cf07f4a013a67d591ca52819` |
+| XL-Base | `ACE-Step/acestep-v15-xl-base` | `220c1166efbdd9583eafcb12eb160594bbfcb241` |
+
+Generation recipes repeat the effective repository/revision set, adapter
+SHA-256 and scale, final effective conditioning metadata, complete inference
+configuration, candidate ranking, and input/output hashes. Recipe schema 2
+adds the post-planning BPM, duration, key/scale, vocal language, and time
+signature. This protects old installs whose original manifest predates source
+provenance and distinguishes requested metadata from the values actually used.
+
+## Parity and local gates
+
+The deterministic test surface covers:
+
+- Turbo and continuous timestep schedules, Euler/Heun updates, CFG, APG, ADG,
+  guidance windows, and stabilization;
+- typed task/checkpoint capability routing and exact Base-only restrictions;
+- source conditioning, repaint masks/injection/splice, retake endpoints and
+  spherical interpolation, and flow-edit integration windows;
+- prompt/condition encoder, audio-tokenizer, DCW, first-velocity, final-latent,
+  and VAE parity dump paths;
+- stable seed fanout, candidate metrics/ranking, batch/session serialization,
+  API decoding/security, WAV headers, LRC, recipes, and DAW bundle topology;
+- PEFT LoRA and LyCORIS LoKr key mapping, numerical contributions, alpha/scale,
+  decomposed Kronecker factors, and adapter stacking.
+
+Pinned-upstream numerical probes isolate every core stage. On the installed
+XL-Turbo stack, Swift versus native MLX measured mean absolute errors of
+`9.74e-7` for DiT, `2.08e-7` for the condition encoder, `8.21e-6` for Qwen
+hidden states, `6.05e-7` for FSQ detokenization, and `6.32e-7` for VAE decode.
+The VAE also passes a real structured-audio round trip. This stage isolation
+identified the prior output failure as orchestration rather than checkpoint or
+kernel drift: Swift supplied a float chunk mask of `2.0`, while upstream stores
+that assignment in a boolean tensor and therefore conditions the model with
+`1.0`.
+
+Run the normal repository contract:
+
+```bash
+./scripts/check.sh
+```
+
+Installed-checkpoint tests are opt-in because they require large local assets.
+The integration tests describe the required `MERERUN_TEST_ACESTEP_*`
+environment variables and skip truthfully when an asset is absent.
+
+## Installed-model evidence
+
+All files below were generated locally at 48 kHz stereo. Hashes make the
+specific validation artifacts identifiable without committing model output.
+
+| Path exercised | Configuration | Result |
+| --- | --- | --- |
+| XL-SFT | 50-step Heun, APG, final quality | `979775ce2503c7c393b3fc435a45515ffb4be80a3658e26d90b541cc57a888a4` |
+| XL-Base extract | one-second source, one step, `Drums` | `9c620ce47d89b67824c2eebd88c20c0a81b1c340355a2ddd0937c61db0f78851` |
+| XL-Base lego | one-second source, one step, `Drums`, 0.2–0.8 s mask | `322d3c757da5477ec3a828d2d198abcb80c9a3ff14a20a3c2786119a6dacb171` |
+| XL-Base complete | one-second source, one step, `Drums,Bass` | `1c8861285bcbf0952035b11aa1676c38f516a543c700c15a896105c0f9fdea35` |
+| XL-Turbo flow edit | one-second source, one step | `ae758bdf4b940277fc09145f9340bdd852b1fd48915921ad231b86488353cb27` |
+| XL-Turbo + 4B recipe v2 | one-second LM-planned vocal, one step | `68b170220cf5849635f3f97f2b75d87d7a80045f2401edf9a707d677db2f2122` |
+| Resident API WAV | warm one-second XL-Turbo request, one step | `9c6f3ef3752f15636aa2f4eb7b74b3dcee556e78a62158e4bc4ac344f6eaee32` |
+| Float32 artifact/DAW workflow | recipe, LRC, candidates, bundle | `d44d8386c6b479e209d169c74ff2aa69bd2b13dd980f83a708b9f381c985e629` |
+| LoRA train/save | one real backward and AdamW step, 256 layers | `b7c9c40c3b74aca7fb8f12fb4999c0be1175db82bf9e1504bb9c19794a29c8dd` |
+| LoRA reload/generate | trained artifact applied to 256 layers | `1ba7876df682c626b1f08da80a739ed0685becdf0182e492bb1c533d07d41449` |
+| LoKr train/save | one real backward and AdamW step, 256 layers | `5175420753533a736b43afa608dfc957e48c8d216ac0ec0d6ac824030e1c739e` |
+| LoKr reload/generate | factored adapter applied to 256 layers | `79a45e0d340ad0232bb81f4c68ff5c5cc57fc9541f11343f5171af0a319e1961` |
+| Provenance recipe | exact pins plus adapter hash and scale | `6c3370f61c3ed3bea3fc48e99369432d1578696be2989d3713abbc094a68a2bb` |
+
+The XL-SFT 50-step run completed in 15.52 seconds with 20.72 GB maximum RSS,
+25.34 GB peak footprint, and no swap. The XL-Turbo flow edit completed in
+4.98 seconds with 21.03 GB maximum RSS, 26.94 GB peak footprint, and no swap.
+The XL-Base extract, lego, and complete smokes loaded the immutable Base
+checkpoint and produced PCM24 output in 3.27, 2.31, and 4.87 seconds. Extract
+and lego peaked near 26.1 GB; complete peaked at 48.34 GB. All three completed
+without swap. The temporary Base installation was then removed through
+`mere.run model remove`, reclaiming 19,949,344,762 bytes while retaining shared
+assets still referenced by installed ACE-Step variants.
+The one-step LoRA train/save smoke took 6.52 seconds with 21.02 GB maximum RSS
+and 25.84 GB peak footprint. LoKr took 2.97 seconds with 21.18 GB maximum RSS
+and 26.15 GB peak footprint. Both adapter reload renders completed in roughly
+2.3 seconds without swap. The real 4B-planned schema 2 recipe retained the
+effective BPM and explicit one-second duration while discarding unsupported
+planner language output.
+
+The real resident API health probe reported XL-Turbo + 4B loaded and warm. A
+one-second PCM24 WAV request returned in 0.68 seconds. A heterogeneous batch
+returned independent candidate counts `[1, 2]`, deterministic seeds `[6201]`
+and `[6301, 6302]`, and exactly one selected candidate per item in 1.16
+seconds. The response preserved per-item BPM, duration, key, and time-signature
+metadata. A real LM-planned API request returned effective BPM 108, G major,
+the explicit one-second duration, and omitted unsupported planner language.
+Wrong-model, wrong-content-type, and raw-WAV batch requests returned actionable
+HTTP 400 JSON errors.
+
+## Listening regression
+
+`Tests/MereRunCLITests/Fixtures/ACEStep/listening-regression.json` freezes
+prompts, lyrics, seeds, duration, quality, candidate count, and listening
+criteria across transient electronic, acoustic, vocal, dense, and ambient
+material.
+
+```bash
+./scripts/acestep-listening-regression.sh
+```
+
+The runner writes the WAVs and exact recipes, SHA manifest, ordered M3U
+playlist, and a review CSV with structure, prompt adherence, audio quality,
+vocal alignment, regression, and notes fields. The automatic gate catches
+silence, clipping, DC, stationary broadband noise, missing time-varying
+spectral structure, and prematurely dead endings. The CSV deliberately
+retains a human listening decision for musical quality and prompt adherence.
+
+The installed XL-Turbo + 4B run completed all five frozen cases as 48 kHz
+stereo PCM24. Each selected candidate used all 60 semantic audio codes expected
+for 12 seconds and passed `temporalSpectralVariation >= 0.85` plus
+`tailEnergyRatio >= 0.05`:
+
+| Case | Score | Spectral variation | Tail ratio | SHA-256 |
+| --- | ---: | ---: | ---: | --- |
+| transient electronic | 86.7512 | 1.3137 | 0.0720 | `1a5c7c56e5373d69400f553256637199bb2b1e04877435abf8f2e2ebe6e555dc` |
+| acoustic space | 90.2295 | 1.2200 | 0.5534 | `bb4a9a1e5a208bb6d594a83820ffd330c98e2d83aca1f932b7429572192dc3b7` |
+| vocal alignment | 87.2707 | 0.9795 | 0.9391 | `781616e86a5947f46383f90744d69161dffb087d0f90e363e72b36fa62bb1b2c` |
+| dense arrangement | 92.6983 | 1.3598 | 1.2525 | `91ca6ad435b7f5ee12a550aa0e19da3348bbfce0c805b110159ed0363680a704` |
+| ambient continuity | 90.0086 | 1.1366 | 0.9754 | `356379ebeffdbeb7b50dd1e3f7062a00bfd742174d3a698cd4d74585a6a25391` |
+
+Repeating the transient case with the same seed reproduced its planner
+metadata, candidate scores/code counts, and WAV byte-for-byte at SHA-256
+`1a5c7c56e5373d69400f553256637199bb2b1e04877435abf8f2e2ebe6e555dc`.
+
+The review CSV remains deliberately unscored until a person listens. The
+technical rank is evidence against the exact stationary-noise regression, but
+it is not a substitute for a musical-quality or lyric-alignment judgment.
+
+For a repeatable timing capture:
+
+```bash
+./scripts/acestep-performance-proof.sh
+```
+
+The installed one-second/one-step XL-Turbo proof completed in 3.14 seconds,
+including process startup and checkpoint load, with 21.35 GB maximum RSS,
+25.35 GB peak footprint, and zero swap. It produced PCM24 stereo at 48 kHz with
+SHA-256
+`a5d5a265488373d9b32beabd1ccdf5c7e99cc4d159b08a1a8aaa006ef12bdf1f`
+and a matching schema 2 recipe.
+
+Do not treat a source-level test, generated recipe, or unchecked listening
+playlist as installed-model proof. Each evidence layer answers a different
+question.

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -48,7 +48,7 @@ Examples:
 - text: `text-chat-gemma4`, `text-chat-q36-nano`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
-- music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
+- music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - sfx: `sfx-woosh-dflow`, `sfx-woosh-flow`, `sfx-woosh-clap`, `sfx-woosh-synchformer`, `sfx-woosh-dvflow-8s`, `sfx-woosh-vflow-8s`, `sfx-mmaudio-large-44k-v2`
 - video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
 

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -8,6 +8,8 @@ and `mere.run music transcribe`.
 
 - `mere.run music generate`
 - `mere.run music analyze`
+- `mere.run music serve`
+- `mere.run music train-adapter`
 - `mere.run music realtime`
 - `mere.run music transcribe`
 
@@ -16,6 +18,8 @@ and `mere.run music transcribe`.
 - `music-acestep`
 - `music-acestep-xl-turbo`
 - `music-acestep-xl-turbo-lm4b`
+- `music-acestep-xl-sft`
+- `music-acestep-xl-base`
 - `music-magenta-rt2-small`
 - `music-magenta-rt2-base`
 - `music-muscriptor-small`
@@ -144,6 +148,75 @@ optional 4B 5 Hz LM for `--use-lm` runs. ACE-Step cover/repaint/extract tasks
 follow upstream and skip the 5 Hz LM phase so source-audio conditioning stays
 faithful.
 
+ACE-Step task routing is typed and checkpoint-aware. Turbo/SFT support
+text-to-music, repaint, cover, and cover-nofsq; extract, lego, and complete are
+accepted only for Base checkpoints. Unknown task names fail in argument
+parsing, while incompatible checkpoint/task pairs fail before weight loading.
+XL-SFT and XL-Base use the native continuous flow schedule, real conditional
+and unconditional decoder batches, CFG/APG/ADG guidance intervals, velocity
+norm/EMA stabilization, and Euler or Heun ODE integration. Turbo remains the
+fast distilled path. Base uniquely enables extract, lego, and complete.
+
+`--quality draft|song|final|edit` is model-aware. It selects checkpoint-safe
+steps, sampler, guidance, velocity stabilization, LM planning policy, automatic
+duration behavior, and a warm best-of-N count. Explicit flags still override
+the preset. `final` prefers the 4B planner when it is installed. Best-of-N
+ranking checks finite samples, level, clipping, DC offset, crest factor,
+spectral flatness, frame-energy movement, periodicity, time-varying spectral
+structure, and tail continuity. This prevents loud stationary noise or a
+prematurely dead ending from winning on level statistics alone.
+
+Every ACE-Step generation writes 48 kHz stereo 24-bit WAV by default plus a
+schema 2 reproducible recipe JSON. The recipe records exact checkpoint
+repositories and immutable revisions, adapter hashes and scales,
+prompt/lyrics/instruction, the final effective BPM, duration, key/scale, vocal
+language and time signature, task/edit configuration, inference controls,
+candidate seeds and technical scores, export policy, and input/output hashes.
+When the 5 Hz LM is active, each candidate also records its semantic audio-code
+count. The generation seed drives both LM sampling and diffusion.
+`--export-format float32` preserves a floating-point master; `--daw-bundle`
+adds candidates, extracted stems, synchronized lyric markers, and a portable
+REAPER project.
+
+Retakes use exact spherical noise interpolation between `--seed` and
+`--retake-seed`. `--flow-edit` implements the upstream source/target velocity
+difference field over a configurable normalized window, including Monte Carlo
+forward-noise averaging and target-only finishing denoise. It is distinct from
+repaint: repaint preserves audio outside a time range, while flow edit morphs
+the whole source toward a new semantic target.
+
+PEFT LoRA and LyCORIS LoKr adapters load natively with `--adapter`; multiple
+files stack and may use one shared or per-adapter scale. LoKr uses factored
+Kronecker evaluation instead of materializing full decoder deltas. Train either
+format with `music train-adapter`; its objective matches ACE-Step flow
+matching, and its output is directly reloadable by `music generate` or the
+resident server.
+
+`music serve` holds the complete pipeline and its adapters in memory. It
+provides `GET /health`, `POST /v1/audio/music`, and serialized
+`POST /v1/audio/music/batches`, with JSON/base64 or raw WAV responses. Binding
+outside loopback requires a bearer token. The API mirrors the CLI controls for
+checkpoint-aware tasks, quality, steps and scheduler, CFG/APG/ADG, retakes,
+cover strength/noise, repaint, flow edit, reference audio, LM metadata and
+sampling, complete-track classes, and tiled VAE decode. Song/final requests
+without `duration_seconds` use the resident LM planner; every JSON result
+returns `conditioning_metadata` with the values actually used.
+
+Batch items may select independent `candidates` values. The server serializes
+them through the warm session, returns every ranked candidate and exactly one
+selected winner per item, and rejects a request whose `model` does not match
+the resident model. Batch responses are JSON; raw `response_format: "wav"` is
+available on the single-generation endpoint.
+
+Repaint is a real bounded edit, not a cover alias. `--repaint-start` and
+`--repaint-end` produce the upstream 25 Hz latent mask. The requested span is
+replaced by the checkpoint silence latent for conditioning, clean source
+latents outside it are re-injected at the appropriate noise level during early
+denoising, and latent crossfades soften both boundaries. After VAE decode the
+runtime splices the original pre-VAE waveform back outside the edit span, with
+a short waveform crossfade. `--repaint-mode` selects conservative, balanced,
+or aggressive preservation; `--repaint-strength` tunes balanced mode.
+
 For covers, `--analyze-source-audio` runs ACE-Step audio understanding before
 the direct DiT cover pass. It converts the source audio to 5 Hz audio codes,
 asks the LM for source BPM, key/scale, language, and time signature, and fills
@@ -214,6 +287,8 @@ notes and continuous controls.
 
 - `Sources/MereRunCLI/Commands/MusicAnalyzeCommand.swift`
 - `Sources/MereRunCLI/Commands/MusicGenerateCommand.swift`
+- `Sources/MereRunCLI/Commands/MusicServeCommand.swift`
+- `Sources/MereRunCLI/Commands/MusicTrainAdapterCommand.swift`
 - `Sources/MereRunCLI/Commands/MusicRealtimeCommand.swift`
 - `Sources/MereRunCLI/Commands/MusicTranscribeCommand.swift`
 
@@ -222,6 +297,12 @@ notes and continuous controls.
 - `Sources/MereRunCore/ACEStep/ACEStepPipeline.swift`
 - `Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift`
 - `Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift`
+- `Sources/MereRunCore/ACEStep/ACEStepTask.swift`
+- `Sources/MereRunCore/ACEStep/ACEStepRepaint.swift`
+- `Sources/MereRunCore/ACEStep/ACEStepFlowEdit.swift`
+- `Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift`
+- `Sources/MereRunCore/ACEStep/ACEStepAdapter.swift`
+- `Sources/MereRunCore/ACEStep/ACEStepAdapterTrainer.swift`
 - `Sources/MereRunCore/MagentaRT2/MagentaRT2Resources.swift`
 - `Sources/MereRunCore/MagentaRT2/MagentaRT2Renderer.swift`
 - `Sources/MereRunCore/MagentaRT2/MagentaRT2RealtimeSession.swift`
@@ -234,6 +315,10 @@ The ACEStep runtime now follows a clean phase split:
 1. `ACEStepPipeline.swift` for the public pipeline and orchestration
 2. `ACEStepPipeline+Prompting.swift` for prompt preparation and conditioning
 3. `ACEStepPipeline+Generation.swift` for the generation path itself
+
+See [ACE-Step validation](./acestep-validation.md) for immutable checkpoint
+pins, parity coverage, installed-model evidence, listening review fixtures,
+and measured performance.
 
 That makes it much easier to follow than a single pipeline monolith.
 

--- a/scripts/acestep-listening-regression.sh
+++ b/scripts/acestep-listening-regression.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="${1:-${repo_root}/Tests/MereRunCLITests/Fixtures/ACEStep/listening-regression.json}"
+output_root="${2:-${repo_root}/.build/acestep-listening-regression}"
+cli="${MERERUN_BIN:-${repo_root}/.build/debug/mere.run}"
+
+if [[ ! -x "${cli}" ]]; then
+  swift build --package-path "${repo_root}"
+fi
+
+mkdir -p "${output_root}"
+
+python3 - "${fixture}" "${output_root}" "${cli}" <<'PY'
+import csv
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+
+fixture_path = pathlib.Path(sys.argv[1]).resolve()
+output_root = pathlib.Path(sys.argv[2]).resolve()
+cli = pathlib.Path(sys.argv[3]).resolve()
+fixture = json.loads(fixture_path.read_text())
+model = fixture["model"]
+duration = fixture["duration_seconds"]
+quality = fixture["quality"]
+candidates = fixture["candidates"]
+manifest = {
+    "schema_version": 1,
+    "fixture": str(fixture_path),
+    "model": model,
+    "cases": [],
+}
+playlist = ["#EXTM3U"]
+review_rows = []
+
+for case in fixture["cases"]:
+    case_id = case["id"]
+    output = output_root / f"{case_id}.wav"
+    command = [
+        str(cli),
+        "music",
+        "generate",
+        case["caption"],
+        "--model",
+        model,
+        "--duration",
+        str(duration),
+        "--quality",
+        quality,
+        "--candidates",
+        str(candidates),
+        "--seed",
+        str(case["seed"]),
+        "--output",
+        str(output),
+    ]
+    if case.get("lyrics"):
+        command.extend(["--lyrics", case["lyrics"]])
+    subprocess.run(command, check=True)
+    recipe = output.with_suffix(".recipe.json")
+    recipe_payload = json.loads(recipe.read_text())
+    selected_candidate = next(
+        candidate
+        for candidate in recipe_payload["candidates"]
+        if candidate["selected"]
+    )
+    metrics = selected_candidate["metrics"]
+    temporal_variation = metrics.get("temporalSpectralVariation", 0)
+    tail_energy_ratio = metrics.get("tailEnergyRatio", 0)
+    if temporal_variation < 0.85:
+        raise RuntimeError(
+            f"{case_id} failed musical-structure gate: "
+            f"temporalSpectralVariation={temporal_variation:.3f} < 0.850"
+        )
+    if tail_energy_ratio < 0.05:
+        raise RuntimeError(
+            f"{case_id} failed tail-continuity gate: "
+            f"tailEnergyRatio={tail_energy_ratio:.3f} < 0.050"
+        )
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    manifest["cases"].append(
+        {
+            "id": case_id,
+            "audio": output.name,
+            "recipe": recipe.name,
+            "sha256": digest,
+            "candidate_score": selected_candidate["score"],
+            "candidate_metrics": metrics,
+            "listen_for": case["listen_for"],
+        }
+    )
+    playlist.append(output.name)
+    review_rows.append(
+        [
+            case_id,
+            case["listen_for"],
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ]
+    )
+
+(output_root / "manifest.json").write_text(
+    json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+)
+(output_root / "playlist.m3u8").write_text("\n".join(playlist) + "\n")
+with (output_root / "review.csv").open("w", newline="") as handle:
+    writer = csv.writer(handle)
+    writer.writerow(
+        [
+            "case",
+            "listen_for",
+            "structure_1_to_5",
+            "prompt_adherence_1_to_5",
+            "audio_quality_1_to_5",
+            "vocal_alignment_1_to_5",
+            "regression_yes_no",
+            "notes",
+        ]
+    )
+    writer.writerows(review_rows)
+PY
+
+printf '%s\n' "${output_root}/playlist.m3u8"

--- a/scripts/acestep-performance-proof.sh
+++ b/scripts/acestep-performance-proof.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+output_root="${1:-${repo_root}/.build/acestep-performance-proof}"
+model="${MERERUN_ACESTEP_PERF_MODEL:-music-acestep-xl-turbo-lm4b}"
+cli="${MERERUN_BIN:-${repo_root}/.build/debug/mere.run}"
+
+if [[ ! -x "${cli}" ]]; then
+  swift build --package-path "${repo_root}"
+fi
+
+mkdir -p "${output_root}"
+result="${output_root}/one-second-one-step.wav"
+timing="${output_root}/time.txt"
+
+/usr/bin/time -lp -o "${timing}" \
+  "${cli}" music generate \
+  "tight electronic drum groove, instrumental" \
+  --model "${model}" \
+  --duration 1 \
+  --steps 1 \
+  --candidates 1 \
+  --no-lm \
+  --seed 4242 \
+  --output "${result}"
+
+shasum -a 256 "${result}" > "${output_root}/sha256.txt"
+printf '%s\n' "${output_root}"


### PR DESCRIPTION
## Summary

- make ACE-Step task and checkpoint routing production-complete across text-to-music, repaint, cover, cover-nofsq, extract, lego, complete, retakes, and flow editing
- add checkpoint-aware quality presets, non-Turbo schedules and guidance, warm best-of-N sessions, resident HTTP serving/batching, high-quality exports, recipes, LRC/DAW bundles, and PEFT LoRA plus LyCORIS LoKr training/inference
- add immutable XL-SFT/XL-Base model definitions, provenance, parity hooks, installed-model validation scripts, and end-user documentation
- fix the real output-noise regression by matching upstream boolean chunk-mask semantics (`1.0`, not `2.0`) and ensuring 5 Hz LM semantic codes reach text-to-music conditioning
- seed LM planning/code generation together with diffusion and reject stationary broadband noise or prematurely dead tails during candidate ranking/listening regression

## Root cause and real-model proof

All core components matched pinned upstream native MLX numerically: DiT MAE `9.74e-7`, condition encoder `2.08e-7`, Qwen hidden states `8.21e-6`, FSQ detokenizer `6.05e-7`, and VAE decode `6.32e-7`. The failure was orchestration: upstream assigns `2.0` into a Bool chunk-mask tensor, which becomes `true`/`1.0`; Swift had passed float `2.0` directly and doubled the entire mask context.

The installed `music-acestep-xl-turbo-lm4b` listening suite regenerated five 12-second, 48 kHz stereo PCM24 cases. Every selected candidate used all 60 semantic codes and passed both `temporalSpectralVariation >= 0.85` and `tailEnergyRatio >= 0.05`. The exact hashes and metrics are recorded in `docs/runtime/acestep-validation.md`.

A repeated seeded transient render reproduced planner metadata, candidate scores/code counts, and the WAV byte-for-byte at SHA-256 `1a5c7c56e5373d69400f553256637199bb2b1e04877435abf8f2e2ebe6e555dc`.

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 0 violations across 1,011 files
  - build: passed
  - XCTest: 2,115 tests, 133 expected opt-in skips, 0 failures
  - Swift Testing suites: passed
  - complete CLI `--help` sweep and hygiene scans: passed
- focused ACE-Step task/repaint/scoring tests: 23 passed
- music recipe/export/server tests: 9 passed
- music CLI parsing tests: 27 passed
- documentation contract tests: 4 passed
- installed VAE structured-audio round trip: passed
- installed XL-Turbo + 4B five-case listening regression: passed