### PR TITLE
Refresh public runtime documentation

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,12 +1,13 @@
 # Benchmarking
 
-`mere.run` has several benchmark lanes. They are intentionally small, local, and
-repeatable. Use them to compare installed models on this machine, verify runtime
-changes, and catch regressions before claiming support. They are not full public
-leaderboards.
+Small, local, repeatable lanes that answer one question: on *this* machine, is
+this model better than the alternative? Use them to compare installed models,
+verify a runtime change, and catch a regression before you claim support for
+something.
 
-For command syntax, see the generated [CLI Reference](./cli.md). This page is
-the decision guide for which benchmark to run and how to read the result.
+They are not public leaderboards and do not try to be. For command syntax, see
+the generated [CLI Reference](./cli.md); this page is the decision guide for
+picking a lane and reading what it tells you.
 
 ## Benchmark Map
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,11 +1,16 @@
 # mere.run CLI
 
-`mere.run` is the public command-line interface for the OSS `mere.run`
-package. It exposes a modality-first command tree for image, text, speech,
-vision, geometry, 3D, music, SFX, video, persistent worlds, model and adapter
-management, local status snapshots, and local API serving.
+The complete command tree, generated from the binary itself. Commands are
+organized by what you want to make — `image`, `text`, `speech`, `vision`,
+`music`, `sfx`, `video`, `world` — with separate families for portable graphs,
+executors, run artifacts, models, adapters, serving, and status.
 
-If you are looking for the broader docs set, start at [mere.run Documentation](/).
+Every path on this page is real: a test in the repo fails if the docs and the
+CLI ever disagree. For per-command advice — prompting patterns, which flags
+matter, troubleshooting — read the offline [cookbooks](/cookbooks) with
+`mere.run guide <command path>`.
+
+New here? Start at [mere.run Documentation](/).
 
 ## Overview
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,8 @@
 # Configuration
 
-These are the persisted CLI settings and public runtime environment variables
-that matter in the OSS repo.
+There are two ways to change how `mere.run` behaves: settings that persist
+across shells, and environment variables you set for a single run. This page
+covers both, and marks which ones hold secrets.
 
 ## Persisted settings: `mere.run config`
 

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -1,8 +1,10 @@
 # Cookbooks
 
-`mere.run guide` is the offline cookbook reader built into the CLI. It prints
-Markdown by default, can emit JSON for agents or tools, and `--markdown` renders
-the topic list as a Markdown table.
+Every command carries its own manual. `mere.run guide` is a cookbook reader
+built into the binary, and it works with the network off — on a plane, in a
+locked-down lab, or on a machine that has never had an API key. It prints
+Markdown by default, emits JSON for agents and tools, and renders the topic
+list as a Markdown table with `--markdown`.
 
 ```bash
 mere.run guide --list
@@ -17,10 +19,9 @@ mere.run guide open-webui
 mere.run guide video generate --json
 ```
 
-The cookbooks are packaged with the CLI binary, so installed copies can read
-them without internet access. They are meant for practical use: what the command
-does, which model to install, which flags matter, prompting patterns, examples,
-iteration tips, troubleshooting, and source links.
+Each guide is written to be used, not skimmed: what the command does, which
+model to install, which flags actually change the output, prompting patterns,
+worked examples, iteration tips, troubleshooting, and links into the source.
 
 ## Available Topics
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,21 +1,27 @@
 # Getting Started
 
-This guide gets a fresh clone to the point where you can build the package,
-inspect the command tree, configure model sources, and run a first local
-workflow.
+By the end of this page you will have built the package from source, pulled a
+model, and generated your first image, paragraph, and spoken line — all on your
+own machine, with nothing leaving it.
 
-## What this repo contains
+If you only want to use the app, install a signed build from
+[mere.run/releases](https://mere.run/releases) instead and jump straight to
+[Pull a model](#pull-a-model). Everything below is the from-source path.
 
-`mere-run` is a Swift package with:
+## What you are building
 
+`mere-run` is one Swift package that produces:
+
+- the public `mere.run` executable — the CLI that does all the actual work
+- `mere.run.app`, an optional macOS studio that drives that same CLI rather
+  than a separate backend
 - reusable inference libraries in `Sources/MereRunCore`, `Sources/AudioCore`,
   `Sources/AudioCodecs`, `Sources/AudioSTT`, and `Sources/AudioTTS`
-- a public executable product named `mere.run`
-- an optional macOS SwiftUI studio named `mere.run.app` that wraps the public
-  CLI
-- tests and smoke harnesses for the package and CLI surfaces
+- tests and smoke harnesses for both surfaces
 
-It does not include hosted-service, billing, or private-deployment surfaces.
+There is no hosted inference service behind it. Inference stays local; network
+access happens only for explicit operations such as model downloads,
+installation and update checks, or Relay.
 
 ## Prerequisites
 
@@ -63,8 +69,8 @@ app_path="$(./scripts/build_mere_run_app.sh debug)"
 open "$app_path"
 ```
 
-That confirms the package graph, CLI product, optional app product, app bundle,
-and basic command parsing are all working.
+If all five succeed, the package resolves, the CLI builds and parses, and the
+Mac app bundles and opens. That is the whole toolchain proven in one pass.
 
 On Linux compatibility branches, keep the first pass headless and stop at the
 CLI surface:
@@ -77,10 +83,10 @@ The macOS app product is intentionally outside the Linux target.
 
 ## Launch the macOS studio
 
-The app is a user-facing local studio backed by the public CLI. It opens to a
-unified canvas and prompt bar, keeps generated outputs in a local library, and
-keeps command previews and logs in Advanced details. Launch it from a checkout
-with:
+The studio is a prompt-first face on the same CLI you just built — one canvas,
+one prompt bar, and a local library of everything you have made. The exact
+command behind each generation is always one click away under Advanced. Launch
+it from a checkout with:
 
 ```bash
 app_path="$(./scripts/build_mere_run_app.sh debug)"
@@ -120,9 +126,10 @@ packages are local smoke artifacts, not useful release targets.
 
 ## Understand the command tree
 
-The public CLI is modality-first, with separate operational families for
-portable graphs, executors, run artifacts, models, adapters, serving, and
-extensions. This inventory is generated from the CLI configuration:
+Commands are organized by what you want to make — `image`, `text`, `speech`,
+`vision`, `music`, `sfx`, `video`, `world` — with separate families for running
+graphs, managing models, and serving. This table is generated from the CLI
+itself, so it always matches the binary you just built:
 
 <!-- BEGIN GENERATED: CLI TOP LEVEL -->
 | Command | Purpose |
@@ -192,10 +199,12 @@ swift run mere.run status --json
 
 ## Pull a model
 
-Managed downloads use cataloged Hugging Face repos. No private model-source host
-or R2 credentials are required.
+Models come from cataloged Hugging Face repos into a local store you own. There
+is no private mere.run model host or inference credential to buy. An upstream
+repository can still require terms acceptance and a Hugging Face token.
 
-Example:
+Ask the machine what it can actually run before spending gigabytes on a
+download:
 
 ```bash
 swift run mere.run model capabilities
@@ -243,7 +252,10 @@ Face and auto-installs Pi; pass `--no-bootstrap` to refuse both. Other
 `start` flags include `--model`, `--prompt`, `--skip-server`,
 `--allow-unsupported`, and `--pi-path`.
 
-## Run a first workflow
+## Make something
+
+Each of these writes a real file to disk, and none of them depend on the
+others. Start wherever you are curious.
 
 ### Image generation
 
@@ -312,7 +324,7 @@ swift run mere.run vision track-live --output ./live.mp4 --prompt "a person"
 
 ## Validate your local environment
 
-Run the repo validation script:
+Before you open a pull request, run the same script CI does:
 
 ```bash
 ./scripts/check.sh

--- a/docs/graph/studio.md
+++ b/docs/graph/studio.md
@@ -1,13 +1,15 @@
 # Graph Studio
 
-Mere Graph Studio is the visual authoring and operations surface for the
-current `mere.run` Graph v2 runtime. Use the hosted app at
-[studio.mere.run](https://studio.mere.run/) or run the cross-platform Tauri 2
-desktop app on macOS, Windows, or Linux.
+Build workflows on a canvas instead of by hand in JSON. Mere Graph Studio is
+the visual authoring and operations surface for the current `mere.run` Graph v2
+runtime — either the hosted app at
+[studio.mere.run](https://studio.mere.run/) or the cross-platform Tauri 2
+desktop build for macOS, Windows, and Linux.
 
-Studio is a client of the portable graph system, not a separate workflow
-engine. It authors the same typed graph, inputs, and immutable job bundle that
-the CLI validates and executes locally, over SSH, or through Relay.
+Studio is a client, not a second engine. It authors exactly the typed graph,
+inputs, and immutable job bundle that the CLI validates and executes locally,
+over SSH, or through Relay — so anything you draw there runs headless
+everywhere else, unchanged.
 
 ## Graph v2 versus `schema_version: 1`
 
@@ -20,7 +22,7 @@ Two version labels describe different layers:
 
 Do not change a workflow to `schema_version: 2`. Graph v2 intentionally keeps
 the version-1 document contract so the CLI, desktop Studio, hosted Studio,
-Relay, and paired Nodes execute the same bytes.
+Relay, and paired Nodes execute the same immutable bundle bytes.
 
 ## Choose a Studio surface
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: mere.run
-  text: Local inference from one machine to a portable fleet
-  tagline: A public Swift package and CLI for multimodal inference, persistent worlds, typed workflow graphs, local APIs, an optional macOS studio, and headless Linux executors.
+  text: Create anything. Locally.
+  tagline: Image, text, video, music, sound, speech, vision, 3D, and persistent worlds in one Swift CLI, on hardware you already own. No inference API key. No upload. No venv.
   actions:
     - theme: brand
       text: Get Started
@@ -20,24 +20,45 @@ hero:
       link: /linux-quickstart
 
 features:
-  - title: Multimodal by design
-    details: Run image, text, speech, vision, 3D, music, sound-effect, video, and persistent-world workloads from one typed CLI.
-  - title: Portable workflow graphs
-    details: Validate once, materialize immutable job bundles, and run the same graph locally, over SSH, or through a relay executor.
-  - title: Live and resident runtimes
-    details: Stream microphone transcription, keep text and video models warm, and preserve causal world state across requests.
-  - title: Managed models and adapters
-    details: Inspect machine capabilities, pull pinned model snapshots and verified LoRAs, configure runtimes, and run deterministic quality gates.
-  - title: Local APIs and companions
-    details: Serve OpenAI-compatible chat, embeddings, images, speech, and transcription; connect Open WebUI or install official companion plugins.
-  - title: Mac-first, headless when needed
-    details: Use the native macOS studio on Apple Silicon or install CLI-only Linux packages for compatible CPU and CUDA hosts.
+  - title: Everything. Actually everything.
+    details: Score a track. With a unified A/V model, render a clip and its soundtrack in the same pass. Clone a voice. Follow an object through a video. Turn a photo into a textured mesh. Same CLI, same afternoon.
+  - title: No venv. Ever.
+    details: Core model paths run through Swift and MLX, with llama.cpp for explicit GGUF models — no Python worker, torch install, wheels to resolve, or environment to activate. Clone it and swift build.
+  - title: Nothing leaves
+    details: Weights live in a store you control. During local inference, prompts, photos, and audio stay on your disk. Nothing is metered or uploaded unless you explicitly use a networked action.
+  - title: Workflow runs keep their receipts
+    details: Portable workflow runs write a durable directory — plan, events, artifacts, SHA-256 manifests. Kill one halfway and resume it. Hand the immutable bundle to another executor with the same resolved inputs and fingerprints.
+  - title: Already speaks OpenAI
+    details: Serve chat, embeddings, images, speech, and transcription on localhost. Point your editor, your scripts, or Open WebUI at it. Change the base URL; change nothing else.
+  - title: One laptop now, a fleet later
+    details: The same immutable bundle runs here, over SSH to a GPU box, or across a relay fleet — with the same resolved seeds, fingerprints, and validation contract.
 ---
 
-## Current public command surface
+## Six commands, six kinds of thing
 
-This inventory is generated from the CLI configuration. Each command links to
-the page that owns its public documentation.
+Install a signed build from [mere.run/releases](https://mere.run/releases), or
+`swift build` from a clone. Then:
+
+```bash
+mere.run image generate --prompt "a ceramic mug in morning light" --output mug.png
+mere.run music generate "arena rock anthem, stacked vocals" --output anthem.wav
+mere.run speech synthesize "Hello from mere.run" --output hello.wav
+mere.run sfx generate "a ceramic mug shattering on tile" --output smash.wav
+mere.run video generate "a drone flight over snowy peaks" --output flight.mp4
+mere.run vision image-to-3d-trellis2 ./mug.png --output ./mug-3d
+```
+
+Same binary. Same grammar. No inference API key in any of them.
+
+Start with `mere.run model capabilities` — it reads your hardware and tells you
+which models this machine can actually run before you spend a gigabyte finding
+out.
+
+## The full command surface
+
+All of it ships in that one executable. The table below is generated from the
+CLI itself, so it cannot drift from what your copy really does — and every row
+links to the page that owns that command.
 
 <!-- BEGIN GENERATED: CLI TOP LEVEL -->
 | Command | Purpose |
@@ -68,36 +89,43 @@ the page that owns its public documentation.
 
 ## Choose a path
 
-### Install and run locally
+### Get it running
+
+Install, pull a first model, and make something in the next ten minutes.
 
 - [Getting Started](/getting-started)
 - [Linux QuickStart](/linux-quickstart)
 - [CLI Reference](/cli)
-- [Offline Cookbooks](/cookbooks)
+- [Offline Cookbooks](/cookbooks) — `mere.run guide` works without a network
 - [Configuration](/configuration)
 - [Model Sources](/model-sources)
 
-### Automate and operate
+### Make things
+
+Each family is its own page: what it generates, which model to pull, and the
+flags that actually change the output.
+
+- [Image](/runtime/image) — text-to-image, edits, and local LoRA training
+- [Text](/runtime/text) — chat, code, embeddings, tool use, PII redaction
+- [Speech](/runtime/speech) — synthesis, voice cloning, live transcription
+- [Vision and 3D](/runtime/vision) — caption, segment, track, depth, mesh, OCR
+- [Music](/runtime/music) — generation, covers, realtime MIDI, transcription
+- [Sound Effects](/runtime/sfx) — Foley from text or from a silent video
+- [Video](/runtime/video) — clips with synchronized audio, subject animation
+- [Persistent Worlds](/runtime/world) — a scene that remembers where you walked
+
+### Put it to work
+
+Serve it, schedule it, measure it, and keep it honest.
 
 - [Portable Workflows, Executors, and Run Artifacts](/workflows)
 - [Model and Adapter Management](/runtime/model-management)
 - [Local API Server and Open WebUI](/runtime/api-server)
 - [Official Companion Plugins](/plugins)
-- [Quality Gate](/gate)
+- [Quality Gate](/gate) — the check that catches a bad build before you do
 - [Benchmarking](/benchmarking)
 
-### Explore runtime families
-
-- [Image](/runtime/image)
-- [Text](/runtime/text)
-- [Speech](/runtime/speech)
-- [Vision and 3D](/runtime/vision)
-- [Music](/runtime/music)
-- [Sound Effects](/runtime/sfx)
-- [Video](/runtime/video)
-- [Persistent Worlds](/runtime/world)
-
-### Contribute to the repo
+### Work on the code
 
 - [Repository Tour](/repository-tour)
 - [Development Workflow](/development-workflow)

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -1,14 +1,15 @@
 # Linux QuickStart
 
-This page is for installing or building the headless `mere.run` CLI on Linux.
-Linux package artifacts are CLI-only and must be validated on the host class
-they target. CUDA artifacts must be built and smoke-tested on matching CUDA
-hardware before being treated as supported.
+Installing or building the headless `mere.run` CLI on Linux.
 
-The macOS path remains the primary hands-on development and runtime validation
-environment for this repo. The Linux package path is real, but intentionally
-narrow: CLI-only packages, Ubuntu-style hosts, x86_64 CPU and CUDA package
-manifests, and CUDA-gated arm64 package work.
+Be clear about what you are getting. The Linux path is real but deliberately
+narrow: CLI only, Ubuntu-style hosts, x86_64 CPU and CUDA package manifests,
+and CUDA-gated arm64 work. There is no studio app here, and macOS remains the
+primary development and runtime-validation environment for this repo.
+
+Nothing is treated as supported until it has been built and smoke-tested on the
+host class it targets — CUDA artifacts on real CUDA hardware, never a
+cross-build taken on faith.
 
 ## Current validation boundary
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -1,12 +1,15 @@
 # Model Sources
 
-This repo supports two model paths:
+Weights reach `mere.run` in exactly two ways:
 
-1. Hugging Face snapshots pulled into the local mere.run model store with `mere.run model pull`
-2. Explicit local paths passed to commands with `--model`, `--model-root`, or equivalent command-specific options
+1. **Managed pulls** — cataloged Hugging Face snapshots installed into the local
+   model store by `mere.run model pull`
+2. **Local paths** — a directory you point at yourself with `--model`,
+   `--model-root`, or the command's equivalent option
 
-The public repo no longer supports private model archives, R2 credentials, or a
-packaged central model host.
+There is no private model archive, no credentialed mirror, and no central host
+in between. Every managed model's source repository and pinned revision are in
+the catalog, so you can see exactly where each byte came from.
 
 The canonical local model store is:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,8 +1,10 @@
 # Companion Plugins
 
-Official mere.run plugins are separate executables distributed outside the
-Swift package. They can add operational integrations and typed workflow graph
-providers without loading third-party code into the `mere.run` process.
+Extend `mere.run` without letting anything into its process. Official plugins
+are separate executables shipped outside the Swift package: they can add
+operational integrations and typed workflow-graph nodes, but they run
+out-of-process and speak one fixed protocol. A plugin manifest cannot inject a
+shell command into your workflow bundle.
 
 ## Discover plugins
 
@@ -52,8 +54,8 @@ verbs: catalog, preflight, and execute. The core runtime validates typed
 requests and events; plugin manifests cannot inject arbitrary shell commands
 into workflow bundles.
 
-See [Portable Workflows](./workflows.md#graph-v1) for the graph ABI and
-[CLI Reference](./cli.md) for every plugin option.
+See [Portable Workflows](./workflows.md#graph-v2-runtime-and-v1-contract) for
+the graph ABI and [CLI Reference](./cli.md) for every plugin option.
 
 ## Source boundary
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -1,13 +1,20 @@
 # Local API Server
 
-This page covers `mere.run api serve`, the local API surface exposed by the package.
+The rest of `mere.run`, behind an OpenAI-compatible endpoint on localhost.
+Point an existing client, your editor, or Open WebUI at it and nothing about
+your setup changes except where the weights live — and where your prompts stop.
 
-## Public surface
+## Commands
 
-- `mere.run api serve`
-- `mere.run model runtime get`
-- `mere.run model runtime set`
-- `mere.run status`
+| Command | What it does |
+| --- | --- |
+| `mere.run api serve` | Start an OpenAI-compatible API server for supported local text, image, vision, and audio models. |
+| `mere.run model runtime get` | Print typed API runtime settings for a managed model. |
+| `mere.run model runtime set` | Update typed API runtime settings for a managed model. |
+| `mere.run status` | Show local server, loaded model, and installed model status. |
+
+## HTTP routes
+
 - `POST /v1/chat/completions`
 - `POST /v1/embeddings`
 - `POST /v1/images/generations`
@@ -22,19 +29,18 @@ This page covers `mere.run api serve`, the local API surface exposed by the pack
 
 ## What it is for
 
-The API server lets you expose supported local engines through a local process
-instead of shelling out to the CLI for every request. It is useful for:
+Serving beats shelling out to the CLI once you are making more than one request
+— the model stays loaded between them. It suits:
 
-- local automation
-- editor tooling
-- local RAG and knowledge-base embeddings
-- local image generation
-- local text-to-speech and speech-to-text
-- simple local integrations
-- experimenting with the runtime through HTTP
+- editor tooling and local automation
+- RAG and knowledge-base embeddings over private documents
+- image generation, speech, and transcription from an existing OpenAI client
+- trying the runtime out over HTTP before wiring anything permanent
 
-It is not a hosted-service or relay layer. This repo keeps the server local and
-package-scoped.
+It is not a hosted service or a relay layer. The server binds to loopback by
+default. For remote jobs, prefer [portable workflows](../workflows.md); when
+you deliberately bind the API server to a non-loopback address, configure its
+bearer token and rate limit first.
 
 ## Runtime entrypoints
 

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -1,19 +1,24 @@
 # Image Runtime
 
-This page covers the image-generation part of `mere.run`: what commands exist, what
-model families are supported, and how the code is organized.
+Generate an image from a prompt — then keep going. Train a LoRA on your own
+pictures without renting a GPU, replay any generation from a saved plan, or
+lift a single photo into a textured 3D mesh. Eight model families are
+supported, from compact ZImage checkpoints up to FLUX.2 Klein, HiDream O1,
+Krea 2, and Ideogram 4.
 
-## Public surface
+## Commands
 
-- `mere.run image dataset`
-- `mere.run image generate`
-- `mere.run image reconstruct-3d`
-- `mere.run image reconstruct-3d-trellis2`
-- `mere.run image reconstruct-3d-multiview`
-- `mere.run image run-plan`
-- `mere.run image train-lora`
-- `mere.run image visualize-run`
-- `mere.run image validate`
+| Command | What it does |
+| --- | --- |
+| `mere.run image generate` | Generate images with local image models. |
+| `mere.run image train-lora` | Train a local image LoRA adapter. |
+| `mere.run image visualize-run` | Open a local LoRA training run viewer to watch loss while it trains. |
+| `mere.run image dataset` | Inspect image training datasets, and discover candidates under a root. |
+| `mere.run image run-plan` | Run a saved image workflow plan. |
+| `mere.run image validate` | Run advanced deterministic validation for local image model families. |
+| `mere.run image reconstruct-3d` | Reconstruct a colored object mesh from one image with native TripoSR. |
+| `mere.run image reconstruct-3d-trellis2` | Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2. |
+| `mere.run image reconstruct-3d-multiview` | Reconstruct a colored mesh from 4 or 6 user-supplied views with native InstantMesh. |
 
 ## Model families
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -1,24 +1,28 @@
 # Model Management
 
-This page covers the shared model store, canonical model IDs, manifests, and
-the model-management commands.
+One store, canonical IDs, and honest accounting. `mere.run` checks whether this
+machine can run a model before it spends your bandwidth on it, reports what a
+model actually costs on disk once shared payloads are counted once, and shows
+exactly what is safe to delete.
 
-## Public surface
+## Commands
 
-- `mere.run model list`
-- `mere.run model capabilities`
-- `mere.run model info`
-- `mere.run model pull`
-- `mere.run model remove`
-- `mere.run model storage`
-- `mere.run model gc`
-- `mere.run model repair-manifests`
-- `mere.run model runtime`
-- `mere.run model benchmark`
-- `mere.run adapter list`
-- `mere.run adapter pull`
-- `mere.run status`
-- `mere.run setup`
+| Command | What it does |
+| --- | --- |
+| `mere.run model capabilities` | Show which managed models this machine can run. |
+| `mere.run model list` | List all known models with install status. |
+| `mere.run model pull` | Download a managed model into the local model store. |
+| `mere.run model info` | Print a model's manifest, validation status, and resolved component paths. |
+| `mere.run model remove` | Remove a model from the local model store. |
+| `mere.run model storage` | Inspect physical model storage, sharing, and reclaimable space. |
+| `mere.run model gc` | Find or delete unreferenced model payloads and partial downloads. |
+| `mere.run model repair-manifests` | Rewrite missing manifest metadata in the local store. |
+| `mere.run model runtime` | Read and update per-model API runtime settings. |
+| `mere.run model benchmark` | Run focused local model benchmarks. |
+| `mere.run adapter list` | List cataloged LoRA adapters and their install state. |
+| `mere.run adapter pull` | Download and verify a cataloged LoRA adapter. |
+| `mere.run status` | Show local server, loaded model, and installed model status. |
+| `mere.run setup` | Choose a guided, BYOA, or manual setup path. |
 
 ## Default model store
 

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -1,17 +1,22 @@
 # Music Runtime
 
-This page covers the native music-generation paths exposed through
-`mere.run music analyze`, `mere.run music generate`, `mere.run music realtime`,
-and `mere.run music transcribe`.
+Write a track from a text prompt, cover an existing song in a different genre,
+play a model live from a MIDI controller, or turn a finished mix back into
+instrument-separated MIDI with tempo, meter, and key already filled in.
+Generation, analysis, adapter training, resident serving, realtime steering,
+and transcription are native Swift and MLX paths — Magenta RT2 takes CC knobs
+while it is still generating.
 
-## Public surface
+## Commands
 
-- `mere.run music generate`
-- `mere.run music analyze`
-- `mere.run music serve`
-- `mere.run music train-adapter`
-- `mere.run music realtime`
-- `mere.run music transcribe`
+| Command | What it does |
+| --- | --- |
+| `mere.run music generate` | Generate audio from a music prompt. |
+| `mere.run music analyze` | Analyze source audio with ACE-Step audio understanding. |
+| `mere.run music serve` | Keep an ACE-Step pipeline resident behind the native music API. |
+| `mere.run music train-adapter` | Train a reloadable ACE-Step LoRA or LoKr adapter. |
+| `mere.run music realtime` | Run Magenta RealTime 2 music generation, steerable from stdin or CoreMIDI. |
+| `mere.run music transcribe` | Transcribe a full music mix into instrument-separated MIDI with MuScriptor. |
 
 ## Model family
 

--- a/docs/runtime/sfx.md
+++ b/docs/runtime/sfx.md
@@ -1,15 +1,19 @@
 # SFX Runtime
 
-This page covers the native sound-effect runtime exposed through `mere.run sfx`.
+Foley from a sentence — or from a silent video. Describe the sound you want and
+get a WAV back, or hand the runtime a clip and let it watch the footage and
+place the hits in sync with what is on screen.
 
-## Public surface
+## Commands
 
-- `mere.run sfx generate`
-- `mere.run sfx ae encode`
-- `mere.run sfx ae decode`
-- `mere.run sfx clap score`
-- `mere.run sfx condition text`
-- `mere.run sfx video generate`
+| Command | What it does |
+| --- | --- |
+| `mere.run sfx generate` | Generate a sound effect from a text prompt. |
+| `mere.run sfx video generate` | Generate an 8-second sound effect from a video or Synchformer features. |
+| `mere.run sfx clap score` | Score a text prompt against an audio file, to rank takes. |
+| `mere.run sfx condition text` | Encode a prompt with the Woosh text conditioner. |
+| `mere.run sfx ae encode` | Encode audio into normalized Woosh-AE latents. |
+| `mere.run sfx ae decode` | Decode normalized Woosh-AE latents into audio. |
 
 ## Model family
 

--- a/docs/runtime/speech.md
+++ b/docs/runtime/speech.md
@@ -1,15 +1,20 @@
 # Speech Runtime
 
-This page covers speech synthesis, transcription, and voice-profile management.
+Read text aloud, clone a voice from a short reference clip and save it for
+reuse, and transcribe either a file or a live microphone. Two ASR backends are
+available and the CLI picks between them by task — none of the audio leaves the
+machine in either direction.
 
-## Public surface
+## Commands
 
-- `mere.run speech synthesize`
-- `mere.run speech transcribe`
-- `mere.run speech listen`
-- `mere.run speech profile list`
-- `mere.run speech profile create`
-- `mere.run speech profile delete`
+| Command | What it does |
+| --- | --- |
+| `mere.run speech synthesize` | Generate speech from text using Qwen3-TTS. |
+| `mere.run speech transcribe` | Transcribe or translate speech to text using native ASR backends. |
+| `mere.run speech listen` | Transcribe a macOS microphone with live Qwen ASR. |
+| `mere.run speech profile create` | Create a reusable voice profile from reference audio. |
+| `mere.run speech profile list` | List saved speech voice profiles. |
+| `mere.run speech profile delete` | Delete a speech profile by id. |
 
 ## Model families
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -1,15 +1,20 @@
 # Text Runtime
 
-This page covers the text-facing command families: chat, code generation,
-embeddings, PII anonymization, and native text LoRA preparation.
+Local chat that can actually do things: stream tokens, run a sandboxed tool
+loop, take an image alongside the prompt, hold a grammar-checked JSON object to
+the last brace, and fine-tune on your own conversations. Alongside it sits a
+separate GGUF path for code, an embedding model for local search, and a PII
+redactor that never sends the text it is redacting anywhere.
 
-## Public surface
+## Commands
 
-- `mere.run text chat`
-- `mere.run text code`
-- `mere.run text embed`
-- `mere.run text anonymize`
-- `mere.run text train-lora`
+| Command | What it does |
+| --- | --- |
+| `mere.run text chat` | Run local chat with text chat models. |
+| `mere.run text code` | Run local code generation with GGUF models via llama.cpp. |
+| `mere.run text embed` | Generate text embeddings using native Qwen3-Embedding-0.6B. |
+| `mere.run text anonymize` | Detect and redact PII using OpenAI Privacy Filter. |
+| `mere.run text train-lora` | Train a native text LoRA adapter from chat-style SFT JSONL. |
 
 ## Model families
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -1,15 +1,21 @@
 # Video Runtime
 
-This page covers the native video-generation path exposed through `mere.run video`.
+Generate a clip from a prompt. With a unified A/V checkpoint, the model writes
+the soundtrack in the same pass rather than layering it on afterwards. Anchor
+the clip to a start frame, steer it toward an end frame, or condition the motion
+on a song you already have. Recast a performer in an existing shot. Keep the
+checkpoint resident and render take after take without paying for the reload.
 
-## Public surface
+## Commands
 
-- `mere.run video generate`
-- `mere.run video cosmos3`
-- `mere.run video animate`
-- `mere.run video prepare-masks`
-- `mere.run video session`
-- `mere.run video export-latents`
+| Command | What it does |
+| --- | --- |
+| `mere.run video generate` | Generate MP4 video with native Swift/MLX video models. |
+| `mere.run video cosmos3` | Run native NVIDIA Cosmos3-Edge generation and action modes. |
+| `mere.run video animate` | Animate or replace a masked subject with native Swift/MLX SCAIL-2. |
+| `mere.run video prepare-masks` | Prepare reviewable, palette-safe SCAIL-2 masks with native SAM 3.1. |
+| `mere.run video session` | Keep an LTX 2.3 runtime resident for JSONL generation requests. |
+| `mere.run video export-latents` | Run native Swift/MLX distilled LTX denoising and export final latents. |
 
 ## Model family
 

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -1,30 +1,50 @@
 # Vision Runtime
 
-This page covers captioning, inspection, face analysis, grounding, segmentation, tracking,
-pose extraction, optical flow, video depth, single- and multi-view geometry,
-image-to-3D reconstruction, and OCR.
+The widest surface in `mere.run`. Ask a question about a photo, cut out any
+object you can name, follow it through a video, read a document, recover metric
+depth and camera intrinsics from a single frame, or reconstruct a PBR mesh —
+nineteen commands, every one of them running on your own machine.
 
-## Public surface
+## Commands
 
-- `mere.run vision caption`
-- `mere.run vision inspect`
-- `mere.run vision face detect`
-- `mere.run vision face embed`
-- `mere.run vision face compare`
-- `mere.run vision face batch`
-- `mere.run vision ground`
-- `mere.run vision segment`
-- `mere.run vision track`
-- `mere.run vision track-live`
-- `mere.run vision pose`
-- `mere.run vision flow`
-- `mere.run vision depth-video`
-- `mere.run vision geometry`
-- `mere.run vision geometry-multiview`
-- `mere.run vision image-to-3d`
-- `mere.run vision image-to-3d-trellis2`
-- `mere.run vision image-to-3d-multiview`
-- `mere.run vision ocr`
+**Understand and read**
+
+| Command | What it does |
+| --- | --- |
+| `mere.run vision inspect` | Describe or answer questions about an image using Qwen3-VL. |
+| `mere.run vision caption` | Generate training-friendly captions for images. |
+| `mere.run vision ocr` | Extract text from images using LightOnOCR, GLM-OCR, or Infinity-Parser2. |
+
+**Find, isolate, and follow**
+
+| Command | What it does |
+| --- | --- |
+| `mere.run vision ground` | Ground text queries in an image with the native Falcon Perception runtime. |
+| `mere.run vision segment` | Segment prompted objects in an image with the native SAM 3.1 runtime. |
+| `mere.run vision track` | Track prompted objects through a video with the native SAM 3.1 runtime. |
+| `mere.run vision track-live` | Capture from a camera and track text-prompted objects with native SAM 3.1. |
+
+**Faces**
+
+| Command | What it does |
+| --- | --- |
+| `mere.run vision face detect` | Detect faces and five-point landmarks in an image. |
+| `mere.run vision face embed` | Create a normalized ArcFace embedding for one face in an image. |
+| `mere.run vision face compare` | Compare one face from each of two images with cosine similarity. |
+| `mere.run vision face batch` | Analyze many images with one warm detector/recognizer session and emit JSONL. |
+
+**Measure, reconstruct, and move**
+
+| Command | What it does |
+| --- | --- |
+| `mere.run vision pose` | Detect body, hand, and face landmarks with the native platform runtime. |
+| `mere.run vision flow` | Generate dense optical flow between two equal-size images. |
+| `mere.run vision depth-video` | Generate temporally consistent relative or metric video depth with native VDA-S. |
+| `mere.run vision geometry` | Generate metric depth, normals, camera intrinsics, and a point cloud with native MoGe-2. |
+| `mere.run vision geometry-multiview` | Solve native DA3-Small multi-view relative geometry, confidence, and cameras. |
+| `mere.run vision image-to-3d` | Reconstruct a colored object mesh from one image with native TripoSR. |
+| `mere.run vision image-to-3d-trellis2` | Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2. |
+| `mere.run vision image-to-3d-multiview` | VFX alias for native 4/6-view InstantMesh reconstruction. |
 
 ## Model family
 

--- a/docs/runtime/world.md
+++ b/docs/runtime/world.md
@@ -1,15 +1,23 @@
 # Persistent World Runtime
 
-`mere.run world` runs a long-lived, local conditioned-video session. The
-loopback-first HTTP server supports two native Swift/MLX backends:
+A generated place you can walk around in. Send a camera move and get back a
+video chunk; send another and it continues from where the last one ended — same
+corridor, same light, same scene. The session is a navigation graph rather than
+a one-way chain, so an exact inverse move replays the edge you arrived on
+instead of inventing a new room on the way back.
+
+It runs as a long-lived local HTTP server, loopback-first, on either of two
+native Swift/MLX backends:
 
 - `dreamx`: Wan 2.2 TI2V resources plus a converted DreamX causal checkpoint
 - `cosmos3`: the official Cosmos3-Edge checkpoint with learned action
   conditioning and the `camera_pose` action domain
 
-## Public surface
+## Commands
 
-- `mere.run world serve`
+| Command | What it does |
+| --- | --- |
+| `mere.run world serve` | Serve one warm native world-model session over HTTP. |
 
 ## Required models
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,21 +1,27 @@
 # Portable Workflows
 
-`mere.run` workflows are immutable, headless job graphs that use the same
-contract locally, over SSH, and through a relay-managed GPU fleet. A future
-canvas can author this document, but it does not own execution behavior.
+Describe a job once as a typed graph, and the same bundle runs on your laptop,
+over SSH to a GPU box, or across a relay fleet — with the same resolved seeds,
+the same fingerprints, and the same execution contract at the other end.
+
+Workflows are immutable and headless. Nothing about *where* a job runs is baked
+into it: executor profiles, tokens, URLs, and machine paths never enter the
+bundle. Visual editors such as [Graph Studio](./graph/studio.md) author these
+documents, but execution behavior is defined here, not on the canvas.
 
 ## Graph v2 runtime and v1 contract
 
-The current execution system is the second-generation graph runtime: immutable
-job bundles, typed provider catalogs, executor preflight, resumable runs,
-parallel scheduling, and one execution contract across local, SSH, and Relay.
-That product/runtime generation is called **Graph v2**.
+Two different things carry version numbers here, and mixing them up causes real
+bugs.
 
-The serialized workflow ABI remains deliberately stable at version 1. Graph v2
-therefore still reads and writes `mere.run/workflow-graph` documents with
-`schema_version: 1`; the runtime name is not a request to emit a
-`schema_version: 2` document. See [Graph Studio](./graph/studio.md) for the
-visual authoring surfaces built on this contract.
+**Graph v2** is the current runtime generation: immutable job bundles, typed
+provider catalogs, executor preflight, resumable runs, parallel scheduling, and
+one execution contract shared by local, SSH, and Relay.
+
+The serialized workflow ABI is a separate thing, and it stays deliberately
+pinned at version 1. Graph v2 still reads and writes `mere.run/workflow-graph`
+documents with `schema_version: 1`. The runtime name is not a request to emit a
+`schema_version: 2` document.
 
 Every graph uses `schema_version: 1` and `kind: "mere.run/workflow-graph"`.
 Identifiers match `[a-z][a-z0-9-]{0,63}`. Supported graph input types are


### PR DESCRIPTION
## Summary

- recover and reconcile the 21-page public documentation refresh from the protected dirty main checkout
- preserve the Laguna S 2.1 managed serving, DFlash, batching, min-p, and benchmark documentation from #209
- sharpen runtime overviews and command tables while keeping local, workflow, networking, and reproducibility claims aligned with the implementation

## Stack

This PR intentionally targets `codex/laguna-acceleration` so its diff contains only documentation. Merge #209 first, then this PR can be retargeted to `main` (or merged after GitHub updates the base automatically).

The original dirty main checkout remains untouched; recovery was performed in an isolated worktree.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm docs:build`
- `swift test --filter DocumentationContractTests` (4/4)
- `./scripts/check.sh` (2,174 XCTest tests, 141 expected skips, 0 failures; 13 Swift Testing tests, 0 failures)
- live checks for `mere.run/releases`, `studio.mere.run`, and `studio.mere.run/app` (HTTP 200)