### PR TITLE
docs: rewrite the docs.mere.run landing atlas copy

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,7 +5,7 @@ export default createMereProductDocsTheme({
   productDomain: 'docs.mere.run',
   docsUrl: 'https://docs.mere.run/',
   productHref: 'https://mere.run',
-  corePrefix: 'Multimodal inference, portable graphs, and persistent local runtimes.',
+  corePrefix: 'Eight runtime families. One local CLI. No cloud in the loop.',
   guideHref: '/getting-started',
   architectureHref: '/architecture',
   operationsHref: '/development-workflow',
@@ -13,5 +13,35 @@ export default createMereProductDocsTheme({
   runtimeHref: '/runtime/image',
   pluginsHref: '/plugins',
   referenceHref: '/cli',
-  cliHref: '/cli'
+  cliHref: '/cli',
+  planes: [
+    {
+      name: 'Make something',
+      signal: 'Image, video, music, speech, vision, 3D, and worlds you can walk around in',
+      href: '/runtime/image',
+      accent: 'green',
+      items: ['Eight families', 'Native MLX', 'On your disk'],
+    },
+    {
+      name: 'Drive it from the CLI',
+      signal: 'Every command and flag, plus offline cookbooks that work with the network off',
+      href: '/cli',
+      accent: 'blue',
+      items: ['Commands', 'Cookbooks', 'Setup'],
+    },
+    {
+      name: 'Run it anywhere',
+      signal: 'Describe a job once, then run it here, over SSH, or across a fleet — same bytes out',
+      href: '/workflows',
+      accent: 'plum',
+      items: ['Graphs', 'Executors', 'Runs'],
+    },
+    {
+      name: 'Extend it safely',
+      signal: 'Typed graph providers that add nodes without entering the mere.run process',
+      href: '/plugins',
+      accent: 'copper',
+      items: ['Catalog', 'Doctor', 'Providers'],
+    },
+  ]
 })

--- a/docs/.vitepress/theme/mere/index.ts
+++ b/docs/.vitepress/theme/mere/index.ts
@@ -31,6 +31,8 @@ export interface MereProductDocsThemeOptions {
   pluginsHref?: string
   referenceHref?: string
   cliHref?: string
+  /** Override the generic four-plane atlas with product-specific copy. */
+  planes?: MereAtlasPlane[]
 }
 
 export function createMereDocsTheme(config: MereDocsThemeUserConfig = {}): Theme {
@@ -54,10 +56,10 @@ export function createMereProductDocsTheme(options: MereProductDocsThemeOptions)
   const operationsHref = options.operationsHref ?? guideHref
   const workflowsHref = options.workflowsHref ?? guideHref
   const runtimeHref = options.runtimeHref ?? architectureHref
-  const pluginsHref = options.pluginsHref ?? referenceHref
   const referenceHref = options.referenceHref ?? guideHref
+  const pluginsHref = options.pluginsHref ?? referenceHref
   const cliHref = options.cliHref ?? referenceHref
-  const planes: MereAtlasPlane[] = [
+  const planes: MereAtlasPlane[] = options.planes ?? [
     {
       name: `${options.productName} CLI`,
       signal: 'Complete command tree, setup paths, and practical cookbooks',

--- a/docs/runtime/world.md
+++ b/docs/runtime/world.md
@@ -9,14 +9,14 @@ instead of inventing a new room on the way back.
 It runs as a long-lived local HTTP server, loopback-first, on either of two
 native Swift/MLX backends:
 
+- `dreamx`: Wan 2.2 TI2V resources plus a converted DreamX causal checkpoint
+- `cosmos3`: the official Cosmos3-Edge checkpoint with learned action
+  conditioning and the `camera_pose` action domain
+
 The macOS Studio app exposes the same resident server in Advanced → Operations
 with typed backend, model, state-directory, warmup, host, port, and
 authentication controls. API keys are injected with `MERERUN_API_KEY` so they
 do not appear in the child process argument list.
-
-- `dreamx`: Wan 2.2 TI2V resources plus a converted DreamX causal checkpoint
-- `cosmos3`: the official Cosmos3-Edge checkpoint with learned action
-  conditioning and the `camera_pose` action domain
 
 ## Commands
 


### PR DESCRIPTION
## Why

The landing copy at [docs.mere.run](https://docs.mere.run/) does not come from `docs/index.md`. The theme injects a `MereAtlasMap` card into VitePress's `#home-hero-image` slot, and that card's text is hardcoded in `docs/.vitepress/theme/`. The prose refresh in #210 never reached it — and on mobile the atlas card is the first thing rendered, so it is what most visitors actually read.

The heading was three stacked abstract nouns, and the four planes described the documentation rather than what the runtime does.

## What changed

**Heading**

> ~~Multimodal inference, portable graphs, and persistent local runtimes.~~
> Eight runtime families. One local CLI. No cloud in the loop.

**Planes** — reordered so "make something" leads, since opening a local-inference landing page with "CLI" buries the payload.

| | Before | After |
|---|---|---|
| 01 | mere.run CLI — *Complete command tree, setup paths, and practical cookbooks* | **Make something** — Image, video, music, speech, vision, 3D, and worlds you can walk around in |
| 02 | Portable workflows — *Immutable bundles across local, SSH, and relay executors* | **Drive it from the CLI** — Every command and flag, plus offline cookbooks that work with the network off |
| 03 | Runtime families — *Image, text, audio, vision, video, 3D, and persistent worlds* | **Run it anywhere** — Describe a job once, then run it here, over SSH, or across a fleet — same bytes out |
| 04 | Companion plugins — *Verified external tools and typed graph providers* | **Extend it safely** — Typed graph providers that add nodes without entering the mere.run process |

## Notes for review

- **The planes were generated inside the shared `createMereProductDocsTheme` factory**, so editing them in place would have changed every mere product docs site. This adds an optional `planes` override to `MereProductDocsThemeOptions` instead — generic defaults are untouched and every other site keeps its current atlas.
- **Fixes a latent TDZ crash in that shared factory.** `pluginsHref` fell back to `referenceHref` one line before that `const` was initialized. `mere.run` passes an explicit `pluginsHref`, so `??` short-circuits and hides it, but any product docs site that omits `pluginsHref` would throw `Cannot access 'referenceHref' before initialization` on load. One-line reorder.
- **Second commit repairs a conflict resolution from #210.** In `docs/runtime/world.md` the macOS Studio paragraph landed between the sentence ending "…on either of two native Swift/MLX backends**:**" and the `dreamx`/`cosmos3` list it introduces. Moved below the list.

## Verification

- `pnpm docs:build` — clean, no dead links
- `swift test --filter DocumentationContractTests` — 4/4 passing
- New copy confirmed present in `dist/index.html`; old heading confirmed gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvrXJUAqdJjTruGxAimjeK