### PR TITLE
feat(app): secure Sparkle updates and SCAIL preflight for 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## 0.27.1 - 2026-07-27
+
+### Added
+
+- added Sparkle 2.9.2 to the macOS Studio with a standard Check for Updates
+  command and daily background discovery through the stable HTTPS appcast.
+  Updates are Developer ID signed, notarized, verified with a pinned Ed25519
+  key before extraction, and delivered through a signed feed.
+
+### Fixed
+
+- made SCAIL-2 fast-profile preflight return a structured blocked report when
+  its managed four-step adapter is missing or fails byte-count/SHA-256
+  verification. Generation still resolves the adapter strictly before loading.
+- bundled and signed Sparkle's versioned framework and nested helpers
+  inside-out while preserving the Downloader service entitlements and framework
+  symlinks.
+
 ## 0.27.0 - 2026-07-27
 
 This release brings the macOS Studio to full public CLI capability coverage,

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "efc91ee4a1505bb1e2465ba4f0c144ff7a05be4c204ecbe28d5c9fdc05463446",
+  "originHash" : "982c34170678d1836c16a60a3f310e687db874202fb65477b499667081b85a2e",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -34,6 +34,15 @@
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
         "revision" : "0c63032c7deeec3cb0600aa933cb0b50d16addb6"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -466,10 +466,19 @@ if !isLinuxPackage {
   targets.append(
     .executableTarget(
       name: "MereRunApp",
-      dependencies: ["MereRunContract"],
+      dependencies: [
+        "MereRunContract",
+        .product(name: "Sparkle", package: "Sparkle")
+      ],
       path: "Sources/MereRunApp",
       exclude: [
         "README.md"
+      ],
+      linkerSettings: [
+        .unsafeFlags([
+          "-Xlinker", "-rpath",
+          "-Xlinker", "@loader_path/../Frameworks"
+        ])
       ]
     )
   )
@@ -499,6 +508,9 @@ var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
 if !isLinuxPackage {
   packageDependencies.append(
     .package(url: "https://github.com/readdle/swift-onnxruntime.git", exact: "1.20.1")
+  )
+  packageDependencies.append(
+    .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.2")
   )
 }
 

--- a/Sources/MereRunApp/MereRunApp.swift
+++ b/Sources/MereRunApp/MereRunApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Quartz
+import Sparkle
 import SwiftUI
 
 final class MereRunAppDelegate: NSObject, NSApplicationDelegate {
@@ -26,6 +27,11 @@ final class MereRunAppDelegate: NSObject, NSApplicationDelegate {
 struct MereRunApp: App {
     @NSApplicationDelegateAdaptor(MereRunAppDelegate.self) private var appDelegate
     @StateObject private var controller = MereRunController()
+    private let updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: nil
+    )
 
     var body: some Scene {
         WindowGroup {
@@ -48,7 +54,10 @@ struct MereRunApp: App {
         .windowResizability(.contentMinSize)
         .defaultSize(width: 1280, height: 820)
         .commands {
-            MereRunCommands(controller: controller)
+            MereRunCommands(
+                controller: controller,
+                updater: updaterController.updater
+            )
         }
 
         Settings {

--- a/Sources/MereRunApp/MereRunCommands.swift
+++ b/Sources/MereRunApp/MereRunCommands.swift
@@ -1,9 +1,11 @@
+import Sparkle
 import SwiftUI
 
 /// Top-level menu bar commands. View-toggle commands (Library/Advanced/Models) are
 /// installed by `StudioRootView` via focused scene values once the UI state is shared.
 struct MereRunCommands: Commands {
     @ObservedObject var controller: MereRunController
+    let updater: SPUUpdater
 
     @FocusedValue(\.showLibrary) private var showLibrary: Binding<Bool>?
     @FocusedValue(\.showAdvanced) private var showAdvanced: Binding<Bool>?
@@ -12,6 +14,10 @@ struct MereRunCommands: Commands {
     var body: some Commands {
         // Single-window studio: remove the default "New" item rather than spawn windows.
         CommandGroup(replacing: .newItem) {}
+
+        CommandGroup(after: .appInfo) {
+            MereRunCheckForUpdatesView(updater: updater)
+        }
 
         // View toggles act on whichever Studio window is key (via focused scene values). When no
         // Studio window holds focus all three are nil, so the group (and its divider) stay empty.

--- a/Sources/MereRunApp/MereRunUpdater.swift
+++ b/Sources/MereRunApp/MereRunUpdater.swift
@@ -1,0 +1,35 @@
+import Combine
+import Sparkle
+import SwiftUI
+
+enum MereRunUpdateConfiguration {
+    static let feedURL = URL(string: "https://mere.run/releases/appcast.xml")!
+    static let publicEDKey = "6sFs+7UqYcE7rThPAovzMDsZtKyf/h4/d8rUmPSH2rw="
+}
+
+@MainActor
+final class MereRunUpdateCheckViewModel: ObservableObject {
+    @Published private(set) var canCheckForUpdates = false
+
+    init(updater: SPUUpdater) {
+        updater.publisher(for: \.canCheckForUpdates)
+            .receive(on: RunLoop.main)
+            .assign(to: &$canCheckForUpdates)
+    }
+}
+
+struct MereRunCheckForUpdatesView: View {
+    @ObservedObject private var viewModel: MereRunUpdateCheckViewModel
+    private let updater: SPUUpdater
+
+    @MainActor
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        viewModel = MereRunUpdateCheckViewModel(updater: updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates…", action: updater.checkForUpdates)
+            .disabled(!viewModel.canCheckForUpdates)
+    }
+}

--- a/Sources/MereRunApp/README.md
+++ b/Sources/MereRunApp/README.md
@@ -78,3 +78,9 @@ the app before placing that already-stapled app into the signed and notarized
 DMG. `LinuxNativeBridgeTests.testMacOSPackageEmbedsTheStapledAppBeforeCreatingTheDMG`
 guards that ordering. Release proof must validate the mounted/installed app and
 its embedded CLI, not only the outer DMG.
+
+The packaged app embeds Sparkle and exposes **Check for Updates…** in the app
+menu. Release builds use the stable HTTPS appcast, automatic daily discovery,
+an Ed25519-signed archive and feed, Developer ID verification, and
+pre-extraction signature validation. Sparkle updates the complete app bundle,
+including its embedded CLI, as one atomic unit.

--- a/Sources/MereRunCLI/Commands/VideoAnimateCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoAnimateCommand.swift
@@ -369,7 +369,8 @@ struct VideoAnimate: AsyncParsableCommand {
 
     func makePreflightReport(
         options: SCAIL2GenerationOptions,
-        modelRootURL: URL?
+        modelRootURL: URL?,
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir
     ) -> SCAIL2AnimationPreflightReport {
         let inputs = [
             options.reference.imageURL,
@@ -378,7 +379,19 @@ struct VideoAnimate: AsyncParsableCommand {
             options.drivingMaskVideoURL,
         ] + options.additionalReferences.flatMap { [$0.imageURL, $0.maskURL] }
             + (options.distilledAdapterURL.map { [$0] } ?? [])
-        let missingInputs = inputs.filter { !FileManager.default.fileExists(atPath: $0.path) }
+        let effectiveAdapterReference = profile == .fast
+            ? distilledAdapter ?? ManagedAdapterCatalog.scail2LightX2VFourStepID
+            : distilledAdapter
+        let managedAdapterSpec = effectiveAdapterReference.flatMap {
+            ManagedAdapterCatalog.spec(for: $0)
+        }
+        let missingInputs = inputs.filter { input in
+            if input == options.distilledAdapterURL,
+               let managedAdapterSpec {
+                return !managedAdapterSpec.isInstalled(adaptersRoot: adaptersRoot)
+            }
+            return !FileManager.default.fileExists(atPath: input.path)
+        }
         let missingModels = modelRootURL.map { SCAIL2Resources(rootURL: $0).validate() } ?? []
         let installed = modelRootURL != nil && missingModels.isEmpty
         return SCAIL2AnimationPreflightReport(

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.27.0"
+    static let current = "0.27.1"
 }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -25,6 +25,132 @@ with the new upstream source, version or commit when known, and license data.
 
 ## Binary package runtime dependencies
 
+### Sparkle for macOS updates
+
+- purpose: secure discovery, verification, and atomic installation of signed
+  MereRun macOS app updates
+- upstream project: [`sparkle-project/Sparkle`](https://github.com/sparkle-project/Sparkle),
+  version `2.9.2`; MIT with the bundled component notices below
+- package location: `MereRun.app/Contents/Frameworks/Sparkle.framework`
+
+```text
+Copyright (c) 2006-2013 Andy Matuschak.
+Copyright (c) 2009-2013 Elgato Systems GmbH.
+Copyright (c) 2011-2014 Kornel Lesiński.
+Copyright (c) 2015-2017 Mayur Pawashe.
+Copyright (c) 2014 C.W. Betts.
+Copyright (c) 2014 Petroules Corporation.
+Copyright (c) 2014 Big Nerd Ranch.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+bspatch.c and bsdiff.c, from bsdiff 4.3:
+
+Copyright 2003-2005 Colin Percival
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted providing that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+sais.c and sais.h, from sais-lite:
+
+Copyright (c) 2008-2010 Yuta Mori All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Portable C implementation of Ed25519, from https://github.com/orlp/ed25519:
+
+Copyright (c) 2015 Orson Peters <orsonpeters@gmail.com>
+
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use
+of this software.
+
+Permission is granted to anyone to use this software for any purpose, including
+commercial applications, and to alter it and redistribute it freely, subject
+to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim
+   that you wrote the original software. If you use this software in a product,
+   an acknowledgment in the product documentation would be appreciated but is
+   not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+SUSignatureVerifier.m:
+
+Copyright (c) 2011 Mark Hamlin.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted providing that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+```
+
 ### NVIDIA CUTLASS CUDA JIT headers
 
 - purpose: Linux CUDA packages bundle the CUTLASS and CuTe headers required by

--- a/Tests/MereRunAppTests/MereRunUpdaterTests.swift
+++ b/Tests/MereRunAppTests/MereRunUpdaterTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import MereRunApp
+
+final class MereRunUpdaterTests: XCTestCase {
+    func testStableUpdateConfigurationIsPinnedToHTTPSAndEd25519() throws {
+        let feedURL = MereRunUpdateConfiguration.feedURL
+
+        XCTAssertEqual(feedURL.scheme, "https")
+        XCTAssertEqual(feedURL.host, "mere.run")
+        XCTAssertEqual(feedURL.path, "/releases/appcast.xml")
+        XCTAssertEqual(
+            Data(base64Encoded: MereRunUpdateConfiguration.publicEDKey)?.count,
+            32
+        )
+    }
+}

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.27.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.27.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -180,6 +180,29 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertFalse(script.contains("if notarize \"$dmg_path\""))
     }
 
+    func testMacOSAppBundlesAndSecurelyConfiguresSparkle() throws {
+        let package = try readRepositoryFile("Package.swift")
+        let script = try readRepositoryFile("scripts/build_mere_run_app.sh")
+
+        XCTAssertTrue(package.contains(#".product(name: "Sparkle", package: "Sparkle")"#))
+        XCTAssertTrue(package.contains(#"sparkle-project/Sparkle", exact: "2.9.2""#))
+        XCTAssertTrue(script.contains("ditto \"$sparkle_framework\" \"${frameworks}/Sparkle.framework\""))
+        XCTAssertTrue(script.contains("SUFeedURL"))
+        XCTAssertTrue(script.contains("https://mere.run/releases/appcast.xml"))
+        XCTAssertTrue(script.contains("git describe --tags --exact-match"))
+        XCTAssertTrue(script.contains(#"sparkle_public_ed_key="6sFs+7UqYcE7rThPAovzMDsZtKyf/h4/d8rUmPSH2rw=""#))
+        XCTAssertTrue(script.contains("SUEnableAutomaticChecks"))
+        XCTAssertTrue(script.contains("SUVerifyUpdateBeforeExtraction"))
+        XCTAssertTrue(script.contains("SURequireSignedFeed"))
+        XCTAssertTrue(script.contains("MereRunDebug.entitlements"))
+        XCTAssertTrue(script.contains(#"if [[ "$identity" == "-" ]]"#))
+        XCTAssertTrue(script.contains("--preserve-metadata=entitlements"))
+        XCTAssertTrue(script.contains("XPCServices/Installer.xpc"))
+        XCTAssertTrue(script.contains("XPCServices/Downloader.xpc"))
+        XCTAssertTrue(script.contains(#""${sparkle_version_root}/Autoupdate""#))
+        XCTAssertTrue(script.contains(#""${sparkle_version_root}/Updater.app""#))
+    }
+
     private func readRepositoryFile(_ relativePath: String) throws -> String {
         let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent(relativePath, isDirectory: false)

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -237,6 +237,9 @@ final class VideoCommandTests: XCTestCase {
 
     func testVideoAnimatePreflightReportsMissingInputsWithoutLoading() throws {
         let adaptersRoot = try makeTempDirectory()
+        let adapterSpec = try XCTUnwrap(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.scail2LightX2VFourStepID)
+        )
         let command = try VideoAnimate.parse([
             "a dancer turns",
             "--reference", "/tmp/missing-ref.png",
@@ -252,19 +255,57 @@ final class VideoCommandTests: XCTestCase {
             requireInstalledAdapter: false,
             adaptersRoot: adaptersRoot
         )
-        let report = command.makePreflightReport(options: options, modelRootURL: nil)
+        let report = command.makePreflightReport(
+            options: options,
+            modelRootURL: nil,
+            adaptersRoot: adaptersRoot
+        )
 
         XCTAssertEqual(report.status, "blocked")
         XCTAssertFalse(report.modelInstalled)
         XCTAssertEqual(report.missingInputFiles.count, 5)
         XCTAssertTrue(
             report.missingInputFiles.contains(
-                try XCTUnwrap(
-                    ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.scail2LightX2VFourStepID)
-                ).installedFileURL(adaptersRoot: adaptersRoot).path
+                adapterSpec.installedFileURL(adaptersRoot: adaptersRoot).path
             )
         )
         XCTAssertEqual(report.mode, "animation")
+    }
+
+    func testVideoAnimatePreflightRejectsUnverifiedManagedAdapter() throws {
+        let adaptersRoot = try makeTempDirectory()
+        let adapterSpec = try XCTUnwrap(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.scail2LightX2VFourStepID)
+        )
+        let adapterURL = adapterSpec.installedFileURL(adaptersRoot: adaptersRoot)
+        try createFile(adapterURL)
+        let reference = try makeTempFile(name: "ref.png")
+        let referenceMask = try makeTempFile(name: "ref-mask.png")
+        let drivingVideo = try makeTempFile(name: "driving.mp4")
+        let drivingMask = try makeTempFile(name: "driving-mask.mov")
+        let command = try VideoAnimate.parse([
+            "a dancer turns",
+            "--reference", reference.path,
+            "--reference-mask", referenceMask.path,
+            "--driving-video", drivingVideo.path,
+            "--driving-mask", drivingMask.path,
+            "--preflight",
+            "--json",
+        ])
+        let options = try command.makeOptions(
+            prompt: command.prompt,
+            outputURL: URL(fileURLWithPath: "/tmp/result.mp4"),
+            requireInstalledAdapter: false,
+            adaptersRoot: adaptersRoot
+        )
+        let report = command.makePreflightReport(
+            options: options,
+            modelRootURL: nil,
+            adaptersRoot: adaptersRoot
+        )
+
+        XCTAssertEqual(report.status, "blocked")
+        XCTAssertEqual(report.missingInputFiles, [adapterURL.path])
     }
 
     func testVideoGenerateParsesDefaults() throws {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,6 +106,12 @@ The studio is macOS-only. Linux users and Linux CI should exercise the CLI and
 local API surfaces directly rather than trying to build or launch
 `mere.run.app`.
 
+MereRun 0.27.1 and newer checks the stable signed update feed once per day and
+also exposes **MereRun > Check for Updates…**. Updates replace the whole signed
+app bundle atomically, so the Studio and its embedded CLI stay on the same
+version. Releases older than 0.27.1 do not contain the updater and need one
+final manual DMG install before future updates can arrive in-app.
+
 ## Build Linux package artifacts
 
 Linux package artifacts are headless CLI-only. They install the `mere.run` CLI

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -169,6 +169,11 @@ The default `--profile fast` managed four-step path selects the pinned
 schedule at 832x480. `--profile quality` remains available as an explicit
 opt-in to the configurable 40-step UniPC/CFG recipe:
 
+Preflight resolves that managed default without loading it, then verifies the
+installed file's exact byte count and SHA-256. A missing or corrupt adapter is
+reported in `missing_input_files`; generation keeps strict resolution and
+cannot continue with an unverified file.
+
 ```bash
 swift run mere.run video animate \
   "a silver puppet follows the dancer" \

--- a/scripts/MereRun.entitlements
+++ b/scripts/MereRun.entitlements
@@ -7,15 +7,19 @@
 	  of the notarized (non-sandboxed) Developer ID build. Mac App Store / App Sandbox is
 	  intentionally out of scope for this OSS distribution.
 
-	  The app target links only system frameworks (Package.swift: MereRunApp dependencies = [])
-	  and does no JIT, executable-memory, or unsigned-library loading itself — all inference and
-	  the AVCaptureSession capture run in the bundled `mere.run` CLI child, which carries those
-	  entitlements on its own signature (see scripts/MereRunCLI.entitlements). So the app needs
-	  only the camera entitlement:
+	  The app target links Sparkle, which is signed with the same Developer ID
+	  Team as the app for distribution. It does no JIT, executable-memory, or
+	  unsigned-library loading itself — all inference and the AVCaptureSession
+	  capture run in the bundled `mere.run` CLI child, which carries those
+	  entitlements on its own signature (see scripts/MereRunCLI.entitlements).
+	  The release app therefore keeps library validation enabled and needs only:
 
 	  - device.camera: the app calls AVCaptureDevice.requestAccess(for: .video) to grant the
 	    camera before launching `vision track-live`; pairs with NSCameraUsageDescription.
 	    (No audio-input: nothing records the microphone in-app — add it when that ships.)
+
+	  Ad-hoc local builds use MereRunDebug.entitlements because ad-hoc signatures
+	  have no shared Team ID with the separately signed Sparkle framework.
 	-->
 	<key>com.apple.security.device.camera</key>
 	<true/>

--- a/scripts/MereRunDebug.entitlements
+++ b/scripts/MereRunDebug.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Ad-hoc local builds have no Team ID. Disable library validation only for
+	  that development signature so the app can load the separately ad-hoc
+	  signed Sparkle framework. Developer ID release builds use
+	  MereRun.entitlements and keep library validation enabled.
+	-->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,19 +15,26 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.27.0"
-if git_version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+default_version="0.27.1"
+if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi
 default_build="$(git rev-list --count HEAD 2>/dev/null || echo 1)"
 app_version="${MERERUN_APP_VERSION:-$default_version}"
 app_build="${MERERUN_APP_BUILD:-$default_build}"
+sparkle_feed_url="${MERERUN_SPARKLE_FEED_URL:-https://mere.run/releases/appcast.xml}"
+sparkle_public_ed_key="6sFs+7UqYcE7rThPAovzMDsZtKyf/h4/d8rUmPSH2rw="
 
 app_icon="${repo_root}/assets/MereRunApp/AppIcon.icns"
-entitlements="${repo_root}/scripts/MereRun.entitlements"
+release_entitlements="${repo_root}/scripts/MereRun.entitlements"
+debug_entitlements="${repo_root}/scripts/MereRunDebug.entitlements"
 # Developer ID Application identity; defaults to ad-hoc ("-") for local/dev builds.
 # Set MERERUN_CODESIGN_IDENTITY="Developer ID Application: ..." for distributable builds.
 identity="${MERERUN_CODESIGN_IDENTITY:--}"
+entitlements="$release_entitlements"
+if [[ "$identity" == "-" ]]; then
+  entitlements="$debug_entitlements"
+fi
 
 swift_app_args=(build --product mere.run.app)
 swift_cli_args=(build --product mere.run)
@@ -65,6 +72,7 @@ bundle="${build_dir}/MereRun.app"
 contents="${bundle}/Contents"
 macos="${contents}/MacOS"
 resources="${contents}/Resources"
+frameworks="${contents}/Frameworks"
 # Executable code (CLI, frameworks, vendored helpers) must NOT live under
 # Contents/Resources or notarization rejects the bundle. Place it flat in Helpers/ (not a
 # same-named subfolder, which codesign would mistake for a malformed bundle) so the CLI and
@@ -73,9 +81,19 @@ helpers="${contents}/Helpers"
 cli_payload="${helpers}"
 
 rm -rf "$bundle"
-mkdir -p "$macos" "$resources" "$cli_payload"
+mkdir -p "$macos" "$resources" "$frameworks" "$cli_payload"
 cp "$executable" "${macos}/mere.run.app"
 cp "$cli_executable" "${cli_payload}/mere.run"
+
+# Sparkle is a versioned framework with symlinked helpers and XPC services.
+# `ditto` preserves that layout; flattening or dereferencing it breaks both
+# dyld lookup and its nested code signatures.
+sparkle_framework="${repo_root}/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
+if [[ ! -d "$sparkle_framework" ]]; then
+  echo "Sparkle framework not found: ${sparkle_framework}" >&2
+  exit 66
+fi
+ditto "$sparkle_framework" "${frameworks}/Sparkle.framework"
 
 if [[ -d "${repo_root}/skills/use-mere-run" ]]; then
   mkdir -p "${resources}/skills"
@@ -129,6 +147,13 @@ plutil -insert NSHighResolutionCapable -bool true "${contents}/Info.plist"
 plutil -insert CFBundleInfoDictionaryVersion -string "6.0" "${contents}/Info.plist"
 plutil -insert LSApplicationCategoryType -string "public.app-category.developer-tools" "${contents}/Info.plist"
 plutil -insert NSHumanReadableCopyright -string "© mere.run" "${contents}/Info.plist"
+plutil -insert SUFeedURL -string "$sparkle_feed_url" "${contents}/Info.plist"
+plutil -insert SUPublicEDKey -string "$sparkle_public_ed_key" "${contents}/Info.plist"
+plutil -insert SUEnableAutomaticChecks -bool true "${contents}/Info.plist"
+plutil -insert SUAutomaticallyUpdate -bool false "${contents}/Info.plist"
+plutil -insert SUScheduledCheckInterval -integer 86400 "${contents}/Info.plist"
+plutil -insert SUVerifyUpdateBeforeExtraction -bool true "${contents}/Info.plist"
+plutil -insert SURequireSignedFeed -bool true "${contents}/Info.plist"
 # TCC usage string. The CLI opens the camera as a child of this bundle, so TCC attributes
 # access to the app and the string must live here. (No microphone string: nothing records the
 # mic yet — add NSMicrophoneUsageDescription when `music realtime` mic capture ships.)
@@ -158,6 +183,19 @@ sign() {
   [[ -n "$ents" ]] && args+=(--entitlements "$ents")
   codesign "${args[@]}" "$@"
 }
+
+# Sparkle's nested services require distinct signing treatment. In particular,
+# Downloader.xpc carries entitlements that must survive re-signing. Keep the
+# explicit inside-out order from Sparkle's distribution guidance.
+sparkle_bundle="${frameworks}/Sparkle.framework"
+sparkle_version_root="${sparkle_bundle}/Versions/B"
+sign "" "${sparkle_version_root}/XPCServices/Installer.xpc"
+sparkle_downloader_args=(--force --options runtime --sign "$identity" --preserve-metadata=entitlements)
+[[ "$identity" != "-" ]] && sparkle_downloader_args+=(--timestamp)
+codesign "${sparkle_downloader_args[@]}" "${sparkle_version_root}/XPCServices/Downloader.xpc"
+sign "" "${sparkle_version_root}/Autoupdate"
+sign "" "${sparkle_version_root}/Updater.app"
+sign "" "$sparkle_bundle"
 
 # 1. Co-located executable frameworks/bundles — no entitlements. SwiftPM also
 #    places resource-only .bundle directories here; those have no executable


### PR DESCRIPTION
## Summary
- bundle Sparkle 2.9.2 into MereRun.app with signed-feed and archive verification
- add automatic daily update checks plus a manual Check for Updates command
- require a valid installed SCAIL adapter during preflight while keeping the fast profile as the existing default
- bump source metadata and documentation to 0.27.1

## Verification
- ./scripts/check.sh (2,214 XCTest + 20 Swift Testing, zero failures)
- pnpm install --frozen-lockfile && pnpm docs:build
- bash ./scripts/agent_readiness_check.sh
- ./scripts/build_mere_run_app.sh debug
- codesign --verify --deep --strict <MereRun.app>
- launched the built app and verified its embedded 0.27.1 CLI and Sparkle framework/rpath/Info.plist configuration
- ./scripts/package-macos.sh debug