### PR TITLE
fix(video): preserve MLX streams across async generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this public repository will be documented in this file.
 
 The format is based on Keep a Changelog.
 
+## 0.28.1 - 2026-07-28
+
+### Fixed
+
+- fixed native LTX video generation on async Swift executors by carrying both
+  CPU and GPU MLX streams across task suspension, preventing the
+  `There is no Stream(cpu, ...) in current thread` crash introduced by the
+  MLX 0.32.1 runtime refresh.
+- scoped text-to-video, unified audio/video, and audio-to-video execution to the
+  executor-safe MLX stream context while preserving validation-before-runtime
+  CLI behavior.
+
 ## 0.28.0 - 2026-07-28
 
 This release turns the optional macOS Studio into a complete, first-class

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "982c34170678d1836c16a60a3f310e687db874202fb65477b499667081b85a2e",
+  "originHash" : "8f6220d9e77d8cbd4b9ff0b02f9d37bd2981cd2e9417c1de60398277f5aa8fac",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
-        "revision" : "0c63032c7deeec3cb0600aa933cb0b50d16addb6"
+        "revision" : "a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -494,7 +494,7 @@ if !isLinuxPackage {
 var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(
     url: "https://github.com/sawfwair/mlx-swift",
-    revision: "0c63032c7deeec3cb0600aa933cb0b50d16addb6"
+    revision: "a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543"
   )
 ]) + [
   .package(

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -469,26 +469,29 @@ struct VideoGenerate: AsyncParsableCommand {
         try validateProductSelection(modelRoot: resolvedRootURL)
         if let sourceAudioURL {
             try validateNativeAudioToVideoModelRoot(resolvedRootURL)
-            try await runNativeAudioToVideoGenerate(
-                prompt: trimmedPrompt,
-                negativePrompt: negativePrompt,
-                audioURL: sourceAudioURL,
-                audioStartTime: audioStartTime,
-                width: resolvedWidth,
-                height: resolvedHeight,
-                numFrames: resolvedNumFrames,
-                fps: fps,
-                seed: seed ?? 42,
-                inferenceSteps: a2vSteps,
-                a2vGuidanceScale: a2vGuidanceScale,
-                videoCFGGuidanceScale: videoCFGGuidanceScale,
-                sourceImageURL: sourceImageURL,
-                imageStrength: imageStrength,
-                endImageURL: endImageURL,
-                endImageStrength: endImageStrength,
-                modelRoot: resolvedRootURL,
-                outputURL: outputURL
-            )
+            try MLXBundleSupport.ensureAvailable(quiet: quiet)
+            try await Stream.withNewDefaultStream {
+                try await runNativeAudioToVideoGenerate(
+                    prompt: trimmedPrompt,
+                    negativePrompt: negativePrompt,
+                    audioURL: sourceAudioURL,
+                    audioStartTime: audioStartTime,
+                    width: resolvedWidth,
+                    height: resolvedHeight,
+                    numFrames: resolvedNumFrames,
+                    fps: fps,
+                    seed: seed ?? 42,
+                    inferenceSteps: a2vSteps,
+                    a2vGuidanceScale: a2vGuidanceScale,
+                    videoCFGGuidanceScale: videoCFGGuidanceScale,
+                    sourceImageURL: sourceImageURL,
+                    imageStrength: imageStrength,
+                    endImageURL: endImageURL,
+                    endImageStrength: endImageStrength,
+                    modelRoot: resolvedRootURL,
+                    outputURL: outputURL
+                )
+            }
             return
         }
         if isWan2ModelRoot(resolvedRootURL) {
@@ -557,27 +560,39 @@ struct VideoGenerate: AsyncParsableCommand {
             }
         }
 
-        try await runNativeGenerate(
-            prompt: trimmedPrompt,
-            width: resolvedWidth,
-            height: resolvedHeight,
-            numFrames: resolvedNumFrames,
-            fps: fps,
-            seed: seed ?? 42,
-            outputMode: effectiveOutputMode,
-            negativePrompt: negativePrompt,
-            inferenceSteps: a2vSteps,
-            videoCFGGuidanceScale: videoCFGGuidanceScale,
-            audioToVideoGuidanceScale: a2vGuidanceScale,
-            audioCFGGuidanceScale: audioCFGGuidanceScale,
-            videoToAudioGuidanceScale: v2aGuidanceScale,
-            sourceImageURL: sourceImageURL,
-            imageStrength: imageStrength,
-            endImageURL: endImageURL,
-            endImageStrength: endImageStrength,
-            modelRoot: resolvedModelRoot,
-            outputURL: outputURL
+        let nativeRoute = resolveLTXVideoGenerationRoute(
+            variant: variant,
+            modelRoot: resolvedRootURL
         )
+        if (timings || timingsOutput != nil), !nativeRoute.supportsPhaseTimings {
+            throw ValidationError(
+                "--timings and --timings-output require an LTX 2.3 split model, --quality final, --output-mode audio-video, or --audio."
+            )
+        }
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        try await Stream.withNewDefaultStream {
+            try await runNativeGenerate(
+                prompt: trimmedPrompt,
+                width: resolvedWidth,
+                height: resolvedHeight,
+                numFrames: resolvedNumFrames,
+                fps: fps,
+                seed: seed ?? 42,
+                outputMode: effectiveOutputMode,
+                negativePrompt: negativePrompt,
+                inferenceSteps: a2vSteps,
+                videoCFGGuidanceScale: videoCFGGuidanceScale,
+                audioToVideoGuidanceScale: a2vGuidanceScale,
+                audioCFGGuidanceScale: audioCFGGuidanceScale,
+                videoToAudioGuidanceScale: v2aGuidanceScale,
+                sourceImageURL: sourceImageURL,
+                imageStrength: imageStrength,
+                endImageURL: endImageURL,
+                endImageStrength: endImageStrength,
+                modelRoot: resolvedModelRoot,
+                outputURL: outputURL
+            )
+        }
     }
 
     private func validateProductSelection(modelRoot: URL) throws {

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -27,7 +27,7 @@ enum MLXBundleSupport {
 
     static let expectedProvenance = MetallibProvenance(
       coreVersion: "0.32.1",
-      swiftRevision: "0c63032c7deeec3cb0600aa933cb0b50d16addb6",
+      swiftRevision: "a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543",
       kernelSourcesSHA256: "4e8781e7bbfd64810b7e23f870c647f561e9e7f1d1867183291778ef43b9d12e"
     )
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.28.0"
+    static let current = "0.28.1"
 }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -510,7 +510,7 @@ SOFTWARE.
 - source project: [`sawfwair/mlx-swift`](https://github.com/sawfwair/mlx-swift),
   based on upstream [`ml-explore/mlx-swift`](https://github.com/ml-explore/mlx-swift)
   0.32.1
-- pinned package revision: `0c63032c7deeec3cb0600aa933cb0b50d16addb6`
+- pinned package revision: `a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543`
 - embedded MLX revision: `9bee51623d5a34806821e0f414fae293f90dda19`
 - generated-kernel source SHA-256:
   `4e8781e7bbfd64810b7e23f870c647f561e9e7f1d1867183291778ef43b9d12e`

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.28.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.28.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/mlx-swift-fork.md
+++ b/docs/mlx-swift-fork.md
@@ -17,7 +17,7 @@ the core quantized helper headers. The source marker
 without either marker compile from the unchanged default header set. The
 embedded MLX core revision is `9bee51623d5a34806821e0f414fae293f90dda19`;
 the mlx-swift revision pinned by mere.run is
-`0c63032c7deeec3cb0600aa933cb0b50d16addb6`.
+`a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543`.
 
 A separate measured one-line compiled-call optimization exists on staging
 branches but is **deliberately not included in the pin**. The rest of this

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.28.0"
+default_version="0.28.1"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi

--- a/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
+++ b/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
@@ -1,6 +1,6 @@
 mlx-core-version: 0.32.1
 mlx-swift-version: unknown
-mlx-swift-revision: 0c63032c7deeec3cb0600aa933cb0b50d16addb6
+mlx-swift-revision: a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543
 kernel-sources-sha256: 4e8781e7bbfd64810b7e23f870c647f561e9e7f1d1867183291778ef43b9d12e
-built-at: 2026-07-27T16:10:30Z
+built-at: 2026-07-28T21:58:08Z
 metal-compiler: Apple metal version 32023.883 (metalfe-32023.883)


### PR DESCRIPTION
## Summary

- carry MLX CPU and GPU default streams across Swift async executor hops
- scope native LTX text-to-video, unified AV, and A2Vid generation inside the executor-safe stream context
- pin the merged mlx-swift fix and refresh exact Metal shader provenance without changing the metallib bytes
- prepare the 0.28.1 patch release metadata

## Root cause

MLX 0.32.1 kept default streams in thread-local state. Native video generation suspends and resumes on Swift executors, so a continuation could land on a thread with no CPU stream and abort with `There is no Stream(cpu, ...) in current thread`. Image generation does not exercise the same async stream path.

Dependency fixes:
- https://github.com/sawfwair/mlx-swift/pull/2
- https://github.com/sawfwair/mlx-swift/pull/3
- final pin: `a9485c38b82b8e0cee76e8f1f5a3e5bf6f36d543`

## Validation

- `./scripts/check.sh`: PASS (SwiftLint, build, 2,259 tests with 0 failures, CLI help sweep, hygiene)
- mlx-swift: 539/539 tests PASS, including focused async stream concurrency coverage
- real A2Vid render on macOS 26.5.2: PASS in 83.68s
  - H.264, 512x320, 9 frames at 24 fps
  - AAC stereo, 24 kHz
  - full ffmpeg decode: PASS
  - SHA-256: `cb1a94c1ceebb94335c29d62a4acf32c8314a53e0f23dc739bf451c666cb71d0`
- rebuilt `default.metallib` SHA-256 is unchanged: `969df624f24b32473fb7bd46cf8b3cddc629467fe1479f4012ad7247546ba1ec`

## Release

This is the source change for `v0.28.1`. Artifact builds and installed-runtime acceptance will run from the final annotated tag on macOS, Linux ARM64 CUDA, and Linux x86_64 CUDA.