### PR TITLE
Prepare mere.run 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.29.0 - 2026-07-29
+
 ### Added
 
+- added native MLX Streaming Sortformer speaker diarization on Apple Metal and
+  NVIDIA CUDA, with managed model installation, JSON/RTTM output, runtime
+  capability discovery, and a durable real-audio A → B → A checkpoint.
 - added `gate --all-installed`, a fail-closed release smoke that discovers the
   exact installed catalog inventory and runs real inference for every text,
   code, image, speech, vision, SAM, grounding, face, geometry/depth, image-to-3D,

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.28.1"
+    static let current = "0.29.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.28.1")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.29.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.28.1"
+default_version="0.29.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## What changed

- Prepare mere.run `0.29.0` as the first release containing native MLX Sortformer speaker diarization.
- Update the CLI, app fallback, and version-contract test together.
- Promote the accumulated release-gate work and diarization capability into the dated changelog entry.

## Why

The merged runtime must not ship under the existing `0.28.1` identity. A distinct minor version keeps installed, packaged, and advertised runtime truth aligned with the new public command and managed model.

## Validation

- `swift test --filter CLIModelStoreBootstrapTests.testMereRunCLIExposesReleaseVersion`
- PR #219 CI and real Metal/CUDA A → B → A diarization checkpoints passed before release preparation.
