### PR TITLE
Release 0.29.1: remove Infinity Flash and harden gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.29.1 - 2026-07-29
+
+### Changed
+
+- removed `vision-ocr-infinity-flash` from the managed catalog, model resolver,
+  Studio defaults, documentation, and exhaustive release inventory; native
+  Infinity OCR now defaults to the validated Pro int8 model.
+- made the exhaustive Sortformer release check consume the same required real
+  A → B → A speaker fixture used by the dedicated Metal and CUDA checkpoints,
+  replacing the unreliable generated two-voice approximation.
+
+### Fixed
+
+- fixed the packaged macOS helper missing SwiftPM resource bundles required by
+  Gemma-family inference.
+
 ## 0.29.0 - 2026-07-29
 
 ### Added
@@ -35,13 +51,6 @@ The format is based on Keep a Changelog.
 - fixed exact managed MoGe model IDs being interpreted as filesystem paths.
 - made ASR, audio, video, SCAIL, and component-checkpoint smokes exercise their
   real production inputs and reject undecodable, silent, or incomplete output.
-
-### Known issues
-
-- `vision-ocr-infinity-flash` may be explicitly quarantined from a release
-  smoke because its native Qwen3.5 path diverges from the reference runtime.
-  Quarantine evidence records it as skipped; Infinity Pro and LightOn OCR
-  remain covered by true inference.
 
 ## 0.28.1 - 2026-07-28
 

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -569,7 +569,7 @@ struct CommandDraft: Equatable, Codable {
     var visionGLMConfig = ""
     var visionInfinityRuntime = "native"
     var visionInfinityParserCLI = "parser"
-    var visionInfinityModel = "vision-ocr-infinity-flash"
+    var visionInfinityModel = "vision-ocr-infinity-pro-int8"
     var visionInfinityBackend = "vllm-server"
     var visionInfinityAPIURL = "http://localhost:8000/v1/chat/completions"
     var visionInfinityAPIKey = "EMPTY"

--- a/Sources/MereRunCLI/Commands/VisionOCRCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionOCRCommand.swift
@@ -46,9 +46,9 @@ struct VisionOCR: AsyncParsableCommand {
           https://github.com/zai-org/GLM-OCR
 
         Infinity-Parser2 uses the native Qwen-family Swift runtime by default
-        with managed model id `vision-ocr-infinity-flash`. Use
-        --infinity-model vision-ocr-infinity-pro-int8 for heavyweight quality
-        evals that can tolerate higher latency and memory use. Use
+        with managed model id `vision-ocr-infinity-pro-int8`. The unquantized
+        `vision-ocr-infinity-pro` model remains available for heavyweight quality
+        evals that can tolerate substantially higher memory use. Use
         --infinity-runtime external only when comparing against the upstream
         `infinity_parser2` Python CLI or an already-started vLLM server.
         """
@@ -79,7 +79,7 @@ struct VisionOCR: AsyncParsableCommand {
     var infinityParserCLI: String = "parser"
 
     @Option(name: [.long], help: "Infinity-Parser2 managed model id or local path for native runs; upstream model/server id for external runs.")
-    var infinityModel: String = Q35Resources.infinityParser2FlashModelId
+    var infinityModel: String = Q35Resources.infinityParser2ProInt8ModelId
 
     @Option(name: [.long], help: "External Infinity-Parser2 backend: transformers | vllm-engine | vllm-server.")
     var infinityBackend: InfinityParserBackend = .vllmServer
@@ -289,7 +289,7 @@ struct VisionOCR: AsyncParsableCommand {
 
         let resolvedModelID = ModelResolver.ModelID(rawValue: infinityModel)
         let generator = Q35Generator(
-            modelId: resolvedModelID?.rawValue ?? Q35Resources.infinityParser2FlashModelId,
+            modelId: resolvedModelID?.rawValue ?? Q35Resources.infinityParser2ProInt8ModelId,
             visionMinPixels: infinityMinPixels,
             visionMaxPixels: infinityMaxPixels
         )

--- a/Sources/MereRunCLI/Guides/vision-ocr.md
+++ b/Sources/MereRunCLI/Guides/vision-ocr.md
@@ -9,9 +9,8 @@ or external comparison CLIs, with optional backend comparison.
 
 Default managed LightOn id: `vision-ocr-lighton`.
 
-Default native Infinity id: `vision-ocr-infinity-flash`. Use
-`vision-ocr-infinity-pro-int8` as the quality-focused Pro eval option when
-latency and memory are acceptable. The full BF16 leaderboard Pro model remains
+Default native Infinity id: `vision-ocr-infinity-pro-int8`. The full BF16
+leaderboard Pro model remains
 available as `vision-ocr-infinity-pro`, but it is large enough that it requires
 an explicit pull and should be treated as a heavyweight compatibility target.
 
@@ -24,7 +23,6 @@ checks against an upstream Transformers/vLLM run.
 
 ```bash
 mere.run model pull vision-ocr-lighton
-mere.run model pull vision-ocr-infinity-flash
 mere.run model pull vision-ocr-infinity-pro-int8
 mere.run vision ocr --help
 ```
@@ -58,9 +56,7 @@ mere.run vision ocr --help
 ## Usage Patterns
 
 - Use `--backend lighton` for the small managed OCR path.
-- Use `--backend infinity` for native Infinity-Parser2 Flash.
-- Use `--backend infinity --infinity-model vision-ocr-infinity-pro-int8` for
-  quality-focused Pro comparisons on representative document samples.
+- Use `--backend infinity` for the native Infinity-Parser2 Pro int8 model.
 - Use `--quiet` for shell pipelines.
 - Use `--compare --backend infinity` when evaluating Infinity-Parser2 against
   the managed LightOn path on a new document type.
@@ -108,8 +104,8 @@ mere.run vision ocr ./page.png \
 ## Troubleshooting
 
 - GLM backend fails: confirm `glmocr` is installed and on PATH, or pass `--glmocr-cli`.
-- Native Infinity model missing: run `mere.run model pull vision-ocr-infinity-flash`.
-  For Pro int8, run `mere.run model pull vision-ocr-infinity-pro-int8`.
+- Native Infinity model missing: run
+  `mere.run model pull vision-ocr-infinity-pro-int8`.
 - External Infinity fails: confirm `parser` is installed and the selected vLLM
   server or CUDA backend is reachable.
 - LightOn model missing: run `mere.run model pull vision-ocr-lighton`.

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -226,16 +226,8 @@ enum InstalledModelSmokePlans {
             }
 
         case .sortformer:
-            return companion(
-                spec,
-                installedIDs: installedIDs,
-                candidates: ["speech-tts-qwen3-nano"],
-                route: "speech diarize of a generated two-speaker fixture"
-            ) { runner, fixtureModel in
-                try await runner.installedDiarizationCheck(
-                    model: spec.id,
-                    fixtureModel: fixtureModel
-                )
+            return direct(spec, route: "speech diarize of a real A-B-A fixture") { runner in
+                try await runner.installedDiarizationCheck(model: spec.id)
             }
 
         case .qwen3Embedding:
@@ -628,51 +620,19 @@ extension GateRunner {
         )
     }
 
-    func installedDiarizationCheck(
-        model: String,
-        fixtureModel: String
-    ) async throws -> GateObservation {
-        let firstVoice = workDirectory.appendingPathComponent("installed-diarization-first.wav")
-        let secondVoice = workDirectory.appendingPathComponent("installed-diarization-second.wav")
-        if !FileManager.default.fileExists(atPath: firstVoice.path) {
-            _ = try await exec(
-                [
-                    "speech", "synthesize",
-                    "Welcome to the speaker diarization release smoke.",
-                    "--model", fixtureModel,
-                    "--voice", "A bright female voice with clear pronunciation",
-                    "--output", firstVoice.path,
-                    "--temperature", "0",
-                    "--quiet",
-                ],
-                timeout: 1_800
+    func installedDiarizationCheck(model: String) async throws -> GateObservation {
+        guard let fixturePath = ProcessInfo.processInfo.environment["MERERUN_SORTFORMER_AUDIO"],
+              !fixturePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw GateError.invalidArtifact(
+                "MERERUN_SORTFORMER_AUDIO must point to the required real A-B-A speaker fixture"
             )
         }
-        if !FileManager.default.fileExists(atPath: secondVoice.path) {
-            _ = try await exec(
-                [
-                    "speech", "synthesize",
-                    "The second speaker confirms that the runtime can separate voices.",
-                    "--model", fixtureModel,
-                    "--voice", "A deep male voice with measured delivery",
-                    "--output", secondVoice.path,
-                    "--temperature", "0",
-                    "--quiet",
-                ],
-                timeout: 1_800
+        let fixture = URL(fileURLWithPath: fixturePath).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: fixture.path) else {
+            throw GateError.invalidArtifact(
+                "MERERUN_SORTFORMER_AUDIO fixture was not found at \(fixture.path)"
             )
         }
-
-        let first = try MediaAudioIO.decode(firstVoice, targetSampleRate: 16_000, channels: 1)
-        let second = try MediaAudioIO.decode(secondVoice, targetSampleRate: 16_000, channels: 1)
-        let silence = [Float](repeating: 0, count: 12_000)
-        let fixture = workDirectory.appendingPathComponent("installed-diarization-two-speaker.wav")
-        try MediaAudioIO.writeFloatWAV(
-            samples: first.samples + silence + second.samples,
-            sampleRate: 16_000,
-            channels: 1,
-            to: fixture
-        )
 
         let run = try await exec(
             [
@@ -685,16 +645,23 @@ extension GateRunner {
         )
         let data = Data(run.stdout.utf8)
         let document = try JSONDecoder().decode(InstalledDiarizationDocument.self, from: data)
-        let speakerIDs = Set(document.segments.map(\.speaker))
+        let speakerIDs = document.segments.map(\.speaker)
+        let distinctSpeakerIDs = Set(speakerIDs)
         let hasValidSegments = document.segments.allSatisfy { $0.startSeconds >= 0 && $0.endSeconds > $0.startSeconds }
+        let firstSpeakerReidentified = speakerIDs.count >= 3
+            && speakerIDs.first == speakerIDs.last
+            && speakerIDs.dropFirst().dropLast().contains { $0 != speakerIDs.first }
         return GateObservation(
             hash: Self.sha256(data),
             secondRunHash: nil,
             wallSeconds: run.wallSeconds,
             decodeTps: nil,
-            semanticFailure: document.speakerCount >= 2 && speakerIDs.count >= 2 && hasValidSegments
+            semanticFailure: document.speakerCount >= 2
+                && distinctSpeakerIDs.count >= 2
+                && hasValidSegments
+                && firstSpeakerReidentified
                 ? nil
-                : "diarization did not identify two valid speaker tracks"
+                : "diarization did not preserve the required A-B-A speaker sequence"
         )
     }
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.29.0"
+    static let current = "0.29.1"
 }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1371,17 +1371,6 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["text anonymize"]
         ),
         ManagedModelSpec(
-            id: Q35Resources.infinityParser2FlashModelId,
-            category: .visionOCR,
-            installShape: .directoryRoot,
-            hubFallback: Q35Resources.profile(for: Q35Resources.infinityParser2FlashModelId)?.hubFallbackConfig,
-            upstreamRepoId: Q35Resources.infinityParser2FlashUpstreamRepoId,
-            upstreamRevision: Q35Resources.infinityParser2FlashUpstreamRevision,
-            validationKind: .q35,
-            estimatedDownloadBytes: 5 * 1_073_741_824,
-            defaultCLICommands: ["vision ocr"]
-        ),
-        ManagedModelSpec(
             id: Q35Resources.infinityParser2ProModelId,
             category: .visionOCR,
             installShape: .directoryRoot,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -527,13 +527,6 @@ public enum ManagedModelCapabilityCatalog {
                 setup: true
             ),
             descriptor(
-                Q35Resources.infinityParser2FlashModelId,
-                "Infinity-Parser2 Flash OCR",
-                "Parses document images with the native Qwen-family Infinity-Parser2 Flash runtime.",
-                minimum: 24,
-                recommended: 32
-            ),
-            descriptor(
                 Q35Resources.infinityParser2ProModelId,
                 "Infinity-Parser2 Pro OCR",
                 "Runs the heavyweight native Infinity-Parser2 Pro eval model for document parsing.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1085,14 +1085,13 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "unsloth/Qwen3.6-35B-A3B-GGUF@main",
                 createdAt: createdAt
             )
-        case .infinityParser2Flash, .infinityParser2Pro, .infinityParser2ProInt8:
-            let isPro = modelID != .infinityParser2Flash
+        case .infinityParser2Pro, .infinityParser2ProInt8:
             let isProInt8 = modelID == .infinityParser2ProInt8
             return MereRunModelManifest(
                 id: modelID.rawValue,
                 engine: .qwen35HybridMoE,
                 family: .ocr,
-                tier: isPro ? .max : .nano,
+                tier: .max,
                 variant: .standard,
                 precision: isProInt8 ? .int8 : .bf16,
                 quantization: isProInt8
@@ -1103,9 +1102,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 components: q35TextComponents,
                 upstreamRepoId: isProInt8
                     ? "\(Q35Resources.infinityParser2ProInt8UpstreamRepoId)@\(Q35Resources.infinityParser2ProInt8UpstreamRevision)"
-                    : isPro
-                    ? "\(Q35Resources.infinityParser2ProUpstreamRepoId)@\(Q35Resources.infinityParser2ProUpstreamRevision)"
-                    : "\(Q35Resources.infinityParser2FlashUpstreamRepoId)@\(Q35Resources.infinityParser2FlashUpstreamRevision)",
+                    : "\(Q35Resources.infinityParser2ProUpstreamRepoId)@\(Q35Resources.infinityParser2ProUpstreamRevision)",
                 createdAt: createdAt
             )
         case .deepseekV4Flash:

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -58,7 +58,6 @@ public struct ModelResolver {
         case qwen3Embedding = "text-embed-qwen3-0.6b"
         case privacyFilter = "text-anonymize-privacy-filter"
         case lightOnOCR = "vision-ocr-lighton"
-        case infinityParser2Flash = "vision-ocr-infinity-flash"
         case infinityParser2Pro = "vision-ocr-infinity-pro"
         case infinityParser2ProInt8 = "vision-ocr-infinity-pro-int8"
         case visionSegmentSAM31 = "vision-segment-sam31"

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -30,7 +30,6 @@ public struct Q35Resources: Sendable, Hashable {
     public static let bonsai27B2BitModelId = "text-chat-bonsai-27b-2bit"
     public static let ornith9BModelId = "text-agent-ornith-9b"
     public static let ornith35BMLXModelId = "text-agent-ornith-35b-mlx"
-    public static let infinityParser2FlashModelId = "vision-ocr-infinity-flash"
     public static let infinityParser2ProModelId = "vision-ocr-infinity-pro"
     public static let infinityParser2ProInt8ModelId = "vision-ocr-infinity-pro-int8"
     public static let defaultModelId = q36NanoModelId
@@ -90,8 +89,6 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith35BMLXUpstreamRepoId = "deepreinforce-ai/Ornith-1.0-35B"
     public static let ornith35BMLXUpstreamRevision = "5df2ed3f675c7beaa490328cc70bb573b65fb660"
     public static let ornith35BMLXEstimatedDownloadBytes: Int64 = 18 * 1_073_741_824
-    public static let infinityParser2FlashUpstreamRepoId = "infly/Infinity-Parser2-Flash"
-    public static let infinityParser2FlashUpstreamRevision = "30f02aca5ee7c32d22a962cbece5c19611147c9e"
     public static let infinityParser2ProUpstreamRepoId = "infly/Infinity-Parser2-Pro"
     public static let infinityParser2ProUpstreamRevision = "1d070df7db5acca0ffa75596229070a047704f89"
     public static let infinityParser2ProInt8UpstreamRepoId = "Sawfwair/Infinity-Parser2-Pro-Int8"
@@ -122,11 +119,6 @@ public struct Q35Resources: Sendable, Hashable {
             modelId: ornith35BMLXModelId,
             upstreamRepoId: ornith35BMLXUpstreamRepoId,
             upstreamRevision: ornith35BMLXUpstreamRevision
-        ),
-        infinityParser2FlashModelId: Profile(
-            modelId: infinityParser2FlashModelId,
-            upstreamRepoId: infinityParser2FlashUpstreamRepoId,
-            upstreamRevision: infinityParser2FlashUpstreamRevision
         ),
         infinityParser2ProModelId: Profile(
             modelId: infinityParser2ProModelId,

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -70,7 +70,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.29.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.29.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/GateSupportTests.swift
+++ b/Tests/MereRunCLITests/GateSupportTests.swift
@@ -10,12 +10,12 @@ final class GateSupportTests: XCTestCase {
             "--all-installed",
             "--require-all",
             "--skip-model",
-            "vision-ocr-infinity-flash",
+            "vision-ocr-lighton",
         ])
 
         XCTAssertTrue(gate.allInstalled)
         XCTAssertTrue(gate.requireAll)
-        XCTAssertEqual(gate.skipModel, "vision-ocr-infinity-flash")
+        XCTAssertEqual(gate.skipModel, "vision-ocr-lighton")
     }
 
     func testGateRunnerDrainsChattyChildPipesWithoutDeadlocking() async throws {

--- a/Tests/MereRunCLITests/VisionOCRCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/VisionOCRCommandParsingTests.swift
@@ -13,7 +13,7 @@ final class VisionOCRCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.model, ModelResolver.ModelID.lightOnOCR.rawValue)
         XCTAssertEqual(cmd.infinityRuntime, .native)
         XCTAssertEqual(cmd.infinityParserCLI, "parser")
-        XCTAssertEqual(cmd.infinityModel, Q35Resources.infinityParser2FlashModelId)
+        XCTAssertEqual(cmd.infinityModel, Q35Resources.infinityParser2ProInt8ModelId)
         XCTAssertEqual(cmd.infinityBackend, .vllmServer)
         XCTAssertEqual(cmd.infinityTask, .doc2json)
         XCTAssertEqual(cmd.infinityOutputFormat, .md)
@@ -59,7 +59,7 @@ final class VisionOCRCommandParsingTests: XCTestCase {
             "--backend", "infinity",
             "--infinity-runtime", "external",
             "--infinity-parser-cli", "/opt/bin/parser",
-            "--infinity-model", "infly/Infinity-Parser2-Flash",
+            "--infinity-model", "infly/Infinity-Parser2-Pro",
             "--infinity-backend", "vllm-engine",
             "--infinity-api-url", "http://127.0.0.1:8000/v1/chat/completions",
             "--infinity-api-key", "test-key",
@@ -74,7 +74,7 @@ final class VisionOCRCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.backend, .infinity)
         XCTAssertEqual(cmd.infinityRuntime, .external)
         XCTAssertEqual(cmd.infinityParserCLI, "/opt/bin/parser")
-        XCTAssertEqual(cmd.infinityModel, "infly/Infinity-Parser2-Flash")
+        XCTAssertEqual(cmd.infinityModel, "infly/Infinity-Parser2-Pro")
         XCTAssertEqual(cmd.infinityBackend, .vllmEngine)
         XCTAssertEqual(cmd.infinityAPIURL, "http://127.0.0.1:8000/v1/chat/completions")
         XCTAssertEqual(cmd.infinityAPIKey, "test-key")

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -653,17 +653,6 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
     }
 
-    func testInfinityParser2FlashUsesNativeQ35VisionOCRSpec() throws {
-        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.infinityParser2FlashModelId))
-
-        XCTAssertEqual(spec.category, .visionOCR)
-        XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.infinityParser2FlashUpstreamRepoId)
-        XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.infinityParser2FlashUpstreamRevision)
-        XCTAssertEqual(spec.validationKind, .q35)
-        XCTAssertTrue(spec.runtimeAutoDownloadAllowed)
-        XCTAssertEqual(spec.defaultCLICommands, ["vision ocr"])
-    }
-
     func testInfinityParser2ProRequiresExplicitPull() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.infinityParser2ProModelId))
 

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -172,21 +172,6 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.upstreamRepoId, "tiiuae/Falcon-Perception")
     }
 
-    func testInfinityParser2FlashTemplateHasExpectedMetadata() throws {
-        let manifest = MereRunModelManifest.template(for: .infinityParser2Flash, createdAt: Date(timeIntervalSince1970: 0))
-
-        XCTAssertEqual(manifest.id, Q35Resources.infinityParser2FlashModelId)
-        XCTAssertEqual(manifest.engine, .qwen35HybridMoE)
-        XCTAssertEqual(manifest.family, .ocr)
-        XCTAssertEqual(manifest.tier, .nano)
-        XCTAssertEqual(manifest.precision, .bf16)
-        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .visionChat, .visionOCR]))
-        XCTAssertEqual(
-            manifest.upstreamRepoId,
-            "\(Q35Resources.infinityParser2FlashUpstreamRepoId)@\(Q35Resources.infinityParser2FlashUpstreamRevision)"
-        )
-    }
-
     func testInfinityParser2ProTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .infinityParser2Pro, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -506,7 +506,7 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(config.textConfig.numExperts, 256)
     }
 
-    func testQ35ConfigAllowsDenseInfinityParser2FlashLayout() throws {
+    func testQ35ConfigAllowsDenseQwen35VisionLayout() throws {
         var configObject = makeBaseConfig()
         configObject["model_type"] = "qwen3_5"
         configObject["architectures"] = ["Qwen3_5ForConditionalGeneration"]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -217,8 +217,8 @@ are:
 - Text anonymize: `text-anonymize-privacy-filter`
 - Speech TTS: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`
 - Speech ASR: `speech-asr-qwen3`, `speech-asr-parakeet`
-- Vision OCR: `vision-ocr-lighton`, `vision-ocr-infinity-flash`,
-  `vision-ocr-infinity-pro-int8`, `vision-ocr-infinity-pro`
+- Vision OCR: `vision-ocr-lighton`, `vision-ocr-infinity-pro-int8`,
+  `vision-ocr-infinity-pro`
 - Vision segmentation / tracking: `vision-segment-sam31`
 - Vision grounding: `vision-ground-falcon-perception`
 - Face detection and identity embeddings: `vision-face-buffalo-l`
@@ -1262,7 +1262,6 @@ Examples:
 
 ```bash
 swift run mere.run model pull vision-ocr-lighton
-swift run mere.run model pull vision-ocr-infinity-flash
 swift run mere.run model pull vision-ocr-infinity-pro-int8
 swift run mere.run vision ocr ./page.png --backend lighton --model ~/Library/Application\ Support/MereRun/models/vision-ocr-lighton
 swift run mere.run vision ocr ./page.png --backend glm

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -74,7 +74,6 @@ from the runtime catalog used by `mere.run model list`,
 | `text-code` | `text-code-qwen3` |
 | `text-embed` | `text-embed-qwen3-0.6b` |
 | `text-anonymize` | `text-anonymize-privacy-filter` |
-| `vision-ocr` | `vision-ocr-infinity-flash` |
 | `vision-ocr` | `vision-ocr-infinity-pro` |
 | `vision-ocr` | `vision-ocr-infinity-pro-int8` |
 | `vision-ocr` | `vision-ocr-lighton` |

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -473,8 +473,8 @@ swift run mere.run vision ocr ./page.png \
 
 LightOnOCR uses the dedicated LightOn runtime and remains the default `vision ocr`
 backend. Native Infinity-Parser2 uses the Q35 text runtime plus the Qwen-family
-vision tower, with `vision-ocr-infinity-flash` as the default Infinity model,
-`vision-ocr-infinity-pro-int8` as the quality-focused Pro eval option, and
+vision tower, with `vision-ocr-infinity-pro-int8` as the default native
+Infinity model and
 `vision-ocr-infinity-pro` as the full BF16 heavyweight compatibility target.
 
 GLM-OCR remains an external CLI adapter that shells out to `glmocr`. Infinity can

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -273,7 +273,8 @@ not a skip.
 The final packaged candidate runs the exhaustive installed-model matrix:
 
 ```bash
-/path/to/extracted/mere.run gate \
+MERERUN_SORTFORMER_AUDIO=/path/to/two-speaker-a-b-a.wav \
+  /path/to/extracted/mere.run gate \
   --all-installed \
   --require-all \
   --json-output ./release-gate.json
@@ -283,7 +284,9 @@ That produces one result per installed model ID, including every image model;
 TripoSR, InstantMesh, and TRELLIS.2; music and SFX; OCR, SAM, grounding, face,
 geometry, and depth; speech, embeddings, privacy, text, and every video/world
 backend. Component-only entries must be consumed by a named true companion run.
-An installed model with no recipe fails closed.
+An installed model with no recipe fails closed. When Sortformer is installed,
+`MERERUN_SORTFORMER_AUDIO` is required and must identify a real fixture whose
+first speaker returns after a different middle speaker.
 
 If a release owner explicitly quarantines a known-broken installed model, add
 `--skip-model <installed-id>`. The evidence retains it as a `skipped` row


### PR DESCRIPTION
## What changed

- remove Infinity Flash from the managed catalog, resolver, Studio defaults, docs, and release inventory
- default native Infinity OCR to the validated Pro int8 model
- require the real A-B-A speaker fixture for Sortformer release coverage
- bump the runtime to 0.29.1

## Validation

- ./scripts/check.sh: 2,276 XCTest tests, 141 skipped, 0 failures; 20 Swift Testing tests passed
- installed speech gate: 4 passed, including Sortformer A-B-A re-identification
- removed the local Infinity Flash install and reclaimed 4,446,562,320 bytes