### PR TITLE
Fix world transition HTTP overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ The format is based on Keep a Changelog.
   Cosmos3-Edge, and the hidden Gemma 3 companion while retaining genuine
   access-gated, non-commercial, research-only, and revenue-limited gates.
 
+### Fixed
+
+- fixed persistent-world HTTP transition decoding so documented snake-case
+  overrides such as `num_frames`, `guidance_scale`, and
+  `model_space_actions` reach the DreamX and Cosmos3 runtimes instead of
+  silently falling back to session defaults.
+
 ## 0.29.1 - 2026-07-29
 
 ### Changed

--- a/Sources/MereRunCLI/Commands/WorldCommand.swift
+++ b/Sources/MereRunCLI/Commands/WorldCommand.swift
@@ -161,7 +161,7 @@ private struct WorldRequestContext: RequestContext, RemoteAddressRequestContext 
     }
 }
 
-private struct WorldTransitionPayload: Codable, Sendable {
+struct WorldTransitionPayload: Codable, Sendable {
     let prompt: String
     let camera: Wan2WorldCameraControl
     let sourceImage: String?
@@ -176,7 +176,7 @@ private struct WorldTransitionPayload: Codable, Sendable {
     let fps: Int?
     let modelSpaceActions: [[Float]]?
 
-    func request(defaults: WorldTransitionDefaults) -> WorldTransitionRuntimeRequest {
+    fileprivate func request(defaults: WorldTransitionDefaults) -> WorldTransitionRuntimeRequest {
         return WorldTransitionRuntimeRequest(
             base: Wan2WorldTransitionRequest(
                 prompt: prompt,
@@ -185,7 +185,7 @@ private struct WorldTransitionPayload: Codable, Sendable {
                 outputURL: output.map { URL(fileURLWithPath: $0).standardizedFileURL },
                 width: width ?? defaults.width,
                 height: height ?? defaults.height,
-            numFrames: numFrames ?? defaults.numFrames,
+                numFrames: numFrames ?? defaults.numFrames,
                 steps: steps ?? defaults.steps,
                 guidanceScale: guidanceScale ?? defaults.guidanceScale,
                 shift: shift ?? defaults.shift,
@@ -196,13 +196,6 @@ private struct WorldTransitionPayload: Codable, Sendable {
         )
     }
 
-    enum CodingKeys: String, CodingKey {
-        case prompt, camera, output, width, height, steps, shift, seed, fps
-        case sourceImage = "sourceImage"
-        case numFrames = "num_frames"
-        case guidanceScale = "guidance_scale"
-        case modelSpaceActions = "model_space_actions"
-    }
 }
 
 private struct WorldTransitionRuntimeRequest: Sendable {

--- a/Tests/MereRunCLITests/WorldCommandTests.swift
+++ b/Tests/MereRunCLITests/WorldCommandTests.swift
@@ -48,4 +48,47 @@ final class WorldCommandTests: XCTestCase {
         )
         XCTAssertNil(command.apiKey)
     }
+
+    func testWorldTransitionPayloadDecodesDocumentedHTTPOverrides() throws {
+        let data = Data(#"""
+        {
+          "prompt": "turn through the same station",
+          "camera": {
+            "motion": "yawRight",
+            "translationMeters": [0, 0, 0],
+            "rotationDegrees": [0, 15, 0]
+          },
+          "sourceImage": "/tmp/vesper.png",
+          "output": "/tmp/vesper-right.mp4",
+          "width": 320,
+          "height": 176,
+          "num_frames": 61,
+          "steps": 30,
+          "guidance_scale": 1.5,
+          "shift": 3,
+          "seed": 7,
+          "fps": 30,
+          "model_space_actions": [[0, 0, 0, 1, 0, 0, 0, 1, 0]]
+        }
+        """#.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let payload = try decoder.decode(WorldTransitionPayload.self, from: data)
+
+        XCTAssertEqual(payload.prompt, "turn through the same station")
+        XCTAssertEqual(payload.camera.motion, .yawRight)
+        XCTAssertEqual(payload.camera.rotationDegrees, [0, 15, 0])
+        XCTAssertEqual(payload.sourceImage, "/tmp/vesper.png")
+        XCTAssertEqual(payload.output, "/tmp/vesper-right.mp4")
+        XCTAssertEqual(payload.width, 320)
+        XCTAssertEqual(payload.height, 176)
+        XCTAssertEqual(payload.numFrames, 61)
+        XCTAssertEqual(payload.steps, 30)
+        XCTAssertEqual(payload.guidanceScale, 1.5)
+        XCTAssertEqual(payload.shift, 3)
+        XCTAssertEqual(payload.seed, 7)
+        XCTAssertEqual(payload.fps, 30)
+        XCTAssertEqual(payload.modelSpaceActions, [[0, 0, 0, 1, 0, 0, 0, 1, 0]])
+    }
 }


### PR DESCRIPTION
## What changed

- remove the conflicting custom coding keys from the persistent-world transition payload
- decode documented snake-case HTTP overrides through the server's existing `convertFromSnakeCase` strategy
- add coverage for frame count, guidance, seed, source image, and normalized model-space action overrides
- document the repair under Unreleased

## Why

The custom coding keys and the JSON decoder's key strategy were both transforming keys. Fields such as `num_frames`, `guidance_scale`, and `model_space_actions` therefore decoded as nil and silently fell back to defaults. For Cosmos 3 this truncated a requested 61-frame move to 17 frames and prevented the requested camera trajectory from being realized.

## Impact

Persistent-world clients can now rely on the documented HTTP contract. A 61-frame Cosmos 3 request reaches the runtime as 61 frames with 60 normalized model-space actions.

## Validation

- `swift test --filter WorldCommandTests`
- `./scripts/check.sh` (2,277 tests passed, 141 fixture-dependent skips, 0 failures)
- live local Cosmos 3 request: 61 decoded frames, 60 normalized actions, 2.03-second yaw-right output
