### PR TITLE
Add native Inkling-Small mixed-precision runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Added
+
+- added Thinking Machines Lab's released Inkling-Small as the opt-in managed
+  `text-chat-inkling-small` model through a pinned mixed-precision native MLX
+  conversion. The routed experts use affine 2-bit/group-128 weights while
+  attention, embeddings, routers, shared experts, and dense MLPs retain BF16.
+  The validated 84.56 GB artifact is text-only in mere.run, requires an
+  explicit pull, and defaults to a 32K operational context for 128 GB
+  unified-memory Macs.
+
 ### Changed
 
 - made text LoRA `--eval` measure held-out assistant-token loss before and

--- a/Package.swift
+++ b/Package.swift
@@ -330,6 +330,7 @@ targets.append(contentsOf: [
       "Geometry/README.md",
       "HiDreamO1/README.md",
       "Ideogram4/README.md",
+      "Inkling/README.md",
       "InstantMesh/README.md",
       "Krea2/README.md",
       "Laguna/README.md",

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ swift run mere.run model pull image-zimage-nano --preflight --json
 swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 swift run mere.run model pull text-chat-laguna-s-2-1
 swift run mere.run model pull text-chat-laguna-xs-2-1
+swift run mere.run model pull text-chat-inkling-small
 swift run mere.run model pull text-chat-bonsai-27b-1bit
 swift run mere.run model pull text-chat-bonsai-27b-2bit
 swift run mere.run model pull text-code-north-mini
@@ -277,6 +278,12 @@ swift run mere.run model pull text-agent-ornith-35b
 swift run mere.run text chat \
   --model text-chat-bonsai-27b-1bit \
   --prompt "Explain unified memory for local inference."
+
+# Inkling-Small is an explicit mixed-precision native MLX pull for 128 GB machines.
+swift run mere.run text chat \
+  --model text-chat-inkling-small \
+  --context-size 32768 \
+  --prompt "Plan a recovery-safe repository migration."
 
 # Pull and apply the promoted Mere Platform Assistant adapter
 swift run mere.run model pull text-chat-gemma4-12b-4bit

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -4580,7 +4580,8 @@ actor CodeGenServer {
                 request: request
             )
         case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
-             .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek, nil:
+             .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek,
+             .inkling, nil:
             throw APIRequestValidationError.invalidField(
                 "model",
                 "model \(resolved.modelID) is not an image generation model"

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -388,7 +388,8 @@ struct ImageGenerate: AsyncParsableCommand {
                 defer { generator.unload() }
                 result = try await generator.generate(request, progressHandler: progressHandler)
             case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
-                 .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek, nil:
+                 .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek,
+                 .inkling, nil:
                 throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")
             }
             try editPreparation?.finish(generatedURL: result.outputURL)

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -151,7 +151,7 @@ struct ModelPull: AsyncParsableCommand {
             }
             stderr("  You are responsible for determining whether your use complies with these terms.")
         }
-        try ModelPullDiskPreflight.check(spec: spec, modelDir: modelDir) { warning in
+        try ModelPullDiskPreflight.check(spec: spec, modelDir: modelDir, force: force) { warning in
             guard !quiet else { return }
             stderr("  warning: \(warning)")
         }
@@ -338,19 +338,56 @@ struct ModelPullDiskPreflight {
         return estimatedDownloadBytes + max(safetyMarginBytes, estimatedDownloadBytes / 5)
     }
 
+    static func estimatedDownloadBytes(
+        for spec: ManagedModelSpec,
+        force: Bool,
+        hubCacheURL: URL,
+        fileManager: FileManager = .default
+    ) -> Int64? {
+        guard !force,
+              spec.mountedHubFallbacks.isEmpty,
+              let config = spec.hubFallback,
+              let cachedSnapshot = try? HubSnapshot.cachedMaterializedSnapshotURL(
+                options: HubSnapshotOptions(
+                    repoId: config.repoId,
+                    revision: config.revision,
+                    patterns: config.patterns,
+                    cacheDirectory: hubCacheURL,
+                    offline: true
+                ),
+                fileManager: fileManager
+              ),
+              spec.missingPaths(in: cachedSnapshot, fileManager: fileManager).isEmpty else {
+            return spec.estimatedDownloadBytes
+        }
+        return 0
+    }
+
     static func check(
         spec: ManagedModelSpec,
         modelDir: URL,
+        force: Bool = false,
+        hubCacheURL: URL? = nil,
         fileManager: FileManager = .default,
         warn: (String) -> Void
     ) throws {
-        let hubCache = try HubSnapshot.resolvedDownloadBase(fileManager: fileManager)
+        let hubCache = try HubSnapshot.resolvedDownloadBase(
+            requested: hubCacheURL,
+            fileManager: fileManager
+        )
         let modelStoreParent = modelDir.deletingLastPathComponent()
         try? fileManager.createDirectory(at: modelStoreParent, withIntermediateDirectories: true)
 
+        let estimatedDownloadBytes = estimatedDownloadBytes(
+            for: spec,
+            force: force,
+            hubCacheURL: hubCache,
+            fileManager: fileManager
+        )
+
         let warnings = try evaluate(
             modelID: spec.id,
-            estimatedDownloadBytes: spec.estimatedDownloadBytes,
+            estimatedDownloadBytes: estimatedDownloadBytes,
             hubCacheURL: hubCache,
             hubCacheAvailableBytes: availableBytes(onFileSystemContaining: hubCache, fileManager: fileManager),
             modelStoreURL: modelStoreParent,

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -38,6 +38,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-gemma4-nano (Gemma 4 4B native Swift runtime)
           - text-chat-laguna-s-2-1 (Poolside Laguna S 2.1 118B-A8B NVFP4 with DFlash)
           - text-chat-laguna-xs-2-1 (Poolside Laguna XS 2.1 33B-A3B NVFP4)
+          - text-chat-inkling-small (Inkling-Small 276B-A12B mixed MLX: routed-expert q2, non-routed BF16)
           - text-chat-lfm25-a1b-8bit (LiquidAI LFM2.5 8B-A1B MLX 8-bit native Swift runtime)
           - text-chat-psi-agent
         Models are cached under ~/Library/Application Support/MereRun/models/<model-id>.
@@ -60,7 +61,10 @@ struct TextChat: AsyncParsableCommand {
     @Option(name: [.long], help: "Max new tokens.")
     var maxTokens: Int = 2048
 
-    @Option(name: [.customLong("context-size")], help: "Maximum prompt plus generation context. Bonsai 27B supports up to 262144 tokens.")
+    @Option(
+        name: [.customLong("context-size")],
+        help: "Maximum prompt plus generation context. Bonsai supports 262144 tokens; Inkling-Small advertises 1048576 and defaults to 32768."
+    )
     var contextSize: Int?
 
     @Option(name: [.long], help: "Temperature. Default: 0.7, or the model's published value where one exists (Laguna/Ornith: 1.0).")
@@ -130,7 +134,7 @@ struct TextChat: AsyncParsableCommand {
         return NativeMLXRuntime.backendDescription
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, text-chat-bonsai-27b-1bit, text-chat-bonsai-27b-2bit, text-chat-q36-nano, text-agent-ornith-9b, text-agent-ornith-35b-mlx, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-bonsai-27b-2bit, text-chat-q36-nano, text-agent-ornith-9b, text-agent-ornith-35b-mlx, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
     var model: String = TextChat.defaultChatModelId
 
     @Option(
@@ -340,6 +344,9 @@ struct TextChat: AsyncParsableCommand {
                 // `text code` uses). On Linux CUDA this is the GB10-optimized
                 // llama.cpp runtime, which has fast quantized-MoE kernels MLX lacks.
                 let generator = CodeGenGenerator(modelId: normalizedModelId)
+                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
+            } else if InklingResources.handles(modelSpec: normalizedModelId) {
+                let generator = InklingGenerator(modelID: normalizedModelId)
                 return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
             } else if LFM2Resources.handles(modelSpec: normalizedModelId) {
                 let effectiveModelId = normalizedModelId.isEmpty ? LFM2Resources.defaultModelId : normalizedModelId
@@ -565,7 +572,9 @@ struct TextChat: AsyncParsableCommand {
                 "--response-format json_object is not yet supported by the llama.cpp/GGUF chat runtime; use the native MLX text-chat-q36-nano model."
             )
         }
-        if modelID == Psi3ChatResources.defaultModelId || LFM2Resources.handles(modelSpec: modelID) {
+        if modelID == Psi3ChatResources.defaultModelId
+            || LFM2Resources.handles(modelSpec: modelID)
+            || InklingResources.handles(modelSpec: modelID) {
             throw ValidationError(
                 "--response-format json_object is supported by native Gemma4 and Qwen-family MLX chat models."
             )

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -174,7 +174,7 @@ enum InstalledModelSmokePlans {
                 try await runner.installedTextCheck(model: spec.id)
             }
 
-        case .laguna, .lfm2, .codegenGGUF, .hfTextChat:
+        case .laguna, .lfm2, .inkling, .codegenGGUF, .hfTextChat:
             return direct(spec, route: "text chat") { runner in
                 try await runner.installedTextCheck(model: spec.id)
             }

--- a/Sources/MereRunCLI/Support/ModelPullPreflight.swift
+++ b/Sources/MereRunCLI/Support/ModelPullPreflight.swift
@@ -149,7 +149,14 @@ struct ModelPullPreflightAnalyzer {
         let specs = selectedSpecs(diagnostics: &diagnostics)
         let hubCache = resolvedHubCache(diagnostics: &diagnostics)
         let modelStore = (modelStoreURL ?? MereRunModelPaths.modelsDir).standardizedFileURL
-        let models = specs.map { modelSummary(for: $0, modelStore: modelStore, diagnostics: &diagnostics) }
+        let models = specs.map {
+            modelSummary(
+                for: $0,
+                modelStore: modelStore,
+                hubCache: hubCache,
+                diagnostics: &diagnostics
+            )
+        }
         appendAggregateDiskDiagnostics(
             models: models,
             hubCache: hubCache,
@@ -232,6 +239,7 @@ struct ModelPullPreflightAnalyzer {
     private func modelSummary(
         for spec: ManagedModelSpec,
         modelStore: URL,
+        hubCache: URL,
         diagnostics: inout [PreflightDiagnostic]
     ) -> ModelPullModelPreflightSummary {
         let support = ManagedModelCapabilityCatalog.support(for: spec)
@@ -250,6 +258,12 @@ struct ModelPullPreflightAnalyzer {
             from: installPath,
             fileManager: fileManager
         ))?.usageTermsAcknowledged == true
+        let estimatedDownloadBytes = ModelPullDiskPreflight.estimatedDownloadBytes(
+            for: spec,
+            force: input.force,
+            hubCacheURL: hubCache,
+            fileManager: fileManager
+        )
         let willDownload = selected && hasSource && !blockedBySupport && !blockedByUsageTerms && (input.force || !installed)
         let status = Self.modelStatus(
             selected: selected,
@@ -324,8 +338,10 @@ struct ModelPullPreflightAnalyzer {
             runtimePath: runtimeURL?.path,
             upstreamRepoID: spec.upstreamRepoId,
             hubRepoIDs: hubRepoIDs(for: spec),
-            estimatedDownloadBytes: spec.estimatedDownloadBytes,
-            estimatedRequiredBytes: ModelPullDiskPreflight.requiredBytes(estimatedDownloadBytes: spec.estimatedDownloadBytes),
+            estimatedDownloadBytes: estimatedDownloadBytes,
+            estimatedRequiredBytes: ModelPullDiskPreflight.requiredBytes(
+                estimatedDownloadBytes: estimatedDownloadBytes
+            ),
             companionModelIDs: spec.companionModelIDs,
             usageTerms: spec.usageRestriction?.terms ?? [],
             usageTermsAcknowledged: spec.usageRestriction != nil

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -170,6 +170,40 @@ public actor HubSnapshot {
         )
     }
 
+    /// Returns a materialized snapshot already present for the requested
+    /// revision without contacting the Hub or trusting an unverified receipt.
+    public static func cachedMaterializedSnapshotURL(
+        options: HubSnapshotOptions,
+        fileManager: FileManager = .default
+    ) throws -> URL? {
+        let downloadBase = try resolveDownloadBase(
+            requested: options.cacheDirectory,
+            fileManager: fileManager
+        )
+        let repositoryRoot = downloadBase
+            .appending(path: "snapshots")
+            .appending(path: options.repoType.rawValue)
+            .appending(path: options.repoId)
+        let referenceURL = downloadBase
+            .appending(path: "refs")
+            .appending(path: options.repoType.rawValue)
+            .appending(path: options.repoId)
+            .appending(path: revisionKey(options.revision) + ".ref")
+
+        if let data = try? Data(contentsOf: referenceURL),
+           let resolved = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !resolved.isEmpty {
+            let referenced = repositoryRoot.appending(path: revisionKey(resolved))
+            if fileManager.fileExists(atPath: referenced.path) {
+                return referenced
+            }
+        }
+
+        let requested = repositoryRoot.appending(path: revisionKey(options.revision))
+        return fileManager.fileExists(atPath: requested.path) ? requested : nil
+    }
+
     private static func resolveDownloadBase(
         requested: URL?,
         fileManager: FileManager

--- a/Sources/MereRunCore/Inkling/InklingConfig.swift
+++ b/Sources/MereRunCore/Inkling/InklingConfig.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+public struct InklingQuantizationConfig: Codable, Sendable, Hashable {
+    public let groupSize: Int
+    public let bits: Int
+    public let mode: String
+    public let scope: String
+
+    private enum CodingKeys: String, CodingKey {
+        case groupSize = "group_size"
+        case bits
+        case mode
+        case scope
+    }
+}
+
+public struct InklingTextConfig: Decodable, Sendable, Hashable {
+    public let hiddenSize: Int
+    public let numHiddenLayers: Int
+    public let vocabSize: Int
+    public let unpaddedVocabSize: Int?
+    public let rmsNormEps: Float
+    public let useEmbedNorm: Bool
+    public let logitsMUPWidthMultiplier: Float
+    public let modelMaxLength: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let swaNumAttentionHeads: Int
+    public let swaNumKeyValueHeads: Int
+    public let swaHeadDim: Int
+    public let slidingWindowSize: Int
+    public let localLayerIDs: Set<Int>
+    public let dRel: Int
+    public let relExtent: Int
+    public let logScalingNFloor: Int?
+    public let logScalingAlpha: Float
+    public let sconvKernelSize: Int
+    public let denseMLPIndex: Int
+    public let denseIntermediateSize: Int
+    public let moeIntermediateSize: Int
+    public let routedExpertCount: Int
+    public let expertsPerToken: Int
+    public let sharedExpertCount: Int
+    public let routeScale: Float
+
+    public func layerIsSliding(_ index: Int) -> Bool {
+        localLayerIDs.contains(index)
+    }
+
+    public func layerIsDense(_ index: Int) -> Bool {
+        index < denseMLPIndex
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case vocabSize = "vocab_size"
+        case unpaddedVocabSize = "unpadded_vocab_size"
+        case rmsNormEps = "rms_norm_eps"
+        case useEmbedNorm = "use_embed_norm"
+        case logitsMUPWidthMultiplier = "logits_mup_width_multiplier"
+        case modelMaxLength = "model_max_length"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case swaNumAttentionHeads = "swa_num_attention_heads"
+        case swaNumKeyValueHeads = "swa_num_key_value_heads"
+        case swaHeadDim = "swa_head_dim"
+        case slidingWindowSize = "sliding_window_size"
+        case localLayerIDs = "local_layer_ids"
+        case dRel = "d_rel"
+        case relExtent = "rel_extent"
+        case logScalingNFloor = "log_scaling_n_floor"
+        case logScalingAlpha = "log_scaling_alpha"
+        case sconvKernelSize = "sconv_kernel_size"
+        case denseMLPIndex = "dense_mlp_idx"
+        case denseIntermediateSize = "dense_intermediate_size"
+        case intermediateSize = "intermediate_size"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case routedExpertCount = "n_routed_experts"
+        case expertsPerToken = "num_experts_per_tok"
+        case sharedExpertCount = "n_shared_experts"
+        case routeScale = "route_scale"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+        vocabSize = try container.decode(Int.self, forKey: .vocabSize)
+        unpaddedVocabSize = try container.decodeIfPresent(Int.self, forKey: .unpaddedVocabSize)
+        rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        useEmbedNorm = try container.decodeIfPresent(Bool.self, forKey: .useEmbedNorm) ?? true
+        logitsMUPWidthMultiplier = try container.decodeIfPresent(
+            Float.self,
+            forKey: .logitsMUPWidthMultiplier
+        ) ?? 1
+        modelMaxLength = try container.decodeIfPresent(Int.self, forKey: .modelMaxLength)
+            ?? container.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings)
+            ?? InklingResources.maximumContextLength
+        numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+        numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
+        headDim = try container.decode(Int.self, forKey: .headDim)
+        swaNumAttentionHeads = try container.decodeIfPresent(Int.self, forKey: .swaNumAttentionHeads)
+            ?? numAttentionHeads
+        swaNumKeyValueHeads = try container.decodeIfPresent(Int.self, forKey: .swaNumKeyValueHeads)
+            ?? numKeyValueHeads
+        swaHeadDim = try container.decodeIfPresent(Int.self, forKey: .swaHeadDim) ?? headDim
+        slidingWindowSize = try container.decodeIfPresent(Int.self, forKey: .slidingWindowSize) ?? 512
+        localLayerIDs = Set(try container.decodeIfPresent([Int].self, forKey: .localLayerIDs) ?? [])
+        dRel = try container.decodeIfPresent(Int.self, forKey: .dRel) ?? 16
+        relExtent = try container.decodeIfPresent(Int.self, forKey: .relExtent) ?? 1_024
+        logScalingNFloor = try container.decodeIfPresent(Int.self, forKey: .logScalingNFloor)
+        logScalingAlpha = try container.decodeIfPresent(Float.self, forKey: .logScalingAlpha) ?? 0.1
+        sconvKernelSize = try container.decodeIfPresent(Int.self, forKey: .sconvKernelSize) ?? 4
+        denseMLPIndex = try container.decodeIfPresent(Int.self, forKey: .denseMLPIndex) ?? 0
+        denseIntermediateSize = try container.decodeIfPresent(Int.self, forKey: .denseIntermediateSize)
+            ?? 24_576
+        moeIntermediateSize = try container.decodeIfPresent(Int.self, forKey: .moeIntermediateSize)
+            ?? container.decodeIfPresent(Int.self, forKey: .intermediateSize)
+            ?? 3_072
+        routedExpertCount = try container.decodeIfPresent(Int.self, forKey: .routedExpertCount) ?? 256
+        expertsPerToken = try container.decodeIfPresent(Int.self, forKey: .expertsPerToken) ?? 6
+        sharedExpertCount = try container.decodeIfPresent(Int.self, forKey: .sharedExpertCount) ?? 2
+        routeScale = try container.decodeIfPresent(Float.self, forKey: .routeScale) ?? 8
+    }
+}
+
+public struct InklingConfig: Decodable, Sendable, Hashable {
+    public let architectures: [String]
+    public let modelType: String
+    public let eosTokenIDs: [Int]
+    public let textConfig: InklingTextConfig
+    public let quantization: InklingQuantizationConfig?
+
+    private enum CodingKeys: String, CodingKey {
+        case architectures
+        case modelType = "model_type"
+        case eosTokenID = "eos_token_id"
+        case textConfig = "text_config"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        modelType = try container.decode(String.self, forKey: .modelType)
+        textConfig = try container.decode(InklingTextConfig.self, forKey: .textConfig)
+        if let multiple = try? container.decodeIfPresent([Int].self, forKey: .eosTokenID) {
+            eosTokenIDs = multiple
+        } else if let single = try container.decodeIfPresent(Int.self, forKey: .eosTokenID) {
+            eosTokenIDs = [single]
+        } else {
+            eosTokenIDs = []
+        }
+        quantization = try container.decodeIfPresent(InklingQuantizationConfig.self, forKey: .quantization)
+            ?? container.decodeIfPresent(InklingQuantizationConfig.self, forKey: .quantizationConfig)
+    }
+}
+
+public enum InklingError: LocalizedError {
+    case modelNotLoaded
+    case unsupportedModelID(String)
+    case missingFiles([String])
+    case downloadFailed(String)
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotLoaded:
+            return "Inkling model is not loaded."
+        case .unsupportedModelID(let id):
+            return "Unsupported Inkling model id: \(id)"
+        case .missingFiles(let files):
+            return "Missing required Inkling files: \(files.joined(separator: ", "))"
+        case .downloadFailed(let message), .generationFailed(let message):
+            return message
+        }
+    }
+}

--- a/Sources/MereRunCore/Inkling/InklingGenerator.swift
+++ b/Sources/MereRunCore/Inkling/InklingGenerator.swift
@@ -1,0 +1,378 @@
+import Foundation
+import MLX
+
+private struct InklingDecodeResult {
+    let tokens: [Int]
+    let decodeSeconds: Double
+    let firstTokenSeconds: Double?
+}
+
+public actor InklingGenerator: ChatGenerator {
+    // The relative-position mask is [heads, query, key]; a conservative chunk
+    // keeps its transient footprint bounded as global layers grow.
+    private static let prefillChunkSize = 64
+
+    private let modelID: String
+    private var model: InklingLanguageModel?
+    private var tokenizerAndTemplate: InklingTokenizerAndTemplate?
+    private var loadedConfig: InklingConfig?
+    private var loadedModelPath: String?
+
+    public init(modelID: String = InklingResources.modelID) {
+        self.modelID = modelID
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await chat(request, modelPath: nil, progressHandler: progressHandler)
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await Stream.withNewDefaultStream {
+            let root = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+            let loadStart = Date()
+            try await ensureLoaded(rootURL: root, progressHandler: progressHandler)
+            let loadSeconds = Date().timeIntervalSince(loadStart)
+            var response = try await generate(request, progressHandler: progressHandler)
+            if var timing = response.timing {
+                timing.loadSeconds = loadSeconds
+                response.timing = timing
+            } else {
+                response.timing = ChatTiming(loadSeconds: loadSeconds)
+            }
+            return response
+        }
+    }
+
+    public func prepare(
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws {
+        try await Stream.withNewDefaultStream {
+            let root = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+            try await ensureLoaded(rootURL: root, progressHandler: progressHandler)
+        }
+    }
+
+    public func unload() {
+        model = nil
+        tokenizerAndTemplate = nil
+        loadedConfig = nil
+        loadedModelPath = nil
+        Memory.clearCache()
+    }
+
+    private func ensureLoaded(
+        rootURL: URL,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        let normalized = InklingResources.normalizedRootURL(rootURL)
+        if loadedModelPath == normalized.path, model != nil, tokenizerAndTemplate != nil {
+            return
+        }
+        let missing = InklingResources.validate(rootURL: normalized)
+        guard missing.isEmpty else {
+            throw InklingError.missingFiles(missing.map(\.path))
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Inkling config"))
+        let config = try JSONDecoder().decode(
+            InklingConfig.self,
+            from: Data(contentsOf: normalized.appendingPathComponent("config.json"))
+        )
+        guard config.quantization?.bits == InklingResources.quantizationBits,
+              config.quantization?.groupSize == InklingResources.quantizationGroupSize,
+              config.quantization?.mode == InklingResources.quantizationMode,
+              config.quantization?.scope == InklingResources.quantizationScope else {
+            throw InklingError.generationFailed(
+                "Inkling artifact must use affine 2-bit/group-128 routed experts with BF16 non-routed weights."
+            )
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Inkling tokenizer"))
+        let tokenizer = try await InklingTokenizerAndTemplate.load(
+            from: normalized,
+            maxLengthOverride: min(
+                InklingResources.defaultContextLength,
+                config.textConfig.modelMaxLength
+            )
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Inkling weights"))
+        let languageModel = InklingLanguageModel(config: config)
+        let index = normalized.appendingPathComponent("model.safetensors.index.json")
+        let single = normalized.appendingPathComponent("model.safetensors")
+        let groupSize = config.quantization?.groupSize ?? InklingResources.quantizationGroupSize
+        let bits = config.quantization?.bits ?? InklingResources.quantizationBits
+        if FileManager.default.fileExists(atPath: index.path) {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                indexURL: index,
+                to: languageModel,
+                groupSize: groupSize,
+                bits: bits,
+                keyMapper: InklingResources.mapWeightKey,
+                mapper: InklingResources.mapWeight(key:value:),
+                progressHandler: { progress in
+                    progressHandler?(ChatProgress(
+                        stage: .loadingModel,
+                        message: "Loading Inkling shard \(progress.shardIndex + 1)/\(progress.shardCount)"
+                    ))
+                }
+            )
+        } else {
+            let arrays = try MLX.loadArrays(url: single)
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                arrays,
+                to: languageModel,
+                groupSize: groupSize,
+                bits: bits,
+                keyMapper: InklingResources.mapWeightKey,
+                mapper: InklingResources.mapWeight(key:value:)
+            )
+        }
+
+        try Task.checkCancellation()
+        model = languageModel
+        tokenizerAndTemplate = tokenizer
+        loadedConfig = config
+        loadedModelPath = normalized.path
+    }
+
+    private func generate(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        guard let model, let tokenizerAndTemplate, let loadedConfig else {
+            throw InklingError.modelNotLoaded
+        }
+        guard request.lora == nil else {
+            throw InklingError.generationFailed("Inkling LoRA loading is not yet supported.")
+        }
+        guard !request.requiresJSON else {
+            throw InklingError.generationFailed("Inkling constrained JSON generation is not yet supported.")
+        }
+
+        let requestedContext = request.maxContextTokens ?? InklingResources.defaultContextLength
+        guard requestedContext > 0 else {
+            throw InklingError.generationFailed("maxContextTokens must be greater than zero.")
+        }
+        let effectiveContext = min(
+            requestedContext,
+            InklingResources.maximumContextLength,
+            loadedConfig.textConfig.modelMaxLength
+        )
+
+        let prefillStart = Date()
+        var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
+            messages: request.messages,
+            tools: request.tools,
+            addGenerationPrompt: true,
+            reasoningEffort: 0.9,
+            maxLength: effectiveContext
+        )
+        if promptTokens.count > effectiveContext {
+            promptTokens = Array(promptTokens.suffix(effectiveContext))
+        }
+        guard !promptTokens.isEmpty else {
+            throw InklingError.generationFailed("Inkling prompt tokenization produced no tokens.")
+        }
+
+        let effectiveKVMode: RuntimeKVCacheMode
+        switch request.kvCacheMode {
+        case .affine4:
+            effectiveKVMode = .affine4
+        case .affine8:
+            effectiveKVMode = .affine8
+        default:
+            effectiveKVMode = .default
+        }
+        let caches = makeCaches(config: loadedConfig, mode: effectiveKVMode)
+        let initialLogits = try await chunkedPrefill(
+            model: model,
+            tokens: promptTokens,
+            cache: caches,
+            progressHandler: progressHandler
+        )
+        let prefillSeconds = Date().timeIntervalSince(prefillStart)
+
+        let tokenBudget = max(0, min(request.maxTokens, effectiveContext - promptTokens.count))
+        progressHandler?(ChatProgress(stage: .generating, message: ""))
+        let generationConfig = GenerationConfig(
+            maxTokens: tokenBudget,
+            temperature: Float(request.temperature),
+            topK: request.topK ?? 0,
+            topP: Float(request.topP),
+            minP: Float(request.minP),
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 64
+        )
+        let decode = try decode(
+            model: model,
+            tokenizer: tokenizerAndTemplate,
+            initialLogits: initialLogits,
+            cache: caches,
+            eosTokens: Set(loadedConfig.eosTokenIDs + tokenizerAndTemplate.stopTokenIDs),
+            generationConfig: generationConfig,
+            tokenBudget: tokenBudget,
+            promptTokens: promptTokens,
+            showThinking: request.showThinking,
+            progressHandler: progressHandler
+        )
+
+        let parsed = InklingOutputParser.parse(tokenizerAndTemplate.decode(tokens: decode.tokens))
+        let visible: String
+        if request.showThinking, let reasoning = parsed.reasoning {
+            visible = "<think>\n\(reasoning)\n</think>\n\(parsed.visible)"
+        } else {
+            visible = parsed.visible
+        }
+        return ChatResponse(
+            response: visible.trimmingCharacters(in: .whitespacesAndNewlines),
+            tokensGenerated: decode.tokens.count,
+            timing: ChatTiming(
+                loadSeconds: 0,
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decode.decodeSeconds,
+                firstTokenSeconds: decode.firstTokenSeconds,
+                kvCacheMode: effectiveKVMode,
+                prefillKVCache: effectiveKVMode.genericCacheLabel,
+                decodeKVCache: effectiveKVMode.genericCacheLabel
+            ),
+            toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
+            promptTokens: promptTokens.count,
+            finishReason: decode.tokens.count >= tokenBudget ? .length : .stop,
+            reasoningContent: parsed.reasoning,
+            reasoningBlockCount: parsed.reasoning == nil ? 0 : 1
+        )
+    }
+
+    private func chunkedPrefill(
+        model: InklingLanguageModel,
+        tokens: [Int],
+        cache: [InklingLayerCache],
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> MLXArray {
+        var offset = 0
+        var logits: MLXArray?
+        while offset < tokens.count {
+            try Task.checkCancellation()
+            let end = min(tokens.count, offset + Self.prefillChunkSize)
+            let chunk = Array(tokens[offset..<end])
+            let output = model.forwardPrefill(
+                MLXArray(chunk.map(Int32.init)).reshaped(1, chunk.count),
+                cache: cache
+            )
+            MLX.eval(output.logits)
+            logits = output.logits
+            offset = end
+            progressHandler?(ChatProgress(
+                stage: .encoding,
+                message: "Prefilled \(offset)/\(tokens.count) tokens"
+            ))
+            await Task.yield()
+        }
+        guard let logits else {
+            throw InklingError.generationFailed("Inkling prefill produced no logits.")
+        }
+        return logits
+    }
+
+    private func decode(
+        model: InklingLanguageModel,
+        tokenizer: InklingTokenizerAndTemplate,
+        initialLogits: MLXArray,
+        cache: [InklingLayerCache],
+        eosTokens: Set<Int>,
+        generationConfig: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int],
+        showThinking: Bool,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> InklingDecodeResult {
+        guard tokenBudget > 0 else {
+            return InklingDecodeResult(tokens: [], decodeSeconds: 0, firstTokenSeconds: nil)
+        }
+        let result = try AutoregressiveDecodeEngine.decode(
+            AutoregressiveDecodeRequest(
+                initialLogits: initialLogits,
+                generationConfig: generationConfig,
+                eosTokens: eosTokens,
+                tokenBudget: tokenBudget,
+                historySeedTokens: promptTokens
+            ),
+            stepForward: { token in model(token, cache: cache) },
+            decodeToken: { tokenizer.decode(token: $0) },
+            emitPiece: { _, piece in
+                // Hidden-reasoning mode buffers output until channel parsing can
+                // separate thinking from the visible answer.
+                if showThinking {
+                    progressHandler?(ChatProgress(stage: .generating, message: piece))
+                }
+            },
+            checkCancellation: { try Task.checkCancellation() }
+        )
+        return InklingDecodeResult(
+            tokens: result.generatedTokens,
+            decodeSeconds: result.decodeSeconds,
+            firstTokenSeconds: result.firstTokenSeconds
+        )
+    }
+
+    private func makeCaches(
+        config: InklingConfig,
+        mode: RuntimeKVCacheMode
+    ) -> [InklingLayerCache] {
+        (0..<config.textConfig.numHiddenLayers).map { _ in
+            let attention: KVCache
+            if mode == .affine4 || mode == .affine8 {
+                attention = AffineQuantizedKVCache(
+                    groupSize: 64,
+                    bits: mode == .affine4 ? 4 : 8,
+                    step: 256
+                )
+            } else {
+                attention = KVCacheSimple(step: 256)
+            }
+            return InklingLayerCache(attention: attention)
+        }
+    }
+
+    private func resolveModelRoot(
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        let requested = modelPath ?? modelID
+        guard InklingResources.handles(modelSpec: requested)
+            || requested.hasPrefix("/")
+            || requested.hasPrefix("~")
+            || requested.hasPrefix(".") else {
+            throw InklingError.unsupportedModelID(requested)
+        }
+        do {
+            let resolved = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: requested,
+                defaultModelID: InklingResources.modelID,
+                progress: { event in
+                    switch event {
+                    case .downloading(let percent):
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Downloading Inkling... \(percent)%"
+                        ))
+                    case .extracting:
+                        progressHandler?(ChatProgress(stage: .loadingModel, message: "Extracting Inkling..."))
+                    }
+                }
+            )
+            return InklingResources.normalizedRootURL(resolved.url)
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw InklingError.downloadFailed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/MereRunCore/Inkling/InklingModel.swift
+++ b/Sources/MereRunCore/Inkling/InklingModel.swift
@@ -1,0 +1,565 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+@inline(__always)
+private func inklingSwiGLU(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
+    MLXNN.silu(gate) * up
+}
+
+public final class InklingConvCache: @unchecked Sendable {
+    fileprivate var states: [MLXArray?] = Array(repeating: nil, count: 4)
+
+    public init() {}
+
+    public func fork() -> InklingConvCache {
+        let copy = InklingConvCache()
+        copy.states = states.map { $0?.asType($0!.dtype) }
+        return copy
+    }
+}
+
+public final class InklingLayerCache: @unchecked Sendable {
+    let attention: KVCache
+    let convolution: InklingConvCache
+
+    public init(attention: KVCache = KVCacheSimple(step: 256)) {
+        self.attention = attention
+        self.convolution = InklingConvCache()
+    }
+
+    public func fork() -> InklingLayerCache {
+        let copy = InklingLayerCache(attention: attention.fork())
+        copy.convolution.states = convolution.states.map { $0?.asType($0!.dtype) }
+        return copy
+    }
+}
+
+private enum InklingBandedMask {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    private static let kernel = MLXFast.metalKernel(
+        name: "mere_inkling_banded_relative_mask",
+        inputNames: ["rel", "proj"],
+        outputNames: ["out"],
+        source: """
+            uint j = thread_position_in_grid.x;
+            uint i = thread_position_in_grid.y;
+            uint bh = thread_position_in_grid.z;
+            if (i >= LQ || j >= S || bh >= B * H) return;
+            uint b = bh / H;
+            uint h = bh % H;
+            int dist = (int(i) + int(Q_OFFSET)) - int(j);
+            T value;
+            if (dist < 0) {
+                value = T(-1e30f);
+            } else if (SLIDING > 0 && dist >= int(SLIDING)) {
+                value = T(-1e30f);
+            } else if (dist < int(REL_EXTENT)) {
+                float total = 0.0f;
+                uint rel_base = ((b * LQ + i) * H + h) * D_REL;
+                for (uint d = 0; d < D_REL; ++d) {
+                    total += float(rel[rel_base + d]) * float(proj[d * REL_EXTENT + uint(dist)]);
+                }
+                value = T(total);
+            } else {
+                value = T(0.0f);
+            }
+            out[((b * H + h) * LQ + i) * S + j] = value;
+        """,
+        ensureRowContiguous: true
+    )
+    #endif
+
+    static func make(
+        relative: MLXArray,
+        projection: MLXArray,
+        queryOffset: Int,
+        keyLength: Int,
+        slidingWindow: Int,
+        relativeExtent: Int
+    ) -> MLXArray {
+        let batch = relative.dim(0)
+        let queryLength = relative.dim(1)
+        let heads = relative.dim(2)
+        let relativeDimensions = relative.dim(3)
+
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        if Device.defaultDevice().deviceType == .gpu {
+            let roundUp: (Int, Int) -> Int = { value, multiple in
+                ((value + multiple - 1) / multiple) * multiple
+            }
+            return kernel(
+                [relative, projection],
+                template: [
+                    ("T", relative.dtype),
+                    ("B", batch),
+                    ("H", heads),
+                    ("LQ", queryLength),
+                    ("S", keyLength),
+                    ("Q_OFFSET", queryOffset),
+                    ("D_REL", relativeDimensions),
+                    ("REL_EXTENT", relativeExtent),
+                    ("SLIDING", slidingWindow),
+                ],
+                grid: (roundUp(keyLength, 8), roundUp(queryLength, 8), batch * heads),
+                threadGroup: (8, 8, 1),
+                outputShapes: [[batch, heads, queryLength, keyLength]],
+                outputDTypes: [relative.dtype]
+            )[0]
+        }
+        #endif
+
+        let projected = relative.matmul(projection).transposed(0, 2, 1, 3)
+        let queryPositions = MLXArray(
+            Int32(queryOffset)..<Int32(queryOffset + queryLength)
+        ).reshaped(queryLength, 1)
+        let keyPositions = MLXArray(0..<Int32(keyLength)).reshaped(1, keyLength)
+        let distance = queryPositions - keyPositions
+        let gatherIndices = MLX.broadcast(
+            MLX.clip(distance, min: 0, max: Float(relativeExtent - 1))
+                .asType(.int32)
+                .reshaped(1, 1, queryLength, keyLength),
+            to: [batch, heads, queryLength, keyLength]
+        )
+        var mask = takeAlong(projected, gatherIndices, axis: -1)
+        mask = MLX.where(
+            (distance .>= relativeExtent).reshaped(1, 1, queryLength, keyLength),
+            MLXArray(0).asType(relative.dtype),
+            mask
+        )
+        var blocked = distance .< 0
+        if slidingWindow > 0 {
+            blocked = blocked .|| (distance .>= slidingWindow)
+        }
+        return MLX.where(
+            blocked.reshaped(1, 1, queryLength, keyLength),
+            MLXArray(-1e30).asType(relative.dtype),
+            mask
+        )
+    }
+}
+
+final class InklingShortConvolution: Module {
+    @ModuleInfo(key: "conv") var conv: Conv1d
+
+    private let kernelSize: Int
+    private let cacheIndex: Int
+
+    init(channels: Int, kernelSize: Int, cacheIndex: Int) {
+        self.kernelSize = kernelSize
+        self.cacheIndex = cacheIndex
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: kernelSize,
+            stride: 1,
+            padding: 0,
+            dilation: 1,
+            groups: channels,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: InklingConvCache?) -> MLXArray {
+        let originalType = x.dtype
+        let floatInput = x.asType(.float32)
+        let keep = max(0, kernelSize - 1)
+        let paddedInput: MLXArray
+        if let cache {
+            let state = cache.states[cacheIndex]
+                ?? MLXArray.zeros([x.dim(0), keep, x.dim(2)], dtype: .float32)
+            paddedInput = concatenated([state, floatInput], axis: 1)
+            cache.states[cacheIndex] = keep > 0
+                ? paddedInput[0..., (paddedInput.dim(1) - keep)..., 0...]
+                : MLXArray.zeros([x.dim(0), 0, x.dim(2)], dtype: .float32)
+        } else {
+            paddedInput = padded(
+                floatInput,
+                widths: [[0, 0], [keep, 0], [0, 0]],
+                value: MLXArray(0).asType(.float32)
+            )
+        }
+        return (conv(paddedInput.asType(conv.weight.dtype)).asType(.float32) + floatInput)
+            .asType(originalType)
+    }
+}
+
+final class InklingAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "r_proj") var rProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "k_sconv") var keyConvolution: InklingShortConvolution
+    @ModuleInfo(key: "v_sconv") var valueConvolution: InklingShortConvolution
+    @ModuleInfo(key: "q_norm") var queryNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: RMSNorm
+    @ParameterInfo(key: "rel_proj") var relativeProjection: MLXArray
+
+    private let headDimension: Int
+    private let headCount: Int
+    private let keyValueHeadCount: Int
+    private let relativeDimensions: Int
+    private let relativeExtent: Int
+    private let slidingWindow: Int
+    private let logScalingFloor: Int?
+    private let logScalingAlpha: Float
+    private let scale: Float
+
+    init(config: InklingTextConfig, layerIndex: Int) {
+        let sliding = config.layerIsSliding(layerIndex)
+        headDimension = sliding ? config.swaHeadDim : config.headDim
+        headCount = sliding ? config.swaNumAttentionHeads : config.numAttentionHeads
+        keyValueHeadCount = sliding ? config.swaNumKeyValueHeads : config.numKeyValueHeads
+        relativeDimensions = config.dRel
+        relativeExtent = sliding ? config.slidingWindowSize : config.relExtent
+        slidingWindow = sliding ? config.slidingWindowSize : 0
+        logScalingFloor = sliding ? nil : config.logScalingNFloor
+        logScalingAlpha = config.logScalingAlpha
+        scale = 1 / Float(max(1, headDimension))
+
+        self._qProj.wrappedValue = Linear(config.hiddenSize, headCount * headDimension, bias: false)
+        self._kProj.wrappedValue = Linear(config.hiddenSize, keyValueHeadCount * headDimension, bias: false)
+        self._vProj.wrappedValue = Linear(config.hiddenSize, keyValueHeadCount * headDimension, bias: false)
+        self._rProj.wrappedValue = Linear(config.hiddenSize, headCount * config.dRel, bias: false)
+        self._oProj.wrappedValue = Linear(headCount * headDimension, config.hiddenSize, bias: false)
+        self._keyConvolution.wrappedValue = InklingShortConvolution(
+            channels: keyValueHeadCount * headDimension,
+            kernelSize: config.sconvKernelSize,
+            cacheIndex: 0
+        )
+        self._valueConvolution.wrappedValue = InklingShortConvolution(
+            channels: keyValueHeadCount * headDimension,
+            kernelSize: config.sconvKernelSize,
+            cacheIndex: 1
+        )
+        self._queryNorm.wrappedValue = RMSNorm(dimensions: headDimension, eps: config.rmsNormEps)
+        self._keyNorm.wrappedValue = RMSNorm(dimensions: headDimension, eps: config.rmsNormEps)
+        self._relativeProjection.wrappedValue = MLXArray.zeros([config.dRel, relativeExtent])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: InklingLayerCache?) -> MLXArray {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        let convolutionCache = cache?.convolution
+        var queries = qProj(x).reshaped(batch, length, headCount, headDimension)
+        var keys = keyConvolution(kProj(x), cache: convolutionCache)
+            .reshaped(batch, length, keyValueHeadCount, headDimension)
+        var values = valueConvolution(vProj(x), cache: convolutionCache)
+            .reshaped(batch, length, keyValueHeadCount, headDimension)
+        let relative = rProj(x).reshaped(batch, length, headCount, relativeDimensions)
+
+        queries = queryNorm(queries).transposed(0, 2, 1, 3)
+        keys = keyNorm(keys).transposed(0, 2, 1, 3)
+        values = values.transposed(0, 2, 1, 3)
+
+        let offset = cache?.attention.offset ?? 0
+        if let cache {
+            (keys, values) = cache.attention.update(keys: keys, values: values)
+        }
+        var mask = InklingBandedMask.make(
+            relative: relative,
+            projection: relativeProjection.asType(x.dtype),
+            queryOffset: offset,
+            keyLength: keys.dim(2),
+            slidingWindow: slidingWindow,
+            relativeExtent: relativeExtent
+        )
+
+        if let logScalingFloor {
+            let positions = MLXArray(
+                Int32(offset + 1)..<Int32(offset + length + 1)
+            ).asType(.float32)
+            let ratio = positions / Float(logScalingFloor)
+            let tau = (1 + logScalingAlpha * MLX.log(MLX.maximum(ratio, MLXArray(1))))
+                .reshaped(1, 1, length, 1)
+                .asType(x.dtype)
+            queries = queries * tau
+            mask = MLX.where(mask .> MLXArray(-1e29).asType(mask.dtype), mask * tau, mask)
+        }
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .array(mask)
+        )
+        return oProj(
+            attended.transposed(0, 2, 1, 3)
+                .reshaped(batch, length, headCount * headDimension)
+        )
+    }
+}
+
+class InklingFeedForward: Module {
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        fatalError("InklingFeedForward is abstract")
+    }
+}
+
+final class InklingDenseMLP: InklingFeedForward {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+    @ParameterInfo(key: "global_scale") var globalScale: MLXArray
+
+    init(config: InklingTextConfig) {
+        self._gateProj.wrappedValue = Linear(config.hiddenSize, config.denseIntermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(config.hiddenSize, config.denseIntermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(config.denseIntermediateSize, config.hiddenSize, bias: false)
+        self._globalScale.wrappedValue = MLXArray.ones([1])
+        super.init()
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(inklingSwiGLU(gateProj(x), upProj(x))) * globalScale
+    }
+}
+
+final class InklingSwitchGLU: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Q35SwitchLinear
+    @ModuleInfo(key: "up_proj") var upProj: Q35SwitchLinear
+    @ModuleInfo(key: "down_proj") var downProj: Q35SwitchLinear
+
+    init(config: InklingTextConfig, expertCount: Int, quantization: InklingQuantizationConfig?) {
+        let groupSize = quantization?.groupSize ?? InklingResources.quantizationGroupSize
+        let bits = quantization?.bits ?? InklingResources.quantizationBits
+        let quantized = quantization != nil
+        self._gateProj.wrappedValue = Q35SwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: config.moeIntermediateSize,
+            numExperts: expertCount,
+            groupSize: groupSize,
+            bits: bits,
+            quantized: quantized,
+            bias: false
+        )
+        self._upProj.wrappedValue = Q35SwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: config.moeIntermediateSize,
+            numExperts: expertCount,
+            groupSize: groupSize,
+            bits: bits,
+            quantized: quantized,
+            bias: false
+        )
+        self._downProj.wrappedValue = Q35SwitchLinear(
+            inputDims: config.moeIntermediateSize,
+            outputDims: config.hiddenSize,
+            numExperts: expertCount,
+            groupSize: groupSize,
+            bits: bits,
+            quantized: quantized,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        downProj(inklingSwiGLU(gateProj(x, indices: indices), upProj(x, indices: indices)), indices: indices)
+    }
+}
+
+final class InklingSparseMoE: InklingFeedForward {
+    @ParameterInfo(key: "gate_weight") var gateWeight: MLXArray
+    @ParameterInfo(key: "e_score_correction_bias") var correctionBias: MLXArray
+    @ParameterInfo(key: "global_scale") var globalScale: MLXArray
+    @ModuleInfo(key: "switch_mlp") var switchMLP: InklingSwitchGLU
+    @ModuleInfo(key: "shared_experts") var sharedExperts: InklingSwitchGLU
+
+    private let routedExpertCount: Int
+    private let sharedExpertCount: Int
+    private let topK: Int
+    private let routeScale: Float
+
+    init(config: InklingTextConfig, quantization: InklingQuantizationConfig?) {
+        routedExpertCount = config.routedExpertCount
+        sharedExpertCount = config.sharedExpertCount
+        topK = config.expertsPerToken
+        routeScale = config.routeScale
+        self._gateWeight.wrappedValue = MLXArray.zeros([
+            config.routedExpertCount + config.sharedExpertCount,
+            config.hiddenSize,
+        ])
+        self._correctionBias.wrappedValue = MLXArray.zeros([config.routedExpertCount])
+        self._globalScale.wrappedValue = MLXArray.ones([1])
+        self._switchMLP.wrappedValue = InklingSwitchGLU(
+            config: config,
+            expertCount: config.routedExpertCount,
+            quantization: quantization
+        )
+        self._sharedExperts.wrappedValue = InklingSwitchGLU(
+            config: config,
+            expertCount: config.sharedExpertCount,
+            quantization: nil
+        )
+        super.init()
+    }
+
+    override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        let dimensions = x.dim(2)
+        let flat = x.reshaped(1, batch * length, dimensions)
+        let logits = flat.matmul(gateWeight.asType(x.dtype).T)
+        let scores = MLX.sigmoid(logits.asType(.float32))
+        let routedScores = scores[.ellipsis, ..<routedExpertCount]
+            + correctionBias.asType(.float32)
+        let indices = argPartition(-routedScores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+
+        let routedLogits = logits[.ellipsis, ..<routedExpertCount]
+        let sharedLogits = logits[.ellipsis, routedExpertCount...]
+        let selected = concatenated(
+            [takeAlong(routedLogits, indices, axis: -1), sharedLogits],
+            axis: -1
+        ).asType(.float32)
+        let logProbabilities = -MLX.logAddExp(MLXArray.zeros(like: selected), -selected)
+        let weights = MLX.exp(
+            logProbabilities - logSumExp(logProbabilities, axis: -1, keepDims: true)
+        ) * routeScale * globalScale.asType(.float32)
+
+        let routedWeights = weights[.ellipsis, ..<topK].asType(x.dtype)
+        let sharedWeights = weights[.ellipsis, topK...].asType(x.dtype)
+        let routed = (
+            switchMLP(flat, indices: indices)
+                * routedWeights.expandedDimensions(axis: -1)
+        ).sum(axis: -2)
+        let sharedIndices = MLX.broadcast(
+            MLXArray(0..<Int32(sharedExpertCount)).reshaped(1, 1, sharedExpertCount),
+            to: [1, batch * length, sharedExpertCount]
+        )
+        let shared = (
+            sharedExperts(flat, indices: sharedIndices)
+                * sharedWeights.expandedDimensions(axis: -1)
+        ).sum(axis: -2)
+        return (routed + shared).reshaped(batch, length, dimensions).asType(x.dtype)
+    }
+}
+
+final class InklingDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: InklingAttention
+    @ModuleInfo(key: "mlp") var mlp: InklingFeedForward
+    @ModuleInfo(key: "input_layernorm") var inputNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: RMSNorm
+    @ModuleInfo(key: "attn_sconv") var attentionConvolution: InklingShortConvolution
+    @ModuleInfo(key: "mlp_sconv") var mlpConvolution: InklingShortConvolution
+
+    init(config: InklingConfig, layerIndex: Int) {
+        let text = config.textConfig
+        self._attention.wrappedValue = InklingAttention(config: text, layerIndex: layerIndex)
+        self._mlp.wrappedValue = text.layerIsDense(layerIndex)
+            ? InklingDenseMLP(config: text)
+            : InklingSparseMoE(config: text, quantization: config.quantization)
+        self._inputNorm.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        self._postAttentionNorm.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        self._attentionConvolution.wrappedValue = InklingShortConvolution(
+            channels: text.hiddenSize,
+            kernelSize: text.sconvKernelSize,
+            cacheIndex: 2
+        )
+        self._mlpConvolution.wrappedValue = InklingShortConvolution(
+            channels: text.hiddenSize,
+            kernelSize: text.sconvKernelSize,
+            cacheIndex: 3
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: InklingLayerCache?) -> MLXArray {
+        let attentionOutput = attention(inputNorm(x), cache: cache)
+        let hidden = x + attentionConvolution(attentionOutput, cache: cache?.convolution)
+        return hidden + mlpConvolution(mlp(postAttentionNorm(hidden)), cache: cache?.convolution)
+    }
+}
+
+final class InklingTransformer: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "embed_norm") var embedNorm: RMSNorm?
+    @ModuleInfo(key: "layers") var layers: [InklingDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(config: InklingConfig) {
+        let text = config.textConfig
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: text.vocabSize,
+            dimensions: text.hiddenSize
+        )
+        self._embedNorm.wrappedValue = text.useEmbedNorm
+            ? RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+            : nil
+        self._layers.wrappedValue = (0..<text.numHiddenLayers).map {
+            InklingDecoderLayer(config: config, layerIndex: $0)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: text.hiddenSize, eps: text.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(_ inputIDs: MLXArray, cache: [InklingLayerCache]?) -> MLXArray {
+        var ids = inputIDs
+        if ids.dtype != .int32 {
+            ids = ids.asType(.int32)
+        }
+        var hidden = embedTokens(ids)
+        if let embedNorm {
+            hidden = embedNorm(hidden)
+        }
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(hidden, cache: cache?[index])
+        }
+        return norm(hidden)
+    }
+}
+
+struct InklingForwardOutput {
+    let hidden: MLXArray
+    let logits: MLXArray
+}
+
+public final class InklingLanguageModel: Module, @unchecked Sendable {
+    @ModuleInfo(key: "model") var model: InklingTransformer
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    public let config: InklingConfig
+
+    public init(config: InklingConfig) {
+        self.config = config
+        self._model.wrappedValue = InklingTransformer(config: config)
+        self._lmHead.wrappedValue = Linear(
+            config.textConfig.hiddenSize,
+            config.textConfig.vocabSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func forward(_ inputIDs: MLXArray, cache: [InklingLayerCache]?) -> InklingForwardOutput {
+        let hidden = model(inputIDs, cache: cache)
+        return InklingForwardOutput(hidden: hidden, logits: logits(from: hidden))
+    }
+
+    func forwardPrefill(_ inputIDs: MLXArray, cache: [InklingLayerCache]?) -> InklingForwardOutput {
+        var hidden = model(inputIDs, cache: cache)
+        if hidden.dim(1) > 1 {
+            hidden = hidden[0..., (hidden.dim(1) - 1)..., 0...]
+        }
+        return InklingForwardOutput(hidden: hidden, logits: logits(from: hidden))
+    }
+
+    public func callAsFunction(_ inputIDs: MLXArray, cache: [InklingLayerCache]?) -> MLXArray {
+        forward(inputIDs, cache: cache).logits
+    }
+
+    private func logits(from hidden: MLXArray) -> MLXArray {
+        var logits = lmHead(hidden / config.textConfig.logitsMUPWidthMultiplier)
+        if let unpadded = config.textConfig.unpaddedVocabSize,
+           unpadded < logits.dim(-1) {
+            logits = logits[.ellipsis, ..<unpadded]
+        }
+        return logits
+    }
+}

--- a/Sources/MereRunCore/Inkling/InklingModel.swift
+++ b/Sources/MereRunCore/Inkling/InklingModel.swift
@@ -421,7 +421,7 @@ final class InklingSparseMoE: InklingFeedForward {
         let logProbabilities = -MLX.logAddExp(MLXArray.zeros(like: selected), -selected)
         let weights = MLX.exp(
             logProbabilities - logSumExp(logProbabilities, axis: -1, keepDims: true)
-        ) * routeScale * globalScale.asType(.float32)
+        ) * MLXArray(routeScale).asType(.float32) * globalScale.asType(.float32)
 
         let routedWeights = weights[.ellipsis, ..<topK].asType(x.dtype)
         let sharedWeights = weights[.ellipsis, topK...].asType(x.dtype)

--- a/Sources/MereRunCore/Inkling/InklingResources.swift
+++ b/Sources/MereRunCore/Inkling/InklingResources.swift
@@ -1,0 +1,122 @@
+import Foundation
+import MLX
+
+/// Managed metadata for the text-only native MLX Inkling-Small runtime.
+public enum InklingResources {
+    public static let modelID = "text-chat-inkling-small"
+
+    public static let baseRepoID = "thinkingmachines/Inkling-Small"
+    public static let baseRevision = "b2d4f225a02032c5d154bff748ab5a00c5ca26e4"
+
+    public static let artifactRepoID = "Sawfwair/Inkling-Small-MLX-Mixed-2bit"
+    public static let artifactRevision = "22c95fc2e30400a893dc9ac9fe4df17f306362ae"
+    public static let quantizationBits = 2
+    public static let quantizationGroupSize = 128
+    public static let quantizationMode = "affine"
+    public static let quantizationScope = "routed_experts"
+
+    public static let defaultContextLength = 32_768
+    public static let maximumContextLength = 1_048_576
+    public static let estimatedDownloadBytes: Int64 = 84_562_401_171
+
+    public static let snapshotPatterns = [
+        "LICENSE*",
+        "README.md",
+        "chat_template.jinja",
+        "config.json",
+        "conversion.json",
+        "generation_config.json",
+        "special_tokens_map.json",
+        "tiktoken/*",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "model.safetensors.index.json",
+        "*.safetensors",
+    ]
+
+    public static let hubFallbackConfig = HubFallbackConfig(
+        repoId: artifactRepoID,
+        revision: artifactRevision,
+        patterns: snapshotPatterns
+    )
+
+    public static func handles(modelSpec: String) -> Bool {
+        let normalized = modelSpec.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return false }
+        return normalized == modelID
+            || normalized == artifactRepoID.lowercased()
+            || normalized.contains("inkling-small")
+    }
+
+    public static func normalizedRootURL(
+        _ rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let standardized = rootURL.standardizedFileURL
+        if fileManager.fileExists(atPath: standardized.appendingPathComponent("config.json").path) {
+            return standardized
+        }
+        if let children = try? fileManager.contentsOfDirectory(
+            at: standardized,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for child in children where
+                fileManager.fileExists(atPath: child.appendingPathComponent("config.json").path) {
+                return child.standardizedFileURL
+            }
+        }
+        return standardized
+    }
+
+    public static func validate(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        let root = normalizedRootURL(rootURL, fileManager: fileManager)
+        var missing = ["config.json", "tokenizer.json", "tokenizer_config.json"]
+            .map { root.appendingPathComponent($0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+        let index = root.appendingPathComponent("model.safetensors.index.json")
+        let single = root.appendingPathComponent("model.safetensors")
+        if fileManager.fileExists(atPath: index.path) {
+            do {
+                let decoded = try JSONDecoder().decode(
+                    HFSafetensorsIndex.self,
+                    from: Data(contentsOf: index)
+                )
+                guard !decoded.shardFilenames.isEmpty else {
+                    missing.append(index)
+                    return missing
+                }
+                missing.append(contentsOf: decoded.shardFilenames
+                    .map { root.appendingPathComponent($0) }
+                    .filter { !fileManager.fileExists(atPath: $0.path) })
+            } catch {
+                missing.append(index)
+            }
+        } else if !fileManager.fileExists(atPath: single.path) {
+            missing.append(index)
+        }
+        return missing
+    }
+
+    static func mapWeightKey(_ key: String) -> String {
+        guard key.hasPrefix("language_model.") else {
+            return "_ignored.\(key)"
+        }
+        return String(key.dropFirst("language_model.".count))
+    }
+
+    static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        guard !key.hasPrefix("_ignored.") else {
+            return []
+        }
+        if key.hasSuffix(".conv.weight"),
+           value.ndim == 3,
+           value.dim(2) > value.dim(1) {
+            return [(key, value.transposed(0, 2, 1))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/Inkling/InklingTokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Inkling/InklingTokenizerAndTemplate.swift
@@ -1,0 +1,278 @@
+import Foundation
+@preconcurrency import Hub
+@preconcurrency import Tokenizers
+
+public final class InklingTokenizerAndTemplate: @unchecked Sendable {
+    public let tokenizer: any Tokenizer
+    public let maxLength: Int
+    public let endSamplingTokenID: Int?
+
+    public init(tokenizer: any Tokenizer, maxLength: Int, endSamplingTokenID: Int?) {
+        self.tokenizer = tokenizer
+        self.maxLength = maxLength
+        self.endSamplingTokenID = endSamplingTokenID
+    }
+
+    public static func load(
+        from rootURL: URL,
+        maxLengthOverride: Int? = nil,
+        hubApi: HubApi = .shared
+    ) async throws -> InklingTokenizerAndTemplate {
+        let tokenizer = try await AutoTokenizer.from(modelFolder: rootURL, hubApi: hubApi)
+        return InklingTokenizerAndTemplate(
+            tokenizer: tokenizer,
+            maxLength: maxLengthOverride ?? InklingResources.defaultContextLength,
+            endSamplingTokenID: tokenizer.convertTokenToId("<|content_model_end_sampling|>")
+        )
+    }
+
+    public func encodeForGeneration(
+        messages: [ChatMessage],
+        tools: [ToolDefinition]? = nil,
+        addGenerationPrompt: Bool = true,
+        reasoningEffort: Double = 0.9,
+        maxLength: Int
+    ) throws -> [Int] {
+        var encoded = tokenizer.encode(
+            text: try Self.renderPrompt(
+                messages: messages,
+                tools: tools,
+                addGenerationPrompt: addGenerationPrompt,
+                reasoningEffort: reasoningEffort
+            ),
+            addSpecialTokens: false
+        )
+        let targetLength = min(maxLength, self.maxLength)
+        if encoded.count > targetLength {
+            encoded = Array(encoded.suffix(targetLength))
+        }
+        return encoded
+    }
+
+    public func decode(tokens: [Int]) -> String {
+        tokenizer.decode(tokens: tokens)
+    }
+
+    public func decode(token: Int) -> String {
+        tokenizer.decode(tokens: [token])
+    }
+
+    public var stopTokenIDs: [Int] {
+        [endSamplingTokenID].compactMap { $0 }
+    }
+
+    public static func renderPrompt(
+        messages: [ChatMessage],
+        tools: [ToolDefinition]? = nil,
+        addGenerationPrompt: Bool = true,
+        reasoningEffort: Double = 0.9
+    ) throws -> String {
+        guard (0...0.99).contains(reasoningEffort) else {
+            throw InklingError.generationFailed("Inkling reasoning effort must be between 0 and 0.99.")
+        }
+        guard messages.allSatisfy({ $0.imageUrl == nil }) else {
+            throw InklingError.generationFailed(
+                "The initial Inkling-Small runtime is text-only; image and audio towers are not loaded."
+            )
+        }
+
+        var prompt = ""
+        if let tools, !tools.isEmpty {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let declarations = tools.map(InklingToolDeclaration.init)
+            let json = String(decoding: try encoder.encode(declarations), as: UTF8.self)
+            prompt += "<|message_system|>tool_declare<|content_xml|>\(json)<|end_message|>"
+        }
+
+        var effortEmitted = false
+        var toolNamesByID: [String: String] = [:]
+        for message in messages {
+            if !effortEmitted, message.role != .system {
+                prompt += effortMessage(reasoningEffort)
+                effortEmitted = true
+            }
+            if let calls = message.toolCalls {
+                for call in calls {
+                    if let id = call.id {
+                        toolNamesByID[id] = call.name
+                    }
+                }
+            }
+            prompt += try render(message, toolNamesByID: toolNamesByID)
+        }
+        if !effortEmitted {
+            prompt += effortMessage(reasoningEffort)
+        }
+        if addGenerationPrompt {
+            prompt += "<|message_model|>"
+        }
+        return prompt
+    }
+
+    private static func effortMessage(_ value: Double) -> String {
+        let rendered = value == 0 ? "0" : String(value)
+        return "<|message_system|><|content_text|>Thinking effort level: \(rendered)<|end_message|>"
+    }
+
+    private static func render(
+        _ message: ChatMessage,
+        toolNamesByID: [String: String]
+    ) throws -> String {
+        let roleToken: String
+        switch message.role {
+        case .system:
+            roleToken = "<|message_system|>"
+        case .user:
+            roleToken = "<|message_user|>"
+        case .assistant:
+            roleToken = "<|message_model|>"
+        case .tool:
+            roleToken = "<|message_tool|>"
+        }
+
+        if message.role == .tool {
+            let toolName = message.name
+                ?? message.toolCallID.flatMap { toolNamesByID[$0] }
+                ?? ""
+            return roleToken
+                + toolName
+                + "<|content_text|>"
+                + message.content
+                + "<|end_message|>"
+        }
+
+        var result = ""
+        if message.role == .assistant,
+           let reasoning = message.reasoningContent,
+           !reasoning.isEmpty {
+            result += "<|message_model|><|content_thinking|>\(reasoning)<|end_message|>"
+        }
+        result += roleToken + "<|content_text|>" + message.content + "<|end_message|>"
+        if message.role == .assistant, let calls = message.toolCalls {
+            for call in calls {
+                let invocation = InklingToolInvocation(name: call.name, args: call.arguments)
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.sortedKeys]
+                let json = String(decoding: try encoder.encode(invocation), as: UTF8.self)
+                result += "<|message_model|>\(call.name)<|content_invoke_tool_json|>\(json)<|end_message|>"
+            }
+        }
+        if message.role == .assistant {
+            result += "<|content_model_end_sampling|>"
+        }
+        return result
+    }
+}
+
+private struct InklingToolDeclaration: Encodable {
+    let description: String
+    let name: String
+    let parameters: InklingToolParameters
+    let type = "function"
+
+    init(_ definition: ToolDefinition) {
+        description = definition.description
+        name = definition.name
+        parameters = InklingToolParameters(definition)
+    }
+}
+
+private struct InklingToolParameters: Encodable {
+    let properties: [String: ToolParameterProperty]
+    let required: [String]
+    let type = "object"
+
+    init(_ definition: ToolDefinition) {
+        properties = definition.parameters
+        required = definition.required
+    }
+}
+
+private struct InklingToolInvocation: Codable {
+    let name: String
+    let args: [String: OpenAIJSONValue]
+}
+
+struct InklingParsedOutput: Sendable, Hashable {
+    let visible: String
+    let reasoning: String?
+    let toolCalls: [ToolCall]
+}
+
+enum InklingOutputParser {
+    static func parse(_ text: String) -> InklingParsedOutput {
+        let reasoning = channelContents("<|content_thinking|>", in: text)
+        var visible = channelContents("<|content_text|>", in: text)
+        if visible.isEmpty, !text.contains("<|content_thinking|>"), !text.contains("<|content_invoke_tool_json|>") {
+            visible = [stripControlTokens(text)]
+        }
+        return InklingParsedOutput(
+            visible: visible.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines),
+            reasoning: reasoning.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+            toolCalls: parseToolCalls(text)
+        )
+    }
+
+    private static func channelContents(_ marker: String, in text: String) -> [String] {
+        var result: [String] = []
+        var searchStart = text.startIndex
+        while let markerRange = text.range(of: marker, range: searchStart..<text.endIndex) {
+            let contentStart = markerRange.upperBound
+            guard let end = text.range(of: "<|end_message|>", range: contentStart..<text.endIndex) else {
+                result.append(String(text[contentStart...]))
+                break
+            }
+            result.append(String(text[contentStart..<end.lowerBound]))
+            searchStart = end.upperBound
+        }
+        return result
+    }
+
+    private static func stripControlTokens(_ text: String) -> String {
+        text.replacingOccurrences(
+            of: "<\\|[^>]+\\|>",
+            with: "",
+            options: .regularExpression
+        )
+    }
+
+    private static func parseToolCalls(_ text: String) -> [ToolCall] {
+        let marker = "<|content_invoke_tool_json|>"
+        var result: [ToolCall] = []
+        var searchStart = text.startIndex
+        let decoder = JSONDecoder()
+        while let markerRange = text.range(of: marker, range: searchStart..<text.endIndex) {
+            let jsonStart = markerRange.upperBound
+            guard let end = text.range(of: "<|end_message|>", range: jsonStart..<text.endIndex) else {
+                break
+            }
+            let data = Data(text[jsonStart..<end.lowerBound].utf8)
+            if let invocation = try? decoder.decode(InklingToolInvocation.self, from: data) {
+                result.append(ToolCall(
+                    name: invocation.name,
+                    arguments: invocation.args.mapValues(stringValue)
+                ))
+            }
+            searchStart = end.upperBound
+        }
+        return result
+    }
+
+    private static func stringValue(_ value: OpenAIJSONValue) -> String {
+        switch value {
+        case .string(let value):
+            return value
+        default:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            return (try? String(decoding: encoder.encode(value), as: UTF8.self)) ?? "null"
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Sources/MereRunCore/Inkling/README.md
+++ b/Sources/MereRunCore/Inkling/README.md
@@ -1,0 +1,19 @@
+# Inkling
+
+Inkling-Small text generation runs in the native Swift/MLX runtime.
+
+- `InklingResources.swift` pins the official BF16 checkpoint and mere.run's
+  mixed MLX conversion: routed experts are affine 2-bit/group-128 and all
+  non-routed weights remain BF16.
+- `InklingModel.swift` implements Inkling's relative-position attention,
+  short-convolution residuals, and sigmoid-routed shared-expert MoE.
+- `InklingGenerator.swift` owns managed loading, prompt encoding, chunked
+  prefill, and autoregressive decode.
+
+The released checkpoint accepts text, images, and audio. This first mere.run
+lane intentionally loads only `language_model.*` weights and exposes text chat;
+the vision and audio towers remain out of scope.
+
+The architecture advertises 1,048,576 tokens. mere.run defaults to 32,768
+because KV-cache and attention-mask residency still grow with context on the
+128 GB machines targeted by this conversion.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -42,6 +42,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case lagunaDFlash
     case q35
     case lfm2
+    case inkling
     case qwen3TTS
     case qwen3ASR
     case parakeet
@@ -1037,6 +1038,18 @@ public enum ManagedModelCatalog {
                 "api serve",
                 "model benchmark chat",
             ]
+        ),
+        ManagedModelSpec(
+            id: InklingResources.modelID,
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: InklingResources.hubFallbackConfig,
+            upstreamRepoId: InklingResources.artifactRepoID,
+            upstreamRevision: InklingResources.artifactRevision,
+            validationKind: .inkling,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: InklingResources.estimatedDownloadBytes,
+            defaultCLICommands: ["text chat"]
         ),
         ManagedModelSpec(
             id: Q35Resources.q36NanoModelId,
@@ -2421,6 +2434,8 @@ public extension ManagedModelSpec {
             return Q35Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .lfm2:
             return LFM2Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .inkling:
+            return InklingResources.validate(rootURL: rootURL, fileManager: fileManager)
         case .sam31:
             return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -381,6 +381,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 48
             ),
             descriptor(
+                InklingResources.modelID,
+                "Inkling-Small 276B-A12B",
+                "Runs Inkling-Small through native Swift/MLX with affine 2-bit/group-128 routed experts and BF16 non-routed weights.",
+                minimum: 128,
+                recommended: 128
+            ),
+            descriptor(
                 Q35Resources.q36NanoModelId,
                 "Qwen3.6 A3B chat nano",
                 "Runs the Qwen3.6 35B-A3B OptiQ 4-bit MLX/MTP snapshot through the native Qwen-family runtime.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -88,6 +88,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case psiChat = "psi-chat"
         /// DeepSeek V4 Flash family, served by the bundled `ds4-server` subprocess.
         case deepseekV4Flash = "deepseek-v4-flash"
+        /// Thinking Machines Lab Inkling family via the native Swift/MLX runtime.
+        case inkling
     }
 
     public enum Family: String, Codable, CaseIterable, Hashable, Sendable {
@@ -117,6 +119,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case video
         case psi
         case deepseek
+        case inkling
     }
 
     public enum Tier: String, Codable, CaseIterable, Hashable, Sendable {
@@ -945,6 +948,25 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 components: nil,
                 upstreamRepoId:
                     "\(LagunaResources.dflashUpstreamModelID)@\(LagunaResources.dflashUpstreamRevision)",
+                createdAt: createdAt
+            )
+        case .inklingSmall:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .inkling,
+                family: .inkling,
+                tier: .small,
+                variant: .standard,
+                precision: .int2,
+                quantization: Quantization(
+                    bits: 2,
+                    groupSize: 128,
+                    scheme: "affine-routed-experts"
+                ),
+                defaults: nil,
+                supports: [.chat, .codeGeneration],
+                components: nil,
+                upstreamRepoId: "\(InklingResources.artifactRepoID)@\(InklingResources.artifactRevision)",
                 createdAt: createdAt
             )
         case .q36Nano:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -164,7 +164,8 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .instantMesh
             || spec?.validationKind == .trellis2
             || spec?.validationKind == .wan22TI2VMLX
-            || spec?.validationKind == .dreamXCausalMLX {
+            || spec?.validationKind == .dreamXCausalMLX
+            || spec?.validationKind == .inkling {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil
             textEncoderDir = nil
@@ -481,7 +482,7 @@ public enum MereRunModelValidator {
                 return true
             }
             switch manifest.engine {
-            case .qwen3Coder?, .northMiniCode?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .mmaudio?, .ltxVideo?,
+            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .woosh?, .mmaudio?, .ltxVideo?,
                  .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?,
                  .insightFace?, .sortformer?:
                 return true

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -38,6 +38,7 @@ public struct ModelResolver {
         case lagunaS21 = "text-chat-laguna-s-2-1"
         case lagunaXS21 = "text-chat-laguna-xs-2-1"
         case lagunaS21DFlash = "text-chat-laguna-s-2-1-dflash"
+        case inklingSmall = "text-chat-inkling-small"
         case ltxGemma3TwelveB4Bit = "text-encoder-ltx-gemma3-12b-4bit"
         case q36Nano = "text-chat-q36-nano"
         case bonsai27B1Bit = "text-chat-bonsai-27b-1bit"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -74,6 +74,7 @@ public enum QuantizedModelManifestWriter {
             case .ltxVideo, .wanVideo, .cosmos3Edge: return .video
             case .psiChat: return .psi
             case .deepseekV4Flash: return .deepseek
+            case .inkling: return .inkling
             }
         }()
 
@@ -164,6 +165,8 @@ public enum QuantizedModelManifestWriter {
                     return [.chat]
                 case .deepseekV4Flash:
                     return [.chat]
+                case .inkling:
+                    return [.chat, .codeGeneration]
                 }
             }()
             return baseline.filter { $0 != .loraTraining }
@@ -237,7 +240,7 @@ public enum QuantizedModelManifestWriter {
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .sortformer, .qwen3Embedding, .openAIPrivacyFilter,
                  .qwen3Coder, .northMiniCode, .lightOnOCR, .woosh, .mmaudio, .psiChat, .deepseekV4Flash,
-                 .muScriptor:
+                 .muScriptor, .inkling:
                 break
             case .aceStep, .magentaRT2, .ltxVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -438,6 +438,104 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertNil(ModelPullDiskPreflight.requiredBytes(estimatedDownloadBytes: nil))
     }
 
+    func testDiskPreflightDoesNotRequireModelBytesForCompleteCachedSnapshot() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = root.appendingPathComponent("hub", isDirectory: true)
+        let revision = "0123456789abcdef0123456789abcdef01234567"
+        let revisionKey = "deb87fabd17715bb31ad4cf4ffb9494eeb15f8d33d85b031a301c64ab3417eaa"
+        let repoID = "example/large-text-model"
+        let snapshot = cache
+            .appendingPathComponent("snapshots/models", isDirectory: true)
+            .appendingPathComponent(repoID, isDirectory: true)
+            .appendingPathComponent(revisionKey, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        for filename in ["config.json", "model.safetensors", "tokenizer.json", "tokenizer_config.json"] {
+            try Data().write(to: snapshot.appendingPathComponent(filename))
+        }
+        let spec = ManagedModelSpec(
+            id: "text-chat-large-cached-test",
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: repoID,
+                revision: revision,
+                patterns: ["*.json", "*.safetensors"]
+            ),
+            validationKind: .hfTextChat,
+            estimatedDownloadBytes: 1_000 * ModelPullDiskPreflight.bytesPerGiB
+        )
+
+        XCTAssertNoThrow(
+            try ModelPullDiskPreflight.check(
+                spec: spec,
+                modelDir: root.appendingPathComponent("models/text-chat-large-cached-test"),
+                hubCacheURL: cache,
+                warn: { _ in }
+            )
+        )
+    }
+
+    func testStructuredPreflightUsesCompleteCachedInklingSnapshotUnlessForced() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = root.appendingPathComponent("hub", isDirectory: true)
+        let modelStore = root.appendingPathComponent("models", isDirectory: true)
+        let revisionKey = "c7e23256263a36e914737a8334ee351882fe3de586fc44865a5a54f163fed8eb"
+        let snapshot = cache
+            .appendingPathComponent("snapshots/models", isDirectory: true)
+            .appendingPathComponent(InklingResources.artifactRepoID, isDirectory: true)
+            .appendingPathComponent(revisionKey, isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        for filename in ["config.json", "tokenizer.json", "tokenizer_config.json"] {
+            try Data("{}".utf8).write(to: snapshot.appendingPathComponent(filename))
+        }
+        let shard = "model-00001-of-00001.safetensors"
+        try Data().write(to: snapshot.appendingPathComponent(shard))
+        let index = #"{"weight_map":{"language_model.model.embed_tokens.weight":"model-00001-of-00001.safetensors"}}"#
+        try Data(index.utf8).write(
+            to: snapshot.appendingPathComponent("model.safetensors.index.json")
+        )
+
+        let cached = try ModelPull.parse([
+            InklingResources.modelID,
+            "--allow-unsupported",
+            "--preflight",
+            "--json",
+        ]).makePreflightEnvelope(
+            hubCacheURL: cache,
+            modelStoreURL: modelStore,
+            diskAvailableBytes: { _ in 3 * ModelPullDiskPreflight.bytesPerGiB }
+        )
+
+        XCTAssertNotEqual(cached.status, .blocked)
+        XCTAssertEqual(cached.result.models.first?.estimatedDownloadBytes, 0)
+        XCTAssertEqual(
+            cached.result.models.first?.estimatedRequiredBytes,
+            ModelPullDiskPreflight.safetyMarginBytes
+        )
+        XCTAssertFalse(cached.diagnostics.contains { $0.id == "hub_cache_space_insufficient" })
+
+        let forced = try ModelPull.parse([
+            InklingResources.modelID,
+            "--allow-unsupported",
+            "--force",
+            "--preflight",
+            "--json",
+        ]).makePreflightEnvelope(
+            hubCacheURL: cache,
+            modelStoreURL: modelStore,
+            diskAvailableBytes: { _ in 3 * ModelPullDiskPreflight.bytesPerGiB }
+        )
+
+        XCTAssertEqual(forced.status, .blocked)
+        XCTAssertEqual(
+            forced.result.models.first?.estimatedDownloadBytes,
+            InklingResources.estimatedDownloadBytes
+        )
+        XCTAssertTrue(forced.diagnostics.contains { $0.id == "hub_cache_space_insufficient" })
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-model-pull-preflight-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -97,6 +97,21 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertTrue(backend.contains("native MLX"))
     }
 
+    func testInklingParsesAsNativeMLXWithOperationalContext() throws {
+        let command = try TextChat.parse([
+            "--model", InklingResources.modelID,
+            "--context-size", "32768",
+            "--prompt", "Plan a migration",
+        ])
+
+        XCTAssertEqual(command.model, InklingResources.modelID)
+        XCTAssertEqual(command.contextSize, InklingResources.defaultContextLength)
+        XCTAssertTrue(TextChat.backendDescription(for: command.model).contains("native MLX"))
+        XCTAssertThrowsError(
+            try TextChat.validate(responseFormat: .jsonObject, modelID: command.model)
+        )
+    }
+
     func testTextChatBackendDescriptionIdentifiesGGUFModels() {
         let backend = TextChat.backendDescription(for: ModelResolver.ModelID.q36NanoGGUF.rawValue)
 

--- a/Tests/MereRunCoreTests/InklingTests.swift
+++ b/Tests/MereRunCoreTests/InklingTests.swift
@@ -1,0 +1,261 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class InklingTests: XCTestCase {
+    func testConfigDecodesOfficialNestedTextShapeAndAffineQuantization() throws {
+        let config = try JSONDecoder().decode(InklingConfig.self, from: Data(Self.configJSON.utf8))
+
+        XCTAssertEqual(config.modelType, "inkling_mm_model")
+        XCTAssertEqual(config.eosTokenIDs, [200_006])
+        XCTAssertEqual(config.textConfig.hiddenSize, 8)
+        XCTAssertEqual(config.textConfig.localLayerIDs, Set([0]))
+        XCTAssertEqual(config.textConfig.denseIntermediateSize, 16)
+        XCTAssertEqual(config.textConfig.moeIntermediateSize, 4)
+        XCTAssertEqual(config.quantization?.bits, 2)
+        XCTAssertEqual(config.quantization?.groupSize, 128)
+        XCTAssertEqual(config.quantization?.mode, "affine")
+        XCTAssertEqual(config.quantization?.scope, "routed_experts")
+    }
+
+    func testConfigPrefersMLXVLMExpertWidthAlias() throws {
+        let compatible = Self.configJSON
+            .replacingOccurrences(
+                of: #""intermediate_size": 4,"#,
+                with: #""intermediate_size": 16, "moe_intermediate_size": 4,"#
+            )
+        let config = try JSONDecoder().decode(InklingConfig.self, from: Data(compatible.utf8))
+
+        XCTAssertEqual(config.textConfig.denseIntermediateSize, 16)
+        XCTAssertEqual(config.textConfig.moeIntermediateSize, 4)
+    }
+
+    func testPromptRendersInklingReasoningAndRoleChannels() throws {
+        let prompt = try InklingTokenizerAndTemplate.renderPrompt(
+            messages: [
+                ChatMessage(role: .system, content: "Be concise."),
+                ChatMessage(role: .user, content: "Hello"),
+            ],
+            reasoningEffort: 0.9
+        )
+
+        XCTAssertEqual(
+            prompt,
+            "<|message_system|><|content_text|>Be concise.<|end_message|>"
+                + "<|message_system|><|content_text|>Thinking effort level: 0.9<|end_message|>"
+                + "<|message_user|><|content_text|>Hello<|end_message|>"
+                + "<|message_model|>"
+        )
+    }
+
+    func testPromptUsesInklingToolDeclarationAndResolvesToolResultName() throws {
+        let prompt = try InklingTokenizerAndTemplate.renderPrompt(
+            messages: [
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [
+                        ChatMessageToolCall(
+                            id: "call-1",
+                            name: "read_file",
+                            arguments: ["path": .string("a.txt")]
+                        ),
+                    ]
+                ),
+                ChatMessage(role: .tool, content: "hello", toolCallID: "call-1"),
+            ],
+            tools: [
+                ToolDefinition(
+                    name: "read_file",
+                    description: "Read a file",
+                    parameters: [
+                        "path": ToolParameterProperty(type: "string", description: "File path"),
+                    ],
+                    required: ["path"]
+                ),
+            ],
+            addGenerationPrompt: false
+        )
+
+        XCTAssertTrue(prompt.hasPrefix(
+            #"<|message_system|>tool_declare<|content_xml|>[{"description":"Read a file","name":"read_file","parameters":{"properties":{"path":{"description":"File path","type":"string"}},"required":["path"],"type":"object"},"type":"function"}]<|end_message|>"#
+        ))
+        XCTAssertTrue(prompt.contains(
+            #"<|message_model|>read_file<|content_invoke_tool_json|>{"args":{"path":"a.txt"},"name":"read_file"}<|end_message|>"#
+        ))
+        XCTAssertTrue(prompt.hasSuffix(
+            "<|content_model_end_sampling|><|message_tool|>read_file<|content_text|>hello<|end_message|>"
+        ))
+    }
+
+    func testOutputParserSeparatesReasoningVisibleTextAndToolInvocation() throws {
+        let raw = "<|content_thinking|>Check the record.<|end_message|>"
+            + "<|message_model|><|content_text|>Done.<|end_message|>"
+            + "<|message_model|>write_file<|content_invoke_tool_json|>"
+            + #"{"args":{"path":"x.txt"},"name":"write_file"}"#
+            + "<|end_message|><|content_model_end_sampling|>"
+
+        let parsed = InklingOutputParser.parse(raw)
+
+        XCTAssertEqual(parsed.reasoning, "Check the record.")
+        XCTAssertEqual(parsed.visible, "Done.")
+        XCTAssertEqual(parsed.toolCalls, [ToolCall(name: "write_file", arguments: ["path": "x.txt"])])
+    }
+
+    func testTinyDenseModelRunsCachedPrefill() throws {
+        let config = try JSONDecoder().decode(InklingConfig.self, from: Data(Self.configJSON.utf8))
+        let model = InklingLanguageModel(config: config)
+        let caches = [InklingLayerCache()]
+
+        let output = model.forwardPrefill(MLXArray([Int32(1), 2, 3]).reshaped(1, 3), cache: caches)
+        MLX.eval(output.logits)
+
+        XCTAssertEqual(output.logits.shape, [1, 1, 32])
+        XCTAssertEqual(caches[0].attention.offset, 3)
+    }
+
+    func testTinySparseModelRunsAffineTwoBitExpertPath() throws {
+        let sparseJSON = Self.configJSON.replacingOccurrences(
+            of: #""dense_mlp_idx": 1"#,
+            with: #""dense_mlp_idx": 0"#
+        )
+        let config = try JSONDecoder().decode(InklingConfig.self, from: Data(sparseJSON.utf8))
+        let model = InklingLanguageModel(config: config)
+
+        let logits = model(MLXArray([Int32(1)]).reshaped(1, 1), cache: [InklingLayerCache()])
+        MLX.eval(logits)
+
+        XCTAssertEqual(logits.shape, [1, 1, 32])
+    }
+
+    func testSparseModelQuantizesOnlyRoutedExperts() throws {
+        let sparseJSON = Self.configJSON.replacingOccurrences(
+            of: #""dense_mlp_idx": 1"#,
+            with: #""dense_mlp_idx": 0"#
+        )
+        let config = try JSONDecoder().decode(InklingConfig.self, from: Data(sparseJSON.utf8))
+        let moe = InklingSparseMoE(config: config.textConfig, quantization: config.quantization)
+
+        XCTAssertNotNil(moe.switchMLP.gateProj.scales)
+        XCTAssertEqual(moe.switchMLP.gateProj.weight.dtype, .uint32)
+        XCTAssertNil(moe.sharedExperts.gateProj.scales)
+        XCTAssertNotEqual(moe.sharedExperts.gateProj.weight.dtype, .uint32)
+    }
+
+    func testWeightMapperKeepsOnlyLanguageModelAndTransposesConv() {
+        let tower = InklingResources.mapWeightKey("vision_tower.blocks.0.weight")
+        XCTAssertTrue(tower.hasPrefix("_ignored."))
+        XCTAssertEqual(
+            InklingResources.mapWeightKey("language_model.model.layers.0.self_attn.q_proj.weight"),
+            "model.layers.0.self_attn.q_proj.weight"
+        )
+
+        let conv = MLXArray.zeros([8, 1, 4])
+        let mapped = InklingResources.mapWeight(
+            key: "model.layers.0.attn_sconv.conv.weight",
+            value: conv
+        )
+        XCTAssertEqual(mapped.first?.1.shape, [8, 4, 1])
+    }
+
+    func testValidationRequiresEveryShardNamedByIndex() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inkling-validation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for name in ["config.json", "tokenizer.json", "tokenizer_config.json"] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: root.appendingPathComponent(name).path,
+                contents: Data("{}".utf8)
+            ))
+        }
+        let index = #"{"weight_map":{"language_model.model.embed_tokens.weight":"model-00001-of-00002.safetensors","language_model.lm_head.weight":"model-00002-of-00002.safetensors"}}"#
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model.safetensors.index.json").path,
+            contents: Data(index.utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model-00001-of-00002.safetensors").path,
+            contents: Data()
+        ))
+
+        XCTAssertEqual(
+            InklingResources.validate(rootURL: root).map(\.lastPathComponent),
+            ["model-00002-of-00002.safetensors"]
+        )
+    }
+
+    func testManagedRootManifestValidationUsesInklingLayout() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inkling-manifest-validation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try MereRunModelManifest.template(
+            for: .inklingSmall,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+        for name in ["config.json", "tokenizer.json", "tokenizer_config.json"] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: root.appendingPathComponent(name).path,
+                contents: Data("{}".utf8)
+            ))
+        }
+        let index = #"{"weight_map":{"language_model.model.embed_tokens.weight":"model-00001-of-00001.safetensors"}}"#
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model.safetensors.index.json").path,
+            contents: Data(index.utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model-00001-of-00001.safetensors").path,
+            contents: Data()
+        ))
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: InklingResources.modelID
+        )
+        XCTAssertTrue(report.isValid, report.errors.joined(separator: "\n"))
+        XCTAssertFalse(report.errors.contains { $0.contains("text_encoder") || $0.contains("tokenizer directory") })
+    }
+
+    private static let configJSON = #"""
+    {
+      "architectures": ["InklingForConditionalGeneration"],
+      "model_type": "inkling_mm_model",
+      "eos_token_id": 200006,
+      "quantization": {"bits": 2, "group_size": 128, "mode": "affine", "scope": "routed_experts"},
+      "text_config": {
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "vocab_size": 32,
+        "unpadded_vocab_size": 32,
+        "rms_norm_eps": 0.000001,
+        "use_embed_norm": true,
+        "logits_mup_width_multiplier": 1.0,
+        "model_max_length": 128,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "swa_num_attention_heads": 2,
+        "swa_num_key_value_heads": 1,
+        "swa_head_dim": 4,
+        "sliding_window_size": 8,
+        "local_layer_ids": [0],
+        "d_rel": 2,
+        "rel_extent": 8,
+        "log_scaling_n_floor": 16,
+        "log_scaling_alpha": 0.1,
+        "sconv_kernel_size": 2,
+        "dense_mlp_idx": 1,
+        "dense_intermediate_size": 16,
+        "intermediate_size": 4,
+        "n_routed_experts": 4,
+        "num_experts_per_tok": 2,
+        "n_shared_experts": 1,
+        "route_scale": 8.0
+      }
+    }
+    """#
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -714,6 +714,60 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.validationKind, .codegenGGUF)
     }
 
+    func testInklingSmallUsesPinnedNativeMLXSource() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: InklingResources.modelID))
+
+        XCTAssertEqual(spec.category, .textChat)
+        XCTAssertEqual(spec.installShape, .directoryRoot)
+        XCTAssertEqual(spec.hubFallback?.repoId, InklingResources.artifactRepoID)
+        XCTAssertEqual(spec.hubFallback?.revision, InklingResources.artifactRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, InklingResources.snapshotPatterns)
+        XCTAssertNil(spec.hubFallback?.filePath)
+        XCTAssertEqual(spec.upstreamRepoId, InklingResources.artifactRepoID)
+        XCTAssertEqual(spec.upstreamRevision, InklingResources.artifactRevision)
+        XCTAssertEqual(spec.validationKind, .inkling)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.estimatedDownloadBytes, InklingResources.estimatedDownloadBytes)
+        XCTAssertNil(spec.defaultRuntimeServingEngine)
+    }
+
+    func testInklingSmallRequiresNativeMLXRootFiles() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: InklingResources.modelID))
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let missing = spec.missingPaths(in: root, fileManager: .default)
+        XCTAssertEqual(Set(missing.map(\.lastPathComponent)), [
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "model.safetensors.index.json",
+        ])
+
+        for filename in [
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: root.appendingPathComponent(filename).path,
+                contents: Data()
+            ))
+        }
+        let index = #"{"weight_map":{"language_model.model.embed_tokens.weight":"model-00001-of-00001.safetensors"}}"#
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model.safetensors.index.json").path,
+            contents: Data(index.utf8)
+        ))
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("model-00001-of-00001.safetensors").path,
+            contents: Data()
+        ))
+
+        XCTAssertTrue(spec.missingPaths(in: root, fileManager: .default).isEmpty)
+        XCTAssertTrue(spec.validateRuntimeURL(root, fileManager: .default).isEmpty)
+    }
+
     func testNorthMiniCodeUsesPinnedHubSource() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: NorthMiniCodeResources.modelId))
 

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -112,6 +112,32 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(accepted.descriptor.recommendedUnifiedMemoryGB, 48)
     }
 
+    func testInklingSmallRequiresOneTwentyEightGB() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: InklingResources.modelID))
+        let undersized = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+        let supported = MereRunMachineProfile(
+            physicalMemoryBytes: 128 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let rejected = ManagedModelCapabilityCatalog.support(for: spec, on: undersized)
+        let accepted = ManagedModelCapabilityCatalog.support(for: spec, on: supported)
+
+        XCTAssertFalse(rejected.isSupported)
+        XCTAssertTrue(
+            rejected.reasons.joined(separator: " ").contains("Requires at least 128 GB")
+        )
+        XCTAssertTrue(accepted.isSupported)
+        XCTAssertTrue(accepted.meetsRecommendedMemory)
+        XCTAssertEqual(accepted.descriptor.minimumUnifiedMemoryGB, 128)
+        XCTAssertEqual(accepted.descriptor.recommendedUnifiedMemoryGB, 128)
+    }
+
     func testQ36NanoIsSupportedOnThirtyTwoGB() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.q36NanoModelId))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -64,6 +64,27 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
+    func testInklingSmallTemplatePinsTheNativeMLXConversion() {
+        let manifest = MereRunModelManifest.template(
+            for: .inklingSmall,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, InklingResources.modelID)
+        XCTAssertEqual(manifest.engine, .inkling)
+        XCTAssertEqual(manifest.family, .inkling)
+        XCTAssertEqual(manifest.tier, .small)
+        XCTAssertEqual(manifest.precision, .int2)
+        XCTAssertEqual(manifest.quantization?.bits, 2)
+        XCTAssertEqual(manifest.quantization?.groupSize, 128)
+        XCTAssertEqual(manifest.quantization?.scheme, "affine-routed-experts")
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration]))
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(InklingResources.artifactRepoID)@\(InklingResources.artifactRevision)"
+        )
+    }
+
     func testTemplateRoundTrip() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -763,8 +763,8 @@ Key options:
 
 ### `mere.run text chat`
 
-Run local text chat with the Gemma 4, Laguna 2.1, Qwen3.6/Bonsai, LFM2, or Psi
-family.
+Run local text chat with the Gemma 4, Laguna 2.1, Inkling-Small, Qwen3.6/Bonsai,
+LFM2, or Psi family.
 
 ```bash
 swift run mere.run text chat --prompt "<text>" [options]
@@ -778,7 +778,9 @@ Key options:
 - `--model-root`: explicit local model root
 - `--max-tokens`
 - `--context-size`: maximum prompt plus generation context. Bonsai 27B uses
-  its published 262,144-token limit by default.
+  its published 262,144-token limit by default. Inkling-Small advertises
+  1,048,576 tokens but uses a 32,768-token operational default because KV
+  residency grows with context.
 - `--temperature`: defaults to 0.7, or the model's published value where one
   exists (Bonsai: 0.7; Ornith lanes: 1.0)
 - `--top-p`: defaults to 0.9, or the model's published value (Bonsai/Ornith: 0.95)
@@ -813,6 +815,7 @@ Examples:
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
 swift run mere.run text chat --model text-chat-bonsai-27b-1bit --context-size 262144 --kv-bits 4 --prompt "Plan a long-context repository review."
 swift run mere.run text chat --model text-chat-bonsai-27b-2bit --context-size 262144 --kv-bits 4 --prompt "Compare two repository migration plans."
+swift run mere.run text chat --model text-chat-inkling-small --context-size 32768 --prompt "Plan a recovery-safe repository migration."
 swift run mere.run text chat --model text-chat-q36-nano --prompt "Explain speculative decoding."
 swift run mere.run text chat --model text-chat-q36-nano --response-format json_object --prompt 'Return an object with a name and an array of tags.'
 swift run mere.run text chat --model text-agent-ornith-9b --prompt "Write a compact Swift slugify helper."

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -56,6 +56,7 @@ from the runtime catalog used by `mere.run model list`,
 | `text-chat` | `text-chat-gemma4-max` |
 | `text-chat` | `text-chat-laguna-s-2-1` |
 | `text-chat` | `text-chat-laguna-xs-2-1` |
+| `text-chat` | `text-chat-inkling-small` |
 | `text-chat` | `text-chat-q36-nano` |
 | `text-chat` | `text-chat-bonsai-27b-1bit` |
 | `text-chat` | `text-chat-bonsai-27b-2bit` |

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -141,6 +141,40 @@ swift run mere.run text chat \
   --stats
 ```
 
+`text-chat-inkling-small` installs mere.run's immutable native MLX conversion
+of Thinking Machines Lab's released Inkling-Small checkpoint. The 256 routed
+experts in each sparse layer use MLX affine 2-bit quantization with group size
+128. Attention, embeddings, routers, shared experts, dense MLPs, and norms
+retain the released BF16 precision. Because it is still a very large artifact,
+it never auto-downloads from an inference command; pull it explicitly on a
+128 GB unified-memory machine.
+
+The released model is a 276B-total / 12B-active multimodal MoE with a
+1,048,576-token architecture limit. This first mere.run lane loads only the
+`language_model.*` weights in native Swift/MLX; image and audio towers are not
+claimed here. The operational context defaults to
+32,768 tokens to leave room for weights, KV cache, and macOS on a 128 GB Mac.
+Larger `--context-size` values are accepted when the host has the additional
+memory.
+
+This mixed recipe replaces the rejected blanket 2-bit experiment, which was
+degraded and repetitive even on a basic arithmetic prompt. Keeping every
+non-routed path at BF16 deliberately spends more memory to protect model
+quality. The managed snapshot is 84.56 GB (78.75 GiB). A full CUDA load used
+84.53 GB of active MLX memory and peaked at 84.77 GB on an H200; greedy checks
+correctly answered `2 + 2`, the "all but 9" sheep question, and generated a
+valid Swift `isEven` function. That is artifact and CUDA-runtime proof; the
+native Apple Silicon generation smoke remains a separate gate.
+
+```bash
+swift run mere.run model pull text-chat-inkling-small
+swift run mere.run text chat \
+  --model text-chat-inkling-small \
+  --context-size 32768 \
+  --prompt "Design a recovery-safe migration plan for a large Swift service." \
+  --stats
+```
+
 Per-model API-serving KV behavior is set with `mere.run model runtime
 --kv-cache-mode` (see [Model Management](./model-management.md)); it is not a
 flag on `text chat` or `api serve`. For Gemma4, Qwen-family, and LFM2 models

--- a/scripts/convert-inkling-mlx.py
+++ b/scripts/convert-inkling-mlx.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Convert the pinned Inkling-Small checkpoint to the managed MLX artifact.
+
+This script deliberately separates conversion from publication. Run the
+conversion, validate the generated config and inventory, then upload the
+directory with the Hugging Face CLI after a successful smoke test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx_vlm.models.inkling as mlx_vlm_inkling
+import mlx_vlm.models.inkling.language as mlx_vlm_inkling_language
+import mlx_vlm.utils as mlx_vlm_utils
+from huggingface_hub import snapshot_download
+from mlx_vlm.convert import convert
+from mlx_vlm.models.inkling.config import AudioConfig, TextConfig, VisionConfig
+from mlx_vlm.models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+
+
+BASE_REPO_ID = "thinkingmachines/Inkling-Small"
+BASE_REVISION = "b2d4f225a02032c5d154bff748ab5a00c5ca26e4"
+MLX_VERSION = "0.32.0"
+MLX_VLM_VERSION = "0.6.7"
+QUANTIZATION = {"bits": 2, "group_size": 128, "mode": "affine"}
+QUANTIZATION_SCOPE = "routed_experts"
+EXPERT_QUANTIZATION_CHUNK_SIZE = 16
+CUDA_VALIDATION = {
+    "validated_at": "2026-07-31",
+    "device": "NVIDIA H200",
+    "mlx_active_bytes": 84_530_593_368,
+    "mlx_peak_bytes": 84_766_898_240,
+    "greedy_checks": {
+        "2_plus_2": "4",
+        "all_but_9": "9",
+        "swift_is_even": "correct",
+    },
+}
+SOURCE_PATTERNS = [
+    "*.json",
+    "*.py",
+    "*.model",
+    "*.tiktoken",
+    "*.txt",
+    "*.jinja",
+    "LICENSE*",
+    "model-*.safetensors",
+]
+
+
+def patch_mlx_vlm_inkling_small_config() -> None:
+    """Map the released Small config onto mlx-vlm 0.6.7's field names.
+
+    Inkling-Small publishes ``dense_intermediate_size`` for its two dense
+    layers and ``intermediate_size`` for its routed experts. mlx-vlm 0.6.7's
+    Inkling dataclass instead calls those fields ``intermediate_size`` and
+    ``moe_intermediate_size``. Without this compatibility mapping it builds
+    placeholder modules with 2,048-wide dense and 3,072-wide expert paths
+    before loading the real tensors.
+    """
+    mlx_vlm_utils.MODEL_REMAPPING["inkling_mm_model"] = "inkling"
+    mlx_vlm_inkling.TextConfig = TextConfig
+    mlx_vlm_inkling.VisionConfig = VisionConfig
+    mlx_vlm_inkling.AudioConfig = AudioConfig
+    original = TextConfig.from_dict.__func__
+    original_vision = VisionConfig.from_dict.__func__
+    original_audio = AudioConfig.from_dict.__func__
+
+    def from_official_config(
+        cls: type[TextConfig],
+        params: dict[str, object],
+    ) -> TextConfig:
+        mapped = dict(params)
+        dense_size = mapped.get("dense_intermediate_size")
+        expert_size = mapped.get("moe_intermediate_size", mapped.get("intermediate_size"))
+        if dense_size is not None:
+            mapped["intermediate_size"] = dense_size
+        if expert_size is not None:
+            mapped["moe_intermediate_size"] = expert_size
+        return original(cls, mapped)
+
+    TextConfig.from_dict = classmethod(from_official_config)
+
+    def from_official_vision_config(
+        cls: type[VisionConfig],
+        params: dict[str, object],
+    ) -> VisionConfig:
+        mapped = dict(params)
+        if "decoder_dmodel" in mapped:
+            mapped["text_hidden_size"] = mapped["decoder_dmodel"]
+        if "n_channels" in mapped:
+            mapped["num_channels"] = mapped["n_channels"]
+        return original_vision(cls, mapped)
+
+    def from_official_audio_config(
+        cls: type[AudioConfig],
+        params: dict[str, object],
+    ) -> AudioConfig:
+        mapped = dict(params)
+        if "decoder_dmodel" in mapped:
+            mapped["text_hidden_size"] = mapped["decoder_dmodel"]
+        return original_audio(cls, mapped)
+
+    VisionConfig.from_dict = classmethod(from_official_vision_config)
+    AudioConfig.from_dict = classmethod(from_official_audio_config)
+
+    original_switch_quantization = SwitchLinear.to_quantized
+
+    def chunked_switch_quantization(
+        layer: SwitchLinear,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+    ) -> QuantizedSwitchLinear:
+        """Avoid MLX's >=2^31-element expert-quantization kernel boundary."""
+        if layer.weight.size < 1 << 31:
+            return original_switch_quantization(layer, group_size, bits, mode)
+
+        quantized_chunks = [
+            mx.quantize(
+                layer.weight[start : start + EXPERT_QUANTIZATION_CHUNK_SIZE],
+                group_size,
+                bits,
+                mode=mode,
+            )
+            for start in range(0, layer.num_experts, EXPERT_QUANTIZATION_CHUNK_SIZE)
+        ]
+        quantized = QuantizedSwitchLinear.__new__(QuantizedSwitchLinear)
+        nn.Module.__init__(quantized)
+        quantized.weight = mx.concatenate([chunk[0] for chunk in quantized_chunks])
+        quantized.scales = mx.concatenate([chunk[1] for chunk in quantized_chunks])
+        quantized.biases = (
+            mx.concatenate([chunk[2] for chunk in quantized_chunks])
+            if len(quantized_chunks[0]) == 3
+            else None
+        )
+        if "bias" in layer:
+            quantized.bias = layer.bias
+        quantized.group_size = group_size
+        quantized.bits = bits
+        quantized.mode = mode
+        quantized.freeze()
+        return quantized
+
+    SwitchLinear.to_quantized = chunked_switch_quantization
+
+    def portable_banded_additive_mask(
+        rel: mx.array,
+        proj: mx.array,
+        q_offset: int,
+        sequence_length: int,
+        sliding: int,
+        rel_extent: int,
+    ) -> mx.array:
+        """Use the released tensor fallback when CUDA has no Metal backend."""
+        batch, query_length, heads, _ = rel.shape
+        dtype = rel.dtype
+        relative_logits = (rel @ proj).transpose(0, 2, 1, 3)
+        query_positions = mx.arange(query_length) + q_offset
+        key_positions = mx.arange(sequence_length)
+        distance = query_positions[:, None] - key_positions[None, :]
+        gather_indices = mx.broadcast_to(
+            mx.clip(distance, 0, rel_extent - 1)[None, None],
+            (batch, heads, query_length, sequence_length),
+        )
+        mask = mx.take_along_axis(relative_logits, gather_indices, axis=-1)
+        mask = mx.where(
+            (distance >= rel_extent)[None, None],
+            mx.array(0.0, dtype),
+            mask,
+        )
+        excluded = distance < 0
+        if sliding > 0:
+            excluded = excluded | (distance >= sliding)
+        return mx.where(
+            excluded[None, None],
+            mx.array(-1e30, dtype),
+            mask,
+        ).astype(dtype)
+
+    mlx_vlm_inkling_language.banded_additive_mask = portable_banded_additive_mask
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def require_version(package: str, expected: str) -> None:
+    actual = importlib.metadata.version(package)
+    if actual != expected:
+        raise RuntimeError(f"{package} {expected} is required; found {actual}")
+
+
+def routed_expert_quant_predicate(
+    path: str,
+    module: nn.Module,
+) -> bool | dict[str, object]:
+    """Quantize only the 256 routed MoE experts; preserve everything else."""
+    if not isinstance(module, SwitchLinear):
+        return False
+    if ".switch_mlp." not in path:
+        return False
+    return dict(QUANTIZATION)
+
+
+def fetch_source() -> Path:
+    return Path(
+        snapshot_download(
+            repo_id=BASE_REPO_ID,
+            revision=BASE_REVISION,
+            allow_patterns=SOURCE_PATTERNS,
+            max_workers=2,
+        )
+    )
+
+
+def write_runtime_compatibility_config(output: Path) -> None:
+    """Persist the released mlx-vlm dispatch name and both MLP-width names."""
+    config_path = output / "config.json"
+    with config_path.open(encoding="utf-8") as handle:
+        config = json.load(handle)
+    config["model_type"] = "inkling"
+    text = config["text_config"]
+    dense_size = text["dense_intermediate_size"]
+    expert_size = text.get("moe_intermediate_size", text["intermediate_size"])
+    text["intermediate_size"] = dense_size
+    text["moe_intermediate_size"] = expert_size
+    vision = config.get("vision_config", {})
+    if "decoder_dmodel" in vision:
+        vision["text_hidden_size"] = vision["decoder_dmodel"]
+    if "n_channels" in vision:
+        vision["num_channels"] = vision["n_channels"]
+    audio = config.get("audio_config", {})
+    if "decoder_dmodel" in audio:
+        audio["text_hidden_size"] = audio["decoder_dmodel"]
+    for key in ("quantization", "quantization_config"):
+        quantization = config.get(key)
+        if not isinstance(quantization, dict):
+            raise RuntimeError(f"converted config is missing {key}")
+        quantization["scope"] = QUANTIZATION_SCOPE
+    config_path.write_text(
+        json.dumps(config, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    tokenizer_path = output / "tokenizer_config.json"
+    with tokenizer_path.open(encoding="utf-8") as handle:
+        tokenizer = json.load(handle)
+    tokenizer["eos_token"] = "<|content_model_end_sampling|>"
+    tokenizer["pad_token"] = "<|endoftext|>"
+    tokenizer_path.write_text(
+        json.dumps(tokenizer, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    special_tokens_path = output / "special_tokens_map.json"
+    with special_tokens_path.open(encoding="utf-8") as handle:
+        special_tokens = json.load(handle)
+    special_tokens["eos_token"] = "<|content_model_end_sampling|>"
+    special_tokens["pad_token"] = "<|endoftext|>"
+    special_tokens_path.write_text(
+        json.dumps(special_tokens, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def copy_reference_files(source: Path, output: Path) -> None:
+    for pattern in ("LICENSE*", "chat_template.jinja"):
+        for path in source.glob(pattern):
+            if path.is_file():
+                shutil.copy2(path, output / path.name)
+
+
+def validate_output(output: Path) -> dict[str, object]:
+    config_path = output / "config.json"
+    with config_path.open(encoding="utf-8") as handle:
+        config = json.load(handle)
+
+    quantization = config.get("quantization")
+    if not isinstance(quantization, dict):
+        raise RuntimeError(f"unexpected quantization config: {quantization!r}")
+    expected_metadata = {**QUANTIZATION, "scope": QUANTIZATION_SCOPE}
+    for key, expected in expected_metadata.items():
+        if quantization.get(key) != expected:
+            raise RuntimeError(
+                f"unexpected quantization {key}: {quantization.get(key)!r}; "
+                f"expected {expected!r}"
+            )
+    per_layer = {
+        key: value
+        for key, value in quantization.items()
+        if isinstance(value, dict)
+    }
+    if len(per_layer) != 120:
+        raise RuntimeError(
+            f"expected 120 routed expert projections in quantization config; "
+            f"found {len(per_layer)}"
+        )
+    for key, value in per_layer.items():
+        if ".switch_mlp." not in key or value != QUANTIZATION:
+            raise RuntimeError(f"unexpected quantized module {key}: {value!r}")
+    if config.get("model_type") != "inkling":
+        raise RuntimeError(f"unexpected model_type: {config.get('model_type')!r}")
+
+    safetensors = sorted(output.glob("*.safetensors"))
+    if not safetensors:
+        raise RuntimeError("conversion produced no safetensors shards")
+
+    index_path = output / "model.safetensors.index.json"
+    with index_path.open(encoding="utf-8") as handle:
+        weight_map = json.load(handle).get("weight_map", {})
+
+    text = config["text_config"]
+    dense_layer = 0
+    sparse_layer = text["dense_mlp_idx"]
+    hidden_size = text["hidden_size"]
+    packed_hidden_size = hidden_size * QUANTIZATION["bits"] // 32
+    shape_expectations = {
+        f"language_model.model.layers.{dense_layer}.mlp.gate_proj.weight": [
+            text["dense_intermediate_size"],
+            hidden_size,
+        ],
+        f"language_model.model.layers.{sparse_layer}.mlp.switch_mlp.gate_proj.weight": [
+            text["n_routed_experts"],
+            text["moe_intermediate_size"],
+            packed_hidden_size,
+        ],
+        f"language_model.model.layers.{sparse_layer}.mlp.shared_experts.gate_proj.weight": [
+            text["n_shared_experts"],
+            text["moe_intermediate_size"],
+            hidden_size,
+        ],
+        f"language_model.model.layers.{sparse_layer}.self_attn.q_proj.weight": [
+            text["num_attention_heads"] * text["head_dim"],
+            hidden_size,
+        ],
+    }
+    for key, expected_shape in shape_expectations.items():
+        shard_name = weight_map.get(key)
+        if shard_name is None:
+            raise RuntimeError(f"converted index is missing {key}")
+        tensors = mx.load(str(output / shard_name))
+        actual_shape = list(tensors[key].shape)
+        if actual_shape != expected_shape:
+            raise RuntimeError(
+                f"unexpected {key} shape: {actual_shape}; expected {expected_shape}"
+            )
+
+        scales_key = key.removesuffix(".weight") + ".scales"
+        should_be_quantized = ".switch_mlp." in key
+        if (scales_key in weight_map) != should_be_quantized:
+            raise RuntimeError(
+                f"unexpected quantization state for {key}: "
+                f"scales_present={scales_key in weight_map}"
+            )
+
+    total_bytes = sum(path.stat().st_size for path in output.rglob("*") if path.is_file())
+    return {
+        "artifact_bytes": total_bytes,
+        "safetensors_shards": len(safetensors),
+    }
+
+
+def write_provenance(output: Path, inventory: dict[str, object]) -> None:
+    provenance = {
+        "schema_version": 1,
+        "base_repo_id": BASE_REPO_ID,
+        "base_revision": BASE_REVISION,
+        "mlx_version": MLX_VERSION,
+        "mlx_vlm_version": MLX_VLM_VERSION,
+        "config_compatibility": "mlx-vlm 0.6.7 dispatch plus official Inkling-Small MLP width aliases",
+        "quantization": {**QUANTIZATION, "scope": QUANTIZATION_SCOPE},
+        "cuda_validation": CUDA_VALIDATION,
+        "converted_at": datetime.now(timezone.utc).isoformat(),
+        **inventory,
+    }
+    (output / "conversion.json").write_text(
+        json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    readme = f"""---
+license: apache-2.0
+language: en
+library_name: mlx
+pipeline_tag: image-text-to-text
+base_model: {BASE_REPO_ID}
+tags:
+- mlx
+- inkling
+- 2-bit
+- mixed-precision
+---
+
+# Inkling-Small MLX mixed 2-bit
+
+Mixed-precision MLX conversion of
+[{BASE_REPO_ID}](https://huggingface.co/{BASE_REPO_ID}) at revision
+`{BASE_REVISION}`. The conversion uses MLX `{MLX_VERSION}` and mlx-vlm
+`{MLX_VLM_VERSION}`. See `conversion.json` for the machine-readable provenance
+and artifact inventory.
+
+Only the 256 routed experts in each sparse MoE layer use affine 2-bit,
+group-128 weights. Attention, embeddings, routers, shared experts, dense MLPs,
+normalization, vision, and audio weights remain at the released BF16
+precision. This conservative split targets 128 GB unified-memory Macs while
+protecting the non-routed paths that blanket 2-bit quantization damaged.
+
+## Validation status
+
+The conversion gate checks the affine 2-bit/group-128 routed-expert metadata,
+all 120 quantized expert projections, every shard, and representative BF16 and
+packed tensor shapes.
+
+On 2026-07-31, a full CUDA load and greedy generation smoke with MLX
+`{MLX_VERSION}` and mlx-vlm `{MLX_VLM_VERSION}` used 84,530,593,368 bytes of
+active MLX memory and peaked at 84,766,898,240 bytes on an NVIDIA H200. The
+model correctly answered `2 + 2` with `4`, the "all but 9" sheep question with
+`9`, and produced a correct Swift `isEven` function. This proves CUDA loading
+and token quality for the generated artifact; Apple Silicon runtime validation
+is tracked separately by mere.run.
+
+mlx-vlm `{MLX_VLM_VERSION}` also required the compatibility shims in the
+conversion script for its Inkling config exports and CUDA mask fallback; the
+managed mere.run lane uses its own native Swift/MLX loader.
+
+```bash
+mere.run text chat --model text-chat-inkling-small --prompt "Who are you?"
+```
+"""
+    (output / "README.md").write_text(readme, encoding="utf-8")
+
+
+def finalize_artifact(output: Path) -> dict[str, object]:
+    write_runtime_compatibility_config(output)
+    inventory = validate_output(output)
+    for _ in range(3):
+        write_provenance(output, inventory)
+        final_inventory = validate_output(output)
+        if final_inventory == inventory:
+            return final_inventory
+        inventory = final_inventory
+    raise RuntimeError("artifact inventory did not stabilize after writing provenance")
+
+
+def main() -> None:
+    args = parse_args()
+    require_version("mlx", MLX_VERSION)
+    require_version("mlx-vlm", MLX_VLM_VERSION)
+    if args.output.exists() and any(args.output.iterdir()):
+        raise RuntimeError(f"output directory is not empty: {args.output}")
+
+    patch_mlx_vlm_inkling_small_config()
+    source = fetch_source()
+    convert(
+        hf_path=str(source),
+        mlx_path=args.output,
+        quantize=True,
+        q_group_size=QUANTIZATION["group_size"],
+        q_bits=QUANTIZATION["bits"],
+        q_mode=QUANTIZATION["mode"],
+        quant_predicate=routed_expert_quant_predicate,
+    )
+    copy_reference_files(source, args.output)
+    inventory = finalize_artifact(args.output)
+    print(json.dumps(inventory, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a text-only native Swift/MLX runtime for Thinking Machines Lab's released Inkling-Small model
- pin the public [Sawfwair/Inkling-Small-MLX-Mixed-2bit](https://huggingface.co/Sawfwair/Inkling-Small-MLX-Mixed-2bit) artifact at immutable revision `22c95fc2e30400a893dc9ac9fe4df17f306362ae`
- quantize only routed MoE experts with MLX affine 2-bit/group-128 weights while preserving attention, embeddings, routers, shared experts, dense MLPs, norms, vision, and audio weights in BF16
- expose an explicit-pull 128 GB managed model lane with a 32K operational context default, chat/API routing, typed config/tokenizer handling, shard-completeness validation, manifests, docs, and focused tests
- include the reproducible RunPod conversion/validation script
- make both live pulls and structured `model pull --preflight --json` cache-aware when a complete immutable snapshot already exists; `--force` still requires full redownload space

## Why

The first uniform affine q2 experiment fit in 128 GB but was materially degraded: both native Swift and stock `mlx-vlm` failed simple arithmetic. The mixed recipe spends roughly 10 GB more to protect every non-routed path and restores coherent arithmetic, reasoning, and code generation while retaining 128 GB viability.

## Artifact proof

- 16 safetensors shards
- 84,562,401,171 bytes total; 84,530,734,533 bytes of shard payload
- all 16 local shard SHA-256 digests match the immutable Hub LFS objects
- the managed snapshot receipt covers 25/25 selected files at `22c95fc…`
- exactly 120 routed `switch_mlp` projections carry quantization scales; no non-routed tensor does
- H200 validation through released `mlx-vlm` answered `2 + 2` with `4`, the "all but 9" prompt with `9`, and produced a correct Swift `isEven` function

## Apple Silicon proof

On a 128 GB Mac, the managed model installed and validated cleanly, all 16 shards loaded through native MLX/Metal, and greedy generation answered `2 + 2` with visible `4`.

A resource-measured run reported:

- 84,902,883,400-byte peak process footprint (~79.1 GiB)
- 0 swaps attributed to the model process
- 16.98 s prefill
- 3.06 decode tok/s
- 9.09 s first token

The host had an unrelated resident Gemma API server and other active applications. System-wide swap grew while macOS displaced those workloads, so the timing is fit/functional proof rather than a clean performance benchmark.

## Validation

- `./scripts/check.sh`
  - strict lint over 1,072 Swift files
  - build and bundled MLX metallib contract
  - 2,315 XCTest cases, 148 expected asset-gated skips, 0 failures
  - Swift Testing suites
  - CLI help sweep
  - hygiene scans
- 24 focused model-pull parsing/preflight tests
- 11 focused Inkling runtime/config/template/quantization tests
- managed `model list`, `model info`, and manifest validation report `isValid: true`

## Scope

This PR exposes text input only. Inkling-Small's vision and audio towers remain present in the mixed artifact at BF16, but mere.run does not claim those modalities until their native processor/runtime paths are implemented and validated.
