### PR TITLE
Prepare mere.run 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,27 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.30.0 - 2026-07-31
+
+This release is the complete public product delta since `v0.29.1`: native
+Laguna XS 2.1 inference and adapter training, a 128 GB Inkling-Small lane,
+production-safe Laguna acceleration, corrected model-license policy, and a
+persistent-world HTTP contract repair.
+
 ### Added
 
+- added Poolside's released Laguna XS 2.1 NVFP4 model through its pinned
+  MLX-native serialization as the opt-in managed model
+  `text-chat-laguna-xs-2-1`, with variant-safe CLI/API resolution, no implicit
+  Laguna S DFlash attachment, a 36 GB minimum / 48 GB recommended memory tier,
+  and retained OpenMDW-1.1 license files.
+- added native `text train-lora` SFT and `text chat --lora` support for
+  `text-chat-laguna-xs-2-1`, including the released chat template,
+  assistant-only loss, q/k/v/o attention adapters, family-specific manifests,
+  task-scoped GPU streams, verified MLX Metal initialization, and
+  correctness-safe invalidation of retained base-only projection layouts.
+  `--eval` now measures held-out assistant-token loss before and after
+  optimization instead of merely counting JSONL records.
 - added Thinking Machines Lab's released Inkling-Small as the opt-in managed
   `text-chat-inkling-small` model through a pinned mixed-precision native MLX
   conversion. The routed experts use affine 2-bit/group-128 weights while
@@ -18,36 +37,35 @@ The format is based on Keep a Changelog.
 
 ### Changed
 
-- made text LoRA `--eval` measure held-out assistant-token loss before and
-  after optimization instead of only counting JSONL records.
-- extended native `text train-lora` SFT and `text chat --lora` inference to
-  `text-chat-laguna-xs-2-1`, with the released Laguna chat template,
-  assistant-only loss, q/k/v/o attention adapters, family-specific manifests,
-  and correctness-safe invalidation of retained base-only projection layouts.
-  Text training now initializes the verified MLX Metal artifact, uses
-  task-scoped GPU streams, and excludes Laguna's inference-only asynchronous
-  prefill ladder from differentiable graphs.
-- added Poolside's released Laguna XS 2.1 NVFP4 model through its pinned
-  MLX-native serialization as the
-  opt-in managed model `text-chat-laguna-xs-2-1`, with variant-safe CLI/API
-  resolution, no license-acceptance gate, and no implicit Laguna S DFlash
-  attachment. Both public Laguna 2.1 pulls retain their OpenMDW-1.1 license
-  files.
 - ported production-safe wins from the MLX Fast Laguna XS 2.1 challenge,
-  where submission `493f1ee1` reached first place with score `1.8435177465`,
-  including the terminal-prefill row specialization and exact
+  where submission `493f1ee1` reached first place on July 30, 2026 with score
+  `1.8435177465`, including the terminal-prefill row specialization and exact
   `[Q; gate]` / `[K; V]` projection banks as a backend-neutral MLX graph path
   that defaults on for M5 Max while retaining full-path fallbacks for DFlash
   captures, batches, and unsupported model shapes. A resident DGX Spark GB10
   CUDA A/B reduced the matched 568-token prefill from 2.102 to 1.689 seconds;
   Metal-native ranked kernels remain separately hardware-guarded.
+- advanced the pinned `mlx-swift` fork and bundled metallib provenance to the
+  exact revision carrying those production Laguna graph optimizations, while
+  retaining startup refusal for stale or mismatched Metal kernel bundles.
+- made live pulls and structured `model pull --preflight --json` reuse a
+  complete immutable Hub snapshot without requiring enough free space for a
+  redundant full download; `--force` continues to require full redownload
+  headroom.
 - audited managed-model acknowledgement policy and removed false-positive
-  `--accept-model-license` gates from public Z-Image Nano, Sortformer,
-  Cosmos3-Edge, and the hidden Gemma 3 companion while retaining genuine
-  access-gated, non-commercial, research-only, and revenue-limited gates.
+  `--accept-model-license` gates from public Laguna S/XS 2.1, Z-Image Nano,
+  Sortformer, Cosmos3-Edge, and the hidden Gemma 3 companion while retaining
+  genuine access-gated, non-commercial, research-only, and revenue-limited
+  gates.
 
 ### Fixed
 
+- fixed live managed pulls redownloading complete externally reconstructed Hub
+  snapshots when Hugging Face sidecar metadata was absent. Exact-size payloads
+  are now adopted only after their pinned LFS SHA-256 or Git-blob SHA-1 ETag is
+  verified, and the local metadata plus immutable receipt are rebuilt.
+- fixed root `--models-root` handling so the parsed override initializes the
+  model store deterministically instead of depending on lazy global access.
 - fixed persistent-world HTTP transition decoding so documented snake-case
   overrides such as `num_frames`, `guidance_scale`, and
   `model_space_actions` reach the DreamX and Cosmos3 runtimes instead of

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.29.1"
+    static let current = "0.30.0"
 }

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -340,6 +340,27 @@ public actor HubSnapshot {
                         + "expected \(resolvedRevision), found \(remote.commitHash)"
                 )
             }
+            if let adopted = try adoptExistingPayload(
+                expectedBytes: expectedBytes,
+                destination: destination,
+                metadataDestination: metadataDestination,
+                remote: remote
+            ) {
+                completedBytes += max(expectedBytes, Self.fileSize(at: destination))
+                receiptFiles.append(
+                    HubSnapshotReceipt.File(
+                        path: entry.path,
+                        size: Self.fileSize(at: destination),
+                        commit: adopted.commitHash,
+                        etag: adopted.etag
+                    )
+                )
+                progressHandler?(HubSnapshotProgress(
+                    completedUnitCount: min(completedBytes, totalBytes),
+                    totalUnitCount: totalBytes
+                ))
+                continue
+            }
             let startedAt = Date()
             let completedBeforeDownload = completedBytes
             let delegate = HubSnapshotDownloadDelegate { written, _, _ in
@@ -578,6 +599,40 @@ public actor HubSnapshot {
         return metadata
     }
 
+    /// Adopt an exact payload reconstructed by an external resumable
+    /// downloader. Size alone is not sufficient: bind the bytes to the pinned
+    /// Hub revision by validating its content-addressed ETag before writing the
+    /// local metadata and receipt used by subsequent offline pulls.
+    private func adoptExistingPayload(
+        expectedBytes: Int64,
+        destination: URL,
+        metadataDestination: URL,
+        remote: HubSnapshotRemoteFile
+    ) throws -> HubSnapshotDownloadMetadata? {
+        guard Self.fileExists(at: destination, expectedBytes: expectedBytes),
+              let etag = remote.etag,
+              try Self.payloadMatchesETag(at: destination, etag: etag, byteCount: expectedBytes) else {
+            return nil
+        }
+
+        let blobURL = contentBlobURL(etag: etag)
+        try FileManager.default.createDirectory(
+            at: blobURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: blobURL.path) {
+            guard Self.fileSize(at: blobURL) == expectedBytes else {
+                throw Hub.HubClientError.downloadError(
+                    "Hub blob identity collision for \(etag)"
+                )
+            }
+        } else {
+            try FileManager.default.linkItem(at: destination, to: blobURL)
+        }
+        try writeDownloadMetadata(remote, to: metadataDestination)
+        return HubSnapshotDownloadMetadata(commitHash: remote.commitHash, etag: etag)
+    }
+
     private func writeSnapshotReceipt(_ receipt: HubSnapshotReceipt, to snapshotURL: URL) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
@@ -718,6 +773,32 @@ public actor HubSnapshot {
 
     static func revisionKey(_ revision: String) -> String {
         SHA256.hash(data: Data(revision.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func payloadMatchesETag(
+        at url: URL,
+        etag: String,
+        byteCount: Int64
+    ) throws -> Bool {
+        let expected = etag.lowercased()
+        guard expected.allSatisfy({ $0.isHexDigit }) else { return false }
+
+        if expected.count == 64 {
+            return try ModelArtifactPin.fileSHA256(url) == expected
+        }
+        guard expected.count == 40 else { return false }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = Insecure.SHA1()
+        hasher.update(data: Data("blob \(byteCount)\0".utf8))
+        while true {
+            let chunk = try handle.read(upToCount: 1_048_576) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        let actual = hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        return actual == expected
     }
 
     private static func contentKey(_ etag: String) -> String {

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.29.1")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.30.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCoreTests/HubSnapshotTests.swift
+++ b/Tests/MereRunCoreTests/HubSnapshotTests.swift
@@ -53,4 +53,42 @@ final class HubSnapshotTests: XCTestCase {
         XCTAssertEqual(next?.absoluteString, "https://huggingface.co/api/models/org/repo/tree/main?cursor=abc")
         XCTAssertNil(HubSnapshot.nextPageURL(from: nil, relativeTo: source))
     }
+
+    func testPayloadIdentityAcceptsHubLFSAndGitBlobETags() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-hub-etag-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let payload = root.appendingPathComponent("payload.bin")
+        try Data("abc".utf8).write(to: payload)
+
+        XCTAssertTrue(try HubSnapshot.payloadMatchesETag(
+            at: payload,
+            etag: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            byteCount: 3
+        ))
+        XCTAssertTrue(try HubSnapshot.payloadMatchesETag(
+            at: payload,
+            etag: "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f",
+            byteCount: 3
+        ))
+    }
+
+    func testPayloadIdentityRejectsMismatchedOrOpaqueETags() throws {
+        let payload = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-hub-etag-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: payload) }
+        try Data("abc".utf8).write(to: payload)
+
+        XCTAssertFalse(try HubSnapshot.payloadMatchesETag(
+            at: payload,
+            etag: String(repeating: "0", count: 64),
+            byteCount: 3
+        ))
+        XCTAssertFalse(try HubSnapshot.payloadMatchesETag(
+            at: payload,
+            etag: "opaque-etag",
+            byteCount: 3
+        ))
+    }
 }

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.29.0"
+default_version="0.30.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the public CLI and packaged-app fallback to 0.30.0
- publish comprehensive release notes for Laguna XS inference and native SFT/LoRA, Inkling-Small, MLX Fast acceleration, license and pull behavior, and the persistent-world HTTP repair
- make complete externally reconstructed Hub snapshots reusable only after pinned LFS SHA-256 or Git-blob SHA-1 ETag verification

## Release scope

- full product delta since `v0.29.1`: 88 files, 7,709 insertions, 437 deletions
- included merged product work: #222, #223, #224, #225, and #226
- Dependabot #205 is intentionally excluded

## Validation

- [x] `./scripts/check.sh`
  - strict lint: 1,079 Swift files, 0 violations
  - 2,331 XCTest cases, 149 expected checkpoint-gated skips, 0 failures
  - 20 Swift Testing cases, 0 failures
  - build, bundled metallib, CLI help, and hygiene checks passed
- [x] production `MereRun.app`: helper and app plist both report 0.30.0; deep signature and exact metallib verification passed
- [x] release-mode exhaustive installed-model gate: 61 passed, 0 warned, 0 failed, 0 skipped using the packaged helper and real Sortformer A-B-A fixture
- [x] Laguna XS live cache adoption: 21.57 GB cryptographically verified and adopted in 9.7 seconds with zero model redownload; installed-model validation passed
- [x] focused Hub snapshot adoption coverage for LFS SHA-256, Git blob SHA-1, mismatch, and opaque ETag behavior
- [x] no `vendor/` changes in this release-prep commit
