### PR TITLE
Fix Cosmos camera trajectory semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Fixed
+
+- fixed Cosmos3 semantic camera controls to compile true frame-relative 9D
+  pose deltas. Forward/backward and left/right now use explicit opposing
+  camera-relative axes, hold and yaw no longer inherit translation from
+  NVIDIA's arbitrary parity sample, rotations use constant per-frame deltas,
+  and continued chunks no longer accumulate the previous relative delta as an
+  absolute pose.
+
 ## 0.30.0 - 2026-07-31
 
 This release is the complete public product delta since `v0.29.1`: native

--- a/Sources/MereRunCore/Cosmos3/Cosmos3CameraTrajectory.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3CameraTrajectory.swift
@@ -2,10 +2,11 @@ import Foundation
 
 /// Normalized `camera_pose` actions consumed directly by Cosmos3-Edge.
 ///
-/// These values are model-space poses, not meters or per-frame physical deltas.
-/// The reference path is NVIDIA's released 60x9 camera trajectory at the pinned
-/// Cosmos3-Edge revision. Keeping the fixture intact gives the native Swift
-/// runtime an exact parity input and avoids inventing a camera normalization.
+/// NVIDIA defines each row as the relative 9D pose delta between consecutive
+/// visual states: translation plus column-based rotation-6D. The bundled
+/// 60x9 trajectory is an exact upstream parity sample, not a canonical forward
+/// path. Semantic controls preserve its per-step translation magnitudes while
+/// compiling explicit camera-relative axes.
 public enum Cosmos3CameraModelSpaceTrajectory {
     public static let nvidiaFrameworkRevision =
         "ed8287fd7477113f8ac4f6b84290514d55cf0cdc"
@@ -34,41 +35,38 @@ public enum Cosmos3CameraModelSpaceTrajectory {
         }
     }()
 
-    /// NVIDIA's autoregressive camera canary continues translation by the
-    /// average displacement of the complete published path. The divisor is
-    /// the action count (60), because the next chunk starts one action after
-    /// the terminal pose and spans another 60 actions.
-    public static let forwardContinuationTranslation: [Float] = {
-        let first = forwardReference[0]
-        let last = forwardReference[forwardReference.count - 1]
-        return (0..<3).map {
-            (last[$0] - first[$0]) / Float(forwardReference.count)
-        }
-    }()
+    public static let identityRotation6D: [Float] = [1, 0, 0, 0, 1, 0]
 
-    /// Returns the published path at its original cadence. Short chunks use a
-    /// prefix, matching NVIDIA's 16-action camera canary. Longer chunks continue
-    /// the final translation trend while keeping the terminal rotation.
+    /// Compiles the semantic forward axis while retaining the exact magnitude
+    /// envelope of NVIDIA's published camera-pose sample.
     public static func forward(actionCount: Int) -> [[Float]] {
-        precondition(actionCount > 0)
-        let reference = forwardReference
-        guard actionCount > reference.count else {
-            return Array(reference.prefix(actionCount))
-        }
+        translated(direction: [0, 0, 1], scale: 1, actionCount: actionCount)
+    }
 
-        var result = reference
-        let first = reference[0]
-        let last = reference[reference.count - 1]
-        let denominator = Float(reference.count - 1)
-        let delta = (0..<3).map { (last[$0] - first[$0]) / denominator }
-        while result.count < actionCount {
-            var next = result[result.count - 1]
-            for axis in 0..<3 {
-                next[axis] += delta[axis]
-            }
-            result.append(next)
+    public static func translated(
+        direction: [Float],
+        scale: Float,
+        actionCount: Int
+    ) -> [[Float]] {
+        precondition(direction.count == 3)
+        precondition(actionCount > 0)
+        precondition(scale.isFinite && scale >= 0)
+        let length = sqrt(direction.reduce(Float.zero) { $0 + $1 * $1 })
+        precondition(length > 0)
+        let unit = direction.map { $0 / length }
+        let reference = fitted(forwardReference, actionCount: actionCount)
+        return reference.map { action in
+            let magnitude = sqrt(action[0] * action[0] + action[1] * action[1] + action[2] * action[2])
+            return unit.map { $0 * magnitude * scale } + identityRotation6D
         }
-        return result
+    }
+
+    public static func stationary(actionCount: Int) -> [[Float]] {
+        precondition(actionCount > 0)
+        return Array(
+            repeating: [0, 0, 0] + identityRotation6D,
+            count: actionCount
+        )
     }
 
     public static func fitted(_ actions: [[Float]], actionCount: Int) -> [[Float]] {

--- a/Sources/MereRunCore/Cosmos3/Cosmos3WorldSession.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3WorldSession.swift
@@ -114,103 +114,59 @@ public enum Cosmos3CameraActionCompiler {
     ) -> [[Float]] {
         precondition(actionCount > 0)
         precondition(startingAction == nil || startingAction?.count == 9)
-        var actions: [[Float]]
-        if let startingAction {
-            actions = continuation(
-                control: control,
-                actionCount: actionCount,
-                startingAction: startingAction
+        // `camera_pose` rows are frame-to-frame deltas. A prior chunk's final
+        // delta is not an absolute pose and must never be accumulated into the
+        // next chunk.
+        _ = startingAction
+        let (direction, scale) = semanticTranslation(for: control)
+        var actions = if let direction {
+            Cosmos3CameraModelSpaceTrajectory.translated(
+                direction: direction,
+                scale: scale,
+                actionCount: actionCount
             )
         } else {
-            switch control.motion {
-            case .hold:
-                let anchor = Cosmos3CameraModelSpaceTrajectory.forwardReference[0]
-                actions = Array(repeating: anchor, count: actionCount)
-            case .backward:
-                actions = Array(
-                    Cosmos3CameraModelSpaceTrajectory.forward(actionCount: actionCount).reversed()
-                )
-            case .strafeLeft:
-                actions = strafe(
-                    Cosmos3CameraModelSpaceTrajectory.forward(actionCount: actionCount),
-                    direction: -1
-                )
-            case .strafeRight:
-                actions = strafe(
-                    Cosmos3CameraModelSpaceTrajectory.forward(actionCount: actionCount),
-                    direction: 1
-                )
-            case .forward, .custom, .yawLeft, .yawRight:
-                // Pure in-place rotation is outside the released camera-pose
-                // canary. Keep turns on the published translation manifold.
-                actions = Cosmos3CameraModelSpaceTrajectory.forward(actionCount: actionCount)
-            }
+            Cosmos3CameraModelSpaceTrajectory.stationary(actionCount: actionCount)
         }
 
         if control.rotationDegrees.contains(where: { abs($0) > 0.0001 }) {
-            let durationScale = min(
-                Float(actionCount) / Float(Cosmos3CameraModelSpaceTrajectory.forwardReference.count),
-                1
+            let radiansPerAction = control.rotationDegrees.map {
+                ($0 / Float(actionCount)) * .pi / 180
+            }
+            let rotation = rotationMatrixXYZ(
+                x: radiansPerAction[0],
+                y: radiansPerAction[1],
+                z: radiansPerAction[2]
             )
+            let deltaRotation = rotation6D(rotation)
             for index in actions.indices {
-                let fraction = Float(index + 1) / Float(actionCount)
-                let radians = control.rotationDegrees.map {
-                    ($0 * durationScale * fraction) * .pi / 180
-                }
-                let rotation = rotationMatrixXYZ(
-                    x: radians[0],
-                    y: radians[1],
-                    z: radians[2]
-                )
-                actions[index].replaceSubrange(3..<9, with: rotation6D(rotation))
+                actions[index].replaceSubrange(3..<9, with: deltaRotation)
             }
         }
         return actions
     }
 
-    private static func continuation(
-        control: Wan2WorldCameraControl,
-        actionCount: Int,
-        startingAction: [Float]
-    ) -> [[Float]] {
-        if control.motion == .hold {
-            return Array(repeating: startingAction, count: actionCount)
-        }
-        var translation = Cosmos3CameraModelSpaceTrajectory.forwardContinuationTranslation
+    private static func semanticTranslation(
+        for control: Wan2WorldCameraControl
+    ) -> (direction: [Float]?, scale: Float) {
+        let requestedMagnitude = sqrt(
+            control.translationMeters.reduce(Float.zero) { $0 + $1 * $1 }
+        )
+        let standardScale = requestedMagnitude > 0.0001 ? requestedMagnitude : 1
         switch control.motion {
+        case .forward:
+            return ([0, 0, 1], standardScale)
         case .backward:
-            translation = translation.map(-)
+            return ([0, 0, -1], standardScale)
         case .strafeLeft:
-            translation = strafeTranslation(translation, direction: -1)
+            return ([-1, 0, 0], standardScale)
         case .strafeRight:
-            translation = strafeTranslation(translation, direction: 1)
-        case .hold, .forward, .custom, .yawLeft, .yawRight:
-            break
+            return ([1, 0, 0], standardScale)
+        case .custom where requestedMagnitude > 0.0001:
+            return (control.translationMeters, requestedMagnitude)
+        case .hold, .custom, .yawLeft, .yawRight:
+            return (nil, 0)
         }
-        return (1...actionCount).map { index in
-            var action = startingAction
-            let fraction = Float(index)
-            for axis in 0..<3 {
-                action[axis] += translation[axis] * fraction
-            }
-            return action
-        }
-    }
-
-    private static func strafe(_ actions: [[Float]], direction: Float) -> [[Float]] {
-        actions.map { action in
-            var transformed = action
-            transformed[0] = direction * action[2]
-            transformed[2] = -direction * action[0]
-            return transformed
-        }
-    }
-
-    private static func strafeTranslation(
-        _ translation: [Float],
-        direction: Float
-    ) -> [Float] {
-        [direction * translation[2], translation[1], -direction * translation[0]]
     }
 
     private static func rotation6D(_ rotation: [[Float]]) -> [Float] {

--- a/Tests/MereRunCoreTests/Cosmos3EdgeTests.swift
+++ b/Tests/MereRunCoreTests/Cosmos3EdgeTests.swift
@@ -781,26 +781,46 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
         XCTAssertEqual(reference[59][8], -0.00047919119242578745, accuracy: 1e-9)
     }
 
-    func testForwardCameraControlUsesPublishedNormalizedModelSpacePrefix() {
-        let actions = Cosmos3CameraActionCompiler.compile(
+    func testSemanticTranslationControlsUseCameraRelativeDeltaAxes() {
+        let forward = Cosmos3CameraActionCompiler.compile(
             control: .forward(meters: 2),
             actionCount: 4
         )
-        XCTAssertEqual(
-            actions,
-            Array(Cosmos3CameraModelSpaceTrajectory.forwardReference.prefix(4))
+        let backward = Cosmos3CameraActionCompiler.compile(
+            control: .backward(meters: 2),
+            actionCount: 4
+        )
+        let left = Cosmos3CameraActionCompiler.compile(
+            control: Wan2WorldCameraControl(
+                motion: .strafeLeft,
+                translationMeters: [-2, 0, 0]
+            ),
+            actionCount: 4
+        )
+        let right = Cosmos3CameraActionCompiler.compile(
+            control: Wan2WorldCameraControl(
+                motion: .strafeRight,
+                translationMeters: [2, 0, 0]
+            ),
+            actionCount: 4
         )
 
-        let yaw = Cosmos3CameraActionCompiler.compile(
-            control: .yawRight(degrees: 90),
-            actionCount: 1
-        )[0]
-        XCTAssertEqual(yaw[3], cos(Float.pi / 120), accuracy: 1e-6)
-        XCTAssertEqual(yaw[4], 0, accuracy: 1e-6)
-        XCTAssertEqual(yaw[5], -sin(Float.pi / 120), accuracy: 1e-6)
-        XCTAssertEqual(yaw[6], 0, accuracy: 1e-6)
-        XCTAssertEqual(yaw[7], 1, accuracy: 1e-6)
-        XCTAssertEqual(yaw[8], 0, accuracy: 1e-6)
+        for index in forward.indices {
+            let reference = Cosmos3CameraModelSpaceTrajectory.forwardReference[index]
+            let magnitude = sqrt(
+                reference[0] * reference[0]
+                    + reference[1] * reference[1]
+                    + reference[2] * reference[2]
+            ) * 2
+            XCTAssertEqual(Array(forward[index][0..<3]), [0, 0, magnitude])
+            XCTAssertEqual(Array(backward[index][0..<3]), [0, 0, -magnitude])
+            XCTAssertEqual(Array(left[index][0..<3]), [-magnitude, 0, 0])
+            XCTAssertEqual(Array(right[index][0..<3]), [magnitude, 0, 0])
+            XCTAssertEqual(
+                Array(forward[index][3..<9]),
+                Cosmos3CameraModelSpaceTrajectory.identityRotation6D
+            )
+        }
     }
 
     func testExplicitModelSpaceTrajectoryFitsChunkWithoutRenormalizing() {
@@ -813,47 +833,55 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
         XCTAssertEqual(fitted, [first, second, second, second])
     }
 
-    func testYawCompilerRampsPublishedColumnRot6DInModelSpace() {
+    func testCustomTranslationPreservesRequestedVectorMagnitude() {
+        let actions = Cosmos3CameraActionCompiler.compile(
+            control: Wan2WorldCameraControl(
+                motion: .custom,
+                translationMeters: [3, 0, 4]
+            ),
+            actionCount: 1
+        )
+        let reference = Cosmos3CameraModelSpaceTrajectory.forwardReference[0]
+        let referenceMagnitude = sqrt(
+            reference[0] * reference[0]
+                + reference[1] * reference[1]
+                + reference[2] * reference[2]
+        )
+        XCTAssertEqual(actions[0][0], referenceMagnitude * 3, accuracy: 1e-6)
+        XCTAssertEqual(actions[0][1], 0, accuracy: 1e-6)
+        XCTAssertEqual(actions[0][2], referenceMagnitude * 4, accuracy: 1e-6)
+    }
+
+    func testYawCompilerUsesStationaryConstantPerFramePoseDeltas() {
         let actions = Cosmos3CameraActionCompiler.compile(
             control: .yawRight(degrees: 15),
             actionCount: 60
         )
         let first = actions[0]
         let last = actions[59]
-        XCTAssertEqual(
-            Array(first.prefix(3)),
-            Array(Cosmos3CameraModelSpaceTrajectory.forwardReference[0].prefix(3))
-        )
-        XCTAssertEqual(
-            Array(last.prefix(3)),
-            Array(Cosmos3CameraModelSpaceTrajectory.forwardReference[59].prefix(3))
-        )
-        XCTAssertEqual(last[3], cos(Float.pi / 12), accuracy: 1e-6)
+        XCTAssertEqual(Array(first.prefix(3)), [0, 0, 0])
+        XCTAssertEqual(Array(last.prefix(3)), [0, 0, 0])
+        XCTAssertEqual(first, last)
+        XCTAssertEqual(last[3], cos(Float.pi / 720), accuracy: 1e-6)
         XCTAssertEqual(last[4], 0, accuracy: 1e-6)
-        XCTAssertEqual(last[5], -sin(Float.pi / 12), accuracy: 1e-6)
+        XCTAssertEqual(last[5], -sin(Float.pi / 720), accuracy: 1e-6)
         XCTAssertEqual(last[6], 0, accuracy: 1e-6)
         XCTAssertEqual(last[7], 1, accuracy: 1e-6)
         XCTAssertEqual(last[8], 0, accuracy: 1e-6)
     }
 
-    func testYawContinuationMatchesPinnedCUDAAutoregressiveTrajectory() {
+    func testSemanticContinuationDoesNotAccumulatePriorPoseDelta() {
         let startingAction = Cosmos3CameraModelSpaceTrajectory.forwardReference[59]
-        let actions = Cosmos3CameraActionCompiler.compile(
+        let continued = Cosmos3CameraActionCompiler.compile(
             control: .yawRight(degrees: 15),
             actionCount: 60,
             startingAction: startingAction
         )
-
-        XCTAssertEqual(actions[0][0], -0.6242110331853231, accuracy: 1e-7)
-        XCTAssertEqual(actions[0][1], -0.10683037837346394, accuracy: 1e-7)
-        XCTAssertEqual(actions[0][2], 0.06115144491195679, accuracy: 1e-7)
-        XCTAssertEqual(actions[0][3], 0.9999904807207345, accuracy: 1e-7)
-        XCTAssertEqual(actions[0][5], -0.00436330928474657, accuracy: 1e-7)
-        XCTAssertEqual(actions[59][0], -0.22022724151611328, accuracy: 1e-7)
-        XCTAssertEqual(actions[59][1], -0.17862796783447266, accuracy: 1e-7)
-        XCTAssertEqual(actions[59][2], -0.002110004425048828, accuracy: 1e-7)
-        XCTAssertEqual(actions[59][3], 0.9659258262890683, accuracy: 1e-7)
-        XCTAssertEqual(actions[59][5], -0.25881904510252074, accuracy: 1e-7)
+        let fresh = Cosmos3CameraActionCompiler.compile(
+            control: .yawRight(degrees: 15),
+            actionCount: 60
+        )
+        XCTAssertEqual(continued, fresh)
     }
 
     func testInteractiveYawUsesPinnedCUDARotationRateAtSixteenActions() {
@@ -865,10 +893,9 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
         )
 
         XCTAssertEqual(actions.count, 16)
-        XCTAssertEqual(actions[0][3], cos(Float.pi / 720), accuracy: 1e-7)
-        XCTAssertEqual(actions[0][5], -sin(Float.pi / 720), accuracy: 1e-7)
-        XCTAssertEqual(actions[15][3], cos(Float.pi / 45), accuracy: 1e-7)
-        XCTAssertEqual(actions[15][5], -sin(Float.pi / 45), accuracy: 1e-7)
+        XCTAssertEqual(actions[0][3], cos(Float.pi / 192), accuracy: 1e-7)
+        XCTAssertEqual(actions[0][5], -sin(Float.pi / 192), accuracy: 1e-7)
+        XCTAssertEqual(actions[15], actions[0])
     }
 
     func testAutoregressiveSeedSequenceMatchesPinnedCUDAChunkPolicy() {
@@ -939,10 +966,12 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
             startingAction: forward[59]
         )
 
-        for axis in 0..<3 {
-            XCTAssertEqual(backward[59][axis], startingAction[axis], accuracy: 1e-6)
+        for index in forward.indices {
+            for axis in 0..<3 {
+                XCTAssertEqual(backward[index][axis], -forward[index][axis], accuracy: 1e-6)
+            }
+            XCTAssertEqual(Array(backward[index][3..<9]), Array(forward[index][3..<9]))
         }
-        XCTAssertEqual(Array(backward[59][3..<9]), Array(forward[59][3..<9]))
     }
 
     func testWorldRejectsMalformedExplicitModelSpaceTrajectoryBeforeLoadingModel() async throws {

--- a/docs/runtime/world.md
+++ b/docs/runtime/world.md
@@ -136,9 +136,10 @@ Omitted sampling fields use backend-specific recipes. DreamX defaults to
 512x320, 17 frames, 40 steps, CFG 5, shift 5, seed 42, and 24 fps. Cosmos3
 uses 320x176, 17 frames, 30 steps, CFG 1, shift 3, seed 0, and 30 fps. Every
 interactive camera primitive uses NVIDIA's default 16-action cadence and the
-same pinned per-action translation and rotation rates. This keeps each
-generative chunk local enough to preserve scene identity. Explicit `num_frames`
-still overrides the default. Each continued chunk uses `base_seed + chunk_index`,
+same pinned translation-magnitude envelope. Rotation intent is divided into a
+constant per-frame pose delta. This keeps each generative chunk local enough to
+preserve scene identity. Explicit `num_frames` still overrides the default.
+Each continued chunk uses `base_seed + chunk_index`,
 matching NVIDIA's autoregressive sampling policy. Cosmos3 frame counts must be
 `4n+1`.
 
@@ -149,10 +150,16 @@ generation depth. Repeated backtracking can therefore traverse multiple parent
 edges without spending stochastic chunks or compounding avoidable scene drift.
 
 For Cosmos3, the semantic camera request selects a normalized model-space
-trajectory. Forward motion uses the exact 60x9 NVIDIA reference sequence;
-rotations are emitted in the published column-based rotation-6D form. These
-values are not meters or per-frame physical deltas. A caller that already has
-a normalized trajectory can provide it directly as `model_space_actions`.
+trajectory. NVIDIA defines every 9D `camera_pose` row as the relative pose delta
+between consecutive visual states: XYZ translation plus column-based
+rotation-6D. The released 60x9 trajectory is retained byte-for-byte as a parity
+fixture, but it is an arbitrary camera sample rather than a canonical forward
+path. Semantic translation controls preserve that sample's per-step magnitude
+envelope while placing each delta on the requested camera-relative axis;
+stationary and yaw controls use zero translation. Request translation values
+scale the normalized envelope and are not a calibrated physical displacement.
+A caller that already has a normalized trajectory can provide it directly as
+`model_space_actions`.
 The server validates nine finite values per row, fits the sequence to the
 requested frame count without renormalizing it, and reports `action_space`,
 `action_domain`, and `model_space_actions` in the receipt (`raw_actions`
@@ -180,8 +187,9 @@ extended by repeating its final row; a longer list is truncated to
 The generated terminal frame seeds the next transition, so a second request
 can omit `sourceImage` and continue moving through the same world. The runtime
 follows NVIDIA's autoregressive recipe: it extracts the public terminal frame,
-re-encodes that image at the start of the next chunk, and continues the
-normalized translation trajectory from the prior terminal action. It does not
+re-encodes that image at the start of the next chunk, and compiles a fresh
+relative-delta trajectory for the next request. It does not accumulate the
+prior chunk's final delta as though it were an absolute pose, and does not
 transplant the terminal latent from the end of one causal VAE timeline into
 frame zero of another. The exact prior public state image is also placed at
 frame zero of the next clip for a pixel-stable player handoff.


### PR DESCRIPTION
## What changed

- treat Cosmos3 camera pose rows as relative frame-to-frame deltas
- compile forward/back/strafe actions onto normalized model-space axes
- keep hold and yaw translation stationary
- emit bounded per-action yaw deltas instead of a cumulative rotation ramp
- stop feeding the prior relative delta back as an absolute continuation pose
- document the trajectory contract and add inverse/continuation regression coverage

## Why

The upstream 60×9 parity fixture was being reused as though it represented an absolute semantic forward trajectory. That made requested directions inherit unrelated translation and made inverse/continuation paths physically incorrect.

## Impact

The runtime now supplies deterministic, composable conditioning tensors. Rendered clips still require a separate pixel-space direction gate because model realization can diverge from valid conditioning.

## Validation

- `swift test --filter Cosmos3EdgeTests` — 33 passed
- `./scripts/check.sh` — 2,330 passed, 149 skipped, 0 failures