### PR TITLE
Add one-click model downloads to Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added one-click managed model downloads to the macOS Studio Models panel,
+  with live pull output, restricted-model terms acknowledgement, cancellable
+  resumable transfers, and automatic inventory refresh after installation.
 - added native `text train-lora` SFT and `text chat --lora` support for
   `text-chat-inkling-small`, including the released Inkling message format,
   configurable training-consistent reasoning effort, assistant-only loss,

--- a/Sources/MereRunApp/MereRunController.swift
+++ b/Sources/MereRunApp/MereRunController.swift
@@ -971,6 +971,7 @@ final class MereRunController: ObservableObject {
 
     func utilityCommandResult(
         args: [String],
+        commandID: UUID = UUID(),
         masksSecrets: Bool = true,
         environmentOverrides: [String: String] = [:],
         onOutput: (@MainActor @Sendable (String) -> Void)? = nil
@@ -985,7 +986,6 @@ final class MereRunController: ObservableObject {
         let display = launch.displayCommand(for: masksSecrets ? cliArgs.maskingSecrets() : cliArgs)
         let output = ReadinessOutputBuffer()
         let errors = ReadinessOutputBuffer()
-        let id = UUID()
 
         return await withCheckedContinuation { continuation in
             do {
@@ -1017,12 +1017,12 @@ final class MereRunController: ObservableObject {
                             stderr: errors.text()
                         )
                         Task { @MainActor in
-                            self?.utilityProcesses[id] = nil
+                            self?.utilityProcesses[commandID] = nil
                             continuation.resume(returning: result)
                         }
                     }
                 )
-                utilityProcesses[id] = process
+                utilityProcesses[commandID] = process
             } catch {
                 continuation.resume(
                     returning: MereRunUtilityCommandResult(
@@ -1034,6 +1034,13 @@ final class MereRunController: ObservableObject {
                 )
             }
         }
+    }
+
+    @discardableResult
+    func cancelUtilityCommand(_ commandID: UUID) -> Bool {
+        guard let process = utilityProcesses[commandID] else { return false }
+        process.terminate()
+        return true
     }
 
     /// A captured snapshot of what to run, decoupled from the live editing state

--- a/Sources/MereRunApp/README.md
+++ b/Sources/MereRunApp/README.md
@@ -79,12 +79,14 @@ identity, placement, scheduling policy, model distribution, worker lifecycle,
 and fleet telemetry. The app links to the Relay console instead of copying
 those schemas or controls.
 
-Models includes a dedicated Health & Repair workspace. Manifest audit is a
-structured dry run, repair requires confirmation and writes only missing known
-manifests, and installed-model correctness/performance gates run as durable
-Library jobs with JSON reports. Existing model browsing, storage cleanup, and
-runtime policy remain in the Models and Serving destinations rather than being
-duplicated.
+Models includes one-click managed downloads with live CLI output, explicit
+third-party terms acknowledgement, cancellation with resumable partials, and a
+dedicated Health & Repair workspace. Successful downloads refresh the inventory
+without reopening the sheet. Manifest audit is a structured dry run, repair
+requires confirmation and writes only missing known manifests, and
+installed-model correctness/performance gates run as durable Library jobs with
+JSON reports. Existing model browsing, storage cleanup, and runtime policy
+remain in the Models and Serving destinations rather than being duplicated.
 
 Serving is also a top-level first-class destination. **Serving & Agents**
 owns API preflight/start/stop/restart, external-server reconnection, LAN/auth

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -44,12 +44,29 @@ struct StudioModelInventoryRow: Identifiable, Equatable {
     }
 }
 
+enum StudioModelDownloadCommand {
+    static func arguments(modelID: String, acknowledgingUsageTerms: Bool) -> [String] {
+        var arguments = ["model", "pull", modelID]
+        if acknowledgingUsageTerms {
+            arguments.append("--accept-model-license")
+        }
+        return arguments
+    }
+
+    static func appendingOutput(_ chunk: String, to current: String, limit: Int = 32 * 1024) -> String {
+        let normalized = chunk.replacingOccurrences(of: "\r", with: "\n")
+        return String((current + normalized).suffix(limit))
+    }
+}
+
 private enum StudioModelsAlert: Identifiable {
+    case download(StudioModelInventoryRow)
     case removal(StudioModelInventoryRow)
     case cleanup(StudioModelGarbagePlan)
 
     var id: String {
         switch self {
+        case .download(let row): "download:\(row.id)"
         case .removal(let row): "removal:\(row.id)"
         case .cleanup: "cleanup"
         }
@@ -212,6 +229,9 @@ struct StudioModelsSheet: View {
     @State private var isRefreshing = false
     @State private var loadingInfoID: String?
     @State private var loadingRuntimeID: String?
+    @State private var downloadingID: String?
+    @State private var downloadCommandID: UUID?
+    @State private var cancellingDownloadID: String?
     @State private var removingID: String?
     @State private var pendingAlert: StudioModelsAlert?
     @State private var storageReport: StudioModelStorageReport?
@@ -281,6 +301,15 @@ struct StudioModelsSheet: View {
         }
         .alert(item: $pendingAlert) { pending in
             switch pending {
+            case .download(let row):
+                Alert(
+                    title: Text("Acknowledge third-party model terms"),
+                    message: Text(downloadTermsMessage(row)),
+                    primaryButton: .default(Text("Acknowledge & Download")) {
+                        Task { await download(row, acknowledgingUsageTerms: true) }
+                    },
+                    secondaryButton: .cancel()
+                )
             case .removal(let row):
                 Alert(
                     title: Text("Purge \(row.id)?"),
@@ -334,10 +363,10 @@ struct StudioModelsSheet: View {
             Button {
                 revealStore()
             } label: {
-                Label("Store", systemImage: "folder")
+                Label("Files", systemImage: "folder")
             }
             .buttonStyle(.bordered)
-            .help("Reveal the model store in Finder")
+            .help("Open model storage in Finder")
 
             Button {
                 Task { await previewStorageCleanup() }
@@ -517,75 +546,136 @@ struct StudioModelsSheet: View {
 
                 Spacer()
 
-                if loadingInfoID == row.id || removingID == row.id {
+                if loadingInfoID == row.id || downloadingID == row.id || removingID == row.id {
                     ProgressView()
                         .controlSize(.small)
                 }
             }
 
-            HStack(spacing: 10) {
-                Button {
-                    Task { await runtimeLoad(row) }
-                } label: {
-                    Label("Load", systemImage: "play.fill")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || loadingRuntimeID != nil)
-
-                Button {
-                    Task { await runtimeUnload(row) }
-                } label: {
-                    Label("Unload", systemImage: "stop.fill")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || loadingRuntimeID != nil)
-
-                Button {
-                    Task { await saveRuntimeSettings(for: row, pinned: true) }
-                } label: {
-                    Label("Pin", systemImage: "pin")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || loadingRuntimeID != nil)
-
-                Button {
-                    Task { await saveRuntimeSettings(for: row, pinned: false) }
-                } label: {
-                    Label("Unpin", systemImage: "pin.slash")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || loadingRuntimeID != nil)
-            }
-
-            runtimeSettingsEditor(row)
-
-            HStack(spacing: 10) {
-                Button {
-                    Task { await loadInfo(for: row) }
-                } label: {
-                    Label("Inspect", systemImage: "info.circle")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || loadingInfoID != nil)
-
-                Button {
-                    Task { await reveal(row) }
-                } label: {
-                    Label("Finder", systemImage: "magnifyingglass")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || loadingInfoID != nil)
-                .help("Reveal this model's source folder in Finder")
-
-                Button(role: .destructive) {
-                    pendingAlert = .removal(row)
-                } label: {
-                    Label("Purge", systemImage: "trash")
-                }
-                .buttonStyle(.bordered)
-                .disabled(!row.isInstalled || removingID != nil)
+            if row.isInstalled {
+                installedModelActions(row)
+                runtimeSettingsEditor(row)
+                installedModelFilesActions(row)
+            } else {
+                missingModelActions(row)
             }
         }
+    }
+
+    private func installedModelActions(_ row: StudioModelInventoryRow) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                Task { await runtimeLoad(row) }
+            } label: {
+                Label("Load", systemImage: "play.fill")
+            }
+            .buttonStyle(.bordered)
+            .disabled(loadingRuntimeID != nil)
+
+            Button {
+                Task { await runtimeUnload(row) }
+            } label: {
+                Label("Unload", systemImage: "stop.fill")
+            }
+            .buttonStyle(.bordered)
+            .disabled(loadingRuntimeID != nil)
+
+            Button {
+                Task { await saveRuntimeSettings(for: row, pinned: true) }
+            } label: {
+                Label("Pin", systemImage: "pin")
+            }
+            .buttonStyle(.bordered)
+            .disabled(loadingRuntimeID != nil)
+
+            Button {
+                Task { await saveRuntimeSettings(for: row, pinned: false) }
+            } label: {
+                Label("Unpin", systemImage: "pin.slash")
+            }
+            .buttonStyle(.bordered)
+            .disabled(loadingRuntimeID != nil)
+        }
+    }
+
+    private func installedModelFilesActions(_ row: StudioModelInventoryRow) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                Task { await loadInfo(for: row) }
+            } label: {
+                Label("Inspect", systemImage: "info.circle")
+            }
+            .buttonStyle(.bordered)
+            .disabled(loadingInfoID != nil)
+
+            Button {
+                Task { await reveal(row) }
+            } label: {
+                Label("Finder", systemImage: "magnifyingglass")
+            }
+            .buttonStyle(.bordered)
+            .disabled(loadingInfoID != nil)
+            .help("Reveal this model's source folder in Finder")
+
+            Button(role: .destructive) {
+                pendingAlert = .removal(row)
+            } label: {
+                Label("Purge", systemImage: "trash")
+            }
+            .buttonStyle(.bordered)
+            .disabled(removingID != nil)
+        }
+    }
+
+    private func missingModelActions(_ row: StudioModelInventoryRow) -> some View {
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
+            Text("Download this model into Mere's managed model storage. The CLI checks hardware, disk space, and the pinned source before transferring weights.")
+                .font(MereRunTheme.bodyFont)
+                .foregroundStyle(MereRunTheme.textSecondary)
+
+            HStack(spacing: MereRunTheme.Spacing.sm) {
+                Button {
+                    requestDownload(row)
+                } label: {
+                    if downloadingID == row.id {
+                        HStack(spacing: 7) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text(cancellingDownloadID == row.id ? "Cancelling…" : "Downloading…")
+                        }
+                    } else {
+                        Label("Download", systemImage: "arrow.down.circle.fill")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(MereRunTheme.accent)
+                .disabled(downloadingID != nil || isRefreshing)
+
+                if downloadingID == row.id {
+                    Button("Cancel", role: .cancel) {
+                        cancelDownload()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(cancellingDownloadID == row.id)
+                }
+
+                Spacer()
+
+                if row.size != "—" {
+                    Text(row.size)
+                        .font(MereRunTheme.monoFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+            }
+
+            if row.usageTerms != nil {
+                Text("Review the linked terms above. Download requires explicit acknowledgement.")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.yellow)
+            }
+        }
+        .padding(MereRunTheme.Spacing.md)
+        .merePanel()
     }
 
     private func runtimeSettingsEditor(_ row: StudioModelInventoryRow) -> some View {
@@ -665,7 +755,7 @@ struct StudioModelsSheet: View {
 
     private func detailBody(for row: StudioModelInventoryRow) -> String {
         if !row.isInstalled {
-            return "\(row.id) is not downloaded."
+            return detailText.isEmpty ? "\(row.id) is not downloaded." : detailText
         }
         if detailText.isEmpty {
             return "Select Inspect to load manifest, validation, and component paths."
@@ -679,6 +769,83 @@ struct StudioModelsSheet: View {
         guard row.isInstalled else { return }
         Task { await loadInfo(for: row) }
         Task { await loadRuntimeSettings(for: row) }
+    }
+
+    private func requestDownload(_ row: StudioModelInventoryRow) {
+        if row.usageTerms != nil {
+            pendingAlert = .download(row)
+        } else {
+            Task { await download(row, acknowledgingUsageTerms: false) }
+        }
+    }
+
+    @MainActor
+    private func download(_ row: StudioModelInventoryRow, acknowledgingUsageTerms: Bool) async {
+        let modelID = row.id
+        downloadingID = modelID
+        cancellingDownloadID = nil
+        let commandID = UUID()
+        downloadCommandID = commandID
+        statusMessage = "Downloading \(modelID)…"
+        detailText = "Starting managed download for \(modelID)…\n"
+
+        let result = await controller.utilityCommandResult(
+            args: StudioModelDownloadCommand.arguments(
+                modelID: modelID,
+                acknowledgingUsageTerms: acknowledgingUsageTerms
+            ),
+            commandID: commandID,
+            onOutput: { chunk in
+                guard selectedID == modelID else { return }
+                detailText = StudioModelDownloadCommand.appendingOutput(chunk, to: detailText)
+            }
+        )
+
+        let wasCancelled = cancellingDownloadID == modelID
+        downloadCommandID = nil
+        downloadingID = nil
+        cancellingDownloadID = nil
+
+        if selectedID == modelID, !result.outputText.isEmpty {
+            detailText = result.outputText
+        }
+        if wasCancelled {
+            statusMessage = "Cancelled download for \(modelID)"
+            if selectedID == modelID {
+                detailText = StudioModelDownloadCommand.appendingOutput(
+                    "\nDownload cancelled. Its resumable partial payload remains available to the next pull.\n",
+                    to: detailText
+                )
+            }
+            return
+        }
+        guard result.exitCode == 0 else {
+            statusMessage = "Could not download \(modelID)"
+            return
+        }
+
+        let keepSelection = selectedID == modelID
+        onModelsChanged()
+        await refresh()
+        if keepSelection, let installed = rows.first(where: { $0.id == modelID }) {
+            select(installed)
+        }
+        statusMessage = "Downloaded \(modelID)"
+    }
+
+    private func cancelDownload() {
+        guard let commandID = downloadCommandID,
+              let modelID = downloadingID,
+              controller.cancelUtilityCommand(commandID) else {
+            return
+        }
+        cancellingDownloadID = modelID
+        statusMessage = "Cancelling download for \(modelID)…"
+    }
+
+    private func downloadTermsMessage(_ row: StudioModelInventoryRow) -> String {
+        let summary = row.usageTerms?.summary ?? "This model has third-party usage terms."
+        return "\(summary)\n\nMere does not determine whether your intended use is permitted. You are responsible for compliance."
     }
 
     @MainActor

--- a/Tests/MereRunAppTests/MereRunControllerTests.swift
+++ b/Tests/MereRunAppTests/MereRunControllerTests.swift
@@ -261,6 +261,30 @@ final class MereRunControllerTests: XCTestCase {
         )
     }
 
+    func testUtilityCommandCanBeCancelledByStableID() async {
+        let runner = RecordingProcessRunner()
+        let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
+        controller.cliPath = "/usr/bin/true"
+        let commandID = UUID()
+
+        let task = Task {
+            await controller.utilityCommandResult(
+                args: ["model", "pull", "image-klein-nano"],
+                commandID: commandID
+            )
+        }
+        await Task.yield()
+
+        XCTAssertEqual(runner.starts.count, 1)
+        XCTAssertTrue(controller.cancelUtilityCommand(commandID))
+        XCTAssertEqual(runner.processes.first?.terminateCallCount, 1)
+        XCTAssertFalse(controller.cancelUtilityCommand(UUID()))
+
+        runner.starts[0].termination(15)
+        let result = await task.value
+        XCTAssertEqual(result.exitCode, 15)
+    }
+
     func testResidentVideoSessionKeepsInputOpenAndPublishesEachResult() async throws {
         let runner = RecordingProcessRunner()
         let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -1848,6 +1848,33 @@ final class StudioTypesTests: XCTestCase {
         XCTAssertTrue(template.arguments(from: draft).contains("--accept-model-license"))
     }
 
+    func testStudioModelDownloadCommandBuildsOpenAndRestrictedPulls() {
+        XCTAssertEqual(
+            StudioModelDownloadCommand.arguments(
+                modelID: "image-klein-nano",
+                acknowledgingUsageTerms: false
+            ),
+            ["model", "pull", "image-klein-nano"]
+        )
+        XCTAssertEqual(
+            StudioModelDownloadCommand.arguments(
+                modelID: "vision-face-buffalo-l",
+                acknowledgingUsageTerms: true
+            ),
+            ["model", "pull", "vision-face-buffalo-l", "--accept-model-license"]
+        )
+    }
+
+    func testStudioModelDownloadOutputNormalizesProgressAndStaysBounded() {
+        let output = StudioModelDownloadCommand.appendingOutput(
+            "25%\r50%\r",
+            to: "start\n",
+            limit: 12
+        )
+
+        XCTAssertEqual(output, "art\n25%\n50%\n")
+    }
+
     func testAgentOnboardTemplatePropagatesUsageTermsAcceptance() throws {
         let template = try XCTUnwrap(CommandCatalog.template(id: .agentOnboard))
         var draft = template.defaultDraft()

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -44,6 +44,15 @@ or:
 swift run mere.run --models-root /path/to/models model list
 ```
 
+## macOS Studio
+
+Open **Models**, switch the scope to **All**, and select any missing model to
+download it directly. Studio streams the underlying `model pull` output, keeps
+cancelled partial downloads resumable, and refreshes the inventory after a
+successful install. Models with restricted third-party terms show their source
+links and require **Acknowledge & Download** before transfer. The **Files**
+button opens the configured model store in Finder; it does not start a download.
+
 ## Canonical model IDs
 
 Examples:


### PR DESCRIPTION
## What changed

- add a prominent Download flow for missing models in Studio's Models panel
- stream pull output, support scoped cancellation and resumable partials, then refresh installed state
- require explicit terms acknowledgement for restricted third-party models
- rename Store to Files so its Finder-only behavior is clear
- retain installed-model load, unload, pin, settings, inspect, Finder, purge, cleanup, and health controls

## Why

The Models panel listed missing models but exposed only disabled runtime actions. Users had to leave Studio and run `mere.run model pull` manually, while Store looked like the download entrypoint but only opened Finder.

## Validation

- `./scripts/check.sh` (2,344 tests, 150 asset-dependent skips, 0 failures)
- `swift test --skip-build --filter MereRunAppTests` (204 tests, 0 failures)
- changed-file `swiftlint --strict` (0 violations)
