### PR TITLE
Add macOS preview deep link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on Keep a Changelog.
 - added one-click managed model downloads to the macOS Studio Models panel,
   with live pull output, restricted-model terms acknowledgement, cancellable
   resumable transfers, and automatic inventory refresh after installation.
+- added a `mererun://preview?path=…` macOS Studio deep link for Raycast and
+  other local launchers. The app validates one percent-encoded absolute file
+  path, activates MereRun, and opens the artifact in native Quick Look.
 - added native `text train-lora` SFT and `text chat --lora` support for
   `text-chat-inkling-small`, including the released Inkling message format,
   configurable training-consistent reasoning effort, assistant-only loss,

--- a/README.md
+++ b/README.md
@@ -139,6 +139,32 @@ cd /Volumes/mere.run/.mere-run
 The installer copies `mere.run` and its colocated runtime assets to
 `/usr/local/bin/mere.run`, using `sudo` only when the destination requires it.
 
+### Preview artifacts from Raycast and other launchers
+
+The macOS app registers a local `mererun://preview` deep link. Pass one
+percent-encoded absolute artifact path and MereRun opens its native Quick Look
+panel, regardless of whether the output is an image, audio, video, text, or a
+Quick Look-compatible 3D file:
+
+```text
+mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
+```
+
+Raycast extensions can construct the URL without manual escaping:
+
+```typescript
+import { open } from "@raycast/api";
+
+const deepLink = new URL("mererun://preview");
+deepLink.searchParams.set("path", outputPath);
+await open(deepLink.toString());
+```
+
+The target must already exist and be a readable file. MereRun rejects relative
+paths, directories, missing files, duplicate `path` values, and extra query
+parameters. The link opens a preview only; it does not import, move, or modify
+the artifact.
+
 Linux package builds are headless CLI-only. They install the `mere.run` CLI plus
 colocated runtime assets; they do not include the macOS SwiftUI studio or DMG
 layout. See the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for the

--- a/Sources/MereRunApp/MereRunApp.swift
+++ b/Sources/MereRunApp/MereRunApp.swift
@@ -27,6 +27,7 @@ final class MereRunAppDelegate: NSObject, NSApplicationDelegate {
 struct MereRunApp: App {
     @NSApplicationDelegateAdaptor(MereRunAppDelegate.self) private var appDelegate
     @StateObject private var controller = MereRunController()
+    @State private var deepLinkError: String?
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: nil,
@@ -48,6 +49,18 @@ struct MereRunApp: App {
                         }
                     }
                 }
+                .onOpenURL(perform: openDeepLink)
+                .alert(
+                    "Couldn’t open preview",
+                    isPresented: Binding(
+                        get: { deepLinkError != nil },
+                        set: { if !$0 { deepLinkError = nil } }
+                    )
+                ) {
+                    Button("OK") { deepLinkError = nil }
+                } message: {
+                    Text(deepLinkError ?? "The preview link is invalid.")
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified(showsTitle: false))
@@ -64,6 +77,22 @@ struct MereRunApp: App {
             MereRunSettingsView()
                 .environmentObject(controller)
                 .frame(width: 560)
+        }
+    }
+
+    private func openDeepLink(_ url: URL) {
+        do {
+            switch try MereRunDeepLink.parse(url) {
+            case .preview(let artifactURL):
+                NSApplication.shared.activate(ignoringOtherApps: true)
+                guard QuickLookCoordinator.shared.preview(artifactURL) else {
+                    deepLinkError = "Quick Look is unavailable."
+                    return
+                }
+                deepLinkError = nil
+            }
+        } catch {
+            deepLinkError = error.localizedDescription
         }
     }
 }

--- a/Sources/MereRunApp/MereRunDeepLink.swift
+++ b/Sources/MereRunApp/MereRunDeepLink.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+enum MereRunDeepLink: Equatable {
+    static let scheme = "mererun"
+
+    case preview(URL)
+
+    static func parse(
+        _ url: URL,
+        fileManager: FileManager = .default
+    ) throws -> MereRunDeepLink {
+        guard url.scheme?.lowercased() == scheme,
+              url.host?.lowercased() == "preview",
+              url.path.isEmpty else {
+            throw MereRunDeepLinkError.unsupportedRoute
+        }
+
+        guard url.user == nil, url.password == nil, url.port == nil,
+              url.fragment == nil else {
+            throw MereRunDeepLinkError.unsupportedRoute
+        }
+
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        guard !queryItems.isEmpty else {
+            throw MereRunDeepLinkError.missingPath
+        }
+        guard queryItems.count == 1, queryItems[0].name == "path" else {
+            throw MereRunDeepLinkError.unsupportedParameters
+        }
+        guard let path = queryItems[0].value, !path.isEmpty else {
+            throw MereRunDeepLinkError.missingPath
+        }
+
+        guard NSString(string: path).isAbsolutePath else {
+            throw MereRunDeepLinkError.pathMustBeAbsolute
+        }
+
+        let fileURL = URL(fileURLWithPath: path).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: fileURL.path, isDirectory: &isDirectory) else {
+            throw MereRunDeepLinkError.fileNotFound(fileURL.path)
+        }
+        guard !isDirectory.boolValue else {
+            throw MereRunDeepLinkError.notAFile(fileURL.path)
+        }
+        guard fileManager.isReadableFile(atPath: fileURL.path) else {
+            throw MereRunDeepLinkError.fileNotReadable(fileURL.path)
+        }
+
+        return .preview(fileURL)
+    }
+}
+
+enum MereRunDeepLinkError: LocalizedError, Equatable {
+    case unsupportedRoute
+    case missingPath
+    case unsupportedParameters
+    case pathMustBeAbsolute
+    case fileNotFound(String)
+    case notAFile(String)
+    case fileNotReadable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedRoute:
+            return "Use mererun://preview with one percent-encoded path parameter."
+        case .missingPath:
+            return "The preview link is missing its artifact path."
+        case .unsupportedParameters:
+            return "The preview link must contain only one path parameter."
+        case .pathMustBeAbsolute:
+            return "The preview artifact path must be absolute."
+        case .fileNotFound(let path):
+            return "No preview artifact exists at \(path)."
+        case .notAFile(let path):
+            return "The preview target is not a file: \(path)."
+        case .fileNotReadable(let path):
+            return "The preview artifact is not readable: \(path)."
+        }
+    }
+}

--- a/Sources/MereRunApp/QuickLookCoordinator.swift
+++ b/Sources/MereRunApp/QuickLookCoordinator.swift
@@ -18,15 +18,17 @@ final class QuickLookCoordinator: NSObject, QLPreviewPanelDataSource {
 
     /// Shows (or reloads) Quick Look for `url`. The panel resolves its data source via the responder
     /// chain (see MereRunAppDelegate's QLPreviewPanelController methods), so we only stash the URL
-    /// and bring the shared panel forward. No-op if the panel is unavailable.
-    func preview(_ url: URL) {
+    /// and bring the shared panel forward. Returns false if the panel is unavailable.
+    @discardableResult
+    func preview(_ url: URL) -> Bool {
         self.url = url
-        guard let panel = QLPreviewPanel.shared() else { return }
+        guard let panel = QLPreviewPanel.shared() else { return false }
         if panel.isVisible {
             panel.reloadData()
         } else {
             panel.makeKeyAndOrderFront(nil)
         }
+        return true
     }
 
     nonisolated func numberOfPreviewItems(in panel: QLPreviewPanel) -> Int {

--- a/Sources/MereRunApp/README.md
+++ b/Sources/MereRunApp/README.md
@@ -2,6 +2,11 @@
 
 Optional SwiftUI studio wrapper around the public `mere.run` CLI.
 
+The packaged app registers `mererun://preview?path=…` for local launchers. Keep
+the parser typed and strict: one percent-encoded absolute path to an existing,
+readable file. External preview links may show Quick Look but must not import or
+mutate artifacts.
+
 - `StudioTypes.swift`: user-facing mode, draft, and request types.
 - `CommandCatalog.swift`: mode-to-command templates.
 - `MereRunController.swift`: child-process launching and log capture.

--- a/Tests/MereRunAppTests/MereRunDeepLinkTests.swift
+++ b/Tests/MereRunAppTests/MereRunDeepLinkTests.swift
@@ -1,0 +1,81 @@
+@testable import MereRunApp
+import XCTest
+
+final class MereRunDeepLinkTests: XCTestCase {
+    func testPreviewLinkResolvesPercentEncodedAbsolutePath() throws {
+        let artifactURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere preview \(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try Data("preview".utf8).write(to: artifactURL)
+        defer { try? FileManager.default.removeItem(at: artifactURL) }
+
+        var components = URLComponents()
+        components.scheme = MereRunDeepLink.scheme
+        components.host = "preview"
+        components.queryItems = [URLQueryItem(name: "path", value: artifactURL.path)]
+        let link = try XCTUnwrap(components.url)
+
+        XCTAssertEqual(
+            try MereRunDeepLink.parse(link),
+            .preview(artifactURL.standardizedFileURL)
+        )
+    }
+
+    func testPreviewLinkRejectsUnsupportedRoute() throws {
+        let link = try XCTUnwrap(URL(string: "mererun://generate?path=/tmp/output.png"))
+
+        XCTAssertThrowsError(try MereRunDeepLink.parse(link)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .unsupportedRoute)
+        }
+    }
+
+    func testPreviewLinkRequiresExactlyOnePathParameter() throws {
+        let missing = try XCTUnwrap(URL(string: "mererun://preview"))
+        let duplicate = try XCTUnwrap(URL(string: "mererun://preview?path=/tmp/a&path=/tmp/b"))
+        let extra = try XCTUnwrap(URL(string: "mererun://preview?path=/tmp/a&title=Result"))
+
+        XCTAssertThrowsError(try MereRunDeepLink.parse(missing)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .missingPath)
+        }
+        XCTAssertThrowsError(try MereRunDeepLink.parse(duplicate)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .unsupportedParameters)
+        }
+        XCTAssertThrowsError(try MereRunDeepLink.parse(extra)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .unsupportedParameters)
+        }
+    }
+
+    func testPreviewLinkRequiresAbsoluteExistingFile() throws {
+        let relative = try XCTUnwrap(URL(string: "mererun://preview?path=output.png"))
+        let missingPath = "/tmp/mere-run-missing-\(UUID().uuidString).png"
+        var missingComponents = URLComponents()
+        missingComponents.scheme = MereRunDeepLink.scheme
+        missingComponents.host = "preview"
+        missingComponents.queryItems = [URLQueryItem(name: "path", value: missingPath)]
+        let missing = try XCTUnwrap(missingComponents.url)
+
+        XCTAssertThrowsError(try MereRunDeepLink.parse(relative)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .pathMustBeAbsolute)
+        }
+        XCTAssertThrowsError(try MereRunDeepLink.parse(missing)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .fileNotFound(missingPath))
+        }
+    }
+
+    func testPreviewLinkRejectsDirectory() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        var components = URLComponents()
+        components.scheme = MereRunDeepLink.scheme
+        components.host = "preview"
+        components.queryItems = [URLQueryItem(name: "path", value: directoryURL.path)]
+        let link = try XCTUnwrap(components.url)
+
+        XCTAssertThrowsError(try MereRunDeepLink.parse(link)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .notAFile(directoryURL.path))
+        }
+    }
+}

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -196,6 +196,8 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(script.contains("SURequireSignedFeed"))
         XCTAssertTrue(script.contains("NSMicrophoneUsageDescription"))
         XCTAssertTrue(script.contains("local voice references and transcription input"))
+        XCTAssertTrue(script.contains("CFBundleURLTypes"))
+        XCTAssertTrue(script.contains(#""CFBundleURLSchemes":["mererun"]"#))
         XCTAssertTrue(script.contains("MereRunDebug.entitlements"))
         XCTAssertTrue(script.contains(#"if [[ "$identity" == "-" ]]"#))
         XCTAssertTrue(script.contains("--preserve-metadata=entitlements"))

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -147,6 +147,9 @@ plutil -insert NSHighResolutionCapable -bool true "${contents}/Info.plist"
 plutil -insert CFBundleInfoDictionaryVersion -string "6.0" "${contents}/Info.plist"
 plutil -insert LSApplicationCategoryType -string "public.app-category.developer-tools" "${contents}/Info.plist"
 plutil -insert NSHumanReadableCopyright -string "© mere.run" "${contents}/Info.plist"
+plutil -insert CFBundleURLTypes -json \
+  '[{"CFBundleTypeRole":"Viewer","CFBundleURLName":"run.mere.preview","CFBundleURLSchemes":["mererun"]}]' \
+  "${contents}/Info.plist"
 plutil -insert SUFeedURL -string "$sparkle_feed_url" "${contents}/Info.plist"
 plutil -insert SUPublicEDKey -string "$sparkle_public_ed_key" "${contents}/Info.plist"
 plutil -insert SUEnableAutomaticChecks -bool true "${contents}/Info.plist"


### PR DESCRIPTION
## Summary

- register a mererun://preview?path=... URL scheme in the packaged macOS app
- validate one absolute, existing, readable file before opening MereRun's native Quick Look panel
- document the Raycast integration and cover URL parsing plus app packaging with tests

## Why

Local launchers such as Raycast need one stable handoff after mere.run finishes generating an artifact. This keeps launcher integrations independent of output type while preserving local-only file handling.

## User impact

A Raycast extension can construct the deep link with URLSearchParams and pass it to the Raycast open API. macOS launches or activates MereRun.app, and MereRun previews any Quick Look-compatible artifact without importing or modifying it.

## Validation

- ./scripts/check.sh — passed (SwiftLint, build, 2,349 XCTest cases with 150 designed skips and 0 failures, CLI help sweep, hygiene scans, and 20 Swift Testing tests)
- focused deep-link and packaging tests — passed
- built and signature-verified MereRun.app; plutil confirmed the mererun URL scheme in Info.plist