### PR TITLE
Prepare mere.run 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.31.0 - 2026-08-01
+
+This release makes large local-agent workflows safer and Studio model
+management faster: one-click managed downloads, a secure preview deep link,
+native Inkling-Small adapter training, and the official DeepSeek V4 Flash
+0731 Q2 runtime with bounded residency settings.
+
 ### Added
 
 - added one-click managed model downloads to the macOS Studio Models panel,

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.30.0"
+    static let current = "0.31.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.30.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.31.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.30.0"
+default_version="0.31.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## What

- cut the changelog section for 0.31.0
- bump the CLI and macOS app fallback version
- update the release-version contract test

## Why

The feature-bearing delta since 0.30.0 is merged and ready for an all-platform release.

## Impact

This prepares the protected-main merge commit that the v0.31.0 tag and platform artifacts will be built from.

## Root cause

The repository still identified itself as 0.30.0 after the Studio download, preview deep-link, Inkling-Small LoRA, and DeepSeek V4 Flash 0731 Q2 changes merged.

## Checks

- `swift test --filter CLIModelStoreBootstrapTests`
- `./scripts/check.sh` (2,352 XCTest cases, 150 fixture-gated skips, 0 failures; Swift Testing and hygiene gates passed)
- Sparkle recovery drill: current generation passed
- Sparkle recovery drill: retained previous generation passed