### PR TITLE
Import Raycast artifacts and harden model downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The format is based on Keep a Changelog.
   independently, validates the exact 394-tensor ConvNeXt V2 U-Net, reproduces
   the published complex-STFT and flow-matching path for 8/12/16/24 kHz input,
   and records ODE, guidance, seed, license, and artifact provenance.
+- added typed `mererun://library/import?receipt=…` ingestion for local
+  launchers. MereRun validates the versioned receipt and referenced artifact,
+  deduplicates repeated handoffs, records the completed result in Library, and
+  opens the owning workspace with the imported row selected. The existing
+  `mererun://preview` route remains a non-importing Quick Look path.
 
 ## 0.31.0 - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ The format is based on Keep a Changelog.
   opens the owning workspace with the imported row selected. The existing
   `mererun://preview` route remains a non-importing Quick Look path.
 
+### Fixed
+
+- made model validation, weight discovery, CLI inspection, and training-data
+  discovery consistently traverse symlinked directory roots produced by
+  managed Hub downloads, including Qwen3 TTS speech-tokenizer and
+  speaker-encoder components.
+
 ## 0.31.0 - 2026-08-01
 
 This release makes large local-agent workflows safer and Studio model

--- a/README.md
+++ b/README.md
@@ -140,7 +140,14 @@ cd /Volumes/mere.run/.mere-run
 The installer copies `mere.run` and its colocated runtime assets to
 `/usr/local/bin/mere.run`, using `sudo` only when the destination requires it.
 
-### Preview artifacts from Raycast and other launchers
+### Import or preview artifacts from Raycast and other launchers
+
+The Raycast extension imports completed generations into MereRun Library by
+default. MereRun validates a small, versioned JSON receipt, records the artifact
+through its own Library store, activates the matching workspace, reveals
+Library, and selects the imported result. Raycast never edits MereRun's
+`library.json` directly. See the [Raycast Integration guide](./docs/raycast.md)
+for the receipt contract and extension preferences.
 
 The macOS app registers a local `mererun://preview` deep link. Pass one
 percent-encoded absolute artifact path and MereRun opens its native Quick Look
@@ -163,10 +170,8 @@ await open(deepLink.toString());
 
 The target must already exist and be a readable file. MereRun rejects relative
 paths, directories, missing files, duplicate `path` values, and extra query
-parameters. The link opens a preview only; it does not import, move, or modify
-the artifact. See the [Raycast Integration guide](./docs/raycast.md) for the
-four launcher commands, development installation, preferences, and
-troubleshooting.
+parameters. This route remains an explicit preview-only option; it does not
+import, move, or modify the artifact.
 
 Linux package builds are headless CLI-only. They install the `mere.run` CLI plus
 colocated runtime assets; they do not include the macOS SwiftUI studio or DMG

--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ await open(deepLink.toString());
 The target must already exist and be a readable file. MereRun rejects relative
 paths, directories, missing files, duplicate `path` values, and extra query
 parameters. The link opens a preview only; it does not import, move, or modify
-the artifact.
+the artifact. See the [Raycast Integration guide](./docs/raycast.md) for the
+four launcher commands, development installation, preferences, and
+troubleshooting.
 
 Linux package builds are headless CLI-only. They install the `mere.run` CLI plus
 colocated runtime assets; they do not include the macOS SwiftUI studio or DMG

--- a/Sources/AudioSTT/Sortformer/SortformerModel.swift
+++ b/Sources/AudioSTT/Sortformer/SortformerModel.swift
@@ -3,6 +3,7 @@
 import Foundation
 import MLX
 import MLXNN
+import MereRunCore
 
 // MARK: - FastConformer Encoder Components
 
@@ -743,7 +744,7 @@ public class SortformerModel: Module {
         let model = SortformerModel(config)
 
         // Load weights
-        let weightFiles = try FileManager.default.contentsOfDirectory(
+        let weightFiles = try FileManager.default.contentsOfDirectoryResolvingSymlinks(
             at: modelURL, includingPropertiesForKeys: nil
         ).filter { $0.pathExtension == "safetensors" }
 

--- a/Sources/AudioTTS/Qwen3TTS/Qwen3TTSResources.swift
+++ b/Sources/AudioTTS/Qwen3TTS/Qwen3TTSResources.swift
@@ -83,14 +83,14 @@ public struct Qwen3TTSResources: Sendable, Hashable {
     }
 
     public var speechTokenizerWeightsURLs: [URL] {
-        return (try? FileManager.default.contentsOfDirectory(
+        return (try? FileManager.default.contentsOfDirectoryResolvingSymlinks(
             at: speechTokenizerDirURL,
             includingPropertiesForKeys: nil
         ))?.filter { $0.pathExtension == "safetensors" } ?? []
     }
 
     public var speakerEncoderWeightsURLs: [URL] {
-        return (try? FileManager.default.contentsOfDirectory(
+        return (try? FileManager.default.contentsOfDirectoryResolvingSymlinks(
             at: speakerEncoderDirURL,
             includingPropertiesForKeys: nil
         ))?.filter { $0.pathExtension == "safetensors" } ?? []
@@ -143,7 +143,7 @@ public struct Qwen3TTSResources: Sendable, Hashable {
             missing.append(speechTokenizerConfigURL)
         }
 
-        let tokenizerWeights = (try? fileManager.contentsOfDirectory(
+        let tokenizerWeights = (try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: speechTokenizerDirURL,
             includingPropertiesForKeys: nil
         ))?.filter { $0.pathExtension == "safetensors" } ?? []

--- a/Sources/MereRunApp/MereRunApp.swift
+++ b/Sources/MereRunApp/MereRunApp.swift
@@ -27,6 +27,8 @@ final class MereRunAppDelegate: NSObject, NSApplicationDelegate {
 struct MereRunApp: App {
     @NSApplicationDelegateAdaptor(MereRunAppDelegate.self) private var appDelegate
     @StateObject private var controller = MereRunController()
+    @StateObject private var library = StudioLibraryStore()
+    @StateObject private var navigation = StudioNavigationCoordinator()
     @State private var deepLinkError: String?
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -38,6 +40,8 @@ struct MereRunApp: App {
         WindowGroup {
             MereRunRootView()
                 .environmentObject(controller)
+                .environmentObject(library)
+                .environmentObject(navigation)
                 .frame(
                     minWidth: StudioLayoutPolicy.minimumWindowWidth,
                     minHeight: StudioLayoutPolicy.minimumWindowHeight
@@ -51,7 +55,7 @@ struct MereRunApp: App {
                 }
                 .onOpenURL(perform: openDeepLink)
                 .alert(
-                    "Couldn’t open preview",
+                    "Couldn’t open MereRun link",
                     isPresented: Binding(
                         get: { deepLinkError != nil },
                         set: { if !$0 { deepLinkError = nil } }
@@ -59,7 +63,7 @@ struct MereRunApp: App {
                 ) {
                     Button("OK") { deepLinkError = nil }
                 } message: {
-                    Text(deepLinkError ?? "The preview link is invalid.")
+                    Text(deepLinkError ?? "The MereRun link is invalid.")
                 }
         }
         .windowStyle(.hiddenTitleBar)
@@ -89,6 +93,11 @@ struct MereRunApp: App {
                     deepLinkError = "Quick Look is unavailable."
                     return
                 }
+                deepLinkError = nil
+            case .libraryImport(let receiptURL):
+                let item = try library.importReceipt(at: receiptURL)
+                NSApplication.shared.activate(ignoringOtherApps: true)
+                navigation.openLibraryItem(id: item.id, mode: item.mode)
                 deepLinkError = nil
             }
         } catch {

--- a/Sources/MereRunApp/MereRunDeepLink.swift
+++ b/Sources/MereRunApp/MereRunDeepLink.swift
@@ -4,14 +4,13 @@ enum MereRunDeepLink: Equatable {
     static let scheme = "mererun"
 
     case preview(URL)
+    case libraryImport(URL)
 
     static func parse(
         _ url: URL,
         fileManager: FileManager = .default
     ) throws -> MereRunDeepLink {
-        guard url.scheme?.lowercased() == scheme,
-              url.host?.lowercased() == "preview",
-              url.path.isEmpty else {
+        guard url.scheme?.lowercased() == scheme else {
             throw MereRunDeepLinkError.unsupportedRoute
         }
 
@@ -20,15 +19,25 @@ enum MereRunDeepLink: Equatable {
             throw MereRunDeepLinkError.unsupportedRoute
         }
 
+        let route: Route
+        switch (url.host?.lowercased(), url.path) {
+        case ("preview", ""):
+            route = .preview
+        case ("library", "/import"):
+            route = .libraryImport
+        default:
+            throw MereRunDeepLinkError.unsupportedRoute
+        }
+
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
         guard !queryItems.isEmpty else {
-            throw MereRunDeepLinkError.missingPath
+            throw route.missingPathError
         }
-        guard queryItems.count == 1, queryItems[0].name == "path" else {
+        guard queryItems.count == 1, queryItems[0].name == route.parameterName else {
             throw MereRunDeepLinkError.unsupportedParameters
         }
         guard let path = queryItems[0].value, !path.isEmpty else {
-            throw MereRunDeepLinkError.missingPath
+            throw route.missingPathError
         }
 
         guard NSString(string: path).isAbsolutePath else {
@@ -47,13 +56,36 @@ enum MereRunDeepLink: Equatable {
             throw MereRunDeepLinkError.fileNotReadable(fileURL.path)
         }
 
-        return .preview(fileURL)
+        switch route {
+        case .preview: return .preview(fileURL)
+        case .libraryImport: return .libraryImport(fileURL)
+        }
+    }
+
+    private enum Route {
+        case preview
+        case libraryImport
+
+        var parameterName: String {
+            switch self {
+            case .preview: return "path"
+            case .libraryImport: return "receipt"
+            }
+        }
+
+        var missingPathError: MereRunDeepLinkError {
+            switch self {
+            case .preview: return .missingPath
+            case .libraryImport: return .missingReceipt
+            }
+        }
     }
 }
 
 enum MereRunDeepLinkError: LocalizedError, Equatable {
     case unsupportedRoute
     case missingPath
+    case missingReceipt
     case unsupportedParameters
     case pathMustBeAbsolute
     case fileNotFound(String)
@@ -63,19 +95,21 @@ enum MereRunDeepLinkError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .unsupportedRoute:
-            return "Use mererun://preview with one percent-encoded path parameter."
+            return "Use mererun://preview or mererun://library/import with one percent-encoded file path."
         case .missingPath:
             return "The preview link is missing its artifact path."
+        case .missingReceipt:
+            return "The Library import link is missing its receipt path."
         case .unsupportedParameters:
-            return "The preview link must contain only one path parameter."
+            return "The link has unsupported or duplicate parameters."
         case .pathMustBeAbsolute:
-            return "The preview artifact path must be absolute."
+            return "The linked file path must be absolute."
         case .fileNotFound(let path):
-            return "No preview artifact exists at \(path)."
+            return "No linked file exists at \(path)."
         case .notAFile(let path):
-            return "The preview target is not a file: \(path)."
+            return "The linked target is not a file: \(path)."
         case .fileNotReadable(let path):
-            return "The preview artifact is not readable: \(path)."
+            return "The linked file is not readable: \(path)."
         }
     }
 }

--- a/Sources/MereRunApp/README.md
+++ b/Sources/MereRunApp/README.md
@@ -2,10 +2,14 @@
 
 Optional SwiftUI studio wrapper around the public `mere.run` CLI.
 
-The packaged app registers `mererun://preview?path=…` for local launchers. Keep
-the parser typed and strict: one percent-encoded absolute path to an existing,
-readable file. External preview links may show Quick Look but must not import or
-mutate artifacts.
+The packaged app registers two typed local-launcher routes. The strict
+`mererun://preview?path=…` route accepts one readable absolute artifact path and
+may show Quick Look but must not import or mutate artifacts. The strict
+`mererun://library/import?receipt=…` route accepts one readable absolute receipt
+path; `StudioLibraryStore` validates the versioned receipt and referenced media,
+owns persistence and deduplication, and publishes navigation through
+`StudioNavigationCoordinator`. External launchers must never edit
+`library.json` directly.
 
 - `StudioTypes.swift`: user-facing mode, draft, and request types.
 - `CommandCatalog.swift`: mode-to-command templates.

--- a/Sources/MereRunApp/StudioLibraryImport.swift
+++ b/Sources/MereRunApp/StudioLibraryImport.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+enum StudioLibrarySource: String, Codable, Equatable {
+    case raycast
+
+    var title: String {
+        switch self {
+        case .raycast: return "Raycast"
+        }
+    }
+}
+
+enum StudioLibraryImportKind: String, Codable, Equatable {
+    case image
+    case video
+    case music
+    case speech
+
+    var mode: StudioMode {
+        switch self {
+        case .image: return .createImage
+        case .video: return .video
+        case .music: return .music
+        case .speech: return .speak
+        }
+    }
+
+    var expectedOutputKind: StudioOutputFileKind {
+        switch self {
+        case .image: return .image
+        case .video: return .video
+        case .music, .speech: return .audio
+        }
+    }
+
+    var commandPreview: String {
+        switch self {
+        case .image: return "mere.run image generate"
+        case .video: return "mere.run video generate"
+        case .music: return "mere.run music generate"
+        case .speech: return "mere.run speech synthesize"
+        }
+    }
+}
+
+struct StudioLibraryImportReceipt: Codable, Equatable {
+    static let currentVersion = 1
+    static let maximumByteCount = 256 * 1_024
+
+    let version: Int
+    let id: UUID
+    let source: StudioLibrarySource
+    let kind: StudioLibraryImportKind
+    let prompt: String
+    let artifactPath: String
+    let createdAt: Date
+
+    static func load(
+        from receiptURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> StudioLibraryImportReceipt {
+        let attributes: [FileAttributeKey: Any]
+        do {
+            attributes = try fileManager.attributesOfItem(atPath: receiptURL.path)
+        } catch {
+            throw StudioLibraryImportError.invalidReceipt
+        }
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw StudioLibraryImportError.invalidReceipt
+        }
+        let byteCount = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard byteCount <= maximumByteCount else {
+            throw StudioLibraryImportError.receiptTooLarge
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: receiptURL)
+        } catch {
+            throw StudioLibraryImportError.invalidReceipt
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let receipt: StudioLibraryImportReceipt
+        do {
+            receipt = try decoder.decode(StudioLibraryImportReceipt.self, from: data)
+        } catch {
+            throw StudioLibraryImportError.invalidReceipt
+        }
+
+        guard receipt.version == currentVersion else {
+            throw StudioLibraryImportError.unsupportedVersion(receipt.version)
+        }
+        guard !receipt.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw StudioLibraryImportError.emptyPrompt
+        }
+        return receipt
+    }
+
+    func artifactURL(fileManager: FileManager = .default) throws -> URL {
+        guard NSString(string: artifactPath).isAbsolutePath else {
+            throw StudioLibraryImportError.artifactPathMustBeAbsolute
+        }
+
+        let url = URL(fileURLWithPath: artifactPath).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            throw StudioLibraryImportError.artifactNotFound(url.path)
+        }
+        guard !isDirectory.boolValue else {
+            throw StudioLibraryImportError.artifactNotAFile(url.path)
+        }
+        guard fileManager.isReadableFile(atPath: url.path) else {
+            throw StudioLibraryImportError.artifactNotReadable(url.path)
+        }
+        guard StudioOutputFileKind.classify(url) == kind.expectedOutputKind else {
+            throw StudioLibraryImportError.artifactKindMismatch(kind.rawValue)
+        }
+        return url
+    }
+}
+
+enum StudioLibraryImportError: LocalizedError, Equatable {
+    case invalidReceipt
+    case receiptTooLarge
+    case unsupportedVersion(Int)
+    case emptyPrompt
+    case artifactPathMustBeAbsolute
+    case artifactNotFound(String)
+    case artifactNotAFile(String)
+    case artifactNotReadable(String)
+    case artifactKindMismatch(String)
+    case receiptIDConflict(UUID)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidReceipt:
+            return "The Library import receipt is not valid JSON or is missing required fields."
+        case .receiptTooLarge:
+            return "The Library import receipt is larger than 256 KiB."
+        case .unsupportedVersion(let version):
+            return "Library import receipt version \(version) is not supported."
+        case .emptyPrompt:
+            return "The Library import receipt has an empty prompt."
+        case .artifactPathMustBeAbsolute:
+            return "The imported artifact path must be absolute."
+        case .artifactNotFound(let path):
+            return "The imported artifact does not exist: \(path)"
+        case .artifactNotAFile(let path):
+            return "The imported artifact is not a file: \(path)"
+        case .artifactNotReadable(let path):
+            return "The imported artifact is not readable: \(path)"
+        case .artifactKindMismatch(let kind):
+            return "The imported artifact does not match the declared \(kind) kind."
+        case .receiptIDConflict(let id):
+            return "Library item \(id.uuidString) already refers to another artifact."
+        }
+    }
+}

--- a/Sources/MereRunApp/StudioLibraryPanel.swift
+++ b/Sources/MereRunApp/StudioLibraryPanel.swift
@@ -317,7 +317,8 @@ private struct StudioLibraryRow: View {
 
     private var subtitle: String {
         if item.status == .completed {
-            return "\(item.displayKindTitle) · \(Self.timeFormatter.string(from: item.createdAt))"
+            let origin = item.source.map { "\($0.title) · " } ?? ""
+            return "\(origin)\(item.displayKindTitle) · \(Self.timeFormatter.string(from: item.createdAt))"
         }
         return "\(item.displayKindTitle) · \(item.status.rawValue)"
     }

--- a/Sources/MereRunApp/StudioLibraryStore.swift
+++ b/Sources/MereRunApp/StudioLibraryStore.swift
@@ -238,6 +238,43 @@ final class StudioLibraryStore: ObservableObject {
         save()
     }
 
+    /// Imports one completed launcher artifact through MereRun's typed receipt contract. The
+    /// Library remains the only writer of its persisted state; launchers never edit library.json.
+    @discardableResult
+    func importReceipt(at receiptURL: URL) throws -> StudioLibraryItem {
+        let receipt = try StudioLibraryImportReceipt.load(from: receiptURL, fileManager: fileManager)
+        let artifactURL = try receipt.artifactURL(fileManager: fileManager)
+
+        if let existing = items.first(where: { $0.id == receipt.id }) {
+            guard existing.outputURL?.standardizedFileURL == artifactURL else {
+                throw StudioLibraryImportError.receiptIDConflict(receipt.id)
+            }
+            return existing
+        }
+        if let existing = items.first(where: { $0.outputURL?.standardizedFileURL == artifactURL }) {
+            return existing
+        }
+
+        var item = StudioLibraryItem(
+            id: receipt.id,
+            mode: receipt.kind.mode,
+            prompt: receipt.prompt,
+            inputURL: nil,
+            outputURL: artifactURL,
+            createdAt: receipt.createdAt,
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: receipt.kind.commandPreview,
+            outputText: nil,
+            templateID: receipt.kind.mode.defaultTemplateID,
+            artifactURLs: [artifactURL]
+        )
+        item.source = receipt.source
+        upsert(item)
+        return item
+    }
+
     private func shouldKeep(_ item: StudioLibraryItem) -> Bool {
         item.status == .completed
             || item.outputURL != nil

--- a/Sources/MereRunApp/StudioNavigationCoordinator.swift
+++ b/Sources/MereRunApp/StudioNavigationCoordinator.swift
@@ -1,0 +1,17 @@
+import Combine
+import Foundation
+
+struct StudioLibraryNavigationRequest: Equatable {
+    let token = UUID()
+    let itemID: UUID
+    let mode: StudioMode
+}
+
+@MainActor
+final class StudioNavigationCoordinator: ObservableObject {
+    @Published private(set) var libraryRequest: StudioLibraryNavigationRequest?
+
+    func openLibraryItem(id: UUID, mode: StudioMode) {
+        libraryRequest = StudioLibraryNavigationRequest(itemID: id, mode: mode)
+    }
+}

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -4,7 +4,8 @@ import UniformTypeIdentifiers
 
 struct StudioRootView: View {
     @EnvironmentObject private var controller: MereRunController
-    @StateObject private var library = StudioLibraryStore()
+    @EnvironmentObject private var library: StudioLibraryStore
+    @EnvironmentObject private var navigation: StudioNavigationCoordinator
     // Persisted per scene so relaunch restores the last mode and panel layout.
     @SceneStorage("studio.mode") private var mode: StudioMode = .createImage
     @SceneStorage("studio.showLibrary") private var showLibrary = true
@@ -323,6 +324,16 @@ struct StudioRootView: View {
     private func deleteLibraryItem(_ id: UUID) {
         library.delete(id: id)
         if selectedLibraryID == id { selectedLibraryID = nil }
+    }
+
+    private func openImportedLibraryItem(_ request: StudioLibraryNavigationRequest) {
+        mode = request.mode
+        selectedLibraryID = request.itemID
+        showLibrary = true
+        showAdvanced = false
+        if layoutClass.isCompact {
+            showCompactLibrary = true
+        }
     }
 
     private func updateLayoutClass(_ nextLayout: StudioLayoutClass) {
@@ -648,6 +659,10 @@ struct StudioRootView: View {
 
     private var navigationObservedShell: some View {
         lifecycleShell
+        .onReceive(navigation.$libraryRequest) { request in
+            guard let request else { return }
+            openImportedLibraryItem(request)
+        }
         .onChange(of: showAdvanced) { _, isShown in
             if isShown {
                 if layoutClass.isCompact { showCompactLibrary = false }

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -985,6 +985,8 @@ struct StudioLibraryItem: Codable, Identifiable, Equatable {
     var messages: [StudioMessage]? = nil
     var systemPrompt: String? = nil
     var model: String? = nil
+    /// Origin for entries imported by an external local launcher. nil means a Studio-owned run.
+    var source: StudioLibrarySource? = nil
 
     var displayTitle: String {
         if let customTitle, !customTitle.isBlank { return customTitle }

--- a/Sources/MereRunCLI/Commands/GraphDatasetCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphDatasetCommand.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import MereRunCore
 
 struct GraphDataset: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -90,7 +91,7 @@ struct WorkflowDatasetDiscoverer {
             throw ValidationError("Dataset discovery root was not found: \(root.path)")
         }
         let keys: [URLResourceKey] = [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
-        guard let enumerator = fileManager.enumerator(
+        guard let enumerator = fileManager.enumeratorResolvingSymlinks(
             at: root,
             includingPropertiesForKeys: keys,
             options: [.skipsHiddenFiles, .skipsPackageDescendants]

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -390,7 +390,7 @@ struct ModelInfo: ParsableCommand {
         fileManager: FileManager,
         matches: (String) -> Bool
     ) -> String {
-        let entries = (try? fileManager.contentsOfDirectory(
+        let entries = (try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: rootURL,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -1250,7 +1250,7 @@ func validateNativeModelRoot(_ rootURL: URL) throws {
         throw ValidationError("Missing tokenizer directory: \(tokenizer.path)")
     }
 
-    let entries = (try? fm.contentsOfDirectory(
+    let entries = (try? fm.contentsOfDirectoryResolvingSymlinks(
         at: rootURL,
         includingPropertiesForKeys: nil,
         options: [.skipsHiddenFiles]

--- a/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
+++ b/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
@@ -195,7 +195,7 @@ enum ACEStepCLIHelper {
             }
         }
 
-        let discovered = (try? fm.contentsOfDirectory(
+        let discovered = (try? fm.contentsOfDirectoryResolvingSymlinks(
             at: root,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
@@ -240,7 +240,7 @@ enum ACEStepCLIHelper {
             }
         }
 
-        let discovered = (try? fm.contentsOfDirectory(
+        let discovered = (try? fm.contentsOfDirectoryResolvingSymlinks(
             at: root,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -1498,7 +1498,7 @@ extension GateRunner {
     }
 
     private func directoryManifest(_ directory: URL) throws -> [String] {
-        guard let enumerator = FileManager.default.enumerator(
+        guard let enumerator = FileManager.default.enumeratorResolvingSymlinks(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCLI/Support/LoRATrainingDatasetInspection.swift
+++ b/Sources/MereRunCLI/Support/LoRATrainingDatasetInspection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MereRunCore
 
 struct LoRATrainingDatasetInspectionResult: Equatable {
     let summary: LoRATrainingDatasetPreflightSummary
@@ -114,7 +115,7 @@ struct LoRATrainingDatasetInspector {
 
         let contents: [URL]
         do {
-            contents = try fileManager.contentsOfDirectory(
+            contents = try fileManager.contentsOfDirectoryResolvingSymlinks(
                 at: directory,
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: [.skipsHiddenFiles]
@@ -445,7 +446,7 @@ struct LoRATrainingDatasetDiscoveryAnalyzer {
             guard current.depth < maxDepth else { continue }
             let childDirectories: [URL]
             do {
-                childDirectories = try fileManager.contentsOfDirectory(
+                childDirectories = try fileManager.contentsOfDirectoryResolvingSymlinks(
                     at: current.url,
                     includingPropertiesForKeys: [.isDirectoryKey],
                     options: [.skipsHiddenFiles]

--- a/Sources/MereRunCLI/Support/ModelInventory.swift
+++ b/Sources/MereRunCLI/Support/ModelInventory.swift
@@ -98,7 +98,7 @@ enum ModelInventory {
         guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
             return false
         }
-        return (try? fileManager.contentsOfDirectory(atPath: url.path))?.isEmpty == false
+        return (try? fileManager.contentsOfDirectoryResolvingSymlinks(at: url))?.isEmpty == false
     }
 
     private static func gemmaAliasInstallURL(for id: String, fileManager: FileManager) -> URL? {

--- a/Sources/MereRunCore/DatasetLoader.swift
+++ b/Sources/MereRunCore/DatasetLoader.swift
@@ -38,7 +38,10 @@ public enum DatasetLoader {
             throw DatasetLoaderError.datasetDirectoryNotFound(directory)
         }
 
-        let contents = try fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        let contents = try fileManager.contentsOfDirectoryResolvingSymlinks(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
 
         let imageExts: Set<String> = ["png", "jpg", "jpeg", "webp"]
         let images = contents

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
@@ -400,7 +400,7 @@ public actor DeepseekV4FlashGenerator: ChatGenerator {
     /// contains "imatrix" win over those that do not, matching the upstream
     /// README's recommendation to prefer the imatrix variant.
     static func preferredGGUF(in directory: URL, fileManager: FileManager = .default) -> URL? {
-        guard let enumerator = fileManager.enumerator(
+        guard let enumerator = fileManager.enumeratorResolvingSymlinks(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/FileManager+SymlinkTraversal.swift
+++ b/Sources/MereRunCore/FileManager+SymlinkTraversal.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension FileManager {
+    /// Lists a directory after resolving the supplied path through any symlinked model-store
+    /// components. Foundation does not traverse a directory when the final URL is a symlink.
+    public func contentsOfDirectoryResolvingSymlinks(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]? = nil,
+        options mask: DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        try contentsOfDirectory(
+            at: url.resolvingSymlinksInPath(),
+            includingPropertiesForKeys: keys,
+            options: mask
+        )
+    }
+
+    /// Creates a recursive enumerator after resolving the supplied root directory. Nested
+    /// symlink children are still treated as entries, so callers retain control over recursion.
+    public func enumeratorResolvingSymlinks(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]? = nil,
+        options mask: DirectoryEnumerationOptions = [],
+        errorHandler handler: ((URL, any Error) -> Bool)? = nil
+    ) -> DirectoryEnumerator? {
+        enumerator(
+            at: url.resolvingSymlinksInPath(),
+            includingPropertiesForKeys: keys,
+            options: mask,
+            errorHandler: handler
+        )
+    }
+}

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
@@ -156,7 +156,7 @@ extension Flux2KleinGenerator {
         let textEncoderQuantization = try ModelWeightsLoader.QuantizationParams.fromManifest(textEncoderComponent.sourceManifest)
 
         // Load transformer
-        // Note: resolve symlinks on each subdir - contentsOfDirectory(at:) doesn't follow symlinks
+        // Shared shard discovery resolves symlinked component directories before listing them.
         progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 0, totalSteps: 1))
         let transformerConfig = try loadTransformerConfig(from: transformerComponent.directoryURL)
         transformer = Flux2Transformer2DModel(config: transformerConfig)

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS+ModelLoading.swift
@@ -444,7 +444,10 @@ extension Flux2KleinGeneratoriOS {
         }
 
         // Sharded weights
-        let files = try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+        let files = try FileManager.default.contentsOfDirectoryResolvingSymlinks(
+            at: url,
+            includingPropertiesForKeys: nil
+        )
             .filter { $0.pathExtension == "safetensors" }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
 

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer.swift
@@ -453,7 +453,7 @@ public enum Flux2KleinLoRATrainer {
         let textEncoderQuantization = try ModelWeightsLoader.QuantizationParams.fromManifest(textEncoderComponent.sourceManifest)
 
         // 1) Load transformer
-        // Note: resolve symlinks - contentsOfDirectory(at:) doesn't follow symlinks
+        // Shared shard discovery resolves symlinked component directories before listing them.
         let transformerConfig = try loadTransformerConfig(from: transformerComponent.directoryURL)
         let transformer = Flux2Transformer2DModel(config: transformerConfig)
         try loadTransformerWeights(from: transformerComponent.directoryURL, to: transformer, quantization: transformerQuantization)
@@ -2127,7 +2127,7 @@ public enum Flux2KleinLoRATrainer {
 
         let entries: [URL]
         do {
-            entries = try fileManager.contentsOfDirectory(
+            entries = try fileManager.contentsOfDirectoryResolvingSymlinks(
                 at: sampleDirectory,
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -2102,7 +2102,7 @@ public actor Gemma4Generator: ChatGenerator {
             guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
                 return nil
             }
-            guard (try? FileManager.default.contentsOfDirectory(atPath: url.path))?.isEmpty == false else {
+            guard (try? FileManager.default.contentsOfDirectoryResolvingSymlinks(at: url))?.isEmpty == false else {
                 return nil
             }
             return url.standardizedFileURL

--- a/Sources/MereRunCore/Gemma4/Gemma4TextModelLoader.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextModelLoader.swift
@@ -184,7 +184,7 @@ public enum Gemma4TextModelLoader {
             guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
                 return nil
             }
-            guard (try? FileManager.default.contentsOfDirectory(atPath: url.path))?.isEmpty == false else {
+            guard (try? FileManager.default.contentsOfDirectoryResolvingSymlinks(at: url))?.isEmpty == false else {
                 return nil
             }
             return url.standardizedFileURL

--- a/Sources/MereRunCore/Inkling/InklingResources.swift
+++ b/Sources/MereRunCore/Inkling/InklingResources.swift
@@ -56,7 +56,7 @@ public enum InklingResources {
         if fileManager.fileExists(atPath: standardized.appendingPathComponent("config.json").path) {
             return standardized
         }
-        if let children = try? fileManager.contentsOfDirectory(
+        if let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: standardized,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/Krea2/Krea2Resources.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Resources.swift
@@ -73,8 +73,7 @@ public struct Krea2Resources: Sendable, Hashable {
     }
 
     private func hasTransformerShard(fileManager: FileManager) -> Bool {
-        let transformerURL = transformerURL.resolvingSymlinksInPath()
-        guard let children = try? fileManager.contentsOfDirectory(
+        guard let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: transformerURL,
             includingPropertiesForKeys: nil
         ) else {

--- a/Sources/MereRunCore/LFM2/LFM2Resources.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Resources.swift
@@ -66,7 +66,7 @@ public struct LFM2Resources: Sendable, Hashable {
         if fileManager.fileExists(atPath: standardized.appendingPathComponent("config.json").path) {
             return standardized
         }
-        if let children = try? fileManager.contentsOfDirectory(
+        if let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: standardized,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
+++ b/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
@@ -1114,7 +1114,11 @@ private func findLTXTransformerWeights(modelRoot: URL) throws -> URL {
         return model19B
     }
 
-    let entries = try fm.contentsOfDirectory(at: modelRoot, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+    let entries = try fm.contentsOfDirectoryResolvingSymlinks(
+        at: modelRoot,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+    )
     let matches = entries
         .filter { $0.pathExtension == "safetensors" && $0.lastPathComponent.hasPrefix("ltx-2-19") }
         .sorted { $0.lastPathComponent < $1.lastPathComponent }

--- a/Sources/MereRunCore/LoRA/LoRACheckpointResolver.swift
+++ b/Sources/MereRunCore/LoRA/LoRACheckpointResolver.swift
@@ -220,7 +220,7 @@ public enum LoRACheckpointResolver {
 
     private static func findMetadataFile(named name: String, in root: URL) -> URL? {
         let fileManager = FileManager.default
-        guard let enumerator = fileManager.enumerator(
+        guard let enumerator = fileManager.enumeratorResolvingSymlinks(
             at: root,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
@@ -239,7 +239,7 @@ public enum LoRACheckpointResolver {
 
     private static func allRegularFiles(in root: URL) -> [URL] {
         let fileManager = FileManager.default
-        guard let enumerator = fileManager.enumerator(
+        guard let enumerator = fileManager.enumeratorResolvingSymlinks(
             at: root,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/LoRA/LoRATrainingMetrics.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingMetrics.swift
@@ -406,7 +406,7 @@ public enum LoRATrainingResumeArtifacts {
         suffix: String,
         fileManager: FileManager
     ) -> URL? {
-        guard let entries = try? fileManager.contentsOfDirectory(
+        guard let entries = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
@@ -470,7 +470,7 @@ public enum LoRATrainingResumeArtifacts {
         }
 
         let sourceSamplesDirectory = sourceDirectory.appendingPathComponent("samples", isDirectory: true)
-        if let entries = try? fileManager.contentsOfDirectory(
+        if let entries = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: sourceSamplesDirectory,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
@@ -481,7 +481,7 @@ public enum LoRATrainingResumeArtifacts {
         }
 
         // Zip bundles flatten files, so sample previews may sit beside the checkpoint.
-        if let sourceEntries = try? fileManager.contentsOfDirectory(
+        if let sourceEntries = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: sourceDirectory,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2951,7 +2951,11 @@ public extension ManagedModelSpec {
         let hasSingle = fileManager.fileExists(atPath: modelWeightsURL.path)
         if !hasIndex && !hasSingle { missing.append(modelIndexURL) }
         if !fileManager.fileExists(atPath: speechTokenizerConfig.path) { missing.append(speechTokenizerConfig) }
-        let tokenizerWeights = (try? fileManager.contentsOfDirectory(at: speechTokenizerDir, includingPropertiesForKeys: nil))?.filter {
+        let resolvedSpeechTokenizerDir = speechTokenizerDir.resolvingSymlinksInPath()
+        let tokenizerWeights = (try? fileManager.contentsOfDirectory(
+            at: resolvedSpeechTokenizerDir,
+            includingPropertiesForKeys: nil
+        ))?.filter {
             $0.pathExtension == "safetensors"
         } ?? []
         if tokenizerWeights.isEmpty { missing.append(speechTokenizerDir) }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2951,9 +2951,8 @@ public extension ManagedModelSpec {
         let hasSingle = fileManager.fileExists(atPath: modelWeightsURL.path)
         if !hasIndex && !hasSingle { missing.append(modelIndexURL) }
         if !fileManager.fileExists(atPath: speechTokenizerConfig.path) { missing.append(speechTokenizerConfig) }
-        let resolvedSpeechTokenizerDir = speechTokenizerDir.resolvingSymlinksInPath()
-        let tokenizerWeights = (try? fileManager.contentsOfDirectory(
-            at: resolvedSpeechTokenizerDir,
+        let tokenizerWeights = (try? fileManager.contentsOfDirectoryResolvingSymlinks(
+            at: speechTokenizerDir,
             includingPropertiesForKeys: nil
         ))?.filter {
             $0.pathExtension == "safetensors"
@@ -3073,9 +3072,8 @@ public extension ManagedModelSpec {
         in rootURL: URL,
         fileManager: FileManager
     ) -> [URL] {
-        let resolved = rootURL.resolvingSymlinksInPath()
-        guard let enumerator = fileManager.enumerator(
-            at: resolved,
+        guard let enumerator = fileManager.enumeratorResolvingSymlinks(
+            at: rootURL,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else {
@@ -3178,7 +3176,11 @@ public extension ManagedModelSpec {
         if !fileManager.fileExists(atPath: textEncoderConfig.path) { missing.append(textEncoderConfig) }
         if !fileManager.fileExists(atPath: textEncoderWeights.path) { missing.append(textEncoderWeights) }
         if !fileManager.fileExists(atPath: tokenizerDir.path) { missing.append(tokenizerDir) }
-        let entries = (try? fileManager.contentsOfDirectory(at: rootURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+        let entries = (try? fileManager.contentsOfDirectoryResolvingSymlinks(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
         let hasTransformer = entries.contains { $0.lastPathComponent.hasPrefix("ltx-2-19") && $0.pathExtension == "safetensors" }
         let hasUpsampler = entries.contains { $0.lastPathComponent.hasPrefix("ltx-2-spatial-upscaler") && $0.pathExtension == "safetensors" }
         if !hasTransformer { missing.append(rootURL.appendingPathComponent("ltx-2-19b-distilled.safetensors")) }
@@ -3318,9 +3320,8 @@ public extension ManagedModelSpec {
     }
 
     static func findFirstGGUFFile(in rootURL: URL, fileManager: FileManager = .default) -> URL? {
-        let resolvedRoot = rootURL.resolvingSymlinksInPath()
-        let enumerator = fileManager.enumerator(
-            at: resolvedRoot,
+        let enumerator = fileManager.enumeratorResolvingSymlinks(
+            at: rootURL,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
         )

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -492,7 +492,7 @@ public enum ManagedModelResolver {
         materializedDirectoryPaths: Set<String> = [],
         excludedRelativePaths: Set<String> = []
     ) throws {
-        let entries = try fileManager.contentsOfDirectory(
+        let entries = try fileManager.contentsOfDirectoryResolvingSymlinks(
             at: snapshotURL,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: []

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -694,8 +694,7 @@ public enum MereRunModelValidator {
     }
 
     private static func hasAnyWeightFiles(in directory: URL, fileManager: FileManager) -> Bool {
-        let directory = directory.resolvingSymlinksInPath()
-        guard let children = try? fileManager.contentsOfDirectory(
+        guard let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles]
@@ -715,8 +714,7 @@ public enum MereRunModelValidator {
     }
 
     private static func containsIncompleteFiles(in rootURL: URL, fileManager: FileManager) -> Bool {
-        let rootURL = rootURL.resolvingSymlinksInPath()
-        guard let e = fileManager.enumerator(
+        guard let e = fileManager.enumeratorResolvingSymlinks(
             at: rootURL,
             includingPropertiesForKeys: [.isRegularFileKey],
             options: [.skipsHiddenFiles, .skipsPackageDescendants]

--- a/Sources/MereRunCore/ModelStorageManager.swift
+++ b/Sources/MereRunCore/ModelStorageManager.swift
@@ -133,6 +133,9 @@ public struct ModelStorageGarbageResult: Codable, Equatable, Sendable {
 /// Model install roots may contain direct files, symlink individual payload files, or be
 /// symlinks themselves. Accounting therefore follows model links for referenced bytes,
 /// but counts file identities only once for physical and reclaimable bytes.
+/// Directory traversal in this type intentionally does not use the runtime's
+/// symlink-resolving helpers: ownership discovery and garbage collection must inspect
+/// link edges without recursively treating their targets as locally owned payloads.
 public final class ModelStorageManager {
     private struct FileIdentity: Hashable {
         let device: UInt64

--- a/Sources/MereRunCore/ModelWeightsLoader.swift
+++ b/Sources/MereRunCore/ModelWeightsLoader.swift
@@ -195,7 +195,11 @@ public enum ModelWeightsLoader {
     // MARK: - mflux-style shards (0.safetensors, 1.safetensors, ...)
 
     public static func safetensorsShards(in directoryURL: URL, fileManager: FileManager = .default) throws -> [URL] {
-        let urls = try fileManager.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+        let urls = try fileManager.contentsOfDirectoryResolvingSymlinks(
+            at: directoryURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
             .filter { $0.pathExtension == "safetensors" }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
         return urls

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -212,7 +212,7 @@ public struct Q35Resources: Sendable, Hashable {
             return standardized
         }
 
-        if let children = try? fileManager.contentsOfDirectory(
+        if let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: standardized,
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/QwenImageEdit/QwenImageEditResources.swift
+++ b/Sources/MereRunCore/QwenImageEdit/QwenImageEditResources.swift
@@ -100,7 +100,7 @@ public enum QwenImageEditRepository {
             return base
         }
 
-        guard let children = try? fileManager.contentsOfDirectory(
+        guard let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: base,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/Training/TrainingDataCache.swift
+++ b/Sources/MereRunCore/Training/TrainingDataCache.swift
@@ -116,7 +116,7 @@ public struct TrainingDataCache: Sendable {
     public func totalSize() throws -> UInt64 {
         guard FileManager.default.fileExists(atPath: cacheDir.path) else { return 0 }
 
-        let contents = try FileManager.default.contentsOfDirectory(
+        let contents = try FileManager.default.contentsOfDirectoryResolvingSymlinks(
             at: cacheDir,
             includingPropertiesForKeys: [.fileSizeKey]
         )
@@ -133,7 +133,7 @@ public struct TrainingDataCache: Sendable {
     public func itemCount() throws -> Int {
         guard FileManager.default.fileExists(atPath: cacheDir.path) else { return 0 }
 
-        let contents = try FileManager.default.contentsOfDirectory(
+        let contents = try FileManager.default.contentsOfDirectoryResolvingSymlinks(
             at: cacheDir,
             includingPropertiesForKeys: nil
         )

--- a/Sources/MereRunCore/VLM/Qwen3VLAutoCaptioner.swift
+++ b/Sources/MereRunCore/VLM/Qwen3VLAutoCaptioner.swift
@@ -173,7 +173,7 @@ public actor Qwen3VLAutoCaptioner {
             return base
         }
 
-        guard let children = try? fileManager.contentsOfDirectory(
+        guard let children = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: base,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
@@ -279,7 +279,10 @@ public actor Qwen3VLAutoCaptioner {
             }
 
             // Link shard files
-            let contents = try fm.contentsOfDirectory(at: sourcePath, includingPropertiesForKeys: nil)
+            let contents = try fm.contentsOfDirectoryResolvingSymlinks(
+                at: sourcePath,
+                includingPropertiesForKeys: nil
+            )
             for file in contents where file.lastPathComponent.hasPrefix("model-") && file.pathExtension == "safetensors" {
                 let targetShard = textEncoderDir.appendingPathComponent(file.lastPathComponent)
                 if !fm.fileExists(atPath: targetShard.path) {

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboLoRATrainer.swift
@@ -2131,7 +2131,7 @@ public enum ZImageTurboLoRATrainer {
 
         let entries: [URL]
         do {
-            entries = try fileManager.contentsOfDirectory(
+            entries = try fileManager.contentsOfDirectoryResolvingSymlinks(
                 at: sampleDirectory,
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: [.skipsHiddenFiles]

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboResources.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboResources.swift
@@ -274,7 +274,7 @@ public struct ZImageTurboResources: Sendable, Hashable {
     }
 
     private static func hasSafetensorsShards(in directoryURL: URL, fileManager: FileManager) -> Bool {
-        guard let urls = try? fileManager.contentsOfDirectory(
+        guard let urls = try? fileManager.contentsOfDirectoryResolvingSymlinks(
             at: directoryURL,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]

--- a/Tests/AudioTTSTests/Qwen3TTSResourcesSymlinkTests.swift
+++ b/Tests/AudioTTSTests/Qwen3TTSResourcesSymlinkTests.swift
@@ -1,0 +1,55 @@
+import AudioTTS
+import Foundation
+import XCTest
+
+final class Qwen3TTSResourcesSymlinkTests: XCTestCase {
+    func testValidationAndWeightDiscoveryTraverseSymlinkedComponents() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let resources = Qwen3TTSResources(rootURL: fixture.model)
+
+        XCTAssertTrue(resources.validate().isEmpty)
+        XCTAssertEqual(
+            resources.speechTokenizerWeightsURLs.map(\.lastPathComponent),
+            ["speech-tokenizer.safetensors"]
+        )
+        XCTAssertEqual(
+            resources.speakerEncoderWeightsURLs.map(\.lastPathComponent),
+            ["speaker-encoder.safetensors"]
+        )
+    }
+
+    private func makeFixture() throws -> (root: URL, model: URL) {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let model = root.appendingPathComponent("model", isDirectory: true)
+        let snapshot = root.appendingPathComponent("snapshot", isDirectory: true)
+        let speechTokenizer = snapshot.appendingPathComponent("speech_tokenizer", isDirectory: true)
+        let speakerEncoder = snapshot.appendingPathComponent("speaker_encoder", isDirectory: true)
+
+        try fileManager.createDirectory(at: model, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: speechTokenizer, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: speakerEncoder, withIntermediateDirectories: true)
+
+        try Data("{}".utf8).write(to: model.appendingPathComponent("config.json"))
+        try Data().write(to: model.appendingPathComponent("model.safetensors"))
+        try Data("{}".utf8).write(to: model.appendingPathComponent("tokenizer.json"))
+        try Data("{}".utf8).write(to: model.appendingPathComponent("tokenizer_config.json"))
+        try Data("{}".utf8).write(to: speechTokenizer.appendingPathComponent("config.json"))
+        try Data().write(to: speechTokenizer.appendingPathComponent("speech-tokenizer.safetensors"))
+        try Data().write(to: speakerEncoder.appendingPathComponent("speaker-encoder.safetensors"))
+
+        try fileManager.createSymbolicLink(
+            at: model.appendingPathComponent("speech_tokenizer", isDirectory: true),
+            withDestinationURL: speechTokenizer
+        )
+        try fileManager.createSymbolicLink(
+            at: model.appendingPathComponent("speaker_encoder", isDirectory: true),
+            withDestinationURL: speakerEncoder
+        )
+
+        return (root, model)
+    }
+}

--- a/Tests/MereRunAppTests/MereRunDeepLinkTests.swift
+++ b/Tests/MereRunAppTests/MereRunDeepLinkTests.swift
@@ -78,4 +78,41 @@ final class MereRunDeepLinkTests: XCTestCase {
             XCTAssertEqual(error as? MereRunDeepLinkError, .notAFile(directoryURL.path))
         }
     }
+
+    func testLibraryImportLinkResolvesReceiptPath() throws {
+        let receiptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-library-import-\(UUID().uuidString)")
+            .appendingPathExtension("json")
+        try Data("{}".utf8).write(to: receiptURL)
+        defer { try? FileManager.default.removeItem(at: receiptURL) }
+
+        var components = URLComponents()
+        components.scheme = MereRunDeepLink.scheme
+        components.host = "library"
+        components.path = "/import"
+        components.queryItems = [URLQueryItem(name: "receipt", value: receiptURL.path)]
+        let link = try XCTUnwrap(components.url)
+
+        XCTAssertEqual(
+            try MereRunDeepLink.parse(link),
+            .libraryImport(receiptURL.standardizedFileURL)
+        )
+    }
+
+    func testLibraryImportLinkRequiresExactlyOneReceiptParameter() throws {
+        let missing = try XCTUnwrap(URL(string: "mererun://library/import"))
+        let wrong = try XCTUnwrap(URL(string: "mererun://library/import?path=/tmp/receipt.json"))
+        let duplicate = try XCTUnwrap(
+            URL(string: "mererun://library/import?receipt=/tmp/a.json&receipt=/tmp/b.json")
+        )
+
+        XCTAssertThrowsError(try MereRunDeepLink.parse(missing)) { error in
+            XCTAssertEqual(error as? MereRunDeepLinkError, .missingReceipt)
+        }
+        for link in [wrong, duplicate] {
+            XCTAssertThrowsError(try MereRunDeepLink.parse(link)) { error in
+                XCTAssertEqual(error as? MereRunDeepLinkError, .unsupportedParameters)
+            }
+        }
+    }
 }

--- a/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
+++ b/Tests/MereRunAppTests/StudioLibraryStoreTests.swift
@@ -271,6 +271,197 @@ final class StudioLibraryStoreTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
     }
 
+    func testRaycastReceiptImportsPersistsAndDeduplicatesArtifact() throws {
+        let libraryURL = try temporaryLibraryURL()
+        let artifactURL = libraryURL.deletingLastPathComponent().appendingPathComponent("result.png")
+        try Data("image".utf8).write(to: artifactURL)
+        let receipt = StudioLibraryImportReceipt(
+            version: StudioLibraryImportReceipt.currentVersion,
+            id: UUID(),
+            source: .raycast,
+            kind: .image,
+            prompt: "a hand-painted lunar greenhouse",
+            artifactPath: artifactURL.path,
+            createdAt: Date(timeIntervalSince1970: 1_785_593_400)
+        )
+        let receiptURL = try writeReceipt(receipt, beside: libraryURL)
+        let store = StudioLibraryStore(libraryURL: libraryURL)
+
+        let imported = try store.importReceipt(at: receiptURL)
+        let duplicate = try store.importReceipt(at: receiptURL)
+
+        XCTAssertEqual(imported, duplicate)
+        XCTAssertEqual(store.items.count, 1)
+        XCTAssertEqual(imported.id, receipt.id)
+        XCTAssertEqual(imported.mode, .createImage)
+        XCTAssertEqual(imported.prompt, receipt.prompt)
+        XCTAssertEqual(imported.outputURL, artifactURL.standardizedFileURL)
+        XCTAssertEqual(imported.status, .completed)
+        XCTAssertEqual(imported.exitCode, 0)
+        XCTAssertEqual(imported.templateID, .imageGenerate)
+        XCTAssertEqual(imported.source, .raycast)
+        XCTAssertEqual(imported.commandPreview, "mere.run image generate")
+
+        let reloaded = StudioLibraryStore(libraryURL: libraryURL)
+        XCTAssertEqual(reloaded.items.first?.id, imported.id)
+        XCTAssertEqual(reloaded.items.first?.outputURL, imported.outputURL)
+        XCTAssertEqual(reloaded.items.first?.source, .raycast)
+    }
+
+    func testReceiptRejectsArtifactKindMismatch() throws {
+        let libraryURL = try temporaryLibraryURL()
+        let artifactURL = libraryURL.deletingLastPathComponent().appendingPathComponent("result.wav")
+        try Data("audio".utf8).write(to: artifactURL)
+        let receipt = StudioLibraryImportReceipt(
+            version: StudioLibraryImportReceipt.currentVersion,
+            id: UUID(),
+            source: .raycast,
+            kind: .image,
+            prompt: "this claims to be an image",
+            artifactPath: artifactURL.path,
+            createdAt: Date()
+        )
+        let receiptURL = try writeReceipt(receipt, beside: libraryURL)
+        let store = StudioLibraryStore(libraryURL: libraryURL)
+
+        XCTAssertThrowsError(try store.importReceipt(at: receiptURL)) { error in
+            XCTAssertEqual(error as? StudioLibraryImportError, .artifactKindMismatch("image"))
+        }
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    func testReceiptIDCannotReplaceAnotherArtifact() throws {
+        let libraryURL = try temporaryLibraryURL()
+        let root = libraryURL.deletingLastPathComponent()
+        let existingURL = root.appendingPathComponent("existing.png")
+        let importedURL = root.appendingPathComponent("imported.png")
+        try Data("one".utf8).write(to: existingURL)
+        try Data("two".utf8).write(to: importedURL)
+        let id = UUID()
+        let store = StudioLibraryStore(libraryURL: libraryURL)
+        store.upsert(StudioLibraryItem(
+            id: id,
+            mode: .createImage,
+            prompt: "existing",
+            inputURL: nil,
+            outputURL: existingURL,
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run image generate",
+            outputText: nil
+        ))
+        let receipt = StudioLibraryImportReceipt(
+            version: StudioLibraryImportReceipt.currentVersion,
+            id: id,
+            source: .raycast,
+            kind: .image,
+            prompt: "collision",
+            artifactPath: importedURL.path,
+            createdAt: Date()
+        )
+        let receiptURL = try writeReceipt(receipt, beside: libraryURL)
+
+        XCTAssertThrowsError(try store.importReceipt(at: receiptURL)) { error in
+            XCTAssertEqual(error as? StudioLibraryImportError, .receiptIDConflict(id))
+        }
+        XCTAssertEqual(store.items.count, 1)
+        XCTAssertEqual(store.items.first?.outputURL, existingURL)
+    }
+
+    func testReceiptRejectsUnsupportedVersionAndEmptyPrompt() throws {
+        let libraryURL = try temporaryLibraryURL()
+        let artifactURL = libraryURL.deletingLastPathComponent().appendingPathComponent("result.png")
+        try Data("image".utf8).write(to: artifactURL)
+        let store = StudioLibraryStore(libraryURL: libraryURL)
+
+        for (receipt, expected) in [
+            (
+                StudioLibraryImportReceipt(
+                    version: 99, id: UUID(), source: .raycast, kind: .image,
+                    prompt: "valid", artifactPath: artifactURL.path, createdAt: Date()
+                ),
+                StudioLibraryImportError.unsupportedVersion(99)
+            ),
+            (
+                StudioLibraryImportReceipt(
+                    version: 1, id: UUID(), source: .raycast, kind: .image,
+                    prompt: "   ", artifactPath: artifactURL.path, createdAt: Date()
+                ),
+                StudioLibraryImportError.emptyPrompt
+            ),
+        ] {
+            let receiptURL = try writeReceipt(receipt, beside: libraryURL)
+            XCTAssertThrowsError(try store.importReceipt(at: receiptURL)) { error in
+                XCTAssertEqual(error as? StudioLibraryImportError, expected)
+            }
+        }
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    func testRaycastJSONContractImportsWithoutSwiftEncoder() throws {
+        let libraryURL = try temporaryLibraryURL()
+        let artifactURL = libraryURL.deletingLastPathComponent().appendingPathComponent("result.wav")
+        try Data("audio".utf8).write(to: artifactURL)
+        let id = UUID()
+        let json = """
+        {
+          "version": 1,
+          "id": "\(id.uuidString.lowercased())",
+          "source": "raycast",
+          "kind": "speech",
+          "prompt": "Welcome aboard.",
+          "artifactPath": "\(artifactURL.path)",
+          "createdAt": "2026-08-01T18:30:00Z"
+        }
+        """
+        let receiptURL = libraryURL.deletingLastPathComponent().appendingPathComponent("raycast-contract.json")
+        try XCTUnwrap(json.data(using: .utf8)).write(to: receiptURL)
+
+        let imported = try StudioLibraryStore(libraryURL: libraryURL).importReceipt(at: receiptURL)
+
+        XCTAssertEqual(imported.id, id)
+        XCTAssertEqual(imported.mode, .speak)
+        XCTAssertEqual(imported.templateID, .speechSynthesize)
+        XCTAssertEqual(imported.source, .raycast)
+    }
+
+    func testReceiptBoundsAndArtifactPathAreEnforced() throws {
+        let libraryURL = try temporaryLibraryURL()
+        let root = libraryURL.deletingLastPathComponent()
+        let oversizedURL = root.appendingPathComponent("oversized.json")
+        try Data(repeating: 0x20, count: StudioLibraryImportReceipt.maximumByteCount + 1).write(to: oversizedURL)
+        let store = StudioLibraryStore(libraryURL: libraryURL)
+
+        XCTAssertThrowsError(try store.importReceipt(at: oversizedURL)) { error in
+            XCTAssertEqual(error as? StudioLibraryImportError, .receiptTooLarge)
+        }
+
+        let relativeReceipt = StudioLibraryImportReceipt(
+            version: 1,
+            id: UUID(),
+            source: .raycast,
+            kind: .image,
+            prompt: "relative output",
+            artifactPath: "result.png",
+            createdAt: Date()
+        )
+        let relativeReceiptURL = try writeReceipt(relativeReceipt, beside: libraryURL)
+        XCTAssertThrowsError(try store.importReceipt(at: relativeReceiptURL)) { error in
+            XCTAssertEqual(error as? StudioLibraryImportError, .artifactPathMustBeAbsolute)
+        }
+    }
+
+    private func writeReceipt(_ receipt: StudioLibraryImportReceipt, beside libraryURL: URL) throws -> URL {
+        let receiptURL = libraryURL.deletingLastPathComponent()
+            .appendingPathComponent("receipt-\(UUID().uuidString).json")
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(receipt).write(to: receiptURL)
+        return receiptURL
+    }
+
     private func temporaryLibraryURL() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-app-tests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunAppTests/StudioNavigationCoordinatorTests.swift
+++ b/Tests/MereRunAppTests/StudioNavigationCoordinatorTests.swift
@@ -1,0 +1,19 @@
+@testable import MereRunApp
+import XCTest
+
+@MainActor
+final class StudioNavigationCoordinatorTests: XCTestCase {
+    func testOpenLibraryItemPublishesFreshNavigationRequest() throws {
+        let coordinator = StudioNavigationCoordinator()
+        let id = UUID()
+
+        coordinator.openLibraryItem(id: id, mode: .createImage)
+        let first = try XCTUnwrap(coordinator.libraryRequest)
+        coordinator.openLibraryItem(id: id, mode: .createImage)
+        let second = try XCTUnwrap(coordinator.libraryRequest)
+
+        XCTAssertEqual(first.itemID, id)
+        XCTAssertEqual(first.mode, .createImage)
+        XCTAssertNotEqual(first.token, second.token)
+    }
+}

--- a/Tests/MereRunCoreTests/FileManagerSymlinkTraversalTests.swift
+++ b/Tests/MereRunCoreTests/FileManagerSymlinkTraversalTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import MereRunCore
+import XCTest
+
+final class FileManagerSymlinkTraversalTests: XCTestCase {
+    func testContentsListsDirectDirectory() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let entries = try FileManager.default.contentsOfDirectoryResolvingSymlinks(at: fixture.target)
+
+        XCTAssertEqual(entries.map(\.lastPathComponent).sorted(), ["nested", "weights.safetensors"])
+    }
+
+    func testContentsListsSymlinkedComponentDirectory() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let entries = try FileManager.default.contentsOfDirectoryResolvingSymlinks(at: fixture.link)
+
+        XCTAssertEqual(entries.map(\.lastPathComponent).sorted(), ["nested", "weights.safetensors"])
+        XCTAssertTrue(entries.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+    }
+
+    func testEnumeratorTraversesSymlinkedRoot() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let enumerator = try XCTUnwrap(FileManager.default.enumeratorResolvingSymlinks(at: fixture.link))
+        let entries = enumerator.compactMap { ($0 as? URL)?.lastPathComponent }
+
+        XCTAssertTrue(entries.contains("weights.safetensors"))
+        XCTAssertTrue(entries.contains("config.json"))
+    }
+
+    func testBrokenDirectorySymlinkStillFails() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let link = root.appendingPathComponent("missing", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: link,
+            withDestinationURL: root.appendingPathComponent("not-created", isDirectory: true)
+        )
+
+        XCTAssertThrowsError(try FileManager.default.contentsOfDirectoryResolvingSymlinks(at: link))
+    }
+
+    private func makeFixture() throws -> (root: URL, target: URL, link: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let target = root.appendingPathComponent("snapshot/component", isDirectory: true)
+        let install = root.appendingPathComponent("install", isDirectory: true)
+        let link = install.appendingPathComponent("component", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: install, withIntermediateDirectories: true)
+        try Data().write(to: target.appendingPathComponent("weights.safetensors"))
+        let nested = target.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data().write(to: nested.appendingPathComponent("config.json"))
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        return (root, target, link)
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -872,6 +872,33 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(missing.contains { $0.hasSuffix("speech_tokenizer") })
     }
 
+    func testQwen3TTSAcceptsSymlinkedSpeechTokenizerDirectory() throws {
+        let root = try makeTemporaryDirectory()
+        let snapshot = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: snapshot)
+        }
+        try writeMinimalQwen3TTSRootWithoutSpeechTokenizer(at: root, id: .qwen3TTSCustomVoice)
+
+        let tokenizer = snapshot.appendingPathComponent("speech_tokenizer", isDirectory: true)
+        try FileManager.default.createDirectory(at: tokenizer, withIntermediateDirectories: true)
+        for file in ["config.json", "model.safetensors"] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: tokenizer.appendingPathComponent(file).path,
+                contents: Data("{}".utf8)
+            ))
+        }
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("speech_tokenizer", isDirectory: true),
+            withDestinationURL: tokenizer
+        )
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "speech-tts-qwen3-customvoice"))
+        XCTAssertTrue(spec.missingPaths(in: root, fileManager: .default).isEmpty)
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+    }
+
     func testZImageNanoAcceptsMFluxLayoutWithoutDiffusersConfigs() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -53,6 +53,7 @@ export default defineConfig({
         items: [
           { text: 'Docs Home', link: '/' },
           { text: 'Getting Started', link: '/getting-started' },
+          { text: 'Raycast Integration', link: '/raycast' },
           { text: 'Linux QuickStart', link: '/linux-quickstart' },
           { text: 'CLI Reference', link: '/cli' },
           { text: 'Offline Cookbooks', link: '/cookbooks' },

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,22 +34,24 @@ CI job, and on `main` it deploys the VitePress output to Pages at
 If you are new to the repo, read these in order:
 
 1. [Getting Started](./getting-started.md)
-2. [Linux QuickStart](./linux-quickstart.md), if you are installing the headless CLI on Linux
-3. [CLI Reference](./cli.md)
-4. [Portable Workflows](./workflows.md), if you are automating local or remote jobs
-5. [Graph Studio](./graph/studio.md), if you want to author Graph v2 workflows visually
-6. [Benchmarking](./benchmarking.md)
-7. [Cookbooks](./cookbooks.md)
-8. [Configuration](./configuration.md)
-9. [Model Sources](./model-sources.md)
-10. [Companion Plugins](./plugins.md)
-11. [Repository Tour](./repository-tour.md)
+2. [Raycast Integration](./raycast.md), if you want launcher-driven local generation on macOS
+3. [Linux QuickStart](./linux-quickstart.md), if you are installing the headless CLI on Linux
+4. [CLI Reference](./cli.md)
+5. [Portable Workflows](./workflows.md), if you are automating local or remote jobs
+6. [Graph Studio](./graph/studio.md), if you want to author Graph v2 workflows visually
+7. [Benchmarking](./benchmarking.md)
+8. [Cookbooks](./cookbooks.md)
+9. [Configuration](./configuration.md)
+10. [Model Sources](./model-sources.md)
+11. [Companion Plugins](./plugins.md)
+12. [Repository Tour](./repository-tour.md)
 
 ## Choose your path
 
 ### I want to use `mere.run`
 
 - [Getting Started](./getting-started.md)
+- [Raycast Integration](./raycast.md)
 - [Linux QuickStart](./linux-quickstart.md)
 - [CLI Reference](./cli.md)
 - [Benchmarking](./benchmarking.md)
@@ -87,6 +89,9 @@ If you are new to the repo, read these in order:
 
 - [Getting Started](./getting-started.md): clone, build, first commands, first
   status checks, Linux release artifacts, model pulls, and local setup
+- [Raycast Integration](./raycast.md): install the development extension, run
+  local image/video/music/speech commands, configure paths, preview artifacts,
+  and troubleshoot the macOS handoff
 - [Linux QuickStart](./linux-quickstart.md): Linux package install, first
   commands, release asset verification, and CUDA validation boundaries
 - [Cookbooks](./cookbooks.md): `mere.run guide` command topics for practical

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ links to the page that owns that command.
 Install, pull a first model, and make something in the next ten minutes.
 
 - [Getting Started](/getting-started)
-- [Raycast Integration](/raycast) — local generation and native artifact preview from the launcher
+- [Raycast Integration](/raycast) — local generation with Library import or Quick Look from the launcher
 - [Linux QuickStart](/linux-quickstart)
 - [CLI Reference](/cli)
 - [Offline Cookbooks](/cookbooks) — `mere.run guide` works without a network

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ links to the page that owns that command.
 Install, pull a first model, and make something in the next ten minutes.
 
 - [Getting Started](/getting-started)
+- [Raycast Integration](/raycast) — local generation and native artifact preview from the launcher
 - [Linux QuickStart](/linux-quickstart)
 - [CLI Reference](/cli)
 - [Offline Cookbooks](/cookbooks) — `mere.run guide` works without a network

--- a/docs/raycast.md
+++ b/docs/raycast.md
@@ -1,0 +1,165 @@
+# Raycast Integration
+
+Generate an image, video, music track, or spoken-audio file from Raycast, then
+open the completed local artifact in MereRun's native Quick Look panel. The
+Raycast extension calls the public `mere.run` CLI and hands the resulting file
+to the macOS app through `mererun://preview`.
+
+The extension is a separate macOS launcher integration. It is not a MereRun
+executable plugin and is not installed through the MereRun plugin catalog.
+
+## Requirements
+
+- macOS with [Raycast](https://www.raycast.com/) installed;
+- MereRun.app v0.31.0 or later installed on the Mac so the preview deep link is
+  available;
+- the app-bundled `mere.run` helper, or another executable CLI path configured
+  in the extension;
+- a locally installed model for the generation command you want to run.
+
+The native preview deep link is part of the macOS app. Linux packages contain
+the headless CLI only and cannot open the MereRun Quick Look panel.
+
+## Install the extension
+
+The extension is not in the Raycast Store yet. Load the development extension
+from its public repository:
+
+```bash
+git clone https://github.com/sawfwair/mere-run-raycast.git
+cd mere-run-raycast
+npm ci
+npm run dev
+```
+
+Keep `npm run dev` running while using the development extension. Raycast shows
+a development warning badge beside locally loaded commands; that badge does not
+mean local generation failed.
+
+To remove the development copy, stop the process with Control-C and use
+Raycast's **Uninstall Extension** action.
+
+## Commands
+
+| Raycast command | Search phrase | CLI operation | Output |
+| --- | --- | --- | --- |
+| **Generate Image** | `mere image` | `mere.run image generate` | PNG |
+| **Generate Video** | `mere video` | `mere.run video generate` | MP4 |
+| **Generate Music** | `mere music` | `mere.run music generate` | WAV |
+| **Synthesize Speech** | `mere speech` | `mere.run speech synthesize` | WAV |
+
+Choose a command, enter its prompt in Raycast, and press Return. Raycast shows
+the CLI's latest diagnostic while generation is active. After the command exits
+successfully and the output is readable, the extension opens the artifact in
+MereRun Preview.
+
+Generated files are durable. By default they are written to
+`~/MereRun/Raycast` with a media-specific name and UTC timestamp, for example:
+
+```text
+mere-image-2026-08-01T22-42-07-653Z.png
+mere-speech-2026-08-01T22-46-28-054Z.wav
+```
+
+## Configure the extension
+
+Open Raycast's extension preferences for **Mere.run** to change either setting:
+
+- **MereRun CLI Path** — optional absolute path to a `mere.run` executable;
+- **Output Directory** — artifact directory, defaulting to
+  `~/MereRun/Raycast`. Tilde paths are supported.
+
+When no CLI path is configured, the extension selects the first executable in
+this order:
+
+1. `/Applications/MereRun.app/Contents/Helpers/mere.run`
+2. `/usr/local/bin/mere.run`
+3. `/opt/homebrew/bin/mere.run`
+4. `~/.local/bin/mere.run`
+
+The app-bundled helper is preferred so the Studio and CLI stay on the same
+release.
+
+## Preview an existing artifact
+
+MereRun.app registers `mererun://preview`. A launcher can pass one
+percent-encoded absolute path:
+
+```text
+mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
+```
+
+Raycast extensions should let the URL API encode the path:
+
+```typescript
+import { open } from "@raycast/api";
+
+const deepLink = new URL("mererun://preview");
+deepLink.searchParams.set("path", outputPath);
+await open(deepLink.toString());
+```
+
+The target must already exist and be a readable file. MereRun rejects relative
+paths, directories, missing files, duplicate `path` values, and extra query
+parameters. Opening a preview does not import, move, or modify the artifact.
+
+## Local and security boundaries
+
+- Prompts and generated artifacts remain local unless another tool moves or
+  uploads them.
+- The extension launches `mere.run` directly without a shell, so prompt text is
+  not interpolated into a shell command.
+- A preview link can open only one existing, readable local file.
+- The extension does not run inside MereRun and cannot add runtime providers or
+  graph nodes.
+
+## Troubleshooting
+
+### The commands do not appear in Raycast
+
+Confirm `npm run dev` is still running in the `mere-run-raycast` checkout. If
+the extension was removed, run the command again to reload the development
+copy.
+
+### Raycast cannot find the CLI
+
+Install MereRun.app in `/Applications`, install the terminal command from
+Studio Settings, or set **MereRun CLI Path** to an executable absolute path in
+the extension preferences.
+
+### Generation reports a missing model
+
+Open **Models** in MereRun Studio and download the required model, or inspect
+the available managed models with:
+
+```bash
+mere.run model list
+```
+
+### Generation finishes but Preview does not open
+
+Confirm that `/Applications/MereRun.app` is v0.31.0 or later and that the output
+file still exists. Exercise the app's deep-link handler independently with a
+small text file:
+
+```bash
+printf 'MereRun preview smoke\n' >/tmp/mere-preview.txt
+open 'mererun://preview?path=%2Ftmp%2Fmere-preview.txt'
+```
+
+If the direct link works, inspect Raycast's toast for the output path and verify
+that the extension's configured output directory is writable.
+
+## Validate an extension checkout
+
+The extension repository owns its TypeScript checks, command mapping tests, and
+Raycast build:
+
+```bash
+npm ci
+npm run check
+```
+
+MereRun owns the CLI behavior, the `mererun://preview` route, and the signed
+macOS release. See [Getting Started](./getting-started.md) for installation and
+[Model Management](./runtime/model-management.md) for managed downloads.

--- a/docs/raycast.md
+++ b/docs/raycast.md
@@ -1,9 +1,9 @@
 # Raycast Integration
 
 Generate an image, video, music track, or spoken-audio file from Raycast, then
-open the completed local artifact in MereRun's native Quick Look panel. The
-Raycast extension calls the public `mere.run` CLI and hands the resulting file
-to the macOS app through `mererun://preview`.
+open the completed local artifact as the selected item in MereRun Library. The
+Raycast extension calls the public `mere.run` CLI, writes a small typed receipt,
+and hands that receipt to the macOS app through `mererun://library/import`.
 
 The extension is a separate macOS launcher integration. It is not a MereRun
 executable plugin and is not installed through the MereRun plugin catalog.
@@ -11,14 +11,14 @@ executable plugin and is not installed through the MereRun plugin catalog.
 ## Requirements
 
 - macOS with [Raycast](https://www.raycast.com/) installed;
-- MereRun.app v0.31.0 or later installed on the Mac so the preview deep link is
-  available;
+- a MereRun.app build containing the `mererun://library/import` route; v0.31.0
+  supports the optional preview-only route but not Library import;
 - the app-bundled `mere.run` helper, or another executable CLI path configured
   in the extension;
 - a locally installed model for the generation command you want to run.
 
-The native preview deep link is part of the macOS app. Linux packages contain
-the headless CLI only and cannot open the MereRun Quick Look panel.
+The native import and preview deep links are part of the macOS app. Linux
+packages contain the headless CLI only and cannot open the MereRun Studio.
 
 ## Install the extension
 
@@ -50,8 +50,8 @@ Raycast's **Uninstall Extension** action.
 
 Choose a command, enter its prompt in Raycast, and press Return. Raycast shows
 the CLI's latest diagnostic while generation is active. After the command exits
-successfully and the output is readable, the extension opens the artifact in
-MereRun Preview.
+successfully and the output is readable, the extension imports the artifact,
+opens its owning MereRun workspace, reveals Library, and selects the new row.
 
 Generated files are durable. By default they are written to
 `~/MereRun/Raycast` with a media-specific name and UTC timestamp, for example:
@@ -67,7 +67,9 @@ Open Raycast's extension preferences for **Mere.run** to change either setting:
 
 - **MereRun CLI Path** — optional absolute path to a `mere.run` executable;
 - **Output Directory** — artifact directory, defaulting to
-  `~/MereRun/Raycast`. Tilde paths are supported.
+  `~/MereRun/Raycast`. Tilde paths are supported;
+- **Open Result In** — **MereRun Library** by default, or **Quick Look Only**
+  when the artifact should not be imported.
 
 When no CLI path is configured, the extension selects the first executable in
 this order:
@@ -79,6 +81,36 @@ this order:
 
 The app-bundled helper is preferred so the Studio and CLI stay on the same
 release.
+
+## Library import contract
+
+Raycast writes receipts beneath its private extension support directory. A
+version 1 receipt contains only the completed local run metadata MereRun needs:
+
+```json
+{
+  "version": 1,
+  "id": "5cb7dc90-a9d4-4634-a486-0b8140226b42",
+  "source": "raycast",
+  "kind": "image",
+  "prompt": "a ceramic coffee mug in soft morning light",
+  "artifactPath": "/Users/me/MereRun/Raycast/mere-image-result.png",
+  "createdAt": "2026-08-01T22:42:07Z"
+}
+```
+
+It then asks Launch Services to open one percent-encoded absolute receipt path:
+
+```text
+mererun://library/import?receipt=%2FUsers%2Fme%2FLibrary%2FApplication%20Support%2Fcom.raycast.macos%2Fextensions%2Fmere-run%2Flibrary-imports%2F5cb7dc90-a9d4-4634-a486-0b8140226b42.json
+```
+
+MereRun accepts receipt version 1 and the typed `image`, `video`, `music`, and
+`speech` kinds. It rejects oversized or malformed receipts, unsupported
+versions, empty prompts, missing or unreadable artifacts, and media that does
+not match the declared kind. Reopening the same receipt or artifact selects the
+existing row instead of duplicating it. MereRun owns `library.json`; the
+launcher never reads or writes that file.
 
 ## Preview an existing artifact
 
@@ -109,6 +141,9 @@ parameters. Opening a preview does not import, move, or modify the artifact.
   uploads them.
 - The extension launches `mere.run` directly without a shell, so prompt text is
   not interpolated into a shell command.
+- Library import accepts one local receipt no larger than 256 KiB and one
+  existing readable artifact whose type matches the receipt.
+- Receipt IDs cannot replace an existing Library row that points elsewhere.
 - A preview link can open only one existing, readable local file.
 - The extension does not run inside MereRun and cannot add runtime providers or
   graph nodes.
@@ -136,11 +171,12 @@ the available managed models with:
 mere.run model list
 ```
 
-### Generation finishes but Preview does not open
+### Generation finishes but the Library item does not open
 
-Confirm that `/Applications/MereRun.app` is v0.31.0 or later and that the output
-file still exists. Exercise the app's deep-link handler independently with a
-small text file:
+Confirm that the installed MereRun.app includes `mererun://library/import`, and
+that both the receipt and generated artifact still exist. Choose **Quick Look
+Only** temporarily to isolate generation from Library import. Exercise the
+preview handler independently with a small text file:
 
 ```bash
 printf 'MereRun preview smoke\n' >/tmp/mere-preview.txt
@@ -160,6 +196,7 @@ npm ci
 npm run check
 ```
 
-MereRun owns the CLI behavior, the `mererun://preview` route, and the signed
-macOS release. See [Getting Started](./getting-started.md) for installation and
-[Model Management](./runtime/model-management.md) for managed downloads.
+MereRun owns the CLI behavior, both typed deep-link routes, Library persistence,
+and the signed macOS release. See [Getting Started](./getting-started.md) for
+installation and [Model Management](./runtime/model-management.md) for managed
+downloads.

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -148,7 +148,7 @@ plutil -insert CFBundleInfoDictionaryVersion -string "6.0" "${contents}/Info.pli
 plutil -insert LSApplicationCategoryType -string "public.app-category.developer-tools" "${contents}/Info.plist"
 plutil -insert NSHumanReadableCopyright -string "© mere.run" "${contents}/Info.plist"
 plutil -insert CFBundleURLTypes -json \
-  '[{"CFBundleTypeRole":"Viewer","CFBundleURLName":"run.mere.preview","CFBundleURLSchemes":["mererun"]}]' \
+  '[{"CFBundleTypeRole":"Viewer","CFBundleURLName":"run.mere.links","CFBundleURLSchemes":["mererun"]}]' \
   "${contents}/Info.plist"
 plutil -insert SUFeedURL -string "$sparkle_feed_url" "${contents}/Info.plist"
 plutil -insert SUPublicEDKey -string "$sparkle_public_ed_key" "${contents}/Info.plist"


### PR DESCRIPTION
## What changed

- add the first-class `mererun://library/import?receipt=...` app route
- decode a versioned, typed Raycast receipt and validate its source, media kind, prompt, timestamp, and artifact
- reject oversized, malformed, missing, unreadable, directory, relative-path, and media-kind-mismatched imports
- persist valid artifacts as completed Library items with `source: raycast`
- deduplicate repeat handoffs, reject receipt ID collisions, navigate to the correct Studio mode, and select the imported item
- surface the Raycast source in Library and document Library import versus Quick Look behavior
- add one shared symlink-aware directory traversal contract for model validation, weight and shard loading, CLI inspection, TTS/STT resources, managed snapshot materialization, and training discovery
- apply the contract across managed model families instead of keeping a Qwen3 TTS-only exception
- keep physical storage accounting and garbage collection explicitly link-aware so shared Hub payload ownership remains correct
- update the local app bundle development version fallback to 0.31.0

## Why

Raycast previously opened generated artifacts only in the app preview surface. That made the image visible momentarily but did not add it to the durable MereRun Library or navigate the user back to normal creation history.

Managed Hub downloads materialize files and component directories as symlinks into pinned snapshots. Foundation directory listing does not traverse a supplied directory when that final path is a symlink, so otherwise complete components could appear empty during validation or runtime weight discovery. The original Qwen3 TTS symptom was one instance of a cross-model filesystem invariant.

## User impact

Raycast generations now land in the MereRun Library, open in the appropriate Studio mode, and remain available after the handoff. Reopening the same receipt selects the existing item without creating a duplicate.

Managed models with symlinked component directories now validate, inspect, and load consistently across image, video, text, speech, GGUF, and training paths. Storage reporting and cleanup still distinguish wrapper links from shared physical payloads.

## Validation

- `./scripts/check.sh`
  - strict lint, build, CLI help/status, and hygiene gates passed
  - 2,405 tests passed, 152 asset-gated tests skipped, 0 failures
- focused symlink traversal and Qwen3 TTS resource tests: 5 passed, 0 failures
- installed `speech-tts-qwen3-customvoice` model inspection: valid, including one symlinked component directory
- installed `speech-tts-qwen3-nano` model inspection: valid
- VitePress docs production build passed
- debug `MereRun.app` build and strict deep code-signature verification passed
- installed-app deep-link smoke persisted and selected a Raycast image in Library
- live companion Raycast smoke generated a 1024x1024 PNG and increased Library from 13 to 14
- Models UI purge/redownload smoke for `vision-depth-vda-small` showed 0% and 100% byte progress, restored inventory from 60 to 61, and validated the resulting 116.5 MB install

Companion Raycast PR: https://github.com/sawfwair/mere-run-raycast/pull/1