### PR TITLE
feat(audio): add native AP-BWE enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on Keep a Changelog.
   upstream 60-band Slaney mel filter bank, overlapping-frequency mask
   averaging, 684-tensor checkpoint inventory, and published overlap defaults;
   outputs remain ordinary hashed stems in the separation manifest.
+- added native AP-BWE speech bandwidth extension through `audio enhance` and
+  the managed `audio-enhance-ap-bwe-16kto48k` model. The runtime admits the
+  official MIT checkpoint only through an exact byte-identical public
+  transport snapshot, verifies the checkpoint/config/code-license/weights-
+  license hashes, reproduces the paired magnitude/phase ConvNeXt graph, and
+  writes a 48 kHz mono float WAV plus a hashed provenance manifest.
 
 ## 0.31.0 - 2026-08-01
 

--- a/Package.swift
+++ b/Package.swift
@@ -317,6 +317,7 @@ targets.append(contentsOf: [
       "ACEStep/README.md",
       "ACEStep/Model/README.md",
       "ACEStep/VAE/README.md",
+      "APBWE/README.md",
       "Asset3D/README.md",
       "CodeGen/README.md",
       "Cosmos3/README.md",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ current flags.
 | Text, code, and agents | `text chat`, `text code`, `text embed`, `text anonymize`, `text train-lora`, `agent` | Local chat and tool use, including Bonsai 27B binary/ternary vision chat; code generation, embeddings, PII redaction, text LoRA training, and guided local-agent setup |
 | Vision understanding | `vision caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
+| Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension from 16 kHz narrowband input to a hashed 48 kHz mono WAV |
 | Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | LTX video, synchronized LTX 2.3 audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
 | Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
 | Speech | `speech synthesize`, `speech transcribe`, `speech diarize`, `speech listen`, `speech profile` | Qwen3 TTS, saved voice profiles, Qwen3 live ASR, Parakeet transcription, and native MLX Sortformer speaker diarization |
@@ -613,6 +614,11 @@ swift run mere.run model pull music-separate-mel-roformer-denoise
 swift run mere.run music separate ./noisy.wav \
   --model music-separate-mel-roformer-denoise \
   --output-dir ./noise-restored
+
+# Extend narrowband speech from 16 kHz to 48 kHz with native AP-BWE
+swift run mere.run model pull audio-enhance-ap-bwe-16kto48k
+swift run mere.run audio enhance ./speech.wav \
+  --output ./speech-wideband.wav
 
 # Generate a style-transfer cover from a source song
 swift run mere.run music generate \

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -4580,7 +4580,7 @@ actor CodeGenServer {
                 request: request
             )
         case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
-             .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek,
+             .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
              .inkling, nil:
             throw APIRequestValidationError.invalidField(
                 "model",

--- a/Sources/MereRunCLI/Commands/AudioCommand.swift
+++ b/Sources/MereRunCLI/Commands/AudioCommand.swift
@@ -1,0 +1,11 @@
+import ArgumentParser
+
+struct Audio: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "audio",
+        abstract: "Enhance general audio locally.",
+        subcommands: [
+            AudioEnhance.self,
+        ]
+    )
+}

--- a/Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift
+++ b/Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift
@@ -1,0 +1,238 @@
+import ArgumentParser
+import Foundation
+import MLX
+import MediaIO
+import MereRunCore
+
+private struct AudioEnhancementManifest: Codable {
+    struct Source: Codable {
+        let path: String
+        let sha256: String
+        let sampleRate: Int
+        let channels: Int
+        let frames: Int64
+    }
+
+    struct Preprocessing: Codable {
+        let decodedSampleRate: Int
+        let decodedChannels: Int
+        let decodedFrames: Int
+        let modelInputSampleRate: Int
+        let modelInputFrames: Int
+        let resampler: String
+    }
+
+    struct Model: Codable {
+        let id: String
+        let sourceRepository: String
+        let sourceRevision: String
+        let artifactRepository: String
+        let artifactRevision: String
+        let license: String
+        let weightsSHA256: String
+        let sourceConfigurationSHA256: String
+        let computeType: String
+    }
+
+    struct Output: Codable {
+        let path: String
+        let sha256: String
+        let sampleRate: Int
+        let channels: Int
+        let frames: Int
+    }
+
+    let schemaVersion: Int
+    let createdAt: String
+    let source: Source
+    let preprocessing: Preprocessing
+    let model: Model
+    let chunkSize: Int
+    let overlap: Int
+    let chunks: Int
+    let elapsedSeconds: Double
+    let output: Output
+    let manifestPath: String
+}
+
+struct AudioEnhance: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "enhance",
+        abstract: "Extend narrowband speech from 16 kHz to 48 kHz with AP-BWE.",
+        discussion: """
+        Decodes the source to 16 kHz mono, performs band-limited 3x
+        interpolation, and reconstructs missing speech bandwidth with the
+        pinned MIT-licensed AP-BWE checkpoint using native Swift/MLX inference.
+        The output is a 48 kHz mono float WAV. A provenance manifest is saved
+        beside the output and emitted as JSON on stdout.
+
+        Examples:
+          mere.run model pull audio-enhance-ap-bwe-16kto48k
+          mere.run audio enhance ./speech.wav
+          mere.run audio enhance ./speech.mp3 --output ./speech-wideband.wav
+          mere.run audio enhance ./speech.wav --dtype float16 --overlap 4
+        """
+    )
+
+    @Argument(help: "Input speech file (WAV, MP3, M4A, FLAC, or another supported format).")
+    var audio: String
+
+    @Option(name: [.customShort("m"), .long], help: "Managed AP-BWE model id.")
+    var model: String = ModelResolver.ModelID.apBWE16kTo48k.rawValue
+
+    @Option(name: [.customLong("model-path")], help: "Explicit local root of the pinned AP-BWE snapshot.")
+    var modelPath: String?
+
+    @Option(name: [.customShort("o"), .long], help: "Output 48 kHz mono float WAV path.")
+    var output: String?
+
+    @Option(name: [.long], help: "Chunk overlap count. Defaults to the published profile value (2).")
+    var overlap: Int?
+
+    @Option(name: [.long], help: "Model compute type: float16 or float32.")
+    var dtype: String = "float32"
+
+    @Flag(name: [.short, .long], help: "Suppress progress diagnostics on stderr.")
+    var quiet: Bool = false
+
+    func validate() throws {
+        guard model == ModelResolver.ModelID.apBWE16kTo48k.rawValue else {
+            throw ValidationError("Unsupported audio enhancement model id: \(model)")
+        }
+        let configuration = try APBWEResources.loadBundledConfiguration()
+        let resolvedOverlap = overlap ?? configuration.overlap
+        guard resolvedOverlap > 0, configuration.chunkSize.isMultiple(of: resolvedOverlap) else {
+            throw ValidationError(
+                "--overlap must be a positive divisor of \(configuration.chunkSize)"
+            )
+        }
+        guard ["float16", "float32"].contains(dtype.lowercased()) else {
+            throw ValidationError("--dtype must be float16 or float32")
+        }
+    }
+
+    func run() throws {
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        let inputURL = Self.userURL(audio)
+        guard FileManager.default.fileExists(atPath: inputURL.path) else {
+            throw ValidationError("Input audio file not found: \(inputURL.path)")
+        }
+        let configuration = try APBWEResources.loadBundledConfiguration()
+        let resolvedOverlap = overlap ?? configuration.overlap
+        let modelRoot = try resolveModelRoot()
+        let outputURL = output.map(Self.userURL) ?? Self.defaultOutputURL(for: inputURL)
+        let manifestURL = outputURL.deletingPathExtension().appendingPathExtension("json")
+        let sourceMetadata = try MediaAudioIO.probe(inputURL)
+
+        if !quiet {
+            CLIStderr.write("Decoding \(inputURL.path) at 16 kHz mono\n")
+        }
+        let decoded = try MediaAudioIO.decode(
+            inputURL,
+            targetSampleRate: configuration.lowSampleRate,
+            channels: 1
+        )
+        guard !decoded.samples.isEmpty else {
+            throw ValidationError("Input audio decoded to an empty buffer.")
+        }
+        let modelInput = APBWEAudio.upsample16kTo48k(decoded.samples)
+        let computeType: DType = dtype.lowercased() == "float16" ? .float16 : .float32
+        if !quiet {
+            CLIStderr.write("Loading \(model) from \(modelRoot.path)\n")
+        }
+        let enhancer = try APBWEEnhancer.load(
+            resources: APBWEResources(rootURL: modelRoot),
+            dtype: computeType
+        )
+        let result = try enhancer.enhance(
+            narrowband48kSamples: modelInput,
+            sampleRate: configuration.highSampleRate,
+            channels: 1,
+            overlap: resolvedOverlap
+        ) { completed, total in
+            if !quiet {
+                CLIStderr.write("AP-BWE chunks: \(completed)/\(total)\n")
+            }
+        }
+        try MediaAudioIO.writeFloatWAV(
+            samples: result.samples,
+            sampleRate: result.sampleRate,
+            channels: result.channels,
+            to: outputURL
+        )
+
+        let manifest = AudioEnhancementManifest(
+            schemaVersion: 1,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            source: .init(
+                path: inputURL.path,
+                sha256: try ModelArtifactPin.fileSHA256(inputURL),
+                sampleRate: sourceMetadata.sampleRate,
+                channels: sourceMetadata.channelCount,
+                frames: sourceMetadata.frameCount
+            ),
+            preprocessing: .init(
+                decodedSampleRate: decoded.sampleRate,
+                decodedChannels: decoded.channelCount,
+                decodedFrames: decoded.samples.count / decoded.channelCount,
+                modelInputSampleRate: configuration.highSampleRate,
+                modelInputFrames: modelInput.count,
+                resampler: "windowed-sinc-lanczos-radius-32"
+            ),
+            model: .init(
+                id: model,
+                sourceRepository: APBWEResources.sourceRepository,
+                sourceRevision: APBWEResources.sourceRevision,
+                artifactRepository: APBWEResources.artifactRepository,
+                artifactRevision: APBWEResources.artifactRevision,
+                license: "MIT",
+                weightsSHA256: APBWEResources.weightsPin.sha256,
+                sourceConfigurationSHA256: APBWEResources.sourceConfigurationPin.sha256,
+                computeType: dtype.lowercased()
+            ),
+            chunkSize: configuration.chunkSize,
+            overlap: resolvedOverlap,
+            chunks: result.chunkCount,
+            elapsedSeconds: result.elapsedSeconds,
+            output: .init(
+                path: outputURL.path,
+                sha256: try ModelArtifactPin.fileSHA256(outputURL),
+                sampleRate: result.sampleRate,
+                channels: result.channels,
+                frames: result.frameCount
+            ),
+            manifestPath: manifestURL.path
+        )
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(manifest)
+        data.append(0x0A)
+        try FileManager.default.createDirectory(
+            at: manifestURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: manifestURL, options: .atomic)
+        try FileHandle.standardOutput.write(contentsOf: data)
+
+        if !quiet {
+            CLIStderr.write("Saved enhanced audio to \(outputURL.path)\n")
+            CLIStderr.write("Saved provenance manifest to \(manifestURL.path)\n")
+        }
+    }
+
+    private func resolveModelRoot() throws -> URL {
+        if let modelPath { return Self.userURL(modelPath) }
+        return try ModelResolver().resolve(.apBWE16kTo48k).rootURL
+    }
+
+    private static func defaultOutputURL(for input: URL) -> URL {
+        input.deletingLastPathComponent().appendingPathComponent(
+            input.deletingPathExtension().lastPathComponent + "-enhanced.wav"
+        )
+    }
+
+    private static func userURL(_ value: String) -> URL {
+        URL(fileURLWithPath: NSString(string: value).expandingTildeInPath).standardizedFileURL
+    }
+}

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -407,6 +407,13 @@ enum GuideRegistry {
             resourceName: "vision-ocr.md"
         ),
         GuideTopic(
+            topic: "audio-enhance",
+            title: "Audio Enhance",
+            commandPaths: [["audio", "enhance"]],
+            models: ["audio-enhance-ap-bwe-16kto48k"],
+            resourceName: "audio-enhance.md"
+        ),
+        GuideTopic(
             topic: "music-generate",
             title: "Music Generate",
             commandPaths: [["music", "generate"]],

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -388,7 +388,7 @@ struct ImageGenerate: AsyncParsableCommand {
                 defer { generator.unload() }
                 result = try await generator.generate(request, progressHandler: progressHandler)
             case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
-                 .tts, .asr, .embed, .code, .ocr, .music, .sfx, .video, .psi, .privacy, .deepseek,
+                 .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
                  .inkling, nil:
                 throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")
             }

--- a/Sources/MereRunCLI/Guides/audio-enhance.md
+++ b/Sources/MereRunCLI/Guides/audio-enhance.md
@@ -1,0 +1,46 @@
+# Audio Enhance
+
+## Purpose
+
+Extend narrowband speech to a hashed 48 kHz mono WAV with native Swift/MLX
+AP-BWE inference. No audio is uploaded and no Python runtime is launched.
+
+`mere.run audio enhance` extends 16 kHz narrowband speech to 48 kHz with the
+pinned AP-BWE checkpoint. Inference stays local and uses the native Swift/MLX
+runtime.
+
+## Install
+
+```bash
+mere.run model pull audio-enhance-ap-bwe-16kto48k
+```
+
+The source code and published checkpoint are MIT-licensed. The managed snapshot
+contains the upstream code and weights license texts and exact, hash-verified
+16→48 kHz checkpoint/configuration artifacts.
+
+## Run
+
+```bash
+mere.run audio enhance ./speech.wav
+mere.run audio enhance ./speech.mp3 --output ./speech-wideband.wav
+mere.run audio enhance ./speech.wav --dtype float16 --overlap 4
+```
+
+The command decodes input to 16 kHz mono, performs band-limited 3x
+interpolation, and runs the AP-BWE generator at 48 kHz. It writes a mono float
+WAV plus a sibling JSON provenance manifest. The same manifest is emitted on
+stdout; progress is diagnostic stderr output.
+
+## Notes
+
+- This profile is intended for speech bandwidth extension, not music mastering.
+- `--model-path` accepts an explicit root only when every pinned artifact matches.
+- `--dtype float32` is the default; `float16` reduces model memory use.
+- Quality depends on the source. A valid output artifact proves runtime
+  execution, not perceptual improvement for every recording.
+
+## Sources
+
+- https://github.com/yxlu-0102/AP-BWE
+- https://huggingface.co/rsxdalv/AP-BWE

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -31,6 +31,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Text.self,
             Speech.self,
             Vision.self,
+            Audio.self,
             Music.self,
             SFX.self,
             Video.self,

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -310,6 +310,11 @@ enum InstalledModelSmokePlans {
                 try await runner.installedMusicSeparationCheck(model: spec.id)
             }
 
+        case .apBWE:
+            return direct(spec, route: "audio enhance") { runner in
+                try await runner.installedAudioEnhancementCheck(model: spec.id)
+            }
+
         case .woosh:
             if spec.id == "sfx-woosh-vflow-8s" || spec.id == "sfx-woosh-dvflow-8s" {
                 return direct(spec, route: "sfx video generate") { runner in
@@ -976,6 +981,24 @@ extension GateRunner {
         _ = try audioObservation(vocals, run: run)
         _ = try audioObservation(instrumental, run: run)
         return try jsonFileObservation(manifest, run: run, label: "music separation manifest")
+    }
+
+    func installedAudioEnhancementCheck(model: String) async throws -> GateObservation {
+        let input = workDirectory.appendingPathComponent("installed-audio-enhancement-source.wav")
+        if !FileManager.default.fileExists(atPath: input.path) {
+            try Self.writeSineWaveFixture(to: input)
+        }
+        let output = artifactURL(model, extension: "wav")
+        let run = try await exec(
+            [
+                "audio", "enhance", input.path,
+                "--model", model,
+                "--output", output.path,
+                "--quiet",
+            ],
+            timeout: 3_600
+        )
+        return try audioObservation(output, run: run)
     }
 
     func installedSFXCheck(model: String) async throws -> GateObservation {

--- a/Sources/MereRunCore/APBWE/APBWEConfiguration.swift
+++ b/Sources/MereRunCore/APBWE/APBWEConfiguration.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+public struct APBWEConfiguration: Codable, Equatable, Sendable {
+    public let channels: Int
+    public let layers: Int
+    public let nFFT: Int
+    public let hopSize: Int
+    public let winSize: Int
+    public let highSampleRate: Int
+    public let lowSampleRate: Int
+    public let chunkSize: Int
+    public let overlap: Int
+
+    enum CodingKeys: String, CodingKey {
+        case channels
+        case layers
+        case nFFT = "n_fft"
+        case hopSize = "hop_size"
+        case winSize = "win_size"
+        case highSampleRate = "high_sample_rate"
+        case lowSampleRate = "low_sample_rate"
+        case chunkSize = "chunk_size"
+        case overlap
+    }
+
+    public var frequencyBins: Int { nFFT / 2 + 1 }
+
+    public func validate() throws {
+        guard channels == 512, layers == 8 else {
+            throw APBWEError.invalidConfiguration(
+                "expected 512 channels and 8 ConvNeXt layers"
+            )
+        }
+        guard nFFT == 1_024, hopSize == 80, winSize == 320 else {
+            throw APBWEError.invalidConfiguration(
+                "expected n_fft=1024, hop_size=80, and win_size=320"
+            )
+        }
+        guard highSampleRate == 48_000, lowSampleRate == 16_000 else {
+            throw APBWEError.invalidConfiguration(
+                "expected the pinned 16 kHz to 48 kHz profile"
+            )
+        }
+        guard chunkSize > nFFT,
+              chunkSize.isMultiple(of: hopSize),
+              overlap > 0,
+              chunkSize.isMultiple(of: overlap) else {
+            throw APBWEError.invalidConfiguration(
+                "chunk_size must exceed n_fft and be divisible by hop_size and overlap"
+            )
+        }
+    }
+}
+
+public enum APBWEError: Error, Equatable, LocalizedError, Sendable {
+    case missingBundledConfiguration
+    case invalidConfiguration(String)
+    case invalidAudioBuffer
+    case unsupportedAudio(sampleRate: Int, channels: Int)
+    case invalidCheckpointInventory(tensors: Int, scalars: Int)
+    case checkpointKeyMismatch(missing: [String], unexpected: [String])
+    case checkpointShapeMismatch(key: String, expected: [Int], actual: [Int])
+    case checkpointIdentityChanged
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingBundledConfiguration:
+            "Bundled AP-BWE configuration is missing."
+        case .invalidConfiguration(let detail):
+            "Invalid AP-BWE configuration: \(detail)."
+        case .invalidAudioBuffer:
+            "AP-BWE requires a non-empty mono floating-point audio buffer."
+        case .unsupportedAudio(let sampleRate, let channels):
+            "AP-BWE requires 48 kHz mono narrowband audio; received \(sampleRate) Hz with \(channels) channels."
+        case .invalidCheckpointInventory(let tensors, let scalars):
+            "AP-BWE checkpoint has \(tensors) tensors/\(scalars) scalars; expected "
+                + "\(APBWEResources.expectedTensorCount)/\(APBWEResources.expectedScalarCount)."
+        case .checkpointKeyMismatch(let missing, let unexpected):
+            "AP-BWE checkpoint keys differ from the native graph; missing=\(missing), unexpected=\(unexpected)."
+        case .checkpointShapeMismatch(let key, let expected, let actual):
+            "AP-BWE checkpoint tensor '\(key)' has shape \(actual); expected \(expected)."
+        case .checkpointIdentityChanged:
+            "AP-BWE checkpoint identity changed after preflight verification."
+        }
+    }
+}

--- a/Sources/MereRunCore/APBWE/APBWEEnhancer.swift
+++ b/Sources/MereRunCore/APBWE/APBWEEnhancer.swift
@@ -1,0 +1,162 @@
+import Foundation
+@preconcurrency import MLX
+
+public struct APBWEEnhancementResult: Sendable {
+    public let samples: [Float]
+    public let sampleRate: Int
+    public let channels: Int
+    public let frameCount: Int
+    public let chunkCount: Int
+    public let elapsedSeconds: Double
+}
+
+public enum APBWEAudio {
+    /// Band-limited 3x interpolation matching the pinned 16 kHz to 48 kHz profile.
+    public static func upsample16kTo48k(_ samples: [Float]) -> [Float] {
+        guard !samples.isEmpty else { return [] }
+        let factor = 3
+        let radius = 32
+        var output = [Float](repeating: 0, count: samples.count * factor)
+        for outputIndex in output.indices {
+            let position = Double(outputIndex) / Double(factor)
+            let center = Int(floor(position))
+            var sum = 0.0
+            var normalization = 0.0
+            for sourceIndex in (center - radius + 1)...(center + radius) {
+                let distance = position - Double(sourceIndex)
+                guard abs(distance) < Double(radius) else { continue }
+                let coefficient = sinc(distance) * sinc(distance / Double(radius))
+                let reflected = reflectedIndex(sourceIndex, count: samples.count)
+                sum += Double(samples[reflected]) * coefficient
+                normalization += coefficient
+            }
+            output[outputIndex] = Float(sum / max(abs(normalization), 1e-12))
+        }
+        return output
+    }
+
+    static func reflectPad(_ samples: [Float], amount: Int) -> [Float] {
+        precondition(amount >= 0)
+        guard amount > 0, !samples.isEmpty else { return samples }
+        return (0..<(samples.count + amount * 2)).map { outputIndex in
+            samples[reflectedIndex(outputIndex - amount, count: samples.count)]
+        }
+    }
+
+    private static func sinc(_ value: Double) -> Double {
+        if abs(value) < 1e-12 { return 1 }
+        let argument = Double.pi * value
+        return sin(argument) / argument
+    }
+
+    private static func reflectedIndex(_ index: Int, count: Int) -> Int {
+        guard count > 1 else { return 0 }
+        let upper = count - 1
+        let period = upper * 2
+        var value = index % period
+        if value < 0 { value += period }
+        return value > upper ? period - value : value
+    }
+}
+
+public final class APBWEEnhancer {
+    public typealias ProgressHandler = @Sendable (_ completedChunks: Int, _ totalChunks: Int) -> Void
+
+    public let checkpoint: APBWECheckpoint
+    public let dtype: DType
+    private let model: APBWEModel
+
+    private init(checkpoint: APBWECheckpoint, dtype: DType, model: APBWEModel) {
+        self.checkpoint = checkpoint
+        self.dtype = dtype
+        self.model = model
+    }
+
+    public static func load(
+        resources: APBWEResources,
+        dtype: DType = .float32
+    ) throws -> APBWEEnhancer {
+        let checkpoint = try resources.resolve()
+        let model = try APBWEModel.load(checkpoint: checkpoint, dtype: dtype)
+        return APBWEEnhancer(checkpoint: checkpoint, dtype: dtype, model: model)
+    }
+
+    public func enhance(
+        narrowband48kSamples: [Float],
+        sampleRate: Int,
+        channels: Int,
+        overlap: Int? = nil,
+        progress: ProgressHandler? = nil
+    ) throws -> APBWEEnhancementResult {
+        let configuration = checkpoint.configuration
+        guard sampleRate == configuration.highSampleRate, channels == 1 else {
+            throw APBWEError.unsupportedAudio(sampleRate: sampleRate, channels: channels)
+        }
+        guard !narrowband48kSamples.isEmpty else {
+            throw APBWEError.invalidAudioBuffer
+        }
+        let started = ContinuousClock.now
+        let resolvedOverlap = overlap ?? configuration.overlap
+        let plan = try RoFormerChunkPlan.make(
+            sampleCount: narrowband48kSamples.count,
+            chunkSize: configuration.chunkSize,
+            overlap: resolvedOverlap
+        )
+        let working = plan.usesBorderPadding
+            ? APBWEAudio.reflectPad(narrowband48kSamples, amount: plan.border)
+            : narrowband48kSamples
+        var accumulated = [Float](repeating: 0, count: working.count)
+        var weights = [Float](repeating: 0, count: working.count)
+
+        for (chunkIndex, start) in plan.starts.enumerated() {
+            let available = min(configuration.chunkSize, working.count - start)
+            var chunk = [Float](repeating: 0, count: configuration.chunkSize)
+            for offset in 0..<available {
+                chunk[offset] = working[start + offset]
+            }
+            if available > configuration.chunkSize / 2, available < configuration.chunkSize {
+                for offset in available..<configuration.chunkSize {
+                    chunk[offset] = working[start + 2 * available - offset - 2]
+                }
+            }
+            let input = MLXArray(chunk)
+                .reshaped(1, 1, configuration.chunkSize)
+                .asType(dtype)
+            let enhanced = model(input)
+                .reshaped(configuration.chunkSize)
+                .asType(.float32)
+            MLX.eval(enhanced)
+            let values = enhanced.asArray(Float.self)
+            let fade = plan.fadeWindow(
+                chunkSize: configuration.chunkSize,
+                chunkIndex: chunkIndex
+            )
+            for offset in 0..<available {
+                let destination = start + offset
+                let weight = fade[offset]
+                let value = values[offset]
+                accumulated[destination] += (value.isFinite ? value : 0) * weight
+                weights[destination] += weight
+            }
+            MLX.Memory.clearCache()
+            progress?(chunkIndex + 1, plan.starts.count)
+        }
+
+        for index in accumulated.indices {
+            accumulated[index] /= max(weights[index], 1e-8)
+        }
+        let output = plan.usesBorderPadding
+            ? Array(accumulated[plan.border..<(plan.border + narrowband48kSamples.count)])
+            : Array(accumulated.prefix(narrowband48kSamples.count))
+        let elapsed = started.duration(to: .now)
+        return APBWEEnhancementResult(
+            samples: output,
+            sampleRate: configuration.highSampleRate,
+            channels: 1,
+            frameCount: output.count,
+            chunkCount: plan.starts.count,
+            elapsedSeconds: Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+        )
+    }
+}

--- a/Sources/MereRunCore/APBWE/APBWEModel.swift
+++ b/Sources/MereRunCore/APBWE/APBWEModel.swift
@@ -1,0 +1,284 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+final class APBWEConvNeXtBlock: Module {
+    @ModuleInfo(key: "dwconv") var depthwiseConvolution: Conv1d
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+    @ModuleInfo(key: "pwconv1") var inputProjection: Linear
+    @ModuleInfo(key: "pwconv2") var outputProjection: Linear
+    @ParameterInfo(key: "gamma") var gamma: MLXArray
+
+    init(dimensions: Int, layerScale: Float) {
+        self._depthwiseConvolution.wrappedValue = Conv1d(
+            inputChannels: dimensions,
+            outputChannels: dimensions,
+            kernelSize: 7,
+            stride: 1,
+            padding: 3,
+            dilation: 1,
+            groups: dimensions,
+            bias: true
+        )
+        self._norm.wrappedValue = LayerNorm(dimensions: dimensions, eps: 1e-6)
+        self._inputProjection.wrappedValue = Linear(
+            dimensions,
+            dimensions * 3,
+            bias: true
+        )
+        self._outputProjection.wrappedValue = Linear(
+            dimensions * 3,
+            dimensions,
+            bias: true
+        )
+        self._gamma.wrappedValue = MLXArray.ones([dimensions]) * layerScale
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let residual = input
+        var hidden = depthwiseConvolution(input)
+        hidden = norm(hidden)
+        hidden = inputProjection(hidden)
+        hidden = Self.exactGELU(hidden)
+        hidden = outputProjection(hidden)
+        return residual + hidden * gamma
+    }
+
+    private static func exactGELU(_ input: MLXArray) -> MLXArray {
+        input * MLXArray(0.5).asType(input.dtype)
+            * (MLXArray(1).asType(input.dtype) + MLX.erf(input / sqrt(Float(2))))
+    }
+}
+
+public final class APBWEModel: Module {
+    @ModuleInfo(key: "conv_pre_mag") var magnitudeInputConvolution: Conv1d
+    @ModuleInfo(key: "norm_pre_mag") var magnitudeInputNorm: LayerNorm
+    @ModuleInfo(key: "conv_pre_pha") var phaseInputConvolution: Conv1d
+    @ModuleInfo(key: "norm_pre_pha") var phaseInputNorm: LayerNorm
+    @ModuleInfo(key: "convnext_mag") var magnitudeBlocks: [APBWEConvNeXtBlock]
+    @ModuleInfo(key: "convnext_pha") var phaseBlocks: [APBWEConvNeXtBlock]
+    @ModuleInfo(key: "norm_post_mag") var magnitudeOutputNorm: LayerNorm
+    @ModuleInfo(key: "norm_post_pha") var phaseOutputNorm: LayerNorm
+    @ModuleInfo(key: "linear_post_mag") var magnitudeOutput: Linear
+    @ModuleInfo(key: "linear_post_pha_r") var phaseRealOutput: Linear
+    @ModuleInfo(key: "linear_post_pha_i") var phaseImaginaryOutput: Linear
+
+    public let configuration: APBWEConfiguration
+
+    public init(configuration: APBWEConfiguration) {
+        self.configuration = configuration
+        let bins = configuration.frequencyBins
+        let dimensions = configuration.channels
+        let layerScale = 1 / Float(configuration.layers)
+        self._magnitudeInputConvolution.wrappedValue = Conv1d(
+            inputChannels: bins,
+            outputChannels: dimensions,
+            kernelSize: 7,
+            stride: 1,
+            padding: 3,
+            dilation: 1,
+            groups: 1,
+            bias: true
+        )
+        self._magnitudeInputNorm.wrappedValue = LayerNorm(
+            dimensions: dimensions,
+            eps: 1e-6
+        )
+        self._phaseInputConvolution.wrappedValue = Conv1d(
+            inputChannels: bins,
+            outputChannels: dimensions,
+            kernelSize: 7,
+            stride: 1,
+            padding: 3,
+            dilation: 1,
+            groups: 1,
+            bias: true
+        )
+        self._phaseInputNorm.wrappedValue = LayerNorm(
+            dimensions: dimensions,
+            eps: 1e-6
+        )
+        self._magnitudeBlocks.wrappedValue = (0..<configuration.layers).map { _ in
+            APBWEConvNeXtBlock(dimensions: dimensions, layerScale: layerScale)
+        }
+        self._phaseBlocks.wrappedValue = (0..<configuration.layers).map { _ in
+            APBWEConvNeXtBlock(dimensions: dimensions, layerScale: layerScale)
+        }
+        self._magnitudeOutputNorm.wrappedValue = LayerNorm(
+            dimensions: dimensions,
+            eps: 1e-6
+        )
+        self._phaseOutputNorm.wrappedValue = LayerNorm(
+            dimensions: dimensions,
+            eps: 1e-6
+        )
+        self._magnitudeOutput.wrappedValue = Linear(dimensions, bins, bias: true)
+        self._phaseRealOutput.wrappedValue = Linear(dimensions, bins, bias: true)
+        self._phaseImaginaryOutput.wrappedValue = Linear(dimensions, bins, bias: true)
+        super.init()
+    }
+
+    public static func load(
+        checkpoint: APBWECheckpoint,
+        dtype: DType = .float32
+    ) throws -> APBWEModel {
+        let model = APBWEModel(configuration: checkpoint.configuration)
+        let archive = try PyTorchStateDictArchive(
+            url: checkpoint.weightsURL.resolvingSymlinksInPath(),
+            verifyEntryChecksums: false
+        )
+        try model.validateCheckpoint(archive)
+
+        var mapped: [String: MLXArray] = [:]
+        mapped.reserveCapacity(archive.tensors.count)
+        var pending: [MLXArray] = []
+        var pendingBytes = 0
+        for descriptor in archive.tensors {
+            var value = try archive.loadArray(for: descriptor, dtype: dtype)
+            if Self.isConvolutionWeight(descriptor.name) {
+                value = value.transposed(0, 2, 1)
+                value = value.reshaped(-1).reshaped(value.shape)
+            }
+            mapped[descriptor.name] = value
+            pending.append(value)
+            pendingBytes += value.size * Self.byteCount(dtype)
+            if pendingBytes >= 64 * 1_024 * 1_024 {
+                MLX.eval(pending)
+                pending.removeAll(keepingCapacity: true)
+                pendingBytes = 0
+            }
+        }
+        if !pending.isEmpty {
+            MLX.eval(pending)
+        }
+        try model.update(parameters: ModuleParameters.unflattened(mapped), verify: .all)
+        MLX.eval(model)
+        return model
+    }
+
+    public func validateCheckpoint(_ archive: PyTorchStateDictArchive) throws {
+        let scalars = archive.tensors.reduce(0) { $0 + $1.elementCount }
+        guard archive.tensors.count == APBWEResources.expectedTensorCount,
+              scalars == APBWEResources.expectedScalarCount,
+              archive.tensors.allSatisfy({ $0.dataType == .float32 }) else {
+            throw APBWEError.invalidCheckpointInventory(
+                tensors: archive.tensors.count,
+                scalars: scalars
+            )
+        }
+
+        let expected = Dictionary(
+            uniqueKeysWithValues: parameters().flattened().map { ($0.0, $0.1.shape) }
+        )
+        let source = Dictionary(
+            uniqueKeysWithValues: archive.tensors.map { descriptor in
+                let shape = Self.isConvolutionWeight(descriptor.name)
+                    ? [descriptor.shape[0], descriptor.shape[2], descriptor.shape[1]]
+                    : descriptor.shape
+                return (descriptor.name, shape)
+            }
+        )
+        let expectedKeys = Set(expected.keys)
+        let sourceKeys = Set(source.keys)
+        guard expectedKeys == sourceKeys else {
+            throw APBWEError.checkpointKeyMismatch(
+                missing: Array(expectedKeys.subtracting(sourceKeys)).sorted(),
+                unexpected: Array(sourceKeys.subtracting(expectedKeys)).sorted()
+            )
+        }
+        for key in expectedKeys.sorted() {
+            guard let expectedShape = expected[key], let actualShape = source[key] else { continue }
+            guard expectedShape == actualShape else {
+                throw APBWEError.checkpointShapeMismatch(
+                    key: key,
+                    expected: expectedShape,
+                    actual: actualShape
+                )
+            }
+        }
+    }
+
+    /// Enhances one 48 kHz mono, channel-major chunk shaped `[batch, 1, samples]`.
+    public func callAsFunction(_ audio: MLXArray) -> MLXArray {
+        precondition(audio.ndim == 3 && audio.dim(1) == 1)
+        let sampleCount = audio.dim(2)
+        let window = Self.paddedPeriodicHannWindow(
+            nFFT: configuration.nFFT,
+            winSize: configuration.winSize,
+            dtype: audio.dtype
+        )
+        let spectrum = RoFormerDSP.stft(
+            audio,
+            nFFT: configuration.nFFT,
+            hopLength: configuration.hopSize,
+            window: window
+        )
+        let real = spectrum[.ellipsis, 0]
+        let imaginary = spectrum[.ellipsis, 1]
+        let logMagnitude = MLX.log(
+            MLX.sqrt(real.square() + imaginary.square())
+                + MLXArray(1e-4).asType(real.dtype)
+        ).transposed(0, 2, 1)
+        let phase = MLX.atan2(imaginary, real).transposed(0, 2, 1)
+
+        var magnitudeHidden = magnitudeInputNorm(magnitudeInputConvolution(logMagnitude))
+        var phaseHidden = phaseInputNorm(phaseInputConvolution(phase))
+        for index in magnitudeBlocks.indices {
+            magnitudeHidden = magnitudeHidden + phaseHidden
+            phaseHidden = phaseHidden + magnitudeHidden
+            magnitudeHidden = magnitudeBlocks[index](magnitudeHidden)
+            phaseHidden = phaseBlocks[index](phaseHidden)
+        }
+
+        let widebandMagnitude = logMagnitude
+            + magnitudeOutput(magnitudeOutputNorm(magnitudeHidden))
+        let normalizedPhase = phaseOutputNorm(phaseHidden)
+        let widebandPhase = MLX.atan2(
+            phaseImaginaryOutput(normalizedPhase),
+            phaseRealOutput(normalizedPhase)
+        )
+        let amplitude = MLX.exp(widebandMagnitude)
+        let reconstructed = MLX.stacked([
+            amplitude * MLX.cos(widebandPhase),
+            amplitude * MLX.sin(widebandPhase),
+        ], axis: -1).transposed(0, 2, 1, 3).expandedDimensions(axis: 1)
+        return RoFormerDSP.istft(
+            reconstructed,
+            channels: 1,
+            length: sampleCount,
+            nFFT: configuration.nFFT,
+            hopLength: configuration.hopSize,
+            window: window,
+            zeroDC: false
+        )
+    }
+
+    private static func paddedPeriodicHannWindow(
+        nFFT: Int,
+        winSize: Int,
+        dtype: DType
+    ) -> MLXArray {
+        let side = (nFFT - winSize) / 2
+        return MLX.concatenated([
+            MLX.zeros([side], dtype: dtype),
+            RoFormerDSP.periodicHannWindow(length: winSize, dtype: dtype),
+            MLX.zeros([nFFT - winSize - side], dtype: dtype),
+        ])
+    }
+
+    private static func isConvolutionWeight(_ key: String) -> Bool {
+        key == "conv_pre_mag.weight"
+            || key == "conv_pre_pha.weight"
+            || key.contains(".dwconv.weight")
+    }
+
+    private static func byteCount(_ dtype: DType) -> Int {
+        switch dtype {
+        case .bool, .int8, .uint8: 1
+        case .float16, .bfloat16, .int16, .uint16: 2
+        case .float32, .int32, .uint32: 4
+        case .float64, .int64, .uint64, .complex64: 8
+        }
+    }
+}

--- a/Sources/MereRunCore/APBWE/APBWEResources.swift
+++ b/Sources/MereRunCore/APBWE/APBWEResources.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public struct APBWECheckpoint: Sendable {
+    public let rootURL: URL
+    public let weightsURL: URL
+    public let sourceConfigurationURL: URL
+    public let codeLicenseURL: URL
+    public let weightsLicenseURL: URL
+    public let configuration: APBWEConfiguration
+}
+
+public struct APBWEResources: Sendable {
+    public static let modelID = "audio-enhance-ap-bwe-16kto48k"
+    public static let sourceRepository = "yxlu-0102/AP-BWE"
+    public static let sourceRevision = "751710f22404c27e5bcc983248f8b856a04b8422"
+    public static let artifactRepository = "rsxdalv/AP-BWE"
+    public static let artifactRevision = "fa3f46d233cbc1d75cec9321188f86db627ba239"
+    public static let officialDriveFolderID = "1IIYTf2zbJWzelu4IftKD6ooHloJ8mnZF"
+    public static let officialWeightsFileID = "1HYkD_5ha9GMrjzbTiSFiO1uQQwxXET15"
+    public static let expectedTensorCount = 162
+    public static let expectedScalarCount = 29_760_515
+
+    public static let weightsPin = ModelArtifactPin(
+        filename: "weights/16kto48k/g_16kto48k.zip",
+        byteCount: 119_097_961,
+        sha256: "305a05dcab7dc29ffba09d32692d7a34550fc8fbdf338013641ff5d39a3cb285"
+    )
+    public static let sourceConfigurationPin = ModelArtifactPin(
+        filename: "weights/16kto48k/config.json",
+        byteCount: 515,
+        sha256: "d722dcda233d6b00669cc37fa1286d9a49ad8d18082f28c20f895303e706852e"
+    )
+    public static let codeLicensePin = ModelArtifactPin(
+        filename: "LICENSE.txt",
+        byteCount: 1_066,
+        sha256: "ebb9bf8bb881d60baf37b56772ad9e83813286ecc8b0853914de9d15fe3fec66"
+    )
+    public static let weightsLicensePin = ModelArtifactPin(
+        filename: "weights_LICENSE.txt",
+        byteCount: 175,
+        sha256: "506d3a47a2c84814c8d6a84f0450a18fb9d67c03bb30d8b7e9d357d9540be2d3"
+    )
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public static func loadBundledConfiguration() throws -> APBWEConfiguration {
+        let nested = Bundle.module.url(
+            forResource: "16kto48k",
+            withExtension: "json",
+            subdirectory: "APBWE"
+        )
+        guard let url = nested ?? Bundle.module.url(
+            forResource: "16kto48k",
+            withExtension: "json"
+        ) else {
+            throw APBWEError.missingBundledConfiguration
+        }
+        let configuration = try JSONDecoder().decode(
+            APBWEConfiguration.self,
+            from: Data(contentsOf: url)
+        )
+        try configuration.validate()
+        return configuration
+    }
+
+    public static var pins: [ModelArtifactPin] {
+        [weightsPin, sourceConfigurationPin, codeLicensePin, weightsLicensePin]
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        Self.pins.compactMap { pin in
+            do {
+                _ = try pin.verify(in: rootURL, fileManager: fileManager)
+                return nil
+            } catch {
+                return rootURL.appendingPathComponent(pin.filename)
+            }
+        }
+    }
+
+    public func validationMessages(fileManager: FileManager = .default) -> [String] {
+        Self.pins.compactMap { pin in
+            do {
+                _ = try pin.verify(in: rootURL, fileManager: fileManager)
+                return nil
+            } catch {
+                return error.localizedDescription
+            }
+        }
+    }
+
+    public func resolve() throws -> APBWECheckpoint {
+        APBWECheckpoint(
+            rootURL: rootURL,
+            weightsURL: try Self.weightsPin.verify(in: rootURL),
+            sourceConfigurationURL: try Self.sourceConfigurationPin.verify(in: rootURL),
+            codeLicenseURL: try Self.codeLicensePin.verify(in: rootURL),
+            weightsLicenseURL: try Self.weightsLicensePin.verify(in: rootURL),
+            configuration: try Self.loadBundledConfiguration()
+        )
+    }
+}

--- a/Sources/MereRunCore/APBWE/README.md
+++ b/Sources/MereRunCore/APBWE/README.md
@@ -1,0 +1,15 @@
+# AP-BWE audio enhancement
+
+This module is a native Swift/MLX port of the MIT-licensed AP-BWE 16 kHz to
+48 kHz speech bandwidth-extension profile.
+
+- `APBWEConfiguration.swift` owns the exact typed profile.
+- `APBWEResources.swift` pins source, transport snapshot, checkpoint, config,
+  code license, and weights license.
+- `APBWEModel.swift` owns the magnitude/phase ConvNeXt graph and restricted
+  PyTorch state-dict loader.
+- `APBWEEnhancer.swift` owns deterministic 3x interpolation and overlap-add
+  chunk execution.
+
+The managed checkpoint is downloaded separately. Do not relax the artifact
+pins or graph-inventory checks to admit a repackaged checkpoint.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -17,6 +17,7 @@ public enum ManagedModelCategory: String, CaseIterable, Hashable, Sendable {
     case visionGeometry = "vision-geometry"
     case visionDepth = "vision-depth"
     case image3D = "image-3d"
+    case audio = "audio"
     case music = "music"
     case sfx = "sfx"
     case video = "video"
@@ -65,6 +66,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case magentaRT2
     case muScriptor
     case roFormer
+    case apBWE
     case woosh
     case wooshClap
     case wooshSynchformer
@@ -1999,6 +2001,21 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["music separate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.apBWE16kTo48k.rawValue,
+            category: .audio,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: APBWEResources.artifactRepository,
+                revision: APBWEResources.artifactRevision,
+                patterns: APBWEResources.pins.map(\.filename)
+            ),
+            upstreamRepoId: APBWEResources.sourceRepository,
+            upstreamRevision: APBWEResources.sourceRevision,
+            validationKind: .apBWE,
+            estimatedDownloadBytes: 119_099_717,
+            defaultCLICommands: ["audio enhance"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.wooshDFlow.rawValue,
             category: .sfx,
             installShape: .structuredRoot,
@@ -2570,6 +2587,8 @@ public extension ManagedModelSpec {
                 return resources.validate(fileManager: fileManager)
             }
             return [rootURL]
+        case .apBWE:
+            return APBWEResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .woosh:
             let checkpointsRoot = WooshResources.normalizeRoot(rootURL, fileManager: fileManager)
             let variant = WooshVariant.resolve(model: id, rootURL: checkpointsRoot, fileManager: fileManager) ?? .dflow
@@ -2725,6 +2744,10 @@ public extension ManagedModelSpec {
                 return resources.validationMessages(fileManager: fileManager)
             }
             return ["Unsupported managed RoFormer model id: \(id)"]
+        case .apBWE:
+            return APBWEResources(
+                rootURL: normalizedRootURL(rootURL, fileManager: fileManager)
+            ).validationMessages(fileManager: fileManager)
         default:
             return missingPaths(in: rootURL, fileManager: fileManager).map { "Missing required file: \($0.path)" }
         }

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -723,6 +723,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 16
             ),
             descriptor(
+                ModelResolver.ModelID.apBWE16kTo48k.rawValue,
+                "AP-BWE speech bandwidth extension",
+                "Extends 16 kHz narrowband speech to 48 kHz with native MLX inference.",
+                minimum: 8,
+                recommended: 16
+            ),
+            descriptor(
                 ModelResolver.ModelID.wooshDFlow.rawValue,
                 "Woosh DFlow",
                 "Generates Foley and sound effects from text prompts with Sony Research Woosh.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -76,6 +76,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case muScriptor = "muscriptor"
         /// Band-split RoFormer music source-separation family.
         case roFormer = "bs-roformer"
+        /// AP-BWE speech bandwidth-extension family.
+        case apBWE = "ap-bwe"
         /// Sony Research Woosh sound-effect generation family.
         case woosh = "woosh"
         /// MMAudio synchronized video-to-audio and text-to-audio family.
@@ -116,6 +118,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case privacy
         case code
         case ocr
+        case audio
         case music
         case sfx
         case video
@@ -170,6 +173,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case musicGeneration = "music_generation"
         case musicTranscription = "music_transcription"
         case musicSeparation = "music_separation"
+        case audioEnhancement = "audio_enhancement"
         case videoGeneration = "video_generation"
         case actionGeneration = "action_generation"
         case worldSimulation = "world_simulation"
@@ -1671,6 +1675,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.musicSeparation],
                 components: nil,
                 upstreamRepoId: "\(RoFormerResources.repository)@\(RoFormerResources.revision)",
+                createdAt: createdAt
+            )
+        case .apBWE16kTo48k:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .apBWE,
+                family: .audio,
+                tier: .small,
+                variant: .standard,
+                precision: .fp32,
+                defaults: nil,
+                supports: [.audioEnhancement],
+                components: nil,
+                upstreamRepoId: "\(APBWEResources.sourceRepository)@\(APBWEResources.sourceRevision)",
                 createdAt: createdAt
             )
         case .wooshDFlow, .wooshFlow, .wooshVFlow8s, .wooshDVFlow8s:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -104,6 +104,7 @@ public enum MereRunModelValidator {
             case .directoryRoot, .structuredRoot:
                 return spec.validationKind != .codegenGGUF
                     && spec.validationKind != .roFormer
+                    && spec.validationKind != .apBWE
                     && spec.validationKind != .deepseekV4FlashIMatrixGGUF
                     && spec.validationKind != .magentaRT2
                     && spec.validationKind != .woosh
@@ -147,6 +148,7 @@ public enum MereRunModelValidator {
             tokenizerDir = nil
         } else if spec?.validationKind == .aceStep
             || spec?.validationKind == .roFormer
+            || spec?.validationKind == .apBWE
             || spec?.validationKind == .sortformer
             || spec?.validationKind == .magentaRT2
             || spec?.validationKind == .muScriptor
@@ -410,6 +412,8 @@ public enum MereRunModelValidator {
                 && engine != .magentaRT2
                 && engine != .muScriptor:
                 warnings.append("Manifest engine mismatch: family=music expects ace-step, bs-roformer, magenta-rt2, or muscriptor.")
+            case .audio where engine != .apBWE:
+                warnings.append("Manifest engine mismatch: family=audio expects ap-bwe.")
             case .sfx where engine != .woosh && engine != .mmaudio:
                 warnings.append("Manifest engine mismatch: family=sfx expects woosh or mmaudio.")
             case .video where engine != .ltxVideo && engine != .wanVideo:
@@ -487,7 +491,7 @@ public enum MereRunModelValidator {
                 return true
             }
             switch manifest.engine {
-            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .roFormer?, .woosh?, .mmaudio?, .ltxVideo?,
+            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .roFormer?, .apBWE?, .woosh?, .mmaudio?, .ltxVideo?,
                  .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?,
                  .insightFace?, .sortformer?:
                 return true

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -86,6 +86,7 @@ public struct ModelResolver {
         case roFormerFourStem = "music-separate-bs-roformer-4stem"
         case melRoFormerDereverb = "music-separate-mel-roformer-dereverb"
         case melRoFormerDenoise = "music-separate-mel-roformer-denoise"
+        case apBWE16kTo48k = "audio-enhance-ap-bwe-16kto48k"
         case wooshDFlow = "sfx-woosh-dflow"
         case wooshFlow = "sfx-woosh-flow"
         case wooshClap = "sfx-woosh-clap"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -70,6 +70,7 @@ public enum QuantizedModelManifestWriter {
             case .qwen3Coder, .northMiniCode: return .code
             case .lightOnOCR: return .ocr
             case .aceStep, .magentaRT2, .muScriptor, .roFormer: return .music
+            case .apBWE: return .audio
             case .woosh, .mmaudio: return .sfx
             case .ltxVideo, .wanVideo, .cosmos3Edge: return .video
             case .psiChat: return .psi
@@ -155,6 +156,8 @@ public enum QuantizedModelManifestWriter {
                     return [.musicTranscription]
                 case .roFormer:
                     return [.musicSeparation]
+                case .apBWE:
+                    return [.audioEnhancement]
                 case .woosh:
                     return [.soundEffectGeneration]
                 case .mmaudio:
@@ -242,7 +245,7 @@ public enum QuantizedModelManifestWriter {
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .sortformer, .qwen3Embedding, .openAIPrivacyFilter,
                  .qwen3Coder, .northMiniCode, .lightOnOCR, .woosh, .mmaudio, .psiChat, .deepseekV4Flash,
-                 .muScriptor, .roFormer, .inkling:
+                 .muScriptor, .roFormer, .apBWE, .inkling:
                 break
             case .aceStep, .magentaRT2, .ltxVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)

--- a/Sources/MereRunCore/Resources/APBWE/16kto48k.json
+++ b/Sources/MereRunCore/Resources/APBWE/16kto48k.json
@@ -1,0 +1,11 @@
+{
+  "channels": 512,
+  "layers": 8,
+  "n_fft": 1024,
+  "hop_size": 80,
+  "win_size": 320,
+  "high_sample_rate": 48000,
+  "low_sample_rate": 16000,
+  "chunk_size": 96000,
+  "overlap": 2
+}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -479,6 +479,40 @@ or distribute NVIDIA's separately proprietary FlexiCubes or renderer source;
 mesh topology is produced by mere.run's native marching-tetrahedra code and no
 FlexiCubes topology-parity claim is made.
 
+### AP-BWE
+
+- purpose: native Swift/MLX 16 kHz to 48 kHz speech bandwidth extension
+- upstream project: [`yxlu-0102/AP-BWE`](https://github.com/yxlu-0102/AP-BWE)
+- upstream commit used for the port: `751710f22404c27e5bcc983248f8b856a04b8422`
+- code and pretrained-weight license: MIT
+
+The model checkpoint is downloaded separately into the user's model store.
+Managed installs retain and verify the upstream code and weights license files.
+
+```text
+MIT License
+
+Copyright (c) 2023 Ye-Xin Lu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### MuScriptor
 
 - purpose: native MLX audio-to-MIDI model, tokenizer, event decoder, and MIDI behavior

--- a/Tests/MereRunCLITests/AudioEnhanceCommandTests.swift
+++ b/Tests/MereRunCLITests/AudioEnhanceCommandTests.swift
@@ -1,0 +1,39 @@
+@testable import MereRunCLI
+import MereRunCore
+import XCTest
+
+final class AudioEnhanceCommandTests: XCTestCase {
+    func testDefaultsUsePinnedAPBWEModel() throws {
+        let command = try AudioEnhance.parse(["speech.wav"])
+        XCTAssertEqual(command.audio, "speech.wav")
+        XCTAssertEqual(command.model, ModelResolver.ModelID.apBWE16kTo48k.rawValue)
+        XCTAssertEqual(command.dtype, "float32")
+        XCTAssertNil(command.overlap)
+        XCTAssertNoThrow(try command.validate())
+    }
+
+    func testParsesOutputAndComputeOptions() throws {
+        let command = try AudioEnhance.parse([
+            "speech.wav",
+            "--output", "wideband.wav",
+            "--dtype", "float16",
+            "--overlap", "4",
+        ])
+        XCTAssertEqual(command.output, "wideband.wav")
+        XCTAssertEqual(command.dtype, "float16")
+        XCTAssertEqual(command.overlap, 4)
+        XCTAssertNoThrow(try command.validate())
+    }
+
+    func testRejectsUnsupportedModelOverlapAndComputeType() {
+        XCTAssertThrowsError(try AudioEnhance.parse([
+            "speech.wav", "--model", "music-separate-bs-roformer-viperx-1297",
+        ]))
+        XCTAssertThrowsError(try AudioEnhance.parse(["speech.wav", "--overlap", "7"]))
+        XCTAssertThrowsError(try AudioEnhance.parse(["speech.wav", "--dtype", "bfloat16"]))
+    }
+
+    func testAudioCommandOwnsEnhanceSubcommand() {
+        XCTAssertEqual(Audio.configuration.subcommands.map { $0.configuration.commandName }, ["enhance"])
+    }
+}

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -117,6 +117,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "text",
             "speech",
             "vision",
+            "audio",
             "music",
             "sfx",
             "video",

--- a/Tests/MereRunCoreTests/APBWETests.swift
+++ b/Tests/MereRunCoreTests/APBWETests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import MLX
+@testable import MereRunCore
+import XCTest
+
+final class APBWETests: MereRunCoreTestCase {
+    func testBundledConfigurationMatchesPinnedProfile() throws {
+        let configuration = try APBWEResources.loadBundledConfiguration()
+        XCTAssertEqual(configuration.channels, 512)
+        XCTAssertEqual(configuration.layers, 8)
+        XCTAssertEqual(configuration.frequencyBins, 513)
+        XCTAssertEqual(configuration.nFFT, 1_024)
+        XCTAssertEqual(configuration.hopSize, 80)
+        XCTAssertEqual(configuration.winSize, 320)
+        XCTAssertEqual(configuration.lowSampleRate, 16_000)
+        XCTAssertEqual(configuration.highSampleRate, 48_000)
+        XCTAssertEqual(configuration.chunkSize, 96_000)
+        XCTAssertEqual(configuration.overlap, 2)
+    }
+
+    func testNativeGraphHasExactUpstreamInventory() throws {
+        let model = APBWEModel(
+            configuration: try APBWEResources.loadBundledConfiguration()
+        )
+        let flattened = model.parameters().flattened()
+        let parameters = Dictionary(uniqueKeysWithValues: flattened)
+        XCTAssertEqual(parameters.count, APBWEResources.expectedTensorCount)
+        XCTAssertEqual(
+            parameters.values.reduce(0) { $0 + $1.size },
+            APBWEResources.expectedScalarCount
+        )
+        XCTAssertEqual(parameters["conv_pre_mag.weight"]?.shape, [512, 7, 513])
+        XCTAssertEqual(parameters["convnext_mag.0.dwconv.weight"]?.shape, [512, 7, 1])
+        XCTAssertEqual(parameters["convnext_pha.7.pwconv1.weight"]?.shape, [1_536, 512])
+        XCTAssertEqual(parameters["linear_post_pha_i.weight"]?.shape, [513, 512])
+    }
+
+    func testBandlimitedUpsamplerProducesThreeSamplesPerInputSample() {
+        let source: [Float] = [0.25, -0.5, 0.75, -1]
+        let upsampled = APBWEAudio.upsample16kTo48k(source)
+        XCTAssertEqual(upsampled.count, source.count * 3)
+        for index in source.indices {
+            XCTAssertEqual(upsampled[index * 3], source[index], accuracy: 1e-5)
+        }
+        XCTAssertTrue(upsampled.allSatisfy(\.isFinite))
+    }
+
+    func testReflectionPaddingSupportsInputsShorterThanChunkBorder() {
+        let source: [Float] = [1, 2, 3, 4]
+        let padded = APBWEAudio.reflectPad(source, amount: 6)
+        XCTAssertEqual(padded.count, 16)
+        XCTAssertEqual(Array(padded[6..<10]), source)
+        XCTAssertEqual(Array(padded.prefix(6)), [1, 2, 3, 4, 3, 2])
+        XCTAssertEqual(Array(padded.suffix(6)), [3, 2, 1, 2, 3, 4])
+    }
+
+    func testPinnedOfficialCheckpointInventoryWhenFixtureIsAvailable() throws {
+        let path = ProcessInfo.processInfo.environment["MERERUN_TEST_APBWE_CHECKPOINT"] ?? ""
+        try XCTSkipIf(
+            path.isEmpty || !FileManager.default.fileExists(atPath: path),
+            "Set MERERUN_TEST_APBWE_CHECKPOINT to the pinned g_16kto48k archive."
+        )
+        let archive = try PyTorchStateDictArchive(
+            url: URL(fileURLWithPath: path),
+            verifyEntryChecksums: false
+        )
+        XCTAssertEqual(archive.tensors.count, APBWEResources.expectedTensorCount)
+        XCTAssertEqual(
+            archive.tensors.reduce(0) { $0 + $1.elementCount },
+            APBWEResources.expectedScalarCount
+        )
+        XCTAssertEqual(Set(archive.tensors.map(\.dataType)), [.float32])
+        XCTAssertEqual(
+            archive.descriptor(named: "conv_pre_mag.weight")?.shape,
+            [512, 513, 7]
+        )
+        XCTAssertEqual(
+            archive.descriptor(named: "convnext_mag.0.dwconv.weight")?.shape,
+            [512, 1, 7]
+        )
+        XCTAssertEqual(
+            archive.descriptor(named: "linear_post_pha_i.weight")?.shape,
+            [513, 512]
+        )
+        try APBWEModel(
+            configuration: APBWEResources.loadBundledConfiguration()
+        ).validateCheckpoint(archive)
+    }
+
+    func testManagedCatalogPinsExactMITSnapshot() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.apBWE16kTo48k.rawValue)
+        )
+        XCTAssertEqual(spec.category, .audio)
+        XCTAssertEqual(spec.validationKind, .apBWE)
+        XCTAssertEqual(spec.upstreamRepoId, APBWEResources.sourceRepository)
+        XCTAssertEqual(spec.upstreamRevision, APBWEResources.sourceRevision)
+        XCTAssertEqual(spec.hubFallback?.repoId, APBWEResources.artifactRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, APBWEResources.artifactRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, APBWEResources.pins.map(\.filename))
+        XCTAssertNil(spec.usageRestriction)
+        XCTAssertEqual(spec.defaultCLICommands, ["audio enhance"])
+    }
+
+    func testManifestTemplateDeclaresAudioEnhancement() {
+        let manifest = MereRunModelManifest.template(
+            for: .apBWE16kTo48k,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.engine, .apBWE)
+        XCTAssertEqual(manifest.family, .audio)
+        XCTAssertEqual(manifest.precision, .fp32)
+        XCTAssertEqual(manifest.supports, [.audioEnhancement])
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(APBWEResources.sourceRepository)@\(APBWEResources.sourceRevision)"
+        )
+    }
+}

--- a/docs/.vitepress/command-pages.tsv
+++ b/docs/.vitepress/command-pages.tsv
@@ -6,6 +6,7 @@ image	/runtime/image
 text	/runtime/text
 speech	/runtime/speech
 vision	/runtime/vision
+audio	/runtime/audio
 music	/runtime/music
 sfx	/runtime/sfx
 video	/runtime/video

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,7 @@ export default defineConfig({
           { text: 'Text Runtime', link: '/runtime/text' },
           { text: 'Speech Runtime', link: '/runtime/speech' },
           { text: 'Vision Runtime', link: '/runtime/vision' },
+          { text: 'Audio Enhancement', link: '/runtime/audio' },
           { text: 'Music Runtime', link: '/runtime/music' },
           { text: 'ACE-Step Validation', link: '/runtime/acestep-validation' },
           { text: 'SFX Runtime', link: '/runtime/sfx' },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,6 +170,15 @@ Music source separation:
   - `Sources/MereRunCore/RoFormer/BSRoFormer.swift`
   - `Sources/MereRunCore/RoFormer/RoFormerDSP.swift`
 
+Speech bandwidth extension:
+
+- CLI: `Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift`
+- Runtime entrypoint: `Sources/MereRunCore/APBWE/APBWEEnhancer.swift`
+- Read next:
+  - `Sources/MereRunCore/APBWE/APBWEResources.swift`
+  - `Sources/MereRunCore/APBWE/APBWEModel.swift`
+  - `docs/architecture/audio-enhancement-ap-bwe-report.md`
+
 Sound-effect generation:
 
 - CLI: `Sources/MereRunCLI/Commands/SFXGenerateCommand.swift`

--- a/docs/architecture/audio-enhancement-ap-bwe-report.md
+++ b/docs/architecture/audio-enhancement-ap-bwe-report.md
@@ -1,0 +1,53 @@
+# AP-BWE speech bandwidth-extension implementation report
+
+## Decision
+
+AP-BWE's 16 kHz to 48 kHz profile is admitted as a separate native audio
+enhancement runtime. It is intentionally not presented as music mastering or
+general audio super-resolution.
+
+## Source and license admission
+
+| Item | Frozen identity | License/admission result |
+| --- | --- | --- |
+| Source | `yxlu-0102/AP-BWE@751710f22404c27e5bcc983248f8b856a04b8422` | MIT |
+| Official checkpoint | Google Drive file `1HYkD_5ha9GMrjzbTiSFiO1uQQwxXET15` | Upstream states weights use the same MIT license |
+| Managed transport | `rsxdalv/AP-BWE@fa3f46d233cbc1d75cec9321188f86db627ba239` | Public mirror used only for transport |
+
+The managed `g_16kto48k.zip` has 119,097,961 bytes and SHA-256
+`305a05dcab7dc29ffba09d32692d7a34550fc8fbdf338013641ff5d39a3cb285`.
+Those bytes match the official Drive checkpoint exactly. The source config,
+code license, and weights-license files are also independently pinned by byte
+count and SHA-256. Runtime readiness fails if any of the four changes.
+
+## Native graph
+
+The typed graph contains 162 float32 tensors and 29,760,515 scalars. It follows
+the published 16→48 kHz profile:
+
+- mono 16 kHz decoding and deterministic 3x band-limited interpolation;
+- centered 1,024-point STFT with a periodic 320-sample Hann window padded to
+  the FFT size and an 80-sample hop;
+- magnitude and phase input convolutions from 513 bins to 512 channels;
+- eight paired ConvNeXt blocks per stream using depthwise kernel-7 convolution,
+  layer norm, exact GELU, 3x channel expansion, layer scale, and residuals;
+- the upstream sequential magnitude/phase cross-add update;
+- residual log-magnitude prediction, atan2 phase reconstruction, and native
+  ISTFT back to the input duration.
+
+PyTorch Conv1d tensors are transposed from `[out, in, kernel]` to MLX's
+`[out, kernel, in]` layout. The loader rejects key, shape, dtype, tensor-count,
+scalar-count, byte-count, and whole-file hash drift.
+
+## Runtime boundary
+
+`mere.run audio enhance` is a new top-level audio command because the same
+surface can later host general audio super-resolution without conflating it
+with music stem separation. This PR adds only AP-BWE; UniverSR remains a
+separate stacked review.
+
+The installed-model gate produces a real WAV artifact through the public
+command. The manual checkpoint smoke additionally verifies a 48 kHz mono,
+finite, non-silent output and reports energy above the original 8 kHz
+narrowband boundary. These checks prove execution and artifact integrity, not
+a perceptual benchmark.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,8 @@ Public tree:
   - `mere.run vision image-to-3d-trellis2` — Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2.
   - `mere.run vision image-to-3d-multiview` — VFX alias for native 4/6-view InstantMesh reconstruction.
   - `mere.run vision ocr` — Extract text from images using LightOnOCR, GLM-OCR, or Infinity-Parser2.
+- [`mere.run audio`](/runtime/audio) — Enhance general audio locally.
+  - `mere.run audio enhance` — Extend narrowband speech from 16 kHz to 48 kHz with AP-BWE.
 - [`mere.run music`](/runtime/music) — Generate, analyze, transcribe, and separate music locally.
   - `mere.run music analyze` — Analyze source audio with ACE-Step audio understanding.
   - `mere.run music generate` — Generate audio from a music prompt.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,6 +146,7 @@ itself, so it always matches the binary you just built:
 | [`mere.run text`](/runtime/text) | Run local chat, code, embedding, and anonymization workflows. |
 | [`mere.run speech`](/runtime/speech) | Synthesize, transcribe, diarize, and manage voice profiles. |
 | [`mere.run vision`](/runtime/vision) | Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media. |
+| [`mere.run audio`](/runtime/audio) | Enhance general audio locally. |
 | [`mere.run music`](/runtime/music) | Generate, analyze, transcribe, and separate music locally. |
 | [`mere.run sfx`](/runtime/sfx) | Generate sound effects locally. |
 | [`mere.run video`](/runtime/video) | Generate and understand video with native Swift/MLX pipelines. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ links to the page that owns that command.
 | [`mere.run text`](/runtime/text) | Run local chat, code, embedding, and anonymization workflows. |
 | [`mere.run speech`](/runtime/speech) | Synthesize, transcribe, diarize, and manage voice profiles. |
 | [`mere.run vision`](/runtime/vision) | Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media. |
+| [`mere.run audio`](/runtime/audio) | Enhance general audio locally. |
 | [`mere.run music`](/runtime/music) | Generate, analyze, transcribe, and separate music locally. |
 | [`mere.run sfx`](/runtime/sfx) | Generate sound effects locally. |
 | [`mere.run video`](/runtime/video) | Generate and understand video with native Swift/MLX pipelines. |

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -103,6 +103,7 @@ from the runtime catalog used by `mere.run model list`,
 | `music` | `music-separate-bs-roformer-4stem` |
 | `music` | `music-separate-mel-roformer-dereverb` |
 | `music` | `music-separate-mel-roformer-denoise` |
+| `audio` | `audio-enhance-ap-bwe-16kto48k` |
 | `sfx` | `sfx-woosh-dflow` |
 | `sfx` | `sfx-woosh-flow` |
 | `sfx` | `sfx-woosh-clap` |
@@ -182,6 +183,12 @@ admits the weights, source configuration, model card, and license only when all
 four match their model-specific frozen byte counts and SHA-256 digests. The
 MelBand profiles additionally retain separate dereverb and denoise source
 configs and exact 913 MB checkpoint hashes.
+
+`audio-enhance-ap-bwe-16kto48k` does not require acknowledgement. AP-BWE's
+pinned source repository states that both code and pretrained weights are MIT.
+The managed public transport snapshot retains the code and weights license
+files, source config, and the exact official 16→48 kHz checkpoint archive;
+mere.run verifies all four byte counts and SHA-256 digests before loading.
 
 `image-zimage-nano` also does not require acknowledgement. Its canonical
 `Tongyi-MAI/Z-Image-Turbo` base is Apache-2.0; the pinned mflux conversion's

--- a/docs/runtime/audio.md
+++ b/docs/runtime/audio.md
@@ -1,0 +1,49 @@
+# Audio Enhancement Runtime
+
+Extend narrowband speech to a 48 kHz wideband artifact with a native Swift/MLX
+port of AP-BWE. The runtime is local-only, verifies the checkpoint and licenses
+before loading, and keeps machine-readable results on stdout.
+
+## Command
+
+| Command | What it does |
+| --- | --- |
+| `mere.run audio enhance` | Decode speech to 16 kHz mono and reconstruct a 48 kHz mono float WAV with AP-BWE. |
+
+## Model
+
+- `audio-enhance-ap-bwe-16kto48k`
+
+The source implementation is pinned to
+[`yxlu-0102/AP-BWE@751710f`](https://github.com/yxlu-0102/AP-BWE/tree/751710f22404c27e5bcc983248f8b856a04b8422).
+The official repository states that both code and pretrained weights are MIT.
+The public Hugging Face transport snapshot is pinned independently; mere.run
+accepts its 16→48 kHz archive only because it is byte-identical to the official
+Google Drive checkpoint.
+
+## Typical workflow
+
+```bash
+swift run mere.run model pull audio-enhance-ap-bwe-16kto48k
+swift run mere.run audio enhance ./narrowband-speech.wav \
+  --output ./wideband-speech.wav
+```
+
+Input is decoded to 16 kHz mono, then upsampled threefold with a deterministic
+windowed-sinc/Lanczos filter before the neural reconstruction stage. The pinned
+profile uses a 1,024-point STFT, 320-sample periodic Hann window, 80-sample hop,
+512 channels, and eight paired magnitude/phase ConvNeXt blocks. Chunked overlap
+uses two-second 48 kHz windows by default.
+
+The command writes the float WAV and a sibling JSON file. That manifest records
+the source and output hashes, original and decoded audio geometry, immutable
+code and artifact revisions, checkpoint/config hashes, compute type, chunk
+count, overlap, and elapsed time. The same JSON is written to stdout; progress
+remains on stderr.
+
+AP-BWE is a speech bandwidth-extension model, not a general mastering model.
+A decoded, finite, non-silent output proves the native route executed; it does
+not by itself establish perceptual improvement for a particular recording.
+
+See the [implementation report](../architecture/audio-enhancement-ap-bwe-report.md)
+for admission evidence and graph details.


### PR DESCRIPTION
## Summary

- add native Swift/MLX AP-BWE speech bandwidth extension through `mere.run audio enhance`
- admit the official MIT 16 kHz to 48 kHz checkpoint through an exact byte-identical public transport snapshot
- reproduce the paired magnitude/phase ConvNeXt graph, deterministic band-limited interpolation, chunking, and overlap behavior
- write a 48 kHz mono float WAV and hashed provenance manifest

## Why

AP-BWE provides a focused, permissively licensed speech enhancement route and establishes a dedicated audio-enhancement command without presenting it as music mastering.

## Validation

- `./scripts/check.sh` — 2,379 tests passed, 151 skipped, 0 failed
- exact official checkpoint fixture: 162 tensors and 29,760,515 scalars validated
- real 2.75-second speech smoke produced a 48 kHz mono output with SHA-256 `c98f7082840f0c418e43fb24efb460538626ba2a83714d8dd3d85d0cb74a31bc`
- output was finite, non-silent, and contained energy above the original 8 kHz boundary

## Stack

Depends on the MelBand branch and targets `codex/roformer-melband` for an isolated review diff.
