### PR TITLE
feat(audio): add native UniverSR enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ The format is based on Keep a Changelog.
   transport snapshot, verifies the checkpoint/config/code-license/weights-
   license hashes, reproduces the paired magnitude/phase ConvNeXt graph, and
   writes a 48 kHz mono float WAV plus a hashed provenance manifest.
+- added native UniverSR general-audio super-resolution through the same
+  `audio enhance` surface and the managed `audio-enhance-universr-audio`
+  model. The port pins the MIT source and CC BY 4.0 official checkpoint
+  independently, validates the exact 394-tensor ConvNeXt V2 U-Net, reproduces
+  the published complex-STFT and flow-matching path for 8/12/16/24 kHz input,
+  and records ODE, guidance, seed, license, and artifact provenance.
 
 ## 0.31.0 - 2026-08-01
 

--- a/Package.swift
+++ b/Package.swift
@@ -345,6 +345,7 @@ targets.append(contentsOf: [
       "MMAudio/README.md",
       "PrivacyFilter/README.md",
       "RoFormer/README.md",
+      "UniverSR/README.md",
       "Pose/README.md",
       "OpticalFlow/README.md",
       "Psi/README.md",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ current flags.
 | Text, code, and agents | `text chat`, `text code`, `text embed`, `text anonymize`, `text train-lora`, `agent` | Local chat and tool use, including Bonsai 27B binary/ternary vision chat; code generation, embeddings, PII redaction, text LoRA training, and guided local-agent setup |
 | Vision understanding | `vision caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
-| Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension from 16 kHz narrowband input to a hashed 48 kHz mono WAV |
+| Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension and UniverSR general-audio super-resolution to hashed 48 kHz mono WAVs |
 | Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | LTX video, synchronized LTX 2.3 audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
 | Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
 | Speech | `speech synthesize`, `speech transcribe`, `speech diarize`, `speech listen`, `speech profile` | Qwen3 TTS, saved voice profiles, Qwen3 live ASR, Parakeet transcription, and native MLX Sortformer speaker diarization |
@@ -619,6 +619,12 @@ swift run mere.run music separate ./noisy.wav \
 swift run mere.run model pull audio-enhance-ap-bwe-16kto48k
 swift run mere.run audio enhance ./speech.wav \
   --output ./speech-wideband.wav
+
+# Super-resolve bandwidth-limited speech, music, or sound effects with UniverSR
+swift run mere.run model pull audio-enhance-universr-audio
+swift run mere.run audio enhance ./music-12k.wav \
+  --model audio-enhance-universr-audio \
+  --output ./music-super-resolved.wav
 
 # Generate a style-transfer cover from a source song
 swift run mere.run music generate \

--- a/Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift
+++ b/Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift
@@ -55,14 +55,76 @@ private struct AudioEnhancementManifest: Codable {
     let manifestPath: String
 }
 
+private struct UniverSREnhancementManifest: Codable {
+    struct Source: Codable {
+        let path: String
+        let sha256: String
+        let sampleRate: Int
+        let channels: Int
+        let frames: Int64
+    }
+
+    struct Preprocessing: Codable {
+        let decodedSampleRate: Int
+        let decodedChannels: Int
+        let decodedFrames: Int
+        let effectiveInputRate: Int
+        let modelInputSampleRate: Int
+        let modelInputFrames: Int
+        let resampler: String
+    }
+
+    struct Model: Codable {
+        let id: String
+        let sourceRepository: String
+        let sourceRevision: String
+        let codeLicense: String
+        let artifactRepository: String
+        let artifactRevision: String
+        let checkpointLicense: String
+        let weightsSHA256: String
+        let sourceConfigurationSHA256: String
+        let modelCardSHA256: String
+        let computeType: String
+    }
+
+    struct Inference: Codable {
+        let odeMethod: String
+        let odeSteps: Int
+        let guidanceScale: Float
+        let seed: UInt64
+        let chunkSeconds: Int
+        let chunks: Int
+        let elapsedSeconds: Double
+    }
+
+    struct Output: Codable {
+        let path: String
+        let sha256: String
+        let sampleRate: Int
+        let channels: Int
+        let frames: Int
+    }
+
+    let schemaVersion: Int
+    let createdAt: String
+    let source: Source
+    let preprocessing: Preprocessing
+    let model: Model
+    let inference: Inference
+    let output: Output
+    let manifestPath: String
+}
+
 struct AudioEnhance: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "enhance",
-        abstract: "Extend narrowband speech from 16 kHz to 48 kHz with AP-BWE.",
+        abstract: "Extend speech or general-audio bandwidth to 48 kHz.",
         discussion: """
-        Decodes the source to 16 kHz mono, performs band-limited 3x
-        interpolation, and reconstructs missing speech bandwidth with the
-        pinned MIT-licensed AP-BWE checkpoint using native Swift/MLX inference.
+        AP-BWE is the default for deterministic 16 kHz speech bandwidth
+        extension. Select audio-enhance-universr-audio for flow-matching
+        super-resolution of speech, music, or sound effects from an effective
+        8, 12, 16, or 24 kHz bandwidth. Both runtimes use native Swift/MLX.
         The output is a 48 kHz mono float WAV. A provenance manifest is saved
         beside the output and emitted as JSON on stdout.
 
@@ -71,16 +133,19 @@ struct AudioEnhance: ParsableCommand {
           mere.run audio enhance ./speech.wav
           mere.run audio enhance ./speech.mp3 --output ./speech-wideband.wav
           mere.run audio enhance ./speech.wav --dtype float16 --overlap 4
+          mere.run model pull audio-enhance-universr-audio
+          mere.run audio enhance ./music-12k.wav --model audio-enhance-universr-audio
+          mere.run audio enhance ./limited-48k.wav --model audio-enhance-universr-audio --input-rate 16000
         """
     )
 
-    @Argument(help: "Input speech file (WAV, MP3, M4A, FLAC, or another supported format).")
+    @Argument(help: "Input audio file (WAV, MP3, M4A, FLAC, or another supported format).")
     var audio: String
 
-    @Option(name: [.customShort("m"), .long], help: "Managed AP-BWE model id.")
+    @Option(name: [.customShort("m"), .long], help: "Managed audio enhancement model id.")
     var model: String = ModelResolver.ModelID.apBWE16kTo48k.rawValue
 
-    @Option(name: [.customLong("model-path")], help: "Explicit local root of the pinned AP-BWE snapshot.")
+    @Option(name: [.customLong("model-path")], help: "Explicit local root of the pinned model snapshot.")
     var modelPath: String?
 
     @Option(name: [.customShort("o"), .long], help: "Output 48 kHz mono float WAV path.")
@@ -89,6 +154,24 @@ struct AudioEnhance: ParsableCommand {
     @Option(name: [.long], help: "Chunk overlap count. Defaults to the published profile value (2).")
     var overlap: Int?
 
+    @Option(name: [.customLong("input-rate")], help: "UniverSR effective input bandwidth rate: 8000, 12000, 16000, or 24000 Hz.")
+    var inputRate: Int?
+
+    @Option(name: [.customLong("ode-method")], help: "UniverSR ODE method: euler, midpoint, or rk4.")
+    var odeMethod: String = "midpoint"
+
+    @Option(name: [.customLong("ode-steps")], help: "UniverSR ODE integration steps.")
+    var odeSteps: Int = 4
+
+    @Option(name: [.customLong("guidance-scale")], help: "UniverSR classifier-free guidance scale.")
+    var guidanceScale: Float = 1.5
+
+    @Option(name: [.long], help: "UniverSR noise seed.")
+    var seed: UInt64 = 42
+
+    @Option(name: [.customLong("chunk-seconds")], help: "UniverSR sequential chunk length in seconds (minimum 3).")
+    var chunkSeconds: Int = 10
+
     @Option(name: [.long], help: "Model compute type: float16 or float32.")
     var dtype: String = "float32"
 
@@ -96,15 +179,41 @@ struct AudioEnhance: ParsableCommand {
     var quiet: Bool = false
 
     func validate() throws {
-        guard model == ModelResolver.ModelID.apBWE16kTo48k.rawValue else {
+        let supported = [
+            ModelResolver.ModelID.apBWE16kTo48k.rawValue,
+            ModelResolver.ModelID.univerSRAudio.rawValue,
+        ]
+        guard supported.contains(model) else {
             throw ValidationError("Unsupported audio enhancement model id: \(model)")
         }
-        let configuration = try APBWEResources.loadBundledConfiguration()
-        let resolvedOverlap = overlap ?? configuration.overlap
-        guard resolvedOverlap > 0, configuration.chunkSize.isMultiple(of: resolvedOverlap) else {
-            throw ValidationError(
-                "--overlap must be a positive divisor of \(configuration.chunkSize)"
-            )
+        if model == ModelResolver.ModelID.apBWE16kTo48k.rawValue {
+            let configuration = try APBWEResources.loadBundledConfiguration()
+            let resolvedOverlap = overlap ?? configuration.overlap
+            guard resolvedOverlap > 0, configuration.chunkSize.isMultiple(of: resolvedOverlap) else {
+                throw ValidationError(
+                    "--overlap must be a positive divisor of \(configuration.chunkSize)"
+                )
+            }
+            if let inputRate, inputRate != configuration.lowSampleRate {
+                throw ValidationError("AP-BWE requires --input-rate 16000 when the option is supplied")
+            }
+        } else {
+            guard overlap == nil else {
+                throw ValidationError("--overlap applies only to AP-BWE")
+            }
+            if let inputRate, ![8_000, 12_000, 16_000, 24_000].contains(inputRate) {
+                throw ValidationError("--input-rate must be 8000, 12000, 16000, or 24000")
+            }
+            guard UniverSRODEMethod(rawValue: odeMethod.lowercased()) != nil else {
+                throw ValidationError("--ode-method must be euler, midpoint, or rk4")
+            }
+            guard odeSteps > 0 else { throw ValidationError("--ode-steps must be positive") }
+            guard guidanceScale >= 0, guidanceScale.isFinite else {
+                throw ValidationError("--guidance-scale must be finite and non-negative")
+            }
+            guard chunkSeconds >= 3 else {
+                throw ValidationError("--chunk-seconds must be at least 3")
+            }
         }
         guard ["float16", "float32"].contains(dtype.lowercased()) else {
             throw ValidationError("--dtype must be float16 or float32")
@@ -112,6 +221,14 @@ struct AudioEnhance: ParsableCommand {
     }
 
     func run() throws {
+        if model == ModelResolver.ModelID.univerSRAudio.rawValue {
+            try runUniverSR()
+        } else {
+            try runAPBWE()
+        }
+    }
+
+    private func runAPBWE() throws {
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
         let inputURL = Self.userURL(audio)
         guard FileManager.default.fileExists(atPath: inputURL.path) else {
@@ -221,9 +338,152 @@ struct AudioEnhance: ParsableCommand {
         }
     }
 
+    private func runUniverSR() throws {
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        let inputURL = Self.userURL(audio)
+        guard FileManager.default.fileExists(atPath: inputURL.path) else {
+            throw ValidationError("Input audio file not found: \(inputURL.path)")
+        }
+        let configuration = try UniverSRResources.loadBundledConfiguration()
+        let sourceMetadata = try MediaAudioIO.probe(inputURL)
+        let effectiveInputRate = inputRate ?? sourceMetadata.sampleRate
+        guard configuration.supportedInputRates.contains(effectiveInputRate) else {
+            if sourceMetadata.sampleRate == configuration.transform.samplingRate, inputRate == nil {
+                throw ValidationError(
+                    "48 kHz input requires --input-rate to declare its effective bandwidth "
+                        + "(8000, 12000, 16000, or 24000)"
+                )
+            }
+            throw ValidationError(
+                "UniverSR effective input rate must be 8000, 12000, 16000, or 24000 Hz"
+            )
+        }
+        guard let method = UniverSRODEMethod(rawValue: odeMethod.lowercased()) else {
+            throw ValidationError("--ode-method must be euler, midpoint, or rk4")
+        }
+        let modelRoot = try resolveModelRoot()
+        let outputURL = output.map(Self.userURL) ?? Self.defaultOutputURL(for: inputURL)
+        let manifestURL = outputURL.deletingPathExtension().appendingPathExtension("json")
+
+        if !quiet {
+            CLIStderr.write("Decoding \(inputURL.path) at \(effectiveInputRate) Hz mono\n")
+        }
+        let decoded = try MediaAudioIO.decode(
+            inputURL,
+            targetSampleRate: effectiveInputRate,
+            channels: 1
+        )
+        guard !decoded.samples.isEmpty else {
+            throw ValidationError("Input audio decoded to an empty buffer.")
+        }
+        let modelInput = try UniverSRAudio.upsampleTo48k(
+            decoded.samples,
+            inputRate: effectiveInputRate
+        )
+        let computeType: DType = dtype.lowercased() == "float16" ? .float16 : .float32
+        if !quiet {
+            CLIStderr.write("Loading \(model) from \(modelRoot.path)\n")
+        }
+        let enhancer = try UniverSREnhancer.load(
+            resources: UniverSRResources(rootURL: modelRoot),
+            dtype: computeType
+        )
+        let result = try enhancer.enhance(
+            lowResolution48kSamples: modelInput,
+            options: UniverSREnhancementOptions(
+                inputRateHz: effectiveInputRate,
+                odeMethod: method,
+                odeSteps: odeSteps,
+                guidanceScale: guidanceScale,
+                seed: seed,
+                chunkSeconds: chunkSeconds
+            )
+        ) { completed, total in
+            if !quiet {
+                CLIStderr.write("UniverSR chunks: \(completed)/\(total)\n")
+            }
+        }
+        try MediaAudioIO.writeFloatWAV(
+            samples: result.samples,
+            sampleRate: result.sampleRate,
+            channels: result.channels,
+            to: outputURL
+        )
+
+        let manifest = UniverSREnhancementManifest(
+            schemaVersion: 1,
+            createdAt: ISO8601DateFormatter().string(from: Date()),
+            source: .init(
+                path: inputURL.path,
+                sha256: try ModelArtifactPin.fileSHA256(inputURL),
+                sampleRate: sourceMetadata.sampleRate,
+                channels: sourceMetadata.channelCount,
+                frames: sourceMetadata.frameCount
+            ),
+            preprocessing: .init(
+                decodedSampleRate: decoded.sampleRate,
+                decodedChannels: decoded.channelCount,
+                decodedFrames: decoded.samples.count / decoded.channelCount,
+                effectiveInputRate: effectiveInputRate,
+                modelInputSampleRate: configuration.transform.samplingRate,
+                modelInputFrames: modelInput.count,
+                resampler: "windowed-sinc-lanczos-radius-32"
+            ),
+            model: .init(
+                id: model,
+                sourceRepository: UniverSRResources.sourceRepository,
+                sourceRevision: UniverSRResources.sourceRevision,
+                codeLicense: "MIT",
+                artifactRepository: UniverSRResources.artifactRepository,
+                artifactRevision: UniverSRResources.artifactRevision,
+                checkpointLicense: "CC BY 4.0",
+                weightsSHA256: UniverSRResources.weightsPin.sha256,
+                sourceConfigurationSHA256: UniverSRResources.sourceConfigurationPin.sha256,
+                modelCardSHA256: UniverSRResources.modelCardPin.sha256,
+                computeType: dtype.lowercased()
+            ),
+            inference: .init(
+                odeMethod: method.rawValue,
+                odeSteps: odeSteps,
+                guidanceScale: guidanceScale,
+                seed: seed,
+                chunkSeconds: chunkSeconds,
+                chunks: result.chunkCount,
+                elapsedSeconds: result.elapsedSeconds
+            ),
+            output: .init(
+                path: outputURL.path,
+                sha256: try ModelArtifactPin.fileSHA256(outputURL),
+                sampleRate: result.sampleRate,
+                channels: result.channels,
+                frames: result.frameCount
+            ),
+            manifestPath: manifestURL.path
+        )
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(manifest)
+        data.append(0x0A)
+        try FileManager.default.createDirectory(
+            at: manifestURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: manifestURL, options: .atomic)
+        try FileHandle.standardOutput.write(contentsOf: data)
+
+        if !quiet {
+            CLIStderr.write("Saved enhanced audio to \(outputURL.path)\n")
+            CLIStderr.write("Saved provenance manifest to \(manifestURL.path)\n")
+        }
+    }
+
     private func resolveModelRoot() throws -> URL {
         if let modelPath { return Self.userURL(modelPath) }
-        return try ModelResolver().resolve(.apBWE16kTo48k).rootURL
+        let modelID: ModelResolver.ModelID = model == ModelResolver.ModelID.univerSRAudio.rawValue
+            ? .univerSRAudio
+            : .apBWE16kTo48k
+        return try ModelResolver().resolve(modelID).rootURL
     }
 
     private static func defaultOutputURL(for input: URL) -> URL {

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -410,7 +410,10 @@ enum GuideRegistry {
             topic: "audio-enhance",
             title: "Audio Enhance",
             commandPaths: [["audio", "enhance"]],
-            models: ["audio-enhance-ap-bwe-16kto48k"],
+            models: [
+                "audio-enhance-ap-bwe-16kto48k",
+                "audio-enhance-universr-audio",
+            ],
             resourceName: "audio-enhance.md"
         ),
         GuideTopic(

--- a/Sources/MereRunCLI/Guides/audio-enhance.md
+++ b/Sources/MereRunCLI/Guides/audio-enhance.md
@@ -2,22 +2,26 @@
 
 ## Purpose
 
-Extend narrowband speech to a hashed 48 kHz mono WAV with native Swift/MLX
-AP-BWE inference. No audio is uploaded and no Python runtime is launched.
+Extend narrowband speech or bandwidth-limited general audio to a hashed 48 kHz
+mono WAV with native Swift/MLX inference. No audio is uploaded and no Python
+runtime is launched.
 
 `mere.run audio enhance` extends 16 kHz narrowband speech to 48 kHz with the
 pinned AP-BWE checkpoint. Inference stays local and uses the native Swift/MLX
-runtime.
+runtime. Select UniverSR for speech, music, or sound effects with an effective
+8, 12, 16, or 24 kHz input bandwidth.
 
 ## Install
 
 ```bash
 mere.run model pull audio-enhance-ap-bwe-16kto48k
+mere.run model pull audio-enhance-universr-audio
 ```
 
-The source code and published checkpoint are MIT-licensed. The managed snapshot
-contains the upstream code and weights license texts and exact, hash-verified
-16→48 kHz checkpoint/configuration artifacts.
+AP-BWE's source code and published checkpoint are MIT-licensed. UniverSR's
+source code is MIT-licensed; its official `universr-audio` checkpoint is CC BY
+4.0. Managed snapshots pin the corresponding source revision, artifact
+revision, model metadata, configuration, byte counts, and SHA-256 digests.
 
 ## Run
 
@@ -25,16 +29,30 @@ contains the upstream code and weights license texts and exact, hash-verified
 mere.run audio enhance ./speech.wav
 mere.run audio enhance ./speech.mp3 --output ./speech-wideband.wav
 mere.run audio enhance ./speech.wav --dtype float16 --overlap 4
+mere.run audio enhance ./music-12k.wav \
+  --model audio-enhance-universr-audio \
+  --output ./music-super-resolved.wav
+mere.run audio enhance ./limited-48k.wav \
+  --model audio-enhance-universr-audio \
+  --input-rate 16000 --seed 42
 ```
 
-The command decodes input to 16 kHz mono, performs band-limited 3x
-interpolation, and runs the AP-BWE generator at 48 kHz. It writes a mono float
-WAV plus a sibling JSON provenance manifest. The same manifest is emitted on
-stdout; progress is diagnostic stderr output.
+AP-BWE decodes input to 16 kHz mono, performs band-limited 3x interpolation,
+and runs its generator at 48 kHz. UniverSR decodes at the declared effective
+input rate, upsamples to 48 kHz, and reconstructs high-frequency content with
+the published flow-matching defaults: midpoint integration, four steps,
+guidance scale 1.5, and seed 42. Both routes write a mono float WAV plus a
+sibling JSON provenance manifest. The same manifest is emitted on stdout;
+progress is diagnostic stderr output.
 
 ## Notes
 
-- This profile is intended for speech bandwidth extension, not music mastering.
+- AP-BWE is intended for speech bandwidth extension. UniverSR is a general
+  audio super-resolution model, not a full mastering chain.
+- UniverSR infers the effective input rate from native 8/12/16/24 kHz files.
+  For bandwidth-limited audio already stored at 48 kHz, pass `--input-rate`.
+- `--ode-method`, `--ode-steps`, `--guidance-scale`, `--seed`, and
+  `--chunk-seconds` apply only to UniverSR; `--overlap` applies only to AP-BWE.
 - `--model-path` accepts an explicit root only when every pinned artifact matches.
 - `--dtype float32` is the default; `float16` reduces model memory use.
 - Quality depends on the source. A valid output artifact proves runtime
@@ -44,3 +62,5 @@ stdout; progress is diagnostic stderr output.
 
 - https://github.com/yxlu-0102/AP-BWE
 - https://huggingface.co/rsxdalv/AP-BWE
+- https://github.com/woongzip1/UniverSR
+- https://huggingface.co/woongzip1/universr-audio

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -310,7 +310,7 @@ enum InstalledModelSmokePlans {
                 try await runner.installedMusicSeparationCheck(model: spec.id)
             }
 
-        case .apBWE:
+        case .apBWE, .univerSR:
             return direct(spec, route: "audio enhance") { runner in
                 try await runner.installedAudioEnhancementCheck(model: spec.id)
             }
@@ -989,15 +989,16 @@ extension GateRunner {
             try Self.writeSineWaveFixture(to: input)
         }
         let output = artifactURL(model, extension: "wav")
-        let run = try await exec(
-            [
-                "audio", "enhance", input.path,
-                "--model", model,
-                "--output", output.path,
-                "--quiet",
-            ],
-            timeout: 3_600
-        )
+        var arguments = [
+            "audio", "enhance", input.path,
+            "--model", model,
+            "--output", output.path,
+            "--quiet",
+        ]
+        if model == ModelResolver.ModelID.univerSRAudio.rawValue {
+            arguments += ["--input-rate", "16000"]
+        }
+        let run = try await exec(arguments, timeout: 3_600)
         return try audioObservation(output, run: run)
     }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -67,6 +67,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case muScriptor
     case roFormer
     case apBWE
+    case univerSR
     case woosh
     case wooshClap
     case wooshSynchformer
@@ -2016,6 +2017,21 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["audio enhance"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.univerSRAudio.rawValue,
+            category: .audio,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: UniverSRResources.artifactRepository,
+                revision: UniverSRResources.artifactRevision,
+                patterns: UniverSRResources.pins.map(\.filename)
+            ),
+            upstreamRepoId: UniverSRResources.sourceRepository,
+            upstreamRevision: UniverSRResources.sourceRevision,
+            validationKind: .univerSR,
+            estimatedDownloadBytes: 229_074_334,
+            defaultCLICommands: ["audio enhance"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.wooshDFlow.rawValue,
             category: .sfx,
             installShape: .structuredRoot,
@@ -2589,6 +2605,8 @@ public extension ManagedModelSpec {
             return [rootURL]
         case .apBWE:
             return APBWEResources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .univerSR:
+            return UniverSRResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .woosh:
             let checkpointsRoot = WooshResources.normalizeRoot(rootURL, fileManager: fileManager)
             let variant = WooshVariant.resolve(model: id, rootURL: checkpointsRoot, fileManager: fileManager) ?? .dflow
@@ -2746,6 +2764,10 @@ public extension ManagedModelSpec {
             return ["Unsupported managed RoFormer model id: \(id)"]
         case .apBWE:
             return APBWEResources(
+                rootURL: normalizedRootURL(rootURL, fileManager: fileManager)
+            ).validationMessages(fileManager: fileManager)
+        case .univerSR:
+            return UniverSRResources(
                 rootURL: normalizedRootURL(rootURL, fileManager: fileManager)
             ).validationMessages(fileManager: fileManager)
         default:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -730,6 +730,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 16
             ),
             descriptor(
+                ModelResolver.ModelID.univerSRAudio.rawValue,
+                "UniverSR general audio",
+                "Extends 8, 12, 16, or 24 kHz speech, music, and sound effects to 48 kHz with native MLX inference.",
+                minimum: 8,
+                recommended: 16
+            ),
+            descriptor(
                 ModelResolver.ModelID.wooshDFlow.rawValue,
                 "Woosh DFlow",
                 "Generates Foley and sound effects from text prompts with Sony Research Woosh.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -78,6 +78,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case roFormer = "bs-roformer"
         /// AP-BWE speech bandwidth-extension family.
         case apBWE = "ap-bwe"
+        /// UniverSR flow-matching general-audio super-resolution family.
+        case univerSR = "universr"
         /// Sony Research Woosh sound-effect generation family.
         case woosh = "woosh"
         /// MMAudio synchronized video-to-audio and text-to-audio family.
@@ -1689,6 +1691,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.audioEnhancement],
                 components: nil,
                 upstreamRepoId: "\(APBWEResources.sourceRepository)@\(APBWEResources.sourceRevision)",
+                createdAt: createdAt
+            )
+        case .univerSRAudio:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .univerSR,
+                family: .audio,
+                tier: .small,
+                variant: .standard,
+                precision: .fp32,
+                defaults: MereRunModelManifest.Defaults(steps: 4, cfg: 1.5),
+                supports: [.audioEnhancement],
+                components: nil,
+                upstreamRepoId: "\(UniverSRResources.sourceRepository)@\(UniverSRResources.sourceRevision)",
                 createdAt: createdAt
             )
         case .wooshDFlow, .wooshFlow, .wooshVFlow8s, .wooshDVFlow8s:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -105,6 +105,7 @@ public enum MereRunModelValidator {
                 return spec.validationKind != .codegenGGUF
                     && spec.validationKind != .roFormer
                     && spec.validationKind != .apBWE
+                    && spec.validationKind != .univerSR
                     && spec.validationKind != .deepseekV4FlashIMatrixGGUF
                     && spec.validationKind != .magentaRT2
                     && spec.validationKind != .woosh
@@ -149,6 +150,7 @@ public enum MereRunModelValidator {
         } else if spec?.validationKind == .aceStep
             || spec?.validationKind == .roFormer
             || spec?.validationKind == .apBWE
+            || spec?.validationKind == .univerSR
             || spec?.validationKind == .sortformer
             || spec?.validationKind == .magentaRT2
             || spec?.validationKind == .muScriptor
@@ -412,8 +414,8 @@ public enum MereRunModelValidator {
                 && engine != .magentaRT2
                 && engine != .muScriptor:
                 warnings.append("Manifest engine mismatch: family=music expects ace-step, bs-roformer, magenta-rt2, or muscriptor.")
-            case .audio where engine != .apBWE:
-                warnings.append("Manifest engine mismatch: family=audio expects ap-bwe.")
+            case .audio where engine != .apBWE && engine != .univerSR:
+                warnings.append("Manifest engine mismatch: family=audio expects ap-bwe or universr.")
             case .sfx where engine != .woosh && engine != .mmaudio:
                 warnings.append("Manifest engine mismatch: family=sfx expects woosh or mmaudio.")
             case .video where engine != .ltxVideo && engine != .wanVideo:
@@ -491,7 +493,7 @@ public enum MereRunModelValidator {
                 return true
             }
             switch manifest.engine {
-            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .roFormer?, .apBWE?, .woosh?, .mmaudio?, .ltxVideo?,
+            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .roFormer?, .apBWE?, .univerSR?, .woosh?, .mmaudio?, .ltxVideo?,
                  .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?,
                  .insightFace?, .sortformer?:
                 return true

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -87,6 +87,7 @@ public struct ModelResolver {
         case melRoFormerDereverb = "music-separate-mel-roformer-dereverb"
         case melRoFormerDenoise = "music-separate-mel-roformer-denoise"
         case apBWE16kTo48k = "audio-enhance-ap-bwe-16kto48k"
+        case univerSRAudio = "audio-enhance-universr-audio"
         case wooshDFlow = "sfx-woosh-dflow"
         case wooshFlow = "sfx-woosh-flow"
         case wooshClap = "sfx-woosh-clap"

--- a/Sources/MereRunCore/PyTorchCheckpoint/PyTorchStateDictArchive.swift
+++ b/Sources/MereRunCore/PyTorchCheckpoint/PyTorchStateDictArchive.swift
@@ -198,6 +198,30 @@ public final class PyTorchStateDictArchive: @unchecked Sendable {
             }
             allowedNames.insert(serializationIDName)
         }
+        // PyTorch 2.8+ adds two inert root metadata files for its ZIP writer.
+        // Admit only the exact filenames and the currently documented scalar
+        // forms; they do not influence tensor decoding or storage addressing.
+        let formatVersionName = "\(root)/.format_version"
+        if zip.entries[formatVersionName] != nil {
+            let formatVersion = try zip.utf8Entry(named: formatVersionName)
+            guard formatVersion == "1" else {
+                throw PyTorchStateDictError.malformedZIP("invalid ZIP format version")
+            }
+            allowedNames.insert(formatVersionName)
+        }
+        let storageAlignmentName = "\(root)/.storage_alignment"
+        if zip.entries[storageAlignmentName] != nil {
+            let rawAlignment = try zip.utf8Entry(named: storageAlignmentName)
+            guard rawAlignment.utf8.count <= 4,
+                  rawAlignment.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+                  let alignment = Int(rawAlignment),
+                  alignment > 0,
+                  alignment <= 4_096,
+                  alignment.nonzeroBitCount == 1 else {
+                throw PyTorchStateDictError.malformedZIP("invalid storage alignment")
+            }
+            allowedNames.insert(storageAlignmentName)
+        }
         if let unexpected = zip.entries.keys.first(where: { !allowedNames.contains($0) }) {
             throw PyTorchStateDictError.unsafeArchivePath(unexpected)
         }

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -70,7 +70,7 @@ public enum QuantizedModelManifestWriter {
             case .qwen3Coder, .northMiniCode: return .code
             case .lightOnOCR: return .ocr
             case .aceStep, .magentaRT2, .muScriptor, .roFormer: return .music
-            case .apBWE: return .audio
+            case .apBWE, .univerSR: return .audio
             case .woosh, .mmaudio: return .sfx
             case .ltxVideo, .wanVideo, .cosmos3Edge: return .video
             case .psiChat: return .psi
@@ -156,7 +156,7 @@ public enum QuantizedModelManifestWriter {
                     return [.musicTranscription]
                 case .roFormer:
                     return [.musicSeparation]
-                case .apBWE:
+                case .apBWE, .univerSR:
                     return [.audioEnhancement]
                 case .woosh:
                     return [.soundEffectGeneration]
@@ -245,7 +245,7 @@ public enum QuantizedModelManifestWriter {
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .sortformer, .qwen3Embedding, .openAIPrivacyFilter,
                  .qwen3Coder, .northMiniCode, .lightOnOCR, .woosh, .mmaudio, .psiChat, .deepseekV4Flash,
-                 .muScriptor, .roFormer, .apBWE, .inkling:
+                 .muScriptor, .roFormer, .apBWE, .univerSR, .inkling:
                 break
             case .aceStep, .magentaRT2, .ltxVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)

--- a/Sources/MereRunCore/Resources/UniverSR/audio.json
+++ b/Sources/MereRunCore/Resources/UniverSR/audio.json
@@ -1,0 +1,32 @@
+{
+  "seed": 42,
+  "path": { "sigma_min": 0.0001 },
+  "transform": {
+    "window": "hann",
+    "n_fft": 1024,
+    "sampling_rate": 48000,
+    "hop_length": 512,
+    "alpha": 0.2,
+    "beta": 1.0,
+    "compression_epsilon": 0.0001
+  },
+  "model": {
+    "input_channels": 2,
+    "output_channels": 2,
+    "dimensions": [96, 192, 384, 768],
+    "depths": [2, 2, 4, 2],
+    "time_dimension": 256,
+    "conditioning_dimension": 384,
+    "total_frequency_bins": 512,
+    "high_frequency_bins": 432,
+    "conditioning_layers": 4,
+    "input_rate_bins": { "8": 80, "12": 128, "16": 170, "24": 256 }
+  },
+  "inference": {
+    "minimum_samples": 32768,
+    "ode_method": "midpoint",
+    "ode_steps": 4,
+    "guidance_scale": 1.5,
+    "chunk_seconds": 10
+  }
+}

--- a/Sources/MereRunCore/UniverSR/README.md
+++ b/Sources/MereRunCore/UniverSR/README.md
@@ -1,0 +1,17 @@
+# UniverSR native runtime
+
+This directory contains the native Swift/MLX port of the official UniverSR
+general-audio checkpoint. It does not launch Python, PyTorch, or CUDA.
+
+- `UniverSRConfiguration.swift` defines the typed, frozen graph and inference
+  profile corresponding to the pinned upstream YAML.
+- `UniverSRResources.swift` independently pins the MIT code revision and the
+  CC BY 4.0 checkpoint snapshot, including exact artifact hashes.
+- `UniverSRModel.swift` owns the conditional ConvNeXt V2 U-Net and restricted
+  PyTorch state-dict loader.
+- `UniverSREnhancer.swift` owns STFT compression, deterministic flow-matching
+  ODE integration, chunking, and waveform reconstruction.
+
+The bundled JSON is runtime configuration, not a copy of the upstream YAML.
+The original `config.yaml`, checkpoint, and model-card license declaration are
+downloaded and verified byte-for-byte by the managed model resolver.

--- a/Sources/MereRunCore/UniverSR/UniverSRConfiguration.swift
+++ b/Sources/MereRunCore/UniverSR/UniverSRConfiguration.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+public struct UniverSRConfiguration: Codable, Equatable, Sendable {
+    public struct Path: Codable, Equatable, Sendable {
+        public let sigmaMinimum: Float
+
+        enum CodingKeys: String, CodingKey {
+            case sigmaMinimum = "sigma_min"
+        }
+    }
+
+    public struct Transform: Codable, Equatable, Sendable {
+        public let window: String
+        public let nFFT: Int
+        public let samplingRate: Int
+        public let hopLength: Int
+        public let alpha: Float
+        public let beta: Float
+        public let compressionEpsilon: Float
+
+        enum CodingKeys: String, CodingKey {
+            case window
+            case nFFT = "n_fft"
+            case samplingRate = "sampling_rate"
+            case hopLength = "hop_length"
+            case alpha
+            case beta
+            case compressionEpsilon = "compression_epsilon"
+        }
+    }
+
+    public struct Model: Codable, Equatable, Sendable {
+        public let inputChannels: Int
+        public let outputChannels: Int
+        public let dimensions: [Int]
+        public let depths: [Int]
+        public let timeDimension: Int
+        public let conditioningDimension: Int
+        public let totalFrequencyBins: Int
+        public let highFrequencyBins: Int
+        public let conditioningLayers: Int
+        public let inputRateBins: [String: Int]
+
+        enum CodingKeys: String, CodingKey {
+            case inputChannels = "input_channels"
+            case outputChannels = "output_channels"
+            case dimensions
+            case depths
+            case timeDimension = "time_dimension"
+            case conditioningDimension = "conditioning_dimension"
+            case totalFrequencyBins = "total_frequency_bins"
+            case highFrequencyBins = "high_frequency_bins"
+            case conditioningLayers = "conditioning_layers"
+            case inputRateBins = "input_rate_bins"
+        }
+
+        public func frequencyBins(for inputRateKHz: Int) -> Int? {
+            inputRateBins[String(inputRateKHz)]
+        }
+    }
+
+    public struct Inference: Codable, Equatable, Sendable {
+        public let minimumSamples: Int
+        public let odeMethod: String
+        public let odeSteps: Int
+        public let guidanceScale: Float
+        public let chunkSeconds: Int
+
+        enum CodingKeys: String, CodingKey {
+            case minimumSamples = "minimum_samples"
+            case odeMethod = "ode_method"
+            case odeSteps = "ode_steps"
+            case guidanceScale = "guidance_scale"
+            case chunkSeconds = "chunk_seconds"
+        }
+    }
+
+    public let seed: UInt64
+    public let path: Path
+    public let transform: Transform
+    public let model: Model
+    public let inference: Inference
+
+    public var supportedInputRates: [Int] {
+        model.inputRateBins.keys.compactMap(Int.init).map { $0 * 1_000 }.sorted()
+    }
+
+    public func validate() throws {
+        guard path.sigmaMinimum == 1e-4 else {
+            throw UniverSRError.invalidConfiguration("expected sigma_min=1e-4")
+        }
+        guard transform.window == "hann",
+              transform.nFFT == 1_024,
+              transform.samplingRate == 48_000,
+              transform.hopLength == 512,
+              transform.alpha == 0.2,
+              transform.beta == 1,
+              transform.compressionEpsilon == 1e-4 else {
+            throw UniverSRError.invalidConfiguration("the complex STFT profile differs from the pinned checkpoint")
+        }
+        guard model.inputChannels == 2,
+              model.outputChannels == 2,
+              model.dimensions == [96, 192, 384, 768],
+              model.depths == [2, 2, 4, 2],
+              model.timeDimension == 256,
+              model.conditioningDimension == 384,
+              model.totalFrequencyBins == 512,
+              model.highFrequencyBins == 432,
+              model.conditioningLayers == 4,
+              model.inputRateBins == ["8": 80, "12": 128, "16": 170, "24": 256] else {
+            throw UniverSRError.invalidConfiguration("the ConvNeXt U-Net graph differs from the pinned checkpoint")
+        }
+        guard inference.minimumSamples == 32_768,
+              inference.odeMethod == "midpoint",
+              inference.odeSteps == 4,
+              inference.guidanceScale == 1.5,
+              inference.chunkSeconds >= 3 else {
+            throw UniverSRError.invalidConfiguration("the inference defaults differ from the published profile")
+        }
+    }
+}
+
+public enum UniverSRODEMethod: String, CaseIterable, Codable, Sendable {
+    case euler
+    case midpoint
+    case rk4
+}
+
+public enum UniverSRError: Error, Equatable, LocalizedError, Sendable {
+    case missingBundledConfiguration
+    case invalidConfiguration(String)
+    case invalidAudioBuffer
+    case unsupportedInputRate(Int)
+    case invalidInferenceOption(String)
+    case invalidCheckpointInventory(tensors: Int, scalars: Int)
+    case checkpointKeyMismatch(missing: [String], unexpected: [String])
+    case checkpointShapeMismatch(key: String, expected: [Int], actual: [Int])
+    case nonFiniteOutput
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingBundledConfiguration:
+            "Bundled UniverSR configuration is missing."
+        case .invalidConfiguration(let detail):
+            "Invalid UniverSR configuration: \(detail)."
+        case .invalidAudioBuffer:
+            "UniverSR requires a non-empty mono floating-point audio buffer."
+        case .unsupportedInputRate(let rate):
+            "UniverSR supports effective input rates of 8000, 12000, 16000, or 24000 Hz; received \(rate) Hz."
+        case .invalidInferenceOption(let detail):
+            "Invalid UniverSR inference option: \(detail)."
+        case .invalidCheckpointInventory(let tensors, let scalars):
+            "UniverSR checkpoint has \(tensors) tensors/\(scalars) scalars; expected "
+                + "\(UniverSRResources.expectedTensorCount)/\(UniverSRResources.expectedScalarCount)."
+        case .checkpointKeyMismatch(let missing, let unexpected):
+            "UniverSR checkpoint keys differ from the native graph; missing=\(missing), unexpected=\(unexpected)."
+        case .checkpointShapeMismatch(let key, let expected, let actual):
+            "UniverSR checkpoint tensor '\(key)' has shape \(actual); expected \(expected)."
+        case .nonFiniteOutput:
+            "UniverSR produced non-finite audio samples."
+        }
+    }
+}

--- a/Sources/MereRunCore/UniverSR/UniverSREnhancer.swift
+++ b/Sources/MereRunCore/UniverSR/UniverSREnhancer.swift
@@ -1,0 +1,334 @@
+import Foundation
+@preconcurrency import MLX
+import MLXRandom
+
+public struct UniverSREnhancementOptions: Equatable, Sendable {
+    public let inputRateHz: Int
+    public let odeMethod: UniverSRODEMethod
+    public let odeSteps: Int
+    public let guidanceScale: Float
+    public let seed: UInt64
+    public let chunkSeconds: Int
+
+    public init(
+        inputRateHz: Int,
+        odeMethod: UniverSRODEMethod = .midpoint,
+        odeSteps: Int = 4,
+        guidanceScale: Float = 1.5,
+        seed: UInt64 = 42,
+        chunkSeconds: Int = 10
+    ) {
+        self.inputRateHz = inputRateHz
+        self.odeMethod = odeMethod
+        self.odeSteps = odeSteps
+        self.guidanceScale = guidanceScale
+        self.seed = seed
+        self.chunkSeconds = chunkSeconds
+    }
+}
+
+public struct UniverSREnhancementResult: Sendable {
+    public let samples: [Float]
+    public let sampleRate: Int
+    public let channels: Int
+    public let frameCount: Int
+    public let chunkCount: Int
+    public let elapsedSeconds: Double
+}
+
+public enum UniverSRAudio {
+    /// Windowed-sinc interpolation for the integer 8/12/16/24 kHz to 48 kHz ratios.
+    public static func upsampleTo48k(_ samples: [Float], inputRate: Int) throws -> [Float] {
+        guard !samples.isEmpty else { return [] }
+        guard [8_000, 12_000, 16_000, 24_000].contains(inputRate) else {
+            throw UniverSRError.unsupportedInputRate(inputRate)
+        }
+        let factor = 48_000 / inputRate
+        let radius = 32
+        var output = [Float](repeating: 0, count: samples.count * factor)
+        for outputIndex in output.indices {
+            let position = Double(outputIndex) / Double(factor)
+            let center = Int(floor(position))
+            var sum = 0.0
+            var normalization = 0.0
+            for sourceIndex in (center - radius + 1)...(center + radius) {
+                let distance = position - Double(sourceIndex)
+                guard abs(distance) < Double(radius) else { continue }
+                let coefficient = sinc(distance) * sinc(distance / Double(radius))
+                let reflected = reflectedIndex(sourceIndex, count: samples.count)
+                sum += Double(samples[reflected]) * coefficient
+                normalization += coefficient
+            }
+            output[outputIndex] = Float(sum / max(abs(normalization), 1e-12))
+        }
+        return output
+    }
+
+    private static func sinc(_ value: Double) -> Double {
+        if abs(value) < 1e-12 { return 1 }
+        let argument = Double.pi * value
+        return sin(argument) / argument
+    }
+
+    private static func reflectedIndex(_ index: Int, count: Int) -> Int {
+        guard count > 1 else { return 0 }
+        let upper = count - 1
+        let period = upper * 2
+        var value = index % period
+        if value < 0 { value += period }
+        return value > upper ? period - value : value
+    }
+}
+
+public final class UniverSREnhancer {
+    public typealias ProgressHandler = @Sendable (_ completedChunks: Int, _ totalChunks: Int) -> Void
+
+    public let checkpoint: UniverSRCheckpoint
+    public let dtype: DType
+    private let model: UniverSRModel
+
+    private init(checkpoint: UniverSRCheckpoint, dtype: DType, model: UniverSRModel) {
+        self.checkpoint = checkpoint
+        self.dtype = dtype
+        self.model = model
+    }
+
+    public static func load(
+        resources: UniverSRResources,
+        dtype: DType = .float32
+    ) throws -> UniverSREnhancer {
+        let checkpoint = try resources.resolve()
+        let model = try UniverSRModel.load(checkpoint: checkpoint, dtype: dtype)
+        return UniverSREnhancer(checkpoint: checkpoint, dtype: dtype, model: model)
+    }
+
+    public func enhance(
+        lowResolution48kSamples: [Float],
+        options: UniverSREnhancementOptions,
+        progress: ProgressHandler? = nil
+    ) throws -> UniverSREnhancementResult {
+        guard !lowResolution48kSamples.isEmpty else { throw UniverSRError.invalidAudioBuffer }
+        try validate(options)
+        let started = ContinuousClock.now
+        let configuration = checkpoint.configuration
+        let chunkSize = options.chunkSeconds * configuration.transform.samplingRate
+        let chunkCount = max(1, Int(ceil(Double(lowResolution48kSamples.count) / Double(chunkSize))))
+        var output: [Float] = []
+        output.reserveCapacity(lowResolution48kSamples.count)
+
+        for chunkIndex in 0..<chunkCount {
+            let start = chunkIndex * chunkSize
+            let end = min(start + chunkSize, lowResolution48kSamples.count)
+            let source = Array(lowResolution48kSamples[start..<end])
+            let requiredLength = max(source.count, configuration.inference.minimumSamples)
+            var padded = source
+            if padded.count < requiredLength {
+                padded.append(contentsOf: repeatElement(0, count: requiredLength - padded.count))
+            }
+            let enhanced = try enhanceChunk(
+                padded,
+                inputRateKHz: options.inputRateHz / 1_000,
+                method: options.odeMethod,
+                steps: options.odeSteps,
+                guidanceScale: options.guidanceScale,
+                seed: options.seed &+ UInt64(chunkIndex)
+            )
+            output.append(contentsOf: enhanced.prefix(source.count))
+            MLX.Memory.clearCache()
+            progress?(chunkIndex + 1, chunkCount)
+        }
+
+        let elapsed = started.duration(to: .now)
+        return UniverSREnhancementResult(
+            samples: output,
+            sampleRate: configuration.transform.samplingRate,
+            channels: 1,
+            frameCount: output.count,
+            chunkCount: chunkCount,
+            elapsedSeconds: Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+        )
+    }
+
+    private func validate(_ options: UniverSREnhancementOptions) throws {
+        guard checkpoint.configuration.supportedInputRates.contains(options.inputRateHz) else {
+            throw UniverSRError.unsupportedInputRate(options.inputRateHz)
+        }
+        guard options.odeSteps > 0 else {
+            throw UniverSRError.invalidInferenceOption("ode_steps must be positive")
+        }
+        guard options.guidanceScale >= 0, options.guidanceScale.isFinite else {
+            throw UniverSRError.invalidInferenceOption("guidance_scale must be finite and non-negative")
+        }
+        guard options.chunkSeconds >= 3 else {
+            throw UniverSRError.invalidInferenceOption("chunk_seconds must be at least 3")
+        }
+    }
+
+    private func enhanceChunk(
+        _ samples: [Float],
+        inputRateKHz: Int,
+        method: UniverSRODEMethod,
+        steps: Int,
+        guidanceScale: Float,
+        seed: UInt64
+    ) throws -> [Float] {
+        let configuration = checkpoint.configuration
+        let waveform = MLXArray(samples).reshaped(1, 1, samples.count).asType(dtype)
+        let representation = preprocess(waveform)
+        guard let lowBinCount = configuration.model.frequencyBins(for: inputRateKHz) else {
+            throw UniverSRError.unsupportedInputRate(inputRateKHz * 1_000)
+        }
+        let highStart = configuration.model.totalFrequencyBins - configuration.model.highFrequencyBins
+        let condition = representation[0..., 0..<lowBinCount, 0..., 0...]
+        let highShape = representation[
+            0..., highStart..<configuration.model.totalFrequencyBins, 0..., 0...
+        ].shape
+        var state = MLXRandom.normal(highShape, key: MLXRandom.key(seed)).asType(dtype)
+        let stepSize = 1 / Float(steps)
+
+        for index in 0..<steps {
+            let time = Float(index) * stepSize
+            switch method {
+            case .euler:
+                state = state + stepSize * vectorField(
+                    state,
+                    time: time,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+            case .midpoint:
+                let first = vectorField(
+                    state,
+                    time: time,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+                let midpoint = state + (stepSize * 0.5) * first
+                let second = vectorField(
+                    midpoint,
+                    time: time + stepSize * 0.5,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+                state = state + stepSize * second
+            case .rk4:
+                let first = vectorField(
+                    state,
+                    time: time,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+                let second = vectorField(
+                    state + (stepSize * 0.5) * first,
+                    time: time + stepSize * 0.5,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+                let third = vectorField(
+                    state + (stepSize * 0.5) * second,
+                    time: time + stepSize * 0.5,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+                let fourth = vectorField(
+                    state + stepSize * third,
+                    time: time + stepSize,
+                    condition: condition,
+                    inputRateKHz: inputRateKHz,
+                    guidanceScale: guidanceScale
+                )
+                state = state + (stepSize / 6) * (first + 2 * second + 2 * third + fourth)
+            }
+            MLX.eval(state)
+        }
+
+        let overlap = max(0, lowBinCount - highStart)
+        let generated = state[0..., overlap..<configuration.model.highFrequencyBins, 0..., 0...]
+        let fullSpectrum = MLX.concatenated([condition, generated], axis: 1)
+        let reconstructed = postprocess(fullSpectrum, length: samples.count)
+            .reshaped(samples.count)
+            .asType(.float32)
+        MLX.eval(reconstructed)
+        let values = reconstructed.asArray(Float.self)
+        guard values.allSatisfy(\.isFinite) else { throw UniverSRError.nonFiniteOutput }
+        return values
+    }
+
+    private func vectorField(
+        _ state: MLXArray,
+        time: Float,
+        condition: MLXArray,
+        inputRateKHz: Int,
+        guidanceScale: Float
+    ) -> MLXArray {
+        let timeArray = MLXArray([time]).asType(dtype)
+        let guided = model(
+            state,
+            time: timeArray,
+            condition: condition,
+            inputRateKHz: inputRateKHz
+        )
+        guard guidanceScale > 0, guidanceScale != 1 else { return guided }
+        let unguided = model(
+            state,
+            time: timeArray,
+            condition: nil,
+            inputRateKHz: inputRateKHz
+        )
+        return (1 - guidanceScale) * unguided + guidanceScale * guided
+    }
+
+    private func preprocess(_ waveform: MLXArray) -> MLXArray {
+        let transform = checkpoint.configuration.transform
+        let spectrum = RoFormerDSP.stft(
+            waveform,
+            nFFT: transform.nFFT,
+            hopLength: transform.hopLength,
+            window: symmetricHannWindow(length: transform.nFFT, dtype: waveform.dtype)
+        )
+        let real = spectrum[0..., 0..<transform.nFFT / 2, 0..., 0] + transform.compressionEpsilon
+        let imaginary = spectrum[0..., 0..<transform.nFFT / 2, 0..., 1]
+        let magnitude = MLX.sqrt(real.square() + imaginary.square())
+        let compressed = MLX.pow(magnitude, transform.alpha) * transform.beta
+        let phase = MLX.atan2(imaginary, real)
+        return MLX.stacked([compressed * MLX.cos(phase), compressed * MLX.sin(phase)], axis: -1)
+    }
+
+    private func postprocess(_ representation: MLXArray, length: Int) -> MLXArray {
+        let transform = checkpoint.configuration.transform
+        let real = representation[.ellipsis, 0]
+        let imaginary = representation[.ellipsis, 1]
+        let magnitude = MLX.sqrt(real.square() + imaginary.square()) / transform.beta
+        let amplitude = MLX.pow(magnitude, 1 / transform.alpha)
+        let phase = MLX.atan2(imaginary, real)
+        let restored = MLX.stacked([amplitude * MLX.cos(phase), amplitude * MLX.sin(phase)], axis: -1)
+        let nyquist = MLX.zeros(
+            [restored.dim(0), 1, restored.dim(2), 2],
+            dtype: restored.dtype
+        )
+        let fullSpectrum = MLX.concatenated([restored, nyquist], axis: 1).expandedDimensions(axis: 1)
+        return RoFormerDSP.istft(
+            fullSpectrum,
+            channels: 1,
+            length: length,
+            nFFT: transform.nFFT,
+            hopLength: transform.hopLength,
+            window: symmetricHannWindow(length: transform.nFFT, dtype: representation.dtype),
+            zeroDC: false
+        ).squeezed(axis: 1).squeezed(axis: 1)
+    }
+
+    private func symmetricHannWindow(length: Int, dtype: DType) -> MLXArray {
+        let positions = MLXArray((0..<length).map(Float.init)).asType(dtype)
+        return MLXArray(0.5).asType(dtype)
+            - MLXArray(0.5).asType(dtype)
+                * MLX.cos(positions * (2 * Float.pi / Float(length - 1)))
+    }
+}

--- a/Sources/MereRunCore/UniverSR/UniverSRModel.swift
+++ b/Sources/MereRunCore/UniverSR/UniverSRModel.swift
@@ -1,0 +1,579 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+private func univerSRReflectPad2D(_ input: MLXArray, amount: Int) -> MLXArray {
+    guard amount > 0 else { return input }
+    precondition(input.dim(1) > amount && input.dim(2) > amount)
+    let height = input.dim(1)
+    let width = input.dim(2)
+    let top = input[0..., 1..<(amount + 1), 0..., 0...][0..., .stride(by: -1), 0..., 0...]
+    let bottom = input[0..., (height - amount - 1)..<(height - 1), 0..., 0...][
+        0..., .stride(by: -1), 0..., 0...
+    ]
+    let vertical = MLX.concatenated([top, input, bottom], axis: 1)
+    let left = vertical[0..., 0..., 1..<(amount + 1), 0...][0..., 0..., .stride(by: -1), 0...]
+    let right = vertical[0..., 0..., (width - amount - 1)..<(width - 1), 0...][
+        0..., 0..., .stride(by: -1), 0...
+    ]
+    return MLX.concatenated([left, vertical, right], axis: 2)
+}
+
+private func univerSRReflectPadFrames(_ input: MLXArray, amount: Int) -> MLXArray {
+    guard amount > 0 else { return input }
+    let width = input.dim(2)
+    precondition(width > amount)
+    let reflected = input[0..., 0..., (width - amount - 1)..<(width - 1), 0...][
+        0..., 0..., .stride(by: -1), 0...
+    ]
+    return MLX.concatenated([input, reflected], axis: 2)
+}
+
+final class UniverSRGRN: Module {
+    @ParameterInfo(key: "gamma") var gamma: MLXArray
+    @ParameterInfo(key: "beta") var beta: MLXArray
+
+    init(dimensions: Int) {
+        self._gamma.wrappedValue = MLX.zeros([1, 1, 1, dimensions], dtype: .float32)
+        self._beta.wrappedValue = MLX.zeros([1, 1, 1, dimensions], dtype: .float32)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let response = MLX.sqrt(MLX.sum(input.square(), axes: [1, 2], keepDims: true))
+        let normalized = response / (response.mean(axis: -1, keepDims: true) + 1e-6)
+        return gamma * (input * normalized) + beta + input
+    }
+}
+
+final class UniverSRConvNeXtBlock: Module {
+    @ModuleInfo(key: "dwconv") var depthwiseConvolution: Conv2d
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+    @ModuleInfo(key: "pwconv1") var inputProjection: Linear
+    @ModuleInfo(key: "grn") var grn: UniverSRGRN
+    @ModuleInfo(key: "pwconv2") var outputProjection: Linear
+
+    init(dimensions: Int) {
+        self._depthwiseConvolution.wrappedValue = Conv2d(
+            inputChannels: dimensions,
+            outputChannels: dimensions,
+            kernelSize: IntOrPair(7),
+            stride: IntOrPair(1),
+            padding: IntOrPair(0),
+            dilation: IntOrPair(1),
+            groups: dimensions,
+            bias: true
+        )
+        self._norm.wrappedValue = LayerNorm(dimensions: dimensions, eps: 1e-6)
+        self._inputProjection.wrappedValue = Linear(dimensions, dimensions * 4, bias: true)
+        self._grn.wrappedValue = UniverSRGRN(dimensions: dimensions * 4)
+        self._outputProjection.wrappedValue = Linear(dimensions * 4, dimensions, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = depthwiseConvolution(univerSRReflectPad2D(input, amount: 3))
+        hidden = norm(hidden)
+        hidden = inputProjection(hidden)
+        hidden = MLXNN.gelu(hidden)
+        hidden = grn(hidden)
+        return input + outputProjection(hidden)
+    }
+}
+
+final class UniverSRTimeAdapter: Module {
+    @ModuleInfo(key: "0") var input: Linear
+    @ModuleInfo(key: "2") var output: Linear
+
+    init(timeDimensions: Int, outputDimensions: Int) {
+        self._input.wrappedValue = Linear(timeDimensions, timeDimensions, bias: true)
+        self._output.wrappedValue = Linear(timeDimensions, outputDimensions, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(MLXNN.silu(input(value)))
+    }
+}
+
+final class UniverSRBlockWithEmbedding: Module {
+    @ModuleInfo(key: "block") var block: UniverSRConvNeXtBlock
+    @ModuleInfo(key: "time_adapter") var timeAdapter: UniverSRTimeAdapter
+
+    init(dimensions: Int, timeDimensions: Int) {
+        self._block.wrappedValue = UniverSRConvNeXtBlock(dimensions: dimensions)
+        self._timeAdapter.wrappedValue = UniverSRTimeAdapter(
+            timeDimensions: timeDimensions,
+            outputDimensions: dimensions
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, time: MLXArray) -> MLXArray {
+        block(input + timeAdapter(time).expandedDimensions(axis: 1).expandedDimensions(axis: 1))
+    }
+}
+
+final class UniverSRDownsampler: Module {
+    @ModuleInfo(key: "0") var norm: LayerNorm
+    @ModuleInfo(key: "1") var convolution: Conv2d
+
+    init(inputDimensions: Int, outputDimensions: Int) {
+        self._norm.wrappedValue = LayerNorm(dimensions: inputDimensions, eps: 1e-6)
+        self._convolution.wrappedValue = Conv2d(
+            inputChannels: inputDimensions,
+            outputChannels: outputDimensions,
+            kernelSize: IntOrPair(2),
+            stride: IntOrPair(2),
+            padding: IntOrPair(0),
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        convolution(norm(input))
+    }
+}
+
+final class UniverSREncoderBlock: Module {
+    @ModuleInfo(key: "blocks") var blocks: [UniverSRBlockWithEmbedding]
+    @ModuleInfo(key: "downsampler") var downsampler: UniverSRDownsampler
+
+    init(inputDimensions: Int, outputDimensions: Int, depth: Int, timeDimensions: Int) {
+        self._blocks.wrappedValue = (0..<depth).map { _ in
+            UniverSRBlockWithEmbedding(dimensions: inputDimensions, timeDimensions: timeDimensions)
+        }
+        self._downsampler.wrappedValue = UniverSRDownsampler(
+            inputDimensions: inputDimensions,
+            outputDimensions: outputDimensions
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, time: MLXArray) -> MLXArray {
+        var hidden = input
+        for block in blocks {
+            hidden = block(hidden, time: time)
+        }
+        return downsampler(hidden)
+    }
+}
+
+final class UniverSRMidcoder: Module {
+    @ModuleInfo(key: "blocks") var blocks: [UniverSRBlockWithEmbedding]
+
+    init(dimensions: Int, depth: Int, timeDimensions: Int) {
+        self._blocks.wrappedValue = (0..<depth).map { _ in
+            UniverSRBlockWithEmbedding(dimensions: dimensions, timeDimensions: timeDimensions)
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, time: MLXArray) -> MLXArray {
+        var hidden = input
+        for block in blocks {
+            hidden = block(hidden, time: time)
+        }
+        return hidden
+    }
+}
+
+final class UniverSRDecoderBlock: Module {
+    @ModuleInfo(key: "upsampler") var upsampler: ConvTransposed2d
+    @ModuleInfo(key: "blocks") var blocks: [UniverSRBlockWithEmbedding]
+
+    init(inputDimensions: Int, outputDimensions: Int, depth: Int, timeDimensions: Int) {
+        self._upsampler.wrappedValue = ConvTransposed2d(
+            inputChannels: inputDimensions,
+            outputChannels: outputDimensions,
+            kernelSize: IntOrPair(2),
+            stride: IntOrPair(2),
+            padding: IntOrPair(0),
+            bias: true
+        )
+        self._blocks.wrappedValue = (0..<depth).map { _ in
+            UniverSRBlockWithEmbedding(dimensions: outputDimensions, timeDimensions: timeDimensions)
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, time: MLXArray) -> MLXArray {
+        var hidden = upsampler(input)
+        for block in blocks {
+            hidden = block(hidden, time: time)
+        }
+        return hidden
+    }
+}
+
+final class UniverSRSRAdapter: Module {
+    @ModuleInfo(key: "0") var input: Linear
+    @ModuleInfo(key: "2") var output: Linear
+
+    init(dimensions: Int) {
+        self._input.wrappedValue = Linear(dimensions, dimensions, bias: true)
+        self._output.wrappedValue = Linear(dimensions, dimensions * 2, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(MLXNN.gelu(input(value)))
+    }
+}
+
+final class UniverSRConditioningEncoder: Module {
+    @ModuleInfo(key: "film_generator") var filmGenerator: Linear
+    @ModuleInfo(key: "head") var head: Conv2d
+    @ModuleInfo(key: "sr_adapter") var sampleRateAdapter: UniverSRSRAdapter
+    @ModuleInfo(key: "blocks") var blocks: [UniverSRConvNeXtBlock]
+
+    init(dimensions: Int, layerCount: Int) {
+        self._filmGenerator.wrappedValue = Linear(dimensions, 4, bias: true)
+        self._head.wrappedValue = Conv2d(
+            inputChannels: 2,
+            outputChannels: dimensions,
+            kernelSize: IntOrPair(1),
+            padding: IntOrPair(0),
+            bias: true
+        )
+        self._sampleRateAdapter.wrappedValue = UniverSRSRAdapter(dimensions: dimensions)
+        self._blocks.wrappedValue = (0..<layerCount).map { _ in
+            UniverSRConvNeXtBlock(dimensions: dimensions)
+        }
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        frequencyEmbedding: MLXArray,
+        sampleRateEmbedding: MLXArray
+    ) -> MLXArray {
+        let frequencyFilm = MLX.split(filmGenerator(frequencyEmbedding), parts: 2, axis: -1)
+        let gamma = frequencyFilm[0].expandedDimensions(axis: 0).expandedDimensions(axis: 2)
+        let beta = frequencyFilm[1].expandedDimensions(axis: 0).expandedDimensions(axis: 2)
+        var hidden = head(input * gamma + beta)
+
+        let sampleRateFilm = MLX.split(sampleRateAdapter(sampleRateEmbedding), parts: 2, axis: -1)
+        let sampleRateGamma = sampleRateFilm[0].expandedDimensions(axis: 1).expandedDimensions(axis: 1)
+        let sampleRateBeta = sampleRateFilm[1].expandedDimensions(axis: 1).expandedDimensions(axis: 1)
+        hidden = hidden * sampleRateGamma + sampleRateBeta
+        for block in blocks {
+            hidden = block(hidden)
+        }
+        return hidden.mean(axis: 1)
+    }
+}
+
+final class UniverSRTimeEmbedding: Module {
+    @ParameterInfo(key: "weights") var weights: MLXArray
+
+    init(dimensions: Int) {
+        self._weights.wrappedValue = MLX.zeros([1, dimensions / 2], dtype: .float32)
+        super.init()
+    }
+
+    func callAsFunction(_ time: MLXArray) -> MLXArray {
+        let frequencies = time.reshaped(-1, 1) * weights * (2 * Float.pi)
+        return MLX.concatenated([MLX.sin(frequencies), MLX.cos(frequencies)], axis: -1) * sqrt(Float(2))
+    }
+}
+
+final class UniverSRFrequencyPositionEmbedding: Module {
+    @ParameterInfo(key: "pe") var value: MLXArray
+
+    init(binCount: Int, dimensions: Int) {
+        self._value.wrappedValue = MLX.zeros([binCount, dimensions], dtype: .float32)
+        super.init()
+    }
+}
+
+final class UniverSRInitialConvolution: Module {
+    @ModuleInfo(key: "0") var convolution: Conv2d
+    @ModuleInfo(key: "1") var norm: LayerNorm
+
+    init(inputChannels: Int, outputChannels: Int) {
+        self._convolution.wrappedValue = Conv2d(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: IntOrPair(1),
+            padding: IntOrPair(0),
+            bias: true
+        )
+        self._norm.wrappedValue = LayerNorm(dimensions: outputChannels, eps: 1e-6)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        norm(convolution(input))
+    }
+}
+
+public final class UniverSRModel: Module {
+    @ParameterInfo(key: "uncond_emb") var unconditionalEmbedding: MLXArray
+    @ModuleInfo(key: "time_embedder") var timeEmbedder: UniverSRTimeEmbedding
+    @ModuleInfo(key: "sr_embedder") var sampleRateEmbedder: Embedding
+    @ModuleInfo(key: "sr_projector") var sampleRateProjector: Linear
+    @ModuleInfo(key: "freq_pos_enc") var frequencyPosition: UniverSRFrequencyPositionEmbedding
+    @ModuleInfo(key: "film_generator") var filmGenerator: Linear
+    @ModuleInfo(key: "conditioning_encoder") var conditioningEncoder: UniverSRConditioningEncoder
+    @ModuleInfo(key: "init_conv") var initialConvolution: UniverSRInitialConvolution
+    @ModuleInfo(key: "encoders") var encoders: [UniverSREncoderBlock]
+    @ModuleInfo(key: "decoders") var decoders: [UniverSRDecoderBlock]
+    @ModuleInfo(key: "midcoder") var midcoder: UniverSRMidcoder
+    @ModuleInfo(key: "final_conv") var finalConvolution: Conv2d
+
+    public let configuration: UniverSRConfiguration
+
+    public init(configuration: UniverSRConfiguration) {
+        self.configuration = configuration
+        let graph = configuration.model
+        self._unconditionalEmbedding.wrappedValue = MLX.zeros(
+            [graph.conditioningDimension],
+            dtype: .float32
+        )
+        self._timeEmbedder.wrappedValue = UniverSRTimeEmbedding(dimensions: graph.timeDimension)
+        self._sampleRateEmbedder.wrappedValue = Embedding(
+            embeddingCount: graph.inputRateBins.count,
+            dimensions: graph.conditioningDimension
+        )
+        self._sampleRateProjector.wrappedValue = Linear(
+            graph.conditioningDimension,
+            graph.timeDimension,
+            bias: true
+        )
+        self._frequencyPosition.wrappedValue = UniverSRFrequencyPositionEmbedding(
+            binCount: graph.totalFrequencyBins,
+            dimensions: graph.conditioningDimension
+        )
+        self._filmGenerator.wrappedValue = Linear(
+            graph.conditioningDimension,
+            graph.conditioningDimension * 2,
+            bias: true
+        )
+        self._conditioningEncoder.wrappedValue = UniverSRConditioningEncoder(
+            dimensions: graph.conditioningDimension,
+            layerCount: graph.conditioningLayers
+        )
+        self._initialConvolution.wrappedValue = UniverSRInitialConvolution(
+            inputChannels: graph.inputChannels + graph.conditioningDimension,
+            outputChannels: graph.dimensions[0]
+        )
+        self._encoders.wrappedValue = graph.depths.indices.map { index in
+            UniverSREncoderBlock(
+                inputDimensions: graph.dimensions[index],
+                outputDimensions: index + 1 < graph.dimensions.count
+                    ? graph.dimensions[index + 1]
+                    : graph.dimensions[index],
+                depth: graph.depths[index],
+                timeDimensions: graph.timeDimension
+            )
+        }
+        self._midcoder.wrappedValue = UniverSRMidcoder(
+            dimensions: graph.dimensions.last ?? 768,
+            depth: graph.depths.last ?? 2,
+            timeDimensions: graph.timeDimension
+        )
+        self._decoders.wrappedValue = graph.depths.indices.reversed().map { index in
+            UniverSRDecoderBlock(
+                inputDimensions: index + 1 < graph.dimensions.count
+                    ? graph.dimensions[index + 1]
+                    : graph.dimensions[index],
+                outputDimensions: graph.dimensions[index],
+                depth: graph.depths[index],
+                timeDimensions: graph.timeDimension
+            )
+        }
+        self._finalConvolution.wrappedValue = Conv2d(
+            inputChannels: graph.dimensions[0],
+            outputChannels: graph.outputChannels,
+            kernelSize: IntOrPair(1),
+            padding: IntOrPair(0),
+            bias: true
+        )
+        super.init()
+    }
+
+    public static func load(
+        checkpoint: UniverSRCheckpoint,
+        dtype: DType = .float32
+    ) throws -> UniverSRModel {
+        let model = UniverSRModel(configuration: checkpoint.configuration)
+        let archive = try PyTorchStateDictArchive(url: checkpoint.weightsURL.resolvingSymlinksInPath())
+        try model.validateCheckpoint(archive)
+
+        var mapped: [String: MLXArray] = [:]
+        mapped.reserveCapacity(archive.tensors.count)
+        var pending: [MLXArray] = []
+        var pendingBytes = 0
+        for descriptor in archive.tensors {
+            var value = try archive.loadArray(for: descriptor, dtype: dtype)
+            if Self.isTransposedConvolutionWeight(descriptor.name) {
+                value = Self.contiguous(value.transposed(1, 2, 3, 0))
+            } else if descriptor.shape.count == 4 && descriptor.name.hasSuffix(".weight") {
+                value = Self.contiguous(value.transposed(0, 2, 3, 1))
+            }
+            mapped[descriptor.name] = value
+            pending.append(value)
+            pendingBytes += value.size * Self.byteCount(dtype)
+            if pendingBytes >= 64 * 1_024 * 1_024 {
+                MLX.eval(pending)
+                pending.removeAll(keepingCapacity: true)
+                pendingBytes = 0
+            }
+        }
+        if !pending.isEmpty { MLX.eval(pending) }
+        let parameters = try model.parameters().mapValues { key, _ in
+            guard let value = mapped[key] else {
+                throw UniverSRError.checkpointKeyMismatch(missing: [key], unexpected: [])
+            }
+            return value
+        }
+        try model.update(parameters: parameters, verify: .all)
+        MLX.eval(model)
+        return model
+    }
+
+    public func validateCheckpoint(_ archive: PyTorchStateDictArchive) throws {
+        let scalars = archive.tensors.reduce(0) { $0 + $1.elementCount }
+        guard archive.tensors.count == UniverSRResources.expectedTensorCount,
+              scalars == UniverSRResources.expectedScalarCount,
+              archive.tensors.allSatisfy({ $0.dataType == .float32 }) else {
+            throw UniverSRError.invalidCheckpointInventory(
+                tensors: archive.tensors.count,
+                scalars: scalars
+            )
+        }
+
+        let expected = Dictionary(
+            uniqueKeysWithValues: parameters().flattened().map { ($0.0, $0.1.shape) }
+        )
+        let source = Dictionary(
+            uniqueKeysWithValues: archive.tensors.map { descriptor in
+                (descriptor.name, Self.mappedShape(for: descriptor))
+            }
+        )
+        let expectedKeys = Set(expected.keys)
+        let sourceKeys = Set(source.keys)
+        guard expectedKeys == sourceKeys else {
+            throw UniverSRError.checkpointKeyMismatch(
+                missing: Array(expectedKeys.subtracting(sourceKeys)).sorted(),
+                unexpected: Array(sourceKeys.subtracting(expectedKeys)).sorted()
+            )
+        }
+        for key in expectedKeys.sorted() {
+            guard let expectedShape = expected[key], let actualShape = source[key] else { continue }
+            guard expectedShape == actualShape else {
+                throw UniverSRError.checkpointShapeMismatch(
+                    key: key,
+                    expected: expectedShape,
+                    actual: actualShape
+                )
+            }
+        }
+    }
+
+    /// Evaluates the conditional vector field on NHWC complex-spectral features.
+    public func callAsFunction(
+        _ input: MLXArray,
+        time: MLXArray,
+        condition: MLXArray?,
+        inputRateKHz: Int
+    ) -> MLXArray {
+        let graph = configuration.model
+        guard let lowBinCount = graph.frequencyBins(for: inputRateKHz) else {
+            preconditionFailure("Unsupported UniverSR input rate: \(inputRateKHz) kHz")
+        }
+        let originalFrameCount = input.dim(2)
+        let stride = 1 << graph.dimensions.count
+        let padding = (stride - originalFrameCount % stride) % stride
+        var hidden = univerSRReflectPadFrames(input, amount: padding)
+        let paddedCondition = condition.map { univerSRReflectPadFrames($0, amount: padding) }
+        let batch = hidden.dim(0)
+        let frameCount = hidden.dim(2)
+
+        let rateIndex = Self.sampleRateIndex(inputRateKHz)
+        let rateEmbedding = sampleRateEmbedder(MLXArray([Int32(rateIndex)]))
+        let tiledRate = MLX.tiled(rateEmbedding, repetitions: [batch, 1])
+        let timeEmbedding = timeEmbedder(time) + sampleRateProjector(tiledRate)
+        let fullFrequencyEmbedding = frequencyPosition.value
+        let lowFrequencyEmbedding = fullFrequencyEmbedding[0..<lowBinCount, 0...]
+        let highStart = graph.totalFrequencyBins - graph.highFrequencyBins
+        let highFrequencyEmbedding = fullFrequencyEmbedding[highStart..<graph.totalFrequencyBins, 0...]
+
+        let encodedCondition: MLXArray
+        if let paddedCondition {
+            encodedCondition = conditioningEncoder(
+                paddedCondition,
+                frequencyEmbedding: lowFrequencyEmbedding,
+                sampleRateEmbedding: tiledRate
+            )
+        } else {
+            encodedCondition = MLX.tiled(
+                unconditionalEmbedding.reshaped(1, 1, graph.conditioningDimension),
+                repetitions: [batch, frameCount, 1]
+            )
+        }
+
+        let highFilm = MLX.split(filmGenerator(highFrequencyEmbedding), parts: 2, axis: -1)
+        let gamma = highFilm[0].expandedDimensions(axis: 0).expandedDimensions(axis: 2)
+        let beta = highFilm[1].expandedDimensions(axis: 0).expandedDimensions(axis: 2)
+        let spatialCondition = encodedCondition.expandedDimensions(axis: 1) * gamma + beta
+        hidden = initialConvolution(MLX.concatenated([hidden, spatialCondition], axis: -1))
+
+        var skips = [hidden]
+        for encoder in encoders {
+            hidden = encoder(hidden, time: timeEmbedding)
+            skips.append(hidden)
+            MLX.eval(hidden)
+        }
+        hidden = midcoder(hidden, time: timeEmbedding)
+        MLX.eval(hidden)
+        for decoder in decoders {
+            guard let skip = skips.popLast() else { preconditionFailure("UniverSR skip underflow") }
+            precondition(hidden.shape == skip.shape)
+            hidden = decoder(hidden + skip, time: timeEmbedding)
+            MLX.eval(hidden)
+        }
+        guard let finalSkip = skips.popLast() else { preconditionFailure("UniverSR skip underflow") }
+        hidden = finalConvolution(hidden + finalSkip)
+        return padding > 0 ? hidden[0..., 0..., 0..<originalFrameCount, 0...] : hidden
+    }
+
+    private static func sampleRateIndex(_ inputRateKHz: Int) -> Int {
+        switch inputRateKHz {
+        case 8: 0
+        case 12: 1
+        case 16: 2
+        case 24: 3
+        default: preconditionFailure("Unsupported UniverSR input rate: \(inputRateKHz) kHz")
+        }
+    }
+
+    private static func mappedShape(for descriptor: PyTorchTensorDescriptor) -> [Int] {
+        if isTransposedConvolutionWeight(descriptor.name) {
+            return [descriptor.shape[1], descriptor.shape[2], descriptor.shape[3], descriptor.shape[0]]
+        }
+        if descriptor.shape.count == 4 && descriptor.name.hasSuffix(".weight") {
+            return [descriptor.shape[0], descriptor.shape[2], descriptor.shape[3], descriptor.shape[1]]
+        }
+        return descriptor.shape
+    }
+
+    private static func isTransposedConvolutionWeight(_ key: String) -> Bool {
+        key.hasPrefix("decoders.") && key.hasSuffix(".upsampler.weight")
+    }
+
+    private static func contiguous(_ value: MLXArray) -> MLXArray {
+        value.reshaped(-1).reshaped(value.shape)
+    }
+
+    private static func byteCount(_ dtype: DType) -> Int {
+        switch dtype {
+        case .bool, .int8, .uint8: 1
+        case .float16, .bfloat16, .int16, .uint16: 2
+        case .float32, .int32, .uint32: 4
+        case .float64, .int64, .uint64, .complex64: 8
+        }
+    }
+}

--- a/Sources/MereRunCore/UniverSR/UniverSRResources.swift
+++ b/Sources/MereRunCore/UniverSR/UniverSRResources.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public struct UniverSRCheckpoint: Sendable {
+    public let rootURL: URL
+    public let weightsURL: URL
+    public let sourceConfigurationURL: URL
+    public let modelCardURL: URL
+    public let configuration: UniverSRConfiguration
+}
+
+public struct UniverSRResources: Sendable {
+    public static let modelID = "audio-enhance-universr-audio"
+    public static let sourceRepository = "woongzip1/UniverSR"
+    public static let sourceRevision = "26dc21c44e11f9f19e823f02b0d4641dd5ea5af2"
+    public static let artifactRepository = "woongzip1/universr-audio"
+    public static let artifactRevision = "1c3294844285af851b6ffa56cbde4e43cd41fc2b"
+    public static let expectedTensorCount = 394
+    public static let expectedScalarCount = 57_231_302
+
+    public static let weightsPin = ModelArtifactPin(
+        filename: "pytorch_model.bin",
+        byteCount: 229_072_395,
+        sha256: "eb99f98943cc32fa82226c2da14b32b5d890416070af4946acbce442b30dc20b"
+    )
+    public static let sourceConfigurationPin = ModelArtifactPin(
+        filename: "config.yaml",
+        byteCount: 533,
+        sha256: "2e035dacc833368319f9d5ba1a34e5efd343faf749008d433e309f3c65f4dac9"
+    )
+    public static let modelCardPin = ModelArtifactPin(
+        filename: "README.md",
+        byteCount: 1_406,
+        sha256: "52aceb799f9fb0db692e59c53ea95ded528578664feb9b5726e8809bac8a44db"
+    )
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public static var pins: [ModelArtifactPin] {
+        [weightsPin, sourceConfigurationPin, modelCardPin]
+    }
+
+    public static func loadBundledConfiguration() throws -> UniverSRConfiguration {
+        let nested = Bundle.module.url(
+            forResource: "audio",
+            withExtension: "json",
+            subdirectory: "UniverSR"
+        )
+        guard let url = nested ?? Bundle.module.url(forResource: "audio", withExtension: "json") else {
+            throw UniverSRError.missingBundledConfiguration
+        }
+        let configuration = try JSONDecoder().decode(
+            UniverSRConfiguration.self,
+            from: Data(contentsOf: url)
+        )
+        try configuration.validate()
+        return configuration
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        Self.pins.compactMap { pin in
+            do {
+                _ = try pin.verify(in: rootURL, fileManager: fileManager)
+                return nil
+            } catch {
+                return rootURL.appendingPathComponent(pin.filename)
+            }
+        }
+    }
+
+    public func validationMessages(fileManager: FileManager = .default) -> [String] {
+        Self.pins.compactMap { pin in
+            do {
+                _ = try pin.verify(in: rootURL, fileManager: fileManager)
+                return nil
+            } catch {
+                return error.localizedDescription
+            }
+        }
+    }
+
+    public func resolve() throws -> UniverSRCheckpoint {
+        UniverSRCheckpoint(
+            rootURL: rootURL,
+            weightsURL: try Self.weightsPin.verify(in: rootURL),
+            sourceConfigurationURL: try Self.sourceConfigurationPin.verify(in: rootURL),
+            modelCardURL: try Self.modelCardPin.verify(in: rootURL),
+            configuration: try Self.loadBundledConfiguration()
+        )
+    }
+}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -513,6 +513,47 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### UniverSR
+
+- purpose: native Swift/MLX general-audio super-resolution to 48 kHz
+- upstream project: [`woongzip1/UniverSR`](https://github.com/woongzip1/UniverSR)
+- upstream commit used for the port: `26dc21c44e11f9f19e823f02b0d4641dd5ea5af2`
+- source-code license: MIT
+- official checkpoint: [`woongzip1/universr-audio`](https://huggingface.co/woongzip1/universr-audio)
+- checkpoint revision: `1c3294844285af851b6ffa56cbde4e43cd41fc2b`
+- checkpoint license: Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+The model checkpoint is downloaded separately into the user's model store.
+Managed installs retain the official model card and verify it alongside the
+checkpoint and source configuration. The checkpoint license is not MIT; users
+redistributing the weights or adaptations must preserve the CC BY 4.0
+attribution and license notice. See the official license text at
+<https://creativecommons.org/licenses/by/4.0/legalcode>.
+
+```text
+MIT License
+
+Copyright (c) 2026 Woongjib Choi, DSPAI Lab, Yonsei University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### MuScriptor
 
 - purpose: native MLX audio-to-MIDI model, tokenizer, event decoder, and MIDI behavior

--- a/Tests/MereRunCLITests/AudioEnhanceCommandTests.swift
+++ b/Tests/MereRunCLITests/AudioEnhanceCommandTests.swift
@@ -9,6 +9,29 @@ final class AudioEnhanceCommandTests: XCTestCase {
         XCTAssertEqual(command.model, ModelResolver.ModelID.apBWE16kTo48k.rawValue)
         XCTAssertEqual(command.dtype, "float32")
         XCTAssertNil(command.overlap)
+        XCTAssertNil(command.inputRate)
+        XCTAssertEqual(command.odeMethod, "midpoint")
+        XCTAssertEqual(command.odeSteps, 4)
+        XCTAssertNoThrow(try command.validate())
+    }
+
+    func testParsesUniverSRGeneralAudioOptions() throws {
+        let command = try AudioEnhance.parse([
+            "music.wav",
+            "--model", ModelResolver.ModelID.univerSRAudio.rawValue,
+            "--input-rate", "12000",
+            "--ode-method", "rk4",
+            "--ode-steps", "6",
+            "--guidance-scale", "2",
+            "--seed", "7",
+            "--chunk-seconds", "5",
+        ])
+        XCTAssertEqual(command.inputRate, 12_000)
+        XCTAssertEqual(command.odeMethod, "rk4")
+        XCTAssertEqual(command.odeSteps, 6)
+        XCTAssertEqual(command.guidanceScale, 2)
+        XCTAssertEqual(command.seed, 7)
+        XCTAssertEqual(command.chunkSeconds, 5)
         XCTAssertNoThrow(try command.validate())
     }
 
@@ -31,6 +54,16 @@ final class AudioEnhanceCommandTests: XCTestCase {
         ]))
         XCTAssertThrowsError(try AudioEnhance.parse(["speech.wav", "--overlap", "7"]))
         XCTAssertThrowsError(try AudioEnhance.parse(["speech.wav", "--dtype", "bfloat16"]))
+        XCTAssertThrowsError(try AudioEnhance.parse([
+            "speech.wav",
+            "--model", ModelResolver.ModelID.univerSRAudio.rawValue,
+            "--input-rate", "44100",
+        ]))
+        XCTAssertThrowsError(try AudioEnhance.parse([
+            "speech.wav",
+            "--model", ModelResolver.ModelID.univerSRAudio.rawValue,
+            "--overlap", "2",
+        ]))
     }
 
     func testAudioCommandOwnsEnhanceSubcommand() {

--- a/Tests/MereRunCoreTests/PyTorchStateDictArchiveTests.swift
+++ b/Tests/MereRunCoreTests/PyTorchStateDictArchiveTests.swift
@@ -66,6 +66,52 @@ final class PyTorchStateDictArchiveTests: XCTestCase {
         XCTAssertEqual(archive.tensors.count, 1)
     }
 
+    func testAcceptsExactModernTorchZIPMetadata() throws {
+        let url = try writeCheckpoint(
+            pickle: stateDictPickle(shape: [1], stride: [1], storageElementCount: 1),
+            storage: floatData([3]),
+            formatVersion: "1",
+            storageAlignment: "64"
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertEqual(try PyTorchStateDictArchive(url: url).tensors.count, 1)
+    }
+
+    func testRejectsUnknownModernTorchZIPMetadataValues() throws {
+        let url = try writeCheckpoint(
+            pickle: stateDictPickle(shape: [1], stride: [1], storageElementCount: 1),
+            storage: floatData([3]),
+            formatVersion: "2",
+            storageAlignment: "63"
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try PyTorchStateDictArchive(url: url)) { error in
+            XCTAssertEqual(
+                error as? PyTorchStateDictError,
+                .malformedZIP("invalid ZIP format version")
+            )
+        }
+    }
+
+    func testRejectsInvalidModernTorchStorageAlignment() throws {
+        let url = try writeCheckpoint(
+            pickle: stateDictPickle(shape: [1], stride: [1], storageElementCount: 1),
+            storage: floatData([3]),
+            formatVersion: "1",
+            storageAlignment: "63"
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try PyTorchStateDictArchive(url: url)) { error in
+            XCTAssertEqual(
+                error as? PyTorchStateDictError,
+                .malformedZIP("invalid storage alignment")
+            )
+        }
+    }
+
     func testRejectsNonDecimalModernTorchSerializationIdentifier() throws {
         let url = try writeCheckpoint(
             pickle: stateDictPickle(shape: [1], stride: [1], storageElementCount: 1),
@@ -233,7 +279,9 @@ final class PyTorchStateDictArchiveTests: XCTestCase {
         pickle: Data,
         storage: Data,
         corruptStorageCRC: Bool = false,
-        serializationID: String? = nil
+        serializationID: String? = nil,
+        formatVersion: String? = nil,
+        storageAlignment: String? = nil
     ) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("state-dict-\(UUID().uuidString).pth")
@@ -247,6 +295,19 @@ final class PyTorchStateDictArchiveTests: XCTestCase {
                 ZIPFixtureEntry(
                     name: "checkpoint/.data/serialization_id",
                     data: Data(serializationID.utf8)
+                )
+            )
+        }
+        if let formatVersion {
+            entries.append(
+                ZIPFixtureEntry(name: "checkpoint/.format_version", data: Data(formatVersion.utf8))
+            )
+        }
+        if let storageAlignment {
+            entries.append(
+                ZIPFixtureEntry(
+                    name: "checkpoint/.storage_alignment",
+                    data: Data(storageAlignment.utf8)
                 )
             )
         }

--- a/Tests/MereRunCoreTests/UniverSRTests.swift
+++ b/Tests/MereRunCoreTests/UniverSRTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import MereRunCore
+import XCTest
+
+final class UniverSRTests: MereRunCoreTestCase {
+    func testBundledConfigurationMatchesPinnedProfile() throws {
+        let configuration = try UniverSRResources.loadBundledConfiguration()
+
+        XCTAssertEqual(configuration.supportedInputRates, [8_000, 12_000, 16_000, 24_000])
+        XCTAssertEqual(configuration.transform.samplingRate, 48_000)
+        XCTAssertEqual(configuration.model.dimensions, [96, 192, 384, 768])
+        XCTAssertEqual(configuration.model.depths, [2, 2, 4, 2])
+        XCTAssertEqual(configuration.inference.odeMethod, "midpoint")
+        XCTAssertEqual(configuration.inference.odeSteps, 4)
+    }
+
+    func testManagedArtifactsPinOfficialCCBY40Snapshot() {
+        XCTAssertEqual(UniverSRResources.sourceRevision.count, 40)
+        XCTAssertEqual(UniverSRResources.artifactRevision.count, 40)
+        XCTAssertEqual(UniverSRResources.weightsPin.byteCount, 229_072_395)
+        XCTAssertEqual(
+            UniverSRResources.weightsPin.sha256,
+            "eb99f98943cc32fa82226c2da14b32b5d890416070af4946acbce442b30dc20b"
+        )
+        XCTAssertEqual(UniverSRResources.pins.map(\.filename), [
+            "pytorch_model.bin",
+            "config.yaml",
+            "README.md",
+        ])
+    }
+
+    func testNativeGraphHasExactOfficialInventory() throws {
+        let model = UniverSRModel(configuration: try UniverSRResources.loadBundledConfiguration())
+        let parameters = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
+        XCTAssertEqual(parameters.count, UniverSRResources.expectedTensorCount)
+        XCTAssertEqual(
+            parameters.values.reduce(0) { $0 + $1.size },
+            UniverSRResources.expectedScalarCount
+        )
+    }
+
+    func testIntegerBandlimitedUpsamplingSupportsEveryPublishedRate() throws {
+        for rate in [8_000, 12_000, 16_000, 24_000] {
+            let result = try UniverSRAudio.upsampleTo48k([0, 1, 0, -1], inputRate: rate)
+            XCTAssertEqual(result.count, 4 * 48_000 / rate)
+            XCTAssertTrue(result.allSatisfy(\.isFinite))
+        }
+    }
+
+    func testPinnedOfficialCheckpointInventoryWhenFixtureIsAvailable() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_TEST_UNIVERSR_CHECKPOINT"] else {
+            throw XCTSkip("Set MERERUN_TEST_UNIVERSR_CHECKPOINT to the pinned pytorch_model.bin fixture.")
+        }
+        let archive = try PyTorchStateDictArchive(url: URL(fileURLWithPath: path))
+        XCTAssertEqual(archive.tensors.count, UniverSRResources.expectedTensorCount)
+        XCTAssertEqual(
+            archive.tensors.reduce(0) { $0 + $1.elementCount },
+            UniverSRResources.expectedScalarCount
+        )
+        XCTAssertTrue(archive.tensors.allSatisfy { $0.dataType == .float32 })
+
+        let model = UniverSRModel(configuration: try UniverSRResources.loadBundledConfiguration())
+        try model.validateCheckpoint(archive)
+
+        let loaded = try UniverSRModel.load(
+            checkpoint: UniverSRCheckpoint(
+                rootURL: URL(fileURLWithPath: path).deletingLastPathComponent(),
+                weightsURL: URL(fileURLWithPath: path),
+                sourceConfigurationURL: URL(fileURLWithPath: path),
+                modelCardURL: URL(fileURLWithPath: path),
+                configuration: try UniverSRResources.loadBundledConfiguration()
+            ),
+            dtype: .float16
+        )
+        XCTAssertEqual(loaded.parameters().flattened().count, UniverSRResources.expectedTensorCount)
+    }
+
+    func testManagedCatalogPinsOfficialMITCodeAndCCBY40Checkpoint() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.univerSRAudio.rawValue)
+        )
+        XCTAssertEqual(spec.category, .audio)
+        XCTAssertEqual(spec.validationKind, .univerSR)
+        XCTAssertEqual(spec.upstreamRepoId, UniverSRResources.sourceRepository)
+        XCTAssertEqual(spec.upstreamRevision, UniverSRResources.sourceRevision)
+        XCTAssertEqual(spec.hubFallback?.repoId, UniverSRResources.artifactRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, UniverSRResources.artifactRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, UniverSRResources.pins.map(\.filename))
+        XCTAssertNil(spec.usageRestriction)
+        XCTAssertEqual(spec.defaultCLICommands, ["audio enhance"])
+    }
+
+    func testManifestTemplateDeclaresGeneralAudioSuperResolution() {
+        let manifest = MereRunModelManifest.template(
+            for: .univerSRAudio,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.engine, .univerSR)
+        XCTAssertEqual(manifest.family, .audio)
+        XCTAssertEqual(manifest.precision, .fp32)
+        XCTAssertEqual(manifest.defaults?.steps, 4)
+        XCTAssertEqual(manifest.defaults?.cfg, 1.5)
+        XCTAssertEqual(manifest.supports, [.audioEnhancement])
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(UniverSRResources.sourceRepository)@\(UniverSRResources.sourceRevision)"
+        )
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,14 +170,18 @@ Music source separation:
   - `Sources/MereRunCore/RoFormer/BSRoFormer.swift`
   - `Sources/MereRunCore/RoFormer/RoFormerDSP.swift`
 
-Speech bandwidth extension:
+Audio bandwidth extension and super-resolution:
 
 - CLI: `Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift`
 - Runtime entrypoint: `Sources/MereRunCore/APBWE/APBWEEnhancer.swift`
+- General-audio entrypoint: `Sources/MereRunCore/UniverSR/UniverSREnhancer.swift`
 - Read next:
   - `Sources/MereRunCore/APBWE/APBWEResources.swift`
   - `Sources/MereRunCore/APBWE/APBWEModel.swift`
+  - `Sources/MereRunCore/UniverSR/UniverSRResources.swift`
+  - `Sources/MereRunCore/UniverSR/UniverSRModel.swift`
   - `docs/architecture/audio-enhancement-ap-bwe-report.md`
+  - `docs/architecture/audio-enhancement-universr-report.md`
 
 Sound-effect generation:
 

--- a/docs/architecture/audio-enhancement-ap-bwe-report.md
+++ b/docs/architecture/audio-enhancement-ap-bwe-report.md
@@ -41,10 +41,10 @@ scalar-count, byte-count, and whole-file hash drift.
 
 ## Runtime boundary
 
-`mere.run audio enhance` is a new top-level audio command because the same
-surface can later host general audio super-resolution without conflating it
-with music stem separation. This PR adds only AP-BWE; UniverSR remains a
-separate stacked review.
+`mere.run audio enhance` is a top-level audio command so speech bandwidth
+extension and general-audio super-resolution do not get conflated with music
+stem separation. AP-BWE remains independently reviewable from the stacked
+UniverSR runtime.
 
 The installed-model gate produces a real WAV artifact through the public
 command. The manual checkpoint smoke additionally verifies a 48 kHz mono,

--- a/docs/architecture/audio-enhancement-universr-report.md
+++ b/docs/architecture/audio-enhancement-universr-report.md
@@ -1,0 +1,57 @@
+# UniverSR general-audio super-resolution implementation report
+
+## Decision
+
+The official general-audio UniverSR profile is admitted as a separate native
+audio enhancement runtime. It supports speech, music, and sound effects with
+effective 8, 12, 16, or 24 kHz input bandwidth and always writes 48 kHz mono
+audio. It is described as audio super-resolution, not a complete mastering
+chain.
+
+## Source and license admission
+
+| Item | Frozen identity | License/admission result |
+| --- | --- | --- |
+| Source | `woongzip1/UniverSR@26dc21c44e11f9f19e823f02b0d4641dd5ea5af2` | MIT |
+| Official checkpoint | `woongzip1/universr-audio@1c3294844285af851b6ffa56cbde4e43cd41fc2b` | CC BY 4.0 |
+
+The source-code and checkpoint licenses are intentionally recorded separately.
+The 229,072,395-byte `pytorch_model.bin` has SHA-256
+`eb99f98943cc32fa82226c2da14b32b5d890416070af4946acbce442b30dc20b`.
+The 533-byte source `config.yaml` and 1,406-byte official model card are also
+pinned by exact byte count and SHA-256. Runtime readiness fails if any of the
+three artifacts changes.
+
+## Native graph
+
+The typed graph contains 394 float32 tensors and 57,231,302 scalars. It follows
+the published general-audio profile:
+
+- deterministic integer-ratio, windowed-sinc interpolation to 48 kHz;
+- symmetric-Hann, 1,024-point complex STFT with a 512-sample hop;
+- power-law magnitude compression with alpha 0.2, beta 1, and epsilon 1e-4;
+- conditional ConvNeXt V2 U-Net dimensions `[96, 192, 384, 768]`, depths
+  `[2, 2, 4, 2]`, 384 conditioning channels, and a 256-dimensional time path;
+- rate-conditioned low-frequency observations and reconstruction of the
+  remaining spectrum;
+- deterministic noise seeding and Euler, midpoint, or RK4 ODE integration;
+- inverse compression and native ISTFT cropped back to the source duration.
+
+PyTorch Conv2d and ConvTranspose2d tensors are transformed into the MLX kernel
+layouts only after the restricted state-dict reader verifies archive metadata,
+key set, shape, dtype, tensor count, scalar count, byte count, and whole-file
+hash.
+
+## Runtime boundary
+
+`mere.run audio enhance --model audio-enhance-universr-audio` selects this
+runtime. Native 8/12/16/24 kHz files determine their effective rate directly;
+bandwidth-limited audio stored in a 48 kHz container requires `--input-rate` so
+the runtime does not guess. The published defaults are midpoint integration,
+four steps, guidance scale 1.5, and seed 42, all recorded in the output
+provenance manifest.
+
+The installed-model gate and manual smoke use the public command to produce a
+real WAV. Finite, non-silent output and spectral energy above the declared
+input boundary prove the native path executed; they are not a perceptual
+quality benchmark.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,7 +71,7 @@ Public tree:
   - `mere.run vision image-to-3d-multiview` — VFX alias for native 4/6-view InstantMesh reconstruction.
   - `mere.run vision ocr` — Extract text from images using LightOnOCR, GLM-OCR, or Infinity-Parser2.
 - [`mere.run audio`](/runtime/audio) — Enhance general audio locally.
-  - `mere.run audio enhance` — Extend narrowband speech from 16 kHz to 48 kHz with AP-BWE.
+  - `mere.run audio enhance` — Extend speech or general-audio bandwidth to 48 kHz.
 - [`mere.run music`](/runtime/music) — Generate, analyze, transcribe, and separate music locally.
   - `mere.run music analyze` — Analyze source audio with ACE-Step audio understanding.
   - `mere.run music generate` — Generate audio from a music prompt.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -104,6 +104,7 @@ from the runtime catalog used by `mere.run model list`,
 | `music` | `music-separate-mel-roformer-dereverb` |
 | `music` | `music-separate-mel-roformer-denoise` |
 | `audio` | `audio-enhance-ap-bwe-16kto48k` |
+| `audio` | `audio-enhance-universr-audio` |
 | `sfx` | `sfx-woosh-dflow` |
 | `sfx` | `sfx-woosh-flow` |
 | `sfx` | `sfx-woosh-clap` |
@@ -189,6 +190,13 @@ pinned source repository states that both code and pretrained weights are MIT.
 The managed public transport snapshot retains the code and weights license
 files, source config, and the exact official 16→48 kHz checkpoint archive;
 mere.run verifies all four byte counts and SHA-256 digests before loading.
+
+`audio-enhance-universr-audio` does not require interactive acknowledgement,
+but its two upstream licenses must not be conflated. The native port follows
+the MIT-licensed `woongzip1/UniverSR` source at its pinned commit. The separately
+downloaded official `woongzip1/universr-audio` checkpoint is CC BY 4.0. The
+managed install verifies the checkpoint, source configuration, and model card
+by frozen revision, byte count, and SHA-256 before loading.
 
 `image-zimage-nano` also does not require acknowledgement. Its canonical
 `Tongyi-MAI/Z-Image-Turbo` base is Apache-2.0; the pinned mflux conversion's

--- a/docs/runtime/audio.md
+++ b/docs/runtime/audio.md
@@ -1,18 +1,20 @@
 # Audio Enhancement Runtime
 
-Extend narrowband speech to a 48 kHz wideband artifact with a native Swift/MLX
-port of AP-BWE. The runtime is local-only, verifies the checkpoint and licenses
-before loading, and keeps machine-readable results on stdout.
+Extend narrowband speech or bandwidth-limited general audio to a 48 kHz
+artifact with native Swift/MLX ports of AP-BWE and UniverSR. Both runtimes are
+local-only, verify their pinned artifacts before loading, and keep
+machine-readable results on stdout.
 
 ## Command
 
 | Command | What it does |
 | --- | --- |
-| `mere.run audio enhance` | Decode speech to 16 kHz mono and reconstruct a 48 kHz mono float WAV with AP-BWE. |
+| `mere.run audio enhance` | Reconstruct a 48 kHz mono float WAV with AP-BWE speech bandwidth extension or UniverSR general-audio super-resolution. |
 
 ## Model
 
 - `audio-enhance-ap-bwe-16kto48k`
+- `audio-enhance-universr-audio`
 
 The source implementation is pinned to
 [`yxlu-0102/AP-BWE@751710f`](https://github.com/yxlu-0102/AP-BWE/tree/751710f22404c27e5bcc983248f8b856a04b8422).
@@ -21,12 +23,30 @@ The public Hugging Face transport snapshot is pinned independently; mere.run
 accepts its 16→48 kHz archive only because it is byte-identical to the official
 Google Drive checkpoint.
 
+UniverSR's native graph is pinned to
+[`woongzip1/UniverSR@26dc21c`](https://github.com/woongzip1/UniverSR/tree/26dc21c44e11f9f19e823f02b0d4641dd5ea5af2),
+whose code is MIT-licensed. Its official
+[`woongzip1/universr-audio@1c32948`](https://huggingface.co/woongzip1/universr-audio/tree/1c3294844285af851b6ffa56cbde4e43cd41fc2b)
+checkpoint is separately licensed CC BY 4.0. The managed profile preserves
+that distinction and pins the checkpoint, source configuration, and model card
+independently.
+
 ## Typical workflow
 
 ```bash
 swift run mere.run model pull audio-enhance-ap-bwe-16kto48k
 swift run mere.run audio enhance ./narrowband-speech.wav \
   --output ./wideband-speech.wav
+
+swift run mere.run model pull audio-enhance-universr-audio
+swift run mere.run audio enhance ./music-12k.wav \
+  --model audio-enhance-universr-audio \
+  --output ./music-super-resolved.wav
+
+# Declare the effective bandwidth when a limited source is stored at 48 kHz.
+swift run mere.run audio enhance ./limited-48k.wav \
+  --model audio-enhance-universr-audio \
+  --input-rate 16000 --seed 42
 ```
 
 Input is decoded to 16 kHz mono, then upsampled threefold with a deterministic
@@ -35,15 +55,27 @@ profile uses a 1,024-point STFT, 320-sample periodic Hann window, 80-sample hop,
 512 channels, and eight paired magnitude/phase ConvNeXt blocks. Chunked overlap
 uses two-second 48 kHz windows by default.
 
+UniverSR accepts effective input rates of 8, 12, 16, or 24 kHz. It applies a
+1,024-point complex STFT, conditions a 394-tensor ConvNeXt V2 U-Net on the
+observed low-frequency region, and reconstructs the remaining spectrum with
+flow matching. The published defaults are midpoint integration, four ODE
+steps, classifier-free guidance 1.5, and seed 42. Native-rate files supply the
+effective rate automatically; a bandwidth-limited 48 kHz container requires
+`--input-rate`.
+
 The command writes the float WAV and a sibling JSON file. That manifest records
 the source and output hashes, original and decoded audio geometry, immutable
-code and artifact revisions, checkpoint/config hashes, compute type, chunk
-count, overlap, and elapsed time. The same JSON is written to stdout; progress
-remains on stderr.
+code and artifact revisions, checkpoint/config hashes, license identities,
+compute type, inference controls, chunk count, and elapsed time. The same JSON
+is written to stdout; progress remains on stderr.
 
 AP-BWE is a speech bandwidth-extension model, not a general mastering model.
-A decoded, finite, non-silent output proves the native route executed; it does
-not by itself establish perceptual improvement for a particular recording.
+UniverSR covers speech, music, and sound effects, but is still super-resolution
+rather than a complete mastering chain. A decoded, finite, non-silent output
+proves the native route executed; it does not by itself establish perceptual
+improvement for a particular recording.
 
 See the [implementation report](../architecture/audio-enhancement-ap-bwe-report.md)
-for admission evidence and graph details.
+for AP-BWE admission evidence and the
+[UniverSR report](../architecture/audio-enhancement-universr-report.md) for its
+separate graph, artifact, and license evidence.


### PR DESCRIPTION
## Summary

- add a native Swift/MLX port of the official UniverSR general-audio super-resolution model
- support effective 8, 12, 16, and 24 kHz speech, music, or sound effects with 48 kHz mono output
- reproduce the complex-STFT, conditional ConvNeXt V2 U-Net, deterministic flow matching, Euler/midpoint/RK4 integration, classifier-free guidance, and chunking path
- pin the MIT source and CC BY 4.0 official checkpoint independently, including exact revisions, byte counts, hashes, and license provenance
- extend `mere.run audio enhance`, managed-model validation, installed-model gates, docs, and tests

## Why

UniverSR is the permissively usable general-audio counterpart to AP-BWE. Keeping it in a separate stacked PR makes the materially different graph and checkpoint license easy to review.

## Validation

- `./scripts/check.sh` — 2,390 tests passed, 152 skipped, 0 failed; strict lint, build, CLI help sweep, agent-readiness, and hygiene scans passed
- official 229.1 MB checkpoint pulled through the managed catalog and verified at SHA-256 `eb99f98943cc32fa82226c2da14b32b5d890416070af4946acbce442b30dc20b`
- exact official fixture fully loaded in FP16: 394 tensors and 57,231,302 scalars
- real default FP32 smoke used midpoint integration, four steps, CFG 1.5, and seed 42; output SHA-256 `c4f11853fdad1091026832d4313bdaac658d4843303df837d71c8ea4de92d831`
- output was a finite, non-silent 48 kHz float WAV with zero NaN/Inf samples and measurable energy above 8.5 kHz
- fail-closed installed-model gate passed the direct `audio enhance` true-inference recipe

## Stack

Depends on the AP-BWE branch and targets `codex/ap-bwe` for an isolated review diff.
