### PR TITLE
feat(runtime): add machine-wide inference admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog.
 
 ### Added
 
+- added crash-safe machine-wide inference admission across direct CLI calls,
+  Studio, launchers such as Raycast, scripts, agents, and API-server processes.
+  A RAM-scaled weighted FIFO preserves concurrency for small and standard work
+  while giving video, DeepSeek V4 Flash, and selected models of at least 48 GiB
+  exclusive machine headroom. Admission refuses new allocation-heavy work below the
+  swap-protecting disk floor, pauses behind memory pressure, removes cancelled
+  or dead-process tickets, and is visible through `mere.run status` and
+  `status --json`. API servers retain their existing resident model pools,
+  prefix caches, continuous batching, and `--max-active-requests` concurrency
+  inside the server's machine reservation.
 - added native Swift/MLX two-stem music source separation through
   `music separate` and the managed `music-separate-bs-roformer-viperx-1297`
   model. The runtime pins the AEmotion Studio MIT license, model card, source

--- a/README.md
+++ b/README.md
@@ -463,6 +463,9 @@ MERERUN_GEMMA4_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
 MERERUN_Q35_CONTINUOUS_BATCHING=1 swift run mere.run api serve \
   --max-active-requests 2
 
+# Inspect both the server request queue and machine-wide inference admission
+swift run mere.run status
+
 # Experimental Gemma4 packed PolarKV for memory-pressure and long-context decode testing
 swift run mere.run api serve \
   --engine text-chat-gemma4 \

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -206,6 +206,16 @@ struct APIServe: AsyncParsableCommand {
         let resolvedLoraPath = try resolveLoraPath(modelPath: resolvedModelPath)
         let gemma4KVCacheQuantization = try resolveGemma4KVCacheQuantization()
         let memoryPressurePolicy = try resolveMemoryPressurePolicy()
+        let machineAdmissionLease = try await MachineInferenceCoordinator.shared.acquire(
+            CLIInferenceAdmissionClassifier.apiServerRequest(engine: engine, modelID: defaultModelID)
+        ) { snapshot in
+            CLIStderr.write(
+                "API server queued by machine admission "
+                    + "(\(snapshot.activePermits)/\(snapshot.capacityPermits) permits active, "
+                    + "\(snapshot.queued.count) queued).\n"
+            )
+        }
+        defer { machineAdmissionLease.release() }
         let server = try await CodeGenServer(
             defaultModelID: defaultModelID,
             modelPath: resolvedModelPath,

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -80,6 +80,8 @@ struct StatusSnapshot: Codable, Equatable {
     let knownModelCount: Int
     let installedModels: [StatusInstalledModelSnapshot]
     var capabilities: StatusCapabilitiesSnapshot = .current
+    var machineAdmission: MachineInferenceAdmissionSnapshot? = nil
+    var machineAdmissionDetail: String? = nil
 }
 
 struct StatusCapabilitiesSnapshot: Codable, Equatable {
@@ -136,6 +138,15 @@ struct StatusSnapshotBuilder {
             }
         let modelStore = MereRunModelPaths.modelStoreResolution()
         let server = await serverSnapshot()
+        let machineAdmission: MachineInferenceAdmissionSnapshot?
+        let machineAdmissionDetail: String?
+        do {
+            machineAdmission = try MachineInferenceCoordinator.shared.snapshot()
+            machineAdmissionDetail = nil
+        } catch {
+            machineAdmission = nil
+            machineAdmissionDetail = error.localizedDescription
+        }
 
         return StatusSnapshot(
             server: server,
@@ -146,7 +157,9 @@ struct StatusSnapshotBuilder {
                 isFallbackToDefault: modelStore.isFallbackToDefault
             ),
             knownModelCount: inventoryRows.count,
-            installedModels: installedModels
+            installedModels: installedModels,
+            machineAdmission: machineAdmission,
+            machineAdmissionDetail: machineAdmissionDetail
         )
     }
 
@@ -361,6 +374,27 @@ enum StatusFormatter {
             }
         } else {
             lines.append("  loaded models: unavailable")
+        }
+
+        if let admission = snapshot.machineAdmission {
+            lines.append(
+                "  machine admission: \(admission.activePermits)/\(admission.capacityPermits) permits active, "
+                    + "\(admission.active.count) running, \(admission.queued.count) queued"
+            )
+            for entry in admission.active {
+                lines.append(
+                    "    active: \(entry.label), pid \(entry.processID), "
+                        + "\(entry.permits) permit(s), \(entry.resourceClass.rawValue)"
+                )
+            }
+            for entry in admission.queued {
+                lines.append(
+                    "    queued: \(entry.label), pid \(entry.processID), "
+                        + "\(entry.permits) permit(s), \(entry.resourceClass.rawValue)"
+                )
+            }
+        } else if let detail = snapshot.machineAdmissionDetail {
+            lines.append("  machine admission: unavailable (\(detail))")
         }
 
         lines.append("  model store: \(modelStoreText(snapshot.modelStore))")

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -158,6 +158,12 @@ download route.
   instead of running later. Raising the limit is an explicit throughput and
   unified-memory tradeoff. Explicit runtime model load/unload maintenance uses
   the same admission queue so it cannot race default-serialized inference.
+- Each API-server process also holds a weighted machine-wide reservation. This
+  coordinates the server with direct CLI calls and other server instances
+  without disabling its resident model pool, prefix reuse, sidecar reuse,
+  continuous batching, or `--max-active-requests` concurrency. Ordinary
+  servers use a standard reservation; DeepSeek V4 Flash servers reserve the
+  full machine capacity.
 - Gemma4, Qwen-family, and LFM2 chat use chunked prefill with
   cancellation/progress checkpoints. This improves long-prompt observability
   without turning prefill itself into continuous batching.

--- a/Sources/MereRunCLI/Guides/status.md
+++ b/Sources/MereRunCLI/Guides/status.md
@@ -5,6 +5,10 @@
 Show one local snapshot of the mere.run runtime: API server reachability, the
 model currently reported by `/v1/models`, the active model-store path, and the
 managed models installed there.
+The snapshot also reads the machine-wide inference admission ledger even when
+the API server is down. It reports weighted permit capacity, active commands,
+queued commands, process IDs, resource classes, memory pressure, and disk
+headroom without recording prompts or generated content.
 When `/runtime/status` is available, the snapshot also includes runtime pool
 entries, active request counts, request admission queue depth, memory pressure,
 runtime capability flags, aggregate cache stats, per-model prefix KV cache
@@ -50,6 +54,9 @@ mere.run guide status
   requests are running and how many are queued behind `--max-active-requests`.
   JSON status also includes admitted, completed, cancelled, pressure, and
   whether admission is currently paused by the memory guard.
+- During overlapping apps or CLI processes, check `machine admission` to see
+  aggregate work across Studio, Raycast, terminals, scripts, agents, and API
+  servers. This is distinct from the per-server request queue.
 - Use `memory` to see the active memory guard tier, pressure level, current
   resident usage, host-available estimate, and computed soft/hard/ceiling limits.
 - Use `process` to inspect server uptime, sampled process CPU, macOS
@@ -88,6 +95,12 @@ MERERUN_API_KEY=change-me mere.run status --json
   `/v1/models` needs `--api-key` or `MERERUN_API_KEY`.
 - The loaded model list is what the API server reports; it is not a system-wide
   RAM/process scan for every runtime family.
+- Machine admission is system-wide for cooperative `mere.run` processes. Small
+  work uses one weighted permit, standard work uses two, and video/DS4-class
+  work takes the full machine capacity. Capacity scales from one permit below
+  48 GiB to two below 96 GiB, four below 192 GiB, and six thereafter.
+- Admission state contains command families and process IDs only. A process
+  exit removes its ticket; a crash is pruned on the next queue or status read.
 - A sidecar can be resident before it is ready because its generator object is
   created before the first operation finishes model loading. Check the per-lane
   state rather than treating residency alone as request readiness.
@@ -109,4 +122,5 @@ MERERUN_API_KEY=change-me mere.run status --json
 ## Sources
 
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/StatusCommand.swift
+- https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Support/ModelInventory.swift

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -18,6 +18,7 @@ struct MereRunCLI: AsyncParsableCommand {
         } else {
             _ = _mereRunCLIModelStoreBootstrap
         }
+        try CLIProcessAdmissionBootstrap.acquireIfNeeded(arguments: CommandLine.arguments)
     }
 
     static let configuration = CommandConfiguration(

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -1,0 +1,685 @@
+import Foundation
+import MereRunCore
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+enum MachineInferenceClass: String, Codable, CaseIterable, Sendable {
+    case small
+    case standard
+    case large
+
+    func permits(capacity: Int) -> Int {
+        switch self {
+        case .small:
+            return 1
+        case .standard:
+            return min(2, capacity)
+        case .large:
+            return capacity
+        }
+    }
+
+    var minimumAvailableBytes: UInt64 {
+        let gibibyte = UInt64(1_073_741_824)
+        switch self {
+        case .small:
+            return 6 * gibibyte
+        case .standard:
+            return 16 * gibibyte
+        case .large:
+            return 32 * gibibyte
+        }
+    }
+}
+
+struct MachineInferenceRequest: Equatable, Sendable {
+    let label: String
+    let resourceClass: MachineInferenceClass
+}
+
+struct MachineInferenceAdmissionEntrySnapshot: Codable, Equatable, Sendable {
+    let id: UUID
+    let processID: Int32
+    let label: String
+    let resourceClass: MachineInferenceClass
+    let permits: Int
+    let queuedAt: Date
+    let admittedAt: Date?
+}
+
+struct MachineInferenceAdmissionSnapshot: Codable, Equatable, Sendable {
+    let capacityPermits: Int
+    let activePermits: Int
+    let active: [MachineInferenceAdmissionEntrySnapshot]
+    let queued: [MachineInferenceAdmissionEntrySnapshot]
+    let memoryPressure: RuntimeMemoryPressureLevel
+    let availableMemoryBytes: UInt64?
+    let availableDiskBytes: UInt64?
+    let minimumDiskBytes: UInt64
+}
+
+struct MachineInferenceHostSnapshot: Equatable, Sendable {
+    let physicalMemoryBytes: UInt64
+    let availableMemoryBytes: UInt64?
+    let memoryPressure: RuntimeMemoryPressureLevel
+    let availableDiskBytes: UInt64?
+}
+
+enum MachineInferenceAdmissionError: LocalizedError, Equatable {
+    case corruptState(String)
+    case missingTicket(UUID)
+    case insufficientDisk(available: UInt64, required: UInt64)
+    case insufficientMemory(available: UInt64, required: UInt64)
+    case criticalMemoryPressure
+    case systemCall(operation: String, code: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .corruptState(let detail):
+            return "Machine inference admission state is invalid: \(detail)"
+        case .missingTicket(let id):
+            return "Machine inference admission ticket \(id.uuidString) disappeared while waiting."
+        case .insufficientDisk(let available, let required):
+            return "Inference was not started because only \(Self.bytes(available)) of disk space is available; "
+                + "at least \(Self.bytes(required)) is reserved for macOS swap and temporary files."
+        case .insufficientMemory(let available, let required):
+            return "Inference was not started because only \(Self.bytes(available)) of reclaimable memory is available; "
+                + "this workload requires at least \(Self.bytes(required)) of admission headroom."
+        case .criticalMemoryPressure:
+            return "Inference was not started because the machine is already under critical memory pressure."
+        case .systemCall(let operation, let code):
+            return "Machine inference admission could not \(operation) (errno \(code))."
+        }
+    }
+
+    private static func bytes(_ value: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(value), countStyle: .memory)
+    }
+}
+
+private enum MachineInferenceTicketState: String, Codable, Sendable {
+    case queued
+    case active
+}
+
+private struct MachineInferenceTicket: Codable, Equatable, Sendable {
+    let id: UUID
+    let processID: Int32
+    let bootSessionID: String
+    let label: String
+    let resourceClass: MachineInferenceClass
+    let permits: Int
+    let queuedAt: Date
+    var admittedAt: Date?
+    var state: MachineInferenceTicketState
+
+    var snapshot: MachineInferenceAdmissionEntrySnapshot {
+        MachineInferenceAdmissionEntrySnapshot(
+            id: id,
+            processID: processID,
+            label: label,
+            resourceClass: resourceClass,
+            permits: permits,
+            queuedAt: queuedAt,
+            admittedAt: admittedAt
+        )
+    }
+}
+
+private struct MachineInferenceAdmissionState: Codable, Equatable, Sendable {
+    static let currentVersion = 1
+
+    var version = currentVersion
+    var tickets: [MachineInferenceTicket] = []
+}
+
+struct MachineInferenceCoordinator: Sendable {
+    static let pollNanoseconds: UInt64 = 250_000_000
+
+    let stateDirectory: URL
+    private let processID: Int32
+    private let bootSessionID: String
+    private let currentDate: @Sendable () -> Date
+    private let hostSnapshot: @Sendable () -> MachineInferenceHostSnapshot
+    private let processIsAlive: @Sendable (Int32) -> Bool
+    private let sleeper: @Sendable (UInt64) async throws -> Void
+
+    static var shared: MachineInferenceCoordinator {
+        MachineInferenceCoordinator()
+    }
+
+    init(
+        stateDirectory: URL = MereRunModelPaths.applicationSupportBase
+            .appendingPathComponent("admission", isDirectory: true),
+        processID: Int32 = getpid(),
+        bootSessionID: String = MachineInferenceCoordinator.currentBootSessionID(),
+        currentDate: @escaping @Sendable () -> Date = Date.init,
+        hostSnapshot: @escaping @Sendable () -> MachineInferenceHostSnapshot = {
+            MachineInferenceCoordinator.currentHostSnapshot()
+        },
+        processIsAlive: @escaping @Sendable (Int32) -> Bool = {
+            MachineInferenceCoordinator.isProcessAlive($0)
+        },
+        sleeper: @escaping @Sendable (UInt64) async throws -> Void = {
+            try await Task.sleep(nanoseconds: $0)
+        }
+    ) {
+        self.stateDirectory = stateDirectory
+        self.processID = processID
+        self.bootSessionID = bootSessionID
+        self.currentDate = currentDate
+        self.hostSnapshot = hostSnapshot
+        self.processIsAlive = processIsAlive
+        self.sleeper = sleeper
+    }
+
+    func acquire(
+        _ request: MachineInferenceRequest,
+        onWait: (@Sendable (MachineInferenceAdmissionSnapshot) -> Void)? = nil
+    ) async throws -> MachineInferenceLease {
+        let ticketID = try register(request)
+        var announcedWait = false
+        do {
+            while true {
+                try Task.checkCancellation()
+                let result = try attemptAdmission(ticketID: ticketID)
+                if result.admitted {
+                    return MachineInferenceLease(coordinator: self, ticketID: ticketID)
+                }
+                if !announcedWait {
+                    onWait?(result.snapshot)
+                    announcedWait = true
+                }
+                try await sleeper(Self.pollNanoseconds)
+            }
+        } catch {
+            try? removeTicket(ticketID)
+            throw error
+        }
+    }
+
+    func acquireBlocking(
+        _ request: MachineInferenceRequest,
+        onWait: ((MachineInferenceAdmissionSnapshot) -> Void)? = nil
+    ) throws -> MachineInferenceLease {
+        let ticketID = try register(request)
+        var announcedWait = false
+        do {
+            while true {
+                let result = try attemptAdmission(ticketID: ticketID)
+                if result.admitted {
+                    return MachineInferenceLease(coordinator: self, ticketID: ticketID)
+                }
+                if !announcedWait {
+                    onWait?(result.snapshot)
+                    announcedWait = true
+                }
+                usleep(useconds_t(Self.pollNanoseconds / 1_000))
+            }
+        } catch {
+            try? removeTicket(ticketID)
+            throw error
+        }
+    }
+
+    func snapshot() throws -> MachineInferenceAdmissionSnapshot {
+        try withLockedState { state in
+            pruneDeadTickets(&state)
+            return makeSnapshot(state: state, host: hostSnapshot())
+        }
+    }
+
+    fileprivate func removeTicket(_ ticketID: UUID) throws {
+        try withLockedState { state in
+            state.tickets.removeAll { $0.id == ticketID }
+        }
+    }
+
+    private func register(_ request: MachineInferenceRequest) throws -> UUID {
+        let host = hostSnapshot()
+        try validateDisk(host)
+        let capacity = Self.capacityPermits(physicalMemoryBytes: host.physicalMemoryBytes)
+        let ticket = MachineInferenceTicket(
+            id: UUID(),
+            processID: processID,
+            bootSessionID: bootSessionID,
+            label: request.label,
+            resourceClass: request.resourceClass,
+            permits: request.resourceClass.permits(capacity: capacity),
+            queuedAt: currentDate(),
+            admittedAt: nil,
+            state: .queued
+        )
+        try withLockedState { state in
+            pruneDeadTickets(&state)
+            state.tickets.append(ticket)
+        }
+        return ticket.id
+    }
+
+    private func attemptAdmission(
+        ticketID: UUID
+    ) throws -> (admitted: Bool, snapshot: MachineInferenceAdmissionSnapshot) {
+        try withLockedState { state in
+            pruneDeadTickets(&state)
+            guard let ticketIndex = state.tickets.firstIndex(where: { $0.id == ticketID }) else {
+                throw MachineInferenceAdmissionError.missingTicket(ticketID)
+            }
+            let host = hostSnapshot()
+            try validateDisk(host)
+            if state.tickets[ticketIndex].state == .active {
+                return (true, makeSnapshot(state: state, host: host))
+            }
+
+            let orderedQueued = state.tickets
+                .filter { $0.state == .queued }
+                .sorted(by: Self.ticketOrder)
+            guard orderedQueued.first?.id == ticketID else {
+                return (false, makeSnapshot(state: state, host: host))
+            }
+
+            let capacity = Self.capacityPermits(physicalMemoryBytes: host.physicalMemoryBytes)
+            let activePermits = state.tickets
+                .filter { $0.state == .active }
+                .reduce(0) { $0 + $1.permits }
+            let requestedPermits = state.tickets[ticketIndex].permits
+            guard activePermits + requestedPermits <= capacity else {
+                return (false, makeSnapshot(state: state, host: host))
+            }
+
+            switch host.memoryPressure {
+            case .critical:
+                throw MachineInferenceAdmissionError.criticalMemoryPressure
+            case .elevated where activePermits > 0:
+                return (false, makeSnapshot(state: state, host: host))
+            case .disabled, .unknown, .nominal, .elevated:
+                break
+            }
+
+            let minimumAvailable = state.tickets[ticketIndex].resourceClass.minimumAvailableBytes
+            if let available = host.availableMemoryBytes, available < minimumAvailable {
+                if activePermits > 0 {
+                    return (false, makeSnapshot(state: state, host: host))
+                }
+                throw MachineInferenceAdmissionError.insufficientMemory(
+                    available: available,
+                    required: minimumAvailable
+                )
+            }
+
+            state.tickets[ticketIndex].state = .active
+            state.tickets[ticketIndex].admittedAt = currentDate()
+            return (true, makeSnapshot(state: state, host: host))
+        }
+    }
+
+    private func validateDisk(_ host: MachineInferenceHostSnapshot) throws {
+        let minimum = Self.minimumDiskBytes(physicalMemoryBytes: host.physicalMemoryBytes)
+        if let available = host.availableDiskBytes, available < minimum {
+            throw MachineInferenceAdmissionError.insufficientDisk(
+                available: available,
+                required: minimum
+            )
+        }
+    }
+
+    private func pruneDeadTickets(_ state: inout MachineInferenceAdmissionState) {
+        state.tickets.removeAll {
+            $0.bootSessionID != bootSessionID || !processIsAlive($0.processID)
+        }
+    }
+
+    private func makeSnapshot(
+        state: MachineInferenceAdmissionState,
+        host: MachineInferenceHostSnapshot
+    ) -> MachineInferenceAdmissionSnapshot {
+        let active = state.tickets
+            .filter { $0.state == .active }
+            .sorted(by: Self.ticketOrder)
+        let queued = state.tickets
+            .filter { $0.state == .queued }
+            .sorted(by: Self.ticketOrder)
+        return MachineInferenceAdmissionSnapshot(
+            capacityPermits: Self.capacityPermits(physicalMemoryBytes: host.physicalMemoryBytes),
+            activePermits: active.reduce(0) { $0 + $1.permits },
+            active: active.map(\.snapshot),
+            queued: queued.map(\.snapshot),
+            memoryPressure: host.memoryPressure,
+            availableMemoryBytes: host.availableMemoryBytes,
+            availableDiskBytes: host.availableDiskBytes,
+            minimumDiskBytes: Self.minimumDiskBytes(physicalMemoryBytes: host.physicalMemoryBytes)
+        )
+    }
+
+    private func withLockedState<T>(
+        _ operation: (inout MachineInferenceAdmissionState) throws -> T
+    ) throws -> T {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: stateDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let lockURL = stateDirectory.appendingPathComponent("state.lock", isDirectory: false)
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR, mode_t(0o600))
+        guard descriptor >= 0 else {
+            throw MachineInferenceAdmissionError.systemCall(operation: "open its lock", code: errno)
+        }
+        defer { close(descriptor) }
+        while flock(descriptor, LOCK_EX) != 0 {
+            guard errno == EINTR else {
+                throw MachineInferenceAdmissionError.systemCall(operation: "lock its state", code: errno)
+            }
+        }
+        defer { flock(descriptor, LOCK_UN) }
+
+        var state = try loadState()
+        let original = state
+        let result = try operation(&state)
+        if state != original {
+            try saveState(state)
+        }
+        return result
+    }
+
+    private func loadState() throws -> MachineInferenceAdmissionState {
+        let url = stateDirectory.appendingPathComponent("state.json", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return MachineInferenceAdmissionState()
+        }
+        do {
+            let state = try JSONDecoder().decode(
+                MachineInferenceAdmissionState.self,
+                from: Data(contentsOf: url)
+            )
+            guard state.version == MachineInferenceAdmissionState.currentVersion else {
+                throw MachineInferenceAdmissionError.corruptState(
+                    "unsupported version \(state.version)"
+                )
+            }
+            return state
+        } catch let error as MachineInferenceAdmissionError {
+            throw error
+        } catch {
+            throw MachineInferenceAdmissionError.corruptState(error.localizedDescription)
+        }
+    }
+
+    private func saveState(_ state: MachineInferenceAdmissionState) throws {
+        let url = stateDirectory.appendingPathComponent("state.json", isDirectory: false)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(state)
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    static func capacityPermits(physicalMemoryBytes: UInt64) -> Int {
+        let gibibyte = UInt64(1_073_741_824)
+        switch physicalMemoryBytes {
+        case ..<(48 * gibibyte):
+            return 1
+        case ..<(96 * gibibyte):
+            return 2
+        case ..<(192 * gibibyte):
+            return 4
+        default:
+            return 6
+        }
+    }
+
+    static func minimumDiskBytes(physicalMemoryBytes: UInt64) -> UInt64 {
+        let gibibyte = UInt64(1_073_741_824)
+        return min(32 * gibibyte, max(8 * gibibyte, physicalMemoryBytes / 8))
+    }
+
+    private static func ticketOrder(_ lhs: MachineInferenceTicket, _ rhs: MachineInferenceTicket) -> Bool {
+        if lhs.queuedAt != rhs.queuedAt {
+            return lhs.queuedAt < rhs.queuedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private static func currentHostSnapshot() -> MachineInferenceHostSnapshot {
+        let memory = RuntimeMemorySample.current()
+        let disk = try? MereRunModelPaths.applicationSupportBase
+            .deletingLastPathComponent()
+            .resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        ).volumeAvailableCapacityForImportantUsage
+        return MachineInferenceHostSnapshot(
+            physicalMemoryBytes: memory.physicalBytes,
+            availableMemoryBytes: memory.availableBytes,
+            memoryPressure: RuntimeMemoryPressurePolicy.default.pressure(for: memory),
+            availableDiskBytes: disk.flatMap { $0 >= 0 ? UInt64($0) : nil }
+        )
+    }
+
+    private static func isProcessAlive(_ processID: Int32) -> Bool {
+        guard processID > 0 else { return false }
+        if kill(processID, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+
+    static func currentBootSessionID() -> String {
+#if os(Linux)
+        if let value = try? String(contentsOfFile: "/proc/sys/kernel/random/boot_id", encoding: .utf8) {
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+#else
+        var bootTime = timeval()
+        var size = MemoryLayout<timeval>.size
+        if sysctlbyname("kern.boottime", &bootTime, &size, nil, 0) == 0 {
+            return "\(bootTime.tv_sec).\(bootTime.tv_usec)"
+        }
+#endif
+        let estimatedBootDate = Date().timeIntervalSince1970 - ProcessInfo.processInfo.systemUptime
+        return String(Int64(estimatedBootDate.rounded()))
+    }
+}
+
+final class MachineInferenceLease: @unchecked Sendable {
+    private let coordinator: MachineInferenceCoordinator
+    private let ticketID: UUID
+    private let lock = NSLock()
+    private var released = false
+
+    fileprivate init(coordinator: MachineInferenceCoordinator, ticketID: UUID) {
+        self.coordinator = coordinator
+        self.ticketID = ticketID
+    }
+
+    deinit {
+        release()
+    }
+
+    func release() {
+        lock.lock()
+        guard !released else {
+            lock.unlock()
+            return
+        }
+        released = true
+        lock.unlock()
+        try? coordinator.removeTicket(ticketID)
+    }
+}
+
+enum CLIInferenceAdmissionClassifier {
+    private static let largeModelBytes = Int64(48 * 1_073_741_824)
+
+    static func request(arguments: [String]) -> MachineInferenceRequest? {
+        let tokens = Array(arguments.dropFirst())
+        guard !tokens.contains("--help"), !tokens.contains("-h"), !tokens.contains("--version") else {
+            return nil
+        }
+        let commandTokens = commandPath(tokens)
+        guard let topLevel = commandTokens.first else { return nil }
+        let subcommand = commandTokens.dropFirst().first
+        let label = [topLevel, subcommand].compactMap { $0 }.joined(separator: " ")
+
+        if tokens.contains(where: { token in
+            let normalized = token.lowercased()
+            return normalized.contains("deepseek-v4") || normalized.contains("ds4")
+        }) {
+            return MachineInferenceRequest(label: label, resourceClass: .large)
+        }
+        if modelIdentifiers(in: tokens).contains(where: isLargeModel) {
+            return MachineInferenceRequest(label: label, resourceClass: .large)
+        }
+
+        switch topLevel {
+        case "speech", "audio":
+            return MachineInferenceRequest(label: label, resourceClass: .small)
+        case "image":
+            let large = [
+                "reconstruct-3d",
+                "reconstruct-3d-multiview",
+                "reconstruct-3d-trellis2",
+                "image-to-3d",
+                "image-to-3d-multiview",
+                "train-lora",
+            ].contains(subcommand)
+            return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
+        case "text":
+            let large = subcommand == "train-lora"
+            return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
+        case "vision":
+            let large = [
+                "geometry",
+                "geometry-multiview",
+                "image-to-3d",
+                "image-to-3d-trellis2",
+                "depth-video",
+            ].contains(subcommand)
+            return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
+        case "music", "sfx":
+            let large = ["train-adapter"].contains(subcommand)
+            return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
+        case "video", "world":
+            return MachineInferenceRequest(label: label, resourceClass: .large)
+        case "model" where subcommand == "benchmark":
+            return MachineInferenceRequest(label: label, resourceClass: .large)
+        case "adapter" where subcommand != "list" && subcommand != "pull":
+            return MachineInferenceRequest(label: label, resourceClass: .standard)
+        case "api", "open-webui", "run", "graph", "executor", "gate", "setup", "agent", "plugin":
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    static func apiServerRequest(engine: APIEngine, modelID: String? = nil) -> MachineInferenceRequest {
+        let resourceClass: MachineInferenceClass = engine == .textChatDeepseekV4Flash || isLargeModel(modelID)
+            ? .large
+            : .standard
+        return MachineInferenceRequest(
+            label: "api serve \(engine.rawValue)",
+            resourceClass: resourceClass
+        )
+    }
+
+    private static func modelIdentifiers(in tokens: [String]) -> [String] {
+        var identifiers: [String] = []
+        for (index, token) in tokens.enumerated() {
+            if token == "--model" || token == "-m" {
+                if tokens.indices.contains(index + 1) {
+                    identifiers.append(tokens[index + 1])
+                }
+            } else if token.hasPrefix("--model=") {
+                identifiers.append(String(token.dropFirst("--model=".count)))
+            }
+        }
+        return identifiers
+    }
+
+    private static func isLargeModel(_ identifier: String?) -> Bool {
+        guard let identifier, !identifier.isEmpty else { return false }
+        if let estimatedBytes = ManagedModelCatalog.spec(for: identifier)?.estimatedDownloadBytes {
+            return estimatedBytes >= largeModelBytes
+        }
+        let fileURL = URL(fileURLWithPath: identifier)
+        guard let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+              values.isRegularFile == true,
+              let fileSize = values.fileSize else {
+            return false
+        }
+        return Int64(fileSize) >= largeModelBytes
+    }
+
+    private static func commandPath(_ tokens: [String]) -> [String] {
+        var result: [String] = []
+        var skipNext = false
+        for token in tokens {
+            if skipNext {
+                skipNext = false
+                continue
+            }
+            if token == "--models-root" {
+                skipNext = true
+                continue
+            }
+            if token.hasPrefix("--models-root=") || token.hasPrefix("-") {
+                continue
+            }
+            result.append(token)
+            if result.count == 2 {
+                break
+            }
+        }
+        return result
+    }
+}
+
+private func releaseCLIProcessAdmission() {
+    CLIProcessAdmissionBootstrap.release()
+}
+
+enum CLIProcessAdmissionBootstrap {
+    private final class Storage: @unchecked Sendable {
+        let lock = NSLock()
+        var lease: MachineInferenceLease?
+        var registeredExitHandler = false
+    }
+
+    private static let storage = Storage()
+
+    static func acquireIfNeeded(arguments: [String]) throws {
+        guard let request = CLIInferenceAdmissionClassifier.request(arguments: arguments) else {
+            return
+        }
+        storage.lock.lock()
+        defer { storage.lock.unlock() }
+        guard storage.lease == nil else { return }
+        var waited = false
+        let lease = try MachineInferenceCoordinator.shared.acquireBlocking(request) { snapshot in
+            waited = true
+            CLIStderr.write(
+                "Queued by machine admission: \(request.label) "
+                    + "(\(snapshot.activePermits)/\(snapshot.capacityPermits) permits active, "
+                    + "\(snapshot.queued.count) queued).\n"
+            )
+        }
+        if waited {
+            CLIStderr.write("Machine admission granted: \(request.label).\n")
+        }
+        storage.lease = lease
+        if !storage.registeredExitHandler {
+            atexit(releaseCLIProcessAdmission)
+            storage.registeredExitHandler = true
+        }
+    }
+
+    static func release() {
+        storage.lock.lock()
+        let lease = storage.lease
+        storage.lease = nil
+        storage.lock.unlock()
+        lease?.release()
+    }
+}

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -445,17 +445,30 @@ struct MachineInferenceCoordinator: Sendable {
 
     private static func currentHostSnapshot() -> MachineInferenceHostSnapshot {
         let memory = RuntimeMemorySample.current()
-        let disk = try? MereRunModelPaths.applicationSupportBase
-            .deletingLastPathComponent()
-            .resourceValues(
-            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
-        ).volumeAvailableCapacityForImportantUsage
+        let disk = availableDiskBytes(
+            at: MereRunModelPaths.applicationSupportBase.deletingLastPathComponent()
+        )
         return MachineInferenceHostSnapshot(
             physicalMemoryBytes: memory.physicalBytes,
             availableMemoryBytes: memory.availableBytes,
             memoryPressure: RuntimeMemoryPressurePolicy.default.pressure(for: memory),
-            availableDiskBytes: disk.flatMap { $0 >= 0 ? UInt64($0) : nil }
+            availableDiskBytes: disk
         )
+    }
+
+    private static func availableDiskBytes(at url: URL) -> UInt64? {
+#if os(Linux)
+        guard let attributes = try? FileManager.default.attributesOfFileSystem(forPath: url.path),
+              let freeBytes = attributes[.systemFreeSize] as? NSNumber else {
+            return nil
+        }
+        return freeBytes.uint64Value
+#else
+        let capacity = try? url.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        ).volumeAvailableCapacityForImportantUsage
+        return capacity.flatMap { $0 >= 0 ? UInt64($0) : nil }
+#endif
     }
 
     private static func isProcessAlive(_ processID: Int32) -> Bool {

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -5,6 +5,8 @@ Shared helpers for the public command surface.
 - `CLIModelStoreBootstrap.swift`: global model-root handling.
 - `CLIOutput.swift` and `CLIStderr.swift`: output channel discipline.
 - `BuiltinTools.swift`: local tool execution guardrails.
+- `MachineInferenceAdmission.swift`: crash-safe weighted admission shared by
+  heavyweight CLI and API-server processes on one machine.
 
 Keep stdout machine-readable when a command can be scripted; diagnostics and
 progress belong on stderr.

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -1,0 +1,352 @@
+import XCTest
+@testable import MereRunCLI
+
+final class MachineInferenceAdmissionTests: XCTestCase {
+    private let gibibyte = UInt64(1_073_741_824)
+
+    func testCapacityScalesWithoutMakingLargeWorkConcurrent() {
+        XCTAssertEqual(MachineInferenceCoordinator.capacityPermits(physicalMemoryBytes: 32 * gibibyte), 1)
+        XCTAssertEqual(MachineInferenceCoordinator.capacityPermits(physicalMemoryBytes: 64 * gibibyte), 2)
+        XCTAssertEqual(MachineInferenceCoordinator.capacityPermits(physicalMemoryBytes: 128 * gibibyte), 4)
+        XCTAssertEqual(MachineInferenceCoordinator.capacityPermits(physicalMemoryBytes: 256 * gibibyte), 6)
+
+        XCTAssertEqual(MachineInferenceClass.small.permits(capacity: 4), 1)
+        XCTAssertEqual(MachineInferenceClass.standard.permits(capacity: 4), 2)
+        XCTAssertEqual(MachineInferenceClass.large.permits(capacity: 4), 4)
+    }
+
+    func testWeightedAdmissionAllowsSafeConcurrencyAndQueuesOverflow() async throws {
+        let directory = try temporaryDirectory()
+        let coordinator = makeCoordinator(directory: directory, processID: 101)
+        let standard = MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+        let small = MachineInferenceRequest(label: "speech synthesize", resourceClass: .small)
+
+        let first = try await coordinator.acquire(standard)
+        let second = try await coordinator.acquire(standard)
+        var snapshot = try coordinator.snapshot()
+        XCTAssertEqual(snapshot.activePermits, 4)
+        XCTAssertEqual(snapshot.active.count, 2)
+
+        let queued = Task {
+            try await coordinator.acquire(small)
+        }
+        try await waitUntil {
+            try coordinator.snapshot().queued.count == 1
+        }
+
+        first.release()
+        let third = try await queued.value
+        snapshot = try coordinator.snapshot()
+        XCTAssertEqual(snapshot.activePermits, 3)
+        XCTAssertEqual(snapshot.active.count, 2)
+        XCTAssertEqual(snapshot.queued.count, 0)
+
+        second.release()
+        third.release()
+        XCTAssertEqual(try coordinator.snapshot().activePermits, 0)
+    }
+
+    func testLargeAdmissionWaitsForExclusiveCapacity() async throws {
+        let directory = try temporaryDirectory()
+        let coordinator = makeCoordinator(directory: directory, processID: 102)
+        let small = try await coordinator.acquire(
+            MachineInferenceRequest(label: "speech synthesize", resourceClass: .small)
+        )
+        let queuedLarge = Task {
+            try await coordinator.acquire(
+                MachineInferenceRequest(label: "video generate", resourceClass: .large)
+            )
+        }
+        try await waitUntil {
+            try coordinator.snapshot().queued.count == 1
+        }
+
+        XCTAssertEqual(try coordinator.snapshot().activePermits, 1)
+        small.release()
+        let large = try await queuedLarge.value
+        let snapshot = try coordinator.snapshot()
+        XCTAssertEqual(snapshot.activePermits, snapshot.capacityPermits)
+        XCTAssertEqual(snapshot.active.first?.label, "video generate")
+        large.release()
+    }
+
+    func testCancellationRemovesQueuedTicket() async throws {
+        let directory = try temporaryDirectory()
+        let coordinator = makeCoordinator(directory: directory, processID: 103)
+        let active = try await coordinator.acquire(
+            MachineInferenceRequest(label: "video generate", resourceClass: .large)
+        )
+        let queued = Task {
+            try await coordinator.acquire(
+                MachineInferenceRequest(label: "speech synthesize", resourceClass: .small)
+            )
+        }
+        try await waitUntil {
+            try coordinator.snapshot().queued.count == 1
+        }
+
+        queued.cancel()
+        do {
+            _ = try await queued.value
+            XCTFail("Expected queued admission to be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(try coordinator.snapshot().queued.count, 0)
+        active.release()
+    }
+
+    func testDeadProcessTicketIsPrunedBeforeNewAdmission() async throws {
+        let directory = try temporaryDirectory()
+        let firstCoordinator = makeCoordinator(
+            directory: directory,
+            processID: 1_001,
+            processIsAlive: { $0 == 1_001 }
+        )
+        let abandoned = try await firstCoordinator.acquire(
+            MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+        )
+        XCTAssertEqual(try firstCoordinator.snapshot().active.count, 1)
+
+        let recoveringCoordinator = makeCoordinator(
+            directory: directory,
+            processID: 1_002,
+            processIsAlive: { $0 == 1_002 }
+        )
+        XCTAssertEqual(try recoveringCoordinator.snapshot().active.count, 0)
+        let recovered = try await recoveringCoordinator.acquire(
+            MachineInferenceRequest(label: "video generate", resourceClass: .large)
+        )
+        XCTAssertEqual(try recoveringCoordinator.snapshot().activePermits, 4)
+
+        abandoned.release()
+        recovered.release()
+    }
+
+    func testPreviousBootTicketIsPrunedEvenWhenPIDWasReused() async throws {
+        let directory = try temporaryDirectory()
+        let previousBoot = makeCoordinator(
+            directory: directory,
+            processID: 1_101,
+            bootSessionID: "previous-boot"
+        )
+        let abandoned = try await previousBoot.acquire(
+            MachineInferenceRequest(label: "video generate", resourceClass: .large)
+        )
+
+        let currentBoot = makeCoordinator(
+            directory: directory,
+            processID: 1_101,
+            bootSessionID: "current-boot"
+        )
+        XCTAssertEqual(try currentBoot.snapshot().active.count, 0)
+        let recovered = try await currentBoot.acquire(
+            MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+        )
+        XCTAssertEqual(try currentBoot.snapshot().activePermits, 2)
+
+        abandoned.release()
+        recovered.release()
+    }
+
+    func testQueuedLargeWorkPreventsNewSmallWorkFromJumpingTheFIFO() async throws {
+        let directory = try temporaryDirectory()
+        let coordinator = makeCoordinator(directory: directory, processID: 106)
+        let active = try await coordinator.acquire(
+            MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+        )
+        let largeTask = Task {
+            try await coordinator.acquire(
+                MachineInferenceRequest(label: "video generate", resourceClass: .large)
+            )
+        }
+        try await waitUntil {
+            try coordinator.snapshot().queued.count == 1
+        }
+        let smallTask = Task {
+            try await coordinator.acquire(
+                MachineInferenceRequest(label: "speech synthesize", resourceClass: .small)
+            )
+        }
+        try await waitUntil {
+            try coordinator.snapshot().queued.count == 2
+        }
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(try coordinator.snapshot().active.count, 1)
+        active.release()
+        let large = try await largeTask.value
+        XCTAssertEqual(try coordinator.snapshot().active.first?.label, "video generate")
+        XCTAssertEqual(try coordinator.snapshot().queued.first?.label, "speech synthesize")
+
+        large.release()
+        let small = try await smallTask.value
+        small.release()
+    }
+
+    func testLowDiskRejectsBeforeRegisteringTicket() async throws {
+        let directory = try temporaryDirectory()
+        let coordinator = makeCoordinator(
+            directory: directory,
+            processID: 104,
+            availableDiskBytes: gibibyte
+        )
+        do {
+            _ = try await coordinator.acquire(
+                MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+            )
+            XCTFail("Expected low disk to block admission")
+        } catch let error as MachineInferenceAdmissionError {
+            guard case .insufficientDisk(let available, let required) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(available, gibibyte)
+            XCTAssertEqual(required, 16 * gibibyte)
+        }
+        XCTAssertEqual(try coordinator.snapshot().active.count, 0)
+        XCTAssertEqual(try coordinator.snapshot().queued.count, 0)
+    }
+
+    func testLowMemoryRejectsWhenNoActiveWorkCanReleaseHeadroom() async throws {
+        let directory = try temporaryDirectory()
+        let coordinator = makeCoordinator(
+            directory: directory,
+            processID: 105,
+            availableMemoryBytes: 8 * gibibyte
+        )
+        do {
+            _ = try await coordinator.acquire(
+                MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+            )
+            XCTFail("Expected low memory to block admission")
+        } catch let error as MachineInferenceAdmissionError {
+            guard case .insufficientMemory(let available, let required) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(available, 8 * gibibyte)
+            XCTAssertEqual(required, 16 * gibibyte)
+        }
+    }
+
+    func testCLIClassifierProtectsMediaAndLeavesLightweightCommandsFree() {
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "image", "generate", "--prompt", "test"]
+            ),
+            MachineInferenceRequest(label: "image generate", resourceClass: .standard)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "speech", "synthesize", "hello"]
+            ),
+            MachineInferenceRequest(label: "speech synthesize", resourceClass: .small)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "video", "generate", "test"]
+            ),
+            MachineInferenceRequest(label: "video generate", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "text", "chat", "--model", "text-chat-deepseek-v4-flash"]
+            ),
+            MachineInferenceRequest(label: "text chat", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "text", "chat", "--model=text-chat-inkling-small"]
+            ),
+            MachineInferenceRequest(label: "text chat", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "text", "chat", "--model", "text-chat-laguna-xs-2-1"]
+            ),
+            MachineInferenceRequest(label: "text chat", resourceClass: .standard)
+        )
+        XCTAssertNil(
+            CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "status"])
+        )
+        XCTAssertNil(
+            CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "model", "list"])
+        )
+        XCTAssertNil(
+            CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "image", "generate", "--help"])
+        )
+    }
+
+    func testAPIServerKeepsInternalConcurrencyInsideWeightedReservation() {
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.apiServerRequest(engine: .textChatGemma4),
+            MachineInferenceRequest(label: "api serve text-chat-gemma4", resourceClass: .standard)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.apiServerRequest(engine: .textChatDeepseekV4Flash),
+            MachineInferenceRequest(label: "api serve text-chat-deepseek-v4-flash", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.apiServerRequest(
+                engine: .textChatLaguna,
+                modelID: "text-chat-laguna-s-2-1"
+            ),
+            MachineInferenceRequest(label: "api serve text-chat-laguna", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.apiServerRequest(
+                engine: .textChatLaguna,
+                modelID: "text-chat-laguna-xs-2-1"
+            ),
+            MachineInferenceRequest(label: "api serve text-chat-laguna", resourceClass: .standard)
+        )
+    }
+
+    private func makeCoordinator(
+        directory: URL,
+        processID: Int32,
+        bootSessionID: String = "test-boot",
+        availableMemoryBytes: UInt64? = 96 * 1_073_741_824,
+        availableDiskBytes: UInt64? = 100 * 1_073_741_824,
+        processIsAlive: @escaping @Sendable (Int32) -> Bool = { _ in true }
+    ) -> MachineInferenceCoordinator {
+        MachineInferenceCoordinator(
+            stateDirectory: directory,
+            processID: processID,
+            bootSessionID: bootSessionID,
+            currentDate: { Date() },
+            hostSnapshot: {
+                MachineInferenceHostSnapshot(
+                    physicalMemoryBytes: 128 * 1_073_741_824,
+                    availableMemoryBytes: availableMemoryBytes,
+                    memoryPressure: .nominal,
+                    availableDiskBytes: availableDiskBytes
+                )
+            },
+            processIsAlive: processIsAlive
+        )
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-machine-admission-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        condition: () throws -> Bool
+    ) async throws {
+        let started = ContinuousClock.now
+        while try !condition() {
+            if started.duration(to: .now) > .nanoseconds(Int64(timeoutNanoseconds)) {
+                XCTFail("Timed out waiting for admission state")
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}

--- a/Tests/MereRunCLITests/StatusCommandTests.swift
+++ b/Tests/MereRunCLITests/StatusCommandTests.swift
@@ -103,6 +103,65 @@ final class StatusCommandTests: XCTestCase {
         XCTAssertTrue(output.contains("    none"))
     }
 
+    func testFormatterShowsMachineWideAdmission() {
+        let now = Date(timeIntervalSince1970: 100)
+        let snapshot = StatusSnapshot(
+            server: StatusServerSnapshot(
+                url: "http://127.0.0.1:8080",
+                health: "down",
+                detail: nil,
+                loadedModels: [],
+                modelsDetail: nil,
+                runtime: nil,
+                runtimeDetail: nil
+            ),
+            modelStore: StatusModelStoreSnapshot(
+                path: "/tmp/models",
+                source: "default",
+                configuredPath: nil,
+                isFallbackToDefault: false
+            ),
+            knownModelCount: 0,
+            installedModels: [],
+            machineAdmission: MachineInferenceAdmissionSnapshot(
+                capacityPermits: 4,
+                activePermits: 2,
+                active: [
+                    MachineInferenceAdmissionEntrySnapshot(
+                        id: UUID(),
+                        processID: 42,
+                        label: "image generate",
+                        resourceClass: .standard,
+                        permits: 2,
+                        queuedAt: now,
+                        admittedAt: now
+                    ),
+                ],
+                queued: [
+                    MachineInferenceAdmissionEntrySnapshot(
+                        id: UUID(),
+                        processID: 43,
+                        label: "video generate",
+                        resourceClass: .large,
+                        permits: 4,
+                        queuedAt: now,
+                        admittedAt: nil
+                    ),
+                ],
+                memoryPressure: .nominal,
+                availableMemoryBytes: 80 * 1_073_741_824,
+                availableDiskBytes: 100 * 1_073_741_824,
+                minimumDiskBytes: 16 * 1_073_741_824
+            )
+        )
+
+        let output = StatusFormatter.text(snapshot)
+
+        XCTAssertTrue(output.contains("machine admission: 2/4 permits active, 1 running, 1 queued"))
+        XCTAssertTrue(output.contains("active: image generate, pid 42, 2 permit(s), standard"))
+        XCTAssertTrue(output.contains("queued: video generate, pid 43, 4 permit(s), large"))
+    }
+
     func testFormatterUsesRuntimeStatusWhenAvailable() {
         var runtime = RuntimeModelPoolStatus(
             object: "runtime.status",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,31 @@ prompt lengths differ. The generator samples all rows with one device readback,
 splits typed cache lanes after each step, and immediately removes EOS or
 token-budget-complete rows. `0` keeps the serial pipelined decoder.
 
+### Machine-wide inference admission
+
+Every allocation-heavy direct `mere.run` command joins a crash-safe weighted
+FIFO shared by Studio, terminals, launchers, scripts, and agents. API-server
+processes hold a reservation while preserving their own model-pool and request
+concurrency. Lightweight inspection and management commands such as `status`,
+`model list`, and `--help` do not consume permits.
+
+Capacity scales with physical memory: one permit below 48 GiB, two below 96
+GiB, four below 192 GiB, and six on larger hosts. Speech and lightweight audio
+use one permit; ordinary image, text, music, and vision work use two; video,
+world generation, model training/benchmarks, geometry/3D, and DeepSeek V4 Flash
+use the entire capacity. Any selected catalog model estimated at 48 GiB or
+larger, and an explicit local model file of that size, is also promoted to the
+exclusive class. FIFO ordering prevents a stream of small jobs from starving
+an earlier large job.
+
+Before registration and admission, the coordinator checks reclaimable memory
+and preserves free disk for swap and temporary files. The disk floor is one
+eighth of physical memory, clamped from 8 to 32 GiB. A command below that floor
+fails before loading a model. Cancelled waiters remove their tickets; dead
+processes are pruned automatically. `mere.run status` shows active and queued
+entries, and the typed ledger lives under
+`~/Library/Application Support/MereRun/admission/` without prompts or content.
+
 ### `MERERUN_GEMMA4_MTP`
 
 Gemma 4 12B MTP is enabled by default when the managed

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -68,6 +68,14 @@ default. For remote jobs, prefer [portable workflows](../workflows.md); when
 you deliberately bind the API server to a non-loopback address, configure its
 bearer token and rate limit first.
 
+The server keeps its existing in-process request admission, resident model
+pool, prefix caches, and continuous batching. In addition, the server process
+holds a weighted machine-wide reservation shared with other `mere.run`
+processes. This prevents a terminal, Studio, Raycast, or a second server from
+blindly loading incompatible working sets while allowing measured concurrency
+inside the resident pool. Standard servers consume two RAM-scaled permits;
+DeepSeek V4 Flash servers run with exclusive machine admission.
+
 ## Runtime entrypoints
 
 ### CLI
@@ -262,6 +270,9 @@ swift run mere.run api serve \
   queued client cancellations are removed from the FIFO instead of being
   admitted later. Explicit runtime model load/unload maintenance shares the
   same queue
+- machine admission complements rather than replaces `--max-active-requests`:
+  the server's local limit controls request and batching concurrency inside its
+  weighted machine reservation
 - Gemma4, Qwen-family, and LFM2 prefills are chunked with cancellation and
   progress checkpoints before decode; this is cooperative single-request
   prefill, not continuous batching


### PR DESCRIPTION
## Summary

- add a crash-safe machine-wide weighted FIFO shared by allocation-heavy CLI commands and API-server processes
- scale permit capacity by physical RAM, reserve disk headroom for swap and temporary files, and pause or refuse admission under memory pressure
- classify video, DeepSeek V4 Flash, and selected models of at least 48 GiB as exclusive while preserving concurrency for smaller audio and standard inference
- expose active and queued machine admission through human and JSON `mere.run status`
- recover cancelled, dead-process, and previous-boot tickets without recording prompts or generated content
- preserve the existing API-server `RuntimeModelPool`, resident sidecars, prefix caches, continuous batching, and `--max-active-requests` concurrency inside the server reservation

## Why

The existing API server has an effective in-process request admission queue and model pool, but independent callers such as Studio, Raycast, terminals, scripts, agents, and additional API servers did not share a machine-level working-set budget. Several callers could therefore begin large model activation at once, exhausting unified-memory and swap headroom even though each individual process was behaving correctly.

This adds the missing cooperative boundary at the public `mere.run` runtime rather than coupling safety to any one launcher.

On a 128 GiB host the default capacity is four permits: up to two standard jobs or four small jobs may overlap, while large jobs wait for exclusive capacity. Strict FIFO prevents small jobs from starving an earlier large job.

## Validation

- `./scripts/check.sh` passed on the final commit
  - 1,122 Swift files linted with zero violations
  - Swift build passed
  - 2,417 XCTest cases passed with zero failures and 152 asset-gated skips
  - Swift Testing and CLI help/hygiene sweeps passed
- 11 focused machine-admission tests passed
- 10 status formatter tests passed
- `pnpm docs:build` passed
- live `status --json` smoke reported the expected four-permit capacity and disk floor
- an invalid heavyweight CLI smoke acquired and released admission without leaving a stale ticket

## Operational note

Coordination is cooperative. Existing installed binaries begin participating after this change is built, installed, and their long-running server processes are restarted.

