### PR TITLE
Prepare mere.run 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.32.0 - 2026-08-02
+
+This release makes mixed local workloads safer and broadens native audio
+production: machine-wide inference admission protects system headroom while
+new separation, restoration, and super-resolution models join a durable
+Raycast-to-Library handoff.
+
 ### Added
 
 - added crash-safe machine-wide inference admission across direct CLI calls,

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.31.0"
+    static let current = "0.32.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.31.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.32.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.31.0"
+default_version="0.32.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## What changed

- cut the changelog at 0.32.0 with a release summary
- bump the CLI and macOS bundle fallback versions to 0.32.0
- update the release-version contract test

## Why

Main now contains machine-wide inference admission, five native audio production models, Raycast-to-Library imports, and symlink-safe managed model validation. These user-facing additions warrant the next minor release.

## Validation

- `./scripts/check.sh`
  - SwiftLint: 1,122 files, zero violations
  - XCTest: 2,417 passed, 152 expected asset-gated skips
  - Swift Testing: 20 passed
