### PR TITLE
Fix music separation release gate and prepare 0.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.32.1 - 2026-08-02
+
+### Fixed
+
+- fixed the exhaustive installed-model release gate to validate each native
+  RoFormer profile's actual stem set. Four-stem, dereverb, and denoise checks
+  now verify every generated WAV for decodability, non-silence, manifest path,
+  and SHA-256 instead of assuming the ViperX vocal/instrumental filenames.
+
 ## 0.32.0 - 2026-08-02
 
 This release makes mixed local workloads safer and broadens native audio

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -141,6 +141,21 @@ private struct InstalledDiarizationDocument: Decodable {
     }
 }
 
+private struct InstalledMusicSeparationDocument: Decodable {
+    struct Model: Decodable {
+        let id: String
+    }
+
+    struct Stem: Decodable {
+        let name: String
+        let path: String
+        let sha256: String
+    }
+
+    let model: Model
+    let stems: [Stem]
+}
+
 /// One explicit release-smoke recipe per managed runtime kind. The release
 /// lane builds checks from the installed inventory, so catalog additions
 /// cannot disappear behind a representative "family" check.
@@ -975,12 +990,62 @@ extension GateRunner {
             ],
             timeout: 3_600
         )
-        let vocals = output.appendingPathComponent("vocals.wav")
-        let instrumental = output.appendingPathComponent("instrumental.wav")
         let manifest = output.appendingPathComponent("separation.json")
-        _ = try audioObservation(vocals, run: run)
-        _ = try audioObservation(instrumental, run: run)
+        let manifestData = try Data(contentsOf: manifest)
+        let document = try JSONDecoder().decode(
+            InstalledMusicSeparationDocument.self,
+            from: manifestData
+        )
+        let expectedNames = try Self.expectedMusicSeparationStemNames(for: model)
+        guard document.model.id == model else {
+            throw GateError.invalidArtifact(
+                "music separation manifest reported model \(document.model.id), expected \(model)"
+            )
+        }
+        guard document.stems.map(\.name) == expectedNames else {
+            throw GateError.invalidArtifact(
+                "music separation manifest reported stems \(document.stems.map(\.name)), "
+                    + "expected \(expectedNames)"
+            )
+        }
+        for stem in document.stems {
+            let expectedFileName = "\(stem.name).wav"
+            guard URL(fileURLWithPath: stem.path).lastPathComponent == expectedFileName else {
+                throw GateError.invalidArtifact(
+                    "music separation manifest path for \(stem.name) was not \(expectedFileName)"
+                )
+            }
+            let observation = try audioObservation(
+                output.appendingPathComponent(expectedFileName),
+                run: run
+            )
+            if let failure = observation.semanticFailure {
+                throw GateError.invalidArtifact("\(expectedFileName): \(failure)")
+            }
+            guard stem.sha256 == observation.hash else {
+                throw GateError.invalidArtifact(
+                    "music separation manifest hash did not match \(expectedFileName)"
+                )
+            }
+        }
         return try jsonFileObservation(manifest, run: run, label: "music separation manifest")
+    }
+
+    static func expectedMusicSeparationStemNames(for model: String) throws -> [String] {
+        switch model {
+        case ModelResolver.ModelID.roFormerViperX1297.rawValue:
+            ["vocals", "instrumental"]
+        case ModelResolver.ModelID.roFormerFourStem.rawValue:
+            ["drums", "bass", "other", "vocals"]
+        case ModelResolver.ModelID.melRoFormerDereverb.rawValue:
+            ["noreverb"]
+        case ModelResolver.ModelID.melRoFormerDenoise.rawValue:
+            ["dry"]
+        default:
+            throw GateError.invalidArtifact(
+                "unsupported music separation model in installed-model gate: \(model)"
+            )
+        }
     }
 
     func installedAudioEnhancementCheck(model: String) async throws -> GateObservation {

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.32.0"
+    static let current = "0.32.1"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.32.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.32.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/GateSupportTests.swift
+++ b/Tests/MereRunCLITests/GateSupportTests.swift
@@ -153,4 +153,34 @@ final class GateSupportTests: XCTestCase {
         XCTAssertGreaterThan(decoded.samples.count, 40_000)
         XCTAssertGreaterThan(peak, 0.1)
     }
+
+    func testMusicSeparationGateUsesProfileSpecificStemSets() throws {
+        XCTAssertEqual(
+            try GateRunner.expectedMusicSeparationStemNames(
+                for: ModelResolver.ModelID.roFormerViperX1297.rawValue
+            ),
+            ["vocals", "instrumental"]
+        )
+        XCTAssertEqual(
+            try GateRunner.expectedMusicSeparationStemNames(
+                for: ModelResolver.ModelID.roFormerFourStem.rawValue
+            ),
+            ["drums", "bass", "other", "vocals"]
+        )
+        XCTAssertEqual(
+            try GateRunner.expectedMusicSeparationStemNames(
+                for: ModelResolver.ModelID.melRoFormerDereverb.rawValue
+            ),
+            ["noreverb"]
+        )
+        XCTAssertEqual(
+            try GateRunner.expectedMusicSeparationStemNames(
+                for: ModelResolver.ModelID.melRoFormerDenoise.rawValue
+            ),
+            ["dry"]
+        )
+        XCTAssertThrowsError(
+            try GateRunner.expectedMusicSeparationStemNames(for: "music-separate-unknown")
+        )
+    }
 }

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.32.0"
+default_version="0.32.1"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- validate each managed RoFormer profile against its actual typed stem inventory
- verify every emitted WAV is decodable, non-silent, correctly named, and matches its manifest SHA-256
- bump the patch release to 0.32.1 after the v0.32.0 packaged smoke exposed the gate-only false failures

## Verification

- `swift test --filter GateSupportTests`
- `./scripts/check.sh` (2,418 XCTest cases, 152 skipped, 0 failures; 20 contract tests passed)