### PR TITLE
Reframe Raycast as a macOS deep-link example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,38 +140,33 @@ cd /Volumes/mere.run/.mere-run
 The installer copies `mere.run` and its colocated runtime assets to
 `/usr/local/bin/mere.run`, using `sudo` only when the destination requires it.
 
-### Import or preview artifacts from Raycast and other launchers
+### Open local artifacts through macOS deep links
 
-The Raycast extension imports completed generations into MereRun Library by
-default. MereRun validates a small, versioned JSON receipt, records the artifact
-through its own Library store, activates the matching workspace, reveals
-Library, and selects the imported result. Raycast never edits MereRun's
-`library.json` directly. See the [Raycast Integration guide](./docs/raycast.md)
-for the receipt contract and extension preferences.
+The macOS app registers typed `mererun://` routes so a launcher, automation,
+agent, or another local app can hand a completed artifact back to MereRun. Use
+`mererun://preview` for a non-importing native Quick Look panel, or
+`mererun://library/import` with a small versioned receipt to validate, persist,
+and select a completed result in MereRun Library.
 
-The macOS app registers a local `mererun://preview` deep link. Pass one
-percent-encoded absolute artifact path and MereRun opens its native Quick Look
-panel, regardless of whether the output is an image, audio, video, text, or a
-Quick Look-compatible 3D file:
+Pass `preview` one percent-encoded absolute artifact path. It supports images,
+audio, video, text, and Quick Look-compatible 3D files:
 
 ```text
 mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
 ```
 
-Raycast extensions can construct the URL without manual escaping:
-
-```typescript
-import { open } from "@raycast/api";
-
-const deepLink = new URL("mererun://preview");
-deepLink.searchParams.set("path", outputPath);
-await open(deepLink.toString());
+```bash
+open 'mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png'
 ```
 
 The target must already exist and be a readable file. MereRun rejects relative
 paths, directories, missing files, duplicate `path` values, and extra query
 parameters. This route remains an explicit preview-only option; it does not
 import, move, or modify the artifact.
+
+See [macOS Deep Links](./docs/macos-deep-links.md) for both route contracts and
+security boundaries. The separate [Raycast integration](./docs/raycast.md) is
+one example client built on the same public handoff.
 
 Linux package builds are headless CLI-only. They install the `mere.run` CLI plus
 colocated runtime assets; they do not include the macOS SwiftUI studio or DMG

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -53,7 +53,7 @@ export default defineConfig({
         items: [
           { text: 'Docs Home', link: '/' },
           { text: 'Getting Started', link: '/getting-started' },
-          { text: 'Raycast Integration', link: '/raycast' },
+          { text: 'macOS Deep Links', link: '/macos-deep-links' },
           { text: 'Linux QuickStart', link: '/linux-quickstart' },
           { text: 'CLI Reference', link: '/cli' },
           { text: 'Offline Cookbooks', link: '/cookbooks' },
@@ -67,7 +67,8 @@ export default defineConfig({
           { text: 'Configuration', link: '/configuration' },
           { text: 'Quality Gate', link: '/gate' },
           { text: 'Model Sources', link: '/model-sources' },
-          { text: 'Companion Plugins', link: '/plugins' }
+          { text: 'Companion Plugins', link: '/plugins' },
+          { text: 'Raycast Example', link: '/raycast' }
         ]
       },
       {

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ CI job, and on `main` it deploys the VitePress output to Pages at
 If you are new to the repo, read these in order:
 
 1. [Getting Started](./getting-started.md)
-2. [Raycast Integration](./raycast.md), if you want launcher-driven local generation on macOS
+2. [macOS Deep Links](./macos-deep-links.md), if a local tool should preview or import artifacts in MereRun
 3. [Linux QuickStart](./linux-quickstart.md), if you are installing the headless CLI on Linux
 4. [CLI Reference](./cli.md)
 5. [Portable Workflows](./workflows.md), if you are automating local or remote jobs
@@ -51,7 +51,7 @@ If you are new to the repo, read these in order:
 ### I want to use `mere.run`
 
 - [Getting Started](./getting-started.md)
-- [Raycast Integration](./raycast.md)
+- [macOS Deep Links](./macos-deep-links.md)
 - [Linux QuickStart](./linux-quickstart.md)
 - [CLI Reference](./cli.md)
 - [Benchmarking](./benchmarking.md)
@@ -89,9 +89,10 @@ If you are new to the repo, read these in order:
 
 - [Getting Started](./getting-started.md): clone, build, first commands, first
   status checks, Linux release artifacts, model pulls, and local setup
-- [Raycast Integration](./raycast.md): install the development extension, run
-  local image/video/music/speech commands, configure paths, preview artifacts,
-  and troubleshoot the macOS handoff
+- [macOS Deep Links](./macos-deep-links.md): preview or import completed local
+  artifacts from launchers, automations, agents, and other macOS apps
+- [Raycast Example Integration](./raycast.md): one launcher client built on the
+  public macOS deep-link surface
 - [Linux QuickStart](./linux-quickstart.md): Linux package install, first
   commands, release asset verification, and CUDA validation boundaries
 - [Cookbooks](./cookbooks.md): `mere.run guide` command topics for practical

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ links to the page that owns that command.
 Install, pull a first model, and make something in the next ten minutes.
 
 - [Getting Started](/getting-started)
-- [Raycast Integration](/raycast) — local generation with Library import or Quick Look from the launcher
+- [macOS Deep Links](/macos-deep-links) — preview or import local artifacts from launchers, automations, agents, and apps
 - [Linux QuickStart](/linux-quickstart)
 - [CLI Reference](/cli)
 - [Offline Cookbooks](/cookbooks) — `mere.run guide` works without a network
@@ -123,6 +123,7 @@ Serve it, schedule it, measure it, and keep it honest.
 
 - [Portable Workflows, Executors, and Run Artifacts](/workflows)
 - [Model and Adapter Management](/runtime/model-management)
+- [Raycast Example Integration](/raycast) — one launcher client for the macOS deep-link routes
 - [Local API Server and Open WebUI](/runtime/api-server)
 - [Official Companion Plugins](/plugins)
 - [Quality Gate](/gate) — the check that catches a bad build before you do

--- a/docs/macos-deep-links.md
+++ b/docs/macos-deep-links.md
@@ -1,0 +1,82 @@
+# macOS Deep Links
+
+MereRun.app exposes two typed local handoff routes through the `mererun://`
+scheme. A launcher, automation, agent, or another macOS app can preview an
+existing artifact or ask MereRun to validate and record a completed result in
+Library. The caller does not need access to MereRun's private Library storage.
+
+These routes belong to the macOS app. Linux releases contain the headless CLI
+only and cannot open MereRun Studio.
+
+## Preview an artifact
+
+Open one existing readable file in MereRun's native Quick Look panel:
+
+```text
+mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
+```
+
+Build the URL with a URL-components API so the absolute path is percent encoded
+exactly once. From a shell, an already encoded link can be passed to Launch
+Services with `open`:
+
+```bash
+open 'mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png'
+```
+
+The target may be an image, audio, video, text, or Quick Look-compatible 3D
+file. MereRun rejects relative paths, directories, missing or unreadable files,
+duplicate `path` values, and extra query parameters. Preview does not import,
+move, or modify the artifact.
+
+## Import a completed result into Library
+
+`mererun://library/import` accepts one percent-encoded absolute path to a small
+JSON receipt:
+
+```text
+mererun://library/import?receipt=%2FUsers%2Fme%2FLibrary%2FApplication%20Support%2FMyLauncher%2Fimports%2F5cb7dc90-a9d4-4634-a486-0b8140226b42.json
+```
+
+A version 1 receipt contains the completed local run metadata MereRun needs:
+
+```json
+{
+  "version": 1,
+  "id": "5cb7dc90-a9d4-4634-a486-0b8140226b42",
+  "source": "raycast",
+  "kind": "image",
+  "prompt": "a ceramic coffee mug in soft morning light",
+  "artifactPath": "/Users/me/MereRun/Artifacts/mere-image-result.png",
+  "createdAt": "2026-08-01T22:42:07Z"
+}
+```
+
+Version 1 currently accepts the `raycast` source and the typed `image`,
+`video`, `music`, and `speech` kinds. The source vocabulary is intentionally
+strict even though the deep-link transport is not coupled to Raycast. New
+maintained clients should add a source case and contract tests before emitting
+receipts under a new source name.
+
+MereRun validates the receipt and referenced artifact, deduplicates repeated
+handoffs, records the completed result through its own Library store, activates
+the matching workspace, reveals Library, and selects the imported row. The
+caller must never read or write `library.json` directly.
+
+## Local and security boundaries
+
+- Each route accepts exactly one named query parameter and one local file.
+- Receipt files must be regular readable files no larger than 256 KiB.
+- Receipt versions, sources, and artifact kinds are typed and fail closed.
+- Imported artifacts must be existing readable files whose media type matches
+  the declared kind.
+- Receipt IDs cannot replace an existing Library row that points elsewhere.
+- Prompts and artifacts remain local unless the calling tool separately moves
+  or uploads them.
+
+## Example clients
+
+The public [Raycast integration](./raycast.md) demonstrates image, video, music,
+and speech generation followed by Library import or preview. It is a separate
+launcher extension, not a MereRun executable plugin, and is only one possible
+client of the macOS handoff routes.

--- a/docs/raycast.md
+++ b/docs/raycast.md
@@ -1,5 +1,9 @@
 # Raycast Integration
 
+Raycast is one example client of MereRun's public macOS handoff surface. Read
+[macOS Deep Links](./macos-deep-links.md) for the app-owned route contracts and
+security boundaries independent of any launcher.
+
 Generate an image, video, music track, or spoken-audio file from Raycast, then
 open the completed local artifact as the selected item in MereRun Library. The
 Raycast extension calls the public `mere.run` CLI, writes a small typed receipt,


### PR DESCRIPTION
## Summary

- center the public `mererun://preview` and `mererun://library/import` macOS contracts in README and docs navigation
- document launchers, automations, agents, and other local apps as the general integration surface
- keep Raycast discoverable as one concrete example client instead of a primary MereRun capability
- state the current strict v1 receipt source vocabulary accurately

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm docs:build`