### PR TITLE
Fix separation gate audibility policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.32.2 - 2026-08-02
+
+### Fixed
+
+- fixed the exhaustive music-separation gate to require every declared stem to
+  decode and match its manifest hash while requiring the separated set, rather
+  than every individual stem, to contain audible signal. A source without
+  drums can legitimately produce a silent `drums.wav`.
+
 ## 0.32.1 - 2026-08-02
 
 ### Fixed

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -1008,6 +1008,7 @@ extension GateRunner {
                     + "expected \(expectedNames)"
             )
         }
+        var stemPeaks: [Float] = []
         for stem in document.stems {
             let expectedFileName = "\(stem.name).wav"
             guard URL(fileURLWithPath: stem.path).lastPathComponent == expectedFileName else {
@@ -1015,10 +1016,12 @@ extension GateRunner {
                     "music separation manifest path for \(stem.name) was not \(expectedFileName)"
                 )
             }
-            let observation = try audioObservation(
+            let artifact = try audioArtifactObservation(
                 output.appendingPathComponent(expectedFileName),
-                run: run
+                run: run,
+                requireAudible: false
             )
+            let observation = artifact.observation
             if let failure = observation.semanticFailure {
                 throw GateError.invalidArtifact("\(expectedFileName): \(failure)")
             }
@@ -1027,8 +1030,18 @@ extension GateRunner {
                     "music separation manifest hash did not match \(expectedFileName)"
                 )
             }
+            stemPeaks.append(artifact.peak)
+        }
+        if let failure = Self.musicSeparationAudibilityFailure(stemPeaks: stemPeaks) {
+            throw GateError.invalidArtifact(failure)
         }
         return try jsonFileObservation(manifest, run: run, label: "music separation manifest")
+    }
+
+    static func musicSeparationAudibilityFailure(stemPeaks: [Float]) -> String? {
+        stemPeaks.contains { $0 > 0.0001 }
+            ? nil
+            : "music separation produced no audible stems"
     }
 
     static func expectedMusicSeparationStemNames(for model: String) throws -> [String] {
@@ -1360,17 +1373,34 @@ extension GateRunner {
     }
 
     private func audioObservation(_ url: URL, run: ExecResult) throws -> GateObservation {
+        try audioArtifactObservation(url, run: run, requireAudible: true).observation
+    }
+
+    private func audioArtifactObservation(
+        _ url: URL,
+        run: ExecResult,
+        requireAudible: Bool
+    ) throws -> (observation: GateObservation, peak: Float) {
         let data = try Data(contentsOf: url)
         let audio = try MediaAudioIO.decode(url, targetSampleRate: 16_000, channels: 2)
         let peak = audio.samples.map(abs).max() ?? 0
-        return GateObservation(
-            hash: Self.sha256(data),
-            secondRunHash: nil,
-            wallSeconds: run.wallSeconds,
-            decodeTps: nil,
-            semanticFailure: audio.samples.isEmpty || data.count <= 1_024 || peak <= 0.0001
-                ? "generated audio did not decode or was silent"
-                : nil
+        let semanticFailure: String?
+        if audio.samples.isEmpty || data.count <= 1_024 {
+            semanticFailure = "generated audio did not decode or was empty"
+        } else if requireAudible && peak <= 0.0001 {
+            semanticFailure = "generated audio was silent"
+        } else {
+            semanticFailure = nil
+        }
+        return (
+            GateObservation(
+                hash: Self.sha256(data),
+                secondRunHash: nil,
+                wallSeconds: run.wallSeconds,
+                decodeTps: nil,
+                semanticFailure: semanticFailure
+            ),
+            peak
         )
     }
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.32.1"
+    static let current = "0.32.2"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.32.1")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.32.2")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/GateSupportTests.swift
+++ b/Tests/MereRunCLITests/GateSupportTests.swift
@@ -183,4 +183,18 @@ final class GateSupportTests: XCTestCase {
             try GateRunner.expectedMusicSeparationStemNames(for: "music-separate-unknown")
         )
     }
+
+    func testMusicSeparationGateAllowsSilentIndividualStems() {
+        XCTAssertNil(
+            GateRunner.musicSeparationAudibilityFailure(
+                stemPeaks: [0, 0.000_01, 0.02, 0]
+            )
+        )
+        XCTAssertEqual(
+            GateRunner.musicSeparationAudibilityFailure(
+                stemPeaks: [0, 0.000_01, 0.000_1, 0]
+            ),
+            "music separation produced no audible stems"
+        )
+    }
 }

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.32.1"
+default_version="0.32.2"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- require every declared separation stem to exist, decode, and match its manifest hash
- allow an individual stem to be silent when the fixture has none of that source, while requiring the separated set to remain audible
- bump the unpublished release candidate to 0.32.2

## Verification

- `swift test --filter GateSupportTests`
- `.build/debug/mere.run gate --all-installed --suite music --require-all` (10/10 installed music models passed)
- `./scripts/check.sh` (SwiftLint 1122/0; 2419 XCTest, 152 skipped, 0 failures; 20 Swift Testing checks passed)