### PR TITLE
Fix macOS updater packaging and upgrade Sparkle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Fixed
+
+- updated the macOS auto-updater to Sparkle 2.9.5 for current compatibility and
+  security fixes, and made packaging reject a stale embedded Sparkle framework
+  before signing.
+
 ## 0.33.0 - 2026-08-02
 
 This release turns native DreamX into a product-grade local world-session

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "651fcbc2242313b82b9a21d24416bd464f85194455dd60c3b3755ef15f88cbac",
+  "originHash" : "64edf531b07c049be9050a514f9b307d693b7feff677f33aa351c11bd7b33d9d",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
-        "version" : "2.9.2"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -516,7 +516,7 @@ if !isLinuxPackage {
     .package(url: "https://github.com/readdle/swift-onnxruntime.git", exact: "1.20.1")
   )
   packageDependencies.append(
-    .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.2")
+    .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.5")
   )
 }
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -30,7 +30,7 @@ with the new upstream source, version or commit when known, and license data.
 - purpose: secure discovery, verification, and atomic installation of signed
   MereRun macOS app updates
 - upstream project: [`sparkle-project/Sparkle`](https://github.com/sparkle-project/Sparkle),
-  version `2.9.2`; MIT with the bundled component notices below
+  version `2.9.5`; MIT with the bundled component notices below
 - package location: `MereRun.app/Contents/Frameworks/Sparkle.framework`
 
 ```text

--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -185,7 +185,10 @@ final class LinuxNativeBridgeTests: XCTestCase {
         let script = try readRepositoryFile("scripts/build_mere_run_app.sh")
 
         XCTAssertTrue(package.contains(#".product(name: "Sparkle", package: "Sparkle")"#))
-        XCTAssertTrue(package.contains(#"sparkle-project/Sparkle", exact: "2.9.2""#))
+        XCTAssertTrue(package.contains(#"sparkle-project/Sparkle", exact: "2.9.5""#))
+        XCTAssertTrue(script.contains(#"sparkle_expected_version="2.9.5""#))
+        XCTAssertTrue(script.contains("CFBundleShortVersionString raw"))
+        XCTAssertTrue(script.contains("Expected Sparkle ${sparkle_expected_version}"))
         XCTAssertTrue(script.contains("ditto \"$sparkle_framework\" \"${frameworks}/Sparkle.framework\""))
         XCTAssertTrue(script.contains("SUFeedURL"))
         XCTAssertTrue(script.contains("https://mere.run/releases/appcast.xml"))

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -93,6 +93,13 @@ if [[ ! -d "$sparkle_framework" ]]; then
   echo "Sparkle framework not found: ${sparkle_framework}" >&2
   exit 66
 fi
+sparkle_expected_version="2.9.5"
+sparkle_framework_version="$(plutil -extract CFBundleShortVersionString raw \
+  "${sparkle_framework}/Versions/B/Resources/Info.plist")"
+if [[ "$sparkle_framework_version" != "$sparkle_expected_version" ]]; then
+  echo "Expected Sparkle ${sparkle_expected_version}, found ${sparkle_framework_version}" >&2
+  exit 66
+fi
 ditto "$sparkle_framework" "${frameworks}/Sparkle.framework"
 
 if [[ -d "${repo_root}/skills/use-mere-run" ]]; then


### PR DESCRIPTION
## What changed

- upgrade the macOS app updater from Sparkle 2.9.2 to 2.9.5
- verify the fetched framework version before copying and signing the app bundle
- update the package lock, contract test, third-party notice, and changelog

## Why

A user reported that the updater reached **Ready to Install** but failed after
**Install and Relaunch**. The signed public 0.31.0 app successfully updated to
0.33.0 through the live appcast during reproduction, so the published feed,
DMG, and signatures are healthy and the exact failure appears specific to the
affected install or host state.

The app was still embedding Sparkle 2.9.2, and packaging did not assert that the
resolved framework matched the intended release. Moving to 2.9.5 brings current
compatibility and security fixes into future builds, while the new packaging
guard prevents a stale framework from being signed into a release.

Existing affected installations may require one manual DMG update because the
updater executing that transaction is already installed with the older app.

## Validation

- `./scripts/check.sh` — 2,432 XCTest cases, 151 expected skips, zero failures;
  all Swift Testing suites passed
- `swift test --filter LinuxNativeBridgeTests.testMacOSAppBundlesAndSecurelyConfiguresSparkle`
- `./scripts/build_mere_run_app.sh debug`
- deep strict code-signature verification of the packaged app
- live signed public 0.31.0 to 0.33.0 updater smoke through the production appcast
