### PR TITLE
Add native MiniMax-H3 video generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ The format is based on Keep a Changelog.
   security fixes, and made packaging reject a stale embedded Sparkle framework
   before signing.
 
+### Added
+
+- added a native Swift/MLX MiniMax-H3 runtime for the released FL2VA and
+  Ref2VA partitions: Qwen3-VL layer-50 multimodal conditioning, the dense 50
+  layer joint video/audio transformer, causal tiled video VAE, DAC/causal
+  audio encoder, BigVGAN decoder, shifted joint flow schedule, synchronized
+  24 fps MP4 plus 32 kHz stereo output, and exact `17*n+5` frame geometry.
+- added ordered Ref2VA `--reference image:path|video:path|audio:path` inputs,
+  including 2 fps paired video presentation timestamps, video soundtrack
+  conditioning, per-reference spatial grids, shared audio/video rotary clocks,
+  and the released reference-count and modality constraints.
+- added an audited, checksum-pinned ConvRot INT8 to MLX affine INT8/group-64
+  converter for both H3 partitions, including conversion receipts, immutable
+  upstream provenance, explicit license/territory documentation, focused
+  architecture/layout tests, and a real synchronized installed-model gate.
+- added `model optimize` for MiniMax-H3 inference-only AdaLN caches. The native
+  runtime can omit the 13B-parameter AdaLN/time-embedding branch at the released
+  31-point schedule, resamples that exact modulation curve for arbitrary valid
+  schedules, reuses invariant text and RoPE work, and retains eager, compiled,
+  and cache parity coverage.
+- added a streaming MiniMax-H3 affine INT8-to-INT4 transformer requantizer with
+  source-bound cache provenance, per-layer error receipts, cache-covered weight
+  omission, and a typed mixed-precision config that retains the conditioner at
+  INT8. Large sequences reuse one staged compiled block runner and exact fused
+  query-chunked attention without growing graph or Metal command-buffer state.
+- added adaptive MiniMax-H3 9/16/31-point schedule tiers, explicit
+  `--h3-weight-mode auto|quantized|resident-bf16`, chassis-aware compact Q4
+  defaults for MacBooks, staged resident-BF16 expansion for desktop Macs, and
+  coordinated 50-64 GiB MLX wired-memory residency. Corrected the released
+  video VAE's per-head-interleaved QKV layout while retaining the converted
+  transformer's global Q/K/V slabs.
+
 ## 0.33.0 - 2026-08-02
 
 This release turns native DreamX into a product-grade local world-session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,21 @@ The format is based on Keep a Changelog.
   including 2 fps paired video presentation timestamps, video soundtrack
   conditioning, per-reference spatial grids, shared audio/video rotary clocks,
   and the released reference-count and modality constraints.
-- added an audited, checksum-pinned ConvRot INT8 to MLX affine INT8/group-64
-  converter for both H3 partitions, including conversion receipts, immutable
+- added an audited official-source FL2VA release converter that directly
+  quantizes MiniMax's pinned BF16 transformer to MLX affine Q4/group-64 and its
+  exact 50-layer Qwen3-VL conditioner to Q8/group-64, computes the AdaLN cache
+  from the original projections, converts both official VAEs, and emits a full
+  source manifest, conversion receipt, license disclosures, and bundle hashes
+  without accepting third-party weight inputs. The converter deinterleaves all
+  52 released per-head fused QKV matrices into the global Q/K/V slabs consumed
+  by the native runtime before quantization.
+- added a checksum-pinned ConvRot INT8 to MLX affine INT8/group-64 converter for
+  the separate local Ref2VA lane, including conversion receipts, immutable
   upstream provenance, explicit license/territory documentation, focused
   architecture/layout tests, and a real synchronized installed-model gate.
-- added `model optimize` for MiniMax-H3 inference-only AdaLN caches. The native
-  runtime can omit the 13B-parameter AdaLN/time-embedding branch at the released
+- added `model optimize` for local MiniMax-H3 roots and bundled the managed
+  FL2VA artifact's inference-only AdaLN cache at pull time. The native runtime
+  can omit the 13B-parameter AdaLN/time-embedding branch at the released
   31-point schedule, resamples that exact modulation curve for arbitrary valid
   schedules, reuses invariant text and RoPE work, and retains eager, compiled,
   and cache parity coverage.

--- a/Package.swift
+++ b/Package.swift
@@ -253,6 +253,7 @@ if !isLinuxPackage {
   mereRunCoreLinkerSettings.append(.linkedFramework("Vision"))
   mereRunCoreLinkerSettings.append(.linkedFramework("ImageIO"))
   mereRunCoreLinkerSettings.append(.linkedFramework("CoreVideo"))
+  mereRunCoreLinkerSettings.append(.linkedFramework("IOKit"))
 }
 
 var audioCodecsDependencies: [Target.Dependency] = mlxDependency("MLX")
@@ -343,6 +344,7 @@ targets.append(contentsOf: [
       "LoRA/README.md",
       "MagentaRT2/README.md",
       "MMAudio/README.md",
+      "MiniMaxH3/README.md",
       "PrivacyFilter/README.md",
       "RoFormer/README.md",
       "UniverSR/README.md",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ current flags.
 | Vision understanding | `vision caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
 | Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension and UniverSR general-audio super-resolution to hashed 48 kHz mono WAVs |
-| Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | LTX video, synchronized LTX 2.3 audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
+| Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | MiniMax-H3 FL2VA/Ref2VA synchronized video and audio, LTX video and synchronized LTX 2.3 audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
 | Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
 | Speech | `speech synthesize`, `speech transcribe`, `speech diarize`, `speech listen`, `speech profile` | Qwen3 TTS, saved voice profiles, Qwen3 live ASR, Parakeet transcription, and native MLX Sortformer speaker diarization |
 | Serving and operations | `api serve`, `open-webui quickstart`, `status`, `run`, `model runtime`, `gate` | OpenAI-compatible chat, embeddings, images, TTS, and STT; resident model pooling, TTL/pinning, memory guards, durable run inspection, and installed-model quality gates |
@@ -754,6 +754,26 @@ swift run mere.run video generate \
   --duration 5 \
   --image ./performer.png \
   --output ./performance.mp4
+
+# MiniMax-H3 text/first-frame to synchronized 24 fps video + 32 kHz stereo
+swift run mere.run model pull video-minimax-h3-fl2va-mlx --accept-model-license
+swift run mere.run model optimize video-minimax-h3-fl2va-mlx
+swift run mere.run video generate \
+  "the paper bird takes flight with crisp wing sounds" \
+  --model video-minimax-h3-fl2va-mlx \
+  --image ./paper-bird.png \
+  --num-frames 124 \
+  --output ./paper-bird-h3.mp4
+
+# A locally converted Ref2VA root preserves reference order semantically
+swift run mere.run video generate \
+  "keep the subject, borrow the camera move, and follow the vocal rhythm" \
+  --model-root ./MiniMax-H3-Ref2VA-MLX \
+  --reference image:./subject.png \
+  --reference video:./camera-and-soundtrack.mp4 \
+  --reference audio:./voice.wav \
+  --num-frames 124 \
+  --output ./referenced-h3.mp4
 
 # Animate a masked reference subject from a driving video with native SCAIL-2
 swift run mere.run model pull video-scail2-14b-mlx

--- a/README.md
+++ b/README.md
@@ -757,7 +757,6 @@ swift run mere.run video generate \
 
 # MiniMax-H3 text/first-frame to synchronized 24 fps video + 32 kHz stereo
 swift run mere.run model pull video-minimax-h3-fl2va-mlx --accept-model-license
-swift run mere.run model optimize video-minimax-h3-fl2va-mlx
 swift run mere.run video generate \
   "the paper bird takes flight with crisp wing sounds" \
   --model video-minimax-h3-fl2va-mlx \

--- a/Sources/MediaIO/AppleMediaVideoIO.swift
+++ b/Sources/MediaIO/AppleMediaVideoIO.swift
@@ -196,9 +196,17 @@ enum AppleMediaVideoIO {
               let compositionAudioTrack = composition.addMutableTrack(withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid) else {
             throw MediaIOError.videoOperationFailed("Could not create composition tracks.")
         }
-        let duration = CMTimeMinimum(videoAsset.duration, audioAsset.duration)
-        try compositionVideoTrack.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: videoTrack, at: .zero)
-        try compositionAudioTrack.insertTimeRange(CMTimeRange(start: .zero, duration: duration), of: audioTrack, at: .zero)
+        let audioDuration = CMTimeMinimum(videoAsset.duration, audioAsset.duration)
+        try compositionVideoTrack.insertTimeRange(
+            CMTimeRange(start: .zero, duration: videoAsset.duration),
+            of: videoTrack,
+            at: .zero
+        )
+        try compositionAudioTrack.insertTimeRange(
+            CMTimeRange(start: .zero, duration: audioDuration),
+            of: audioTrack,
+            at: .zero
+        )
         compositionVideoTrack.preferredTransform = videoTrack.preferredTransform
         try exportComposition(composition, outputURL: outputURL, videoComposition: nil, audioMix: nil)
     }

--- a/Sources/MediaIO/FFmpegMediaIO.swift
+++ b/Sources/MediaIO/FFmpegMediaIO.swift
@@ -335,6 +335,7 @@ enum FFmpegMediaIO {
         outputURL: URL,
         audioBitRate: Int? = nil
     ) throws {
+        let videoDuration = try videoDurationSeconds(videoURL)
         try FileManager.default.createDirectory(
             at: outputURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -344,20 +345,44 @@ enum FFmpegMediaIO {
             "-y",
             "-i", videoURL.path,
             "-i", audioURL.path,
+            "-map", "0:v:0",
+            "-map", "1:a:0",
             "-c:v", "copy",
             "-c:a", "aac",
+            // Preserve every generated video frame when decoded audio is a few
+            // samples short. Without padding, `-shortest` can discard delayed
+            // H.264 B-frames before their presentation timestamps are reached.
+            "-af", "apad",
         ]
         if let audioBitRate {
             arguments += ["-b:a", "\(max(1, audioBitRate))"]
         }
         arguments += [
-            "-shortest",
+            "-t", String(videoDuration),
             outputURL.path,
         ]
         _ = try FFmpegProcess.run(
             tool: MediaTool.ffmpegPath,
             arguments: arguments
         )
+    }
+
+    private static func videoDurationSeconds(_ url: URL) throws -> Double {
+        let result = try FFmpegProcess.run(
+            tool: MediaTool.ffprobePath,
+            arguments: [
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                url.path,
+            ]
+        )
+        let rawDuration = String(decoding: result.stdout, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let duration = Double(rawDuration), duration.isFinite, duration > 0 else {
+            throw MediaIOError.videoOperationFailed("Could not determine video duration for muxing.")
+        }
+        return duration
     }
 
     static func extractFrames(

--- a/Sources/MereRunCLI/Commands/ModelCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCommand.swift
@@ -3,7 +3,7 @@ import ArgumentParser
 struct Model: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "model",
-        abstract: "List, pull, remove, inspect, and clean up models.",
+        abstract: "List, pull, remove, inspect, optimize, and clean up models.",
         subcommands: [
             ModelList.self,
             ModelPull.self,
@@ -13,6 +13,7 @@ struct Model: ParsableCommand {
             ModelInfo.self,
             ModelCapabilities.self,
             ModelRuntime.self,
+            ModelOptimize.self,
             ModelBenchmark.self,
             ModelRepairManifests.self,
         ]

--- a/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
@@ -1,0 +1,75 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ModelOptimize: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "optimize",
+        abstract: "Build inference-only caches for a supported installed model."
+    )
+
+    @Argument(help: "Canonical model id or local model root path.")
+    var target: String
+
+    @Flag(name: [.long], help: "Replace an existing compatible optimization cache.")
+    var force: Bool = false
+
+    @Flag(name: [.long], help: "Emit the result as JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        let rootURL = try resolveRootURL()
+        let resources = MiniMaxH3Resources(rootURL: rootURL)
+        let outputURL = try MiniMaxH3ModelOptimizer.optimize(
+            resources: resources,
+            replacing: force,
+            progressHandler: { completed, total in
+                CLIStderr.write("MiniMax-H3 AdaLN cache: \(completed)/\(total)\n")
+            }
+        )
+        let bytes = (try? outputURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let output = ModelOptimizeOutput(
+            modelRoot: rootURL.path,
+            artifact: outputURL.path,
+            bytes: bytes
+        )
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(output)
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw ValidationError("Could not encode optimization result as UTF-8.")
+            }
+            print(text)
+        } else {
+            print("Model optimization complete")
+            print("  model: \(output.modelRoot)")
+            print("  artifact: \(output.artifact)")
+            print("  size: \(ByteCountFormatter.string(fromByteCount: Int64(output.bytes), countStyle: .file))")
+        }
+    }
+
+    private func resolveRootURL() throws -> URL {
+        let pathURL = URL(fileURLWithPath: target).standardizedFileURL
+        if FileManager.default.fileExists(atPath: pathURL.path) {
+            return pathURL
+        }
+        guard let modelID = ModelResolver.ModelID(rawValue: target) else {
+            throw ValidationError("Not a path and not a known model id: \(target)")
+        }
+        guard modelID == .miniMaxH3FL2VAMLX || modelID == .miniMaxH3Ref2VAMLX else {
+            throw ValidationError("Model optimization currently supports MiniMax-H3 MLX models.")
+        }
+        do {
+            return try ModelResolver().resolve(modelID).rootURL
+        } catch {
+            throw ValidationError("Model \(target) is not installed in the local model store.")
+        }
+    }
+}
+
+private struct ModelOptimizeOutput: Codable {
+    let modelRoot: String
+    let artifact: String
+    let bytes: Int
+}

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -38,6 +38,42 @@ func resolveLTXVideoGenerationRoute(
     }
 }
 
+enum MiniMaxH3CLITransformerWeightMode: String, CaseIterable, ExpressibleByArgument {
+    case automatic = "auto"
+    case quantized
+    case residentBF16 = "resident-bf16"
+
+    var generationMode: MiniMaxH3TransformerWeightMode {
+        switch self {
+        case .automatic: .automatic
+        case .quantized: .quantized
+        case .residentBF16: .residentBF16
+        }
+    }
+}
+
+private struct MiniMaxH3WiredMemoryPolicy: WiredMemoryPolicy, Hashable {
+    func limit(baseline: Int, activeSizes: [Int]) -> Int {
+        max(baseline, activeSizes.max() ?? baseline)
+    }
+}
+
+private func miniMaxH3WiredMemoryTargetBytes() -> Int {
+    let gibibyte = 1_073_741_824
+    let desired = ProcessInfo.processInfo.physicalMemory >= UInt64(96 * gibibyte)
+        ? 64 * gibibyte
+        : 50 * gibibyte
+#if os(macOS)
+    let safetyMargin = 1_048_576
+    guard let recommended = GPU.maxRecommendedWorkingSetBytes() else {
+        return min(desired, Int(ProcessInfo.processInfo.physicalMemory / 2))
+    }
+    return min(desired, max(0, recommended - safetyMargin))
+#else
+    return min(desired, Int(ProcessInfo.processInfo.physicalMemory / 2))
+#endif
+}
+
 func resolveLTXVideoGenerationRoute(
     variant: LTXVideoVariant,
     modelRoot: URL,
@@ -194,6 +230,7 @@ struct VideoGenerate: AsyncParsableCommand {
           swift run mere.run video generate "dialogue with clean background music" --quality final --output-mode audio-video --duration 15 --fps 24
           swift run mere.run video generate "a kinetic live performance" --audio song.wav --audio-start-time 30 --duration 5 --image performer.png
           swift run mere.run video generate "the camera walks forward" --model video-wan22-ti2v-5b-mlx --image frame.png --num-frames 41 --width 1280 --height 704
+          swift run mere.run video generate "use this subject and motion" --model-root ./MiniMax-H3-Ref2VA-MLX --reference image:subject.png --reference video:motion.mp4
         """
     )
 
@@ -215,7 +252,7 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("variant")], help: "Compatibility selector: distilled defaults to draft video-only; unified-av defaults to final audio-video.")
     var legacyVariant: LTXVideoVariant?
 
-    @Option(name: [.customLong("model-root")], help: "Local LTX model root. Takes precedence over --model.")
+    @Option(name: [.customLong("model-root")], help: "Local video model root. Takes precedence over --model.")
     var modelRoot: String?
 
     @Option(name: [.long], help: "Output width (snapped to the selected model's native geometry).")
@@ -236,8 +273,17 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.long], help: "Seed value.")
     var seed: Int?
 
-    @Option(name: [.long], help: "Wan denoising steps.")
-    var steps: Int = 40
+    @Option(
+        name: [.long],
+        help: "Denoising schedule points. Defaults to 40 for Wan; MiniMax-H3 selects 9, 16, or 31 from packed geometry."
+    )
+    var steps: Int?
+
+    @Option(
+        name: [.customLong("h3-weight-mode")],
+        help: "MiniMax-H3 transformer compute: auto, quantized, or resident-bf16."
+    )
+    var h3WeightMode: MiniMaxH3CLITransformerWeightMode = .automatic
 
     @Option(name: [.customLong("guidance-scale")], help: "Wan classifier-free guidance scale.")
     var guidanceScale: Float = 5
@@ -277,6 +323,9 @@ struct VideoGenerate: AsyncParsableCommand {
 
     @Option(name: [.customLong("end-image")], help: "Optional end keyframe path; conditions the last frame so the clip interpolates a directed start->end motion. Requires --image.")
     var endImage: String?
+
+    @Option(name: [.customLong("reference")], help: "Ordered MiniMax-H3 Ref2VA input as image:path, video:path, or audio:path. Repeat to preserve semantic order.")
+    var references: [String] = []
 
     @Option(name: [.customLong("end-image-strength")], help: "End keyframe conditioning strength in [0, 1].")
     var endImageStrength: Float = 1.0
@@ -382,7 +431,7 @@ struct VideoGenerate: AsyncParsableCommand {
         guard numFrames >= 5 else {
             throw ValidationError("--num-frames must be >= 5")
         }
-        guard steps > 0 else {
+        if let steps, steps <= 0 {
             throw ValidationError("--steps must be >= 1")
         }
         guard guidanceScale >= 0 else {
@@ -467,6 +516,89 @@ struct VideoGenerate: AsyncParsableCommand {
 
         let resolvedRootURL = URL(fileURLWithPath: resolvedModelRoot).standardizedFileURL
         try validateProductSelection(modelRoot: resolvedRootURL)
+        if isMiniMaxH3ModelRoot(resolvedRootURL) {
+            guard sourceAudioURL == nil else {
+                throw ValidationError("MiniMax-H3 FL2VA generates its own synchronized audio and does not accept --audio.")
+            }
+            if timings || timingsOutput != nil {
+                throw ValidationError("--timings and --timings-output are not available for MiniMax-H3 yet.")
+            }
+            let h3Resources = MiniMaxH3Resources(rootURL: resolvedRootURL)
+            let h3Configuration = try h3Resources.loadConfiguration()
+            let parsedReferences = try parseMiniMaxH3References()
+            if h3Configuration.task == "fl2va", !parsedReferences.isEmpty {
+                throw ValidationError("--reference requires a MiniMax-H3 Ref2VA model root.")
+            }
+            if h3Configuration.task == "ref2va" {
+                guard sourceImageURL == nil, endImageURL == nil else {
+                    throw ValidationError("MiniMax-H3 Ref2VA uses ordered --reference inputs, not --image/--end-image.")
+                }
+                guard !parsedReferences.isEmpty else {
+                    throw ValidationError("MiniMax-H3 Ref2VA requires at least one --reference.")
+                }
+            }
+            let h3Width = max(32, (width / 32) * 32)
+            let h3Height = max(32, (height / 32) * 32)
+            let requestedH3Frames = duration.map { Int(($0 * 24).rounded()) } ?? numFrames
+            let h3Frames = try MiniMaxH3Geometry.alignFrameCount(max(22, requestedH3Frames))
+            if !quiet {
+                CLIStderr.write("Engine: native MiniMax-H3 \(h3Configuration.task.uppercased())\n")
+                CLIStderr.write("Model root: \(resolvedRootURL.path)\n")
+                if h3Width != width || h3Height != height {
+                    CLIStderr.write("Adjusted MiniMax-H3 size to \(h3Width)x\(h3Height) (must be divisible by 32)\n")
+                }
+                if h3Frames != requestedH3Frames {
+                    CLIStderr.write("Adjusted MiniMax-H3 frame count to \(h3Frames) (must have form 17*n+5)\n")
+                }
+            }
+            try MLXBundleSupport.ensureAvailable(quiet: quiet)
+            let h3Options = try MiniMaxH3GenerationOptions(
+                prompt: trimmedPrompt,
+                width: h3Width,
+                height: h3Height,
+                numFrames: h3Frames,
+                steps: steps,
+                seed: UInt64(bitPattern: Int64(seed ?? 42)),
+                transformerWeightMode: h3WeightMode.generationMode,
+                firstFrameURL: sourceImageURL,
+                lastFrameURL: endImageURL,
+                references: parsedReferences
+            )
+            let generator = MiniMaxH3Generator()
+            let reportsProgress = !quiet
+            let wiredMemoryTicket = MiniMaxH3WiredMemoryPolicy().ticket(
+                size: miniMaxH3WiredMemoryTargetBytes()
+            )
+            let result = try await wiredMemoryTicket.withWiredLimit {
+                try Stream.withNewDefaultStream {
+                    try generator.generate(
+                        options: h3Options,
+                        resources: h3Resources,
+                        progressHandler: { progress in
+                            guard reportsProgress else { return }
+                            if progress.stage == .denoising {
+                                CLIStderr.write("Denoising \(progress.stepIndex + 1)/\(progress.totalSteps)\n")
+                            } else {
+                                CLIStderr.write("\(progress.stage.rawValue)\n")
+                            }
+                        }
+                    )
+                }
+            }
+            try LTXVideoMP4Writer.writeMP4(
+                frames: result.frames,
+                fps: MiniMaxH3Geometry.framesPerSecond,
+                to: outputURL,
+                audioWaveform: result.audio,
+                audioSampleRate: MiniMaxH3AudioVAE.samplingRate
+            )
+            if !quiet { CLIStderr.write("Saved: \(outputURL.path)\n") }
+            print(outputURL.path)
+            return
+        }
+        if !references.isEmpty {
+            throw ValidationError("--reference is only supported by MiniMax-H3 Ref2VA model roots.")
+        }
         if let sourceAudioURL {
             try validateNativeAudioToVideoModelRoot(resolvedRootURL)
             try MLXBundleSupport.ensureAvailable(quiet: quiet)
@@ -529,7 +661,7 @@ struct VideoGenerate: AsyncParsableCommand {
                 width: wanWidth,
                 height: wanHeight,
                 numFrames: wanFrames,
-                steps: steps,
+                steps: steps ?? 40,
                 guidanceScale: guidanceScale,
                 shift: shift,
                 fps: fps,
@@ -596,6 +728,12 @@ struct VideoGenerate: AsyncParsableCommand {
     }
 
     private func validateProductSelection(modelRoot: URL) throws {
+        if isMiniMaxH3ModelRoot(modelRoot) {
+            if quality != nil || outputMode != nil || legacyVariant != nil {
+                throw ValidationError("--quality, --output-mode, and --variant select LTX behavior and cannot be combined with MiniMax-H3.")
+            }
+            return
+        }
         if isWan2ModelRoot(modelRoot) {
             if quality != nil || outputMode != nil {
                 throw ValidationError("--quality and --output-mode currently select native LTX generation, not Wan2.2 TI2V.")
@@ -623,6 +761,29 @@ struct VideoGenerate: AsyncParsableCommand {
     private func isWan2ModelRoot(_ rootURL: URL) -> Bool {
         let resources = Wan2Resources(rootURL: rootURL)
         return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
+    }
+
+    private func isMiniMaxH3ModelRoot(_ rootURL: URL) -> Bool {
+        let resources = MiniMaxH3Resources(rootURL: rootURL)
+        return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
+    }
+
+    private func parseMiniMaxH3References() throws -> [MiniMaxH3ReferenceInput] {
+        try references.map { raw in
+            guard let separator = raw.firstIndex(of: ":") else {
+                throw ValidationError("--reference must be image:path, video:path, or audio:path (got \(raw)).")
+            }
+            let rawKind = String(raw[..<separator]).lowercased()
+            let rawPath = String(raw[raw.index(after: separator)...])
+            guard let kind = MiniMaxH3ReferenceKind(rawValue: rawKind), !rawPath.isEmpty else {
+                throw ValidationError("--reference must be image:path, video:path, or audio:path (got \(raw)).")
+            }
+            let url = URL(fileURLWithPath: rawPath).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ValidationError("Reference file not found: \(url.path)")
+            }
+            return MiniMaxH3ReferenceInput(kind: kind, url: url)
+        }
     }
 
     private func runNativeWanGenerate(
@@ -1121,6 +1282,7 @@ struct VideoGenerate: AsyncParsableCommand {
             imageStrength: imageStrength,
             endImage: endImage,
             endImageStrength: endImageStrength,
+            references: references,
             timings: timings,
             timingsOutput: timingsOutput,
             generationArgv: generationActionArguments(outputURL: outputURL),
@@ -1182,6 +1344,9 @@ struct VideoGenerate: AsyncParsableCommand {
         if let seed {
             args += ["--seed", String(seed)]
         }
+        if let steps {
+            args += ["--steps", String(steps)]
+        }
         if let negativePrompt {
             args += ["--negative-prompt", negativePrompt]
         }
@@ -1205,6 +1370,9 @@ struct VideoGenerate: AsyncParsableCommand {
         }
         if let endImage {
             args += ["--end-image", endImage, "--end-image-strength", String(endImageStrength)]
+        }
+        for reference in references {
+            args += ["--reference", reference]
         }
         if quiet {
             args.append("--quiet")

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -413,6 +413,11 @@ enum InstalledModelSmokePlans {
                 try await runner.installedWanCheck(model: spec.id)
             }
 
+        case .miniMaxH3MLX:
+            return direct(spec, route: "video generate MiniMax-H3 synchronized AV") { runner in
+                try await runner.installedMiniMaxH3Check(model: spec.id)
+            }
+
         case .cosmos3EdgeMLX:
             return direct(spec, route: "video cosmos3 image-to-video") { runner in
                 try await runner.installedCosmosCheck(model: spec.id)
@@ -1191,6 +1196,35 @@ extension GateRunner {
             timeout: 3_600
         )
         return try generatedVideoObservation(output, run: run)
+    }
+
+    func installedMiniMaxH3Check(model: String) async throws -> GateObservation {
+        let output = artifactURL(model, extension: "mp4")
+        var arguments = [
+            "video", "generate",
+            "A red cube rotates slowly on a neutral background with a soft mechanical hum.",
+            "--model", model,
+            "--width", "128",
+            "--height", "128",
+            "--num-frames", "22",
+            "--steps", "2",
+            "--seed", "7",
+            "--output", output.path,
+            "--quiet",
+        ]
+        if model == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
+            let image = try fixtureImage()
+            arguments.append(contentsOf: ["--reference", "image:\(image.path)"])
+        }
+        let run = try await exec(arguments, timeout: 7_200)
+        let bytes = try Data(contentsOf: output)
+        return GateObservation(
+            hash: Self.sha256(bytes),
+            secondRunHash: nil,
+            wallSeconds: run.wallSeconds,
+            decodeTps: nil,
+            semanticFailure: try validateVideoArtifact(output, requireAudio: true)
+        )
     }
 
     func installedCosmosCheck(model: String) async throws -> GateObservation {

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -31,6 +31,7 @@ struct VideoGenerationPreflightInput {
     let imageStrength: Float
     let endImage: String?
     let endImageStrength: Float
+    let references: [String]
     let timings: Bool
     let timingsOutput: String?
     let generationArgv: [String]
@@ -63,6 +64,7 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
     let imageStrength: Float
     let endImage: String?
     let endImageStrength: Float
+    let references: [String]?
     let timings: Bool?
     let timingsOutput: String?
 
@@ -92,6 +94,7 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
         case imageStrength = "image_strength"
         case endImage = "end_image"
         case endImageStrength = "end_image_strength"
+        case references
         case timings
         case timingsOutput = "timings_output"
     }
@@ -153,6 +156,7 @@ struct VideoGenerationInputPreflightSummary: Codable, Equatable {
     let sourceAudio: VideoGenerationPathPreflightSummary?
     let sourceImage: VideoGenerationPathPreflightSummary?
     let endImage: VideoGenerationPathPreflightSummary?
+    let references: [VideoGenerationPathPreflightSummary]?
     let missingCount: Int
 
     enum CodingKeys: String, CodingKey {
@@ -160,6 +164,7 @@ struct VideoGenerationInputPreflightSummary: Codable, Equatable {
         case sourceAudio = "source_audio"
         case sourceImage = "source_image"
         case endImage = "end_image"
+        case references
         case missingCount = "missing_count"
     }
 }
@@ -250,6 +255,17 @@ struct VideoGenerationPreflightAnalyzer {
         return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
     }
 
+    private var usesMiniMaxH3Geometry: Bool {
+        let requested = input.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if requested == ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
+            return true
+        }
+        let candidate = input.modelRoot ?? input.model
+        let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: candidate).standardizedFileURL)
+        return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
+    }
+
     private var usesAudioConditioning: Bool {
         guard let audio = input.audio else { return false }
         return !audio.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -314,6 +330,7 @@ struct VideoGenerationPreflightAnalyzer {
             imageStrength: input.imageStrength,
             endImage: input.endImage,
             endImageStrength: input.endImageStrength,
+            references: input.references.isEmpty ? nil : input.references,
             timings: input.timings,
             timingsOutput: input.timingsOutput
         )
@@ -325,6 +342,17 @@ struct VideoGenerationPreflightAnalyzer {
     ) {
         guard input.timings || input.timingsOutput != nil else { return }
         guard !usesAudioConditioning else { return }
+        guard !usesMiniMaxH3Geometry else {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "timings_lane_unsupported",
+                    severity: .blocker,
+                    title: "Phase timings are unavailable for this lane",
+                    message: "--timings and --timings-output are not available for MiniMax-H3 yet."
+                )
+            )
+            return
+        }
         guard !usesWanGeometry else {
             diagnostics.append(
                 PreflightDiagnostic(
@@ -387,6 +415,16 @@ struct VideoGenerationPreflightAnalyzer {
                     severity: .blocker,
                     title: "LTX product options do not apply to Wan",
                     message: "--quality and --output-mode currently select native LTX generation, not Wan2.2 TI2V."
+                )
+            )
+        }
+        if usesMiniMaxH3Geometry, input.quality != nil || input.outputMode != nil || input.legacyVariant != nil {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "ltx_product_selection_with_minimax_h3",
+                    severity: .blocker,
+                    title: "LTX product options do not apply to MiniMax-H3",
+                    message: "--quality, --output-mode, and --variant cannot be combined with MiniMax-H3."
                 )
             )
         }
@@ -467,8 +505,8 @@ struct VideoGenerationPreflightAnalyzer {
                 )
             )
         }
-        let minimumSpatialDimension = usesWanGeometry ? 32 : 64
-        let minimumFrameCount = usesWanGeometry ? 5 : 9
+        let minimumSpatialDimension = usesWanGeometry || usesMiniMaxH3Geometry ? 32 : 64
+        let minimumFrameCount = usesMiniMaxH3Geometry ? 22 : (usesWanGeometry ? 5 : 9)
         if input.width < minimumSpatialDimension {
             diagnostics.append(
                 PreflightDiagnostic(
@@ -536,6 +574,16 @@ struct VideoGenerationPreflightAnalyzer {
                     severity: .warning,
                     title: "LTX audio/video is tuned for 24 fps",
                     message: "LTX audio/video is trained around 24 fps; --fps \(input.fps) can make motion look time-stretched relative to audio."
+                )
+            )
+        }
+        if usesMiniMaxH3Geometry, input.fps != MiniMaxH3Geometry.framesPerSecond {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "minimax_h3_fps_fixed",
+                    severity: .note,
+                    title: "MiniMax-H3 uses fixed 24 fps",
+                    message: "MiniMax-H3 output will use 24 fps; --fps \(input.fps) is ignored."
                 )
             )
         }
@@ -769,6 +817,10 @@ struct VideoGenerationPreflightAnalyzer {
     }
 
     private func videoLayout(at url: URL) -> String? {
+        let h3 = MiniMaxH3Resources(rootURL: url)
+        if h3.validate().isEmpty, let configuration = try? h3.loadConfiguration() {
+            return "minimax_h3_\(configuration.task)_mlx"
+        }
         let resources = Wan2Resources(rootURL: url)
         if resources.validate().isEmpty, (try? resources.loadConfiguration()) != nil {
             return "wan22_ti2v_mlx"
@@ -785,7 +837,14 @@ struct VideoGenerationPreflightAnalyzer {
     }
 
     private func validateSelectedModelRoot(_ url: URL) throws {
-        if usesAudioConditioning {
+        if usesMiniMaxH3Geometry {
+            let resources = MiniMaxH3Resources(rootURL: url)
+            let missing = resources.validate(fileManager: fileManager)
+            guard missing.isEmpty else {
+                throw ValidationError("Missing MiniMax-H3 files: \(missing.map(\.path).joined(separator: ", "))")
+            }
+            _ = try resources.loadConfiguration()
+        } else if usesAudioConditioning {
             try validateNativeAudioToVideoModelRoot(url, fileManager: fileManager)
         } else if input.variant == .unifiedAV,
                   isLTX23AudioToVideoModelRoot(url, fileManager: fileManager),
@@ -858,6 +917,10 @@ struct VideoGenerationPreflightAnalyzer {
         let sourceAudio = usesAudioConditioning ? input.audio.map { pathSummary(requested: $0) } : nil
         let sourceImage = input.image.map { pathSummary(requested: $0) }
         let endImage = input.endImage.map { pathSummary(requested: $0) }
+        let references = input.references.map { raw -> VideoGenerationPathPreflightSummary in
+            let path = raw.firstIndex(of: ":").map { String(raw[raw.index(after: $0)...]) } ?? raw
+            return pathSummary(requested: path)
+        }
         for (summary, prefix) in [
             (sourceAudio, "source_audio"),
             (sourceImage, "source_image"),
@@ -886,9 +949,30 @@ struct VideoGenerationPreflightAnalyzer {
                 )
             }
         }
+        for (index, summary) in references.enumerated() {
+            if !summary.exists {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "reference_\(index)_missing",
+                    severity: .blocker,
+                    title: "Reference media missing",
+                    message: "Reference media not found: \(summary.path)",
+                    locations: [.init(kind: "file", path: summary.path)]
+                ))
+            } else if summary.isDirectory {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "reference_\(index)_is_directory",
+                    severity: .blocker,
+                    title: "Reference media is a directory",
+                    message: "Reference media path is a directory: \(summary.path)",
+                    locations: [.init(kind: "directory", path: summary.path)]
+                ))
+            }
+        }
 
         let mode: String
-        if sourceAudio != nil {
+        if !references.isEmpty {
+            mode = "reference_to_video_audio"
+        } else if sourceAudio != nil {
             if sourceImage == nil {
                 mode = "audio_to_video"
             } else if endImage == nil {
@@ -901,12 +985,13 @@ struct VideoGenerationPreflightAnalyzer {
                 ? "text_to_video"
                 : (endImage == nil ? "image_to_video" : "directed_image_to_video")
         }
-        let allInputs = [sourceAudio, sourceImage, endImage].compactMap { $0 }
+        let allInputs = [sourceAudio, sourceImage, endImage].compactMap { $0 } + references
         return VideoGenerationInputPreflightSummary(
             mode: mode,
             sourceAudio: sourceAudio,
             sourceImage: sourceImage,
             endImage: endImage,
+            references: references.isEmpty ? nil : references,
             missingCount: allInputs.filter { !$0.exists }.count
         )
     }
@@ -928,20 +1013,21 @@ struct VideoGenerationPreflightAnalyzer {
         inputs: VideoGenerationInputPreflightSummary,
         diagnostics: inout [PreflightDiagnostic]
     ) -> VideoGenerationPlanPreflightSummary {
-        let spatialMultiple = usesWanGeometry ? 32 : 64
+        let spatialMultiple = usesWanGeometry || usesMiniMaxH3Geometry ? 32 : 64
         let temporalMultiple = usesWanGeometry ? 4 : 8
-        let minimumFrames = usesWanGeometry ? 5 : 9
+        let minimumFrames = usesMiniMaxH3Geometry ? 22 : (usesWanGeometry ? 5 : 9)
         let resolvedWidth = max(spatialMultiple, (input.width / spatialMultiple) * spatialMultiple)
         let resolvedHeight = max(spatialMultiple, (input.height / spatialMultiple) * spatialMultiple)
         let requestedFrames = input.duration.map {
-            usesWanGeometry
+            usesMiniMaxH3Geometry
+                ? Int(($0 * Double(MiniMaxH3Geometry.framesPerSecond)).rounded())
+                : usesWanGeometry
                 ? nearestWanFrameCount(duration: $0, fps: input.fps)
                 : nearestLTXFrameCount(duration: $0, fps: input.fps)
         } ?? input.numFrames
-        let resolvedFrames = max(
-            minimumFrames,
-            ((requestedFrames - 1) / temporalMultiple) * temporalMultiple + 1
-        )
+        let resolvedFrames = usesMiniMaxH3Geometry
+            ? (try? MiniMaxH3Geometry.alignFrameCount(max(minimumFrames, requestedFrames))) ?? minimumFrames
+            : max(minimumFrames, ((requestedFrames - 1) / temporalMultiple) * temporalMultiple + 1)
 
         if input.width >= spatialMultiple,
            input.height >= spatialMultiple,
@@ -961,12 +1047,15 @@ struct VideoGenerationPreflightAnalyzer {
                     id: "num_frames_will_be_adjusted",
                     severity: .note,
                     title: "Frame count will be adjusted",
-                    message: "Frame count will be snapped from \(input.numFrames) to \(resolvedFrames) to satisfy \(temporalMultiple)n+1."
+                    message: usesMiniMaxH3Geometry
+                        ? "Frame count will be snapped from \(input.numFrames) to \(resolvedFrames) to satisfy 17*n+5."
+                        : "Frame count will be snapped from \(input.numFrames) to \(resolvedFrames) to satisfy \(temporalMultiple)n+1."
                 )
             )
         }
         if let duration = input.duration, input.fps > 0, duration > 0 {
-            let resolvedSeconds = Double(resolvedFrames) / Double(input.fps)
+            let outputFPS = usesMiniMaxH3Geometry ? MiniMaxH3Geometry.framesPerSecond : input.fps
+            let resolvedSeconds = Double(resolvedFrames) / Double(outputFPS)
             diagnostics.append(
                 PreflightDiagnostic(
                     id: "duration_resolved_to_frame_count",
@@ -976,7 +1065,7 @@ struct VideoGenerationPreflightAnalyzer {
                         format: "Duration %.2fs resolves to %d frames at %d fps (~%.2fs).",
                         duration,
                         resolvedFrames,
-                        input.fps,
+                        outputFPS,
                         resolvedSeconds
                     )
                 )
@@ -985,11 +1074,13 @@ struct VideoGenerationPreflightAnalyzer {
 
         let routeWritesAudio = resolvedLTXRoute(model: model)?.writesAudio
             ?? (input.variant == .unifiedAV)
-        let resolvedOutputMode: LTXVideoOutputMode? = usesWanGeometry
+        let resolvedOutputMode: LTXVideoOutputMode? = usesWanGeometry || usesMiniMaxH3Geometry
             ? nil
             : (usesAudioConditioning || input.variant == .unifiedAV ? .audioVideo : .videoOnly)
         return VideoGenerationPlanPreflightSummary(
-            variant: usesWanGeometry
+            variant: usesMiniMaxH3Geometry
+                ? "minimax-h3"
+                : usesWanGeometry
                 ? "wan22-ti2v"
                 : (usesAudioConditioning ? "audio-to-video" : input.variant.rawValue),
             quality: resolvedQuality(model: model)?.rawValue,
@@ -1001,11 +1092,13 @@ struct VideoGenerationPreflightAnalyzer {
             resolvedHeight: resolvedHeight,
             requestedNumFrames: input.numFrames,
             requestedDurationSeconds: input.duration,
-            fps: input.fps,
+            fps: usesMiniMaxH3Geometry ? MiniMaxH3Geometry.framesPerSecond : input.fps,
             resolvedNumFrames: resolvedFrames,
-            resolvedDurationSeconds: input.fps > 0 ? Double(resolvedFrames) / Double(input.fps) : nil,
+            resolvedDurationSeconds: input.fps > 0
+                ? Double(resolvedFrames) / Double(usesMiniMaxH3Geometry ? MiniMaxH3Geometry.framesPerSecond : input.fps)
+                : nil,
             seed: input.seed ?? 42,
-            writesAudio: usesAudioConditioning || (!usesWanGeometry && routeWritesAudio),
+            writesAudio: usesMiniMaxH3Geometry || usesAudioConditioning || (!usesWanGeometry && routeWritesAudio),
             audioConditioning: usesAudioConditioning,
             preservesSourceAudio: usesAudioConditioning,
             resolvedAudioStartTime: usesAudioConditioning ? input.audioStartTime : nil

--- a/Sources/MereRunCore/MMAudio/MMAudioBigVGAN.swift
+++ b/Sources/MereRunCore/MMAudio/MMAudioBigVGAN.swift
@@ -234,20 +234,37 @@ public final class MMAudioBigVGAN: Module {
     @ModuleInfo(key: "resblocks") private var residualBlocks: [MMAudioAMPBlock]
     @ModuleInfo(key: "activation_post") private var postActivation: MMAudioAliasFreeActivation
     @ModuleInfo(key: "conv_post") private var postConvolution: MMAudioBigVGANConv1D
+    private let useFloat32: Bool
 
-    public override init() {
-        let rates = [8, 4, 2, 2, 2, 2]
-        let kernels = [16, 8, 4, 4, 4, 4]
+    public convenience override init() {
+        self.init(
+            inputChannels: 128,
+            initialChannels: 1_536,
+            upsampleRates: [8, 4, 2, 2, 2, 2],
+            upsampleKernelSizes: [16, 8, 4, 4, 4, 4],
+            useFloat32: false
+        )
+    }
+
+    public init(
+        inputChannels: Int,
+        initialChannels: Int,
+        upsampleRates: [Int],
+        upsampleKernelSizes: [Int],
+        useFloat32: Bool = false
+    ) {
+        self.useFloat32 = useFloat32
+        precondition(!upsampleRates.isEmpty && upsampleRates.count == upsampleKernelSizes.count)
         var upsamplers: [MMAudioBigVGANUpsample] = []
         var residualBlocks: [MMAudioAMPBlock] = []
-        for stage in rates.indices {
-            let inputChannels = 1_536 / (1 << stage)
-            let outputChannels = 1_536 / (1 << (stage + 1))
+        for stage in upsampleRates.indices {
+            let stageInputChannels = initialChannels / (1 << stage)
+            let outputChannels = initialChannels / (1 << (stage + 1))
             upsamplers.append(MMAudioBigVGANUpsample(
-                inputChannels: inputChannels,
+                inputChannels: stageInputChannels,
                 outputChannels: outputChannels,
-                kernelSize: kernels[stage],
-                stride: rates[stage]
+                kernelSize: upsampleKernelSizes[stage],
+                stride: upsampleRates[stage]
             ))
             for residualKernel in [3, 7, 11] {
                 residualBlocks.append(MMAudioAMPBlock(
@@ -258,16 +275,17 @@ public final class MMAudioBigVGAN: Module {
         }
 
         self._preConvolution.wrappedValue = MMAudioBigVGANConv1D(
-            inputChannels: 128,
-            outputChannels: 1_536,
+            inputChannels: inputChannels,
+            outputChannels: initialChannels,
             kernelSize: 7,
             padding: 3
         )
         self._upsamplers.wrappedValue = upsamplers
         self._residualBlocks.wrappedValue = residualBlocks
-        self._postActivation.wrappedValue = MMAudioAliasFreeActivation(channels: 24)
+        let finalChannels = initialChannels / (1 << upsampleRates.count)
+        self._postActivation.wrappedValue = MMAudioAliasFreeActivation(channels: finalChannels)
         self._postConvolution.wrappedValue = MMAudioBigVGANConv1D(
-            inputChannels: 24,
+            inputChannels: finalChannels,
             outputChannels: 1,
             kernelSize: 7,
             padding: 3,
@@ -276,7 +294,7 @@ public final class MMAudioBigVGAN: Module {
     }
 
     public func callAsFunction(_ spectrogram: MLXArray) -> MLXArray {
-        var hidden = preConvolution(spectrogram.asType(.float16))
+        var hidden = preConvolution(spectrogram.asType(useFloat32 ? .float32 : .float16))
         for stage in upsamplers.indices {
             hidden = upsamplers[stage](hidden)
             let start = stage * 3
@@ -336,10 +354,11 @@ public final class MMAudioBigVGAN: Module {
         return components.joined(separator: ".")
     }
 
-    private static func mapSafetensorsWeights(key: String, value: MLXArray) -> [(String, MLXArray)] {
-        if key.hasSuffix(".weight"), value.ndim == 3 {
-            let base = String(key.dropLast(".weight".count))
-            let isTranspose = key.hasPrefix("ups.")
+    static func mapSafetensorsWeights(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        let mappedKey = remapUpsampleKey(key)
+        if mappedKey.hasSuffix(".weight"), value.ndim == 3 {
+            let base = String(mappedKey.dropLast(".weight".count))
+            let isTranspose = mappedKey.hasPrefix("ups.")
             let transposed = isTranspose ? value.transposed(1, 2, 0) : value.transposed(0, 2, 1)
             let magnitudeAxes = isTranspose ? [0, 1] : [1, 2]
             let magnitude = MLX.sqrt(MLX.sum(transposed * transposed, axes: magnitudeAxes, keepDims: true))
@@ -351,6 +370,6 @@ public final class MMAudioBigVGAN: Module {
                 ("\(base).parametrizations.weight.original1", transposed),
             ]
         }
-        return mapCheckpointWeight(key: key, value: value)
+        return mapCheckpointWeight(key: mappedKey, value: value)
     }
 }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -77,6 +77,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case ltxVideo23FullMLX
     case ltxVideo23A2VMLX
     case wan22TI2VMLX
+    case miniMaxH3MLX
     case cosmos3EdgeMLX
     case scail2MLX
     case dreamXCausalMLX
@@ -392,6 +393,14 @@ public enum ManagedModelCatalog {
         "special_tokens_map.json",
         "generation_config.json",
     ]
+
+    private static let miniMaxH3UsageRestriction = usageRestriction(
+        summary: "MiniMax-H3 weights may not be used, distributed, or displayed in the United States, European Union, United Kingdom, or Republic of Korea; downstream distribution also requires the Community License agreement, notice, and safeguards.",
+        license: "MiniMax-H3 Community License",
+        sourceRepoId: MiniMaxH3Resources.sourceRepository,
+        sourceRevision: MiniMaxH3Resources.sourceRevision,
+        licenseURL: "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/ec19cc6daf5d8add9417c18e86b6b58cc6c55027/LICENSE"
+    )
 
     private static func usageRestriction(
         summary: String,
@@ -2330,6 +2339,35 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["video generate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: MiniMaxH3Resources.artifactRepository,
+                revision: MiniMaxH3Resources.artifactRevision,
+                patterns: MiniMaxH3Resources.requiredFiles
+            ),
+            upstreamRepoId: MiniMaxH3Resources.artifactRepository,
+            upstreamRevision: MiniMaxH3Resources.artifactRevision,
+            usageRestriction: miniMaxH3UsageRestriction,
+            validationKind: .miniMaxH3MLX,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 69_284_785_360,
+            defaultCLICommands: ["video generate"]
+        ),
+        ManagedModelSpec(
+            id: ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            upstreamRepoId: MiniMaxH3Resources.conversionSourceRepository,
+            upstreamRevision: MiniMaxH3Resources.conversionSourceRevision,
+            usageRestriction: miniMaxH3UsageRestriction,
+            validationKind: .miniMaxH3MLX,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 70_060_217_720,
+            defaultCLICommands: ["video generate"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.cosmos3EdgeMLX.rawValue,
             category: .video,
             installShape: .structuredRoot,
@@ -2631,6 +2669,8 @@ public extension ManagedModelSpec {
             return Self.missingLTXVideo23A2VMLXPaths(in: rootURL, fileManager: fileManager)
         case .wan22TI2VMLX:
             return Wan2Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .miniMaxH3MLX:
+            return MiniMaxH3Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .cosmos3EdgeMLX:
             let resources = Cosmos3Resources(rootURL: rootURL)
             return resources.validate(fileManager: fileManager)
@@ -2701,8 +2741,21 @@ public extension ManagedModelSpec {
             if !missing.isEmpty {
                 return missing.map { "Missing required Wan2.2 TI2V MLX file: \($0.path)" }
             }
+            return []
+        case .miniMaxH3MLX:
+            let resources = MiniMaxH3Resources(
+                rootURL: normalizedRootURL(rootURL, fileManager: fileManager)
+            )
+            let missing = resources.validate(fileManager: fileManager)
+            if !missing.isEmpty {
+                return missing.map { "Missing required MiniMax-H3 MLX file: \($0.path)" }
+            }
             do {
-                _ = try resources.loadConfiguration()
+                let configuration = try resources.loadConfiguration()
+                let expectedTask = id == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue ? "ref2va" : "fl2va"
+                guard configuration.task == expectedTask else {
+                    return ["MiniMax-H3 model \(id) requires partition \(expectedTask), got \(configuration.task)."]
+                }
                 return []
             } catch {
                 return [error.localizedDescription]

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2345,14 +2345,14 @@ public enum ManagedModelCatalog {
             hubFallback: HubFallbackConfig(
                 repoId: MiniMaxH3Resources.artifactRepository,
                 revision: MiniMaxH3Resources.artifactRevision,
-                patterns: MiniMaxH3Resources.requiredFiles
+                patterns: MiniMaxH3Resources.compactArtifactFiles
             ),
             upstreamRepoId: MiniMaxH3Resources.artifactRepository,
             upstreamRevision: MiniMaxH3Resources.artifactRevision,
             usageRestriction: miniMaxH3UsageRestriction,
             validationKind: .miniMaxH3MLX,
             runtimeAutoDownloadAllowed: false,
-            estimatedDownloadBytes: 69_284_785_360,
+            estimatedDownloadBytes: 46_250_104_566,
             defaultCLICommands: ["video generate"]
         ),
         ManagedModelSpec(

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -821,6 +821,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 96
             ),
             descriptor(
+                ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue,
+                "MiniMax-H3 FL2VA MLX",
+                "Generates native 24 fps video with synchronized 32 kHz stereo audio from text and optional first/last keyframes.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
+                ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
+                "MiniMax-H3 Ref2VA MLX",
+                "Runs a locally converted Ref2VA root with ordered image, video, and audio references; no redistributable managed snapshot is bundled.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 ModelResolver.ModelID.cosmos3EdgeMLX.rawValue,
                 "Cosmos3-Edge MLX",
                 "Runs NVIDIA Cosmos3-Edge video, action, navigation, and reasoner modes with native Swift MLX.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1850,8 +1850,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 family: .video,
                 tier: .latest,
                 variant: .distilled,
-                precision: .int8,
-                quantization: Quantization(bits: 8, groupSize: 64, scheme: "mlx-affine"),
+                precision: .int4,
+                quantization: Quantization(bits: 4, groupSize: 64, scheme: "mlx-affine"),
                 defaults: Defaults(steps: 31, cfg: 1.0, sigmaShift: 12.0),
                 supports: [.videoGeneration],
                 components: Components(

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -88,6 +88,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case ltxVideo = "ltx-video"
         /// Wan2 native video family.
         case wanVideo = "wan-video"
+        /// MiniMax-H3 joint video/audio family.
+        case miniMaxH3 = "minimax-h3"
         /// NVIDIA Cosmos3-Edge native omnimodal world-model family.
         case cosmos3Edge = "cosmos3-edge"
         /// Psi agent chat family.
@@ -1839,6 +1841,48 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     scheduler: nil
                 ),
                 upstreamRepoId: "\(Wan2Resources.managedRepoID)@\(Wan2Resources.managedRevision)",
+                createdAt: createdAt
+            )
+        case .miniMaxH3FL2VAMLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .miniMaxH3,
+                family: .video,
+                tier: .latest,
+                variant: .distilled,
+                precision: .int8,
+                quantization: Quantization(bits: 8, groupSize: 64, scheme: "mlx-affine"),
+                defaults: Defaults(steps: 31, cfg: 1.0, sigmaShift: 12.0),
+                supports: [.videoGeneration],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: .local(path: "."),
+                    scheduler: nil
+                ),
+                upstreamRepoId: "\(MiniMaxH3Resources.artifactRepository)@\(MiniMaxH3Resources.artifactRevision)",
+                createdAt: createdAt
+            )
+        case .miniMaxH3Ref2VAMLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .miniMaxH3,
+                family: .video,
+                tier: .latest,
+                variant: .distilled,
+                precision: .int8,
+                quantization: Quantization(bits: 8, groupSize: 64, scheme: "mlx-affine"),
+                defaults: Defaults(steps: 31, cfg: 1.0, sigmaShift: 12.0),
+                supports: [.videoGeneration],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: .local(path: "."),
+                    scheduler: nil
+                ),
+                upstreamRepoId: "\(MiniMaxH3Resources.conversionSourceRepository)@\(MiniMaxH3Resources.conversionSourceRevision)",
                 createdAt: createdAt
             )
         case .cosmos3EdgeMLX:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -418,8 +418,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=audio expects ap-bwe or universr.")
             case .sfx where engine != .woosh && engine != .mmaudio:
                 warnings.append("Manifest engine mismatch: family=sfx expects woosh or mmaudio.")
-            case .video where engine != .ltxVideo && engine != .wanVideo:
-                warnings.append("Manifest engine mismatch: family=video expects ltx-video or wan-video.")
+            case .video where engine != .ltxVideo && engine != .wanVideo && engine != .miniMaxH3:
+                warnings.append("Manifest engine mismatch: family=video expects ltx-video, wan-video, or minimax-h3.")
             case .psi where engine != .psiChat:
                 warnings.append("Manifest engine mismatch: family=psi expects psi-chat.")
             default:

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3AdaLNCache.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3AdaLNCache.swift
@@ -1,0 +1,340 @@
+import Foundation
+import MLX
+
+public enum MiniMaxH3AdaLNCacheError: LocalizedError, Sendable {
+    case incompatible(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .incompatible(let reason):
+            return "MiniMax-H3 AdaLN cache is incompatible: \(reason)"
+        }
+    }
+}
+
+struct MiniMaxH3AdaLNCache {
+    static let filename = "adaln_cache.safetensors"
+    static let schemaVersion = "2"
+
+    let timeEmbeddings: MLXArray
+    let blockModulations: [MLXArray]
+    let finalModulations: MLXArray
+    let videoSigmas: [Float]
+    let audioSigmas: [Float]
+    let sourceIdentity: String
+
+    var stepCount: Int { videoSigmas.count - 1 }
+
+    func step(at index: Int) -> MiniMaxH3AdaLNStep {
+        precondition(index >= 0 && index < stepCount)
+        return MiniMaxH3AdaLNStep(
+            timeEmbedding: timeEmbeddings[index],
+            blockModulations: blockModulations.map { $0[index] },
+            finalModulation: finalModulations[index]
+        )
+    }
+
+    func isCompatible(
+        configuration: MiniMaxH3TransformerConfiguration,
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule
+    ) -> Bool {
+        isStructurallyCompatible(configuration: configuration)
+            && videoSigmas == videoSchedule.sigmas
+            && audioSigmas == audioSchedule.sigmas
+    }
+
+    private func isStructurallyCompatible(
+        configuration: MiniMaxH3TransformerConfiguration
+    ) -> Bool {
+        videoSigmas.count >= 2
+            && videoSigmas.count == audioSigmas.count
+            && blockModulations.count == configuration.layerCount
+            && timeEmbeddings.shape == [stepCount, 3, configuration.timeEmbeddingDimension]
+            && finalModulations.shape == [stepCount, 3, 2 * configuration.hiddenSize]
+            && blockModulations.allSatisfy {
+                $0.shape == [stepCount, 3 * 3, 6 * configuration.hiddenSize]
+            }
+    }
+
+    /// Rebuilds the small inference table for another sampler schedule without
+    /// restoring the 13B-parameter AdaLN branch. AdaLN is a smooth function of
+    /// timestep, and every stored video/audio point contains all three modality
+    /// rows. Combining both source schedules therefore gives up to twice the
+    /// sampling density of either schedule alone.
+    func resampled(
+        configuration: MiniMaxH3TransformerConfiguration,
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule
+    ) throws -> MiniMaxH3AdaLNCache {
+        guard isStructurallyCompatible(configuration: configuration) else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("source tensor geometry does not match")
+        }
+        guard videoSchedule.timesteps.count == audioSchedule.timesteps.count else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("target video/audio schedules disagree")
+        }
+        if isCompatible(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        ) {
+            return self
+        }
+
+        let samples = sourceSamples()
+        let targetTimesteps = videoSchedule.timesteps.indices.map { index in
+            [
+                videoSchedule.timesteps[index],
+                audioSchedule.timesteps[index],
+                max(videoSchedule.timesteps[index], 0.999),
+            ]
+        }
+
+        let resampledTimeEmbeddings = try MLX.stacked(targetTimesteps.map { step in
+            try MLX.stacked(step.map { timestep in
+                try interpolatedValue(timestep: timestep, samples: samples) { sample in
+                    timeEmbeddings[sample.stepIndex, sample.timestepIndex, 0...]
+                }
+            }, axis: 0)
+        }, axis: 0)
+        MLX.eval(resampledTimeEmbeddings)
+
+        var resampledBlocks: [MLXArray] = []
+        resampledBlocks.reserveCapacity(blockModulations.count)
+        for source in blockModulations {
+            let resampled = try MLX.stacked(targetTimesteps.map { step in
+                try MLX.concatenated(step.map { timestep in
+                    try interpolatedValue(timestep: timestep, samples: samples) { sample in
+                        let start = sample.timestepIndex * 3
+                        return source[sample.stepIndex, start..<(start + 3), 0...]
+                    }
+                }, axis: 0)
+            }, axis: 0)
+            MLX.eval(resampled)
+            resampledBlocks.append(resampled)
+        }
+
+        let resampledFinal = try MLX.stacked(targetTimesteps.map { step in
+            try MLX.stacked(step.map { timestep in
+                try interpolatedValue(timestep: timestep, samples: samples) { sample in
+                    finalModulations[sample.stepIndex, sample.timestepIndex, 0...]
+                }
+            }, axis: 0)
+        }, axis: 0)
+        MLX.eval(resampledFinal)
+
+        return MiniMaxH3AdaLNCache(
+            timeEmbeddings: resampledTimeEmbeddings,
+            blockModulations: resampledBlocks,
+            finalModulations: resampledFinal,
+            videoSigmas: videoSchedule.sigmas,
+            audioSigmas: audioSchedule.sigmas,
+            sourceIdentity: sourceIdentity
+        )
+    }
+
+    func save(to url: URL, replacing: Bool) throws {
+        var arrays = [
+            "time_embeddings": timeEmbeddings,
+            "final_modulations": finalModulations,
+            "video_sigmas": MLXArray(videoSigmas),
+            "audio_sigmas": MLXArray(audioSigmas),
+        ]
+        for (index, modulation) in blockModulations.enumerated() {
+            arrays["blocks.\(index).modulations"] = modulation
+        }
+        let temporaryURL = url.deletingLastPathComponent().appending(
+            path: ".\(url.lastPathComponent).\(UUID().uuidString).tmp.safetensors"
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryURL) }
+        try MLX.save(
+            arrays: arrays,
+            metadata: [
+                "schema_version": Self.schemaVersion,
+                "format": "mere.run.minimax-h3-adaln-cache",
+                "source_identity": sourceIdentity,
+            ],
+            url: temporaryURL
+        )
+        if FileManager.default.fileExists(atPath: url.path) {
+            guard replacing else {
+                throw MiniMaxH3AdaLNCacheError.incompatible("cache already exists at \(url.path)")
+            }
+            try FileManager.default.removeItem(at: url)
+        }
+        try FileManager.default.moveItem(at: temporaryURL, to: url)
+    }
+
+    static func load(
+        from url: URL,
+        configuration: MiniMaxH3TransformerConfiguration,
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule,
+        sourceIdentity: String,
+        allowScheduleResampling: Bool = false
+    ) throws -> MiniMaxH3AdaLNCache {
+        let (arrays, metadata) = try MLX.loadArraysAndMetadata(url: url)
+        guard metadata["schema_version"] == schemaVersion else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("unsupported schema version")
+        }
+        guard metadata["source_identity"] == sourceIdentity else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("transformer artifact changed")
+        }
+        guard let timeEmbeddings = arrays["time_embeddings"],
+              let finalModulations = arrays["final_modulations"],
+              let videoSigmaArray = arrays["video_sigmas"],
+              let audioSigmaArray = arrays["audio_sigmas"] else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("required tensors are missing")
+        }
+        let blockModulations = try (0..<configuration.layerCount).map { index in
+            guard let value = arrays["blocks.\(index).modulations"] else {
+                throw MiniMaxH3AdaLNCacheError.incompatible("block \(index) is missing")
+            }
+            return value
+        }
+        MLX.eval(videoSigmaArray, audioSigmaArray)
+        let cache = MiniMaxH3AdaLNCache(
+            timeEmbeddings: timeEmbeddings,
+            blockModulations: blockModulations,
+            finalModulations: finalModulations,
+            videoSigmas: videoSigmaArray.asArray(Float.self),
+            audioSigmas: audioSigmaArray.asArray(Float.self),
+            sourceIdentity: sourceIdentity
+        )
+        guard cache.isStructurallyCompatible(configuration: configuration) else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("source tensor geometry does not match")
+        }
+        if cache.isCompatible(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        ) {
+            return cache
+        }
+        guard allowScheduleResampling else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("schedule does not match")
+        }
+        return try cache.resampled(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        )
+    }
+}
+
+private extension MiniMaxH3AdaLNCache {
+    struct SourceSample {
+        let timestep: Float
+        let stepIndex: Int
+        /// 0 = video, 1 = audio, 2 = condition. Block caches hold three
+        /// modality rows per timestep; final/time tables hold one row.
+        let timestepIndex: Int
+    }
+
+    struct Interpolation {
+        let lower: SourceSample
+        let upper: SourceSample
+        let fraction: Float
+    }
+
+    func sourceSamples() -> [SourceSample] {
+        var values: [SourceSample] = []
+        values.reserveCapacity(stepCount * 3)
+        for index in 0..<stepCount {
+            let videoTimestep = 1 - videoSigmas[index]
+            values.append(.init(timestep: videoTimestep, stepIndex: index, timestepIndex: 0))
+            values.append(.init(
+                timestep: 1 - audioSigmas[index],
+                stepIndex: index,
+                timestepIndex: 1
+            ))
+            values.append(.init(
+                timestep: max(videoTimestep, 0.999),
+                stepIndex: index,
+                timestepIndex: 2
+            ))
+        }
+        values.sort { $0.timestep < $1.timestep }
+        return values.reduce(into: []) { unique, sample in
+            if unique.last?.timestep != sample.timestep {
+                unique.append(sample)
+            }
+        }
+    }
+
+    func interpolation(
+        for timestep: Float,
+        samples: [SourceSample]
+    ) throws -> Interpolation {
+        guard let first = samples.first, let last = samples.last,
+              timestep >= first.timestep, timestep <= last.timestep else {
+            throw MiniMaxH3AdaLNCacheError.incompatible(
+                "target timestep \(timestep) is outside the cached curve"
+            )
+        }
+        let upperIndex = samples.firstIndex { $0.timestep >= timestep } ?? (samples.count - 1)
+        let upper = samples[upperIndex]
+        if upper.timestep == timestep || upperIndex == 0 {
+            return Interpolation(lower: upper, upper: upper, fraction: 0)
+        }
+        let lower = samples[upperIndex - 1]
+        let fraction = (timestep - lower.timestep) / (upper.timestep - lower.timestep)
+        return Interpolation(lower: lower, upper: upper, fraction: fraction)
+    }
+
+    func interpolatedValue(
+        timestep: Float,
+        samples: [SourceSample],
+        value: (SourceSample) -> MLXArray
+    ) throws -> MLXArray {
+        let interpolation = try interpolation(for: timestep, samples: samples)
+        let lower = value(interpolation.lower)
+        guard interpolation.fraction != 0 else { return lower }
+        let upper = value(interpolation.upper)
+        return lower * (1 - interpolation.fraction) + upper * interpolation.fraction
+    }
+}
+
+public enum MiniMaxH3ModelOptimizer {
+    @discardableResult
+    public static func optimize(
+        resources: MiniMaxH3Resources,
+        replacing: Bool = false,
+        progressHandler: (@Sendable (Int, Int) -> Void)? = nil
+    ) throws -> URL {
+        let missing = resources.validate()
+        guard missing.isEmpty else { throw MiniMaxH3GeneratorError.missingModelFiles(missing) }
+        let configuration = try resources.loadConfiguration()
+        let videoSchedule = try MiniMaxH3Schedule(
+            pointCount: configuration.sampleSteps,
+            shift: configuration.videoFlowShift
+        )
+        let audioSchedule = try MiniMaxH3Schedule(
+            pointCount: configuration.sampleSteps,
+            shift: configuration.audioFlowShift
+        )
+        let sourceIdentity = try resources.adaLNCacheSourceIdentity()
+        if FileManager.default.fileExists(atPath: resources.adaLNCacheURL.path), !replacing {
+            _ = try MiniMaxH3AdaLNCache.load(
+                from: resources.adaLNCacheURL,
+                configuration: .init(configuration),
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule,
+                sourceIdentity: sourceIdentity
+            )
+            return resources.adaLNCacheURL
+        }
+        let transformer = try MiniMaxH3ModelLoader.loadTransformer(
+            resources: resources,
+            configuration: configuration
+        )
+        let cache = transformer.precomputeAdaLN(
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: sourceIdentity,
+            progressHandler: progressHandler
+        )
+        try cache.save(to: resources.adaLNCacheURL, replacing: replacing)
+        return resources.adaLNCacheURL
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3AudioVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3AudioVAE.swift
@@ -1,0 +1,342 @@
+import Foundation
+import MLX
+import MLXNN
+
+private final class MiniMaxH3AudioSnake: Module {
+    @ParameterInfo(key: "alpha") var alpha: MLXArray
+
+    init(channels: Int) {
+        self._alpha.wrappedValue = MLXArray.ones([1, channels, 1])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let frequency = alpha.transposed(0, 2, 1)
+        let periodic = MLX.sin(input * frequency)
+        return input + periodic * periodic / (frequency + 1e-9)
+    }
+}
+
+private final class MiniMaxH3AudioResidualUnit: Module {
+    @ModuleInfo(key: "block") private var layers: [Module]
+    private let firstActivation: MiniMaxH3AudioSnake
+    private let firstConvolution: Conv1d
+    private let secondActivation: MiniMaxH3AudioSnake
+    private let secondConvolution: Conv1d
+
+    init(channels: Int, dilation: Int) {
+        let firstActivation = MiniMaxH3AudioSnake(channels: channels)
+        let firstConvolution = Conv1d(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 7,
+            padding: 3 * dilation,
+            dilation: dilation
+        )
+        let secondActivation = MiniMaxH3AudioSnake(channels: channels)
+        let secondConvolution = Conv1d(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 1
+        )
+        self.firstActivation = firstActivation
+        self.firstConvolution = firstConvolution
+        self.secondActivation = secondActivation
+        self.secondConvolution = secondConvolution
+        self._layers.wrappedValue = [
+            firstActivation,
+            firstConvolution,
+            secondActivation,
+            secondConvolution,
+        ]
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let update = secondConvolution(secondActivation(firstConvolution(firstActivation(input))))
+        let difference = input.dim(1) - update.dim(1)
+        guard difference > 0 else { return input + update }
+        let left = difference / 2
+        return input[0..., left..<(input.dim(1) - difference + left), 0...] + update
+    }
+}
+
+private final class MiniMaxH3AudioEncoderBlock: Module {
+    @ModuleInfo(key: "block") private var layers: [Module]
+    private let firstResidual: MiniMaxH3AudioResidualUnit
+    private let secondResidual: MiniMaxH3AudioResidualUnit
+    private let thirdResidual: MiniMaxH3AudioResidualUnit
+    private let activation: MiniMaxH3AudioSnake
+    private let downsample: Conv1d
+
+    init(inputChannels: Int, outputChannels: Int, stride: Int) {
+        let firstResidual = MiniMaxH3AudioResidualUnit(channels: inputChannels, dilation: 1)
+        let secondResidual = MiniMaxH3AudioResidualUnit(channels: inputChannels, dilation: 3)
+        let thirdResidual = MiniMaxH3AudioResidualUnit(channels: inputChannels, dilation: 9)
+        let activation = MiniMaxH3AudioSnake(channels: inputChannels)
+        let downsample = Conv1d(
+            inputChannels: inputChannels,
+            outputChannels: outputChannels,
+            kernelSize: 2 * stride,
+            stride: stride,
+            padding: (stride + 1) / 2
+        )
+        self.firstResidual = firstResidual
+        self.secondResidual = secondResidual
+        self.thirdResidual = thirdResidual
+        self.activation = activation
+        self.downsample = downsample
+        self._layers.wrappedValue = [firstResidual, secondResidual, thirdResidual, activation, downsample]
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        downsample(activation(thirdResidual(secondResidual(firstResidual(input)))))
+    }
+}
+
+private final class MiniMaxH3AudioEncoder: Module {
+    @ModuleInfo(key: "block") private var layers: [Module]
+    private let input: Conv1d
+    private let firstBlock: MiniMaxH3AudioEncoderBlock
+    private let secondBlock: MiniMaxH3AudioEncoderBlock
+    private let thirdBlock: MiniMaxH3AudioEncoderBlock
+    private let fourthBlock: MiniMaxH3AudioEncoderBlock
+    private let fifthBlock: MiniMaxH3AudioEncoderBlock
+    private let outputActivation: MiniMaxH3AudioSnake
+    private let output: Conv1d
+
+    override init() {
+        let input = Conv1d(inputChannels: 1, outputChannels: 64, kernelSize: 7, padding: 3)
+        let firstBlock = MiniMaxH3AudioEncoderBlock(
+            inputChannels: 64, outputChannels: 128, stride: 2
+        )
+        let secondBlock = MiniMaxH3AudioEncoderBlock(
+            inputChannels: 128, outputChannels: 256, stride: 4
+        )
+        let thirdBlock = MiniMaxH3AudioEncoderBlock(
+            inputChannels: 256, outputChannels: 512, stride: 4
+        )
+        let fourthBlock = MiniMaxH3AudioEncoderBlock(
+            inputChannels: 512, outputChannels: 1_024, stride: 5
+        )
+        let fifthBlock = MiniMaxH3AudioEncoderBlock(
+            inputChannels: 1_024, outputChannels: 2_048, stride: 5
+        )
+        let outputActivation = MiniMaxH3AudioSnake(channels: 2_048)
+        let output = Conv1d(
+            inputChannels: 2_048, outputChannels: 2_048, kernelSize: 3, padding: 1
+        )
+        self.input = input
+        self.firstBlock = firstBlock
+        self.secondBlock = secondBlock
+        self.thirdBlock = thirdBlock
+        self.fourthBlock = fourthBlock
+        self.fifthBlock = fifthBlock
+        self.outputActivation = outputActivation
+        self.output = output
+        self._layers.wrappedValue = [
+            input,
+            firstBlock,
+            secondBlock,
+            thirdBlock,
+            fourthBlock,
+            fifthBlock,
+            outputActivation,
+            output,
+        ]
+        super.init()
+    }
+
+    func callAsFunction(_ waveform: MLXArray) -> MLXArray {
+        output(outputActivation(fifthBlock(fourthBlock(thirdBlock(secondBlock(firstBlock(input(waveform))))))))
+    }
+}
+
+private final class MiniMaxH3AudioCausalAttention: Module {
+    @ModuleInfo(key: "qkv") var qkv: Linear
+    @ParameterInfo(key: "q_bias") var queryBias: MLXArray
+    @ParameterInfo(key: "v_bias") var valueBias: MLXArray
+    @ParameterInfo(key: "zero_k_bias") var keyBias: MLXArray
+    @ModuleInfo(key: "proj") var output: Linear
+
+    private let headCount = 8
+    private let headDimension = 256
+
+    override init() {
+        self._qkv.wrappedValue = Linear(2_048, 6_144, bias: false)
+        self._queryBias.wrappedValue = MLXArray.zeros([2_048])
+        self._valueBias.wrappedValue = MLXArray.zeros([2_048])
+        self._keyBias.wrappedValue = MLXArray.zeros([2_048])
+        self._output.wrappedValue = Linear(32, 32)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let bias = MLX.concatenated([queryBias, keyBias, valueBias])
+        let projected = (qkv(input) + bias)
+            .reshaped(input.dim(0), input.dim(1), 3, headCount, headDimension)
+            .transposed(2, 0, 3, 1, 4)
+        let queries = projected[0]
+        let keys = projected[1]
+        let values = projected[2]
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: 1 / sqrt(Float(headDimension)),
+            mask: .causal
+        ).transposed(0, 2, 1, 3)
+        let pooledHeads = MLX.mean(attended, axis: 2)
+        let pooledFeatures = MLX.mean(
+            pooledHeads.reshaped(input.dim(0), input.dim(1), 32, headDimension / 32),
+            axis: 3
+        )
+        return output(pooledFeatures)
+    }
+}
+
+private final class MiniMaxH3AudioGeGLU: Module {
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+    @ModuleInfo(key: "w0") var gate: Linear
+    @ModuleInfo(key: "w1") var value: Linear
+    @ModuleInfo(key: "w2") var output: Linear
+
+    override init() {
+        self._norm.wrappedValue = LayerNorm(dimensions: 32)
+        self._gate.wrappedValue = Linear(32, 64)
+        self._value.wrappedValue = Linear(32, 64)
+        self._output.wrappedValue = Linear(64, 32)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let normalized = norm(input)
+        return output(geluApproximate(gate(normalized)) * value(normalized))
+    }
+
+    private func geluApproximate(_ input: MLXArray) -> MLXArray {
+        0.5 * input * (1 + MLX.tanh(sqrt(2 / Float.pi) * (input + 0.044715 * input * input * input)))
+    }
+}
+
+private final class MiniMaxH3AudioAttentionProjection: Module {
+    @ModuleInfo(key: "norm1") var attentionNorm: LayerNorm
+    @ModuleInfo(key: "attn") var attention: MiniMaxH3AudioCausalAttention
+    @ModuleInfo(key: "proj") var projection: Linear
+    @ModuleInfo(key: "norm3") var projectionNorm: LayerNorm
+    @ModuleInfo(key: "norm2") var feedForwardNorm: LayerNorm
+    @ModuleInfo(key: "mlp") var feedForward: MiniMaxH3AudioGeGLU
+
+    override init() {
+        self._attentionNorm.wrappedValue = LayerNorm(dimensions: 2_048)
+        self._attention.wrappedValue = MiniMaxH3AudioCausalAttention()
+        self._projection.wrappedValue = Linear(2_048, 32)
+        self._projectionNorm.wrappedValue = LayerNorm(dimensions: 2_048)
+        self._feedForwardNorm.wrappedValue = LayerNorm(dimensions: 32)
+        self._feedForward.wrappedValue = MiniMaxH3AudioGeGLU()
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let hidden = projection(projectionNorm(input)) + attention(attentionNorm(input))
+        return hidden + feedForward(feedForwardNorm(hidden))
+    }
+}
+
+/// H3's waveform autoencoder. Stereo is represented as two batch items
+/// throughout the model and only interleaved at the media boundary.
+public final class MiniMaxH3AudioVAE: Module {
+    public static let samplingRate = 32_000
+    public static let hopLength = 800
+
+    @ModuleInfo(key: "encoder") private var encoder: MiniMaxH3AudioEncoder
+    @ModuleInfo(key: "pre_block") private var preBlock: MiniMaxH3AudioAttentionProjection
+    @ModuleInfo(key: "mean_proj") var meanProjection: Conv1d
+    @ModuleInfo(key: "logs_proj") var logStandardDeviationProjection: Conv1d
+    @ModuleInfo(key: "dec_in_proj") var inputProjection: Conv1d
+    @ModuleInfo(key: "decoder") var decoder: MMAudioBigVGAN
+    @ParameterInfo(key: "latents_mean") var latentMean: MLXArray
+    @ParameterInfo(key: "latents_std") var latentStandardDeviation: MLXArray
+
+    public override init() {
+        _encoder.wrappedValue = MiniMaxH3AudioEncoder()
+        _preBlock.wrappedValue = MiniMaxH3AudioAttentionProjection()
+        _meanProjection.wrappedValue = Conv1d(inputChannels: 32, outputChannels: 32, kernelSize: 1)
+        _logStandardDeviationProjection.wrappedValue = Conv1d(
+            inputChannels: 32, outputChannels: 32, kernelSize: 1
+        )
+        _inputProjection.wrappedValue = Conv1d(
+            inputChannels: 32,
+            outputChannels: 2_048,
+            kernelSize: 1,
+            bias: true
+        )
+        _decoder.wrappedValue = MMAudioBigVGAN(
+            inputChannels: 2_048,
+            initialChannels: 1_024,
+            upsampleRates: [5, 5, 2, 2, 2, 2, 2],
+            upsampleKernelSizes: [9, 9, 4, 4, 4, 4, 4],
+            useFloat32: true
+        )
+        _latentMean.wrappedValue = MLXArray.zeros([32])
+        _latentStandardDeviation.wrappedValue = MLXArray.ones([32])
+        super.init()
+    }
+
+    /// Encodes `[1, samples, 2]` stereo to normalized `[1, 32, 2, T]`
+    /// latents. H3 conditions on the posterior mean, never a posterior sample.
+    public func encode(_ waveform: MLXArray) -> MLXArray {
+        precondition(waveform.ndim == 3 && waveform.dim(0) == 1 && waveform.dim(2) == 2)
+        let sampleCount = waveform.dim(1)
+        let paddedCount = ((sampleCount + Self.hopLength - 1) / Self.hopLength) * Self.hopLength
+        var stereoBatch = waveform[0].transposed(1, 0).expandedDimensions(axis: 2)
+        if paddedCount > sampleCount {
+            stereoBatch = MLX.padded(
+                stereoBatch,
+                widths: [[0, 0], [0, paddedCount - sampleCount], [0, 0]]
+            )
+        }
+        let trunk = encoder(stereoBatch.asType(.float32))
+        let mean = meanProjection(preBlock(trunk))
+        let channelsFirst = mean.transposed(0, 2, 1)
+        let normalized = (
+            channelsFirst - latentMean.reshaped(1, 32, 1)
+        ) / latentStandardDeviation.reshaped(1, 32, 1)
+        return normalized.transposed(1, 0, 2).expandedDimensions(axis: 0)
+    }
+
+    /// Decodes normalized `[1, 32, 2, T]` latents to `[1, samples, 2]` stereo.
+    public func decode(_ normalizedLatents: MLXArray) -> MLXArray {
+        precondition(
+            normalizedLatents.ndim == 4
+                && normalizedLatents.dim(0) == 1
+                && normalizedLatents.dim(1) == 32
+                && normalizedLatents.dim(2) == 2
+        )
+        let mean = latentMean.reshaped(1, 32, 1, 1)
+        let standardDeviation = latentStandardDeviation.reshaped(1, 32, 1, 1)
+        let denormalized = normalizedLatents * standardDeviation + mean
+        let stereoBatch = denormalized[0].transposed(1, 2, 0)
+        let projected = inputProjection(stereoBatch.asType(.float32))
+        let monoBatch = decoder(projected)
+        return monoBatch[0..., 0..., 0].transposed(1, 0).expandedDimensions(axis: 0)
+    }
+
+    static func mapConvertedWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "latents_mean" || key == "latents_std" {
+            return [(key, value)]
+        }
+        let mappedKey = key
+        let plainConvolutionPrefixes = ["encoder.", "mean_proj.", "logs_proj.", "dec_in_proj."]
+        if plainConvolutionPrefixes.contains(where: mappedKey.hasPrefix),
+           mappedKey.hasSuffix(".weight"), value.ndim == 3 {
+            return [(mappedKey, value.transposed(0, 2, 1))]
+        }
+        if mappedKey.hasPrefix("encoder.") || mappedKey.hasPrefix("pre_block.") {
+            return [(mappedKey, value)]
+        }
+        guard mappedKey.hasPrefix("decoder.") else { return [] }
+        let suffix = String(mappedKey.dropFirst("decoder.".count))
+        return MMAudioBigVGAN.mapSafetensorsWeights(key: suffix, value: value).map {
+            ("decoder.\($0.0)", $0.1)
+        }
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -1,0 +1,1210 @@
+import Foundation
+import MediaIO
+import MLX
+import MLXRandom
+#if canImport(Darwin)
+import Darwin
+#endif
+#if canImport(IOKit.ps)
+import IOKit.ps
+#endif
+
+@inline(__always)
+private func withMiniMaxH3AutoreleasePool<T>(_ body: () throws -> T) rethrows -> T {
+    #if canImport(ObjectiveC)
+    return try autoreleasepool(invoking: body)
+    #else
+    return try body()
+    #endif
+}
+
+public enum MiniMaxH3GeneratorError: LocalizedError {
+    case missingModelFiles([URL])
+    case invalidOptions(String)
+    case imageDecodeFailed(URL)
+    case mediaDecodeFailed(URL, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingModelFiles(let files):
+            return "MiniMax-H3 model root is missing: \(files.map(\.lastPathComponent).joined(separator: ", "))"
+        case .invalidOptions(let reason): return "Invalid MiniMax-H3 request: \(reason)"
+        case .imageDecodeFailed(let url): return "MiniMax-H3 could not decode image: \(url.path)"
+        case .mediaDecodeFailed(let url, let reason):
+            return "MiniMax-H3 could not decode reference \(url.path): \(reason)"
+        }
+    }
+}
+
+public struct MiniMaxH3ReferenceInput: Sendable, Hashable {
+    public let kind: MiniMaxH3ReferenceKind
+    public let url: URL
+
+    public init(kind: MiniMaxH3ReferenceKind, url: URL) {
+        self.kind = kind
+        self.url = url.standardizedFileURL
+    }
+}
+
+public enum MiniMaxH3TransformerWeightMode: String, Sendable, Hashable {
+    case automatic = "auto"
+    case quantized
+    case residentBF16 = "resident-bf16"
+}
+
+public enum MiniMaxH3StepPolicy {
+    public static let practicalPointCount = 9
+    public static let extendedPointCount = 16
+    public static let maximumQualityPointCount = 31
+    public static let practicalPackedRowLimit = 13_500
+    public static let extendedPackedRowLimit = 26_000
+
+    public static func recommendedPointCount(
+        width: Int,
+        height: Int,
+        numFrames: Int,
+        keyframeCount: Int = 0,
+        referenceKinds: [MiniMaxH3ReferenceKind] = []
+    ) throws -> Int {
+        let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: numFrames)
+        let rowsPerVideoFrame = (height / 32) * (width / 32)
+        let targetVideoRows = latentFrames * rowsPerVideoFrame
+        let targetAudioRows = MiniMaxH3Geometry.audioLatentFrameCount(for: numFrames) * 2
+        var estimatedRows = 128 + targetVideoRows + targetAudioRows
+        estimatedRows += keyframeCount * rowsPerVideoFrame
+        for kind in referenceKinds {
+            switch kind {
+            case .image:
+                estimatedRows += rowsPerVideoFrame
+            case .video:
+                estimatedRows += targetVideoRows + targetAudioRows
+            case .audio:
+                estimatedRows += targetAudioRows
+            }
+        }
+        if estimatedRows <= practicalPackedRowLimit {
+            return practicalPointCount
+        }
+        if estimatedRows <= extendedPackedRowLimit {
+            return extendedPointCount
+        }
+        return maximumQualityPointCount
+    }
+}
+
+enum MiniMaxH3ResidentBF16Policy {
+    static let gibibyte = UInt64(1_073_741_824)
+    static let minimumPackedRows = 2_048
+
+    static func automaticReserveBytes(sequenceLength: Int) -> UInt64 {
+        let base = 16 * gibibyte
+        let rowsBeyondPracticalTier = UInt64(max(0, sequenceLength - 13_000))
+        let geometryReserve = rowsBeyondPracticalTier * 384 * 1_024
+        return min(32 * gibibyte, base + geometryReserve)
+    }
+
+    static func shouldMaterialize(
+        mode: MiniMaxH3TransformerWeightMode,
+        physicalMemoryBytes: UInt64,
+        estimatedResidentBytes: UInt64,
+        sequenceLength: Int,
+        hasAdaLNCache: Bool,
+        isPortableMac: Bool
+    ) throws -> Bool {
+        switch mode {
+        case .quantized:
+            return false
+        case .automatic:
+            guard !isPortableMac,
+                  hasAdaLNCache,
+                  estimatedResidentBytes > 0,
+                  sequenceLength >= minimumPackedRows else { return false }
+            let reserve = automaticReserveBytes(sequenceLength: sequenceLength)
+            return estimatedResidentBytes <= physicalMemoryBytes - min(physicalMemoryBytes, reserve)
+        case .residentBF16:
+            guard hasAdaLNCache else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "resident-bf16 requires a compatible AdaLN cache"
+                )
+            }
+            let reserve = 8 * gibibyte
+            guard estimatedResidentBytes <= physicalMemoryBytes - min(physicalMemoryBytes, reserve) else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "resident-bf16 does not fit physical memory with the required runtime reserve"
+                )
+            }
+            return true
+        }
+    }
+}
+
+enum MiniMaxH3Host {
+    static var isPortableMac: Bool {
+        #if canImport(IOKit.ps)
+        let snapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
+        let sources = IOPSCopyPowerSourcesList(snapshot).takeRetainedValue() as NSArray
+        return sources.contains { source in
+            guard let description = IOPSGetPowerSourceDescription(
+                snapshot,
+                source as CFTypeRef
+            )?.takeUnretainedValue() as NSDictionary? else {
+                return false
+            }
+            return description[kIOPSTypeKey] as? String == kIOPSInternalBatteryType
+        }
+        #else
+        return false
+        #endif
+    }
+}
+
+public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
+    public let prompt: String
+    public let width: Int
+    public let height: Int
+    public let numFrames: Int
+    public let steps: Int
+    public let seed: UInt64
+    public let transformerWeightMode: MiniMaxH3TransformerWeightMode
+    public let firstFrameURL: URL?
+    public let lastFrameURL: URL?
+    public let references: [MiniMaxH3ReferenceInput]
+
+    public init(
+        prompt: String,
+        width: Int = 768,
+        height: Int = 768,
+        numFrames: Int = 124,
+        steps: Int? = nil,
+        seed: UInt64 = 42,
+        transformerWeightMode: MiniMaxH3TransformerWeightMode = .automatic,
+        firstFrameURL: URL? = nil,
+        lastFrameURL: URL? = nil,
+        references: [MiniMaxH3ReferenceInput] = []
+    ) throws {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw MiniMaxH3GeneratorError.invalidOptions("prompt cannot be empty") }
+        guard width > 0, height > 0, width.isMultiple(of: 32), height.isMultiple(of: 32) else {
+            throw MiniMaxH3GeneratorError.invalidOptions("width and height must be positive multiples of 32")
+        }
+        guard numFrames >= 22, numFrames % 17 == 5 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("frame count must be at least 22 and have the form 17*n+5")
+        }
+        guard lastFrameURL == nil || firstFrameURL != nil else {
+            throw MiniMaxH3GeneratorError.invalidOptions("a last frame requires a first frame")
+        }
+        guard references.count <= 12 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA accepts at most 12 ordered references")
+        }
+        guard references.count(where: { $0.kind == .image }) <= 9,
+              references.count(where: { $0.kind == .video }) <= 3,
+              references.count(where: { $0.kind == .audio }) <= 3 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA accepts at most 9 images, 3 videos, and 3 audio clips")
+        }
+        if references.contains(where: { $0.kind == .audio }),
+           !references.contains(where: { $0.kind != .audio }) {
+            throw MiniMaxH3GeneratorError.invalidOptions("an audio reference must be paired with an image or video")
+        }
+        let resolvedSteps = try steps ?? MiniMaxH3StepPolicy.recommendedPointCount(
+            width: width,
+            height: height,
+            numFrames: numFrames,
+            keyframeCount: [firstFrameURL, lastFrameURL].compactMap { $0 }.count,
+            referenceKinds: references.map(\.kind)
+        )
+        guard resolvedSteps >= 2 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("steps must be at least 2")
+        }
+        self.prompt = trimmed
+        self.width = width
+        self.height = height
+        self.numFrames = numFrames
+        self.steps = resolvedSteps
+        self.seed = seed
+        self.transformerWeightMode = transformerWeightMode
+        self.firstFrameURL = firstFrameURL
+        self.lastFrameURL = lastFrameURL
+        self.references = references
+    }
+}
+
+public enum MiniMaxH3GenerationStage: String, Sendable {
+    case loadingTextEncoder = "loading-text-encoder"
+    case encodingText = "encoding-text"
+    case encodingKeyframes = "encoding-keyframes"
+    case encodingReferences = "encoding-references"
+    case loadingTransformer = "loading-transformer"
+    case materializingTransformerBF16 = "materializing-transformer-bf16"
+    case denoising
+    case decodingVideo = "decoding-video"
+    case decodingAudio = "decoding-audio"
+}
+
+public struct MiniMaxH3GenerationProgress: Sendable {
+    public let stage: MiniMaxH3GenerationStage
+    public let stepIndex: Int
+    public let totalSteps: Int
+}
+
+public struct MiniMaxH3GenerationResult: @unchecked Sendable {
+    public let frames: MLXArray
+    public let audio: MLXArray
+    public let seed: UInt64
+}
+
+public final class MiniMaxH3Generator: @unchecked Sendable {
+    private struct ConditionerPresentation {
+        let tokenIDs: [Int]
+        let tokenTags: [Int32]
+        let images: [QwenVLEncoder.ConditioningImage]
+    }
+
+    private struct PreparedReference {
+        let kind: MiniMaxH3ReferenceKind
+        let visual: MLXArray?
+        let visionBlocks: [MLXArray]
+        let blockTimestamps: [Double]
+        let waveform: MLXArray?
+        let geometry: MiniMaxH3PreparedReferenceGeometry
+    }
+
+    public init() {}
+
+    static func mediaFrames(from decodedFrames: MLXArray) -> MLXArray {
+        MLX.clip(decodedFrames * 255, min: 0, max: 255).asType(.uint8)
+    }
+
+    private func loadDenoisingTransformer(
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        adaLNCache: MiniMaxH3AdaLNCache?,
+        sequenceLength: Int,
+        weightMode: MiniMaxH3TransformerWeightMode,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
+    ) throws -> MiniMaxH3Transformer {
+        let transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
+            resources: resources,
+            configuration: configuration,
+            cachedAdaLN: adaLNCache,
+            progressHandler: { shard in
+                progressHandler?(.init(
+                    stage: .loadingTransformer,
+                    stepIndex: shard.shardIndex,
+                    totalSteps: shard.shardCount
+                ))
+            }
+        )
+        let shouldMaterialize = try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: weightMode,
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
+            estimatedResidentBytes: transformer.estimatedResidentBF16ByteCount,
+            sequenceLength: sequenceLength,
+            hasAdaLNCache: adaLNCache != nil,
+            isPortableMac: MiniMaxH3Host.isPortableMac
+        )
+        if shouldMaterialize {
+            progressHandler?(.init(
+                stage: .materializingTransformerBF16,
+                stepIndex: 0,
+                totalSteps: 1
+            ))
+            _ = transformer.materializeResidentBF16()
+        }
+        return transformer
+    }
+
+    private func denoise(
+        transformer: MiniMaxH3Transformer,
+        videoRows initialVideoRows: MLXArray,
+        audioRows initialAudioRows: MLXArray,
+        conditionVideoRows: MLXArray?,
+        conditionAudioRows: MLXArray?,
+        promptStates: MLXArray,
+        layout: MiniMaxH3PackedLayout,
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule,
+        adaLNCache: MiniMaxH3AdaLNCache?,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
+    ) -> (videoRows: MLXArray, audioRows: MLXArray) {
+        precondition(videoSchedule.timesteps.count == audioSchedule.timesteps.count)
+        let profileLogger = MereRunRuntimeDebug.logger(
+            keys: ["MERERUN_H3_PROFILE_BLOCKS"],
+            prefix: "[minimax-h3-profile]"
+        )
+        profileLogger?("rows=\(layout.sequenceLength) blocks=\(transformer.configuration.layerCount)")
+        transformer.blockTimingHandler = profileLogger.map { logger in
+            { index, elapsed, memory in
+                logger(String(
+                    format: "block=%02d seconds=%.3f active_gib=%.2f cache_gib=%.2f peak_gib=%.2f",
+                    index,
+                    elapsed,
+                    Double(memory.activeMemory) / 1_073_741_824,
+                    Double(memory.cacheMemory) / 1_073_741_824,
+                    Double(memory.peakMemory) / 1_073_741_824
+                ))
+            }
+        }
+        let context = transformer.prepare(textStates: promptStates, layout: layout)
+        var videoRows = initialVideoRows
+        var audioRows = initialAudioRows
+        MLX.eval(videoRows, audioRows)
+        if let conditionVideoRows { MLX.eval(conditionVideoRows) }
+        if let conditionAudioRows { MLX.eval(conditionAudioRows) }
+
+        // Quantized projections benefit from a compiled whole-step graph at
+        // practical sequence lengths. Resident bf16 already dispatches dense
+        // GEMMs at the hardware-efficient shapes, while wrapping all 50 blocks
+        // in one compiled call adds substantial graph overhead. Evaluate its
+        // eager block stack once per step, matching the upstream MLX engine and
+        // allowing the allocator to reuse intermediate buffers across blocks.
+        // Very large sequences keep independent compiled block boundaries to
+        // avoid the macOS watchdog.
+        let requiresBlockwiseExecution = layout.sequenceLength > 16_384
+        let usesCompiledStep = !transformer.usesResidentBF16 && !requiresBlockwiseExecution
+        transformer.usesBlockwiseCompilation = requiresBlockwiseExecution
+        transformer.usesLayerwiseEvaluation = false
+        transformer.clearsCacheAfterLayerwiseEvaluation = false
+
+        let compiledStep = MLX.compile { (inputs: [MLXArray]) -> [MLXArray] in
+            let videoSample = inputs[0]
+            let audioSample = inputs[1]
+            let timestepValues = inputs[2]
+            let videoCoefficients = inputs[3]
+            let audioCoefficients = inputs[4]
+            let videoInput = conditionVideoRows.map {
+                MLX.concatenated([$0, videoSample], axis: 1)
+            } ?? videoSample
+            let audioInput = conditionAudioRows.map {
+                MLX.concatenated([$0, audioSample], axis: 1)
+            } ?? audioSample
+            let predicted = transformer(
+                videoRows: videoInput,
+                audioRows: audioInput,
+                context: context,
+                timesteps: timestepValues,
+                cachedAdaLN: adaLNCache.map { _ in
+                    let blockStart = 6
+                    let blockEnd = blockStart + transformer.configuration.layerCount
+                    return MiniMaxH3AdaLNStep(
+                        timeEmbedding: inputs[5],
+                        blockModulations: Array(inputs[blockStart..<blockEnd]),
+                        finalModulation: inputs[blockEnd]
+                    )
+                }
+            )
+            return [
+                Self.advance(
+                    sample: videoSample,
+                    velocity: predicted.videoVelocityRows,
+                    coefficients: videoCoefficients
+                ),
+                Self.advance(
+                    sample: audioSample,
+                    velocity: predicted.audioVelocityRows,
+                    coefficients: audioCoefficients
+                ),
+            ]
+        }
+
+        for index in videoSchedule.timesteps.indices {
+            progressHandler?(.init(
+                stage: .denoising,
+                stepIndex: index,
+                totalSteps: videoSchedule.timesteps.count
+            ))
+            let videoTimestep = videoSchedule.timesteps[index]
+            let audioTimestep = audioSchedule.timesteps[index]
+            let timestepValues = MLXArray([
+                videoTimestep,
+                audioTimestep,
+                max(videoTimestep, 0.999),
+            ])
+            let videoCoefficients = Self.scheduleCoefficients(videoSchedule, index: index)
+            let audioCoefficients = Self.scheduleCoefficients(audioSchedule, index: index)
+            if usesCompiledStep {
+                var inputs = [
+                    videoRows,
+                    audioRows,
+                    timestepValues,
+                    videoCoefficients,
+                    audioCoefficients,
+                ]
+                if let cacheStep = adaLNCache?.step(at: index) {
+                    inputs.append(cacheStep.timeEmbedding)
+                    inputs.append(contentsOf: cacheStep.blockModulations)
+                    inputs.append(cacheStep.finalModulation)
+                }
+                let outputs = compiledStep(inputs)
+                videoRows = outputs[0]
+                audioRows = outputs[1]
+            } else {
+                let videoInput = conditionVideoRows.map {
+                    MLX.concatenated([$0, videoRows], axis: 1)
+                } ?? videoRows
+                let audioInput = conditionAudioRows.map {
+                    MLX.concatenated([$0, audioRows], axis: 1)
+                } ?? audioRows
+                let predicted = transformer(
+                    videoRows: videoInput,
+                    audioRows: audioInput,
+                    context: context,
+                    timesteps: timestepValues,
+                    cachedAdaLN: adaLNCache?.step(at: index)
+                )
+                videoRows = Self.advance(
+                    sample: videoRows,
+                    velocity: predicted.videoVelocityRows,
+                    coefficients: videoCoefficients
+                )
+                audioRows = Self.advance(
+                    sample: audioRows,
+                    velocity: predicted.audioVelocityRows,
+                    coefficients: audioCoefficients
+                )
+            }
+            MLX.eval(videoRows, audioRows)
+        }
+        return (videoRows, audioRows)
+    }
+
+    private static func scheduleCoefficients(_ schedule: MiniMaxH3Schedule, index: Int) -> MLXArray {
+        MLXArray([
+            schedule.timesteps[index],
+            schedule.sigmas[index + 1] / schedule.sigmas[index],
+        ])
+    }
+
+    private static func advance(
+        sample: MLXArray,
+        velocity: MLXArray,
+        coefficients: MLXArray
+    ) -> MLXArray {
+        let timestep = coefficients[0]
+        let ratio = coefficients[1]
+        let denoised = sample + (1 - timestep) * velocity
+        return (
+            ratio * sample.asType(.float32)
+                + (1 - ratio) * denoised.asType(.float32)
+        ).asType(sample.dtype)
+    }
+
+    private static func loadAdaLNCache(
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule
+    ) throws -> MiniMaxH3AdaLNCache? {
+        do {
+            return try MiniMaxH3AdaLNCache.load(
+                from: resources.adaLNCacheURL,
+                configuration: .init(configuration),
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule,
+                sourceIdentity: resources.adaLNCacheSourceIdentity(),
+                allowScheduleResampling: true
+            )
+        } catch {
+            let metadata = try resources.transformerMetadata()
+            guard metadata["cache_covered_weights_omitted"] != "true" else {
+                throw error
+            }
+            return nil
+        }
+    }
+
+    public func generate(
+        options: MiniMaxH3GenerationOptions,
+        resources: MiniMaxH3Resources,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)? = nil
+    ) throws -> MiniMaxH3GenerationResult {
+        let missing = resources.validate()
+        guard missing.isEmpty else { throw MiniMaxH3GeneratorError.missingModelFiles(missing) }
+        let configuration = try resources.loadConfiguration()
+        if configuration.task == "ref2va" {
+            return try generateRef2VA(
+                options: options,
+                resources: resources,
+                configuration: configuration,
+                progressHandler: progressHandler
+            )
+        }
+        guard options.references.isEmpty else {
+            throw MiniMaxH3GeneratorError.invalidOptions("--reference requires a Ref2VA model root")
+        }
+        let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: options.numFrames)
+        let latentHeight = options.height / 16
+        let latentWidth = options.width / 16
+        let audioFrames = MiniMaxH3Geometry.audioLatentFrameCount(for: options.numFrames)
+
+        progressHandler?(.init(stage: .loadingTextEncoder, stepIndex: 0, totalSteps: options.steps - 1))
+        let tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: 262_144)
+        let presentation = try conditionerPresentation(tokenizer: tokenizer, options: options)
+        guard !presentation.tokenIDs.isEmpty else {
+            throw MiniMaxH3GeneratorError.invalidOptions("prompt tokenized to zero rows")
+        }
+        guard presentation.tokenIDs.count <= 262_144 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("multimodal presentation exceeds 262144 tokens")
+        }
+        let inputIDs = MLXArray(presentation.tokenIDs.map(Int32.init)).reshaped(1, presentation.tokenIDs.count)
+        let attentionMask = MLXArray.ones([1, presentation.tokenIDs.count], dtype: .int32)
+        let promptStates: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let encoder = try MiniMaxH3ModelLoader.loadConditioner(
+                resources: resources,
+                configuration: configuration,
+                progressHandler: { shard in
+                    progressHandler?(.init(
+                        stage: .loadingTextEncoder,
+                        stepIndex: shard.shardIndex,
+                        totalSteps: shard.shardCount
+                    ))
+                }
+            )
+            progressHandler?(.init(stage: .encodingText, stepIndex: 0, totalSteps: options.steps - 1))
+            guard let states = try encoder.forwardMultimodalActivationHiddenState(
+                inputIds: inputIDs,
+                attentionMask: attentionMask,
+                images: presentation.images,
+                activationLayer: 49
+            ) else {
+                throw MiniMaxH3GeneratorError.invalidOptions("text encoder did not return layer-50 states")
+            }
+            MLX.eval(states)
+            return states
+        }
+        Memory.clearCache()
+
+        let keyframeURLs = [options.firstFrameURL, options.lastFrameURL].compactMap { $0 }
+        let keyframeAnchors: [MiniMaxH3KeyframeAnchor] = options.lastFrameURL == nil
+            ? (options.firstFrameURL == nil ? [] : [.first])
+            : [.first, .last]
+        var conditionRows = try encodeKeyframes(
+            keyframeURLs,
+            options: options,
+            resources: resources,
+            progressHandler: progressHandler
+        )
+        Memory.clearCache()
+
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: presentation.tokenTags,
+            videoLatentFrames: latentFrames,
+            latentHeight: latentHeight,
+            latentWidth: latentWidth,
+            audioLatentFrames: audioFrames,
+            keyframeAnchors: keyframeAnchors
+        )
+        MLXRandom.seed(options.seed)
+        if let currentConditions = conditionRows {
+            let conditionNoise = MLXRandom.normal(currentConditions.shape).asType(.float32)
+            conditionRows = MiniMaxH3Schedule.noise(
+                clean: currentConditions,
+                timestep: 0.999,
+                noise: conditionNoise
+            )
+        }
+        var video = MLXRandom.normal([
+            1, 24, latentFrames, latentHeight, latentWidth,
+        ]).asType(.float32)
+        var videoRows = MiniMaxH3Geometry.patchifyVideo(video)
+        var audioRows = MLXRandom.normal([1, audioFrames * 2, 32]).asType(.float32)
+        let videoSchedule = try MiniMaxH3Schedule(pointCount: options.steps, shift: configuration.videoFlowShift)
+        let audioSchedule = try MiniMaxH3Schedule(pointCount: options.steps, shift: configuration.audioFlowShift)
+
+        progressHandler?(.init(stage: .loadingTransformer, stepIndex: 0, totalSteps: options.steps - 1))
+        try withMiniMaxH3AutoreleasePool {
+            let adaLNCache = try Self.loadAdaLNCache(
+                resources: resources,
+                configuration: configuration,
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule
+            )
+            let transformer = try loadDenoisingTransformer(
+                resources: resources,
+                configuration: configuration,
+                adaLNCache: adaLNCache,
+                sequenceLength: layout.sequenceLength,
+                weightMode: options.transformerWeightMode,
+                progressHandler: progressHandler
+            )
+            (videoRows, audioRows) = denoise(
+                transformer: transformer,
+                videoRows: videoRows,
+                audioRows: audioRows,
+                conditionVideoRows: conditionRows,
+                conditionAudioRows: nil,
+                promptStates: promptStates,
+                layout: layout,
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule,
+                adaLNCache: adaLNCache,
+                progressHandler: progressHandler
+            )
+        }
+        Memory.clearCache()
+        video = MiniMaxH3Geometry.unpatchifyVideo(
+            videoRows,
+            frames: latentFrames,
+            height: latentHeight,
+            width: latentWidth
+        )
+        let audio = MiniMaxH3Geometry.unpackAudio(audioRows[0])
+        progressHandler?(.init(stage: .decodingVideo, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
+        let frames: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+            let pixels = Self.mediaFrames(from: vae.decode(video))
+            MLX.eval(pixels)
+            return pixels
+        }
+        Memory.clearCache()
+        progressHandler?(.init(stage: .decodingAudio, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
+        let waveform: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let vae = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources)
+            let decoded = vae.decode(audio)
+            MLX.eval(decoded)
+            return decoded
+        }
+        Memory.clearCache()
+        return MiniMaxH3GenerationResult(frames: frames, audio: waveform, seed: options.seed)
+    }
+
+    private func generateRef2VA(
+        options: MiniMaxH3GenerationOptions,
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
+    ) throws -> MiniMaxH3GenerationResult {
+        guard options.firstFrameURL == nil, options.lastFrameURL == nil else {
+            throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA uses ordered references, not FL2VA keyframes")
+        }
+        guard !options.references.isEmpty else {
+            throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA requires at least one --reference")
+        }
+        let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: options.numFrames)
+        let latentHeight = options.height / 16
+        let latentWidth = options.width / 16
+        let audioFrames = MiniMaxH3Geometry.audioLatentFrameCount(for: options.numFrames)
+        let prepared = try prepareReferences(options: options)
+
+        progressHandler?(.init(stage: .loadingTextEncoder, stepIndex: 0, totalSteps: options.steps - 1))
+        let tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: 262_144)
+        let presentation = try referenceConditionerPresentation(
+            tokenizer: tokenizer,
+            prompt: options.prompt,
+            references: prepared
+        )
+        guard !presentation.tokenIDs.isEmpty, presentation.tokenIDs.count <= 262_144 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA presentation must contain 1...262144 tokens")
+        }
+        let inputIDs = MLXArray(presentation.tokenIDs.map(Int32.init)).reshaped(1, presentation.tokenIDs.count)
+        let attentionMask = MLXArray.ones([1, presentation.tokenIDs.count], dtype: .int32)
+        let promptStates: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let encoder = try MiniMaxH3ModelLoader.loadConditioner(
+                resources: resources,
+                configuration: configuration,
+                progressHandler: { shard in
+                    progressHandler?(.init(
+                        stage: .loadingTextEncoder,
+                        stepIndex: shard.shardIndex,
+                        totalSteps: shard.shardCount
+                    ))
+                }
+            )
+            progressHandler?(.init(stage: .encodingText, stepIndex: 0, totalSteps: options.steps - 1))
+            guard let states = try encoder.forwardMultimodalActivationHiddenState(
+                inputIds: inputIDs,
+                attentionMask: attentionMask,
+                images: presentation.images,
+                activationLayer: 49
+            ) else {
+                throw MiniMaxH3GeneratorError.invalidOptions("text encoder did not return layer-50 states")
+            }
+            MLX.eval(states)
+            return states
+        }
+        Memory.clearCache()
+
+        progressHandler?(.init(stage: .encodingReferences, stepIndex: 0, totalSteps: prepared.count))
+        let conditionVideoRows: MLXArray? = try withMiniMaxH3AutoreleasePool {
+            guard prepared.contains(where: { $0.visual != nil }) else { return nil }
+            let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+            var rows: [MLXArray] = []
+            for (index, reference) in prepared.enumerated() {
+                guard let visual = reference.visual else { continue }
+                let latent = reference.kind == .image
+                    ? vae.encodeKeyframe(visual)
+                    : vae.encodeReferenceVideo(visual)
+                let packed = MiniMaxH3Geometry.patchifyVideo(latent).asType(.float32)
+                MLX.eval(packed)
+                rows.append(packed)
+                progressHandler?(.init(stage: .encodingReferences, stepIndex: index + 1, totalSteps: prepared.count))
+            }
+            return MLX.concatenated(rows, axis: 1)
+        }
+        Memory.clearCache()
+        let conditionAudioRows: MLXArray? = try withMiniMaxH3AutoreleasePool {
+            guard prepared.contains(where: { $0.waveform != nil }) else { return nil }
+            let vae = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources)
+            var rows: [MLXArray] = []
+            for (index, reference) in prepared.enumerated() {
+                guard let waveform = reference.waveform else { continue }
+                let packed = MiniMaxH3Geometry.packAudio(vae.encode(waveform)).expandedDimensions(axis: 0)
+                MLX.eval(packed)
+                rows.append(packed)
+                progressHandler?(.init(stage: .encodingReferences, stepIndex: index + 1, totalSteps: prepared.count))
+            }
+            return MLX.concatenated(rows, axis: 1)
+        }
+        Memory.clearCache()
+
+        let layout = try MiniMaxH3Geometry.buildRef2VA(
+            textTokenTags: presentation.tokenTags,
+            references: prepared.map(\.geometry),
+            videoLatentFrames: latentFrames,
+            latentHeight: latentHeight,
+            latentWidth: latentWidth,
+            audioLatentFrames: audioFrames
+        )
+        MLXRandom.seed(options.seed)
+        let noisedVideoConditions = conditionVideoRows.map {
+            MiniMaxH3Schedule.noise(
+                clean: $0,
+                timestep: 0.999,
+                noise: MLXRandom.normal($0.shape).asType(.float32)
+            )
+        }
+        let noisedAudioConditions = conditionAudioRows.map {
+            MiniMaxH3Schedule.noise(
+                clean: $0,
+                timestep: 0.999,
+                noise: MLXRandom.normal($0.shape).asType(.float32)
+            )
+        }
+        var videoRows = MiniMaxH3Geometry.patchifyVideo(
+            MLXRandom.normal([1, 24, latentFrames, latentHeight, latentWidth]).asType(.float32)
+        )
+        var audioRows = MLXRandom.normal([1, audioFrames * 2, 32]).asType(.float32)
+        let videoSchedule = try MiniMaxH3Schedule(pointCount: options.steps, shift: configuration.videoFlowShift)
+        let audioSchedule = try MiniMaxH3Schedule(pointCount: options.steps, shift: configuration.audioFlowShift)
+
+        progressHandler?(.init(stage: .loadingTransformer, stepIndex: 0, totalSteps: options.steps - 1))
+        try withMiniMaxH3AutoreleasePool {
+            let adaLNCache = try Self.loadAdaLNCache(
+                resources: resources,
+                configuration: configuration,
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule
+            )
+            let transformer = try loadDenoisingTransformer(
+                resources: resources,
+                configuration: configuration,
+                adaLNCache: adaLNCache,
+                sequenceLength: layout.sequenceLength,
+                weightMode: options.transformerWeightMode,
+                progressHandler: progressHandler
+            )
+            (videoRows, audioRows) = denoise(
+                transformer: transformer,
+                videoRows: videoRows,
+                audioRows: audioRows,
+                conditionVideoRows: noisedVideoConditions,
+                conditionAudioRows: noisedAudioConditions,
+                promptStates: promptStates,
+                layout: layout,
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule,
+                adaLNCache: adaLNCache,
+                progressHandler: progressHandler
+            )
+        }
+        Memory.clearCache()
+        let video = MiniMaxH3Geometry.unpatchifyVideo(
+            videoRows,
+            frames: latentFrames,
+            height: latentHeight,
+            width: latentWidth
+        )
+        let audio = MiniMaxH3Geometry.unpackAudio(audioRows[0])
+        progressHandler?(.init(stage: .decodingVideo, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
+        let frames: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let pixels = Self.mediaFrames(
+                from: try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources).decode(video)
+            )
+            MLX.eval(pixels)
+            return pixels
+        }
+        Memory.clearCache()
+        progressHandler?(.init(stage: .decodingAudio, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
+        let waveform: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let decoded = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources).decode(audio)
+            MLX.eval(decoded)
+            return decoded
+        }
+        Memory.clearCache()
+        return MiniMaxH3GenerationResult(frames: frames, audio: waveform, seed: options.seed)
+    }
+
+    private func prepareReferences(options: MiniMaxH3GenerationOptions) throws -> [PreparedReference] {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-minimax-h3-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+        let maxSamples = Int(
+            (Double(options.numFrames) / Double(MiniMaxH3Geometry.framesPerSecond)
+                * Double(MiniMaxH3AudioVAE.samplingRate)).rounded()
+        )
+        var prepared: [PreparedReference] = []
+        for (referenceIndex, input) in options.references.enumerated() {
+            switch input.kind {
+            case .image:
+                let source: MediaImage
+                do { source = try MediaImageIO.decode(input.url) } catch {
+                    throw MiniMaxH3GeneratorError.mediaDecodeFailed(input.url, error.localizedDescription)
+                }
+                let size = try resolveReferenceImageSize(width: source.width, height: source.height)
+                let image = try MediaImageIO.resized(source, width: size.width, height: size.height)
+                let visual = Self.rgbTensor(image).expandedDimensions(axis: 0)
+                let vision = try QwenVLImageLoader.pixelValues(image: image, patchSize: 16, spatialMergeSize: 2)
+                prepared.append(.init(
+                    kind: .image,
+                    visual: visual,
+                    visionBlocks: [vision],
+                    blockTimestamps: [],
+                    waveform: nil,
+                    geometry: .init(
+                        kind: .image,
+                        videoLatentFrames: 1,
+                        latentHeight: size.height / 16,
+                        latentWidth: size.width / 16
+                    )
+                ))
+            case .video:
+                let framesDirectory = temporaryRoot.appendingPathComponent("video-\(referenceIndex)", isDirectory: true)
+                try FileManager.default.createDirectory(at: framesDirectory, withIntermediateDirectories: true)
+                let sequence: VideoFrameSequence
+                do { sequence = try MediaVideoIO.extractFrames(from: input.url, into: framesDirectory) } catch {
+                    throw MiniMaxH3GeneratorError.mediaDecodeFailed(input.url, error.localizedDescription)
+                }
+                guard !sequence.frameURLs.isEmpty else {
+                    throw MiniMaxH3GeneratorError.mediaDecodeFailed(input.url, "video contains no frames")
+                }
+                let resampled = Self.resampledFrameIndices(
+                    sourceCount: sequence.frameURLs.count,
+                    sourceFPS: sequence.fps,
+                    maximumCount: options.numFrames
+                )
+                let selected = resampled.isEmpty ? [0] : resampled
+                let alignedCount = Self.trimReferenceFrameCount(selected.count)
+                var indices = selected
+                if indices.count < alignedCount {
+                    indices.append(contentsOf: repeatElement(indices.last!, count: alignedCount - indices.count))
+                } else {
+                    indices = Array(indices.prefix(alignedCount))
+                }
+                let canvas = try resolveVideoCanvas(width: sequence.frameWidth, height: sequence.frameHeight)
+                var images: [MediaImage] = []
+                images.reserveCapacity(indices.count)
+                for index in indices {
+                    let image = try MediaImageIO.decode(sequence.frameURLs[index])
+                    images.append(try MediaImageIO.resized(image, width: canvas.width, height: canvas.height))
+                }
+                let visual = MLX.stacked(images.map(Self.rgbTensor), axis: 0).expandedDimensions(axis: 0)
+                let sampled = stride(from: 0, to: images.count, by: 12).map { images[$0] }
+                var blocks: [MLXArray] = []
+                var timestamps: [Double] = []
+                for start in stride(from: 0, to: sampled.count, by: 2) {
+                    let second = min(start + 1, sampled.count - 1)
+                    let firstPixels = try QwenVLImageLoader.pixelValues(
+                        image: sampled[start], patchSize: 16, spatialMergeSize: 2
+                    )
+                    let secondPixels = try QwenVLImageLoader.pixelValues(
+                        image: sampled[second], patchSize: 16, spatialMergeSize: 2
+                    )
+                    blocks.append(MLX.concatenated([firstPixels, secondPixels], axis: 0))
+                    timestamps.append((Double(start) / 2 + Double(second) / 2) / 2)
+                }
+                let waveform = MediaVideoIO.hasAudioTrack(input.url)
+                    ? try decodeReferenceAudio(input.url, maximumSamples: maxSamples)
+                    : nil
+                prepared.append(.init(
+                    kind: .video,
+                    visual: visual,
+                    visionBlocks: blocks,
+                    blockTimestamps: timestamps,
+                    waveform: waveform,
+                    geometry: .init(
+                        kind: .video,
+                        videoLatentFrames: try MiniMaxH3Geometry.videoLatentFrameCount(for: alignedCount),
+                        latentHeight: canvas.height / 16,
+                        latentWidth: canvas.width / 16,
+                        audioLatentFrames: waveform.map { ($0.dim(1) + 799) / 800 } ?? 0
+                    )
+                ))
+            case .audio:
+                let waveform = try decodeReferenceAudio(input.url, maximumSamples: maxSamples)
+                prepared.append(.init(
+                    kind: .audio,
+                    visual: nil,
+                    visionBlocks: [],
+                    blockTimestamps: [],
+                    waveform: waveform,
+                    geometry: .init(
+                        kind: .audio,
+                        audioLatentFrames: (waveform.dim(1) + 799) / 800
+                    )
+                ))
+            }
+        }
+        return prepared
+    }
+
+    private func decodeReferenceAudio(_ url: URL, maximumSamples: Int) throws -> MLXArray {
+        let buffer: MediaAudioBuffer
+        do {
+            buffer = try MediaAudioIO.decode(
+                url,
+                targetSampleRate: MiniMaxH3AudioVAE.samplingRate,
+                channels: 2
+            )
+        } catch {
+            throw MiniMaxH3GeneratorError.mediaDecodeFailed(url, error.localizedDescription)
+        }
+        let frameCount = min(maximumSamples, buffer.samples.count / 2)
+        guard frameCount > 0 else {
+            throw MiniMaxH3GeneratorError.mediaDecodeFailed(url, "audio contains no samples")
+        }
+        return MLXArray(Array(buffer.samples.prefix(frameCount * 2)))
+            .reshaped(1, frameCount, 2)
+    }
+
+    private func referenceConditionerPresentation(
+        tokenizer: QwenTokenizer,
+        prompt: String,
+        references: [PreparedReference]
+    ) throws -> ConditionerPresentation {
+        guard let imageTokenID = tokenizer.imageTokenId,
+              let videoTokenID = tokenizer.videoTokenId,
+              let visionStartTokenID = tokenizer.visionStartTokenId,
+              let visionEndTokenID = tokenizer.visionEndTokenId else {
+            throw MiniMaxH3GeneratorError.invalidOptions("Qwen3-VL tokenizer is missing Ref2VA vision tokens")
+        }
+        var tokenIDs: [Int] = []
+        var tokenTags: [Int32] = []
+        var images: [QwenVLEncoder.ConditioningImage] = []
+        var imageCount = 0
+        var videoCount = 0
+        var audioCount = 0
+        func appendText(_ value: String) {
+            let ids = tokenizer.encodeText(value)
+            tokenIDs.append(contentsOf: ids)
+            tokenTags.append(contentsOf: repeatElement(MiniMaxH3Modality.text.rawValue, count: ids.count))
+        }
+        func appendVision(_ pixels: MLXArray, padToken: Int) {
+            let patchHeight = pixels.dim(2) / 16
+            let patchWidth = pixels.dim(3) / 16
+            let temporal = max(1, (pixels.dim(0) + 1) / 2)
+            let count = temporal * (patchHeight / 2) * (patchWidth / 2)
+            tokenIDs.append(visionStartTokenID)
+            tokenTags.append(MiniMaxH3Modality.video.rawValue)
+            let range = tokenIDs.count..<(tokenIDs.count + count)
+            tokenIDs.append(contentsOf: repeatElement(padToken, count: count))
+            tokenTags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: count))
+            tokenIDs.append(visionEndTokenID)
+            tokenTags.append(MiniMaxH3Modality.video.rawValue)
+            images.append(.init(
+                pixelValues: pixels,
+                tokenRange: range,
+                temporalPatchCount: temporal,
+                heightPatchCount: patchHeight,
+                widthPatchCount: patchWidth
+            ))
+        }
+        for reference in references {
+            if reference.waveform != nil {
+                audioCount += 1
+                appendText("<Audio \(audioCount)>: ")
+            }
+            switch reference.kind {
+            case .image:
+                imageCount += 1
+                appendText("<Picture \(imageCount)>: ")
+                appendVision(reference.visionBlocks[0], padToken: imageTokenID)
+            case .video:
+                videoCount += 1
+                appendText("<Video \(videoCount)>: ")
+                for (index, block) in reference.visionBlocks.enumerated() {
+                    let rounded = (reference.blockTimestamps[index] * 10).rounded(.toNearestOrEven) / 10
+                    appendText(String(format: "<%.1f seconds>", rounded))
+                    appendVision(block, padToken: videoTokenID)
+                }
+            case .audio:
+                break
+            }
+        }
+        appendText(prompt)
+        return ConditionerPresentation(tokenIDs: tokenIDs, tokenTags: tokenTags, images: images)
+    }
+
+    private static func rgbTensor(_ image: MediaImage) -> MLXArray {
+        MLXArray(MediaImageIO.rgbCHWFloat(image, normalizedToMinusOneToOne: false))
+            .reshaped(3, image.height, image.width)
+            .transposed(1, 2, 0)
+    }
+
+    private func resolveReferenceImageSize(width: Int, height: Int) throws -> (width: Int, height: Int) {
+        guard width > 0, height > 0, width <= 4 * height, height <= 4 * width else {
+            throw MiniMaxH3GeneratorError.invalidOptions("reference image aspect ratio must be between 1:4 and 4:1")
+        }
+        let scale = 2_048 / Double(min(width, height))
+        return (
+            max(32, Int((Double(width) * scale / 32).rounded()) * 32),
+            max(32, Int((Double(height) * scale / 32).rounded()) * 32)
+        )
+    }
+
+    private func resolveVideoCanvas(width: Int, height: Int) throws -> (width: Int, height: Int) {
+        guard width > 0, height > 0, width <= 4 * height, height <= 4 * width else {
+            throw MiniMaxH3GeneratorError.invalidOptions("reference video aspect ratio must be between 1:4 and 4:1")
+        }
+        let ratio = Double(width) / Double(height)
+        var resolvedWidth = ratio >= 1 ? 768 * ratio : 768
+        var resolvedHeight = ratio >= 1 ? 768.0 : 768 / ratio
+        let maximumArea = Double(768 * 1_344)
+        if resolvedWidth * resolvedHeight > maximumArea {
+            let scale = sqrt(maximumArea / (resolvedWidth * resolvedHeight))
+            resolvedWidth *= scale
+            resolvedHeight *= scale
+        }
+        return (
+            max(32, Int((resolvedWidth / 32).rounded()) * 32),
+            max(32, Int((resolvedHeight / 32).rounded()) * 32)
+        )
+    }
+
+    private static func resampledFrameIndices(
+        sourceCount: Int,
+        sourceFPS: Double,
+        maximumCount: Int
+    ) -> [Int] {
+        guard sourceCount > 0, sourceFPS > 0 else { return [] }
+        if sourceFPS == Double(MiniMaxH3Geometry.framesPerSecond) {
+            return Array(0..<min(sourceCount, maximumCount))
+        }
+        let scale = Double(MiniMaxH3Geometry.framesPerSecond) / sourceFPS
+        let slots = (0..<sourceCount).map { Int((Double($0) * scale).rounded()) }
+        let end = Int((Double(sourceCount) * scale).rounded())
+        var result: [Int] = []
+        for index in 0..<sourceCount {
+            let next = index + 1 < sourceCount ? slots[index + 1] : end
+            if next > slots[index] {
+                result.append(contentsOf: repeatElement(index, count: next - slots[index]))
+            }
+            if result.count >= maximumCount { return Array(result.prefix(maximumCount)) }
+        }
+        return result
+    }
+
+    private static func trimReferenceFrameCount(_ count: Int) -> Int {
+        max(1, (count - 5) / 17) * 17 + 5
+    }
+
+    private func encodeKeyframes(
+        _ urls: [URL],
+        options: MiniMaxH3GenerationOptions,
+        resources: MiniMaxH3Resources,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
+    ) throws -> MLXArray? {
+        guard !urls.isEmpty else { return nil }
+        progressHandler?(.init(stage: .encodingKeyframes, stepIndex: 0, totalSteps: urls.count))
+        return try withMiniMaxH3AutoreleasePool {
+            let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+            var rows: [MLXArray] = []
+            for (index, url) in urls.enumerated() {
+                let image: MediaImage
+                do {
+                    image = try MediaImageIO.resized(
+                        try MediaImageIO.decode(url), width: options.width, height: options.height
+                    )
+                } catch {
+                    throw MiniMaxH3GeneratorError.imageDecodeFailed(url)
+                }
+                let chw = MLXArray(MediaImageIO.rgbCHWFloat(image, normalizedToMinusOneToOne: false))
+                    .reshaped(1, 3, options.height, options.width)
+                let rgb = chw.transposed(0, 2, 3, 1)
+                rows.append(MiniMaxH3Geometry.patchifyVideo(vae.encodeKeyframe(rgb)).asType(.float32))
+                progressHandler?(.init(stage: .encodingKeyframes, stepIndex: index + 1, totalSteps: urls.count))
+            }
+            let result = MLX.concatenated(rows, axis: 1)
+            MLX.eval(result)
+            return result
+        }
+    }
+
+    private func conditionerPresentation(
+        tokenizer: QwenTokenizer,
+        options: MiniMaxH3GenerationOptions
+    ) throws -> ConditionerPresentation {
+        let keyframeURLs = [options.firstFrameURL, options.lastFrameURL].compactMap { $0 }
+        var tokenIDs: [Int] = []
+        var tokenTags: [Int32] = []
+        var images: [QwenVLEncoder.ConditioningImage] = []
+
+        if !keyframeURLs.isEmpty {
+            guard let imageTokenID = tokenizer.imageTokenId,
+                  let visionStartTokenID = tokenizer.visionStartTokenId,
+                  let visionEndTokenID = tokenizer.visionEndTokenId else {
+                throw MiniMaxH3GeneratorError.invalidOptions("Qwen3-VL tokenizer is missing vision tokens")
+            }
+            for (index, url) in keyframeURLs.enumerated() {
+                let prepared: MediaImage
+                do {
+                    prepared = try MediaImageIO.resized(
+                        try MediaImageIO.decode(url),
+                        width: options.width,
+                        height: options.height
+                    )
+                } catch {
+                    throw MiniMaxH3GeneratorError.imageDecodeFailed(url)
+                }
+                let pixelValues = try QwenVLImageLoader.pixelValues(
+                    image: prepared,
+                    patchSize: 16,
+                    spatialMergeSize: 2
+                )
+                let patchHeight = pixelValues.dim(2) / 16
+                let patchWidth = pixelValues.dim(3) / 16
+                let imageTokenCount = QwenVLEncoder.imageTokenCount(
+                    imageHeight: pixelValues.dim(2),
+                    imageWidth: pixelValues.dim(3),
+                    patchSize: 16,
+                    spatialMergeSize: 2
+                )
+                let labelIDs = tokenizer.encodeText("<Picture \(index + 1)>: ")
+                tokenIDs.append(contentsOf: labelIDs)
+                tokenTags.append(contentsOf: repeatElement(
+                    MiniMaxH3Modality.text.rawValue,
+                    count: labelIDs.count
+                ))
+                tokenIDs.append(visionStartTokenID)
+                tokenTags.append(MiniMaxH3Modality.video.rawValue)
+                let tokenRange = tokenIDs.count..<(tokenIDs.count + imageTokenCount)
+                tokenIDs.append(contentsOf: repeatElement(imageTokenID, count: imageTokenCount))
+                tokenTags.append(contentsOf: repeatElement(
+                    MiniMaxH3Modality.video.rawValue,
+                    count: imageTokenCount
+                ))
+                tokenIDs.append(visionEndTokenID)
+                tokenTags.append(MiniMaxH3Modality.video.rawValue)
+                images.append(.init(
+                    pixelValues: pixelValues,
+                    tokenRange: tokenRange,
+                    heightPatchCount: patchHeight,
+                    widthPatchCount: patchWidth
+                ))
+            }
+        }
+        let promptIDs = tokenizer.encodeText(options.prompt)
+        tokenIDs.append(contentsOf: promptIDs)
+        tokenTags.append(contentsOf: repeatElement(MiniMaxH3Modality.text.rawValue, count: promptIDs.count))
+        return ConditionerPresentation(tokenIDs: tokenIDs, tokenTags: tokenTags, images: images)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Layout.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Layout.swift
@@ -1,0 +1,495 @@
+import Foundation
+import MLX
+
+public enum MiniMaxH3LayoutError: LocalizedError, Sendable {
+    case invalidGeometry(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidGeometry(let reason): return "Invalid MiniMax-H3 geometry: \(reason)"
+        }
+    }
+}
+
+public enum MiniMaxH3Modality: Int32, Sendable {
+    case video = 0
+    case text = 1
+    case audio = 2
+}
+
+public enum MiniMaxH3KeyframeAnchor: String, Codable, Sendable {
+    case first
+    case last
+}
+
+public struct MiniMaxH3ConditionSegment: Sendable {
+    public let modality: MiniMaxH3Modality
+    public let packedRows: Range<Int>
+    public let sourceRows: Range<Int>
+}
+
+public enum MiniMaxH3ReferenceKind: String, Codable, Sendable {
+    case image
+    case video
+    case audio
+}
+
+public struct MiniMaxH3PreparedReferenceGeometry: Sendable {
+    public let kind: MiniMaxH3ReferenceKind
+    public let videoLatentFrames: Int
+    public let latentHeight: Int
+    public let latentWidth: Int
+    public let audioLatentFrames: Int
+
+    public init(
+        kind: MiniMaxH3ReferenceKind,
+        videoLatentFrames: Int = 0,
+        latentHeight: Int = 0,
+        latentWidth: Int = 0,
+        audioLatentFrames: Int = 0
+    ) {
+        self.kind = kind
+        self.videoLatentFrames = videoLatentFrames
+        self.latentHeight = latentHeight
+        self.latentWidth = latentWidth
+        self.audioLatentFrames = audioLatentFrames
+    }
+
+    var videoRowCount: Int {
+        kind == .audio ? 0 : videoLatentFrames * (latentHeight / 2) * (latentWidth / 2)
+    }
+
+    var audioRowCount: Int { audioLatentFrames * 2 }
+}
+
+public struct MiniMaxH3PackedLayout: @unchecked Sendable {
+    public let positions: MLXArray
+    public let tokenTags: [Int32]
+    public let textRows: Range<Int>
+    public let conditionRows: Range<Int>
+    public let conditionSegments: [MiniMaxH3ConditionSegment]
+    public let conditionVideoRowCount: Int
+    public let conditionAudioRowCount: Int
+    public let targetAudioRows: Range<Int>
+    public let targetVideoRows: Range<Int>
+    public let videoLatentFrames: Int
+    public let latentHeight: Int
+    public let latentWidth: Int
+    public let audioLatentFrames: Int
+
+    public var sequenceLength: Int { tokenTags.count }
+}
+
+public enum MiniMaxH3Geometry {
+    public static let framesPerSecond = 24
+    public static let audioLatentsPerSecond = 40
+    public static let videoFramesPerChunk = 17
+    public static let videoLatentsPerChunk = 5
+    public static let frameSpanPattern: [Double] = [1, 4, 4, 4, 4]
+    public static let frameSpanScale = 5.0 / 3.0
+
+    public static func alignFrameCount(_ frameCount: Int) throws -> Int {
+        guard frameCount > 0 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("frame count must be positive")
+        }
+        var aligned = frameCount
+        while aligned % videoFramesPerChunk != videoLatentsPerChunk {
+            aligned += 1
+        }
+        return aligned
+    }
+
+    public static func videoLatentFrameCount(for frameCount: Int) throws -> Int {
+        guard frameCount % videoFramesPerChunk == videoLatentsPerChunk else {
+            throw MiniMaxH3LayoutError.invalidGeometry("frame count must have form 17*n+5")
+        }
+        return ((frameCount - videoLatentsPerChunk) / videoFramesPerChunk) * videoLatentsPerChunk + 2
+    }
+
+    public static func audioLatentFrameCount(for frameCount: Int) -> Int {
+        Int((Double(frameCount) / Double(framesPerSecond) * Double(audioLatentsPerSecond)).rounded())
+    }
+
+    public static func shiftedSigma(_ sigma: Float, from sourceShift: Float, to targetShift: Float) -> Float {
+        let base = sigma / (sourceShift + sigma * (1 - sourceShift))
+        return targetShift * base / (1 + (targetShift - 1) * base)
+    }
+
+    public static func shiftedSigmaSlope(_ sigma: Float, from sourceShift: Float, to targetShift: Float) -> Float {
+        let base = sigma / (sourceShift + sigma * (1 - sourceShift))
+        let numerator = targetShift * pow(1 + (sourceShift - 1) * base, 2)
+        let denominator = sourceShift * pow(1 + (targetShift - 1) * base, 2)
+        return numerator / denominator
+    }
+
+    public static func patchifyVideo(_ latent: MLXArray, patchSize: [Int] = [1, 2, 2]) -> MLXArray {
+        precondition(latent.ndim == 5)
+        let batch = latent.dim(0)
+        let channels = latent.dim(1)
+        let frames = latent.dim(2)
+        let height = latent.dim(3)
+        let width = latent.dim(4)
+        let temporalPatch = patchSize[0]
+        let heightPatch = patchSize[1]
+        let widthPatch = patchSize[2]
+        return latent
+            .reshaped(
+                batch, channels, frames / temporalPatch, temporalPatch,
+                height / heightPatch, heightPatch, width / widthPatch, widthPatch
+            )
+            .transposed(0, 2, 4, 6, 1, 3, 5, 7)
+            .reshaped(
+                batch,
+                (frames / temporalPatch) * (height / heightPatch) * (width / widthPatch),
+                channels * temporalPatch * heightPatch * widthPatch
+            )
+    }
+
+    public static func unpatchifyVideo(
+        _ rows: MLXArray,
+        frames: Int,
+        height: Int,
+        width: Int,
+        channels: Int = 24,
+        patchSize: [Int] = [1, 2, 2]
+    ) -> MLXArray {
+        let temporalPatch = patchSize[0]
+        let heightPatch = patchSize[1]
+        let widthPatch = patchSize[2]
+        return rows
+            .reshaped(
+                rows.dim(0), frames / temporalPatch, height / heightPatch, width / widthPatch,
+                channels, temporalPatch, heightPatch, widthPatch
+            )
+            .transposed(0, 4, 1, 5, 2, 6, 3, 7)
+            .reshaped(rows.dim(0), channels, frames, height, width)
+    }
+
+    public static func packAudio(_ latent: MLXArray) -> MLXArray {
+        precondition(latent.ndim == 4 && latent.dim(0) == 1 && latent.dim(2) == 2)
+        return latent[0].transposed(1, 2, 0).reshaped(2 * latent.dim(3), latent.dim(1))
+    }
+
+    public static func unpackAudio(_ rows: MLXArray) -> MLXArray {
+        let frames = rows.dim(0) / 2
+        return rows.reshaped(2, frames, rows.dim(1)).transposed(2, 0, 1).expandedDimensions(axis: 0)
+    }
+
+    public static func buildFL2VA(
+        textTokenTags: [Int32],
+        videoLatentFrames: Int,
+        latentHeight: Int,
+        latentWidth: Int,
+        audioLatentFrames: Int,
+        keyframeAnchors: [MiniMaxH3KeyframeAnchor]
+    ) throws -> MiniMaxH3PackedLayout {
+        guard videoLatentFrames > 0, latentHeight > 0, latentWidth > 0, audioLatentFrames > 0 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("all latent dimensions must be positive")
+        }
+        guard latentHeight.isMultiple(of: 2), latentWidth.isMultiple(of: 2) else {
+            throw MiniMaxH3LayoutError.invalidGeometry("latent spatial dimensions must be divisible by 2")
+        }
+        let textCount = textTokenTags.count
+        let rowsPerFrame = (latentHeight / 2) * (latentWidth / 2)
+        let conditionCount = keyframeAnchors.count * rowsPerFrame
+        let audioCount = audioLatentFrames * 2
+        let videoCount = videoLatentFrames * rowsPerFrame
+        let textRows = 0..<textCount
+        let conditionRows = textCount..<(textCount + conditionCount)
+        let audioRows = conditionRows.upperBound..<(conditionRows.upperBound + audioCount)
+        let videoRows = audioRows.upperBound..<(audioRows.upperBound + videoCount)
+
+        let squareRootArea = sqrt(Double(latentHeight * latentWidth))
+        let heightGrid = spatialGrid(dimension: latentHeight, patch: 2, squareRootArea: squareRootArea)
+        let widthGrid = spatialGrid(dimension: latentWidth, patch: 2, squareRootArea: squareRootArea)
+        let frameGrid = heightGrid.flatMap { height in widthGrid.map { width in (height, width) } }
+        var positions = Array(repeating: Float(0), count: videoRows.upperBound * 3)
+        for row in textRows {
+            positions[row * 3] = Float(row)
+        }
+        for (index, anchor) in keyframeAnchors.enumerated() {
+            let time: Double = switch anchor {
+            case .first: Double(textCount)
+            case .last: Double(textCount) + temporalSpan(videoLatentFrames) - frameSpanScale
+            }
+            for (offset, spatial) in frameGrid.enumerated() {
+                let row = conditionRows.lowerBound + index * rowsPerFrame + offset
+                positions[row * 3] = Float(time)
+                positions[row * 3 + 1] = Float(spatial.0)
+                positions[row * 3 + 2] = Float(spatial.1)
+            }
+        }
+        for channel in 0..<2 {
+            for frame in 0..<audioLatentFrames {
+                let row = audioRows.lowerBound + channel * audioLatentFrames + frame
+                positions[row * 3] = Float(textCount + frame)
+                positions[row * 3 + 2] = Float(channel == 0 ? widthGrid[0] : widthGrid[widthGrid.count - 1])
+            }
+        }
+        let temporal = temporalGrid(videoLatentFrames, origin: Double(textCount))
+        for frame in 0..<videoLatentFrames {
+            for (offset, spatial) in frameGrid.enumerated() {
+                let row = videoRows.lowerBound + frame * rowsPerFrame + offset
+                positions[row * 3] = Float(temporal[frame])
+                positions[row * 3 + 1] = Float(spatial.0)
+                positions[row * 3 + 2] = Float(spatial.1)
+            }
+        }
+
+        var tags = textTokenTags
+        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: conditionCount))
+        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: audioCount))
+        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: videoCount))
+        return MiniMaxH3PackedLayout(
+            positions: MLXArray(positions, [videoRows.upperBound, 3]),
+            tokenTags: tags,
+            textRows: textRows,
+            conditionRows: conditionRows,
+            conditionSegments: conditionRows.isEmpty ? [] : [.init(
+                modality: .video,
+                packedRows: conditionRows,
+                sourceRows: 0..<conditionRows.count
+            )],
+            conditionVideoRowCount: conditionRows.count,
+            conditionAudioRowCount: 0,
+            targetAudioRows: audioRows,
+            targetVideoRows: videoRows,
+            videoLatentFrames: videoLatentFrames,
+            latentHeight: latentHeight,
+            latentWidth: latentWidth,
+            audioLatentFrames: audioLatentFrames
+        )
+    }
+
+    public static func buildRef2VA(
+        textTokenTags: [Int32],
+        references: [MiniMaxH3PreparedReferenceGeometry],
+        videoLatentFrames: Int,
+        latentHeight: Int,
+        latentWidth: Int,
+        audioLatentFrames: Int
+    ) throws -> MiniMaxH3PackedLayout {
+        guard videoLatentFrames > 0, latentHeight > 0, latentWidth > 0, audioLatentFrames > 0 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("all target latent dimensions must be positive")
+        }
+        guard latentHeight.isMultiple(of: 2), latentWidth.isMultiple(of: 2) else {
+            throw MiniMaxH3LayoutError.invalidGeometry("target latent spatial dimensions must be divisible by 2")
+        }
+        for reference in references {
+            switch reference.kind {
+            case .image, .video:
+                guard reference.videoLatentFrames > 0,
+                      reference.latentHeight > 0,
+                      reference.latentWidth > 0,
+                      reference.latentHeight.isMultiple(of: 2),
+                      reference.latentWidth.isMultiple(of: 2) else {
+                    throw MiniMaxH3LayoutError.invalidGeometry("visual reference latent geometry is invalid")
+                }
+            case .audio:
+                guard reference.audioLatentFrames > 0 else {
+                    throw MiniMaxH3LayoutError.invalidGeometry("audio reference must contain latent frames")
+                }
+            }
+        }
+
+        let textRows = 0..<textTokenTags.count
+        let targetVideoCount = videoLatentFrames * (latentHeight / 2) * (latentWidth / 2)
+        let targetAudioCount = audioLatentFrames * 2
+        let conditionVideoCount = references.reduce(0) { $0 + $1.videoRowCount }
+        let conditionAudioCount = references.reduce(0) { $0 + $1.audioRowCount }
+        let conditionRows = textRows.upperBound..<(textRows.upperBound + conditionVideoCount + conditionAudioCount)
+        let targetAudioRows = conditionRows.upperBound..<(conditionRows.upperBound + targetAudioCount)
+        let targetVideoRows = targetAudioRows.upperBound..<(targetAudioRows.upperBound + targetVideoCount)
+        var positions = Array(repeating: Float(0), count: targetVideoRows.upperBound * 3)
+        for row in textRows { positions[row * 3] = Float(row) }
+
+        let targetGrid = framePositionGrid(latentHeight: latentHeight, latentWidth: latentWidth)
+        var packedCursor = conditionRows.lowerBound
+        var videoCursor = 0
+        var audioCursor = 0
+        var rotaryTime = Double(textRows.count)
+        var segments: [MiniMaxH3ConditionSegment] = []
+        var tags = textTokenTags
+        for reference in references {
+            switch reference.kind {
+            case .image:
+                let packed = packedCursor..<(packedCursor + reference.videoRowCount)
+                let source = videoCursor..<(videoCursor + reference.videoRowCount)
+                segments.append(.init(modality: .video, packedRows: packed, sourceRows: source))
+                fillVideoPositions(
+                    &positions,
+                    rows: packed,
+                    latentFrames: 1,
+                    latentHeight: reference.latentHeight,
+                    latentWidth: reference.latentWidth,
+                    origin: rotaryTime,
+                    singleImage: true
+                )
+                tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: packed.count))
+                packedCursor = packed.upperBound
+                videoCursor = source.upperBound
+                rotaryTime += 1
+            case .audio:
+                let packed = packedCursor..<(packedCursor + reference.audioRowCount)
+                let source = audioCursor..<(audioCursor + reference.audioRowCount)
+                segments.append(.init(modality: .audio, packedRows: packed, sourceRows: source))
+                fillAudioPositions(
+                    &positions,
+                    rows: packed,
+                    frames: reference.audioLatentFrames,
+                    origin: rotaryTime,
+                    widthGrid: targetGrid.width
+                )
+                tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: packed.count))
+                packedCursor = packed.upperBound
+                audioCursor = source.upperBound
+                rotaryTime += Double(reference.audioLatentFrames)
+            case .video:
+                if reference.audioRowCount > 0 {
+                    let packed = packedCursor..<(packedCursor + reference.audioRowCount)
+                    let source = audioCursor..<(audioCursor + reference.audioRowCount)
+                    segments.append(.init(modality: .audio, packedRows: packed, sourceRows: source))
+                    let grid = framePositionGrid(
+                        latentHeight: reference.latentHeight,
+                        latentWidth: reference.latentWidth
+                    )
+                    fillAudioPositions(
+                        &positions,
+                        rows: packed,
+                        frames: reference.audioLatentFrames,
+                        origin: rotaryTime,
+                        widthGrid: grid.width
+                    )
+                    tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: packed.count))
+                    packedCursor = packed.upperBound
+                    audioCursor = source.upperBound
+                }
+                let packed = packedCursor..<(packedCursor + reference.videoRowCount)
+                let source = videoCursor..<(videoCursor + reference.videoRowCount)
+                segments.append(.init(modality: .video, packedRows: packed, sourceRows: source))
+                fillVideoPositions(
+                    &positions,
+                    rows: packed,
+                    latentFrames: reference.videoLatentFrames,
+                    latentHeight: reference.latentHeight,
+                    latentWidth: reference.latentWidth,
+                    origin: rotaryTime,
+                    singleImage: false
+                )
+                tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: packed.count))
+                packedCursor = packed.upperBound
+                videoCursor = source.upperBound
+                rotaryTime += max(
+                    Double(reference.audioLatentFrames),
+                    temporalSpan(reference.videoLatentFrames)
+                )
+            }
+        }
+
+        fillAudioPositions(
+            &positions,
+            rows: targetAudioRows,
+            frames: audioLatentFrames,
+            origin: rotaryTime,
+            widthGrid: targetGrid.width
+        )
+        fillVideoPositions(
+            &positions,
+            rows: targetVideoRows,
+            latentFrames: videoLatentFrames,
+            latentHeight: latentHeight,
+            latentWidth: latentWidth,
+            origin: rotaryTime,
+            singleImage: false
+        )
+        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: targetAudioRows.count))
+        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: targetVideoRows.count))
+        return MiniMaxH3PackedLayout(
+            positions: MLXArray(positions, [targetVideoRows.upperBound, 3]),
+            tokenTags: tags,
+            textRows: textRows,
+            conditionRows: conditionRows,
+            conditionSegments: segments,
+            conditionVideoRowCount: conditionVideoCount,
+            conditionAudioRowCount: conditionAudioCount,
+            targetAudioRows: targetAudioRows,
+            targetVideoRows: targetVideoRows,
+            videoLatentFrames: videoLatentFrames,
+            latentHeight: latentHeight,
+            latentWidth: latentWidth,
+            audioLatentFrames: audioLatentFrames
+        )
+    }
+
+    private static func framePositionGrid(
+        latentHeight: Int,
+        latentWidth: Int
+    ) -> (frame: [(Double, Double)], width: [Double]) {
+        let squareRootArea = sqrt(Double(latentHeight * latentWidth))
+        let height = spatialGrid(dimension: latentHeight, patch: 2, squareRootArea: squareRootArea)
+        let width = spatialGrid(dimension: latentWidth, patch: 2, squareRootArea: squareRootArea)
+        return (height.flatMap { y in width.map { x in (y, x) } }, width)
+    }
+
+    private static func fillAudioPositions(
+        _ positions: inout [Float],
+        rows: Range<Int>,
+        frames: Int,
+        origin: Double,
+        widthGrid: [Double]
+    ) {
+        guard frames > 0 else { return }
+        for channel in 0..<2 {
+            for frame in 0..<frames {
+                let row = rows.lowerBound + channel * frames + frame
+                positions[row * 3] = Float(origin + Double(frame))
+                positions[row * 3 + 2] = Float(channel == 0 ? widthGrid[0] : widthGrid[widthGrid.count - 1])
+            }
+        }
+    }
+
+    private static func fillVideoPositions(
+        _ positions: inout [Float],
+        rows: Range<Int>,
+        latentFrames: Int,
+        latentHeight: Int,
+        latentWidth: Int,
+        origin: Double,
+        singleImage: Bool
+    ) {
+        let grid = framePositionGrid(latentHeight: latentHeight, latentWidth: latentWidth).frame
+        let temporal = singleImage ? [origin] : temporalGrid(latentFrames, origin: origin)
+        for frame in 0..<latentFrames {
+            for (offset, spatial) in grid.enumerated() {
+                let row = rows.lowerBound + frame * grid.count + offset
+                positions[row * 3] = Float(temporal[frame])
+                positions[row * 3 + 1] = Float(spatial.0)
+                positions[row * 3 + 2] = Float(spatial.1)
+            }
+        }
+    }
+
+    private static func spatialGrid(dimension: Int, patch: Int, squareRootArea: Double) -> [Double] {
+        let ratio = Double(dimension) / squareRootArea
+        let count = dimension / patch
+        let left = (1 - ratio) / 2
+        return (0..<count).map { (left + Double($0) * ratio / Double(count)) * 32 }
+    }
+
+    private static func temporalGrid(_ count: Int, origin: Double) -> [Double] {
+        var values: [Double] = []
+        values.reserveCapacity(count)
+        var current = origin
+        for index in 0..<count {
+            values.append(current)
+            current += frameSpanScale * frameSpanPattern[index % frameSpanPattern.count]
+        }
+        return values
+    }
+
+    private static func temporalSpan(_ count: Int) -> Double {
+        (0..<count).reduce(0) { partial, index in
+            partial + frameSpanScale * frameSpanPattern[index % frameSpanPattern.count]
+        }
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3ModelLoader.swift
@@ -1,0 +1,197 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum MiniMaxH3ModelLoaderError: LocalizedError, Sendable {
+    case adaLNCacheRequired
+
+    public var errorDescription: String? {
+        switch self {
+        case .adaLNCacheRequired:
+            return "The compact MiniMax-H3 transformer requires its matching AdaLN cache."
+        }
+    }
+}
+
+public enum MiniMaxH3ModelLoader {
+    public static func loadTransformer(
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> MiniMaxH3Transformer {
+        try loadInferenceTransformer(
+            resources: resources,
+            configuration: configuration,
+            cachedAdaLN: nil,
+            progressHandler: progressHandler
+        )
+    }
+
+    static func loadInferenceTransformer(
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        cachedAdaLN: MiniMaxH3AdaLNCache?,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> MiniMaxH3Transformer {
+        let transformer = MiniMaxH3Transformer(
+            configuration: .init(configuration),
+            includeAdaLN: cachedAdaLN == nil
+        )
+        let (loadedWeights, metadata) = try MLX.loadArraysAndMetadata(
+            url: resources.transformerWeightsURL
+        )
+        if metadata["cache_covered_weights_omitted"] == "true", cachedAdaLN == nil {
+            throw MiniMaxH3ModelLoaderError.adaLNCacheRequired
+        }
+        var weights = loadedWeights
+        if cachedAdaLN != nil {
+            weights = weights.filter { key, _ in
+                !key.contains(".adaln_proj.") && !key.hasPrefix("time_embedder.")
+            }
+        }
+        if let quantization = configuration.quantization {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                weights,
+                to: transformer,
+                groupSize: quantization.groupSize,
+                bits: quantization.bits
+            )
+        } else {
+            try transformer.update(
+                parameters: ModuleParameters.unflattened(weights.map { ($0.key, $0.value) }),
+                verify: [.shapeMismatch]
+            )
+        }
+        #if os(Linux)
+        if configuration.quantization != nil, Device.defaultDevice().deviceType == .gpu {
+            for (_, module) in transformer.leafModules().flattened() {
+                (module as? PortableQuantizedLinear)?.cacheDenseFallbackWeight = false
+            }
+            transformer.usesLayerwiseEvaluation = true
+        }
+        #endif
+        return transformer
+    }
+
+    public static func loadConditioner(
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> QwenVLEncoder {
+        let textConfiguration = QwenTextEncoderConfiguration(
+            vocabSize: 151_936,
+            hiddenSize: 5_120,
+            numHiddenLayers: 50,
+            numAttentionHeads: 64,
+            numKeyValueHeads: 8,
+            intermediateSize: 25_600,
+            ropeTheta: 5_000_000,
+            maxPositionEmbeddings: 262_144,
+            rmsNormEps: 1e-6,
+            headDim: 128,
+            mropeSection: [24, 20, 20],
+            mropeInterleaved: true
+        )
+        let visionConfiguration = QwenVisionConfiguration(
+            depth: 27,
+            embedDim: 1_152,
+            mlpHiddenDim: 4_304,
+            hiddenAct: .geluApproximate,
+            numHeads: 16,
+            patchSize: 16,
+            temporalPatchSize: 2,
+            spatialMergeSize: 2,
+            inChannels: 3,
+            outHiddenDim: 5_120,
+            windowSize: 112,
+            fullAttentionBlockIndices: [],
+            patchEmbedBias: true,
+            numPositionEmbeddings: 2_304,
+            useLearnedPosEmbed: true,
+            deepstackVisualIndexes: [8, 16, 24]
+        )
+        let encoder = QwenVLEncoder(
+            textEncoderConfig: textConfiguration,
+            visionConfig: visionConfiguration
+        )
+        if let quantization = configuration.textEncoderQuantization {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                MLX.loadArrays(url: resources.textEncoderWeightsURL),
+                to: encoder,
+                groupSize: quantization.groupSize,
+                bits: quantization.bits,
+                keyMapper: conditionerWeightKey,
+                mapper: conditionerWeight
+            )
+        } else {
+            try HFSafetensorsWeightsLoader.applyWeights(
+                url: resources.textEncoderWeightsURL,
+                to: encoder,
+                dtype: .bfloat16,
+                verify: [.shapeMismatch],
+                mapper: { rawKey, value in
+                    conditionerWeight(key: conditionerWeightKey(rawKey), value: value)
+                }
+            )
+        }
+        return encoder
+    }
+
+    public static func loadVideoVAE(
+        resources: MiniMaxH3Resources,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> MiniMaxH3VideoVAE {
+        let model = MiniMaxH3VideoVAE()
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.videoVAEWeightsURL,
+            to: model,
+            dtype: nil,
+            verify: [.shapeMismatch],
+            mapper: MiniMaxH3VideoVAE.mapCheckpointWeight
+        )
+        return model
+    }
+
+    public static func loadAudioVAE(
+        resources: MiniMaxH3Resources,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> MiniMaxH3AudioVAE {
+        let model = MiniMaxH3AudioVAE()
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.audioVAEWeightsURL,
+            to: model,
+            dtype: .float32,
+            verify: [.shapeMismatch],
+            mapper: MiniMaxH3AudioVAE.mapConvertedWeight
+        )
+        return model
+    }
+
+    static func conditionerWeightKey(_ rawKey: String) -> String {
+        var key = rawKey
+        if key.hasPrefix("model.") {
+            key = "textEncoder.encoder." + String(key.dropFirst("model.".count))
+        } else if key.hasPrefix("visual.") {
+            key = "visionTower." + String(key.dropFirst("visual.".count))
+        }
+        key = key.replacingOccurrences(of: ".merger.", with: ".patch_merger.")
+        key = key.replacingOccurrences(of: ".patch_merger.norm.", with: ".patch_merger.ln_q.")
+        key = key.replacingOccurrences(of: ".patch_merger.linear_fc1.", with: ".patch_merger.mlp_0.")
+        key = key.replacingOccurrences(of: ".patch_merger.linear_fc2.", with: ".patch_merger.mlp_2.")
+        if key.contains(".deepstack_merger_list.") {
+            key = key.replacingOccurrences(of: ".norm.", with: ".ln_q.")
+            key = key.replacingOccurrences(of: ".linear_fc1.", with: ".mlp_0.")
+            key = key.replacingOccurrences(of: ".linear_fc2.", with: ".mlp_2.")
+        }
+        key = key.replacingOccurrences(of: ".mlp.linear_fc1.", with: ".mlp.fc1.")
+        key = key.replacingOccurrences(of: ".mlp.linear_fc2.", with: ".mlp.fc2.")
+        return key
+    }
+
+    static func conditionerWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "visionTower.patch_embed.proj.weight", value.ndim == 5 {
+            return [(key, value.transposed(0, 2, 3, 4, 1))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+public enum MiniMaxH3ResourcesError: LocalizedError, Sendable {
+    case invalidConfiguration(URL, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let url, let reason):
+            return "Invalid MiniMax-H3 configuration at \(url.path): \(reason)"
+        }
+    }
+}
+
+public struct MiniMaxH3QuantizationConfiguration: Codable, Hashable, Sendable {
+    public let bits: Int
+    public let groupSize: Int
+    public let mode: String
+
+    enum CodingKeys: String, CodingKey {
+        case bits
+        case groupSize = "group_size"
+        case mode
+    }
+}
+
+public struct MiniMaxH3Configuration: Decodable, Hashable, Sendable {
+    public let modelType: String
+    public let task: String
+    public let hiddenSize: Int
+    public let layerCount: Int
+    public let refinerLayerCount: Int
+    public let attentionHeadCount: Int
+    public let attentionHeadDimension: Int
+    public let feedForwardSize: Int
+    public let videoLatentChannels: Int
+    public let audioLatentChannels: Int
+    public let patchSize: [Int]
+    public let textDimension: Int
+    public let timeFrequencyDimension: Int
+    public let timeEmbeddingHiddenSize: Int
+    public let timeEmbeddingDimension: Int
+    public let videoFlowShift: Float
+    public let audioFlowShift: Float
+    public let sampleSteps: Int
+    public let quantization: MiniMaxH3QuantizationConfiguration?
+    public let textEncoderQuantization: MiniMaxH3QuantizationConfiguration?
+
+    private struct Transformer: Decodable {
+        let hiddenSize: Int
+        let layerCount: Int
+        let attentionHeadCount: Int
+        let attentionHeadDimension: Int
+        let feedForwardSize: Int
+        let videoLatentChannels: Int
+        let audioLatentChannels: Int
+        let textDimension: Int
+        let timeEmbeddingHiddenSize: Int?
+        let timeEmbeddingDimension: Int
+        let ropeFrequencyCount: Int
+
+        enum CodingKeys: String, CodingKey {
+            case hiddenSize = "hidden_size"
+            case layerCount = "num_layers"
+            case attentionHeadCount = "num_attention_heads"
+            case attentionHeadDimension = "attention_head_dim"
+            case feedForwardSize = "ffn_hidden_size"
+            case videoLatentChannels = "latents_dim"
+            case audioLatentChannels = "audio_latents_dim"
+            case textDimension = "text_dim"
+            case timeEmbeddingHiddenSize = "time_embed_hidden_dim"
+            case timeEmbeddingDimension = "time_embed_dim"
+            case ropeFrequencyCount = "rope_inv_freq_len"
+        }
+    }
+
+    private struct SigmaShifts: Decodable {
+        let video: Float
+        let audio: Float
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case partition
+        case transformer
+        case sigmaShifts = "sigma_shift_scales"
+        case quantization
+        case textEncoderQuantization = "text_encoder_quantization"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let transformer = try container.decode(Transformer.self, forKey: .transformer)
+        let shifts = try container.decode(SigmaShifts.self, forKey: .sigmaShifts)
+        self.modelType = try container.decode(String.self, forKey: .modelType)
+        self.task = try container.decode(String.self, forKey: .partition)
+        self.hiddenSize = transformer.hiddenSize
+        self.layerCount = transformer.layerCount
+        self.refinerLayerCount = 2
+        self.attentionHeadCount = transformer.attentionHeadCount
+        self.attentionHeadDimension = transformer.attentionHeadDimension
+        self.feedForwardSize = transformer.feedForwardSize
+        self.videoLatentChannels = transformer.videoLatentChannels
+        self.audioLatentChannels = transformer.audioLatentChannels
+        self.patchSize = [1, 2, 2]
+        self.textDimension = transformer.textDimension
+        self.timeFrequencyDimension = 256
+        self.timeEmbeddingHiddenSize = transformer.timeEmbeddingHiddenSize ?? transformer.hiddenSize
+        self.timeEmbeddingDimension = transformer.timeEmbeddingDimension
+        self.videoFlowShift = shifts.video
+        self.audioFlowShift = shifts.audio
+        self.sampleSteps = 31
+        self.quantization = try container.decodeIfPresent(
+            MiniMaxH3QuantizationConfiguration.self,
+            forKey: .quantization
+        )
+        self.textEncoderQuantization = try container.decodeIfPresent(
+            MiniMaxH3QuantizationConfiguration.self,
+            forKey: .textEncoderQuantization
+        ) ?? quantization
+    }
+
+    public func validationIssues() -> [String] {
+        var issues: [String] = []
+        if modelType != "minimax_h3" { issues.append("model_type must be minimax_h3") }
+        if task != "fl2va" && task != "ref2va" { issues.append("task must be fl2va or ref2va") }
+        if hiddenSize != 5_376 { issues.append("hidden_size must be 5376") }
+        if layerCount != 50 { issues.append("num_layers must be 50") }
+        if refinerLayerCount != 2 { issues.append("num_refiner_layers must be 2") }
+        if attentionHeadCount != 56 || attentionHeadDimension != 128 {
+            issues.append("attention geometry must be 56 heads x 128")
+        }
+        if feedForwardSize != 14_336 { issues.append("ffn_dim must be 14336") }
+        if videoLatentChannels != 24 || audioLatentChannels != 32 {
+            issues.append("video/audio latent channels must be 24/32")
+        }
+        if patchSize != [1, 2, 2] { issues.append("patch_size must be [1, 2, 2]") }
+        if textDimension != 5_120 { issues.append("text_dim must be 5120") }
+        if timeFrequencyDimension != 256
+            || timeEmbeddingHiddenSize != 5_376
+            || timeEmbeddingDimension != 2_688 {
+            issues.append("time embedding must be 256 -> 5376 -> 2688")
+        }
+        if videoFlowShift <= 0 || audioFlowShift <= 0 { issues.append("flow shifts must be positive") }
+        if sampleSteps < 2 { issues.append("sample_steps must be at least 2") }
+        return issues
+    }
+}
+
+public struct MiniMaxH3Resources: Sendable {
+    private struct SafetensorsHeader: Decodable {
+        let metadata: [String: String]?
+
+        enum CodingKeys: String, CodingKey {
+            case metadata = "__metadata__"
+        }
+    }
+
+    public static let fl2vaModelID = "video-minimax-h3-fl2va-mlx"
+    public static let ref2vaModelID = "video-minimax-h3-ref2va-mlx"
+    public static let sourceRepository = "MiniMaxAI/MiniMax-H3"
+    public static let sourceRevision = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
+    public static let artifactRepository = "ddalcu/MiniMax-H3-FL2VA-MLX-Serve-8bit"
+    public static let artifactRevision = "32bfc37f1dc8bd331394573859a627bc0aa9822b"
+    public static let conversionSourceRepository = "Comfy-Org/MiniMax-H3"
+    public static let conversionSourceRevision = "fd70b39279d1ae6eb214c903f53e1bec3af19a77"
+    public static let ref2vaSourceSHA256 = "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9"
+    public static let ref2vaConvertedSHA256 = "c3ddde0dc29503281cd4c03c1f82b9cb640f4670da68caa5f55e3cec8f2045e8"
+
+    public static let requiredFiles = [
+        "config.json",
+        "transformer.safetensors",
+        "text_encoder.safetensors",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "video_vae.safetensors",
+        "audio_vae.safetensors",
+        "LICENSE",
+        "NOTICE",
+        "MODIFICATIONS.md",
+    ]
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var configURL: URL { rootURL.appending(path: "config.json") }
+    public var transformerWeightsURL: URL { rootURL.appending(path: "transformer.safetensors") }
+    public var textEncoderWeightsURL: URL { rootURL.appending(path: "text_encoder.safetensors") }
+    public var tokenizerURL: URL { rootURL }
+    public var videoVAEWeightsURL: URL { rootURL.appending(path: "video_vae.safetensors") }
+    public var audioVAEWeightsURL: URL { rootURL.appending(path: "audio_vae.safetensors") }
+    public var adaLNCacheURL: URL { rootURL.appending(path: MiniMaxH3AdaLNCache.filename) }
+
+    func adaLNCacheSourceIdentity() throws -> String {
+        if let inheritedIdentity = try transformerMetadata()["adaln_cache_source_identity"] {
+            return inheritedIdentity
+        }
+        let values = try transformerWeightsURL.resourceValues(forKeys: [
+            .fileSizeKey,
+            .contentModificationDateKey,
+        ])
+        guard let fileSize = values.fileSize, let modificationDate = values.contentModificationDate else {
+            throw MiniMaxH3AdaLNCacheError.incompatible("transformer file identity is unavailable")
+        }
+        let nanoseconds = Int64((modificationDate.timeIntervalSince1970 * 1_000_000_000).rounded())
+        return "\(fileSize):\(nanoseconds)"
+    }
+
+    func transformerMetadata() throws -> [String: String] {
+        let handle = try FileHandle(forReadingFrom: transformerWeightsURL)
+        defer { try? handle.close() }
+        guard let lengthData = try handle.read(upToCount: MemoryLayout<UInt64>.size),
+              lengthData.count == MemoryLayout<UInt64>.size else {
+            throw MiniMaxH3ResourcesError.invalidConfiguration(
+                transformerWeightsURL,
+                "safetensors header length is missing"
+            )
+        }
+        let rawLength = lengthData.withUnsafeBytes { bytes in
+            bytes.loadUnaligned(as: UInt64.self)
+        }
+        let headerLength = UInt64(littleEndian: rawLength)
+        guard headerLength > 0, headerLength <= 64 * 1_024 * 1_024 else {
+            throw MiniMaxH3ResourcesError.invalidConfiguration(
+                transformerWeightsURL,
+                "safetensors header length is invalid"
+            )
+        }
+        guard let headerData = try handle.read(upToCount: Int(headerLength)),
+              headerData.count == Int(headerLength) else {
+            throw MiniMaxH3ResourcesError.invalidConfiguration(
+                transformerWeightsURL,
+                "safetensors header is truncated"
+            )
+        }
+        do {
+            return try JSONDecoder().decode(SafetensorsHeader.self, from: headerData).metadata ?? [:]
+        } catch {
+            throw MiniMaxH3ResourcesError.invalidConfiguration(
+                transformerWeightsURL,
+                "safetensors metadata is invalid: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func requiresAdaLNCache() throws -> Bool {
+        try transformerMetadata()["cache_covered_weights_omitted"] == "true"
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        Self.requiredFiles
+            .map { rootURL.appending(path: $0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+
+    public func loadConfiguration() throws -> MiniMaxH3Configuration {
+        let configuration: MiniMaxH3Configuration
+        do {
+            configuration = try JSONDecoder().decode(
+                MiniMaxH3Configuration.self,
+                from: Data(contentsOf: configURL)
+            )
+        } catch {
+            throw MiniMaxH3ResourcesError.invalidConfiguration(configURL, error.localizedDescription)
+        }
+        let issues = configuration.validationIssues()
+        guard issues.isEmpty else {
+            throw MiniMaxH3ResourcesError.invalidConfiguration(configURL, issues.joined(separator: "; "))
+        }
+        return configuration
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
@@ -159,8 +159,8 @@ public struct MiniMaxH3Resources: Sendable {
     public static let ref2vaModelID = "video-minimax-h3-ref2va-mlx"
     public static let sourceRepository = "MiniMaxAI/MiniMax-H3"
     public static let sourceRevision = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
-    public static let artifactRepository = "ddalcu/MiniMax-H3-FL2VA-MLX-Serve-8bit"
-    public static let artifactRevision = "32bfc37f1dc8bd331394573859a627bc0aa9822b"
+    public static let artifactRepository = "Sawfwair/MiniMax-H3-FL2VA-MLX-4bit"
+    public static let artifactRevision = "e1244ad93d60c737c7e0f065a1c9372f3de7caf8"
     public static let conversionSourceRepository = "Comfy-Org/MiniMax-H3"
     public static let conversionSourceRevision = "fd70b39279d1ae6eb214c903f53e1bec3af19a77"
     public static let ref2vaSourceSHA256 = "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9"
@@ -177,6 +177,12 @@ public struct MiniMaxH3Resources: Sendable {
         "LICENSE",
         "NOTICE",
         "MODIFICATIONS.md",
+    ]
+    public static let compactArtifactFiles = requiredFiles + [
+        "adaln_cache.safetensors",
+        "SOURCE_MANIFEST.json",
+        "transformer.conversion.json",
+        "SHA256SUMS",
     ]
 
     public let rootURL: URL

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Scheduler.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Scheduler.swift
@@ -1,0 +1,39 @@
+import Foundation
+import MLX
+
+public struct MiniMaxH3Schedule: Sendable {
+    public let sigmas: [Float]
+    public let timesteps: [Float]
+
+    public init(pointCount: Int, shift: Float) throws {
+        guard pointCount >= 2 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("schedule needs at least two points")
+        }
+        guard shift > 0 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("schedule shift must be positive")
+        }
+        var shifted: [Float] = []
+        shifted.reserveCapacity(pointCount)
+        for index in 0..<pointCount {
+            let base = Float(pointCount - 1 - index) / Float(pointCount - 1)
+            let sigma = shift * base / (1 + (shift - 1) * base)
+            if shifted.last != sigma { shifted.append(sigma) }
+        }
+        self.sigmas = shifted
+        self.timesteps = shifted.dropLast().map { 1 - $0 }
+    }
+
+    public func step(sample: MLXArray, velocity: MLXArray, index: Int) -> MLXArray {
+        precondition(index >= 0 && index + 1 < sigmas.count)
+        let sigma = sigmas[index]
+        let sigmaNext = sigmas[index + 1]
+        let timestep = timesteps[index]
+        let denoised = sample + (1 - timestep) * velocity
+        let ratio = sigmaNext / sigma
+        return (ratio * sample.asType(.float32) + (1 - ratio) * denoised.asType(.float32)).asType(sample.dtype)
+    }
+
+    public static func noise(clean: MLXArray, timestep: Float, noise: MLXArray) -> MLXArray {
+        timestep * clean + (1 - timestep) * noise
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -1,0 +1,1109 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+@inline(__always)
+private func miniMaxH3Linear(_ linear: Linear, _ value: MLXArray) -> MLXArray {
+    let activationDType = (linear as? QuantizedLinear)?.scales.dtype ?? linear.weight.dtype
+    return linear(value.asType(activationDType))
+}
+
+func miniMaxH3SplitProjectedQKV(
+    _ projected: MLXArray,
+    heads: Int,
+    headDimension: Int
+) -> [MLXArray] {
+    precondition(projected.dim(-1) == heads * 3 * headDimension)
+    return MLX.split(projected, parts: 3, axis: -1).map {
+        $0.reshaped(projected.dim(0), projected.dim(1), heads, headDimension)
+    }
+}
+
+public struct MiniMaxH3TransformerConfiguration: Hashable, Sendable {
+    public let hiddenSize: Int
+    public let layerCount: Int
+    public let refinerLayerCount: Int
+    public let attentionHeadCount: Int
+    public let attentionHeadDimension: Int
+    public let feedForwardSize: Int
+    public let videoLatentChannels: Int
+    public let audioLatentChannels: Int
+    public let patchSize: [Int]
+    public let textDimension: Int
+    public let timeFrequencyDimension: Int
+    public let timeEmbeddingHiddenSize: Int
+    public let timeEmbeddingDimension: Int
+    public let ropeFrequencyCount: Int
+    public let ropeTheta: Float
+    public let normEpsilon: Float
+    public let queryKeyNormEpsilon: Float
+
+    public init(
+        hiddenSize: Int = 5_376,
+        layerCount: Int = 50,
+        refinerLayerCount: Int = 2,
+        attentionHeadCount: Int = 56,
+        attentionHeadDimension: Int = 128,
+        feedForwardSize: Int = 14_336,
+        videoLatentChannels: Int = 24,
+        audioLatentChannels: Int = 32,
+        patchSize: [Int] = [1, 2, 2],
+        textDimension: Int = 5_120,
+        timeFrequencyDimension: Int = 256,
+        timeEmbeddingHiddenSize: Int = 5_376,
+        timeEmbeddingDimension: Int = 2_688,
+        ropeFrequencyCount: Int = 16,
+        ropeTheta: Float = 10_000,
+        normEpsilon: Float = 1e-5,
+        queryKeyNormEpsilon: Float = 1e-5
+    ) {
+        precondition(hiddenSize > 0 && layerCount > 0 && refinerLayerCount >= 0)
+        precondition(attentionHeadCount > 0 && attentionHeadDimension > 0)
+        precondition(patchSize.count == 3)
+        self.hiddenSize = hiddenSize
+        self.layerCount = layerCount
+        self.refinerLayerCount = refinerLayerCount
+        self.attentionHeadCount = attentionHeadCount
+        self.attentionHeadDimension = attentionHeadDimension
+        self.feedForwardSize = feedForwardSize
+        self.videoLatentChannels = videoLatentChannels
+        self.audioLatentChannels = audioLatentChannels
+        self.patchSize = patchSize
+        self.textDimension = textDimension
+        self.timeFrequencyDimension = timeFrequencyDimension
+        self.timeEmbeddingHiddenSize = timeEmbeddingHiddenSize
+        self.timeEmbeddingDimension = timeEmbeddingDimension
+        self.ropeFrequencyCount = ropeFrequencyCount
+        self.ropeTheta = ropeTheta
+        self.normEpsilon = normEpsilon
+        self.queryKeyNormEpsilon = queryKeyNormEpsilon
+    }
+
+    public init(_ configuration: MiniMaxH3Configuration) {
+        self.init(
+            hiddenSize: configuration.hiddenSize,
+            layerCount: configuration.layerCount,
+            refinerLayerCount: configuration.refinerLayerCount,
+            attentionHeadCount: configuration.attentionHeadCount,
+            attentionHeadDimension: configuration.attentionHeadDimension,
+            feedForwardSize: configuration.feedForwardSize,
+            videoLatentChannels: configuration.videoLatentChannels,
+            audioLatentChannels: configuration.audioLatentChannels,
+            patchSize: configuration.patchSize,
+            textDimension: configuration.textDimension,
+            timeFrequencyDimension: configuration.timeFrequencyDimension,
+            timeEmbeddingHiddenSize: configuration.timeEmbeddingHiddenSize,
+            timeEmbeddingDimension: configuration.timeEmbeddingDimension
+        )
+    }
+
+    var videoPatchDimension: Int {
+        videoLatentChannels * patchSize.reduce(1, *)
+    }
+}
+
+public struct MiniMaxH3TransformerOutput {
+    public let videoVelocityRows: MLXArray
+    public let audioVelocityRows: MLXArray
+}
+
+private final class MiniMaxH3Attention: Module {
+    let heads: Int
+    let headDimension: Int
+    let innerDimension: Int
+    let scale: Float
+
+    @ModuleInfo(key: "qkv_proj") var queryKeyValue: Linear
+    @ModuleInfo(key: "q_norm") var queryNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: RMSNorm
+    @ModuleInfo(key: "out_proj") var output: Linear
+
+    init(configuration: MiniMaxH3TransformerConfiguration) {
+        self.heads = configuration.attentionHeadCount
+        self.headDimension = configuration.attentionHeadDimension
+        self.innerDimension = heads * headDimension
+        self.scale = 1 / sqrt(Float(headDimension))
+        self._queryKeyValue.wrappedValue = Linear(
+            configuration.hiddenSize,
+            3 * innerDimension,
+            bias: false
+        )
+        self._queryNorm.wrappedValue = RMSNorm(
+            dimensions: headDimension,
+            eps: configuration.queryKeyNormEpsilon
+        )
+        self._keyNorm.wrappedValue = RMSNorm(
+            dimensions: headDimension,
+            eps: configuration.queryKeyNormEpsilon
+        )
+        self._output.wrappedValue = Linear(innerDimension, configuration.hiddenSize, bias: false)
+    }
+
+    func callAsFunction(_ input: MLXArray, rope: MiniMaxH3RotaryEmbedding?) -> MLXArray {
+        let projected = project(input, rope: rope)
+        let attended = scaledDotProductAttention(
+            queries: projected[0],
+            keys: projected[1],
+            values: projected[2],
+            maximumQueryTokens: nil
+        )
+        return projectOutput(attended)
+    }
+
+    func project(_ input: MLXArray, rope: MiniMaxH3RotaryEmbedding?) -> [MLXArray] {
+        // The MLX-Serve artifact deinterleaves the released checkpoint's
+        // per-head rows into three global Q/K/V slabs before quantization.
+        // Do not apply the raw-checkpoint interleave a second time here.
+        let projected = miniMaxH3SplitProjectedQKV(
+            queryKeyValue(input), heads: heads, headDimension: headDimension
+        )
+        var query = queryNorm(projected[0])
+        var key = keyNorm(projected[1])
+        if let rope {
+            query = rope.apply(query)
+            key = rope.apply(key)
+        }
+        query = query.transposed(0, 2, 1, 3)
+        key = key.transposed(0, 2, 1, 3)
+        let value = projected[2].transposed(0, 2, 1, 3)
+        return [query, key, value]
+    }
+
+    func scaledDotProductAttention(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        maximumQueryTokens: Int?,
+        maximumKernelsPerEvaluation: Int = 1
+    ) -> MLXArray {
+        guard let maximumQueryTokens,
+              maximumQueryTokens > 0,
+              queries.dim(2) > maximumQueryTokens else {
+            return MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+        }
+
+        precondition(maximumKernelsPerEvaluation > 0)
+        var chunks: [MLXArray] = []
+        chunks.reserveCapacity((queries.dim(2) + maximumQueryTokens - 1) / maximumQueryTokens)
+        var pending: [MLXArray] = []
+        pending.reserveCapacity(maximumKernelsPerEvaluation)
+        for start in stride(from: 0, to: queries.dim(2), by: maximumQueryTokens) {
+            let end = min(start + maximumQueryTokens, queries.dim(2))
+            let chunk = MLXFast.scaledDotProductAttention(
+                queries: queries[0..., 0..., start..<end, 0...],
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+            chunks.append(chunk)
+            pending.append(chunk)
+            if pending.count == maximumKernelsPerEvaluation {
+                MLX.eval(pending)
+                pending.removeAll(keepingCapacity: true)
+            }
+        }
+        if !pending.isEmpty {
+            MLX.eval(pending)
+        }
+        return MLX.concatenated(chunks, axis: 2)
+    }
+
+    func projectOutput(_ attended: MLXArray) -> MLXArray {
+        let batch = attended.dim(0)
+        let sequence = attended.dim(2)
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, innerDimension))
+    }
+}
+
+private final class MiniMaxH3FeedForward: Module {
+    @ModuleInfo(key: "fc1") var input: Linear
+    @ModuleInfo(key: "fc2") var output: Linear
+
+    init(configuration: MiniMaxH3TransformerConfiguration) {
+        self._input.wrappedValue = Linear(
+            configuration.hiddenSize,
+            2 * configuration.feedForwardSize,
+            bias: false
+        )
+        self._output.wrappedValue = Linear(
+            configuration.feedForwardSize,
+            configuration.hiddenSize,
+            bias: false
+        )
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(project(value))
+    }
+
+    func project(_ value: MLXArray) -> MLXArray {
+        let parts = MLX.split(input(value), parts: 2, axis: -1)
+        return MLXNN.silu(parts[0]) * parts[1]
+    }
+
+    func projectOutput(_ value: MLXArray) -> MLXArray {
+        output(value)
+    }
+}
+
+private final class MiniMaxH3TokenRefinerBlock: Module {
+    @ModuleInfo(key: "norm1") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attn") var attention: MiniMaxH3Attention
+    @ModuleInfo(key: "norm2") var feedForwardNorm: RMSNorm
+    @ModuleInfo(key: "mlp") var feedForward: MiniMaxH3FeedForward
+
+    init(configuration: MiniMaxH3TransformerConfiguration) {
+        self._attentionNorm.wrappedValue = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.normEpsilon
+        )
+        self._attention.wrappedValue = MiniMaxH3Attention(configuration: configuration)
+        self._feedForwardNorm.wrappedValue = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.normEpsilon
+        )
+        self._feedForward.wrappedValue = MiniMaxH3FeedForward(configuration: configuration)
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        let attended = value + attention(attentionNorm(value), rope: nil)
+        return attended + feedForward(feedForwardNorm(attended))
+    }
+}
+
+private final class MiniMaxH3TokenRefiner: Module {
+    @ModuleInfo(key: "blocks") var blocks: [MiniMaxH3TokenRefinerBlock]
+    @ModuleInfo(key: "final_norm") var finalNorm: RMSNorm
+
+    init(configuration: MiniMaxH3TransformerConfiguration) {
+        self._blocks.wrappedValue = (0..<configuration.refinerLayerCount).map { _ in
+            MiniMaxH3TokenRefinerBlock(configuration: configuration)
+        }
+        self._finalNorm.wrappedValue = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.normEpsilon
+        )
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        finalNorm(blocks.reduce(value) { hidden, block in block(hidden) })
+    }
+}
+
+private final class MiniMaxH3AdaLNProjection: Module {
+    let hiddenSize: Int
+    let partCount: Int
+    let modalityCount: Int
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    init(inputDimension: Int, hiddenSize: Int, partCount: Int, modalityCount: Int) {
+        self.hiddenSize = hiddenSize
+        self.partCount = partCount
+        self.modalityCount = modalityCount
+        self._linear.wrappedValue = Linear(
+            inputDimension,
+            partCount * modalityCount * hiddenSize,
+            bias: true
+        )
+    }
+
+    func callAsFunction(_ timeEmbedding: MLXArray) -> [MLXArray] {
+        let projected = miniMaxH3Linear(linear, MLXNN.silu(timeEmbedding))
+            .reshaped(timeEmbedding.dim(0) * modalityCount, partCount * hiddenSize)
+        return MLX.split(projected, parts: partCount, axis: -1)
+    }
+
+    func concatenated(_ timeEmbedding: MLXArray) -> MLXArray {
+        MLX.concatenated(self(timeEmbedding), axis: -1)
+    }
+}
+
+private final class MiniMaxH3TimeEmbedding: Module {
+    @ModuleInfo(key: "proj_in") var input: Linear
+    @ModuleInfo(key: "proj_out") var output: Linear
+
+    init(configuration: MiniMaxH3TransformerConfiguration) {
+        self._input.wrappedValue = Linear(
+            configuration.timeFrequencyDimension,
+            configuration.timeEmbeddingHiddenSize,
+            bias: true
+        )
+        self._output.wrappedValue = Linear(
+            configuration.timeEmbeddingHiddenSize,
+            configuration.timeEmbeddingDimension,
+            bias: true
+        )
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        miniMaxH3Linear(output, MLXNN.silu(miniMaxH3Linear(input, value)))
+    }
+}
+
+private final class MiniMaxH3TransformerBlock: Module {
+    @ModuleInfo(key: "norm1") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attn") var attention: MiniMaxH3Attention
+    @ModuleInfo(key: "norm2") var feedForwardNorm: RMSNorm
+    @ModuleInfo(key: "mlp") var feedForward: MiniMaxH3FeedForward
+    @ModuleInfo(key: "adaln_proj") var adaLN: MiniMaxH3AdaLNProjection?
+
+    init(configuration: MiniMaxH3TransformerConfiguration, includeAdaLN: Bool) {
+        self._attentionNorm.wrappedValue = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.normEpsilon
+        )
+        self._attention.wrappedValue = MiniMaxH3Attention(configuration: configuration)
+        self._feedForwardNorm.wrappedValue = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.normEpsilon
+        )
+        self._feedForward.wrappedValue = MiniMaxH3FeedForward(configuration: configuration)
+        self._adaLN.wrappedValue = includeAdaLN
+            ? MiniMaxH3AdaLNProjection(
+                inputDimension: configuration.timeEmbeddingDimension,
+                hiddenSize: configuration.hiddenSize,
+                partCount: 6,
+                modalityCount: 3
+            )
+            : nil
+    }
+
+    var includesAdaLN: Bool {
+        adaLN != nil
+    }
+
+    func callAsFunction(
+        _ value: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        rope: MiniMaxH3RotaryEmbedding,
+        cachedModulation: MLXArray?
+    ) -> MLXArray {
+        let attended = attentionResidual(
+            value,
+            timeEmbedding: timeEmbedding,
+            adaLNIndices: adaLNIndices,
+            rope: rope,
+            cachedModulation: cachedModulation
+        )
+        return feedForwardResidual(
+            attended,
+            timeEmbedding: timeEmbedding,
+            adaLNIndices: adaLNIndices,
+            cachedModulation: cachedModulation
+        )
+    }
+
+    func attentionResidual(
+        _ value: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        rope: MiniMaxH3RotaryEmbedding,
+        cachedModulation: MLXArray?
+    ) -> MLXArray {
+        let modulation: [MLXArray]
+        if let cachedModulation {
+            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+        } else {
+            guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+            modulation = adaLN(timeEmbedding)
+        }
+        let shiftAttention = MLX.take(modulation[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let scaleAttention = MLX.take(modulation[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        return value + gateAttention * attention(attentionInput, rope: rope)
+    }
+
+    func feedForwardResidual(
+        _ attended: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        cachedModulation: MLXArray?
+    ) -> MLXArray {
+        let modulation: [MLXArray]
+        if let cachedModulation {
+            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+        } else {
+            guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+            modulation = adaLN(timeEmbedding)
+        }
+        let shiftFeedForward = MLX.take(modulation[3], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let scaleFeedForward = MLX.take(modulation[4], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let gateFeedForward = MLX.take(modulation[5], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let feedForwardInput = feedForwardNorm(attended) * (1 + scaleFeedForward) + shiftFeedForward
+        return attended + gateFeedForward * feedForward(feedForwardInput)
+    }
+
+    func attentionProjection(
+        _ value: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        rope: MiniMaxH3RotaryEmbedding,
+        cachedModulation: MLXArray?
+    ) -> [MLXArray] {
+        let modulation: [MLXArray]
+        if let cachedModulation {
+            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+        } else {
+            guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+            modulation = adaLN(timeEmbedding)
+        }
+        let shiftAttention = MLX.take(modulation[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let scaleAttention = MLX.take(modulation[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        return attention.project(attentionInput, rope: rope) + [gateAttention]
+    }
+
+    func scaledDotProductAttention(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        maximumQueryTokens: Int,
+        maximumKernelsPerEvaluation: Int
+    ) -> MLXArray {
+        attention.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            maximumQueryTokens: maximumQueryTokens,
+            maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
+        )
+    }
+
+    func attentionProjectionResidual(
+        _ value: MLXArray,
+        attended: MLXArray,
+        gate: MLXArray
+    ) -> MLXArray {
+        value + gate * attention.projectOutput(attended)
+    }
+
+    func feedForwardProjection(
+        _ attended: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        cachedModulation: MLXArray?
+    ) -> [MLXArray] {
+        let modulation: [MLXArray]
+        if let cachedModulation {
+            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+        } else {
+            guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+            modulation = adaLN(timeEmbedding)
+        }
+        let shiftFeedForward = MLX.take(modulation[3], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let scaleFeedForward = MLX.take(modulation[4], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let gateFeedForward = MLX.take(modulation[5], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let feedForwardInput = feedForwardNorm(attended) * (1 + scaleFeedForward) + shiftFeedForward
+        return [feedForward.project(feedForwardInput), gateFeedForward]
+    }
+
+    func feedForwardProjectionResidual(
+        _ attended: MLXArray,
+        projected: MLXArray,
+        gate: MLXArray
+    ) -> MLXArray {
+        attended + gate * feedForward.projectOutput(projected)
+    }
+
+    func precomputeModulation(timeEmbedding: MLXArray) -> MLXArray {
+        guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN weights are not loaded") }
+        return adaLN.concatenated(timeEmbedding)
+    }
+}
+
+private final class MiniMaxH3FinalLayer: Module {
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "adaln_proj") var adaLN: MiniMaxH3AdaLNProjection?
+    @ModuleInfo(key: "video_out") var videoOutput: Linear
+    @ModuleInfo(key: "audio_out") var audioOutput: Linear
+
+    init(configuration: MiniMaxH3TransformerConfiguration, includeAdaLN: Bool) {
+        self._norm.wrappedValue = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.normEpsilon
+        )
+        self._adaLN.wrappedValue = includeAdaLN
+            ? MiniMaxH3AdaLNProjection(
+                inputDimension: configuration.timeEmbeddingDimension,
+                hiddenSize: configuration.hiddenSize,
+                partCount: 2,
+                modalityCount: 1
+            )
+            : nil
+        self._videoOutput.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.videoPatchDimension,
+            bias: true
+        )
+        self._audioOutput.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.audioLatentChannels,
+            bias: true
+        )
+    }
+
+    func callAsFunction(
+        _ value: MLXArray,
+        timeEmbedding: MLXArray,
+        videoRows: Range<Int>,
+        videoTimeIndex: Int32,
+        audioRows: Range<Int>,
+        audioTimeIndex: Int32,
+        cachedModulation: MLXArray?
+    ) -> MiniMaxH3TransformerOutput {
+        let modulation: [MLXArray]
+        if let cachedModulation {
+            modulation = MLX.split(cachedModulation, parts: 2, axis: -1)
+        } else {
+            guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+            modulation = adaLN(timeEmbedding)
+        }
+        let normalizedVideo = norm(value[0..., videoRows, 0...])
+        let videoIndex = MLXArray([videoTimeIndex])
+        let videoHidden = normalizedVideo * (1 + MLX.take(modulation[1], videoIndex, axis: 0))
+            + MLX.take(modulation[0], videoIndex, axis: 0)
+        let normalizedAudio = norm(value[0..., audioRows, 0...])
+        let audioIndex = MLXArray([audioTimeIndex])
+        let audioHidden = normalizedAudio * (1 + MLX.take(modulation[1], audioIndex, axis: 0))
+            + MLX.take(modulation[0], audioIndex, axis: 0)
+        return MiniMaxH3TransformerOutput(
+            videoVelocityRows: miniMaxH3Linear(videoOutput, videoHidden),
+            audioVelocityRows: miniMaxH3Linear(audioOutput, audioHidden)
+        )
+    }
+
+    func precomputeModulation(timeEmbedding: MLXArray) -> MLXArray {
+        guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN weights are not loaded") }
+        return adaLN.concatenated(timeEmbedding)
+    }
+}
+
+struct MiniMaxH3TransformerPreparedContext {
+    let text: MLXArray
+    let adaLNIndices: MLXArray
+    let rope: MiniMaxH3RotaryEmbedding
+    let layout: MiniMaxH3PackedLayout
+}
+
+struct MiniMaxH3AdaLNStep {
+    let timeEmbedding: MLXArray
+    let blockModulations: [MLXArray]
+    let finalModulation: MLXArray
+}
+
+private typealias MiniMaxH3CompiledBlockForward = @Sendable ([MLXArray]) -> [MLXArray]
+
+private struct MiniMaxH3CompiledBlockForwards {
+    let attentionProjection: MiniMaxH3CompiledBlockForward
+    let attentionOutput: MiniMaxH3CompiledBlockForward
+    let feedForwardProjection: MiniMaxH3CompiledBlockForward
+    let feedForwardOutput: MiniMaxH3CompiledBlockForward
+}
+
+struct MiniMaxH3ResidentBF16Materialization: Sendable, Equatable {
+    let linearCount: Int
+    let byteCount: UInt64
+}
+
+private func miniMaxH3ResidentBF16Linear(
+    _ linear: Linear
+) -> (linear: Linear, byteCount: UInt64)? {
+    guard let quantized = linear as? QuantizedLinear else { return nil }
+    var weight = MLX.dequantized(
+        quantized.weight,
+        scales: quantized.scales,
+        biases: quantized.biases,
+        groupSize: quantized.groupSize,
+        bits: quantized.bits,
+        mode: quantized.mode,
+        dtype: .bfloat16
+    )
+    if let globalScale = quantized.globalScale {
+        weight = (weight * (globalScale / (448 * 6))).asType(.bfloat16)
+    }
+    let bias = quantized.bias?.asType(.bfloat16)
+    if let bias {
+        MLX.eval(weight, bias)
+    } else {
+        MLX.eval(weight)
+    }
+    let shape = quantized.shape
+    let weightBytes = UInt64(shape.0) * UInt64(shape.1) * 2
+    let biasBytes = UInt64(quantized.bias?.size ?? 0) * 2
+    return (Linear(weight: weight, bias: bias), weightBytes + biasBytes)
+}
+
+private func miniMaxH3MaterializeResidentBF16(
+    in module: Module
+) -> MiniMaxH3ResidentBF16Materialization {
+    var replacements: [(String, Module)] = []
+    var byteCount: UInt64 = 0
+    for (path, leaf) in module.leafModules().flattened() {
+        guard let linear = leaf as? Linear,
+              let resident = miniMaxH3ResidentBF16Linear(linear) else { continue }
+        replacements.append((path, resident.linear))
+        byteCount += resident.byteCount
+    }
+    if !replacements.isEmpty {
+        module.update(modules: ModuleChildren.unflattened(replacements))
+    }
+    return .init(linearCount: replacements.count, byteCount: byteCount)
+}
+
+struct MiniMaxH3RotaryEmbedding {
+    let cosine: MLXArray
+    let sine: MLXArray
+
+    func apply(_ value: MLXArray) -> MLXArray {
+        let rotaryDimension = cosine.dim(-1)
+        let rotary = value[0..., 0..., 0..., 0..<rotaryDimension]
+        let passthrough = value[0..., 0..., 0..., rotaryDimension...]
+        let halves = MLX.split(rotary, parts: 2, axis: -1)
+        let rotated = MLX.concatenated([-halves[1], halves[0]], axis: -1)
+        return MLX.concatenated(
+            [rotary * cosine + rotated * sine, passthrough],
+            axis: -1
+        )
+    }
+}
+
+public final class MiniMaxH3Transformer: Module {
+    public let configuration: MiniMaxH3TransformerConfiguration
+    var usesLayerwiseEvaluation = false
+    var clearsCacheAfterLayerwiseEvaluation = true
+    var usesBlockwiseCompilation = false
+    private(set) var usesResidentBF16 = false
+    var maximumAttentionQueryTokensPerKernel = 2_048
+    var maximumAttentionKernelsPerEvaluation = 4
+    var blockTimingHandler: ((Int, TimeInterval, Memory.Snapshot) -> Void)?
+    @ModuleInfo(key: "video_patch_proj") var videoInput: Linear
+    @ModuleInfo(key: "audio_patch_proj") var audioInput: Linear
+    @ModuleInfo(key: "condition_proj") var textInput: Linear
+    @ModuleInfo(key: "time_embedder") private var timeEmbedder: MiniMaxH3TimeEmbedding?
+    @ModuleInfo(key: "token_refiner") private var tokenRefiner: MiniMaxH3TokenRefiner
+    @ModuleInfo(key: "blocks") private var blocks: [MiniMaxH3TransformerBlock]
+    @ModuleInfo(key: "final_layer") private var finalLayer: MiniMaxH3FinalLayer
+
+    private let inverseFrequencies: MLXArray
+    private let timeFrequencies: MLXArray
+    private var compiledBlockRunner: MiniMaxH3TransformerBlock?
+    private var compiledBlockForwards: MiniMaxH3CompiledBlockForwards?
+
+    public init(
+        configuration: MiniMaxH3TransformerConfiguration = .init(),
+        includeAdaLN: Bool = true
+    ) {
+        self.configuration = configuration
+        self._videoInput.wrappedValue = Linear(
+            configuration.videoPatchDimension,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._audioInput.wrappedValue = Linear(
+            configuration.audioLatentChannels,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._textInput.wrappedValue = Linear(
+            configuration.textDimension,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._timeEmbedder.wrappedValue = includeAdaLN
+            ? MiniMaxH3TimeEmbedding(configuration: configuration)
+            : nil
+        self._tokenRefiner.wrappedValue = MiniMaxH3TokenRefiner(configuration: configuration)
+        self._blocks.wrappedValue = (0..<configuration.layerCount).map { _ in
+            MiniMaxH3TransformerBlock(configuration: configuration, includeAdaLN: includeAdaLN)
+        }
+        self._finalLayer.wrappedValue = MiniMaxH3FinalLayer(
+            configuration: configuration,
+            includeAdaLN: includeAdaLN
+        )
+        let frequencies = (0..<configuration.ropeFrequencyCount).map { index in
+            1 / pow(configuration.ropeTheta, Float(index) / Float(configuration.ropeFrequencyCount))
+        }
+        self.inverseFrequencies = MLXArray(frequencies)
+        let halfTimeDimension = configuration.timeFrequencyDimension / 2
+        self.timeFrequencies = MLXArray((0..<halfTimeDimension).map { index in
+            exp(-log(Float(10_000)) * Float(index) / Float(halfTimeDimension))
+        })
+    }
+
+    var estimatedResidentBF16ByteCount: UInt64 {
+        leafModules().flattened().reduce(into: UInt64(0)) { total, entry in
+            guard let quantized = entry.1 as? QuantizedLinear else { return }
+            let shape = quantized.shape
+            total += UInt64(shape.0) * UInt64(shape.1) * 2
+            total += UInt64(quantized.bias?.size ?? 0) * 2
+        }
+    }
+
+    /// Expands compact quantized storage into resident bf16 linear weights.
+    /// Each transformer/refiner block is replaced and the Metal cache is
+    /// cleared before moving to the next one, bounding conversion residency
+    /// instead of retaining a second whole-model copy.
+    func materializeResidentBF16() -> MiniMaxH3ResidentBF16Materialization {
+        compiledBlockRunner = nil
+        compiledBlockForwards = nil
+        var total = MiniMaxH3ResidentBF16Materialization(linearCount: 0, byteCount: 0)
+
+        func include(_ materialization: MiniMaxH3ResidentBF16Materialization) {
+            total = .init(
+                linearCount: total.linearCount + materialization.linearCount,
+                byteCount: total.byteCount + materialization.byteCount
+            )
+            MLX.Memory.clearCache()
+        }
+
+        for block in tokenRefiner.blocks {
+            include(miniMaxH3MaterializeResidentBF16(in: block))
+        }
+        for block in blocks {
+            include(miniMaxH3MaterializeResidentBF16(in: block))
+        }
+        if let timeEmbedder {
+            include(miniMaxH3MaterializeResidentBF16(in: timeEmbedder))
+        }
+        include(miniMaxH3MaterializeResidentBF16(in: finalLayer))
+
+        var rootReplacements: [(String, Module)] = []
+        var rootBytes: UInt64 = 0
+        for (path, linear) in [
+            ("video_patch_proj", videoInput),
+            ("audio_patch_proj", audioInput),
+            ("condition_proj", textInput),
+        ] {
+            guard let resident = miniMaxH3ResidentBF16Linear(linear) else { continue }
+            rootReplacements.append((path, resident.linear))
+            rootBytes += resident.byteCount
+        }
+        if !rootReplacements.isEmpty {
+            update(modules: ModuleChildren.unflattened(rootReplacements))
+            include(.init(linearCount: rootReplacements.count, byteCount: rootBytes))
+        }
+        usesResidentBF16 = total.linearCount > 0
+        return total
+    }
+
+    public func callAsFunction(
+        videoRows: MLXArray,
+        audioRows: MLXArray,
+        textStates: MLXArray,
+        layout: MiniMaxH3PackedLayout,
+        videoTimestep: Float,
+        audioTimestep: Float,
+        conditionVideoTimestep: Float = 0.999
+    ) -> MiniMaxH3TransformerOutput {
+        let context = prepare(textStates: textStates, layout: layout)
+        return self(
+            videoRows: videoRows,
+            audioRows: audioRows,
+            context: context,
+            timesteps: MLXArray([
+                videoTimestep,
+                audioTimestep,
+                max(videoTimestep, conditionVideoTimestep),
+            ]),
+            cachedAdaLN: nil
+        )
+    }
+
+    func prepare(
+        textStates: MLXArray,
+        layout: MiniMaxH3PackedLayout
+    ) -> MiniMaxH3TransformerPreparedContext {
+        precondition(textStates.dim(1) == layout.textRows.count)
+        let text = tokenRefiner(miniMaxH3Linear(textInput, textStates))
+        var timeIndices = Array(repeating: 0, count: layout.sequenceLength)
+        for row in layout.conditionRows { timeIndices[row] = 2 }
+        for row in layout.targetAudioRows { timeIndices[row] = 1 }
+        let adaLNIndices = MLXArray(zip(timeIndices, layout.tokenTags).map { timeIndex, tag in
+            Int32(timeIndex * 3) + max(tag, 0)
+        })
+        let rope = rotaryEmbedding(positions: layout.positions)
+        MLX.eval(text, adaLNIndices, rope.cosine, rope.sine)
+        return MiniMaxH3TransformerPreparedContext(
+            text: text,
+            adaLNIndices: adaLNIndices,
+            rope: rope,
+            layout: layout
+        )
+    }
+
+    func callAsFunction(
+        videoRows: MLXArray,
+        audioRows: MLXArray,
+        context: MiniMaxH3TransformerPreparedContext,
+        timesteps: MLXArray,
+        cachedAdaLN: MiniMaxH3AdaLNStep?
+    ) -> MiniMaxH3TransformerOutput {
+        let layout = context.layout
+        precondition(videoRows.dim(1) == layout.conditionVideoRowCount + layout.targetVideoRows.count)
+        precondition(audioRows.dim(1) == layout.conditionAudioRowCount + layout.targetAudioRows.count)
+        precondition(timesteps.shape == [3])
+        let video = miniMaxH3Linear(videoInput, videoRows).asType(context.text.dtype)
+        let audio = miniMaxH3Linear(audioInput, audioRows).asType(context.text.dtype)
+        let targetVideo = video[0..., layout.conditionVideoRowCount..., 0...]
+        let targetAudio = audio[0..., layout.conditionAudioRowCount..., 0...]
+        var packed: [MLXArray] = [context.text]
+        for segment in layout.conditionSegments {
+            switch segment.modality {
+            case .video:
+                packed.append(video[0..., segment.sourceRows, 0...])
+            case .audio:
+                packed.append(audio[0..., segment.sourceRows, 0...])
+            case .text:
+                preconditionFailure("condition segments cannot contain text")
+            }
+        }
+        packed.append(targetAudio)
+        packed.append(targetVideo)
+        var hidden = MLX.concatenated(packed, axis: 1)
+
+        let timeEmbedding = cachedAdaLN?.timeEmbedding ?? embedTimesteps(timesteps)
+        if let cachedAdaLN {
+            precondition(cachedAdaLN.blockModulations.count == blocks.count)
+        }
+        for (index, block) in blocks.enumerated() {
+            let blockStarted = blockTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
+            if usesBlockwiseCompilation {
+                var attentionInputs = [
+                    hidden,
+                    timeEmbedding,
+                    context.adaLNIndices,
+                    context.rope.cosine,
+                    context.rope.sine,
+                ]
+                if let modulation = cachedAdaLN?.blockModulations[index] {
+                    attentionInputs.append(modulation)
+                }
+                let compiled = compiledBlockForward(for: block)
+                let projectedAttention = compiled.attentionProjection(attentionInputs)
+                MLX.eval(projectedAttention)
+                let attended = block.scaledDotProductAttention(
+                    queries: projectedAttention[0],
+                    keys: projectedAttention[1],
+                    values: projectedAttention[2],
+                    maximumQueryTokens: maximumAttentionQueryTokensPerKernel,
+                    maximumKernelsPerEvaluation: maximumAttentionKernelsPerEvaluation
+                )
+                hidden = compiled.attentionOutput([hidden, attended, projectedAttention[3]])[0]
+                MLX.eval(hidden)
+                var feedForwardInputs = [hidden, timeEmbedding, context.adaLNIndices]
+                if let modulation = cachedAdaLN?.blockModulations[index] {
+                    feedForwardInputs.append(modulation)
+                }
+                let projectedFeedForward = compiled.feedForwardProjection(feedForwardInputs)
+                MLX.eval(projectedFeedForward)
+                hidden = compiled.feedForwardOutput([
+                    hidden,
+                    projectedFeedForward[0],
+                    projectedFeedForward[1],
+                ])[0]
+                MLX.eval(hidden)
+            } else {
+                hidden = block(
+                    hidden,
+                    timeEmbedding: timeEmbedding,
+                    adaLNIndices: context.adaLNIndices,
+                    rope: context.rope,
+                    cachedModulation: cachedAdaLN?.blockModulations[index]
+                )
+            }
+            if usesLayerwiseEvaluation || blockTimingHandler != nil {
+                MLX.eval(hidden)
+                if clearsCacheAfterLayerwiseEvaluation {
+                    MLX.Memory.clearCache()
+                }
+            }
+            if let blockStarted, let blockTimingHandler {
+                blockTimingHandler(
+                    index,
+                    CFAbsoluteTimeGetCurrent() - blockStarted,
+                    Memory.snapshot()
+                )
+            }
+        }
+        return finalLayer(
+            hidden,
+            timeEmbedding: timeEmbedding,
+            videoRows: layout.targetVideoRows,
+            videoTimeIndex: 0,
+            audioRows: layout.targetAudioRows,
+            audioTimeIndex: 1,
+            cachedModulation: cachedAdaLN?.finalModulation
+        )
+    }
+
+    private func compiledBlockForward(
+        for block: MiniMaxH3TransformerBlock
+    ) -> MiniMaxH3CompiledBlockForwards {
+        if let compiledBlockRunner, let compiledBlockForwards {
+            compiledBlockRunner.update(parameters: block.parameters())
+            return compiledBlockForwards
+        }
+
+        let runner = makeCompiledBlockRunner(from: block)
+        runner.update(parameters: block.parameters())
+        let attentionProjection = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+            runner.attentionProjection(
+                inputs[0],
+                timeEmbedding: inputs[1],
+                adaLNIndices: inputs[2],
+                rope: MiniMaxH3RotaryEmbedding(cosine: inputs[3], sine: inputs[4]),
+                cachedModulation: inputs.count == 6 ? inputs[5] : nil
+            )
+        }
+        let attentionOutput = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+            [runner.attentionProjectionResidual(
+                inputs[0],
+                attended: inputs[1],
+                gate: inputs[2]
+            )]
+        }
+        let feedForwardProjection = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+            runner.feedForwardProjection(
+                inputs[0],
+                timeEmbedding: inputs[1],
+                adaLNIndices: inputs[2],
+                cachedModulation: inputs.count == 4 ? inputs[3] : nil
+            )
+        }
+        let feedForwardOutput = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+            [runner.feedForwardProjectionResidual(
+                inputs[0],
+                projected: inputs[1],
+                gate: inputs[2]
+            )]
+        }
+        let forwards = MiniMaxH3CompiledBlockForwards(
+            attentionProjection: attentionProjection,
+            attentionOutput: attentionOutput,
+            feedForwardProjection: feedForwardProjection,
+            feedForwardOutput: feedForwardOutput
+        )
+        compiledBlockRunner = runner
+        compiledBlockForwards = forwards
+        return forwards
+    }
+
+    private func makeCompiledBlockRunner(
+        from block: MiniMaxH3TransformerBlock
+    ) -> MiniMaxH3TransformerBlock {
+        let runner = MiniMaxH3TransformerBlock(
+            configuration: configuration,
+            includeAdaLN: block.includesAdaLN
+        )
+        let replacements: [(String, Module)] = block.leafModules().flattened().compactMap { path, module in
+            guard let quantized = module as? QuantizedLinear else { return nil }
+            let weight = MLXArray.zeros(quantized.weight.shape, dtype: quantized.weight.dtype)
+            let bias = quantized.bias.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }
+            let scales = MLXArray.zeros(quantized.scales.shape, dtype: quantized.scales.dtype)
+            let biases = quantized.biases.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }
+            let globalScale = quantized.globalScale.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }
+            let clone: Module
+            if let portable = quantized as? PortableQuantizedLinear {
+                let portableClone = PortableQuantizedLinear(
+                    weight: weight,
+                    bias: bias,
+                    scales: scales,
+                    biases: biases,
+                    groupSize: portable.groupSize,
+                    bits: portable.bits,
+                    mode: portable.mode,
+                    globalScale: globalScale
+                )
+                portableClone.cacheDenseFallbackWeight = portable.cacheDenseFallbackWeight
+                portableClone.useUncachedDenseFallback = portable.useUncachedDenseFallback
+                clone = portableClone
+            } else {
+                clone = QuantizedLinear(
+                    weight: weight,
+                    bias: bias,
+                    scales: scales,
+                    biases: biases,
+                    groupSize: quantized.groupSize,
+                    bits: quantized.bits,
+                    mode: quantized.mode,
+                    globalScale: globalScale
+                )
+            }
+            return (path, clone)
+        }
+        runner.update(modules: ModuleChildren.unflattened(replacements))
+        return runner
+    }
+
+    func precomputeAdaLN(
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule,
+        sourceIdentity: String,
+        progressHandler: (@Sendable (Int, Int) -> Void)? = nil
+    ) -> MiniMaxH3AdaLNCache {
+        precondition(videoSchedule.timesteps.count == audioSchedule.timesteps.count)
+        let stepCount = videoSchedule.timesteps.count
+        let flattenedTimesteps = videoSchedule.timesteps.indices.flatMap { index in
+            let videoTimestep = videoSchedule.timesteps[index]
+            let audioTimestep = audioSchedule.timesteps[index]
+            return [videoTimestep, audioTimestep, max(videoTimestep, 0.999)]
+        }
+        let timeEmbeddings = embedTimesteps(MLXArray(flattenedTimesteps))
+            .reshaped(stepCount, 3, configuration.timeEmbeddingDimension)
+        MLX.eval(timeEmbeddings)
+
+        let progressTotal = blocks.count + 2
+        progressHandler?(1, progressTotal)
+        var blockModulations: [MLXArray] = []
+        blockModulations.reserveCapacity(blocks.count)
+        for (index, block) in blocks.enumerated() {
+            let modulation = block.precomputeModulation(
+                timeEmbedding: timeEmbeddings.reshaped(stepCount * 3, configuration.timeEmbeddingDimension)
+            ).reshaped(stepCount, 3 * 3, 6 * configuration.hiddenSize)
+            MLX.eval(modulation)
+            blockModulations.append(modulation)
+            progressHandler?(index + 2, progressTotal)
+        }
+        let finalModulations = finalLayer.precomputeModulation(
+            timeEmbedding: timeEmbeddings.reshaped(stepCount * 3, configuration.timeEmbeddingDimension)
+        ).reshaped(stepCount, 3, 2 * configuration.hiddenSize)
+        MLX.eval(finalModulations)
+        progressHandler?(progressTotal, progressTotal)
+        return MiniMaxH3AdaLNCache(
+            timeEmbeddings: timeEmbeddings,
+            blockModulations: blockModulations,
+            finalModulations: finalModulations,
+            videoSigmas: videoSchedule.sigmas,
+            audioSigmas: audioSchedule.sigmas,
+            sourceIdentity: sourceIdentity
+        )
+    }
+
+    private func embedTimesteps(_ timesteps: MLXArray) -> MLXArray {
+        guard let timeEmbedder else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+        let arguments = timesteps.reshaped(-1, 1) * timeFrequencies.reshaped(1, -1)
+        let sinusoidal = MLX.concatenated([MLX.cos(arguments), MLX.sin(arguments)], axis: -1)
+        return timeEmbedder(sinusoidal.asType(.float32))
+    }
+
+    private func rotaryEmbedding(positions: MLXArray) -> MiniMaxH3RotaryEmbedding {
+        let frequencies = positions.asType(.float32).expandedDimensions(axis: -1)
+            * inverseFrequencies.reshaped(1, 1, -1)
+        let combined = frequencies.reshaped(positions.dim(0), 3 * configuration.ropeFrequencyCount)
+        let angles = MLX.concatenated([combined, combined], axis: -1)
+            .reshaped(1, positions.dim(0), 1, 6 * configuration.ropeFrequencyCount)
+        return MiniMaxH3RotaryEmbedding(cosine: MLX.cos(angles), sine: MLX.sin(angles))
+    }
+
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoEncoder.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoEncoder.swift
@@ -1,0 +1,205 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+final class MiniMaxH3CausalConv3D: Module {
+    let kernel: (Int, Int, Int)
+    let stride: (Int, Int, Int)
+    let spatialPadding: Int
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    @ParameterInfo(key: "bias") var bias: MLXArray
+
+    init(
+        inputChannels: Int,
+        outputChannels: Int,
+        kernel: (Int, Int, Int),
+        stride: (Int, Int, Int) = (1, 1, 1),
+        spatialPadding: Int = 0
+    ) {
+        self.kernel = kernel
+        self.stride = stride
+        self.spatialPadding = spatialPadding
+        _weight.wrappedValue = MLXArray.zeros([outputChannels, kernel.0, kernel.1, kernel.2, inputChannels])
+        _bias.wrappedValue = MLXArray.zeros([outputChannels])
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        var hidden = value
+        if kernel.0 > 1 {
+            hidden = MLX.concatenated([
+                MLXArray.zeros(
+                    [hidden.dim(0), kernel.0 - 1, hidden.dim(2), hidden.dim(3), hidden.dim(4)],
+                    dtype: hidden.dtype
+                ),
+                hidden,
+            ], axis: 1)
+        }
+        if spatialPadding > 0 {
+            hidden = MiniMaxH3CausalConv3D.reflectPad(hidden, amount: spatialPadding)
+        }
+        return MLX.conv3d(
+            hidden,
+            weight,
+            stride: .init([stride.0, stride.1, stride.2]),
+            padding: .init(0)
+        ) + bias
+    }
+
+    static func reflectPad(_ value: MLXArray, amount: Int) -> MLXArray {
+        var hidden = value
+        let reverse = MLXArray(Array(Swift.stride(from: amount - 1, through: 0, by: -1)).map(Int32.init))
+        let top = MLX.take(hidden[0..., 0..., 1..<(amount + 1), 0..., 0...], reverse, axis: 2)
+        let bottom = MLX.take(
+            hidden[0..., 0..., (hidden.dim(2) - amount - 1)..<(hidden.dim(2) - 1), 0..., 0...],
+            reverse,
+            axis: 2
+        )
+        hidden = MLX.concatenated([top, hidden, bottom], axis: 2)
+        let left = MLX.take(hidden[0..., 0..., 0..., 1..<(amount + 1), 0...], reverse, axis: 3)
+        let right = MLX.take(
+            hidden[0..., 0..., 0..., (hidden.dim(3) - amount - 1)..<(hidden.dim(3) - 1), 0...],
+            reverse,
+            axis: 3
+        )
+        return MLX.concatenated([left, hidden, right], axis: 3)
+    }
+}
+
+final class MiniMaxH3FrameGroupNorm: Module {
+    let groups: Int
+    let channels: Int
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    @ParameterInfo(key: "bias") var bias: MLXArray
+
+    init(groups: Int = 32, channels: Int) {
+        self.groups = groups
+        self.channels = channels
+        _weight.wrappedValue = MLXArray.ones([channels])
+        _bias.wrappedValue = MLXArray.zeros([channels])
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        let batch = value.dim(0)
+        let frames = value.dim(1)
+        let height = value.dim(2)
+        let width = value.dim(3)
+        var hidden = value.asType(.float32).reshaped(batch * frames, height * width, groups, channels / groups)
+        let mean = MLX.mean(hidden, axes: [1, 3], keepDims: true)
+        let variance = MLX.mean((hidden - mean) * (hidden - mean), axes: [1, 3], keepDims: true)
+        hidden = (hidden - mean) / MLX.sqrt(variance + 1e-6)
+        hidden = hidden.reshaped(batch, frames, height, width, channels)
+        return (hidden * weight.reshaped(1, 1, 1, 1, channels) + bias.reshaped(1, 1, 1, 1, channels))
+            .asType(value.dtype)
+    }
+}
+
+final class MiniMaxH3VideoEncoderResnet: Module {
+    @ModuleInfo(key: "norm1") var firstNorm: MiniMaxH3FrameGroupNorm
+    @ModuleInfo(key: "conv1") var firstConvolution: MiniMaxH3CausalConv3D
+    @ModuleInfo(key: "norm2") var secondNorm: MiniMaxH3FrameGroupNorm
+    @ModuleInfo(key: "conv2") var secondConvolution: MiniMaxH3CausalConv3D
+    @ModuleInfo(key: "conv_shortcut") var shortcut: MiniMaxH3CausalConv3D?
+
+    init(inputChannels: Int, outputChannels: Int) {
+        _firstNorm.wrappedValue = MiniMaxH3FrameGroupNorm(channels: inputChannels)
+        _firstConvolution.wrappedValue = MiniMaxH3CausalConv3D(
+            inputChannels: inputChannels, outputChannels: outputChannels, kernel: (3, 3, 3), spatialPadding: 1
+        )
+        _secondNorm.wrappedValue = MiniMaxH3FrameGroupNorm(channels: outputChannels)
+        _secondConvolution.wrappedValue = MiniMaxH3CausalConv3D(
+            inputChannels: outputChannels, outputChannels: outputChannels, kernel: (3, 3, 3), spatialPadding: 1
+        )
+        _shortcut.wrappedValue = inputChannels == outputChannels ? nil : MiniMaxH3CausalConv3D(
+            inputChannels: inputChannels, outputChannels: outputChannels, kernel: (1, 1, 1)
+        )
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        var hidden = firstConvolution(MLXNN.silu(firstNorm(value)))
+        hidden = secondConvolution(MLXNN.silu(secondNorm(hidden)))
+        return hidden + (shortcut?(value) ?? value)
+    }
+}
+
+final class MiniMaxH3VideoDownsampler: Module {
+    let spatialStride: Int
+    @ModuleInfo(key: "conv") var convolution: MiniMaxH3CausalConv3D
+
+    init(channels: Int, temporalStride: Int, spatialStride: Int) {
+        self.spatialStride = spatialStride
+        _convolution.wrappedValue = MiniMaxH3CausalConv3D(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernel: (3, 3, 3),
+            stride: (temporalStride, spatialStride, spatialStride)
+        )
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        guard spatialStride == 2 else { return convolution(value) }
+        let bottom = value[0..., 0..., (value.dim(2) - 2)..<(value.dim(2) - 1), 0..., 0...]
+        let spatial = MLX.concatenated([value, bottom], axis: 2)
+        let right = spatial[0..., 0..., 0..., (spatial.dim(3) - 2)..<(spatial.dim(3) - 1), 0...]
+        return convolution(MLX.concatenated([spatial, right], axis: 3))
+    }
+}
+
+final class MiniMaxH3VideoDownBlock: Module {
+    @ModuleInfo(key: "resnets") var resnets: [MiniMaxH3VideoEncoderResnet]
+    @ModuleInfo(key: "downsamplers") var downsamplers: [MiniMaxH3VideoDownsampler]
+
+    init(inputChannels: Int, outputChannels: Int, temporalFactor: Int, spatialFactor: Int) {
+        _resnets.wrappedValue = [
+            MiniMaxH3VideoEncoderResnet(inputChannels: inputChannels, outputChannels: outputChannels),
+            MiniMaxH3VideoEncoderResnet(inputChannels: outputChannels, outputChannels: outputChannels),
+        ]
+        _downsamplers.wrappedValue = temporalFactor * spatialFactor > 1
+            ? [MiniMaxH3VideoDownsampler(
+                channels: outputChannels, temporalStride: temporalFactor, spatialStride: spatialFactor
+            )]
+            : []
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        var hidden = resnets.reduce(value) { current, block in block(current) }
+        for downsampler in downsamplers { hidden = downsampler(hidden) }
+        return hidden
+    }
+}
+
+public final class MiniMaxH3VideoEncoder: Module {
+    @ModuleInfo(key: "conv_in") var input: MiniMaxH3CausalConv3D
+    @ModuleInfo(key: "down_blocks") var blocks: [MiniMaxH3VideoDownBlock]
+    @ModuleInfo(key: "norm_out") var outputNorm: MiniMaxH3FrameGroupNorm
+    @ModuleInfo(key: "conv_out") var output: MiniMaxH3CausalConv3D
+
+    public override init() {
+        let channels = [128, 256, 256, 512, 512, 1_024]
+        let inputChannels = [128, 128, 256, 256, 512, 512]
+        let spatial = [2, 2, 2, 2, 1, 1]
+        let temporal = [1, 2, 2, 1, 1, 1]
+        _input.wrappedValue = MiniMaxH3CausalConv3D(
+            inputChannels: 3, outputChannels: 128, kernel: (3, 3, 3), spatialPadding: 1
+        )
+        _blocks.wrappedValue = channels.indices.map { index in
+            MiniMaxH3VideoDownBlock(
+                inputChannels: inputChannels[index],
+                outputChannels: channels[index],
+                temporalFactor: temporal[index],
+                spatialFactor: spatial[index]
+            )
+        }
+        _outputNorm.wrappedValue = MiniMaxH3FrameGroupNorm(channels: 1_024)
+        _output.wrappedValue = MiniMaxH3CausalConv3D(
+            inputChannels: 1_024, outputChannels: 48, kernel: (3, 3, 3), spatialPadding: 1
+        )
+        super.init()
+    }
+
+    public func callAsFunction(_ video: MLXArray) -> MLXArray {
+        var hidden = input(video)
+        for block in blocks { hidden = block(hidden) }
+        return output(MLXNN.silu(outputNorm(hidden)))
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
@@ -1,0 +1,559 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+public struct MiniMaxH3VideoDecoderConfiguration: Hashable, Sendable {
+    public let latentChannels: Int
+    public let outputChannels: Int
+    public let patchSize: Int
+    public let temporalPatchSize: Int
+    public let layerCount: Int
+    public let headCount: Int
+    public let headDimension: Int
+    public let registerTokenCount: Int
+    public let feedForwardMultiplier: Int
+    public let rotaryDimensionRatio: Float
+    public let rotaryTheta: Float
+
+    public init(
+        latentChannels: Int = 24,
+        outputChannels: Int = 3,
+        patchSize: Int = 16,
+        temporalPatchSize: Int = 4,
+        layerCount: Int = 36,
+        headCount: Int = 32,
+        headDimension: Int = 64,
+        registerTokenCount: Int = 4,
+        feedForwardMultiplier: Int = 4,
+        rotaryDimensionRatio: Float = 0.75,
+        rotaryTheta: Float = 100
+    ) {
+        self.latentChannels = latentChannels
+        self.outputChannels = outputChannels
+        self.patchSize = patchSize
+        self.temporalPatchSize = temporalPatchSize
+        self.layerCount = layerCount
+        self.headCount = headCount
+        self.headDimension = headDimension
+        self.registerTokenCount = registerTokenCount
+        self.feedForwardMultiplier = feedForwardMultiplier
+        self.rotaryDimensionRatio = rotaryDimensionRatio
+        self.rotaryTheta = rotaryTheta
+    }
+
+    var hiddenSize: Int { headCount * headDimension }
+    var rotaryDimension: Int { Int(Float(headDimension) * rotaryDimensionRatio) }
+}
+
+final class MiniMaxH3VideoDecoderAttention: Module {
+    let headCount: Int
+    let headDimension: Int
+    let rotaryDimension: Int
+
+    @ModuleInfo(key: "to_q") var query: Linear
+    @ModuleInfo(key: "to_k") var key: Linear
+    @ModuleInfo(key: "to_v") var value: Linear
+    @ModuleInfo(key: "to_out") var output: Linear
+
+    init(configuration: MiniMaxH3VideoDecoderConfiguration) {
+        headCount = configuration.headCount
+        headDimension = configuration.headDimension
+        rotaryDimension = configuration.rotaryDimension
+        let hidden = configuration.hiddenSize
+        _query.wrappedValue = Linear(hidden, hidden, bias: true)
+        _key.wrappedValue = Linear(hidden, hidden, bias: true)
+        _value.wrappedValue = Linear(hidden, hidden, bias: true)
+        _output.wrappedValue = Linear(hidden, hidden, bias: true)
+    }
+
+    func callAsFunction(_ input: MLXArray, cosine: MLXArray, sine: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        var q = query(input).reshaped(batch, sequence, headCount, headDimension)
+        var k = key(input).reshaped(batch, sequence, headCount, headDimension)
+        let v = value(input).reshaped(batch, sequence, headCount, headDimension)
+
+        q = MiniMaxH3VideoDecoderAttention.rmsNormalizeHeads(q)
+        k = MiniMaxH3VideoDecoderAttention.rmsNormalizeHeads(k)
+        q = applyRotary(q, cosine: cosine, sine: sine)
+        k = applyRotary(k, cosine: cosine, sine: sine)
+
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q.transposed(0, 2, 1, 3),
+            keys: k.transposed(0, 2, 1, 3),
+            values: v.transposed(0, 2, 1, 3),
+            scale: 1 / sqrt(Float(headDimension)),
+            mask: .none
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, sequence, -1))
+    }
+
+    private static func rmsNormalizeHeads(_ value: MLXArray) -> MLXArray {
+        let value32 = value.asType(.float32)
+        let denominator = MLX.sqrt(MLX.mean(value32 * value32, axis: -1, keepDims: true) + 1e-5)
+        return (value32 / denominator).asType(value.dtype)
+    }
+
+    private func applyRotary(_ value: MLXArray, cosine: MLXArray, sine: MLXArray) -> MLXArray {
+        let rotary = value[0..., 0..., 0..., 0..<rotaryDimension]
+        let pass = value[0..., 0..., 0..., rotaryDimension...]
+        let halves = MLX.split(rotary, parts: 2, axis: -1)
+        let rotated = MLX.concatenated([-halves[1], halves[0]], axis: -1)
+        return MLX.concatenated([rotary * cosine + rotated * sine, pass], axis: -1)
+    }
+}
+
+final class MiniMaxH3VideoDecoderFeedForward: Module {
+    @ModuleInfo(key: "linear_in") var input: Linear
+    @ModuleInfo(key: "linear_out") var output: Linear
+
+    init(configuration: MiniMaxH3VideoDecoderConfiguration) {
+        let hidden = configuration.hiddenSize
+        let intermediate = hidden * configuration.feedForwardMultiplier
+        _input.wrappedValue = Linear(hidden, intermediate * 2, bias: true)
+        _output.wrappedValue = Linear(intermediate, hidden, bias: true)
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        let parts = MLX.split(input(value), parts: 2, axis: -1)
+        return output(MLXNN.silu(parts[0]) * parts[1])
+    }
+}
+
+final class MiniMaxH3VideoDecoderBlock: Module {
+    @ModuleInfo(key: "norm1") var attentionNorm: RMSNorm
+    @ModuleInfo(key: "attn") var attention: MiniMaxH3VideoDecoderAttention
+    @ParameterInfo(key: "scale1") var attentionScale: MLXArray
+    @ModuleInfo(key: "norm2") var feedForwardNorm: RMSNorm
+    @ModuleInfo(key: "ff") var feedForward: MiniMaxH3VideoDecoderFeedForward
+    @ParameterInfo(key: "scale2") var feedForwardScale: MLXArray
+
+    init(configuration: MiniMaxH3VideoDecoderConfiguration) {
+        _attentionNorm.wrappedValue = RMSNorm(dimensions: configuration.hiddenSize, eps: 1e-5)
+        _attention.wrappedValue = MiniMaxH3VideoDecoderAttention(configuration: configuration)
+        _attentionScale.wrappedValue = MLXArray.zeros([configuration.hiddenSize])
+        _feedForwardNorm.wrappedValue = RMSNorm(dimensions: configuration.hiddenSize, eps: 1e-5)
+        _feedForward.wrappedValue = MiniMaxH3VideoDecoderFeedForward(configuration: configuration)
+        _feedForwardScale.wrappedValue = MLXArray.zeros([configuration.hiddenSize])
+    }
+
+    func callAsFunction(_ value: MLXArray, cosine: MLXArray, sine: MLXArray) -> MLXArray {
+        var hidden = value
+        hidden = hidden + attention(attentionNorm(hidden), cosine: cosine, sine: sine) * attentionScale
+        return hidden + feedForward(feedForwardNorm(hidden)) * feedForwardScale
+    }
+}
+
+public final class MiniMaxH3VideoDecoder: Module {
+    public let configuration: MiniMaxH3VideoDecoderConfiguration
+
+    @ModuleInfo(key: "proj_in") var input: Linear
+    @ParameterInfo(key: "register_tokens") var registerTokens: MLXArray
+    @ModuleInfo(key: "transformer_blocks") var blocks: [MiniMaxH3VideoDecoderBlock]
+    @ModuleInfo(key: "norm_out") var outputNorm: LayerNorm
+    @ModuleInfo(key: "proj_out") var output: Linear
+
+    public init(configuration: MiniMaxH3VideoDecoderConfiguration = .init()) {
+        self.configuration = configuration
+        _input.wrappedValue = Linear(configuration.latentChannels, configuration.hiddenSize, bias: true)
+        _registerTokens.wrappedValue = MLXArray.zeros([
+            1, configuration.registerTokenCount, configuration.hiddenSize,
+        ])
+        _blocks.wrappedValue = (0..<configuration.layerCount).map { _ in
+            MiniMaxH3VideoDecoderBlock(configuration: configuration)
+        }
+        _outputNorm.wrappedValue = LayerNorm(dimensions: configuration.hiddenSize, eps: 1e-5)
+        _output.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.outputChannels * configuration.temporalPatchSize
+                * configuration.patchSize * configuration.patchSize,
+            bias: true
+        )
+    }
+
+    /// Decodes denormalized `[B, C, T, H, W]` H3 latents to ImageNet-normalized RGB.
+    public func callAsFunction(_ latents: MLXArray) -> MLXArray {
+        precondition(latents.ndim == 5 && latents.dim(1) == configuration.latentChannels)
+        let batch = latents.dim(0)
+        let frames = latents.dim(2)
+        let height = latents.dim(3)
+        let width = latents.dim(4)
+        var hidden = input(
+            latents.transposed(0, 2, 3, 4, 1)
+                .reshaped(batch, frames * height * width, configuration.latentChannels)
+        )
+        let patchCount = hidden.dim(1)
+        let registers = MLX.tiled(registerTokens, repetitions: [batch, 1, 1])
+        let zeroToken = MLXArray.zeros([batch, 1, configuration.hiddenSize], dtype: hidden.dtype)
+        hidden = MLX.concatenated([hidden, registers.asType(hidden.dtype), zeroToken], axis: 1)
+        let (cosine, sine) = rotaryEmbedding(
+            batch: batch,
+            frames: frames,
+            height: height,
+            width: width,
+            dtype: hidden.dtype
+        )
+        for block in blocks {
+            hidden = block(hidden, cosine: cosine, sine: sine)
+        }
+        hidden = output(outputNorm(hidden))[0..., 0..<patchCount, 0...]
+        let patch = configuration.patchSize
+        let temporalPatch = configuration.temporalPatchSize
+        return hidden
+            .reshaped(batch, frames, height, width, configuration.outputChannels, temporalPatch, patch, patch)
+            .transposed(0, 4, 1, 5, 2, 6, 3, 7)
+            .reshaped(batch, configuration.outputChannels, frames * temporalPatch, height * patch, width * patch)
+    }
+
+    private func rotaryEmbedding(
+        batch: Int,
+        frames: Int,
+        height: Int,
+        width: Int,
+        dtype: DType
+    ) -> (MLXArray, MLXArray) {
+        let axisWidth = configuration.rotaryDimension / 6
+        let inverse = MLX.pow(
+            MLXArray(configuration.rotaryTheta),
+            -MLXArray(stride(from: 0, to: axisWidth * 2, by: 2).map(Float.init))
+                / Float(axisWidth * 2)
+        )
+        func normalized(_ count: Int) -> MLXArray {
+            (2 * ((MLXArray(0..<count).asType(.float32) + 0.5) / Float(count)) - 1) * (2 * Float.pi)
+        }
+        let t = normalized(frames).reshaped(frames, 1, 1, 1) * inverse
+        let h = normalized(height).reshaped(1, height, 1, 1) * inverse
+        let w = normalized(width).reshaped(1, 1, width, 1) * inverse
+        var angles = MLX.concatenated([
+            MLX.broadcast(t, to: [frames, height, width, axisWidth]),
+            MLX.broadcast(h, to: [frames, height, width, axisWidth]),
+            MLX.broadcast(w, to: [frames, height, width, axisWidth]),
+        ], axis: -1).reshaped(1, frames * height * width, 1, configuration.rotaryDimension / 2)
+        angles = MLX.concatenated([angles, angles], axis: -1)
+        let suffix = MLXArray.zeros([
+            1, configuration.registerTokenCount + 1, 1, configuration.rotaryDimension,
+        ])
+        angles = MLX.tiled(MLX.concatenated([angles, suffix], axis: 1), repetitions: [batch, 1, configuration.headCount, 1])
+        return (MLX.cos(angles).asType(dtype), MLX.sin(angles).asType(dtype))
+    }
+}
+
+public final class MiniMaxH3VideoVAE: Module {
+    @ModuleInfo(key: "encoder") public var encoder: MiniMaxH3VideoEncoder
+    @ModuleInfo(key: "quant_conv") var quantConvolution: Conv3d
+    @ModuleInfo(key: "post_quant_conv") var postQuantConvolution: Conv3d
+    @ModuleInfo(key: "decoder") public var decoder: MiniMaxH3VideoDecoder
+    @ParameterInfo(key: "latents_mean") var latentMean: MLXArray
+    @ParameterInfo(key: "latents_std") var latentStandardDeviation: MLXArray
+
+    public override init() {
+        _encoder.wrappedValue = MiniMaxH3VideoEncoder()
+        _quantConvolution.wrappedValue = Conv3d(
+            inputChannels: 48,
+            outputChannels: 48,
+            kernelSize: .init(1),
+            bias: true
+        )
+        _postQuantConvolution.wrappedValue = Conv3d(
+            inputChannels: 24,
+            outputChannels: 24,
+            kernelSize: .init(1),
+            bias: true
+        )
+        _decoder.wrappedValue = MiniMaxH3VideoDecoder()
+        _latentMean.wrappedValue = MLXArray.zeros([24])
+        _latentStandardDeviation.wrappedValue = MLXArray.ones([24])
+        super.init()
+    }
+
+    static func mapCheckpointWeight(key rawKey: String, value: MLXArray) -> [(String, MLXArray)] {
+        if rawKey == "decoder.mask_token" { return [] }
+        var key = rawKey
+        key = key.replacingOccurrences(of: "decoder.x_embedder.", with: "decoder.proj_in.")
+        key = key.replacingOccurrences(of: ".ff.w1.", with: ".ff.linear_in.")
+        key = key.replacingOccurrences(of: ".ff.w2.", with: ".ff.linear_out.")
+        key = key.replacingOccurrences(of: "encoder.down.", with: "encoder.down_blocks.")
+        key = key.replacingOccurrences(of: ".block.", with: ".resnets.")
+        key = key.replacingOccurrences(of: ".nin_shortcut.", with: ".conv_shortcut.")
+        if key.contains(".downsample.conv.") {
+            key = key.replacingOccurrences(of: ".downsample.conv.", with: ".downsamplers.0.conv.")
+        }
+
+        if key.contains(".attn.to_qkv.") {
+            let queryKey = key.replacingOccurrences(of: ".attn.to_qkv.", with: ".attn.to_q.")
+            let keyKey = key.replacingOccurrences(of: ".attn.to_qkv.", with: ".attn.to_k.")
+            let valueKey = key.replacingOccurrences(of: ".attn.to_qkv.", with: ".attn.to_v.")
+            // The released VAE projects to [head, qkv, headDimension], not
+            // [qkv, head, headDimension]. Deinterleave the per-head groups
+            // before loading the three standalone MLX Linear modules.
+            let headCount = 32
+            let headDimension = 64
+            precondition(value.dim(0) == headCount * 3 * headDimension)
+            let trailingShape = Array(value.shape.dropFirst())
+            let grouped = value.reshaped([headCount, 3, headDimension] + trailingShape)
+            let pieces = MLX.split(grouped, parts: 3, axis: 1).map {
+                $0.squeezed(axis: 1).reshaped([headCount * headDimension] + trailingShape)
+            }
+            return [(queryKey, pieces[0]), (keyKey, pieces[1]), (valueKey, pieces[2])]
+        }
+        if value.ndim == 5 {
+            return [(key, value.transposed(0, 2, 3, 4, 1))]
+        }
+        return [(key, value)]
+    }
+
+    /// Encodes one prepared RGB keyframe `[1, H, W, 3]` with H3's fixed
+    /// posterior seed and returns normalized `[1, 24, 1, H/16, W/16]` latents.
+    public func encodeKeyframe(_ rgb: MLXArray) -> MLXArray {
+        precondition(rgb.ndim == 4 && rgb.dim(0) == 1 && rgb.dim(3) == 3)
+        let meanRGB = MLXArray([Float(0.485), 0.456, 0.406]).reshaped(1, 1, 1, 3)
+        let stdRGB = MLXArray([Float(0.229), 0.224, 0.225]).reshaped(1, 1, 1, 3)
+        let normalized = ((rgb - meanRGB) / stdRGB).expandedDimensions(axis: 1)
+        let moments = encodeClip(normalized)
+        return sampleAndNormalize(moments)
+    }
+
+    /// Encodes prepared `[1, T, H, W, 3]` RGB reference video. Frames are
+    /// repeated to 17-frame chunks and H3's three trailing latent tokens are
+    /// dropped after concatenation, matching the released Ref2VA pipeline.
+    public func encodeReferenceVideo(_ rgb: MLXArray) -> MLXArray {
+        precondition(rgb.ndim == 5 && rgb.dim(0) == 1 && rgb.dim(4) == 3 && rgb.dim(1) > 0)
+        let meanRGB = MLXArray([Float(0.485), 0.456, 0.406]).reshaped(1, 1, 1, 1, 3)
+        let stdRGB = MLXArray([Float(0.229), 0.224, 0.225]).reshaped(1, 1, 1, 1, 3)
+        var normalized = (rgb - meanRGB) / stdRGB
+        let remainder = normalized.dim(1) % MiniMaxH3Geometry.videoFramesPerChunk
+        if remainder != 0 {
+            let count = MiniMaxH3Geometry.videoFramesPerChunk - remainder
+            let last = normalized[0..., (normalized.dim(1) - 1)..., 0..., 0..., 0...]
+            normalized = MLX.concatenated(
+                [normalized, MLX.tiled(last, repetitions: [1, count, 1, 1, 1])],
+                axis: 1
+            )
+        }
+        var chunks: [MLXArray] = []
+        for start in stride(from: 0, to: normalized.dim(1), by: MiniMaxH3Geometry.videoFramesPerChunk) {
+            chunks.append(encodeClip(
+                normalized[0..., start..<(start + MiniMaxH3Geometry.videoFramesPerChunk), 0..., 0..., 0...]
+            ))
+        }
+        let moments = MLX.concatenated(chunks, axis: 1)
+        precondition(moments.dim(1) > 3)
+        return sampleAndNormalize(moments[0..., 0..<(moments.dim(1) - 3), 0..., 0..., 0...])
+    }
+
+    private func sampleAndNormalize(_ moments: MLXArray) -> MLXArray {
+        let parts = MLX.split(moments, parts: 2, axis: -1)
+        MLXRandom.seed(42)
+        let logVariance = MLX.clip(parts[1], min: -30, max: 20)
+        let sample = parts[0] + MLX.exp(0.5 * logVariance) * MLXRandom.normal(parts[0].shape)
+        let channelFirst = sample.asType(.float16).asType(.float32).transposed(0, 4, 1, 2, 3)
+        return (channelFirst - latentMean.reshaped(1, 24, 1, 1, 1))
+            / latentStandardDeviation.reshaped(1, 24, 1, 1, 1)
+    }
+
+    private func encodeClip(_ video: MLXArray) -> MLXArray {
+        let pixelHeight = video.dim(2)
+        let pixelWidth = video.dim(3)
+        let y = Self.tilePlan(length: pixelHeight)
+        let x = Self.tilePlan(length: pixelWidth)
+        var tiles: [MLXArray] = []
+        for (yIndex, yStart) in y.starts.enumerated() {
+            for (xIndex, xStart) in x.starts.enumerated() {
+                tiles.append(video[
+                    0..., 0...,
+                    yStart..<(yStart + y.lengths[yIndex]),
+                    xStart..<(xStart + x.lengths[xIndex]),
+                    0...
+                ])
+            }
+        }
+        let encodedTiles = MLX.split(
+            quantConvolution(encoder(MLX.concatenated(tiles, axis: 0))),
+            parts: tiles.count,
+            axis: 0
+        )
+        var rows: [[MLXArray]] = []
+        rows.reserveCapacity(y.starts.count)
+        for rowIndex in y.starts.indices {
+            let start = rowIndex * x.starts.count
+            rows.append(Array(encodedTiles[start..<(start + x.starts.count)]))
+        }
+
+        let yOverlaps = y.overlaps.map { $0 / 16 }
+        let xOverlaps = x.overlaps.map { $0 / 16 }
+        var stitchedRows: [MLXArray] = []
+        for rowIndex in rows.indices {
+            var pieces: [MLXArray] = []
+            for columnIndex in rows[rowIndex].indices {
+                var tile = rows[rowIndex][columnIndex]
+                if rowIndex > 0 {
+                    tile = Self.blend(rows[rowIndex - 1][columnIndex], tile, extent: yOverlaps[rowIndex - 1], axis: 2)
+                }
+                if columnIndex > 0 {
+                    tile = Self.blend(rows[rowIndex][columnIndex - 1], tile, extent: xOverlaps[columnIndex - 1], axis: 3)
+                }
+                if rowIndex + 1 < rows.count {
+                    tile = tile[0..., 0..., 0..<(tile.dim(2) - yOverlaps[rowIndex]), 0..., 0...]
+                }
+                if columnIndex + 1 < rows[rowIndex].count {
+                    tile = tile[0..., 0..., 0..., 0..<(tile.dim(3) - xOverlaps[columnIndex]), 0...]
+                }
+                pieces.append(tile)
+            }
+            stitchedRows.append(MLX.concatenated(pieces, axis: 3))
+        }
+        return MLX.concatenated(stitchedRows, axis: 2)
+    }
+
+    /// Converts normalized H3 latents to `[B, T, H, W, 3]` RGB in `[0, 1]`.
+    public func decode(_ normalizedLatents: MLXArray) -> MLXArray {
+        precondition(normalizedLatents.dim(2) >= 7, "H3 video decode requires at least seven latent frames")
+        let mean = latentMean.reshaped(1, 24, 1, 1, 1)
+        let standardDeviation = latentStandardDeviation.reshaped(1, 24, 1, 1, 1)
+        var denormalized = normalizedLatents * standardDeviation + mean
+        let tokensPerChunk = 5
+        let tokenOverlap = 2
+        let tokenDrop = 3
+        let pixelFramesPerChunk = 20
+        let framePrePadding = 3
+        let frameOverlap = 5
+        let padTokens = (-(denormalized.dim(2) + tokenDrop)).quotientAndRemainder(dividingBy: tokensPerChunk).remainder
+        let resolvedPadTokens = padTokens == 0 ? 0 : padTokens + tokensPerChunk
+        let originalTokenCount = denormalized.dim(2)
+        if resolvedPadTokens > 0 {
+            let last = denormalized[0..., 0..., (originalTokenCount - 1)..., 0..., 0...]
+            denormalized = MLX.concatenated(
+                [denormalized, MLX.tiled(last, repetitions: [1, 1, resolvedPadTokens, 1, 1])],
+                axis: 2
+            )
+        }
+        let chunkCount = (originalTokenCount + tokenDrop + resolvedPadTokens) / tokensPerChunk - 1
+        var decodedChunks: [MLXArray] = []
+        var overlap: MLXArray?
+        let tileDecoder = MLX.compile { (channelLast: MLXArray) -> MLXArray in
+            let projected = self.postQuantConvolution(channelLast).transposed(0, 4, 1, 2, 3)
+            return self.decoder(projected)
+        }
+        for index in 0..<chunkCount {
+            let start = index * tokensPerChunk
+            let clip = decodeClip(
+                denormalized[0..., 0..., start..<(start + tokensPerChunk + tokenOverlap), 0..., 0...],
+                tileDecoder: tileDecoder
+            )
+            MLX.eval(clip)
+            for part in 0..<2 {
+                let frameStart = part * pixelFramesPerChunk
+                let frameEnd = min(frameStart + pixelFramesPerChunk, clip.dim(2))
+                guard frameEnd > frameStart + framePrePadding else { continue }
+                var chunk = clip[0..., 0..., (frameStart + framePrePadding)..<frameEnd, 0..., 0...]
+                if part == 0 {
+                    if let overlap { chunk = Self.blend(overlap, chunk, extent: frameOverlap, axis: 2) }
+                    decodedChunks.append(chunk)
+                } else {
+                    overlap = chunk
+                }
+            }
+        }
+        if let overlap { decodedChunks.append(overlap) }
+        var imageNet = MLX.concatenated(decodedChunks, axis: 2)
+        if resolvedPadTokens > 0 {
+            let intraTail = 1
+            var padFrames = 0
+            for index in 0..<resolvedPadTokens {
+                padFrames += (originalTokenCount + index).isMultiple(of: tokensPerChunk) ? intraTail : 4
+            }
+            imageNet = imageNet[0..., 0..., 0..<(imageNet.dim(2) - padFrames), 0..., 0...]
+        }
+        imageNet = imageNet.transposed(0, 2, 3, 4, 1)
+        let meanRGB = MLXArray([Float(0.485), 0.456, 0.406]).reshaped(1, 1, 1, 1, 3)
+        let stdRGB = MLXArray([Float(0.229), 0.224, 0.225]).reshaped(1, 1, 1, 1, 3)
+        return MLX.clip(imageNet * stdRGB + meanRGB, min: 0, max: 1)
+    }
+
+    private func decodeClip(
+        _ latent: MLXArray,
+        tileDecoder: @Sendable (MLXArray) -> MLXArray
+    ) -> MLXArray {
+        let pixelHeight = latent.dim(3) * 16
+        let pixelWidth = latent.dim(4) * 16
+        let y = Self.tilePlan(length: pixelHeight)
+        let x = Self.tilePlan(length: pixelWidth)
+        var tiles: [MLXArray] = []
+        for (yIndex, yStart) in y.starts.enumerated() {
+            for (xIndex, xStart) in x.starts.enumerated() {
+                let tile = latent[
+                    0..., 0..., 0...,
+                    (yStart / 16)..<((yStart + y.lengths[yIndex]) / 16),
+                    (xStart / 16)..<((xStart + x.lengths[xIndex]) / 16)
+                ]
+                tiles.append(tile.transposed(0, 2, 3, 4, 1))
+            }
+        }
+        let decodedTiles = MLX.split(
+            tileDecoder(MLX.concatenated(tiles, axis: 0)),
+            parts: tiles.count,
+            axis: 0
+        )
+        var rows: [[MLXArray]] = []
+        rows.reserveCapacity(y.starts.count)
+        for rowIndex in y.starts.indices {
+            let start = rowIndex * x.starts.count
+            rows.append(Array(decodedTiles[start..<(start + x.starts.count)]))
+        }
+
+        var stitchedRows: [MLXArray] = []
+        for rowIndex in rows.indices {
+            var pieces: [MLXArray] = []
+            for columnIndex in rows[rowIndex].indices {
+                var tile = rows[rowIndex][columnIndex]
+                if rowIndex > 0 {
+                    tile = Self.blend(rows[rowIndex - 1][columnIndex], tile, extent: y.overlaps[rowIndex - 1], axis: 3)
+                }
+                if columnIndex > 0 {
+                    tile = Self.blend(rows[rowIndex][columnIndex - 1], tile, extent: x.overlaps[columnIndex - 1], axis: 4)
+                }
+                if rowIndex + 1 < rows.count {
+                    tile = tile[0..., 0..., 0..., 0..<(tile.dim(3) - y.overlaps[rowIndex]), 0...]
+                }
+                if columnIndex + 1 < rows[rowIndex].count {
+                    tile = tile[0..., 0..., 0..., 0..., 0..<(tile.dim(4) - x.overlaps[columnIndex])]
+                }
+                pieces.append(tile)
+            }
+            stitchedRows.append(MLX.concatenated(pieces, axis: 4))
+        }
+        return MLX.concatenated(stitchedRows, axis: 3)
+    }
+
+    private static func tilePlan(length: Int) -> (starts: [Int], lengths: [Int], overlaps: [Int]) {
+        let tileSize = 256
+        let minimumOverlap = 64
+        guard length > tileSize else { return ([0], [length], []) }
+        var count = Int(ceil(Double(length) / Double(tileSize)))
+        while tileSize * count - minimumOverlap * (count - 1) < length { count += 1 }
+        var overlaps = Array(repeating: minimumOverlap, count: count - 1)
+        let remaining = tileSize * count - overlaps.reduce(0, +) - length
+        for index in 0..<(remaining / 16) { overlaps[index % overlaps.count] += 16 }
+        var starts = [0]
+        for index in overlaps.indices { starts.append(starts.last! + tileSize - overlaps[index]) }
+        return (starts, Array(repeating: tileSize, count: count), overlaps)
+    }
+
+    private static func blend(_ previous: MLXArray, _ current: MLXArray, extent: Int, axis: Int) -> MLXArray {
+        let length = min(previous.dim(axis), current.dim(axis), extent)
+        guard length > 0 else { return current }
+        var shape = Array(repeating: 1, count: current.ndim)
+        shape[axis] = length
+        let position = MLXArray(0..<length).asType(.float32) / Float(length)
+        let weightCurrent = position.reshaped(shape).asType(current.dtype)
+        let weightPrevious = 1 - weightCurrent
+        let previousIndices = MLXArray(((previous.dim(axis) - length)..<previous.dim(axis)).map(Int32.init))
+        let currentIndices = MLXArray((0..<length).map(Int32.init))
+        let blended = MLX.take(previous, previousIndices, axis: axis) * weightPrevious
+            + MLX.take(current, currentIndices, axis: axis) * weightCurrent
+        guard length < current.dim(axis) else { return blended }
+        let restIndices = MLXArray((length..<current.dim(axis)).map(Int32.init))
+        return MLX.concatenated([blended, MLX.take(current, restIndices, axis: axis)], axis: axis)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -34,8 +34,16 @@ Kingdom, and Republic of Korea. Managed artifacts are explicit-pull only and
 require the user to acknowledge the model license. Conversion must likewise
 run in an allowed territory. See `scripts/model-conversion/README.md`.
 
-The explicit-pull FL2VA package is pinned to
-`ddalcu/MiniMax-H3-FL2VA-MLX-Serve-8bit@32bfc37f1dc8bd331394573859a627bc0aa9822b`.
+The explicit-pull FL2VA package is published as
+`Sawfwair/MiniMax-H3-FL2VA-MLX-4bit` and pinned to its immutable verified Hub
+commit `e1244ad93d60c737c7e0f065a1c9372f3de7caf8`. It is produced only from
+`MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027` by
+`scripts/model-conversion/convert_minimax_h3_official_mlx.py`; no converted or
+quantized third-party checkpoint is a weight input. The package includes the
+source manifest and conversion hashes alongside the runtime files. Its 52
+fused transformer QKV matrices are deinterleaved from the released per-head
+rows into the global Q/K/V slabs expected by the native runtime before Q4
+packing.
 Ref2VA is a local conversion lane because this repository does not publish a
 redistributable converted snapshot. Convert the pinned
 `Comfy-Org/MiniMax-H3` ConvRot source with

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -1,0 +1,49 @@
+# MiniMax-H3
+
+This directory contains the native Swift/MLX implementation of MiniMax-H3. The
+runtime consumes a flat, self-contained MLX artifact rather than either
+roughly 144 GB upstream partition directly.
+
+Supported open-checkpoint paths:
+
+- text-to-video-and-audio with the FL2VA checkpoint;
+- first-frame and first/last-frame video-and-audio conditioning with FL2VA;
+- ordered image, video (including its soundtrack), and audio reference
+  conditioning with Ref2VA. The released limits are 12 total references,
+  including at most 9 images, 3 videos, and 3 audio clips; audio cannot be the
+  only reference type.
+
+H3 emits 24 fps RGB video and native 32 kHz stereo audio. Frame counts use the
+released `17*n+5` temporal geometry. The transformer is CFG-distilled; the
+runtime therefore performs a single model evaluation per denoising step.
+The default schedule adapts to packed-row cost at 9, 16, or 31 points. A
+source-bound cache stores the exact released 31-point AdaLN curve and resamples
+it for explicit point-count overrides. The converted transformer stores global
+Q/K/V slabs; the unmodified video VAE retains the released per-head interleave.
+
+Compact Q4 is the automatic MacBook lane. Desktop Macs with sufficient unified
+memory may expand those weights once to resident BF16 for compute-bound denoise;
+the CLI can force either mode. H3 inference also raises MLX wired residency
+through the shared ticket coordinator so weights and activation workspaces do
+not silently fall out of the GPU residency set.
+
+The model weights are governed by the MiniMax-H3 Community License, not the
+mere.run source license. In particular, the published license excludes use,
+distribution, and display in the United States, European Union, United
+Kingdom, and Republic of Korea. Managed artifacts are explicit-pull only and
+require the user to acknowledge the model license. Conversion must likewise
+run in an allowed territory. See `scripts/model-conversion/README.md`.
+
+The explicit-pull FL2VA package is pinned to
+`ddalcu/MiniMax-H3-FL2VA-MLX-Serve-8bit@32bfc37f1dc8bd331394573859a627bc0aa9822b`.
+Ref2VA is a local conversion lane because this repository does not publish a
+redistributable converted snapshot. Convert the pinned
+`Comfy-Org/MiniMax-H3` ConvRot source with
+`scripts/model-conversion/convert_minimax_h3_convrot.py`, then stage the
+result as `transformer.safetensors` beside the FL package's exact conditioner,
+VAEs, tokenizer, configuration, license, notice, and modification files.
+Change only `partition` in `config.json` to `ref2va`; retain the conversion
+receipt next to the root as provenance.
+
+The implementation follows the published MiniMax/Hugging Face architecture.
+No ComfyUI source is included or used at runtime.

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -100,6 +100,8 @@ public struct ModelResolver {
         case ltxVideo23FullMLX = "video-ltx23-full-mlx"
         case ltxVideo23A2VMLX = "video-ltx23-a2vid-mlx"
         case wan22TI2V5BMLX = "video-wan22-ti2v-5b-mlx"
+        case miniMaxH3FL2VAMLX = "video-minimax-h3-fl2va-mlx"
+        case miniMaxH3Ref2VAMLX = "video-minimax-h3-ref2va-mlx"
         case cosmos3EdgeMLX = "video-cosmos3-edge-mlx"
         case scail2Video14BMLX = "video-scail2-14b-mlx"
         case dreamXWorld5BARMLX = "video-dreamx-world-5b-ar-mlx"

--- a/Sources/MereRunCore/Quantization/PortableQuantizedMatmul.swift
+++ b/Sources/MereRunCore/Quantization/PortableQuantizedMatmul.swift
@@ -159,6 +159,10 @@ public enum MLXCUDAQuant {
 public final class PortableQuantizedLinear: QuantizedLinear {
     private var cachedDequantizedWeight: MLXArray?
     private var cachedDequantizedWeightDType: DType?
+    /// Retain the dequantized CUDA fallback weight between calls. Large dense
+    /// transformers can disable this and evaluate layerwise to bound residency
+    /// while preserving native quantized kernels when they are available.
+    public var cacheDenseFallbackWeight = true
     /// Training can prefer bounded residency over the native quantized kernel.
     /// The dequantized weight remains part of the current lazy graph only and is
     /// not retained by the module between calls.
@@ -179,7 +183,7 @@ public final class PortableQuantizedLinear: QuantizedLinear {
             case .native:
                 return super.callAsFunction(x)
             case .dense:
-                return denseOutput(x, cacheWeight: true)
+                return denseOutput(x, cacheWeight: cacheDenseFallbackWeight)
             case .probe:
                 let output = super.callAsFunction(x)
                 do {
@@ -200,7 +204,7 @@ public final class PortableQuantizedLinear: QuantizedLinear {
                         quantizationMode: mode,
                         supported: false
                     )
-                    return denseOutput(x, cacheWeight: true)
+                    return denseOutput(x, cacheWeight: cacheDenseFallbackWeight)
                 }
             }
         }

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -72,7 +72,7 @@ public enum QuantizedModelManifestWriter {
             case .aceStep, .magentaRT2, .muScriptor, .roFormer: return .music
             case .apBWE, .univerSR: return .audio
             case .woosh, .mmaudio: return .sfx
-            case .ltxVideo, .wanVideo, .cosmos3Edge: return .video
+            case .ltxVideo, .wanVideo, .miniMaxH3, .cosmos3Edge: return .video
             case .psiChat: return .psi
             case .deepseekV4Flash: return .deepseek
             case .inkling: return .inkling
@@ -162,7 +162,7 @@ public enum QuantizedModelManifestWriter {
                     return [.soundEffectGeneration]
                 case .mmaudio:
                     return [.soundEffectGeneration, .videoToAudioGeneration]
-                case .ltxVideo, .wanVideo:
+                case .ltxVideo, .wanVideo, .miniMaxH3:
                     return [.videoGeneration]
                 case .cosmos3Edge:
                     return [.videoGeneration, .actionGeneration, .worldSimulation, .visionReasoning]
@@ -251,6 +251,8 @@ public enum QuantizedModelManifestWriter {
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)
             case .wanVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 40, cfg: 5.0, sigmaShift: 5.0)
+            case .miniMaxH3:
+                manifest.defaults = MereRunModelManifest.Defaults(steps: 31, cfg: 1.0, sigmaShift: 12.0)
             case .cosmos3Edge:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 35, cfg: 6.0, sigmaShift: 10.0)
             }

--- a/Sources/MereRunCore/VLM/QwenVLEncoder.swift
+++ b/Sources/MereRunCore/VLM/QwenVLEncoder.swift
@@ -113,6 +113,28 @@ public struct QwenVLTextEncoderConfig: Decodable, Sendable, Hashable {
 }
 
 public final class QwenVLEncoder: Module {
+    public struct ConditioningImage: @unchecked Sendable {
+        public let pixelValues: MLXArray
+        public let tokenRange: Range<Int>
+        public let temporalPatchCount: Int
+        public let heightPatchCount: Int
+        public let widthPatchCount: Int
+
+        public init(
+            pixelValues: MLXArray,
+            tokenRange: Range<Int>,
+            temporalPatchCount: Int = 1,
+            heightPatchCount: Int,
+            widthPatchCount: Int
+        ) {
+            self.pixelValues = pixelValues
+            self.tokenRange = tokenRange
+            self.temporalPatchCount = temporalPatchCount
+            self.heightPatchCount = heightPatchCount
+            self.widthPatchCount = widthPatchCount
+        }
+    }
+
     private static let debugVisionStats: Bool = {
         guard let raw = ProcessInfo.processInfo.environment["MERERUN_VLM_DEBUG_STATS"]?.lowercased() else {
             return false
@@ -156,6 +178,122 @@ public final class QwenVLEncoder: Module {
         let mergedH = patchH / spatialMergeSize
         let mergedW = patchW / spatialMergeSize
         return max(1, mergedH * mergedW)
+    }
+
+    /// Encodes H3-style multimodal presentations without a chat template or
+    /// language-model head. Each image pad run is replaced in place with the
+    /// Qwen3-VL vision tower output; the unnormalized activation immediately
+    /// after `activationLayer` is returned.
+    public func forwardMultimodalActivationHiddenState(
+        inputIds: MLXArray,
+        attentionMask: MLXArray,
+        images: [ConditioningImage],
+        activationLayer: Int
+    ) throws -> MLXArray? {
+        var tokenIds = inputIds
+        if tokenIds.dtype != .int32 { tokenIds = tokenIds.asType(.int32) }
+        let embeddings = textEncoder.encoder.embed(inputIds: tokenIds)
+        var deepstackByImage: [[MLXArray]] = []
+
+        for image in images {
+            let expectedTokens = max(
+                1,
+                image.temporalPatchCount
+                    * max(1, image.heightPatchCount / visionSpatialMergeSize)
+                    * max(1, image.widthPatchCount / visionSpatialMergeSize)
+            )
+            precondition(
+                image.tokenRange.count == expectedTokens,
+                "Qwen3-VL image placeholder count does not match its patch grid"
+            )
+            let patchInputs = Self.preparePatchInputs(
+                pixelValues: image.pixelValues,
+                patchSize: visionPatchSize,
+                mergeSize: visionSpatialMergeSize
+            )
+            let output = try visionTower(
+                patchInputs: patchInputs,
+                grid: [QwenVisionGrid(
+                    temporal: image.temporalPatchCount,
+                    height: image.heightPatchCount,
+                    width: image.widthPatchCount
+                )]
+            )
+            var visual = output.hiddenStates
+            if let projection = visionProjection { visual = projection(visual) }
+            precondition(
+                visual.dim(0) == image.tokenRange.count,
+                "Qwen3-VL vision tower output does not match its presentation span"
+            )
+            if visual.dtype != embeddings.dtype { visual = visual.asType(embeddings.dtype) }
+            embeddings[0, image.tokenRange, 0...] = visual
+            deepstackByImage.append(output.deepstackFeatures)
+        }
+
+        let deepstackLayerCount = deepstackByImage.map(\.count).max() ?? 0
+        let deepstackByLayer: [[MLXArray]] = (0..<deepstackLayerCount).map { layer in
+            deepstackByImage.map { imageFeatures in
+                precondition(
+                    layer < imageFeatures.count,
+                    "Qwen3-VL images must expose the same number of deepstack features"
+                )
+                return imageFeatures[layer]
+            }
+        }
+        let positionIds = Self.multimodalPositionIDs(
+            sequenceLength: embeddings.dim(1),
+            images: images,
+            spatialMergeSize: visionSpatialMergeSize
+        )
+        return textEncoder.encoder.forwardMultimodalActivationHiddenState(
+            embeddings: embeddings,
+            attentionMask: attentionMask,
+            positionIds: positionIds,
+            visualTokenRanges: images.map(\.tokenRange),
+            deepstackFeatures: deepstackByLayer,
+            activationLayer: activationLayer
+        )
+    }
+
+    private static func multimodalPositionIDs(
+        sequenceLength: Int,
+        images: [ConditioningImage],
+        spatialMergeSize: Int
+    ) -> MLXArray {
+        var axes = Array(repeating: [Int32](), count: 3)
+        for axis in axes.indices { axes[axis].reserveCapacity(sequenceLength) }
+        var cursor = 0
+        var nextPosition = 0
+
+        for image in images.sorted(by: { $0.tokenRange.lowerBound < $1.tokenRange.lowerBound }) {
+            precondition(image.tokenRange.lowerBound >= cursor && image.tokenRange.upperBound <= sequenceLength)
+            while cursor < image.tokenRange.lowerBound {
+                for axis in axes.indices { axes[axis].append(Int32(nextPosition)) }
+                cursor += 1
+                nextPosition += 1
+            }
+
+            let temporal = max(1, image.temporalPatchCount)
+            let height = max(1, image.heightPatchCount / spatialMergeSize)
+            let width = max(1, image.widthPatchCount / spatialMergeSize)
+            for temporalIndex in 0..<temporal {
+                for heightIndex in 0..<height {
+                    for widthIndex in 0..<width {
+                        axes[0].append(Int32(nextPosition + temporalIndex))
+                        axes[1].append(Int32(nextPosition + heightIndex))
+                        axes[2].append(Int32(nextPosition + widthIndex))
+                        cursor += 1
+                    }
+                }
+            }
+            nextPosition += max(temporal, max(height, width))
+        }
+        while cursor < sequenceLength {
+            for axis in axes.indices { axes[axis].append(Int32(nextPosition)) }
+            cursor += 1
+            nextPosition += 1
+        }
+        return MLXArray(axes.flatMap { $0 }, [3, 1, sequenceLength])
     }
 
     /// Prefill step for generation with vision embeddings injected into the prompt.
@@ -318,7 +456,7 @@ public final class QwenVLEncoder: Module {
     // MARK: - Patch inputs + replacement helpers
 
     private static func preparePatchInputs(pixelValues: MLXArray, patchSize: Int, mergeSize: Int = 2) -> MLXArray {
-        let batch = pixelValues.dim(0)
+        let frameCount = pixelValues.dim(0)
         let channels = pixelValues.dim(1)
         let height = pixelValues.dim(2)
         let width = pixelValues.dim(3)
@@ -334,7 +472,9 @@ public final class QwenVLEncoder: Module {
         // Input: [batch, C, H, W]
         // Reshape to separate merge blocks:
         // [batch, C, blockH, mergeSize, patchSize, blockW, mergeSize, patchSize]
-        var x = pixelValues.reshaped(batch, channels, blockH, mergeSize, patchSize, blockW, mergeSize, patchSize)
+        var x = pixelValues.reshaped(
+            frameCount, channels, blockH, mergeSize, patchSize, blockW, mergeSize, patchSize
+        )
 
         // Transpose to merge-permuted order:
         // [batch, blockH, blockW, mergeSize, mergeSize, C, patchSize, patchSize]
@@ -342,16 +482,21 @@ public final class QwenVLEncoder: Module {
         x = x.transposed(0, 2, 5, 3, 6, 1, 4, 7)
 
         // Flatten to: [batch, numPatches, C, spatialSize]
-        x = x.reshaped(batch, numPatches, channels, spatialSize)
+        x = x.reshaped(frameCount, numPatches, channels, spatialSize)
 
         // For temporal duplication (temporal_patch_size=2):
         // Duplicate along temporal dimension to match [C, T, H, W] layout
-        let t0 = x.expandedDimensions(axis: 3)  // [batch, numPatches, C, 1, spatial]
-        let t1 = x.expandedDimensions(axis: 3)  // [batch, numPatches, C, 1, spatial]
-        let temporal = MLX.concatenated([t0, t1], axis: 3)  // [batch, numPatches, C, 2, spatial]
+        if !frameCount.isMultiple(of: temporalPatchSize) {
+            x = MLX.concatenated([x, x[(frameCount - 1)..., 0..., 0..., 0...]], axis: 0)
+        }
+        let temporalPatchCount = x.dim(0) / temporalPatchSize
+        let temporal = x
+            .reshaped(temporalPatchCount, temporalPatchSize, numPatches, channels, spatialSize)
+            .transposed(0, 2, 3, 1, 4)
 
-        // Flatten to [batch, numPatches, C * T * spatial]
-        return temporal.reshaped(batch, numPatches, channels * temporalPatchSize * spatialSize)
+        // One media item per call: temporal patches extend the token axis, not
+        // the batch axis described by the single Qwen grid entry.
+        return temporal.reshaped(1, temporalPatchCount * numPatches, channels * temporalPatchSize * spatialSize)
     }
 
     /// Replace the expanded <|image_pad|> token span with vision embeddings.

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -436,6 +436,63 @@ public final class QwenEncoder: Module {
     return activationLayers.compactMap { captured[$0] }
   }
 
+  /// Runs the multimodal Qwen stack while injecting Qwen3-VL deepstack
+  /// features into each vision span. The returned activation is captured
+  /// immediately after the requested decoder block and before the final RMS
+  /// norm, which is the representation diffusion conditioners consume.
+  public func forwardMultimodalActivationHiddenState(
+    embeddings: MLXArray,
+    attentionMask: MLXArray?,
+    positionIds: MLXArray,
+    visualTokenRanges: [Range<Int>],
+    deepstackFeatures: [[MLXArray]],
+    activationLayer: Int
+  ) -> MLXArray? {
+    guard layers.indices.contains(activationLayer) else { return nil }
+    let computeDType: DType = configuration.useFloat32Activations ? .float32 : .bfloat16
+    var h = embeddings.dtype == computeDType ? embeddings : embeddings.asType(computeDType)
+    let mask = createAttentionMask(h: h, attentionMask: attentionMask)
+
+    for (index, layer) in layers.enumerated() {
+      h = layer(h, mask: mask, positionIds: positionIds)
+      if index < deepstackFeatures.count {
+        let features = deepstackFeatures[index]
+        precondition(
+          features.count == visualTokenRanges.count,
+          "Qwen3-VL deepstack feature count must match the vision spans"
+        )
+        for (range, feature) in zip(visualTokenRanges, features) {
+          h = Self.applyingVisualFeatures(
+            hiddenStates: h,
+            visualTokenRange: range,
+            visualEmbeds: feature
+          )
+        }
+      }
+      if index == activationLayer { return h }
+    }
+    return nil
+  }
+
+  private static func applyingVisualFeatures(
+    hiddenStates: MLXArray,
+    visualTokenRange: Range<Int>,
+    visualEmbeds: MLXArray
+  ) -> MLXArray {
+    precondition(
+      visualTokenRange.lowerBound >= 0
+        && visualTokenRange.upperBound <= hiddenStates.dim(1)
+        && visualTokenRange.count == visualEmbeds.dim(0),
+      "Qwen3-VL visual features must exactly cover their token span"
+    )
+    let features = visualEmbeds.dtype == hiddenStates.dtype
+      ? visualEmbeds
+      : visualEmbeds.asType(hiddenStates.dtype)
+    let padded = MLXArray.zeros(hiddenStates.shape, dtype: hiddenStates.dtype)
+    padded[0, visualTokenRange, 0...] = features
+    return hiddenStates + padded
+  }
+
   private func createAttentionMask(
     h: MLXArray,
     attentionMask: MLXArray?,

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionTower.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionTower.swift
@@ -339,11 +339,11 @@ final class QwenVisionTower: Module {
 
     // Build output (simplified - no window reordering needed for Qwen3-VL)
     var cuMergedLens: [Int] = [0]
-    for (_, h, w) in gridThw {
+    for (t, h, w) in gridThw {
       let mergedH = h / configuration.spatialMergeSize
       let mergedW = w / configuration.spatialMergeSize
       let mergedPerFrame = mergedH * mergedW
-      for _ in 0..<1 {  // t is always 1 for single images
+      for _ in 0..<t {
         cuMergedLens.append(cuMergedLens.last! + mergedPerFrame)
       }
     }

--- a/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
@@ -29,6 +29,7 @@ public final class QwenTokenizer {
   public let padTokenId: Int
   public let maxLength: Int
   public let imageTokenId: Int?
+  public let videoTokenId: Int?
   public let visionStartTokenId: Int?
   public let visionEndTokenId: Int?
 
@@ -72,6 +73,7 @@ public final class QwenTokenizer {
     suffixTokens: [Int],
     tokenizer: Tokenizer,
     imageTokenId: Int? = nil,
+    videoTokenId: Int? = nil,
     visionStartTokenId: Int? = nil,
     visionEndTokenId: Int? = nil,
     encode: @escaping @Sendable (String) -> [Int]
@@ -82,6 +84,7 @@ public final class QwenTokenizer {
     self.suffixTokens = suffixTokens
     self.tokenizer = tokenizer
     self.imageTokenId = imageTokenId
+    self.videoTokenId = videoTokenId
     self.visionStartTokenId = visionStartTokenId
     self.visionEndTokenId = visionEndTokenId
     self.encodeFunction = encode
@@ -161,9 +164,10 @@ public final class QwenTokenizer {
       prefixTokens: prefixTokens,
       suffixTokens: suffixTokens,
       tokenizer: tokenizer,
-      imageTokenId: addedTokens["<|image_pad|>"],
-      visionStartTokenId: addedTokens["<|vision_start|>"],
-      visionEndTokenId: addedTokens["<|vision_end|>"]
+      imageTokenId: addedTokens["<|image_pad|>"] ?? tokenizer.convertTokenToId("<|image_pad|>"),
+      videoTokenId: addedTokens["<|video_pad|>"] ?? tokenizer.convertTokenToId("<|video_pad|>"),
+      visionStartTokenId: addedTokens["<|vision_start|>"] ?? tokenizer.convertTokenToId("<|vision_start|>"),
+      visionEndTokenId: addedTokens["<|vision_end|>"] ?? tokenizer.convertTokenToId("<|vision_end|>")
     ) { text in
       tokenizer.encode(text: text)
     }

--- a/Tests/MereRunCLITests/ModelOptimizeCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelOptimizeCommandTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import MereRunCLI
+
+final class ModelOptimizeCommandTests: XCTestCase {
+    func testModelCommandExposesOptimize() {
+        let names = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(names.contains("optimize"))
+    }
+
+    func testOptimizeFlagsParse() throws {
+        let command = try ModelOptimize.parse([
+            "video-minimax-h3-fl2va-mlx",
+            "--force",
+            "--json",
+        ])
+        XCTAssertEqual(command.target, "video-minimax-h3-fl2va-mlx")
+        XCTAssertTrue(command.force)
+        XCTAssertTrue(command.json)
+    }
+}

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -326,6 +326,8 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(cmd.numFrames, 65)
         XCTAssertNil(cmd.duration)
         XCTAssertEqual(cmd.fps, 24)
+        XCTAssertNil(cmd.steps)
+        XCTAssertEqual(cmd.h3WeightMode, .automatic)
         XCTAssertEqual(cmd.imageStrength, 1.0)
         XCTAssertNil(cmd.endImage)
         XCTAssertEqual(cmd.endImageStrength, 1.0)
@@ -334,6 +336,28 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertFalse(cmd.json)
         XCTAssertFalse(cmd.timings)
         XCTAssertNil(cmd.timingsOutput)
+    }
+
+    func testVideoGenerateParsesMiniMaxH3ReferencesAndStepsInOrder() throws {
+        let cmd = try VideoGenerate.parse([
+            "preserve the references",
+            "--model", ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
+            "--reference", "image:/tmp/subject.png",
+            "--reference", "video:/tmp/motion.mp4",
+            "--reference", "audio:/tmp/voice.wav",
+            "--steps", "31",
+            "--h3-weight-mode", "resident-bf16",
+        ])
+
+        XCTAssertEqual(cmd.model, ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue)
+        XCTAssertEqual(cmd.steps, 31)
+        XCTAssertEqual(cmd.h3WeightMode, .residentBF16)
+        XCTAssertEqual(cmd.h3WeightMode.generationMode, .residentBF16)
+        XCTAssertEqual(cmd.references, [
+            "image:/tmp/subject.png",
+            "video:/tmp/motion.mp4",
+            "audio:/tmp/voice.wav",
+        ])
     }
 
     func testVideoGenerateSeparatesCheckpointQualityFromOutputMode() throws {

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -523,6 +523,110 @@ final class DiTShapeBenchTests: XCTestCase {
         }
     }
 
+    /// MiniMax-H3's dominant projections at its practical 512-square and
+    /// 768x448 packed row counts. The cached arm models loading a compact
+    /// checkpoint, dequantizing each projection once, and keeping bf16 weights
+    /// resident for the denoising loop.
+    func testMiniMaxH3QmmVsResidentBF16() throws {
+        try benchGate()
+
+        Stream.withNewDefaultStream {
+
+            func pairedTime(
+                _ label: String,
+                qmm: QuantizedLinear,
+                dense: BenchCachedDenseLinear,
+                input: MLXArray
+            ) {
+                MLX.eval(qmm(input), dense(input))
+                var bestQMM = Double.greatestFiniteMagnitude
+                var bestDense = Double.greatestFiniteMagnitude
+                for _ in 0..<2 {
+                    var start = CFAbsoluteTimeGetCurrent()
+                    MLX.eval(qmm(input))
+                    bestQMM = min(bestQMM, CFAbsoluteTimeGetCurrent() - start)
+                    start = CFAbsoluteTimeGetCurrent()
+                    MLX.eval(dense(input))
+                    bestDense = min(bestDense, CFAbsoluteTimeGetCurrent() - start)
+                }
+                print(String(
+                    format: "[dit-bench] H3 %@ qmm=%.0fms resident-bf16=%.0fms qmm/bf16=%.2fx",
+                    label,
+                    bestQMM * 1_000,
+                    bestDense * 1_000,
+                    bestQMM / bestDense
+                ))
+            }
+
+            for rows in [4_608, 12_925] {
+                for (name, inputDimension, outputDimension) in [
+                    ("qkv", 5_376, 21_504),
+                    ("ff2", 14_336, 5_376),
+                ] {
+                    let input = MLXRandom.normal([1, rows, inputDimension]).asType(.bfloat16)
+                    let qmm = QuantizedLinear(
+                        inputDimension,
+                        outputDimension,
+                        bias: false,
+                        groupSize: 64,
+                        bits: 4
+                    )
+                    MLX.eval(input, qmm.parameters())
+                    pairedTime(
+                        "rows=\(rows) \(name) \(inputDimension)->\(outputDimension)",
+                        qmm: qmm,
+                        dense: BenchCachedDenseLinear(copying: qmm),
+                        input: input
+                    )
+                    MLX.Memory.clearCache()
+                }
+            }
+        }
+    }
+
+    /// Exact dense MiniMax-H3 attention shape for the 768x448, 124-frame
+    /// practical tier. Reports effective QK+AV throughput so attention can be
+    /// separated from the already-qualified dense GEMM ceiling.
+    func testMiniMaxH3PracticalTierSDPA() throws {
+        try benchGate()
+        Stream.withNewDefaultStream {
+            let rows = 12_925
+            let heads = 56
+            let headDimension = 128
+            let query = MLXRandom.normal([1, heads, rows, headDimension]).asType(.bfloat16)
+            let key = MLXRandom.normal([1, heads, rows, headDimension]).asType(.bfloat16)
+            let value = MLXRandom.normal([1, heads, rows, headDimension]).asType(.bfloat16)
+            MLX.eval(query, key, value)
+
+            func attention() -> MLXArray {
+                MLXFast.scaledDotProductAttention(
+                    queries: query,
+                    keys: key,
+                    values: value,
+                    scale: Float(1 / sqrt(Double(headDimension))),
+                    mask: .none
+                )
+            }
+
+            MLX.eval(attention())
+            var best = Double.greatestFiniteMagnitude
+            for _ in 0..<3 {
+                let start = CFAbsoluteTimeGetCurrent()
+                MLX.eval(attention())
+                best = min(best, CFAbsoluteTimeGetCurrent() - start)
+            }
+            let operations = 4 * Double(heads) * Double(rows) * Double(rows) * Double(headDimension)
+            print(String(
+                format: "[dit-bench] H3 SDPA rows=%d heads=%d dim=%d %.0fms %.2fTFLOP/s",
+                rows,
+                heads,
+                headDimension,
+                best * 1_000,
+                operations / best / 1e12
+            ))
+        }
+    }
+
     /// Full-model paired A/B: the same quantized klein-nano forward with the
     /// native qmm kernels versus the large-M dense path (transient dequant)
     /// versus a resident cached-dequant arm. Interleaved in one process.

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -76,6 +76,8 @@ final class ManagedModelCatalogTests: XCTestCase {
             "video-ltx23-av-mlx",
             "video-ltx23-full-mlx",
             "video-ltx23-a2vid-mlx",
+            "video-minimax-h3-fl2va-mlx",
+            "video-minimax-h3-ref2va-mlx",
         ])
         let visibleAndCompanionSpecs = ManagedModelCatalog.allSpecs
             + ManagedModelCatalog.allSpecs

--- a/Tests/MereRunCoreTests/MediaIOTests.swift
+++ b/Tests/MereRunCoreTests/MediaIOTests.swift
@@ -331,6 +331,56 @@ final class MediaIOTests: XCTestCase {
         let audio = try MediaAudioIO.probe(outputURL)
         XCTAssertEqual(decoded.frameURLs.count, frameCount)
         XCTAssertEqual(decoded.fps, Double(fps), accuracy: 0.001)
+        XCTAssertEqual(audio.durationSeconds, duration, accuracy: 0.002)
+        XCTAssertTrue(MediaVideoIO.hasAudioTrack(outputURL))
+    }
+
+    func testVideoAudioMuxDoesNotDropDelayedFramesWhenAudioIsSlightlyShort() throws {
+        guard isExecutableAvailable(MediaTool.ffmpegPath),
+              isExecutableAvailable(MediaTool.ffprobePath) else {
+            throw XCTSkip("ffmpeg and ffprobe are required")
+        }
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mediaio-short-audio-mux-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let frameCount = 56
+        let fps = 24
+        let duration = Double(frameCount) / Double(fps)
+        let silentURL = root.appendingPathComponent("silent.mp4")
+        let audioURL = root.appendingPathComponent("audio.wav")
+        let outputURL = root.appendingPathComponent("muxed.mp4")
+        try MediaVideoIO.writeMP4(
+            rgb24: [UInt8](repeating: 127, count: 32 * 32 * 3 * frameCount),
+            width: 32,
+            height: 32,
+            frameCount: frameCount,
+            fps: fps,
+            to: silentURL
+        )
+        let audioFrameCount = Int(((duration - 0.008) * 32_000).rounded())
+        try MediaAudioIO.writeFloatWAV(
+            samples: [Float](repeating: 0.1, count: audioFrameCount * 2),
+            sampleRate: 32_000,
+            channels: 2,
+            to: audioURL
+        )
+
+        try MediaVideoIO.mux(
+            videoURL: silentURL,
+            audioURL: audioURL,
+            outputURL: outputURL,
+            audioBitRate: 192_000
+        )
+
+        let decoded = try MediaVideoIO.extractFrames(
+            from: outputURL,
+            into: root.appendingPathComponent("decoded", isDirectory: true)
+        )
+        let audio = try MediaAudioIO.probe(outputURL)
+        XCTAssertEqual(decoded.frameURLs.count, frameCount)
+        XCTAssertEqual(decoded.fps, Double(fps), accuracy: 0.001)
         XCTAssertEqual(audio.durationSeconds, duration, accuracy: 0.001)
         XCTAssertTrue(MediaVideoIO.hasAudioTrack(outputURL))
     }

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -72,6 +72,43 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(configuration.validationIssues().isEmpty)
     }
 
+    func testManagedFL2VAProfileUsesOfficialSourceCompactQ4Artifact() throws {
+        XCTAssertEqual(
+            MiniMaxH3Resources.artifactRepository,
+            "Sawfwair/MiniMax-H3-FL2VA-MLX-4bit"
+        )
+        XCTAssertEqual(
+            MiniMaxH3Resources.sourceRepository,
+            "MiniMaxAI/MiniMax-H3"
+        )
+        XCTAssertEqual(
+            MiniMaxH3Resources.sourceRevision,
+            "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
+        )
+        XCTAssertTrue(MiniMaxH3Resources.compactArtifactFiles.contains("adaln_cache.safetensors"))
+        XCTAssertTrue(MiniMaxH3Resources.compactArtifactFiles.contains("SOURCE_MANIFEST.json"))
+        XCTAssertTrue(MiniMaxH3Resources.compactArtifactFiles.contains("transformer.conversion.json"))
+        XCTAssertTrue(MiniMaxH3Resources.compactArtifactFiles.contains("SHA256SUMS"))
+
+        let manifest = MereRunModelManifest.template(
+            for: .miniMaxH3FL2VAMLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(MiniMaxH3Resources.artifactRepository)@\(MiniMaxH3Resources.artifactRevision)"
+        )
+
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: MiniMaxH3Resources.fl2vaModelID))
+        XCTAssertEqual(spec.hubFallback?.repoId, MiniMaxH3Resources.artifactRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, MiniMaxH3Resources.artifactRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, MiniMaxH3Resources.compactArtifactFiles)
+    }
+
     func testCompactTransformerPreservesAdaLNCacheSourceIdentity() throws {
         let rootURL = FileManager.default.temporaryDirectory
             .appending(path: "minimax-h3-compact-\(UUID().uuidString)")

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -1,0 +1,909 @@
+import MLX
+import MLXNN
+import XCTest
+@testable import MereRunCore
+
+final class MiniMaxH3Tests: MereRunCoreTestCase {
+    func testTransformerQKVUsesConvertedGlobalSlabs() {
+        let projected = MLXArray((0..<12).map(Float.init)).reshaped(1, 1, 12)
+        let parts = miniMaxH3SplitProjectedQKV(projected, heads: 2, headDimension: 2)
+        MLX.eval(parts)
+
+        XCTAssertEqual(parts[0].asArray(Float.self), [0, 1, 2, 3])
+        XCTAssertEqual(parts[1].asArray(Float.self), [4, 5, 6, 7])
+        XCTAssertEqual(parts[2].asArray(Float.self), [8, 9, 10, 11])
+    }
+
+    func testPinnedMLXArtifactConfigurationDecodes() throws {
+        let data = Data(#"""
+        {
+          "model_type": "minimax_h3",
+          "partition": "fl2va",
+          "sigma_shift_scales": {"video": 12.0, "audio": 3.0},
+          "quantization": {"group_size": 64, "bits": 8, "mode": "affine"},
+          "transformer": {
+            "hidden_size": 5376,
+            "num_layers": 50,
+            "num_attention_heads": 56,
+            "attention_head_dim": 128,
+            "ffn_hidden_size": 14336,
+            "latents_dim": 24,
+            "audio_latents_dim": 32,
+            "text_dim": 5120,
+            "time_embed_dim": 2688,
+            "rope_inv_freq_len": 16
+          }
+        }
+        """#.utf8)
+        let configuration = try JSONDecoder().decode(MiniMaxH3Configuration.self, from: data)
+        XCTAssertEqual(configuration.task, "fl2va")
+        XCTAssertEqual(configuration.quantization?.bits, 8)
+        XCTAssertEqual(configuration.textEncoderQuantization?.bits, 8)
+        XCTAssertEqual(configuration.timeEmbeddingHiddenSize, 5_376)
+        XCTAssertEqual(configuration.timeEmbeddingDimension, 2_688)
+        XCTAssertTrue(configuration.validationIssues().isEmpty)
+    }
+
+    func testMixedTransformerAndTextEncoderQuantizationDecodes() throws {
+        let data = Data(#"""
+        {
+          "model_type": "minimax_h3",
+          "partition": "fl2va",
+          "sigma_shift_scales": {"video": 12.0, "audio": 3.0},
+          "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+          "text_encoder_quantization": {"group_size": 64, "bits": 8, "mode": "affine"},
+          "transformer": {
+            "hidden_size": 5376,
+            "num_layers": 50,
+            "num_attention_heads": 56,
+            "attention_head_dim": 128,
+            "ffn_hidden_size": 14336,
+            "latents_dim": 24,
+            "audio_latents_dim": 32,
+            "text_dim": 5120,
+            "time_embed_dim": 2688,
+            "rope_inv_freq_len": 16
+          }
+        }
+        """#.utf8)
+        let configuration = try JSONDecoder().decode(MiniMaxH3Configuration.self, from: data)
+        XCTAssertEqual(configuration.quantization?.bits, 4)
+        XCTAssertEqual(configuration.textEncoderQuantization?.bits, 8)
+        XCTAssertTrue(configuration.validationIssues().isEmpty)
+    }
+
+    func testCompactTransformerPreservesAdaLNCacheSourceIdentity() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appending(path: "minimax-h3-compact-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let transformerURL = rootURL.appending(path: "transformer.safetensors")
+        try MLX.save(
+            arrays: ["probe": MLXArray.zeros([1])],
+            metadata: [
+                "adaln_cache_source_identity": "35248980296:1785757316960297728",
+                "cache_covered_weights_omitted": "true",
+            ],
+            url: transformerURL
+        )
+        let resources = MiniMaxH3Resources(rootURL: rootURL)
+        XCTAssertEqual(
+            try resources.adaLNCacheSourceIdentity(),
+            "35248980296:1785757316960297728"
+        )
+        XCTAssertEqual(
+            try resources.transformerMetadata()["cache_covered_weights_omitted"],
+            "true"
+        )
+        XCTAssertTrue(try resources.requiresAdaLNCache())
+    }
+
+    func testPinnedArtifactWeightMaps() {
+        XCTAssertEqual(
+            MiniMaxH3ModelLoader.conditionerWeightKey("model.layers.0.self_attn.q_proj.weight"),
+            "textEncoder.encoder.layers.0.self_attn.q_proj.weight"
+        )
+        XCTAssertEqual(
+            MiniMaxH3ModelLoader.conditionerWeightKey("visual.merger.linear_fc1.weight"),
+            "visionTower.patch_merger.mlp_0.weight"
+        )
+        let convolution = MLXArray(0..<720).reshaped(2, 3, 4, 5, 6)
+        let mappedConvolution = MiniMaxH3VideoVAE.mapCheckpointWeight(
+            key: "encoder.conv_in.weight",
+            value: convolution
+        )
+        XCTAssertEqual(mappedConvolution.first?.0, "encoder.conv_in.weight")
+        XCTAssertEqual(mappedConvolution.first?.1.shape, [2, 4, 5, 6, 3])
+
+        let fused = MLXArray(0..<6_144)
+        let split = MiniMaxH3VideoVAE.mapCheckpointWeight(
+            key: "decoder.transformer_blocks.0.attn.to_qkv.weight",
+            value: fused
+        )
+        XCTAssertEqual(split.map(\.0), [
+            "decoder.transformer_blocks.0.attn.to_q.weight",
+            "decoder.transformer_blocks.0.attn.to_k.weight",
+            "decoder.transformer_blocks.0.attn.to_v.weight",
+        ])
+        XCTAssertTrue(split.allSatisfy { $0.1.shape == [2_048] })
+        XCTAssertEqual(split[0].1.asArray(Int32.self)[0], 0)
+        XCTAssertEqual(split[0].1.asArray(Int32.self)[64], 192)
+        XCTAssertEqual(split[0].1.asArray(Int32.self)[2_047], 6_015)
+        XCTAssertEqual(split[1].1.asArray(Int32.self)[0], 64)
+        XCTAssertEqual(split[1].1.asArray(Int32.self)[64], 256)
+        XCTAssertEqual(split[1].1.asArray(Int32.self)[2_047], 6_079)
+        XCTAssertEqual(split[2].1.asArray(Int32.self)[0], 128)
+        XCTAssertEqual(split[2].1.asArray(Int32.self)[64], 320)
+        XCTAssertEqual(split[2].1.asArray(Int32.self)[2_047], 6_143)
+
+        let audioEncoder = MiniMaxH3AudioVAE.mapConvertedWeight(
+            key: "encoder.block.0.weight",
+            value: MLXArray.zeros([64, 1, 7])
+        )
+        XCTAssertEqual(audioEncoder.first?.1.shape, [64, 7, 1])
+        let audioResidual = MiniMaxH3AudioVAE.mapConvertedWeight(
+            key: "encoder.block.1.block.0.block.1.weight",
+            value: MLXArray.zeros([64, 64, 7])
+        )
+        XCTAssertEqual(audioResidual.first?.0, "encoder.block.1.block.0.block.1.weight")
+        XCTAssertEqual(audioResidual.first?.1.shape, [64, 7, 64])
+        let audioDecoder = MiniMaxH3AudioVAE.mapConvertedWeight(
+            key: "decoder.conv_pre.weight",
+            value: MLXArray.zeros([4, 2, 7])
+        )
+        XCTAssertEqual(audioDecoder.map(\.0), [
+            "decoder.conv_pre.parametrizations.weight.original0",
+            "decoder.conv_pre.parametrizations.weight.original1",
+        ])
+
+        let audioUpsample = MiniMaxH3AudioVAE.mapConvertedWeight(
+            key: "decoder.ups.0.0.weight",
+            value: MLXArray.zeros([1_024, 512, 9])
+        )
+        XCTAssertEqual(audioUpsample.map(\.0), [
+            "decoder.ups.0.convolution.parametrizations.weight.original0",
+            "decoder.ups.0.convolution.parametrizations.weight.original1",
+        ])
+        XCTAssertEqual(audioUpsample[0].1.shape, [1_024, 1, 1])
+        XCTAssertEqual(audioUpsample[1].1.shape, [512, 9, 1_024])
+    }
+
+    func testReleasedTemporalGeometry() throws {
+        XCTAssertEqual(try MiniMaxH3Geometry.alignFrameCount(120), 124)
+        XCTAssertEqual(try MiniMaxH3Geometry.videoLatentFrameCount(for: 124), 37)
+        XCTAssertEqual(MiniMaxH3Geometry.audioLatentFrameCount(for: 124), 207)
+        XCTAssertThrowsError(try MiniMaxH3Geometry.videoLatentFrameCount(for: 120))
+    }
+
+    func testFL2VAPackedLayoutRangesAndTags() throws {
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: [1, 0, 1],
+            videoLatentFrames: 7,
+            latentHeight: 4,
+            latentWidth: 6,
+            audioLatentFrames: 5,
+            keyframeAnchors: [.first, .last]
+        )
+        XCTAssertEqual(layout.textRows, 0..<3)
+        XCTAssertEqual(layout.conditionVideoRowCount, 12)
+        XCTAssertEqual(layout.targetAudioRows.count, 10)
+        XCTAssertEqual(layout.targetVideoRows.count, 42)
+        XCTAssertEqual(layout.sequenceLength, 67)
+        XCTAssertEqual(layout.positions.shape, [67, 3])
+        XCTAssertEqual(layout.tokenTags[0..<3], [1, 0, 1])
+        XCTAssertTrue(layout.tokenTags[3..<15].allSatisfy { $0 == MiniMaxH3Modality.video.rawValue })
+    }
+
+    func testVideoAndAudioPackingRoundTrip() {
+        let video = MLXArray(0..<384).asType(.float32).reshaped(1, 3, 2, 8, 8)
+        let rows = MiniMaxH3Geometry.patchifyVideo(video)
+        let roundTrip = MiniMaxH3Geometry.unpatchifyVideo(
+            rows,
+            frames: 2,
+            height: 8,
+            width: 8,
+            channels: 3
+        )
+        MLX.eval(roundTrip)
+        XCTAssertEqual(roundTrip.shape, video.shape)
+        XCTAssertEqual(roundTrip.asArray(Float.self), video.asArray(Float.self))
+
+        let audio = MLXArray(0..<40).asType(.float32).reshaped(1, 4, 2, 5)
+        let audioRows = MiniMaxH3Geometry.packAudio(audio)
+        let audioRoundTrip = MiniMaxH3Geometry.unpackAudio(audioRows)
+        MLX.eval(audioRoundTrip)
+        XCTAssertEqual(audioRoundTrip.shape, audio.shape)
+        XCTAssertEqual(audioRoundTrip.asArray(Float.self), audio.asArray(Float.self))
+    }
+
+    func testDecodedFramesConvertToMediaPixels() {
+        let decoded = MLXArray([Float(0), 0.5, 1]).reshaped(1, 1, 1, 1, 3)
+        let pixels = MiniMaxH3Generator.mediaFrames(from: decoded)
+        MLX.eval(pixels)
+        XCTAssertEqual(pixels.dtype, .uint8)
+        XCTAssertEqual(pixels.shape, decoded.shape)
+        XCTAssertEqual(pixels.asArray(UInt8.self), [0, 127, 255])
+    }
+
+    func testRef2VAPackedLayoutPreservesOrderedReferenceBlocks() throws {
+        let layout = try MiniMaxH3Geometry.buildRef2VA(
+            textTokenTags: [1, 0],
+            references: [
+                .init(kind: .image, videoLatentFrames: 1, latentHeight: 4, latentWidth: 4),
+                .init(
+                    kind: .video,
+                    videoLatentFrames: 2,
+                    latentHeight: 4,
+                    latentWidth: 6,
+                    audioLatentFrames: 3
+                ),
+                .init(kind: .audio, audioLatentFrames: 2),
+            ],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 4
+        )
+        XCTAssertEqual(layout.conditionVideoRowCount, 16)
+        XCTAssertEqual(layout.conditionAudioRowCount, 10)
+        XCTAssertEqual(layout.conditionRows, 2..<28)
+        XCTAssertEqual(layout.targetAudioRows, 28..<36)
+        XCTAssertEqual(layout.targetVideoRows, 36..<44)
+        XCTAssertEqual(layout.conditionSegments.map(\.modality), [.video, .audio, .video, .audio])
+        XCTAssertEqual(layout.conditionSegments.map(\.packedRows), [2..<6, 6..<12, 12..<24, 24..<28])
+        XCTAssertEqual(layout.conditionSegments.map(\.sourceRows), [0..<4, 0..<6, 4..<16, 6..<10])
+        XCTAssertTrue(layout.tokenTags[6..<12].allSatisfy { $0 == MiniMaxH3Modality.audio.rawValue })
+        XCTAssertTrue(layout.tokenTags[12..<24].allSatisfy { $0 == MiniMaxH3Modality.video.rawValue })
+    }
+
+    func testShiftedSchedulesTerminateAtCleanEndpoint() throws {
+        let video = try MiniMaxH3Schedule(pointCount: 5, shift: 12)
+        let audio = try MiniMaxH3Schedule(pointCount: 5, shift: 3)
+        XCTAssertEqual(video.sigmas.first, 1)
+        XCTAssertEqual(video.sigmas.last, 0)
+        XCTAssertEqual(audio.sigmas.first, 1)
+        XCTAssertEqual(audio.sigmas.last, 0)
+        XCTAssertEqual(video.timesteps.count, 4)
+        XCTAssertEqual(video.timesteps.first, 0)
+
+        let sample = MLXArray([1, 2, 3, 4]).reshaped(1, 4)
+        let velocity = MLXArray.ones([1, 4])
+        let final = video.step(sample: sample, velocity: velocity, index: video.timesteps.count - 1)
+        MLX.eval(final)
+        XCTAssertTrue(final.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+
+    func testResidentBF16PolicyAccountsForGeometryAndMemory() throws {
+        let denseBytes = 41 * MiniMaxH3ResidentBF16Policy.gibibyte
+        XCTAssertTrue(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .automatic,
+            physicalMemoryBytes: 64 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 12_925,
+            hasAdaLNCache: true,
+            isPortableMac: false
+        ))
+        XCTAssertFalse(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .automatic,
+            physicalMemoryBytes: 64 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 37_966,
+            hasAdaLNCache: true,
+            isPortableMac: false
+        ))
+        XCTAssertTrue(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .automatic,
+            physicalMemoryBytes: 128 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 37_966,
+            hasAdaLNCache: true,
+            isPortableMac: false
+        ))
+        XCTAssertFalse(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .quantized,
+            physicalMemoryBytes: 128 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 12_925,
+            hasAdaLNCache: true,
+            isPortableMac: false
+        ))
+        XCTAssertFalse(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .automatic,
+            physicalMemoryBytes: 128 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 12_925,
+            hasAdaLNCache: false,
+            isPortableMac: false
+        ))
+        XCTAssertFalse(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .automatic,
+            physicalMemoryBytes: 128 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 12_925,
+            hasAdaLNCache: true,
+            isPortableMac: true
+        ))
+        XCTAssertThrowsError(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .residentBF16,
+            physicalMemoryBytes: 48 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 12_925,
+            hasAdaLNCache: true,
+            isPortableMac: true
+        ))
+    }
+
+    func testStepPolicyUsesPracticalExtendedAndMaximumEnvelopes() throws {
+        XCTAssertEqual(
+            try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: 512,
+                height: 512,
+                numFrames: 56
+            ),
+            9
+        )
+        XCTAssertEqual(
+            try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: 768,
+                height: 448,
+                numFrames: 124
+            ),
+            9
+        )
+        XCTAssertEqual(
+            try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: 768,
+                height: 512,
+                numFrames: 124
+            ),
+            16
+        )
+        XCTAssertEqual(
+            try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: 1_344,
+                height: 768,
+                numFrames: 124
+            ),
+            31
+        )
+        XCTAssertEqual(
+            try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: 768,
+                height: 448,
+                numFrames: 124,
+                referenceKinds: [.video]
+            ),
+            16
+        )
+
+        let automatic = try MiniMaxH3GenerationOptions(
+            prompt: "a practical local video",
+            width: 768,
+            height: 448,
+            numFrames: 124
+        )
+        XCTAssertEqual(automatic.steps, 9)
+        let explicit = try MiniMaxH3GenerationOptions(
+            prompt: "a maximum quality local video",
+            width: 768,
+            height: 448,
+            numFrames: 124,
+            steps: 31
+        )
+        XCTAssertEqual(explicit.steps, 31)
+    }
+
+    func testTinyTransformerResidentBF16MatchesQuantizedExecution() throws {
+        let configuration = MiniMaxH3TransformerConfiguration(
+            hiddenSize: 32,
+            layerCount: 2,
+            refinerLayerCount: 1,
+            attentionHeadCount: 4,
+            attentionHeadDimension: 8,
+            feedForwardSize: 64,
+            videoLatentChannels: 8,
+            audioLatentChannels: 32,
+            patchSize: [1, 2, 2],
+            textDimension: 32,
+            timeFrequencyDimension: 32,
+            timeEmbeddingHiddenSize: 32,
+            timeEmbeddingDimension: 32,
+            ropeFrequencyCount: 1
+        )
+        let model = MiniMaxH3Transformer(configuration: configuration)
+        model.update(parameters: model.parameters().mapValues { $0.asType(.bfloat16) })
+        quantize(
+            model: model,
+            groupSize: 32,
+            bits: 4,
+            filter: { _, _ in true },
+            apply: { module, groupSize, bits, mode in
+                guard let quantized = quantizeSingle(
+                    layer: module,
+                    groupSize: groupSize,
+                    bits: bits,
+                    mode: mode
+                ) as? QuantizedLinear else { return nil }
+                return PortableQuantizedLinear(
+                    weight: quantized.weight,
+                    bias: quantized.bias,
+                    scales: quantized.scales,
+                    biases: quantized.biases,
+                    groupSize: quantized.groupSize,
+                    bits: quantized.bits,
+                    mode: quantized.mode,
+                    globalScale: quantized.globalScale
+                )
+            }
+        )
+        let quantizedCount = model.leafModules().flattened()
+            .count(where: { $0.1 is QuantizedLinear })
+        let estimatedBytes = model.estimatedResidentBF16ByteCount
+        XCTAssertGreaterThan(quantizedCount, 0)
+        XCTAssertGreaterThan(estimatedBytes, 0)
+
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: [1, 1],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: [.first]
+        )
+        let video = MLXArray.zeros([1, 12, 32], dtype: .bfloat16)
+        let audio = MLXArray.zeros([1, 6, 32], dtype: .bfloat16)
+        let text = MLXArray.zeros([1, 2, 32], dtype: .bfloat16)
+        let quantizedOutput = model(
+            videoRows: video,
+            audioRows: audio,
+            textStates: text,
+            layout: layout,
+            videoTimestep: 0.2,
+            audioTimestep: 0.4
+        )
+        MLX.eval(quantizedOutput.videoVelocityRows, quantizedOutput.audioVelocityRows)
+
+        let materialized = model.materializeResidentBF16()
+        XCTAssertTrue(model.usesResidentBF16)
+        XCTAssertEqual(materialized.linearCount, quantizedCount)
+        XCTAssertEqual(materialized.byteCount, estimatedBytes)
+        XCTAssertFalse(model.leafModules().flattened().contains { $0.1 is QuantizedLinear })
+        let denseOutput = model(
+            videoRows: video,
+            audioRows: audio,
+            textStates: text,
+            layout: layout,
+            videoTimestep: 0.2,
+            audioTimestep: 0.4
+        )
+        MLX.eval(denseOutput.videoVelocityRows, denseOutput.audioVelocityRows)
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                quantizedOutput.videoVelocityRows.asType(.float32)
+                    - denseOutput.videoVelocityRows.asType(.float32)
+            ).max().item(Float.self),
+            0.05
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                quantizedOutput.audioVelocityRows.asType(.float32)
+                    - denseOutput.audioVelocityRows.asType(.float32)
+            ).max().item(Float.self),
+            0.05
+        )
+    }
+
+    func testTinyTransformerPreservesTargetShapes() throws {
+        let configuration = MiniMaxH3TransformerConfiguration(
+            hiddenSize: 12,
+            layerCount: 2,
+            refinerLayerCount: 1,
+            attentionHeadCount: 2,
+            attentionHeadDimension: 6,
+            feedForwardSize: 16,
+            videoLatentChannels: 3,
+            audioLatentChannels: 4,
+            patchSize: [1, 2, 2],
+            textDimension: 10,
+            timeFrequencyDimension: 4,
+            timeEmbeddingHiddenSize: 12,
+            timeEmbeddingDimension: 8,
+            ropeFrequencyCount: 1
+        )
+        let model = MiniMaxH3Transformer(configuration: configuration)
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: [1, 1],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: [.first]
+        )
+        let result = model(
+            videoRows: MLXArray.zeros([1, 12, 12]),
+            audioRows: MLXArray.zeros([1, 6, 4]),
+            textStates: MLXArray.zeros([1, 2, 10]),
+            layout: layout,
+            videoTimestep: 0.2,
+            audioTimestep: 0.4
+        )
+        MLX.eval(result.videoVelocityRows, result.audioVelocityRows)
+        XCTAssertEqual(result.videoVelocityRows.shape, [1, 8, 12])
+        XCTAssertEqual(result.audioVelocityRows.shape, [1, 6, 4])
+    }
+
+    func testTinyTransformerAcceptsRef2VAConditionAudioAndVideo() throws {
+        let configuration = MiniMaxH3TransformerConfiguration(
+            hiddenSize: 12,
+            layerCount: 1,
+            refinerLayerCount: 1,
+            attentionHeadCount: 2,
+            attentionHeadDimension: 6,
+            feedForwardSize: 16,
+            videoLatentChannels: 3,
+            audioLatentChannels: 4,
+            patchSize: [1, 2, 2],
+            textDimension: 10,
+            timeFrequencyDimension: 4,
+            timeEmbeddingHiddenSize: 12,
+            timeEmbeddingDimension: 8,
+            ropeFrequencyCount: 1
+        )
+        let layout = try MiniMaxH3Geometry.buildRef2VA(
+            textTokenTags: [1, 1],
+            references: [
+                .init(
+                    kind: .video,
+                    videoLatentFrames: 1,
+                    latentHeight: 4,
+                    latentWidth: 4,
+                    audioLatentFrames: 2
+                ),
+            ],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3
+        )
+        let result = MiniMaxH3Transformer(configuration: configuration)(
+            videoRows: MLXArray.zeros([1, 12, 12]),
+            audioRows: MLXArray.zeros([1, 10, 4]),
+            textStates: MLXArray.zeros([1, 2, 10]),
+            layout: layout,
+            videoTimestep: 0.2,
+            audioTimestep: 0.4
+        )
+        MLX.eval(result.videoVelocityRows, result.audioVelocityRows)
+        XCTAssertEqual(result.videoVelocityRows.shape, [1, 8, 12])
+        XCTAssertEqual(result.audioVelocityRows.shape, [1, 6, 4])
+    }
+
+    func testPreparedAndCompiledTinyTransformerMatchDirectExecution() throws {
+        let configuration = MiniMaxH3TransformerConfiguration(
+            hiddenSize: 32,
+            layerCount: 2,
+            refinerLayerCount: 1,
+            attentionHeadCount: 4,
+            attentionHeadDimension: 8,
+            feedForwardSize: 64,
+            videoLatentChannels: 3,
+            audioLatentChannels: 4,
+            patchSize: [1, 2, 2],
+            textDimension: 32,
+            timeFrequencyDimension: 8,
+            timeEmbeddingHiddenSize: 32,
+            timeEmbeddingDimension: 32,
+            ropeFrequencyCount: 1
+        )
+        let model = MiniMaxH3Transformer(configuration: configuration)
+        quantize(
+            model: model,
+            groupSize: 32,
+            bits: 4,
+            filter: { path, _ in path.hasPrefix("blocks.") },
+            apply: { module, groupSize, bits, mode in
+                guard let quantized = quantizeSingle(
+                    layer: module,
+                    groupSize: groupSize,
+                    bits: bits,
+                    mode: mode
+                ) as? QuantizedLinear else { return nil }
+                return PortableQuantizedLinear(
+                    weight: quantized.weight,
+                    bias: quantized.bias,
+                    scales: quantized.scales,
+                    biases: quantized.biases,
+                    groupSize: quantized.groupSize,
+                    bits: quantized.bits,
+                    mode: quantized.mode,
+                    globalScale: quantized.globalScale
+                )
+            }
+        )
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: [1, 1],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: [.first]
+        )
+        let video = MLXArray.zeros([1, 12, 12])
+        let audio = MLXArray.zeros([1, 6, 4])
+        let text = MLXArray.zeros([1, 2, 32])
+        let timesteps = MLXArray([Float(0.2), 0.4, 0.999])
+        let direct = model(
+            videoRows: video,
+            audioRows: audio,
+            textStates: text,
+            layout: layout,
+            videoTimestep: 0.2,
+            audioTimestep: 0.4
+        )
+        let context = model.prepare(textStates: text, layout: layout)
+        let prepared = model(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil
+        )
+        let compiled = MLX.compile { (inputs: [MLXArray]) -> [MLXArray] in
+            let output = model(
+                videoRows: inputs[0],
+                audioRows: inputs[1],
+                context: context,
+                timesteps: inputs[2],
+                cachedAdaLN: nil
+            )
+            return [output.videoVelocityRows, output.audioVelocityRows]
+        }
+        let compiledOutputs = compiled([video, audio, timesteps])
+        MLX.eval(compiledOutputs)
+        model.maximumAttentionQueryTokensPerKernel = 2
+        model.usesBlockwiseCompilation = true
+        let blockwiseCompiled = model(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil
+        )
+        MLX.eval(blockwiseCompiled.videoVelocityRows, blockwiseCompiled.audioVelocityRows)
+        model.usesBlockwiseCompilation = false
+        model.usesLayerwiseEvaluation = true
+        model.clearsCacheAfterLayerwiseEvaluation = false
+        let layerwise = model(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil
+        )
+        MLX.eval(layerwise.videoVelocityRows, layerwise.audioVelocityRows)
+        model.usesLayerwiseEvaluation = false
+        MLX.eval(
+            direct.videoVelocityRows,
+            direct.audioVelocityRows,
+            prepared.videoVelocityRows,
+            prepared.audioVelocityRows,
+            compiledOutputs[0],
+            compiledOutputs[1],
+            blockwiseCompiled.videoVelocityRows,
+            blockwiseCompiled.audioVelocityRows,
+            layerwise.videoVelocityRows,
+            layerwise.audioVelocityRows
+        )
+        XCTAssertTrue(direct.videoVelocityRows.allClose(prepared.videoVelocityRows).item(Bool.self))
+        XCTAssertTrue(direct.audioVelocityRows.allClose(prepared.audioVelocityRows).item(Bool.self))
+        XCTAssertLessThanOrEqual(
+            MLX.abs(prepared.videoVelocityRows - compiledOutputs[0]).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(prepared.audioVelocityRows - compiledOutputs[1]).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(prepared.videoVelocityRows - blockwiseCompiled.videoVelocityRows).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(prepared.audioVelocityRows - blockwiseCompiled.audioVelocityRows)
+                .max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(prepared.videoVelocityRows - layerwise.videoVelocityRows)
+                .max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(prepared.audioVelocityRows - layerwise.audioVelocityRows)
+                .max().item(Float.self),
+            1e-5
+        )
+
+        let videoSchedule = try MiniMaxH3Schedule(pointCount: 3, shift: 12)
+        let audioSchedule = try MiniMaxH3Schedule(pointCount: 3, shift: 3)
+        let cache = model.precomputeAdaLN(
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: "test-transformer"
+        )
+        let scheduleTimesteps = MLXArray([
+            videoSchedule.timesteps[1],
+            audioSchedule.timesteps[1],
+            max(videoSchedule.timesteps[1], 0.999),
+        ])
+        let eagerScheduleOutput = model(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: scheduleTimesteps,
+            cachedAdaLN: nil
+        )
+        let cachedScheduleOutput = model(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: scheduleTimesteps,
+            cachedAdaLN: cache.step(at: 1)
+        )
+        model.usesBlockwiseCompilation = true
+        let blockwiseCachedScheduleOutput = model(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: scheduleTimesteps,
+            cachedAdaLN: cache.step(at: 1)
+        )
+        MLX.eval(
+            blockwiseCachedScheduleOutput.videoVelocityRows,
+            blockwiseCachedScheduleOutput.audioVelocityRows
+        )
+        model.usesBlockwiseCompilation = false
+        MLX.eval(
+            eagerScheduleOutput.videoVelocityRows,
+            eagerScheduleOutput.audioVelocityRows,
+            cachedScheduleOutput.videoVelocityRows,
+            cachedScheduleOutput.audioVelocityRows,
+            blockwiseCachedScheduleOutput.videoVelocityRows,
+            blockwiseCachedScheduleOutput.audioVelocityRows
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                eagerScheduleOutput.videoVelocityRows
+                    - cachedScheduleOutput.videoVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                eagerScheduleOutput.audioVelocityRows
+                    - cachedScheduleOutput.audioVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                cachedScheduleOutput.videoVelocityRows
+                    - blockwiseCachedScheduleOutput.videoVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                cachedScheduleOutput.audioVelocityRows
+                    - blockwiseCachedScheduleOutput.audioVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+
+        let cacheURL = FileManager.default.temporaryDirectory
+            .appending(path: "minimax-h3-adaln-\(UUID().uuidString).safetensors")
+        defer { try? FileManager.default.removeItem(at: cacheURL) }
+        try cache.save(to: cacheURL, replacing: false)
+        let loaded = try MiniMaxH3AdaLNCache.load(
+            from: cacheURL,
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: "test-transformer"
+        )
+        XCTAssertEqual(loaded.stepCount, 2)
+        XCTAssertEqual(loaded.blockModulations.count, 2)
+        XCTAssertTrue(loaded.isCompatible(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        ))
+        XCTAssertThrowsError(try MiniMaxH3AdaLNCache.load(
+            from: cacheURL,
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: "stale-transformer"
+        ))
+
+        let denseVideoSchedule = try MiniMaxH3Schedule(pointCount: 5, shift: 12)
+        let denseAudioSchedule = try MiniMaxH3Schedule(pointCount: 5, shift: 3)
+        let denseCache = model.precomputeAdaLN(
+            videoSchedule: denseVideoSchedule,
+            audioSchedule: denseAudioSchedule,
+            sourceIdentity: "test-transformer"
+        )
+        let resampled = try denseCache.resampled(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        )
+        MLX.eval(
+            [resampled.timeEmbeddings, resampled.finalModulations]
+                + resampled.blockModulations
+        )
+        XCTAssertTrue(resampled.isCompatible(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        ))
+        XCTAssertEqual(resampled.timeEmbeddings.dtype, denseCache.timeEmbeddings.dtype)
+        XCTAssertEqual(resampled.finalModulations.dtype, denseCache.finalModulations.dtype)
+        XCTAssertEqual(resampled.blockModulations[0].dtype, denseCache.blockModulations[0].dtype)
+        XCTAssertLessThanOrEqual(
+            MLX.abs(resampled.timeEmbeddings - cache.timeEmbeddings).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(resampled.finalModulations - cache.finalModulations).max().item(Float.self),
+            1e-5
+        )
+        for index in cache.blockModulations.indices {
+            XCTAssertLessThanOrEqual(
+                MLX.abs(resampled.blockModulations[index] - cache.blockModulations[index])
+                    .max().item(Float.self),
+                1e-5
+            )
+        }
+
+        try denseCache.save(to: cacheURL, replacing: true)
+        XCTAssertThrowsError(try MiniMaxH3AdaLNCache.load(
+            from: cacheURL,
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: "test-transformer"
+        ))
+        let loadedResampled = try MiniMaxH3AdaLNCache.load(
+            from: cacheURL,
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: "test-transformer",
+            allowScheduleResampling: true
+        )
+        XCTAssertTrue(loadedResampled.isCompatible(
+            configuration: configuration,
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule
+        ))
+    }
+
+    func testTinyVideoDecoderShape() {
+        let decoder = MiniMaxH3VideoDecoder(configuration: .init(
+            latentChannels: 2,
+            outputChannels: 3,
+            patchSize: 2,
+            temporalPatchSize: 2,
+            layerCount: 1,
+            headCount: 2,
+            headDimension: 6,
+            registerTokenCount: 1,
+            feedForwardMultiplier: 2,
+            rotaryDimensionRatio: 1
+        ))
+        let result = decoder(MLXArray.zeros([1, 2, 2, 2, 2]))
+        MLX.eval(result)
+        XCTAssertEqual(result.shape, [1, 3, 4, 4, 4])
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1997,18 +1997,21 @@ revision-addressed layout without copying matching payload bytes on a later pull
 
 ### `mere.run model optimize`
 
-Build a reusable inference-only cache for an installed MiniMax-H3 MLX model:
+Build a reusable inference-only cache for a compatible locally converted
+MiniMax-H3 MLX model that still contains the full AdaLN branch:
 
 ```bash
-mere.run model optimize video-minimax-h3-fl2va-mlx
-mere.run model optimize video-minimax-h3-fl2va-mlx --json
+mere.run model optimize ./MiniMax-H3-FL2VA-full-MLX
+mere.run model optimize ./MiniMax-H3-FL2VA-full-MLX --json
 ```
 
 The generated `adaln_cache.safetensors` contains the released 31-point
 video/audio schedule's AdaLN modulation tables. Compatible H3 generations then
 skip loading the 13B-parameter AdaLN/time-embedding branch and resample that
 exact curve for their selected point count. `--force` replaces an existing
-cache atomically after the new cache has been built.
+cache atomically after the new cache has been built. The managed
+`video-minimax-h3-fl2va-mlx` artifact already includes this source-bound cache;
+no post-pull optimization is needed.
 
 ### `mere.run model remove`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,7 +138,7 @@ Public tree:
   - `mere.run run fetch` — Fetch a remote graph run into the standard local run-directory format.
   - `mere.run run cancel` — Cancel a graph run.
   - `mere.run run retry` — Retry an immutable relay graph job.
-- [`mere.run model`](/runtime/model-management) — List, pull, remove, inspect, and clean up models.
+- [`mere.run model`](/runtime/model-management) — List, pull, remove, inspect, optimize, and clean up models.
   - `mere.run model list` — List all known models with install status.
   - `mere.run model pull` — Download a managed model into the local model store.
   - `mere.run model remove` — Remove a model from the local model store.
@@ -149,6 +149,7 @@ Public tree:
   - `mere.run model runtime` — Read and update per-model API runtime settings.
     - `mere.run model runtime get` — Print typed API runtime settings for a managed model.
     - `mere.run model runtime set` — Update typed API runtime settings for a managed model.
+  - `mere.run model optimize` — Build inference-only caches for a supported installed model.
   - `mere.run model benchmark` — Run focused local model benchmarks.
     - `mere.run model benchmark chat` — Run a small grounded-chat eval slice against local assistant models.
     - `mere.run model benchmark tool-calls` — Run a small tool-call selection eval against local chat models.
@@ -1761,7 +1762,7 @@ a canonical hashed manifest.
 
 ### `mere.run video generate`
 
-Generate MP4 video with the native LTX and Wan2.2 pipelines.
+Generate MP4 video with the native MiniMax-H3, LTX, and Wan2.2 pipelines.
 
 ```bash
 swift run mere.run video generate "<prompt>" [options]
@@ -1782,7 +1783,9 @@ Key options:
 - `--duration`
 - `--fps`
 - `--seed`
-- `--steps`, `--guidance-scale`, `--shift`, `--negative-prompt` for Wan2.2
+- `--steps`: MiniMax-H3 schedule-point override or Wan2.2 inference steps
+- `--h3-weight-mode`: `auto`, `quantized`, or `resident-bf16`
+- `--guidance-scale`, `--shift`, `--negative-prompt` for Wan2.2
 - `--audio`: source audio path; automatically selects native LTX 2.3 A2Vid
 - `--audio-start-time`: source segment offset in seconds (default `0`)
 - `--a2v-guidance-scale`: audio-modality guidance (default `3`)
@@ -1796,6 +1799,8 @@ Key options:
 - `--image-strength`
 - `--end-image`
 - `--end-image-strength`
+- `--reference`: repeatable ordered MiniMax-H3 Ref2VA input in
+  `image:path`, `video:path`, or `audio:path` form
 - `--preflight`
 - `--json`: only with `--preflight`
 - `--timings`: native LTX 2.3 split-distilled, unified-AV, or A2Vid phase
@@ -1837,6 +1842,17 @@ For native Wan2.2 image-to-video, pass
 to multiples of 32 and frame counts follow `4n+1`; 512x320 with 17 frames is a
 useful short world-transition baseline. Tiny 128-pixel outputs are structural
 smokes, not quality renders.
+
+MiniMax-H3 always emits synchronized 24 fps video and 32 kHz stereo audio.
+FL2VA accepts `--image` and optional `--end-image`; Ref2VA accepts ordered
+`--reference` values and rejects those keyframe flags. H3 dimensions snap to
+32-pixel multiples, frame counts snap upward to `17*n+5`, and its
+CFG-distilled transformer needs one evaluation per schedule step. Ref2VA roots
+are locally converted; the public managed pull exists only for FL2VA.
+When `--steps` is omitted, H3 selects 9, 16, or 31 schedule points from packed
+row cost. Its source-bound AdaLN cache resamples the exact released 31-point
+curve for explicit overrides. `--h3-weight-mode auto` keeps compact Q4 on
+MacBooks and may expand to resident BF16 on memory-qualified desktop Macs.
 
 Preflight mode:
 
@@ -1904,6 +1920,14 @@ swift run mere.run video generate \
   --end-image ./car-end.png \
   --num-frames 65 \
   --output ./car-start-to-end.mp4
+
+swift run mere.run video generate \
+  "keep the reference subject and follow the camera movement" \
+  --model-root ./MiniMax-H3-Ref2VA-MLX \
+  --reference image:./subject.png \
+  --reference video:./camera.mp4 \
+  --num-frames 124 \
+  --output ./h3-ref2va.mp4
 ```
 
 ### `mere.run video session`
@@ -1970,6 +1994,21 @@ mere.run model gc --force
 Cleanup rechecks the ownership graph under the same lock used by managed pulls.
 Existing legacy cache layouts remain readable and are adopted into the
 revision-addressed layout without copying matching payload bytes on a later pull.
+
+### `mere.run model optimize`
+
+Build a reusable inference-only cache for an installed MiniMax-H3 MLX model:
+
+```bash
+mere.run model optimize video-minimax-h3-fl2va-mlx
+mere.run model optimize video-minimax-h3-fl2va-mlx --json
+```
+
+The generated `adaln_cache.safetensors` contains the released 31-point
+video/audio schedule's AdaLN modulation tables. Compatible H3 generations then
+skip loading the 13B-parameter AdaLN/time-embedding branch and resample that
+exact curve for their selected point count. `--force` replaces an existing
+cache atomically after the new cache has been built.
 
 ### `mere.run model remove`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -154,7 +154,7 @@ itself, so it always matches the binary you just built:
 | [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
 | [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
 | [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
-| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, and clean up models. |
+| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, optimize, and clean up models. |
 | [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |
 | [`mere.run status`](/runtime/model-management) | Show local server, loaded model, and installed model status. |
 | [`mere.run gate`](/gate) | Run the end-to-end quality gate against installed models. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ links to the page that owns that command.
 | [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
 | [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
 | [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
-| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, and clean up models. |
+| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, optimize, and clean up models. |
 | [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |
 | [`mere.run status`](/runtime/model-management) | Show local server, loaded model, and installed model status. |
 | [`mere.run gate`](/gate) | Run the end-to-end quality gate against installed models. |

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -117,6 +117,8 @@ from the runtime catalog used by `mere.run model list`,
 | `video` | `video-ltx23-full-mlx` |
 | `video` | `video-ltx23-a2vid-mlx` |
 | `video` | `video-wan22-ti2v-5b-mlx` |
+| `video` | `video-minimax-h3-fl2va-mlx` |
+| `video` | `video-minimax-h3-ref2va-mlx` |
 | `video` | `video-cosmos3-edge-mlx` |
 | `video` | `video-scail2-14b-mlx` |
 | `video` | `video-dreamx-world-5b-ar-mlx` |
@@ -153,6 +155,7 @@ validates all configured models before downloading any; both accept the same
 | `text-chat-lfm25-a1b-8bit` | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
 | `vision-segment-sam31` | Meta SAM License custom use, trade-control, attribution, and redistribution conditions |
 | `vision-face-buffalo-l` | InsightFace pretrained weights; non-commercial research use |
+| `video-minimax-h3-fl2va-mlx`, `video-minimax-h3-ref2va-mlx` | MiniMax-H3 Community License; use, distribution, and display are excluded in the United States, European Union, United Kingdom, and Republic of Korea, with downstream notice and safeguard obligations |
 | `image-3d-trellis2-4b` | the mounted DINOv3 encoder is gated under Meta's custom DINOv3 License |
 | `music-muscriptor-{small,medium,large}` | CC BY-NC 4.0 model weights |
 | `sfx-woosh-*` | CC BY-NC 4.0 Woosh or MMAudio Synchformer weights |
@@ -763,6 +766,55 @@ Its legacy narrow manifest may omit the vocoder, so it can run final-quality
 video-only and source-audio A2Vid but not generated-audio output. Requests for
 either the legacy ID or the new full ID resolve to an already-installed
 compatible root when possible. New pulls should use `video-ltx23-full-mlx`.
+
+### MiniMax-H3 FL2VA and Ref2VA
+
+The native MiniMax-H3 implementation covers both released 33B dense
+partitions: FL2VA text/first/last-frame conditioning and Ref2VA ordered
+image/video/audio conditioning. It jointly denoises 24-channel video and
+32-channel stereo-as-batch audio latents, then decodes 24 fps RGB video and
+32 kHz stereo audio into one MP4.
+
+The explicit-pull FL2VA root is the flat
+`ddalcu/MiniMax-H3-FL2VA-MLX-Serve-8bit` package pinned at immutable revision
+`32bfc37f1dc8bd331394573859a627bc0aa9822b` (69,284,785,360 bytes). The package
+contains the affine 8-bit/group-64 transformer and Qwen3-VL conditioner,
+float32 video/audio VAEs, tokenizer, configuration, `LICENSE`, `NOTICE`, and
+`MODIFICATIONS.md`. Runtime auto-download is disabled.
+
+Ref2VA is conversion-only. The audited converter accepts only
+`minimax_h3_ref2va_int8_convrot.safetensors` from
+`Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77`, exactly
+34,038,894,550 bytes with SHA-256
+`9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9`.
+It reverses the regular-Hadamard ConvRot basis, reproduces MLX affine INT8
+group-64 packing, and emits a hashed receipt. The verified conversion used for
+runtime validation is 36,024,412,656 bytes with SHA-256
+`c3ddde0dc29503281cd4c03c1f82b9cb640f4670da68caa5f55e3cec8f2045e8`.
+Stage it as `transformer.safetensors` beside the exact FL conditioner, VAEs,
+tokenizer, notices, and a `config.json` whose `partition` is `ref2va`.
+
+`requantize_minimax_h3_mlx.py` can derive a compact inference-only transformer
+from either verified affine INT8 artifact after `model optimize` creates its
+source-bound AdaLN cache. The streaming converter writes affine INT4/group-64
+active matrices, omits only the cache-covered AdaLN/time-embedding branch, and
+emits both a per-layer error/hash receipt and a mixed-precision config. That
+config is significant: the transformer is INT4 while the unchanged Qwen3-VL
+conditioner remains INT8. Install the transformer, config, receipt, and matching
+cache as one unit. The runtime resamples the cache's exact released 31-point
+modulation curve, so compact roots support arbitrary valid schedule-point
+counts without restoring the omitted inference-redundant branch.
+
+The model weights use the MiniMax-H3 Community License, not Apache-2.0. At the
+pinned official source revision
+`ec19cc6daf5d8add9417c18e86b6b58cc6c55027`, the license excludes use,
+distribution, and display in the United States, European Union, United
+Kingdom, and Republic of Korea and imposes notice, modification-disclosure,
+and safety obligations on downstream distribution. The CLI therefore requires
+explicit license acceptance for the managed FL pull, and conversion must be
+performed only where the model terms permit it. The upstream FL2VA and Ref2VA
+trees are about 144 GB each; the complete upstream repository is roughly
+498 GB, so compile success is not artifact or generation proof.
 
 ### `video-wan22-ti2v-5b-mlx`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -776,11 +776,20 @@ image/video/audio conditioning. It jointly denoises 24-channel video and
 32 kHz stereo audio into one MP4.
 
 The explicit-pull FL2VA root is the flat
-`ddalcu/MiniMax-H3-FL2VA-MLX-Serve-8bit` package pinned at immutable revision
-`32bfc37f1dc8bd331394573859a627bc0aa9822b` (69,284,785,360 bytes). The package
-contains the affine 8-bit/group-64 transformer and Qwen3-VL conditioner,
-float32 video/audio VAEs, tokenizer, configuration, `LICENSE`, `NOTICE`, and
-`MODIFICATIONS.md`. Runtime auto-download is disabled.
+`Sawfwair/MiniMax-H3-FL2VA-MLX-4bit` package pinned at immutable Hub commit
+`e1244ad93d60c737c7e0f065a1c9372f3de7caf8`.
+Every tensor in that package is derived directly from
+`MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027`; converted or
+quantized third-party weights are not inputs. The transformer core is affine
+Q4/group-64 with dense precision islands, the exact 50-layer Qwen3-VL
+conditioner is affine Q8/group-64, the video VAE is FP16, and the audio VAE has
+its released weight normalization folded for the native runtime. The 14-file
+managed download is exactly 46,250,104,566 bytes and also carries the tokenizer,
+configuration, source manifest, conversion receipt, hashes, `LICENSE`,
+`NOTICE`, and `MODIFICATIONS.md`. Before Q4 packing, all 52 fused transformer
+QKV matrices are deinterleaved from MiniMax's released per-head row order into
+the global Q/K/V slabs consumed by the native runtime. Runtime auto-download is
+disabled.
 
 Ref2VA is conversion-only. The audited converter accepts only
 `minimax_h3_ref2va_int8_convrot.safetensors` from
@@ -794,16 +803,14 @@ runtime validation is 36,024,412,656 bytes with SHA-256
 Stage it as `transformer.safetensors` beside the exact FL conditioner, VAEs,
 tokenizer, notices, and a `config.json` whose `partition` is `ref2va`.
 
-`requantize_minimax_h3_mlx.py` can derive a compact inference-only transformer
-from either verified affine INT8 artifact after `model optimize` creates its
-source-bound AdaLN cache. The streaming converter writes affine INT4/group-64
-active matrices, omits only the cache-covered AdaLN/time-embedding branch, and
-emits both a per-layer error/hash receipt and a mixed-precision config. That
-config is significant: the transformer is INT4 while the unchanged Qwen3-VL
-conditioner remains INT8. Install the transformer, config, receipt, and matching
-cache as one unit. The runtime resamples the cache's exact released 31-point
-modulation curve, so compact roots support arbitrary valid schedule-point
-counts without restoring the omitted inference-redundant branch.
+`convert_minimax_h3_official_mlx.py` creates the managed FL2VA package in one
+audited pass from the official release. It computes the source-bound AdaLN
+cache from the original BF16/F32 projections, directly quantizes the active
+transformer and conditioner matrices once, and emits the cache, weights,
+configuration, receipts, and source manifest as one unit. The runtime resamples
+the cache's exact released 31-point modulation curve, so the package supports
+arbitrary valid schedule-point counts without restoring the omitted
+inference-redundant branch.
 
 The model weights use the MiniMax-H3 Community License, not Apache-2.0. At the
 pinned official source revision

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -16,6 +16,7 @@ exactly what is safe to delete.
 | `mere.run model remove` | Remove a model from the local model store. |
 | `mere.run model storage` | Inspect physical model storage, sharing, and reclaimable space. |
 | `mere.run model gc` | Find or delete unreferenced model payloads and partial downloads. |
+| `mere.run model optimize` | Build inference-only caches for a supported installed model. |
 | `mere.run model repair-manifests` | Rewrite missing manifest metadata in the local store. |
 | `mere.run model runtime` | Read and update per-model API runtime settings. |
 | `mere.run model benchmark` | Run focused local model benchmarks. |
@@ -95,6 +96,23 @@ cache units, stale payloads, partial downloads, dead revision references, and
 unlinked blobs. Newly created unreferenced snapshots have a one-hour grace
 period. Installed model links and legacy links under MereRun application support
 keep their backing payloads live.
+
+### `mere.run model optimize`
+
+For MiniMax-H3 MLX installs, precompute the released 31-point schedule's AdaLN
+modulation tables once:
+
+```bash
+mere.run model optimize video-minimax-h3-fl2va-mlx
+```
+
+The cache is written beside the installed model. Compatible generation runs use
+it to avoid loading the inference-redundant AdaLN/time-embedding weights and
+resample its exact released curve for the selected schedule-point count. A
+compact transformer produced by `requantize_minimax_h3_mlx.py` intentionally
+omits those covered weights while retaining arbitrary valid schedule counts;
+its generated config keeps the transformer at INT4 and the Qwen3-VL
+conditioner at INT8.
 
 ### `mere.run status`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -99,20 +99,19 @@ keep their backing payloads live.
 
 ### `mere.run model optimize`
 
-For MiniMax-H3 MLX installs, precompute the released 31-point schedule's AdaLN
-modulation tables once:
+For compatible locally converted MiniMax-H3 roots that still contain the full
+AdaLN branch, precompute the released 31-point schedule's modulation tables:
 
 ```bash
-mere.run model optimize video-minimax-h3-fl2va-mlx
+mere.run model optimize ./MiniMax-H3-FL2VA-full-MLX
 ```
 
 The cache is written beside the installed model. Compatible generation runs use
 it to avoid loading the inference-redundant AdaLN/time-embedding weights and
-resample its exact released curve for the selected schedule-point count. A
-compact transformer produced by `requantize_minimax_h3_mlx.py` intentionally
-omits those covered weights while retaining arbitrary valid schedule counts;
-its generated config keeps the transformer at INT4 and the Qwen3-VL
-conditioner at INT8.
+resample its exact released curve for the selected schedule-point count. The
+managed `video-minimax-h3-fl2va-mlx` artifact already bundles a cache computed
+from the official BF16/F32 projections, so it does not require this command
+after pull.
 
 ### `mere.run status`
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -47,6 +47,16 @@ are an escape hatch, not the capability contract.
 
 ## Model family
 
+- `video-minimax-h3-fl2va-mlx`: explicit-pull MiniMax-H3 FL2VA affine-INT8
+  package. It generates 24 fps RGB and synchronized 32 kHz stereo audio from
+  text, a first frame, or directed first/last frames. Frame counts follow
+  `17*n+5`; width and height are multiples of 32.
+- `video-minimax-h3-ref2va-mlx`: identifier for a locally converted Ref2VA
+  root. Repeated `--reference image:path|video:path|audio:path` options retain
+  request order. Video soundtracks are conditioned with their video; a
+  standalone audio reference must be paired with an image or video. There is
+  no managed Ref2VA download because mere.run does not publish a converted
+  copy of the territory-restricted weights.
 - `video-ltx23-av-mlx`: standalone distilled LTX 2.3 MLX checkpoint for fast
   drafts. This is the default `--quality draft` checkpoint.
 - `video-ltx23-full-mlx`: LTX 2.3 dev checkpoint, official distilled LoRA,
@@ -70,6 +80,40 @@ are an escape hatch, not the capability contract.
   weights are governed by OpenMDW-1.1.
 
 ## Typical workflows
+
+### MiniMax-H3 synchronized video and audio
+
+```bash
+mere.run model pull video-minimax-h3-fl2va-mlx --accept-model-license
+mere.run model optimize video-minimax-h3-fl2va-mlx
+mere.run video generate "a glass marble rolls across wood with a delicate rattle" \
+  --model video-minimax-h3-fl2va-mlx \
+  --image ./marble.png \
+  --num-frames 124 \
+  --output ./marble-h3.mp4
+
+mere.run video generate "preserve the person and use the reference motion" \
+  --model-root ./MiniMax-H3-Ref2VA-MLX \
+  --reference image:./person.png \
+  --reference video:./motion.mp4 \
+  --output ./ref2va.mp4
+```
+
+MiniMax-H3 is CFG-distilled, so `--steps` is a schedule-point count without a
+second unconditional model evaluation. The Community License excludes use,
+distribution, and display in the United States, European Union, United
+Kingdom, and Republic of Korea. Read and accept the model terms before pulling,
+converting, using, or redistributing any artifact.
+
+The released 31-point modulation curve supports an inference-only AdaLN cache.
+Run `model optimize` once after pull or conversion; generation then skips
+loading and executing the transformer's 13B-parameter AdaLN/time-embedding
+branch and resamples that exact curve for the selected schedule. By default H3
+uses 9 points through 13,500 packed rows, 16 through 26,000, and 31 above that;
+`--steps` remains an explicit schedule-point override. Compact cache-backed
+INT4 transformers therefore remain correct at arbitrary point counts. MacBooks
+keep Q4 resident by default; desktop Macs may select resident BF16 when memory
+admits it, and `--h3-weight-mode` can force either path.
 
 ### Cosmos3 generation, actions, and reasoning
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -47,10 +47,11 @@ are an escape hatch, not the capability contract.
 
 ## Model family
 
-- `video-minimax-h3-fl2va-mlx`: explicit-pull MiniMax-H3 FL2VA affine-INT8
-  package. It generates 24 fps RGB and synchronized 32 kHz stereo audio from
-  text, a first frame, or directed first/last frames. Frame counts follow
-  `17*n+5`; width and height are multiples of 32.
+- `video-minimax-h3-fl2va-mlx`: explicit-pull MiniMax-H3 FL2VA package with a
+  direct-from-official Q4 transformer core, Q8 conditioner, and bundled
+  source-bound AdaLN cache. It generates 24 fps RGB and synchronized 32 kHz
+  stereo audio from text, a first frame, or directed first/last frames. Frame
+  counts follow `17*n+5`; width and height are multiples of 32.
 - `video-minimax-h3-ref2va-mlx`: identifier for a locally converted Ref2VA
   root. Repeated `--reference image:path|video:path|audio:path` options retain
   request order. Video soundtracks are conditioned with their video; a
@@ -85,7 +86,6 @@ are an escape hatch, not the capability contract.
 
 ```bash
 mere.run model pull video-minimax-h3-fl2va-mlx --accept-model-license
-mere.run model optimize video-minimax-h3-fl2va-mlx
 mere.run video generate "a glass marble rolls across wood with a delicate rattle" \
   --model video-minimax-h3-fl2va-mlx \
   --image ./marble.png \
@@ -105,15 +105,18 @@ distribution, and display in the United States, European Union, United
 Kingdom, and Republic of Korea. Read and accept the model terms before pulling,
 converting, using, or redistributing any artifact.
 
-The released 31-point modulation curve supports an inference-only AdaLN cache.
-Run `model optimize` once after pull or conversion; generation then skips
-loading and executing the transformer's 13B-parameter AdaLN/time-embedding
-branch and resamples that exact curve for the selected schedule. By default H3
-uses 9 points through 13,500 packed rows, 16 through 26,000, and 31 above that;
-`--steps` remains an explicit schedule-point override. Compact cache-backed
-INT4 transformers therefore remain correct at arbitrary point counts. MacBooks
-keep Q4 resident by default; desktop Macs may select resident BF16 when memory
-admits it, and `--h3-weight-mode` can force either path.
+The managed package already includes the inference-only AdaLN cache computed
+from the official BF16/F32 projections; no post-pull optimization step is
+required. Generation skips loading and executing the transformer's
+13B-parameter AdaLN/time-embedding branch and resamples its exact released
+31-point curve for the selected schedule. By default H3 uses 9 points through
+13,500 packed rows, 16 through 26,000, and 31 above that; `--steps` remains an
+explicit schedule-point override. Compact cache-backed INT4 transformers
+therefore remain correct at arbitrary point counts. MacBooks keep Q4 resident
+by default; desktop Macs may select resident BF16 when memory admits it, and
+`--h3-weight-mode` can force either path. `model optimize` remains available
+for compatible locally converted roots that still contain the full AdaLN
+branch.
 
 ### Cosmos3 generation, actions, and reasoning
 

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -56,6 +56,49 @@ uses the cache's exact released 31-point modulation curve. The runtime resamples
 that curve for arbitrary valid schedule-point counts without restoring the
 omitted inference-redundant weights.
 
+`convert_minimax_h3_official_mlx.py` builds the publishable FL2VA bundle from
+MiniMax's official BF16/FP32 release at one immutable revision. It downloads
+and hashes every official input, verifies the MiniMax license bytes, and
+self-tests MLX Q4/Q8 packing against an Apple Silicon byte-level fixture before
+conversion. No converted or quantized third-party checkpoint is accepted.
+
+The transformer core is quantized directly from official BF16 to affine
+Q4/group-64 while precision-sensitive projections remain dense. Before
+quantization, all 52 fused QKV matrices are deinterleaved from MiniMax's raw
+per-head checkpoint rows into the official reference model's
+`[all-q; all-k; all-v]` layout expected by the native runtime. A deterministic
+QKV permutation fixture fails the conversion if that contract changes. The
+Qwen3-VL conditioner is quantized directly from official BF16 to affine
+Q8/group-64. The AdaLN cache is evaluated from the original released
+projections before those inference-redundant weights are omitted. The official
+video VAE is cast to FP16 and the official audio VAE has weight normalization
+folded exactly as required by the native runtime.
+
+```bash
+HF_HOME=/workspace/hf-cache HF_XET_CHUNK_CACHE_SIZE_BYTES=0 \
+  python3 scripts/model-conversion/convert_minimax_h3_official_mlx.py \
+    --cache-dir /workspace/hf-cache \
+    --conversion-location "CA-MTL-3, Canada" \
+    --output /workspace/minimax-h3-sawfwair
+```
+
+The output carries `SOURCE_MANIFEST.json`, conversion metadata, the exact
+upstream license and notices, and SHA-256 receipts for the publishable bundle.
+Run the converter with `--plan` before provisioning storage, or with
+`--self-test-only` to validate MLX's active backend before downloading weights.
+Before publication, run the fail-closed structural and hash gate:
+
+```bash
+python3 scripts/model-conversion/validate_minimax_h3_official_artifact.py \
+  /workspace/minimax-h3-sawfwair \
+  --conversion-location "CA-MTL-3, Canada"
+```
+
+The validator rehashes every distributed file and checks the complete official
+source manifest, license bytes, Q4/Q8 and QKV fixture receipts, component tensor
+counts, dtypes, retained 50-layer conditioner, cache geometry, and forbidden
+omitted branches.
+
 ## Gemma 4 12B MLX 4-bit
 
 `convert_gemma4_12b_mlx.py` verifies Google's exact 23,919,549,408-byte Gemma 4

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -3,6 +3,59 @@
 These scripts are audited release tools. They are never invoked by a
 `mere.run` inference command and never become a Python sidecar.
 
+## MiniMax-H3 FL2VA and Ref2VA
+
+`convert_minimax_h3_convrot.py` converts either pinned MiniMax-H3 transformer
+partition from Comfy-Org's exact per-row ConvRot INT8 checkpoint into native
+MLX affine 8-bit tensors with group size 64. It first restores the unrotated
+weight basis, then reproduces MLX's affine scale, bias, and uint32 packing. It
+rejects any source whose filename, byte count, or SHA-256 differs from the
+pinned Hub revision and writes a hashed conversion receipt beside the output.
+
+The converter only handles transformer weights. A self-contained native model
+root must also contain the pinned Qwen3-VL conditioner, video/audio VAEs,
+tokenizer, `config.json`, `LICENSE`, `NOTICE`, and `MODIFICATIONS.md` described
+by `Sources/MereRunCore/MiniMaxH3/README.md`.
+
+```bash
+python3 scripts/model-conversion/convert_minimax_h3_convrot.py \
+  --partition ref2va \
+  --source minimax_h3_ref2va_int8_convrot.safetensors \
+  --output transformer.safetensors
+```
+
+The MiniMax-H3 Community License restricts territory and redistribution.
+Conversion and use must occur in an allowed territory, and converted packages
+must retain the upstream license, notice, modification disclosure, and safety
+requirements. Python and CUDA are conversion tooling only; inference remains
+native Swift/MLX.
+
+`requantize_minimax_h3_mlx.py` produces a compact inference-only transformer
+from that verified MLX 8-bit artifact. It requantizes affine linear weights to
+4-bit/group-64, omits only the AdaLN and time-embedding weights already covered
+by a verified `adaln_cache.safetensors`, and records the parent cache identity
+in safetensors metadata. The script streams the output transactionally, emits
+per-layer error statistics and SHA-256 receipts, and writes a matching config
+that keeps the Qwen3-VL conditioner at INT8 while selecting INT4 for the
+transformer. It never becomes part of the native inference path.
+
+```bash
+uv run --script scripts/model-conversion/requantize_minimax_h3_mlx.py \
+  --source transformer.safetensors \
+  --adaln-cache adaln_cache.safetensors \
+  --config config.json \
+  --output transformer-int4.safetensors \
+  --output-config config-int4.json \
+  --receipt transformer-int4.conversion.json
+```
+
+Install the emitted transformer and config together, retain the AdaLN cache and
+receipt beside them, and set the local manifest precision/quantization to INT4.
+Because cache-covered weights are intentionally absent, this compact artifact
+uses the cache's exact released 31-point modulation curve. The runtime resamples
+that curve for arbitrary valid schedule-point counts without restoring the
+omitted inference-redundant weights.
+
 ## Gemma 4 12B MLX 4-bit
 
 `convert_gemma4_12b_mlx.py` verifies Google's exact 23,919,549,408-byte Gemma 4

--- a/scripts/model-conversion/convert_minimax_h3_convrot.py
+++ b/scripts/model-conversion/convert_minimax_h3_convrot.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Convert a pinned Comfy-Kitchen ConvRot INT8 H3 transformer to MLX affine INT8.
+
+This is release tooling only. The native Swift runtime never invokes Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+SOURCE_REPOSITORY = "Comfy-Org/MiniMax-H3"
+SOURCE_REVISION = "fd70b39279d1ae6eb214c903f53e1bec3af19a77"
+SOURCE_FILES = {
+    "fl2va": {
+        "name": "minimax_h3_fl2va_int8_convrot.safetensors",
+        "byte_count": 34_038_892_334,
+        "sha256": "7ad4c73e6e378b822ffd1629f27f632d3787d95f5e468e3af958f98c58df96a5",
+    },
+    "ref2va": {
+        "name": "minimax_h3_ref2va_int8_convrot.safetensors",
+        "byte_count": 34_038_894_550,
+        "sha256": "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9",
+    },
+}
+GROUP_SIZE = 64
+BITS = 8
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_source(path: Path, partition: str) -> None:
+    pin = SOURCE_FILES[partition]
+    if path.name != pin["name"]:
+        raise ValueError(f"Expected {pin['name']}, got {path.name}")
+    if path.stat().st_size != pin["byte_count"]:
+        raise ValueError(
+            f"{path} has {path.stat().st_size} bytes; expected {pin['byte_count']}"
+        )
+    digest = file_sha256(path)
+    if digest != pin["sha256"]:
+        raise ValueError(f"{path} has SHA-256 {digest}; expected {pin['sha256']}")
+
+
+def regular_hadamard(size: int, device: torch.device) -> torch.Tensor:
+    """Return Comfy-Kitchen's normalized regular-Hadamard ConvRot basis."""
+    if size < 4 or size & (size - 1) or not math.log(size, 4).is_integer():
+        raise ValueError(f"ConvRot group size must be a power of four, got {size}")
+    h4 = torch.tensor(
+        [[1, 1, 1, -1], [1, 1, -1, 1], [1, -1, 1, 1], [-1, 1, 1, 1]],
+        dtype=torch.float32,
+        device=device,
+    )
+    matrix = h4
+    current = 4
+    while current < size:
+        matrix = torch.kron(matrix, h4)
+        current *= 4
+    return matrix / math.sqrt(size)
+
+
+def undo_convrot(
+    codes: torch.Tensor,
+    row_scales: torch.Tensor,
+    hadamard: torch.Tensor,
+) -> torch.Tensor:
+    """Dequantize per-row symmetric INT8 and restore the original weight basis."""
+    rows, columns = codes.shape
+    if columns % GROUP_SIZE:
+        raise ValueError(f"ConvRot input width {columns} is not divisible by {GROUP_SIZE}")
+    rotated = codes.to(torch.float32) * row_scales.to(torch.float32)
+    return torch.matmul(rotated.reshape(rows, -1, GROUP_SIZE), hadamard.T).reshape(rows, columns)
+
+
+def mlx_affine_quantize(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reproduce MLX affine 8-bit/group-64 quantization and uint32 packing."""
+    rows, columns = weight.shape
+    if columns % GROUP_SIZE:
+        raise ValueError(f"MLX affine input width {columns} is not divisible by {GROUP_SIZE}")
+    grouped = weight.reshape(rows, -1, GROUP_SIZE)
+    minimum = grouped.amin(dim=-1)
+    maximum = grouped.amax(dim=-1)
+    scale = torch.maximum((maximum - minimum) / 255.0, torch.tensor(1e-7, device=weight.device))
+    use_minimum = minimum.abs() > maximum.abs()
+    scale = torch.where(use_minimum, scale, -scale)
+    edge = torch.where(use_minimum, minimum, maximum)
+    q0 = torch.round(edge / scale)
+    at_zero = q0 == 0
+    scale = torch.where(at_zero, scale, edge / q0)
+    bias = torch.where(at_zero, torch.zeros_like(edge), edge)
+    codes = torch.round((grouped - bias[..., None]) / scale[..., None]).clamp(0, 255).to(torch.uint8)
+    packed_bytes = codes.reshape(rows, columns).contiguous()
+    packed = packed_bytes.view(torch.uint32).reshape(rows, columns // 4)
+    return packed.cpu(), scale.to(torch.bfloat16).cpu(), bias.to(torch.bfloat16).cpu()
+
+
+def convert(source: Path, output: Path, device: torch.device) -> None:
+    if output.exists():
+        raise ValueError(f"Output path already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    converted: dict[str, torch.Tensor] = {}
+    with safe_open(source, framework="pt", device="cpu") as archive:
+        keys = set(archive.keys())
+        hadamard = regular_hadamard(GROUP_SIZE, device)
+        quantized_count = 0
+        dense_count = 0
+        for index, key in enumerate(sorted(keys), start=1):
+            if key.endswith(".comfy_quant") or key.endswith(".weight_scale"):
+                continue
+            value = archive.get_tensor(key)
+            scale_key = f"{key}_scale"
+            if key.endswith(".weight") and value.dtype == torch.int8 and scale_key in keys:
+                row_scales = archive.get_tensor(scale_key)
+                dense = undo_convrot(value.to(device), row_scales.to(device), hadamard)
+                packed, scales, biases = mlx_affine_quantize(dense)
+                converted[key] = packed
+                converted[f"{key.removesuffix('.weight')}.scales"] = scales
+                converted[f"{key.removesuffix('.weight')}.biases"] = biases
+                quantized_count += 1
+                del dense, packed, scales, biases
+            else:
+                converted[key] = value.contiguous()
+                dense_count += 1
+            print(f"[{index}/{len(keys)}] {key}", flush=True)
+
+    save_file(
+        converted,
+        output,
+        metadata={
+            "quantization": "affine 8-bit g64",
+            "quantized_tensors": str(quantized_count),
+            "dense_tensors": str(dense_count),
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+        },
+    )
+
+
+def write_receipt(source: Path, output: Path, partition: str) -> None:
+    receipt = {
+        "converter": "scripts/model-conversion/convert_minimax_h3_convrot.py",
+        "converter_version": 1,
+        "partition": partition,
+        "source": {
+            "repository": SOURCE_REPOSITORY,
+            "revision": SOURCE_REVISION,
+            "filename": source.name,
+            "byte_count": source.stat().st_size,
+            "sha256": file_sha256(source),
+        },
+        "output": {
+            "filename": output.name,
+            "byte_count": output.stat().st_size,
+            "sha256": file_sha256(output),
+        },
+        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": "affine"},
+    }
+    receipt_path = output.with_suffix(".conversion.json")
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert pinned MiniMax-H3 ConvRot INT8 weights to MLX affine INT8."
+    )
+    parser.add_argument("--partition", choices=sorted(SOURCE_FILES), required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    verify_source(source, args.partition)
+    convert(source, output, torch.device(args.device))
+    write_receipt(source, output, args.partition)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model-conversion/convert_minimax_h3_official_mlx.py
+++ b/scripts/model-conversion/convert_minimax_h3_official_mlx.py
@@ -1,0 +1,1116 @@
+#!/usr/bin/env python3
+"""Build mere.run's MiniMax-H3 MLX bundle directly from MiniMax's release.
+
+This is audited release tooling, never a runtime sidecar. Every weight input is
+downloaded from the exact pinned ``MiniMaxAI/MiniMax-H3`` revision below. No
+third-party converted or quantized checkpoint is accepted as an input.
+
+The converter is intentionally usable with MLX's CUDA backend on Linux. That
+lets a release operator build the large artifact on an ephemeral GPU host while
+preserving the exact MLX affine quantizer used by Apple Silicon at inference.
+
+Remote prerequisites (the official RunPod PyTorch image already supplies
+Python and CUDA)::
+
+    python -m pip install 'mlx[cuda]==0.29.3' 'huggingface_hub[hf_xet]==0.34.4' \
+        'safetensors==0.6.2' 'numpy==2.2.6'
+
+Example::
+
+    HF_HOME=/workspace/hf-cache HF_XET_CHUNK_CACHE_SIZE_BYTES=0 \
+      python convert_minimax_h3_official_mlx.py \
+        --cache-dir /workspace/hf-cache \
+        --conversion-location "CA-MTL-3, Canada" \
+        --output /workspace/minimax-h3-sawfwair
+
+The output transformer is mixed precision: the 208 transformer/refiner core
+linears are affine Q4/group-64, while the released BF16/F32 precision islands
+remain dense. The Qwen3-VL conditioner retains exactly the 50 language layers
+H3 reads and uses affine Q8/group-64 for 439 eligible linears. The AdaLN cache
+is evaluated from the original BF16/F32 projections before those 13B
+inference-redundant parameters are omitted from the compact transformer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import importlib.metadata as importlib_metadata
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SOURCE_REPOSITORY = "MiniMaxAI/MiniMax-H3"
+SOURCE_REVISION = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
+SOURCE_LICENSE_SHA256 = "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
+SOURCE_LICENSE_BYTES = 17_604
+GROUP_SIZE = 64
+TRANSFORMER_BITS = 4
+TEXT_ENCODER_BITS = 8
+SAMPLE_POINTS = 31
+VIDEO_SHIFT = 12.0
+AUDIO_SHIFT = 3.0
+TRANSFORMER_HEAD_COUNT = 56
+TRANSFORMER_HEAD_DIMENSION = 128
+
+TRANSFORMER_INDEX = "FL2VA/transformer/model.safetensors.index.json"
+TEXT_ENCODER_INDEX = "FL2VA/text_encoder/model.safetensors.index.json"
+VIDEO_VAE_WEIGHTS = "FL2VA/video_vae/source/model.safetensors"
+AUDIO_VAE_WEIGHTS = "FL2VA/audio_vae/model.safetensors"
+
+COMMON_SOURCE_FILES = {
+    "LICENSE",
+    "README.md",
+    "FL2VA/processor/tokenizer.json",
+    "FL2VA/processor/tokenizer_config.json",
+}
+
+TRANSFORMER_DENSE_PREFIXES = (
+    "video_patch_proj.",
+    "audio_patch_proj.",
+    "condition_proj.",
+    "time_embedder.",
+    "final_layer.video_out.",
+    "final_layer.audio_out.",
+    "final_layer.adaln_proj.",
+)
+
+TRANSFORMER_QUANTIZED_SUFFIXES = (
+    ".attn.qkv_proj.weight",
+    ".attn.out_proj.weight",
+    ".mlp.fc1.weight",
+    ".mlp.fc2.weight",
+)
+
+QUANTIZER_SELF_TEST = {
+    4: {
+        "weight": "74bebb64dcbfbd2d77e121a4de4f154ce21a5a35f481f699b2df23b135656ec8",
+        "scales": "22f7ad21bdcfec89ace95b550404bd3433de39214b81cdc38c775724125499dc",
+        "biases": "09ebd55dbdba503aa1b594d6b6a5333be87bb9dd51caaaf4063903e08780d2a5",
+    },
+    8: {
+        "weight": "e7eabb58287772294ce23f376e9f65877545152b2613d172e6d33ec6bcb244c4",
+        "scales": "d84bf16b039914838f39df1823f37d9bcd640ea1108a33a2b0e7e4aa42e7ed1c",
+        "biases": "09ebd55dbdba503aa1b594d6b6a5333be87bb9dd51caaaf4063903e08780d2a5",
+    },
+}
+QKV_REORDER_SELF_TEST_SHA256 = "11a9143204ee0defe33828d431cca9f051c2a221050ae8543b543cda5c7b7786"
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(16 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def fetch_hub_metadata() -> dict[str, Any]:
+    encoded_repo = urllib.parse.quote(SOURCE_REPOSITORY, safe="/")
+    url = (
+        f"https://huggingface.co/api/models/{encoded_repo}/revision/"
+        f"{SOURCE_REVISION}?blobs=true"
+    )
+    with urllib.request.urlopen(url, timeout=120) as response:
+        metadata = json.load(response)
+    if metadata.get("sha") != SOURCE_REVISION:
+        raise ValueError(
+            f"Hub resolved {SOURCE_REPOSITORY}@{SOURCE_REVISION} to {metadata.get('sha')}"
+        )
+    if metadata.get("private") or metadata.get("gated"):
+        raise ValueError("The pinned official source unexpectedly became private or gated")
+    return metadata
+
+
+def component_source_files(metadata: dict[str, Any], components: set[str]) -> list[str]:
+    available = {entry["rfilename"] for entry in metadata["siblings"]}
+    selected = set(COMMON_SOURCE_FILES)
+    if "transformer" in components:
+        selected.update(name for name in available if name.startswith("FL2VA/transformer/"))
+    if "text_encoder" in components:
+        selected.update(name for name in available if name.startswith("FL2VA/text_encoder/"))
+    if "video_vae" in components:
+        selected.update(
+            {
+                "FL2VA/video_vae/config.json",
+                "FL2VA/video_vae/source/config.json",
+                VIDEO_VAE_WEIGHTS,
+            }
+        )
+    if "audio_vae" in components:
+        selected.update(
+            {
+                "FL2VA/audio_vae/config.json",
+                "FL2VA/audio_vae/metadata.json",
+                AUDIO_VAE_WEIGHTS,
+            }
+        )
+    missing = sorted(selected - available)
+    if missing:
+        raise ValueError(f"Pinned source is missing required files: {missing}")
+    return sorted(selected)
+
+
+def metadata_by_name(metadata: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {entry["rfilename"]: entry for entry in metadata["siblings"]}
+
+
+def print_plan(metadata: dict[str, Any], source_files: list[str]) -> None:
+    entries = metadata_by_name(metadata)
+    total = sum(int(entries[name].get("size") or 0) for name in source_files)
+    print(f"source: {SOURCE_REPOSITORY}@{SOURCE_REVISION}")
+    print(f"files: {len(source_files)}")
+    print(f"download bytes: {total} ({total / 1e9:.2f} GB)")
+    for name in source_files:
+        print(f"  {entries[name].get('size', 0):>12}  {name}")
+
+
+def download_sources(
+    metadata: dict[str, Any],
+    source_files: list[str],
+    cache_dir: Path,
+    source_manifest_path: Path,
+) -> dict[str, Path]:
+    from huggingface_hub import hf_hub_download
+
+    entries = metadata_by_name(metadata)
+    downloaded: dict[str, Path] = {}
+    receipt_files: list[dict[str, Any]] = []
+    for index, name in enumerate(source_files, start=1):
+        print(f"source [{index}/{len(source_files)}] {name}", flush=True)
+        local = Path(
+            hf_hub_download(
+                repo_id=SOURCE_REPOSITORY,
+                filename=name,
+                revision=SOURCE_REVISION,
+                cache_dir=str(cache_dir),
+            )
+        )
+        expected_size = int(entries[name].get("size") or 0)
+        actual_size = local.stat().st_size
+        if expected_size and actual_size != expected_size:
+            raise ValueError(f"{name} has {actual_size} bytes; expected {expected_size}")
+        digest = sha256_file(local)
+        lfs = entries[name].get("lfs") or {}
+        expected_digest = lfs.get("sha256")
+        if expected_digest and digest != expected_digest:
+            raise ValueError(f"{name} has SHA-256 {digest}; expected {expected_digest}")
+        if name == "LICENSE":
+            if actual_size != SOURCE_LICENSE_BYTES or digest != SOURCE_LICENSE_SHA256:
+                raise ValueError("Pinned MiniMax H3 license bytes changed")
+        downloaded[name] = local
+        receipt_files.append(
+            {
+                "path": name,
+                "byte_count": actual_size,
+                "sha256": digest,
+                "hub_lfs_sha256": expected_digest,
+            }
+        )
+
+    atomic_json(
+        source_manifest_path,
+        {
+            "repository": SOURCE_REPOSITORY,
+            "revision": SOURCE_REVISION,
+            "public": True,
+            "gated": False,
+            "files": receipt_files,
+        },
+    )
+    return downloaded
+
+
+def load_index(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value.get("weight_map"), dict):
+        raise ValueError(f"Invalid safetensors index: {path}")
+    return value
+
+
+def source_shards(
+    prefix: str,
+    index: dict[str, Any],
+    downloaded: dict[str, Path],
+) -> list[tuple[str, Path, list[str]]]:
+    weight_map: dict[str, str] = index["weight_map"]
+    result = []
+    for shard in sorted(set(weight_map.values())):
+        keys = sorted(key for key, value in weight_map.items() if value == shard)
+        name = f"{prefix}/{shard}"
+        result.append((name, downloaded[name], keys))
+    return result
+
+
+def release_arrays(arrays: dict[str, Any]) -> None:
+    arrays.clear()
+    try:
+        import mlx.core as mx
+
+        mx.clear_cache()
+    except Exception:
+        pass
+
+
+def atomic_safetensors(path: Path, arrays: dict[str, Any], metadata: dict[str, str]) -> None:
+    import mlx.core as mx
+
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp.safetensors")
+    try:
+        mx.save_safetensors(str(temporary), arrays, metadata=metadata)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def bf16_bytes(array: Any) -> bytes:
+    import numpy as np
+
+    values = np.asarray(array.tolist(), dtype=np.float32)
+    words = values.view(np.uint32)
+    rounding = np.uint32(0x7FFF) + ((words >> np.uint32(16)) & np.uint32(1))
+    return ((words + rounding) >> np.uint32(16)).astype("<u2").tobytes()
+
+
+def quantizer_self_test() -> dict[str, dict[str, str]]:
+    import mlx.core as mx
+    import numpy as np
+
+    indices = np.arange(17 * 128, dtype=np.int32)
+    values = (
+        ((indices % 257) - 128).astype(np.float32) / np.float32(32)
+        + ((indices * 17) % 31).astype(np.float32) / np.float32(1024)
+    ).reshape(17, 128)
+    weight = mx.array(values).astype(mx.bfloat16)
+    observed: dict[str, dict[str, str]] = {}
+    for bits in (TRANSFORMER_BITS, TEXT_ENCODER_BITS):
+        packed, scales, biases = mx.quantize(
+            weight,
+            group_size=GROUP_SIZE,
+            bits=bits,
+            mode="affine",
+        )
+        mx.eval(packed, scales, biases)
+        packed_bytes = np.asarray(packed.tolist(), dtype="<u4").tobytes()
+        values_by_name = {
+            "weight": hashlib.sha256(packed_bytes).hexdigest(),
+            "scales": hashlib.sha256(bf16_bytes(scales)).hexdigest(),
+            "biases": hashlib.sha256(bf16_bytes(biases)).hexdigest(),
+        }
+        if values_by_name != QUANTIZER_SELF_TEST[bits]:
+            raise ValueError(
+                f"MLX affine {bits}-bit quantizer differs from the Apple Silicon release contract: "
+                f"{values_by_name}"
+            )
+        observed[str(bits)] = values_by_name
+    print("MLX affine Q4/Q8 byte-level self-test passed", flush=True)
+    return observed
+
+
+def quantize_weight(value: Any, bits: int) -> tuple[Any, Any, Any]:
+    import mlx.core as mx
+
+    if value.ndim != 2 or value.shape[-1] % GROUP_SIZE:
+        raise ValueError(f"Cannot quantize shape {value.shape} at group size {GROUP_SIZE}")
+    packed, scales, biases = mx.quantize(
+        value,
+        group_size=GROUP_SIZE,
+        bits=bits,
+        mode="affine",
+    )
+    mx.eval(packed, scales, biases)
+    return packed, scales, biases
+
+
+def reorder_transformer_qkv(value: Any) -> Any:
+    """Convert raw per-head QKV rows to the global slabs expected by the runtime.
+
+    MiniMax's checkpoint stores
+    ``[head0:q,k,v; head1:q,k,v; ...]``.  The native runtime splits a fused
+    projection into ``[all-q; all-k; all-v]`` before reshaping by head, matching
+    the official reference model's load-time reorder.  Quantization must happen
+    after this permutation so each packed row retains the correct identity.
+    """
+    import mlx.core as mx
+
+    expected_rows = TRANSFORMER_HEAD_COUNT * 3 * TRANSFORMER_HEAD_DIMENSION
+    if value.ndim != 2 or value.shape[0] != expected_rows:
+        raise ValueError(
+            "Unexpected MiniMax-H3 fused QKV shape: "
+            f"{value.shape}; expected [{expected_rows}, hidden_size]"
+        )
+    trailing_shape = list(value.shape[1:])
+    grouped = value.reshape(
+        [TRANSFORMER_HEAD_COUNT, 3, TRANSFORMER_HEAD_DIMENSION] + trailing_shape
+    )
+    query, key, output = (
+        part.reshape(
+            [TRANSFORMER_HEAD_COUNT * TRANSFORMER_HEAD_DIMENSION] + trailing_shape
+        )
+        for part in mx.split(grouped, 3, axis=1)
+    )
+    reordered = mx.concatenate([query, key, output], axis=0)
+    mx.eval(reordered)
+    return reordered
+
+
+def qkv_reorder_self_test() -> dict[str, Any]:
+    import mlx.core as mx
+    import numpy as np
+
+    rows = TRANSFORMER_HEAD_COUNT * 3 * TRANSFORMER_HEAD_DIMENSION
+    raw = mx.array(np.arange(rows, dtype=np.int32).reshape(rows, 1))
+    reordered = reorder_transformer_qkv(raw)
+    observed = np.asarray(reordered.tolist(), dtype="<i4").reshape(-1)
+    digest = hashlib.sha256(observed.tobytes()).hexdigest()
+    if digest != QKV_REORDER_SELF_TEST_SHA256:
+        raise ValueError(f"MiniMax-H3 QKV reorder self-test differs: {digest}")
+    receipt = {
+        "head_count": TRANSFORMER_HEAD_COUNT,
+        "head_dimension": TRANSFORMER_HEAD_DIMENSION,
+        "layout": "global-qkv-slabs",
+        "sha256": digest,
+    }
+    print("MiniMax-H3 QKV deinterleave self-test passed", flush=True)
+    return receipt
+
+
+def schedule(point_count: int, shift: float) -> tuple[list[float], list[float]]:
+    import numpy as np
+
+    shifted: list[np.float32] = []
+    shift32 = np.float32(shift)
+    one = np.float32(1)
+    for index in range(point_count):
+        base = np.float32(point_count - 1 - index) / np.float32(point_count - 1)
+        sigma = shift32 * base / (one + (shift32 - one) * base)
+        if not shifted or shifted[-1] != sigma:
+            shifted.append(sigma)
+    sigmas = [float(value) for value in shifted]
+    timesteps = [float(np.float32(one - value)) for value in shifted[:-1]]
+    return sigmas, timesteps
+
+
+def load_requested_keys(
+    prefix: str,
+    index: dict[str, Any],
+    downloaded: dict[str, Path],
+    requested: Iterable[str],
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    weight_map: dict[str, str] = index["weight_map"]
+    wanted = set(requested)
+    result: dict[str, Any] = {}
+    by_shard: dict[str, list[str]] = {}
+    for key in wanted:
+        shard = weight_map.get(key)
+        if shard is None:
+            raise ValueError(f"Official transformer is missing {key}")
+        by_shard.setdefault(shard, []).append(key)
+    for shard, keys in sorted(by_shard.items()):
+        raw = mx.load(str(downloaded[f"{prefix}/{shard}"]))
+        for key in keys:
+            value = raw[key]
+            mx.eval(value)
+            result[key] = value
+        del raw
+    return result
+
+
+def linear(value: Any, weight: Any, bias: Any) -> Any:
+    import mlx.core as mx
+
+    return mx.matmul(value.astype(weight.dtype), weight.T) + bias
+
+
+def build_adaln_cache(
+    output: Path,
+    transformer_index: dict[str, Any],
+    downloaded: dict[str, Path],
+    source_identity: str,
+) -> dict[str, Any]:
+    import mlx.core as mx
+    import mlx.nn as nn
+    import numpy as np
+
+    video_sigmas, video_timesteps = schedule(SAMPLE_POINTS, VIDEO_SHIFT)
+    audio_sigmas, audio_timesteps = schedule(SAMPLE_POINTS, AUDIO_SHIFT)
+    if len(video_timesteps) != 30 or len(audio_timesteps) != 30:
+        raise ValueError("Unexpected MiniMax-H3 sampler schedule geometry")
+
+    flat_timesteps: list[np.float32] = []
+    condition = np.float32(0.999)
+    for video, audio in zip(video_timesteps, audio_timesteps, strict=True):
+        video32 = np.float32(video)
+        audio32 = np.float32(audio)
+        flat_timesteps.extend((video32, audio32, max(video32, condition)))
+
+    time_keys = (
+        "time_embedder.proj_in.weight",
+        "time_embedder.proj_in.bias",
+        "time_embedder.proj_out.weight",
+        "time_embedder.proj_out.bias",
+    )
+    time_weights = load_requested_keys(
+        "FL2VA/transformer", transformer_index, downloaded, time_keys
+    )
+    half_dimension = 128
+    frequency_indices = np.arange(half_dimension, dtype=np.float32)
+    frequencies = np.exp(
+        -np.log(np.float32(10_000)) * frequency_indices / np.float32(half_dimension)
+    ).astype(np.float32)
+    arguments = mx.array(np.asarray(flat_timesteps, dtype=np.float32)).reshape(-1, 1) \
+        * mx.array(frequencies).reshape(1, -1)
+    sinusoidal = mx.concatenate([mx.cos(arguments), mx.sin(arguments)], axis=-1)
+    time_embeddings = linear(
+        nn.silu(linear(
+            sinusoidal.astype(mx.float32),
+            time_weights["time_embedder.proj_in.weight"],
+            time_weights["time_embedder.proj_in.bias"],
+        )),
+        time_weights["time_embedder.proj_out.weight"],
+        time_weights["time_embedder.proj_out.bias"],
+    ).reshape(30, 3, 2_688)
+    mx.eval(time_embeddings)
+    release_arrays(time_weights)
+
+    activated = nn.silu(time_embeddings.reshape(90, 2_688)).astype(mx.bfloat16)
+    mx.eval(activated)
+    block_modulations: list[Any | None] = [None] * 50
+    weight_map: dict[str, str] = transformer_index["weight_map"]
+    blocks_by_shard: dict[str, list[int]] = {}
+    for block in range(50):
+        key = f"blocks.{block}.adaln_proj.linear.weight"
+        blocks_by_shard.setdefault(weight_map[key], []).append(block)
+
+    for shard, blocks in sorted(blocks_by_shard.items()):
+        raw = mx.load(str(downloaded[f"FL2VA/transformer/{shard}"]))
+        for block in blocks:
+            prefix = f"blocks.{block}.adaln_proj.linear"
+            projected = linear(activated, raw[f"{prefix}.weight"], raw[f"{prefix}.bias"])
+            modulation = projected.reshape(30, 9, 32_256).astype(mx.bfloat16)
+            mx.eval(modulation)
+            block_modulations[block] = modulation
+            print(f"AdaLN cache block {block + 1}/50", flush=True)
+        del raw
+        mx.clear_cache()
+    if any(value is None for value in block_modulations):
+        raise ValueError("Not every AdaLN block was cached")
+
+    final_keys = (
+        "final_layer.adaln_proj.linear.weight",
+        "final_layer.adaln_proj.linear.bias",
+    )
+    final_weights = load_requested_keys(
+        "FL2VA/transformer", transformer_index, downloaded, final_keys
+    )
+    final_modulations = linear(
+        activated,
+        final_weights["final_layer.adaln_proj.linear.weight"],
+        final_weights["final_layer.adaln_proj.linear.bias"],
+    ).reshape(30, 3, 10_752).astype(mx.bfloat16)
+    mx.eval(final_modulations)
+    release_arrays(final_weights)
+
+    arrays: dict[str, Any] = {
+        "audio_sigmas": mx.array(audio_sigmas, dtype=mx.float32),
+        "final_modulations": final_modulations,
+        "time_embeddings": time_embeddings,
+        "video_sigmas": mx.array(video_sigmas, dtype=mx.float32),
+    }
+    for block, modulation in enumerate(block_modulations):
+        arrays[f"blocks.{block}.modulations"] = modulation
+    atomic_safetensors(
+        output,
+        dict(sorted(arrays.items())),
+        {
+            "schema_version": "2",
+            "format": "mere.run.minimax-h3-adaln-cache",
+            "source_identity": source_identity,
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+            "source_precision": "released mixed BF16/F32",
+        },
+    )
+    stats = {
+        "tensor_count": len(arrays),
+        "sample_points": SAMPLE_POINTS,
+        "steps": 30,
+        "video_shift": VIDEO_SHIFT,
+        "audio_shift": AUDIO_SHIFT,
+        "source_identity": source_identity,
+    }
+    release_arrays(arrays)
+    del activated, time_embeddings, final_modulations, block_modulations
+    mx.clear_cache()
+    return stats
+
+
+def is_cache_covered_transformer_key(key: str) -> bool:
+    return ".adaln_proj." in key or key.startswith("time_embedder.")
+
+
+def is_quantized_transformer_key(key: str) -> bool:
+    if key.startswith(TRANSFORMER_DENSE_PREFIXES):
+        return False
+    return key.endswith(TRANSFORMER_QUANTIZED_SUFFIXES)
+
+
+def convert_transformer(
+    output: Path,
+    index: dict[str, Any],
+    downloaded: dict[str, Path],
+    source_identity: str,
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    converted: dict[str, Any] = {}
+    quantized = copied = omitted = qkv_reordered = 0
+    for shard_index, (name, shard_path, keys) in enumerate(
+        source_shards("FL2VA/transformer", index, downloaded), start=1
+    ):
+        raw = mx.load(str(shard_path))
+        print(f"transformer shard {shard_index}/13: {name}", flush=True)
+        for key in keys:
+            if key == "rope.inv_freq" or is_cache_covered_transformer_key(key):
+                omitted += 1
+                continue
+            value = raw[key]
+            if is_quantized_transformer_key(key):
+                if key.endswith(".attn.qkv_proj.weight"):
+                    value = reorder_transformer_qkv(value)
+                    qkv_reordered += 1
+                packed, scales, biases = quantize_weight(value, TRANSFORMER_BITS)
+                prefix = key.removesuffix(".weight")
+                converted[key] = packed
+                converted[f"{prefix}.scales"] = scales
+                converted[f"{prefix}.biases"] = biases
+                quantized += 1
+            else:
+                mx.eval(value)
+                converted[key] = value
+                copied += 1
+        del raw
+        mx.clear_cache()
+
+    if (quantized, copied, omitted, qkv_reordered, len(converted)) != (208, 220, 107, 52, 844):
+        raise ValueError(
+            "Unexpected compact transformer geometry: "
+            f"quantized={quantized}, copied={copied}, omitted={omitted}, "
+            f"qkv_reordered={qkv_reordered}, arrays={len(converted)}"
+        )
+    atomic_safetensors(
+        output,
+        dict(sorted(converted.items())),
+        {
+            "format": "mere.run.minimax-h3-inference-transformer",
+            "quantization": "affine 4-bit g64",
+            "source_precision": "released mixed BF16/F32",
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+            "cache_covered_weights_omitted": "true",
+            "adaln_cache_source_identity": source_identity,
+            "qkv_layout": "global-qkv-slabs",
+        },
+    )
+    stats = {
+        "input_tensors": len(index["weight_map"]),
+        "output_tensors": len(converted),
+        "quantized_linears": quantized,
+        "copied_dense_tensors": copied,
+        "omitted_cache_or_rope_tensors": omitted,
+        "qkv_matrices_deinterleaved": qkv_reordered,
+        "qkv_layout": "global-qkv-slabs",
+        "quantization": {"bits": 4, "group_size": 64, "mode": "affine"},
+        "dense_precision_islands_preserved": list(TRANSFORMER_DENSE_PREFIXES),
+    }
+    release_arrays(converted)
+    return stats
+
+
+def text_encoder_key(source_key: str) -> str | None:
+    if source_key == "lm_head.weight" or source_key == "model.language_model.norm.weight":
+        return None
+    if source_key.startswith("model.language_model.layers."):
+        layer = int(source_key.split(".")[3])
+        if layer >= 50:
+            return None
+    if source_key.startswith("model.language_model."):
+        return "model." + source_key.removeprefix("model.language_model.")
+    if source_key.startswith("model.visual."):
+        return "visual." + source_key.removeprefix("model.visual.")
+    raise ValueError(f"Unrecognized official text-encoder tensor: {source_key}")
+
+
+def is_text_encoder_lookup(key: str) -> bool:
+    return key in {"model.embed_tokens.weight", "visual.pos_embed.weight"}
+
+
+def convert_text_encoder(
+    output: Path,
+    index: dict[str, Any],
+    downloaded: dict[str, Path],
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    converted: dict[str, Any] = {}
+    quantized = copied = skipped = 0
+    shards = source_shards("FL2VA/text_encoder", index, downloaded)
+    for shard_index, (name, shard_path, keys) in enumerate(shards, start=1):
+        raw = mx.load(str(shard_path))
+        print(f"text encoder shard {shard_index}/14: {name}", flush=True)
+        for source_key in keys:
+            key = text_encoder_key(source_key)
+            if key is None:
+                skipped += 1
+                continue
+            value = raw[source_key]
+            eligible = (
+                key.endswith(".weight")
+                and value.ndim == 2
+                and value.shape[-1] % GROUP_SIZE == 0
+                and not is_text_encoder_lookup(key)
+            )
+            if eligible:
+                packed, scales, biases = quantize_weight(value, TEXT_ENCODER_BITS)
+                prefix = key.removesuffix(".weight")
+                converted[key] = packed
+                converted[f"{prefix}.scales"] = scales
+                converted[f"{prefix}.biases"] = biases
+                quantized += 1
+            else:
+                mx.eval(value)
+                converted[key] = value
+                copied += 1
+        del raw
+        mx.clear_cache()
+
+    if (quantized, copied, skipped, len(converted)) != (439, 463, 156, 1_780):
+        raise ValueError(
+            "Unexpected conditioner geometry: "
+            f"quantized={quantized}, copied={copied}, skipped={skipped}, arrays={len(converted)}"
+        )
+    atomic_safetensors(
+        output,
+        dict(sorted(converted.items())),
+        {
+            "format": "mere.run.minimax-h3-qwen3-vl-conditioner",
+            "quantization": "affine 8-bit g64",
+            "source_precision": "released BF16",
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+            "language_layers_retained": "50",
+        },
+    )
+    stats = {
+        "input_tensors": len(index["weight_map"]),
+        "output_tensors": len(converted),
+        "quantized_linears": quantized,
+        "copied_dense_tensors": copied,
+        "skipped_unused_tensors": skipped,
+        "language_layers_retained": 50,
+        "quantization": {"bits": 8, "group_size": 64, "mode": "affine"},
+    }
+    release_arrays(converted)
+    return stats
+
+
+def convert_video_vae(
+    output: Path,
+    downloaded: dict[str, Path],
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    wrapper = json.loads(downloaded["FL2VA/video_vae/config.json"].read_text())
+    raw = mx.load(str(downloaded[VIDEO_VAE_WEIGHTS]))
+    converted: dict[str, Any] = {}
+    for index, key in enumerate(sorted(raw), start=1):
+        value = raw[key].astype(mx.float16)
+        mx.eval(value)
+        converted[key] = value
+        if index % 50 == 0:
+            print(f"video VAE tensor {index}/{len(raw)}", flush=True)
+    converted["latents_mean"] = mx.array(wrapper["latents_mean"], dtype=mx.float16)
+    converted["latents_std"] = mx.array(wrapper["latents_std"], dtype=mx.float16)
+    del raw
+    if len(converted) != 562:
+        raise ValueError(f"Unexpected video VAE tensor count: {len(converted)}")
+    atomic_safetensors(
+        output,
+        dict(sorted(converted.items())),
+        {
+            "format": "mere.run.minimax-h3-video-vae",
+            "conversion": "official FP32 tensors cast directly to FP16; latent statistics added",
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+        },
+    )
+    stats = {
+        "input_tensors": 560,
+        "output_tensors": len(converted),
+        "source_precision": "FP32",
+        "output_precision": "FP16",
+        "layout_transform": "none in artifact; native loader maps convolution/QKV layouts",
+    }
+    release_arrays(converted)
+    return stats
+
+
+def convert_audio_vae(
+    output: Path,
+    downloaded: dict[str, Path],
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    wrapper = json.loads(downloaded["FL2VA/audio_vae/config.json"].read_text())
+    raw = mx.load(str(downloaded[AUDIO_VAE_WEIGHTS]))
+    converted: dict[str, Any] = {}
+    folded = 0
+    for index, key in enumerate(sorted(raw), start=1):
+        if key.endswith(".weight_g"):
+            continue
+        value = raw[key]
+        output_key = key
+        if key.endswith(".weight_v"):
+            output_key = key[: -len("_v")]
+            gain = raw[f"{output_key}_g"]
+            vector = value
+            norm_shape = [vector.shape[0]] + [1] * (vector.ndim - 1)
+            norm = mx.sqrt(mx.sum(mx.square(vector.reshape(vector.shape[0], -1)), axis=1)) \
+                .reshape(norm_shape)
+            value = gain * vector / norm
+            folded += 1
+        mx.eval(value)
+        converted[output_key] = value
+        if index % 100 == 0:
+            print(f"audio VAE tensor {index}/{len(raw)}", flush=True)
+    converted["latents_mean"] = mx.array(wrapper["latents_mean"], dtype=mx.float32)
+    converted["latents_std"] = mx.array(wrapper["latents_std"], dtype=mx.float32)
+    del raw
+    if folded != 172 or len(converted) != 917:
+        raise ValueError(
+            f"Unexpected audio VAE geometry: folded={folded}, arrays={len(converted)}"
+        )
+    atomic_safetensors(
+        output,
+        dict(sorted(converted.items())),
+        {
+            "format": "mere.run.minimax-h3-audio-vae",
+            "conversion": "official FP32 weight-normalization pairs folded; latent statistics added",
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+        },
+    )
+    stats = {
+        "input_tensors": 1_087,
+        "output_tensors": len(converted),
+        "weight_norm_pairs_folded": folded,
+        "precision": "FP32",
+        "layout_transform": "none in artifact; native loader maps convolution layouts",
+    }
+    release_arrays(converted)
+    return stats
+
+
+def write_package_support(output: Path, downloaded: dict[str, Path]) -> None:
+    shutil.copyfile(downloaded["LICENSE"], output / "LICENSE")
+    shutil.copyfile(
+        downloaded["FL2VA/processor/tokenizer.json"], output / "tokenizer.json"
+    )
+    shutil.copyfile(
+        downloaded["FL2VA/processor/tokenizer_config.json"],
+        output / "tokenizer_config.json",
+    )
+    (output / "NOTICE").write_text(
+        "MiniMax H3 is licensed under the MiniMax H3 Community License Agreement, "
+        "Copyright © 2026 MiniMax. All Rights Reserved.\n",
+        encoding="utf-8",
+    )
+    (output / "MODIFICATIONS.md").write_text(
+        """# Modifications to MiniMax H3
+
+These files are MODIFIED versions of the MiniMax H3 Works, redistributed under
+the MiniMax H3 Community License Agreement in `LICENSE` and `NOTICE`.
+
+Modified by: Sawfwair (https://github.com/sawfwair/mere-run)
+
+Every weight input came directly from the public official checkpoint
+`MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027`.
+No third-party converted or quantized weights were used.
+
+* The 52 fused transformer and token-refiner QKV matrices were first reordered
+  from MiniMax's raw per-head interleave into the official reference model's
+  `[all-q; all-k; all-v]` layout. The 208 core linear weights were then
+  quantized directly from the released BF16 tensors to MLX affine 4-bit,
+  group size 64.
+  Precision-sensitive BF16/F32 input, timestep, normalization, and output
+  tensors remain at their released precision.
+* The original BF16/F32 AdaLN projections and timestep MLP were evaluated over
+  mere.run's released 31-point schedules. Their resulting inference table is
+  stored in `adaln_cache.safetensors`; the 13B cache-covered parameters and the
+  recomputed RoPE inverse frequencies are omitted from the compact transformer.
+* The Qwen3-VL conditioner keeps the exact 50 language layers MiniMax H3 reads.
+  Its 439 eligible linear weights were quantized directly from official BF16 to
+  MLX affine 8-bit, group size 64. Unused layers 50-63, the LM head, and final
+  language norm are omitted.
+* The official video VAE tensors were cast directly from FP32 to FP16 and the
+  released latent statistics were added. No weights were trained or inferred.
+* The official audio VAE remains FP32. Its 172 weight-normalization pairs were
+  folded algebraically into equivalent plain convolution weights, and the
+  released latent statistics were added.
+* Tokenizer files and the MiniMax H3 license are exact copies from the pinned
+  official checkpoint. `SOURCE_MANIFEST.json` and
+  `transformer.conversion.json` record the complete input/output provenance.
+
+No weights were retrained, distilled, merged, or pruned beyond the explicit
+inference-only omissions and numeric conversions above.
+""",
+        encoding="utf-8",
+    )
+    config = {
+        "model_type": "minimax_h3",
+        "partition": "fl2va",
+        "tasks": ["t2va", "fl2va"],
+        "sigma_shift_scales": {"video": VIDEO_SHIFT, "audio": AUDIO_SHIFT},
+        "fps": 24,
+        "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "text_encoder_quantization": {
+            "group_size": 64,
+            "bits": 8,
+            "mode": "affine",
+        },
+        "transformer": {
+            "hidden_size": 5_376,
+            "num_layers": 50,
+            "num_attention_heads": 56,
+            "attention_head_dim": 128,
+            "ffn_hidden_size": 14_336,
+            "latents_dim": 24,
+            "audio_latents_dim": 32,
+            "text_dim": 5_120,
+            "time_embed_hidden_dim": 5_376,
+            "time_embed_dim": 2_688,
+            "rope_inv_freq_len": 16,
+        },
+        "text_encoder": {
+            "hidden": 5_120,
+            "layers": 50,
+            "heads": 64,
+            "kv_heads": 8,
+            "head_dim": 128,
+            "intermediate": 25_600,
+            "theta": 5_000_000.0,
+        },
+    }
+    atomic_json(output / "config.json", config)
+
+
+def hardware_receipt() -> dict[str, Any]:
+    receipt: dict[str, Any] = {
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+    }
+    try:
+        query = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,uuid,driver_version",
+                "--format=csv,noheader",
+            ],
+            text=True,
+            timeout=30,
+        ).strip()
+        receipt["nvidia_smi"] = query.splitlines()
+    except Exception as error:
+        receipt["nvidia_smi_error"] = str(error)
+    return receipt
+
+
+def output_receipt(output: Path, filename: str, stats: dict[str, Any]) -> dict[str, Any]:
+    path = output / filename
+    return {
+        "filename": filename,
+        "byte_count": path.stat().st_size,
+        "sha256": sha256_file(path),
+        **stats,
+    }
+
+
+def write_sha256sums(output: Path) -> None:
+    excluded = {"SHA256SUMS", "README.md"}
+    lines = []
+    for path in sorted(value for value in output.iterdir() if value.is_file()):
+        if path.name in excluded or path.name.startswith("."):
+            continue
+        lines.append(f"{sha256_file(path)}  {path.name}")
+    (output / "SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--cache-dir", type=Path, default=Path(".cache/huggingface"))
+    parser.add_argument(
+        "--conversion-location",
+        help="Declared physical conversion location recorded in the release receipt.",
+    )
+    parser.add_argument(
+        "--components",
+        nargs="+",
+        choices=("transformer", "text_encoder", "video_vae", "audio_vae"),
+        default=("transformer", "text_encoder", "video_vae", "audio_vae"),
+    )
+    parser.add_argument("--plan", action="store_true")
+    parser.add_argument("--self-test-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    components = set(args.components)
+    if args.self_test_only:
+        quantizer_self_test()
+        qkv_reorder_self_test()
+        return 0
+
+    metadata = fetch_hub_metadata()
+    source_files = component_source_files(metadata, components)
+    if args.plan:
+        print_plan(metadata, source_files)
+        return 0
+    if args.output is None:
+        raise ValueError("--output is required unless --plan or --self-test-only is used")
+    if not args.conversion_location:
+        raise ValueError("--conversion-location is required for a release conversion")
+
+    output = args.output.expanduser().resolve()
+    cache_dir = args.cache_dir.expanduser().resolve()
+    if output.exists() and any(output.iterdir()):
+        raise ValueError(f"Output directory is not empty: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    started_at = utc_now()
+
+    source_manifest_path = output / "SOURCE_MANIFEST.json"
+    downloaded = download_sources(
+        metadata, source_files, cache_dir, source_manifest_path
+    )
+    write_package_support(output, downloaded)
+    self_test = quantizer_self_test()
+    qkv_self_test = qkv_reorder_self_test()
+
+    import mlx
+    import mlx.core as mx
+    import numpy
+    import safetensors
+    import huggingface_hub
+
+    if not mx.cuda.is_available():
+        print("warning: MLX CUDA is unavailable; conversion is using the current MLX device", flush=True)
+
+    component_stats: dict[str, dict[str, Any]] = {}
+    transformer_index = None
+    source_identity = None
+    if "transformer" in components:
+        transformer_index = load_index(downloaded[TRANSFORMER_INDEX])
+        index_sha = sha256_file(downloaded[TRANSFORMER_INDEX])
+        source_identity = (
+            f"{SOURCE_REPOSITORY}@{SOURCE_REVISION}:FL2VA/transformer:index-sha256:{index_sha}"
+        )
+        cache_stats = build_adaln_cache(
+            output / "adaln_cache.safetensors",
+            transformer_index,
+            downloaded,
+            source_identity,
+        )
+        component_stats["adaln_cache.safetensors"] = cache_stats
+        transformer_stats = convert_transformer(
+            output / "transformer.safetensors",
+            transformer_index,
+            downloaded,
+            source_identity,
+        )
+        component_stats["transformer.safetensors"] = transformer_stats
+
+    if "text_encoder" in components:
+        text_index = load_index(downloaded[TEXT_ENCODER_INDEX])
+        component_stats["text_encoder.safetensors"] = convert_text_encoder(
+            output / "text_encoder.safetensors", text_index, downloaded
+        )
+    if "video_vae" in components:
+        component_stats["video_vae.safetensors"] = convert_video_vae(
+            output / "video_vae.safetensors", downloaded
+        )
+    if "audio_vae" in components:
+        component_stats["audio_vae.safetensors"] = convert_audio_vae(
+            output / "audio_vae.safetensors", downloaded
+        )
+
+    outputs = {
+        filename: output_receipt(output, filename, stats)
+        for filename, stats in component_stats.items()
+    }
+    conversion_receipt = {
+        "converter": "scripts/model-conversion/convert_minimax_h3_official_mlx.py",
+        "converter_version": 2,
+        "converter_sha256": sha256_file(Path(__file__).resolve()),
+        "started_at": started_at,
+        "completed_at": utc_now(),
+        "source": {
+            "repository": SOURCE_REPOSITORY,
+            "revision": SOURCE_REVISION,
+            "source_manifest": "SOURCE_MANIFEST.json",
+            "source_manifest_sha256": sha256_file(source_manifest_path),
+            "third_party_weight_inputs": [],
+        },
+        "software": {
+            "mlx": importlib_metadata.version("mlx"),
+            "mlx_cuda": importlib_metadata.version("mlx-cuda")
+            if mx.cuda.is_available()
+            else None,
+            "numpy": numpy.__version__,
+            "safetensors": safetensors.__version__,
+            "huggingface_hub": huggingface_hub.__version__,
+        },
+        "hardware": hardware_receipt(),
+        "declared_conversion_location": args.conversion_location,
+        "mlx_cuda_available": bool(mx.cuda.is_available()),
+        "quantizer_self_test": self_test,
+        "qkv_reorder_self_test": qkv_self_test,
+        "outputs": outputs,
+    }
+    atomic_json(output / "transformer.conversion.json", conversion_receipt)
+    write_sha256sums(output)
+
+    print(json.dumps(conversion_receipt, indent=2, sort_keys=True), flush=True)
+    print(f"complete: {output}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model-conversion/requantize_minimax_h3_mlx.py
+++ b/scripts/model-conversion/requantize_minimax_h3_mlx.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "numpy==2.2.6",
+# ]
+# ///
+"""Compact an MLX affine INT8 MiniMax-H3 transformer to inference-only INT4.
+
+This is release tooling only. The native Swift runtime never invokes Python.
+The source artifact must already use MLX affine 8-bit/group-64 tensors and must
+have a compatible AdaLN cache before its cache-covered weights may be omitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mmap
+import os
+import shutil
+import struct
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+
+
+GROUP_SIZE = 64
+SOURCE_BITS = 8
+OUTPUT_BITS = 4
+LEVELS = (1 << OUTPUT_BITS) - 1
+SAFETENSORS_ALIGNMENT = 8
+CHUNK_ROWS = 64
+MIN_FREE_HEADROOM = 1 << 30
+
+
+DTYPES: dict[str, np.dtype] = {
+    "BF16": np.dtype("<u2"),
+    "F16": np.dtype("<f2"),
+    "F32": np.dtype("<f4"),
+    "I8": np.dtype("i1"),
+    "I32": np.dtype("<i4"),
+    "U8": np.dtype("u1"),
+    "U32": np.dtype("<u4"),
+}
+
+
+@dataclass(frozen=True)
+class TensorInfo:
+    dtype: str
+    shape: tuple[int, ...]
+    start: int
+    end: int
+
+    @property
+    def byte_count(self) -> int:
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class CopyPlan:
+    key: str
+    source: TensorInfo
+
+
+@dataclass(frozen=True)
+class QuantizePlan:
+    weight_key: str
+    source_weight: TensorInfo
+    source_scales: TensorInfo
+    source_biases: TensorInfo | None
+
+    @property
+    def scales_key(self) -> str:
+        return self.weight_key.removesuffix(".weight") + ".scales"
+
+    @property
+    def biases_key(self) -> str:
+        return self.weight_key.removesuffix(".weight") + ".biases"
+
+    @property
+    def rows(self) -> int:
+        return self.source_weight.shape[0]
+
+    @property
+    def columns(self) -> int:
+        return self.source_weight.shape[1] * (32 // SOURCE_BITS)
+
+    @property
+    def output_weight_shape(self) -> tuple[int, int]:
+        return (self.rows, self.columns // (32 // OUTPUT_BITS))
+
+
+Plan = CopyPlan | QuantizePlan
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_header(handle: BinaryIO) -> tuple[int, dict[str, object]]:
+    encoded_length = handle.read(8)
+    if len(encoded_length) != 8:
+        raise ValueError("Safetensors header length is missing")
+    header_length = struct.unpack("<Q", encoded_length)[0]
+    if header_length <= 0 or header_length > 64 * 1024 * 1024:
+        raise ValueError(f"Invalid safetensors header length: {header_length}")
+    encoded_header = handle.read(header_length)
+    if len(encoded_header) != header_length:
+        raise ValueError("Safetensors header is truncated")
+    header = json.loads(encoded_header)
+    if not isinstance(header, dict):
+        raise ValueError("Safetensors header must be an object")
+    return header_length, header
+
+
+def parse_tensors(header: dict[str, object]) -> dict[str, TensorInfo]:
+    tensors: dict[str, TensorInfo] = {}
+    for key, raw in header.items():
+        if key == "__metadata__":
+            continue
+        if not isinstance(raw, dict):
+            raise ValueError(f"Tensor descriptor for {key} is not an object")
+        dtype = raw.get("dtype")
+        shape = raw.get("shape")
+        offsets = raw.get("data_offsets")
+        if dtype not in DTYPES:
+            raise ValueError(f"Tensor {key} has unsupported dtype {dtype}")
+        if not isinstance(shape, list) or not all(isinstance(value, int) for value in shape):
+            raise ValueError(f"Tensor {key} has an invalid shape")
+        if (
+            not isinstance(offsets, list)
+            or len(offsets) != 2
+            or not all(isinstance(value, int) for value in offsets)
+        ):
+            raise ValueError(f"Tensor {key} has invalid data offsets")
+        info = TensorInfo(dtype, tuple(shape), offsets[0], offsets[1])
+        expected = int(np.prod(info.shape, dtype=np.int64)) * DTYPES[dtype].itemsize
+        if info.byte_count != expected:
+            raise ValueError(
+                f"Tensor {key} has {info.byte_count} bytes; expected {expected}"
+            )
+        tensors[key] = info
+    return tensors
+
+
+def is_cache_covered(key: str) -> bool:
+    return ".adaln_proj." in key or key.startswith("time_embedder.")
+
+
+def make_plan(tensors: dict[str, TensorInfo]) -> list[Plan]:
+    active = {key: value for key, value in tensors.items() if not is_cache_covered(key)}
+    quantized_weights: dict[str, QuantizePlan] = {}
+    quantized_related: set[str] = set()
+    for key, weight in active.items():
+        if not key.endswith(".weight") or weight.dtype != "U32" or len(weight.shape) != 2:
+            continue
+        prefix = key.removesuffix(".weight")
+        scales_key = prefix + ".scales"
+        biases_key = prefix + ".biases"
+        scales = active.get(scales_key)
+        biases = active.get(biases_key)
+        if scales is None or scales.dtype != "BF16" or len(scales.shape) != 2:
+            raise ValueError(f"Quantized tensor {key} is missing BF16 scales")
+        columns = weight.shape[1] * (32 // SOURCE_BITS)
+        expected_scale_shape = (weight.shape[0], columns // GROUP_SIZE)
+        if scales.shape != expected_scale_shape:
+            raise ValueError(
+                f"Tensor {key} scales have shape {scales.shape}; expected {expected_scale_shape}"
+            )
+        if biases is not None and biases.shape != expected_scale_shape:
+            raise ValueError(
+                f"Tensor {key} biases have shape {biases.shape}; expected {expected_scale_shape}"
+            )
+        if columns % GROUP_SIZE or columns % (32 // OUTPUT_BITS):
+            raise ValueError(f"Tensor {key} input width {columns} cannot use INT4 group-{GROUP_SIZE}")
+        quantized_weights[key] = QuantizePlan(key, weight, scales, biases)
+        quantized_related.update((key, scales_key))
+        if biases is not None:
+            quantized_related.add(biases_key)
+
+    plan: list[Plan] = []
+    for key in sorted(active):
+        if key in quantized_weights:
+            plan.append(quantized_weights[key])
+        elif key not in quantized_related:
+            plan.append(CopyPlan(key, active[key]))
+    if not quantized_weights:
+        raise ValueError("No MLX affine INT8 weights were found")
+    return plan
+
+
+def plan_output_tensors(plan: list[Plan]) -> list[tuple[str, str, tuple[int, ...]]]:
+    output: list[tuple[str, str, tuple[int, ...]]] = []
+    for item in plan:
+        if isinstance(item, CopyPlan):
+            output.append((item.key, item.source.dtype, item.source.shape))
+        else:
+            output.extend(
+                [
+                    (item.weight_key, "U32", item.output_weight_shape),
+                    (item.scales_key, "BF16", item.source_scales.shape),
+                    (item.biases_key, "BF16", item.source_scales.shape),
+                ]
+            )
+    return output
+
+
+def output_header(
+    tensors: list[tuple[str, str, tuple[int, ...]]],
+    metadata: dict[str, str],
+) -> tuple[bytes, int]:
+    header: dict[str, object] = {"__metadata__": metadata}
+    offset = 0
+    for key, dtype, shape in tensors:
+        byte_count = int(np.prod(shape, dtype=np.int64)) * DTYPES[dtype].itemsize
+        header[key] = {
+            "dtype": dtype,
+            "shape": list(shape),
+            "data_offsets": [offset, offset + byte_count],
+        }
+        offset += byte_count
+    encoded = json.dumps(header, separators=(",", ":"), sort_keys=False).encode("utf-8")
+    padding = (-len(encoded)) % SAFETENSORS_ALIGNMENT
+    return encoded + b" " * padding, offset
+
+
+def mapped_array(
+    mapping: mmap.mmap,
+    data_start: int,
+    info: TensorInfo,
+) -> np.ndarray:
+    dtype = DTYPES[info.dtype]
+    return np.ndarray(
+        info.shape,
+        dtype=dtype,
+        buffer=mapping,
+        offset=data_start + info.start,
+        order="C",
+    )
+
+
+def bf16_to_float32(values: np.ndarray) -> np.ndarray:
+    words = values.astype(np.uint32, copy=False)
+    return np.left_shift(words, np.uint32(16)).view(np.float32)
+
+
+def float32_to_bf16(values: np.ndarray) -> np.ndarray:
+    words = np.ascontiguousarray(values, dtype=np.float32).view(np.uint32)
+    rounding = np.uint32(0x7FFF) + ((words >> np.uint32(16)) & np.uint32(1))
+    return ((words + rounding) >> np.uint32(16)).astype(np.uint16)
+
+
+def requantize_group(
+    source_codes: np.ndarray,
+    source_scales: np.ndarray,
+    source_biases: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, float, int]:
+    rows, columns = source_codes.shape
+    groups = columns // GROUP_SIZE
+    values = (
+        source_codes.reshape(rows, groups, GROUP_SIZE).astype(np.float32)
+        * source_scales[..., None]
+        + source_biases[..., None]
+    )
+    minimum = values.min(axis=-1)
+    maximum = values.max(axis=-1)
+    scale = np.maximum((maximum - minimum) / np.float32(LEVELS), np.float32(1e-7))
+    use_minimum = np.abs(minimum) > np.abs(maximum)
+    scale = np.where(use_minimum, scale, -scale)
+    edge = np.where(use_minimum, minimum, maximum)
+    q0 = np.rint(edge / scale)
+    at_zero = q0 == 0
+    scale = np.where(at_zero, scale, edge / np.where(at_zero, np.float32(1), q0))
+    bias = np.where(at_zero, np.float32(0), edge)
+    codes = np.clip(
+        np.rint((values - bias[..., None]) / scale[..., None]),
+        0,
+        LEVELS,
+    ).astype(np.uint32)
+    packed_groups = codes.reshape(rows, columns // 8, 8)
+    packed = np.zeros((rows, columns // 8), dtype=np.uint32)
+    for index in range(8):
+        packed |= packed_groups[..., index] << np.uint32(index * OUTPUT_BITS)
+
+    restored = codes.astype(np.float32).reshape(rows, groups, GROUP_SIZE)
+    restored = restored * scale[..., None] + bias[..., None]
+    difference = values - restored
+    absolute = np.abs(difference)
+    return (
+        packed,
+        float32_to_bf16(scale),
+        float32_to_bf16(bias),
+        float(absolute.sum(dtype=np.float64)),
+        float(np.square(difference, dtype=np.float64).sum(dtype=np.float64)),
+        difference.size,
+    )
+
+
+def convert_quantized(
+    item: QuantizePlan,
+    mapping: mmap.mmap,
+    data_start: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, float]]:
+    source_weight = mapped_array(mapping, data_start, item.source_weight)
+    source_scales_bf16 = mapped_array(mapping, data_start, item.source_scales)
+    source_biases_bf16 = (
+        mapped_array(mapping, data_start, item.source_biases)
+        if item.source_biases is not None
+        else np.zeros(item.source_scales.shape, dtype=np.uint16)
+    )
+    output_weight = np.empty(item.output_weight_shape, dtype=np.uint32)
+    output_scales = np.empty(item.source_scales.shape, dtype=np.uint16)
+    output_biases = np.empty(item.source_scales.shape, dtype=np.uint16)
+    absolute_sum = 0.0
+    squared_sum = 0.0
+    value_count = 0
+
+    for start in range(0, item.rows, CHUNK_ROWS):
+        end = min(start + CHUNK_ROWS, item.rows)
+        source_codes = source_weight[start:end].view(np.uint8).reshape(end - start, item.columns)
+        source_scales = bf16_to_float32(source_scales_bf16[start:end])
+        source_biases = bf16_to_float32(source_biases_bf16[start:end])
+        packed, scales, biases, chunk_absolute, chunk_squared, chunk_count = requantize_group(
+            source_codes,
+            source_scales,
+            source_biases,
+        )
+        output_weight[start:end] = packed
+        output_scales[start:end] = scales
+        output_biases[start:end] = biases
+        absolute_sum += chunk_absolute
+        squared_sum += chunk_squared
+        value_count += chunk_count
+
+    return (
+        output_weight,
+        output_scales,
+        output_biases,
+        {
+            "mean_absolute_error": absolute_sum / value_count,
+            "root_mean_squared_error": (squared_sum / value_count) ** 0.5,
+        },
+    )
+
+
+def write_bytes(handle: BinaryIO, values: np.ndarray) -> None:
+    contiguous = np.ascontiguousarray(values)
+    handle.write(memoryview(contiguous).cast("B"))
+
+
+def safetensors_metadata(path: Path) -> dict[str, str]:
+    with path.open("rb") as handle:
+        _, header = read_header(handle)
+    metadata = header.get("__metadata__", {})
+    if not isinstance(metadata, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in metadata.items()
+    ):
+        raise ValueError(f"Safetensors metadata is invalid: {path}")
+    return metadata
+
+
+def compact_configuration(document: object) -> dict[str, object]:
+    if not isinstance(document, dict):
+        raise ValueError("MiniMax-H3 config must be a JSON object")
+    quantization = document.get("quantization")
+    if quantization != {"group_size": GROUP_SIZE, "bits": SOURCE_BITS, "mode": "affine"}:
+        raise ValueError("MiniMax-H3 config must declare affine 8-bit group-64 quantization")
+    text_encoder_quantization = document.get("text_encoder_quantization", quantization)
+    if text_encoder_quantization != quantization:
+        raise ValueError("Source transformer and text encoder quantization must both be affine INT8")
+    result = json.loads(json.dumps(document))
+    result["quantization"] = {
+        "group_size": GROUP_SIZE,
+        "bits": OUTPUT_BITS,
+        "mode": "affine",
+    }
+    result["text_encoder_quantization"] = dict(quantization)
+    return result
+
+
+def write_json_atomic(path: Path, document: object) -> None:
+    temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(document, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def convert(
+    source: Path,
+    ada_ln_cache: Path,
+    source_config: Path,
+    output: Path,
+    output_config: Path,
+    receipt: Path,
+    source_sha256: str | None,
+) -> None:
+    if output.exists():
+        raise ValueError(f"Output path already exists: {output}")
+    if receipt.exists():
+        raise ValueError(f"Receipt path already exists: {receipt}")
+    if output_config.exists():
+        raise ValueError(f"Output config path already exists: {output_config}")
+    with source_config.open(encoding="utf-8") as handle:
+        converted_config = compact_configuration(json.load(handle))
+    with source.open("rb") as source_handle:
+        source_header_length, source_header = read_header(source_handle)
+    source_metadata = source_header.get("__metadata__", {})
+    if not isinstance(source_metadata, dict):
+        raise ValueError("Source safetensors metadata is invalid")
+    if source_metadata.get("quantization") != "affine 8-bit g64":
+        raise ValueError("Source must declare affine 8-bit g64 quantization")
+    tensors = parse_tensors(source_header)
+    plan = make_plan(tensors)
+    output_tensors = plan_output_tensors(plan)
+    cache_metadata = safetensors_metadata(ada_ln_cache)
+    if cache_metadata.get("format") != "mere.run.minimax-h3-adaln-cache":
+        raise ValueError(f"Not a MiniMax-H3 AdaLN cache: {ada_ln_cache}")
+    if cache_metadata.get("schema_version") != "2":
+        raise ValueError("AdaLN cache schema must be version 2")
+    cache_identity = cache_metadata.get("source_identity")
+    if cache_identity is None:
+        raise ValueError("AdaLN cache source identity is missing")
+    source_size_prefix = cache_identity.partition(":")[0]
+    if source_size_prefix != str(source.stat().st_size):
+        raise ValueError("AdaLN cache does not belong to the source transformer")
+    metadata = {
+        "format": "mere.run.minimax-h3-inference-transformer",
+        "quantization": "affine 4-bit g64",
+        "source_quantization": "affine 8-bit g64",
+        "adaln_cache_source_identity": cache_identity,
+        "cache_covered_weights_omitted": "true",
+    }
+    encoded_header, output_data_bytes = output_header(output_tensors, metadata)
+    required = 8 + len(encoded_header) + output_data_bytes + MIN_FREE_HEADROOM
+    free = shutil.disk_usage(output.parent).free
+    if free < required:
+        raise ValueError(
+            f"Conversion needs {required} free bytes including headroom; only {free} are available"
+        )
+
+    temporary = output.parent / f".{output.name}.{uuid.uuid4().hex}.tmp"
+    quantization_errors: dict[str, dict[str, float]] = {}
+    copied_tensors = 0
+    quantized_tensors = 0
+    try:
+        with source.open("rb") as source_handle, temporary.open("xb") as output_handle:
+            mapping = mmap.mmap(source_handle.fileno(), 0, access=mmap.ACCESS_READ)
+            try:
+                data_start = 8 + source_header_length
+                output_handle.write(struct.pack("<Q", len(encoded_header)))
+                output_handle.write(encoded_header)
+                for index, item in enumerate(plan, start=1):
+                    if isinstance(item, CopyPlan):
+                        start = data_start + item.source.start
+                        end = data_start + item.source.end
+                        output_handle.write(mapping[start:end])
+                        copied_tensors += 1
+                        label = item.key
+                    else:
+                        weight, scales, biases, errors = convert_quantized(
+                            item,
+                            mapping,
+                            data_start,
+                        )
+                        write_bytes(output_handle, weight)
+                        write_bytes(output_handle, scales)
+                        write_bytes(output_handle, biases)
+                        quantization_errors[item.weight_key] = errors
+                        quantized_tensors += 1
+                        label = item.weight_key
+                    print(f"[{index}/{len(plan)}] {label}", flush=True)
+                output_handle.flush()
+                os.fsync(output_handle.fileno())
+            finally:
+                mapping.close()
+        if temporary.stat().st_size != 8 + len(encoded_header) + output_data_bytes:
+            raise ValueError("Converted safetensors byte count does not match its header")
+        temporary.replace(output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+    input_digest = source_sha256 or file_sha256(source)
+    output_digest = file_sha256(output)
+    write_json_atomic(output_config, converted_config)
+    aggregate_mae = sum(value["mean_absolute_error"] for value in quantization_errors.values())
+    aggregate_rmse = sum(value["root_mean_squared_error"] for value in quantization_errors.values())
+    error_count = len(quantization_errors)
+    document = {
+        "converter": "scripts/model-conversion/requantize_minimax_h3_mlx.py",
+        "converter_version": 2,
+        "source": {
+            "path": str(source),
+            "byte_count": source.stat().st_size,
+            "sha256": input_digest,
+            "identity": cache_identity,
+            "quantization": "affine 8-bit g64",
+        },
+        "output": {
+            "path": str(output),
+            "byte_count": output.stat().st_size,
+            "sha256": output_digest,
+            "quantization": "affine 4-bit g64",
+        },
+        "configuration": {
+            "source": str(source_config),
+            "output": str(output_config),
+            "transformer_quantization": "affine 4-bit g64",
+            "text_encoder_quantization": "affine 8-bit g64",
+        },
+        "cache_covered_weights_omitted": True,
+        "copied_tensors": copied_tensors,
+        "requantized_tensors": quantized_tensors,
+        "mean_layer_mae": aggregate_mae / error_count,
+        "mean_layer_rmse": aggregate_rmse / error_count,
+        "layer_errors": quantization_errors,
+    }
+    write_json_atomic(receipt, document)
+
+
+def unpack_q4(values: np.ndarray, columns: int) -> np.ndarray:
+    expanded = np.empty((values.shape[0], values.shape[1], 8), dtype=np.uint32)
+    for index in range(8):
+        expanded[..., index] = (values >> np.uint32(index * OUTPUT_BITS)) & np.uint32(LEVELS)
+    return expanded.reshape(values.shape[0], columns)
+
+
+def self_test() -> None:
+    rng = np.random.default_rng(314159)
+    source_codes = rng.integers(0, 256, size=(3, 128), dtype=np.uint8)
+    source_scales = rng.uniform(0.0005, 0.05, size=(3, 2)).astype(np.float32)
+    source_biases = rng.uniform(-2, 2, size=(3, 2)).astype(np.float32)
+    packed, scales_bf16, biases_bf16, _, _, count = requantize_group(
+        source_codes,
+        source_scales,
+        source_biases,
+    )
+    assert packed.shape == (3, 16)
+    assert scales_bf16.shape == (3, 2)
+    assert biases_bf16.shape == (3, 2)
+    assert count == source_codes.size
+    restored_codes = unpack_q4(packed, 128)
+    restored = (
+        restored_codes.reshape(3, 2, 64).astype(np.float32)
+        * bf16_to_float32(scales_bf16)[..., None]
+        + bf16_to_float32(biases_bf16)[..., None]
+    )
+    original = (
+        source_codes.reshape(3, 2, 64).astype(np.float32)
+        * source_scales[..., None]
+        + source_biases[..., None]
+    )
+    maximum_step = np.abs(bf16_to_float32(scales_bf16)).max()
+    assert np.abs(original - restored).max() <= maximum_step * 0.55
+    values = np.array([0.0, 1.0, -1.0, 0.1, -0.1], dtype=np.float32)
+    round_trip = bf16_to_float32(float32_to_bf16(values))
+    assert np.allclose(round_trip, values, rtol=0.004, atol=0.0001)
+    config = compact_configuration(
+        {"quantization": {"group_size": 64, "bits": 8, "mode": "affine"}}
+    )
+    assert config["quantization"] == {"group_size": 64, "bits": 4, "mode": "affine"}
+    assert config["text_encoder_quantization"] == {
+        "group_size": 64,
+        "bits": 8,
+        "mode": "affine",
+    }
+    print("MiniMax-H3 INT4 requantizer self-test passed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compact an MLX affine INT8 MiniMax-H3 transformer to cache-backed INT4."
+    )
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--adaln-cache", type=Path)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--output-config", type=Path)
+    parser.add_argument("--receipt", type=Path)
+    parser.add_argument("--source-sha256")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return
+    if (
+        args.source is None
+        or args.adaln_cache is None
+        or args.config is None
+        or args.output is None
+        or args.output_config is None
+        or args.receipt is None
+    ):
+        parser.error(
+            "--source, --adaln-cache, --config, --output, --output-config, and --receipt "
+            "are required unless --self-test is used"
+        )
+    source = args.source.expanduser().resolve()
+    ada_ln_cache = args.adaln_cache.expanduser().resolve()
+    source_config = args.config.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    output_config = args.output_config.expanduser().resolve()
+    receipt = args.receipt.expanduser().resolve()
+    if not source.is_file():
+        raise ValueError(f"Source does not exist: {source}")
+    if not ada_ln_cache.is_file():
+        raise ValueError(f"AdaLN cache does not exist: {ada_ln_cache}")
+    if not source_config.is_file():
+        raise ValueError(f"Config does not exist: {source_config}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output_config.parent.mkdir(parents=True, exist_ok=True)
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    convert(
+        source,
+        ada_ln_cache,
+        source_config,
+        output,
+        output_config,
+        receipt,
+        args.source_sha256,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model-conversion/validate_minimax_h3_official_artifact.py
+++ b/scripts/model-conversion/validate_minimax_h3_official_artifact.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Validate a MiniMax-H3 FL2VA bundle built by the official-source converter."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SOURCE_REPOSITORY = "MiniMaxAI/MiniMax-H3"
+SOURCE_REVISION = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
+SOURCE_BYTES = 144_035_116_604
+SOURCE_FILE_COUNT = 48
+LICENSE_SHA256 = "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
+LICENSE_BYTES = 17_604
+EXPECTED_QUANTIZER_SELF_TEST = {
+    "4": {
+        "weight": "74bebb64dcbfbd2d77e121a4de4f154ce21a5a35f481f699b2df23b135656ec8",
+        "scales": "22f7ad21bdcfec89ace95b550404bd3433de39214b81cdc38c775724125499dc",
+        "biases": "09ebd55dbdba503aa1b594d6b6a5333be87bb9dd51caaaf4063903e08780d2a5",
+    },
+    "8": {
+        "weight": "e7eabb58287772294ce23f376e9f65877545152b2613d172e6d33ec6bcb244c4",
+        "scales": "d84bf16b039914838f39df1823f37d9bcd640ea1108a33a2b0e7e4aa42e7ed1c",
+        "biases": "09ebd55dbdba503aa1b594d6b6a5333be87bb9dd51caaaf4063903e08780d2a5",
+    },
+}
+EXPECTED_QKV_REORDER_SELF_TEST = {
+    "head_count": 56,
+    "head_dimension": 128,
+    "layout": "global-qkv-slabs",
+    "sha256": "11a9143204ee0defe33828d431cca9f051c2a221050ae8543b543cda5c7b7786",
+}
+RUNTIME_FILES = {
+    "LICENSE",
+    "MODIFICATIONS.md",
+    "NOTICE",
+    "SHA256SUMS",
+    "SOURCE_MANIFEST.json",
+    "adaln_cache.safetensors",
+    "audio_vae.safetensors",
+    "config.json",
+    "text_encoder.safetensors",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "transformer.conversion.json",
+    "transformer.safetensors",
+    "video_vae.safetensors",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(16 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    require(isinstance(value, dict), f"{path.name} must contain a JSON object")
+    return value
+
+
+def safetensors_header(path: Path) -> tuple[dict[str, Any], dict[str, str]]:
+    with path.open("rb") as handle:
+        raw_length = handle.read(8)
+        require(len(raw_length) == 8, f"{path.name} has no safetensors header")
+        header_length = int.from_bytes(raw_length, "little")
+        require(0 < header_length <= 64 * 1024 * 1024, f"{path.name} header is invalid")
+        raw_header = handle.read(header_length)
+    require(len(raw_header) == header_length, f"{path.name} header is truncated")
+    header = json.loads(raw_header)
+    metadata = header.pop("__metadata__", {})
+    require(isinstance(metadata, dict), f"{path.name} metadata must be an object")
+    spans = sorted(
+        (int(entry["data_offsets"][0]), int(entry["data_offsets"][1]), key)
+        for key, entry in header.items()
+    )
+    cursor = 0
+    for start, end, key in spans:
+        require(start == cursor and end >= start, f"{path.name}:{key} has invalid offsets")
+        cursor = end
+    require(
+        8 + header_length + cursor == path.stat().st_size,
+        f"{path.name} payload extent does not match file size",
+    )
+    return header, metadata
+
+
+def verify_sha256sums(root: Path) -> dict[str, str]:
+    lines = (root / "SHA256SUMS").read_text(encoding="utf-8").splitlines()
+    observed: dict[str, str] = {}
+    for line in lines:
+        digest, filename = line.split("  ", maxsplit=1)
+        require(re.fullmatch(r"[0-9a-f]{64}", digest) is not None, f"bad hash for {filename}")
+        require(filename not in observed, f"duplicate SHA256SUMS entry: {filename}")
+        observed[filename] = digest
+    expected = RUNTIME_FILES - {"SHA256SUMS"}
+    require(set(observed) == expected, "SHA256SUMS file set does not match the release contract")
+    for filename, expected_digest in observed.items():
+        actual = sha256_file(root / filename)
+        require(actual == expected_digest, f"SHA-256 mismatch for {filename}")
+    return observed
+
+
+def verify_source_manifest(root: Path) -> None:
+    manifest = load_json(root / "SOURCE_MANIFEST.json")
+    require(manifest.get("repository") == SOURCE_REPOSITORY, "wrong source repository")
+    require(manifest.get("revision") == SOURCE_REVISION, "wrong source revision")
+    require(manifest.get("public") is True, "official source was not recorded as public")
+    require(manifest.get("gated") is False, "official source was not recorded as ungated")
+    files = manifest.get("files")
+    require(isinstance(files, list) and len(files) == SOURCE_FILE_COUNT, "wrong source file count")
+    require(sum(entry["byte_count"] for entry in files) == SOURCE_BYTES, "wrong source byte total")
+    paths = [entry["path"] for entry in files]
+    require(paths == sorted(set(paths)), "source paths must be unique and sorted")
+    for entry in files:
+        require(re.fullmatch(r"[0-9a-f]{64}", entry["sha256"]) is not None, "bad source hash")
+        lfs_hash = entry.get("hub_lfs_sha256")
+        require(lfs_hash is None or lfs_hash == entry["sha256"], "source LFS hash disagrees")
+
+
+def verify_transformer(root: Path) -> None:
+    tensors, metadata = safetensors_header(root / "transformer.safetensors")
+    require(len(tensors) == 844, "wrong compact transformer tensor count")
+    require(metadata.get("source_repository") == SOURCE_REPOSITORY, "wrong transformer source")
+    require(metadata.get("source_revision") == SOURCE_REVISION, "wrong transformer revision")
+    require(metadata.get("quantization") == "affine 4-bit g64", "wrong transformer quantization")
+    require(metadata.get("cache_covered_weights_omitted") == "true", "cache omission not declared")
+    require(metadata.get("qkv_layout") == "global-qkv-slabs", "wrong transformer QKV layout")
+    require(len([key for key in tensors if key.endswith(".scales")]) == 208, "wrong Q4 scale count")
+    require(len([key for key in tensors if key.endswith(".biases")]) == 208, "wrong Q4 bias count")
+    require("condition_proj.weight" in tensors, "dense condition projection is missing")
+    require(tensors["condition_proj.weight"]["dtype"] == "BF16", "condition projection lost BF16")
+    require(not any("adaln_proj" in key for key in tensors), "AdaLN weight survived compaction")
+    require(not any(key.startswith("time_embedder.") for key in tensors), "time MLP survived compaction")
+    require("rope.inv_freq" not in tensors, "recomputed RoPE tensor survived compaction")
+
+
+def verify_text_encoder(root: Path) -> None:
+    tensors, metadata = safetensors_header(root / "text_encoder.safetensors")
+    require(len(tensors) == 1_780, "wrong conditioner tensor count")
+    require(metadata.get("source_repository") == SOURCE_REPOSITORY, "wrong conditioner source")
+    require(metadata.get("source_revision") == SOURCE_REVISION, "wrong conditioner revision")
+    require(metadata.get("quantization") == "affine 8-bit g64", "wrong conditioner quantization")
+    require(metadata.get("language_layers_retained") == "50", "wrong conditioner layer declaration")
+    require(len([key for key in tensors if key.endswith(".scales")]) == 439, "wrong Q8 scale count")
+    require(len([key for key in tensors if key.endswith(".biases")]) == 439, "wrong Q8 bias count")
+    for key in tensors:
+        match = re.match(r"model\.layers\.(\d+)\.", key)
+        require(match is None or int(match.group(1)) < 50, f"unused language layer in {key}")
+    require(not any(key.startswith("lm_head.") for key in tensors), "unused LM head survived")
+
+
+def verify_vaes_and_cache(root: Path) -> None:
+    video, video_metadata = safetensors_header(root / "video_vae.safetensors")
+    require(len(video) == 562, "wrong video VAE tensor count")
+    require({entry["dtype"] for entry in video.values()} == {"F16"}, "video VAE is not all FP16")
+    require(video_metadata.get("source_repository") == SOURCE_REPOSITORY, "wrong video VAE source")
+
+    audio, audio_metadata = safetensors_header(root / "audio_vae.safetensors")
+    require(len(audio) == 917, "wrong audio VAE tensor count")
+    require({entry["dtype"] for entry in audio.values()} == {"F32"}, "audio VAE is not all FP32")
+    require(audio_metadata.get("source_repository") == SOURCE_REPOSITORY, "wrong audio VAE source")
+    require(not any(key.endswith(".weight_g") or key.endswith(".weight_v") for key in audio),
+            "audio weight normalization was not fully folded")
+
+    cache, cache_metadata = safetensors_header(root / "adaln_cache.safetensors")
+    require(len(cache) == 54, "wrong AdaLN cache tensor count")
+    require(cache_metadata.get("schema_version") == "2", "wrong AdaLN cache schema")
+    require(cache_metadata.get("source_repository") == SOURCE_REPOSITORY, "wrong cache source")
+    require(len([key for key in cache if re.fullmatch(r"blocks\.\d+\.modulations", key)]) == 50,
+            "wrong cached block count")
+
+
+def verify_receipts(root: Path, hashes: dict[str, str], location: str) -> None:
+    require((root / "LICENSE").stat().st_size == LICENSE_BYTES, "wrong license byte count")
+    require(hashes["LICENSE"] == LICENSE_SHA256, "wrong license hash")
+    config = load_json(root / "config.json")
+    require(config.get("model_type") == "minimax_h3", "wrong config model type")
+    require(config.get("partition") == "fl2va", "wrong config partition")
+    require(config.get("quantization") == {"bits": 4, "group_size": 64, "mode": "affine"},
+            "wrong transformer config quantization")
+    require(config.get("text_encoder_quantization") ==
+            {"bits": 8, "group_size": 64, "mode": "affine"},
+            "wrong conditioner config quantization")
+
+    receipt = load_json(root / "transformer.conversion.json")
+    source = receipt.get("source", {})
+    require(source.get("repository") == SOURCE_REPOSITORY, "wrong receipt source repository")
+    require(source.get("revision") == SOURCE_REVISION, "wrong receipt source revision")
+    require(source.get("third_party_weight_inputs") == [], "third-party weight input recorded")
+    require(receipt.get("mlx_cuda_available") is True, "release conversion did not use MLX CUDA")
+    require(receipt.get("declared_conversion_location") == location, "wrong conversion location")
+    require(receipt.get("quantizer_self_test") == EXPECTED_QUANTIZER_SELF_TEST,
+            "quantizer self-test receipt differs")
+    require(receipt.get("qkv_reorder_self_test") == EXPECTED_QKV_REORDER_SELF_TEST,
+            "QKV reorder self-test receipt differs")
+    software = receipt.get("software", {})
+    require(software.get("mlx") == "0.29.3", "wrong MLX version")
+    require(software.get("mlx_cuda") == "0.29.3", "wrong MLX CUDA version")
+    for filename, output in receipt.get("outputs", {}).items():
+        require(filename in hashes, f"unhashed receipt output: {filename}")
+        require(output.get("sha256") == hashes[filename], f"receipt hash differs for {filename}")
+        require(output.get("byte_count") == (root / filename).stat().st_size,
+                f"receipt byte count differs for {filename}")
+    transformer = receipt.get("outputs", {}).get("transformer.safetensors", {})
+    require(transformer.get("qkv_matrices_deinterleaved") == 52,
+            "wrong transformer QKV reorder count")
+    require(transformer.get("qkv_layout") == "global-qkv-slabs",
+            "wrong transformer QKV receipt layout")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--conversion-location", required=True)
+    args = parser.parse_args()
+    root = args.root.expanduser().resolve()
+    missing = sorted(RUNTIME_FILES - {path.name for path in root.iterdir() if path.is_file()})
+    require(not missing, f"missing release files: {missing}")
+
+    hashes = verify_sha256sums(root)
+    verify_source_manifest(root)
+    verify_transformer(root)
+    verify_text_encoder(root)
+    verify_vaes_and_cache(root)
+    verify_receipts(root, hashes, args.conversion_location)
+    total = sum((root / filename).stat().st_size for filename in RUNTIME_FILES)
+    print(json.dumps({"status": "verified", "files": len(RUNTIME_FILES), "bytes": total}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a native Swift/MLX MiniMax-H3 runtime for FL2VA and Ref2VA with synchronized 24 fps video and 32 kHz stereo audio
- implement Qwen3-VL multimodal conditioning, the 50-layer joint transformer, causal video/audio VAEs, ordered image/video/audio references, and exact `17*n+5` frame geometry
- add adaptive 9/16/31-forward schedules, bundled and reusable AdaLN caches, compiled invariant work, compact Q4 and resident-BF16 transformer modes, and chassis-aware MacBook defaults
- publish and pin the verified public [`Sawfwair/MiniMax-H3-FL2VA-MLX-4bit`](https://huggingface.co/Sawfwair/MiniMax-H3-FL2VA-MLX-4bit/tree/e1244ad93d60c737c7e0f065a1c9372f3de7caf8) artifact at immutable revision `e1244ad93d60c737c7e0f065a1c9372f3de7caf8`
- add official-source conversion and validation tools, managed-model validation, explicit license acceptance, installed-model quality gates, CLI documentation, and focused regression tests

## Artifact provenance and quality fix

The managed FL2VA artifact is produced exclusively from the public official checkpoint `MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027`. The converter accepts no third-party converted or quantized weight input. Its source manifest records all 48 official files, 144,035,116,604 source bytes, and their SHA-256 hashes; the final 14-file managed bundle is 46,250,104,566 bytes with its own receipt and `SHA256SUMS`.

The tiled/garbled generations came from a concrete layout bug: the released fused transformer QKV rows are per-head interleaved (`head0:q,k,v; ...`), while the Swift runtime consumes global Q/K/V slabs. The official Diffusers loader performs this permutation at load time. The release converter now deinterleaves all 52 affected matrices before Q4 packing, records a deterministic fixture hash, and the Swift tests assert the resulting global-slab behavior.

The Hub repository is public and ungated. A fresh anonymous verifier checked the exact 18-file public revision, fully downloaded all metadata and example media, and range-validated all five large tensor files.

## Real local production proof

- optimized arm64 release executable on the local M4 Max (128 GB), not a debug build and not remote inference
- prompt: `a jeweled hummingbird hovering beside a red orchid, cinematic natural light`
- 512x512, 56 frames, 24 fps, 31 denoising points, seed `314159`, synchronized MP4
- 18:54.15 end-to-end
- 27,617,329,152-byte max RSS; 27,771,572,360-byte peak footprint; zero swaps
- H.264 video plus AAC stereo 32 kHz audio; 2.334 seconds; audio -26.1 dB mean / -7.8 dB peak
- MP4 SHA-256 `08259a8c1a37a4947f3d8a3b329c63df59f6056a16698f595a817aeb2aaa0c6f`
- coherent hummingbird, orchid, composition, and wing motion across the clip; no tiled/noise failure
- the exact sample and contact sheet are published in the pinned Hub artifact

## Validation

- [x] `./scripts/check.sh` on the exact rebased PR head
  - strict SwiftLint passed across 1,137 files
  - 2,463 XCTest cases, 153 expected asset-dependent skips, zero failures
  - all additional Swift Testing suites passed
- [x] `swift test --filter MiniMaxH3Tests` — 19 passed
- [x] `MERERUN_CHECK_LINUX_ALLOW_NON_LINUX=1 ./scripts/check-linux.sh --manifest-only`
- [x] official artifact validator — 14 files, 46,250,104,566 bytes, status `verified`
- [x] anonymous public Hub verification at the pinned revision
- [x] optimized release build and real full 31-point local synchronized video/audio generation
- [x] Python converter syntax, `git diff --check`, public vocabulary scan, and documentation checks
- [x] no vendored artifacts or dependency pins changed

## Model and license boundary

This source repository distributes no MiniMax weight files. The public converted artifact carries the upstream MiniMax-H3 Community License, notice, modification disclosure, source manifest, conversion receipt, and hashes. The mere.run managed pull remains explicit and requires `--accept-model-license`; Ref2VA remains a separate local conversion lane. Documentation records the upstream territorial, notice, redistribution, and safety restrictions.
