### PR TITLE
Add Falcon Perception workflow node

### DIFF
--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -952,6 +952,7 @@ struct WorkflowGraphRequirements: Equatable {
             switch node.kind {
             case "image.train-lora": return ImageTrainLoRA.defaultManagedModelID.rawValue
             case "image.generate": return ImageGenerate.defaultManagedModelID.rawValue
+            case "vision.ground": return VisionGround.defaultManagedModelID.rawValue
             case "video.generate": return ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
             default: return nil
             }

--- a/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
@@ -3,6 +3,28 @@ import Foundation
 import MereRunCore
 
 struct VisionGround: AsyncParsableCommand {
+    struct PreflightReport: Codable, Equatable {
+        let status: String
+        let capability: String
+        let modelID: String
+        let image: String
+        let queries: [String]
+        let annotatedImage: String
+        let detectionsJSON: String
+        let maskOutputDirectory: String?
+
+        enum CodingKeys: String, CodingKey {
+            case status
+            case capability
+            case modelID = "model_id"
+            case image
+            case queries
+            case annotatedImage = "annotated_image"
+            case detectionsJSON = "detections_json"
+            case maskOutputDirectory = "mask_output_directory"
+        }
+    }
+
     struct ResolvedModel {
         let modelID: String
         let rootURL: URL
@@ -43,15 +65,25 @@ struct VisionGround: AsyncParsableCommand {
     @Option(name: [.customLong("mask-output-dir")], help: "Optional directory for per-detection PNG mask exports.")
     var maskOutputDir: String?
 
+    @Flag(name: [.customLong("preflight")], help: "Validate the image, model, queries, and outputs without loading Falcon Perception.")
+    var preflight: Bool = false
+
+    @Flag(name: [.customLong("json")], help: "With --preflight, emit a structured JSON report.")
+    var json: Bool = false
+
+    @Flag(name: [.short, .long], help: "Print only the annotated output image path.")
+    var quiet: Bool = false
+
     func validate() throws {
         guard !query.isEmpty else {
             throw ValidationError("Provide at least one --query or --prompt value.")
         }
+        if json && !preflight {
+            throw ValidationError("--json is only supported with --preflight for vision ground.")
+        }
     }
 
     func run() async throws {
-        try MLXBundleSupport.ensureAvailable(quiet: false)
-
         let fileManager = FileManager.default
         let imageURL = URL(fileURLWithPath: image).standardizedFileURL
         guard fileManager.fileExists(atPath: imageURL.path) else {
@@ -62,6 +94,36 @@ struct VisionGround: AsyncParsableCommand {
         let outputImageURL = Self.resolveAnnotatedOutputURL(output, inputImageURL: imageURL)
         let outputJSONURL = Self.resolveJSONOutputURL(jsonOutput, inputImageURL: imageURL)
         let maskOutputDirectoryURL = Self.resolveDirectoryURL(maskOutputDir)
+
+        if preflight {
+            let report = PreflightReport(
+                status: "ready",
+                capability: "vision.ground",
+                modelID: resolvedModel.modelID,
+                image: imageURL.path,
+                queries: query,
+                annotatedImage: outputImageURL.path,
+                detectionsJSON: outputJSONURL.path,
+                maskOutputDirectory: maskOutputDirectoryURL?.path
+            )
+            if json {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+                print(String(decoding: try encoder.encode(report), as: UTF8.self))
+            } else {
+                print("Ready: \(report.capability) with \(report.modelID)")
+                print("Image: \(report.image)")
+                print("Queries: \(report.queries.joined(separator: ", "))")
+                print("Annotated image: \(report.annotatedImage)")
+                print("Detections JSON: \(report.detectionsJSON)")
+                if let maskOutputDirectory = report.maskOutputDirectory {
+                    print("Masks: \(maskOutputDirectory)")
+                }
+            }
+            return
+        }
+
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
         let grounder = try FalconPerceptionGrounder(
             modelRootURL: resolvedModel.rootURL,
@@ -76,12 +138,16 @@ struct VisionGround: AsyncParsableCommand {
             maskOutputDirectoryURL: maskOutputDirectoryURL
         )
 
-        print("Model: \(result.modelID)")
-        print("Detections: \(result.detections.count)")
-        print("Image: \(result.annotatedImageURL.path)")
-        print("JSON: \(result.jsonOutputURL.path)")
-        if let maskOutputDirectoryURL {
-            print("Masks: \(maskOutputDirectoryURL.path)")
+        if quiet {
+            print(result.annotatedImageURL.path)
+        } else {
+            print("Model: \(result.modelID)")
+            print("Detections: \(result.detections.count)")
+            print("Image: \(result.annotatedImageURL.path)")
+            print("JSON: \(result.jsonOutputURL.path)")
+            if let maskOutputDirectoryURL {
+                print("Masks: \(maskOutputDirectoryURL.path)")
+            }
         }
     }
 

--- a/Sources/MereRunCLI/Guides/vision-ground.md
+++ b/Sources/MereRunCLI/Guides/vision-ground.md
@@ -23,6 +23,9 @@ mere.run vision ground --help
 - `--output`, `-o`: annotated image path.
 - `--json-output`: JSON metadata path.
 - `--mask-output-dir`: directory for per-detection mask PNGs.
+- `--preflight --json`: validate inputs, model availability, and artifact paths
+  without loading the model.
+- `--quiet`, `-q`: print only the annotated output image path.
 
 ## Prompting Patterns
 
@@ -45,6 +48,15 @@ mere.run vision ground ./street.jpg \
 - Start broad, then add attributes to reduce false positives.
 - Save masks when downstream compositing or measurement needs exact regions.
 - For crowded scenes, test one query at a time.
+
+## Portable Workflows
+
+Use the built-in `vision.ground` graph node to keep grounding portable across
+local, SSH, and Relay execution. It accepts an image asset and a JSON array of
+queries, defaults to the managed Falcon model, and emits verified annotated
+`image` and structured `detections` artifacts. Treat detections as candidate
+geometry until an authoritative source or human review promotes them. Direct
+CLI runs may additionally request per-detection masks with `--mask-output-dir`.
 
 ## Troubleshooting
 

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -830,6 +830,48 @@ enum WorkflowNodeRegistry {
             presentation: .init(style: "material", primaryArgument: "image")
         ),
         WorkflowNodeCatalogEntry(
+            kind: "vision.ground",
+            title: "Ground objects",
+            description: "Locate open-vocabulary candidate regions with Falcon Perception.",
+            category: "vision",
+            inputs: [
+                .init(
+                    name: "image",
+                    type: .asset,
+                    required: true,
+                    acceptedContentTypes: ["image/png", "image/jpeg", "image/webp"]
+                ),
+                .init(
+                    name: "queries",
+                    type: .json,
+                    required: true,
+                    description: "One or more candidate-region expressions.",
+                    valueSchema: .init(type: .array, items: .init(type: .string))
+                ),
+                .init(name: "model", type: .string, required: false),
+            ],
+            outputs: [
+                .init(
+                    name: "image",
+                    type: .asset,
+                    description: "Annotated candidate-region image.",
+                    contentTypes: ["image/png"]
+                ),
+                .init(
+                    name: "detections",
+                    type: .asset,
+                    description: "Structured candidate detections and normalized geometry.",
+                    contentTypes: ["application/json"]
+                ),
+            ],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            ),
+            presentation: .init(style: "material", primaryArgument: "image")
+        ),
+        WorkflowNodeCatalogEntry(
             kind: "image.train-lora",
             title: "Train image LoRA",
             category: "image",

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -702,6 +702,7 @@ struct WorkflowBundleMaterializer {
             switch node.kind {
             case "image.train-lora": return ImageTrainLoRA.defaultManagedModelID.rawValue
             case "image.generate": return ImageGenerate.defaultManagedModelID.rawValue
+            case "vision.ground": return VisionGround.defaultManagedModelID.rawValue
             case "video.generate": return ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
             default: return nil
             }
@@ -1328,6 +1329,30 @@ enum WorkflowNodeCommandBuilder {
                 streamsEvents: false,
                 stdoutOutputName: "text"
             )
+        case "vision.ground":
+            let outputImage = artifacts.appendingPathComponent("image.png")
+            let detections = artifacts.appendingPathComponent("detections.json")
+            var args = [
+                "vision", "ground", try requiredString("image", in: arguments),
+                "--query",
+            ]
+            args.append(contentsOf: try requiredStringArray("queries", in: arguments))
+            appendString("model", flag: "--model", from: arguments, to: &args)
+            args += [
+                "--output", outputImage.path,
+                "--json-output", detections.path,
+            ]
+            return .init(
+                command: ["vision", "ground"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args + ["--quiet"],
+                outputs: [
+                    "image": fileOutput(outputImage, contentTypes: ["image/png"]),
+                    "detections": fileOutput(detections, contentTypes: ["application/json"]),
+                ],
+                streamsEvents: false
+            )
         case "image.train-lora":
             let output = artifacts.appendingPathComponent("adapter.safetensors")
             var args = ["image", "train-lora", "--data", try requiredString("data", in: arguments), "--output", output.path]
@@ -1510,6 +1535,20 @@ enum WorkflowNodeCommandBuilder {
             throw ValidationError("Workflow node argument '\(name)' did not resolve to a string.")
         }
         return value
+    }
+
+    private static func requiredStringArray(
+        _ name: String,
+        in arguments: [String: WorkflowValue]
+    ) throws -> [String] {
+        guard case .array(let values)? = arguments[name] else {
+            throw ValidationError("Workflow node argument '\(name)' did not resolve to an array.")
+        }
+        let strings = values.compactMap(\.stringValue)
+        guard strings.count == values.count, !strings.isEmpty, strings.allSatisfy({ !$0.isEmpty }) else {
+            throw ValidationError("Workflow node argument '\(name)' must contain one or more strings.")
+        }
+        return strings
     }
 
     private static func appendString(

--- a/Tests/MereRunCLITests/VisionGroundCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/VisionGroundCommandParsingTests.swift
@@ -34,6 +34,33 @@ final class VisionGroundCommandParsingTests: XCTestCase {
         XCTAssertNil(cmd.output)
         XCTAssertNil(cmd.jsonOutput)
         XCTAssertNil(cmd.maskOutputDir)
+        XCTAssertFalse(cmd.preflight)
+        XCTAssertFalse(cmd.json)
+        XCTAssertFalse(cmd.quiet)
+    }
+
+    func testVisionGroundParsesWorkflowFlags() throws {
+        let cmd = try VisionGround.parse([
+            "/tmp/image.png",
+            "--query", "washed-out road", "debris",
+            "--preflight",
+            "--json",
+            "--quiet",
+        ])
+
+        XCTAssertEqual(cmd.query, ["washed-out road", "debris"])
+        XCTAssertTrue(cmd.preflight)
+        XCTAssertTrue(cmd.json)
+        XCTAssertTrue(cmd.quiet)
+        XCTAssertNoThrow(try cmd.validate())
+    }
+
+    func testVisionGroundRejectsJSONOutsidePreflight() throws {
+        XCTAssertThrowsError(try VisionGround.parse([
+            "/tmp/image.png",
+            "--query", "road",
+            "--json",
+        ]))
     }
 
     func testVisionGroundParsesPromptAliasAndOverrides() throws {

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -45,6 +45,30 @@ final class WorkflowGraphTests: XCTestCase {
         )
     }
 
+    func testVisionGroundCatalogExposesCandidateArtifacts() throws {
+        let entry = try XCTUnwrap(WorkflowNodeRegistry.entry(for: "vision.ground"))
+
+        XCTAssertEqual(entry.category, "vision")
+        XCTAssertEqual(entry.presentation?.style, "material")
+        XCTAssertEqual(entry.presentation?.primaryArgument, "image")
+        XCTAssertEqual(
+            entry.inputs.first(where: { $0.name == "queries" })?.valueSchema?.type,
+            .array
+        )
+        XCTAssertEqual(
+            entry.inputs.first(where: { $0.name == "queries" })?.valueSchema?.items?.type,
+            .string
+        )
+        XCTAssertEqual(
+            entry.outputs.map(\.name),
+            ["image", "detections"]
+        )
+        XCTAssertEqual(
+            entry.outputs.first(where: { $0.name == "detections" })?.contentTypes,
+            ["application/json"]
+        )
+    }
+
     func testCreativeMaterialIntrinsicsHaveExactSemantics() throws {
         XCTAssertEqual(
             try WorkflowIntrinsicInvocation(
@@ -200,6 +224,94 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertTrue(invocation.runArguments.contains("--require-installed"))
         XCTAssertTrue(invocation.runArguments.contains("--no-thinking"))
         XCTAssertEqual(invocation.stdoutOutputName, "text")
+    }
+
+    func testVisionGroundBuildsPreflightAndArtifactInvocation() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = WorkflowNode(
+            id: "ground",
+            kind: "vision.ground",
+            arguments: [
+                "image": .string("/tmp/post-event.png"),
+                "queries": .array([
+                    .string("washed-out roadway"),
+                    .string("debris accumulation"),
+                ]),
+            ],
+            dependsOn: nil
+        )
+
+        let invocation = try WorkflowNodeCommandBuilder.invocation(
+            node: node,
+            arguments: node.arguments,
+            nodeDirectory: root
+        )
+
+        XCTAssertEqual(invocation.command, ["vision", "ground"])
+        XCTAssertTrue(invocation.preflightArguments.suffix(2).elementsEqual(["--preflight", "--json"]))
+        XCTAssertTrue(invocation.runArguments.contains("--quiet"))
+        XCTAssertTrue(invocation.runArguments.contains("washed-out roadway"))
+        XCTAssertTrue(invocation.runArguments.contains("debris accumulation"))
+        XCTAssertEqual(invocation.outputs["image"]?.type, .asset)
+        XCTAssertEqual(invocation.outputs["detections"]?.contentTypes, ["application/json"])
+        XCTAssertTrue(invocation.outputs["image"]?.path?.hasSuffix("/artifacts/image.png") == true)
+        XCTAssertTrue(invocation.outputs["detections"]?.path?.hasSuffix("/artifacts/detections.json") == true)
+        XCTAssertFalse(invocation.runArguments.contains("--mask-output-dir"))
+    }
+
+    func testVisionGroundRequiresAtLeastOneStringQuery() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = WorkflowNode(
+            id: "ground",
+            kind: "vision.ground",
+            arguments: [
+                "image": .string("/tmp/post-event.png"),
+                "queries": .array([]),
+            ],
+            dependsOn: nil
+        )
+
+        XCTAssertThrowsError(try WorkflowNodeCommandBuilder.invocation(
+            node: node,
+            arguments: node.arguments,
+            nodeDirectory: root
+        ))
+    }
+
+    func testVisionGroundDefaultsManagedModelRequirement() throws {
+        let graph = try decodeGraph("""
+        {
+          "schema_version": 1,
+          "kind": "mere.run/workflow-graph",
+          "name": "ground-candidates",
+          "inputs": {
+            "image": {"type": "asset", "content_types": ["image/png"]}
+          },
+          "nodes": [
+            {
+              "id": "ground",
+              "kind": "vision.ground",
+              "arguments": {
+                "image": {"$ref": "inputs.image"},
+                "queries": ["road", "debris"]
+              }
+            }
+          ],
+          "outputs": {
+            "detections": {"$ref": "nodes.ground.outputs.detections"}
+          }
+        }
+        """)
+        let requirements = WorkflowGraphRequirements.resolve(
+            graph: graph,
+            inputs: .init(values: ["image": .string("/tmp/post-event.png")])
+        )
+
+        XCTAssertEqual(requirements.nodeKinds, ["vision.ground"])
+        XCTAssertEqual(requirements.modelIDs, ["vision-ground-falcon-perception"])
+        XCTAssertEqual(requirements.acceleratorBackends, ["cuda", "metal"])
     }
 
     func testNVIDIAMemoryProbeParsesLargestGPU() {

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -205,7 +205,15 @@ model store; it also accepts a local Falcon Perception model root directory.
 The annotated image defaults to `<stem>_grounded.<ext>` (`--output`/`-o`
 overrides it), JSON metadata defaults to `<stem>_grounded.json`
 (`--json-output` overrides it), and `--mask-output-dir` exports one PNG mask
-per detection.
+per detection. `--preflight --json` validates the image, installed model,
+queries, and output plan without loading the model; `--quiet` prints only the
+annotated image path.
+
+Portable graphs expose the same runtime as the built-in `vision.ground` node.
+The node accepts an image plus a JSON array of queries and produces a verified
+annotated `image` plus structured `detections` JSON. These outputs are candidate
+geometry, not authoritative evidence. Direct CLI runs may additionally export
+per-detection masks with `--mask-output-dir`.
 
 ### Track objects through a video
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -51,6 +51,7 @@ The V1 node catalog contains:
 - `seed.value`, `choice.value`
 - `text.join`, `text.template`
 - `text.enhance`, `image.describe`
+- `vision.ground`
 - `image.train-lora`
 - `image.generate`
 - `video.generate`
@@ -61,6 +62,11 @@ templates execute as native deterministic intrinsics. `text.template` accepts
 strict `{{name}}` identifiers, preserves escaped `\{{name}}` text, and blocks
 missing variables. `text.enhance` and `image.describe` require an explicit
 installed model and never trigger a hidden pull.
+
+`vision.ground` uses the managed `vision-ground-falcon-perception` model by
+default. It emits an annotated image and structured detections JSON as verified
+artifacts. Grounding output is candidate geometry; graph execution does not
+promote it into evidence or findings.
 
 Catalog value schemas recursively describe array items, object properties, and
 additional properties. Editors may expose those nested slots as typed ports


### PR DESCRIPTION
## Summary
- register `vision.ground` as a first-class portable workflow node
- emit verified annotated-image and structured-detections artifacts while defaulting placement requirements to `vision-ground-falcon-perception`
- add model-aware `vision ground --preflight --json` and workflow-safe `--quiet` behavior
- document candidate geometry as non-authoritative until corroborated

## Verification
- `./scripts/check.sh` (2,438 tests, 151 asset-dependent skips, 0 failures)
- focused VisionGround, WorkflowGraph, and documentation contract tests (63 passed)
- real Helene graph preflight and local execution with installed Falcon Perception
- exported `mere.run/job-bundle.v1` advertises `vision.ground` and the pinned Falcon model
