### PR TITLE
Restore explicit model license acceptance copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,8 @@ swift run mere.run video generate \
   --output ./performance.mp4
 
 # MiniMax-H3 text/first-frame to synchronized 24 fps video + 32 kHz stereo
+# Passing --accept-model-license confirms review and acceptance of the listed
+# terms and agreement to comply before the download begins.
 swift run mere.run model pull video-minimax-h3-fl2va-mlx --accept-model-license
 swift run mere.run video generate \
   "the paper bird takes flight with crisp wing sounds" \

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -4343,7 +4343,7 @@ private struct OpenWebUIOptions: View {
                         Toggle("Quiet", isOn: $controller.draft.quiet)
                     }
                     Toggle(
-                        "Acknowledge third-party model terms",
+                        "Accept third-party model terms",
                         isOn: $controller.draft.acceptModelLicense
                     )
                     .toggleStyle(.checkbox)
@@ -4558,7 +4558,7 @@ private struct AgentOptions: View {
                     Toggle("Install Pi", isOn: $controller.draft.all)
                     Toggle("Configure Pi", isOn: $controller.draft.stream)
                 }
-                Toggle("Acknowledge third-party model terms", isOn: $controller.draft.acceptModelLicense)
+                Toggle("Accept third-party model terms", isOn: $controller.draft.acceptModelLicense)
                     .toggleStyle(.checkbox)
                 AdaptiveControlRow {
                     TextField("Host", text: $controller.draft.host)
@@ -4584,14 +4584,20 @@ private struct ModelPullOptions: View {
                     Toggle("Allow unsupported", isOn: $controller.draft.stream)
                     Toggle("Quiet", isOn: $controller.draft.quiet)
                 }
-                Toggle("Acknowledge third-party model terms", isOn: $controller.draft.acceptModelLicense)
+                Toggle("Accept third-party model terms", isOn: $controller.draft.acceptModelLicense)
                     .toggleStyle(.checkbox)
                 AdaptiveControlRow {
                     Toggle("Preflight", isOn: $controller.draft.preflight)
                     Toggle("JSON", isOn: $controller.draft.json)
                         .disabled(!controller.draft.preflight)
                 }
-                Text("Required for access-gated downloads and models with material non-commercial, research-only, or revenue-limited terms. A custom license alone does not trigger this acknowledgement. The command output lists the exact model/component terms. Mere does not determine whether your intended use is permitted; you are responsible for compliance.")
+                Text(
+                    "Required for access-gated downloads and models with material non-commercial, research-only, "
+                        + "or revenue-limited terms. Enabling this option confirms that you reviewed and accept the "
+                        + "listed terms and agree to comply with them. A custom license alone does not trigger this "
+                        + "requirement. Mere does not determine whether your intended use is permitted; you are "
+                        + "responsible for compliance."
+                )
                     .font(MereRunTheme.captionFont)
                     .foregroundStyle(MereRunTheme.textMuted)
             }

--- a/Sources/MereRunApp/README.md
+++ b/Sources/MereRunApp/README.md
@@ -89,7 +89,7 @@ and fleet telemetry. The app links to the Relay console instead of copying
 those schemas or controls.
 
 Models includes one-click managed downloads with live CLI output, explicit
-third-party terms acknowledgement, cancellation with resumable partials, and a
+explicit third-party terms acceptance, cancellation with resumable partials, and a
 dedicated Health & Repair workspace. Successful downloads refresh the inventory
 without reopening the sheet. Manifest audit is a structured dry run, repair
 requires confirmation and writes only missing known manifests, and

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -303,9 +303,9 @@ struct StudioModelsSheet: View {
             switch pending {
             case .download(let row):
                 Alert(
-                    title: Text("Acknowledge third-party model terms"),
+                    title: Text("Accept third-party model terms"),
                     message: Text(downloadTermsMessage(row)),
-                    primaryButton: .default(Text("Acknowledge & Download")) {
+                    primaryButton: .default(Text("Accept & Download")) {
                         Task { await download(row, acknowledgingUsageTerms: true) }
                     },
                     secondaryButton: .cancel()
@@ -529,7 +529,7 @@ struct StudioModelsSheet: View {
                         .font(MereRunTheme.captionFont)
                         .foregroundStyle(MereRunTheme.textMuted)
                     if let usageTerms = row.usageTerms {
-                        Text("Third-party usage terms · acknowledgement required for new downloads")
+                        Text("Third-party usage terms · acceptance required for new downloads")
                             .font(MereRunTheme.captionFont)
                             .foregroundStyle(MereRunTheme.yellow)
                         Text(usageTerms.summary)
@@ -669,7 +669,7 @@ struct StudioModelsSheet: View {
             }
 
             if row.usageTerms != nil {
-                Text("Review the linked terms above. Download requires explicit acknowledgement.")
+                Text("Review the linked terms above. Download requires explicit acceptance.")
                     .font(MereRunTheme.captionFont)
                     .foregroundStyle(MereRunTheme.yellow)
             }
@@ -845,7 +845,12 @@ struct StudioModelsSheet: View {
 
     private func downloadTermsMessage(_ row: StudioModelInventoryRow) -> String {
         let summary = row.usageTerms?.summary ?? "This model has third-party usage terms."
-        return "\(summary)\n\nMere does not determine whether your intended use is permitted. You are responsible for compliance."
+        return """
+        \(summary)
+
+        By continuing, you confirm that you reviewed and accept the listed terms and agree to comply with them. \
+        Mere does not determine whether your intended use is permitted. You are responsible for compliance.
+        """
     }
 
     @MainActor

--- a/Sources/MereRunApp/StudioRootView.swift
+++ b/Sources/MereRunApp/StudioRootView.swift
@@ -596,7 +596,7 @@ struct StudioRootView: View {
                 .environmentObject(library)
             }
             .alert(
-                "Acknowledge third-party model terms",
+                "Accept third-party model terms",
                 isPresented: Binding(
                     get: { pendingRestrictedPull != nil },
                     set: { if !$0 { pendingRestrictedPull = nil } }
@@ -606,14 +606,19 @@ struct StudioRootView: View {
                 Button("Cancel", role: .cancel) {
                     pendingRestrictedPull = nil
                 }
-                Button("Acknowledge & Download") {
+                Button("Accept & Download") {
                     pendingRestrictedPull = nil
                     startPull(request, acknowledgingUsageTerms: true)
                 }
             } message: { request in
                 let usageTerms = modelUsageTermsByID[request.draft.model]
                 Text(
-                    "\(usageTerms?.summary ?? "This model has third-party usage terms.")\n\nMere does not determine whether your intended use is permitted. You are responsible for compliance."
+                    """
+                    \(usageTerms?.summary ?? "This model has third-party usage terms.")
+
+                    By continuing, you confirm that you reviewed and accept the listed terms and agree to comply with them. \
+                    Mere does not determine whether your intended use is permitted. You are responsible for compliance.
+                    """
                 )
             }
             .focusedSceneValue(\.showLibrary, visibleLibraryBinding)

--- a/Sources/MereRunCLI/Commands/AgentCommand.swift
+++ b/Sources/MereRunCLI/Commands/AgentCommand.swift
@@ -184,7 +184,7 @@ struct AgentOnboard: AsyncParsableCommand {
 
     @Flag(
         name: [.customLong("accept-model-license")],
-        help: "Acknowledge listed third-party model/component terms before downloading restricted recommended models."
+        help: "Confirm that you reviewed and accept listed third-party model/component terms before downloading restricted recommended models."
     )
     var acceptModelLicense: Bool = false
 
@@ -303,7 +303,8 @@ struct AgentOnboard: AsyncParsableCommand {
                !acceptModelLicense {
                 CLIStderr.write(
                     "[\(report.spec.id)] skipping restricted model: \(restriction.summary) "
-                    + "Review \(restriction.terms.map(\.licenseURL).joined(separator: ", ")) and pass --accept-model-license.\n"
+                    + "Review \(restriction.terms.map(\.licenseURL).joined(separator: ", ")) and pass "
+                    + "--accept-model-license to accept the terms and agree to comply with them.\n"
                 )
                 continue
             }

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -25,7 +25,7 @@ struct ModelPull: AsyncParsableCommand {
 
     @Flag(
         name: [.customLong("accept-model-license")],
-        help: "Acknowledge all listed third-party model/component terms before downloading a restricted model."
+        help: "Confirm that you reviewed and accept all listed third-party model/component terms before downloading a restricted model."
     )
     var acceptModelLicense: Bool = false
 
@@ -75,7 +75,10 @@ struct ModelPull: AsyncParsableCommand {
                     ))
                 if requiresUsageTermsAcknowledgement, !acceptModelLicense {
                     if !quiet {
-                        stderr("[\(spec.id)] skipping (pass --accept-model-license to acknowledge its third-party model/component terms)")
+                        stderr(
+                            "[\(spec.id)] skipping (pass --accept-model-license to review and accept its "
+                                + "third-party model/component terms)"
+                        )
                     }
                     continue
                 }
@@ -150,6 +153,10 @@ struct ModelPull: AsyncParsableCommand {
                 stderr("    terms: \(term.licenseURL)")
             }
             stderr("  You are responsible for determining whether your use complies with these terms.")
+            stderr(
+                "  By continuing, you confirm that you reviewed and accept these terms "
+                    + "and agree to comply with them."
+            )
         }
         try ModelPullDiskPreflight.check(spec: spec, modelDir: modelDir, force: force) { warning in
             guard !quiet else { return }
@@ -231,11 +238,13 @@ struct ModelPull: AsyncParsableCommand {
         guard let restriction = spec.usageRestriction, !acceptModelLicense else {
             return nil
         }
+        let confirmation = "Re-run with --accept-model-license to confirm that you reviewed and accept "
+            + "these terms and agree to comply with them. Download begins only after this confirmation."
         return """
         Model \(spec.id) has third-party usage terms: \(restriction.summary)
         \(restriction.terms.map { "- \($0.component): \($0.license)\n  \($0.licenseURL)" }.joined(separator: "\n"))
         Mere does not decide whether your intended use is permitted. You are responsible for compliance.
-        Re-run with --accept-model-license to acknowledge these terms before download.
+        \(confirmation)
         """
     }
 

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -91,7 +91,7 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
 
     @Flag(
         name: [.customLong("accept-model-license")],
-        help: "Acknowledge listed third-party model/component terms before downloading restricted configured models."
+        help: "Confirm that you reviewed and accept listed third-party model/component terms before downloading restricted configured models."
     )
     var acceptModelLicense: Bool = false
 
@@ -345,7 +345,8 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
         Open WebUI --pull includes configured models with third-party usage terms:
         \(details)
         Mere does not determine whether your intended use is permitted. You are responsible for compliance.
-        Review the terms and re-run with --accept-model-license, or pre-install a different model.
+        Re-run with --accept-model-license to confirm that you reviewed and accept these terms and agree to comply with them, \
+        or pre-install a different model.
         """
     }
 

--- a/Sources/MereRunCLI/Guides/agent-onboard.md
+++ b/Sources/MereRunCLI/Guides/agent-onboard.md
@@ -25,7 +25,7 @@ mere.run agent onboard --help
 ## Parameters
 
 - `--pull-recommended`: pull supported first-setup model packages.
-- `--accept-model-license`: acknowledge listed third-party terms before restricted recommended-model downloads.
+- `--accept-model-license`: confirm that you reviewed and accept the listed third-party terms and agree to comply with them before restricted recommended-model downloads.
 - `--install-pi`: install the latest Pi coding-agent release.
 - `--configure-pi`: write a Pi extension for the local mere.run API provider.
 - `--host`: local API host for the provider extension.

--- a/Sources/MereRunCLI/Guides/agent-status.md
+++ b/Sources/MereRunCLI/Guides/agent-status.md
@@ -56,7 +56,7 @@ mere.run agent status --pi-path "$HOME/bin/pi" --json
 - Provider not configured: run
   `mere.run agent onboard --configure-pi --model <id>`.
 - Recommended model not installed: run `mere.run model pull <id>` and
-  acknowledge model terms when required.
+  review and accept model terms when required.
 
 ## Sources
 

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -24,6 +24,9 @@ mere.run model list
 - `--force`: re-download even if already installed.
 - `--quiet`, `-q`: suppress progress.
 - `--allow-unsupported`: bypass platform and memory support checks.
+- `--accept-model-license`: confirm that you reviewed and accept all listed
+  third-party model/component terms and agree to comply with them before a
+  restricted download begins.
 - `--preflight`: inspect support, source, install state, and disk paths without downloading.
 - `--json`: with `--preflight`, emit a structured report for scripts and apps.
 
@@ -73,6 +76,8 @@ MERERUN_MODELS_DIR=/Volumes/Models/mere.run \
 - Unknown id: run `mere.run model list`.
 - No Hugging Face source: use a local path or choose a pullable model.
 - Unsupported machine: pick a smaller recommended model or pass `--allow-unsupported` only when the user accepts the risk.
+- Restricted model terms: review every listed license URL and pass
+  `--accept-model-license` only to confirm acceptance and agreement to comply.
 - Not enough free disk space: free the reported cache volume, run `mere.run model remove <id>`, or move both the Hugging Face cache and model store:
   `MERERUN_HUB_CACHE=/Volumes/Models/huggingface MERERUN_MODELS_DIR=/Volumes/Models/mere.run mere.run model pull <id>`.
 

--- a/Sources/MereRunCLI/Guides/video-cosmos3.md
+++ b/Sources/MereRunCLI/Guides/video-cosmos3.md
@@ -18,7 +18,7 @@ mere.run model pull video-cosmos3-edge-mlx
 The managed model pins `nvidia/Cosmos3-Edge` at revision
 `6f58f6b4c91288838e60b6bcb2cc45d997e961de`. The model is governed by
 OpenMDW-1.1. The public pull retains `LICENSE.md` and does not add a separate
-mere.run acknowledgement gate.
+mere.run acceptance gate.
 
 ## Generation Modes
 

--- a/Sources/MereRunCLI/Support/ModelPullPreflight.swift
+++ b/Sources/MereRunCLI/Support/ModelPullPreflight.swift
@@ -302,8 +302,10 @@ struct ModelPullPreflightAnalyzer {
                 PreflightDiagnostic(
                     id: "model_usage_terms_unacknowledged",
                     severity: .blocker,
-                    title: "Third-party model terms require acknowledgement",
-                    message: "\(restriction.summary) Review the listed terms and pass --accept-model-license to acknowledge them before download."
+                    title: "Third-party model terms require acceptance",
+                    message: restriction.summary
+                        + " Pass --accept-model-license to confirm that you reviewed and accept the listed terms "
+                        + "and agree to comply with them. Download begins only after this confirmation."
                 )
             )
         }

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -65,7 +65,7 @@ public enum ManagedModelResolver {
             case .autoDownloadDisabled(let id):
                 return "Model \(id) is not installed and does not support auto-download in this command."
             case .usageTermsNotAcknowledged(let id):
-                return "Model \(id) has third-party usage terms that must be acknowledged before download."
+                return "Model \(id) has third-party usage terms that must be reviewed and accepted before download."
             case .unsupportedInstallShape(let id):
                 return "Managed install shape is not supported for \(id)."
             case .downloadFailed(let message):

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -407,10 +407,10 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     /// Exact repositories and requested revisions materialized into this managed install.
     public var sources: [SourceProvenance]?
 
-    /// Third-party model/component terms that required explicit acknowledgement before download.
+    /// Third-party model/component terms that required explicit acceptance before download.
     public var usageTerms: [ManagedModelUsageTerm]?
 
-    /// True only when the managed installer was invoked with explicit acknowledgement.
+    /// True only when the managed installer was invoked with explicit confirmation of acceptance.
     public var usageTermsAcknowledged: Bool?
 
     /// ISO8601 timestamp; informational only.

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -24,7 +24,10 @@ final class ModelPullCommandParsingTests: XCTestCase {
         ])
 
         XCTAssertNotNil(restricted.usageRestriction)
-        XCTAssertNotNil(blocked.licenseAcceptanceMessage(for: restricted))
+        let message = try XCTUnwrap(blocked.licenseAcceptanceMessage(for: restricted))
+        XCTAssertTrue(message.contains("reviewed and accept these terms"))
+        XCTAssertTrue(message.contains("agree to comply with them"))
+        XCTAssertTrue(message.contains("Download begins only after this confirmation"))
         XCTAssertNil(accepted.licenseAcceptanceMessage(for: restricted))
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2132,9 +2132,11 @@ Models that are access-gated or carry material non-commercial, research-only,
 or revenue-limited terms require `--accept-model-license` before a new
 download. A custom license alone does not trigger the flag.
 The preflight reports the exact component terms and blocks without
-acknowledgement; `--all` skips restricted entries unless the flag is present.
-mere.run records the immutable source revisions and acknowledged term URLs in
-the installed `mererun_model.json`, but the user remains responsible for
+acceptance; `--all` skips restricted entries unless the flag is present.
+Passing `--accept-model-license` and continuing with the download confirms that
+the user reviewed and accepts the listed terms and agrees to comply. mere.run
+records the immutable source revisions and accepted term URLs in the installed
+`mererun_model.json`, but the user remains responsible for
 deciding whether their intended use complies. See
 [`model-sources.md`](./model-sources.md#restricted-model-downloads).
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -131,7 +131,9 @@ terms of their respective owners. mere.run does not bundle these weights,
 decide whether a user's intended use qualifies, or police use after install.
 For every new download that is access-gated or carries a material use limit—
 such as non-commercial, research-only, or revenue-limited terms—the user must
-review the listed terms and pass `--accept-model-license`:
+review the listed terms and pass `--accept-model-license`. Passing the flag and
+continuing with the download confirms that the user accepts those terms and
+agrees to comply with them:
 
 ```bash
 mere.run model pull vision-face-buffalo-l --accept-model-license
@@ -140,14 +142,14 @@ mere.run model pull --all --accept-model-license
 
 Without that flag, a single-model pull and its preflight are blocked; `--all`
 skips restricted models. Restricted models never auto-download from an
-inference command. The macOS app presents the same acknowledgement before a
+inference command. The macOS app presents the same explicit acceptance before a
 download and exposes the term links in its Models and Advanced views.
 Batch downloads through `agent onboard --pull-recommended` skip restricted
-entries without acknowledgement, while `open-webui quickstart --pull`
+entries without acceptance, while `open-webui quickstart --pull`
 validates all configured models before downloading any; both accept the same
 `--accept-model-license` flag.
 
-| Models | Upstream terms that require acknowledgement |
+| Models | Upstream terms that require acceptance |
 | --- | --- |
 | `image-klein-9b`, `image-klein-base-9b` | FLUX Non-Commercial License v2.1; non-commercial, non-production use |
 | `image-krea2-raw`, `image-krea2-turbo` | Krea 2 Community License; commercial use is limited to entities below USD 1M trailing annual revenue, plus use/distribution conditions |
@@ -164,10 +166,10 @@ validates all configured models before downloading any; both accept the same
 
 The catalog pins every restricted download source to an immutable commit. New
 managed installs write those repository revisions, every applicable
-model/component license and URL, and the acknowledgement result into schema 3
+model/component license and URL, and the acceptance result into schema 3
 of `mererun_model.json`. `mere.run model info MODEL` displays the same record.
 Pre-existing installs remain usable and are not retroactively treated as an
-acknowledgement.
+acceptance.
 
 The flag is not a generic click-through for every custom model license. Public,
 ungated downloads whose licenses grant commercial use by exercising the
@@ -180,7 +182,7 @@ README, attribution, and immutable source provenance.
 `music-separate-bs-roformer-viperx-1297`,
 `music-separate-bs-roformer-4stem`,
 `music-separate-mel-roformer-dereverb`, and
-`music-separate-mel-roformer-denoise` also do not require acknowledgement. The
+`music-separate-mel-roformer-denoise` also do not require separate acceptance. The
 pinned AEmotion Studio model release includes an explicit MIT `LICENSE`
 and an MIT model-card declaration. The managed install retains both files and
 admits the weights, source configuration, model card, and license only when all
@@ -188,20 +190,20 @@ four match their model-specific frozen byte counts and SHA-256 digests. The
 MelBand profiles additionally retain separate dereverb and denoise source
 configs and exact 913 MB checkpoint hashes.
 
-`audio-enhance-ap-bwe-16kto48k` does not require acknowledgement. AP-BWE's
+`audio-enhance-ap-bwe-16kto48k` does not require separate acceptance. AP-BWE's
 pinned source repository states that both code and pretrained weights are MIT.
 The managed public transport snapshot retains the code and weights license
 files, source config, and the exact official 16→48 kHz checkpoint archive;
 mere.run verifies all four byte counts and SHA-256 digests before loading.
 
-`audio-enhance-universr-audio` does not require interactive acknowledgement,
+`audio-enhance-universr-audio` does not require interactive acceptance,
 but its two upstream licenses must not be conflated. The native port follows
 the MIT-licensed `woongzip1/UniverSR` source at its pinned commit. The separately
 downloaded official `woongzip1/universr-audio` checkpoint is CC BY 4.0. The
 managed install verifies the checkpoint, source configuration, and model card
 by frozen revision, byte count, and SHA-256 before loading.
 
-`image-zimage-nano` also does not require acknowledgement. Its canonical
+`image-zimage-nano` also does not require separate acceptance. Its canonical
 `Tongyi-MAI/Z-Image-Turbo` base is Apache-2.0; the pinned mflux conversion's
 model-card license label is inconsistent with that canonical source and is not
 treated as a new restriction on the converted weights.
@@ -902,7 +904,7 @@ mere.run guide video-cosmos3
 
 The checkpoint is governed by NVIDIA Open Model Development and Use License
 1.1 (`OpenMDW-1.1`). Exercising the licensed rights constitutes acceptance;
-the public, ungated pull does not require mere.run's acknowledgement flag.
+the public, ungated pull does not require mere.run's acceptance flag.
 The managed snapshot retains `LICENSE.md`, and runtime auto-download remains
 disabled.
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -51,7 +51,8 @@ Open **Models**, switch the scope to **All**, and select any missing model to
 download it directly. Studio streams the underlying `model pull` output, keeps
 cancelled partial downloads resumable, and refreshes the inventory after a
 successful install. Models with restricted third-party terms show their source
-links and require **Acknowledge & Download** before transfer. The **Files**
+links and require **Accept & Download** before transfer. Continuing confirms
+that the user reviewed and accepts the listed terms and agrees to comply. The **Files**
 button opens the configured model store in Finder; it does not start a download.
 
 ## Canonical model IDs
@@ -143,15 +144,17 @@ Access-gated models and models with material non-commercial, research-only, or
 revenue-limited terms require `--accept-model-license` for new downloads and
 never auto-download at runtime. A custom license alone does not trigger the
 flag. The CLI and macOS app show the
-applicable model/component terms before acceptance; schema 3 of the installed
-`mererun_model.json` records the immutable source revisions, term URLs, and
-acknowledgement. mere.run does not determine whether a user's intended use is
+applicable model/component terms before acceptance. Passing the flag or choosing
+**Accept & Download** confirms that the user reviewed and accepts those terms
+and agrees to comply. Schema 3 of the installed `mererun_model.json` records the
+immutable source revisions, term URLs, and acceptance confirmation. mere.run
+does not determine whether a user's intended use is
 permitted. The complete inventory is in
 [`model-sources.md`](../model-sources.md#restricted-model-downloads).
 
 Laguna XS 2.1 is released under the permissive OpenMDW-1.1 license, and its
 public Hugging Face repository is not gated. It therefore installs without a
-separate acknowledgement flag while retaining the upstream license file:
+separate acceptance flag while retaining the upstream license file:
 
 ```bash
 mere.run model pull text-chat-laguna-xs-2-1

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -103,7 +103,9 @@ MiniMax-H3 is CFG-distilled, so `--steps` is a schedule-point count without a
 second unconditional model evaluation. The Community License excludes use,
 distribution, and display in the United States, European Union, United
 Kingdom, and Republic of Korea. Read and accept the model terms before pulling,
-converting, using, or redistributing any artifact.
+converting, using, or redistributing any artifact. Passing
+`--accept-model-license` and continuing with the download confirms that you
+accept those terms and agree to comply with them.
 
 The managed package already includes the inference-only AdaLN cache computed
 from the official BF16/F32 projections; no post-pull optimization step is


### PR DESCRIPTION
## Summary

- make the CLI and macOS app state that continuing confirms review, acceptance, and agreement to comply with listed model terms
- keep the existing fail-closed download gate and manifest schema while replacing ambiguous acknowledgement-only copy
- document the same consent boundary for model pull, preflight, agent onboarding, Open WebUI, and MiniMax-H3
- publish matching wording on the public MiniMax-H3 MLX model card at Hugging Face commit 13a5f3d3658e73b166bbcaa49084722b5dabde25

## Validation

- ./scripts/check.sh
- 2,463 XCTest cases passed, 153 expected asset-dependent skips, zero failures
- strict SwiftLint: zero violations
- focused ModelPullCommandParsingTests: 24 passed
- direct MiniMax-H3 forced pull without the flag fails before transfer and prints the explicit acceptance message
- CLI help, model list, status, and hygiene tail: passed