### PR TITLE
Preserve TIFF metadata for workflow outputs

### DIFF
--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -789,6 +789,7 @@ struct WorkflowBundleMaterializer {
         case "webp": "image/webp"
         case "mp4": "video/mp4"
         case "wav": "audio/wav"
+        case "tif", "tiff": "image/tiff"
         case "json": "application/json"
         case "txt": "text/plain"
         case "safetensors": "application/x-safetensors"
@@ -1517,13 +1518,14 @@ enum WorkflowNodeCommandBuilder {
         }
     }
 
-    private static func outputExtension(contentTypes: [String]) -> String {
+    static func outputExtension(contentTypes: [String]) -> String {
         switch contentTypes.first {
         case "image/png": ".png"
         case "image/jpeg": ".jpg"
         case "image/webp": ".webp"
         case "video/mp4": ".mp4"
         case "audio/wav": ".wav"
+        case "image/tiff": ".tif"
         case "application/json": ".json"
         case "application/x-safetensors": ".safetensors"
         default: ""

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -2087,6 +2087,7 @@ struct WorkflowRunner: @unchecked Sendable {
         case "webp": "image/webp"
         case "mp4": "video/mp4"
         case "wav": "audio/wav"
+        case "tif", "tiff": "image/tiff"
         case "json": "application/json"
         case "txt": "text/plain"
         case "safetensors": "application/x-safetensors"

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -280,6 +280,17 @@ final class WorkflowGraphTests: XCTestCase {
         ))
     }
 
+    func testPluginTIFFOutputUsesPortableExtension() {
+        XCTAssertEqual(
+            WorkflowNodeCommandBuilder.outputExtension(contentTypes: ["image/tiff"]),
+            ".tif"
+        )
+        XCTAssertEqual(
+            WorkflowNodeCommandBuilder.outputExtension(contentTypes: ["application/json"]),
+            ".json"
+        )
+    }
+
     func testVisionGroundDefaultsManagedModelRequirement() throws {
         let graph = try decodeGraph("""
         {


### PR DESCRIPTION
## Summary

- map `image/tiff` provider outputs to portable `.tif` artifact paths
- infer TIFF content types while materializing workflow and run outputs
- cover the provider-output extension contract with regression tests

## Validation

- `./scripts/check.sh`
- strict lint, build, metallib verification, and 2,464 tests passed
- the TerraMind-enabled mere.earth graph emitted `flood-mask.tif` and `flood-probability.tif` as `image/tiff`