### PR TITLE
Fix plugin doctor installation diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on Keep a Changelog.
 
 ### Fixed
 
+- made `plugin list` and `plugin doctor` diagnose stale editable `pipx`
+  installations with the missing source path and an exact forced-reinstall
+  command instead of surfacing only a companion executable traceback.
 - updated the macOS auto-updater to Sparkle 2.9.5 for current compatibility and
   security fixes, and made packaging reject a stale embedded Sparkle framework
   before signing.

--- a/Sources/MereRunCLI/Commands/PluginCommand.swift
+++ b/Sources/MereRunCLI/Commands/PluginCommand.swift
@@ -49,6 +49,15 @@ struct PluginList: ParsableCommand {
             print("  \(plugin.description)")
             print("  command: \(plugin.entrypoint)")
             print("  install: \(PluginInstallCommand.render(install: install))")
+            if installation.installed, !installation.verified {
+                let diagnosis = PluginInstallationFailureDiagnosis.make(
+                    plugin: plugin,
+                    install: install,
+                    inspection: installation
+                )
+                print("  issue: \(diagnosis.summary)")
+                print("  repair: \(diagnosis.repairCommand)")
+            }
             print("")
         }
     }
@@ -163,14 +172,23 @@ struct PluginDoctor: ParsableCommand {
     func run() throws {
         let catalog = try PluginCatalogClient.load(catalogURL: catalogURL)
         let plugin = try catalog.requirePlugin(id)
-        guard PluginProcess.which(plugin.entrypoint) != nil else {
-            let install = try plugin.install(channel: catalog.defaultChannel)
+        let install = try plugin.install(channel: catalog.defaultChannel)
+        let installation = PluginInstallationInspection.inspect(plugin)
+        guard installation.installed else {
             throw ValidationError(
                 """
                 Plugin \(plugin.id) is not installed on PATH.
                 Install it with: \(PluginInstallCommand.render(install: install))
                 """
             )
+        }
+        guard installation.verified else {
+            let diagnosis = PluginInstallationFailureDiagnosis.make(
+                plugin: plugin,
+                install: install,
+                inspection: installation
+            )
+            throw ValidationError(diagnosis.rendered)
         }
         try PluginProcess.runExecutable(plugin.entrypoint, arguments: ["doctor"])
     }

--- a/Sources/MereRunCLI/Commands/PluginInstallationDiagnosis.swift
+++ b/Sources/MereRunCLI/Commands/PluginInstallationDiagnosis.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+struct PluginInstallationFailureDiagnosis: Equatable {
+    let pluginID: String
+    let summary: String
+    let verificationError: String?
+    let repairCommand: String
+
+    var rendered: String {
+        var lines = [
+            "Plugin \(pluginID) is installed but cannot run its doctor.",
+            "Diagnosis: \(summary)",
+        ]
+        if let verificationError {
+            lines.append("Verification error: \(verificationError)")
+        }
+        lines.append("Repair with:")
+        lines.append("  \(repairCommand)")
+        return lines.joined(separator: "\n")
+    }
+
+    static func make(
+        plugin: PluginCatalogEntry,
+        install: PluginCatalogInstall,
+        inspection: PluginInstallationInspection
+    ) -> PluginInstallationFailureDiagnosis {
+        make(
+            plugin: plugin,
+            install: install,
+            inspection: inspection,
+            missingEditableSourcePath: PluginPipxInstallationMetadata.missingEditableSourcePath(for: plugin)
+        )
+    }
+
+    static func make(
+        plugin: PluginCatalogEntry,
+        install: PluginCatalogInstall,
+        inspection: PluginInstallationInspection,
+        missingEditableSourcePath: String?
+    ) -> PluginInstallationFailureDiagnosis {
+        let repairArguments = install.manager == "pipx"
+            ? "plugin install \(ShellCommand.quote(plugin.id)) --yes --force"
+            : "plugin install \(ShellCommand.quote(plugin.id)) --yes"
+        if let missingEditableSourcePath {
+            return PluginInstallationFailureDiagnosis(
+                pluginID: plugin.id,
+                summary: "editable source path no longer exists: \(missingEditableSourcePath)",
+                verificationError: nil,
+                repairCommand: "mere.run \(repairArguments)"
+            )
+        }
+        return PluginInstallationFailureDiagnosis(
+            pluginID: plugin.id,
+            summary: "plugin manifest verification failed",
+            verificationError: conciseVerificationError(inspection.error),
+            repairCommand: "mere.run \(repairArguments)"
+        )
+    }
+
+    private static func conciseVerificationError(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let lines = raw.split(whereSeparator: \Character.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return lines.last.map { String($0.prefix(500)) }
+    }
+}
+
+enum PluginPipxInstallationMetadata {
+    static func missingEditableSourcePath(for plugin: PluginCatalogEntry) -> String? {
+        guard PluginProcess.which("pipx") != nil,
+              let data = try? PluginProcess.captureExecutable("pipx", arguments: ["list", "--json"]) else {
+            return nil
+        }
+        return try? missingEditableSourcePath(
+            for: plugin,
+            metadata: data,
+            fileExists: { FileManager.default.fileExists(atPath: $0) }
+        )
+    }
+
+    static func missingEditableSourcePath(
+        for plugin: PluginCatalogEntry,
+        metadata: Data,
+        fileExists: (String) -> Bool
+    ) throws -> String? {
+        let list = try JSONDecoder().decode(PipxList.self, from: metadata)
+        let environment = list.venvs[plugin.package]
+            ?? list.venvs[plugin.id]
+            ?? list.venvs.values.first { $0.metadata.mainPackage.package == plugin.package }
+        guard let package = environment?.metadata.mainPackage,
+              package.pipArgs.contains(where: { $0 == "--editable" || $0 == "-e" }),
+              let path = localPath(package.packageOrURL),
+              !fileExists(path) else {
+            return nil
+        }
+        return path
+    }
+
+    private static func localPath(_ raw: String) -> String? {
+        if raw.hasPrefix("file://") {
+            return URL(string: raw)?.standardizedFileURL.path
+        }
+        guard raw.hasPrefix("/") || raw.hasPrefix("~") else { return nil }
+        return URL(
+            fileURLWithPath: NSString(string: raw).expandingTildeInPath
+        ).standardizedFileURL.path
+    }
+}
+
+private struct PipxList: Decodable {
+    let venvs: [String: PipxEnvironment]
+}
+
+private struct PipxEnvironment: Decodable {
+    let metadata: PipxEnvironmentMetadata
+}
+
+private struct PipxEnvironmentMetadata: Decodable {
+    let mainPackage: PipxMainPackage
+
+    enum CodingKeys: String, CodingKey {
+        case mainPackage = "main_package"
+    }
+}
+
+private struct PipxMainPackage: Decodable {
+    let package: String
+    let packageOrURL: String
+    let pipArgs: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case package
+        case packageOrURL = "package_or_url"
+        case pipArgs = "pip_args"
+    }
+}

--- a/Sources/MereRunCLI/Guides/plugin.md
+++ b/Sources/MereRunCLI/Guides/plugin.md
@@ -86,6 +86,10 @@ mere.run plugin list \
   `--catalog-url`.
 - `Executable not found on PATH`: ensure `pipx ensurepath` has been run and
   your shell sees the plugin entrypoint.
+- `Editable source path no longer exists`: the plugin was installed from a
+  local checkout that moved or was removed. Run the exact
+  `mere.run plugin install <id> --yes --force` repair command printed by
+  `plugin list` or `plugin doctor`.
 - Manifest mismatch: the installed command is not the cataloged plugin. Reinstall
   with `--force` or inspect your PATH ordering.
 

--- a/Tests/MereRunCLITests/PluginCommandTests.swift
+++ b/Tests/MereRunCLITests/PluginCommandTests.swift
@@ -105,6 +105,74 @@ final class PluginCommandTests: XCTestCase {
         XCTAssertTrue(snapshot.plugins.first?.installCommand?.contains("pipx install") == true)
     }
 
+    func testBrokenEditableInstallationReportsMissingSourceAndRepairCommand() throws {
+        let catalog = try PluginCatalogClient.load(catalogURL: writeCatalog().path)
+        let plugin = try catalog.requirePlugin("mere-runpod")
+        let install = try plugin.install(channel: catalog.defaultChannel)
+        let metadata = Data(staleEditablePipxJSON.utf8)
+        let missingPath = try PluginPipxInstallationMetadata.missingEditableSourcePath(
+            for: plugin,
+            metadata: metadata,
+            fileExists: { _ in false }
+        )
+        let inspection = PluginInstallationInspection(
+            installed: true,
+            verified: false,
+            version: nil,
+            path: "/Users/test/.local/bin/mere-runpod",
+            error: "ModuleNotFoundError: No module named 'mere_runpod'"
+        )
+
+        let diagnosis = PluginInstallationFailureDiagnosis.make(
+            plugin: plugin,
+            install: install,
+            inspection: inspection,
+            missingEditableSourcePath: missingPath
+        )
+
+        XCTAssertEqual(missingPath, "/Users/test/mere/mere-plugins/packages/mere-runpod")
+        XCTAssertEqual(
+            diagnosis.summary,
+            "editable source path no longer exists: /Users/test/mere/mere-plugins/packages/mere-runpod"
+        )
+        XCTAssertNil(diagnosis.verificationError)
+        XCTAssertEqual(
+            diagnosis.repairCommand,
+            "mere.run plugin install mere-runpod --yes --force"
+        )
+        XCTAssertTrue(diagnosis.rendered.contains("cannot run its doctor"))
+    }
+
+    func testGenericVerificationFailureKeepsConciseErrorAndRepairCommand() throws {
+        let catalog = try PluginCatalogClient.load(catalogURL: writeCatalog().path)
+        let plugin = try catalog.requirePlugin("mere-runpod")
+        let install = try plugin.install(channel: catalog.defaultChannel)
+        let inspection = PluginInstallationInspection(
+            installed: true,
+            verified: false,
+            version: nil,
+            path: "/usr/local/bin/mere-runpod",
+            error: "Traceback (most recent call last):\nModuleNotFoundError: No module named 'mere_runpod'"
+        )
+
+        let diagnosis = PluginInstallationFailureDiagnosis.make(
+            plugin: plugin,
+            install: install,
+            inspection: inspection,
+            missingEditableSourcePath: nil
+        )
+
+        XCTAssertEqual(diagnosis.summary, "plugin manifest verification failed")
+        XCTAssertEqual(
+            diagnosis.verificationError,
+            "ModuleNotFoundError: No module named 'mere_runpod'"
+        )
+        XCTAssertEqual(
+            diagnosis.repairCommand,
+            "mere.run plugin install mere-runpod --yes --force"
+        )
+    }
+
     func testUnknownPluginErrorListsKnownPlugins() throws {
         let catalogURL = try writeCatalog()
         let catalog = try PluginCatalogClient.load(catalogURL: catalogURL.path)
@@ -160,6 +228,23 @@ if [ "$1" = "graph" ] && [ "$2" = "catalog" ]; then
   exit 0
 fi
 exit 2
+"""#
+
+private let staleEditablePipxJSON = #"""
+{
+  "pipx_spec_version": "0.1",
+  "venvs": {
+    "mere-runpod": {
+      "metadata": {
+        "main_package": {
+          "package": "mere-runpod",
+          "package_or_url": "/Users/test/mere/mere-plugins/packages/mere-runpod",
+          "pip_args": ["--editable"]
+        }
+      }
+    }
+  }
+}
 """#
 
 private let catalogJSON = """

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -62,8 +62,11 @@ mere.run plugin doctor mere-runpod
 ```
 
 The doctor command resolves the catalog entry, verifies that its executable is
-on `PATH`, and invokes the plugin's fixed `doctor` verb. Plugin stdout and exit
-status remain owned by that executable.
+on `PATH`, verifies its manifest, and invokes the plugin's fixed `doctor` verb.
+If the entrypoint cannot start, mere.run diagnoses the installation before
+delegating. A stale editable `pipx` install reports its missing source path and
+the exact forced-reinstall command instead of exposing only a Python traceback.
+Plugin stdout and exit status remain owned by a verified executable.
 
 ## Workflow-provider boundary
 


### PR DESCRIPTION
## Summary

- verify a plugin manifest before delegating to its doctor executable
- diagnose stale editable pipx installs with the missing source path and exact forced-reinstall command
- surface the same issue and repair guidance in human-readable plugin list output while preserving its JSON contract
- document and test the repair path

## Validation

- `swift test --filter PluginCommandTests`
- `./scripts/check.sh` (2,466 XCTest cases plus 20 Swift Testing cases, zero failures)
- exercised the development CLI against an actual stale editable `mere-runpod` installation
- `npx gitnexus detect-changes --scope compare --base-ref main --repo mere-run` (medium; three plugin inspection flows)