### PR TITLE
Add native TerraMind flood inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ artifact contracts instead of becoming a model-specific sidecar.
 
 ### Video and synchronized audio
 
+- added `mere.run geo flood`, a native Swift/MLX TerraMind Flood runtime for
+  four-timestep Sentinel-2, Sentinel-1, and DEM tiles, plus a checksum-pinned
+  float32-only converter for the official ImpactMesh checkpoint. Real Helene
+  parity preserves all 126 candidate pixels with mask Jaccard 1.0; unsafe FP16
+  conversions are rejected.
 - added a native Swift/MLX MiniMax-H3 runtime for the released FL2VA and
   Ref2VA partitions: Qwen3-VL layer-50 multimodal conditioning, the dense 50
   layer joint video/audio transformer, causal tiled video VAE, DAC/causal

--- a/Package.swift
+++ b/Package.swift
@@ -360,6 +360,7 @@ targets.append(contentsOf: [
       "SCAIL2/README.md",
       "Support/README.md",
       "Trellis2/README.md",
+      "TerraMindFlood/README.md",
       "TripoSR/README.md",
       "VLM/README.md",
       "VideoDepth/README.md",

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -4589,7 +4589,7 @@ actor CodeGenServer {
                 modelPath: resolved.rootURL.path,
                 request: request
             )
-        case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
+        case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .terramind, .face, .geometry, .depth, .threeD,
              .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
              .inkling, nil:
             throw APIRequestValidationError.invalidField(

--- a/Sources/MereRunCLI/Commands/GeoCommand.swift
+++ b/Sources/MereRunCLI/Commands/GeoCommand.swift
@@ -1,0 +1,9 @@
+import ArgumentParser
+
+struct Geo: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "geo",
+        abstract: "Run native geospatial inference models on local Earth-observation data.",
+        subcommands: [GeoFlood.self]
+    )
+}

--- a/Sources/MereRunCLI/Commands/GeoFloodCommand.swift
+++ b/Sources/MereRunCLI/Commands/GeoFloodCommand.swift
@@ -1,0 +1,154 @@
+import ArgumentParser
+import Foundation
+@preconcurrency import MLX
+import MereRunCore
+
+struct GeoFlood: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "flood",
+        abstract: "Run native TerraMind Flood tile inference with MLX on Apple silicon."
+    )
+
+    @Argument(help: "Safetensors input containing normalized S2L2A, S1RTC, and DEM tile batches.")
+    var input: String
+
+    @Option(name: [.customShort("o"), .long], help: "Output safetensors path for logits.")
+    var output: String
+
+    @Option(name: [.long], help: "Managed model id or converted TerraMind Flood model root.")
+    var model: String?
+
+    @Flag(name: [.long], help: "Validate inputs and model availability without loading weights.")
+    var preflight = false
+
+    @Flag(name: [.long], help: "Print structured execution metadata on stdout.")
+    var json = false
+
+    mutating func run() async throws {
+        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: inputURL.path) else {
+            throw ValidationError("Input safetensors not found: \(inputURL.path)")
+        }
+        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
+        let checkpoint = try await TerraMindFloodResources.resolve(requestedModel: model)
+        let inputs = try MLX.loadArrays(url: inputURL)
+        guard let s2l2a = inputs["S2L2A"], let s1rtc = inputs["S1RTC"], let dem = inputs["DEM"] else {
+            throw ValidationError("Input safetensors must contain S2L2A, S1RTC, and DEM tensors")
+        }
+        let batchSize = s2l2a.dim(0)
+        let plan = GeoFloodPayload(
+            status: preflight ? "ready" : "completed",
+            modelID: TerraMindFloodResources.defaultModelID,
+            modelPath: checkpoint.rootURL.path,
+            inputPath: inputURL.path,
+            outputPath: outputURL.path,
+            batchSize: batchSize,
+            device: "metal",
+            modelLoadSeconds: nil,
+            inferenceSeconds: nil
+        )
+        if preflight {
+            print(try Self.jsonString(plan))
+            return
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let loadStart = ContinuousClock.now
+        let nativeModel = try TerraMindFloodResources.loadModel(from: checkpoint)
+        let loadSeconds = Self.seconds(since: loadStart)
+        let inferenceStart = ContinuousClock.now
+        let logits = try nativeModel(s2l2a: s2l2a, s1rtc: s1rtc, dem: dem)
+        MLX.eval(logits)
+        let inferenceSeconds = Self.seconds(since: inferenceStart)
+        try MLX.save(
+            arrays: ["logits": logits.asType(.float32)],
+            metadata: [
+                "format": "mere.run/terramind-flood-logits-v1",
+                "model_id": TerraMindFloodResources.defaultModelID,
+                "source_revision": TerraMindFloodResources.sourceRevision,
+            ],
+            url: outputURL
+        )
+        let result = GeoFloodPayload(
+            status: "completed",
+            modelID: TerraMindFloodResources.defaultModelID,
+            modelPath: checkpoint.rootURL.path,
+            inputPath: inputURL.path,
+            outputPath: outputURL.path,
+            batchSize: batchSize,
+            device: "metal",
+            modelLoadSeconds: loadSeconds,
+            inferenceSeconds: inferenceSeconds
+        )
+        if json {
+            print(try Self.jsonString(result))
+        } else {
+            print(outputURL.path)
+        }
+    }
+
+    private static func seconds(since start: ContinuousClock.Instant) -> Double {
+        let duration = start.duration(to: .now)
+        return Double(duration.components.seconds)
+            + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
+    }
+
+    private static func jsonString<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return String(decoding: try encoder.encode(value), as: UTF8.self)
+    }
+}
+
+struct GeoFloodPayload: Codable, Equatable {
+    let schemaVersion: Int
+    let status: String
+    let modelID: String
+    let modelPath: String
+    let inputPath: String
+    let outputPath: String
+    let batchSize: Int
+    let device: String
+    let modelLoadSeconds: Double?
+    let inferenceSeconds: Double?
+
+    init(
+        schemaVersion: Int = 1,
+        status: String,
+        modelID: String,
+        modelPath: String,
+        inputPath: String,
+        outputPath: String,
+        batchSize: Int,
+        device: String,
+        modelLoadSeconds: Double?,
+        inferenceSeconds: Double?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.status = status
+        self.modelID = modelID
+        self.modelPath = modelPath
+        self.inputPath = inputPath
+        self.outputPath = outputPath
+        self.batchSize = batchSize
+        self.device = device
+        self.modelLoadSeconds = modelLoadSeconds
+        self.inferenceSeconds = inferenceSeconds
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case status
+        case modelID = "model_id"
+        case modelPath = "model_path"
+        case inputPath = "input_path"
+        case outputPath = "output_path"
+        case batchSize = "batch_size"
+        case device
+        case modelLoadSeconds = "model_load_seconds"
+        case inferenceSeconds = "inference_seconds"
+    }
+}

--- a/Sources/MereRunCLI/Commands/GeoFloodCommand.swift
+++ b/Sources/MereRunCLI/Commands/GeoFloodCommand.swift
@@ -25,6 +25,7 @@ struct GeoFlood: AsyncParsableCommand {
     var json = false
 
     mutating func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: json)
         let inputURL = URL(fileURLWithPath: input).standardizedFileURL
         guard FileManager.default.fileExists(atPath: inputURL.path) else {
             throw ValidationError("Input safetensors not found: \(inputURL.path)")

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -387,7 +387,7 @@ struct ImageGenerate: AsyncParsableCommand {
                 let generator = Ideogram4Generator()
                 defer { generator.unload() }
                 result = try await generator.generate(request, progressHandler: progressHandler)
-            case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .face, .geometry, .depth, .threeD,
+            case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .terramind, .face, .geometry, .depth, .threeD,
                  .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
                  .inkling, nil:
                 throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -32,6 +32,7 @@ struct MereRunCLI: AsyncParsableCommand {
             Text.self,
             Speech.self,
             Vision.self,
+            Geo.self,
             Audio.self,
             Music.self,
             SFX.self,

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import MLX
 import MediaIO
 import MereRunCore
 
@@ -268,6 +269,11 @@ enum InstalledModelSmokePlans {
         case .falconPerception:
             return direct(spec, route: "vision ground") { runner in
                 try await runner.installedGroundingCheck(model: spec.id)
+            }
+
+        case .terramindFlood:
+            return direct(spec, route: "geo flood normalized tensor smoke") { runner in
+                try await runner.installedFloodCheck(model: spec.id)
             }
 
         case .insightFaceBuffaloL:
@@ -793,6 +799,47 @@ extension GateRunner {
             timeout: 1_800
         )
         return try jsonFileObservation(json, run: run, label: "grounding JSON")
+    }
+
+    func installedFloodCheck(model: String) async throws -> GateObservation {
+        let input = artifactURL("\(model)-input", extension: "safetensors")
+        let output = artifactURL(model, extension: "safetensors")
+        try MLX.save(
+            arrays: [
+                "S2L2A": MLX.zeros([1, 12, 4, 256, 256], dtype: .float32),
+                "S1RTC": MLX.zeros([1, 2, 4, 256, 256], dtype: .float32),
+                "DEM": MLX.zeros([1, 1, 4, 256, 256], dtype: .float32),
+            ],
+            metadata: ["format": "mere.run/terramind-flood-smoke-v1"],
+            url: input
+        )
+        let run = try await exec(
+            [
+                "geo", "flood", input.path,
+                "--model", model,
+                "--output", output.path,
+                "--json",
+            ],
+            timeout: 1_800
+        )
+        let data = try Data(contentsOf: output)
+        let arrays = try MLX.loadArrays(url: output)
+        guard let logits = arrays["logits"] else {
+            throw GateError.invalidArtifact("TerraMind flood output did not contain logits")
+        }
+        let values = logits.asArray(Float.self)
+        let valid = logits.shape == [1, 2, 256, 256]
+            && values.allSatisfy(\.isFinite)
+            && !values.isEmpty
+        return GateObservation(
+            hash: Self.sha256(data),
+            secondRunHash: nil,
+            wallSeconds: run.wallSeconds,
+            decodeTps: nil,
+            semanticFailure: valid
+                ? nil
+                : "TerraMind flood logits were missing, non-finite, or had the wrong shape"
+        )
     }
 
     func installedFaceCheck(model: String) async throws -> GateObservation {

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -45,7 +45,6 @@ enum MLXBundleSupport {
     static func ensureAvailable(quiet: Bool) throws {
       try validateLinkedRuntime()
 
-      let fm = FileManager.default
       let execDir = executableDirectory()
       let destBundleURL = execDir.appendingPathComponent(bundleName, isDirectory: true)
 
@@ -73,8 +72,7 @@ enum MLXBundleSupport {
       // husk without a metallib inside): copy one in, preferring candidates
       // whose stamp matches this binary.
       if let source = locateCandidateBundle(executableDir: execDir) {
-        try? fm.removeItem(at: destBundleURL)
-        try fm.copyItem(at: source, to: destBundleURL)
+        try installBundleIfMissing(from: source, to: destBundleURL)
         if !quiet {
           CLIStderr.write(
             "[mererun] Installed \(bundleName) for mlx-swift Metal shaders (from \(source.path)).\n"
@@ -483,6 +481,62 @@ enum MLXBundleSupport {
         try? fm.removeItem(at: tmp)
         // Tolerate races with a concurrent startup that produced the file.
         if fm.fileExists(atPath: destination.path) {
+          return
+        }
+        throw error
+      }
+    }
+
+    /// Installs a missing Cmlx bundle through a unique staging directory. Two
+    /// CLI processes may reach first-run bootstrap together (for example,
+    /// parallel workflow nodes). The winner moves its complete bundle into
+    /// place; losers accept that complete destination instead of surfacing
+    /// Cocoa's "item already exists" copy error.
+    static func installBundleIfMissing(from source: URL, to destination: URL) throws {
+      let fm = FileManager.default
+      let lockURL = destination.deletingLastPathComponent().appendingPathComponent(
+        ".\(bundleName).install.lock",
+        isDirectory: false
+      )
+      let descriptor = lockURL.path.withCString {
+        open($0, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+      }
+      guard descriptor >= 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+      }
+      defer { close(descriptor) }
+      while flock(descriptor, LOCK_EX) != 0 {
+        guard errno == EINTR else {
+          throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+      }
+      defer { flock(descriptor, LOCK_UN) }
+
+      if hasMetallib(destination) {
+        return
+      }
+
+      let staged =
+        destination
+        .deletingLastPathComponent()
+        .appendingPathComponent(
+          ".\(bundleName).tmp-\(getpid())-\(UUID().uuidString)",
+          isDirectory: true
+        )
+      try? fm.removeItem(at: staged)
+      defer { try? fm.removeItem(at: staged) }
+      try fm.copyItem(at: source, to: staged)
+
+      if hasMetallib(destination) {
+        return
+      }
+      if fm.fileExists(atPath: destination.path) {
+        try? fm.removeItem(at: destination)
+      }
+      do {
+        try fm.moveItem(at: staged, to: destination)
+      } catch {
+        if hasMetallib(destination) {
           return
         }
         throw error

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -13,6 +13,7 @@ public enum ManagedModelCategory: String, CaseIterable, Hashable, Sendable {
     case visionChat = "vision-chat"
     case visionSegment = "vision-segment"
     case visionGround = "vision-ground"
+    case visionFlood = "vision-flood"
     case visionFace = "vision-face"
     case visionGeometry = "vision-geometry"
     case visionDepth = "vision-depth"
@@ -55,6 +56,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case lightOnOCR
     case sam31
     case falconPerception
+    case terramindFlood
     case insightFaceBuffaloL
     case moge2
     case videoDepthAnything
@@ -1498,6 +1500,28 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["vision ground"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.visionFloodTerraMindBase.rawValue,
+            category: .visionFlood,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: TerraMindFloodResources.sourceRepository,
+                revision: TerraMindFloodResources.sourceRevision,
+                patterns: [
+                    "README.md",
+                    "LICENSE*",
+                    "NOTICE*",
+                    TerraMindFloodResources.sourceCheckpointFilename,
+                    TerraMindFloodResources.sourceConfigurationFilename,
+                ]
+            ),
+            upstreamRepoId: TerraMindFloodResources.sourceRepository,
+            upstreamRevision: TerraMindFloodResources.sourceRevision,
+            validationKind: .terramindFlood,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 673_199_088,
+            defaultCLICommands: ["geo flood"]
+        ),
+        ManagedModelSpec(
             id: FaceAnalysisResources.modelID,
             category: .visionFace,
             installShape: .directoryRoot,
@@ -2506,11 +2530,21 @@ public extension ManagedModelSpec {
     }
 
     var requiresManagedConversion: Bool {
-        validationKind == .instantMesh
+        validationKind == .instantMesh || validationKind == .terramindFlood
     }
 
     func managedConversionGuidance(at rootURL: URL) -> String? {
         guard requiresManagedConversion else { return nil }
+        if validationKind == .terramindFlood {
+            let source = rootURL.appendingPathComponent(TerraMindFloodResources.sourceCheckpointFilename).path
+            let configuration = rootURL.appendingPathComponent(
+                TerraMindFloodResources.sourceConfigurationFilename
+            ).path
+            return "Pinned TerraMind Flood source downloaded at \(source). Deterministic conversion is required "
+                + "before native MLX inference; run scripts/convert-terramind-flood-mlx.py "
+                + "--checkpoint \"\(source)\" --configuration \"\(configuration)\" "
+                + "--output \"\(rootURL.path)\" --dtype float32. FP16 is intentionally unsupported by parity evidence."
+        }
         let source = rootURL.appendingPathComponent("instant_mesh_base.ckpt").path
         let output = rootURL.appendingPathComponent(
             InstantMeshResources.managedConvertedDirectoryName,
@@ -2592,6 +2626,8 @@ public extension ManagedModelSpec {
             return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:
             return FalconPerceptionResources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .terramindFlood:
+            return TerraMindFloodResources.missingSourcePaths(in: rootURL, fileManager: fileManager)
         case .insightFaceBuffaloL:
             return FaceAnalysisResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .moge2, .videoDepthAnything, .depthAnything3, .tripoSR:
@@ -2841,6 +2877,8 @@ public extension ManagedModelSpec {
                 in: normalized,
                 fileManager: fileManager
             ).isEmpty
+        case .terramindFlood:
+            return (try? TerraMindFloodResources.inspect(normalized)) != nil
         case .moge2, .videoDepthAnything, .depthAnything3, .tripoSR:
             guard let pin = GeometryModelPins.pin(for: id) else { return false }
             return Self.invalidPinnedArtifacts(

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -569,6 +569,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 24
             ),
             descriptor(
+                ModelResolver.ModelID.visionFloodTerraMindBase.rawValue,
+                "Geospatial flood segmentation",
+                "Runs four-timestep Sentinel-2, Sentinel-1, and DEM flood segmentation with native Swift MLX.",
+                minimum: 16,
+                recommended: 24
+            ),
+            descriptor(
                 FaceAnalysisResources.modelID,
                 "Face analysis",
                 "Detects faces and landmarks, creates identity embeddings, and compares people locally.",
@@ -887,6 +894,10 @@ public enum ManagedModelCapabilityCatalog {
 
         if spec.validationKind == .magentaRT2 && !machine.isAppleSiliconMac {
             reasons.append("Magenta RT2 requires Apple Silicon macOS.")
+        }
+
+        if spec.validationKind == .terramindFlood && !machine.isAppleSiliconMac {
+            reasons.append("TerraMind Flood requires Apple Silicon macOS.")
         }
 
         if machine.unifiedMemoryGB < descriptor.minimumUnifiedMemoryGB {

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -36,6 +36,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case samSegmentation = "sam-segmentation"
         /// Falcon Perception grounded detection and segmentation family.
         case falconPerception = "falcon-perception"
+        /// IBM/ESA TerraMind temporal flood-segmentation family.
+        case terramindFlood = "terramind-flood"
         /// InsightFace Buffalo-L face detection and identity-embedding family.
         case insightFace = "insightface"
         /// MoGe-2 metric monocular geometry family.
@@ -112,6 +114,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case qwen
         case sam
         case falcon
+        case terramind
         case face
         case geometry
         case depth
@@ -186,6 +189,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case loraInference = "lora_inference"
         case loraTraining = "lora_training"
         case visionSegmentation = "vision_segmentation"
+        case floodSegmentation = "flood_segmentation"
         case visionTracking = "vision_tracking"
         case visionGrounding = "vision_grounding"
         case visionDetection = "vision_detection"
@@ -1358,6 +1362,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.visionGrounding, .visionDetection, .visionSegmentation],
                 components: falconPerceptionComponents,
                 upstreamRepoId: "tiiuae/Falcon-Perception",
+                createdAt: createdAt
+            )
+        case .visionFloodTerraMindBase:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .terramindFlood,
+                family: .terramind,
+                tier: .base,
+                variant: .standard,
+                precision: .fp32,
+                defaults: nil,
+                supports: [.floodSegmentation],
+                components: nil,
+                upstreamRepoId: "\(TerraMindFloodResources.sourceRepository)@\(TerraMindFloodResources.sourceRevision)",
                 createdAt: createdAt
             )
         case .visionFaceBuffaloL:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -395,6 +395,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=sam expects sam-segmentation.")
             case .falcon where engine != .falconPerception:
                 warnings.append("Manifest engine mismatch: family=falcon expects falcon-perception.")
+            case .terramind where engine != .terramindFlood:
+                warnings.append("Manifest engine mismatch: family=terramind expects terramind-flood.")
             case .face where engine != .insightFace:
                 warnings.append("Manifest engine mismatch: family=face expects insightface.")
             case .tts where engine != .qwen3TTS:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -171,6 +171,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .trellis2
             || spec?.validationKind == .wan22TI2VMLX
             || spec?.validationKind == .dreamXCausalMLX
+            || spec?.validationKind == .terramindFlood
             || spec?.validationKind == .inkling {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil
@@ -497,7 +498,7 @@ public enum MereRunModelValidator {
             switch manifest.engine {
             case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .roFormer?, .apBWE?, .univerSR?, .woosh?, .mmaudio?, .ltxVideo?,
                  .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?,
-                 .insightFace?, .sortformer?:
+                 .insightFace?, .sortformer?, .terramindFlood?:
                 return true
             default:
                 return false
@@ -551,6 +552,7 @@ public enum MereRunModelValidator {
         if modelId.hasPrefix("text-chat-laguna-") { return .laguna }
         if modelId.hasPrefix("vision-segment-") { return .sam }
         if modelId.hasPrefix("vision-ground-") { return .falcon }
+        if modelId.hasPrefix("vision-flood-") { return .terramind }
         if modelId.hasPrefix("vision-face-") { return .face }
         if modelId.hasPrefix("vision-geometry-") { return .geometry }
         if modelId.hasPrefix("vision-depth-") { return .depth }

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -64,6 +64,7 @@ public struct ModelResolver {
         case infinityParser2ProInt8 = "vision-ocr-infinity-pro-int8"
         case visionSegmentSAM31 = "vision-segment-sam31"
         case visionGroundFalconPerception = "vision-ground-falcon-perception"
+        case visionFloodTerraMindBase = "vision-flood-terramind-base"
         case visionFaceBuffaloL = "vision-face-buffalo-l"
         case visionGeometryMoGe2Small = "vision-geometry-moge2-small"
         case visionDepthVDASmall = "vision-depth-vda-small"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -58,6 +58,7 @@ public enum QuantizedModelManifestWriter {
             case .qwen35HybridMoE: return .qwen
             case .samSegmentation: return .sam
             case .falconPerception: return .falcon
+            case .terramindFlood: return .terramind
             case .insightFace: return .face
             case .moge2, .depthAnything3: return .geometry
             case .videoDepthAnything: return .depth
@@ -124,6 +125,8 @@ public enum QuantizedModelManifestWriter {
                     return [.visionSegmentation, .visionTracking]
                 case .falconPerception:
                     return [.visionGrounding, .visionDetection, .visionSegmentation]
+                case .terramindFlood:
+                    return [.floodSegmentation]
                 case .insightFace:
                     return [.faceDetection, .faceLandmarks, .faceEmbedding, .faceVerification]
                 case .moge2:
@@ -240,7 +243,8 @@ public enum QuantizedModelManifestWriter {
                 break
             case .qwen35HybridMoE:
                 break
-            case .samSegmentation, .falconPerception, .insightFace, .moge2, .videoDepthAnything, .depthAnything3,
+            case .samSegmentation, .falconPerception, .terramindFlood, .insightFace, .moge2,
+                 .videoDepthAnything, .depthAnything3,
                  .tripoSR, .instantMesh, .trellis2:
                 break
             case .qwen3TTS, .qwen3ASR, .parakeetASR, .sortformer, .qwen3Embedding, .openAIPrivacyFilter,

--- a/Sources/MereRunCore/TerraMindFlood/README.md
+++ b/Sources/MereRunCore/TerraMindFlood/README.md
@@ -1,0 +1,21 @@
+# TerraMind Flood Source Map
+
+This module owns the native, inference-only Swift/MLX implementation of the
+pinned IBM/ESA TerraMind ImpactMesh flood checkpoint.
+
+- `TerraMindFloodModel.swift` implements the exact multimodal encoder, selected
+  feature pyramid, temporal UNet decoder, and two-class segmentation head.
+- `TerraMindFloodResources.swift` validates the immutable upstream source pin
+  and the deterministic float32 safetensors conversion before loading weights.
+
+The public CLI boundary is `mere.run geo flood`. It accepts already normalized
+and tiled `S2L2A`, `S1RTC`, and `DEM` arrays and emits logits. Raster discovery,
+reprojection, tiling policy, reconstruction, COG export, and evidence
+classification belong to a geospatial provider such as `mere-geo-tools`, not
+this model module.
+
+Keep the runtime float32-only unless a new real-raster parity gate proves an
+alternative precision preserves the decision boundary. Native code must never
+interpret the upstream Lightning/pickle checkpoint; use
+`scripts/convert-terramind-flood-mlx.py` to produce the pinned safetensors
+package.

--- a/Sources/MereRunCore/TerraMindFlood/TerraMindFloodModel.swift
+++ b/Sources/MereRunCore/TerraMindFlood/TerraMindFloodModel.swift
@@ -1,0 +1,288 @@
+import Foundation
+@preconcurrency import MLX
+import MLXFast
+import MLXNN
+
+/// Native MLX implementation of the pinned TerraMind-1.0-base ImpactMesh Flood graph.
+///
+/// Inputs use the TerraTorch layout `[batch, channels, 4, 256, 256]`. The model
+/// returns unnormalized logits in `[batch, 2, 256, 256]`; callers must blend
+/// tiled logits before applying softmax to preserve TerraTorch parity.
+public final class TerraMindFloodModel: @unchecked Sendable {
+    public static let tileSize = 256
+    public static let timestampCount = 4
+    public static let classCount = 2
+
+    private let weights: [String: MLXArray]
+    private let dtype: DType
+
+    public init(weights: [String: MLXArray]) throws {
+        let missing = Self.requiredTensorNames.filter { weights[$0] == nil }
+        guard missing.isEmpty else {
+            throw TerraMindFloodModelError.missingTensors(missing)
+        }
+        self.weights = weights
+        self.dtype = weights["encoder.encoder.encoder.0.attn.qkv.weight"]!.dtype
+    }
+
+    public func callAsFunction(
+        s2l2a: MLXArray,
+        s1rtc: MLXArray,
+        dem: MLXArray
+    ) throws -> MLXArray {
+        try Self.validateInput(s2l2a, channels: 12, name: "S2L2A")
+        try Self.validateInput(s1rtc, channels: 2, name: "S1RTC")
+        try Self.validateInput(dem, channels: 1, name: "DEM")
+        guard s2l2a.dim(0) == s1rtc.dim(0), s2l2a.dim(0) == dem.dim(0) else {
+            throw TerraMindFloodModelError.inconsistentBatchSize
+        }
+
+        var levels = Array(repeating: [MLXArray](), count: 4)
+        for timestamp in 0..<Self.timestampCount {
+            var hidden = MLX.concatenated([
+                embed(s2l2a, timestamp: timestamp, modality: "untok_sen2l2a@224", channels: 12),
+                embed(s1rtc, timestamp: timestamp, modality: "untok_sen1rtc@224", channels: 2),
+                embed(dem, timestamp: timestamp, modality: "untok_dem@224", channels: 1),
+            ], axis: 1)
+
+            var selectedIndex = 0
+            for block in 0..<12 {
+                hidden = transformerBlock(hidden, index: block)
+                // Materialize each block so four temporal passes do not retain one
+                // enormous lazy attention graph on the unified-memory heap.
+                MLX.eval(hidden)
+                guard Self.selectedBlocks.contains(block) else { continue }
+                let output = block == 11
+                    ? layerNorm(
+                        hidden,
+                        weight: weight("encoder.encoder.encoder_norm.weight"),
+                        bias: weight("encoder.encoder.encoder_norm.bias"),
+                        epsilon: 1e-6
+                    )
+                    : hidden
+                let merged = output
+                    .reshaped(output.dim(0), 3, 256, 768)
+                    .mean(axis: 1)
+                MLX.eval(merged)
+                levels[selectedIndex].append(merged)
+                selectedIndex += 1
+            }
+        }
+
+        let temporal = levels.map { timestepFeatures in
+            MLX.concatenated(timestepFeatures, axis: 2)
+                .reshaped(timestepFeatures[0].dim(0), 16, 16, 3_072)
+        }
+        return decode(temporal).transposed(0, 3, 1, 2)
+    }
+
+    private func embed(
+        _ input: MLXArray,
+        timestamp: Int,
+        modality: String,
+        channels: Int
+    ) -> MLXArray {
+        let image = input[0..., 0..., timestamp, 0..., 0...]
+            .asType(dtype)
+            .transposed(0, 2, 3, 1)
+        let batch = image.dim(0)
+        let patches = image
+            .reshaped(batch, 16, 16, 16, 16, channels)
+            .transposed(0, 1, 3, 2, 4, 5)
+            .reshaped(batch, 256, 256 * channels)
+        let projected = MLX.matmul(
+            patches,
+            weight("encoder.encoder.encoder_embeddings.\(modality).proj.weight").T
+        )
+        return projected
+            + weight("encoder.encoder.encoder_embeddings.\(modality).pos_emb")
+            + weight("encoder.encoder.encoder_embeddings.\(modality).mod_emb")
+    }
+
+    private func transformerBlock(_ input: MLXArray, index: Int) -> MLXArray {
+        let prefix = "encoder.encoder.encoder.\(index)"
+        let normalizedAttention = layerNorm(
+            input,
+            weight: weight("\(prefix).norm1.weight"),
+            bias: weight("\(prefix).norm1.bias"),
+            epsilon: 1e-6
+        )
+        let qkv = MLX.matmul(normalizedAttention, weight("\(prefix).attn.qkv.weight").T)
+        let batch = qkv.dim(0)
+        let count = qkv.dim(1)
+        let split = qkv
+            .reshaped(batch, count, 3, 12, 64)
+            .transposed(2, 0, 3, 1, 4)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: split[0],
+            keys: split[1],
+            values: split[2],
+            scale: 0.125,
+            mask: .none
+        )
+        let attentionOutput = MLX.matmul(
+            attended.transposed(0, 2, 1, 3).reshaped(batch, count, 768),
+            weight("\(prefix).attn.proj.weight").T
+        )
+        let residual = input + attentionOutput
+        let normalizedMLP = layerNorm(
+            residual,
+            weight: weight("\(prefix).norm2.weight"),
+            bias: weight("\(prefix).norm2.bias"),
+            epsilon: 1e-6
+        )
+        let gated = MLXNN.silu(MLX.matmul(normalizedMLP, weight("\(prefix).mlp.fc1.weight").T))
+            * MLX.matmul(normalizedMLP, weight("\(prefix).mlp.fc3.weight").T)
+        return residual + MLX.matmul(gated, weight("\(prefix).mlp.fc2.weight").T)
+    }
+
+    private func decode(_ features: [MLXArray]) -> MLXArray {
+        var pyramid: [MLXArray] = []
+
+        var first = transposedConvolution(
+            features[0],
+            weight: weight("neck.2.fpn1.0.weight"),
+            bias: weight("neck.2.fpn1.0.bias")
+        )
+        first = batchNorm(first, prefix: "neck.2.fpn1.1")
+        first = MLXNN.gelu(first)
+        first = transposedConvolution(
+            first,
+            weight: weight("neck.2.fpn1.3.weight"),
+            bias: weight("neck.2.fpn1.3.bias")
+        )
+        pyramid.append(first)
+        pyramid.append(transposedConvolution(
+            features[1],
+            weight: weight("neck.2.fpn2.0.weight"),
+            bias: weight("neck.2.fpn2.0.bias")
+        ))
+        pyramid.append(features[2])
+        pyramid.append(MaxPool2d(kernelSize: 2, stride: 2)(features[3]))
+
+        var hidden = pyramid[3]
+        for block in 0..<4 {
+            let target = block == 3 ? hidden : upsampleNearest(hidden, factor: 2)
+            if block < 3 {
+                hidden = MLX.concatenated([target, pyramid[2 - block]], axis: 3)
+            } else {
+                hidden = target
+            }
+            hidden = decoderConvolution(hidden, prefix: "decoder.decoder.blocks.\(block).conv1")
+            hidden = decoderConvolution(hidden, prefix: "decoder.decoder.blocks.\(block).conv2")
+            MLX.eval(hidden)
+        }
+
+        var logits = MLX.conv2d(hidden, weight("head.head.2.weight"), padding: 0)
+        logits = logits + weight("head.head.2.bias")
+        return Upsample(scaleFactor: 4.0, mode: .linear(alignCorners: false))(logits)
+    }
+
+    private func decoderConvolution(_ input: MLXArray, prefix: String) -> MLXArray {
+        let convolved = MLX.conv2d(input, weight("\(prefix).0.weight"), padding: 1)
+        return MLXNN.relu(batchNorm(convolved, prefix: "\(prefix).1"))
+    }
+
+    private func transposedConvolution(
+        _ input: MLXArray,
+        weight: MLXArray,
+        bias: MLXArray
+    ) -> MLXArray {
+        MLX.convTransposed2d(input, weight, stride: 2) + bias
+    }
+
+    private func batchNorm(_ input: MLXArray, prefix: String) -> MLXArray {
+        let promoted = input.asType(.float32)
+        let mean = weight("\(prefix).running_mean").asType(.float32)
+        let variance = weight("\(prefix).running_var").asType(.float32)
+        let scale = weight("\(prefix).weight").asType(.float32)
+        let bias = weight("\(prefix).bias").asType(.float32)
+        return (((promoted - mean) / MLX.sqrt(variance + 1e-5)) * scale + bias).asType(input.dtype)
+    }
+
+    private func layerNorm(
+        _ input: MLXArray,
+        weight: MLXArray,
+        bias: MLXArray,
+        epsilon: Float
+    ) -> MLXArray {
+        let promoted = input.asType(.float32)
+        let mean = promoted.mean(axis: -1, keepDims: true)
+        let centered = promoted - mean
+        let variance = (centered * centered).mean(axis: -1, keepDims: true)
+        return ((centered / MLX.sqrt(variance + epsilon))
+            * weight.asType(.float32) + bias.asType(.float32)).asType(input.dtype)
+    }
+
+    private func upsampleNearest(_ input: MLXArray, factor: Float) -> MLXArray {
+        Upsample(scaleFactor: FloatOrArray(factor), mode: .nearest)(input)
+    }
+
+    private func weight(_ name: String) -> MLXArray { weights[name]! }
+
+    private static func validateInput(_ input: MLXArray, channels: Int, name: String) throws {
+        let expectedTail = [channels, timestampCount, tileSize, tileSize]
+        guard input.ndim == 5, Array(input.shape.dropFirst()) == expectedTail else {
+            throw TerraMindFloodModelError.invalidInputShape(
+                name: name,
+                expected: [-1] + expectedTail,
+                actual: input.shape
+            )
+        }
+    }
+
+    private static let selectedBlocks: Set<Int> = [2, 5, 8, 11]
+
+    public static let requiredTensorNames: [String] = {
+        var names: [String] = []
+        for modality in ["untok_sen2l2a@224", "untok_sen1rtc@224", "untok_dem@224"] {
+            let prefix = "encoder.encoder.encoder_embeddings.\(modality)"
+            names += ["\(prefix).mod_emb", "\(prefix).pos_emb", "\(prefix).proj.weight"]
+        }
+        for block in 0..<12 {
+            let prefix = "encoder.encoder.encoder.\(block)"
+            names += [
+                "\(prefix).norm1.weight", "\(prefix).norm1.bias",
+                "\(prefix).attn.qkv.weight", "\(prefix).attn.proj.weight",
+                "\(prefix).norm2.weight", "\(prefix).norm2.bias",
+                "\(prefix).mlp.fc1.weight", "\(prefix).mlp.fc2.weight", "\(prefix).mlp.fc3.weight",
+            ]
+        }
+        names += ["encoder.encoder.encoder_norm.weight", "encoder.encoder.encoder_norm.bias"]
+        for block in 0..<4 {
+            for convolution in ["conv1", "conv2"] {
+                let prefix = "decoder.decoder.blocks.\(block).\(convolution)"
+                names += [
+                    "\(prefix).0.weight", "\(prefix).1.weight", "\(prefix).1.bias",
+                    "\(prefix).1.running_mean", "\(prefix).1.running_var",
+                ]
+            }
+        }
+        names += [
+            "head.head.2.weight", "head.head.2.bias",
+            "neck.2.fpn1.0.weight", "neck.2.fpn1.0.bias",
+            "neck.2.fpn1.1.weight", "neck.2.fpn1.1.bias",
+            "neck.2.fpn1.1.running_mean", "neck.2.fpn1.1.running_var",
+            "neck.2.fpn1.3.weight", "neck.2.fpn1.3.bias",
+            "neck.2.fpn2.0.weight", "neck.2.fpn2.0.bias",
+        ]
+        return names
+    }()
+}
+
+public enum TerraMindFloodModelError: Error, Equatable, LocalizedError, Sendable {
+    case missingTensors([String])
+    case invalidInputShape(name: String, expected: [Int], actual: [Int])
+    case inconsistentBatchSize
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingTensors(let names):
+            "TerraMind Flood checkpoint is missing tensors: \(names.joined(separator: ", "))."
+        case .invalidInputShape(let name, let expected, let actual):
+            "TerraMind Flood \(name) input must have shape \(expected); found \(actual)."
+        case .inconsistentBatchSize:
+            "TerraMind Flood modalities must use the same batch size."
+        }
+    }
+}

--- a/Sources/MereRunCore/TerraMindFlood/TerraMindFloodResources.swift
+++ b/Sources/MereRunCore/TerraMindFlood/TerraMindFloodResources.swift
@@ -1,0 +1,230 @@
+import Foundation
+@preconcurrency import MLX
+
+public struct TerraMindFloodConversionConfiguration: Codable, Equatable, Sendable {
+    public let format: String
+    public let modelID: String
+    public let sourceRepository: String
+    public let sourceRevision: String
+    public let sourceCheckpoint: String
+    public let sourceCheckpointSHA256: String
+    public let sourceConfigurationSHA256: String
+    public let converter: String
+    public let dtype: String
+    public let tensorCount: Int
+    public let scalarCount: Int
+    public let tileSize: Int
+    public let timestamps: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case format
+        case modelID = "model_id"
+        case sourceRepository = "source_repository"
+        case sourceRevision = "source_revision"
+        case sourceCheckpoint = "source_checkpoint"
+        case sourceCheckpointSHA256 = "source_checkpoint_sha256"
+        case sourceConfigurationSHA256 = "source_configuration_sha256"
+        case converter
+        case dtype
+        case tensorCount = "tensor_count"
+        case scalarCount = "scalar_count"
+        case tileSize = "tile_size"
+        case timestamps
+    }
+}
+
+public struct TerraMindFloodCheckpoint: Equatable, Sendable {
+    public let rootURL: URL
+    public let weightsURL: URL
+    public let configurationURL: URL
+    public let configuration: TerraMindFloodConversionConfiguration
+}
+
+public enum TerraMindFloodResourceError: Error, Equatable, LocalizedError, Sendable {
+    case unsupportedModel(String)
+    case modelNotFound(String)
+    case missingArtifact(String)
+    case invalidConfiguration(String)
+    case unsupportedFormat(String)
+    case unsupportedSource(String, String)
+    case unsupportedPrecision(String)
+    case unsupportedDimensions(tileSize: Int, timestamps: Int)
+    case tensorInventory(expected: Int, actual: Int)
+    case scalarInventory(expected: Int, actual: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedModel(let value):
+            "Unsupported TerraMind Flood model '\(value)'."
+        case .modelNotFound(let path):
+            "TerraMind Flood model was not found: \(path)"
+        case .missingArtifact(let path):
+            "TerraMind Flood model artifact is missing: \(path)"
+        case .invalidConfiguration(let message):
+            "TerraMind Flood config.json is invalid: \(message)"
+        case .unsupportedFormat(let value):
+            "Unsupported TerraMind Flood conversion format '\(value)'."
+        case .unsupportedSource(let repository, let revision):
+            "Unsupported TerraMind Flood source pin \(repository)@\(revision)."
+        case .unsupportedPrecision(let value):
+            "Unsupported TerraMind Flood conversion precision '\(value)'; exact flood parity requires float32."
+        case .unsupportedDimensions(let tileSize, let timestamps):
+            "TerraMind Flood conversion requires tile_size=256 and timestamps=4; found \(tileSize)/\(timestamps)."
+        case .tensorInventory(let expected, let actual):
+            "TerraMind Flood tensor inventory mismatch: expected \(expected), found \(actual)."
+        case .scalarInventory(let expected, let actual):
+            "TerraMind Flood scalar inventory mismatch: expected \(expected), found \(actual)."
+        }
+    }
+}
+
+public enum TerraMindFloodResources {
+    public static let defaultModelID = ModelResolver.ModelID.visionFloodTerraMindBase.rawValue
+    public static let sourceRepository = "ibm-esa-geospatial/TerraMind-base-Flood"
+    public static let sourceRevision = "1e4b2429d17234922f8d92beb0d725af4db85c08"
+    public static let sourceCheckpointSHA256 =
+        "22627584c2db618c2f6ddb64b411a95762a893becb25104e3f66bfebecaa71e9"
+    public static let sourceCheckpointFilename = "TerraMind_v1_base_ImpactMesh_flood.pt"
+    public static let sourceConfigurationFilename = "terramind_v1_base_impactmesh_flood.yaml"
+    public static let conversionFormat = "mere.run/terramind-flood-mlx-v1"
+    public static let weightsFilename = "model.safetensors"
+    public static let configurationFilename = "config.json"
+    public static let tensorCount = 171
+    public static let scalarCount = 168_416_386
+    public static let weightsArtifact = ModelArtifactPin(
+        filename: weightsFilename,
+        byteCount: 673_684_984,
+        sha256: "4940ad94df06a923e3a919f944a71ad01892872e89c428abe718eefc44d0f95a"
+    )
+    public static let configurationArtifact = ModelArtifactPin(
+        filename: configurationFilename,
+        byteCount: 662,
+        sha256: "28f507dd0ad3f9825e64300b545bb889b125df4b53fc9c313f7ecd977b40c63d"
+    )
+
+    public static func missingSourcePaths(
+        in rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        [sourceCheckpointFilename, sourceConfigurationFilename]
+            .map { rootURL.appendingPathComponent($0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+
+    public static func resolve(requestedModel: String?) async throws -> TerraMindFloodCheckpoint {
+        let requested = requestedModel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !requested.isEmpty {
+            let explicit = URL(fileURLWithPath: requested).standardizedFileURL
+            if FileManager.default.fileExists(atPath: explicit.path) {
+                return try inspect(explicit)
+            }
+            if requested.contains("/") || requested.hasPrefix(".") {
+                throw TerraMindFloodResourceError.modelNotFound(explicit.path)
+            }
+        }
+
+        let modelID = requested.isEmpty ? defaultModelID : requested.lowercased()
+        guard modelID == defaultModelID else {
+            throw TerraMindFloodResourceError.unsupportedModel(modelID)
+        }
+        let resolution = try await ManagedModelResolver.resolveForRuntime(
+            requestedModel: modelID,
+            defaultModelID: defaultModelID,
+            allowAutoDownload: false
+        )
+        return try inspect(resolution.url)
+    }
+
+    public static func inspect(_ url: URL) throws -> TerraMindFloodCheckpoint {
+        let standardized = url.standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: standardized.path, isDirectory: &isDirectory) else {
+            throw TerraMindFloodResourceError.modelNotFound(standardized.path)
+        }
+        let root = isDirectory.boolValue ? standardized : standardized.deletingLastPathComponent()
+        let weightsURL = isDirectory.boolValue
+            ? root.appendingPathComponent(weightsFilename)
+            : standardized
+        let configurationURL = root.appendingPathComponent(configurationFilename)
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw TerraMindFloodResourceError.missingArtifact(weightsURL.path)
+        }
+        guard FileManager.default.fileExists(atPath: configurationURL.path) else {
+            throw TerraMindFloodResourceError.missingArtifact(configurationURL.path)
+        }
+        _ = try weightsArtifact.verify(in: root)
+        _ = try configurationArtifact.verify(in: root)
+        let configuration: TerraMindFloodConversionConfiguration
+        do {
+            configuration = try JSONDecoder().decode(
+                TerraMindFloodConversionConfiguration.self,
+                from: Data(contentsOf: configurationURL)
+            )
+        } catch {
+            throw TerraMindFloodResourceError.invalidConfiguration(error.localizedDescription)
+        }
+        try validateConfiguration(configuration)
+        return TerraMindFloodCheckpoint(
+            rootURL: root,
+            weightsURL: weightsURL,
+            configurationURL: configurationURL,
+            configuration: configuration
+        )
+    }
+
+    static func validateConfiguration(_ configuration: TerraMindFloodConversionConfiguration) throws {
+        guard configuration.format == conversionFormat else {
+            throw TerraMindFloodResourceError.unsupportedFormat(configuration.format)
+        }
+        guard configuration.sourceRepository == sourceRepository,
+              configuration.sourceRevision == sourceRevision,
+              configuration.sourceCheckpointSHA256 == sourceCheckpointSHA256 else {
+            throw TerraMindFloodResourceError.unsupportedSource(
+                configuration.sourceRepository,
+                configuration.sourceRevision
+            )
+        }
+        guard configuration.dtype == "float32" else {
+            throw TerraMindFloodResourceError.unsupportedPrecision(configuration.dtype)
+        }
+        guard configuration.tensorCount == tensorCount else {
+            throw TerraMindFloodResourceError.tensorInventory(
+                expected: tensorCount,
+                actual: configuration.tensorCount
+            )
+        }
+        guard configuration.scalarCount == scalarCount else {
+            throw TerraMindFloodResourceError.scalarInventory(
+                expected: scalarCount,
+                actual: configuration.scalarCount
+            )
+        }
+        guard configuration.tileSize == TerraMindFloodModel.tileSize,
+              configuration.timestamps == TerraMindFloodModel.timestampCount else {
+            throw TerraMindFloodResourceError.unsupportedDimensions(
+                tileSize: configuration.tileSize,
+                timestamps: configuration.timestamps
+            )
+        }
+    }
+
+    public static func loadModel(from checkpoint: TerraMindFloodCheckpoint) throws -> TerraMindFloodModel {
+        let arrays = try MLX.loadArrays(url: checkpoint.weightsURL)
+        guard arrays.count == checkpoint.configuration.tensorCount else {
+            throw TerraMindFloodResourceError.tensorInventory(
+                expected: checkpoint.configuration.tensorCount,
+                actual: arrays.count
+            )
+        }
+        let scalarCount = arrays.values.reduce(0) { partial, value in
+            partial + value.shape.reduce(1, *)
+        }
+        guard scalarCount == checkpoint.configuration.scalarCount else {
+            throw TerraMindFloodResourceError.scalarInventory(
+                expected: checkpoint.configuration.scalarCount,
+                actual: scalarCount
+            )
+        }
+        return try TerraMindFloodModel(weights: arrays)
+    }
+}

--- a/Tests/MereRunCLITests/GateSupportTests.swift
+++ b/Tests/MereRunCLITests/GateSupportTests.swift
@@ -87,6 +87,24 @@ final class GateSupportTests: XCTestCase {
         XCTAssertTrue(plan.check.successDetail.contains("sfx video generate"))
     }
 
+    func testTerraMindFloodHasDirectNativeInferenceSmokePlan() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.visionFloodTerraMindBase.rawValue)
+        )
+        let plan = try XCTUnwrap(InstalledModelSmokePlans.plan(
+            for: spec,
+            installedIDs: [spec.id]
+        ))
+
+        XCTAssertEqual(plan.check.id, "installed-vision-flood-terramind-base")
+        XCTAssertEqual(plan.check.suite, "vision-flood")
+        XCTAssertEqual(plan.check.requiredModels, [spec.id])
+        XCTAssertEqual(
+            plan.check.successDetail,
+            "direct true inference: geo flood normalized tensor smoke"
+        )
+    }
+
     func testDreamXRequiresWanAndUsesAWorldTransition() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "video-dreamx-world-5b-ar-mlx"))
 

--- a/Tests/MereRunCLITests/GeoFloodCommandTests.swift
+++ b/Tests/MereRunCLITests/GeoFloodCommandTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import MereRunCLI
+
+final class GeoFloodCommandTests: XCTestCase {
+    func testParsesNativeFloodOptions() throws {
+        let command = try GeoFlood.parse([
+            "/tmp/input.safetensors",
+            "--output", "/tmp/logits.safetensors",
+            "--model", "/tmp/terramind",
+            "--preflight",
+            "--json",
+        ])
+
+        XCTAssertEqual(command.input, "/tmp/input.safetensors")
+        XCTAssertEqual(command.output, "/tmp/logits.safetensors")
+        XCTAssertEqual(command.model, "/tmp/terramind")
+        XCTAssertTrue(command.preflight)
+        XCTAssertTrue(command.json)
+    }
+
+    func testGeoCommandRegistersFlood() {
+        XCTAssertTrue(Geo.configuration.subcommands.contains { $0 == GeoFlood.self })
+    }
+}

--- a/Tests/MereRunCLITests/MLXBundleSupportTests.swift
+++ b/Tests/MereRunCLITests/MLXBundleSupportTests.swift
@@ -84,4 +84,56 @@ final class MLXBundleSupportTests: XCTestCase {
       ])
     )
   }
+
+  func testConcurrentFirstRunBundleInstallIsIdempotent() throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "mere-run-mlx-bundle-race-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    defer { try? FileManager.default.removeItem(at: root) }
+    let source = root.appendingPathComponent("source/mlx-swift_Cmlx.bundle", isDirectory: true)
+    let resources = source.appendingPathComponent("Contents/Resources", isDirectory: true)
+    try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+    let metallib = Data("fixture-metallib".utf8)
+    try metallib.write(to: resources.appendingPathComponent("default.metallib"))
+    let destination = root.appendingPathComponent("debug/mlx-swift_Cmlx.bundle", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: destination.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    let results = ConcurrentBundleInstallResults()
+
+    DispatchQueue.concurrentPerform(iterations: 8) { _ in
+      do {
+        try MLXBundleSupport.installBundleIfMissing(from: source, to: destination)
+        results.recordSuccess()
+      } catch {
+        results.recordFailure(error)
+      }
+    }
+
+    XCTAssertEqual(results.successCount, 8)
+    XCTAssertEqual(results.failures, [])
+    XCTAssertEqual(
+      try Data(contentsOf: destination.appendingPathComponent("Contents/Resources/default.metallib")),
+      metallib
+    )
+  }
+}
+
+private final class ConcurrentBundleInstallResults: @unchecked Sendable {
+  private let lock = NSLock()
+  private var successes = 0
+  private var recordedFailures: [String] = []
+
+  var successCount: Int { lock.withLock { successes } }
+  var failures: [String] { lock.withLock { recordedFailures } }
+
+  func recordSuccess() {
+    lock.withLock { successes += 1 }
+  }
+
+  func recordFailure(_ error: Error) {
+    lock.withLock { recordedFailures.append(String(describing: error)) }
+  }
 }

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -122,6 +122,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "sfx",
             "video",
             "world",
+            "geo",
             "graph",
             "executor",
             "run",

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -11,6 +11,32 @@ final class ManagedModelSupportTests: XCTestCase {
         }
     }
 
+    func testTerraMindFloodSupportRequiresAppleSiliconAndSixteenGB() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.visionFloodTerraMindBase.rawValue)
+        )
+        let appleSilicon = MereRunMachineProfile(
+            physicalMemoryBytes: 16 * 1_073_741_824,
+            processorName: "M2 Pro",
+            isAppleSiliconMac: true
+        )
+        let linux = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "Linux",
+            isAppleSiliconMac: false,
+            isLinux: true
+        )
+
+        let supported = ManagedModelCapabilityCatalog.support(for: spec, on: appleSilicon)
+        let rejected = ManagedModelCapabilityCatalog.support(for: spec, on: linux)
+
+        XCTAssertTrue(supported.isSupported)
+        XCTAssertEqual(supported.descriptor.minimumUnifiedMemoryGB, 16)
+        XCTAssertEqual(supported.descriptor.recommendedUnifiedMemoryGB, 24)
+        XCTAssertFalse(rejected.isSupported)
+        XCTAssertEqual(rejected.reasons, ["TerraMind Flood requires Apple Silicon macOS."])
+    }
+
     func testLargeCoderModelIsRejectedBelowMemoryThreshold() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: CodeGenResources.defaultModelId))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -208,6 +208,25 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.upstreamRepoId, "tiiuae/Falcon-Perception")
     }
 
+    func testTerraMindFloodTemplateHasExpectedNativeMetadata() {
+        let manifest = MereRunModelManifest.template(
+            for: .visionFloodTerraMindBase,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, TerraMindFloodResources.defaultModelID)
+        XCTAssertEqual(manifest.engine, .terramindFlood)
+        XCTAssertEqual(manifest.family, .terramind)
+        XCTAssertEqual(manifest.tier, .base)
+        XCTAssertEqual(manifest.precision, .fp32)
+        XCTAssertEqual(manifest.supports, [.floodSegmentation])
+        XCTAssertNil(manifest.components)
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(TerraMindFloodResources.sourceRepository)@\(TerraMindFloodResources.sourceRevision)"
+        )
+    }
+
     func testInfinityParser2ProTemplateHasExpectedMetadata() throws {
         let manifest = MereRunModelManifest.template(for: .infinityParser2Pro, createdAt: Date(timeIntervalSince1970: 0))
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -748,6 +748,33 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertTrue(report.errors.contains { $0.contains("tokenizer.json") })
     }
 
+    func testTerraMindFloodSourceRootPassesWithoutTextComponents() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(TerraMindFloodResources.defaultModelID, isDirectory: true)
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(
+            for: .visionFloodTerraMindBase,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent(TerraMindFloodResources.sourceCheckpointFilename)
+        )
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent(TerraMindFloodResources.sourceConfigurationFilename)
+        )
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: TerraMindFloodResources.defaultModelID
+        )
+
+        XCTAssertTrue(report.isValid, report.errors.joined(separator: "\n"))
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertNil(report.manifest?.components)
+    }
+
     func testFalconValidationFailsWithoutConfig() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/TerraMindFloodResourcesTests.swift
+++ b/Tests/MereRunCoreTests/TerraMindFloodResourcesTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import MereRunCore
+
+final class TerraMindFloodResourcesTests: XCTestCase {
+    func testPinsExactFP32ConversionContract() throws {
+        let configuration = try decodeConfiguration(dtype: "float32")
+
+        XCTAssertNoThrow(try TerraMindFloodResources.validateConfiguration(configuration))
+        XCTAssertEqual(TerraMindFloodResources.tensorCount, 171)
+        XCTAssertEqual(TerraMindFloodResources.scalarCount, 168_416_386)
+        XCTAssertEqual(TerraMindFloodModel.requiredTensorNames.count, 171)
+        XCTAssertEqual(
+            TerraMindFloodResources.weightsArtifact.sha256,
+            "4940ad94df06a923e3a919f944a71ad01892872e89c428abe718eefc44d0f95a"
+        )
+    }
+
+    func testRejectsFP16BecauseItChangesFloodBoundary() throws {
+        let configuration = try decodeConfiguration(dtype: "float16")
+
+        XCTAssertThrowsError(try TerraMindFloodResources.validateConfiguration(configuration)) { error in
+            XCTAssertEqual(error as? TerraMindFloodResourceError, .unsupportedPrecision("float16"))
+        }
+    }
+
+    private func decodeConfiguration(dtype: String) throws -> TerraMindFloodConversionConfiguration {
+        let json = """
+        {
+          "converter": "scripts/convert-terramind-flood-mlx.py@v1",
+          "dtype": "\(dtype)",
+          "format": "mere.run/terramind-flood-mlx-v1",
+          "model_id": "vision-flood-terramind-base",
+          "scalar_count": 168416386,
+          "source_checkpoint": "TerraMind_v1_base_ImpactMesh_flood.pt",
+          "source_checkpoint_sha256": "22627584c2db618c2f6ddb64b411a95762a893becb25104e3f66bfebecaa71e9",
+          "source_configuration_sha256": "d6c74ef58085a6d3f27bca2d570d84b9256100b885e7c51521c9d0cf7f335282",
+          "source_repository": "ibm-esa-geospatial/TerraMind-base-Flood",
+          "source_revision": "1e4b2429d17234922f8d92beb0d725af4db85c08",
+          "tensor_count": 171,
+          "tile_size": 256,
+          "timestamps": 4
+        }
+        """
+        return try JSONDecoder().decode(
+            TerraMindFloodConversionConfiguration.self,
+            from: Data(json.utf8)
+        )
+    }
+}

--- a/docs/.vitepress/command-pages.tsv
+++ b/docs/.vitepress/command-pages.tsv
@@ -6,6 +6,7 @@ image	/runtime/image
 text	/runtime/text
 speech	/runtime/speech
 vision	/runtime/vision
+geo	/runtime/geo
 audio	/runtime/audio
 music	/runtime/music
 sfx	/runtime/sfx

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
           { text: 'Text Runtime', link: '/runtime/text' },
           { text: 'Speech Runtime', link: '/runtime/speech' },
           { text: 'Vision Runtime', link: '/runtime/vision' },
+          { text: 'Geospatial Runtime', link: '/runtime/geo' },
           { text: 'Audio Enhancement', link: '/runtime/audio' },
           { text: 'Music Runtime', link: '/runtime/music' },
           { text: 'ACE-Step Validation', link: '/runtime/acestep-validation' },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,8 @@ Public tree:
   - `mere.run vision image-to-3d-trellis2` — Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2.
   - `mere.run vision image-to-3d-multiview` — VFX alias for native 4/6-view InstantMesh reconstruction.
   - `mere.run vision ocr` — Extract text from images using LightOnOCR, GLM-OCR, or Infinity-Parser2.
+- [`mere.run geo`](/runtime/geo) — Run native geospatial inference models on local Earth-observation data.
+  - `mere.run geo flood` — Run native TerraMind Flood tile inference with MLX on Apple silicon.
 - [`mere.run audio`](/runtime/audio) — Enhance general audio locally.
   - `mere.run audio enhance` — Extend speech or general-audio bandwidth to 48 kHz.
 - [`mere.run music`](/runtime/music) — Generate, analyze, transcribe, and separate music locally.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,6 +146,7 @@ itself, so it always matches the binary you just built:
 | [`mere.run text`](/runtime/text) | Run local chat, code, embedding, and anonymization workflows. |
 | [`mere.run speech`](/runtime/speech) | Synthesize, transcribe, diarize, and manage voice profiles. |
 | [`mere.run vision`](/runtime/vision) | Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media. |
+| [`mere.run geo`](/runtime/geo) | Run native geospatial inference models on local Earth-observation data. |
 | [`mere.run audio`](/runtime/audio) | Enhance general audio locally. |
 | [`mere.run music`](/runtime/music) | Generate, analyze, transcribe, and separate music locally. |
 | [`mere.run sfx`](/runtime/sfx) | Generate sound effects locally. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ links to the page that owns that command.
 | [`mere.run text`](/runtime/text) | Run local chat, code, embedding, and anonymization workflows. |
 | [`mere.run speech`](/runtime/speech) | Synthesize, transcribe, diarize, and manage voice profiles. |
 | [`mere.run vision`](/runtime/vision) | Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media. |
+| [`mere.run geo`](/runtime/geo) | Run native geospatial inference models on local Earth-observation data. |
 | [`mere.run audio`](/runtime/audio) | Enhance general audio locally. |
 | [`mere.run music`](/runtime/music) | Generate, analyze, transcribe, and separate music locally. |
 | [`mere.run sfx`](/runtime/sfx) | Generate sound effects locally. |

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -81,6 +81,7 @@ from the runtime catalog used by `mere.run model list`,
 | `vision-ocr` | `vision-ocr-lighton` |
 | `vision-segment` | `vision-segment-sam31` |
 | `vision-ground` | `vision-ground-falcon-perception` |
+| `vision-flood` | `vision-flood-terramind-base` |
 | `vision-face` | `vision-face-buffalo-l` |
 | `vision-geometry` | `vision-geometry-moge2-small` |
 | `vision-depth` | `vision-depth-vda-small` |

--- a/docs/runtime/geo.md
+++ b/docs/runtime/geo.md
@@ -1,0 +1,47 @@
+# Geospatial Runtime
+
+`mere.run geo` is the native inference boundary for Earth-observation models.
+Acquisition, reprojection, raster tiling, COG export, and analyst evidence can
+remain in geospatial workflow providers while the neural forward pass runs
+locally through Swift, MLX, and Apple Metal.
+
+## TerraMind Flood
+
+`mere.run geo flood` runs IBM and ESA's ImpactMesh flood checkpoint with the
+native TerraMind encoder, feature pyramid, temporal UNet decoder, and binary
+head. The command accepts normalized, pre-tiled safetensors and emits float32
+logits:
+
+```bash
+mere.run geo flood flood-input.safetensors \
+  --output flood-logits.safetensors \
+  --model /path/to/converted-terramind-flood \
+  --json
+```
+
+The input must contain `S2L2A`, `S1RTC`, and `DEM` arrays shaped
+`[batch, channels, 4, 256, 256]`. This low-level tensor contract keeps raster
+policy outside the model runtime. The `mere-geo-tools` graph provider prepares
+those arrays, reconstructs the tiled output, and writes georeferenced
+candidate-only artifacts.
+
+## Model conversion
+
+The managed model id is `vision-flood-terramind-base`. Its source is pinned to
+the official `ibm-esa-geospatial/TerraMind-base-Flood` revision and remains a
+non-executable Lightning checkpoint until explicit conversion:
+
+```bash
+python3 scripts/convert-terramind-flood-mlx.py \
+  --checkpoint /path/to/TerraMind_v1_base_ImpactMesh_flood.pt \
+  --configuration /path/to/terramind_v1_base_impactmesh_flood.yaml \
+  --output /path/to/converted-terramind-flood
+```
+
+Conversion is float32-only. FP32 reproduces the reference Helene candidate mask
+exactly; FP16 changed the decision boundary and is rejected by the runtime.
+The converted package is checksum-pinned and contains safetensors only, so
+native inference never interprets the upstream pickle checkpoint.
+
+Flood outputs are candidates, not authoritative findings. Promotion requires
+independent corroboration and local validation.

--- a/scripts/convert-terramind-flood-mlx.py
+++ b/scripts/convert-terramind-flood-mlx.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Deterministically convert the pinned TerraMind Flood Lightning checkpoint to MLX safetensors."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+MODEL_ID = "vision-flood-terramind-base"
+SOURCE_REPOSITORY = "ibm-esa-geospatial/TerraMind-base-Flood"
+SOURCE_REVISION = "1e4b2429d17234922f8d92beb0d725af4db85c08"
+SOURCE_CHECKPOINT = "TerraMind_v1_base_ImpactMesh_flood.pt"
+SOURCE_CONFIGURATION = "terramind_v1_base_impactmesh_flood.yaml"
+SOURCE_CHECKPOINT_SHA256 = "22627584c2db618c2f6ddb64b411a95762a893becb25104e3f66bfebecaa71e9"
+FORMAT = "mere.run/terramind-flood-mlx-v1"
+CONVERTER = "scripts/convert-terramind-flood-mlx.py@v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=pathlib.Path, help="Pinned Lightning .pt checkpoint")
+    parser.add_argument("--configuration", type=pathlib.Path, help="Pinned TerraTorch YAML configuration")
+    parser.add_argument("--output", type=pathlib.Path, required=True, help="Converted model directory")
+    parser.add_argument(
+        "--dtype",
+        choices=["float32"],
+        default="float32",
+        help="Conversion precision. Flood boundary parity requires float32.",
+    )
+    return parser.parse_args()
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_sources(args: argparse.Namespace) -> tuple[pathlib.Path, pathlib.Path]:
+    if args.checkpoint and args.configuration:
+        return args.checkpoint.resolve(), args.configuration.resolve()
+    if bool(args.checkpoint) != bool(args.configuration):
+        raise SystemExit("--checkpoint and --configuration must be supplied together")
+    from huggingface_hub import hf_hub_download
+
+    checkpoint = pathlib.Path(
+        hf_hub_download(
+            repo_id=SOURCE_REPOSITORY,
+            filename=SOURCE_CHECKPOINT,
+            revision=SOURCE_REVISION,
+        )
+    )
+    configuration = pathlib.Path(
+        hf_hub_download(
+            repo_id=SOURCE_REPOSITORY,
+            filename=SOURCE_CONFIGURATION,
+            revision=SOURCE_REVISION,
+        )
+    )
+    return checkpoint.resolve(), configuration.resolve()
+
+
+def interpolate_position_embedding(value: torch.Tensor) -> torch.Tensor:
+    if tuple(value.shape) != (1, 196, 768):
+        raise ValueError(f"unexpected positional embedding shape: {tuple(value.shape)}")
+    resized = F.interpolate(
+        value.reshape(1, 14, 14, 768).permute(0, 3, 1, 2),
+        size=(16, 16),
+        mode="bicubic",
+        align_corners=False,
+    )
+    return resized.permute(0, 2, 3, 1).reshape(1, 256, 768).contiguous()
+
+
+def convert_tensor(name: str, value: torch.Tensor, dtype: torch.dtype) -> tuple[str, torch.Tensor] | None:
+    if name.endswith(".num_batches_tracked"):
+        return None
+    if not name.startswith("model."):
+        raise ValueError(f"unexpected checkpoint key: {name}")
+    target = name.removeprefix("model.")
+    tensor = value.detach().cpu()
+    if target.endswith(".pos_emb"):
+        tensor = interpolate_position_embedding(tensor)
+    if (
+        target.startswith("decoder.decoder.blocks.") and target.endswith(".0.weight")
+    ) or target == "head.head.2.weight":
+        # PyTorch Conv2d [out, in, height, width] -> MLX [out, height, width, in].
+        tensor = tensor.permute(0, 2, 3, 1)
+    if target in {
+        "neck.2.fpn1.0.weight",
+        "neck.2.fpn1.3.weight",
+        "neck.2.fpn2.0.weight",
+    }:
+        # PyTorch ConvTranspose2d [in, out, height, width] -> MLX [out, height, width, in].
+        tensor = tensor.permute(1, 2, 3, 0)
+    return target, tensor.to(dtype=dtype).contiguous()
+
+
+def write_json(path: pathlib.Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    checkpoint, configuration = resolve_sources(args)
+    actual_checkpoint_hash = sha256(checkpoint)
+    if actual_checkpoint_hash != SOURCE_CHECKPOINT_SHA256:
+        raise SystemExit(
+            f"checkpoint SHA-256 mismatch: expected {SOURCE_CHECKPOINT_SHA256}, found {actual_checkpoint_hash}"
+        )
+    state = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    if not isinstance(state, dict) or not isinstance(state.get("state_dict"), dict):
+        raise SystemExit("checkpoint does not contain a weights-only state_dict")
+
+    dtype = torch.float32
+    converted: dict[str, torch.Tensor] = {}
+    for source_name, source_tensor in state["state_dict"].items():
+        item = convert_tensor(source_name, source_tensor, dtype)
+        if item is not None:
+            converted[item[0]] = item[1]
+    converted = dict(sorted(converted.items()))
+    scalar_count = sum(value.numel() for value in converted.values())
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    weights_path = args.output / "model.safetensors"
+    save_file(
+        converted,
+        weights_path,
+        metadata={
+            "format": FORMAT,
+            "model_id": MODEL_ID,
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+            "source_checkpoint_sha256": SOURCE_CHECKPOINT_SHA256,
+            "dtype": args.dtype,
+        },
+    )
+    config = {
+        "format": FORMAT,
+        "model_id": MODEL_ID,
+        "source_repository": SOURCE_REPOSITORY,
+        "source_revision": SOURCE_REVISION,
+        "source_checkpoint": SOURCE_CHECKPOINT,
+        "source_checkpoint_sha256": SOURCE_CHECKPOINT_SHA256,
+        "source_configuration_sha256": sha256(configuration),
+        "converter": CONVERTER,
+        "dtype": args.dtype,
+        "tensor_count": len(converted),
+        "scalar_count": scalar_count,
+        "tile_size": 256,
+        "timestamps": 4,
+    }
+    write_json(args.output / "config.json", config)
+    result = {
+        **config,
+        "weights_bytes": weights_path.stat().st_size,
+        "weights_sha256": sha256(weights_path),
+        "configuration_bytes": (args.output / "config.json").stat().st_size,
+        "configuration_sha256": sha256(args.output / "config.json"),
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"conversion failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/convert-terramind-flood-mlx.py
+++ b/scripts/convert-terramind-flood-mlx.py
@@ -7,12 +7,12 @@ import argparse
 import hashlib
 import json
 import pathlib
+import struct
 import sys
 from typing import Any
 
 import torch
 import torch.nn.functional as F
-from safetensors.torch import save_file
 
 MODEL_ID = "vision-flood-terramind-base"
 SOURCE_REPOSITORY = "ibm-esa-geospatial/TerraMind-base-Flood"
@@ -110,6 +110,36 @@ def write_json(path: pathlib.Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
+def write_deterministic_safetensors(
+    path: pathlib.Path,
+    tensors: dict[str, torch.Tensor],
+    metadata: dict[str, str],
+) -> None:
+    """Write the simple float32 subset used here without Rust HashMap ordering drift."""
+    header: dict[str, Any] = {"__metadata__": metadata}
+    offset = 0
+    for name, tensor in tensors.items():
+        if tensor.device.type != "cpu" or tensor.dtype != torch.float32 or not tensor.is_contiguous():
+            raise ValueError(f"{name} is not a contiguous CPU float32 tensor")
+        byte_count = tensor.numel() * tensor.element_size()
+        header[name] = {
+            "dtype": "F32",
+            "shape": list(tensor.shape),
+            "data_offsets": [offset, offset + byte_count],
+        }
+        offset += byte_count
+
+    encoded = json.dumps(header, separators=(",", ":"), ensure_ascii=True).encode()
+    encoded += b" " * ((8 - len(encoded) % 8) % 8)
+    partial = path.with_suffix(f"{path.suffix}.partial")
+    with partial.open("wb") as target:
+        target.write(struct.pack("<Q", len(encoded)))
+        target.write(encoded)
+        for tensor in tensors.values():
+            target.write(tensor.numpy().tobytes(order="C"))
+    partial.replace(path)
+
+
 def main() -> int:
     args = parse_args()
     checkpoint, configuration = resolve_sources(args)
@@ -133,16 +163,19 @@ def main() -> int:
 
     args.output.mkdir(parents=True, exist_ok=True)
     weights_path = args.output / "model.safetensors"
-    save_file(
-        converted,
+    write_deterministic_safetensors(
         weights_path,
+        converted,
+        # This explicit order reproduces the already released, checksum-pinned
+        # v1 package. safetensors <=0.8 passes metadata through a randomized
+        # Rust HashMap, so save_file() is not byte-deterministic across runs.
         metadata={
+            "source_checkpoint_sha256": SOURCE_CHECKPOINT_SHA256,
+            "dtype": args.dtype,
             "format": FORMAT,
             "model_id": MODEL_ID,
             "source_repository": SOURCE_REPOSITORY,
             "source_revision": SOURCE_REVISION,
-            "source_checkpoint_sha256": SOURCE_CHECKPOINT_SHA256,
-            "dtype": args.dtype,
         },
     )
     config = {


### PR DESCRIPTION
## Summary
- add `mere.run geo flood` backed by native Swift/MLX on Apple Metal
- pin and validate the exact TerraMind Flood checkpoint and float32 converted package
- register managed-model, gate, CLI, docs, and conversion contracts
- make safetensors conversion byte-deterministic while reproducing the existing `4940ad94…` artifact exactly

## Verification
- `swift test --filter TerraMind` — 6 passed
- converter run twice — identical 673,684,984-byte output, SHA-256 `4940ad94df06a923e3a919f944a71ad01892872e89c428abe718eefc44d0f95a`
- native ImpactMesh CEMS-labeled chip through Swift/MLX: water IoU 0.70177381, F1 0.82475568, pixel accuracy 0.82324219

## Evidence boundary
The command emits candidate flood geometry and provenance. It does not promote model output to observed evidence.