### PR TITLE
Accelerate MiniMax-H3 on Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .swiftpm/
 .DS_Store
 .tmp/
+/tmp/
 DerivedData/
 *.xcuserstate
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,75 @@ The format is based on Keep a Changelog.
   Studio. Recipe schema 4 persists the effective LM sampling policy so a
   supposedly reproducible render no longer hides hardcoded planner behavior.
 
+### MiniMax-H3 performance
+
+- added `video-minimax-h3-fl2va-bf16-mlx` as a first-class maximum-fidelity
+  CLI, managed-model, and macOS Studio choice. The runtime consumes
+  PipeNetwork's immutable 13-shard BF16 MLX checkpoint directly, streams one
+  shard at a time, builds exact AdaLN values for the requested schedule before
+  dropping 106 AdaLN/time tensors from live memory, and performs the released
+  per-head QKV deinterleave in memory instead of
+  publishing another derivative checkpoint. Pulls remain explicitly gated by
+  the MiniMax-H3 Community License acknowledgement.
+- enabled the faster resident-BF16 transformer path automatically on
+  memory-qualified 96+ GiB MacBooks, while retaining compact Q4 defaults on
+  lower-memory portable systems and preserving geometry-aware runtime reserve.
+- added shape-aware compiled execution: full-step compilation for smaller
+  sequences and staged blockwise compilation for larger packed sequences. The
+  latter reduced a matched 14,958-row resident-BF16 denoise step from 201.2 s
+  eager to 127.9 s on an M4 Max without changing the model or sampler.
+- fused the video VAE decoder's released per-head-interleaved QKV projection
+  into one global-QKV linear after exact load-time deinterleaving, removing two
+  projection dispatches per decoder block while retaining tiled geometry.
+- added non-perturbing per-step performance telemetry, made block profiling
+  select a safe eager execution path instead of evaluating inside an MLX
+  compile transform, and added exact H3 attention/projection shape benchmarks.
+- tightened the true-768 fused-attention query schedule from 2,048 to 1,024
+  tokens after a matched whole-block sweep measured an approximately 10%
+  improvement with identical output. The pinned MLX fork also recognizes only
+  H3's four large BF16 projection shapes on 32,768+ packed rows and selects the
+  faster exact Steel GEMM schedule. Isolated projections improved by 10-20%,
+  while an order-balanced full block improved from 7.892 s to 7.619 s (1.036x)
+  with `rel_l2=0`; environment overrides remain available for reproducible
+  kernel-lab controls. The mlx-swift dependency and bundled Metal library
+  provenance are pinned to the public fork commits that carry this schedule.
+- added first-class `quality`, `balanced`, and `maximum` H3 denoise modes in
+  both the CLI and macOS Studio. The speed modes reuse a bounded tail-block
+  residual only across small adjacent sigma changes, run at least two complete
+  evaluations before the first reuse, use mode-specific bounded refresh
+  streaks, and keep the final schedule region native. On a matched warm-cache
+  16-point, 1,216-row M4 Max loop, the initial `maximum` policy reduced denoise
+  time from 112.413 s to 74.754 s (1.504x); `quality` remains the exact default.
+- made H3 speed choices durable in `video generate --preflight --json`: the
+  request and resolved plan report schedule points, transformer weight mode,
+  and acceleration mode, and the declarative action preserves both H3 flags
+  for automation and macOS Studio receipts.
+- capped long-geometry automatic schedules at 21 points (20 model
+  evaluations), matching the current H3 CUDA runtime default instead of
+  spending 30 evaluations without an upstream quality requirement. Explicit
+  `maximum` acceleration caps automatic schedules at 12 points (11 model
+  evaluations), while `--steps` continues to override either policy. The
+  accepted 12-point schedule executes 365 block calls instead of the old
+  long-geometry policy's 1,500: 75.7% less transformer-block work. A matched
+  512x320, 22-frame, same-seed acceptance pair measured 62.847 s of denoise
+  and 73.07 s end to end in `quality`, versus 41.928 s and 51.45 s in
+  `maximum` (1.499x denoise). The accepted artifact remained free of the
+  spatial lattice produced by more aggressive cache schedules.
+- added a checkpoint-free H3 AdaLN modulation lab inspired by contiguous-run
+  CUDA implementations. At the full 29,018-row shape, run modulation was
+  numerically exact and reduced that isolated operation from 10.4 ms to 5.7 ms
+  (1.835x), but the absolute saving was too small to justify changing the
+  production MLX graph.
+- expanded the explicitly approximate `maximum` lane after a locked BF16 proxy
+  acceptance run. A 20-point schedule now executes six full evaluations and 13
+  nine-block cache evaluations (417 block calls versus 950 exact). On the
+  matched 416x256, 107-frame M4 Max proxy, denoise fell from 674.031 s exact to
+  203.805 s and end-to-end time from 703.423 s to 231.740 s; the accepted MP4
+  retained coherent rain, character, levitating-bus, and dragon motion without
+  the rejected spatial lattice. The real 832x480, 124-frame, 20-point BF16 run
+  then completed in 1,653.711 s (27:33.711) end to end: 1,526.533 s denoise,
+  119.544 s video decode, and 0.892 s audio decode. `quality` remains the exact
+  default.
 ## 0.34.0 - 2026-08-04
 
 This release advances the complete local creation stack across five first-class
@@ -58,7 +127,7 @@ artifact contracts instead of becoming a model-specific sidecar.
   including 2 fps paired video presentation timestamps, video soundtrack
   conditioning, per-reference spatial grids, shared audio/video rotary clocks,
   and the released reference-count and modality constraints.
-- added adaptive MiniMax-H3 9/16/31-point schedule tiers, explicit
+- added adaptive MiniMax-H3 9/16/21-point schedule tiers, explicit
   `--h3-weight-mode auto|quantized|resident-bf16`, chassis-aware compact Q4
   defaults for MacBooks, staged resident-BF16 expansion for desktop Macs, and
   coordinated 50-64 GiB MLX wired-memory residency. Large sequences reuse one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format is based on Keep a Changelog.
 
 ### MiniMax-H3 performance
 
+- fixed hissy H3 soundtracks by restoring the released audio VAE's
+  `mean_proj`, `logs_proj`, and `dec_in_proj` biases during checkpoint
+  conversion. A deterministic FP32 decode that previously diverged from the
+  ComfyUI reference at `rel_l2=0.463` now reaches `rel_l2=0.0000194` with
+  effectively unit cosine similarity. The release-mode kernel lab now carries
+  a checkpoint-backed audio parity fixture so this cannot silently regress.
 - added `video-minimax-h3-fl2va-bf16-mlx` as a first-class maximum-fidelity
   CLI, managed-model, and macOS Studio choice. The runtime consumes
   PipeNetwork's immutable 13-shard BF16 MLX checkpoint directly, streams one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,13 +59,20 @@ The format is based on Keep a Changelog.
   compile transform, and added exact H3 attention/projection shape benchmarks.
 - tightened the true-768 fused-attention query schedule from 2,048 to 1,024
   tokens after a matched whole-block sweep measured an approximately 10%
-  improvement with identical output. The pinned MLX fork also recognizes only
+  improvement with identical output. A subsequent order-balanced whole-block
+  gate selected 768-query single-evaluation batches for 32,768+ row sequences;
+  two fresh paired processes measured 1.015x and 1.019x with `rel_l2=0`. The
+  pinned MLX fork also recognizes only
   H3's four large BF16 projection shapes on 32,768+ packed rows and selects the
   faster exact Steel GEMM schedule. Isolated projections improved by 10-20%,
   while an order-balanced full block improved from 7.892 s to 7.619 s (1.036x)
   with `rel_l2=0`; environment overrides remain available for reproducible
   kernel-lab controls. The mlx-swift dependency and bundled Metal library
   provenance are pinned to the public fork commits that carry this schedule.
+  A fresh 37,794-row, 50-block BF16 evaluation then fell from 953.192 s to
+  775.062 s (1.230x), and its complete 1344x768 generation boundary fell from
+  1,253.425 s to 1,027.310 s. The resulting H.264/AAC artifact retained the
+  exact prior SHA-256, proving the speed path did not change model output.
 - added first-class `quality`, `balanced`, and `maximum` H3 denoise modes in
   both the CLI and macOS Studio. The speed modes reuse a bounded tail-block
   residual only across small adjacent sigma changes, run at least two complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ The format is based on Keep a Changelog.
 - fused the video VAE decoder's released per-head-interleaved QKV projection
   into one global-QKV linear after exact load-time deinterleaving, removing two
   projection dispatches per decoder block while retaining tiled geometry.
+- increased the H3 video VAE's default spatial tile from 256 to 320 pixels
+  after fresh-process checkpoint sweeps. At 832x480 and 124 frames the matched
+  decode fell from 96.091 s to 76.421 s (1.257x) while reported peak Metal
+  memory fell from 9.85 to 8.91 GiB. The true 1344x768 lab shape completed in
+  213.005 s; a 480-pixel candidate exceeded that boundary and was rejected.
+  The accepted path retains the released decoder, precision, causal tiling,
+  and overlap blending while reducing redundant overlap work.
 - added non-perturbing per-step performance telemetry, made block profiling
   select a safe eager execution path instead of evaluating inside an MLX
   compile transform, and added exact H3 attention/projection shape benchmarks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,14 @@ The format is based on Keep a Changelog.
   775.062 s (1.230x), and its complete 1344x768 generation boundary fell from
   1,253.425 s to 1,027.310 s. The resulting H.264/AAC artifact retained the
   exact prior SHA-256, proving the speed path did not change model output.
+- added a separate exact attention schedule for 65,536+ packed rows after the
+  true 73,470-row, 10.125-second geometry showed that attention consumed 74.6%
+  of a production-width block. Splitting the 56 independent heads into
+  eight-head submissions with 640 query rows per kernel reduced a complete
+  attention pass from 22.088 s to 16.383 s. The order-balanced full-block gate
+  then improved from 32.249 s to 25.173 s (1.281x) with bit-identical BF16
+  output (`rel_l2=0`), moving the projected physical one-evaluation boundary
+  from roughly 31-33 minutes to roughly 28 minutes including decode.
 - added first-class `quality`, `balanced`, and `maximum` H3 denoise modes in
   both the CLI and macOS Studio. The speed modes reuse a bounded tail-block
   residual only across small adjacent sigma changes, run at least two complete

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
-        "revision" : "009a42f024a04e50bb50bb6ce90d0a3e396c1760"
+        "revision" : "79bc410c85df66c3f4246084057bdfd971932ac7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -503,7 +503,7 @@ if !isLinuxPackage {
 var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(
     url: "https://github.com/sawfwair/mlx-swift",
-    revision: "009a42f024a04e50bb50bb6ce90d0a3e396c1760"
+    revision: "79bc410c85df66c3f4246084057bdfd971932ac7"
   )
 ]) + [
   .package(

--- a/README.md
+++ b/README.md
@@ -768,6 +768,14 @@ swift run mere.run video generate \
   --num-frames 124 \
   --output ./paper-bird-h3.mp4
 
+# Maximum-fidelity H3: direct pinned 13-shard BF16 MLX transformer
+swift run mere.run model pull video-minimax-h3-fl2va-bf16-mlx --accept-model-license
+swift run mere.run video generate \
+  "a cinematic rain-soaked bus stop at night" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --width 1280 --height 768 --duration 10 --steps 20 \
+  --output ./bus-stop-bf16.mp4
+
 # A locally converted Ref2VA root preserves reference order semantically
 swift run mere.run video generate \
   "keep the subject, borrow the camera move, and follow the vocal rhythm" \

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -716,7 +716,9 @@ struct CommandDraft: Equatable, Codable {
     var timingsOutputPath = ""
     /// Optional preserves older Library rows before MiniMax-H3 became a Studio-native workflow.
     var h3WeightMode: String?
-    /// Nil keeps MiniMax-H3's geometry-aware 9/16/31-point adaptive schedule.
+    /// Quality is exact; balanced and maximum enable bounded approximate block reuse.
+    var h3AccelerationMode: String?
+    /// Nil keeps MiniMax-H3's geometry-aware 9/16/21-point adaptive schedule.
     var h3Steps: Int?
     /// Ordered `image:path`, `video:path`, and `audio:path` reference specifications.
     var h3ReferenceInputs: [String]?
@@ -2265,6 +2267,10 @@ struct CommandTemplate: Identifiable, Equatable {
                 if let h3Steps = draft.h3Steps { args += ["--steps", String(h3Steps)] }
                 if let weightMode = draft.h3WeightMode, !weightMode.isBlank {
                     args += ["--h3-weight-mode", weightMode]
+                }
+                if let accelerationMode = draft.h3AccelerationMode,
+                   !accelerationMode.isBlank {
+                    args += ["--h3-acceleration", accelerationMode]
                 }
                 for reference in draft.h3ReferenceInputs ?? [] where !reference.isBlank {
                     args += ["--reference", reference]

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -3653,18 +3653,33 @@ private struct VideoOptions: View {
             Text("Resident BF16").tag("resident-bf16")
         }
         .pickerStyle(.segmented)
+        Picker(
+            "Denoise acceleration",
+            selection: Binding(
+                get: { controller.draft.h3AccelerationMode ?? "quality" },
+                set: { controller.draft.h3AccelerationMode = $0 }
+            )
+        ) {
+            Text("Exact").tag("quality")
+            Text("Balanced").tag("balanced")
+            Text("Maximum").tag("maximum")
+        }
+        .pickerStyle(.segmented)
+        Text("Balanced and Maximum are faster approximate paths; Exact preserves the native trajectory.")
+            .font(MereRunTheme.captionFont)
+            .foregroundStyle(MereRunTheme.textMuted)
         Toggle(
-            "Override adaptive 9 / 16 / 31-point schedule",
+            "Override adaptive 9 / 16 / 21-point schedule",
             isOn: Binding(
                 get: { controller.draft.h3Steps != nil },
-                set: { controller.draft.h3Steps = $0 ? 31 : nil }
+                set: { controller.draft.h3Steps = $0 ? 21 : nil }
             )
         )
         if controller.draft.h3Steps != nil {
             NumberStepper(
                 title: "Schedule points",
                 value: Binding(
-                    get: { controller.draft.h3Steps ?? 31 },
+                    get: { controller.draft.h3Steps ?? 21 },
                     set: { controller.draft.h3Steps = $0 }
                 ),
                 range: 1...64,

--- a/Sources/MereRunApp/README.md
+++ b/Sources/MereRunApp/README.md
@@ -27,6 +27,7 @@ both cataloged and accepted by ArgumentParser.
 The primary Video surface uses model-family-aware controls: LTX uses `--quality`
 and `--output-mode`, while native MiniMax-H3 exposes its exact `17*n+5` frame
 cadence, adaptive or explicit denoising schedule, weight-residency policy, and
+exact, balanced, or maximum denoise acceleration, plus
 ordered Ref2VA image/video/audio references without emitting incompatible LTX
 flags. Its general attachment workflow supports a start image, end keyframe,
 and source audio. Advanced Video contains

--- a/Sources/MereRunApp/StudioComposer.swift
+++ b/Sources/MereRunApp/StudioComposer.swift
@@ -776,19 +776,34 @@ struct StudioOptionsPanel: View {
                 Text("BF16").tag("resident-bf16")
             }
             .pickerStyle(.segmented)
+            Picker(
+                "Denoise",
+                selection: Binding(
+                    get: { draft.h3AccelerationMode ?? "quality" },
+                    set: { draft.h3AccelerationMode = $0 }
+                )
+            ) {
+                Text("Exact").tag("quality")
+                Text("Balanced").tag("balanced")
+                Text("Maximum").tag("maximum")
+            }
+            .pickerStyle(.segmented)
+            Text("Balanced and Maximum trade exact-seed trajectory fidelity for faster denoising.")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
             Toggle(
                 "Override adaptive schedule",
                 isOn: Binding(
                     get: { draft.h3Steps != nil },
-                    set: { draft.h3Steps = $0 ? 31 : nil }
+                    set: { draft.h3Steps = $0 ? 21 : nil }
                 )
             )
             .font(MereRunTheme.captionFont)
             if draft.h3Steps != nil {
                 Stepper(
-                    "Schedule points \(draft.h3Steps ?? 31)",
+                    "Schedule points \(draft.h3Steps ?? 21)",
                     value: Binding(
-                        get: { draft.h3Steps ?? 31 },
+                        get: { draft.h3Steps ?? 21 },
                         set: { draft.h3Steps = $0 }
                     ),
                     in: 1...64

--- a/Sources/MereRunApp/StudioModelsView.swift
+++ b/Sources/MereRunApp/StudioModelsView.swift
@@ -63,6 +63,7 @@ enum StudioModelOptimizationCommand {
     static func supports(modelID: String) -> Bool {
         let normalized = modelID.lowercased()
         return normalized == "video-minimax-h3-fl2va-mlx"
+            || normalized == "video-minimax-h3-fl2va-bf16-mlx"
             || normalized == "video-minimax-h3-ref2va-mlx"
     }
 

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -389,6 +389,7 @@ struct StudioDraft: Codable, Equatable {
     var timingsOutputPath = ""
     /// Optional fields preserve saved Studio drafts from before MiniMax-H3 support.
     var h3WeightMode: String?
+    var h3AccelerationMode: String?
     var h3Steps: Int?
     var h3ReferenceInputs: [String]?
 
@@ -503,6 +504,7 @@ struct StudioDraft: Codable, Equatable {
         timings = false
         timingsOutputPath = ""
         h3WeightMode = nil
+        h3AccelerationMode = nil
         h3Steps = nil
         h3ReferenceInputs = nil
     }
@@ -828,6 +830,7 @@ enum StudioCommandAdapter {
             draft.timings = studioDraft.timings
             draft.timingsOutputPath = studioDraft.timingsOutputPath
             draft.h3WeightMode = studioDraft.h3WeightMode
+            draft.h3AccelerationMode = studioDraft.h3AccelerationMode
             draft.h3Steps = studioDraft.h3Steps
             draft.h3ReferenceInputs = studioDraft.h3ReferenceInputs
 

--- a/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
@@ -57,7 +57,9 @@ struct ModelOptimize: ParsableCommand {
         guard let modelID = ModelResolver.ModelID(rawValue: target) else {
             throw ValidationError("Not a path and not a known model id: \(target)")
         }
-        guard modelID == .miniMaxH3FL2VAMLX || modelID == .miniMaxH3Ref2VAMLX else {
+        guard modelID == .miniMaxH3FL2VAMLX
+                || modelID == .miniMaxH3FL2VABF16MLX
+                || modelID == .miniMaxH3Ref2VAMLX else {
             throw ValidationError("Model optimization currently supports MiniMax-H3 MLX models.")
         }
         do {

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -349,27 +349,78 @@ struct ModelPullDiskPreflight {
 
     static func estimatedDownloadBytes(
         for spec: ManagedModelSpec,
+        modelDir: URL,
         force: Bool,
         hubCacheURL: URL,
         fileManager: FileManager = .default
     ) -> Int64? {
-        guard !force,
-              spec.mountedHubFallbacks.isEmpty,
-              let config = spec.hubFallback,
-              let cachedSnapshot = try? HubSnapshot.cachedMaterializedSnapshotURL(
-                options: HubSnapshotOptions(
-                    repoId: config.repoId,
-                    revision: config.revision,
-                    patterns: config.patterns,
-                    cacheDirectory: hubCacheURL,
-                    offline: true
-                ),
-                fileManager: fileManager
-              ),
-              spec.missingPaths(in: cachedSnapshot, fileManager: fileManager).isEmpty else {
-            return spec.estimatedDownloadBytes
+        if !force,
+           spec.mountedHubFallbacks.isEmpty,
+           let config = spec.hubFallback,
+           let cachedSnapshot = try? HubSnapshot.cachedMaterializedSnapshotURL(
+            options: HubSnapshotOptions(
+                repoId: config.repoId,
+                revision: config.revision,
+                patterns: config.patterns,
+                cacheDirectory: hubCacheURL,
+                offline: true
+            ),
+            fileManager: fileManager
+           ),
+           spec.missingPaths(in: cachedSnapshot, fileManager: fileManager).isEmpty {
+            return 0
         }
-        return 0
+
+        guard let estimate = spec.estimatedDownloadBytes else { return nil }
+        guard !force else { return estimate }
+        let reclaimableBytes = reclaimableLocalBytes(
+            in: modelDir,
+            onFileSystemContaining: hubCacheURL,
+            fileManager: fileManager
+        )
+        return max(0, estimate - reclaimableBytes)
+    }
+
+    static func reclaimableLocalBytes(
+        in modelDir: URL,
+        onFileSystemContaining hubCacheURL: URL,
+        fileManager: FileManager = .default
+    ) -> Int64 {
+        guard fileManager.fileExists(atPath: modelDir.path),
+              let modelVolume = try? modelDir.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
+              let hubPath = existingPath(for: hubCacheURL, fileManager: fileManager),
+              let hubVolume = try? hubPath.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier,
+              modelVolume.isEqual(hubVolume),
+              let enumerator = fileManager.enumerator(
+                at: modelDir,
+                includingPropertiesForKeys: [
+                    .isRegularFileKey,
+                    .isSymbolicLinkKey,
+                    .fileAllocatedSizeKey,
+                    .totalFileAllocatedSizeKey,
+                ],
+                options: [.skipsPackageDescendants]
+              ) else {
+            return 0
+        }
+
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+                .fileAllocatedSizeKey,
+                .totalFileAllocatedSizeKey,
+            ]),
+            values.isRegularFile == true,
+            values.isSymbolicLink != true else {
+                continue
+            }
+            let allocated = values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? 0
+            let byteCount = Int64(max(0, allocated))
+            total = total > Int64.max - byteCount ? Int64.max : total + byteCount
+        }
+        return total
     }
 
     static func check(
@@ -389,6 +440,7 @@ struct ModelPullDiskPreflight {
 
         let estimatedDownloadBytes = estimatedDownloadBytes(
             for: spec,
+            modelDir: modelDir,
             force: force,
             hubCacheURL: hubCache,
             fileManager: fileManager

--- a/Sources/MereRunCLI/Commands/ModelRepairManifestsCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelRepairManifestsCommand.swift
@@ -14,7 +14,20 @@ struct ModelRepairManifests: ParsableCommand {
     @Flag(name: [.long], help: "Emit a structured JSON repair report.")
     var json: Bool = false
 
+    @Flag(
+        name: [.customLong("accept-model-license")],
+        help: "Record that you reviewed and accept the listed third-party model terms when writing a missing manifest."
+    )
+    var acceptModelLicense: Bool = false
+
+    @Option(name: [.long], help: "Repair only this canonical model ID.")
+    var model: String?
+
     func run() throws {
+        if let requested = normalizedRequestedModel,
+           ModelResolver.ModelID(rawValue: requested) == nil {
+            throw ValidationError("Unknown canonical model id: \(requested)")
+        }
         let modelDirs = resolveCandidateModelDirs()
         guard !modelDirs.isEmpty else {
             throw ValidationError("Could not locate any model directories to repair.")
@@ -55,7 +68,9 @@ struct ModelRepairManifests: ParsableCommand {
     ) -> ModelRepairManifestsReport {
         var entries: [ModelRepairManifestEntry] = []
 
-        for modelID in ModelResolver.ModelID.allCases {
+        let modelIDs = normalizedRequestedModel.flatMap(ModelResolver.ModelID.init(rawValue:))
+            .map { [$0] } ?? ModelResolver.ModelID.allCases
+        for modelID in modelIDs {
             var foundAnyModel = false
             for modelsDir in modelDirs {
                 let modelRoot = modelsDir.appendingPathComponent(modelID.rawValue, isDirectory: true)
@@ -78,7 +93,8 @@ struct ModelRepairManifests: ParsableCommand {
                 do {
                     _ = try MereRunModelManifest.writeTemplateIfKnown(
                         modelId: modelID.rawValue,
-                        to: modelRoot
+                        to: modelRoot,
+                        usageTermsAcknowledged: acceptModelLicense
                     )
                     entries.append(.init(modelID: modelID.rawValue, status: .wrote, path: manifestURL.path))
                 } catch {
@@ -111,6 +127,12 @@ struct ModelRepairManifests: ParsableCommand {
 
     private func resolveCandidateModelDirs() -> [URL] {
         [MereRunModelPaths.modelsDir]
+    }
+
+    private var normalizedRequestedModel: String? {
+        guard let model else { return nil }
+        let normalized = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? nil : normalized
     }
 }
 

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -52,6 +52,20 @@ enum MiniMaxH3CLITransformerWeightMode: String, CaseIterable, ExpressibleByArgum
     }
 }
 
+enum MiniMaxH3CLIAccelerationMode: String, CaseIterable, ExpressibleByArgument {
+    case quality
+    case balanced
+    case maximum
+
+    var generationMode: MiniMaxH3AccelerationMode {
+        switch self {
+        case .quality: .quality
+        case .balanced: .balanced
+        case .maximum: .maximum
+        }
+    }
+}
+
 private struct MiniMaxH3WiredMemoryPolicy: WiredMemoryPolicy, Hashable {
     func limit(baseline: Int, activeSizes: [Int]) -> Int {
         max(baseline, activeSizes.max() ?? baseline)
@@ -275,7 +289,7 @@ struct VideoGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.long],
-        help: "Denoising schedule points. Defaults to 40 for Wan; MiniMax-H3 selects 9, 16, or 31 from packed geometry."
+        help: "Denoising schedule points. Defaults to 40 for Wan; MiniMax-H3 selects 9, 16, or 21 from packed geometry."
     )
     var steps: Int?
 
@@ -284,6 +298,12 @@ struct VideoGenerate: AsyncParsableCommand {
         help: "MiniMax-H3 transformer compute: auto, quantized, or resident-bf16."
     )
     var h3WeightMode: MiniMaxH3CLITransformerWeightMode = .automatic
+
+    @Option(
+        name: [.customLong("h3-acceleration")],
+        help: "MiniMax-H3 denoise mode: quality runs every block; balanced/maximum reuse bounded tail-block residuals for speed."
+    )
+    var h3Acceleration: MiniMaxH3CLIAccelerationMode = .quality
 
     @Option(name: [.customLong("guidance-scale")], help: "Wan classifier-free guidance scale.")
     var guidanceScale: Float = 5
@@ -560,6 +580,7 @@ struct VideoGenerate: AsyncParsableCommand {
                 steps: steps,
                 seed: UInt64(bitPattern: Int64(seed ?? 42)),
                 transformerWeightMode: h3WeightMode.generationMode,
+                accelerationMode: h3Acceleration.generationMode,
                 firstFrameURL: sourceImageURL,
                 lastFrameURL: endImageURL,
                 references: parsedReferences
@@ -1267,6 +1288,9 @@ struct VideoGenerate: AsyncParsableCommand {
             width: width,
             height: height,
             numFrames: numFrames,
+            steps: steps,
+            h3WeightMode: h3WeightMode.rawValue,
+            h3AccelerationMode: h3Acceleration.rawValue,
             duration: duration,
             fps: fps,
             seed: seed,
@@ -1338,6 +1362,12 @@ struct VideoGenerate: AsyncParsableCommand {
         if let legacyVariant {
             args += ["--variant", legacyVariant.rawValue]
         }
+        if isMiniMaxH3Request {
+            args += [
+                "--h3-weight-mode", h3WeightMode.rawValue,
+                "--h3-acceleration", h3Acceleration.rawValue,
+            ]
+        }
         if let duration {
             args += ["--duration", String(duration)]
         }
@@ -1384,6 +1414,20 @@ struct VideoGenerate: AsyncParsableCommand {
             args += ["--timings-output", timingsOutput]
         }
         return args
+    }
+
+    private var isMiniMaxH3Request: Bool {
+        let requested = resolvedRequestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if requested == ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
+            return true
+        }
+        guard let modelRoot else { return false }
+        let resources = MiniMaxH3Resources(
+            rootURL: URL(fileURLWithPath: modelRoot).standardizedFileURL
+        )
+        return resources.validate().isEmpty && (try? resources.loadConfiguration()) != nil
     }
 }
 

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -27,7 +27,7 @@ enum MLXBundleSupport {
 
     static let expectedProvenance = MetallibProvenance(
       coreVersion: "0.32.1",
-      swiftRevision: "009a42f024a04e50bb50bb6ce90d0a3e396c1760",
+      swiftRevision: "79bc410c85df66c3f4246084057bdfd971932ac7",
       kernelSourcesSHA256: "a4a91e902e4a3c196ba45f3c6ee65c769c26b5825ae3b72d8b93ca233db2d93f"
     )
 

--- a/Sources/MereRunCLI/Support/ModelPullPreflight.swift
+++ b/Sources/MereRunCLI/Support/ModelPullPreflight.swift
@@ -260,6 +260,7 @@ struct ModelPullPreflightAnalyzer {
         ))?.usageTermsAcknowledged == true
         let estimatedDownloadBytes = ModelPullDiskPreflight.estimatedDownloadBytes(
             for: spec,
+            modelDir: installPath,
             force: input.force,
             hubCacheURL: hubCache,
             fileManager: fileManager

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -16,6 +16,9 @@ struct VideoGenerationPreflightInput {
     let width: Int
     let height: Int
     let numFrames: Int
+    let steps: Int?
+    let h3WeightMode: String
+    let h3AccelerationMode: String
     let duration: Double?
     let fps: Int
     let seed: Int?
@@ -49,6 +52,9 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
     let width: Int
     let height: Int
     let numFrames: Int
+    let steps: Int?
+    let h3WeightMode: String?
+    let h3AccelerationMode: String?
     let duration: Double?
     let fps: Int
     let seed: Int?
@@ -79,6 +85,9 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
         case width
         case height
         case numFrames = "num_frames"
+        case steps
+        case h3WeightMode = "h3_weight_mode"
+        case h3AccelerationMode = "h3_acceleration"
         case duration
         case fps
         case seed
@@ -194,6 +203,9 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
     let resolvedHeight: Int
     let requestedNumFrames: Int
     let requestedDurationSeconds: Double?
+    let resolvedSteps: Int?
+    let h3WeightMode: String?
+    let h3AccelerationMode: String?
     let fps: Int
     let resolvedNumFrames: Int
     let resolvedDurationSeconds: Double?
@@ -214,6 +226,9 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
         case resolvedHeight = "resolved_height"
         case requestedNumFrames = "requested_num_frames"
         case requestedDurationSeconds = "requested_duration_seconds"
+        case resolvedSteps = "resolved_steps"
+        case h3WeightMode = "h3_weight_mode"
+        case h3AccelerationMode = "h3_acceleration"
         case fps
         case resolvedNumFrames = "resolved_num_frames"
         case resolvedDurationSeconds = "resolved_duration_seconds"
@@ -258,6 +273,7 @@ struct VideoGenerationPreflightAnalyzer {
     private var usesMiniMaxH3Geometry: Bool {
         let requested = input.model.trimmingCharacters(in: .whitespacesAndNewlines)
         if requested == ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
             return true
         }
@@ -315,6 +331,9 @@ struct VideoGenerationPreflightAnalyzer {
             width: input.width,
             height: input.height,
             numFrames: input.numFrames,
+            steps: input.steps,
+            h3WeightMode: usesMiniMaxH3Geometry ? input.h3WeightMode : nil,
+            h3AccelerationMode: usesMiniMaxH3Geometry ? input.h3AccelerationMode : nil,
             duration: input.duration,
             fps: input.fps,
             seed: input.seed,
@@ -1077,6 +1096,21 @@ struct VideoGenerationPreflightAnalyzer {
         let resolvedOutputMode: LTXVideoOutputMode? = usesWanGeometry || usesMiniMaxH3Geometry
             ? nil
             : (usesAudioConditioning || input.variant == .unifiedAV ? .audioVideo : .videoOnly)
+        let h3AccelerationMode = MiniMaxH3AccelerationMode(rawValue: input.h3AccelerationMode) ?? .quality
+        let resolvedH3Steps: Int? = if usesMiniMaxH3Geometry {
+            input.steps ?? (try? MiniMaxH3StepPolicy.recommendedPointCount(
+                width: resolvedWidth,
+                height: resolvedHeight,
+                numFrames: resolvedFrames,
+                keyframeCount: [input.image, input.endImage].compactMap { $0 }.count,
+                referenceKinds: input.references.compactMap { reference in
+                    MiniMaxH3ReferenceKind(rawValue: String(reference.prefix { $0 != ":" }))
+                },
+                accelerationMode: h3AccelerationMode
+            ))
+        } else {
+            nil
+        }
         return VideoGenerationPlanPreflightSummary(
             variant: usesMiniMaxH3Geometry
                 ? "minimax-h3"
@@ -1092,6 +1126,9 @@ struct VideoGenerationPreflightAnalyzer {
             resolvedHeight: resolvedHeight,
             requestedNumFrames: input.numFrames,
             requestedDurationSeconds: input.duration,
+            resolvedSteps: resolvedH3Steps,
+            h3WeightMode: usesMiniMaxH3Geometry ? input.h3WeightMode : nil,
+            h3AccelerationMode: usesMiniMaxH3Geometry ? input.h3AccelerationMode : nil,
             fps: usesMiniMaxH3Geometry ? MiniMaxH3Geometry.framesPerSecond : input.fps,
             resolvedNumFrames: resolvedFrames,
             resolvedDurationSeconds: input.fps > 0

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2445,6 +2445,33 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["video generate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: MiniMaxH3Resources.artifactRepository,
+                revision: MiniMaxH3Resources.artifactRevision,
+                patterns: MiniMaxH3Resources.bf16SupportArtifactFiles
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: MiniMaxH3Resources.bf16TransformerDirectory,
+                    hubFallback: HubFallbackConfig(
+                        repoId: MiniMaxH3Resources.bf16ArtifactRepository,
+                        revision: MiniMaxH3Resources.bf16ArtifactRevision,
+                        patterns: MiniMaxH3Resources.bf16ArtifactFiles
+                    )
+                ),
+            ],
+            upstreamRepoId: MiniMaxH3Resources.bf16ArtifactRepository,
+            upstreamRevision: MiniMaxH3Resources.bf16ArtifactRevision,
+            usageRestriction: miniMaxH3UsageRestriction,
+            validationKind: .miniMaxH3MLX,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 100_279_671_824,
+            defaultCLICommands: ["video generate"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
             category: .video,
             installShape: .structuredRoot,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -857,6 +857,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+                "MiniMax-H3 FL2VA BF16 MLX",
+                "Uses the faithful BF16 H3 transformer for maximum visual quality while reusing the native tokenizer, conditioner, and audio/video decoders.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
                 "MiniMax-H3 Ref2VA MLX",
                 "Runs a locally converted Ref2VA root with ordered image, video, and audio references; no redistributable managed snapshot is bundled.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1920,6 +1920,26 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "\(MiniMaxH3Resources.artifactRepository)@\(MiniMaxH3Resources.artifactRevision)",
                 createdAt: createdAt
             )
+        case .miniMaxH3FL2VABF16MLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .miniMaxH3,
+                family: .video,
+                tier: .latest,
+                variant: .base,
+                precision: .bf16,
+                defaults: Defaults(steps: 31, cfg: 1.0, sigmaShift: 12.0),
+                supports: [.videoGeneration],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: MiniMaxH3Resources.bf16TransformerDirectory),
+                    vae: .local(path: "."),
+                    scheduler: nil
+                ),
+                upstreamRepoId: "\(MiniMaxH3Resources.bf16ArtifactRepository)@\(MiniMaxH3Resources.bf16ArtifactRevision)",
+                createdAt: createdAt
+            )
         case .miniMaxH3Ref2VAMLX:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3AudioVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3AudioVAE.swift
@@ -326,9 +326,11 @@ public final class MiniMaxH3AudioVAE: Module {
         }
         let mappedKey = key
         let plainConvolutionPrefixes = ["encoder.", "mean_proj.", "logs_proj.", "dec_in_proj."]
-        if plainConvolutionPrefixes.contains(where: mappedKey.hasPrefix),
-           mappedKey.hasSuffix(".weight"), value.ndim == 3 {
-            return [(mappedKey, value.transposed(0, 2, 1))]
+        if plainConvolutionPrefixes.contains(where: mappedKey.hasPrefix) {
+            if mappedKey.hasSuffix(".weight"), value.ndim == 3 {
+                return [(mappedKey, value.transposed(0, 2, 1))]
+            }
+            return [(mappedKey, value)]
         }
         if mappedKey.hasPrefix("encoder.") || mappedKey.hasPrefix("pre_block.") {
             return [(mappedKey, value)]

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -139,14 +139,34 @@ enum MiniMaxH3DenoiseExecutionMode: Equatable {
 enum MiniMaxH3DenoiseExecutionPolicy {
     static let blockwiseSequenceThreshold = 13_500
     static let largeSequenceAttentionThreshold = 32_768
+    static let veryLargeSequenceAttentionThreshold = 65_536
 
     static func attentionKernelSchedule(
         sequenceLength: Int
-    ) -> (maximumQueryTokens: Int, maximumKernelsPerEvaluation: Int) {
-        if sequenceLength >= largeSequenceAttentionThreshold {
-            return (maximumQueryTokens: 768, maximumKernelsPerEvaluation: 1)
+    ) -> (
+        maximumQueryTokens: Int,
+        maximumHeadsPerKernel: Int?,
+        maximumKernelsPerEvaluation: Int
+    ) {
+        if sequenceLength >= veryLargeSequenceAttentionThreshold {
+            return (
+                maximumQueryTokens: 640,
+                maximumHeadsPerKernel: 8,
+                maximumKernelsPerEvaluation: 1
+            )
         }
-        return (maximumQueryTokens: 1_024, maximumKernelsPerEvaluation: 4)
+        if sequenceLength >= largeSequenceAttentionThreshold {
+            return (
+                maximumQueryTokens: 768,
+                maximumHeadsPerKernel: nil,
+                maximumKernelsPerEvaluation: 1
+            )
+        }
+        return (
+            maximumQueryTokens: 1_024,
+            maximumHeadsPerKernel: nil,
+            maximumKernelsPerEvaluation: 4
+        )
     }
 
     static func mode(
@@ -568,6 +588,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         )
         transformer.maximumAttentionQueryTokensPerKernel = attentionKernelSchedule
             .maximumQueryTokens
+        transformer.maximumAttentionHeadsPerKernel = attentionKernelSchedule
+            .maximumHeadsPerKernel
         transformer.maximumAttentionKernelsPerEvaluation = attentionKernelSchedule
             .maximumKernelsPerEvaluation
         transformer.usesFusedPostAttention = ProcessInfo.processInfo
@@ -578,6 +600,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             "execution_mode=\(executionMode) acceleration=\(accelerationMode.rawValue) "
                 + "fused_post_attention=\(transformer.usesFusedPostAttention) "
                 + "attention_query_tokens=\(attentionKernelSchedule.maximumQueryTokens) "
+                + "attention_heads_per_kernel="
+                + "\(attentionKernelSchedule.maximumHeadsPerKernel ?? transformer.configuration.attentionHeadCount) "
                 + "attention_evaluation_batch="
                 + "\(attentionKernelSchedule.maximumKernelsPerEvaluation)"
         )

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -52,10 +52,124 @@ public enum MiniMaxH3TransformerWeightMode: String, Sendable, Hashable {
     case residentBF16 = "resident-bf16"
 }
 
+public enum MiniMaxH3AccelerationMode: String, Sendable, Hashable {
+    case quality
+    case balanced
+    case maximum
+
+    var blockReusePolicy: MiniMaxH3BlockReusePolicy? {
+        switch self {
+        case .quality: nil
+        case .balanced:
+            MiniMaxH3BlockReusePolicy(
+                cacheDepth: 0.5,
+                window: 0.1...0.9,
+                maximumConsecutiveCachedSteps: 2
+            )
+        case .maximum:
+            MiniMaxH3BlockReusePolicy(
+                cacheDepth: 0.82,
+                window: 0.1...0.9,
+                maximumConsecutiveCachedSteps: 4
+            )
+        }
+    }
+}
+
+struct MiniMaxH3BlockReusePolicy {
+    static let maximumSigmaDelta: Float = 0.12
+
+    let cacheDepth: Double
+    let window: ClosedRange<Float>
+    let maximumConsecutiveCachedSteps: Int
+
+    init(
+        cacheDepth: Double,
+        window: ClosedRange<Float> = 0.1...0.9,
+        maximumConsecutiveCachedSteps: Int = 2
+    ) {
+        precondition((0..<1).contains(cacheDepth))
+        precondition((0...1).contains(window.lowerBound))
+        precondition((0...1).contains(window.upperBound))
+        precondition(maximumConsecutiveCachedSteps >= 0)
+        self.cacheDepth = cacheDepth
+        self.window = window
+        self.maximumConsecutiveCachedSteps = maximumConsecutiveCachedSteps
+    }
+
+    func warmBlockCount(totalBlockCount: Int) -> Int {
+        precondition(totalBlockCount > 0)
+        let count = Int((Double(totalBlockCount) * (1 - cacheDepth)).rounded())
+        return max(0, min(totalBlockCount - 1, count))
+    }
+
+    func shouldReuseTail(
+        stepIndex: Int,
+        stepCount: Int,
+        videoSigmas: [Float],
+        audioSigmas: [Float],
+        hasCachedResidual: Bool,
+        consecutiveCachedSteps: Int
+    ) -> Bool {
+        guard stepIndex >= 2,
+              stepIndex < stepCount,
+              videoSigmas.count == stepCount + 1,
+              audioSigmas.count == stepCount + 1,
+              hasCachedResidual,
+              consecutiveCachedSteps < maximumConsecutiveCachedSteps else { return false }
+        let position = Float(stepIndex) / Float(stepCount)
+        guard window.contains(position) else { return false }
+        let videoDelta = abs(videoSigmas[stepIndex - 1] - videoSigmas[stepIndex])
+        let audioDelta = abs(audioSigmas[stepIndex - 1] - audioSigmas[stepIndex])
+        return max(videoDelta, audioDelta) < Self.maximumSigmaDelta
+    }
+}
+
+enum MiniMaxH3DenoiseExecutionMode: Equatable {
+    case compiledStep
+    case eagerStep
+    case blockwiseCompiled
+
+    var usesLayerwiseEvaluation: Bool {
+        self == .eagerStep
+    }
+}
+
+enum MiniMaxH3DenoiseExecutionPolicy {
+    static let blockwiseSequenceThreshold = 13_500
+    static let maximumAttentionQueryTokensPerKernel = 1_024
+
+    static func mode(
+        usesResidentBF16: Bool,
+        sequenceLength: Int,
+        usesBlockProfiling: Bool,
+        denoiseStepCount: Int = 2,
+        profilingOverride: String? = nil
+    ) -> MiniMaxH3DenoiseExecutionMode {
+        if !usesBlockProfiling {
+            switch profilingOverride?.lowercased() {
+            case "compiled": return .compiledStep
+            case "eager": return .eagerStep
+            case "blockwise": return .blockwiseCompiled
+            default: break
+            }
+        }
+        if sequenceLength > blockwiseSequenceThreshold {
+            return .blockwiseCompiled
+        }
+        if usesBlockProfiling || (usesResidentBF16 && denoiseStepCount == 1) {
+            return .eagerStep
+        }
+        return .compiledStep
+    }
+
+}
+
 public enum MiniMaxH3StepPolicy {
     public static let practicalPointCount = 9
     public static let extendedPointCount = 16
-    public static let maximumQualityPointCount = 31
+    public static let maximumQualityPointCount = 21
+    public static let maximumSpeedPointCount = 12
     public static let practicalPackedRowLimit = 13_500
     public static let extendedPackedRowLimit = 26_000
 
@@ -64,7 +178,8 @@ public enum MiniMaxH3StepPolicy {
         height: Int,
         numFrames: Int,
         keyframeCount: Int = 0,
-        referenceKinds: [MiniMaxH3ReferenceKind] = []
+        referenceKinds: [MiniMaxH3ReferenceKind] = [],
+        accelerationMode: MiniMaxH3AccelerationMode = .quality
     ) throws -> Int {
         let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: numFrames)
         let rowsPerVideoFrame = (height / 32) * (width / 32)
@@ -82,19 +197,27 @@ public enum MiniMaxH3StepPolicy {
                 estimatedRows += targetAudioRows
             }
         }
+        let geometryPointCount: Int
         if estimatedRows <= practicalPackedRowLimit {
-            return practicalPointCount
+            geometryPointCount = practicalPointCount
+        } else if estimatedRows <= extendedPackedRowLimit {
+            geometryPointCount = extendedPointCount
+        } else {
+            geometryPointCount = maximumQualityPointCount
         }
-        if estimatedRows <= extendedPackedRowLimit {
-            return extendedPointCount
+        switch accelerationMode {
+        case .quality, .balanced:
+            return geometryPointCount
+        case .maximum:
+            return min(geometryPointCount, maximumSpeedPointCount)
         }
-        return maximumQualityPointCount
     }
 }
 
 enum MiniMaxH3ResidentBF16Policy {
     static let gibibyte = UInt64(1_073_741_824)
     static let minimumPackedRows = 2_048
+    static let minimumPortableMemoryBytes = 96 * gibibyte
 
     static func automaticReserveBytes(sequenceLength: Int) -> UInt64 {
         let base = 16 * gibibyte
@@ -115,7 +238,9 @@ enum MiniMaxH3ResidentBF16Policy {
         case .quantized:
             return false
         case .automatic:
-            guard !isPortableMac,
+            let portableMemoryQualified = !isPortableMac
+                || physicalMemoryBytes >= minimumPortableMemoryBytes
+            guard portableMemoryQualified,
                   hasAdaLNCache,
                   estimatedResidentBytes > 0,
                   sequenceLength >= minimumPackedRows else { return false }
@@ -166,6 +291,7 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
     public let steps: Int
     public let seed: UInt64
     public let transformerWeightMode: MiniMaxH3TransformerWeightMode
+    public let accelerationMode: MiniMaxH3AccelerationMode
     public let firstFrameURL: URL?
     public let lastFrameURL: URL?
     public let references: [MiniMaxH3ReferenceInput]
@@ -178,6 +304,7 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         steps: Int? = nil,
         seed: UInt64 = 42,
         transformerWeightMode: MiniMaxH3TransformerWeightMode = .automatic,
+        accelerationMode: MiniMaxH3AccelerationMode = .quality,
         firstFrameURL: URL? = nil,
         lastFrameURL: URL? = nil,
         references: [MiniMaxH3ReferenceInput] = []
@@ -210,7 +337,8 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
             height: height,
             numFrames: numFrames,
             keyframeCount: [firstFrameURL, lastFrameURL].compactMap { $0 }.count,
-            referenceKinds: references.map(\.kind)
+            referenceKinds: references.map(\.kind),
+            accelerationMode: accelerationMode
         )
         guard resolvedSteps >= 2 else {
             throw MiniMaxH3GeneratorError.invalidOptions("steps must be at least 2")
@@ -222,6 +350,7 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         self.steps = resolvedSteps
         self.seed = seed
         self.transformerWeightMode = transformerWeightMode
+        self.accelerationMode = accelerationMode
         self.firstFrameURL = firstFrameURL
         self.lastFrameURL = lastFrameURL
         self.references = references
@@ -274,18 +403,36 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         MLX.clip(decodedFrames * 255, min: 0, max: 255).asType(.uint8)
     }
 
-    private func loadDenoisingTransformer(
+    private func loadDenoisingRuntime(
         resources: MiniMaxH3Resources,
         configuration: MiniMaxH3Configuration,
-        adaLNCache: MiniMaxH3AdaLNCache?,
+        videoSchedule: MiniMaxH3Schedule,
+        audioSchedule: MiniMaxH3Schedule,
         sequenceLength: Int,
         weightMode: MiniMaxH3TransformerWeightMode,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
-    ) throws -> MiniMaxH3Transformer {
+    ) throws -> (transformer: MiniMaxH3Transformer, adaLNCache: MiniMaxH3AdaLNCache?) {
+        let adaLNCache: MiniMaxH3AdaLNCache?
+        let cachedAdaLNForLoading: MiniMaxH3AdaLNCache?
+        if resources.usesShardedBF16Transformer {
+            // The released BF16 artifact retains the schedule-only projections.
+            // Build their exact table for this run instead of interpolating the
+            // compact package's fixed 31-point cache.
+            adaLNCache = nil
+            cachedAdaLNForLoading = nil
+        } else {
+            adaLNCache = try Self.loadAdaLNCache(
+                resources: resources,
+                configuration: configuration,
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule
+            )
+            cachedAdaLNForLoading = adaLNCache
+        }
         let transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
             resources: resources,
             configuration: configuration,
-            cachedAdaLN: adaLNCache,
+            cachedAdaLN: cachedAdaLNForLoading,
             progressHandler: { shard in
                 progressHandler?(.init(
                     stage: .loadingTransformer,
@@ -294,12 +441,24 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 ))
             }
         )
+        let resolvedAdaLNCache: MiniMaxH3AdaLNCache?
+        if resources.usesShardedBF16Transformer {
+            resolvedAdaLNCache = transformer.precomputeAdaLN(
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule,
+                sourceIdentity: try resources.adaLNCacheSourceIdentity()
+            )
+            transformer.discardAdaLNWeights()
+            Memory.clearCache()
+        } else {
+            resolvedAdaLNCache = adaLNCache
+        }
         let shouldMaterialize = try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
             mode: weightMode,
             physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
             estimatedResidentBytes: transformer.estimatedResidentBF16ByteCount,
             sequenceLength: sequenceLength,
-            hasAdaLNCache: adaLNCache != nil,
+            hasAdaLNCache: resolvedAdaLNCache != nil,
             isPortableMac: MiniMaxH3Host.isPortableMac
         )
         if shouldMaterialize {
@@ -310,7 +469,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             ))
             _ = transformer.materializeResidentBF16()
         }
-        return transformer
+        return (transformer, resolvedAdaLNCache)
     }
 
     private func denoise(
@@ -324,15 +483,24 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         videoSchedule: MiniMaxH3Schedule,
         audioSchedule: MiniMaxH3Schedule,
         adaLNCache: MiniMaxH3AdaLNCache?,
+        accelerationMode: MiniMaxH3AccelerationMode,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
     ) -> (videoRows: MLXArray, audioRows: MLXArray) {
         precondition(videoSchedule.timesteps.count == audioSchedule.timesteps.count)
-        let profileLogger = MereRunRuntimeDebug.logger(
+        let blockProfileLogger = MereRunRuntimeDebug.logger(
             keys: ["MERERUN_H3_PROFILE_BLOCKS"],
             prefix: "[minimax-h3-profile]"
         )
-        profileLogger?("rows=\(layout.sequenceLength) blocks=\(transformer.configuration.layerCount)")
-        transformer.blockTimingHandler = profileLogger.map { logger in
+        let stepProfileLogger = MereRunRuntimeDebug.logger(
+            keys: ["MERERUN_H3_PROFILE_STEPS"],
+            prefix: "[minimax-h3-step-profile]"
+        )
+        blockProfileLogger?("rows=\(layout.sequenceLength) blocks=\(transformer.configuration.layerCount)")
+        stepProfileLogger?(
+            "rows=\(layout.sequenceLength) steps=\(videoSchedule.timesteps.count) "
+                + "resident_bf16=\(transformer.usesResidentBF16)"
+        )
+        transformer.blockTimingHandler = blockProfileLogger.map { logger in
             { index, elapsed, memory in
                 logger(String(
                     format: "block=%02d seconds=%.3f active_gib=%.2f cache_gib=%.2f peak_gib=%.2f",
@@ -351,19 +519,56 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         if let conditionVideoRows { MLX.eval(conditionVideoRows) }
         if let conditionAudioRows { MLX.eval(conditionAudioRows) }
 
-        // Quantized projections benefit from a compiled whole-step graph at
-        // practical sequence lengths. Resident bf16 already dispatches dense
-        // GEMMs at the hardware-efficient shapes, while wrapping all 50 blocks
-        // in one compiled call adds substantial graph overhead. Evaluate its
-        // eager block stack once per step, matching the upstream MLX engine and
-        // allowing the allocator to reuse intermediate buffers across blocks.
+        // Practical sequence lengths benefit from a compiled whole-step graph
+        // once its first invocation is amortized. A single-step diagnostic is
+        // faster with resident bf16 when its eager stack synchronizes after
+        // each block; this bounds the lazy graph and keeps the allocator
+        // reusing intermediate buffers without paying compilation overhead.
         // Very large sequences keep independent compiled block boundaries to
         // avoid the macOS watchdog.
-        let requiresBlockwiseExecution = layout.sequenceLength > 16_384
-        let usesCompiledStep = !transformer.usesResidentBF16 && !requiresBlockwiseExecution
-        transformer.usesBlockwiseCompilation = requiresBlockwiseExecution
-        transformer.usesLayerwiseEvaluation = false
+        let blockReusePolicy = accelerationMode.blockReusePolicy.map { policy in
+            let environment = ProcessInfo.processInfo.environment
+            let requestedCacheDepth = Double(environment["MERERUN_H3_REUSE_DEPTH"] ?? "")
+            let cacheDepth = requestedCacheDepth.flatMap {
+                (0..<1).contains($0) ? $0 : nil
+            } ?? policy.cacheDepth
+            let requestedReuseStreak = Int(environment["MERERUN_H3_REUSE_STREAK"] ?? "")
+            let maximumConsecutiveCachedSteps = requestedReuseStreak.flatMap {
+                $0 >= 0 ? $0 : nil
+            } ?? policy.maximumConsecutiveCachedSteps
+            return MiniMaxH3BlockReusePolicy(
+                cacheDepth: cacheDepth,
+                window: policy.window,
+                maximumConsecutiveCachedSteps: maximumConsecutiveCachedSteps
+            )
+        }
+        let executionMode = blockReusePolicy == nil
+            ? MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: transformer.usesResidentBF16,
+                sequenceLength: layout.sequenceLength,
+                usesBlockProfiling: blockProfileLogger != nil,
+                denoiseStepCount: videoSchedule.timesteps.count,
+                profilingOverride: ProcessInfo.processInfo.environment["MERERUN_H3_EXECUTION_MODE"]
+            )
+            : .blockwiseCompiled
+        let usesCompiledStep = executionMode == .compiledStep
+        transformer.usesBlockwiseCompilation = executionMode == .blockwiseCompiled
+        transformer.maximumAttentionQueryTokensPerKernel = MiniMaxH3DenoiseExecutionPolicy
+            .maximumAttentionQueryTokensPerKernel
+        transformer.usesFusedPostAttention = ProcessInfo.processInfo
+            .environment["MERERUN_H3_FUSED_POST_ATTENTION"] == "1"
+        transformer.usesLayerwiseEvaluation = executionMode.usesLayerwiseEvaluation
         transformer.clearsCacheAfterLayerwiseEvaluation = false
+        stepProfileLogger?(
+            "execution_mode=\(executionMode) acceleration=\(accelerationMode.rawValue) "
+                + "fused_post_attention=\(transformer.usesFusedPostAttention)"
+        )
+        if let blockReusePolicy {
+            stepProfileLogger?(
+                "reuse_depth=\(blockReusePolicy.cacheDepth) "
+                    + "reuse_streak=\(blockReusePolicy.maximumConsecutiveCachedSteps)"
+            )
+        }
 
         let compiledStep = MLX.compile { (inputs: [MLXArray]) -> [MLXArray] in
             let videoSample = inputs[0]
@@ -406,7 +611,14 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             ]
         }
 
+        let totalBlockCount = transformer.configuration.layerCount
+        let warmBlockCount = blockReusePolicy?.warmBlockCount(totalBlockCount: totalBlockCount)
+        var cachedTailResidual: MLXArray?
+        var consecutiveCachedSteps = 0
+        var cachedStepCount = 0
+
         for index in videoSchedule.timesteps.indices {
+            let stepStarted = stepProfileLogger.map { _ in CFAbsoluteTimeGetCurrent() }
             progressHandler?(.init(
                 stage: .denoising,
                 stepIndex: index,
@@ -421,6 +633,20 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             ])
             let videoCoefficients = Self.scheduleCoefficients(videoSchedule, index: index)
             let audioCoefficients = Self.scheduleCoefficients(audioSchedule, index: index)
+            let reusesTail = blockReusePolicy?.shouldReuseTail(
+                stepIndex: index,
+                stepCount: videoSchedule.timesteps.count,
+                videoSigmas: videoSchedule.sigmas,
+                audioSigmas: audioSchedule.sigmas,
+                hasCachedResidual: cachedTailResidual != nil,
+                consecutiveCachedSteps: consecutiveCachedSteps
+            ) ?? false
+            if let warmBlockCount {
+                stepProfileLogger?(
+                    "step_plan=\(index + 1)/\(videoSchedule.timesteps.count) "
+                        + "cached_tail=\(reusesTail) blocks=\(reusesTail ? warmBlockCount : totalBlockCount)"
+                )
+            }
             if usesCompiledStep {
                 var inputs = [
                     videoRows,
@@ -444,13 +670,34 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 let audioInput = conditionAudioRows.map {
                     MLX.concatenated([$0, audioRows], axis: 1)
                 } ?? audioRows
-                let predicted = transformer(
-                    videoRows: videoInput,
-                    audioRows: audioInput,
-                    context: context,
-                    timesteps: timestepValues,
-                    cachedAdaLN: adaLNCache?.step(at: index)
-                )
+                let predicted: MiniMaxH3TransformerOutput
+                if let warmBlockCount {
+                    let result = transformer.callWithBlockResidualReuse(
+                        videoRows: videoInput,
+                        audioRows: audioInput,
+                        context: context,
+                        timesteps: timestepValues,
+                        cachedAdaLN: adaLNCache?.step(at: index),
+                        warmBlockCount: warmBlockCount,
+                        cachedTailResidual: reusesTail ? cachedTailResidual : nil
+                    )
+                    predicted = result.output
+                    if let refreshedTailResidual = result.refreshedTailResidual {
+                        cachedTailResidual = refreshedTailResidual
+                        consecutiveCachedSteps = 0
+                    } else {
+                        consecutiveCachedSteps += 1
+                        cachedStepCount += 1
+                    }
+                } else {
+                    predicted = transformer(
+                        videoRows: videoInput,
+                        audioRows: audioInput,
+                        context: context,
+                        timesteps: timestepValues,
+                        cachedAdaLN: adaLNCache?.step(at: index)
+                    )
+                }
                 videoRows = Self.advance(
                     sample: videoRows,
                     velocity: predicted.videoVelocityRows,
@@ -463,6 +710,23 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 )
             }
             MLX.eval(videoRows, audioRows)
+            if let stepStarted, let stepProfileLogger {
+                let memory = Memory.snapshot()
+                stepProfileLogger(String(
+                    format: "step=%02d/%02d seconds=%.3f active_gib=%.2f cache_gib=%.2f peak_gib=%.2f",
+                    index + 1,
+                    videoSchedule.timesteps.count,
+                    CFAbsoluteTimeGetCurrent() - stepStarted,
+                    Double(memory.activeMemory) / 1_073_741_824,
+                    Double(memory.cacheMemory) / 1_073_741_824,
+                    Double(memory.peakMemory) / 1_073_741_824
+                ))
+            }
+        }
+        if warmBlockCount != nil {
+            stepProfileLogger?(
+                "cached_steps=\(cachedStepCount)/\(videoSchedule.timesteps.count)"
+            )
         }
         return (videoRows, audioRows)
     }
@@ -504,8 +768,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 allowScheduleResampling: true
             )
         } catch {
-            let metadata = try resources.transformerMetadata()
-            guard metadata["cache_covered_weights_omitted"] != "true" else {
+            guard try !resources.requiresAdaLNCache() else {
                 throw error
             }
             return nil
@@ -517,6 +780,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         resources: MiniMaxH3Resources,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)? = nil
     ) throws -> MiniMaxH3GenerationResult {
+        let phaseProfileLogger = MereRunRuntimeDebug.logger(
+            keys: ["MERERUN_H3_PROFILE_PHASES"],
+            prefix: "[minimax-h3-phase-profile]"
+        )
+        let generationStarted = CFAbsoluteTimeGetCurrent()
         let missing = resources.validate()
         guard missing.isEmpty else { throw MiniMaxH3GeneratorError.missingModelFiles(missing) }
         let configuration = try resources.loadConfiguration()
@@ -537,6 +805,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let audioFrames = MiniMaxH3Geometry.audioLatentFrameCount(for: options.numFrames)
 
         progressHandler?(.init(stage: .loadingTextEncoder, stepIndex: 0, totalSteps: options.steps - 1))
+        let conditionerPreparationStarted = CFAbsoluteTimeGetCurrent()
         let tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: 262_144)
         let presentation = try conditionerPresentation(tokenizer: tokenizer, options: options)
         guard !presentation.tokenIDs.isEmpty else {
@@ -547,7 +816,12 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         }
         let inputIDs = MLXArray(presentation.tokenIDs.map(Int32.init)).reshaped(1, presentation.tokenIDs.count)
         let attentionMask = MLXArray.ones([1, presentation.tokenIDs.count], dtype: .int32)
+        phaseProfileLogger?(String(
+            format: "phase=conditioner_preparation seconds=%.3f",
+            CFAbsoluteTimeGetCurrent() - conditionerPreparationStarted
+        ))
         let promptStates: MLXArray = try withMiniMaxH3AutoreleasePool {
+            let conditionerLoadStarted = CFAbsoluteTimeGetCurrent()
             let encoder = try MiniMaxH3ModelLoader.loadConditioner(
                 resources: resources,
                 configuration: configuration,
@@ -559,7 +833,12 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                     ))
                 }
             )
+            phaseProfileLogger?(String(
+                format: "phase=conditioner_load seconds=%.3f",
+                CFAbsoluteTimeGetCurrent() - conditionerLoadStarted
+            ))
             progressHandler?(.init(stage: .encodingText, stepIndex: 0, totalSteps: options.steps - 1))
+            let textEncodingStarted = CFAbsoluteTimeGetCurrent()
             guard let states = try encoder.forwardMultimodalActivationHiddenState(
                 inputIds: inputIDs,
                 attentionMask: attentionMask,
@@ -569,6 +848,10 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 throw MiniMaxH3GeneratorError.invalidOptions("text encoder did not return layer-50 states")
             }
             MLX.eval(states)
+            phaseProfileLogger?(String(
+                format: "phase=text_encoding seconds=%.3f",
+                CFAbsoluteTimeGetCurrent() - textEncodingStarted
+            ))
             return states
         }
         Memory.clearCache()
@@ -577,12 +860,17 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let keyframeAnchors: [MiniMaxH3KeyframeAnchor] = options.lastFrameURL == nil
             ? (options.firstFrameURL == nil ? [] : [.first])
             : [.first, .last]
+        let keyframeEncodingStarted = CFAbsoluteTimeGetCurrent()
         var conditionRows = try encodeKeyframes(
             keyframeURLs,
             options: options,
             resources: resources,
             progressHandler: progressHandler
         )
+        phaseProfileLogger?(String(
+            format: "phase=keyframe_encoding seconds=%.3f",
+            CFAbsoluteTimeGetCurrent() - keyframeEncodingStarted
+        ))
         Memory.clearCache()
 
         let layout = try MiniMaxH3Geometry.buildFL2VA(
@@ -612,22 +900,24 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
 
         progressHandler?(.init(stage: .loadingTransformer, stepIndex: 0, totalSteps: options.steps - 1))
         try withMiniMaxH3AutoreleasePool {
-            let adaLNCache = try Self.loadAdaLNCache(
+            let transformerPreparationStarted = CFAbsoluteTimeGetCurrent()
+            let runtime = try loadDenoisingRuntime(
                 resources: resources,
                 configuration: configuration,
                 videoSchedule: videoSchedule,
-                audioSchedule: audioSchedule
-            )
-            let transformer = try loadDenoisingTransformer(
-                resources: resources,
-                configuration: configuration,
-                adaLNCache: adaLNCache,
+                audioSchedule: audioSchedule,
                 sequenceLength: layout.sequenceLength,
                 weightMode: options.transformerWeightMode,
                 progressHandler: progressHandler
             )
+            phaseProfileLogger?(String(
+                format: "phase=transformer_preparation seconds=%.3f resident_bf16=%@",
+                CFAbsoluteTimeGetCurrent() - transformerPreparationStarted,
+                runtime.transformer.usesResidentBF16 ? "true" : "false"
+            ))
+            let denoisingStarted = CFAbsoluteTimeGetCurrent()
             (videoRows, audioRows) = denoise(
-                transformer: transformer,
+                transformer: runtime.transformer,
                 videoRows: videoRows,
                 audioRows: audioRows,
                 conditionVideoRows: conditionRows,
@@ -636,9 +926,14 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 layout: layout,
                 videoSchedule: videoSchedule,
                 audioSchedule: audioSchedule,
-                adaLNCache: adaLNCache,
+                adaLNCache: runtime.adaLNCache,
+                accelerationMode: options.accelerationMode,
                 progressHandler: progressHandler
             )
+            phaseProfileLogger?(String(
+                format: "phase=denoising seconds=%.3f",
+                CFAbsoluteTimeGetCurrent() - denoisingStarted
+            ))
         }
         Memory.clearCache()
         video = MiniMaxH3Geometry.unpatchifyVideo(
@@ -649,21 +944,35 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         )
         let audio = MiniMaxH3Geometry.unpackAudio(audioRows[0])
         progressHandler?(.init(stage: .decodingVideo, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
+        let videoDecodingStarted = CFAbsoluteTimeGetCurrent()
         let frames: MLXArray = try withMiniMaxH3AutoreleasePool {
             let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
             let pixels = Self.mediaFrames(from: vae.decode(video))
             MLX.eval(pixels)
             return pixels
         }
+        phaseProfileLogger?(String(
+            format: "phase=video_decoding seconds=%.3f",
+            CFAbsoluteTimeGetCurrent() - videoDecodingStarted
+        ))
         Memory.clearCache()
         progressHandler?(.init(stage: .decodingAudio, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
+        let audioDecodingStarted = CFAbsoluteTimeGetCurrent()
         let waveform: MLXArray = try withMiniMaxH3AutoreleasePool {
             let vae = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources)
             let decoded = vae.decode(audio)
             MLX.eval(decoded)
             return decoded
         }
+        phaseProfileLogger?(String(
+            format: "phase=audio_decoding seconds=%.3f",
+            CFAbsoluteTimeGetCurrent() - audioDecodingStarted
+        ))
         Memory.clearCache()
+        phaseProfileLogger?(String(
+            format: "phase=generation_total seconds=%.3f",
+            CFAbsoluteTimeGetCurrent() - generationStarted
+        ))
         return MiniMaxH3GenerationResult(frames: frames, audio: waveform, seed: options.seed)
     }
 
@@ -788,22 +1097,17 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
 
         progressHandler?(.init(stage: .loadingTransformer, stepIndex: 0, totalSteps: options.steps - 1))
         try withMiniMaxH3AutoreleasePool {
-            let adaLNCache = try Self.loadAdaLNCache(
+            let runtime = try loadDenoisingRuntime(
                 resources: resources,
                 configuration: configuration,
                 videoSchedule: videoSchedule,
-                audioSchedule: audioSchedule
-            )
-            let transformer = try loadDenoisingTransformer(
-                resources: resources,
-                configuration: configuration,
-                adaLNCache: adaLNCache,
+                audioSchedule: audioSchedule,
                 sequenceLength: layout.sequenceLength,
                 weightMode: options.transformerWeightMode,
                 progressHandler: progressHandler
             )
             (videoRows, audioRows) = denoise(
-                transformer: transformer,
+                transformer: runtime.transformer,
                 videoRows: videoRows,
                 audioRows: audioRows,
                 conditionVideoRows: noisedVideoConditions,
@@ -812,7 +1116,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 layout: layout,
                 videoSchedule: videoSchedule,
                 audioSchedule: audioSchedule,
-                adaLNCache: adaLNCache,
+                adaLNCache: runtime.adaLNCache,
+                accelerationMode: options.accelerationMode,
                 progressHandler: progressHandler
             )
         }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -123,6 +123,7 @@ struct MiniMaxH3BlockReusePolicy {
         let audioDelta = abs(audioSigmas[stepIndex - 1] - audioSigmas[stepIndex])
         return max(videoDelta, audioDelta) < Self.maximumSigmaDelta
     }
+
 }
 
 enum MiniMaxH3DenoiseExecutionMode: Equatable {
@@ -137,7 +138,16 @@ enum MiniMaxH3DenoiseExecutionMode: Equatable {
 
 enum MiniMaxH3DenoiseExecutionPolicy {
     static let blockwiseSequenceThreshold = 13_500
-    static let maximumAttentionQueryTokensPerKernel = 1_024
+    static let largeSequenceAttentionThreshold = 32_768
+
+    static func attentionKernelSchedule(
+        sequenceLength: Int
+    ) -> (maximumQueryTokens: Int, maximumKernelsPerEvaluation: Int) {
+        if sequenceLength >= largeSequenceAttentionThreshold {
+            return (maximumQueryTokens: 768, maximumKernelsPerEvaluation: 1)
+        }
+        return (maximumQueryTokens: 1_024, maximumKernelsPerEvaluation: 4)
+    }
 
     static func mode(
         usesResidentBF16: Bool,
@@ -553,15 +563,23 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             : .blockwiseCompiled
         let usesCompiledStep = executionMode == .compiledStep
         transformer.usesBlockwiseCompilation = executionMode == .blockwiseCompiled
-        transformer.maximumAttentionQueryTokensPerKernel = MiniMaxH3DenoiseExecutionPolicy
-            .maximumAttentionQueryTokensPerKernel
+        let attentionKernelSchedule = MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(
+            sequenceLength: layout.sequenceLength
+        )
+        transformer.maximumAttentionQueryTokensPerKernel = attentionKernelSchedule
+            .maximumQueryTokens
+        transformer.maximumAttentionKernelsPerEvaluation = attentionKernelSchedule
+            .maximumKernelsPerEvaluation
         transformer.usesFusedPostAttention = ProcessInfo.processInfo
             .environment["MERERUN_H3_FUSED_POST_ATTENTION"] == "1"
         transformer.usesLayerwiseEvaluation = executionMode.usesLayerwiseEvaluation
         transformer.clearsCacheAfterLayerwiseEvaluation = false
         stepProfileLogger?(
             "execution_mode=\(executionMode) acceleration=\(accelerationMode.rawValue) "
-                + "fused_post_attention=\(transformer.usesFusedPostAttention)"
+                + "fused_post_attention=\(transformer.usesFusedPostAttention) "
+                + "attention_query_tokens=\(attentionKernelSchedule.maximumQueryTokens) "
+                + "attention_evaluation_batch="
+                + "\(attentionKernelSchedule.maximumKernelsPerEvaluation)"
         )
         if let blockReusePolicy {
             stepProfileLogger?(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3ModelLoader.swift
@@ -37,33 +37,58 @@ public enum MiniMaxH3ModelLoader {
             configuration: .init(configuration),
             includeAdaLN: cachedAdaLN == nil
         )
-        let (loadedWeights, metadata) = try MLX.loadArraysAndMetadata(
-            url: resources.transformerWeightsURL
-        )
-        if metadata["cache_covered_weights_omitted"] == "true", cachedAdaLN == nil {
-            throw MiniMaxH3ModelLoaderError.adaLNCacheRequired
+        guard let layout = resources.transformerWeightsLayout() else {
+            throw HFSafetensorsWeightsLoader.LoaderError.shardFileMissing(
+                resources.transformerWeightsURL
+            )
         }
-        var weights = loadedWeights
-        if cachedAdaLN != nil {
-            weights = weights.filter { key, _ in
-                !key.contains(".adaln_proj.") && !key.hasPrefix("time_embedder.")
+        switch layout {
+        case .shardedBF16(let indexURL):
+            try HFSafetensorsWeightsLoader.applyShardedWeights(
+                indexURL: indexURL,
+                to: transformer,
+                dtype: nil,
+                verify: [.shapeMismatch],
+                mapper: { key, value in
+                    releasedBF16TransformerWeight(
+                        key: key,
+                        value: value,
+                        omitCachedAdaLNWeights: cachedAdaLN != nil,
+                        headCount: configuration.attentionHeadCount,
+                        headDimension: configuration.attentionHeadDimension
+                    )
+                },
+                progressHandler: progressHandler
+            )
+        case .single(let weightsURL):
+            let (loadedWeights, metadata) = try MLX.loadArraysAndMetadata(url: weightsURL)
+            if metadata["cache_covered_weights_omitted"] == "true", cachedAdaLN == nil {
+                throw MiniMaxH3ModelLoaderError.adaLNCacheRequired
+            }
+            var weights = loadedWeights
+            if cachedAdaLN != nil {
+                weights = weights.filter { key, _ in
+                    !key.contains(".adaln_proj.") && !key.hasPrefix("time_embedder.")
+                }
+            }
+            if let quantization = configuration.quantization {
+                try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                    weights,
+                    to: transformer,
+                    groupSize: quantization.groupSize,
+                    bits: quantization.bits
+                )
+            } else {
+                try transformer.update(
+                    parameters: ModuleParameters.unflattened(weights.map { ($0.key, $0.value) }),
+                    verify: [.shapeMismatch]
+                )
             }
         }
-        if let quantization = configuration.quantization {
-            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
-                weights,
-                to: transformer,
-                groupSize: quantization.groupSize,
-                bits: quantization.bits
-            )
-        } else {
-            try transformer.update(
-                parameters: ModuleParameters.unflattened(weights.map { ($0.key, $0.value) }),
-                verify: [.shapeMismatch]
-            )
-        }
         #if os(Linux)
-        if configuration.quantization != nil, Device.defaultDevice().deviceType == .gpu {
+        if configuration.quantization != nil,
+           !resources.usesShardedBF16Transformer,
+           Device.defaultDevice().deviceType == .gpu {
             for (_, module) in transformer.leafModules().flattened() {
                 (module as? PortableQuantizedLinear)?.cacheDenseFallbackWeight = false
             }
@@ -71,6 +96,30 @@ public enum MiniMaxH3ModelLoader {
         }
         #endif
         return transformer
+    }
+
+    static func releasedBF16TransformerWeight(
+        key: String,
+        value: MLXArray,
+        omitCachedAdaLNWeights: Bool,
+        headCount: Int = 56,
+        headDimension: Int = 128
+    ) -> [(String, MLXArray)] {
+        if omitCachedAdaLNWeights,
+           (key.contains(".adaln_proj.") || key.hasPrefix("time_embedder.")) {
+            return []
+        }
+        guard key.hasSuffix(".attn.qkv_proj.weight") else {
+            return [(key, value)]
+        }
+        let expectedRows = headCount * 3 * headDimension
+        precondition(value.ndim == 2 && value.dim(0) == expectedRows)
+        let trailingShape = Array(value.shape.dropFirst())
+        let grouped = value.reshaped([headCount, 3, headDimension] + trailingShape)
+        let pieces = MLX.split(grouped, parts: 3, axis: 1).map {
+            $0.squeezed(axis: 1).reshaped([headCount * headDimension] + trailingShape)
+        }
+        return [(key, MLX.concatenated(pieces, axis: 0))]
     }
 
     public static func loadConditioner(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
@@ -147,6 +147,11 @@ public struct MiniMaxH3Configuration: Decodable, Hashable, Sendable {
 }
 
 public struct MiniMaxH3Resources: Sendable {
+    public enum TransformerWeightsLayout: Sendable, Hashable {
+        case single(URL)
+        case shardedBF16(indexURL: URL)
+    }
+
     private struct SafetensorsHeader: Decodable {
         let metadata: [String: String]?
 
@@ -156,11 +161,18 @@ public struct MiniMaxH3Resources: Sendable {
     }
 
     public static let fl2vaModelID = "video-minimax-h3-fl2va-mlx"
+    public static let fl2vaBF16ModelID = "video-minimax-h3-fl2va-bf16-mlx"
     public static let ref2vaModelID = "video-minimax-h3-ref2va-mlx"
     public static let sourceRepository = "MiniMaxAI/MiniMax-H3"
     public static let sourceRevision = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
     public static let artifactRepository = "Sawfwair/MiniMax-H3-FL2VA-MLX-4bit"
     public static let artifactRevision = "e1244ad93d60c737c7e0f065a1c9372f3de7caf8"
+    public static let bf16ArtifactRepository = "pipenetwork/MiniMax-H3-MLX-bf16"
+    public static let bf16ArtifactRevision = "1486555759eed9e3037edf29f9e055a0713bab2f"
+    public static let bf16TransformerDirectory = "transformer-bf16"
+    public static let officialTransformerSourceIdentity =
+        "MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027:"
+        + "FL2VA/transformer:index-sha256:fb457a26ffa6294660e249b0ddd03a337f2e5393f770b5c34c8b8f90a29a7efb"
     public static let conversionSourceRepository = "Comfy-Org/MiniMax-H3"
     public static let conversionSourceRevision = "fd70b39279d1ae6eb214c903f53e1bec3af19a77"
     public static let ref2vaSourceSHA256 = "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9"
@@ -184,6 +196,19 @@ public struct MiniMaxH3Resources: Sendable {
         "transformer.conversion.json",
         "SHA256SUMS",
     ]
+    public static let bf16SupportArtifactFiles = compactArtifactFiles.filter {
+        $0 != "transformer.safetensors" && $0 != MiniMaxH3AdaLNCache.filename
+    }
+    public static let bf16ArtifactFiles = [
+        "README.md",
+        "LICENSE",
+        "config.json",
+        "model.safetensors.index.json",
+        "model-*.safetensors",
+    ]
+    public static let bf16ShardFilenames = (1...13).map {
+        String(format: "model-%05d-of-00013.safetensors", $0)
+    }
 
     public let rootURL: URL
 
@@ -193,13 +218,37 @@ public struct MiniMaxH3Resources: Sendable {
 
     public var configURL: URL { rootURL.appending(path: "config.json") }
     public var transformerWeightsURL: URL { rootURL.appending(path: "transformer.safetensors") }
+    public var bf16TransformerRootURL: URL {
+        rootURL.appending(path: Self.bf16TransformerDirectory, directoryHint: .isDirectory)
+    }
+    public var bf16TransformerIndexURL: URL {
+        bf16TransformerRootURL.appending(path: "model.safetensors.index.json")
+    }
     public var textEncoderWeightsURL: URL { rootURL.appending(path: "text_encoder.safetensors") }
     public var tokenizerURL: URL { rootURL }
     public var videoVAEWeightsURL: URL { rootURL.appending(path: "video_vae.safetensors") }
     public var audioVAEWeightsURL: URL { rootURL.appending(path: "audio_vae.safetensors") }
     public var adaLNCacheURL: URL { rootURL.appending(path: MiniMaxH3AdaLNCache.filename) }
 
+    public func transformerWeightsLayout(fileManager: FileManager = .default) -> TransformerWeightsLayout? {
+        if fileManager.fileExists(atPath: bf16TransformerIndexURL.path) {
+            return .shardedBF16(indexURL: bf16TransformerIndexURL)
+        }
+        if fileManager.fileExists(atPath: transformerWeightsURL.path) {
+            return .single(transformerWeightsURL)
+        }
+        return nil
+    }
+
+    public var usesShardedBF16Transformer: Bool {
+        if case .shardedBF16 = transformerWeightsLayout() { return true }
+        return false
+    }
+
     func adaLNCacheSourceIdentity() throws -> String {
+        if usesShardedBF16Transformer {
+            return Self.officialTransformerSourceIdentity
+        }
         if let inheritedIdentity = try transformerMetadata()["adaln_cache_source_identity"] {
             return inheritedIdentity
         }
@@ -215,6 +264,7 @@ public struct MiniMaxH3Resources: Sendable {
     }
 
     func transformerMetadata() throws -> [String: String] {
+        guard !usesShardedBF16Transformer else { return [:] }
         let handle = try FileHandle(forReadingFrom: transformerWeightsURL)
         defer { try? handle.close() }
         guard let lengthData = try handle.read(upToCount: MemoryLayout<UInt64>.size),
@@ -252,13 +302,26 @@ public struct MiniMaxH3Resources: Sendable {
     }
 
     func requiresAdaLNCache() throws -> Bool {
-        try transformerMetadata()["cache_covered_weights_omitted"] == "true"
+        if usesShardedBF16Transformer { return false }
+        return try transformerMetadata()["cache_covered_weights_omitted"] == "true"
     }
 
     public func validate(fileManager: FileManager = .default) -> [URL] {
-        Self.requiredFiles
+        var missing = Self.requiredFiles
+            .filter { $0 != "transformer.safetensors" }
             .map { rootURL.appending(path: $0) }
             .filter { !fileManager.fileExists(atPath: $0.path) }
+        switch transformerWeightsLayout(fileManager: fileManager) {
+        case .single:
+            break
+        case .shardedBF16:
+            missing += Self.bf16ShardFilenames
+                .map { bf16TransformerRootURL.appending(path: $0) }
+                .filter { !fileManager.fileExists(atPath: $0.path) }
+        case nil:
+            missing.append(transformerWeightsURL)
+        }
+        return missing
     }
 
     public func loadConfiguration() throws -> MiniMaxH3Configuration {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -768,10 +768,18 @@ final class MiniMaxH3BlockScheduleBenchmark {
         )
     }
 
-    func callAsFunction(schedule: Schedule) -> MLXArray {
+    func callAsFunction(
+        schedule: Schedule,
+        maximumQueryTokens: Int? = nil,
+        maximumKernelsPerEvaluation: Int? = nil
+    ) -> MLXArray {
         let projectedAttention = projectAttention()
         MLX.eval(projectedAttention)
-        let attended = attend(projectedAttention)
+        let attended = attend(
+            projectedAttention,
+            maximumQueryTokens: maximumQueryTokens,
+            maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
+        )
         return postAttention(
             schedule: schedule,
             attended: attended,
@@ -790,13 +798,18 @@ final class MiniMaxH3BlockScheduleBenchmark {
         ])
     }
 
-    func attend(_ projectedAttention: [MLXArray]) -> MLXArray {
+    func attend(
+        _ projectedAttention: [MLXArray],
+        maximumQueryTokens: Int? = nil,
+        maximumKernelsPerEvaluation: Int? = nil
+    ) -> MLXArray {
         block.scaledDotProductAttention(
             queries: projectedAttention[0],
             keys: projectedAttention[1],
             values: projectedAttention[2],
-            maximumQueryTokens: maximumQueryTokens,
+            maximumQueryTokens: maximumQueryTokens ?? self.maximumQueryTokens,
             maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
+                ?? self.maximumKernelsPerEvaluation
         )
     }
 

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -2,6 +2,9 @@ import Foundation
 import MLX
 import MLXFast
 import MLXNN
+#if DEBUG
+import MLXRandom
+#endif
 
 @inline(__always)
 private func miniMaxH3Linear(_ linear: Linear, _ value: MLXArray) -> MLXArray {
@@ -106,6 +109,11 @@ public struct MiniMaxH3TransformerConfiguration: Hashable, Sendable {
 public struct MiniMaxH3TransformerOutput {
     public let videoVelocityRows: MLXArray
     public let audioVelocityRows: MLXArray
+}
+
+struct MiniMaxH3BlockReuseResult {
+    let output: MiniMaxH3TransformerOutput
+    let refreshedTailResidual: MLXArray?
 }
 
 private final class MiniMaxH3Attention: Module {
@@ -315,6 +323,10 @@ private final class MiniMaxH3AdaLNProjection: Module {
         )
     }
 
+    convenience init(discarded: Void) {
+        self.init(inputDimension: 1, hiddenSize: 1, partCount: 1, modalityCount: 1)
+    }
+
     func callAsFunction(_ timeEmbedding: MLXArray) -> [MLXArray] {
         let projected = miniMaxH3Linear(linear, MLXNN.silu(timeEmbedding))
             .reshaped(timeEmbedding.dim(0) * modalityCount, partCount * hiddenSize)
@@ -343,6 +355,11 @@ private final class MiniMaxH3TimeEmbedding: Module {
         )
     }
 
+    init(discarded: Void) {
+        self._input.wrappedValue = Linear(1, 1, bias: false)
+        self._output.wrappedValue = Linear(1, 1, bias: false)
+    }
+
     func callAsFunction(_ value: MLXArray) -> MLXArray {
         miniMaxH3Linear(output, MLXNN.silu(miniMaxH3Linear(input, value)))
     }
@@ -354,8 +371,10 @@ private final class MiniMaxH3TransformerBlock: Module {
     @ModuleInfo(key: "norm2") var feedForwardNorm: RMSNorm
     @ModuleInfo(key: "mlp") var feedForward: MiniMaxH3FeedForward
     @ModuleInfo(key: "adaln_proj") var adaLN: MiniMaxH3AdaLNProjection?
+    private var adaLNWeightsAvailable: Bool
 
     init(configuration: MiniMaxH3TransformerConfiguration, includeAdaLN: Bool) {
+        self.adaLNWeightsAvailable = includeAdaLN
         self._attentionNorm.wrappedValue = RMSNorm(
             dimensions: configuration.hiddenSize,
             eps: configuration.normEpsilon
@@ -377,7 +396,15 @@ private final class MiniMaxH3TransformerBlock: Module {
     }
 
     var includesAdaLN: Bool {
-        adaLN != nil
+        adaLNWeightsAvailable
+    }
+
+    func discardAdaLNWeights() {
+        guard adaLNWeightsAvailable else { return }
+        update(modules: ModuleChildren.unflattened([
+            ("adaln_proj", MiniMaxH3AdaLNProjection(discarded: ())),
+        ]))
+        adaLNWeightsAvailable = false
     }
 
     func callAsFunction(
@@ -517,7 +544,9 @@ private final class MiniMaxH3TransformerBlock: Module {
     }
 
     func precomputeModulation(timeEmbedding: MLXArray) -> MLXArray {
-        guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN weights are not loaded") }
+        guard adaLNWeightsAvailable, let adaLN else {
+            preconditionFailure("MiniMax-H3 AdaLN weights are not loaded")
+        }
         return adaLN.concatenated(timeEmbedding)
     }
 }
@@ -551,6 +580,13 @@ private final class MiniMaxH3FinalLayer: Module {
             configuration.audioLatentChannels,
             bias: true
         )
+    }
+
+    func discardAdaLNWeights() {
+        guard adaLN != nil else { return }
+        update(modules: ModuleChildren.unflattened([
+            ("adaln_proj", MiniMaxH3AdaLNProjection(discarded: ())),
+        ]))
     }
 
     func callAsFunction(
@@ -609,7 +645,199 @@ private struct MiniMaxH3CompiledBlockForwards {
     let attentionOutput: MiniMaxH3CompiledBlockForward
     let feedForwardProjection: MiniMaxH3CompiledBlockForward
     let feedForwardOutput: MiniMaxH3CompiledBlockForward
+    let postAttention: MiniMaxH3CompiledBlockForward
 }
+
+#if DEBUG
+/// Test-only harness for timing the exact production H3 block schedules at
+/// realistic packed-row counts without loading the complete checkpoint.
+final class MiniMaxH3BlockScheduleBenchmark {
+    enum Schedule {
+        case splitPostAttention
+        case fusedPostAttention
+    }
+
+    let rowCount: Int
+    private let maximumQueryTokens: Int
+    private let maximumKernelsPerEvaluation: Int
+    private let block: MiniMaxH3TransformerBlock
+    private let forwards: MiniMaxH3CompiledBlockForwards
+    private let hidden: MLXArray
+    private let timeEmbedding: MLXArray
+    private let adaLNIndices: MLXArray
+    private let rope: MiniMaxH3RotaryEmbedding
+    private let cachedModulation: MLXArray
+
+    init(
+        rowCount: Int,
+        maximumQueryTokens: Int,
+        maximumKernelsPerEvaluation: Int
+    ) {
+        precondition(rowCount > 0)
+        precondition(maximumQueryTokens > 0)
+        precondition(maximumKernelsPerEvaluation > 0)
+        self.rowCount = rowCount
+        self.maximumQueryTokens = maximumQueryTokens
+        self.maximumKernelsPerEvaluation = maximumKernelsPerEvaluation
+
+        let configuration = MiniMaxH3TransformerConfiguration()
+        let block = MiniMaxH3TransformerBlock(configuration: configuration, includeAdaLN: false)
+        block.update(parameters: block.parameters().mapValues { $0.asType(.bfloat16) })
+        MLX.eval(block.parameters())
+        self.block = block
+
+        let attentionProjection = MLX.compile(inputs: [block]) { inputs in
+            block.attentionProjection(
+                inputs[0],
+                timeEmbedding: inputs[1],
+                adaLNIndices: inputs[2],
+                rope: MiniMaxH3RotaryEmbedding(cosine: inputs[3], sine: inputs[4]),
+                cachedModulation: inputs[5]
+            )
+        }
+        let attentionOutput = MLX.compile(inputs: [block]) { inputs in
+            [block.attentionProjectionResidual(
+                inputs[0],
+                attended: inputs[1],
+                gate: inputs[2]
+            )]
+        }
+        let feedForwardProjection = MLX.compile(inputs: [block]) { inputs in
+            block.feedForwardProjection(
+                inputs[0],
+                timeEmbedding: inputs[1],
+                adaLNIndices: inputs[2],
+                cachedModulation: inputs[3]
+            )
+        }
+        let feedForwardOutput = MLX.compile(inputs: [block]) { inputs in
+            [block.feedForwardProjectionResidual(
+                inputs[0],
+                projected: inputs[1],
+                gate: inputs[2]
+            )]
+        }
+        let postAttention = MLX.compile(inputs: [block]) { inputs in
+            let attended = block.attentionProjectionResidual(
+                inputs[0],
+                attended: inputs[1],
+                gate: inputs[2]
+            )
+            return [block.feedForwardResidual(
+                attended,
+                timeEmbedding: inputs[3],
+                adaLNIndices: inputs[4],
+                cachedModulation: inputs[5]
+            )]
+        }
+        self.forwards = MiniMaxH3CompiledBlockForwards(
+            attentionProjection: attentionProjection,
+            attentionOutput: attentionOutput,
+            feedForwardProjection: feedForwardProjection,
+            feedForwardOutput: feedForwardOutput,
+            postAttention: postAttention
+        )
+
+        self.hidden = MLXRandom.normal([1, rowCount, configuration.hiddenSize])
+            .asType(.bfloat16)
+        self.timeEmbedding = MLXArray.zeros(
+            [3, configuration.timeEmbeddingDimension],
+            dtype: .bfloat16
+        )
+        self.adaLNIndices = MLXArray((0..<rowCount).map { Int32($0 % 9) })
+        self.rope = MiniMaxH3RotaryEmbedding(
+            cosine: MLXArray.ones(
+                [1, rowCount, 1, 6 * configuration.ropeFrequencyCount],
+                dtype: .bfloat16
+            ),
+            sine: MLXArray.zeros(
+                [1, rowCount, 1, 6 * configuration.ropeFrequencyCount],
+                dtype: .bfloat16
+            )
+        )
+        self.cachedModulation = (
+            MLXRandom.normal([9, 6 * configuration.hiddenSize]) * Float(0.1)
+        ).asType(.bfloat16)
+        MLX.eval(
+            hidden,
+            timeEmbedding,
+            adaLNIndices,
+            rope.cosine,
+            rope.sine,
+            cachedModulation
+        )
+    }
+
+    func callAsFunction(schedule: Schedule) -> MLXArray {
+        let projectedAttention = projectAttention()
+        MLX.eval(projectedAttention)
+        let attended = attend(projectedAttention)
+        return postAttention(
+            schedule: schedule,
+            attended: attended,
+            gate: projectedAttention[3]
+        )
+    }
+
+    func projectAttention() -> [MLXArray] {
+        forwards.attentionProjection([
+            hidden,
+            timeEmbedding,
+            adaLNIndices,
+            rope.cosine,
+            rope.sine,
+            cachedModulation,
+        ])
+    }
+
+    func attend(_ projectedAttention: [MLXArray]) -> MLXArray {
+        block.scaledDotProductAttention(
+            queries: projectedAttention[0],
+            keys: projectedAttention[1],
+            values: projectedAttention[2],
+            maximumQueryTokens: maximumQueryTokens,
+            maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
+        )
+    }
+
+    func postAttention(schedule: Schedule, attended: MLXArray, gate: MLXArray) -> MLXArray {
+        switch schedule {
+        case .splitPostAttention:
+            let attentionOutput = forwards.attentionOutput([
+                hidden,
+                attended,
+                gate,
+            ])[0]
+            MLX.eval(attentionOutput)
+            let projectedFeedForward = forwards.feedForwardProjection([
+                attentionOutput,
+                timeEmbedding,
+                adaLNIndices,
+                cachedModulation,
+            ])
+            MLX.eval(projectedFeedForward)
+            let output = forwards.feedForwardOutput([
+                attentionOutput,
+                projectedFeedForward[0],
+                projectedFeedForward[1],
+            ])[0]
+            MLX.eval(output)
+            return output
+        case .fusedPostAttention:
+            let output = forwards.postAttention([
+                hidden,
+                attended,
+                gate,
+                timeEmbedding,
+                adaLNIndices,
+                cachedModulation,
+            ])[0]
+            MLX.eval(output)
+            return output
+        }
+    }
+}
+#endif
 
 struct MiniMaxH3ResidentBF16Materialization: Sendable, Equatable {
     let linearCount: Int
@@ -683,8 +911,9 @@ public final class MiniMaxH3Transformer: Module {
     var usesLayerwiseEvaluation = false
     var clearsCacheAfterLayerwiseEvaluation = true
     var usesBlockwiseCompilation = false
+    var usesFusedPostAttention = true
     private(set) var usesResidentBF16 = false
-    var maximumAttentionQueryTokensPerKernel = 2_048
+    var maximumAttentionQueryTokensPerKernel = 1_024
     var maximumAttentionKernelsPerEvaluation = 4
     var blockTimingHandler: ((Int, TimeInterval, Memory.Snapshot) -> Void)?
     @ModuleInfo(key: "video_patch_proj") var videoInput: Linear
@@ -699,11 +928,13 @@ public final class MiniMaxH3Transformer: Module {
     private let timeFrequencies: MLXArray
     private var compiledBlockRunner: MiniMaxH3TransformerBlock?
     private var compiledBlockForwards: MiniMaxH3CompiledBlockForwards?
+    private var adaLNWeightsAvailable: Bool
 
     public init(
         configuration: MiniMaxH3TransformerConfiguration = .init(),
         includeAdaLN: Bool = true
     ) {
+        self.adaLNWeightsAvailable = includeAdaLN
         self.configuration = configuration
         self._videoInput.wrappedValue = Linear(
             configuration.videoPatchDimension,
@@ -849,6 +1080,91 @@ public final class MiniMaxH3Transformer: Module {
         timesteps: MLXArray,
         cachedAdaLN: MiniMaxH3AdaLNStep?
     ) -> MiniMaxH3TransformerOutput {
+        let prepared = prepareBlockInput(
+            videoRows: videoRows,
+            audioRows: audioRows,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: cachedAdaLN
+        )
+        let hidden = runBlocks(
+            prepared.hidden,
+            range: blocks.indices,
+            context: context,
+            timeEmbedding: prepared.timeEmbedding,
+            cachedAdaLN: cachedAdaLN
+        )
+        return finalize(
+            hidden,
+            context: context,
+            timeEmbedding: prepared.timeEmbedding,
+            cachedAdaLN: cachedAdaLN
+        )
+    }
+
+    func callWithBlockResidualReuse(
+        videoRows: MLXArray,
+        audioRows: MLXArray,
+        context: MiniMaxH3TransformerPreparedContext,
+        timesteps: MLXArray,
+        cachedAdaLN: MiniMaxH3AdaLNStep?,
+        warmBlockCount: Int,
+        cachedTailResidual: MLXArray?
+    ) -> MiniMaxH3BlockReuseResult {
+        precondition(warmBlockCount >= 0 && warmBlockCount < blocks.count)
+        let prepared = prepareBlockInput(
+            videoRows: videoRows,
+            audioRows: audioRows,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: cachedAdaLN
+        )
+        let warmHidden = runBlocks(
+            prepared.hidden,
+            range: 0..<warmBlockCount,
+            context: context,
+            timeEmbedding: prepared.timeEmbedding,
+            cachedAdaLN: cachedAdaLN
+        )
+
+        let hidden: MLXArray
+        let refreshedTailResidual: MLXArray?
+        if let cachedTailResidual {
+            precondition(cachedTailResidual.shape == warmHidden.shape)
+            hidden = warmHidden + cachedTailResidual
+            refreshedTailResidual = nil
+            MLX.eval(hidden)
+        } else {
+            hidden = runBlocks(
+                warmHidden,
+                range: warmBlockCount..<blocks.count,
+                context: context,
+                timeEmbedding: prepared.timeEmbedding,
+                cachedAdaLN: cachedAdaLN
+            )
+            let residual = hidden - warmHidden
+            MLX.eval(residual)
+            refreshedTailResidual = residual
+        }
+
+        return MiniMaxH3BlockReuseResult(
+            output: finalize(
+                hidden,
+                context: context,
+                timeEmbedding: prepared.timeEmbedding,
+                cachedAdaLN: cachedAdaLN
+            ),
+            refreshedTailResidual: refreshedTailResidual
+        )
+    }
+
+    private func prepareBlockInput(
+        videoRows: MLXArray,
+        audioRows: MLXArray,
+        context: MiniMaxH3TransformerPreparedContext,
+        timesteps: MLXArray,
+        cachedAdaLN: MiniMaxH3AdaLNStep?
+    ) -> (hidden: MLXArray, timeEmbedding: MLXArray) {
         let layout = context.layout
         precondition(videoRows.dim(1) == layout.conditionVideoRowCount + layout.targetVideoRows.count)
         precondition(audioRows.dim(1) == layout.conditionAudioRowCount + layout.targetAudioRows.count)
@@ -870,13 +1186,26 @@ public final class MiniMaxH3Transformer: Module {
         }
         packed.append(targetAudio)
         packed.append(targetVideo)
-        var hidden = MLX.concatenated(packed, axis: 1)
+        let hidden = MLX.concatenated(packed, axis: 1)
 
         let timeEmbedding = cachedAdaLN?.timeEmbedding ?? embedTimesteps(timesteps)
         if let cachedAdaLN {
             precondition(cachedAdaLN.blockModulations.count == blocks.count)
         }
-        for (index, block) in blocks.enumerated() {
+        return (hidden, timeEmbedding)
+    }
+
+    private func runBlocks(
+        _ initialHidden: MLXArray,
+        range: Range<Int>,
+        context: MiniMaxH3TransformerPreparedContext,
+        timeEmbedding: MLXArray,
+        cachedAdaLN: MiniMaxH3AdaLNStep?
+    ) -> MLXArray {
+        precondition(range.lowerBound >= 0 && range.upperBound <= blocks.count)
+        var hidden = initialHidden
+        for index in range {
+            let block = blocks[index]
             let blockStarted = blockTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
             if usesBlockwiseCompilation {
                 var attentionInputs = [
@@ -899,20 +1228,35 @@ public final class MiniMaxH3Transformer: Module {
                     maximumQueryTokens: maximumAttentionQueryTokensPerKernel,
                     maximumKernelsPerEvaluation: maximumAttentionKernelsPerEvaluation
                 )
-                hidden = compiled.attentionOutput([hidden, attended, projectedAttention[3]])[0]
-                MLX.eval(hidden)
-                var feedForwardInputs = [hidden, timeEmbedding, context.adaLNIndices]
-                if let modulation = cachedAdaLN?.blockModulations[index] {
-                    feedForwardInputs.append(modulation)
+                if usesFusedPostAttention {
+                    var postAttentionInputs = [
+                        hidden,
+                        attended,
+                        projectedAttention[3],
+                        timeEmbedding,
+                        context.adaLNIndices,
+                    ]
+                    if let modulation = cachedAdaLN?.blockModulations[index] {
+                        postAttentionInputs.append(modulation)
+                    }
+                    hidden = compiled.postAttention(postAttentionInputs)[0]
+                    MLX.eval(hidden)
+                } else {
+                    hidden = compiled.attentionOutput([hidden, attended, projectedAttention[3]])[0]
+                    MLX.eval(hidden)
+                    var feedForwardInputs = [hidden, timeEmbedding, context.adaLNIndices]
+                    if let modulation = cachedAdaLN?.blockModulations[index] {
+                        feedForwardInputs.append(modulation)
+                    }
+                    let projectedFeedForward = compiled.feedForwardProjection(feedForwardInputs)
+                    MLX.eval(projectedFeedForward)
+                    hidden = compiled.feedForwardOutput([
+                        hidden,
+                        projectedFeedForward[0],
+                        projectedFeedForward[1],
+                    ])[0]
+                    MLX.eval(hidden)
                 }
-                let projectedFeedForward = compiled.feedForwardProjection(feedForwardInputs)
-                MLX.eval(projectedFeedForward)
-                hidden = compiled.feedForwardOutput([
-                    hidden,
-                    projectedFeedForward[0],
-                    projectedFeedForward[1],
-                ])[0]
-                MLX.eval(hidden)
             } else {
                 hidden = block(
                     hidden,
@@ -936,12 +1280,21 @@ public final class MiniMaxH3Transformer: Module {
                 )
             }
         }
-        return finalLayer(
+        return hidden
+    }
+
+    private func finalize(
+        _ hidden: MLXArray,
+        context: MiniMaxH3TransformerPreparedContext,
+        timeEmbedding: MLXArray,
+        cachedAdaLN: MiniMaxH3AdaLNStep?
+    ) -> MiniMaxH3TransformerOutput {
+        finalLayer(
             hidden,
             timeEmbedding: timeEmbedding,
-            videoRows: layout.targetVideoRows,
+            videoRows: context.layout.targetVideoRows,
             videoTimeIndex: 0,
-            audioRows: layout.targetAudioRows,
+            audioRows: context.layout.targetAudioRows,
             audioTimeIndex: 1,
             cachedModulation: cachedAdaLN?.finalModulation
         )
@@ -951,12 +1304,12 @@ public final class MiniMaxH3Transformer: Module {
         for block: MiniMaxH3TransformerBlock
     ) -> MiniMaxH3CompiledBlockForwards {
         if let compiledBlockRunner, let compiledBlockForwards {
-            compiledBlockRunner.update(parameters: block.parameters())
+            updateCompiledBlockRunner(compiledBlockRunner, from: block)
             return compiledBlockForwards
         }
 
         let runner = makeCompiledBlockRunner(from: block)
-        runner.update(parameters: block.parameters())
+        updateCompiledBlockRunner(runner, from: block)
         let attentionProjection = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
             runner.attentionProjection(
                 inputs[0],
@@ -988,15 +1341,39 @@ public final class MiniMaxH3Transformer: Module {
                 gate: inputs[2]
             )]
         }
+        let postAttention = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+            let attended = runner.attentionProjectionResidual(
+                inputs[0],
+                attended: inputs[1],
+                gate: inputs[2]
+            )
+            return [runner.feedForwardResidual(
+                attended,
+                timeEmbedding: inputs[3],
+                adaLNIndices: inputs[4],
+                cachedModulation: inputs.count == 6 ? inputs[5] : nil
+            )]
+        }
         let forwards = MiniMaxH3CompiledBlockForwards(
             attentionProjection: attentionProjection,
             attentionOutput: attentionOutput,
             feedForwardProjection: feedForwardProjection,
-            feedForwardOutput: feedForwardOutput
+            feedForwardOutput: feedForwardOutput,
+            postAttention: postAttention
         )
         compiledBlockRunner = runner
         compiledBlockForwards = forwards
         return forwards
+    }
+
+    private func updateCompiledBlockRunner(
+        _ runner: MiniMaxH3TransformerBlock,
+        from block: MiniMaxH3TransformerBlock
+    ) {
+        let parameters = block.parameters().flattened().filter { path, _ in
+            block.includesAdaLN || !path.hasPrefix("adaln_proj.")
+        }
+        runner.update(parameters: ModuleParameters.unflattened(parameters))
     }
 
     private func makeCompiledBlockRunner(
@@ -1090,8 +1467,27 @@ public final class MiniMaxH3Transformer: Module {
         )
     }
 
+    /// Releases the schedule-only projection weights after an exact modulation
+    /// table has been built for the current run. The remaining dense core is
+    /// the complete denoising transformer.
+    func discardAdaLNWeights() {
+        guard adaLNWeightsAvailable else { return }
+        compiledBlockRunner = nil
+        compiledBlockForwards = nil
+        update(modules: ModuleChildren.unflattened([
+            ("time_embedder", MiniMaxH3TimeEmbedding(discarded: ())),
+        ]))
+        for block in blocks {
+            block.discardAdaLNWeights()
+        }
+        finalLayer.discardAdaLNWeights()
+        adaLNWeightsAvailable = false
+    }
+
     private func embedTimesteps(_ timesteps: MLXArray) -> MLXArray {
-        guard let timeEmbedder else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+        guard adaLNWeightsAvailable, let timeEmbedder else {
+            preconditionFailure("MiniMax-H3 AdaLN cache is required")
+        }
         let arguments = timesteps.reshaped(-1, 1) * timeFrequencies.reshaped(1, -1)
         let sinusoidal = MLX.concatenated([MLX.cos(arguments), MLX.sin(arguments)], axis: -1)
         return timeEmbedder(sinusoidal.asType(.float32))

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -654,6 +654,7 @@ private struct MiniMaxH3CompiledBlockForwards {
 final class MiniMaxH3BlockScheduleBenchmark {
     enum Schedule {
         case splitPostAttention
+        case fusedFeedForward
         case fusedPostAttention
     }
 
@@ -661,7 +662,9 @@ final class MiniMaxH3BlockScheduleBenchmark {
     private let maximumQueryTokens: Int
     private let maximumKernelsPerEvaluation: Int
     private let block: MiniMaxH3TransformerBlock
+    private let originalParameters: [(String, MLXArray)]
     private let forwards: MiniMaxH3CompiledBlockForwards
+    private let fusedFeedForward: MiniMaxH3CompiledBlockForward
     private let hidden: MLXArray
     private let timeEmbedding: MLXArray
     private let adaLNIndices: MLXArray
@@ -672,7 +675,9 @@ final class MiniMaxH3BlockScheduleBenchmark {
         rowCount: Int,
         maximumQueryTokens: Int,
         maximumKernelsPerEvaluation: Int,
-        dtype: DType = .bfloat16
+        dtype: DType = .bfloat16,
+        weightSeed: UInt64? = nil,
+        inputSeed: UInt64? = nil
     ) {
         precondition(rowCount > 0)
         precondition(maximumQueryTokens > 0)
@@ -682,10 +687,12 @@ final class MiniMaxH3BlockScheduleBenchmark {
         self.maximumKernelsPerEvaluation = maximumKernelsPerEvaluation
 
         let configuration = MiniMaxH3TransformerConfiguration()
+        if let weightSeed { MLXRandom.seed(weightSeed) }
         let block = MiniMaxH3TransformerBlock(configuration: configuration, includeAdaLN: false)
         block.update(parameters: block.parameters().mapValues { $0.asType(dtype) })
         MLX.eval(block.parameters())
         self.block = block
+        self.originalParameters = block.parameters().flattened()
 
         let attentionProjection = MLX.compile(inputs: [block]) { inputs in
             block.attentionProjection(
@@ -718,6 +725,14 @@ final class MiniMaxH3BlockScheduleBenchmark {
                 gate: inputs[2]
             )]
         }
+        let feedForward = MLX.compile(inputs: [block]) { inputs in
+            [block.feedForwardResidual(
+                inputs[0],
+                timeEmbedding: inputs[1],
+                adaLNIndices: inputs[2],
+                cachedModulation: inputs[3]
+            )]
+        }
         let postAttention = MLX.compile(inputs: [block]) { inputs in
             let attended = block.attentionProjectionResidual(
                 inputs[0],
@@ -738,7 +753,9 @@ final class MiniMaxH3BlockScheduleBenchmark {
             feedForwardOutput: feedForwardOutput,
             postAttention: postAttention
         )
+        self.fusedFeedForward = feedForward
 
+        if let inputSeed { MLXRandom.seed(inputSeed) }
         self.hidden = MLXRandom.normal([1, rowCount, configuration.hiddenSize])
             .asType(dtype)
         self.timeEmbedding = MLXArray.zeros(
@@ -767,6 +784,10 @@ final class MiniMaxH3BlockScheduleBenchmark {
             rope.sine,
             cachedModulation
         )
+    }
+
+    func useOriginalWeights(from source: MiniMaxH3BlockScheduleBenchmark) {
+        block.update(parameters: ModuleParameters.unflattened(source.originalParameters))
     }
 
     func callAsFunction(
@@ -834,6 +855,21 @@ final class MiniMaxH3BlockScheduleBenchmark {
                 attentionOutput,
                 projectedFeedForward[0],
                 projectedFeedForward[1],
+            ])[0]
+            MLX.eval(output)
+            return output
+        case .fusedFeedForward:
+            let attentionOutput = forwards.attentionOutput([
+                hidden,
+                attended,
+                gate,
+            ])[0]
+            MLX.eval(attentionOutput)
+            let output = fusedFeedForward([
+                attentionOutput,
+                timeEmbedding,
+                adaLNIndices,
+                cachedModulation,
             ])[0]
             MLX.eval(output)
             return output

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -790,12 +790,16 @@ final class MiniMaxH3BlockScheduleBenchmark {
         block.update(parameters: ModuleParameters.unflattened(source.originalParameters))
     }
 
+    var defaultInput: MLXArray { hidden }
+
     func callAsFunction(
         schedule: Schedule,
         maximumQueryTokens: Int? = nil,
-        maximumKernelsPerEvaluation: Int? = nil
+        maximumKernelsPerEvaluation: Int? = nil,
+        input: MLXArray? = nil
     ) -> MLXArray {
-        let projectedAttention = projectAttention()
+        let hidden = input ?? self.hidden
+        let projectedAttention = projectAttention(input: hidden)
         MLX.eval(projectedAttention)
         let attended = attend(
             projectedAttention,
@@ -805,13 +809,14 @@ final class MiniMaxH3BlockScheduleBenchmark {
         return postAttention(
             schedule: schedule,
             attended: attended,
-            gate: projectedAttention[3]
+            gate: projectedAttention[3],
+            input: hidden
         )
     }
 
-    func projectAttention() -> [MLXArray] {
+    func projectAttention(input: MLXArray? = nil) -> [MLXArray] {
         forwards.attentionProjection([
-            hidden,
+            input ?? hidden,
             timeEmbedding,
             adaLNIndices,
             rope.cosine,
@@ -835,29 +840,77 @@ final class MiniMaxH3BlockScheduleBenchmark {
         )
     }
 
-    func postAttention(schedule: Schedule, attended: MLXArray, gate: MLXArray) -> MLXArray {
+    func attentionOutput(
+        input: MLXArray,
+        attended: MLXArray,
+        gate: MLXArray
+    ) -> MLXArray {
+        let output = forwards.attentionOutput([input, attended, gate])[0]
+        MLX.eval(output)
+        return output
+    }
+
+    func splitFeedForward(input: MLXArray) -> MLXArray {
+        let projected = forwards.feedForwardProjection([
+            input,
+            timeEmbedding,
+            adaLNIndices,
+            cachedModulation,
+        ])
+        MLX.eval(projected)
+        let output = forwards.feedForwardOutput([input, projected[0], projected[1]])[0]
+        MLX.eval(output)
+        return output
+    }
+
+    func makeFusedBoundary(
+        to successor: MiniMaxH3BlockScheduleBenchmark
+    ) -> @Sendable ([MLXArray]) -> [MLXArray] {
+        MLX.compile(inputs: [block, successor.block]) { inputs in
+            let nextHidden = self.block.feedForwardResidual(
+                inputs[0],
+                timeEmbedding: inputs[1],
+                adaLNIndices: inputs[2],
+                cachedModulation: inputs[3]
+            )
+            return [nextHidden] + successor.block.attentionProjection(
+                nextHidden,
+                timeEmbedding: inputs[4],
+                adaLNIndices: inputs[5],
+                rope: MiniMaxH3RotaryEmbedding(cosine: inputs[6], sine: inputs[7]),
+                cachedModulation: inputs[8]
+            )
+        }
+    }
+
+    func fusedBoundaryInputs(
+        to successor: MiniMaxH3BlockScheduleBenchmark,
+        input: MLXArray
+    ) -> [MLXArray] {
+        [
+            input,
+            timeEmbedding,
+            adaLNIndices,
+            cachedModulation,
+            successor.timeEmbedding,
+            successor.adaLNIndices,
+            successor.rope.cosine,
+            successor.rope.sine,
+            successor.cachedModulation,
+        ]
+    }
+
+    func postAttention(
+        schedule: Schedule,
+        attended: MLXArray,
+        gate: MLXArray,
+        input: MLXArray? = nil
+    ) -> MLXArray {
+        let hidden = input ?? self.hidden
         switch schedule {
         case .splitPostAttention:
-            let attentionOutput = forwards.attentionOutput([
-                hidden,
-                attended,
-                gate,
-            ])[0]
-            MLX.eval(attentionOutput)
-            let projectedFeedForward = forwards.feedForwardProjection([
-                attentionOutput,
-                timeEmbedding,
-                adaLNIndices,
-                cachedModulation,
-            ])
-            MLX.eval(projectedFeedForward)
-            let output = forwards.feedForwardOutput([
-                attentionOutput,
-                projectedFeedForward[0],
-                projectedFeedForward[1],
-            ])[0]
-            MLX.eval(output)
-            return output
+            let attendedHidden = attentionOutput(input: hidden, attended: attended, gate: gate)
+            return splitFeedForward(input: attendedHidden)
         case .fusedFeedForward:
             let attentionOutput = forwards.attentionOutput([
                 hidden,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -154,7 +154,8 @@ private final class MiniMaxH3Attention: Module {
             queries: projected[0],
             keys: projected[1],
             values: projected[2],
-            maximumQueryTokens: nil
+            maximumQueryTokens: nil,
+            maximumHeadsPerKernel: nil
         )
         return projectOutput(attended)
     }
@@ -183,11 +184,14 @@ private final class MiniMaxH3Attention: Module {
         keys: MLXArray,
         values: MLXArray,
         maximumQueryTokens: Int?,
+        maximumHeadsPerKernel: Int?,
         maximumKernelsPerEvaluation: Int = 1
     ) -> MLXArray {
-        guard let maximumQueryTokens,
-              maximumQueryTokens > 0,
-              queries.dim(2) > maximumQueryTokens else {
+        if let maximumQueryTokens { precondition(maximumQueryTokens > 0) }
+        if let maximumHeadsPerKernel { precondition(maximumHeadsPerKernel > 0) }
+        let queryChunkSize = min(maximumQueryTokens ?? queries.dim(2), queries.dim(2))
+        let headChunkSize = min(maximumHeadsPerKernel ?? queries.dim(1), queries.dim(1))
+        guard queryChunkSize < queries.dim(2) || headChunkSize < queries.dim(1) else {
             return MLXFast.scaledDotProductAttention(
                 queries: queries,
                 keys: keys,
@@ -198,30 +202,38 @@ private final class MiniMaxH3Attention: Module {
         }
 
         precondition(maximumKernelsPerEvaluation > 0)
-        var chunks: [MLXArray] = []
-        chunks.reserveCapacity((queries.dim(2) + maximumQueryTokens - 1) / maximumQueryTokens)
+        var headOutputs: [MLXArray] = []
+        headOutputs.reserveCapacity((queries.dim(1) + headChunkSize - 1) / headChunkSize)
         var pending: [MLXArray] = []
         pending.reserveCapacity(maximumKernelsPerEvaluation)
-        for start in stride(from: 0, to: queries.dim(2), by: maximumQueryTokens) {
-            let end = min(start + maximumQueryTokens, queries.dim(2))
-            let chunk = MLXFast.scaledDotProductAttention(
-                queries: queries[0..., 0..., start..<end, 0...],
-                keys: keys,
-                values: values,
-                scale: scale,
-                mask: .none
-            )
-            chunks.append(chunk)
-            pending.append(chunk)
-            if pending.count == maximumKernelsPerEvaluation {
-                MLX.eval(pending)
-                pending.removeAll(keepingCapacity: true)
+        for headStart in stride(from: 0, to: queries.dim(1), by: headChunkSize) {
+            let headEnd = min(headStart + headChunkSize, queries.dim(1))
+            var queryOutputs: [MLXArray] = []
+            queryOutputs.reserveCapacity((queries.dim(2) + queryChunkSize - 1) / queryChunkSize)
+            for queryStart in stride(from: 0, to: queries.dim(2), by: queryChunkSize) {
+                let queryEnd = min(queryStart + queryChunkSize, queries.dim(2))
+                let chunk = MLXFast.scaledDotProductAttention(
+                    queries: queries[
+                        0..., headStart..<headEnd, queryStart..<queryEnd, 0...
+                    ],
+                    keys: keys[0..., headStart..<headEnd, 0..., 0...],
+                    values: values[0..., headStart..<headEnd, 0..., 0...],
+                    scale: scale,
+                    mask: .none
+                )
+                queryOutputs.append(chunk)
+                pending.append(chunk)
+                if pending.count == maximumKernelsPerEvaluation {
+                    MLX.eval(pending)
+                    pending.removeAll(keepingCapacity: true)
+                }
             }
+            headOutputs.append(MLX.concatenated(queryOutputs, axis: 2))
         }
         if !pending.isEmpty {
             MLX.eval(pending)
         }
-        return MLX.concatenated(chunks, axis: 2)
+        return MLX.concatenated(headOutputs, axis: 1)
     }
 
     func projectOutput(_ attended: MLXArray) -> MLXArray {
@@ -496,6 +508,7 @@ private final class MiniMaxH3TransformerBlock: Module {
         keys: MLXArray,
         values: MLXArray,
         maximumQueryTokens: Int,
+        maximumHeadsPerKernel: Int?,
         maximumKernelsPerEvaluation: Int
     ) -> MLXArray {
         attention.scaledDotProductAttention(
@@ -503,6 +516,7 @@ private final class MiniMaxH3TransformerBlock: Module {
             keys: keys,
             values: values,
             maximumQueryTokens: maximumQueryTokens,
+            maximumHeadsPerKernel: maximumHeadsPerKernel,
             maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
         )
     }
@@ -660,6 +674,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
 
     let rowCount: Int
     private let maximumQueryTokens: Int
+    private let maximumHeadsPerKernel: Int?
     private let maximumKernelsPerEvaluation: Int
     private let block: MiniMaxH3TransformerBlock
     private let originalParameters: [(String, MLXArray)]
@@ -675,6 +690,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
         rowCount: Int,
         maximumQueryTokens: Int,
         maximumKernelsPerEvaluation: Int,
+        maximumHeadsPerKernel: Int? = nil,
         dtype: DType = .bfloat16,
         weightSeed: UInt64? = nil,
         inputSeed: UInt64? = nil
@@ -682,8 +698,10 @@ final class MiniMaxH3BlockScheduleBenchmark {
         precondition(rowCount > 0)
         precondition(maximumQueryTokens > 0)
         precondition(maximumKernelsPerEvaluation > 0)
+        if let maximumHeadsPerKernel { precondition(maximumHeadsPerKernel > 0) }
         self.rowCount = rowCount
         self.maximumQueryTokens = maximumQueryTokens
+        self.maximumHeadsPerKernel = maximumHeadsPerKernel
         self.maximumKernelsPerEvaluation = maximumKernelsPerEvaluation
 
         let configuration = MiniMaxH3TransformerConfiguration()
@@ -795,6 +813,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
     func callAsFunction(
         schedule: Schedule,
         maximumQueryTokens: Int? = nil,
+        maximumHeadsPerKernel: Int? = nil,
         maximumKernelsPerEvaluation: Int? = nil,
         input: MLXArray? = nil
     ) -> MLXArray {
@@ -804,6 +823,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
         let attended = attend(
             projectedAttention,
             maximumQueryTokens: maximumQueryTokens,
+            maximumHeadsPerKernel: maximumHeadsPerKernel,
             maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
         )
         return postAttention(
@@ -828,6 +848,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
     func attend(
         _ projectedAttention: [MLXArray],
         maximumQueryTokens: Int? = nil,
+        maximumHeadsPerKernel: Int? = nil,
         maximumKernelsPerEvaluation: Int? = nil
     ) -> MLXArray {
         block.scaledDotProductAttention(
@@ -835,6 +856,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
             keys: projectedAttention[1],
             values: projectedAttention[2],
             maximumQueryTokens: maximumQueryTokens ?? self.maximumQueryTokens,
+            maximumHeadsPerKernel: maximumHeadsPerKernel ?? self.maximumHeadsPerKernel,
             maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
                 ?? self.maximumKernelsPerEvaluation
         )
@@ -1017,6 +1039,7 @@ public final class MiniMaxH3Transformer: Module {
     var usesFusedPostAttention = true
     private(set) var usesResidentBF16 = false
     var maximumAttentionQueryTokensPerKernel = 1_024
+    var maximumAttentionHeadsPerKernel: Int?
     var maximumAttentionKernelsPerEvaluation = 4
     var blockTimingHandler: ((Int, TimeInterval, Memory.Snapshot) -> Void)?
     @ModuleInfo(key: "video_patch_proj") var videoInput: Linear
@@ -1329,6 +1352,7 @@ public final class MiniMaxH3Transformer: Module {
                     keys: projectedAttention[1],
                     values: projectedAttention[2],
                     maximumQueryTokens: maximumAttentionQueryTokensPerKernel,
+                    maximumHeadsPerKernel: maximumAttentionHeadsPerKernel,
                     maximumKernelsPerEvaluation: maximumAttentionKernelsPerEvaluation
                 )
                 if usesFusedPostAttention {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -671,7 +671,8 @@ final class MiniMaxH3BlockScheduleBenchmark {
     init(
         rowCount: Int,
         maximumQueryTokens: Int,
-        maximumKernelsPerEvaluation: Int
+        maximumKernelsPerEvaluation: Int,
+        dtype: DType = .bfloat16
     ) {
         precondition(rowCount > 0)
         precondition(maximumQueryTokens > 0)
@@ -682,7 +683,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
 
         let configuration = MiniMaxH3TransformerConfiguration()
         let block = MiniMaxH3TransformerBlock(configuration: configuration, includeAdaLN: false)
-        block.update(parameters: block.parameters().mapValues { $0.asType(.bfloat16) })
+        block.update(parameters: block.parameters().mapValues { $0.asType(dtype) })
         MLX.eval(block.parameters())
         self.block = block
 
@@ -739,25 +740,25 @@ final class MiniMaxH3BlockScheduleBenchmark {
         )
 
         self.hidden = MLXRandom.normal([1, rowCount, configuration.hiddenSize])
-            .asType(.bfloat16)
+            .asType(dtype)
         self.timeEmbedding = MLXArray.zeros(
             [3, configuration.timeEmbeddingDimension],
-            dtype: .bfloat16
+            dtype: dtype
         )
         self.adaLNIndices = MLXArray((0..<rowCount).map { Int32($0 % 9) })
         self.rope = MiniMaxH3RotaryEmbedding(
             cosine: MLXArray.ones(
                 [1, rowCount, 1, 6 * configuration.ropeFrequencyCount],
-                dtype: .bfloat16
+                dtype: dtype
             ),
             sine: MLXArray.zeros(
                 [1, rowCount, 1, 6 * configuration.ropeFrequencyCount],
-                dtype: .bfloat16
+                dtype: dtype
             )
         )
         self.cachedModulation = (
             MLXRandom.normal([9, 6 * configuration.hiddenSize]) * Float(0.1)
-        ).asType(.bfloat16)
+        ).asType(dtype)
         MLX.eval(
             hidden,
             timeEmbedding,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
@@ -51,9 +51,7 @@ final class MiniMaxH3VideoDecoderAttention: Module {
     let headDimension: Int
     let rotaryDimension: Int
 
-    @ModuleInfo(key: "to_q") var query: Linear
-    @ModuleInfo(key: "to_k") var key: Linear
-    @ModuleInfo(key: "to_v") var value: Linear
+    @ModuleInfo(key: "to_qkv") var queryKeyValue: Linear
     @ModuleInfo(key: "to_out") var output: Linear
 
     init(configuration: MiniMaxH3VideoDecoderConfiguration) {
@@ -61,18 +59,17 @@ final class MiniMaxH3VideoDecoderAttention: Module {
         headDimension = configuration.headDimension
         rotaryDimension = configuration.rotaryDimension
         let hidden = configuration.hiddenSize
-        _query.wrappedValue = Linear(hidden, hidden, bias: true)
-        _key.wrappedValue = Linear(hidden, hidden, bias: true)
-        _value.wrappedValue = Linear(hidden, hidden, bias: true)
+        _queryKeyValue.wrappedValue = Linear(hidden, 3 * hidden, bias: true)
         _output.wrappedValue = Linear(hidden, hidden, bias: true)
     }
 
     func callAsFunction(_ input: MLXArray, cosine: MLXArray, sine: MLXArray) -> MLXArray {
         let batch = input.dim(0)
         let sequence = input.dim(1)
-        var q = query(input).reshaped(batch, sequence, headCount, headDimension)
-        var k = key(input).reshaped(batch, sequence, headCount, headDimension)
-        let v = value(input).reshaped(batch, sequence, headCount, headDimension)
+        let projected = MLX.split(queryKeyValue(input), parts: 3, axis: -1)
+        var q = projected[0].reshaped(batch, sequence, headCount, headDimension)
+        var k = projected[1].reshaped(batch, sequence, headCount, headDimension)
+        let v = projected[2].reshaped(batch, sequence, headCount, headDimension)
 
         q = MiniMaxH3VideoDecoderAttention.rmsNormalizeHeads(q)
         k = MiniMaxH3VideoDecoderAttention.rmsNormalizeHeads(k)
@@ -240,6 +237,11 @@ public final class MiniMaxH3VideoDecoder: Module {
 }
 
 public final class MiniMaxH3VideoVAE: Module {
+    static let defaultSpatialTileSize = 256
+    static let minimumSpatialTileOverlap = 64
+
+    var spatialTileSize = defaultSpatialTileSize
+
     @ModuleInfo(key: "encoder") public var encoder: MiniMaxH3VideoEncoder
     @ModuleInfo(key: "quant_conv") var quantConvolution: Conv3d
     @ModuleInfo(key: "post_quant_conv") var postQuantConvolution: Conv3d
@@ -281,12 +283,9 @@ public final class MiniMaxH3VideoVAE: Module {
         }
 
         if key.contains(".attn.to_qkv.") {
-            let queryKey = key.replacingOccurrences(of: ".attn.to_qkv.", with: ".attn.to_q.")
-            let keyKey = key.replacingOccurrences(of: ".attn.to_qkv.", with: ".attn.to_k.")
-            let valueKey = key.replacingOccurrences(of: ".attn.to_qkv.", with: ".attn.to_v.")
             // The released VAE projects to [head, qkv, headDimension], not
             // [qkv, head, headDimension]. Deinterleave the per-head groups
-            // before loading the three standalone MLX Linear modules.
+            // before loading the fused global-QKV MLX Linear module.
             let headCount = 32
             let headDimension = 64
             precondition(value.dim(0) == headCount * 3 * headDimension)
@@ -295,7 +294,7 @@ public final class MiniMaxH3VideoVAE: Module {
             let pieces = MLX.split(grouped, parts: 3, axis: 1).map {
                 $0.squeezed(axis: 1).reshaped([headCount * headDimension] + trailingShape)
             }
-            return [(queryKey, pieces[0]), (keyKey, pieces[1]), (valueKey, pieces[2])]
+            return [(key, MLX.concatenated(pieces, axis: 0))]
         }
         if value.ndim == 5 {
             return [(key, value.transposed(0, 2, 3, 4, 1))]
@@ -355,8 +354,8 @@ public final class MiniMaxH3VideoVAE: Module {
     private func encodeClip(_ video: MLXArray) -> MLXArray {
         let pixelHeight = video.dim(2)
         let pixelWidth = video.dim(3)
-        let y = Self.tilePlan(length: pixelHeight)
-        let x = Self.tilePlan(length: pixelWidth)
+        let y = Self.tilePlan(length: pixelHeight, tileSize: spatialTileSize)
+        let x = Self.tilePlan(length: pixelWidth, tileSize: spatialTileSize)
         var tiles: [MLXArray] = []
         for (yIndex, yStart) in y.starts.enumerated() {
             for (xIndex, xStart) in x.starts.enumerated() {
@@ -477,8 +476,8 @@ public final class MiniMaxH3VideoVAE: Module {
     ) -> MLXArray {
         let pixelHeight = latent.dim(3) * 16
         let pixelWidth = latent.dim(4) * 16
-        let y = Self.tilePlan(length: pixelHeight)
-        let x = Self.tilePlan(length: pixelWidth)
+        let y = Self.tilePlan(length: pixelHeight, tileSize: spatialTileSize)
+        let x = Self.tilePlan(length: pixelWidth, tileSize: spatialTileSize)
         var tiles: [MLXArray] = []
         for (yIndex, yStart) in y.starts.enumerated() {
             for (xIndex, xStart) in x.starts.enumerated() {
@@ -526,9 +525,12 @@ public final class MiniMaxH3VideoVAE: Module {
         return MLX.concatenated(stitchedRows, axis: 3)
     }
 
-    private static func tilePlan(length: Int) -> (starts: [Int], lengths: [Int], overlaps: [Int]) {
-        let tileSize = 256
-        let minimumOverlap = 64
+    static func tilePlan(
+        length: Int,
+        tileSize: Int
+    ) -> (starts: [Int], lengths: [Int], overlaps: [Int]) {
+        precondition(tileSize >= minimumSpatialTileOverlap && tileSize.isMultiple(of: 16))
+        let minimumOverlap = minimumSpatialTileOverlap
         guard length > tileSize else { return ([0], [length], []) }
         var count = Int(ceil(Double(length) / Double(tileSize)))
         while tileSize * count - minimumOverlap * (count - 1) < length { count += 1 }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
@@ -237,7 +237,7 @@ public final class MiniMaxH3VideoDecoder: Module {
 }
 
 public final class MiniMaxH3VideoVAE: Module {
-    static let defaultSpatialTileSize = 256
+    static let defaultSpatialTileSize = 320
     static let minimumSpatialTileOverlap = 64
 
     var spatialTileSize = defaultSpatialTileSize

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -16,16 +16,28 @@ Supported open-checkpoint paths:
 H3 emits 24 fps RGB video and native 32 kHz stereo audio. Frame counts use the
 released `17*n+5` temporal geometry. The transformer is CFG-distilled; the
 runtime therefore performs a single model evaluation per denoising step.
-The default schedule adapts to packed-row cost at 9, 16, or 31 points. A
+The default schedule adapts to packed-row cost at 9, 16, or 21 points. The
+maximum acceleration mode caps automatic schedules at 12 points (11 model
+evaluations). A
 source-bound cache stores the exact released 31-point AdaLN curve and resamples
 it for explicit point-count overrides. The converted transformer stores global
 Q/K/V slabs; the unmodified video VAE retains the released per-head interleave.
 
-Compact Q4 is the automatic MacBook lane. Desktop Macs with sufficient unified
-memory may expand those weights once to resident BF16 for compute-bound denoise;
+Compact Q4 remains the automatic lane on lower-memory MacBooks. Memory-qualified
+MacBooks with at least 96 GiB of unified memory, and desktop Macs with sufficient
+headroom, expand those weights once to resident BF16 for compute-bound denoise;
 the CLI can force either mode. H3 inference also raises MLX wired residency
 through the shared ticket coordinator so weights and activation workspaces do
 not silently fall out of the GPU residency set.
+
+`--h3-acceleration quality` executes every transformer block and preserves the
+native same-seed trajectory. The explicit `balanced` and `maximum` modes trade
+exact trajectory identity for speed: a full step captures the contribution of
+the trailing 50% or 75% of blocks, eligible adjacent steps recompute the prefix
+and reuse that residual, and a full refresh follows at most two cache hits.
+Both modalities must have a sigma delta below 0.12. At least two complete
+evaluations precede reuse, and the final schedule region always executes all
+50 blocks.
 
 The model weights are governed by the MiniMax-H3 Community License, not the
 mere.run source license. In particular, the published license excludes use,

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -105,6 +105,7 @@ public struct ModelResolver {
         case ltxVideo23A2VMLX = "video-ltx23-a2vid-mlx"
         case wan22TI2V5BMLX = "video-wan22-ti2v-5b-mlx"
         case miniMaxH3FL2VAMLX = "video-minimax-h3-fl2va-mlx"
+        case miniMaxH3FL2VABF16MLX = "video-minimax-h3-fl2va-bf16-mlx"
         case miniMaxH3Ref2VAMLX = "video-minimax-h3-ref2va-mlx"
         case cosmos3EdgeMLX = "video-cosmos3-edge-mlx"
         case scail2Video14BMLX = "video-scail2-14b-mlx"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -642,8 +642,8 @@ SOFTWARE.
 - source project: [`sawfwair/mlx-swift`](https://github.com/sawfwair/mlx-swift),
   based on upstream [`ml-explore/mlx-swift`](https://github.com/ml-explore/mlx-swift)
   0.32.1
-- pinned package revision: `009a42f024a04e50bb50bb6ce90d0a3e396c1760`
-- embedded MLX revision: `6398fb307f8b6f19d8319a0744a510602c2b818e`
+- pinned package revision: `79bc410c85df66c3f4246084057bdfd971932ac7`
+- embedded MLX revision: `2a977448c20451eb4f100691bd2f6513e610f150`
 - generated-kernel source SHA-256:
   `a4a91e902e4a3c196ba45f3c6ee65c769c26b5825ae3b72d8b93ca233db2d93f`
 - license: MIT

--- a/Tests/MereRunAppTests/StudioTypesTests.swift
+++ b/Tests/MereRunAppTests/StudioTypesTests.swift
@@ -1651,6 +1651,7 @@ final class StudioTypesTests: XCTestCase {
         draft.steps = 40
         draft.h3Steps = 16
         draft.h3WeightMode = "quantized"
+        draft.h3AccelerationMode = "maximum"
         draft.audioPath = "/tmp/should-not-be-used.wav"
         draft.timings = true
 
@@ -1665,6 +1666,7 @@ final class StudioTypesTests: XCTestCase {
         assertPair(args, "--num-frames", "73")
         assertPair(args, "--steps", "16")
         assertPair(args, "--h3-weight-mode", "quantized")
+        assertPair(args, "--h3-acceleration", "maximum")
     }
 
     func testMiniMaxH3Ref2VAPreservesOrderedMultimodalReferences() throws {

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -479,6 +479,57 @@ final class ModelPullCommandParsingTests: XCTestCase {
         )
     }
 
+    func testDiskPreflightCreditsReclaimablePartialInstallForCompositePull() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cache = root.appendingPathComponent("hub", isDirectory: true)
+        let modelDir = root.appendingPathComponent("models/video-composite-test", isDirectory: true)
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        try Data(repeating: 0xA5, count: 4 * 1_048_576).write(
+            to: modelDir.appendingPathComponent("existing-support.safetensors")
+        )
+
+        let estimate = 20 * ModelPullDiskPreflight.bytesPerGiB
+        let spec = ManagedModelSpec(
+            id: "video-composite-test",
+            category: .video,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "example/support",
+                revision: "0123456789abcdef0123456789abcdef01234567",
+                patterns: ["existing-support.safetensors"]
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "transformer",
+                    hubFallback: HubFallbackConfig(
+                        repoId: "example/transformer",
+                        revision: "fedcba9876543210fedcba9876543210fedcba98",
+                        patterns: ["model.safetensors"]
+                    )
+                ),
+            ],
+            validationKind: .miniMaxH3MLX,
+            estimatedDownloadBytes: estimate
+        )
+        let reclaimable = ModelPullDiskPreflight.reclaimableLocalBytes(
+            in: modelDir,
+            onFileSystemContaining: cache
+        )
+
+        XCTAssertGreaterThan(reclaimable, 0)
+        XCTAssertEqual(
+            ModelPullDiskPreflight.estimatedDownloadBytes(
+                for: spec,
+                modelDir: modelDir,
+                force: false,
+                hubCacheURL: cache
+            ),
+            estimate - reclaimable
+        )
+    }
+
     func testStructuredPreflightUsesCompleteCachedInklingSnapshotUnlessForced() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MereRunCLITests/ModelRepairManifestsCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelRepairManifestsCommandTests.swift
@@ -5,10 +5,34 @@ import XCTest
 
 final class ModelRepairManifestsCommandTests: XCTestCase {
     func testParsesStructuredPreviewOptions() throws {
-        let command = try ModelRepairManifests.parse(["--dry-run", "--json"])
+        let command = try ModelRepairManifests.parse([
+            "--dry-run", "--json", "--accept-model-license",
+            "--model", "video-minimax-h3-fl2va-bf16-mlx",
+        ])
 
         XCTAssertTrue(command.dryRun)
         XCTAssertTrue(command.json)
+        XCTAssertTrue(command.acceptModelLicense)
+        XCTAssertEqual(command.model, "video-minimax-h3-fl2va-bf16-mlx")
+    }
+
+    func testRepairCanRecordExplicitRestrictedModelAcceptance() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelRepairManifests.\(UUID().uuidString)", isDirectory: true)
+        let modelID = ModelResolver.ModelID.miniMaxH3FL2VABF16MLX
+        let modelRoot = root.appendingPathComponent(modelID.rawValue, isDirectory: true)
+        try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let command = try ModelRepairManifests.parse([
+            "--accept-model-license", "--model", modelID.rawValue,
+        ])
+        let report = command.makeReport(modelDirs: [root])
+        let entry = try XCTUnwrap(report.entries.first { $0.modelID == modelID.rawValue })
+        let manifest = try MereRunModelManifest.loadRequired(from: modelRoot)
+
+        XCTAssertEqual(entry.status, .wrote)
+        XCTAssertEqual(manifest.usageTermsAcknowledged, true)
     }
 
     func testPreviewReportIdentifiesMissingManifestWithoutWritingIt() throws {
@@ -19,8 +43,7 @@ final class ModelRepairManifestsCommandTests: XCTestCase {
         try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        var command = ModelRepairManifests()
-        command.dryRun = true
+        let command = try ModelRepairManifests.parse(["--dry-run"])
         let report = command.makeReport(modelDirs: [root])
         let entry = try XCTUnwrap(report.entries.first { $0.modelID == modelID.rawValue })
 

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -328,6 +328,7 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(cmd.fps, 24)
         XCTAssertNil(cmd.steps)
         XCTAssertEqual(cmd.h3WeightMode, .automatic)
+        XCTAssertEqual(cmd.h3Acceleration, .quality)
         XCTAssertEqual(cmd.imageStrength, 1.0)
         XCTAssertNil(cmd.endImage)
         XCTAssertEqual(cmd.endImageStrength, 1.0)
@@ -347,12 +348,15 @@ final class VideoCommandTests: XCTestCase {
             "--reference", "audio:/tmp/voice.wav",
             "--steps", "31",
             "--h3-weight-mode", "resident-bf16",
+            "--h3-acceleration", "maximum",
         ])
 
         XCTAssertEqual(cmd.model, ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue)
         XCTAssertEqual(cmd.steps, 31)
         XCTAssertEqual(cmd.h3WeightMode, .residentBF16)
         XCTAssertEqual(cmd.h3WeightMode.generationMode, .residentBF16)
+        XCTAssertEqual(cmd.h3Acceleration, .maximum)
+        XCTAssertEqual(cmd.h3Acceleration.generationMode, .maximum)
         XCTAssertEqual(cmd.references, [
             "image:/tmp/subject.png",
             "video:/tmp/motion.mp4",
@@ -515,6 +519,38 @@ final class VideoCommandTests: XCTestCase {
 
         XCTAssertTrue(cmd.preflight)
         XCTAssertTrue(cmd.json)
+    }
+
+    func testMiniMaxH3PreflightPreservesResolvedSpeedPolicy() throws {
+        let output = makeTempOutput(name: "h3-maximum.mp4")
+        let cmd = try VideoGenerate.parse([
+            "a superhero waits under an umbrella as a portal opens",
+            "--model", ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue,
+            "--width", "832",
+            "--height", "480",
+            "--num-frames", "243",
+            "--h3-weight-mode", "resident-bf16",
+            "--h3-acceleration", "maximum",
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.request.h3WeightMode, "resident-bf16")
+        XCTAssertEqual(envelope.request.h3AccelerationMode, "maximum")
+        XCTAssertEqual(envelope.result.plan.resolvedSteps, 12)
+        XCTAssertEqual(envelope.result.plan.h3WeightMode, "resident-bf16")
+        XCTAssertEqual(envelope.result.plan.h3AccelerationMode, "maximum")
+        let actionArguments = envelope.actions.first { $0.id == "start-video-generation" }?.command?.argv
+        XCTAssertTrue(actionArguments?.contains("--h3-weight-mode") == true)
+        XCTAssertTrue(actionArguments?.contains("resident-bf16") == true)
+        XCTAssertTrue(actionArguments?.contains("--h3-acceleration") == true)
+        XCTAssertTrue(actionArguments?.contains("maximum") == true)
     }
 
     func testVideoGenerateParsesStartAndEndKeyframes() throws {

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -558,7 +558,12 @@ final class DiTShapeBenchTests: XCTestCase {
                 ))
             }
 
-            for rows in [4_608, 12_925] {
+            let configuredRows = ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_ROWS"]?
+                .split(separator: ",")
+                .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                .filter { $0 > 0 } ?? []
+            let rowCounts = configuredRows.isEmpty ? [4_608, 12_925] : configuredRows
+            for rows in rowCounts {
                 for (name, inputDimension, outputDimension) in [
                     ("qkv", 5_376, 21_504),
                     ("ff2", 14_336, 5_376),
@@ -582,6 +587,91 @@ final class DiTShapeBenchTests: XCTestCase {
                 }
             }
         }
+    }
+
+    /// Compares H3's current per-token AdaLN gather with Maestro's exact-math
+    /// contiguous-run formulation. The latter avoids materializing index
+    /// gathers for layouts whose modality/timestep pairs form a handful of
+    /// long runs. Both arms produce the same packed tensor and retain a single
+    /// projection-sized input; this is a speed experiment, not an approximation.
+    func testMiniMaxH3AdaLNRunModulation() throws {
+        try benchGate()
+        let rows = max(
+            1,
+            Int(ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 29_018
+        )
+        let hiddenSize = 5_376
+        let textRows = min(256, rows)
+        let conditionRows = min(1_600, max(0, rows - textRows))
+        let audioRows = min(840, max(0, rows - textRows - conditionRows))
+        let boundaries = [
+            0,
+            textRows,
+            textRows + conditionRows,
+            textRows + conditionRows + audioRows,
+            rows,
+        ]
+        let runIndices: [Int32] = [1, 6, 5, 0]
+        let runs = zip(boundaries, boundaries.dropFirst()).enumerated().compactMap { offset, pair in
+            pair.0 < pair.1 ? (range: pair.0..<pair.1, index: Int(runIndices[offset])) : nil
+        }
+        let indices = MLXArray(runs.flatMap { run in
+            repeatElement(Int32(run.index), count: run.range.count)
+        })
+        let value = MLXRandom.normal([1, rows, hiddenSize]).asType(.bfloat16)
+        let modulation = MLXRandom.normal([9, 3, hiddenSize]).asType(.bfloat16)
+        MLX.eval(value, modulation, indices)
+
+        func gathered() -> MLXArray {
+            let shift = MLX.take(modulation[0..., 0, 0...], indices, axis: 0)
+                .expandedDimensions(axis: 0)
+            let scale = MLX.take(modulation[0..., 1, 0...], indices, axis: 0)
+                .expandedDimensions(axis: 0)
+            let gate = MLX.take(modulation[0..., 2, 0...], indices, axis: 0)
+                .expandedDimensions(axis: 0)
+            return gate * (value * (1 + scale) + shift)
+        }
+
+        func byRuns() -> MLXArray {
+            MLX.concatenated(runs.map { run in
+                let parameters = modulation[run.index, 0..., 0...]
+                let shift = parameters[0, 0...]
+                let scale = parameters[1, 0...]
+                let gate = parameters[2, 0...]
+                let slice = value[0..., run.range, 0...]
+                return gate * (slice * (1 + scale) + shift)
+            }, axis: 1)
+        }
+
+        let gatheredOutput = gathered()
+        let runOutput = byRuns()
+        MLX.eval(gatheredOutput, runOutput)
+        let maximumAbsoluteError = MLX.max(MLX.abs(
+            gatheredOutput.asType(.float32) - runOutput.asType(.float32)
+        )).item(Float.self)
+        XCTAssertEqual(maximumAbsoluteError, 0)
+
+        func measure(_ body: () -> MLXArray) -> Double {
+            var best = Double.greatestFiniteMagnitude
+            for _ in 0..<3 {
+                let started = CFAbsoluteTimeGetCurrent()
+                MLX.eval(body())
+                best = min(best, CFAbsoluteTimeGetCurrent() - started)
+            }
+            return best
+        }
+        let gatheredSeconds = measure(gathered)
+        let runSeconds = measure(byRuns)
+        print(String(
+            format: "[h3-lab] modulation rows=%d hidden=%d runs=%d gather_ms=%.1f run_ms=%.1f speedup=%.3fx max_abs=%.6g",
+            rows,
+            hiddenSize,
+            runs.count,
+            gatheredSeconds * 1_000,
+            runSeconds * 1_000,
+            gatheredSeconds / runSeconds,
+            maximumAbsoluteError
+        ))
     }
 
     /// Exact dense MiniMax-H3 attention shape for the 768x448, 124-frame
@@ -625,6 +715,784 @@ final class DiTShapeBenchTests: XCTestCase {
                 operations / best / 1e12
             ))
         }
+    }
+
+    /// Searches exact H3 attention schedules across query chunks, head chunks,
+    /// and Metal evaluation batches. Every candidate is compared numerically
+    /// with the production 2,048-query/56-head/4-kernel schedule; this is a
+    /// kernel-scheduling search, not an attention approximation.
+    ///
+    /// Configure the frontier with:
+    ///
+    /// - `MERERUN_H3_BENCH_ROWS=14958,37966`
+    /// - `MERERUN_H3_BENCH_CHUNKS=1024,1536,2048,2560,3072,4096`
+    /// - `MERERUN_H3_BENCH_HEAD_CHUNKS=14,28,56`
+    /// - `MERERUN_H3_BENCH_EVAL_BATCHES=1,2,4,8`
+    /// - `MERERUN_H3_BENCH_ROUNDS=2`
+    /// - `MERERUN_H3_BENCH_SEARCH=coordinate` for a fast three-axis search,
+    ///   or `grid` for the complete Cartesian frontier
+    /// - `MERERUN_H3_BENCH_FAST=1` to share one paired baseline and defer
+    ///   validation while searching; this keeps the full key/value length but
+    ///   samples 8,192 query rows by default, then extrapolates the full pass
+    /// - `MERERUN_H3_BENCH_SAMPLE_QUERY_ROWS=8192` to tune that fast sample
+    ///   size; rerun the winner without fast mode for full-pass parity
+    /// - `MERERUN_H3_BENCH_VALIDATE=0` to skip the exactness calculation
+    /// - `MERERUN_H3_BENCH_DTYPE=fp16` to compare Metal's FP16 attention path
+    ///   with the production-default BF16 path
+    func testMiniMaxH3AttentionChunkSizes() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let benchmarkDType: DType = environment["MERERUN_H3_BENCH_DTYPE"] == "fp16"
+            ? .float16
+            : .bfloat16
+        let benchmarkDTypeLabel = benchmarkDType == .float16 ? "fp16" : "bf16"
+
+        func configuredIntegers(_ key: String) -> [Int] {
+            environment[key]?
+                .split(separator: ",")
+                .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                .filter { $0 > 0 } ?? []
+        }
+
+        let configuredRows = configuredIntegers("MERERUN_H3_BENCH_ROWS")
+        let rowCounts = configuredRows.isEmpty ? [14_958] : configuredRows
+        let configuredChunks = configuredIntegers("MERERUN_H3_BENCH_CHUNKS")
+        let chunkSizes = configuredChunks.isEmpty
+            ? [1_024, 1_536, 2_048, 2_560, 3_072, 4_096, 8_192]
+            : configuredChunks
+        let configuredHeadChunks = configuredIntegers("MERERUN_H3_BENCH_HEAD_CHUNKS")
+        let headChunkSizes = configuredHeadChunks.isEmpty ? [14, 28, 56] : configuredHeadChunks
+        let configuredEvaluationBatches = configuredIntegers("MERERUN_H3_BENCH_EVAL_BATCHES")
+        let evaluationBatchSizes = configuredEvaluationBatches.isEmpty
+            ? [1, 2, 4, 8]
+            : configuredEvaluationBatches
+        let rounds = max(1, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
+        let searchMode = environment["MERERUN_H3_BENCH_SEARCH"] ?? "coordinate"
+        let usesFastSearch = environment["MERERUN_H3_BENCH_FAST"] == "1"
+        let validatesExactness = environment["MERERUN_H3_BENCH_VALIDATE"] != "0"
+
+        Stream.withNewDefaultStream {
+            let heads = 56
+            let headDimension = 128
+            let scale = Float(1 / sqrt(Double(headDimension)))
+
+            func attention(
+                query: MLXArray,
+                key: MLXArray,
+                value: MLXArray,
+                queryChunkSize: Int,
+                headChunkSize: Int,
+                evaluationBatchSize: Int
+            ) -> MLXArray {
+                var headOutputs: [MLXArray] = []
+                var pending: [MLXArray] = []
+                for headStart in stride(from: 0, to: query.dim(1), by: headChunkSize) {
+                    let headEnd = min(headStart + headChunkSize, query.dim(1))
+                    var queryOutputs: [MLXArray] = []
+                    for queryStart in stride(from: 0, to: query.dim(2), by: queryChunkSize) {
+                        let queryEnd = min(queryStart + queryChunkSize, query.dim(2))
+                        let chunk = MLXFast.scaledDotProductAttention(
+                            queries: query[0..., headStart..<headEnd, queryStart..<queryEnd, 0...],
+                            keys: key[0..., headStart..<headEnd, 0..., 0...],
+                            values: value[0..., headStart..<headEnd, 0..., 0...],
+                            scale: scale,
+                            mask: .none
+                        )
+                        queryOutputs.append(chunk)
+                        pending.append(chunk)
+                        if pending.count == evaluationBatchSize {
+                            MLX.eval(pending)
+                            pending.removeAll(keepingCapacity: true)
+                        }
+                    }
+                    headOutputs.append(MLX.concatenated(queryOutputs, axis: 2))
+                }
+                if !pending.isEmpty {
+                    MLX.eval(pending)
+                }
+                return MLX.concatenated(headOutputs, axis: 1)
+            }
+
+            for rows in rowCounts {
+                let configuredSampleRows = max(
+                    1,
+                    Int(environment["MERERUN_H3_BENCH_SAMPLE_QUERY_ROWS"] ?? "") ?? 8_192
+                )
+                let queryRows = usesFastSearch ? min(rows, configuredSampleRows) : rows
+                let query = MLXRandom.normal([1, heads, queryRows, headDimension])
+                    .asType(benchmarkDType)
+                let key = MLXRandom.normal([1, heads, rows, headDimension])
+                    .asType(benchmarkDType)
+                let value = MLXRandom.normal([1, heads, rows, headDimension])
+                    .asType(benchmarkDType)
+                MLX.eval(query, key, value)
+
+                let baseline = {
+                    attention(
+                        query: query,
+                        key: key,
+                        value: value,
+                        queryChunkSize: min(2_048, rows),
+                        headChunkSize: heads,
+                        evaluationBatchSize: 4
+                    )
+                }
+                let baselineOutput = baseline()
+                MLX.eval(baselineOutput)
+                let baseline32 = validatesExactness ? baselineOutput.asType(.float32) : nil
+                if let baseline32 { MLX.eval(baseline32) }
+
+                struct AttentionSchedule: Hashable {
+                    let queryChunkSize: Int
+                    let headChunkSize: Int
+                    let evaluationBatchSize: Int
+                }
+
+                struct Measurement {
+                    let candidateSeconds: Double
+                    let baselineSeconds: Double
+
+                    var speedup: Double { baselineSeconds / candidateSeconds }
+                }
+
+                var measured: [AttentionSchedule: Measurement] = [:]
+                var bestSeconds = Double.greatestFiniteMagnitude
+                var bestSpeedup = 0.0
+                var bestDescription = ""
+
+                func elapsed(_ body: () -> MLXArray) -> Double {
+                    let started = CFAbsoluteTimeGetCurrent()
+                    MLX.eval(body())
+                    return CFAbsoluteTimeGetCurrent() - started
+                }
+                let sharedBaselineSeconds: Double? = usesFastSearch ? elapsed(baseline) : nil
+
+                func measure(_ schedule: AttentionSchedule) -> Measurement {
+                    if let measurement = measured[schedule] { return measurement }
+                    Memory.peakMemory = 0
+                    let candidate = {
+                        attention(
+                            query: query,
+                            key: key,
+                            value: value,
+                            queryChunkSize: schedule.queryChunkSize,
+                            headChunkSize: schedule.headChunkSize,
+                            evaluationBatchSize: schedule.evaluationBatchSize
+                        )
+                    }
+                    let measurement: Measurement
+                    let output: MLXArray?
+                    if let sharedBaselineSeconds {
+                        MLX.eval(candidate())
+                        measurement = Measurement(
+                            candidateSeconds: elapsed(candidate),
+                            baselineSeconds: sharedBaselineSeconds
+                        )
+                        output = nil
+                    } else {
+                        MLX.eval(baseline(), candidate())
+                        var baselineSeconds = 0.0
+                        var candidateSeconds = 0.0
+                        for round in 0..<rounds {
+                            if round.isMultiple(of: 2) {
+                                baselineSeconds += elapsed(baseline)
+                                candidateSeconds += elapsed(candidate)
+                            } else {
+                                candidateSeconds += elapsed(candidate)
+                                baselineSeconds += elapsed(baseline)
+                            }
+                        }
+                        measurement = Measurement(
+                            candidateSeconds: candidateSeconds / Double(rounds),
+                            baselineSeconds: baselineSeconds / Double(rounds)
+                        )
+                        let candidateOutput = candidate()
+                        MLX.eval(candidateOutput)
+                        output = candidateOutput
+                    }
+                    let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
+                    var maximumAbsoluteError = 0.0
+                    var relativeL2Error = 0.0
+                    if let baseline32, let output {
+                        let delta = output.asType(.float32) - baseline32
+                        let errorSquared = MLX.sum(delta * delta).item(Float.self)
+                        let referenceSquared = MLX.sum(baseline32 * baseline32).item(Float.self)
+                        maximumAbsoluteError = Double(MLX.max(MLX.abs(delta)).item(Float.self))
+                        relativeL2Error = sqrt(
+                            Double(errorSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude)
+                        )
+                        XCTAssertLessThan(relativeL2Error, 1e-3)
+                    }
+                    let operations = 4 * Double(heads) * Double(queryRows)
+                        * Double(rows) * Double(headDimension)
+                    let fullPassScale = Double(rows) / Double(queryRows)
+                    print(String(
+                        format: "[h3-lab] attention dtype=%@ rows=%d sampled_queries=%d query=%d "
+                            + "heads=%d batch=%d sample_kernels=%d full_kernels=%d "
+                            + "sample_ms=%.0f estimated_full_ms=%.0f paired_base_ms=%.0f "
+                            + "speedup=%.3fx tflops=%.2f max_abs=%.6g rel_l2=%.6g peak_gib=%.2f",
+                        benchmarkDTypeLabel,
+                        rows,
+                        queryRows,
+                        schedule.queryChunkSize,
+                        schedule.headChunkSize,
+                        schedule.evaluationBatchSize,
+                        ((queryRows + schedule.queryChunkSize - 1) / schedule.queryChunkSize)
+                            * ((heads + schedule.headChunkSize - 1) / schedule.headChunkSize),
+                        ((rows + schedule.queryChunkSize - 1) / schedule.queryChunkSize)
+                            * ((heads + schedule.headChunkSize - 1) / schedule.headChunkSize),
+                        measurement.candidateSeconds * 1_000,
+                        measurement.candidateSeconds * fullPassScale * 1_000,
+                        measurement.baselineSeconds * 1_000,
+                        measurement.speedup,
+                        operations / measurement.candidateSeconds / 1e12,
+                        maximumAbsoluteError,
+                        relativeL2Error,
+                        peakGiB
+                    ))
+                    measured[schedule] = measurement
+                    if measurement.speedup > bestSpeedup {
+                        bestSeconds = measurement.candidateSeconds
+                        bestSpeedup = measurement.speedup
+                        bestDescription = "query=\(schedule.queryChunkSize) "
+                            + "heads=\(schedule.headChunkSize) batch=\(schedule.evaluationBatchSize)"
+                    }
+                    Memory.clearCache()
+                    return measurement
+                }
+
+                func fastest(_ schedules: [AttentionSchedule]) -> AttentionSchedule {
+                    precondition(!schedules.isEmpty)
+                    var winner = schedules[0]
+                    var winnerSpeedup = measure(winner).speedup
+                    for schedule in schedules.dropFirst() {
+                        let speedup = measure(schedule).speedup
+                        if speedup > winnerSpeedup {
+                            winner = schedule
+                            winnerSpeedup = speedup
+                        }
+                    }
+                    return winner
+                }
+
+                if searchMode == "grid" {
+                    for requestedChunkSize in chunkSizes {
+                        for requestedHeadChunkSize in headChunkSizes {
+                            for evaluationBatchSize in evaluationBatchSizes {
+                                _ = measure(AttentionSchedule(
+                                    queryChunkSize: min(requestedChunkSize, rows),
+                                    headChunkSize: min(requestedHeadChunkSize, heads),
+                                    evaluationBatchSize: evaluationBatchSize
+                                ))
+                            }
+                        }
+                    }
+                } else {
+                    let queryWinner = fastest(chunkSizes.map {
+                        AttentionSchedule(
+                            queryChunkSize: min($0, rows),
+                            headChunkSize: heads,
+                            evaluationBatchSize: 4
+                        )
+                    })
+                    let headWinner = fastest(headChunkSizes.map {
+                        AttentionSchedule(
+                            queryChunkSize: queryWinner.queryChunkSize,
+                            headChunkSize: min($0, heads),
+                            evaluationBatchSize: 4
+                        )
+                    })
+                    _ = fastest(evaluationBatchSizes.map {
+                        AttentionSchedule(
+                            queryChunkSize: headWinner.queryChunkSize,
+                            headChunkSize: headWinner.headChunkSize,
+                            evaluationBatchSize: $0
+                        )
+                    })
+                }
+                print(String(
+                    format: "[h3-lab] winner dtype=%@ rows=%d sampled_queries=%d search=%@ "
+                        + "%@ estimated_full_ms=%.0f speedup=%.3fx candidates=%d",
+                    benchmarkDTypeLabel,
+                    rows,
+                    queryRows,
+                    searchMode,
+                    bestDescription,
+                    bestSeconds * Double(rows) / Double(queryRows) * 1_000,
+                    bestSpeedup,
+                    measured.count
+                ))
+                Memory.clearCache()
+            }
+        }
+    }
+
+    /// Laboratory sweep for the non-NAX MLX Steel GEMM tile and threadgroup
+    /// swizzle at H3's true-768 QKV projection shape.
+    func testMiniMaxH3MetalGEMMTiles() throws {
+        try benchGate()
+
+        struct Tile: Hashable {
+            let blockRows: Int
+            let blockColumns: Int
+            let blockDepth: Int
+            let rowWarps: Int
+            let columnWarps: Int
+        }
+        struct Arm: Hashable {
+            let tile: Tile
+            let swizzle: Int
+        }
+
+        let defaultTile = Tile(
+            blockRows: 64,
+            blockColumns: 64,
+            blockDepth: 16,
+            rowWarps: 1,
+            columnWarps: 2
+        )
+        let tiles = [
+            defaultTile,
+            Tile(blockRows: 64, blockColumns: 64, blockDepth: 16, rowWarps: 2, columnWarps: 2),
+            Tile(blockRows: 64, blockColumns: 32, blockDepth: 32, rowWarps: 2, columnWarps: 2),
+            Tile(blockRows: 32, blockColumns: 64, blockDepth: 16, rowWarps: 1, columnWarps: 2),
+            Tile(blockRows: 32, blockColumns: 32, blockDepth: 16, rowWarps: 2, columnWarps: 2),
+            Tile(blockRows: 64, blockColumns: 32, blockDepth: 8, rowWarps: 4, columnWarps: 1),
+        ]
+        let arms = tiles.flatMap { tile in
+            (0...3).map { Arm(tile: tile, swizzle: $0) }
+        }
+
+        func select(_ arm: Arm) {
+            setenv("MLX_GEMM_BM", String(arm.tile.blockRows), 1)
+            setenv("MLX_GEMM_BN", String(arm.tile.blockColumns), 1)
+            setenv("MLX_GEMM_BK", String(arm.tile.blockDepth), 1)
+            setenv("MLX_GEMM_WM", String(arm.tile.rowWarps), 1)
+            setenv("MLX_GEMM_WN", String(arm.tile.columnWarps), 1)
+            setenv("MLX_GEMM_SWIZZLE_LOG", String(arm.swizzle), 1)
+        }
+
+        let defaultArm = Arm(tile: defaultTile, swizzle: 0)
+        defer { select(defaultArm) }
+
+        Stream.withNewDefaultStream {
+            let rows = 37_966
+            let inputDimension = 5_376
+            let outputDimension = 21_504
+            let input = MLXRandom.normal([1, rows, inputDimension]).asType(.bfloat16)
+            let weight = MLXRandom.normal([outputDimension, inputDimension]).asType(.bfloat16)
+            MLX.eval(input, weight)
+
+            func projection() -> MLXArray {
+                MLX.matmul(input, weight.T)
+            }
+
+            select(defaultArm)
+            let reference = projection()
+            MLX.eval(reference)
+            let referenceSample = reference[0..., 0..<128, 0...].asType(.float32)
+            MLX.eval(referenceSample)
+
+            for tile in tiles {
+                let arm = Arm(tile: tile, swizzle: 0)
+                select(arm)
+                let output = projection()
+                MLX.eval(output)
+                let delta = output[0..., 0..<128, 0...].asType(.float32) - referenceSample
+                let errorSquared = MLX.sum(delta * delta).item(Float.self)
+                let referenceSquared = MLX.sum(referenceSample * referenceSample).item(Float.self)
+                let maximumAbsoluteError = MLX.max(MLX.abs(delta)).item(Float.self)
+                let relativeL2Error = sqrt(
+                    Double(errorSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude)
+                )
+                XCTAssertLessThan(relativeL2Error, 1e-3)
+                print(String(
+                    format: "[h3-lab] gemm-parity bm=%d bn=%d bk=%d wm=%d wn=%d "
+                        + "max_abs=%.6g rel_l2=%.6g",
+                    tile.blockRows,
+                    tile.blockColumns,
+                    tile.blockDepth,
+                    tile.rowWarps,
+                    tile.columnWarps,
+                    maximumAbsoluteError,
+                    relativeL2Error
+                ))
+            }
+
+            var totals = Dictionary(uniqueKeysWithValues: arms.map { ($0, 0.0) })
+            for orderedArms in [arms, Array(arms.reversed())] {
+                for arm in orderedArms {
+                    select(arm)
+                    let started = CFAbsoluteTimeGetCurrent()
+                    MLX.eval(projection())
+                    totals[arm, default: 0] += CFAbsoluteTimeGetCurrent() - started
+                }
+            }
+
+            let operations = 2 * Double(rows) * Double(inputDimension) * Double(outputDimension)
+            for arm in arms {
+                let seconds = totals[arm, default: 0] / 2
+                print(String(
+                    format: "[h3-lab] gemm-tile bm=%d bn=%d bk=%d wm=%d wn=%d "
+                        + "swizzle=%d mean_ms=%.1f tflops=%.2f",
+                    arm.tile.blockRows,
+                    arm.tile.blockColumns,
+                    arm.tile.blockDepth,
+                    arm.tile.rowWarps,
+                    arm.tile.columnWarps,
+                    arm.swizzle,
+                    seconds * 1_000,
+                    operations / seconds / 1e12
+                ))
+            }
+        }
+    }
+
+    /// Confirms the QKV winner against every dense projection in a production
+    /// H3 block before any MLX heuristic changes are considered.
+    func testMiniMaxH3MetalGEMMProjectionShapes() throws {
+        try benchGate()
+
+        struct Arm {
+            let name: String
+            let blockRows: Int
+            let blockColumns: Int
+            let blockDepth: Int
+            let rowWarps: Int
+            let columnWarps: Int
+            let swizzle: Int
+        }
+
+        let arms = [
+            Arm(name: "default", blockRows: 64, blockColumns: 64, blockDepth: 16,
+                rowWarps: 1, columnWarps: 2, swizzle: 0),
+            Arm(name: "default-sw1", blockRows: 64, blockColumns: 64, blockDepth: 16,
+                rowWarps: 1, columnWarps: 2, swizzle: 1),
+            Arm(name: "four-warp-sw2", blockRows: 64, blockColumns: 64, blockDepth: 16,
+                rowWarps: 2, columnWarps: 2, swizzle: 2),
+            Arm(name: "narrow-m-sw2", blockRows: 32, blockColumns: 64, blockDepth: 16,
+                rowWarps: 1, columnWarps: 2, swizzle: 2),
+        ]
+        let shapes = [
+            (name: "qkv", input: 5_376, output: 21_504),
+            (name: "attention-out", input: 7_168, output: 5_376),
+            (name: "ff-in", input: 5_376, output: 28_672),
+            (name: "ff-out", input: 14_336, output: 5_376),
+        ]
+
+        func select(_ arm: Arm) {
+            setenv("MLX_GEMM_BM", String(arm.blockRows), 1)
+            setenv("MLX_GEMM_BN", String(arm.blockColumns), 1)
+            setenv("MLX_GEMM_BK", String(arm.blockDepth), 1)
+            setenv("MLX_GEMM_WM", String(arm.rowWarps), 1)
+            setenv("MLX_GEMM_WN", String(arm.columnWarps), 1)
+            setenv("MLX_GEMM_SWIZZLE_LOG", String(arm.swizzle), 1)
+        }
+
+        defer { select(arms[0]) }
+
+        Stream.withNewDefaultStream {
+            let rows = 37_966
+            for shape in shapes {
+                let input = MLXRandom.normal([1, rows, shape.input]).asType(.bfloat16)
+                let weight = MLXRandom.normal([shape.output, shape.input]).asType(.bfloat16)
+                MLX.eval(input, weight)
+
+                func projection() -> MLXArray {
+                    MLX.matmul(input, weight.T)
+                }
+
+                select(arms[0])
+                let reference = projection()
+                MLX.eval(reference)
+                let referenceSample = reference[0..., 0..<128, 0...].asType(.float32)
+                MLX.eval(referenceSample)
+
+                var totals = Dictionary(uniqueKeysWithValues: arms.map { ($0.name, 0.0) })
+                for orderedArms in [arms, Array(arms.reversed())] {
+                    for arm in orderedArms {
+                        select(arm)
+                        let started = CFAbsoluteTimeGetCurrent()
+                        let output = projection()
+                        MLX.eval(output)
+                        totals[arm.name, default: 0] += CFAbsoluteTimeGetCurrent() - started
+
+                        let delta = output[0..., 0..<128, 0...].asType(.float32) - referenceSample
+                        let errorSquared = MLX.sum(delta * delta).item(Float.self)
+                        let referenceSquared = MLX.sum(referenceSample * referenceSample).item(Float.self)
+                        let relativeL2Error = sqrt(
+                            Double(errorSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude)
+                        )
+                        XCTAssertLessThan(relativeL2Error, 1e-3)
+                    }
+                }
+
+                let operations = 2 * Double(rows) * Double(shape.input) * Double(shape.output)
+                for arm in arms {
+                    let seconds = totals[arm.name, default: 0] / 2
+                    print(String(
+                        format: "[h3-lab] gemm-shape %@ %@ %d->%d mean_ms=%.1f tflops=%.2f",
+                        shape.name,
+                        arm.name,
+                        shape.input,
+                        shape.output,
+                        seconds * 1_000,
+                        operations / seconds / 1e12
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Paired whole-block confirmation for the default and candidate GEMM
+    /// schedules so thermal drift hits both arms symmetrically.
+    func testMiniMaxH3BlockGEMMSchedules() throws {
+        try benchGate()
+        let rows = 37_966
+        let benchmark = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: 1_024,
+            maximumKernelsPerEvaluation: 4
+        )
+
+        func selectDefault() {
+            setenv("MLX_GEMM_H3_TUNED", "0", 1)
+            setenv("MLX_GEMM_BM", "64", 1)
+            setenv("MLX_GEMM_BN", "64", 1)
+            setenv("MLX_GEMM_BK", "16", 1)
+            setenv("MLX_GEMM_WM", "1", 1)
+            setenv("MLX_GEMM_WN", "2", 1)
+            setenv("MLX_GEMM_SWIZZLE_LOG", "0", 1)
+        }
+
+        func selectCandidate() {
+            setenv("MLX_GEMM_H3_TUNED", "0", 1)
+            setenv("MLX_GEMM_BM", "64", 1)
+            setenv("MLX_GEMM_BN", "64", 1)
+            setenv("MLX_GEMM_BK", "16", 1)
+            setenv("MLX_GEMM_WM", "2", 1)
+            setenv("MLX_GEMM_WN", "2", 1)
+            setenv("MLX_GEMM_SWIZZLE_LOG", "2", 1)
+        }
+
+        func selectHybrid() {
+            setenv("MLX_GEMM_H3_TUNED", "1", 1)
+        }
+
+        defer { selectDefault() }
+
+        selectDefault()
+        let reference = benchmark(schedule: .splitPostAttention)
+        MLX.eval(reference)
+        selectCandidate()
+        let candidate = benchmark(schedule: .splitPostAttention)
+        MLX.eval(candidate)
+        selectHybrid()
+        let hybrid = benchmark(schedule: .splitPostAttention)
+        MLX.eval(hybrid)
+        let reference32 = reference.asType(.float32)
+        MLX.eval(reference32)
+        func relativeL2(_ output: MLXArray) -> Double {
+            let delta = output.asType(.float32) - reference32
+            let errorSquared = MLX.sum(delta * delta).item(Float.self)
+            let referenceSquared = MLX.sum(reference32 * reference32).item(Float.self)
+            return sqrt(Double(errorSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude))
+        }
+        let candidateRelativeL2Error = relativeL2(candidate)
+        let hybridRelativeL2Error = relativeL2(hybrid)
+        XCTAssertLessThan(candidateRelativeL2Error, 1e-3)
+        XCTAssertLessThan(hybridRelativeL2Error, 1e-3)
+
+        var totals = [Double](repeating: 0, count: 3)
+        let rounds = 3
+        for round in 0..<rounds {
+            let order: [(select: () -> Void, arm: Int)]
+            switch round {
+            case 0:
+                order = [(selectDefault, 0), (selectCandidate, 1), (selectHybrid, 2)]
+            case 1:
+                order = [(selectCandidate, 1), (selectHybrid, 2), (selectDefault, 0)]
+            default:
+                order = [(selectHybrid, 2), (selectDefault, 0), (selectCandidate, 1)]
+            }
+            for arm in order {
+                arm.select()
+                let started = CFAbsoluteTimeGetCurrent()
+                MLX.eval(benchmark(schedule: .splitPostAttention))
+                totals[arm.arm] += CFAbsoluteTimeGetCurrent() - started
+            }
+        }
+        totals = totals.map { $0 / Double(rounds) }
+        print(String(
+            format: "[h3-lab] block-gemm rows=%d default_ms=%.0f generic_ms=%.0f "
+                + "hybrid_ms=%.0f generic_speedup=%.3fx hybrid_speedup=%.3fx "
+                + "generic_rel_l2=%.6g hybrid_rel_l2=%.6g",
+            rows,
+            totals[0] * 1_000,
+            totals[1] * 1_000,
+            totals[2] * 1_000,
+            totals[0] / totals[1],
+            totals[0] / totals[2],
+            candidateRelativeL2Error,
+            hybridRelativeL2Error
+        ))
+    }
+
+    /// Measures the exact compiled schedules used by one production H3 block.
+    /// This catches graph-boundary and synchronization costs that isolated GEMM
+    /// and SDPA probes cannot see. Use 37,966 rows for the true-768 target.
+    func testMiniMaxH3BlockExecutionSchedules() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 14_958)
+        let queryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_QUERY_TOKENS"] ?? "") ?? 1_024
+        )
+        let evaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_EVAL_BATCH"] ?? "") ?? 4
+        )
+        let rounds = max(1, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
+        let benchmark = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch
+        )
+
+        func elapsed(_ schedule: MiniMaxH3BlockScheduleBenchmark.Schedule) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(benchmark(schedule: schedule))
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        MLX.eval(benchmark(schedule: .splitPostAttention))
+        MLX.eval(benchmark(schedule: .fusedPostAttention))
+
+        let splitOutput = benchmark(schedule: .splitPostAttention).asType(.float32)
+        let fusedOutput = benchmark(schedule: .fusedPostAttention).asType(.float32)
+        MLX.eval(splitOutput, fusedOutput)
+        let fusedDelta = fusedOutput - splitOutput
+        let referenceSquared = MLX.sum(splitOutput * splitOutput).item(Float.self)
+        let fusedRelativeL2Error = sqrt(
+            Double(MLX.sum(fusedDelta * fusedDelta).item(Float.self))
+                / max(Double(referenceSquared), .leastNonzeroMagnitude)
+        )
+        XCTAssertLessThan(fusedRelativeL2Error, 1e-3)
+
+        var splitBest = Double.greatestFiniteMagnitude
+        var fusedBest = Double.greatestFiniteMagnitude
+        Memory.peakMemory = 0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                splitBest = min(splitBest, elapsed(.splitPostAttention))
+                fusedBest = min(fusedBest, elapsed(.fusedPostAttention))
+            } else {
+                fusedBest = min(fusedBest, elapsed(.fusedPostAttention))
+                splitBest = min(splitBest, elapsed(.splitPostAttention))
+            }
+        }
+
+        let projectedAttention = benchmark.projectAttention()
+        MLX.eval(projectedAttention)
+        let attended = benchmark.attend(projectedAttention)
+        MLX.eval(attended)
+        func phaseElapsed(_ body: () -> Void) -> Double {
+            var best = Double.greatestFiniteMagnitude
+            for _ in 0..<rounds {
+                let started = CFAbsoluteTimeGetCurrent()
+                body()
+                best = min(best, CFAbsoluteTimeGetCurrent() - started)
+            }
+            return best
+        }
+        let attentionProjectionSeconds = phaseElapsed {
+            MLX.eval(benchmark.projectAttention())
+        }
+        let attentionSeconds = phaseElapsed {
+            MLX.eval(benchmark.attend(projectedAttention))
+        }
+        let splitPostAttentionSeconds = phaseElapsed {
+            MLX.eval(benchmark.postAttention(
+                schedule: .splitPostAttention,
+                attended: attended,
+                gate: projectedAttention[3]
+            ))
+        }
+        let fusedPostAttentionSeconds = phaseElapsed {
+            MLX.eval(benchmark.postAttention(
+                schedule: .fusedPostAttention,
+                attended: attended,
+                gate: projectedAttention[3]
+            ))
+        }
+
+        let configuration = MiniMaxH3TransformerConfiguration()
+        let projectionOperations = 2 * Double(rows) * Double(configuration.hiddenSize)
+            * Double(
+                4 * configuration.attentionHeadCount * configuration.attentionHeadDimension
+                    + 3 * configuration.feedForwardSize
+            )
+        let attentionOperations = 4 * Double(configuration.attentionHeadCount) * Double(rows)
+            * Double(rows) * Double(configuration.attentionHeadDimension)
+        let operations = projectionOperations + attentionOperations
+        let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
+        print(String(
+            format: "[h3-lab] block rows=%d query=%d batch=%d split_ms=%.0f "
+                + "fused_ms=%.0f fused_speedup=%.3fx split_tflops=%.2f fused_tflops=%.2f "
+                + "fused_rel_l2=%.6g peak_gib=%.2f",
+            rows,
+            queryTokens,
+            evaluationBatch,
+            splitBest * 1_000,
+            fusedBest * 1_000,
+            splitBest / fusedBest,
+            operations / splitBest / 1e12,
+            operations / fusedBest / 1e12,
+            fusedRelativeL2Error,
+            peakGiB
+        ))
+        print(String(
+            format: "[h3-lab] block-phases rows=%d attention_projection_ms=%.0f "
+                + "attention_ms=%.0f split_post_ms=%.0f fused_post_ms=%.0f",
+            rows,
+            attentionProjectionSeconds * 1_000,
+            attentionSeconds * 1_000,
+            splitPostAttentionSeconds * 1_000,
+            fusedPostAttentionSeconds * 1_000
+        ))
+        Memory.clearCache()
+    }
+
+    /// Loads the released H3 video VAE and times one complete 124-frame decode
+    /// with a configurable spatial tile. Run each size in a fresh process:
+    /// `MERERUN_H3_VAE_TILE_SIZE=320` and `MERERUN_H3_MODEL_ROOT=/path/to/root`.
+    func testMiniMaxH3VideoVAETileSize() throws {
+        try benchGate()
+        guard let root = ProcessInfo.processInfo.environment["MERERUN_H3_MODEL_ROOT"],
+              !root.isEmpty else {
+            throw XCTSkip("Set MERERUN_H3_MODEL_ROOT to an installed H3 model root")
+        }
+        let tileSize = Int(
+            ProcessInfo.processInfo.environment["MERERUN_H3_VAE_TILE_SIZE"] ?? ""
+        ) ?? MiniMaxH3VideoVAE.defaultSpatialTileSize
+        let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: root, isDirectory: true))
+        let model = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+        model.spatialTileSize = tileSize
+        let latents = MLXRandom.normal([1, 24, 37, 30, 52]).asType(.float32)
+        MLX.eval(latents)
+
+        let started = CFAbsoluteTimeGetCurrent()
+        let decoded = model.decode(latents)
+        MLX.eval(decoded)
+        print(String(
+            format: "[dit-bench] H3 video VAE tile=%d frames=%d %.3fs peak=%.2fGiB",
+            tileSize,
+            decoded.dim(1),
+            CFAbsoluteTimeGetCurrent() - started,
+            Double(Memory.snapshot().peakMemory) / 1_073_741_824
+        ))
+        XCTAssertEqual(decoded.shape, [1, 124, 480, 832, 3])
     }
 
     /// Full-model paired A/B: the same quantized klein-nano forward with the

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1596,6 +1596,10 @@ final class DiTShapeBenchTests: XCTestCase {
         let frameCount = Int(environment["MERERUN_H3_VAE_FRAMES"] ?? "") ?? 124
         XCTAssertTrue(width.isMultiple(of: 16))
         XCTAssertTrue(height.isMultiple(of: 16))
+        guard frameCount >= 22 else {
+            XCTFail("H3 video VAE decode requires at least 22 output frames")
+            return
+        }
         let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: frameCount)
         let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: root, isDirectory: true))
         let model = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1896,6 +1896,10 @@ final class DiTShapeBenchTests: XCTestCase {
             1,
             Int(environment["MERERUN_H3_BENCH_REFERENCE_EVAL_BATCH"] ?? "") ?? 4
         )
+        let referenceHeads = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_REFERENCE_HEADS"] ?? "") ?? 56
+        )
         let candidateQueryTokens = max(
             1,
             Int(environment["MERERUN_H3_BENCH_CANDIDATE_QUERY_TOKENS"] ?? "") ?? 768
@@ -1904,33 +1908,52 @@ final class DiTShapeBenchTests: XCTestCase {
             1,
             Int(environment["MERERUN_H3_BENCH_CANDIDATE_EVAL_BATCH"] ?? "") ?? 1
         )
+        let candidateHeads = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_CANDIDATE_HEADS"] ?? "") ?? 56
+        )
         let benchmark = MiniMaxH3BlockScheduleBenchmark(
             rowCount: rows,
             maximumQueryTokens: referenceQueryTokens,
             maximumKernelsPerEvaluation: referenceEvaluationBatch
         )
 
-        func output(queryTokens: Int, evaluationBatch: Int) -> MLXArray {
+        func output(queryTokens: Int, heads: Int, evaluationBatch: Int) -> MLXArray {
             benchmark(
                 schedule: .splitPostAttention,
                 maximumQueryTokens: queryTokens,
+                maximumHeadsPerKernel: heads,
                 maximumKernelsPerEvaluation: evaluationBatch
             )
         }
-        func elapsed(queryTokens: Int, evaluationBatch: Int) -> Double {
+        func elapsed(queryTokens: Int, heads: Int, evaluationBatch: Int) -> Double {
             let started = CFAbsoluteTimeGetCurrent()
-            MLX.eval(output(queryTokens: queryTokens, evaluationBatch: evaluationBatch))
+            MLX.eval(output(
+                queryTokens: queryTokens,
+                heads: heads,
+                evaluationBatch: evaluationBatch
+            ))
             return CFAbsoluteTimeGetCurrent() - started
         }
 
-        MLX.eval(output(queryTokens: referenceQueryTokens, evaluationBatch: referenceEvaluationBatch))
-        MLX.eval(output(queryTokens: candidateQueryTokens, evaluationBatch: candidateEvaluationBatch))
+        MLX.eval(output(
+            queryTokens: referenceQueryTokens,
+            heads: referenceHeads,
+            evaluationBatch: referenceEvaluationBatch
+        ))
+        MLX.eval(output(
+            queryTokens: candidateQueryTokens,
+            heads: candidateHeads,
+            evaluationBatch: candidateEvaluationBatch
+        ))
         let reference = output(
             queryTokens: referenceQueryTokens,
+            heads: referenceHeads,
             evaluationBatch: referenceEvaluationBatch
         ).asType(.float32)
         let candidate = output(
             queryTokens: candidateQueryTokens,
+            heads: candidateHeads,
             evaluationBatch: candidateEvaluationBatch
         ).asType(.float32)
         MLX.eval(reference, candidate)
@@ -1948,19 +1971,23 @@ final class DiTShapeBenchTests: XCTestCase {
             if round.isMultiple(of: 2) {
                 referenceTotal += elapsed(
                     queryTokens: referenceQueryTokens,
+                    heads: referenceHeads,
                     evaluationBatch: referenceEvaluationBatch
                 )
                 candidateTotal += elapsed(
                     queryTokens: candidateQueryTokens,
+                    heads: candidateHeads,
                     evaluationBatch: candidateEvaluationBatch
                 )
             } else {
                 candidateTotal += elapsed(
                     queryTokens: candidateQueryTokens,
+                    heads: candidateHeads,
                     evaluationBatch: candidateEvaluationBatch
                 )
                 referenceTotal += elapsed(
                     queryTokens: referenceQueryTokens,
+                    heads: referenceHeads,
                     evaluationBatch: referenceEvaluationBatch
                 )
             }
@@ -1968,13 +1995,15 @@ final class DiTShapeBenchTests: XCTestCase {
         let referenceSeconds = referenceTotal / Double(rounds)
         let candidateSeconds = candidateTotal / Double(rounds)
         print(String(
-            format: "[h3-lab] block-attention rows=%d reference=%dx%d reference_ms=%.0f "
-                + "candidate=%dx%d candidate_ms=%.0f speedup=%.3fx relative_l2=%.6g",
+            format: "[h3-lab] block-attention rows=%d reference=%dx%dx%d reference_ms=%.0f "
+                + "candidate=%dx%dx%d candidate_ms=%.0f speedup=%.3fx relative_l2=%.6g",
             rows,
             referenceQueryTokens,
+            referenceHeads,
             referenceEvaluationBatch,
             referenceSeconds * 1_000,
             candidateQueryTokens,
+            candidateHeads,
             candidateEvaluationBatch,
             candidateSeconds * 1_000,
             referenceSeconds / candidateSeconds,

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1380,29 +1380,45 @@ final class DiTShapeBenchTests: XCTestCase {
         }
 
         MLX.eval(benchmark(schedule: .splitPostAttention))
+        MLX.eval(benchmark(schedule: .fusedFeedForward))
         MLX.eval(benchmark(schedule: .fusedPostAttention))
 
         let splitOutput = benchmark(schedule: .splitPostAttention).asType(.float32)
+        let feedForwardOutput = benchmark(schedule: .fusedFeedForward).asType(.float32)
         let fusedOutput = benchmark(schedule: .fusedPostAttention).asType(.float32)
-        MLX.eval(splitOutput, fusedOutput)
+        MLX.eval(splitOutput, feedForwardOutput, fusedOutput)
+        let feedForwardDelta = feedForwardOutput - splitOutput
         let fusedDelta = fusedOutput - splitOutput
         let referenceSquared = MLX.sum(splitOutput * splitOutput).item(Float.self)
+        let feedForwardRelativeL2Error = sqrt(
+            Double(MLX.sum(feedForwardDelta * feedForwardDelta).item(Float.self))
+                / max(Double(referenceSquared), .leastNonzeroMagnitude)
+        )
         let fusedRelativeL2Error = sqrt(
             Double(MLX.sum(fusedDelta * fusedDelta).item(Float.self))
                 / max(Double(referenceSquared), .leastNonzeroMagnitude)
         )
+        XCTAssertLessThan(feedForwardRelativeL2Error, 1e-3)
         XCTAssertLessThan(fusedRelativeL2Error, 1e-3)
 
         var splitBest = Double.greatestFiniteMagnitude
+        var feedForwardBest = Double.greatestFiniteMagnitude
         var fusedBest = Double.greatestFiniteMagnitude
         Memory.peakMemory = 0
         for round in 0..<rounds {
-            if round.isMultiple(of: 2) {
+            switch round % 3 {
+            case 0:
                 splitBest = min(splitBest, elapsed(.splitPostAttention))
+                feedForwardBest = min(feedForwardBest, elapsed(.fusedFeedForward))
                 fusedBest = min(fusedBest, elapsed(.fusedPostAttention))
-            } else {
+            case 1:
+                feedForwardBest = min(feedForwardBest, elapsed(.fusedFeedForward))
                 fusedBest = min(fusedBest, elapsed(.fusedPostAttention))
                 splitBest = min(splitBest, elapsed(.splitPostAttention))
+            default:
+                fusedBest = min(fusedBest, elapsed(.fusedPostAttention))
+                splitBest = min(splitBest, elapsed(.splitPostAttention))
+                feedForwardBest = min(feedForwardBest, elapsed(.fusedFeedForward))
             }
         }
 
@@ -1432,6 +1448,13 @@ final class DiTShapeBenchTests: XCTestCase {
                 gate: projectedAttention[3]
             ))
         }
+        let fusedFeedForwardSeconds = phaseElapsed {
+            MLX.eval(benchmark.postAttention(
+                schedule: .fusedFeedForward,
+                attended: attended,
+                gate: projectedAttention[3]
+            ))
+        }
         let fusedPostAttentionSeconds = phaseElapsed {
             MLX.eval(benchmark.postAttention(
                 schedule: .fusedPostAttention,
@@ -1452,26 +1475,33 @@ final class DiTShapeBenchTests: XCTestCase {
         let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
         print(String(
             format: "[h3-lab] block rows=%d query=%d batch=%d split_ms=%.0f "
-                + "fused_ms=%.0f fused_speedup=%.3fx split_tflops=%.2f fused_tflops=%.2f "
-                + "fused_rel_l2=%.6g peak_gib=%.2f",
+                + "ff_fused_ms=%.0f fused_ms=%.0f ff_fused_speedup=%.3fx "
+                + "fused_speedup=%.3fx split_tflops=%.2f ff_fused_tflops=%.2f "
+                + "fused_tflops=%.2f ff_fused_rel_l2=%.6g fused_rel_l2=%.6g peak_gib=%.2f",
             rows,
             queryTokens,
             evaluationBatch,
             splitBest * 1_000,
+            feedForwardBest * 1_000,
             fusedBest * 1_000,
+            splitBest / feedForwardBest,
             splitBest / fusedBest,
             operations / splitBest / 1e12,
+            operations / feedForwardBest / 1e12,
             operations / fusedBest / 1e12,
+            feedForwardRelativeL2Error,
             fusedRelativeL2Error,
             peakGiB
         ))
         print(String(
             format: "[h3-lab] block-phases rows=%d attention_projection_ms=%.0f "
-                + "attention_ms=%.0f split_post_ms=%.0f fused_post_ms=%.0f",
+                + "attention_ms=%.0f split_post_ms=%.0f ff_fused_post_ms=%.0f "
+                + "fused_post_ms=%.0f",
             rows,
             attentionProjectionSeconds * 1_000,
             attentionSeconds * 1_000,
             splitPostAttentionSeconds * 1_000,
+            fusedFeedForwardSeconds * 1_000,
             fusedPostAttentionSeconds * 1_000
         ))
         Memory.clearCache()
@@ -1576,6 +1606,131 @@ final class DiTShapeBenchTests: XCTestCase {
             qualityGate,
             relativeL2Error <= qualityGate ? "yes" : "no",
             peakGiB
+        ))
+        Memory.clearCache()
+    }
+
+    /// Separates the cost of rebinding the shared compiled block runner from
+    /// the cost of turning over independent H3 weight sets. Production reuses
+    /// one compiled graph across 50 blocks, so a hot single-block loop can
+    /// otherwise overstate sustained checkpoint throughput.
+    func testMiniMaxH3BlockWeightTurnover() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 14_958)
+        let queryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_QUERY_TOKENS"] ?? "") ?? 1_024
+        )
+        let evaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_EVAL_BATCH"] ?? "") ?? 4
+        )
+        let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
+        let inputSeed: UInt64 = 20_260_805
+        let shared = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            weightSeed: 1,
+            inputSeed: inputSeed
+        )
+        let sourceA = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            weightSeed: 1,
+            inputSeed: inputSeed
+        )
+        let sourceB = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            weightSeed: 2,
+            inputSeed: inputSeed
+        )
+
+        func output(_ benchmark: MiniMaxH3BlockScheduleBenchmark) -> MLXArray {
+            benchmark(schedule: .splitPostAttention)
+        }
+        func relativeL2(_ candidate: MLXArray, reference: MLXArray) -> Double {
+            let candidate32 = candidate.asType(.float32)
+            let reference32 = reference.asType(.float32)
+            MLX.eval(candidate32, reference32)
+            let delta = candidate32 - reference32
+            let errorSquared = MLX.sum(delta * delta).item(Float.self)
+            let referenceSquared = MLX.sum(reference32 * reference32).item(Float.self)
+            return sqrt(
+                Double(errorSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude)
+            )
+        }
+
+        let dedicatedA = output(sourceA)
+        MLX.eval(dedicatedA)
+        shared.useOriginalWeights(from: sourceA)
+        let reboundA = output(shared)
+        MLX.eval(reboundA)
+        let reboundARelativeL2 = relativeL2(reboundA, reference: dedicatedA)
+        XCTAssertLessThan(reboundARelativeL2, 1e-3)
+
+        let dedicatedB = output(sourceB)
+        MLX.eval(dedicatedB)
+        shared.useOriginalWeights(from: sourceB)
+        let reboundB = output(shared)
+        MLX.eval(reboundB)
+        let reboundBRelativeL2 = relativeL2(reboundB, reference: dedicatedB)
+        XCTAssertLessThan(reboundBRelativeL2, 1e-3)
+
+        func elapsed(_ body: () -> MLXArray) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(body())
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        var hotTotal = 0.0
+        var reboundSameTotal = 0.0
+        var reboundAlternatingTotal = 0.0
+        var dedicatedAlternatingTotal = 0.0
+        for round in 0..<rounds {
+            let selectedSource = round.isMultiple(of: 2) ? sourceA : sourceB
+            let selectedDedicated = round.isMultiple(of: 2) ? sourceA : sourceB
+
+            shared.useOriginalWeights(from: selectedSource)
+            hotTotal += elapsed { output(shared) }
+
+            reboundSameTotal += elapsed {
+                shared.useOriginalWeights(from: selectedSource)
+                return output(shared)
+            }
+
+            let alternateSource = round.isMultiple(of: 2) ? sourceB : sourceA
+            reboundAlternatingTotal += elapsed {
+                shared.useOriginalWeights(from: alternateSource)
+                return output(shared)
+            }
+
+            dedicatedAlternatingTotal += elapsed { output(selectedDedicated) }
+        }
+
+        let hotSeconds = hotTotal / Double(rounds)
+        let reboundSameSeconds = reboundSameTotal / Double(rounds)
+        let reboundAlternatingSeconds = reboundAlternatingTotal / Double(rounds)
+        let dedicatedAlternatingSeconds = dedicatedAlternatingTotal / Double(rounds)
+        print(String(
+            format: "[h3-lab] block-turnover rows=%d query=%d batch=%d "
+                + "hot_ms=%.0f rebound_same_ms=%.0f rebound_alternating_ms=%.0f "
+                + "dedicated_alternating_ms=%.0f dedicated_speedup=%.3fx "
+                + "rebound_a_rel_l2=%.6g rebound_b_rel_l2=%.6g",
+            rows,
+            queryTokens,
+            evaluationBatch,
+            hotSeconds * 1_000,
+            reboundSameSeconds * 1_000,
+            reboundAlternatingSeconds * 1_000,
+            dedicatedAlternatingSeconds * 1_000,
+            reboundAlternatingSeconds / dedicatedAlternatingSeconds,
+            reboundARelativeL2,
+            reboundBRelativeL2
         ))
         Memory.clearCache()
     }

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1031,6 +1031,8 @@ final class DiTShapeBenchTests: XCTestCase {
     /// swizzle at H3's true-768 QKV projection shape.
     func testMiniMaxH3MetalGEMMTiles() throws {
         try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_966)
 
         struct Tile: Hashable {
             let blockRows: Int
@@ -1064,6 +1066,7 @@ final class DiTShapeBenchTests: XCTestCase {
         }
 
         func select(_ arm: Arm) {
+            setenv("MLX_GEMM_H3_TUNED", "0", 1)
             setenv("MLX_GEMM_BM", String(arm.tile.blockRows), 1)
             setenv("MLX_GEMM_BN", String(arm.tile.blockColumns), 1)
             setenv("MLX_GEMM_BK", String(arm.tile.blockDepth), 1)
@@ -1076,7 +1079,6 @@ final class DiTShapeBenchTests: XCTestCase {
         defer { select(defaultArm) }
 
         Stream.withNewDefaultStream {
-            let rows = 37_966
             let inputDimension = 5_376
             let outputDimension = 21_504
             let input = MLXRandom.normal([1, rows, inputDimension]).asType(.bfloat16)
@@ -1149,9 +1151,12 @@ final class DiTShapeBenchTests: XCTestCase {
     }
 
     /// Confirms the QKV winner against every dense projection in a production
-    /// H3 block before any MLX heuristic changes are considered.
+    /// H3 block before any MLX heuristic changes are considered. Set
+    /// `MERERUN_H3_BENCH_ROWS` to retune a longer packed sequence.
     func testMiniMaxH3MetalGEMMProjectionShapes() throws {
         try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_966)
 
         struct Arm {
             let name: String
@@ -1168,10 +1173,18 @@ final class DiTShapeBenchTests: XCTestCase {
                 rowWarps: 1, columnWarps: 2, swizzle: 0),
             Arm(name: "default-sw1", blockRows: 64, blockColumns: 64, blockDepth: 16,
                 rowWarps: 1, columnWarps: 2, swizzle: 1),
+            Arm(name: "four-warp-sw1", blockRows: 64, blockColumns: 64, blockDepth: 16,
+                rowWarps: 2, columnWarps: 2, swizzle: 1),
             Arm(name: "four-warp-sw2", blockRows: 64, blockColumns: 64, blockDepth: 16,
                 rowWarps: 2, columnWarps: 2, swizzle: 2),
+            Arm(name: "four-warp-sw3", blockRows: 64, blockColumns: 64, blockDepth: 16,
+                rowWarps: 2, columnWarps: 2, swizzle: 3),
+            Arm(name: "narrow-m-sw1", blockRows: 32, blockColumns: 64, blockDepth: 16,
+                rowWarps: 1, columnWarps: 2, swizzle: 1),
             Arm(name: "narrow-m-sw2", blockRows: 32, blockColumns: 64, blockDepth: 16,
                 rowWarps: 1, columnWarps: 2, swizzle: 2),
+            Arm(name: "narrow-m-sw3", blockRows: 32, blockColumns: 64, blockDepth: 16,
+                rowWarps: 1, columnWarps: 2, swizzle: 3),
         ]
         let shapes = [
             (name: "qkv", input: 5_376, output: 21_504),
@@ -1181,6 +1194,7 @@ final class DiTShapeBenchTests: XCTestCase {
         ]
 
         func select(_ arm: Arm) {
+            setenv("MLX_GEMM_H3_TUNED", "0", 1)
             setenv("MLX_GEMM_BM", String(arm.blockRows), 1)
             setenv("MLX_GEMM_BN", String(arm.blockColumns), 1)
             setenv("MLX_GEMM_BK", String(arm.blockDepth), 1)
@@ -1192,7 +1206,6 @@ final class DiTShapeBenchTests: XCTestCase {
         defer { select(arms[0]) }
 
         Stream.withNewDefaultStream {
-            let rows = 37_966
             for shape in shapes {
                 let input = MLXRandom.normal([1, rows, shape.input]).asType(.bfloat16)
                 let weight = MLXRandom.normal([shape.output, shape.input]).asType(.bfloat16)
@@ -1472,10 +1485,26 @@ final class DiTShapeBenchTests: XCTestCase {
         let environment = ProcessInfo.processInfo.environment
         let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_966)
         let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4)
+        let referenceQueryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_REFERENCE_QUERY_TOKENS"] ?? "") ?? 1_024
+        )
+        let referenceEvaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_REFERENCE_EVAL_BATCH"] ?? "") ?? 4
+        )
+        let candidateQueryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_CANDIDATE_QUERY_TOKENS"] ?? "") ?? 768
+        )
+        let candidateEvaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_CANDIDATE_EVAL_BATCH"] ?? "") ?? 1
+        )
         let benchmark = MiniMaxH3BlockScheduleBenchmark(
             rowCount: rows,
-            maximumQueryTokens: 1_024,
-            maximumKernelsPerEvaluation: 4
+            maximumQueryTokens: referenceQueryTokens,
+            maximumKernelsPerEvaluation: referenceEvaluationBatch
         )
 
         func output(queryTokens: Int, evaluationBatch: Int) -> MLXArray {
@@ -1491,10 +1520,16 @@ final class DiTShapeBenchTests: XCTestCase {
             return CFAbsoluteTimeGetCurrent() - started
         }
 
-        MLX.eval(output(queryTokens: 1_024, evaluationBatch: 4))
-        MLX.eval(output(queryTokens: 768, evaluationBatch: 1))
-        let reference = output(queryTokens: 1_024, evaluationBatch: 4).asType(.float32)
-        let candidate = output(queryTokens: 768, evaluationBatch: 1).asType(.float32)
+        MLX.eval(output(queryTokens: referenceQueryTokens, evaluationBatch: referenceEvaluationBatch))
+        MLX.eval(output(queryTokens: candidateQueryTokens, evaluationBatch: candidateEvaluationBatch))
+        let reference = output(
+            queryTokens: referenceQueryTokens,
+            evaluationBatch: referenceEvaluationBatch
+        ).asType(.float32)
+        let candidate = output(
+            queryTokens: candidateQueryTokens,
+            evaluationBatch: candidateEvaluationBatch
+        ).asType(.float32)
         MLX.eval(reference, candidate)
         let delta = candidate - reference
         let referenceSquared = MLX.sum(reference * reference).item(Float.self)
@@ -1508,20 +1543,36 @@ final class DiTShapeBenchTests: XCTestCase {
         var candidateTotal = 0.0
         for round in 0..<rounds {
             if round.isMultiple(of: 2) {
-                referenceTotal += elapsed(queryTokens: 1_024, evaluationBatch: 4)
-                candidateTotal += elapsed(queryTokens: 768, evaluationBatch: 1)
+                referenceTotal += elapsed(
+                    queryTokens: referenceQueryTokens,
+                    evaluationBatch: referenceEvaluationBatch
+                )
+                candidateTotal += elapsed(
+                    queryTokens: candidateQueryTokens,
+                    evaluationBatch: candidateEvaluationBatch
+                )
             } else {
-                candidateTotal += elapsed(queryTokens: 768, evaluationBatch: 1)
-                referenceTotal += elapsed(queryTokens: 1_024, evaluationBatch: 4)
+                candidateTotal += elapsed(
+                    queryTokens: candidateQueryTokens,
+                    evaluationBatch: candidateEvaluationBatch
+                )
+                referenceTotal += elapsed(
+                    queryTokens: referenceQueryTokens,
+                    evaluationBatch: referenceEvaluationBatch
+                )
             }
         }
         let referenceSeconds = referenceTotal / Double(rounds)
         let candidateSeconds = candidateTotal / Double(rounds)
         print(String(
-            format: "[h3-lab] block-attention rows=%d reference=1024x4 reference_ms=%.0f "
-                + "candidate=768x1 candidate_ms=%.0f speedup=%.3fx relative_l2=%.6g",
+            format: "[h3-lab] block-attention rows=%d reference=%dx%d reference_ms=%.0f "
+                + "candidate=%dx%d candidate_ms=%.0f speedup=%.3fx relative_l2=%.6g",
             rows,
+            referenceQueryTokens,
+            referenceEvaluationBatch,
             referenceSeconds * 1_000,
+            candidateQueryTokens,
+            candidateEvaluationBatch,
             candidateSeconds * 1_000,
             referenceSeconds / candidateSeconds,
             relativeL2Error
@@ -1529,35 +1580,48 @@ final class DiTShapeBenchTests: XCTestCase {
         Memory.clearCache()
     }
 
-    /// Loads the released H3 video VAE and times one complete 124-frame decode
-    /// with a configurable spatial tile. Run each size in a fresh process:
-    /// `MERERUN_H3_VAE_TILE_SIZE=320` and `MERERUN_H3_MODEL_ROOT=/path/to/root`.
+    /// Loads the released H3 video VAE and times one complete decode with a
+    /// configurable spatial tile and geometry. Run each size in a fresh process.
     func testMiniMaxH3VideoVAETileSize() throws {
         try benchGate()
+        let environment = ProcessInfo.processInfo.environment
         guard let root = ProcessInfo.processInfo.environment["MERERUN_H3_MODEL_ROOT"],
               !root.isEmpty else {
             throw XCTSkip("Set MERERUN_H3_MODEL_ROOT to an installed H3 model root")
         }
-        let tileSize = Int(
-            ProcessInfo.processInfo.environment["MERERUN_H3_VAE_TILE_SIZE"] ?? ""
-        ) ?? MiniMaxH3VideoVAE.defaultSpatialTileSize
+        let tileSize = Int(environment["MERERUN_H3_VAE_TILE_SIZE"] ?? "")
+            ?? MiniMaxH3VideoVAE.defaultSpatialTileSize
+        let width = Int(environment["MERERUN_H3_VAE_WIDTH"] ?? "") ?? 832
+        let height = Int(environment["MERERUN_H3_VAE_HEIGHT"] ?? "") ?? 480
+        let frameCount = Int(environment["MERERUN_H3_VAE_FRAMES"] ?? "") ?? 124
+        XCTAssertTrue(width.isMultiple(of: 16))
+        XCTAssertTrue(height.isMultiple(of: 16))
+        let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: frameCount)
         let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: root, isDirectory: true))
         let model = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
         model.spatialTileSize = tileSize
-        let latents = MLXRandom.normal([1, 24, 37, 30, 52]).asType(.float32)
+        let latents = MLXRandom.normal([
+            1,
+            24,
+            latentFrames,
+            height / 16,
+            width / 16,
+        ]).asType(.float32)
         MLX.eval(latents)
 
         let started = CFAbsoluteTimeGetCurrent()
         let decoded = model.decode(latents)
         MLX.eval(decoded)
         print(String(
-            format: "[dit-bench] H3 video VAE tile=%d frames=%d %.3fs peak=%.2fGiB",
+            format: "[dit-bench] H3 video VAE tile=%d size=%dx%d frames=%d %.3fs peak=%.2fGiB",
             tileSize,
+            width,
+            height,
             decoded.dim(1),
             CFAbsoluteTimeGetCurrent() - started,
             Double(Memory.snapshot().peakMemory) / 1_073_741_824
         ))
-        XCTAssertEqual(decoded.shape, [1, 124, 480, 832, 3])
+        XCTAssertEqual(decoded.shape, [1, frameCount, height, width, 3])
     }
 
     /// Full-model paired A/B: the same quantized klein-nano forward with the

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1464,6 +1464,71 @@ final class DiTShapeBenchTests: XCTestCase {
         Memory.clearCache()
     }
 
+    /// Compares attention chunk schedules inside the same compiled, weighted
+    /// production block. This is the acceptance gate for changing the true-768
+    /// H3 schedule; isolated SDPA timings are only useful for finding candidates.
+    func testMiniMaxH3BlockAttentionSchedules() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_966)
+        let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4)
+        let benchmark = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: 1_024,
+            maximumKernelsPerEvaluation: 4
+        )
+
+        func output(queryTokens: Int, evaluationBatch: Int) -> MLXArray {
+            benchmark(
+                schedule: .splitPostAttention,
+                maximumQueryTokens: queryTokens,
+                maximumKernelsPerEvaluation: evaluationBatch
+            )
+        }
+        func elapsed(queryTokens: Int, evaluationBatch: Int) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(output(queryTokens: queryTokens, evaluationBatch: evaluationBatch))
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        MLX.eval(output(queryTokens: 1_024, evaluationBatch: 4))
+        MLX.eval(output(queryTokens: 768, evaluationBatch: 1))
+        let reference = output(queryTokens: 1_024, evaluationBatch: 4).asType(.float32)
+        let candidate = output(queryTokens: 768, evaluationBatch: 1).asType(.float32)
+        MLX.eval(reference, candidate)
+        let delta = candidate - reference
+        let referenceSquared = MLX.sum(reference * reference).item(Float.self)
+        let relativeL2Error = sqrt(
+            Double(MLX.sum(delta * delta).item(Float.self))
+                / max(Double(referenceSquared), .leastNonzeroMagnitude)
+        )
+        XCTAssertLessThan(relativeL2Error, 1e-3)
+
+        var referenceTotal = 0.0
+        var candidateTotal = 0.0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                referenceTotal += elapsed(queryTokens: 1_024, evaluationBatch: 4)
+                candidateTotal += elapsed(queryTokens: 768, evaluationBatch: 1)
+            } else {
+                candidateTotal += elapsed(queryTokens: 768, evaluationBatch: 1)
+                referenceTotal += elapsed(queryTokens: 1_024, evaluationBatch: 4)
+            }
+        }
+        let referenceSeconds = referenceTotal / Double(rounds)
+        let candidateSeconds = candidateTotal / Double(rounds)
+        print(String(
+            format: "[h3-lab] block-attention rows=%d reference=1024x4 reference_ms=%.0f "
+                + "candidate=768x1 candidate_ms=%.0f speedup=%.3fx relative_l2=%.6g",
+            rows,
+            referenceSeconds * 1_000,
+            candidateSeconds * 1_000,
+            referenceSeconds / candidateSeconds,
+            relativeL2Error
+        ))
+        Memory.clearCache()
+    }
+
     /// Loads the released H3 video VAE and times one complete 124-frame decode
     /// with a configurable spatial tile. Run each size in a fresh process:
     /// `MERERUN_H3_VAE_TILE_SIZE=320` and `MERERUN_H3_MODEL_ROOT=/path/to/root`.

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1366,11 +1366,16 @@ final class DiTShapeBenchTests: XCTestCase {
             1,
             Int(environment["MERERUN_H3_BENCH_EVAL_BATCH"] ?? "") ?? 4
         )
+        let headsPerKernel = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_HEADS"] ?? "") ?? 56
+        )
         let rounds = max(1, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
         let benchmark = MiniMaxH3BlockScheduleBenchmark(
             rowCount: rows,
             maximumQueryTokens: queryTokens,
-            maximumKernelsPerEvaluation: evaluationBatch
+            maximumKernelsPerEvaluation: evaluationBatch,
+            maximumHeadsPerKernel: headsPerKernel
         )
 
         func elapsed(_ schedule: MiniMaxH3BlockScheduleBenchmark.Schedule) -> Double {
@@ -1474,12 +1479,13 @@ final class DiTShapeBenchTests: XCTestCase {
         let operations = projectionOperations + attentionOperations
         let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
         print(String(
-            format: "[h3-lab] block rows=%d query=%d batch=%d split_ms=%.0f "
+            format: "[h3-lab] block rows=%d query=%d heads=%d batch=%d split_ms=%.0f "
                 + "ff_fused_ms=%.0f fused_ms=%.0f ff_fused_speedup=%.3fx "
                 + "fused_speedup=%.3fx split_tflops=%.2f ff_fused_tflops=%.2f "
                 + "fused_tflops=%.2f ff_fused_rel_l2=%.6g fused_rel_l2=%.6g peak_gib=%.2f",
             rows,
             queryTokens,
+            headsPerKernel,
             evaluationBatch,
             splitBest * 1_000,
             feedForwardBest * 1_000,
@@ -1503,6 +1509,86 @@ final class DiTShapeBenchTests: XCTestCase {
             splitPostAttentionSeconds * 1_000,
             fusedFeedForwardSeconds * 1_000,
             fusedPostAttentionSeconds * 1_000
+        ))
+        Memory.clearCache()
+    }
+
+    /// Compares the existing split post-attention graph with the exact fully
+    /// fused residual/MLP tail on top of one selected attention schedule.
+    func testMiniMaxH3BlockPostAttentionSchedules() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 73_470)
+        let queryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_QUERY_TOKENS"] ?? "") ?? 640
+        )
+        let headsPerKernel = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_HEADS"] ?? "") ?? 8
+        )
+        let evaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_EVAL_BATCH"] ?? "") ?? 1
+        )
+        let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
+        let benchmark = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            maximumHeadsPerKernel: headsPerKernel
+        )
+
+        func output(_ schedule: MiniMaxH3BlockScheduleBenchmark.Schedule) -> MLXArray {
+            benchmark(schedule: schedule)
+        }
+        func elapsed(_ schedule: MiniMaxH3BlockScheduleBenchmark.Schedule) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(output(schedule))
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        let reference = output(.splitPostAttention).asType(.float32)
+        let candidate = output(.fusedPostAttention).asType(.float32)
+        MLX.eval(reference, candidate)
+        let delta = candidate - reference
+        let referenceSquared = MLX.sum(reference * reference).item(Float.self)
+        let maximumAbsoluteError = Double(MLX.max(MLX.abs(delta)).item(Float.self))
+        let relativeL2Error = sqrt(
+            Double(MLX.sum(delta * delta).item(Float.self))
+                / max(Double(referenceSquared), .leastNonzeroMagnitude)
+        )
+        XCTAssertLessThan(relativeL2Error, 1e-3)
+
+        var splitTotal = 0.0
+        var fusedTotal = 0.0
+        Memory.peakMemory = 0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                splitTotal += elapsed(.splitPostAttention)
+                fusedTotal += elapsed(.fusedPostAttention)
+            } else {
+                fusedTotal += elapsed(.fusedPostAttention)
+                splitTotal += elapsed(.splitPostAttention)
+            }
+        }
+        let splitSeconds = splitTotal / Double(rounds)
+        let fusedSeconds = fusedTotal / Double(rounds)
+        let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
+        print(String(
+            format: "[h3-lab] block-post rows=%d query=%d heads=%d batch=%d "
+                + "split_ms=%.0f fused_ms=%.0f speedup=%.3fx "
+                + "max_abs=%.6g rel_l2=%.6g peak_gib=%.2f",
+            rows,
+            queryTokens,
+            headsPerKernel,
+            evaluationBatch,
+            splitSeconds * 1_000,
+            fusedSeconds * 1_000,
+            splitSeconds / fusedSeconds,
+            maximumAbsoluteError,
+            relativeL2Error,
+            peakGiB
         ))
         Memory.clearCache()
     }

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1610,6 +1610,151 @@ final class DiTShapeBenchTests: XCTestCase {
         Memory.clearCache()
     }
 
+    /// Tests whether keeping one block's feed-forward tail and the next
+    /// block's attention projection in one compiled graph can eliminate two
+    /// large hidden-state materialization boundaries without changing H3 math.
+    func testMiniMaxH3TwoBlockBoundaryFusion() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 14_958)
+        let queryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_QUERY_TOKENS"] ?? "") ?? 1_024
+        )
+        let evaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_EVAL_BATCH"] ?? "") ?? 4
+        )
+        let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
+        let inputSeed: UInt64 = 20_260_805
+        let first = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            weightSeed: 1,
+            inputSeed: inputSeed
+        )
+        let second = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            weightSeed: 2,
+            inputSeed: inputSeed
+        )
+        let fusedBoundary = first.makeFusedBoundary(to: second)
+
+        let firstProjection = first.projectAttention()
+        MLX.eval(firstProjection)
+        let firstAttended = first.attend(firstProjection)
+        let boundaryInput = first.attentionOutput(
+            input: first.defaultInput,
+            attended: firstAttended,
+            gate: firstProjection[3]
+        )
+
+        func baselineBoundary() -> [MLXArray] {
+            let nextHidden = first.splitFeedForward(input: boundaryInput)
+            let projected = second.projectAttention(input: nextHidden)
+            MLX.eval(projected)
+            return [nextHidden] + projected
+        }
+
+        func candidateBoundary() -> [MLXArray] {
+            let outputs = fusedBoundary(first.fusedBoundaryInputs(
+                to: second,
+                input: boundaryInput
+            ))
+            MLX.eval(outputs)
+            return outputs
+        }
+
+        func finish(_ boundary: [MLXArray]) -> MLXArray {
+            let nextHidden = boundary[0]
+            let projected = Array(boundary[1...4])
+            let attended = second.attend(projected)
+            return second.postAttention(
+                schedule: .splitPostAttention,
+                attended: attended,
+                gate: projected[3],
+                input: nextHidden
+            )
+        }
+
+        func relativeL2(_ candidate: MLXArray, reference: MLXArray) -> Double {
+            let candidate32 = candidate.asType(.float32)
+            let reference32 = reference.asType(.float32)
+            MLX.eval(candidate32, reference32)
+            let delta = candidate32 - reference32
+            let errorSquared = MLX.sum(delta * delta).item(Float.self)
+            let referenceSquared = MLX.sum(reference32 * reference32).item(Float.self)
+            return sqrt(
+                Double(errorSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude)
+            )
+        }
+
+        MLX.eval(finish(baselineBoundary()))
+        MLX.eval(finish(candidateBoundary()))
+        let reference = finish(baselineBoundary())
+        let candidate = finish(candidateBoundary())
+        MLX.eval(reference, candidate)
+        let candidateRelativeL2 = relativeL2(candidate, reference: reference)
+        XCTAssertLessThan(candidateRelativeL2, 1e-3)
+
+        func elapsed(_ body: () -> MLXArray) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(body())
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+        func boundaryElapsed(_ body: () -> [MLXArray]) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(body())
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        var baselineTotal = 0.0
+        var candidateTotal = 0.0
+        var baselineBoundaryTotal = 0.0
+        var candidateBoundaryTotal = 0.0
+        Memory.peakMemory = 0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                baselineTotal += elapsed { finish(baselineBoundary()) }
+                candidateTotal += elapsed { finish(candidateBoundary()) }
+                baselineBoundaryTotal += boundaryElapsed { baselineBoundary() }
+                candidateBoundaryTotal += boundaryElapsed { candidateBoundary() }
+            } else {
+                candidateBoundaryTotal += boundaryElapsed { candidateBoundary() }
+                baselineBoundaryTotal += boundaryElapsed { baselineBoundary() }
+                candidateTotal += elapsed { finish(candidateBoundary()) }
+                baselineTotal += elapsed { finish(baselineBoundary()) }
+            }
+        }
+
+        let baselineSeconds = baselineTotal / Double(rounds)
+        let candidateSeconds = candidateTotal / Double(rounds)
+        let baselineBoundarySeconds = baselineBoundaryTotal / Double(rounds)
+        let candidateBoundarySeconds = candidateBoundaryTotal / Double(rounds)
+        let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
+        print(String(
+            format: "[h3-lab] two-block-boundary rows=%d query=%d batch=%d "
+                + "baseline_ms=%.0f fused_ms=%.0f speedup=%.3fx "
+                + "baseline_boundary_ms=%.0f fused_boundary_ms=%.0f "
+                + "boundary_speedup=%.3fx fused_rel_l2=%.6g peak_gib=%.2f",
+            rows,
+            queryTokens,
+            evaluationBatch,
+            baselineSeconds * 1_000,
+            candidateSeconds * 1_000,
+            baselineSeconds / candidateSeconds,
+            baselineBoundarySeconds * 1_000,
+            candidateBoundarySeconds * 1_000,
+            baselineBoundarySeconds / candidateBoundarySeconds,
+            candidateRelativeL2,
+            peakGiB
+        ))
+        Memory.clearCache()
+    }
+
     /// Separates the cost of rebinding the shared compiled block runner from
     /// the cost of turning over independent H3 weight sets. Production reuses
     /// one compiled graph across 50 blocks, so a hot single-block loop can

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -1477,6 +1477,109 @@ final class DiTShapeBenchTests: XCTestCase {
         Memory.clearCache()
     }
 
+    /// Screens the complete weighted H3 block in fp16 against the production
+    /// bf16 path. Both arms reset the same PRNG seed so their weights and
+    /// inputs differ only by the requested storage and execution dtype.
+    func testMiniMaxH3BlockDTypes() throws {
+        try benchGate()
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_966)
+        let queryTokens = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_QUERY_TOKENS"] ?? "") ?? 768
+        )
+        let evaluationBatch = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_EVAL_BATCH"] ?? "") ?? 1
+        )
+        let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 3)
+        let seed: UInt64 = 20_260_805
+
+        MLXRandom.seed(seed)
+        let bf16 = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            dtype: .bfloat16
+        )
+        MLXRandom.seed(seed)
+        let fp16 = MiniMaxH3BlockScheduleBenchmark(
+            rowCount: rows,
+            maximumQueryTokens: queryTokens,
+            maximumKernelsPerEvaluation: evaluationBatch,
+            dtype: .float16
+        )
+
+        func output(_ benchmark: MiniMaxH3BlockScheduleBenchmark) -> MLXArray {
+            benchmark(schedule: .fusedPostAttention).asType(.float32)
+        }
+        func elapsed(_ benchmark: MiniMaxH3BlockScheduleBenchmark) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(output(benchmark))
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        MLX.eval(output(bf16))
+        MLX.eval(output(fp16))
+        let bf16Output = output(bf16)
+        let fp16Output = output(fp16)
+        MLX.eval(bf16Output, fp16Output)
+        let delta = fp16Output - bf16Output
+        let referenceSquared = MLX.sum(bf16Output * bf16Output).item(Float.self)
+        let deltaSquared = MLX.sum(delta * delta).item(Float.self)
+        let relativeL2Error = sqrt(
+            Double(deltaSquared) / max(Double(referenceSquared), .leastNonzeroMagnitude)
+        )
+        let maximumAbsoluteError = MLX.max(MLX.abs(delta)).item(Float.self)
+        XCTAssertTrue(relativeL2Error.isFinite)
+        XCTAssertTrue(Double(maximumAbsoluteError).isFinite)
+
+        var bf16Best = Double.greatestFiniteMagnitude
+        var fp16Best = Double.greatestFiniteMagnitude
+        Memory.peakMemory = 0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                bf16Best = min(bf16Best, elapsed(bf16))
+                fp16Best = min(fp16Best, elapsed(fp16))
+            } else {
+                fp16Best = min(fp16Best, elapsed(fp16))
+                bf16Best = min(bf16Best, elapsed(bf16))
+            }
+        }
+
+        let qualityGate = 0.01
+        let configuration = MiniMaxH3TransformerConfiguration()
+        let projectionOperations = 2 * Double(rows) * Double(configuration.hiddenSize)
+            * Double(
+                4 * configuration.attentionHeadCount * configuration.attentionHeadDimension
+                    + 3 * configuration.feedForwardSize
+            )
+        let attentionOperations = 4 * Double(configuration.attentionHeadCount) * Double(rows)
+            * Double(rows) * Double(configuration.attentionHeadDimension)
+        let operations = projectionOperations + attentionOperations
+        let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
+        print(String(
+            format: "[h3-lab] block-dtype rows=%d query=%d batch=%d "
+                + "bf16_ms=%.0f fp16_ms=%.0f fp16_speedup=%.3fx "
+                + "bf16_tflops=%.2f fp16_tflops=%.2f max_abs=%.6g rel_l2=%.6g "
+                + "quality_gate=%.3g quality_safe=%@ peak_gib=%.2f",
+            rows,
+            queryTokens,
+            evaluationBatch,
+            bf16Best * 1_000,
+            fp16Best * 1_000,
+            bf16Best / fp16Best,
+            operations / bf16Best / 1e12,
+            operations / fp16Best / 1e12,
+            maximumAbsoluteError,
+            relativeL2Error,
+            qualityGate,
+            relativeL2Error <= qualityGate ? "yes" : "no",
+            peakGiB
+        ))
+        Memory.clearCache()
+    }
+
     /// Compares attention chunk schedules inside the same compiled, weighted
     /// production block. This is the acceptance gate for changing the true-768
     /// H3 schedule; isolated SDPA timings are only useful for finding candidates.

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -78,6 +78,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "video-ltx23-full-mlx",
             "video-ltx23-a2vid-mlx",
             "video-minimax-h3-fl2va-mlx",
+            "video-minimax-h3-fl2va-bf16-mlx",
             "video-minimax-h3-ref2va-mlx",
         ])
         let visibleAndCompanionSpecs = ManagedModelCatalog.allSpecs

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -14,6 +14,28 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(parts[2].asArray(Float.self), [8, 9, 10, 11])
     }
 
+    func testReleasedBF16TransformerQKVIsDeinterleavedAtLoadTime() {
+        let raw = MLXArray(0..<12).reshaped(12, 1)
+        let mapped = MiniMaxH3ModelLoader.releasedBF16TransformerWeight(
+            key: "blocks.0.attn.qkv_proj.weight",
+            value: raw,
+            omitCachedAdaLNWeights: true,
+            headCount: 2,
+            headDimension: 2
+        )
+        MLX.eval(mapped.map(\.1))
+
+        XCTAssertEqual(mapped.map(\.0), ["blocks.0.attn.qkv_proj.weight"])
+        XCTAssertEqual(mapped[0].1.asArray(Int32.self), [0, 1, 6, 7, 2, 3, 8, 9, 4, 5, 10, 11])
+        XCTAssertTrue(
+            MiniMaxH3ModelLoader.releasedBF16TransformerWeight(
+                key: "blocks.0.adaln_proj.linear.weight",
+                value: raw,
+                omitCachedAdaLNWeights: true
+            ).isEmpty
+        )
+    }
+
     func testPinnedMLXArtifactConfigurationDecodes() throws {
         let data = Data(#"""
         {
@@ -109,6 +131,41 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns, MiniMaxH3Resources.compactArtifactFiles)
     }
 
+    func testManagedBF16ProfileUsesPinnedExistingMLXArtifact() throws {
+        XCTAssertEqual(
+            MiniMaxH3Resources.bf16ArtifactRepository,
+            "pipenetwork/MiniMax-H3-MLX-bf16"
+        )
+        XCTAssertEqual(
+            MiniMaxH3Resources.bf16ArtifactRevision,
+            "1486555759eed9e3037edf29f9e055a0713bab2f"
+        )
+        XCTAssertEqual(MiniMaxH3Resources.bf16ShardFilenames.count, 13)
+        XCTAssertFalse(MiniMaxH3Resources.bf16SupportArtifactFiles.contains("transformer.safetensors"))
+        XCTAssertFalse(MiniMaxH3Resources.bf16SupportArtifactFiles.contains("adaln_cache.safetensors"))
+
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MiniMaxH3Resources.fl2vaBF16ModelID)
+        )
+        XCTAssertEqual(spec.hubFallback?.repoId, MiniMaxH3Resources.artifactRepository)
+        XCTAssertEqual(spec.hubFallback?.patterns, MiniMaxH3Resources.bf16SupportArtifactFiles)
+        let transformer = try XCTUnwrap(spec.mountedHubFallbacks.first)
+        XCTAssertEqual(transformer.destinationPath, MiniMaxH3Resources.bf16TransformerDirectory)
+        XCTAssertEqual(transformer.hubFallback.repoId, MiniMaxH3Resources.bf16ArtifactRepository)
+        XCTAssertEqual(transformer.hubFallback.revision, MiniMaxH3Resources.bf16ArtifactRevision)
+
+        let manifest = MereRunModelManifest.template(
+            for: .miniMaxH3FL2VABF16MLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertNil(manifest.quantization)
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(MiniMaxH3Resources.bf16ArtifactRepository)@\(MiniMaxH3Resources.bf16ArtifactRevision)"
+        )
+    }
+
     func testCompactTransformerPreservesAdaLNCacheSourceIdentity() throws {
         let rootURL = FileManager.default.temporaryDirectory
             .appending(path: "minimax-h3-compact-\(UUID().uuidString)")
@@ -153,25 +210,24 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(mappedConvolution.first?.1.shape, [2, 4, 5, 6, 3])
 
         let fused = MLXArray(0..<6_144)
-        let split = MiniMaxH3VideoVAE.mapCheckpointWeight(
+        let mappedQKV = MiniMaxH3VideoVAE.mapCheckpointWeight(
             key: "decoder.transformer_blocks.0.attn.to_qkv.weight",
             value: fused
         )
-        XCTAssertEqual(split.map(\.0), [
-            "decoder.transformer_blocks.0.attn.to_q.weight",
-            "decoder.transformer_blocks.0.attn.to_k.weight",
-            "decoder.transformer_blocks.0.attn.to_v.weight",
+        XCTAssertEqual(mappedQKV.map(\.0), [
+            "decoder.transformer_blocks.0.attn.to_qkv.weight",
         ])
-        XCTAssertTrue(split.allSatisfy { $0.1.shape == [2_048] })
-        XCTAssertEqual(split[0].1.asArray(Int32.self)[0], 0)
-        XCTAssertEqual(split[0].1.asArray(Int32.self)[64], 192)
-        XCTAssertEqual(split[0].1.asArray(Int32.self)[2_047], 6_015)
-        XCTAssertEqual(split[1].1.asArray(Int32.self)[0], 64)
-        XCTAssertEqual(split[1].1.asArray(Int32.self)[64], 256)
-        XCTAssertEqual(split[1].1.asArray(Int32.self)[2_047], 6_079)
-        XCTAssertEqual(split[2].1.asArray(Int32.self)[0], 128)
-        XCTAssertEqual(split[2].1.asArray(Int32.self)[64], 320)
-        XCTAssertEqual(split[2].1.asArray(Int32.self)[2_047], 6_143)
+        XCTAssertEqual(mappedQKV[0].1.shape, [6_144])
+        let packedQKV = mappedQKV[0].1.asArray(Int32.self)
+        XCTAssertEqual(packedQKV[0], 0)
+        XCTAssertEqual(packedQKV[64], 192)
+        XCTAssertEqual(packedQKV[2_047], 6_015)
+        XCTAssertEqual(packedQKV[2_048], 64)
+        XCTAssertEqual(packedQKV[2_112], 256)
+        XCTAssertEqual(packedQKV[4_095], 6_079)
+        XCTAssertEqual(packedQKV[4_096], 128)
+        XCTAssertEqual(packedQKV[4_160], 320)
+        XCTAssertEqual(packedQKV[6_143], 6_143)
 
         let audioEncoder = MiniMaxH3AudioVAE.mapConvertedWeight(
             key: "encoder.block.0.weight",
@@ -262,6 +318,20 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(pixels.asArray(UInt8.self), [0, 127, 255])
     }
 
+    func testVideoVAETilePlansPreserveCanvasAndMinimumOverlap() {
+        for tileSize in [256, 320] {
+            for length in [480, 832, 1_344] {
+                let plan = MiniMaxH3VideoVAE.tilePlan(length: length, tileSize: tileSize)
+                XCTAssertEqual(plan.starts.first, 0)
+                XCTAssertEqual(plan.starts.last! + plan.lengths.last!, length)
+                XCTAssertTrue(plan.lengths.allSatisfy { $0 == tileSize || $0 == length })
+                XCTAssertTrue(plan.overlaps.allSatisfy {
+                    $0 >= MiniMaxH3VideoVAE.minimumSpatialTileOverlap
+                })
+            }
+        }
+    }
+
     func testRef2VAPackedLayoutPreservesOrderedReferenceBlocks() throws {
         let layout = try MiniMaxH3Geometry.buildRef2VA(
             textTokenTags: [1, 0],
@@ -310,6 +380,65 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(final.asArray(Float.self).allSatisfy(\.isFinite))
     }
 
+    func testBlockReusePolicyBoundsCacheStepsForPracticalSchedule() throws {
+        XCTAssertNil(MiniMaxH3AccelerationMode.quality.blockReusePolicy)
+        XCTAssertEqual(
+            MiniMaxH3BlockReusePolicy(cacheDepth: 0.5).warmBlockCount(totalBlockCount: 50),
+            25
+        )
+        let policy = try XCTUnwrap(MiniMaxH3AccelerationMode.maximum.blockReusePolicy)
+        XCTAssertEqual(policy.warmBlockCount(totalBlockCount: 50), 9)
+        XCTAssertEqual(policy.maximumConsecutiveCachedSteps, 4)
+
+        let video = try MiniMaxH3Schedule(pointCount: 9, shift: 12)
+        let audio = try MiniMaxH3Schedule(pointCount: 9, shift: 3)
+        var hasResidual = false
+        var consecutive = 0
+        var decisions: [Bool] = []
+        for index in video.timesteps.indices {
+            let reuses = policy.shouldReuseTail(
+                stepIndex: index,
+                stepCount: video.timesteps.count,
+                videoSigmas: video.sigmas,
+                audioSigmas: audio.sigmas,
+                hasCachedResidual: hasResidual,
+                consecutiveCachedSteps: consecutive
+            )
+            decisions.append(reuses)
+            if reuses {
+                consecutive += 1
+            } else {
+                hasResidual = true
+                consecutive = 0
+            }
+        }
+        XCTAssertEqual(decisions, [false, false, true, true, true, true, false, false])
+
+        let longVideo = try MiniMaxH3Schedule(pointCount: 16, shift: 12)
+        let longAudio = try MiniMaxH3Schedule(pointCount: 16, shift: 3)
+        hasResidual = false
+        consecutive = 0
+        var longCachedSteps = 0
+        for index in longVideo.timesteps.indices {
+            let reuses = policy.shouldReuseTail(
+                stepIndex: index,
+                stepCount: longVideo.timesteps.count,
+                videoSigmas: longVideo.sigmas,
+                audioSigmas: longAudio.sigmas,
+                hasCachedResidual: hasResidual,
+                consecutiveCachedSteps: consecutive
+            )
+            if reuses {
+                longCachedSteps += 1
+                consecutive += 1
+            } else {
+                hasResidual = true
+                consecutive = 0
+            }
+        }
+        XCTAssertEqual(longCachedSteps, 10)
+    }
+
     func testResidentBF16PolicyAccountsForGeometryAndMemory() throws {
         let denseBytes = 41 * MiniMaxH3ResidentBF16Policy.gibibyte
         XCTAssertTrue(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
@@ -352,9 +481,17 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             hasAdaLNCache: false,
             isPortableMac: false
         ))
-        XCTAssertFalse(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+        XCTAssertTrue(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
             mode: .automatic,
             physicalMemoryBytes: 128 * MiniMaxH3ResidentBF16Policy.gibibyte,
+            estimatedResidentBytes: denseBytes,
+            sequenceLength: 12_925,
+            hasAdaLNCache: true,
+            isPortableMac: true
+        ))
+        XCTAssertFalse(try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
+            mode: .automatic,
+            physicalMemoryBytes: 64 * MiniMaxH3ResidentBF16Policy.gibibyte,
             estimatedResidentBytes: denseBytes,
             sequenceLength: 12_925,
             hasAdaLNCache: true,
@@ -368,6 +505,79 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             hasAdaLNCache: true,
             isPortableMac: true
         ))
+    }
+
+    func testDenoiseExecutionPolicyKeepsProfilingOutsideCompiledTransforms() {
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: false,
+                sequenceLength: 12_925,
+                usesBlockProfiling: false
+            ),
+            .compiledStep
+        )
+        XCTAssertFalse(MiniMaxH3DenoiseExecutionMode.compiledStep.usesLayerwiseEvaluation)
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: false,
+                sequenceLength: 12_925,
+                usesBlockProfiling: true
+            ),
+            .eagerStep
+        )
+        XCTAssertTrue(MiniMaxH3DenoiseExecutionMode.eagerStep.usesLayerwiseEvaluation)
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: true,
+                sequenceLength: 12_925,
+                usesBlockProfiling: false,
+                denoiseStepCount: 1
+            ),
+            .eagerStep
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: true,
+                sequenceLength: 12_925,
+                usesBlockProfiling: false,
+                denoiseStepCount: 2
+            ),
+            .compiledStep
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: true,
+                sequenceLength: 12_925,
+                usesBlockProfiling: false,
+                profilingOverride: "compiled"
+            ),
+            .compiledStep
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: false,
+                sequenceLength: 12_925,
+                usesBlockProfiling: true,
+                profilingOverride: "compiled"
+            ),
+            .eagerStep
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.mode(
+                usesResidentBF16: true,
+                sequenceLength: MiniMaxH3DenoiseExecutionPolicy.blockwiseSequenceThreshold + 1,
+                usesBlockProfiling: true
+            ),
+            .blockwiseCompiled
+        )
+        XCTAssertFalse(MiniMaxH3DenoiseExecutionMode.blockwiseCompiled.usesLayerwiseEvaluation)
+    }
+
+    func testDenoiseExecutionPolicyUsesMeasuredBlockwiseKernelSchedule() {
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.maximumAttentionQueryTokensPerKernel,
+            1_024
+        )
     }
 
     func testStepPolicyUsesPracticalExtendedAndMaximumEnvelopes() throws {
@@ -401,7 +611,16 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
                 height: 768,
                 numFrames: 124
             ),
-            31
+            21
+        )
+        XCTAssertEqual(
+            try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: 1_344,
+                height: 768,
+                numFrames: 124,
+                accelerationMode: .maximum
+            ),
+            12
         )
         XCTAssertEqual(
             try MiniMaxH3StepPolicy.recommendedPointCount(
@@ -428,6 +647,61 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             steps: 31
         )
         XCTAssertEqual(explicit.steps, 31)
+        let longClip = try MiniMaxH3GenerationOptions(
+            prompt: "a ten second local video",
+            width: 832,
+            height: 480,
+            numFrames: 243
+        )
+        XCTAssertEqual(longClip.steps, 21)
+        let acceleratedLongClip = try MiniMaxH3GenerationOptions(
+            prompt: "a fast ten second local video",
+            width: 832,
+            height: 480,
+            numFrames: 243,
+            accelerationMode: .maximum
+        )
+        XCTAssertEqual(acceleratedLongClip.steps, 12)
+    }
+
+    func testExactScheduleCacheSurvivesDiscardingBF16AdaLNWeights() throws {
+        let configuration = MiniMaxH3TransformerConfiguration(
+            hiddenSize: 32,
+            layerCount: 2,
+            refinerLayerCount: 1,
+            attentionHeadCount: 4,
+            attentionHeadDimension: 8,
+            feedForwardSize: 64,
+            videoLatentChannels: 8,
+            audioLatentChannels: 32,
+            patchSize: [1, 2, 2],
+            textDimension: 32,
+            timeFrequencyDimension: 32,
+            timeEmbeddingHiddenSize: 32,
+            timeEmbeddingDimension: 32,
+            ropeFrequencyCount: 1
+        )
+        let model = MiniMaxH3Transformer(configuration: configuration)
+        let videoSchedule = try MiniMaxH3Schedule(pointCount: 4, shift: 12)
+        let audioSchedule = try MiniMaxH3Schedule(pointCount: 4, shift: 3)
+        let cache = model.precomputeAdaLN(
+            videoSchedule: videoSchedule,
+            audioSchedule: audioSchedule,
+            sourceIdentity: "test"
+        )
+        XCTAssertEqual(cache.stepCount, 3)
+        let scheduleBytesBefore = model.parameters().flattened()
+            .filter { $0.0.contains("adaln_proj") || $0.0.hasPrefix("time_embedder.") }
+            .reduce(0) { $0 + $1.1.nbytes }
+        XCTAssertGreaterThan(scheduleBytesBefore, 1_000)
+
+        model.discardAdaLNWeights()
+
+        let scheduleParametersAfter = model.parameters().flattened()
+            .filter { $0.0.contains("adaln_proj") || $0.0.hasPrefix("time_embedder.") }
+        XCTAssertTrue(scheduleParametersAfter.allSatisfy { $0.1.size == 1 })
+        XCTAssertLessThan(scheduleParametersAfter.reduce(0) { $0 + $1.1.nbytes }, scheduleBytesBefore)
+        XCTAssertEqual(cache.step(at: 0).blockModulations.count, 2)
     }
 
     func testTinyTransformerResidentBF16MatchesQuantizedExecution() throws {
@@ -707,6 +981,30 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             cachedAdaLN: nil
         )
         MLX.eval(blockwiseCompiled.videoVelocityRows, blockwiseCompiled.audioVelocityRows)
+        let refreshedReuse = model.callWithBlockResidualReuse(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil,
+            warmBlockCount: 1,
+            cachedTailResidual: nil
+        )
+        let reusedTail = model.callWithBlockResidualReuse(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil,
+            warmBlockCount: 1,
+            cachedTailResidual: try XCTUnwrap(refreshedReuse.refreshedTailResidual)
+        )
+        MLX.eval(
+            refreshedReuse.output.videoVelocityRows,
+            refreshedReuse.output.audioVelocityRows,
+            reusedTail.output.videoVelocityRows,
+            reusedTail.output.audioVelocityRows
+        )
         model.usesBlockwiseCompilation = false
         model.usesLayerwiseEvaluation = true
         model.clearsCacheAfterLayerwiseEvaluation = false
@@ -748,6 +1046,34 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertLessThanOrEqual(
             MLX.abs(prepared.audioVelocityRows - blockwiseCompiled.audioVelocityRows)
                 .max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                blockwiseCompiled.videoVelocityRows
+                    - refreshedReuse.output.videoVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                blockwiseCompiled.audioVelocityRows
+                    - refreshedReuse.output.audioVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                refreshedReuse.output.videoVelocityRows
+                    - reusedTail.output.videoVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                refreshedReuse.output.audioVelocityRows
+                    - reusedTail.output.audioVelocityRows
+            ).max().item(Float.self),
             1e-5
         )
         XCTAssertLessThanOrEqual(

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -319,6 +319,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
     }
 
     func testVideoVAETilePlansPreserveCanvasAndMinimumOverlap() {
+        XCTAssertEqual(MiniMaxH3VideoVAE.defaultSpatialTileSize, 320)
         for tileSize in [256, 320] {
             for length in [480, 832, 1_344] {
                 let plan = MiniMaxH3VideoVAE.tilePlan(length: length, tileSize: tileSize)

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -234,6 +234,12 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             value: MLXArray.zeros([64, 1, 7])
         )
         XCTAssertEqual(audioEncoder.first?.1.shape, [64, 7, 1])
+        let audioInputBias = MiniMaxH3AudioVAE.mapConvertedWeight(
+            key: "dec_in_proj.bias",
+            value: MLXArray.zeros([2_048])
+        )
+        XCTAssertEqual(audioInputBias.map(\.0), ["dec_in_proj.bias"])
+        XCTAssertEqual(audioInputBias.first?.1.shape, [2_048])
         let audioResidual = MiniMaxH3AudioVAE.mapConvertedWeight(
             key: "encoder.block.1.block.0.block.1.weight",
             value: MLXArray.zeros([64, 64, 7])
@@ -307,6 +313,43 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         MLX.eval(audioRoundTrip)
         XCTAssertEqual(audioRoundTrip.shape, audio.shape)
         XCTAssertEqual(audioRoundTrip.asArray(Float.self), audio.asArray(Float.self))
+    }
+
+    func testInstalledAudioVAEDecodeMatchesReference() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_H3_MODEL_ROOT"], !root.isEmpty else {
+            throw XCTSkip(
+                "Set MERERUN_H3_MODEL_ROOT to run the checkpoint-backed H3 audio parity fixture."
+            )
+        }
+
+        let latentFrames = 8
+        let latentValues = (0..<(32 * 2 * latentFrames)).map { index in
+            Float((index * 37) % 257 - 128) / 64
+        }
+        let latent = MLXArray(latentValues).reshaped(1, 32, 2, latentFrames)
+        let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: root, isDirectory: true))
+        let waveform = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources).decode(latent)
+        MLX.eval(waveform)
+
+        XCTAssertEqual(waveform.shape, [1, latentFrames * MiniMaxH3AudioVAE.hopLength, 2])
+        let values = waveform.asArray(Float.self)
+        XCTAssertTrue(values.allSatisfy(\.isFinite))
+        // FP32 samples from ComfyUI's MiniMaxH3AudioVAE at
+        // 16e3f3034f2bba1fff6c70cbd759339778555cd6 for the latent fixture above.
+        let referenceSamples: [(Int, Float)] = [
+            (0, 0.044_520_34), (1, 0.011_212_92), (2, -0.013_318_60),
+            (63, -0.142_264_11), (255, 0.202_620_71), (511, -0.673_421_03),
+            (1_023, 0.361_299_25), (2_047, -0.206_609_98),
+            (4_095, -0.600_924_31), (6_143, 0.713_577_15),
+            (8_191, 0.200_860_02), (10_239, 0.757_872_64),
+            (12_287, -0.011_021_69), (12_799, 0.009_704_24),
+        ]
+        for (index, expected) in referenceSamples {
+            XCTAssertEqual(values[index], expected, accuracy: 0.000_1, "reference sample \(index)")
+        }
+        let rootMeanSquare = sqrt(values.reduce(0) { $0 + $1 * $1 } / Float(values.count))
+        XCTAssertEqual(rootMeanSquare, 0.556_741_18, accuracy: 0.000_1)
     }
 
     func testDecodedFramesConvertToMediaPixels() {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -575,8 +575,24 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
 
     func testDenoiseExecutionPolicyUsesMeasuredBlockwiseKernelSchedule() {
         XCTAssertEqual(
-            MiniMaxH3DenoiseExecutionPolicy.maximumAttentionQueryTokensPerKernel,
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 14_958)
+                .maximumQueryTokens,
             1_024
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 14_958)
+                .maximumKernelsPerEvaluation,
+            4
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 37_966)
+                .maximumQueryTokens,
+            768
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 37_966)
+                .maximumKernelsPerEvaluation,
+            1
         )
     }
 

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -628,6 +628,10 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
                 .maximumKernelsPerEvaluation,
             4
         )
+        XCTAssertNil(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 14_958)
+                .maximumHeadsPerKernel
+        )
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 37_966)
                 .maximumQueryTokens,
@@ -635,6 +639,25 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         )
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 37_966)
+                .maximumKernelsPerEvaluation,
+            1
+        )
+        XCTAssertNil(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 37_966)
+                .maximumHeadsPerKernel
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 73_470)
+                .maximumQueryTokens,
+            640
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 73_470)
+                .maximumHeadsPerKernel,
+            8
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 73_470)
                 .maximumKernelsPerEvaluation,
             1
         )
@@ -1032,6 +1055,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         let compiledOutputs = compiled([video, audio, timesteps])
         MLX.eval(compiledOutputs)
         model.maximumAttentionQueryTokensPerKernel = 2
+        model.maximumAttentionHeadsPerKernel = 1
         model.usesBlockwiseCompilation = true
         let blockwiseCompiled = model(
             videoRows: video,

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -126,6 +126,13 @@ near 24-26 minutes. Scaling the measured 124-frame VAE decode only as an
 arithmetic estimate adds roughly seven minutes, placing the single-evaluation
 10-second boundary near 31-33 minutes.
 
+A deterministic full-block dtype gate at these exact 73,470 rows measured
+29.679 seconds in BF16 and 30.204 seconds in FP16. The FP16 output remained
+numerically close for one block (`rel_l2=0.00243324`), but it was 1.7% slower;
+the shorter 14,958- and 37,966-row screens were also slower. The runtime keeps
+BF16 because changing precision does not unlock additional M4 throughput for
+this workload.
+
 That number is the physical one-evaluation boundary, not a quality render.
 A 20-point exact schedule still performs 19 complete model evaluations and
 therefore projects to roughly 7.7-8.3 hours of denoising before decode. The

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -157,3 +157,20 @@ Inference-only solver screens did not change that conclusion. On the locked
 A two-evaluation Heun solve reached the desired compute class—45.548 seconds of
 proxy denoise—but produced tiled chromatic noise at 0.327 SSIM. Both candidates
 were removed; these are rejection receipts, not available runtime modes.
+
+### Arithmetic roof
+
+At 73,470 packed rows, the released 50-layer transformer performs about 211.390
+TFLOP per block: 154.767 TFLOP of dense attention and 56.624 TFLOP of linear
+projections. The accepted 25.173-second block is therefore about 8.40 effective
+TFLOP/s. For scale, even treating 36 TFLOP/s as a perfectly attainable
+end-to-end ceiling gives 5.872 seconds per block and 293.6 seconds per complete
+model evaluation. The 19-evaluation exact schedule cannot fall below roughly
+93 minutes of transformer arithmetic, while the 417-block `maximum` schedule
+cannot fall below roughly 40.8 minutes, before the approximately seven-minute
+video decode estimate. Real execution must be slower than those floors.
+
+This bound rules out a 30-minute ten-second result from exact kernel scheduling
+alone. Reaching that class requires less model math—distillation, a validated
+sparser attention structure, or fewer evaluated blocks—not more disk, unified
+memory, or a debug-versus-release correction.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -64,27 +64,31 @@ scripts/h3-end-to-end-benchmark.sh probe-768
 - geometry: 1344x768, 124 frames, 24 fps
 - schedule: two points / one complete 50-block model evaluation
 - packed rows: 37,794
-- execution: dense BF16, blockwise compiled, 1,024-query attention chunks
+- execution: dense BF16, blockwise compiled, 768-query single-evaluation attention chunks
 - acceleration: exact `quality` (no tail reuse)
 
-| Phase | Time |
-| --- | ---: |
-| Text encoding | 4.218 s |
-| Transformer preparation | 4.661 s |
-| Denoising | **953.485 s (15:53.485)** |
-| Video VAE decode | 289.586 s (4:49.586) |
-| Audio decode | 0.873 s |
-| End to end | **1,253.425 s (20:53.425)** |
+| Phase | Baseline | Optimized exact |
+| --- | ---: | ---: |
+| Text encoding | 4.218 s | 4.078 s |
+| Transformer preparation | 4.661 s | 4.510 s |
+| Denoising | 953.485 s | **775.336 s (12:55.336)** |
+| Video VAE decode | 289.586 s | 242.004 s |
+| Audio decode | 0.873 s | 0.829 s |
+| End to end | 1,253.425 s | **1,027.310 s (17:07.310)** |
 
-The full model evaluation itself measured 953.192 seconds. Peak reported Metal
-memory was 48.77 GiB, so this workload is compute-bound rather than blocked by
-unified-memory capacity. The valid H.264/AAC output is 1344x768 at 24 fps with
-32 kHz stereo audio and a 5.167-second duration. Its SHA-256 is
-`f74e0d2ab0cf9a58233e954560a9aa6c05a1f905fd78914350a077b70f7e5848`.
+The full model evaluation itself fell from 953.192 to 775.062 seconds, a
+1.230x throughput improvement and 18.7% less wall time. End to end, the boundary
+is 3:46.115 faster (18.0%). Peak reported Metal memory remained 48.77 GiB, so
+this workload is compute-bound rather than blocked by unified-memory capacity.
+The valid H.264/AAC output is 1344x768 at 24 fps with 32 kHz stereo audio and a
+5.167-second duration. Its SHA-256 is
+`f74e0d2ab0cf9a58233e954560a9aa6c05a1f905fd78914350a077b70f7e5848`—exactly
+the same as the baseline artifact, proving the optimized execution did not
+change model output.
 
 The two-point artifact is intentionally noise-like and is not a visual quality
 gate. Using its full-evaluation time only as an arithmetic bound, a 20-point
-exact run projects to about 5.11 hours end to end. The existing 417-block
-`maximum` policy projects to about 2.29 hours. Those are projections, not
+exact run now projects to about 4.16 hours end to end. The existing 417-block
+`maximum` policy projects to about 1.87 hours. Those are projections, not
 measured 768p render receipts; a near-30-minute quality result requires fewer
 model/block evaluations rather than another small scheduling adjustment.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -92,3 +92,38 @@ exact run now projects to about 4.16 hours end to end. The existing 417-block
 `maximum` policy projects to about 1.87 hours. Those are projections, not
 measured 768p render receipts; a near-30-minute quality result requires fewer
 model/block evaluations rather than another small scheduling adjustment.
+
+## VAE tile frontier
+
+A later fresh-process sweep of the released BF16 video decoder changed the
+production spatial tile from 256 to 320 pixels. At 832x480 and 124 frames, the
+matched decode fell from 96.091 to 76.421 seconds (1.257x) while reported peak
+Metal memory fell from 9.85 to 8.91 GiB. A 480-pixel arm reached 77.577 seconds
+and lost. At the true 1344x768 shape, the accepted 320-pixel arm completed in
+213.005 seconds at a 15.12 GiB reported peak; the 480-pixel arm crossed 252
+seconds without completing and was stopped.
+
+This is a non-quantized runtime change: the released decoder, precision,
+causal tiling, and overlap blend remain intact. The larger tile performs fewer
+overlapping tile evaluations and gives each evaluation more spatial context.
+The earlier end-to-end table remains the immutable artifact receipt; replacing
+its 242.004-second decode with 213.005 seconds would be an arithmetic projection,
+not a newly measured end-to-end result.
+
+## Ten-second physical boundary
+
+The first valid frame count beyond ten seconds is 243 frames (10.125 seconds),
+which yields 72 video latent frames and 73,470 packed rows for the locked prompt.
+True-shape whole-block gates measured 29.088-31.438 seconds per transformer
+block with the accepted policies. That puts one exact 50-block model evaluation
+near 24-26 minutes. Scaling the measured 124-frame VAE decode only as an
+arithmetic estimate adds roughly seven minutes, placing the single-evaluation
+10-second boundary near 31-33 minutes.
+
+That number is the physical one-evaluation boundary, not a quality render.
+A 20-point exact schedule still performs 19 complete model evaluations and
+therefore projects to roughly 7.7-8.3 hours of denoising before decode. The
+417-block `maximum` schedule projects to roughly 3.4-3.7 hours before decode.
+Reaching near 30 minutes with comparable visual quality consequently requires
+a materially lower-evaluation model or sampler, such as an upstream distilled
+checkpoint; it cannot come from another one-percent kernel scheduling win.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -150,3 +150,10 @@ Reaching near 30 minutes with comparable visual quality consequently requires
 a materially lower-evaluation model or sampler, such as an upstream distilled
 checkpoint; the exact head-scheduling win does not remove the remaining
 evaluation-count multiplier.
+
+Inference-only solver screens did not change that conclusion. On the locked
+416x256 proxy, 12-point variable-step Adams-Bashforth was less faithful to the
+20-point Euler artifact than plain 12-point Euler (0.667 versus 0.694 SSIM).
+A two-evaluation Heun solve reached the desired compute class—45.548 seconds of
+proxy denoise—but produced tiled chromatic noise at 0.327 SSIM. Both candidates
+were removed; these are rejection receipts, not available runtime modes.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -44,6 +44,12 @@ Visual acceptance confirmed a coherent caped figure and yellow umbrella,
 wet-street reflections, levitating bus, and luminous dragon motion without the
 spatial lattice rejected in earlier aggressive cache experiments.
 
+The locked MP4 predates the audio-VAE bias-loading correction documented in
+the kernel lab. Its video remains the accepted visual and timing receipt, but
+its hissy soundtrack is not an audio-quality reference. The corrected decoder
+matches the released FP32 reference at `rel_l2=0.0000194`; a future long render
+must replace the soundtrack acceptance receipt rather than reusing this file.
+
 ## Duration boundary
 
 MiniMax-H3 frame counts follow `17*n+5`. The locked 124-frame artifact is

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -126,11 +126,14 @@ not a newly measured end-to-end result.
 
 The first valid frame count beyond ten seconds is 243 frames (10.125 seconds),
 which yields 72 video latent frames and 73,470 packed rows for the locked prompt.
-True-shape whole-block gates measured 29.088-31.438 seconds per transformer
-block with the accepted policies. That puts one exact 50-block model evaluation
-near 24-26 minutes. Scaling the measured 124-frame VAE decode only as an
-arithmetic estimate adds roughly seven minutes, placing the single-evaluation
-10-second boundary near 31-33 minutes.
+The accepted exact attention schedule splits the 56 independent heads into
+eight-head submissions with 640 query rows per kernel. An order-balanced
+full-block gate measured 32.249 seconds for the previous 768-query/56-head
+schedule and 25.173 seconds for the new schedule, a 1.281x speedup with
+bit-identical BF16 output (`rel_l2=0`). That puts one exact 50-block model
+evaluation near 21 minutes. Scaling the measured 124-frame VAE decode only as
+an arithmetic estimate adds roughly seven minutes, placing the
+single-evaluation 10-second boundary near 28 minutes.
 
 A deterministic full-block dtype gate at these exact 73,470 rows measured
 29.679 seconds in BF16 and 30.204 seconds in FP16. The FP16 output remained
@@ -141,8 +144,9 @@ this workload.
 
 That number is the physical one-evaluation boundary, not a quality render.
 A 20-point exact schedule still performs 19 complete model evaluations and
-therefore projects to roughly 7.7-8.3 hours of denoising before decode. The
-417-block `maximum` schedule projects to roughly 3.4-3.7 hours before decode.
+therefore projects to roughly 6.6 hours of denoising before decode. The
+417-block `maximum` schedule projects to roughly 2.9 hours before decode.
 Reaching near 30 minutes with comparable visual quality consequently requires
 a materially lower-evaluation model or sampler, such as an upstream distilled
-checkpoint; it cannot come from another one-percent kernel scheduling win.
+checkpoint; the exact head-scheduling win does not remove the remaining
+evaluation-count multiplier.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -106,6 +106,12 @@ seconds without completing and was stopped.
 This is a non-quantized runtime change: the released decoder, precision,
 causal tiling, and overlap blend remain intact. The larger tile performs fewer
 overlapping tile evaluations and gives each evaluation more spatial context.
+At true 1344x768 spatial geometry, an order-balanced 22-frame screen confirmed
+that 320 pixels also beats the tempting overlap-count breakpoints: a hot-state
+416-versus-320 pair measured 33.756 versus 32.321 seconds, and 432- and
+496-pixel arms were materially slower. A two-temporal-chunk submission
+prototype produced no repeatable speedup and raised reported peak Metal memory
+from 13.49 to 21.40 GiB, so the accepted path keeps serial causal chunks.
 The earlier end-to-end table remains the immutable artifact receipt; replacing
 its 242.004-second decode with 213.005 seconds would be an arithmetic projection,
 not a newly measured end-to-end result.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -1,0 +1,90 @@
+# MiniMax-H3 BF16 on M4 Max
+
+This receipt records a real local end-to-end MiniMax-H3 FL2VA generation on an
+M4 Max with 128 GiB unified memory. It is an artifact benchmark, not a
+transformer-only extrapolation.
+
+## Locked workload
+
+- checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
+- mode: resident BF16 transformer, `maximum` acceleration
+- geometry: 832x480, 124 frames, 24 fps
+- schedule: 20 points / 19 model evaluations
+- seed: `20260804`
+- packed rows: 14,928
+- execution: blockwise compiled
+- policy: six complete 50-block evaluations and thirteen nine-block cached-tail
+  evaluations, with native start, refresh, and endpoint evaluations
+
+The command is reproducible with the repository benchmark harness:
+
+```bash
+scripts/h3-end-to-end-benchmark.sh target-maximum
+```
+
+## Result
+
+| Phase | Time |
+| --- | ---: |
+| Text encoding | 3.847 s |
+| Transformer preparation | 2.359 s |
+| Denoising | 1,526.533 s (25:26.533) |
+| Video VAE decode | 119.544 s |
+| Audio decode | 0.892 s |
+| End to end | **1,653.711 s (27:33.711)** |
+
+The six full evaluations averaged 184.268 seconds. The thirteen cached-tail
+evaluations averaged 32.372 seconds with a 32.191-second median. Peak reported
+Metal memory was 43.41 GiB and active memory remained approximately 38.24 GiB.
+
+The output is an H.264/AAC MP4 at 832x480, 24 fps, with synchronized 32 kHz
+stereo audio. Its SHA-256 is
+`270544693662769fd8f90971d1ccabce3405fe00ff21885f96b9b0e218cb921f`.
+Visual acceptance confirmed a coherent caped figure and yellow umbrella,
+wet-street reflections, levitating bus, and luminous dragon motion without the
+spatial lattice rejected in earlier aggressive cache experiments.
+
+## Duration boundary
+
+MiniMax-H3 frame counts follow `17*n+5`. The locked 124-frame artifact is
+5.167 seconds at 24 fps. It proves the near-30-minute target for this workload;
+it is not a ten-second runtime claim. The first valid frame count beyond ten
+seconds is 243 frames (10.125 seconds), which requires a separate measured
+receipt.
+
+## True-768 one-evaluation boundary
+
+A separate release-mode probe locks the physical 768-line target without
+pretending that a two-point sampler is a quality result:
+
+```bash
+scripts/h3-end-to-end-benchmark.sh probe-768
+```
+
+- geometry: 1344x768, 124 frames, 24 fps
+- schedule: two points / one complete 50-block model evaluation
+- packed rows: 37,794
+- execution: dense BF16, blockwise compiled, 1,024-query attention chunks
+- acceleration: exact `quality` (no tail reuse)
+
+| Phase | Time |
+| --- | ---: |
+| Text encoding | 4.218 s |
+| Transformer preparation | 4.661 s |
+| Denoising | **953.485 s (15:53.485)** |
+| Video VAE decode | 289.586 s (4:49.586) |
+| Audio decode | 0.873 s |
+| End to end | **1,253.425 s (20:53.425)** |
+
+The full model evaluation itself measured 953.192 seconds. Peak reported Metal
+memory was 48.77 GiB, so this workload is compute-bound rather than blocked by
+unified-memory capacity. The valid H.264/AAC output is 1344x768 at 24 fps with
+32 kHz stereo audio and a 5.167-second duration. Its SHA-256 is
+`f74e0d2ab0cf9a58233e954560a9aa6c05a1f905fd78914350a077b70f7e5848`.
+
+The two-point artifact is intentionally noise-like and is not a visual quality
+gate. Using its full-evaluation time only as an arithmetic bound, a 20-point
+exact run projects to about 5.11 hours end to end. The existing 417-block
+`maximum` policy projects to about 2.29 hours. Those are projections, not
+measured 768p render receipts; a near-30-minute quality result requires fewer
+model/block evaluations rather than another small scheduling adjustment.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1865,10 +1865,22 @@ FL2VA accepts `--image` and optional `--end-image`; Ref2VA accepts ordered
 32-pixel multiples, frame counts snap upward to `17*n+5`, and its
 CFG-distilled transformer needs one evaluation per schedule step. Ref2VA roots
 are locally converted; the public managed pull exists only for FL2VA.
-When `--steps` is omitted, H3 selects 9, 16, or 31 schedule points from packed
-row cost. Its source-bound AdaLN cache resamples the exact released 31-point
+When `--steps` is omitted, H3 selects 9, 16, or 21 schedule points from packed
+row cost. Maximum acceleration caps the automatic schedule at 12 points. Its
+source-bound AdaLN cache resamples the exact released 31-point
 curve for explicit overrides. `--h3-weight-mode auto` keeps compact Q4 on
-MacBooks and may expand to resident BF16 on memory-qualified desktop Macs.
+MacBooks below 96 GiB and expands to the faster resident BF16 path on memory-qualified
+desktops and 96+ GiB MacBooks when the requested geometry leaves the required
+runtime reserve.
+
+`--h3-acceleration quality` is the exact default. `balanced` reuses the measured
+contribution of the trailing 50% of transformer blocks on eligible adjacent
+schedule steps and refreshes after at most two cache hits. `maximum` is the
+explicit speed lane: it reuses the trailing 82% and refreshes after at most
+four cache hits. Both require two complete evaluations before the first reuse
+and keep the schedule boundaries native. They remain approximate: the same
+prompt and seed may follow a different motion or composition trajectory. Use
+`quality` when exact-seed fidelity matters.
 
 Preflight mode:
 
@@ -1876,8 +1888,9 @@ Preflight mode:
   video model, creating directories, or writing an MP4.
 - the report includes model availability, output path state, source/end image
   and audio state, resolved dimensions, resolved frame count/duration, source
-  audio offset, seed, input mode, whether audio conditions generation, whether
-  the source soundtrack is preserved, diagnostics, and declarative actions.
+  audio offset, seed, input mode, the resolved H3 steps/weight/acceleration
+  policy when applicable, whether audio conditions generation, whether the
+  source soundtrack is preserved, diagnostics, and declarative actions.
 - blockers such as a missing model root, missing image, invalid frame rate, or
   `--end-image` without `--image` produce JSON and a nonzero exit. Requesting
   phase timings on a legacy merged distilled root or Wan2.2 is also blocked.

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -245,6 +245,14 @@ also lost its order-balanced whole-block gate (29.151 s versus 29.088 s,
 near 24-26 minutes before VAE decode; a 20-point exact schedule still needs 19
 such evaluations.
 
+Full-block FP16 execution was also screened rather than inferred from nominal
+GPU peak rates. With identical seeded weights and inputs, FP16 stayed inside a
+one-block `rel_l2 <= 0.01` gate but was slower at every measured packed shape:
+1.772 versus 1.652 seconds at 14,958 rows, 8.778 versus 8.644 seconds at 37,966
+rows, and 30.204 versus 29.679 seconds at the true ten-second 73,470-row shape.
+Production therefore remains resident BF16. Re-run the deterministic comparison
+after an MLX or Metal update with `scripts/h3-kernel-lab.sh dtype`.
+
 The video VAE did retain a separate full-precision runtime win. Fresh-process released-
 checkpoint sweeps at 832x480 and 124 frames measured 96.091 s with 256-pixel
 tiles, 76.421 s with 320-pixel tiles, and 77.577 s with 480-pixel tiles. The

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -86,3 +86,176 @@ lower resolution, or smaller models — not kernel work.
 - Single blocks fuse QKV+MLP-in into one 3072→18432 projection and
   attn+MLP-out into one 12288→3072 projection — already the right shape for
   the hardware; splitting or refusing them was not worth measuring further.
+
+## MiniMax-H3 kernel lab
+
+H3 performance experiments must start with bounded, non-generative loops. The
+default lab loads no checkpoint, runs no conditioner or VAE, and writes no
+media. It searches exact schedules for the dominant dense-attention kernel at
+the measured 14,958-row shape:
+
+```bash
+scripts/h3-kernel-lab.sh quick
+```
+
+The script reuses the release XCTest bundle while it is newer than `Package.swift`,
+`Sources/`, and `Tests/`; set `MERERUN_H3_LAB_REBUILD=1` to force a cold rebuild.
+
+The quick loop walks query chunk size, attention-head chunk size, and the number
+of Metal kernels queued before synchronization using coordinate descent. That
+keeps the default inner loop to about a dozen arms instead of a Cartesian sweep.
+It reports wall time, effective TFLOP/s, peak memory, and speedup relative to the
+current production schedule. Every arm is compared with that schedule using
+maximum absolute and relative-L2 error; a numerically divergent arm fails the
+test instead of becoming a runtime candidate.
+
+Each arm is timed next to the production schedule, with their order reversed on
+alternate rounds. This paired design cancels most thermal drift and sweep-order
+bias; do not promote a raw first-arm timing from an unpaired loop.
+
+The search surface is configurable without editing code:
+
+```bash
+MERERUN_H3_BENCH_ROWS=37966 \
+MERERUN_H3_BENCH_CHUNKS=1024,1536,2048,2560,3072,4096 \
+MERERUN_H3_BENCH_HEAD_CHUNKS=14,28,56 \
+MERERUN_H3_BENCH_EVAL_BATCHES=1,2,4,8 \
+scripts/h3-kernel-lab.sh attention
+```
+
+`attention` defaults to the exhaustive grid. Set
+`MERERUN_H3_BENCH_SEARCH=coordinate` when narrowing a larger shape before the
+full confirmation sweep.
+
+Projection-only loops isolate Q4 matrix multiplication from the resident-BF16
+path without running a transformer step:
+
+```bash
+MERERUN_H3_BENCH_ROWS=14958,37966 scripts/h3-kernel-lab.sh projections
+```
+
+The modulation loop compares per-token AdaLN gathers with exact contiguous-run
+modulation, without loading a checkpoint:
+
+```bash
+scripts/h3-kernel-lab.sh modulation
+```
+
+At 29,018 rows, the run formulation matched exactly and measured 5.7 ms versus
+10.4 ms for gathers (1.835x). That isolated saving is too small relative to a
+full H3 block to justify production graph complexity, so the experiment remains
+in the lab.
+
+The full-block loop instantiates one production-width H3 block with resident
+BF16 weights. It measures the real compiled graph boundaries, chunked SDPA,
+and MLP together instead of extrapolating from isolated kernels:
+
+```bash
+MERERUN_H3_BENCH_ROWS=37966 scripts/h3-kernel-lab.sh block
+```
+
+At the 37,966-row true-768 shape, exact fresh-process controls measured the
+1,024-query schedule at 9.287 seconds for a split full block and 6.511 seconds
+for its attention phase. The previous 2,048-query schedule measured 10.350 and
+7.120 seconds respectively. The 1,024-query schedule therefore carries into
+production; its output matched the previous schedule exactly in the attention
+gate (`max_abs=0`, `rel_l2=0`).
+
+Several tempting graph changes did not carry. Explicitly materializing
+contiguous Q/K/V copies regressed the full block to 15.148 seconds. Narrowing
+the implicit module state passed to each compiled closure also regressed, and
+larger post-attention fusion did not repeatably beat the existing split graph.
+Those arms remain rejected rather than becoming hidden runtime switches.
+
+The lower-level MLX Metal tile is not an untapped switch either. A temporary
+JIT-controlled sweep ran one BF16 attention chunk with 56 heads, 1,024 query
+rows, 37,966 key/value rows, and head dimension 128. Every arm was checked
+against the default output before the dependency checkout was restored:
+
+| Steel tile (BQ x BK) | Median | Effective throughput |
+| --- | ---: | ---: |
+| **32 x 16 (MLX default)** | **102.4 ms** | **10.89 TFLOP/s** |
+| 16 x 16 | 157.3 ms | 7.09 TFLOP/s |
+| 32 x 8 | 103.7 ms | 10.75 TFLOP/s |
+| 32 x 32 | 123.4 ms | 9.04 TFLOP/s |
+| 64 x 16 | 107.6 ms | 10.36 TFLOP/s |
+| 64 x 32 | 115.2 ms | 9.67 TFLOP/s |
+
+The default was both fastest and bit-identical to its repeated control. The
+different-key-tile arms remained well inside the numerical gate but did not
+improve time. H3 is already using MLX's fused Steel full-attention path on M4;
+the NAX path is unavailable on this generation, and replacing Steel with a new
+approximate attention algorithm would be a model-math change rather than a
+runtime scheduling optimization.
+
+Dense projection dispatch did expose one exact M4 win. MLX's large-device BF16
+heuristic used a 64 x 64 x 16 Steel GEMM tile with two total warps and no
+threadgroup swizzle. At the true-768 row count, four total warps plus a two-bit
+swizzle improved every production projection family; selecting the alternate
+32-row tile for the two shapes where it won preserved the same whole-block gain:
+
+| H3 projection | MLX default | Tuned | Speedup |
+| --- | ---: | ---: | ---: |
+| QKV, 5,376 -> 21,504 | 745.1 ms | 621.2 ms | 1.199x |
+| attention out, 7,168 -> 5,376 | 270.0 ms | 237.7 ms | 1.136x |
+| feed-forward in, 5,376 -> 28,672 | 1,099.1 ms | 994.4 ms | 1.105x |
+| feed-forward out, 14,336 -> 5,376 | 669.0 ms | 583.9 ms | 1.146x |
+
+Every projection arm was bit-identical in BF16. A three-arm, order-balanced
+whole-block comparison then measured 7.892 seconds for MLX's default, 7.625
+seconds for the generic four-warp schedule, and 7.619 seconds for the
+shape-aware schedule. The shape-aware result is a 1.036x exact full-block
+speedup (`rel_l2=0`), and is deliberately restricted to H3's four exact
+projection dimensions above 32,768 packed rows. Reproduce the projection and
+whole-block checks with `scripts/h3-kernel-lab.sh gemm` and
+`scripts/h3-kernel-lab.sh gemm-block`.
+
+The release-mode one-evaluation model probe packed 37,794 rows and took 953.192
+seconds for 50 blocks. Counting the dominant projection and dense-attention
+arithmetic gives about 3.504 PFLOP per evaluation, or 3.68 effective TFLOP/s
+across the whole sustained pass. This is lower than both the 7.6 TFLOP/s hot
+single-block result and the 10-14 TFLOP/s isolated-kernel roof because the real
+pass turns over 50 independent parameter sets and includes every dependent
+normalization, modulation, transpose, synchronization, and thermal effect.
+Peak Metal memory was only 48.77 GiB; additional disk or unified memory does
+not close that utilization gap.
+
+Only improvements that repeat across fresh processes, preserve the numerical
+gate, and improve a matched full-block or denoise-step probe should move into
+the runtime. Full video generation remains a final quality gate, not the inner
+optimization loop.
+
+### Bounded tail-block reuse
+
+Exact attention scheduling and resident BF16 improve each native call, but H3
+still executes 50 sequential transformer blocks. The explicit `balanced` and
+`maximum` acceleration modes reduce the number of blocks on safe adjacent
+schedule steps. A full step stores `finalHidden - warmHidden`; a cache step
+recomputes 25 leading blocks in `balanced` or nine in `maximum`, then adds that
+stored tail residual. Both video and audio sigma deltas must be below 0.12, the
+schedule position must be inside 10%...90%, and at least two complete
+evaluations must precede reuse. Balanced refreshes after two cache steps;
+maximum refreshes after four.
+
+Automatic long-geometry schedules use 21 points (20 model evaluations),
+matching the current practical CUDA default instead of the previous 31 points.
+Maximum acceleration caps automatic schedules at 12 points. With an explicit
+20-point schedule, its bounded reuse policy runs six full evaluations and
+recomputes nine of 50 blocks on 13 cache evaluations, for 417 block calls
+versus 950 in exact quality (56.1% less transformer-block work).
+
+On the M4 Max 128 GB test machine, a matched warm-cache 512x320, 22-frame,
+16-point run measured 112.413 s of denoise in exact `quality` mode and 74.754 s
+in `maximum`: 1.504x faster, or 33.5% less denoise time. Eight of fifteen calls
+used 13 blocks. The same-seed MP4 remained coherent but changed portal framing.
+For the accepted automatic-speed envelope, a matched 512x320, 22-frame,
+12-point same-seed pair measured 62.847 s of denoise and 73.07 s end to end in
+`quality`, versus 41.928 s and 51.45 s in `maximum` (1.499x denoise). The
+accelerated artifact remained free of the spatial lattice seen when reuse began
+after only one full evaluation. This is an approximate trajectory accelerator
+rather than an exact kernel optimization; exact `quality` remains the default
+and video/audio artifacts are the acceptance boundary for speed-mode changes.
+
+The full acceptance receipt, including per-step timings, artifact geometry,
+hash, and the important 124-frame duration boundary, is recorded in
+[MiniMax-H3 BF16 on M4 Max](../benchmarks/minimax-h3-bf16-m4-max.md).

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -234,6 +234,37 @@ normalization, modulation, transpose, synchronization, and thermal effect.
 Peak Metal memory was only 48.77 GiB; additional disk or unified memory does
 not close that utilization gap.
 
+The first valid ten-second geometry is 243 frames, which produces 72 video
+latent frames. At 1344x768, the locked benchmark prompt therefore packs 73,470
+rows: 72,576 video rows, 810 audio rows, and 84 text rows. True-shape searches
+did not justify another transformer policy. A sampled 384-query/four-kernel
+attention candidate lost its full-block gate to the shipped 768-query/single-
+kernel schedule (31.845 s versus 31.438 s, `rel_l2=0`). A longer-row GEMM tier
+also lost its order-balanced whole-block gate (29.151 s versus 29.088 s,
+`rel_l2=0`) and was removed. These results put one exact 50-block evaluation
+near 24-26 minutes before VAE decode; a 20-point exact schedule still needs 19
+such evaluations.
+
+The video VAE did retain a separate full-precision runtime win. Fresh-process released-
+checkpoint sweeps at 832x480 and 124 frames measured 96.091 s with 256-pixel
+tiles, 76.421 s with 320-pixel tiles, and 77.577 s with 480-pixel tiles. The
+320-pixel arm was 1.257x faster than the old default and reduced reported peak
+Metal memory from 9.85 to 8.91 GiB. At 1344x768 it decoded the same 124 frames
+in 213.005 s at 15.12 GiB peak; the 480-pixel arm crossed 252 seconds without
+finishing and was stopped. The production default is therefore 320 pixels.
+The model, precision, causal tile algorithm, and overlap blend are unchanged;
+the larger tile reduces redundant overlap and tile-boundary context loss.
+Reproduce a candidate in a fresh process with:
+
+```bash
+MERERUN_H3_MODEL_ROOT=/path/to/h3 \
+MERERUN_H3_VAE_TILE_SIZE=320 \
+MERERUN_H3_VAE_WIDTH=1344 \
+MERERUN_H3_VAE_HEIGHT=768 \
+MERERUN_H3_VAE_FRAMES=124 \
+scripts/h3-kernel-lab.sh vae
+```
+
 Only improvements that repeat across fresh processes, preserve the numerical
 gate, and improve a matched full-block or denoise-step probe should move into
 the runtime. Full video generation remains a final quality gate, not the inner

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -333,6 +333,25 @@ from 0.602x to 0.928x; several unsupported tile shapes also failed the output
 gate. The temporary selection controls were removed rather than adding a
 non-winning H3-specific Steel branch.
 
+A focused 42-candidate schedule grid then searched 592...688 query rows and
+five, six, eight, nine, ten, or twelve heads per submission. A short 2,048-row
+screen suggested 608/eight, but the complete 73,470-query gate reversed it:
+608/eight measured 18.567 seconds versus 17.926 seconds for 640/eight, with
+exact output. Queuing every 640/eight submission through `asyncEval` also lost
+its direct four-round gate, 18.650 seconds versus 17.182 seconds for synchronous
+evaluation (`rel_l2=0`). Both laboratory controls were removed.
+
+The true-ten-second arithmetic explains the remaining scale. One transformer
+block contains approximately 211.390 TFLOP: 154.767 TFLOP (73.2%) in dense
+attention and 56.624 TFLOP (26.8%) in the four linear projections. The accepted
+25.173-second block therefore sustains about 8.40 TFLOP/s end to end. Even an
+unattainable 36-TFLOP/s-perfect execution would require 5.872 seconds per block
+and 293.6 seconds per complete 50-block evaluation. Nineteen exact evaluations
+have a compute-only floor of about 93 minutes; the 417-block `maximum` schedule
+has a floor of about 40.8 minutes before VAE decode. This is an arithmetic
+lower bound, not a performance forecast, and shows why the current checkpoint
+cannot reach a 30-minute ten-second render through exact dispatch tuning alone.
+
 The video VAE did retain a separate full-precision runtime win. Fresh-process released-
 checkpoint sweeps at 832x480 and 124 frames measured 96.091 s with 256-pixel
 tiles, 76.421 s with 320-pixel tiles, and 77.577 s with 480-pixel tiles. The

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -288,6 +288,22 @@ MERERUN_H3_VAE_FRAMES=124 \
 scripts/h3-kernel-lab.sh vae
 ```
 
+The audio VAE has its own checkpoint-backed parity loop:
+
+```bash
+MERERUN_H3_MODEL_ROOT=/path/to/h3 scripts/h3-kernel-lab.sh audio-parity
+```
+
+This fixture caught a checkpoint-mapping defect that discarded the released
+`mean_proj`, `logs_proj`, and `dec_in_proj` biases. With identical deterministic
+latents and FP32 weights, the old waveform differed from ComfyUI's
+MiniMaxH3AudioVAE at `16e3f3034f2bba1fff6c70cbd759339778555cd6` by
+`rel_l2=0.463`. Restoring the biases reduced the complete decode error to
+`rel_l2=0.0000194` with effectively unit cosine similarity. The gate locks
+reference waveform samples and RMS across the full decoder, while the
+production path remains the released 32 kHz stereo model with no denoiser or
+post-processing added.
+
 Only improvements that repeat across fresh processes, preserve the numerical
 gate, and improve a matched full-block or denoise-step probe should move into
 the runtime. Full video generation remains a final quality gate, not the inner

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -253,6 +253,14 @@ rows, and 30.204 versus 29.679 seconds at the true ten-second 73,470-row shape.
 Production therefore remains resident BF16. Re-run the deterministic comparison
 after an MLX or Metal update with `scripts/h3-kernel-lab.sh dtype`.
 
+The fused non-NAX Steel attention microtile was then swept locally at 14,958
+rows with exact output checks. Apple's existing 32-query x 16-key tile with
+four SIMD groups measured 511 ms in the initial cool-state run. Query tiles of
+16, 24, 40, 48, and 64 rows and key tiles of 8, 24, 32, and 64 rows did not
+beat it; the valid candidates ranged from 535 to 678 ms. A 48-key candidate
+also failed exactness (`rel_l2=0.278`) and was rejected. The temporary MLX
+controls were removed, leaving the upstream Steel attention dispatch intact.
+
 The video VAE did retain a separate full-precision runtime win. Fresh-process released-
 checkpoint sweeps at 832x480 and 124 frames measured 96.091 s with 256-pixel
 tiles, 76.421 s with 320-pixel tiles, and 77.577 s with 480-pixel tiles. The

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -301,6 +301,13 @@ fused graph, a bit-identical but only 1.009x improvement (`max_abs=0`,
 keeps the simpler split graph. Re-run this rejection gate with
 `scripts/h3-kernel-lab.sh post`.
 
+A subsequent 40-candidate local grid searched 512...768 query chunks, four,
+seven, eight, or fourteen heads per submission, and one or two submissions per
+evaluation. Each candidate used 4,096 sampled query rows against the complete
+73,470-row key/value shape. The existing 640-query/eight-head/single-submission
+schedule remained the winner, projecting 16.532 seconds for the complete
+attention pass; the earlier exact full-pass gate measured 16.383 seconds.
+
 Full-block FP16 execution was also screened rather than inferred from nominal
 GPU peak rates. With identical seeded weights and inputs, FP16 stayed inside a
 one-block `rel_l2 <= 0.01` gate but was slower at every measured packed shape:
@@ -413,3 +420,20 @@ four-cache-step block count. It added no meaningful runtime cost, but the
 same-seed 416x256 proxy fell from 0.688 SSIM against the exact trajectory to
 0.583 and visibly shifted exposure and composition. The predictor was removed;
 maximum mode keeps the more faithful bounded stale residual.
+
+Lower-evaluation ODE math was tested on that same 416x256, 107-frame prompt and
+seed before any long render. A 12-point variable-step Adams-Bashforth candidate
+completed denoise in 314.742 seconds but reached only 0.667 SSIM and 19.22 dB
+PSNR against the 20-point Euler reference. Plain 12-point Euler was both faster
+on this small compiled-step geometry (253.063 seconds) and closer to the
+reference at 0.694 SSIM and 20.57 dB, so the multistep candidate was removed.
+
+The highest-leverage undistilled screen used one Heun interval: an Euler
+predictor plus endpoint correction, or two complete model evaluations. It
+finished denoise in 45.548 seconds and the complete proxy in 74.344 seconds,
+but decoded into tiled chromatic noise rather than a coherent scene. Its 0.327
+SSIM and 13.22 dB PSNR confirm that the released H3 vector field is not straight
+enough for a two-evaluation solve. The candidate and its endpoint AdaLN path
+were removed. On this checkpoint, reducing the quality schedule to the physical
+one- or two-evaluation boundary therefore requires learned distillation rather
+than an inference-only integrator swap.

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -324,6 +324,15 @@ beat it; the valid candidates ranged from 535 to 678 ms. A 48-key candidate
 also failed exactness (`rel_l2=0.278`) and was rejected. The temporary MLX
 controls were removed, leaving the upstream Steel attention dispatch intact.
 
+The production 73,470-key call was then swept separately with eight heads and
+640 query rows per exact Steel submission. Across 20 BQ/BK/warp
+specializations, the existing 32-query x 16-key tile with four SIMD groups
+remained the local winner: 17.129 ms versus its paired 17.181 ms control, only
+measurement noise. Every numerically valid alternative was slower, ranging
+from 0.602x to 0.928x; several unsupported tile shapes also failed the output
+gate. The temporary selection controls were removed rather than adding a
+non-winning H3-specific Steel branch.
+
 The video VAE did retain a separate full-precision runtime win. Fresh-process released-
 checkpoint sweeps at 832x480 and 124 frames measured 96.091 s with 256-pixel
 tiles, 76.421 s with 320-pixel tiles, and 77.577 s with 480-pixel tiles. The

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -465,3 +465,34 @@ enough for a two-evaluation solve. The candidate and its endpoint AdaLN path
 were removed. On this checkpoint, reducing the quality schedule to the physical
 one- or two-evaluation boundary therefore requires learned distillation rather
 than an inference-only integrator swap.
+
+Spatial token reduction and depth pruning were also screened behind temporary
+laboratory controls, then removed. A KV-only candidate kept conditioning tokens
+exact, retained full-resolution keys and values for nearby video frames, and
+2x2-pooled only distant video keys and values. On the 416x256, 107-frame,
+12-point proxy, a one-frame-radius arm measured 0.591 SSIM and 16.18 dB PSNR
+against dense 12-point Euler. A three-frame-radius arm improved that to 0.617
+SSIM and 16.73 dB and remained visually coherent, but still changed composition
+and motion. At the true 73,470-row call shape, the corresponding full-block
+times were 14.635 and 17.908 seconds versus 25.173 seconds for exact dense
+attention.
+
+That speedup is real but insufficient. The automatic 12-point `maximum`
+schedule executes 304 transformer blocks under its accepted reuse policy. The
+measured sparse-block times therefore project to 74.1 minutes of denoise at the
+one-frame radius or 90.7 minutes at the better-quality three-frame radius,
+before roughly seven minutes of video/audio decode. Running every fifth block
+with dense attention scored only 0.602 SSIM and 16.38 dB, below the simpler
+three-frame arm. Combining the one-frame arm with an intentionally more
+aggressive 235-block reuse schedule fell to 0.488 SSIM and 15.21 dB and exposed
+a visible spatial lattice. None of those variants moved into production.
+
+Pooling 2x2 video queries as well as distant keys and values reduced the proxy
+one-evaluation denoise from 24.556 to 21.012 seconds, but the decoded result
+collapsed into large spatial blocks (0.444 SSIM, 10.39 dB). Executing alternate
+transformer layers was faster still, but both unscaled and 2x-residual-scaled
+variants collapsed into a finer latent lattice at one evaluation (0.184 and
+0.179 SSIM). These failures bound the remaining inference-only frontier:
+near-30-minute output at this geometry needs a checkpoint trained for fewer
+evaluations and/or fewer layers, not an untrained token- or depth-pruning
+shortcut.

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -254,6 +254,13 @@ in 213.005 s at 15.12 GiB peak; the 480-pixel arm crossed 252 seconds without
 finishing and was stopped. The production default is therefore 320 pixels.
 The model, precision, causal tile algorithm, and overlap blend are unchanged;
 the larger tile reduces redundant overlap and tile-boundary context loss.
+The true-spatial 22-frame screen also rejected tile-count breakpoints that a
+pixel-work estimate alone made attractive: in a hot-state pair, 416-pixel tiles
+took 33.756 s versus 32.321 s at 320 pixels, while 432- and 496-pixel arms were
+materially slower. Batching two independent temporal chunks into one decoder
+submission likewise produced no repeatable wall-time win at 39 frames and
+raised peak Metal memory from 13.49 to 21.40 GiB, so temporal chunk execution
+remains serial.
 Reproduce a candidate in a fresh process with:
 
 ```bash

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -161,6 +161,18 @@ for its attention phase. The previous 2,048-query schedule measured 10.350 and
 production; its output matched the previous schedule exactly in the attention
 gate (`max_abs=0`, `rel_l2=0`).
 
+A finer coordinate pass found a smaller but repeatable improvement at that
+large-row tier: 768 query rows with one attention kernel evaluated at a time.
+The order-balanced whole-block acceptance gate measured 9.733 versus 9.592
+seconds (1.015x) in one fresh process and 10.475 versus 10.278 seconds (1.019x)
+in a second, with bit-identical BF16 output (`rel_l2=0`). Production therefore
+uses 768-by-1 for 32,768+ packed rows while retaining 1,024-by-4 below that
+measured tier. Reproduce the paired gate directly with:
+
+```bash
+scripts/h3-kernel-lab.sh attention-block
+```
+
 Several tempting graph changes did not carry. Explicitly materializing
 contiguous Q/K/V copies regressed the full block to 15.148 seconds. Narrowing
 the implicit module state passed to each compiled closure also regressed, and
@@ -210,10 +222,12 @@ projection dimensions above 32,768 packed rows. Reproduce the projection and
 whole-block checks with `scripts/h3-kernel-lab.sh gemm` and
 `scripts/h3-kernel-lab.sh gemm-block`.
 
-The release-mode one-evaluation model probe packed 37,794 rows and took 953.192
-seconds for 50 blocks. Counting the dominant projection and dense-attention
-arithmetic gives about 3.504 PFLOP per evaluation, or 3.68 effective TFLOP/s
-across the whole sustained pass. This is lower than both the 7.6 TFLOP/s hot
+The release-mode one-evaluation model probe packed 37,794 rows. After the
+shape-aware GEMM and large-row attention schedules landed, its 50 blocks fell
+from 953.192 to 775.062 seconds (1.230x). Counting the dominant projection and
+dense-attention arithmetic gives about 3.504 PFLOP per evaluation, improving
+the sustained pass from 3.68 to 4.52 effective TFLOP/s. This is lower than both
+the 7.6 TFLOP/s hot
 single-block result and the 10-14 TFLOP/s isolated-kernel roof because the real
 pass turns over 50 independent parameter sets and includes every dependent
 normalization, modulation, transpose, synchronization, and thermal effect.
@@ -259,3 +273,9 @@ and video/audio artifacts are the acceptance boundary for speed-mode changes.
 The full acceptance receipt, including per-step timings, artifact geometry,
 hash, and the important 124-frame duration boundary, is recorded in
 [MiniMax-H3 BF16 on M4 Max](../benchmarks/minimax-h3-bf16-m4-max.md).
+
+A first-order tail-residual extrapolation was also tested at the accepted
+four-cache-step block count. It added no meaningful runtime cost, but the
+same-seed 416x256 proxy fell from 0.688 SSIM against the exact trajectory to
+0.583 and visibly shifted exposure and composition. The predictor was removed;
+maximum mode keeps the more faithful bounded stale residual.

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -293,6 +293,14 @@ versus 29.088 s, `rel_l2=0`) and was removed. The accepted head schedule puts
 one exact 50-block evaluation near 21 minutes before VAE decode. A 20-point
 exact schedule still needs 19 such evaluations.
 
+The accepted eight-head schedule was also paired with the transformer's
+existing fused post-attention graph. At 73,470 rows, an order-balanced two-round
+gate measured 24.801 seconds for the split graph and 24.570 seconds for the
+fused graph, a bit-identical but only 1.009x improvement (`max_abs=0`,
+`rel_l2=0`). That falls below the 1.02 production threshold, so the runtime
+keeps the simpler split graph. Re-run this rejection gate with
+`scripts/h3-kernel-lab.sh post`.
+
 Full-block FP16 execution was also screened rather than inferred from nominal
 GPU peak rates. With identical seeded weights and inputs, FP16 stayed inside a
 one-block `rel_l2 <= 0.01` gate but was slower at every measured packed shape:

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -177,6 +177,11 @@ Several tempting graph changes did not carry. Explicitly materializing
 contiguous Q/K/V copies regressed the full block to 15.148 seconds. Narrowing
 the implicit module state passed to each compiled closure also regressed, and
 larger post-attention fusion did not repeatably beat the existing split graph.
+Fusing only the feed-forward half was exact but lost at both practical production
+shapes: 1.879 versus 1.830 seconds at 14,958 rows and 10.517 versus 10.021
+seconds at 37,966 rows. Its 30.581 versus 30.800 second result at the 73,470-row
+ten-second shape was only a 1.007x lead, too small and too shape-specific to
+justify a second production schedule.
 Those arms remain rejected rather than becoming hidden runtime switches.
 
 The lower-level MLX Metal tile is not an untapped switch either. A temporary
@@ -233,6 +238,15 @@ pass turns over 50 independent parameter sets and includes every dependent
 normalization, modulation, transpose, synchronization, and thermal effect.
 Peak Metal memory was only 48.77 GiB; additional disk or unified memory does
 not close that utilization gap.
+
+The `turnover` lab checks whether that gap comes from reusing one compiled
+runner for all 50 parameter sets. At 14,958 rows, two dedicated compiled runners
+beat alternating weight rebinding by 1.077x, but the result reversed at the
+37,966-row true-768 shape: dedicated runners measured 14.325 seconds versus
+13.909 seconds for the shared runner, or 0.971x. Rebound output matched the
+corresponding dedicated runner exactly (`rel_l2=0`). Production therefore keeps
+one runner rather than multiplying compiled state for a small-shape-only win.
+Reproduce the release-mode comparison with `scripts/h3-kernel-lab.sh turnover`.
 
 The first valid ten-second geometry is 243 frames, which produces 72 video
 latent frames. At 1344x768, the locked benchmark prompt therefore packs 73,470
@@ -320,6 +334,14 @@ stored tail residual. Both video and audio sigma deltas must be below 0.12, the
 schedule position must be inside 10%...90%, and at least two complete
 evaluations must precede reuse. Balanced refreshes after two cache steps;
 maximum refreshes after four.
+
+This is also the acceleration primitive published by
+[TE-Speed-MiniMaxH3-OSS](https://github.com/HELPMEEADICE/TE-Speed-MiniMaxH3-OSS):
+its defaults use the same 0.12 sigma-delta test and 10%...90% window, while
+recomputing 25% of the blocks and forcing a full refresh after two cached steps.
+`maximum` is already more aggressive, recomputing 18% and allowing four cached
+steps. TE-Speed therefore confirms the existing model-math lane rather than
+supplying a second exact kernel optimization.
 
 Automatic long-geometry schedules use 21 points (20 model evaluations),
 matching the current practical CUDA default instead of the previous 31 points.

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -260,14 +260,38 @@ Reproduce the release-mode comparison with `scripts/h3-kernel-lab.sh turnover`.
 
 The first valid ten-second geometry is 243 frames, which produces 72 video
 latent frames. At 1344x768, the locked benchmark prompt therefore packs 73,470
-rows: 72,576 video rows, 810 audio rows, and 84 text rows. True-shape searches
-did not justify another transformer policy. A sampled 384-query/four-kernel
-attention candidate lost its full-block gate to the shipped 768-query/single-
-kernel schedule (31.845 s versus 31.438 s, `rel_l2=0`). A longer-row GEMM tier
-also lost its order-balanced whole-block gate (29.151 s versus 29.088 s,
-`rel_l2=0`) and was removed. These results put one exact 50-block evaluation
-near 24-26 minutes before VAE decode; a 20-point exact schedule still needs 19
-such evaluations.
+rows: 72,576 video rows, 810 audio rows, and 84 text rows. A phase ledger at
+that shape measured 32.645 seconds for one split block: 24.351 seconds (74.6%)
+in exact attention, 2.079 seconds in its input projection, and 4.424 seconds in
+the complete post-attention and feed-forward tail.
+
+Splitting the 56 independent attention heads across smaller Steel submissions
+exposed a large exact scheduling win that query-only searches missed. A full
+73,470-query attention pass with 640-query chunks, eight heads per kernel, and
+one kernel evaluated per submission measured 16.383 seconds versus 22.088
+seconds for the paired legacy control (`max_abs=0`, `rel_l2=0`). The decisive
+order-balanced full-block gate then measured 32.249 seconds for the shipped
+768-query/56-head schedule and 25.173 seconds for 640-query/eight-head
+execution: a 1.281x exact speedup with `rel_l2=0`. Production uses this schedule
+only at 65,536 or more packed rows; the separately measured 37,966-row schedule
+remains unchanged. Reproduce the acceptance gate with:
+
+```bash
+MERERUN_H3_BENCH_ROWS=73470 \
+MERERUN_H3_BENCH_REFERENCE_QUERY_TOKENS=768 \
+MERERUN_H3_BENCH_REFERENCE_HEADS=56 \
+MERERUN_H3_BENCH_REFERENCE_EVAL_BATCH=1 \
+MERERUN_H3_BENCH_CANDIDATE_QUERY_TOKENS=640 \
+MERERUN_H3_BENCH_CANDIDATE_HEADS=8 \
+MERERUN_H3_BENCH_CANDIDATE_EVAL_BATCH=1 \
+scripts/h3-kernel-lab.sh attention-block
+```
+
+A sampled 384-query/four-kernel attention candidate still loses, and a
+longer-row GEMM tier also lost its order-balanced whole-block gate (29.151 s
+versus 29.088 s, `rel_l2=0`) and was removed. The accepted head schedule puts
+one exact 50-block evaluation near 21 minutes before VAE decode. A 20-point
+exact schedule still needs 19 such evaluations.
 
 Full-block FP16 execution was also screened rather than inferred from nominal
 GPU peak rates. With identical seeded weights and inputs, FP16 stayed inside a

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -182,6 +182,16 @@ shapes: 1.879 versus 1.830 seconds at 14,958 rows and 10.517 versus 10.021
 seconds at 37,966 rows. Its 30.581 versus 30.800 second result at the 73,470-row
 ten-second shape was only a 1.007x lead, too small and too shape-specific to
 justify a second production schedule.
+
+Fusing that feed-forward tail across the next block's attention-projection
+boundary was also exact, but did not survive the true-shape gate. The paired
+two-block work improved from 2.388 to 2.370 seconds at 14,958 rows and from
+13.219 to 12.159 seconds at 37,966 rows. At the 73,470-row ten-second shape,
+however, it improved only from 29.557 to 29.295 seconds (1.009x), while the
+boundary itself regressed from 5.684 to 5.770 seconds. Production therefore
+keeps the simpler split boundary. Reproduce the order-balanced release-mode
+probe with `scripts/h3-kernel-lab.sh boundary`.
+
 Those arms remain rejected rather than becoming hidden runtime switches.
 
 The lower-level MLX Metal tile is not an untapped switch either. A temporary

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -122,6 +122,7 @@ from the runtime catalog used by `mere.run model list`,
 | `video` | `video-ltx23-a2vid-mlx` |
 | `video` | `video-wan22-ti2v-5b-mlx` |
 | `video` | `video-minimax-h3-fl2va-mlx` |
+| `video` | `video-minimax-h3-fl2va-bf16-mlx` |
 | `video` | `video-minimax-h3-ref2va-mlx` |
 | `video` | `video-cosmos3-edge-mlx` |
 | `video` | `video-scail2-14b-mlx` |
@@ -161,7 +162,7 @@ validates all configured models before downloading any; both accept the same
 | `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-2.6b-4bit` | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
 | `vision-segment-sam31` | Meta SAM License custom use, trade-control, attribution, and redistribution conditions |
 | `vision-face-buffalo-l` | InsightFace pretrained weights; non-commercial research use |
-| `video-minimax-h3-fl2va-mlx`, `video-minimax-h3-ref2va-mlx` | MiniMax-H3 Community License; use, distribution, and display are excluded in the United States, European Union, United Kingdom, and Republic of Korea, with downstream notice and safeguard obligations |
+| `video-minimax-h3-fl2va-mlx`, `video-minimax-h3-fl2va-bf16-mlx`, `video-minimax-h3-ref2va-mlx` | MiniMax-H3 Community License; use, distribution, and display are excluded in the United States, European Union, United Kingdom, and Republic of Korea, with downstream notice and safeguard obligations |
 | `image-3d-trellis2-4b` | the mounted DINOv3 encoder is gated under Meta's custom DINOv3 License |
 | `music-muscriptor-{small,medium,large}` | CC BY-NC 4.0 model weights |
 | `sfx-woosh-*` | CC BY-NC 4.0 Woosh or MMAudio Synchformer weights |

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -223,6 +223,8 @@ the exact writes and consume a typed report with:
 ```bash
 mere.run model repair-manifests --dry-run --json
 mere.run model repair-manifests --json
+mere.run model repair-manifests --model video-minimax-h3-fl2va-bf16-mlx \
+  --accept-model-license --json
 ```
 
 The report identifies healthy manifests, proposed or completed writes, absent

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -52,6 +52,13 @@ are an escape hatch, not the capability contract.
   source-bound AdaLN cache. It generates 24 fps RGB and synchronized 32 kHz
   stereo audio from text, a first frame, or directed first/last frames. Frame
   counts follow `17*n+5`; width and height are multiples of 32.
+- `video-minimax-h3-fl2va-bf16-mlx`: maximum-fidelity FL2VA package. It streams
+  PipeNetwork's pinned 13-shard BF16 MLX transformer directly, discards the
+  schedule-only AdaLN tensors after building an exact cache for the requested
+  schedule, and deinterleaves the released per-head QKV layout in memory. The tokenizer,
+  Q8 conditioner, FP16 video VAE, and FP32 audio VAE come from the same pinned
+  native support package. The managed install is about 100 GB on disk; the
+  active transformer is about 40 GB after the cached AdaLN tensors are omitted.
 - `video-minimax-h3-ref2va-mlx`: identifier for a locally converted Ref2VA
   root. Repeated `--reference image:path|video:path|audio:path` options retain
   request order. Video soundtracks are conditioned with their video; a
@@ -92,6 +99,13 @@ mere.run video generate "a glass marble rolls across wood with a delicate rattle
   --num-frames 124 \
   --output ./marble-h3.mp4
 
+# Maximum-fidelity BF16 transformer; same native Studio and CLI workflow
+mere.run model pull video-minimax-h3-fl2va-bf16-mlx --accept-model-license
+mere.run video generate "a cinematic rain-soaked bus stop at night" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --width 1280 --height 768 --duration 10 --steps 20 \
+  --output ./bus-stop-bf16.mp4
+
 mere.run video generate "preserve the person and use the reference motion" \
   --model-root ./MiniMax-H3-Ref2VA-MLX \
   --reference image:./person.png \
@@ -112,13 +126,25 @@ from the official BF16/F32 projections; no post-pull optimization step is
 required. Generation skips loading and executing the transformer's
 13B-parameter AdaLN/time-embedding branch and resamples its exact released
 31-point curve for the selected schedule. By default H3 uses 9 points through
-13,500 packed rows, 16 through 26,000, and 31 above that; `--steps` remains an
+13,500 packed rows, 16 through 26,000, and 21 above that. Maximum acceleration
+caps the automatic schedule at 12 points; `--steps` remains an
 explicit schedule-point override. Compact cache-backed INT4 transformers
-therefore remain correct at arbitrary point counts. MacBooks keep Q4 resident
-by default; desktop Macs may select resident BF16 when memory admits it, and
-`--h3-weight-mode` can force either path. `model optimize` remains available
-for compatible locally converted roots that still contain the full AdaLN
-branch.
+therefore remain correct at arbitrary point counts. MacBooks below 96 GiB keep
+Q4 resident by default; memory-qualified desktops and 96+ GiB MacBooks select the
+faster resident BF16 path when the requested geometry leaves the required
+runtime reserve. `--h3-weight-mode` can force either path. `model optimize`
+remains available for compatible locally converted roots that still contain
+the full AdaLN branch.
+
+The denoise policy is independently selectable. `--h3-acceleration quality`
+executes all 50 blocks and is the exact default. `balanced` recomputes the
+leading 50% of blocks on eligible small-sigma-delta steps and refreshes after
+at most two cache hits. `maximum` is the explicitly approximate speed lane: it
+recomputes the leading nine of 50 blocks and refreshes after at most four cache
+hits. Both modes run at least two complete evaluations before reuse and retain
+full evaluations at the schedule boundaries. They can materially reduce
+denoise time, but they are
+approximate and may change motion or composition for the same prompt and seed.
 
 ### Cosmos3 generation, actions, and reasoning
 

--- a/scripts/h3-end-to-end-benchmark.sh
+++ b/scripts/h3-end-to-end-benchmark.sh
@@ -72,6 +72,11 @@ case "$mode" in
     ;;
 esac
 
+width="${MERERUN_H3_BENCH_WIDTH:-$width}"
+height="${MERERUN_H3_BENCH_HEIGHT:-$height}"
+frames="${MERERUN_H3_BENCH_FRAMES:-$frames}"
+steps="${MERERUN_H3_BENCH_STEPS:-$steps}"
+
 if [[ ! -x "$binary" || "${MERERUN_H3_BENCH_REBUILD:-0}" == "1" ]]; then
   swift build -c release --product mere.run
 fi

--- a/scripts/h3-end-to-end-benchmark.sh
+++ b/scripts/h3-end-to-end-benchmark.sh
@@ -1,0 +1,102 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+script_dir="${0:A:h}"
+repo_root="${script_dir:h}"
+binary="$repo_root/.build/arm64-apple-macosx/release/mere.run"
+model_root="${MERERUN_H3_MODEL_ROOT:-/Users/nerd/Library/Application Support/MereRun/models/video-minimax-h3-fl2va-bf16-mlx}"
+mode="${1:-probe}"
+width=832
+height=480
+frames=124
+
+case "$mode" in
+  probe)
+    steps=2
+    acceleration=quality
+    ;;
+  reuse-probe)
+    steps=4
+    acceleration=maximum
+    ;;
+  probe-768)
+    width=1344
+    height=768
+    steps=2
+    acceleration=quality
+    ;;
+  reuse-probe-768)
+    width=1344
+    height=768
+    steps=4
+    acceleration=maximum
+    ;;
+  target-quality)
+    steps=20
+    acceleration=quality
+    ;;
+  target-maximum)
+    steps=20
+    acceleration=maximum
+    ;;
+  target-768-quality)
+    width=1344
+    height=768
+    steps=20
+    acceleration=quality
+    ;;
+  target-768-maximum)
+    width=1344
+    height=768
+    steps=20
+    acceleration=maximum
+    ;;
+  proxy-quality)
+    width=416
+    height=256
+    frames=107
+    steps=20
+    acceleration=quality
+    ;;
+  proxy-maximum)
+    width=416
+    height=256
+    frames=107
+    steps=20
+    acceleration=maximum
+    ;;
+  *)
+    print -u2 "usage: scripts/h3-end-to-end-benchmark.sh [probe|reuse-probe|probe-768|reuse-probe-768|proxy-quality|proxy-maximum|target-quality|target-maximum|target-768-quality|target-768-maximum]"
+    exit 64
+    ;;
+esac
+
+if [[ ! -x "$binary" || "${MERERUN_H3_BENCH_REBUILD:-0}" == "1" ]]; then
+  swift build -c release --product mere.run
+fi
+if pgrep -f "$binary video generate" >/dev/null; then
+  print -u2 "another mere.run video generation is active; refusing a contaminated benchmark"
+  exit 75
+fi
+
+output_dir="$repo_root/tmp/h3-benchmark"
+mkdir -p "$output_dir"
+output="$output_dir/h3-${mode}-${width}x${height}-f${frames}-s${steps}.mp4"
+prompt="Epic cinematic night at a rain-soaked city bus stop: a caped superhero stands calmly beneath a bright yellow umbrella. A silent lightning vortex tears open above the street, a city bus lifts weightlessly into the air, transforms into a colossal luminous dragon, and circles the hero while rain freezes in midair; dramatic volumetric lighting, realistic materials, fluid continuous camera movement, coherent anatomy, blockbuster visual effects."
+
+export MERERUN_H3_PROFILE_PHASES=1
+export MERERUN_H3_PROFILE_STEPS=1
+export CFFIXED_USER_HOME="${MERERUN_H3_BENCH_HOME:-${TMPDIR:-/tmp}/mere-run-h3-end-to-end-home}"
+mkdir -p "$CFFIXED_USER_HOME"
+
+exec "$binary" video generate "$prompt" \
+  --model-root "$model_root" \
+  --output "$output" \
+  --width "$width" \
+  --height "$height" \
+  --num-frames "$frames" \
+  --steps "$steps" \
+  --seed 20260804 \
+  --h3-weight-mode resident-bf16 \
+  --h3-acceleration "$acceleration"

--- a/scripts/h3-end-to-end-benchmark.sh
+++ b/scripts/h3-end-to-end-benchmark.sh
@@ -82,7 +82,8 @@ fi
 
 output_dir="$repo_root/tmp/h3-benchmark"
 mkdir -p "$output_dir"
-output="$output_dir/h3-${mode}-${width}x${height}-f${frames}-s${steps}.mp4"
+label="${MERERUN_H3_BENCH_LABEL:+-${MERERUN_H3_BENCH_LABEL}}"
+output="$output_dir/h3-${mode}${label}-${width}x${height}-f${frames}-s${steps}.mp4"
 prompt="Epic cinematic night at a rain-soaked city bus stop: a caped superhero stands calmly beneath a bright yellow umbrella. A silent lightning vortex tears open above the street, a city bus lifts weightlessly into the air, transforms into a colossal luminous dragon, and circles the hero while rain freezes in midair; dramatic volumetric lighting, realistic materials, fluid continuous camera movement, coherent anatomy, blockbuster visual effects."
 
 export MERERUN_H3_PROFILE_PHASES=1

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -66,6 +66,13 @@ case "$mode" in
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-3}"
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockDTypes
     ;;
+  turnover)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-14958}"
+    export MERERUN_H3_BENCH_QUERY_TOKENS="${MERERUN_H3_BENCH_QUERY_TOKENS:-1024}"
+    export MERERUN_H3_BENCH_EVAL_BATCH="${MERERUN_H3_BENCH_EVAL_BATCH:-4}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3BlockWeightTurnover
+    ;;
   attention-block)
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-37966}"
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-4}"
@@ -84,7 +91,7 @@ case "$mode" in
     run_release_test MiniMaxH3Tests/testInstalledAudioVAEDecodeMatchesReference
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|gemm|gemm-block|vae|audio-parity]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|turnover|gemm|gemm-block|vae|audio-parity]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -73,6 +73,13 @@ case "$mode" in
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockWeightTurnover
     ;;
+  boundary)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-14958}"
+    export MERERUN_H3_BENCH_QUERY_TOKENS="${MERERUN_H3_BENCH_QUERY_TOKENS:-1024}"
+    export MERERUN_H3_BENCH_EVAL_BATCH="${MERERUN_H3_BENCH_EVAL_BATCH:-4}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3TwoBlockBoundaryFusion
+    ;;
   attention-block)
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-37966}"
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-4}"
@@ -91,7 +98,7 @@ case "$mode" in
     run_release_test MiniMaxH3Tests/testInstalledAudioVAEDecodeMatchesReference
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|turnover|gemm|gemm-block|vae|audio-parity]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -59,6 +59,14 @@ case "$mode" in
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockExecutionSchedules
     ;;
+  post)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-73470}"
+    export MERERUN_H3_BENCH_QUERY_TOKENS="${MERERUN_H3_BENCH_QUERY_TOKENS:-640}"
+    export MERERUN_H3_BENCH_HEADS="${MERERUN_H3_BENCH_HEADS:-8}"
+    export MERERUN_H3_BENCH_EVAL_BATCH="${MERERUN_H3_BENCH_EVAL_BATCH:-1}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3BlockPostAttentionSchedules
+    ;;
   dtype)
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-37966}"
     export MERERUN_H3_BENCH_QUERY_TOKENS="${MERERUN_H3_BENCH_QUERY_TOKENS:-768}"
@@ -98,7 +106,7 @@ case "$mode" in
     run_release_test MiniMaxH3Tests/testInstalledAudioVAEDecodeMatchesReference
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|post|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -80,8 +80,11 @@ case "$mode" in
   vae)
     run_release_test DiTShapeBenchTests/testMiniMaxH3VideoVAETileSize
     ;;
+  audio-parity)
+    run_release_test MiniMaxH3Tests/testInstalledAudioVAEDecodeMatchesReference
+    ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|gemm|gemm-block|vae]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|gemm|gemm-block|vae|audio-parity]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -59,6 +59,11 @@ case "$mode" in
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockExecutionSchedules
     ;;
+  attention-block)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-37966}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-4}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3BlockAttentionSchedules
+    ;;
   gemm)
     run_release_test DiTShapeBenchTests/testMiniMaxH3MetalGEMMProjectionShapes
     ;;
@@ -66,7 +71,7 @@ case "$mode" in
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockGEMMSchedules
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|projections|modulation|block|gemm|gemm-block]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|gemm|gemm-block]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -1,0 +1,72 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+script_dir="${0:A:h}"
+repo_root="${script_dir:h}"
+cd "$repo_root"
+
+mode="${1:-quick}"
+export MERERUN_DIT_BENCH=1
+export CFFIXED_USER_HOME="${MERERUN_H3_LAB_HOME:-${TMPDIR:-/tmp}/mere-run-h3-kernel-home}"
+mkdir -p "$CFFIXED_USER_HOME"
+
+run_release_test() {
+  local filter="$1"
+  local release_root="$repo_root/.build/arm64-apple-macosx/release"
+  local test_binary_root="$release_root/MereRunPackageTests.xctest/Contents/MacOS"
+  local test_binary="$test_binary_root/MereRunPackageTests"
+  local stale_source=""
+
+  if [[ -f "$test_binary" ]]; then
+    stale_source="$(find Package.swift Sources Tests -type f -newer "$test_binary" -print -quit)"
+  fi
+  if [[ ! -f "$test_binary" || -n "$stale_source" || "${MERERUN_H3_LAB_REBUILD:-0}" == "1" ]]; then
+    swift build --build-tests -c release -Xswiftc -enable-testing -Xswiftc -DDEBUG
+  fi
+  if [[ ! -f "$test_binary_root/mlx.metallib" ]]; then
+    mkdir -p "$test_binary_root"
+    cp "$release_root/Resources/default.metallib" "$test_binary_root/mlx.metallib"
+  fi
+  xcrun xctest -XCTest "$filter" "$release_root/MereRunPackageTests.xctest"
+}
+
+case "$mode" in
+  quick)
+    export MERERUN_H3_BENCH_SEARCH=coordinate
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-14958}"
+    export MERERUN_H3_BENCH_CHUNKS="${MERERUN_H3_BENCH_CHUNKS:-1024,1536,2048,2560,3072,4096}"
+    export MERERUN_H3_BENCH_HEAD_CHUNKS="${MERERUN_H3_BENCH_HEAD_CHUNKS:-14,28,56}"
+    export MERERUN_H3_BENCH_EVAL_BATCHES="${MERERUN_H3_BENCH_EVAL_BATCHES:-1,2,4,8}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3AttentionChunkSizes
+    ;;
+  attention)
+    export MERERUN_H3_BENCH_SEARCH="${MERERUN_H3_BENCH_SEARCH:-grid}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3AttentionChunkSizes
+    ;;
+  projections)
+    run_release_test DiTShapeBenchTests/testMiniMaxH3QmmVsResidentBF16
+    ;;
+  modulation)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-29018}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3AdaLNRunModulation
+    ;;
+  block)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-14958}"
+    export MERERUN_H3_BENCH_QUERY_TOKENS="${MERERUN_H3_BENCH_QUERY_TOKENS:-1024}"
+    export MERERUN_H3_BENCH_EVAL_BATCH="${MERERUN_H3_BENCH_EVAL_BATCH:-4}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3BlockExecutionSchedules
+    ;;
+  gemm)
+    run_release_test DiTShapeBenchTests/testMiniMaxH3MetalGEMMProjectionShapes
+    ;;
+  gemm-block)
+    run_release_test DiTShapeBenchTests/testMiniMaxH3BlockGEMMSchedules
+    ;;
+  *)
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|projections|modulation|block|gemm|gemm-block]"
+    exit 64
+    ;;
+esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -59,6 +59,13 @@ case "$mode" in
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockExecutionSchedules
     ;;
+  dtype)
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-37966}"
+    export MERERUN_H3_BENCH_QUERY_TOKENS="${MERERUN_H3_BENCH_QUERY_TOKENS:-768}"
+    export MERERUN_H3_BENCH_EVAL_BATCH="${MERERUN_H3_BENCH_EVAL_BATCH:-1}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-3}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3BlockDTypes
+    ;;
   attention-block)
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-37966}"
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-4}"
@@ -74,7 +81,7 @@ case "$mode" in
     run_release_test DiTShapeBenchTests/testMiniMaxH3VideoVAETileSize
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|gemm|gemm-block|vae]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|dtype|gemm|gemm-block|vae]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -70,8 +70,11 @@ case "$mode" in
   gemm-block)
     run_release_test DiTShapeBenchTests/testMiniMaxH3BlockGEMMSchedules
     ;;
+  vae)
+    run_release_test DiTShapeBenchTests/testMiniMaxH3VideoVAETileSize
+    ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|gemm|gemm-block]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|modulation|block|gemm|gemm-block|vae]"
     exit 64
     ;;
 esac

--- a/scripts/model-conversion/convert_minimax_h3_official_mlx.py
+++ b/scripts/model-conversion/convert_minimax_h3_official_mlx.py
@@ -21,14 +21,16 @@ Example::
       python convert_minimax_h3_official_mlx.py \
         --cache-dir /workspace/hf-cache \
         --conversion-location "CA-MTL-3, Canada" \
+        --transformer-precision bf16 \
         --output /workspace/minimax-h3-sawfwair
 
 The output transformer is mixed precision: the 208 transformer/refiner core
-linears are affine Q4/group-64, while the released BF16/F32 precision islands
-remain dense. The Qwen3-VL conditioner retains exactly the 50 language layers
-H3 reads and uses affine Q8/group-64 for 439 eligible linears. The AdaLN cache
-is evaluated from the original BF16/F32 projections before those 13B
-inference-redundant parameters are omitted from the compact transformer.
+linears use the selected affine Q4 or Q8/group-64 width, while the released
+BF16/F32 precision islands remain dense. The Qwen3-VL conditioner retains
+exactly the 50 language layers H3 reads and uses affine Q8/group-64 for 439
+eligible linears. The AdaLN cache is evaluated from the original BF16/F32
+projections before those 13B inference-redundant parameters are omitted from
+the compact transformer.
 """
 
 from __future__ import annotations
@@ -56,7 +58,6 @@ SOURCE_REVISION = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
 SOURCE_LICENSE_SHA256 = "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
 SOURCE_LICENSE_BYTES = 17_604
 GROUP_SIZE = 64
-TRANSFORMER_BITS = 4
 TEXT_ENCODER_BITS = 8
 SAMPLE_POINTS = 31
 VIDEO_SHIFT = 12.0
@@ -307,7 +308,7 @@ def quantizer_self_test() -> dict[str, dict[str, str]]:
     ).reshape(17, 128)
     weight = mx.array(values).astype(mx.bfloat16)
     observed: dict[str, dict[str, str]] = {}
-    for bits in (TRANSFORMER_BITS, TEXT_ENCODER_BITS):
+    for bits in sorted(QUANTIZER_SELF_TEST):
         packed, scales, biases = mx.quantize(
             weight,
             group_size=GROUP_SIZE,
@@ -586,11 +587,13 @@ def convert_transformer(
     index: dict[str, Any],
     downloaded: dict[str, Path],
     source_identity: str,
+    transformer_precision: str,
 ) -> dict[str, Any]:
     import mlx.core as mx
 
+    transformer_bits = {"q4": 4, "q8": 8, "bf16": None}[transformer_precision]
     converted: dict[str, Any] = {}
-    quantized = copied = omitted = qkv_reordered = 0
+    quantized = dense_core = copied = omitted = qkv_reordered = 0
     for shard_index, (name, shard_path, keys) in enumerate(
         source_shards("FL2VA/transformer", index, downloaded), start=1
     ):
@@ -605,12 +608,17 @@ def convert_transformer(
                 if key.endswith(".attn.qkv_proj.weight"):
                     value = reorder_transformer_qkv(value)
                     qkv_reordered += 1
-                packed, scales, biases = quantize_weight(value, TRANSFORMER_BITS)
-                prefix = key.removesuffix(".weight")
-                converted[key] = packed
-                converted[f"{prefix}.scales"] = scales
-                converted[f"{prefix}.biases"] = biases
-                quantized += 1
+                if transformer_bits is None:
+                    mx.eval(value)
+                    converted[key] = value
+                    dense_core += 1
+                else:
+                    packed, scales, biases = quantize_weight(value, transformer_bits)
+                    prefix = key.removesuffix(".weight")
+                    converted[key] = packed
+                    converted[f"{prefix}.scales"] = scales
+                    converted[f"{prefix}.biases"] = biases
+                    quantized += 1
             else:
                 mx.eval(value)
                 converted[key] = value
@@ -618,18 +626,27 @@ def convert_transformer(
         del raw
         mx.clear_cache()
 
-    if (quantized, copied, omitted, qkv_reordered, len(converted)) != (208, 220, 107, 52, 844):
+    expected = (0, 208, 220, 107, 52, 428) if transformer_bits is None else (
+        208, 0, 220, 107, 52, 844
+    )
+    if (quantized, dense_core, copied, omitted, qkv_reordered, len(converted)) != expected:
         raise ValueError(
             "Unexpected compact transformer geometry: "
-            f"quantized={quantized}, copied={copied}, omitted={omitted}, "
+            f"quantized={quantized}, dense_core={dense_core}, copied={copied}, omitted={omitted}, "
             f"qkv_reordered={qkv_reordered}, arrays={len(converted)}"
         )
+    precision_metadata = (
+        "released mixed BF16/F32"
+        if transformer_bits is None
+        else f"affine {transformer_bits}-bit g64"
+    )
     atomic_safetensors(
         output,
         dict(sorted(converted.items())),
         {
             "format": "mere.run.minimax-h3-inference-transformer",
-            "quantization": "affine 4-bit g64",
+            "precision": transformer_precision,
+            "quantization": "none" if transformer_bits is None else precision_metadata,
             "source_precision": "released mixed BF16/F32",
             "source_repository": SOURCE_REPOSITORY,
             "source_revision": SOURCE_REVISION,
@@ -642,11 +659,17 @@ def convert_transformer(
         "input_tensors": len(index["weight_map"]),
         "output_tensors": len(converted),
         "quantized_linears": quantized,
+        "dense_core_linears": dense_core,
         "copied_dense_tensors": copied,
         "omitted_cache_or_rope_tensors": omitted,
         "qkv_matrices_deinterleaved": qkv_reordered,
         "qkv_layout": "global-qkv-slabs",
-        "quantization": {"bits": 4, "group_size": 64, "mode": "affine"},
+        "precision": transformer_precision,
+        "quantization": None if transformer_bits is None else {
+            "bits": transformer_bits,
+            "group_size": 64,
+            "mode": "affine",
+        },
         "dense_precision_islands_preserved": list(TRANSFORMER_DENSE_PREFIXES),
     }
     release_arrays(converted)
@@ -837,7 +860,12 @@ def convert_audio_vae(
     return stats
 
 
-def write_package_support(output: Path, downloaded: dict[str, Path]) -> None:
+def write_package_support(
+    output: Path,
+    downloaded: dict[str, Path],
+    transformer_precision: str,
+) -> None:
+    transformer_bits = {"q4": 4, "q8": 8, "bf16": None}[transformer_precision]
     shutil.copyfile(downloaded["LICENSE"], output / "LICENSE")
     shutil.copyfile(
         downloaded["FL2VA/processor/tokenizer.json"], output / "tokenizer.json"
@@ -851,8 +879,13 @@ def write_package_support(output: Path, downloaded: dict[str, Path]) -> None:
         "Copyright © 2026 MiniMax. All Rights Reserved.\n",
         encoding="utf-8",
     )
+    core_precision_description = (
+        "preserved at the released BF16 precision"
+        if transformer_bits is None
+        else f"quantized directly from the released BF16 tensors to MLX affine {transformer_bits}-bit, group size 64"
+    )
     (output / "MODIFICATIONS.md").write_text(
-        """# Modifications to MiniMax H3
+        f"""# Modifications to MiniMax H3
 
 These files are MODIFIED versions of the MiniMax H3 Works, redistributed under
 the MiniMax H3 Community License Agreement in `LICENSE` and `NOTICE`.
@@ -866,8 +899,7 @@ No third-party converted or quantized weights were used.
 * The 52 fused transformer and token-refiner QKV matrices were first reordered
   from MiniMax's raw per-head interleave into the official reference model's
   `[all-q; all-k; all-v]` layout. The 208 core linear weights were then
-  quantized directly from the released BF16 tensors to MLX affine 4-bit,
-  group size 64.
+  {core_precision_description}.
   Precision-sensitive BF16/F32 input, timestep, normalization, and output
   tensors remain at their released precision.
 * The original BF16/F32 AdaLN projections and timestep MLP were evaluated over
@@ -898,7 +930,6 @@ inference-only omissions and numeric conversions above.
         "tasks": ["t2va", "fl2va"],
         "sigma_shift_scales": {"video": VIDEO_SHIFT, "audio": AUDIO_SHIFT},
         "fps": 24,
-        "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
         "text_encoder_quantization": {
             "group_size": 64,
             "bits": 8,
@@ -927,6 +958,12 @@ inference-only omissions and numeric conversions above.
             "theta": 5_000_000.0,
         },
     }
+    if transformer_bits is not None:
+        config["quantization"] = {
+            "group_size": 64,
+            "bits": transformer_bits,
+            "mode": "affine",
+        }
     atomic_json(output / "config.json", config)
 
 
@@ -985,6 +1022,12 @@ def parse_args() -> argparse.Namespace:
         choices=("transformer", "text_encoder", "video_vae", "audio_vae"),
         default=("transformer", "text_encoder", "video_vae", "audio_vae"),
     )
+    parser.add_argument(
+        "--transformer-precision",
+        choices=("q4", "q8", "bf16"),
+        default="q4",
+        help="Storage precision for the 208 transformer core linears.",
+    )
     parser.add_argument("--plan", action="store_true")
     parser.add_argument("--self-test-only", action="store_true")
     return parser.parse_args()
@@ -1020,7 +1063,7 @@ def main() -> int:
     downloaded = download_sources(
         metadata, source_files, cache_dir, source_manifest_path
     )
-    write_package_support(output, downloaded)
+    write_package_support(output, downloaded, args.transformer_precision)
     self_test = quantizer_self_test()
     qkv_self_test = qkv_reorder_self_test()
 
@@ -1054,6 +1097,7 @@ def main() -> int:
             transformer_index,
             downloaded,
             source_identity,
+            args.transformer_precision,
         )
         component_stats["transformer.safetensors"] = transformer_stats
 
@@ -1077,7 +1121,7 @@ def main() -> int:
     }
     conversion_receipt = {
         "converter": "scripts/model-conversion/convert_minimax_h3_official_mlx.py",
-        "converter_version": 2,
+        "converter_version": 3,
         "converter_sha256": sha256_file(Path(__file__).resolve()),
         "started_at": started_at,
         "completed_at": utc_now(),

--- a/scripts/model-conversion/validate_minimax_h3_official_artifact.py
+++ b/scripts/model-conversion/validate_minimax_h3_official_artifact.py
@@ -131,16 +131,23 @@ def verify_source_manifest(root: Path) -> None:
         require(lfs_hash is None or lfs_hash == entry["sha256"], "source LFS hash disagrees")
 
 
-def verify_transformer(root: Path) -> None:
+def verify_transformer(root: Path, transformer_precision: str) -> None:
+    transformer_bits = {"q4": 4, "q8": 8, "bf16": None}[transformer_precision]
     tensors, metadata = safetensors_header(root / "transformer.safetensors")
-    require(len(tensors) == 844, "wrong compact transformer tensor count")
+    expected_tensor_count = 428 if transformer_bits is None else 844
+    require(len(tensors) == expected_tensor_count, "wrong compact transformer tensor count")
     require(metadata.get("source_repository") == SOURCE_REPOSITORY, "wrong transformer source")
     require(metadata.get("source_revision") == SOURCE_REVISION, "wrong transformer revision")
-    require(metadata.get("quantization") == "affine 4-bit g64", "wrong transformer quantization")
+    expected_quantization = "none" if transformer_bits is None else f"affine {transformer_bits}-bit g64"
+    require(metadata.get("precision") == transformer_precision, "wrong transformer precision")
+    require(metadata.get("quantization") == expected_quantization, "wrong transformer quantization")
     require(metadata.get("cache_covered_weights_omitted") == "true", "cache omission not declared")
     require(metadata.get("qkv_layout") == "global-qkv-slabs", "wrong transformer QKV layout")
-    require(len([key for key in tensors if key.endswith(".scales")]) == 208, "wrong Q4 scale count")
-    require(len([key for key in tensors if key.endswith(".biases")]) == 208, "wrong Q4 bias count")
+    expected_quantized_linears = 0 if transformer_bits is None else 208
+    require(len([key for key in tensors if key.endswith(".scales")]) == expected_quantized_linears,
+            "wrong transformer scale count")
+    require(len([key for key in tensors if key.endswith(".biases")]) == expected_quantized_linears,
+            "wrong transformer bias count")
     require("condition_proj.weight" in tensors, "dense condition projection is missing")
     require(tensors["condition_proj.weight"]["dtype"] == "BF16", "condition projection lost BF16")
     require(not any("adaln_proj" in key for key in tensors), "AdaLN weight survived compaction")
@@ -184,13 +191,24 @@ def verify_vaes_and_cache(root: Path) -> None:
             "wrong cached block count")
 
 
-def verify_receipts(root: Path, hashes: dict[str, str], location: str) -> None:
+def verify_receipts(
+    root: Path,
+    hashes: dict[str, str],
+    location: str,
+    transformer_precision: str,
+) -> None:
+    transformer_bits = {"q4": 4, "q8": 8, "bf16": None}[transformer_precision]
     require((root / "LICENSE").stat().st_size == LICENSE_BYTES, "wrong license byte count")
     require(hashes["LICENSE"] == LICENSE_SHA256, "wrong license hash")
     config = load_json(root / "config.json")
     require(config.get("model_type") == "minimax_h3", "wrong config model type")
     require(config.get("partition") == "fl2va", "wrong config partition")
-    require(config.get("quantization") == {"bits": 4, "group_size": 64, "mode": "affine"},
+    expected_quantization = None if transformer_bits is None else {
+        "bits": transformer_bits,
+        "group_size": 64,
+        "mode": "affine",
+    }
+    require(config.get("quantization") == expected_quantization,
             "wrong transformer config quantization")
     require(config.get("text_encoder_quantization") ==
             {"bits": 8, "group_size": 64, "mode": "affine"},
@@ -216,6 +234,10 @@ def verify_receipts(root: Path, hashes: dict[str, str], location: str) -> None:
         require(output.get("byte_count") == (root / filename).stat().st_size,
                 f"receipt byte count differs for {filename}")
     transformer = receipt.get("outputs", {}).get("transformer.safetensors", {})
+    require(transformer.get("precision") == transformer_precision,
+            "wrong transformer receipt precision")
+    require(transformer.get("quantization") == expected_quantization,
+            "wrong transformer receipt quantization")
     require(transformer.get("qkv_matrices_deinterleaved") == 52,
             "wrong transformer QKV reorder count")
     require(transformer.get("qkv_layout") == "global-qkv-slabs",
@@ -226,6 +248,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("root", type=Path)
     parser.add_argument("--conversion-location", required=True)
+    parser.add_argument(
+        "--transformer-precision",
+        choices=("q4", "q8", "bf16"),
+        default="q4",
+    )
     args = parser.parse_args()
     root = args.root.expanduser().resolve()
     missing = sorted(RUNTIME_FILES - {path.name for path in root.iterdir() if path.is_file()})
@@ -233,10 +260,10 @@ def main() -> int:
 
     hashes = verify_sha256sums(root)
     verify_source_manifest(root)
-    verify_transformer(root)
+    verify_transformer(root, args.transformer_precision)
     verify_text_encoder(root)
     verify_vaes_and_cache(root)
-    verify_receipts(root, hashes, args.conversion_location)
+    verify_receipts(root, hashes, args.conversion_location, args.transformer_precision)
     total = sum((root / filename).stat().st_size for filename in RUNTIME_FILES)
     print(json.dumps({"status": "verified", "files": len(RUNTIME_FILES), "bytes": total}, sort_keys=True))
     return 0

--- a/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
+++ b/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
@@ -1,6 +1,6 @@
 mlx-core-version: 0.32.1
 mlx-swift-version: unknown
-mlx-swift-revision: 009a42f024a04e50bb50bb6ce90d0a3e396c1760
+mlx-swift-revision: 79bc410c85df66c3f4246084057bdfd971932ac7
 kernel-sources-sha256: a4a91e902e4a3c196ba45f3c6ee65c769c26b5825ae3b72d8b93ca233db2d93f
-built-at: 2026-07-29T04:43:45Z
+built-at: 2026-08-05T21:40:04Z
 metal-compiler: Apple metal version 32023.883 (metalfe-32023.883)


### PR DESCRIPTION
## Summary

This is the post-#247 MiniMax-H3 performance and quality stack for Apple Silicon. It makes the BF16 model a first-class CLI and macOS Studio capability, fixes the released audio decode, adds exact shape-aware execution and bounded model-math reuse, and records the measured M4 Max frontier without presenting projections as completed renders.

### First-class product surface

- add managed `video-minimax-h3-fl2va-bf16-mlx` support from the immutable public BF16 MLX checkpoint
- expose BF16 H3, `quality|balanced|maximum` acceleration, and transformer weight modes through the CLI, preflight JSON, declarative action, and macOS Studio
- keep `quality` as the exact default; faster modes are explicit and reported in receipts
- automatically select resident BF16 only on memory-qualified machines while preserving compact Q4 defaults and geometry-aware reserve elsewhere
- retain explicit MiniMax-H3 Community License acknowledgement before model download

### Runtime acceleration

- add shape-aware compiled execution: whole-step compilation for smaller sequences and staged blockwise compilation for large packed sequences
- pin the public M4 Max Steel GEMM tuning from sawfwair/mlx#2 through sawfwair/mlx-swift#4
- tune exact H3 attention independently for medium, true-768, and 10-second packed-row regimes
- increase the causal video VAE spatial tile from 256 to the measured 320-pixel winner
- fuse the video VAE QKV projection after exact load-time deinterleaving
- add bounded adjacent-sigma tail-block reuse for `balanced` and `maximum`, including native start, refresh, and endpoint evaluations
- cap automatic long-geometry quality schedules at the current 20-evaluation production envelope while preserving explicit `--steps`
- add non-perturbing step telemetry plus reproducible projection, attention, block, VAE, and end-to-end benchmark harnesses

### Audio-quality correction

The released audio VAE's `mean_proj`, `logs_proj`, and `dec_in_proj` biases are now loaded during conversion. The deterministic FP32 decode moved from `rel_l2=0.463` against the released reference to `rel_l2=0.0000194` with effectively unit cosine similarity. The kernel lab carries a checkpoint-backed parity fixture.

## Measured M4 Max results

All timings below are optimized arm64 release execution on the local M4 Max with 128 GiB unified memory.

### Real accepted maximum-mode artifact

- 832x480, 124 frames / 5.167 seconds, 24 fps
- resident BF16, 20 schedule points
- six complete transformer evaluations plus thirteen bounded nine-block cached-tail evaluations
- denoise: **25:26.533**
- video decode: **1:59.544**
- end to end: **27:33.711**
- peak reported Metal memory: 43.41 GiB
- H.264/AAC SHA-256: `270544693662769fd8f90971d1ccabce3405fe00ff21885f96b9b0e218cb921f`
- visual acceptance: coherent caped figure and umbrella, wet-street reflections, levitating bus, and luminous dragon motion; no rejected spatial lattice

This MP4 predates the audio-bias correction. Its video is the accepted visual/timing receipt; its hissy soundtrack is explicitly not reused as the audio-quality receipt.

### Exact 1344x768 boundary

A one-evaluation, 124-frame exact probe improved as follows:

| phase | baseline | optimized |
|---|---:|---:|
| full transformer evaluation | 953.192 s | **775.062 s** |
| denoise | 953.485 s | **775.336 s** |
| end to end | 1,253.425 s | **1,027.310 s** |

That is **1.230x transformer throughput**, 18.7% less transformer wall time, and 3:46.115 less end-to-end time. The baseline and optimized H.264/AAC files have the same SHA-256, proving the exact acceleration path did not alter output. This two-point probe is intentionally not presented as a visual-quality render.

The measured 320-pixel VAE tile separately reduced the matched 832x480 decode from 96.091 s to 76.421 s (1.257x) and completed the true 1344x768 decode in 213.005 s.

### Ten-second physical boundary

At the first valid duration beyond ten seconds—243 frames / 10.125 seconds and 73,470 packed rows—the accepted 640-query/eight-head attention schedule improved a complete production-width block from 32.249 s to **25.173 s (1.281x)** with bit-identical BF16 output.

That places the projected single-evaluation plus decode boundary near 28 minutes. It does **not** make the current quality schedule a 28-minute render:

- 20-point exact denoise still projects to roughly 6.6 hours before decode
- the current 417-block `maximum` policy projects to roughly 2.9 hours before decode
- even a mathematically perfect 36 TFLOP/s execution floor leaves roughly 93 minutes exact or 40.8 minutes maximum before decode

The remaining multiplier is evaluated model math. A materially distilled checkpoint or validated sparse-attention model is required for a comparable-quality ten-second result near 30 minutes.

## Rejected shortcuts retained as evidence

- FP16 was 1.7% slower than BF16 at the exact ten-second block shape
- variable-step Adams-Bashforth reduced fidelity versus the same-count Euler control
- two-evaluation Heun reached the desired compute class but produced tiled chromatic noise
- low-evaluation pruning, cross-block submission, larger VAE tiles, temporal parallel decode, and alternate Steel attention tiles failed their numerical or matched wall-time gates
- the faster-but-visually-broken cache schedules remain unavailable

## Dependencies

- [x] sawfwair/mlx#2 — exact shape-gated M4 Max Steel GEMM tuning
- [x] sawfwair/mlx-swift#4 — pin the tuned MLX core for Swift consumers
- [x] this branch pins mlx-swift revision `79bc410c85df66c3f4246084057bdfd971932ac7`
- [x] bundled Metal library provenance matches that revision and the expected kernel-source digest

## Validation

- [x] rebased onto current `origin/main`; recovery ref retained locally
- [x] `git range-diff`: 14/15 commits patch-identical; first commit differs only by retaining newer Text/Music changelog entries
- [x] `git diff --check`
- [x] strict SwiftLint across 1,146 files: zero violations
- [x] `swift test --filter MiniMaxH3Tests`: 27 executed, one expected real-checkpoint skip, zero failures
- [x] `./scripts/check.sh`: 2,534 XCTest cases, 166 expected asset-dependent skips, zero failures; all additional Swift Testing suites passed
- [x] `MERERUN_CHECK_LINUX_ALLOW_NON_LINUX=1 ./scripts/check-linux.sh --manifest-only`
- [x] `swift build -c release`
- [x] release CLI preflight for the locked BF16 maximum-mode request: installed model, 832x480, 124 frames, 20 points, synchronized audio, status `ok`
- [x] converter/validator Python syntax checks
- [x] no H3 weight files or benchmark media added to the source repository

## Review notes

The benchmark receipt explicitly distinguishes measured artifacts, arithmetic projections, rejected candidates, and the remaining model-math limit. A new multi-hour 768p quality render was intentionally not started after the user stopped long renders; the accepted short artifact and exact mathematical gates are preserved instead.