### PR TITLE
Harden documentation dependency installs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - 'docs/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
       - '.github/workflows/docs.yml'
       - 'README.md'
   pull_request:
@@ -14,14 +15,13 @@ on:
       - 'docs/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
       - '.github/workflows/docs.yml'
       - 'README.md'
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-pages
@@ -30,11 +30,15 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -67,6 +71,10 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Security
+
+- hardened the documentation supply chain with pnpm 10.34.5, a three-day
+  minimum release age, no-downgrade trust checks, exotic-subdependency
+  blocking, and a strict build-script allowlist limited to the pinned esbuild
+  package. The Pages workflow now grants write and OIDC permissions only to
+  the deploy job and prevents checkout credentials from persisting.
+
 ### Text
 
 - added the pinned `LiquidAI/LFM2.5-2.6B-MLX` 4-bit partition as

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mere-run-docs",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.34.5",
   "engines": {
     "node": ">=20"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+minimumReleaseAge: 4320
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 10080
+blockExoticSubdeps: true
+strictDepBuilds: true
+allowBuilds:
+  esbuild@0.27.3: true


### PR DESCRIPTION
## Summary

- pin the documentation toolchain to pnpm 10.34.5
- enforce a three-day release-age floor, no-downgrade trust checks, exotic-subdependency blocking, and a strict esbuild-only lifecycle-script allowlist
- scope Pages write and OIDC permissions to the deploy job, prevent checkout credential persistence, and include the workspace policy in workflow path filters
- document the security-sensitive defaults in the changelog

## Validation

- `./scripts/check.sh` — 2,534 XCTest cases passed with 166 expected skips; all 21 Swift Testing cases passed
- `pnpm install --frozen-lockfile`
- `pnpm docs:build`
- `actionlint .github/workflows/docs.yml`
- `git diff --check`