### PR TITLE
Release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.35.0 - 2026-08-06
+
+This release makes MiniMax-H3 materially faster and more faithful on Apple
+Silicon, adds native LFM2.5 text inference and TerraMind flood mapping, restores
+ACE-Step planner parity, and hardens the documentation supply chain. Creative
+capabilities retain first-class CLI and macOS Studio controls; the specialized
+TerraMind tensor workflow is intentionally CLI-only in this release.
+
+### Geospatial inference
+
+- added the CLI-only `mere.run geo flood`, a native Swift/MLX TerraMind Flood
+  runtime for four-timestep Sentinel-2, Sentinel-1, and DEM tiles, plus a
+  checksum-pinned float32-only converter for the official ImpactMesh
+  checkpoint. Real Helene parity preserves all 126 candidate pixels with mask
+  Jaccard 1.0; unsafe FP16 conversions are rejected.
+
 ### Security
 
 - hardened the documentation supply chain with pnpm 10.34.5, a three-day
@@ -139,6 +155,7 @@ The format is based on Keep a Changelog.
   then completed in 1,653.711 s (27:33.711) end to end: 1,526.533 s denoise,
   119.544 s video decode, and 0.892 s audio decode. `quality` remains the exact
   default.
+
 ## 0.34.0 - 2026-08-04
 
 This release advances the complete local creation stack across five first-class
@@ -149,11 +166,6 @@ artifact contracts instead of becoming a model-specific sidecar.
 
 ### Video and synchronized audio
 
-- added `mere.run geo flood`, a native Swift/MLX TerraMind Flood runtime for
-  four-timestep Sentinel-2, Sentinel-1, and DEM tiles, plus a checksum-pinned
-  float32-only converter for the official ImpactMesh checkpoint. Real Helene
-  parity preserves all 126 candidate pixels with mask Jaccard 1.0; unsafe FP16
-  conversions are rejected.
 - added a native Swift/MLX MiniMax-H3 runtime for the released FL2VA and
   Ref2VA partitions: Qwen3-VL layer-50 multimodal conditioning, the dense 50
   layer joint video/audio transformer, causal tiled video VAE, DAC/causal
@@ -163,7 +175,7 @@ artifact contracts instead of becoming a model-specific sidecar.
   including 2 fps paired video presentation timestamps, video soundtrack
   conditioning, per-reference spatial grids, shared audio/video rotary clocks,
   and the released reference-count and modality constraints.
-- added adaptive MiniMax-H3 9/16/21-point schedule tiers, explicit
+- added adaptive MiniMax-H3 9/16/31-point schedule tiers, explicit
   `--h3-weight-mode auto|quantized|resident-bf16`, chassis-aware compact Q4
   defaults for MacBooks, staged resident-BF16 expansion for desktop Macs, and
   coordinated 50-64 GiB MLX wired-memory residency. Large sequences reuse one

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.34.0"
+    static let current = "0.35.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.34.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.35.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.34.0"
+default_version="0.35.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -174,7 +174,7 @@ core_suite() {
   if require_model "speech-asr-parakeet" && [[ -f "$speech_tts_wav" ]]; then
     run_step "speech_transcribe_parakeet" 240 \
       "$MERERUN_BIN" speech transcribe "$speech_tts_wav" --backend parakeet --model speech-asr-parakeet --no-timestamps --quiet
-    assert_contains "speech_transcribe_parakeet_output" "$OUT_DIR/speech_transcribe_parakeet.stdout" "local inference smoke test"
+    assert_contains "speech_transcribe_parakeet_output" "$OUT_DIR/speech_transcribe_parakeet.stdout" "local inference.*smoke.*test"
   fi
 
   if require_model "speech-asr-qwen3" && [[ -f "$speech_tts_wav" ]]; then


### PR DESCRIPTION
## Summary

Release mere.run v0.35.0 with the full post-v0.34 stack:

- materially faster and more faithful MiniMax-H3 on Apple Silicon, including exact and approximate performance modes
- native LFM2.5 2.6B text inference with prefix reuse and TTFT optimizations
- restored ACE-Step planner parity and audio regression fixes
- native TerraMind flood inference as an intentionally CLI-only specialized workflow
- hardened documentation dependency installation and release notes covering all recent capability work
- punctuation-tolerant Parakeet smoke assertion for semantically identical stochastic TTS outputs

## Validation

- `./scripts/check.sh` (final candidate): 2,534 XCTest cases, 166 fixture-gated skips, 0 failures; 21 Swift Testing cases, 0 failures
- `pnpm install --frozen-lockfile`
- `pnpm docs:build`
- `actionlint .github/workflows/*.yml`
- `MERERUN_RUN_E2E=core ./scripts/check.sh`: 10 passed, 0 failed, 1 unavailable-model skip
- `MERERUN_RUN_E2E=installed ./scripts/check.sh`: 14 passed, 0 failed, 4 unavailable/exact-ID skips
- real local artifacts covered TTS, Parakeet and Qwen ASR, Z-Image Max, ACE-Step, LightOn OCR, and Klein Nano

The signed/notarized packaged all-installed gate and platform artifact verification run after this PR lands on the exact tagged `main` commit.