### PR TITLE
Optimize Laguna prefill scale reuse

### DIFF
--- a/Sources/MereRunCore/Laguna/LagunaModel.swift
+++ b/Sources/MereRunCore/Laguna/LagunaModel.swift
@@ -54,6 +54,10 @@ enum LagunaMoEAccelerationPolicy {
         "MERERUN_LAGUNA_FUSED_ROUTED_SHARED_DOWN_RESIDUAL",
         default: m5MaxDefaultsEnabled
     )
+    static let prefillExpertPairwiseScaleReuseEnabled = booleanEnvironment(
+        "MERERUN_LAGUNA_PREFILL_EXPERT_PAIRWISE_SCALES",
+        default: m5MaxDefaultsEnabled
+    )
     static let decodeNVFP4RowsPerSIMDGroup = decodeRowsPerSIMDGroup(
         ProcessInfo.processInfo.environment[
             "MERERUN_LAGUNA_DECODE_NVFP4_ROWS_PER_SIMDGROUP"
@@ -110,6 +114,38 @@ enum LagunaMoEAccelerationPolicy {
         }
         return xsCandidate
     }
+}
+
+/// Proves that every adjacent pair in an NVFP4 group-16 scale plane is
+/// byte-identical except for explicitly preserved pairs. The Laguna XS expert
+/// tensors shipped by Poolside were produced by a simdgroup-wide quantizer:
+/// the two group-16 halves of each 32-weight span therefore share one scale,
+/// while the first pair may carry the quantizer's duplicated-write exception.
+///
+/// This is a fail-closed, input-independent certificate over the weights that
+/// were actually loaded. A false result keeps the stock prefill loader. A true
+/// result permits the M5 kernel to load the even scale byte once and broadcast
+/// it to the adjacent SIMD lane without changing a single dequantized value.
+func lagunaNVFP4AdjacentScalePairsCertified(
+    _ scales: MLXArray,
+    allowedFlatPairs: Set<Int> = [0]
+) -> Bool {
+    let pairCount = scales.size / 2
+    guard scales.dtype == .uint8,
+          scales.ndim >= 1,
+          scales.size.isMultiple(of: 2),
+          scales.dim(-1).isMultiple(of: 2),
+          allowedFlatPairs.allSatisfy({ $0 >= 0 && $0 < pairCount }) else {
+        return false
+    }
+
+    let pairs = contiguous(scales).reshaped([pairCount, 2])
+    let mismatch = (pairs[0..., 0] .!= pairs[0..., 1]).asType(.int32)
+    var violations = mismatch.sum()
+    for index in allowedFlatPairs {
+        violations = violations - mismatch[index]
+    }
+    return violations.item(Int32.self) == 0
 }
 
 enum LagunaGraphAccelerationPolicy {
@@ -972,6 +1008,7 @@ final class LagunaSwitchGLU: Module {
     @ModuleInfo(key: "up_proj") var upProj: LagunaSwitchLinear
     @ModuleInfo(key: "down_proj") var downProj: LagunaSwitchLinear
     private let decodeNVFP4RowsPerSIMDGroup: Int
+    private(set) var prefillPairwiseScaleReuseCertified = false
 
     init(config: LagunaConfig) {
         self.decodeNVFP4RowsPerSIMDGroup =
@@ -1081,7 +1118,8 @@ final class LagunaSwitchGLU: Module {
                upScales: upScales,
                sortedExpertIndices: sortedIndices,
                groupSize: gateProj.groupSize,
-               bits: gateProj.bits
+               bits: gateProj.bits,
+               pairwiseScaleReuse: prefillPairwiseScaleReuseCertified
            ) {
             activated = fused
         } else {
@@ -1225,6 +1263,32 @@ final class LagunaSwitchGLU: Module {
             bits: downProj.bits
         )
     }
+
+    /// Certifies the loaded routed gate/up scale planes once, before warmup.
+    /// The result is retained as a Boolean only; unlike the challenge runtime's
+    /// packed decode-bank reuse, production needs no additional scale storage.
+    func preparePrefillPairwiseScaleReuse() {
+        prefillPairwiseScaleReuseCertified = false
+        guard LagunaMoEAccelerationPolicy.prefillExpertPairwiseScaleReuseEnabled,
+              gateProj.mode == .nvfp4,
+              upProj.mode == .nvfp4,
+              gateProj.groupSize == 16,
+              upProj.groupSize == 16,
+              gateProj.bits == 4,
+              upProj.bits == 4,
+              gateProj.biases == nil,
+              upProj.biases == nil,
+              let gateScales = gateProj.scales,
+              let upScales = upProj.scales,
+              gateScales.dtype == .uint8,
+              upScales.dtype == .uint8,
+              gateScales.shape == upScales.shape else {
+            return
+        }
+        prefillPairwiseScaleReuseCertified =
+            lagunaNVFP4AdjacentScalePairsCertified(gateScales)
+            && lagunaNVFP4AdjacentScalePairsCertified(upScales)
+    }
 }
 
 final class LagunaRouter: Module {
@@ -1337,6 +1401,10 @@ final class LagunaSparseMoE: LagunaFeedForward {
 
     func preparePrefillAcceleration() -> MLXArray? {
         switchMLP.prepareSortedDownWarmUp()
+    }
+
+    func preparePrefillPairwiseScaleReuse() {
+        switchMLP.preparePrefillPairwiseScaleReuse()
     }
 }
 
@@ -2066,6 +2134,9 @@ final class LagunaLanguageModel: Module {
     func prepareRuntimeAcceleration() -> [MLXArray] {
         var arrays = preparePrefillAcceleration()
         for layer in layers {
+            if let sparse = layer.mlp as? LagunaSparseMoE {
+                sparse.preparePrefillPairwiseScaleReuse()
+            }
             arrays.append(contentsOf: layer.selfAttention.prepareNativeAffineQKV())
             arrays.append(
                 contentsOf: layer.selfAttention.prepareTerminalPrefillProjectionWeights()

--- a/Sources/MereRunCore/Quantization/RoutedMoERouting.swift
+++ b/Sources/MereRunCore/Quantization/RoutedMoERouting.swift
@@ -252,7 +252,8 @@ enum RoutedMoERouting {
         upScales: MLXArray,
         sortedExpertIndices: MLXArray,
         groupSize: Int,
-        bits: Int
+        bits: Int,
+        pairwiseScaleReuse: Bool = false
     ) -> MLXArray? {
         #if os(macOS)
         guard supportsExpertAlignedNVFP4Metal,
@@ -330,6 +331,7 @@ enum RoutedMoERouting {
                 ("ROUTE_COUNT", routeCount),
                 ("OUTPUT_DIMENSIONS", outputDimensions),
                 ("INPUT_DIMENSIONS", inputDimensions),
+                ("PAIRWISE_SCALE_REUSE", pairwiseScaleReuse),
             ],
             grid: (outputTiles * 32, maximumRouteTiles * 2, 1),
             threadGroup: (32, 2, 1),
@@ -642,6 +644,115 @@ enum RoutedMoERouting {
         ensureRowContiguous: true
     )
 
+    /// Drop-in replacement for MLX's `QuantizedBlockLoader` at the one exact
+    /// Laguna prefill geometry. Two adjacent SIMD lanes own the two group-16
+    /// halves of one 32-weight span. Once the loaded scale planes have passed
+    /// `lagunaNVFP4AdjacentScalePairsCertified`, the even lane loads their
+    /// shared uint8 scale and broadcasts it to the odd lane. The first logical
+    /// pair of every output tile is conservatively read by both lanes, which
+    /// preserves the only pair the checkpoint quantizer may leave unequal.
+    ///
+    /// No values are recomputed or converted differently: `fp4nv_scale_x16384`,
+    /// code loads, decode order, threadgroup stores, and MMA order are copied
+    /// directly from the stock loader. The false template arm below continues
+    /// to instantiate MLX's original loader as the exact kill-switch path.
+    private static let pairwiseNVFP4BlockLoaderHeader = """
+        // MLX_INCLUDE_FP_QUANTIZED_HEADERS
+
+        template <
+            typename T,
+            short BROWS,
+            short BCOLS,
+            short dst_ld,
+            short reduction_dim,
+            short tgp_size,
+            short group_size,
+            short bits>
+        struct MereLagunaPairwiseNVFP4BlockLoader {
+            MLX_MTL_CONST short pack_factor = get_pack_factor<8, bits>();
+            MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack();
+            MLX_MTL_CONST short BCOLS_PACKED = BCOLS / pack_factor;
+            MLX_MTL_CONST short n_reads =
+                (BCOLS_PACKED * BROWS) / tgp_size;
+
+            static_assert(BROWS == 32, "Laguna pairwise loader requires BROWS=32");
+            static_assert(BCOLS == 32, "Laguna pairwise loader requires BCOLS=32");
+            static_assert(reduction_dim == 1, "Laguna pairwise loader requires reduction_dim=1");
+            static_assert(tgp_size == 64, "Laguna pairwise loader requires 64 threads");
+            static_assert(group_size == 16, "Laguna pairwise loader requires group-16");
+            static_assert(bits == 4, "Laguna pairwise loader requires NVFP4");
+            static_assert(pack_factor == 2, "Laguna pairwise loader requires pack factor 2");
+            static_assert(bytes_per_pack == 1, "Laguna pairwise loader requires byte packs");
+            static_assert(n_reads == 8, "Laguna pairwise loader requires eight reads per lane");
+
+            const int src_ld;
+            const int tile_stride;
+            const short thread_idx;
+            const short bi;
+            const short bj;
+
+            threadgroup T* dst;
+            const device uint8_t* src;
+            const device uint8_t* scales;
+            bool first_k;
+
+            MereLagunaPairwiseNVFP4BlockLoader(
+                const device uint8_t* src_,
+                const device uint8_t* scales_,
+                const int src_ld_,
+                threadgroup T* dst_,
+                ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+                ushort simd_lane_id [[thread_index_in_simdgroup]])
+                : src_ld(src_ld_),
+                  tile_stride(BCOLS_PACKED * bytes_per_pack),
+                  thread_idx(simd_group_id * 32 + simd_lane_id),
+                  bi(n_reads * thread_idx / BCOLS_PACKED),
+                  bj((n_reads * thread_idx) % BCOLS_PACKED),
+                  dst(dst_ + bi * dst_ld + bj * pack_factor),
+                  src(src_ + bi * src_ld * bytes_per_pack / pack_factor
+                      + bj * bytes_per_pack),
+                  scales(scales_ + bi * src_ld / group_size
+                      + (bj * pack_factor) / group_size),
+                  first_k(true) {}
+
+            void load_unsafe() const {
+                const bool even_group = (thread_idx & 1) == 0;
+                uint scale_bits = 0;
+                if (even_group) {
+                    scale_bits = uint(*scales);
+                }
+                const uint paired_scale =
+                    simd_shuffle_xor(scale_bits, ushort(1));
+                if (!even_group) {
+                    scale_bits = paired_scale;
+                }
+                // Preserve the odd byte of the first logical pair. Doing this
+                // for every output tile is conservative and makes the loader
+                // exact without specializing on an expert/tile coordinate.
+                if (first_k && bi == 0 && !even_group) {
+                    scale_bits = uint(*scales);
+                }
+
+                const float scale =
+                    fp4nv_scale_x16384(uint8_t(scale_bits));
+                for (int i = 0; i < n_reads / 4; ++i) {
+                    T values[8];
+                    fp4nv_decode8<T>(
+                        fp4nv_pack4(src + i * 4), scale, values);
+                    for (int j = 0; j < 8; ++j) {
+                        dst[i * 8 + j] = values[j];
+                    }
+                }
+            }
+
+            void next() {
+                src += tile_stride;
+                scales += BCOLS / group_size;
+                first_k = false;
+            }
+        };
+        """
+
     private static let fusedSortedNVFP4SwiGLUKernel = MLXFast.metalKernel(
         name: "mere_routed_moe_sorted_nvfp4_swiglu",
         inputNames: [
@@ -694,15 +805,26 @@ enum RoutedMoERouting {
                 BK_PADDED,
                 1,
                 WM * WN * SIMD_SIZE>;
-            using weight_loader_t = QuantizedBlockLoader<
-                DataT,
-                BN,
-                BK,
-                BK_PADDED,
-                true,
-                WM * WN * SIMD_SIZE,
-                GROUP_SIZE,
-                BITS>;
+            using weight_loader_t = metal::conditional_t<
+                PAIRWISE_SCALE_REUSE,
+                MereLagunaPairwiseNVFP4BlockLoader<
+                    DataT,
+                    BN,
+                    BK,
+                    BK_PADDED,
+                    true,
+                    WM * WN * SIMD_SIZE,
+                    GROUP_SIZE,
+                    BITS>,
+                QuantizedBlockLoader<
+                    DataT,
+                    BN,
+                    BK,
+                    BK_PADDED,
+                    true,
+                    WM * WN * SIMD_SIZE,
+                    GROUP_SIZE,
+                    BITS>>;
 
             threadgroup DataT input_tile[BM * BK_PADDED];
             threadgroup DataT gate_weight_tile[BN * BK_PADDED];
@@ -819,7 +941,7 @@ enum RoutedMoERouting {
                     short2(BN, tile_rows));
             }
         """,
-        header: "// MLX_INCLUDE_FP_QUANTIZED_HEADERS\n",
+        header: pairwiseNVFP4BlockLoaderHeader,
         ensureRowContiguous: true
     )
 

--- a/Tests/MereRunCoreTests/LagunaModelTests.swift
+++ b/Tests/MereRunCoreTests/LagunaModelTests.swift
@@ -1418,6 +1418,201 @@ final class LagunaModelTests: MereRunCoreTestCase {
         }
     }
 
+    func testNVFP4AdjacentScalePairCertificateFailsClosed() {
+        let certified = MLXArray([
+            UInt8(7), 11,  // the explicitly preserved first-pair exception
+            13, 13,
+            17, 17,
+            19, 19,
+        ]).reshaped([2, 4])
+        XCTAssertTrue(lagunaNVFP4AdjacentScalePairsCertified(certified))
+        XCTAssertFalse(
+            lagunaNVFP4AdjacentScalePairsCertified(
+                certified,
+                allowedFlatPairs: []
+            )
+        )
+
+        let unexpectedMismatch = MLXArray([
+            UInt8(7), 11,
+            13, 13,
+            17, 23,
+            19, 19,
+        ]).reshaped([2, 4])
+        XCTAssertFalse(
+            lagunaNVFP4AdjacentScalePairsCertified(unexpectedMismatch)
+        )
+        XCTAssertFalse(
+            lagunaNVFP4AdjacentScalePairsCertified(
+                MLXArray([UInt8(1), 1, 2]).reshaped([1, 3])
+            )
+        )
+    }
+
+    func testPairwiseScaleReuseMatchesStockSortedNVFP4SwiGLU() throws {
+        guard Device.defaultDevice().deviceType == .gpu,
+              GPU.deviceInfo().architecture == "applegpu_g16s" else {
+            throw XCTSkip("The pairwise prefill kernel requires an M4 Max GPU.")
+        }
+        MLXRandom.seed(61)
+        let expertCount = 4
+        let inputDimensions = 512
+        let outputDimensions = 64
+        let groupSize = 16
+        let bits = 4
+        let gate = MLX.quantized(
+            MLXRandom.uniform(
+                low: -0.25,
+                high: 0.25,
+                [expertCount, outputDimensions, inputDimensions]
+            ),
+            groupSize: groupSize,
+            bits: bits,
+            mode: .nvfp4
+        )
+        let up = MLX.quantized(
+            MLXRandom.uniform(
+                low: -0.25,
+                high: 0.25,
+                [expertCount, outputDimensions, inputDimensions]
+            ),
+            groupSize: groupSize,
+            bits: bits,
+            mode: .nvfp4
+        )
+        MLX.eval(gate.wq, gate.scales, up.wq, up.scales)
+
+        func certifiedPairPlane(_ scales: MLXArray) throws -> MLXArray {
+            var values = scales.asArray(UInt8.self)
+            for index in stride(from: 0, to: values.count, by: 2) {
+                values[index + 1] = values[index]
+            }
+            let first = values[0]
+            let replacement = try XCTUnwrap(
+                values.dropFirst(2).first(where: { $0 != first })
+            )
+            values[1] = replacement
+            let plane = MLXArray(values).reshaped(scales.shape)
+            XCTAssertTrue(lagunaNVFP4AdjacentScalePairsCertified(plane))
+            return plane
+        }
+
+        let gateScales = try certifiedPairPlane(gate.scales)
+        let upScales = try certifiedPairPlane(up.scales)
+        let routeCount = 64
+        let input = MLXRandom.uniform(
+            low: -0.5,
+            high: 0.5,
+            [routeCount, 1, inputDimensions]
+        ).asType(.bfloat16)
+        let indices = MLXArray(
+            (0..<routeCount).map { Int32($0 / (routeCount / expertCount)) }
+        )
+
+        let gateOutput = portableGatherQuantizedMM(
+            input,
+            gate.wq,
+            scales: gateScales,
+            biases: nil,
+            rhsIndices: indices,
+            transpose: true,
+            groupSize: groupSize,
+            bits: bits,
+            mode: .nvfp4,
+            sortedIndices: true
+        )
+        let upOutput = portableGatherQuantizedMM(
+            input,
+            up.wq,
+            scales: upScales,
+            biases: nil,
+            rhsIndices: indices,
+            transpose: true,
+            groupSize: groupSize,
+            bits: bits,
+            mode: .nvfp4,
+            sortedIndices: true
+        )
+        let reference = MLXNN.silu(gateOutput) * upOutput
+        let stock = try XCTUnwrap(
+            RoutedMoERouting.fusedSortedNVFP4SwiGLU(
+                input,
+                gateWeight: gate.wq,
+                gateScales: gateScales,
+                upWeight: up.wq,
+                upScales: upScales,
+                sortedExpertIndices: indices,
+                groupSize: groupSize,
+                bits: bits,
+                pairwiseScaleReuse: false
+            )
+        )
+        let pairwise = try XCTUnwrap(
+            RoutedMoERouting.fusedSortedNVFP4SwiGLU(
+                input,
+                gateWeight: gate.wq,
+                gateScales: gateScales,
+                upWeight: up.wq,
+                upScales: upScales,
+                sortedExpertIndices: indices,
+                groupSize: groupSize,
+                bits: bits,
+                pairwiseScaleReuse: true
+            )
+        )
+        MLX.eval(reference, stock, pairwise)
+
+        XCTAssertEqual(
+            MLX.max(
+                MLX.abs(reference.asType(.float32) - stock.asType(.float32))
+            ).item(Float.self),
+            0
+        )
+        XCTAssertEqual(
+            MLX.max(
+                MLX.abs(stock.asType(.float32) - pairwise.asType(.float32))
+            ).item(Float.self),
+            0
+        )
+
+        Memory.clearCache()
+        let activeBefore = Memory.activeMemory
+        for _ in 0..<8 {
+            autoreleasepool {
+                let repeated = RoutedMoERouting.fusedSortedNVFP4SwiGLU(
+                    input,
+                    gateWeight: gate.wq,
+                    gateScales: gateScales,
+                    upWeight: up.wq,
+                    upScales: upScales,
+                    sortedExpertIndices: indices,
+                    groupSize: groupSize,
+                    bits: bits,
+                    pairwiseScaleReuse: true
+                )
+                XCTAssertNotNil(repeated)
+                if let repeated {
+                    MLX.eval(repeated)
+                    XCTAssertEqual(
+                        MLX.max(
+                            MLX.abs(
+                                pairwise.asType(.float32)
+                                    - repeated.asType(.float32)
+                            )
+                        ).item(Float.self),
+                        0
+                    )
+                }
+            }
+        }
+        Memory.clearCache()
+        XCTAssertLessThanOrEqual(
+            Memory.activeMemory,
+            activeBefore + 1_048_576,
+            "Pairwise prefill scale reuse must not retain per-forward MLX buffers."
+        )
+    }
+
     func testSortedNVFP4DownProjectionMatchesNativeGather() throws {
         guard Device.defaultDevice().deviceType == .gpu,
               GPU.deviceInfo().architecture == "applegpu_g16s" else {
@@ -2045,6 +2240,20 @@ final class LagunaModelTests: MereRunCoreTestCase {
                 to: model,
                 dtype: nil,
                 verify: .shapeMismatch
+            )
+        }
+
+        if LagunaMoEAccelerationPolicy.prefillExpertPairwiseScaleReuseEnabled {
+            _ = model.prepareRuntimeAcceleration()
+            let sparseLayers = model.model.layers.compactMap {
+                $0.mlp as? LagunaSparseMoE
+            }
+            XCTAssertEqual(
+                sparseLayers.filter {
+                    $0.switchMLP.prefillPairwiseScaleReuseCertified
+                }.count,
+                sparseLayers.count,
+                "Every loaded routed gate/up scale plane must pass the lossless pair certificate."
             )
         }
 


### PR DESCRIPTION
## Summary

- certify the loaded Laguna XS 2.1 routed gate/up NVFP4 group-16 scale planes at initialization
- specialize the existing sorted prefill kernel so adjacent SIMD lanes reuse a certified-identical scale byte
- preserve the quantizer's allowed first-pair exception, exact dequantization and MMA ordering
- fail closed to the stock MLX loader and retain an operator kill switch

This ports the crown-taking mechanism from MLX Fast submission `db8b4df1-f4f0-4571-a177-fe743f5266aa` / [challenge PR #1599](https://github.com/Layr-Labs/mlxfast-challenge/pull/1599), which promoted on the paired M5 Max runner at score `2.5901857153934094` with 1,344/1,344 checked tokens and `max_abs_diff=0`.

Production uses the existing expert-aligned sorted prefill kernel rather than copying the challenge's vendored MLX backend. The certificate runs over the actual loaded checkpoint and retains only a Boolean; no side scale bank or model-sized copy is added. The optimization defaults on only for M5 Max and can be disabled with `MERERUN_LAGUNA_PREFILL_EXPERT_PAIRWISE_SCALES=0`.

## Validation

- `./scripts/check.sh`
  - SwiftLint: 1,146 files, 0 violations
  - full XCTest suite: 2,536 tests, 167 asset-dependent skips, 0 failures
  - Swift Testing suites: 21 tests, 0 failures
  - build, CLI help inventory and hygiene scans passed
- focused GPU equivalence on M4 Max: stock and pairwise Metal kernels matched exactly, including the allowed first-pair exception
- eight repeated optimized forwards remained exact and showed no retained active-memory growth
- installed Poolside Laguna XS 2.1 checkpoint: all 39 sparse layers passed the loaded-scale certificate
- release build passed
- release CLI loaded all five installed shards and completed a deterministic one-token chat through the forced optimized path

M4 timing was used only for correctness and compilation. Performance evidence comes from the official paired M5 Max promotion above.
