### PR TITLE
Add MiniMax-H3 Turbo LoRA runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- added the immutable, checksum-pinned `minimax-h3-turbo-4step` managed
+  adapter and first-class `video generate --h3-adapter` controls for the BF16
+  FL2VA model. The native MLX runtime applies all 259 mixed-rank LoRA pairs in
+  activation space, remaps fused QKV rows, includes AdaLN deltas in the exact
+  schedule cache, and defaults to four denoise evaluations. Preflight resolves
+  the managed path and rejects missing adapters, compact/Ref2VA bases,
+  incompatible step counts, and compounded block-reuse acceleration. A real
+  release-mode 1280x768, 124-frame generation completed in 60:59.420 wall time
+  with 56:13.421 of denoising, 51.37 GiB peak reported Metal memory, zero
+  swaps, and no spatial lattice in the accepted output.
+
 ## 0.35.0 - 2026-08-06
 
 This release makes MiniMax-H3 materially faster and more faithful on Apple

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -305,6 +305,15 @@ struct VideoGenerate: AsyncParsableCommand {
     )
     var h3Acceleration: MiniMaxH3CLIAccelerationMode = .quality
 
+    @Option(
+        name: [.customLong("h3-adapter")],
+        help: "Installed MiniMax-H3 adapter catalog id or local safetensors path. Turbo defaults to four denoise evaluations."
+    )
+    var h3Adapter: String?
+
+    @Option(name: [.customLong("h3-adapter-strength")], help: "MiniMax-H3 runtime adapter multiplier.")
+    var h3AdapterStrength: Float = 1
+
     @Option(name: [.customLong("guidance-scale")], help: "Wan classifier-free guidance scale.")
     var guidanceScale: Float = 5
 
@@ -475,6 +484,9 @@ struct VideoGenerate: AsyncParsableCommand {
         guard v2aGuidanceScale >= 0 else {
             throw ValidationError("--v2a-guidance-scale must be >= 0")
         }
+        guard h3AdapterStrength > 0 else {
+            throw ValidationError("--h3-adapter-strength must be > 0")
+        }
         guard a2vSteps > 0 else {
             throw ValidationError("--a2v-steps must be >= 1")
         }
@@ -545,6 +557,13 @@ struct VideoGenerate: AsyncParsableCommand {
             }
             let h3Resources = MiniMaxH3Resources(rootURL: resolvedRootURL)
             let h3Configuration = try h3Resources.loadConfiguration()
+            if h3Adapter != nil, !h3Resources.usesShardedBF16Transformer {
+                throw ValidationError("--h3-adapter currently requires the MiniMax-H3 BF16 FL2VA model.")
+            }
+            let resolvedH3Adapter = try ManagedAdapterArgumentResolver.resolve(
+                h3Adapter,
+                baseModelID: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
+            ).map { URL(fileURLWithPath: $0).standardizedFileURL }
             let parsedReferences = try parseMiniMaxH3References()
             if h3Configuration.task == "fl2va", !parsedReferences.isEmpty {
                 throw ValidationError("--reference requires a MiniMax-H3 Ref2VA model root.")
@@ -564,6 +583,9 @@ struct VideoGenerate: AsyncParsableCommand {
             if !quiet {
                 CLIStderr.write("Engine: native MiniMax-H3 \(h3Configuration.task.uppercased())\n")
                 CLIStderr.write("Model root: \(resolvedRootURL.path)\n")
+                if let resolvedH3Adapter {
+                    CLIStderr.write("Adapter: \(resolvedH3Adapter.path) (strength \(h3AdapterStrength))\n")
+                }
                 if h3Width != width || h3Height != height {
                     CLIStderr.write("Adjusted MiniMax-H3 size to \(h3Width)x\(h3Height) (must be divisible by 32)\n")
                 }
@@ -581,6 +603,8 @@ struct VideoGenerate: AsyncParsableCommand {
                 seed: UInt64(bitPattern: Int64(seed ?? 42)),
                 transformerWeightMode: h3WeightMode.generationMode,
                 accelerationMode: h3Acceleration.generationMode,
+                adapterURL: resolvedH3Adapter,
+                adapterStrength: h3AdapterStrength,
                 firstFrameURL: sourceImageURL,
                 lastFrameURL: endImageURL,
                 references: parsedReferences
@@ -616,6 +640,9 @@ struct VideoGenerate: AsyncParsableCommand {
             if !quiet { CLIStderr.write("Saved: \(outputURL.path)\n") }
             print(outputURL.path)
             return
+        }
+        if h3Adapter != nil {
+            throw ValidationError("--h3-adapter can only be used with a MiniMax-H3 model.")
         }
         if !references.isEmpty {
             throw ValidationError("--reference is only supported by MiniMax-H3 Ref2VA model roots.")
@@ -1291,6 +1318,8 @@ struct VideoGenerate: AsyncParsableCommand {
             steps: steps,
             h3WeightMode: h3WeightMode.rawValue,
             h3AccelerationMode: h3Acceleration.rawValue,
+            h3Adapter: h3Adapter,
+            h3AdapterStrength: h3AdapterStrength,
             duration: duration,
             fps: fps,
             seed: seed,
@@ -1367,6 +1396,9 @@ struct VideoGenerate: AsyncParsableCommand {
                 "--h3-weight-mode", h3WeightMode.rawValue,
                 "--h3-acceleration", h3Acceleration.rawValue,
             ]
+            if let h3Adapter {
+                args += ["--h3-adapter", h3Adapter, "--h3-adapter-strength", String(h3AdapterStrength)]
+            }
         }
         if let duration {
             args += ["--duration", String(duration)]

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -19,6 +19,8 @@ struct VideoGenerationPreflightInput {
     let steps: Int?
     let h3WeightMode: String
     let h3AccelerationMode: String
+    let h3Adapter: String?
+    let h3AdapterStrength: Float
     let duration: Double?
     let fps: Int
     let seed: Int?
@@ -55,6 +57,8 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
     let steps: Int?
     let h3WeightMode: String?
     let h3AccelerationMode: String?
+    let h3Adapter: String?
+    let h3AdapterStrength: Float?
     let duration: Double?
     let fps: Int
     let seed: Int?
@@ -88,6 +92,8 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
         case steps
         case h3WeightMode = "h3_weight_mode"
         case h3AccelerationMode = "h3_acceleration"
+        case h3Adapter = "h3_adapter"
+        case h3AdapterStrength = "h3_adapter_strength"
         case duration
         case fps
         case seed
@@ -166,6 +172,7 @@ struct VideoGenerationInputPreflightSummary: Codable, Equatable {
     let sourceImage: VideoGenerationPathPreflightSummary?
     let endImage: VideoGenerationPathPreflightSummary?
     let references: [VideoGenerationPathPreflightSummary]?
+    let adapter: VideoGenerationPathPreflightSummary?
     let missingCount: Int
 
     enum CodingKeys: String, CodingKey {
@@ -174,6 +181,7 @@ struct VideoGenerationInputPreflightSummary: Codable, Equatable {
         case sourceImage = "source_image"
         case endImage = "end_image"
         case references
+        case adapter
         case missingCount = "missing_count"
     }
 }
@@ -206,6 +214,8 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
     let resolvedSteps: Int?
     let h3WeightMode: String?
     let h3AccelerationMode: String?
+    let h3Adapter: String?
+    let h3AdapterStrength: Float?
     let fps: Int
     let resolvedNumFrames: Int
     let resolvedDurationSeconds: Double?
@@ -229,6 +239,8 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
         case resolvedSteps = "resolved_steps"
         case h3WeightMode = "h3_weight_mode"
         case h3AccelerationMode = "h3_acceleration"
+        case h3Adapter = "h3_adapter"
+        case h3AdapterStrength = "h3_adapter_strength"
         case fps
         case resolvedNumFrames = "resolved_num_frames"
         case resolvedDurationSeconds = "resolved_duration_seconds"
@@ -334,6 +346,10 @@ struct VideoGenerationPreflightAnalyzer {
             steps: input.steps,
             h3WeightMode: usesMiniMaxH3Geometry ? input.h3WeightMode : nil,
             h3AccelerationMode: usesMiniMaxH3Geometry ? input.h3AccelerationMode : nil,
+            h3Adapter: usesMiniMaxH3Geometry ? input.h3Adapter : nil,
+            h3AdapterStrength: usesMiniMaxH3Geometry && input.h3Adapter != nil
+                ? input.h3AdapterStrength
+                : nil,
             duration: input.duration,
             fps: input.fps,
             seed: input.seed,
@@ -446,6 +462,38 @@ struct VideoGenerationPreflightAnalyzer {
                     message: "--quality, --output-mode, and --variant cannot be combined with MiniMax-H3."
                 )
             )
+        }
+        if !usesMiniMaxH3Geometry, input.h3Adapter != nil {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_adapter_with_non_h3_model",
+                severity: .blocker,
+                title: "MiniMax-H3 adapter requires MiniMax-H3",
+                message: "--h3-adapter can only be used with a MiniMax-H3 model."
+            ))
+        }
+        if input.h3Adapter != nil, input.h3AdapterStrength <= 0 {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_adapter_strength_invalid",
+                severity: .blocker,
+                title: "MiniMax-H3 adapter strength is invalid",
+                message: "--h3-adapter-strength must be > 0."
+            ))
+        }
+        if input.h3Adapter != nil, input.h3AccelerationMode != MiniMaxH3AccelerationMode.quality.rawValue {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_adapter_acceleration_conflict",
+                severity: .blocker,
+                title: "MiniMax-H3 Turbo already distills the denoise schedule",
+                message: "Use --h3-acceleration quality with --h3-adapter."
+            ))
+        }
+        if input.h3Adapter != nil, !input.references.isEmpty {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_adapter_ref2va_unsupported",
+                severity: .blocker,
+                title: "MiniMax-H3 Turbo does not support Ref2VA",
+                message: "Use the Turbo adapter for FL2VA text or keyframe generation without --reference."
+            ))
         }
         if input.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             diagnostics.append(
@@ -612,6 +660,33 @@ struct VideoGenerationPreflightAnalyzer {
         model: VideoGenerationModelPreflightSummary,
         diagnostics: inout [PreflightDiagnostic]
     ) {
+        if input.h3Adapter != nil, usesMiniMaxH3Geometry {
+            let usesBF16: Bool
+            if let path = model.path {
+                usesBF16 = MiniMaxH3Resources(
+                    rootURL: URL(fileURLWithPath: path).standardizedFileURL
+                ).usesShardedBF16Transformer
+            } else {
+                usesBF16 = model.requested == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
+            }
+            if !usesBF16 {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "h3_adapter_requires_bf16",
+                    severity: .blocker,
+                    title: "MiniMax-H3 Turbo requires the BF16 base model",
+                    message: "Use --model \(ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue)."
+                ))
+            }
+            if let steps = input.steps,
+               steps != MiniMaxH3TurboAdapter.recommendedSchedulePointCount {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "h3_adapter_steps_invalid",
+                    severity: .blocker,
+                    title: "MiniMax-H3 Turbo uses four denoise evaluations",
+                    message: "Omit --steps or set --steps 5 (five schedule points)."
+                ))
+            }
+        }
         guard let requestedQuality = input.quality,
               let actualQuality = resolvedQuality(model: model),
               requestedQuality != actualQuality else {
@@ -940,6 +1015,10 @@ struct VideoGenerationPreflightAnalyzer {
             let path = raw.firstIndex(of: ":").map { String(raw[raw.index(after: $0)...]) } ?? raw
             return pathSummary(requested: path)
         }
+        let adapter = input.h3Adapter.map { reference -> VideoGenerationPathPreflightSummary in
+            let path = ManagedAdapterCatalog.spec(for: reference)?.installedFileURL().path ?? reference
+            return pathSummary(requested: reference, resolvedPath: path)
+        }
         for (summary, prefix) in [
             (sourceAudio, "source_audio"),
             (sourceImage, "source_image"),
@@ -987,6 +1066,26 @@ struct VideoGenerationPreflightAnalyzer {
                 ))
             }
         }
+        if let adapter, !adapter.exists {
+            let pullHint = ManagedAdapterCatalog.spec(for: adapter.requested).map {
+                " Run `mere.run adapter pull \($0.id)`."
+            } ?? ""
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_adapter_missing",
+                severity: .blocker,
+                title: "MiniMax-H3 adapter missing",
+                message: "Adapter not found: \(adapter.path).\(pullHint)",
+                locations: [.init(kind: "file", path: adapter.path)]
+            ))
+        } else if let adapter, adapter.isDirectory {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_adapter_is_directory",
+                severity: .blocker,
+                title: "MiniMax-H3 adapter path is a directory",
+                message: "Adapter path must be a safetensors file: \(adapter.path)",
+                locations: [.init(kind: "directory", path: adapter.path)]
+            ))
+        }
 
         let mode: String
         if !references.isEmpty {
@@ -1004,19 +1103,23 @@ struct VideoGenerationPreflightAnalyzer {
                 ? "text_to_video"
                 : (endImage == nil ? "image_to_video" : "directed_image_to_video")
         }
-        let allInputs = [sourceAudio, sourceImage, endImage].compactMap { $0 } + references
+        let allInputs = [sourceAudio, sourceImage, endImage, adapter].compactMap { $0 } + references
         return VideoGenerationInputPreflightSummary(
             mode: mode,
             sourceAudio: sourceAudio,
             sourceImage: sourceImage,
             endImage: endImage,
             references: references.isEmpty ? nil : references,
+            adapter: adapter,
             missingCount: allInputs.filter { !$0.exists }.count
         )
     }
 
-    private func pathSummary(requested: String) -> VideoGenerationPathPreflightSummary {
-        let url = URL(fileURLWithPath: requested).standardizedFileURL
+    private func pathSummary(
+        requested: String,
+        resolvedPath: String? = nil
+    ) -> VideoGenerationPathPreflightSummary {
+        let url = URL(fileURLWithPath: resolvedPath ?? requested).standardizedFileURL
         var isDirectory: ObjCBool = false
         let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
         return VideoGenerationPathPreflightSummary(
@@ -1098,7 +1201,9 @@ struct VideoGenerationPreflightAnalyzer {
             : (usesAudioConditioning || input.variant == .unifiedAV ? .audioVideo : .videoOnly)
         let h3AccelerationMode = MiniMaxH3AccelerationMode(rawValue: input.h3AccelerationMode) ?? .quality
         let resolvedH3Steps: Int? = if usesMiniMaxH3Geometry {
-            input.steps ?? (try? MiniMaxH3StepPolicy.recommendedPointCount(
+            input.steps ?? (input.h3Adapter != nil
+                ? MiniMaxH3TurboAdapter.recommendedSchedulePointCount
+                : (try? MiniMaxH3StepPolicy.recommendedPointCount(
                 width: resolvedWidth,
                 height: resolvedHeight,
                 numFrames: resolvedFrames,
@@ -1107,7 +1212,7 @@ struct VideoGenerationPreflightAnalyzer {
                     MiniMaxH3ReferenceKind(rawValue: String(reference.prefix { $0 != ":" }))
                 },
                 accelerationMode: h3AccelerationMode
-            ))
+            )))
         } else {
             nil
         }
@@ -1129,6 +1234,10 @@ struct VideoGenerationPreflightAnalyzer {
             resolvedSteps: resolvedH3Steps,
             h3WeightMode: usesMiniMaxH3Geometry ? input.h3WeightMode : nil,
             h3AccelerationMode: usesMiniMaxH3Geometry ? input.h3AccelerationMode : nil,
+            h3Adapter: usesMiniMaxH3Geometry ? input.h3Adapter : nil,
+            h3AdapterStrength: usesMiniMaxH3Geometry && input.h3Adapter != nil
+                ? input.h3AdapterStrength
+                : nil,
             fps: usesMiniMaxH3Geometry ? MiniMaxH3Geometry.framesPerSecond : input.fps,
             resolvedNumFrames: resolvedFrames,
             resolvedDurationSeconds: input.fps > 0

--- a/Sources/MereRunCore/ManagedAdapterCatalog.swift
+++ b/Sources/MereRunCore/ManagedAdapterCatalog.swift
@@ -79,6 +79,8 @@ public enum ManagedAdapterCatalog {
     public static let merePlatformAssistantID = "mere-platform-assistant"
     public static let scail2LightX2VFourStepID = "scail2-lightx2v-4step"
     public static let scail2LightX2VFourStepRevision = "27ae38da91014b947dd39cc3fa78b97cd7b386dd"
+    public static let miniMaxH3TurboFourStepID = "minimax-h3-turbo-4step"
+    public static let miniMaxH3TurboFourStepRevision = "b604dd5fe25c4c747699f698a1e63f6c46d4a066"
 
     public static let allSpecs: [ManagedAdapterSpec] = [
         ManagedAdapterSpec(
@@ -120,6 +122,27 @@ public enum ManagedAdapterCatalog {
                 filename: "wan2.1_i2v_lora_rank64_lightx2v_4step.safetensors",
                 byteCount: 739_472_104,
                 sha256: "8833bd4fd7c8eabebf0bc8ee5cfaf47f4f310ce116928a02c1adf8941dd4b0f1"
+            )
+        ),
+        ManagedAdapterSpec(
+            id: miniMaxH3TurboFourStepID,
+            title: "MiniMax-H3 Turbo 4-step",
+            version: String(miniMaxH3TurboFourStepRevision.prefix(12)),
+            summary: "Four-evaluation runtime LoRA for the native MiniMax-H3 BF16 FL2VA model.",
+            baseModelID: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            format: MiniMaxH3TurboAdapter.format,
+            license: "Apache-2.0 (adapter); MiniMax-H3 Community License (base model)",
+            upstreamRevision: miniMaxH3TurboFourStepRevision,
+            releaseManifestURL: URL(
+                string: "https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora/commit/\(miniMaxH3TurboFourStepRevision)"
+            )!,
+            downloadURL: URL(
+                string: "https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora/resolve/\(miniMaxH3TurboFourStepRevision)/minimax_h3_turbo_4step_ema_ckpt850.safetensors?download=true"
+            )!,
+            artifact: ModelArtifactPin(
+                filename: "minimax_h3_turbo_4step_ema_ckpt850.safetensors",
+                byteCount: 779_849_816,
+                sha256: "5a6eeba171cf183020a4ad48774bb2968f29f8168afd6ec17a04987f3528b4ea"
             )
         ),
     ]

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -322,6 +322,8 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
     public let seed: UInt64
     public let transformerWeightMode: MiniMaxH3TransformerWeightMode
     public let accelerationMode: MiniMaxH3AccelerationMode
+    public let adapterURL: URL?
+    public let adapterStrength: Float
     public let firstFrameURL: URL?
     public let lastFrameURL: URL?
     public let references: [MiniMaxH3ReferenceInput]
@@ -335,6 +337,8 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         seed: UInt64 = 42,
         transformerWeightMode: MiniMaxH3TransformerWeightMode = .automatic,
         accelerationMode: MiniMaxH3AccelerationMode = .quality,
+        adapterURL: URL? = nil,
+        adapterStrength: Float = 1,
         firstFrameURL: URL? = nil,
         lastFrameURL: URL? = nil,
         references: [MiniMaxH3ReferenceInput] = []
@@ -362,16 +366,44 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
            !references.contains(where: { $0.kind != .audio }) {
             throw MiniMaxH3GeneratorError.invalidOptions("an audio reference must be paired with an image or video")
         }
-        let resolvedSteps = try steps ?? MiniMaxH3StepPolicy.recommendedPointCount(
-            width: width,
-            height: height,
-            numFrames: numFrames,
-            keyframeCount: [firstFrameURL, lastFrameURL].compactMap { $0 }.count,
-            referenceKinds: references.map(\.kind),
-            accelerationMode: accelerationMode
-        )
+        if adapterURL != nil {
+            guard adapterStrength > 0 else {
+                throw MiniMaxH3GeneratorError.invalidOptions("adapter strength must be greater than zero")
+            }
+            guard accelerationMode == .quality else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "MiniMax-H3 Turbo already distills the denoise schedule and cannot be combined with block-reuse acceleration"
+                )
+            }
+            guard references.isEmpty else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "MiniMax-H3 Turbo supports FL2VA text/keyframe generation, not Ref2VA references"
+                )
+            }
+        }
+        let resolvedSteps: Int
+        if let steps {
+            resolvedSteps = steps
+        } else if adapterURL != nil {
+            resolvedSteps = MiniMaxH3TurboAdapter.recommendedSchedulePointCount
+        } else {
+            resolvedSteps = try MiniMaxH3StepPolicy.recommendedPointCount(
+                width: width,
+                height: height,
+                numFrames: numFrames,
+                keyframeCount: [firstFrameURL, lastFrameURL].compactMap { $0 }.count,
+                referenceKinds: references.map(\.kind),
+                accelerationMode: accelerationMode
+            )
+        }
         guard resolvedSteps >= 2 else {
             throw MiniMaxH3GeneratorError.invalidOptions("steps must be at least 2")
+        }
+        if adapterURL != nil,
+           resolvedSteps != MiniMaxH3TurboAdapter.recommendedSchedulePointCount {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "MiniMax-H3 Turbo requires 5 schedule points (4 denoise evaluations)"
+            )
         }
         self.prompt = trimmed
         self.width = width
@@ -381,6 +413,8 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         self.seed = seed
         self.transformerWeightMode = transformerWeightMode
         self.accelerationMode = accelerationMode
+        self.adapterURL = adapterURL
+        self.adapterStrength = adapterStrength
         self.firstFrameURL = firstFrameURL
         self.lastFrameURL = lastFrameURL
         self.references = references
@@ -440,6 +474,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         audioSchedule: MiniMaxH3Schedule,
         sequenceLength: Int,
         weightMode: MiniMaxH3TransformerWeightMode,
+        adapterURL: URL?,
+        adapterStrength: Float,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
     ) throws -> (transformer: MiniMaxH3Transformer, adaLNCache: MiniMaxH3AdaLNCache?) {
         let adaLNCache: MiniMaxH3AdaLNCache?
@@ -471,6 +507,18 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 ))
             }
         )
+        if let adapterURL {
+            guard resources.usesShardedBF16Transformer else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "MiniMax-H3 Turbo currently requires the BF16 FL2VA model"
+                )
+            }
+            try MiniMaxH3TurboAdapter.install(
+                url: adapterURL,
+                into: transformer,
+                strength: adapterStrength
+            )
+        }
         let resolvedAdaLNCache: MiniMaxH3AdaLNCache?
         if resources.usesShardedBF16Transformer {
             resolvedAdaLNCache = transformer.precomputeAdaLN(
@@ -950,6 +998,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 audioSchedule: audioSchedule,
                 sequenceLength: layout.sequenceLength,
                 weightMode: options.transformerWeightMode,
+                adapterURL: options.adapterURL,
+                adapterStrength: options.adapterStrength,
                 progressHandler: progressHandler
             )
             phaseProfileLogger?(String(
@@ -1146,6 +1196,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 audioSchedule: audioSchedule,
                 sequenceLength: layout.sequenceLength,
                 weightMode: options.transformerWeightMode,
+                adapterURL: options.adapterURL,
+                adapterStrength: options.adapterStrength,
                 progressHandler: progressHandler
             )
             (videoRows, audioRows) = denoise(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3ModelLoader.swift
@@ -112,6 +112,18 @@ public enum MiniMaxH3ModelLoader {
         guard key.hasSuffix(".attn.qkv_proj.weight") else {
             return [(key, value)]
         }
+        return [(key, deinterleavedQKVOutputRows(
+            value,
+            headCount: headCount,
+            headDimension: headDimension
+        ))]
+    }
+
+    static func deinterleavedQKVOutputRows(
+        _ value: MLXArray,
+        headCount: Int,
+        headDimension: Int
+    ) -> MLXArray {
         let expectedRows = headCount * 3 * headDimension
         precondition(value.ndim == 2 && value.dim(0) == expectedRows)
         let trailingShape = Array(value.shape.dropFirst())
@@ -119,7 +131,7 @@ public enum MiniMaxH3ModelLoader {
         let pieces = MLX.split(grouped, parts: 3, axis: 1).map {
             $0.squeezed(axis: 1).reshaped([headCount * headDimension] + trailingShape)
         }
-        return [(key, MLX.concatenated(pieces, axis: 0))]
+        return MLX.concatenated(pieces, axis: 0)
     }
 
     public static func loadConditioner(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -1511,6 +1511,21 @@ public final class MiniMaxH3Transformer: Module {
             includeAdaLN: block.includesAdaLN
         )
         let replacements: [(String, Module)] = block.leafModules().flattened().compactMap { path, module in
+            if let lora = module as? MiniMaxH3RuntimeLoRALinear {
+                let base = Linear(
+                    weight: MLXArray.zeros(lora.weight.shape, dtype: lora.weight.dtype),
+                    bias: lora.bias.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }
+                )
+                return (
+                    path,
+                    MiniMaxH3RuntimeLoRALinear(
+                        base: base,
+                        loraDown: MLXArray.zeros(lora.loraDown.shape, dtype: lora.loraDown.dtype),
+                        loraUp: MLXArray.zeros(lora.loraUp.shape, dtype: lora.loraUp.dtype),
+                        strength: lora.strength
+                    )
+                )
+            }
             guard let quantized = module as? QuantizedLinear else { return nil }
             let weight = MLXArray.zeros(quantized.weight.shape, dtype: quantized.weight.dtype)
             let bias = quantized.bias.map { MLXArray.zeros($0.shape, dtype: $0.dtype) }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
@@ -1,0 +1,165 @@
+import Foundation
+import MLX
+import MLXNN
+
+public enum MiniMaxH3TurboAdapter {
+    public static let format = "minimax-h3-runtime-lora-v1"
+    public static let expectedPairCount = 259
+    public static let recommendedSchedulePointCount = 5
+
+    enum AdapterError: LocalizedError {
+        case noPairs(URL)
+        case unexpectedPairCount(expected: Int, actual: Int)
+        case missingTargetModule(String)
+        case targetIsNotDenseLinear(String)
+        case duplicateTarget(String)
+        case invalidPairShape(String, a: [Int], b: [Int])
+        case targetShapeMismatch(String, expected: [Int], actual: [Int])
+
+        var errorDescription: String? {
+            switch self {
+            case .noPairs(let url):
+                return "No MiniMax-H3 LoRA tensor pairs were found in \(url.path)."
+            case .unexpectedPairCount(let expected, let actual):
+                return "MiniMax-H3 LoRA tensor-pair count mismatch: expected \(expected), found \(actual)."
+            case .missingTargetModule(let path):
+                return "MiniMax-H3 LoRA target module is missing: \(path)"
+            case .targetIsNotDenseLinear(let path):
+                return "MiniMax-H3 Turbo currently requires the BF16 transformer; target \(path) is not a dense Linear layer."
+            case .duplicateTarget(let path):
+                return "MiniMax-H3 LoRA contains a duplicate target: \(path)"
+            case .invalidPairShape(let path, let a, let b):
+                return "Invalid MiniMax-H3 LoRA pair for \(path): A=\(a), B=\(b)."
+            case .targetShapeMismatch(let path, let expected, let actual):
+                return "MiniMax-H3 LoRA target \(path) has shape \(actual); expected \(expected)."
+            }
+        }
+    }
+
+    @discardableResult
+    static func install(
+        url: URL,
+        into transformer: MiniMaxH3Transformer,
+        strength: Float,
+        expectedPairCount: Int? = expectedPairCount
+    ) throws -> Int {
+        let leafModules = transformer.leafModules().flattened()
+        let modulesByPath = Dictionary(uniqueKeysWithValues: leafModules)
+        var replacements: [String: Module] = [:]
+
+        let pairCount = try SafetensorsStreamingLoader.forEachTensorPair(
+            url: url,
+            firstSuffix: ".lora_A.weight",
+            secondSuffix: ".lora_B.weight"
+        ) { modulePath, rawDown, rawUp in
+            guard replacements[modulePath] == nil else {
+                throw AdapterError.duplicateTarget(modulePath)
+            }
+            guard let module = modulesByPath[modulePath] else {
+                throw AdapterError.missingTargetModule(modulePath)
+            }
+            guard let linear = module as? Linear,
+                  !(linear is QuantizedLinear) else {
+                throw AdapterError.targetIsNotDenseLinear(modulePath)
+            }
+            guard rawDown.ndim == 2,
+                  rawUp.ndim == 2,
+                  rawUp.dim(1) == rawDown.dim(0) else {
+                throw AdapterError.invalidPairShape(
+                    modulePath,
+                    a: rawDown.shape,
+                    b: rawUp.shape
+                )
+            }
+
+            let up = modulePath.hasSuffix(".attn.qkv_proj")
+                ? MiniMaxH3ModelLoader.deinterleavedQKVOutputRows(
+                    rawUp,
+                    headCount: transformer.configuration.attentionHeadCount,
+                    headDimension: transformer.configuration.attentionHeadDimension
+                )
+                : rawUp
+            guard rawDown.dim(1) == linear.shape.1,
+                  up.dim(0) == linear.shape.0 else {
+                throw AdapterError.targetShapeMismatch(
+                    modulePath,
+                    expected: [linear.shape.0, linear.shape.1],
+                    actual: [up.dim(0), rawDown.dim(1)]
+                )
+            }
+
+            let layer = MiniMaxH3RuntimeLoRALinear(
+                base: linear,
+                loraDown: rawDown,
+                loraUp: up,
+                strength: strength
+            )
+            MLX.eval(layer.loraDown, layer.loraUp)
+            replacements[modulePath] = layer
+        }
+
+        guard pairCount > 0 else { throw AdapterError.noPairs(url) }
+        if let expectedPairCount, pairCount != expectedPairCount {
+            throw AdapterError.unexpectedPairCount(expected: expectedPairCount, actual: pairCount)
+        }
+        applyModuleReplacements(replacements, leafModules: leafModules, to: transformer)
+        Memory.clearCache()
+        return pairCount
+    }
+
+    private static func applyModuleReplacements(
+        _ replacements: [String: Module],
+        leafModules: [(String, Module)],
+        to model: Module
+    ) {
+        var arrayUpdates: [String: [(Int, Module)]] = [:]
+        var directUpdates: [(String, Module)] = []
+
+        for (path, replacement) in replacements {
+            let components = path.split(separator: ".")
+            if let last = components.last, let index = Int(last) {
+                let parentPath = components.dropLast().joined(separator: ".")
+                arrayUpdates[parentPath, default: []].append((index, replacement))
+            } else {
+                directUpdates.append((path, replacement))
+            }
+        }
+
+        var moduleUpdates = directUpdates
+        for (parentPath, indexedReplacements) in arrayUpdates {
+            let currentModules = leafModules.filter { path, _ in
+                let parts = path.split(separator: ".")
+                guard parts.count >= 2, Int(parts.last!) != nil else { return false }
+                return parts.dropLast().joined(separator: ".") == parentPath
+            }
+            let replacementMap = Dictionary(uniqueKeysWithValues: indexedReplacements)
+            for (modulePath, originalModule) in currentModules {
+                let index = Int(modulePath.split(separator: ".").last!)!
+                moduleUpdates.append((modulePath, replacementMap[index] ?? originalModule))
+            }
+        }
+        model.update(modules: ModuleChildren.unflattened(moduleUpdates))
+    }
+}
+
+final class MiniMaxH3RuntimeLoRALinear: Linear {
+    @ParameterInfo(key: "lora_down") var loraDown: MLXArray
+    @ParameterInfo(key: "lora_up") var loraUp: MLXArray
+    let strength: Float
+
+    init(base: Linear, loraDown: MLXArray, loraUp: MLXArray, strength: Float) {
+        self._loraDown.wrappedValue = loraDown.asType(base.weight.dtype)
+        self._loraUp.wrappedValue = loraUp.asType(base.weight.dtype)
+        self.strength = strength
+        super.init(weight: base.weight, bias: base.bias)
+    }
+
+    override func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let baseOutput = super.callAsFunction(input)
+        let adapterOutput = MLX.matmul(
+            MLX.matmul(input.asType(loraDown.dtype), loraDown.T),
+            loraUp.T
+        ) * MLXArray(strength).asType(loraDown.dtype)
+        return baseOutput + adapterOutput.asType(baseOutput.dtype)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -30,6 +30,14 @@ the CLI can force either mode. H3 inference also raises MLX wired residency
 through the shared ticket coordinator so weights and activation workspaces do
 not silently fall out of the GPU residency set.
 
+The optional checksum-pinned `minimax-h3-turbo-4step` LoRA runs only with the
+BF16 FL2VA transformer. Its 259 mixed-rank pairs are applied as
+activation-space deltas rather than merged into the base, and its fused QKV
+rows are deinterleaved to match the runtime's global slabs. AdaLN adapter
+deltas are included while the exact four-evaluation schedule cache is built,
+before the large schedule-only weights are discarded. Turbo cannot be
+combined with Ref2VA or tail-residual reuse.
+
 `--h3-acceleration quality` executes every transformer block and preserves the
 native same-seed trajectory. The explicit `balanced` and `maximum` modes trade
 exact trajectory identity for speed: a full step captures the contribution of

--- a/Tests/MereRunCLITests/AdapterCommandTests.swift
+++ b/Tests/MereRunCLITests/AdapterCommandTests.swift
@@ -26,6 +26,14 @@ struct AdapterCommandTests {
         #expect(command.target == ManagedAdapterCatalog.scail2LightX2VFourStepID)
     }
 
+    @Test("MiniMax-H3 Turbo adapter pull parses its canonical id")
+    func parsesMiniMaxH3TurboPull() throws {
+        let command = try AdapterPull.parse([
+            ManagedAdapterCatalog.miniMaxH3TurboFourStepID,
+        ])
+        #expect(command.target == ManagedAdapterCatalog.miniMaxH3TurboFourStepID)
+    }
+
     @Test("Local LoRA paths remain supported")
     func resolvesLocalPath() throws {
         let relative = "fixtures/local-adapter.safetensors"

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -364,6 +364,42 @@ final class VideoCommandTests: XCTestCase {
         ])
     }
 
+    func testVideoGenerateParsesMiniMaxH3TurboAdapter() throws {
+        let command = try VideoGenerate.parse([
+            "a superhero at a bus stop",
+            "--model", ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            "--h3-adapter", ManagedAdapterCatalog.miniMaxH3TurboFourStepID,
+            "--h3-adapter-strength", "0.9",
+        ])
+        XCTAssertEqual(command.h3Adapter, ManagedAdapterCatalog.miniMaxH3TurboFourStepID)
+        XCTAssertEqual(command.h3AdapterStrength, 0.9)
+    }
+
+    func testMiniMaxH3TurboPreflightPreservesAdapterAndFourEvaluations() throws {
+        let missingAdapter = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-h3-turbo-\(UUID().uuidString).safetensors")
+        let command = try VideoGenerate.parse([
+            "a superhero at a bus stop",
+            "--model", ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            "--h3-adapter", missingAdapter.path,
+            "--h3-adapter-strength", "0.9",
+        ])
+        let envelope = command.makePreflightEnvelope(
+            outputURL: makeTempOutput(name: "h3-turbo.mp4"),
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.request.h3Adapter, missingAdapter.path)
+        XCTAssertEqual(envelope.request.h3AdapterStrength, 0.9)
+        XCTAssertEqual(envelope.result.plan.resolvedSteps, 5)
+        XCTAssertEqual(envelope.result.inputs.adapter?.path, missingAdapter.path)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "h3_adapter_missing" })
+        let action = envelope.actions.first { $0.id == "start-video-generation" }
+        XCTAssertTrue(action?.command?.argv.contains("--h3-adapter") == true)
+        XCTAssertTrue(action?.command?.argv.contains(missingAdapter.path) == true)
+    }
+
     func testVideoGenerateSeparatesCheckpointQualityFromOutputMode() throws {
         let finalVideo = try VideoGenerate.parse([
             "a cinematic final shot",

--- a/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
@@ -37,6 +37,22 @@ struct ManagedAdapterCatalogTests {
         #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
     }
 
+    @Test("MiniMax-H3 Turbo release is an immutable BF16 runtime pin")
+    func miniMaxH3TurboReleaseIsPinned() throws {
+        let spec = try #require(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.miniMaxH3TurboFourStepID)
+        )
+        #expect(spec.version == "b604dd5fe25c")
+        #expect(spec.baseModelID == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue)
+        #expect(spec.format == MiniMaxH3TurboAdapter.format)
+        #expect(spec.upstreamRevision == "b604dd5fe25c4c747699f698a1e63f6c46d4a066")
+        #expect(spec.artifact.filename == "minimax_h3_turbo_4step_ema_ckpt850.safetensors")
+        #expect(spec.artifact.byteCount == 779_849_816)
+        #expect(spec.artifact.sha256 == "5a6eeba171cf183020a4ad48774bb2968f29f8168afd6ec17a04987f3528b4ea")
+        #expect(spec.downloadURL.host == "huggingface.co")
+        #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
+    }
+
     @Test("Catalog ids resolve case-insensitively")
     func normalizedLookup() {
         #expect(ManagedAdapterCatalog.spec(for: " MERE-PLATFORM-ASSISTANT ")?.version == "22")

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -4,6 +4,43 @@ import XCTest
 @testable import MereRunCore
 
 final class MiniMaxH3Tests: MereRunCoreTestCase {
+    func testRuntimeLoRAAppliesDeltaInActivationSpace() {
+        let base = Linear(
+            weight: MLXArray([Float(1), 0, 0, 1]).reshaped(2, 2),
+            bias: nil
+        )
+        let layer = MiniMaxH3RuntimeLoRALinear(
+            base: base,
+            loraDown: MLXArray([Float(1), 0]).reshaped(1, 2),
+            loraUp: MLXArray([Float(2), 3]).reshaped(2, 1),
+            strength: 0.5
+        )
+        let output = layer(MLXArray([Float(4), 5]).reshaped(1, 2))
+        MLX.eval(output)
+        XCTAssertEqual(output.asArray(Float.self), [8, 11])
+    }
+
+    func testTurboAdapterUsesFourDenoiseEvaluationsByDefault() throws {
+        let options = try MiniMaxH3GenerationOptions(
+            prompt: "a cinematic local video",
+            width: 256,
+            height: 160,
+            numFrames: 22,
+            adapterURL: URL(fileURLWithPath: "/tmp/minimax-h3-turbo.safetensors")
+        )
+        XCTAssertEqual(options.steps, 5)
+        XCTAssertEqual(options.adapterStrength, 1)
+
+        XCTAssertThrowsError(try MiniMaxH3GenerationOptions(
+            prompt: "invalid compounded acceleration",
+            width: 256,
+            height: 160,
+            numFrames: 22,
+            accelerationMode: .maximum,
+            adapterURL: URL(fileURLWithPath: "/tmp/minimax-h3-turbo.safetensors")
+        ))
+    }
+
     func testTransformerQKVUsesConvertedGlobalSlabs() {
         let projected = MLXArray((0..<12).map(Float.init)).reshaped(1, 1, 12)
         let parts = miniMaxH3SplitProjectedQKV(projected, heads: 2, headDimension: 2)

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -58,6 +58,44 @@ it is not a ten-second runtime claim. The first valid frame count beyond ten
 seconds is 243 frames (10.125 seconds), which requires a separate measured
 receipt.
 
+## Turbo four-evaluation receipt
+
+The optional `minimax-h3-turbo-4step` adapter was validated separately with a
+real release-mode generation rather than extrapolating its tiny-shape smoke
+test:
+
+- checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
+- adapter: checksum-pinned `minimax-h3-turbo-4step`, strength `0.9`
+- geometry: 1280x768, 124 frames, 24 fps
+- schedule: five points / four complete model evaluations
+- seed: `20260804`
+- packed rows: 36,047
+- execution: dense BF16, blockwise compiled, exact `quality` acceleration
+
+| Phase | Time |
+| --- | ---: |
+| Text encoding | 4.066 s |
+| Transformer and adapter preparation | 4.231 s |
+| Denoising | 3,373.421 s (56:13.421) |
+| Video VAE decode | 272.737 s (4:32.737) |
+| Audio decode | 0.987 s |
+| Native generation total | **3,656.608 s (60:56.608)** |
+| Process wall time | **3,659.420 s (60:59.420)** |
+
+The four evaluations measured 842.253, 829.334, 825.381, and 876.346 seconds.
+Peak reported Metal memory was 51.37 GiB, the process reported zero swaps, and
+the final H.264/AAC MP4 contained 124 unique frames with synchronized 32 kHz
+stereo audio. Its SHA-256 is
+`bf651365864295b8de793af7b4311e8b2e84269fd280bda88f4a38068fd19665`.
+
+Visual acceptance confirmed a stable umbrella and caped figure, wet-street
+reflections, a levitating bus, and a luminous dragon developing through the
+shot without the rejected spatial lattice. The final dragon remains slightly
+soft and translucent, so this is a practical four-evaluation receipt rather
+than a claim of parity with the full 19-evaluation trajectory. The prompt
+requested driving rain, so its broadband soundtrack is not a clean-noise or
+hiss acceptance reference.
+
 ## True-768 one-evaluation boundary
 
 A separate release-mode probe locks the physical 768-line target without

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1801,6 +1801,10 @@ Key options:
 - `--seed`
 - `--steps`: MiniMax-H3 schedule-point override or Wan2.2 inference steps
 - `--h3-weight-mode`: `auto`, `quantized`, or `resident-bf16`
+- `--h3-acceleration`: `quality`, `balanced`, or `maximum`
+- `--h3-adapter`: installed MiniMax-H3 adapter catalog id or local safetensors
+  path
+- `--h3-adapter-strength`: MiniMax-H3 runtime adapter multiplier
 - `--guidance-scale`, `--shift`, `--negative-prompt` for Wan2.2
 - `--audio`: source audio path; automatically selects native LTX 2.3 A2Vid
 - `--audio-start-time`: source segment offset in seconds (default `0`)
@@ -1881,6 +1885,14 @@ four cache hits. Both require two complete evaluations before the first reuse
 and keep the schedule boundaries native. They remain approximate: the same
 prompt and seed may follow a different motion or composition trajectory. Use
 `quality` when exact-seed fidelity matters.
+
+`--h3-adapter minimax-h3-turbo-4step` selects the separately pulled Turbo
+LoRA for `video-minimax-h3-fl2va-bf16-mlx`. When `--steps` is omitted it uses
+five schedule points (four transformer evaluations). It runs the LoRA in
+activation space and requires `--h3-acceleration quality`; Ref2VA and the
+compact quantized H3 package are rejected. The preflight report resolves the
+managed adapter path, verifies its presence, and preserves the adapter id,
+strength, and resolved schedule in the declarative action.
 
 Preflight mode:
 
@@ -2178,6 +2190,7 @@ mere.run adapter list
 mere.run adapter list --json
 mere.run adapter pull mere-platform-assistant
 mere.run adapter pull scail2-lightx2v-4step
+mere.run adapter pull minimax-h3-turbo-4step
 ```
 
 The pull verifies the cataloged byte count and SHA-256 before atomically
@@ -2186,6 +2199,8 @@ verification diagnostics go to stderr. Use the adapter id directly with
 `text chat --lora`, `api serve --lora`, or the matching SCAIL
 `video animate --distilled-adapter` option. `video animate --profile fast`
 selects `scail2-lightx2v-4step` and its fixed four-step schedule.
+Use `minimax-h3-turbo-4step` with `video generate --h3-adapter`; its BF16
+FL2VA base remains subject to the MiniMax-H3 Community License acceptance.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 sections below are the command reference for each benchmark lane.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -845,6 +845,18 @@ performed only where the model terms permit it. The upstream FL2VA and Ref2VA
 trees are about 144 GB each; the complete upstream repository is roughly
 498 GB, so compile success is not artifact or generation proof.
 
+The optional `minimax-h3-turbo-4step` runtime adapter is the EMA checkpoint
+`minimax_h3_turbo_4step_ema_ckpt850.safetensors` from
+`larryvrh/MiniMax-H3-Turbo-Lora`, pinned at immutable commit
+`b604dd5fe25c4c747699f698a1e63f6c46d4a066`. The catalog verifies its exact
+779,849,816-byte length and SHA-256
+`5a6eeba171cf183020a4ad48774bb2968f29f8168afd6ec17a04987f3528b4ea`.
+The adapter card declares Apache-2.0, but using it does not replace or relax
+the MiniMax-H3 Community License governing the required BF16 base model.
+The runtime remaps the adapter's fused QKV output rows into the same global
+Q/K/V slab order as the converted base and applies all 259 LoRA pairs as live
+activation deltas, including the schedule-only AdaLN projections.
+
 ### `video-wan22-ti2v-5b-mlx`
 
 The native Wan2.2 TI2V-5B model root is:

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -106,6 +106,14 @@ mere.run video generate "a cinematic rain-soaked bus stop at night" \
   --width 1280 --height 768 --duration 10 --steps 20 \
   --output ./bus-stop-bf16.mp4
 
+# Optional four-evaluation Turbo lane for the BF16 FL2VA model
+mere.run adapter pull minimax-h3-turbo-4step
+mere.run video generate "a superhero waits beneath an umbrella at a bus stop" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --h3-adapter minimax-h3-turbo-4step \
+  --h3-adapter-strength 0.9 \
+  --output ./bus-stop-turbo.mp4
+
 mere.run video generate "preserve the person and use the reference motion" \
   --model-root ./MiniMax-H3-Ref2VA-MLX \
   --reference image:./person.png \
@@ -120,6 +128,16 @@ Kingdom, and Republic of Korea. Read and accept the model terms before pulling,
 converting, using, or redistributing any artifact. Passing
 `--accept-model-license` and continuing with the download confirms that you
 accept those terms and agree to comply with them.
+
+The optional `minimax-h3-turbo-4step` adapter is checksum-pinned separately
+and applied in activation space so its small BF16 deltas are not rounded into
+the base transformer. It defaults to five schedule points, which are four
+model evaluations. The current adapter was trained for FL2VA, requires the
+BF16 base model, and cannot be combined with Ref2VA references or H3
+tail-residual reuse. Omit `--steps` (or set it to `5`) and keep
+`--h3-acceleration quality`. Strengths around `0.8` to `0.95` can soften the
+preview adapter's oversharp or plastic artifacts; `1.0` applies the released
+weights exactly.
 
 The managed package already includes the inference-only AdaLN cache computed
 from the official BF16/F32 projections; no post-pull optimization step is


### PR DESCRIPTION
## Summary

- add the immutable, checksum-pinned `minimax-h3-turbo-4step` managed adapter
- apply all 259 mixed-rank LoRA pairs natively in activation space, including fused-QKV row remapping and schedule-cached AdaLN deltas
- expose `video generate --h3-adapter` and `--h3-adapter-strength` with truthful preflight resolution
- default the adapter to five schedule points / four transformer evaluations
- reject incompatible compact, Ref2VA, step-count, and tail-reuse combinations before loading MLX
- document the source, license boundary, CLI workflow, runtime constraints, and real M4 Max artifact receipt

The adapter card declares Apache-2.0. It does not replace or relax the MiniMax-H3 Community License governing the required BF16 FL2VA base model.

## Managed artifact

- source: `larryvrh/MiniMax-H3-Turbo-Lora`
- immutable revision: `b604dd5fe25c4c747699f698a1e63f6c46d4a066`
- file: `minimax_h3_turbo_4step_ema_ckpt850.safetensors`
- bytes: `779849816`
- SHA-256: `5a6eeba171cf183020a4ad48774bb2968f29f8168afd6ec17a04987f3528b4ea`

The real pull path was exercised with:

```bash
mere.run adapter pull minimax-h3-turbo-4step
```

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 0 violations
  - build and CLI help sweep: passed
  - XCTest: 2,538 tests, 166 expected fixture skips, 0 failures
  - Swift Testing suites: passed
  - hygiene scans: passed
- focused H3/catalog/adapter/video tests: 85 XCTest tests plus 12 Swift Testing tests, 0 failures
- `pnpm docs:build`: passed
- `git diff --check`: passed

## Real local generation receipt

Release-mode native generation on the M4 Max used the managed BF16 FL2VA base, adapter strength `0.9`, exact `quality` execution, seed `20260804`, 1280x768, 124 frames at 24 fps, and four complete transformer evaluations.

| Phase | Time |
| --- | ---: |
| Text encoding | 4.066 s |
| Transformer and adapter preparation | 4.231 s |
| Denoising | 3,373.421 s (56:13.421) |
| Video VAE decode | 272.737 s (4:32.737) |
| Audio decode | 0.987 s |
| Native generation total | 3,656.608 s (60:56.608) |
| Process wall time | **3,659.420 s (60:59.420)** |

Evaluation times were 842.253, 829.334, 825.381, and 876.346 seconds. Peak reported Metal memory was 51.37 GiB and the process reported zero swaps.

The resulting H.264/AAC MP4 contains all 124 unique frames and synchronized 32 kHz stereo audio. SHA-256: `bf651365864295b8de793af7b4311e8b2e84269fd280bda88f4a38068fd19665`.

Visual review confirmed a stable umbrella and caped figure, wet-street reflections, a levitating bus, and a luminous dragon without the rejected spatial lattice. The final dragon remains slightly soft/translucent. Generated MP4 and PNG review artifacts are intentionally not committed.
