### PR TITLE
Release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.35.1 - 2026-08-06
+
+This patch release adds a checksum-pinned four-step MiniMax-H3 Turbo path,
+promotes an exact Laguna XS 2.1 prefill optimization, and completes the Linux
+CUDA runtime-JIT dependency closure. The H3 adapter is first-class in the CLI
+and uses the same managed-model, license, preflight, receipt, and native MLX
+runtime contracts as the base BF16 model.
+
+### Video
+
 - added the immutable, checksum-pinned `minimax-h3-turbo-4step` managed
   adapter and first-class `video generate --h3-adapter` controls for the BF16
   FL2VA model. The native MLX runtime applies all 259 mixed-rank LoRA pairs in
@@ -17,13 +27,19 @@ The format is based on Keep a Changelog.
   with 56:13.421 of denoising, 51.37 GiB peak reported Metal memory, zero
   swaps, and no spatial lattice in the accepted output.
 
-## 0.35.0 - 2026-08-06
+### Text performance
 
-This release makes MiniMax-H3 materially faster and more faithful on Apple
-Silicon, adds native LFM2.5 text inference and TerraMind flood mapping, restores
-ACE-Step planner parity, and hardens the documentation supply chain. Creative
-capabilities retain first-class CLI and macOS Studio controls; the specialized
-TerraMind tensor workflow is intentionally CLI-only in this release.
+- certified the loaded Laguna XS 2.1 routed gate/up NVFP4 group-16 scale
+  planes at initialization and specialized the existing sorted prefill Metal
+  kernel so adjacent SIMD lanes can reuse a certified-identical scale byte.
+  The path preserves the quantizer's allowed first-pair exception, exact
+  dequantization and MMA ordering, retains only a Boolean certificate, and
+  fails closed to the stock MLX loader with
+  `MERERUN_LAGUNA_PREFILL_EXPERT_PAIRWISE_SCALES=0` as an operator kill switch.
+  All 39 sparse layers in the installed Poolside Laguna XS 2.1 checkpoint
+  passed the certificate; forced release inference loaded all five shards and
+  completed deterministically. The paired M5 Max promotion checked all 1,344
+  tokens with `max_abs_diff=0` at score `2.5901857153934094`.
 
 ### Linux packaging
 
@@ -31,6 +47,14 @@ TerraMind tensor workflow is intentionally CLI-only in this release.
   Debian dependencies. MLX compiles specialized kernels with NVRTC during
   inference, so clean runtime installs now include headers such as
   `cuda_bf16.h` instead of failing when the first GPU kernel is compiled.
+
+## 0.35.0 - 2026-08-06
+
+This release makes MiniMax-H3 materially faster and more faithful on Apple
+Silicon, adds native LFM2.5 text inference and TerraMind flood mapping, restores
+ACE-Step planner parity, and hardens the documentation supply chain. Creative
+capabilities retain first-class CLI and macOS Studio controls; the specialized
+TerraMind tensor workflow is intentionally CLI-only in this release.
 
 ### Geospatial inference
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.35.0"
+    static let current = "0.35.1"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -106,7 +106,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.35.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.35.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.35.0"
+default_version="0.35.1"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- release MiniMax-H3 Turbo as a checksum-pinned, managed four-step LoRA path with first-class CLI adapter controls and native MLX application of all 259 LoRA pairs
- release the exact Laguna XS 2.1 routed-prefill scale-reuse optimization with checkpoint certification, fail-closed fallback, and operator kill switch
- release the Linux CUDA runtime-JIT development-header dependency closure
- bump CLI, app fallback, tests, and changelog to 0.35.1 without moving the already-published v0.35.0 tag

## Runtime evidence

- accepted MiniMax-H3 Turbo render: 1280x768, 5.167 seconds, 124 unique frames, four denoise steps, 60:59.420 wall time, 51.37 GiB peak Metal memory, zero swaps, no spatial lattice
- Laguna promotion: all 39 sparse layers certified; five shards loaded; deterministic forced release inference; 1,344-token paired M5 Max check with `max_abs_diff=0`
- CUDA PR matrix passed macOS, Linux CLI, compatibility/docs, dependency review, and secret scan before merge

## Validation

- `./scripts/check.sh` — pass; 2,540 XCTest cases, 167 expected checkpoint or hardware skips, 0 failures; 23 Swift Testing cases passed
- `pnpm install --frozen-lockfile && pnpm docs:build` — pass
- `actionlint .github/workflows/*.yml` — pass
- `swift build -c release --product mere.run` — pass
- `.build/release/mere.run --version` — `0.35.1`
- `git diff --check` — pass

Signed packaging, notarization, installed-artifact smoke, Linux release assets, checksums, and upload run from the immutable v0.35.1 tag after this PR merges.