### PR TITLE
Optimize Laguna routed down prefill scale reuse

### DIFF
--- a/Sources/MereRunCore/Laguna/LagunaModel.swift
+++ b/Sources/MereRunCore/Laguna/LagunaModel.swift
@@ -1009,6 +1009,7 @@ final class LagunaSwitchGLU: Module {
     @ModuleInfo(key: "down_proj") var downProj: LagunaSwitchLinear
     private let decodeNVFP4RowsPerSIMDGroup: Int
     private(set) var prefillPairwiseScaleReuseCertified = false
+    private(set) var prefillDownPairwiseScaleReuseCertified = false
 
     init(config: LagunaConfig) {
         self.decodeNVFP4RowsPerSIMDGroup =
@@ -1148,7 +1149,8 @@ final class LagunaSwitchGLU: Module {
                scales: downScales,
                sortedExpertIndices: sortedIndices,
                groupSize: downProj.groupSize,
-               bits: downProj.bits
+               bits: downProj.bits,
+               pairwiseScaleReuse: prefillDownPairwiseScaleReuseCertified
            ) {
             sortedOutput = fusedDown
         } else {
@@ -1260,34 +1262,46 @@ final class LagunaSwitchGLU: Module {
             scales: scales,
             sortedExpertIndices: indices,
             groupSize: downProj.groupSize,
-            bits: downProj.bits
+            bits: downProj.bits,
+            pairwiseScaleReuse: prefillDownPairwiseScaleReuseCertified
         )
     }
 
-    /// Certifies the loaded routed gate/up scale planes once, before warmup.
-    /// The result is retained as a Boolean only; unlike the challenge runtime's
-    /// packed decode-bank reuse, production needs no additional scale storage.
+    /// Certifies the loaded routed scale planes once, before warmup. The
+    /// results are retained as Booleans only; unlike the challenge runtime's
+    /// packed banks, production needs no additional scale storage.
     func preparePrefillPairwiseScaleReuse() {
         prefillPairwiseScaleReuseCertified = false
-        guard LagunaMoEAccelerationPolicy.prefillExpertPairwiseScaleReuseEnabled,
-              gateProj.mode == .nvfp4,
-              upProj.mode == .nvfp4,
-              gateProj.groupSize == 16,
-              upProj.groupSize == 16,
-              gateProj.bits == 4,
-              upProj.bits == 4,
-              gateProj.biases == nil,
-              upProj.biases == nil,
-              let gateScales = gateProj.scales,
-              let upScales = upProj.scales,
-              gateScales.dtype == .uint8,
-              upScales.dtype == .uint8,
-              gateScales.shape == upScales.shape else {
+        prefillDownPairwiseScaleReuseCertified = false
+        guard LagunaMoEAccelerationPolicy.prefillExpertPairwiseScaleReuseEnabled else {
             return
         }
-        prefillPairwiseScaleReuseCertified =
-            lagunaNVFP4AdjacentScalePairsCertified(gateScales)
-            && lagunaNVFP4AdjacentScalePairsCertified(upScales)
+        if gateProj.mode == .nvfp4,
+           upProj.mode == .nvfp4,
+           gateProj.groupSize == 16,
+           upProj.groupSize == 16,
+           gateProj.bits == 4,
+           upProj.bits == 4,
+           gateProj.biases == nil,
+           upProj.biases == nil,
+           let gateScales = gateProj.scales,
+           let upScales = upProj.scales,
+           gateScales.dtype == .uint8,
+           upScales.dtype == .uint8,
+           gateScales.shape == upScales.shape {
+            prefillPairwiseScaleReuseCertified =
+                lagunaNVFP4AdjacentScalePairsCertified(gateScales)
+                && lagunaNVFP4AdjacentScalePairsCertified(upScales)
+        }
+        if downProj.mode == .nvfp4,
+           downProj.groupSize == 16,
+           downProj.bits == 4,
+           downProj.biases == nil,
+           let downScales = downProj.scales,
+           downScales.dtype == .uint8 {
+            prefillDownPairwiseScaleReuseCertified =
+                lagunaNVFP4AdjacentScalePairsCertified(downScales)
+        }
     }
 }
 
@@ -2132,11 +2146,13 @@ final class LagunaLanguageModel: Module {
     }
 
     func prepareRuntimeAcceleration() -> [MLXArray] {
-        var arrays = preparePrefillAcceleration()
         for layer in layers {
             if let sparse = layer.mlp as? LagunaSparseMoE {
                 sparse.preparePrefillPairwiseScaleReuse()
             }
+        }
+        var arrays = preparePrefillAcceleration()
+        for layer in layers {
             arrays.append(contentsOf: layer.selfAttention.prepareNativeAffineQKV())
             arrays.append(
                 contentsOf: layer.selfAttention.prepareTerminalPrefillProjectionWeights()

--- a/Sources/MereRunCore/Quantization/RoutedMoERouting.swift
+++ b/Sources/MereRunCore/Quantization/RoutedMoERouting.swift
@@ -353,7 +353,8 @@ enum RoutedMoERouting {
         scales: MLXArray,
         sortedExpertIndices: MLXArray,
         groupSize: Int,
-        bits: Int
+        bits: Int,
+        pairwiseScaleReuse: Bool = false
     ) -> MLXArray? {
         #if os(macOS)
         guard supportsExpertAlignedNVFP4Metal,
@@ -424,6 +425,7 @@ enum RoutedMoERouting {
                 ("DataT", sortedInput.dtype),
                 ("OUTPUT_DIMENSIONS", outputDimensions),
                 ("INPUT_DIMENSIONS", inputDimensions),
+                ("PAIRWISE_SCALE_REUSE", pairwiseScaleReuse),
             ],
             grid: ((outputDimensions / 32) * 32, maximumRouteTiles * 2, 1),
             threadGroup: (32, 2, 1),
@@ -644,9 +646,10 @@ enum RoutedMoERouting {
         ensureRowContiguous: true
     )
 
-    /// Drop-in replacement for MLX's `QuantizedBlockLoader` at the one exact
-    /// Laguna prefill geometry. Two adjacent SIMD lanes own the two group-16
-    /// halves of one 32-weight span. Once the loaded scale planes have passed
+    /// Drop-in replacement for MLX's `QuantizedBlockLoader` at the exact tiled
+    /// geometry shared by Laguna's routed gate, up, and down prefill kernels.
+    /// Two adjacent SIMD lanes own the two group-16 halves of one 32-weight
+    /// span. Once a loaded scale plane has passed
     /// `lagunaNVFP4AdjacentScalePairsCertified`, the even lane loads their
     /// shared uint8 scale and broadcasts it to the odd lane. The first logical
     /// pair of every output tile is conservatively read by both lanes, which
@@ -717,24 +720,26 @@ enum RoutedMoERouting {
 
             void load_unsafe() const {
                 const bool even_group = (thread_idx & 1) == 0;
-                uint scale_bits = 0;
+                float scale = 0.0f;
                 if (even_group) {
-                    scale_bits = uint(*scales);
+                    scale = fp4nv_scale_x16384(*scales);
                 }
-                const uint paired_scale =
-                    simd_shuffle_xor(scale_bits, ushort(1));
+                const float paired_scale =
+                    simd_shuffle_xor(scale, ushort(1));
                 if (!even_group) {
-                    scale_bits = paired_scale;
+                    scale = paired_scale;
                 }
                 // Preserve the odd byte of the first logical pair. Doing this
                 // for every output tile is conservative and makes the loader
                 // exact without specializing on an expert/tile coordinate.
                 if (first_k && bi == 0 && !even_group) {
-                    scale_bits = uint(*scales);
+                    scale = fp4nv_scale_x16384(*scales);
                 }
 
-                const float scale =
-                    fp4nv_scale_x16384(uint8_t(scale_bits));
+                // The normal odd lane reuses the same converted float bits as
+                // the even lane instead of converting their certified-alias
+                // byte again. This is the production form of the officially
+                // promoted M5 prefill scale-conversion hoist.
                 for (int i = 0; i < n_reads / 4; ++i) {
                     T values[8];
                     fp4nv_decode8<T>(
@@ -996,15 +1001,26 @@ enum RoutedMoERouting {
                 BK_PADDED,
                 1,
                 WM * WN * SIMD_SIZE>;
-            using weight_loader_t = QuantizedBlockLoader<
-                DataT,
-                BN,
-                BK,
-                BK_PADDED,
-                true,
-                WM * WN * SIMD_SIZE,
-                GROUP_SIZE,
-                BITS>;
+            using weight_loader_t = metal::conditional_t<
+                PAIRWISE_SCALE_REUSE,
+                MereLagunaPairwiseNVFP4BlockLoader<
+                    DataT,
+                    BN,
+                    BK,
+                    BK_PADDED,
+                    true,
+                    WM * WN * SIMD_SIZE,
+                    GROUP_SIZE,
+                    BITS>,
+                QuantizedBlockLoader<
+                    DataT,
+                    BN,
+                    BK,
+                    BK_PADDED,
+                    true,
+                    WM * WN * SIMD_SIZE,
+                    GROUP_SIZE,
+                    BITS>>;
 
             threadgroup DataT input_tile[BM * BK_PADDED];
             threadgroup DataT weight_tile[BN * BK_PADDED];
@@ -1074,7 +1090,7 @@ enum RoutedMoERouting {
                     short2(BN, tile_rows));
             }
         """,
-        header: "// MLX_INCLUDE_FP_QUANTIZED_HEADERS\n",
+        header: pairwiseNVFP4BlockLoaderHeader,
         ensureRowContiguous: true
     )
 

--- a/Tests/MereRunCoreTests/LagunaModelTests.swift
+++ b/Tests/MereRunCoreTests/LagunaModelTests.swift
@@ -1634,6 +1634,21 @@ final class LagunaModelTests: MereRunCoreTestCase {
             bits: bits,
             mode: .nvfp4
         )
+        MLX.eval(projection.wq, projection.scales)
+        var scaleValues = projection.scales.asArray(UInt8.self)
+        for index in stride(from: 0, to: scaleValues.count, by: 2) {
+            scaleValues[index + 1] = scaleValues[index]
+        }
+        let first = scaleValues[0]
+        let replacement = try XCTUnwrap(
+            scaleValues.dropFirst(2).first(where: { $0 != first })
+        )
+        scaleValues[1] = replacement
+        let pairwiseScales = MLXArray(scaleValues)
+            .reshaped(projection.scales.shape)
+        XCTAssertTrue(
+            lagunaNVFP4AdjacentScalePairsCertified(pairwiseScales)
+        )
         for routeCount in [64, 512, 1_024] {
             let input = MLXRandom.uniform(
                 low: -0.5,
@@ -1649,7 +1664,7 @@ final class LagunaModelTests: MereRunCoreTestCase {
             let reference = portableGatherQuantizedMM(
                 input,
                 projection.wq,
-                scales: projection.scales,
+                scales: pairwiseScales,
                 biases: projection.biases,
                 rhsIndices: indices,
                 transpose: true,
@@ -1658,21 +1673,38 @@ final class LagunaModelTests: MereRunCoreTestCase {
                 mode: .nvfp4,
                 sortedIndices: true
             )
-            let actual = try XCTUnwrap(RoutedMoERouting.sortedNVFP4Projection(
+            let stock = try XCTUnwrap(RoutedMoERouting.sortedNVFP4Projection(
                 input,
                 weight: projection.wq,
-                scales: projection.scales,
+                scales: pairwiseScales,
                 sortedExpertIndices: indices,
                 groupSize: groupSize,
-                bits: bits
+                bits: bits,
+                pairwiseScaleReuse: false
             ))
-            MLX.eval(reference, actual)
+            let pairwise = try XCTUnwrap(
+                RoutedMoERouting.sortedNVFP4Projection(
+                    input,
+                    weight: projection.wq,
+                    scales: pairwiseScales,
+                    sortedExpertIndices: indices,
+                    groupSize: groupSize,
+                    bits: bits,
+                    pairwiseScaleReuse: true
+                )
+            )
+            MLX.eval(reference, stock, pairwise)
 
-            XCTAssertEqual(actual.shape, reference.shape)
-            let maximumDifference = MLX.max(
-                MLX.abs(reference.asType(.float32) - actual.asType(.float32))
+            XCTAssertEqual(stock.shape, reference.shape)
+            XCTAssertEqual(pairwise.shape, reference.shape)
+            let stockDifference = MLX.max(
+                MLX.abs(reference.asType(.float32) - stock.asType(.float32))
             ).item(Float.self)
-            XCTAssertEqual(maximumDifference, 0, "routeCount=\(routeCount)")
+            let pairwiseDifference = MLX.max(
+                MLX.abs(stock.asType(.float32) - pairwise.asType(.float32))
+            ).item(Float.self)
+            XCTAssertEqual(stockDifference, 0, "routeCount=\(routeCount)")
+            XCTAssertEqual(pairwiseDifference, 0, "routeCount=\(routeCount)")
         }
     }
 
@@ -2254,6 +2286,13 @@ final class LagunaModelTests: MereRunCoreTestCase {
                 }.count,
                 sparseLayers.count,
                 "Every loaded routed gate/up scale plane must pass the lossless pair certificate."
+            )
+            XCTAssertEqual(
+                sparseLayers.filter {
+                    $0.switchMLP.prefillDownPairwiseScaleReuseCertified
+                }.count,
+                sparseLayers.count,
+                "Every loaded routed down scale plane must pass the lossless pair certificate."
             )
         }
 


### PR DESCRIPTION
## Outcome

Ports the latest officially confirmed MLX Fast Laguna XS 2.1 prefill win into the production runtime without touching public behavior or changing model numerics.

The official paired M5 Max submission f2b7ccc promoted at score 2.5978748179058484 with 1,344/1,344 exact tokens and max_abs_diff 0. Its narrow new mechanism hoisted repeated conversion of certified-alias NVFP4 pair scales. The routed-down pairwise layout underneath it had also passed five exact official M5 runs.

## Production adaptation

- Certifies loaded routed down-projection scale planes independently from gate/up and fails closed to the stock loader.
- Selects the pairwise loader for the existing expert-aligned down prefill kernel only after that certificate passes.
- Hoists E4M3-to-float conversion across each certified adjacent pair and reuses the same float bits.
- Preserves the first-pair quantizer exception by loading and converting the odd scale independently.
- Runs all certificates before kernel warmup so the true specialization is compiled before the first request.
- Keeps the existing MERERUN_LAGUNA_PREFILL_EXPERT_PAIRWISE_SCALES kill switch; false still instantiates the original MLX QuantizedBlockLoader.
- Adds no retained runtime buffer and changes no CLI or public API.

## Exactness

The fast path only activates after an input-independent certificate proves adjacent authoritative uint8 scale codes are equal apart from the explicitly preserved exception. Equal E4M3 codes produce the same float bits through the same conversion function. Weight codes, routes, tensor instructions, accumulation order, BF16 stores, and output ordering are unchanged.

## Verification

- M4 Max Metal parity, gate/up pairwise versus stock: passed with zero difference.
- M4 Max Metal parity, down pairwise versus stock and portable reference across route counts 64, 512, and 1,024: passed with zero difference.
- swiftlint --strict: 0 violations across 1,147 files.
- Full repository gate: 2,540 XCTest cases, 167 asset-dependent skips, 0 failures; 23 Swift Testing cases passed.
- Release build: passed.
- git diff --check: passed.

No local performance number is claimed; the official M5 result is the performance authority. This worktree was isolated from the dirty main checkout.