### PR TITLE
Add SAM 3.1 workflow graph nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,10 @@ artifact contracts instead of becoming a model-specific sidecar.
 - added model-aware `vision ground --preflight --json` and workflow-safe
   `--quiet` behavior so agents and graph runners can validate placement,
   inputs, and artifact paths without loading the model or parsing diagnostics.
+- added `vision.segment` and `vision.track` as portable SAM 3.1 graph nodes with
+  graph-safe preflight, quiet execution, structured JSON, annotated media, and
+  durable per-object or per-frame PNG mask directories. SAM outputs remain
+  candidate geometry until a downstream mission workflow accepts them.
 - preserved TIFF provider outputs as portable `.tif` artifacts with
   `image/tiff` metadata throughout workflow materialization, run bundles, and
   fetched results instead of degrading geospatial rasters to generic binary

--- a/Sources/MereRunCLI/Commands/GraphCommand.swift
+++ b/Sources/MereRunCLI/Commands/GraphCommand.swift
@@ -940,25 +940,35 @@ struct WorkflowGraphRequirements: Equatable {
     let networkAccess: Bool
 
     static func resolve(graph: WorkflowGraphDocument, inputs: WorkflowInputsDocument) -> WorkflowGraphRequirements {
-        var modelIDs = graph.nodes.compactMap { node -> String? in
+        let modelIDs = graph.nodes.flatMap { node -> [String] in
+            let selectedModelID: String?
             if let model = node.arguments["model"] {
-                if case .string(let value) = model { return value }
-                if case .reference(let rawReference) = model,
-                   let reference = try? WorkflowReference(rawReference),
-                   case .input(let name) = reference.source {
-                    return (inputs.values[name] ?? graph.inputs[name]?.defaultValue)?.stringValue
+                if case .string(let value) = model {
+                    selectedModelID = value
+                } else if case .reference(let rawReference) = model,
+                          let reference = try? WorkflowReference(rawReference),
+                          case .input(let name) = reference.source {
+                    selectedModelID = (inputs.values[name] ?? graph.inputs[name]?.defaultValue)?.stringValue
+                } else {
+                    selectedModelID = nil
                 }
+            } else {
+                selectedModelID = nil
             }
+            let defaultModelID: String?
             switch node.kind {
-            case "image.train-lora": return ImageTrainLoRA.defaultManagedModelID.rawValue
-            case "image.generate": return ImageGenerate.defaultManagedModelID.rawValue
-            case "vision.ground": return VisionGround.defaultManagedModelID.rawValue
-            case "video.generate": return ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
-            default: return nil
+            case "image.train-lora": defaultModelID = ImageTrainLoRA.defaultManagedModelID.rawValue
+            case "image.generate": defaultModelID = ImageGenerate.defaultManagedModelID.rawValue
+            case "vision.ground": defaultModelID = VisionGround.defaultManagedModelID.rawValue
+            case "vision.segment", "vision.track": defaultModelID = VisionSegment.defaultManagedModelID.rawValue
+            case "video.generate": defaultModelID = ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
+            default: defaultModelID = nil
             }
-        }
-        for node in graph.nodes {
-            modelIDs.append(contentsOf: WorkflowNodeRegistry.entry(for: node)?.requirements.modelIDs ?? [])
+            return resolveModelIDs(
+                selectedModelID: selectedModelID,
+                registryModelIDs: WorkflowNodeRegistry.entry(for: node)?.requirements.modelIDs ?? [],
+                defaultModelID: defaultModelID
+            )
         }
         var acceleratorBackends = Set(["cpu", "metal", "cuda", "rocm"])
         var minimumAcceleratorMemoryBytes: Int64?
@@ -1001,6 +1011,16 @@ struct WorkflowGraphRequirements: Equatable {
             minimumCPUCores: minimumCPUCores,
             networkAccess: networkAccess
         )
+    }
+
+    static func resolveModelIDs(
+        selectedModelID: String?,
+        registryModelIDs: [String],
+        defaultModelID: String?
+    ) -> [String] {
+        if let selectedModelID { return [selectedModelID] }
+        if !registryModelIDs.isEmpty { return registryModelIDs }
+        return defaultModelID.map { [$0] } ?? []
     }
 }
 

--- a/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
@@ -67,7 +67,22 @@ struct VisionSegment: AsyncParsableCommand {
     @Flag(name: [.long], help: "For geometry prompts, emit multiple mask candidates per prompted object.")
     var multimask: Bool = false
 
+    @Flag(name: [.customLong("preflight")], help: "Inspect the segmentation request without loading SAM or processing the image.")
+    var preflight: Bool = false
+
+    @Flag(name: [.customLong("json")], help: "With --preflight, emit a structured JSON report.")
+    var json: Bool = false
+
+    @Flag(name: [.customShort("q"), .long], help: "Suppress normal progress output.")
+    var quiet: Bool = false
+
     func validate() throws {
+        if json && !preflight {
+            throw ValidationError("--json is only supported with --preflight for vision segment.")
+        }
+        if preflight {
+            return
+        }
         guard !prompt.isEmpty || !box.isEmpty || !point.isEmpty else {
             throw ValidationError("Provide at least one --prompt, --box, or --point value.")
         }
@@ -81,18 +96,28 @@ struct VisionSegment: AsyncParsableCommand {
     }
 
     func run() async throws {
-        try MLXBundleSupport.ensureAvailable(quiet: false)
+        let imageURL = URL(fileURLWithPath: image).standardizedFileURL
+        let outputImageURL = Self.resolveAnnotatedOutputURL(output, inputImageURL: imageURL)
+        let outputJSONURL = Self.resolveJSONOutputURL(jsonOutput, inputImageURL: imageURL)
+        let maskOutputDirectoryURL = Self.resolveDirectoryURL(maskOutputDir)
+        if preflight {
+            try runPreflight(
+                imageURL: imageURL,
+                outputImageURL: outputImageURL,
+                outputJSONURL: outputJSONURL,
+                maskOutputDirectoryURL: maskOutputDirectoryURL
+            )
+            return
+        }
+
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
         let fileManager = FileManager.default
-        let imageURL = URL(fileURLWithPath: image).standardizedFileURL
         guard fileManager.fileExists(atPath: imageURL.path) else {
             throw ValidationError("Image not found: \(imageURL.path)")
         }
 
         let resolvedModel = try Self.resolveModelRoot(model, fileManager: fileManager)
-        let outputImageURL = Self.resolveAnnotatedOutputURL(output, inputImageURL: imageURL)
-        let outputJSONURL = Self.resolveJSONOutputURL(jsonOutput, inputImageURL: imageURL)
-        let maskOutputDirectoryURL = Self.resolveDirectoryURL(maskOutputDir)
         let promptSet = try parsedPromptSet()
 
         let segmenter = try SAM31ImageSegmenter(
@@ -112,13 +137,111 @@ struct VisionSegment: AsyncParsableCommand {
             maskOutputDirectoryURL: maskOutputDirectoryURL
         )
 
-        print("Model: \(result.modelID)")
-        print("Detections: \(result.detections.count)")
-        print("Image: \(result.annotatedImageURL.path)")
-        print("JSON: \(result.jsonOutputURL.path)")
-        if let maskOutputDirectoryURL {
-            print("Masks: \(maskOutputDirectoryURL.path)")
+        if !quiet {
+            print("Model: \(result.modelID)")
+            print("Detections: \(result.detections.count)")
+            print("Image: \(result.annotatedImageURL.path)")
+            print("JSON: \(result.jsonOutputURL.path)")
+            if let maskOutputDirectoryURL {
+                print("Masks: \(maskOutputDirectoryURL.path)")
+            }
         }
+    }
+
+    func makePreflightEnvelope(
+        imageURL: URL,
+        outputImageURL: URL,
+        outputJSONURL: URL,
+        maskOutputDirectoryURL: URL?,
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init
+    ) -> VisionSegmentPreflightEnvelope {
+        let input = VisionSegmentPreflightInput(
+            imageURL: imageURL,
+            outputImageURL: outputImageURL,
+            outputJSONURL: outputJSONURL,
+            maskOutputDirectoryURL: maskOutputDirectoryURL,
+            prompt: prompt,
+            box: box,
+            point: point,
+            model: model,
+            threshold: threshold,
+            resolution: resolution,
+            showBoxes: showBoxes,
+            multimask: multimask,
+            segmentArgv: segmentActionArguments(
+                imageURL: imageURL,
+                outputImageURL: outputImageURL,
+                outputJSONURL: outputJSONURL,
+                maskOutputDirectoryURL: maskOutputDirectoryURL
+            ),
+            cwd: fileManager.currentDirectoryPath
+        )
+        return VisionSegmentPreflightAnalyzer(
+            input: input,
+            fileManager: fileManager,
+            now: now
+        ).envelope()
+    }
+
+    private func runPreflight(
+        imageURL: URL,
+        outputImageURL: URL,
+        outputJSONURL: URL,
+        maskOutputDirectoryURL: URL?
+    ) throws {
+        let envelope = makePreflightEnvelope(
+            imageURL: imageURL,
+            outputImageURL: outputImageURL,
+            outputJSONURL: outputJSONURL,
+            maskOutputDirectoryURL: maskOutputDirectoryURL
+        )
+        if json {
+            print(try StructuredRunOutput.encode(envelope))
+        } else {
+            print(envelope.summary)
+            for diagnostic in envelope.diagnostics {
+                print("[\(diagnostic.severity.rawValue)] \(diagnostic.title): \(diagnostic.message)")
+            }
+        }
+        if envelope.status == .blocked {
+            throw ExitCode.failure
+        }
+    }
+
+    private func segmentActionArguments(
+        imageURL: URL,
+        outputImageURL: URL,
+        outputJSONURL: URL,
+        maskOutputDirectoryURL: URL?
+    ) -> [String] {
+        var args = ["mere.run", "vision", "segment", imageURL.path]
+        if !prompt.isEmpty {
+            args.append("--prompt")
+            args.append(contentsOf: prompt)
+        }
+        for boxPrompt in box {
+            args += ["--box", boxPrompt]
+        }
+        for pointPrompt in point {
+            args += ["--point", pointPrompt]
+        }
+        if let model {
+            args += ["--model", model]
+        }
+        args += ["--output", outputImageURL.path]
+        args += ["--json-output", outputJSONURL.path]
+        if let maskOutputDirectoryURL {
+            args += ["--mask-output-dir", maskOutputDirectoryURL.path]
+        }
+        args += ["--threshold", String(threshold), "--resolution", String(resolution)]
+        if showBoxes {
+            args.append("--show-boxes")
+        }
+        if multimask {
+            args.append("--multimask")
+        }
+        return args
     }
 
     static func resolveModelRoot(

--- a/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
@@ -60,6 +60,9 @@ struct VisionTrack: AsyncParsableCommand {
     @Flag(name: [.customLong("json")], help: "With --preflight, emit a structured JSON report.")
     var json: Bool = false
 
+    @Flag(name: [.customShort("q"), .long], help: "Suppress normal progress output.")
+    var quiet: Bool = false
+
     func validate() throws {
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision track.")
@@ -101,7 +104,7 @@ struct VisionTrack: AsyncParsableCommand {
             return
         }
 
-        try MLXBundleSupport.ensureAvailable(quiet: false)
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
 
         guard FileManager.default.fileExists(atPath: videoURL.path) else {
             throw ValidationError("Video not found: \(videoURL.path)")
@@ -130,15 +133,17 @@ struct VisionTrack: AsyncParsableCommand {
             maskOutputDirectoryURL: maskOutputDirectoryURL
         )
 
-        print("Model: \(result.modelID)")
-        print("Objects: \(result.objects.count)")
-        print("Frames: \(result.frames.count)")
-        print("Video: \(result.annotatedVideoPath)")
-        if let jsonOutputPath = result.jsonOutputPath {
-            print("JSON: \(jsonOutputPath)")
-        }
-        if let maskOutputDirectoryURL {
-            print("Masks: \(maskOutputDirectoryURL.path)")
+        if !quiet {
+            print("Model: \(result.modelID)")
+            print("Objects: \(result.objects.count)")
+            print("Frames: \(result.frames.count)")
+            print("Video: \(result.annotatedVideoPath)")
+            if let jsonOutputPath = result.jsonOutputPath {
+                print("JSON: \(jsonOutputPath)")
+            }
+            if let maskOutputDirectoryURL {
+                print("Masks: \(maskOutputDirectoryURL.path)")
+            }
         }
     }
 

--- a/Sources/MereRunCLI/Support/VisionSegmentPreflight.swift
+++ b/Sources/MereRunCLI/Support/VisionSegmentPreflight.swift
@@ -1,0 +1,583 @@
+import Foundation
+import MereRunCore
+
+struct VisionSegmentPreflightInput {
+    let imageURL: URL
+    let outputImageURL: URL
+    let outputJSONURL: URL
+    let maskOutputDirectoryURL: URL?
+    let prompt: [String]
+    let box: [String]
+    let point: [String]
+    let model: String?
+    let threshold: Double
+    let resolution: Int
+    let showBoxes: Bool
+    let multimask: Bool
+    let segmentArgv: [String]
+    let cwd: String
+}
+
+struct VisionSegmentPreflightRequest: Codable, Equatable {
+    let image: String
+    let output: String
+    let jsonOutput: String
+    let maskOutputDir: String?
+    let prompt: [String]
+    let box: [String]
+    let point: [String]
+    let model: String?
+    let threshold: Double
+    let resolution: Int
+    let showBoxes: Bool
+    let multimask: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case image
+        case output
+        case jsonOutput = "json_output"
+        case maskOutputDir = "mask_output_dir"
+        case prompt
+        case box
+        case point
+        case model
+        case threshold
+        case resolution
+        case showBoxes = "show_boxes"
+        case multimask
+    }
+}
+
+struct VisionSegmentPreflightResult: Codable, Equatable {
+    let model: VisionTrackModelPreflightSummary
+    let image: VisionTrackPathPreflightSummary
+    let prompts: VisionTrackPromptPreflightSummary
+    let outputs: VisionSegmentOutputsPreflightSummary
+    let plan: VisionSegmentPlanPreflightSummary
+}
+
+struct VisionSegmentOutputsPreflightSummary: Codable, Equatable {
+    let annotatedImage: VisionTrackOutputPreflightSummary
+    let segmentationJSON: VisionTrackOutputPreflightSummary
+    let maskDirectory: VisionTrackDirectoryPreflightSummary?
+
+    enum CodingKeys: String, CodingKey {
+        case annotatedImage = "annotated_image"
+        case segmentationJSON = "segmentation_json"
+        case maskDirectory = "mask_directory"
+    }
+}
+
+struct VisionSegmentPlanPreflightSummary: Codable, Equatable {
+    let threshold: Double
+    let resolution: Int
+    let showBoxes: Bool
+    let multimask: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case threshold
+        case resolution
+        case showBoxes = "show_boxes"
+        case multimask
+    }
+}
+
+typealias VisionSegmentPreflightEnvelope = StructuredRunEnvelope<
+    VisionSegmentPreflightRequest,
+    VisionSegmentPreflightResult
+>
+
+struct VisionSegmentPreflightAnalyzer {
+    let input: VisionSegmentPreflightInput
+    let fileManager: FileManager
+    let now: () -> Date
+
+    init(
+        input: VisionSegmentPreflightInput,
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.input = input
+        self.fileManager = fileManager
+        self.now = now
+    }
+
+    func envelope() -> VisionSegmentPreflightEnvelope {
+        var diagnostics: [PreflightDiagnostic] = []
+        let image = imageSummary(diagnostics: &diagnostics)
+        validateStaticOptions(diagnostics: &diagnostics)
+        let prompts = promptSummary(diagnostics: &diagnostics)
+        let model = modelSummary(diagnostics: &diagnostics)
+        let outputs = outputSummaries(diagnostics: &diagnostics)
+        let plan = VisionSegmentPlanPreflightSummary(
+            threshold: input.threshold,
+            resolution: input.resolution,
+            showBoxes: input.showBoxes,
+            multimask: input.multimask
+        )
+        let status = StructuredRunOutput.status(for: diagnostics)
+
+        return VisionSegmentPreflightEnvelope(
+            schemaVersion: 1,
+            mereRunVersion: MereRunCLIVersion.current,
+            command: ["vision", "segment"],
+            mode: .preflight,
+            status: status,
+            createdAt: now(),
+            cwd: input.cwd,
+            summary: summary(status: status, diagnostics: diagnostics),
+            request: request(),
+            result: VisionSegmentPreflightResult(
+                model: model,
+                image: image,
+                prompts: prompts,
+                outputs: outputs,
+                plan: plan
+            ),
+            diagnostics: diagnostics,
+            actions: actions(status: status, model: model, image: image, outputs: outputs)
+        )
+    }
+
+    private func request() -> VisionSegmentPreflightRequest {
+        VisionSegmentPreflightRequest(
+            image: input.imageURL.path,
+            output: input.outputImageURL.path,
+            jsonOutput: input.outputJSONURL.path,
+            maskOutputDir: input.maskOutputDirectoryURL?.path,
+            prompt: input.prompt,
+            box: input.box,
+            point: input.point,
+            model: input.model,
+            threshold: input.threshold,
+            resolution: input.resolution,
+            showBoxes: input.showBoxes,
+            multimask: input.multimask
+        )
+    }
+
+    private func imageSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> VisionTrackPathPreflightSummary {
+        let summary = pathSummary(requested: input.imageURL.path)
+        if !summary.exists {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "image_missing",
+                    severity: .blocker,
+                    title: "Image missing",
+                    message: "Image not found: \(summary.path)",
+                    locations: [.init(kind: "file", path: summary.path)]
+                )
+            )
+        } else if summary.isDirectory {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "image_is_directory",
+                    severity: .blocker,
+                    title: "Image path is a directory",
+                    message: "Image path is a directory: \(summary.path)",
+                    locations: [.init(kind: "directory", path: summary.path)]
+                )
+            )
+        }
+        return summary
+    }
+
+    private func validateStaticOptions(diagnostics: inout [PreflightDiagnostic]) {
+        if input.prompt.isEmpty, input.box.isEmpty, input.point.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "prompt_set_empty",
+                    severity: .blocker,
+                    title: "Prompt set is empty",
+                    message: "Provide at least one --prompt, --box, or --point value."
+                )
+            )
+        }
+        if !(0.0...1.0).contains(input.threshold) {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "threshold_invalid",
+                    severity: .blocker,
+                    title: "Threshold is invalid",
+                    message: "--threshold must be between 0 and 1."
+                )
+            )
+        }
+        if input.resolution <= 0 {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "resolution_invalid",
+                    severity: .blocker,
+                    title: "Resolution is invalid",
+                    message: "--resolution must be greater than 0."
+                )
+            )
+        }
+    }
+
+    private func promptSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> VisionTrackPromptPreflightSummary {
+        let normalizedTextPrompts = VisionSegment.normalizedTextPrompts(input.prompt)
+        do {
+            _ = try input.box.map(VisionSegment.parseBoxPrompt)
+            _ = try input.point.map(VisionSegment.parsePointPrompt)
+        } catch {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "prompt_parse_failed",
+                    severity: .blocker,
+                    title: "Prompt parse failed",
+                    message: error.localizedDescription
+                )
+            )
+        }
+        if normalizedTextPrompts.isEmpty,
+           input.box.isEmpty,
+           input.point.isEmpty,
+           !input.prompt.isEmpty {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "text_prompts_empty_after_normalization",
+                    severity: .blocker,
+                    title: "Text prompts are empty",
+                    message: "Text prompts must include object words after normalization."
+                )
+            )
+        }
+
+        return VisionTrackPromptPreflightSummary(
+            textPrompts: input.prompt,
+            normalizedTextPrompts: normalizedTextPrompts,
+            boxPrompts: input.box,
+            pointPrompts: input.point,
+            textCount: normalizedTextPrompts.count,
+            boxCount: input.box.count,
+            pointCount: input.point.count,
+            totalCount: normalizedTextPrompts.count + input.box.count + input.point.count
+        )
+    }
+
+    private func modelSummary(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> VisionTrackModelPreflightSummary {
+        let requested = input.model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveRequested = requested?.isEmpty == false
+            ? requested!
+            : VisionSegment.defaultManagedModelID.rawValue
+
+        if let requested, !requested.isEmpty {
+            let url = URL(fileURLWithPath: requested).standardizedFileURL
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+                if !isDirectory.boolValue {
+                    diagnostics.append(
+                        PreflightDiagnostic(
+                            id: "model_path_not_directory",
+                            severity: .blocker,
+                            title: "Model path is not a directory",
+                            message: "Model path is not a directory: \(url.path)",
+                            locations: [.init(kind: "file", path: url.path)]
+                        )
+                    )
+                    return modelResult(
+                        requested: requested,
+                        kind: "local_path",
+                        installed: false,
+                        path: url.path
+                    )
+                }
+                return modelResult(
+                    requested: requested,
+                    kind: "local_path",
+                    installed: true,
+                    path: url.path
+                )
+            }
+        }
+
+        guard let modelID = ModelResolver.ModelID(rawValue: effectiveRequested),
+              let spec = ManagedModelCatalog.spec(for: effectiveRequested) else {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "model_unknown",
+                    severity: .blocker,
+                    title: "Unknown model",
+                    message: "Model path not found and not a known model id: \(effectiveRequested)."
+                )
+            )
+            return modelResult(requested: effectiveRequested, kind: "unknown", installed: false)
+        }
+
+        if let resolution = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID) {
+            return modelResult(
+                requested: effectiveRequested,
+                kind: "managed_model",
+                installed: true,
+                path: resolution.rootURL.path,
+                id: modelID.rawValue,
+                upstreamRepoID: spec.upstreamRepoId,
+                estimatedDownloadBytes: spec.estimatedDownloadBytes
+            )
+        }
+
+        diagnostics.append(
+            PreflightDiagnostic(
+                id: "model_missing",
+                severity: .blocker,
+                title: "Model missing",
+                message: "Model \(effectiveRequested) is not installed. Pull it before segmentation.",
+                suggestedActionIDs: ["pull-model"]
+            )
+        )
+        return modelResult(
+            requested: effectiveRequested,
+            kind: "managed_model",
+            installed: false,
+            id: modelID.rawValue,
+            upstreamRepoID: spec.upstreamRepoId,
+            estimatedDownloadBytes: spec.estimatedDownloadBytes
+        )
+    }
+
+    private func modelResult(
+        requested: String,
+        kind: String,
+        installed: Bool,
+        path: String? = nil,
+        id: String? = nil,
+        upstreamRepoID: String? = nil,
+        estimatedDownloadBytes: Int64? = nil
+    ) -> VisionTrackModelPreflightSummary {
+        VisionTrackModelPreflightSummary(
+            requested: requested,
+            kind: kind,
+            installed: installed,
+            path: path,
+            id: id,
+            upstreamRepoID: upstreamRepoID,
+            estimatedDownloadBytes: estimatedDownloadBytes
+        )
+    }
+
+    private func outputSummaries(
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> VisionSegmentOutputsPreflightSummary {
+        VisionSegmentOutputsPreflightSummary(
+            annotatedImage: outputSummary(
+                url: input.outputImageURL,
+                expectedExtension: "png",
+                role: "annotated image",
+                diagnosticPrefix: "output_image",
+                diagnostics: &diagnostics
+            ),
+            segmentationJSON: outputSummary(
+                url: input.outputJSONURL,
+                expectedExtension: "json",
+                role: "segmentation JSON",
+                diagnosticPrefix: "json_output",
+                diagnostics: &diagnostics
+            ),
+            maskDirectory: input.maskOutputDirectoryURL.map {
+                maskDirectorySummary(url: $0, diagnostics: &diagnostics)
+            }
+        )
+    }
+
+    private func outputSummary(
+        url: URL,
+        expectedExtension: String,
+        role: String,
+        diagnosticPrefix: String,
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> VisionTrackOutputPreflightSummary {
+        let parent = url.deletingLastPathComponent()
+        var parentIsDirectory: ObjCBool = false
+        let parentExists = fileManager.fileExists(atPath: parent.path, isDirectory: &parentIsDirectory)
+        let outputExists = fileManager.fileExists(atPath: url.path)
+        let extensionValid = url.pathExtension.lowercased() == expectedExtension
+
+        if parentExists, !parentIsDirectory.boolValue {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "\(diagnosticPrefix)_parent_not_directory",
+                    severity: .blocker,
+                    title: "Output parent is not a directory",
+                    message: "\(role) parent is not a directory: \(parent.path)",
+                    locations: [.init(kind: "file", path: parent.path)]
+                )
+            )
+        }
+        if outputExists {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "\(diagnosticPrefix)_exists",
+                    severity: .warning,
+                    title: "Output exists",
+                    message: "\(role) already exists and may be overwritten: \(url.path)",
+                    locations: [.init(kind: "file", path: url.path)]
+                )
+            )
+        }
+        if !extensionValid {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "\(diagnosticPrefix)_extension_unusual",
+                    severity: .warning,
+                    title: "Output extension is unusual",
+                    message: "\(role) should use a .\(expectedExtension) output path for clarity.",
+                    locations: [.init(kind: "file", path: url.path)]
+                )
+            )
+        }
+
+        return VisionTrackOutputPreflightSummary(
+            path: url.path,
+            parentDirectory: parent.path,
+            parentExists: parentExists && parentIsDirectory.boolValue,
+            parentWillBeCreated: !parentExists,
+            exists: outputExists,
+            expectedExtension: expectedExtension,
+            extensionValid: extensionValid
+        )
+    }
+
+    private func maskDirectorySummary(
+        url: URL,
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> VisionTrackDirectoryPreflightSummary {
+        let parent = url.deletingLastPathComponent()
+        var parentIsDirectory: ObjCBool = false
+        let parentExists = fileManager.fileExists(atPath: parent.path, isDirectory: &parentIsDirectory)
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+
+        if parentExists, !parentIsDirectory.boolValue {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "mask_output_parent_not_directory",
+                    severity: .blocker,
+                    title: "Mask output parent is not a directory",
+                    message: "Mask output parent is not a directory: \(parent.path)",
+                    locations: [.init(kind: "file", path: parent.path)]
+                )
+            )
+        }
+        if exists, !isDirectory.boolValue {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "mask_output_not_directory",
+                    severity: .blocker,
+                    title: "Mask output path is not a directory",
+                    message: "Mask output path is not a directory: \(url.path)",
+                    locations: [.init(kind: "file", path: url.path)]
+                )
+            )
+        }
+
+        return VisionTrackDirectoryPreflightSummary(
+            path: url.path,
+            parentDirectory: parent.path,
+            parentExists: parentExists && parentIsDirectory.boolValue,
+            parentWillBeCreated: !parentExists,
+            exists: exists,
+            isDirectory: exists && isDirectory.boolValue
+        )
+    }
+
+    private func pathSummary(requested: String) -> VisionTrackPathPreflightSummary {
+        let url = URL(fileURLWithPath: requested).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        return VisionTrackPathPreflightSummary(
+            requested: requested,
+            path: url.path,
+            exists: exists,
+            isDirectory: exists && isDirectory.boolValue
+        )
+    }
+
+    private func actions(
+        status: StructuredRunStatus,
+        model: VisionTrackModelPreflightSummary,
+        image: VisionTrackPathPreflightSummary,
+        outputs: VisionSegmentOutputsPreflightSummary
+    ) -> [DeclarativeAction] {
+        var actions = [
+            DeclarativeAction(
+                id: "start-segmentation",
+                label: "Start segmentation",
+                kind: .command,
+                style: .primary,
+                enabled: status != .blocked,
+                disabledReason: status == .blocked ? "Resolve hard blockers first." : nil,
+                command: DeclarativeCommand(
+                    argv: input.segmentArgv,
+                    cwd: input.cwd,
+                    commandPath: ["vision", "segment"]
+                ),
+                requires: ["preflight.passed"]
+            )
+        ]
+
+        if model.kind == "managed_model", !model.installed {
+            actions.append(
+                DeclarativeAction(
+                    id: "pull-model",
+                    label: "Pull model",
+                    kind: .command,
+                    style: .secondary,
+                    command: DeclarativeCommand(
+                        argv: ["mere.run", "model", "pull", model.requested],
+                        cwd: input.cwd,
+                        commandPath: ["model", "pull"]
+                    )
+                )
+            )
+        }
+
+        actions.append(
+            DeclarativeAction(
+                id: "reveal-input-image",
+                label: "Reveal input image",
+                kind: .revealFile,
+                style: .link,
+                enabled: image.exists && !image.isDirectory,
+                path: image.path
+            )
+        )
+        actions.append(
+            DeclarativeAction(
+                id: "open-output-directory",
+                label: "Open output directory",
+                kind: .openDirectory,
+                style: .link,
+                enabled: outputs.annotatedImage.parentExists,
+                disabledReason: outputs.annotatedImage.parentExists
+                    ? nil
+                    : "Output directory will be created when segmentation starts.",
+                path: outputs.annotatedImage.parentDirectory
+            )
+        )
+        return actions
+    }
+
+    private func summary(
+        status: StructuredRunStatus,
+        diagnostics: [PreflightDiagnostic]
+    ) -> String {
+        switch status {
+        case .ok:
+            return "Vision segmentation preflight passed."
+        case .warning:
+            return "Vision segmentation preflight found \(diagnostics.count) warning(s) or note(s)."
+        case .blocked:
+            let blockers = diagnostics.filter { $0.severity == .blocker }.count
+            return "Vision segmentation preflight blocked by \(blockers) issue(s)."
+        default:
+            return "Vision segmentation preflight status: \(status.rawValue)."
+        }
+    }
+}

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -872,6 +872,112 @@ enum WorkflowNodeRegistry {
             presentation: .init(style: "material", primaryArgument: "image")
         ),
         WorkflowNodeCatalogEntry(
+            kind: "vision.segment",
+            title: "Segment objects",
+            description: "Refine prompted candidate regions into SAM 3.1 masks.",
+            category: "vision",
+            inputs: [
+                .init(
+                    name: "image",
+                    type: .asset,
+                    required: true,
+                    acceptedContentTypes: ["image/png", "image/jpeg", "image/webp"]
+                ),
+                .init(
+                    name: "prompts",
+                    type: .json,
+                    required: true,
+                    description: "One or more text prompts for candidate-mask refinement.",
+                    valueSchema: .init(type: .array, items: .init(type: .string))
+                ),
+                .init(name: "model", type: .string, required: false),
+                .init(name: "threshold", type: .number, required: false, defaultValue: .number(0.05), minimum: 0),
+                .init(name: "resolution", type: .integer, required: false, defaultValue: .integer(1008), minimum: 1),
+                .init(name: "show_boxes", type: .boolean, required: false, defaultValue: .boolean(false)),
+                .init(name: "multimask", type: .boolean, required: false, defaultValue: .boolean(false)),
+            ],
+            outputs: [
+                .init(
+                    name: "image",
+                    type: .asset,
+                    description: "Annotated segmentation image.",
+                    contentTypes: ["image/png"]
+                ),
+                .init(
+                    name: "segments",
+                    type: .asset,
+                    description: "Structured candidate segments and mask metadata.",
+                    contentTypes: ["application/json"]
+                ),
+                .init(
+                    name: "masks",
+                    type: .assetDirectory,
+                    description: "Per-object PNG masks.",
+                    contentTypes: ["image/png"]
+                ),
+            ],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            ),
+            presentation: .init(style: "material", primaryArgument: "image")
+        ),
+        WorkflowNodeCatalogEntry(
+            kind: "vision.track",
+            title: "Track objects",
+            description: "Propagate prompted SAM 3.1 masks through a video.",
+            category: "vision",
+            inputs: [
+                .init(
+                    name: "video",
+                    type: .asset,
+                    required: true,
+                    acceptedContentTypes: ["video/mp4", "video/quicktime"]
+                ),
+                .init(
+                    name: "prompts",
+                    type: .json,
+                    required: true,
+                    description: "One or more text prompts used to seed tracking.",
+                    valueSchema: .init(type: .array, items: .init(type: .string))
+                ),
+                .init(name: "model", type: .string, required: false),
+                .init(name: "threshold", type: .number, required: false, defaultValue: .number(0.05), minimum: 0),
+                .init(name: "resolution", type: .integer, required: false, defaultValue: .integer(1008), minimum: 1),
+                .init(name: "init_frame", type: .integer, required: false, defaultValue: .integer(0), minimum: 0),
+                .init(name: "end_frame", type: .integer, required: false, minimum: 0),
+                .init(name: "show_boxes", type: .boolean, required: false, defaultValue: .boolean(false)),
+                .init(name: "show_labels", type: .boolean, required: false, defaultValue: .boolean(false)),
+            ],
+            outputs: [
+                .init(
+                    name: "video",
+                    type: .asset,
+                    description: "Annotated tracking video.",
+                    contentTypes: ["video/mp4"]
+                ),
+                .init(
+                    name: "tracks",
+                    type: .asset,
+                    description: "Structured per-frame tracks and mask metadata.",
+                    contentTypes: ["application/json"]
+                ),
+                .init(
+                    name: "masks",
+                    type: .assetDirectory,
+                    description: "Per-frame PNG masks.",
+                    contentTypes: ["image/png"]
+                ),
+            ],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            ),
+            presentation: .init(style: "material", primaryArgument: "video")
+        ),
+        WorkflowNodeCatalogEntry(
             kind: "image.train-lora",
             title: "Train image LoRA",
             category: "image",

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -703,6 +703,7 @@ struct WorkflowBundleMaterializer {
             case "image.train-lora": return ImageTrainLoRA.defaultManagedModelID.rawValue
             case "image.generate": return ImageGenerate.defaultManagedModelID.rawValue
             case "vision.ground": return VisionGround.defaultManagedModelID.rawValue
+            case "vision.segment", "vision.track": return VisionSegment.defaultManagedModelID.rawValue
             case "video.generate": return ModelResolver.ModelID.ltxVideo23AVMLX.rawValue
             default: return nil
             }
@@ -1354,6 +1355,70 @@ enum WorkflowNodeCommandBuilder {
                 ],
                 streamsEvents: false
             )
+        case "vision.segment":
+            let outputImage = artifacts.appendingPathComponent("image.png")
+            let segments = artifacts.appendingPathComponent("segments.json")
+            let masks = artifacts.appendingPathComponent("masks", isDirectory: true)
+            var args = [
+                "vision", "segment", try requiredString("image", in: arguments),
+                "--prompt",
+            ]
+            args.append(contentsOf: try requiredStringArray("prompts", in: arguments))
+            appendString("model", flag: "--model", from: arguments, to: &args)
+            appendNumber("threshold", flag: "--threshold", from: arguments, to: &args)
+            appendInteger("resolution", flag: "--resolution", from: arguments, to: &args)
+            appendFlag("show_boxes", flag: "--show-boxes", from: arguments, to: &args)
+            appendFlag("multimask", flag: "--multimask", from: arguments, to: &args)
+            args += [
+                "--output", outputImage.path,
+                "--json-output", segments.path,
+                "--mask-output-dir", masks.path,
+            ]
+            return .init(
+                command: ["vision", "segment"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args + ["--quiet"],
+                outputs: [
+                    "image": fileOutput(outputImage, contentTypes: ["image/png"]),
+                    "segments": fileOutput(segments, contentTypes: ["application/json"]),
+                    "masks": directoryOutput(masks, contentTypes: ["image/png"]),
+                ],
+                streamsEvents: false
+            )
+        case "vision.track":
+            let outputVideo = artifacts.appendingPathComponent("video.mp4")
+            let tracks = artifacts.appendingPathComponent("tracks.json")
+            let masks = artifacts.appendingPathComponent("masks", isDirectory: true)
+            var args = [
+                "vision", "track", try requiredString("video", in: arguments),
+                "--prompt",
+            ]
+            args.append(contentsOf: try requiredStringArray("prompts", in: arguments))
+            appendString("model", flag: "--model", from: arguments, to: &args)
+            appendNumber("threshold", flag: "--threshold", from: arguments, to: &args)
+            appendInteger("resolution", flag: "--resolution", from: arguments, to: &args)
+            appendInteger("init_frame", flag: "--init-frame", from: arguments, to: &args)
+            appendInteger("end_frame", flag: "--end-frame", from: arguments, to: &args)
+            appendFlag("show_boxes", flag: "--show-boxes", from: arguments, to: &args)
+            appendFlag("show_labels", flag: "--show-labels", from: arguments, to: &args)
+            args += [
+                "--output", outputVideo.path,
+                "--json-output", tracks.path,
+                "--mask-output-dir", masks.path,
+            ]
+            return .init(
+                command: ["vision", "track"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args + ["--quiet"],
+                outputs: [
+                    "video": fileOutput(outputVideo, contentTypes: ["video/mp4"]),
+                    "tracks": fileOutput(tracks, contentTypes: ["application/json"]),
+                    "masks": directoryOutput(masks, contentTypes: ["image/png"]),
+                ],
+                streamsEvents: false
+            )
         case "image.train-lora":
             let output = artifacts.appendingPathComponent("adapter.safetensors")
             var args = ["image", "train-lora", "--data", try requiredString("data", in: arguments), "--output", output.path]
@@ -1489,6 +1554,15 @@ enum WorkflowNodeCommandBuilder {
     private static func fileOutput(_ url: URL, contentTypes: [String]) -> WorkflowInvocationOutput {
         WorkflowInvocationOutput(
             type: .asset,
+            path: url.path,
+            optional: false,
+            contentTypes: contentTypes
+        )
+    }
+
+    private static func directoryOutput(_ url: URL, contentTypes: [String]) -> WorkflowInvocationOutput {
+        WorkflowInvocationOutput(
+            type: .assetDirectory,
             path: url.path,
             optional: false,
             contentTypes: contentTypes

--- a/Tests/MereRunCLITests/VisionSegmentCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/VisionSegmentCommandParsingTests.swift
@@ -34,6 +34,9 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
         XCTAssertNil(cmd.output)
         XCTAssertNil(cmd.jsonOutput)
         XCTAssertFalse(cmd.showBoxes)
+        XCTAssertFalse(cmd.preflight)
+        XCTAssertFalse(cmd.json)
+        XCTAssertFalse(cmd.quiet)
         XCTAssertEqual(cmd.threshold, 0.05, accuracy: 0.0001)
         XCTAssertEqual(cmd.resolution, 1008)
     }
@@ -50,6 +53,7 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
             "--mask-output-dir", "/tmp/masks",
             "--show-boxes",
             "--multimask",
+            "--quiet",
             "--threshold", "0.45",
             "--resolution", "504",
         ])
@@ -63,8 +67,51 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.maskOutputDir, "/tmp/masks")
         XCTAssertTrue(cmd.showBoxes)
         XCTAssertTrue(cmd.multimask)
+        XCTAssertTrue(cmd.quiet)
         XCTAssertEqual(cmd.threshold, 0.45, accuracy: 0.0001)
         XCTAssertEqual(cmd.resolution, 504)
+    }
+
+    func testVisionSegmentPreflightReportsRunnablePlan() throws {
+        let temp = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let modelRoot = temp.appendingPathComponent("sam31", isDirectory: true)
+        try writeMinimalSAM31Model(at: modelRoot)
+        let imageURL = try makeTempFile(name: "scene.png", in: temp)
+        let outputURL = temp.appendingPathComponent("scene-segmented.png")
+        let jsonURL = temp.appendingPathComponent("scene-segmented.json")
+        let maskDir = temp.appendingPathComponent("masks", isDirectory: true)
+        let cmd = try VisionSegment.parse([
+            imageURL.path,
+            "--prompt", "a damaged building", "debris",
+            "--model", modelRoot.path,
+            "--output", outputURL.path,
+            "--json-output", jsonURL.path,
+            "--mask-output-dir", maskDir.path,
+            "--show-boxes",
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            imageURL: imageURL,
+            outputImageURL: outputURL,
+            outputJSONURL: jsonURL,
+            maskOutputDirectoryURL: maskDir,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.command, ["vision", "segment"])
+        XCTAssertTrue(envelope.result.image.exists)
+        XCTAssertEqual(envelope.result.model.kind, "local_path")
+        XCTAssertEqual(envelope.result.prompts.normalizedTextPrompts, ["damaged building", "debris"])
+        XCTAssertEqual(envelope.result.outputs.annotatedImage.path, outputURL.path)
+        XCTAssertEqual(envelope.result.outputs.segmentationJSON.path, jsonURL.path)
+        XCTAssertEqual(envelope.result.outputs.maskDirectory?.path, maskDir.path)
+        XCTAssertTrue(envelope.actions.contains { $0.id == "start-segmentation" && $0.enabled })
     }
 
     func testVisionSegmentParsesPromptSetFromTextBoxesAndPoints() throws {
@@ -102,6 +149,7 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
         XCTAssertFalse(cmd.showBoxes)
         XCTAssertFalse(cmd.preflight)
         XCTAssertFalse(cmd.json)
+        XCTAssertFalse(cmd.quiet)
     }
 
     func testVisionTrackResolvesDefaultOutputPaths() {
@@ -122,10 +170,12 @@ final class VisionSegmentCommandParsingTests: XCTestCase {
             "--prompt", "a dog",
             "--preflight",
             "--json",
+            "--quiet",
         ])
 
         XCTAssertTrue(cmd.preflight)
         XCTAssertTrue(cmd.json)
+        XCTAssertTrue(cmd.quiet)
     }
 
     func testVisionTrackPreflightReportsRunnablePlan() throws {

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -69,6 +69,18 @@ final class WorkflowGraphTests: XCTestCase {
         )
     }
 
+    func testVisionSAMCatalogExposesMasksAndStructuredArtifacts() throws {
+        let segment = try XCTUnwrap(WorkflowNodeRegistry.entry(for: "vision.segment"))
+        let track = try XCTUnwrap(WorkflowNodeRegistry.entry(for: "vision.track"))
+
+        XCTAssertEqual(segment.presentation?.primaryArgument, "image")
+        XCTAssertEqual(track.presentation?.primaryArgument, "video")
+        XCTAssertEqual(segment.outputs.map(\.name), ["image", "segments", "masks"])
+        XCTAssertEqual(track.outputs.map(\.name), ["video", "tracks", "masks"])
+        XCTAssertEqual(segment.outputs.first(where: { $0.name == "masks" })?.type, .assetDirectory)
+        XCTAssertEqual(track.outputs.first(where: { $0.name == "masks" })?.contentTypes, ["image/png"])
+    }
+
     func testCreativeMaterialIntrinsicsHaveExactSemantics() throws {
         XCTAssertEqual(
             try WorkflowIntrinsicInvocation(
@@ -280,6 +292,66 @@ final class WorkflowGraphTests: XCTestCase {
         ))
     }
 
+    func testVisionSegmentBuildsPreflightAndMaskArtifactInvocation() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = WorkflowNode(
+            id: "segment",
+            kind: "vision.segment",
+            arguments: [
+                "image": .string("/tmp/post-event.png"),
+                "prompts": .array([.string("damaged roof"), .string("debris")]),
+                "threshold": .number(0.12),
+                "show_boxes": .boolean(true),
+            ],
+            dependsOn: nil
+        )
+
+        let invocation = try WorkflowNodeCommandBuilder.invocation(
+            node: node,
+            arguments: node.arguments,
+            nodeDirectory: root
+        )
+
+        XCTAssertEqual(invocation.command, ["vision", "segment"])
+        XCTAssertTrue(invocation.preflightArguments.suffix(2).elementsEqual(["--preflight", "--json"]))
+        XCTAssertTrue(invocation.runArguments.contains("--quiet"))
+        XCTAssertTrue(invocation.runArguments.contains("damaged roof"))
+        XCTAssertTrue(invocation.runArguments.contains("--mask-output-dir"))
+        XCTAssertEqual(invocation.outputs["segments"]?.contentTypes, ["application/json"])
+        XCTAssertEqual(invocation.outputs["masks"]?.type, .assetDirectory)
+        XCTAssertTrue(invocation.outputs["masks"]?.path?.hasSuffix("/artifacts/masks") == true)
+    }
+
+    func testVisionTrackBuildsPreflightAndMaskArtifactInvocation() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = WorkflowNode(
+            id: "track",
+            kind: "vision.track",
+            arguments: [
+                "video": .string("/tmp/collection.mp4"),
+                "prompts": .array([.string("bridge")]),
+                "init_frame": .integer(4),
+                "end_frame": .integer(18),
+            ],
+            dependsOn: nil
+        )
+
+        let invocation = try WorkflowNodeCommandBuilder.invocation(
+            node: node,
+            arguments: node.arguments,
+            nodeDirectory: root
+        )
+
+        XCTAssertEqual(invocation.command, ["vision", "track"])
+        XCTAssertTrue(invocation.preflightArguments.suffix(2).elementsEqual(["--preflight", "--json"]))
+        XCTAssertTrue(invocation.runArguments.contains("--quiet"))
+        XCTAssertEqual(invocation.outputs["video"]?.contentTypes, ["video/mp4"])
+        XCTAssertEqual(invocation.outputs["tracks"]?.contentTypes, ["application/json"])
+        XCTAssertEqual(invocation.outputs["masks"]?.type, .assetDirectory)
+    }
+
     func testPluginTIFFOutputUsesPortableExtension() {
         XCTAssertEqual(
             WorkflowNodeCommandBuilder.outputExtension(contentTypes: ["image/tiff"]),
@@ -322,6 +394,69 @@ final class WorkflowGraphTests: XCTestCase {
 
         XCTAssertEqual(requirements.nodeKinds, ["vision.ground"])
         XCTAssertEqual(requirements.modelIDs, ["vision-ground-falcon-perception"])
+        XCTAssertEqual(requirements.acceleratorBackends, ["cuda", "metal"])
+    }
+
+    func testExplicitModelSelectionOverridesProviderCandidateRequirements() {
+        XCTAssertEqual(
+            WorkflowGraphRequirements.resolveModelIDs(
+                selectedModelID: "vision-embed-olmoearth-v12-base",
+                registryModelIDs: [
+                    "vision-embed-olmoearth-v12-nano",
+                    "vision-embed-olmoearth-v12-tiny",
+                    "vision-embed-olmoearth-v12-small",
+                    "vision-embed-olmoearth-v12-base",
+                ],
+                defaultModelID: nil
+            ),
+            ["vision-embed-olmoearth-v12-base"]
+        )
+    }
+
+    func testVisionSAMDefaultsManagedModelRequirement() throws {
+        let graph = try decodeGraph("""
+        {
+          "schema_version": 1,
+          "kind": "mere.run/workflow-graph",
+          "name": "sam-candidates",
+          "inputs": {
+            "image": {"type": "asset", "content_types": ["image/png"]},
+            "video": {"type": "asset", "content_types": ["video/mp4"]}
+          },
+          "nodes": [
+            {
+              "id": "segment",
+              "kind": "vision.segment",
+              "arguments": {
+                "image": {"$ref": "inputs.image"},
+                "prompts": ["building", "debris"]
+              }
+            },
+            {
+              "id": "track",
+              "kind": "vision.track",
+              "arguments": {
+                "video": {"$ref": "inputs.video"},
+                "prompts": ["bridge"]
+              }
+            }
+          ],
+          "outputs": {
+            "segments": {"$ref": "nodes.segment.outputs.segments"},
+            "tracks": {"$ref": "nodes.track.outputs.tracks"}
+          }
+        }
+        """)
+        let requirements = WorkflowGraphRequirements.resolve(
+            graph: graph,
+            inputs: .init(values: [
+                "image": .string("/tmp/post-event.png"),
+                "video": .string("/tmp/collection.mp4"),
+            ])
+        )
+
+        XCTAssertEqual(requirements.nodeKinds, ["vision.segment", "vision.track"])
+        XCTAssertEqual(requirements.modelIDs, ["vision-segment-sam31"])
         XCTAssertEqual(requirements.acceleratorBackends, ["cuda", "metal"])
     }
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -51,7 +51,7 @@ The V1 node catalog contains:
 - `seed.value`, `choice.value`
 - `text.join`, `text.template`
 - `text.enhance`, `image.describe`
-- `vision.ground`
+- `vision.ground`, `vision.segment`, `vision.track`
 - `image.train-lora`
 - `image.generate`
 - `video.generate`
@@ -67,6 +67,12 @@ installed model and never trigger a hidden pull.
 default. It emits an annotated image and structured detections JSON as verified
 artifacts. Grounding output is candidate geometry; graph execution does not
 promote it into evidence or findings.
+
+`vision.segment` and `vision.track` use the managed `vision-segment-sam31`
+model by default. Both emit an annotated media artifact, structured JSON, and a
+portable directory of PNG masks. They refine or propagate candidate geometry;
+their masks remain review candidates until a mission workflow corroborates and
+accepts them.
 
 Catalog value schemas recursively describe array items, object properties, and
 additional properties. Editors may expose those nested slots as typed ports


### PR DESCRIPTION
## Summary

- expose SAM 3.1 segmentation and tracking as typed `vision.segment` and `vision.track` workflow nodes
- pass text-prompt lists through the portable graph contract while retaining native CLI box and point prompting
- add model requirement, preflight, quiet JSON execution, tests, CLI docs, and changelog coverage

## Why

Portable graph workflows need a bounded segmentation lane for review candidates and an optional temporal tracking lane. SAM outputs remain model-generated geometry for operator review rather than confirmed real-world evidence.

## Verification

- `./scripts/check.sh`
  - SwiftLint passed across 1,159 files
  - 2,557 XCTest cases passed, 167 skipped, 0 failures
  - Swift Testing suite: 23 passed
  - CLI help sweep and hygiene scans passed
- workflow command-builder tests cover typed segmentation and tracking invocations, declared artifacts, preflight, and quiet execution
- native CLI parsing and preflight tests cover segmentation prompts and tracking output planning

## Impact

Public CLI and workflow contract addition only. No hosted-service, billing, vendor artifact, or model-output evidence changes.
