### PR TITLE
Optimize MiniMax H3 sustained inference

### DIFF
--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -609,6 +609,8 @@ enum CLIInferenceAdmissionClassifier {
             return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
         case "video", "world":
             return MachineInferenceRequest(label: label, resourceClass: .large)
+        case "geo":
+            return MachineInferenceRequest(label: label, resourceClass: .large)
         case "model" where subcommand == "benchmark":
             return MachineInferenceRequest(label: label, resourceClass: .large)
         case "adapter" where subcommand != "list" && subcommand != "pull":

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -458,17 +458,50 @@ struct MachineInferenceCoordinator: Sendable {
 
     private static func availableDiskBytes(at url: URL) -> UInt64? {
 #if os(Linux)
+        return fileSystemFreeBytes(at: url)
+#else
+        let importantUsageCapacity = try? url.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        ).volumeAvailableCapacityForImportantUsage
+        return reconciledAvailableDiskBytes(
+            importantUsageCapacity: importantUsageCapacity,
+            fileSystemFreeBytes: fileSystemFreeBytes(at: url)
+        )
+#endif
+    }
+
+    /// The important-usage capacity probe can return zero when macOS cannot
+    /// reach `sysmond`, including inside a restricted process sandbox. A
+    /// positive filesystem value proves that the volume is not actually full.
+    /// When both probes succeed, use the smaller value for admission safety.
+    static func reconciledAvailableDiskBytes(
+        importantUsageCapacity: Int64?,
+        fileSystemFreeBytes: UInt64?
+    ) -> UInt64? {
+        let positiveFileSystemBytes = fileSystemFreeBytes.flatMap { $0 > 0 ? $0 : nil }
+        guard let importantUsageCapacity else {
+            return fileSystemFreeBytes
+        }
+        guard importantUsageCapacity > 0 else {
+            if importantUsageCapacity == 0 {
+                return positiveFileSystemBytes ?? 0
+            }
+            return fileSystemFreeBytes
+        }
+
+        let importantBytes = UInt64(importantUsageCapacity)
+        guard let positiveFileSystemBytes else {
+            return importantBytes
+        }
+        return min(importantBytes, positiveFileSystemBytes)
+    }
+
+    private static func fileSystemFreeBytes(at url: URL) -> UInt64? {
         guard let attributes = try? FileManager.default.attributesOfFileSystem(forPath: url.path),
               let freeBytes = attributes[.systemFreeSize] as? NSNumber else {
             return nil
         }
         return freeBytes.uint64Value
-#else
-        let capacity = try? url.resourceValues(
-            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
-        ).volumeAvailableCapacityForImportantUsage
-        return capacity.flatMap { $0 >= 0 ? UInt64($0) : nil }
-#endif
     }
 
     private static func isProcessAlive(_ processID: Int32) -> Bool {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -137,7 +137,8 @@ enum MiniMaxH3DenoiseExecutionMode: Equatable {
 }
 
 enum MiniMaxH3DenoiseExecutionPolicy {
-    static let blockwiseSequenceThreshold = 13_500
+    static let blockwiseSequenceThreshold = 12_000
+    static let practicalAttentionUpperBound = 13_500
     static let largeSequenceAttentionThreshold = 32_768
     static let veryLargeSequenceAttentionThreshold = 65_536
 
@@ -162,10 +163,18 @@ enum MiniMaxH3DenoiseExecutionPolicy {
                 maximumKernelsPerEvaluation: 1
             )
         }
+        if sequenceLength > blockwiseSequenceThreshold,
+           sequenceLength <= practicalAttentionUpperBound {
+            return (
+                maximumQueryTokens: 640,
+                maximumHeadsPerKernel: nil,
+                maximumKernelsPerEvaluation: 1
+            )
+        }
         return (
             maximumQueryTokens: 1_024,
             maximumHeadsPerKernel: nil,
-            maximumKernelsPerEvaluation: 4
+            maximumKernelsPerEvaluation: 1
         )
     }
 
@@ -597,13 +606,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         if let conditionVideoRows { MLX.eval(conditionVideoRows) }
         if let conditionAudioRows { MLX.eval(conditionAudioRows) }
 
-        // Practical sequence lengths benefit from a compiled whole-step graph
-        // once its first invocation is amortized. A single-step diagnostic is
-        // faster with resident bf16 when its eager stack synchronizes after
-        // each block; this bounds the lazy graph and keeps the allocator
-        // reusing intermediate buffers without paying compilation overhead.
-        // Very large sequences keep independent compiled block boundaries to
-        // avoid the macOS watchdog.
+        // The practical H3 tier uses independent compiled block boundaries to
+        // bound the graph, reuse intermediate buffers, and hold steadier clocks
+        // during a sustained denoise pass. Smaller graphs can still amortize a
+        // compiled whole-step transform; very large graphs also stay blockwise
+        // to avoid the macOS watchdog.
         let blockReusePolicy = accelerationMode.blockReusePolicy.map { policy in
             let environment = ProcessInfo.processInfo.environment
             let requestedCacheDepth = Double(environment["MERERUN_H3_REUSE_DEPTH"] ?? "")
@@ -634,24 +641,33 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let attentionKernelSchedule = MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(
             sequenceLength: layout.sequenceLength
         )
-        transformer.maximumAttentionQueryTokensPerKernel = attentionKernelSchedule
-            .maximumQueryTokens
-        transformer.maximumAttentionHeadsPerKernel = attentionKernelSchedule
-            .maximumHeadsPerKernel
-        transformer.maximumAttentionKernelsPerEvaluation = attentionKernelSchedule
-            .maximumKernelsPerEvaluation
+        let environment = ProcessInfo.processInfo.environment
+        transformer.maximumAttentionQueryTokensPerKernel = max(
+            1,
+            Int(environment["MERERUN_H3_ATTENTION_QUERY_TOKENS"] ?? "")
+                ?? attentionKernelSchedule.maximumQueryTokens
+        )
+        transformer.maximumAttentionHeadsPerKernel = Int(
+            environment["MERERUN_H3_ATTENTION_HEADS_PER_KERNEL"] ?? ""
+        ).map { max(1, $0) } ?? attentionKernelSchedule.maximumHeadsPerKernel
+        transformer.maximumAttentionKernelsPerEvaluation = max(
+            1,
+            Int(environment["MERERUN_H3_ATTENTION_EVALUATION_BATCH"] ?? "")
+                ?? attentionKernelSchedule.maximumKernelsPerEvaluation
+        )
         transformer.usesFusedPostAttention = ProcessInfo.processInfo
             .environment["MERERUN_H3_FUSED_POST_ATTENTION"] == "1"
         transformer.usesLayerwiseEvaluation = executionMode.usesLayerwiseEvaluation
         transformer.clearsCacheAfterLayerwiseEvaluation = false
+        let attentionHeadsPerKernel = transformer.maximumAttentionHeadsPerKernel
+            ?? transformer.configuration.attentionHeadCount
         stepProfileLogger?(
             "execution_mode=\(executionMode) acceleration=\(accelerationMode.rawValue) "
                 + "fused_post_attention=\(transformer.usesFusedPostAttention) "
-                + "attention_query_tokens=\(attentionKernelSchedule.maximumQueryTokens) "
-                + "attention_heads_per_kernel="
-                + "\(attentionKernelSchedule.maximumHeadsPerKernel ?? transformer.configuration.attentionHeadCount) "
+                + "attention_query_tokens=\(transformer.maximumAttentionQueryTokensPerKernel) "
+                + "attention_heads_per_kernel=\(attentionHeadsPerKernel) "
                 + "attention_evaluation_batch="
-                + "\(attentionKernelSchedule.maximumKernelsPerEvaluation)"
+                + "\(transformer.maximumAttentionKernelsPerEvaluation)"
         )
         if let blockReusePolicy {
             stepProfileLogger?(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -173,9 +173,12 @@ private final class MiniMaxH3Attention: Module {
             query = rope.apply(query)
             key = rope.apply(key)
         }
-        query = query.transposed(0, 2, 1, 3)
-        key = key.transposed(0, 2, 1, 3)
-        let value = projected[2].transposed(0, 2, 1, 3)
+        // Chunked SDPA reuses the complete K/V tensors for every query slice.
+        // Materialize the transposed head-major views once so MLX does not
+        // repack the same strided K/V storage inside every attention kernel.
+        query = query.transposed(0, 2, 1, 3).contiguous()
+        key = key.transposed(0, 2, 1, 3).contiguous()
+        let value = projected[2].transposed(0, 2, 1, 3).contiguous()
         return [query, key, value]
     }
 
@@ -1014,6 +1017,23 @@ private func miniMaxH3MaterializeResidentBF16(
     return .init(linearCount: replacements.count, byteCount: byteCount)
 }
 
+private func miniMaxH3ResidentBF16ByteCount(_ linear: Linear) -> UInt64 {
+    if let quantized = linear as? QuantizedLinear {
+        let shape = quantized.shape
+        return UInt64(shape.0) * UInt64(shape.1) * 2
+            + UInt64(quantized.bias?.size ?? 0) * 2
+    }
+    return linear.parameters().flattened().reduce(into: UInt64(0)) { total, entry in
+        total += UInt64(entry.1.size) * 2
+    }
+}
+
+private func miniMaxH3EvaluateParameters(in module: Module) {
+    let parameters = module.parameters().flattened().map(\.1)
+    guard !parameters.isEmpty else { return }
+    MLX.eval(parameters)
+}
+
 struct MiniMaxH3RotaryEmbedding {
     let cosine: MLXArray
     let sine: MLXArray
@@ -1100,10 +1120,8 @@ public final class MiniMaxH3Transformer: Module {
 
     var estimatedResidentBF16ByteCount: UInt64 {
         leafModules().flattened().reduce(into: UInt64(0)) { total, entry in
-            guard let quantized = entry.1 as? QuantizedLinear else { return }
-            let shape = quantized.shape
-            total += UInt64(shape.0) * UInt64(shape.1) * 2
-            total += UInt64(quantized.bias?.size ?? 0) * 2
+            guard let linear = entry.1 as? Linear else { return }
+            total += miniMaxH3ResidentBF16ByteCount(linear)
         }
     }
 
@@ -1114,29 +1132,25 @@ public final class MiniMaxH3Transformer: Module {
     func materializeResidentBF16() -> MiniMaxH3ResidentBF16Materialization {
         compiledBlockRunner = nil
         compiledBlockForwards = nil
-        var total = MiniMaxH3ResidentBF16Materialization(linearCount: 0, byteCount: 0)
 
-        func include(_ materialization: MiniMaxH3ResidentBF16Materialization) {
-            total = .init(
-                linearCount: total.linearCount + materialization.linearCount,
-                byteCount: total.byteCount + materialization.byteCount
-            )
+        func materialize(_ module: Module) {
+            _ = miniMaxH3MaterializeResidentBF16(in: module)
+            miniMaxH3EvaluateParameters(in: module)
             MLX.Memory.clearCache()
         }
 
         for block in tokenRefiner.blocks {
-            include(miniMaxH3MaterializeResidentBF16(in: block))
+            materialize(block)
         }
         for block in blocks {
-            include(miniMaxH3MaterializeResidentBF16(in: block))
+            materialize(block)
         }
         if let timeEmbedder {
-            include(miniMaxH3MaterializeResidentBF16(in: timeEmbedder))
+            materialize(timeEmbedder)
         }
-        include(miniMaxH3MaterializeResidentBF16(in: finalLayer))
+        materialize(finalLayer)
 
         var rootReplacements: [(String, Module)] = []
-        var rootBytes: UInt64 = 0
         for (path, linear) in [
             ("video_patch_proj", videoInput),
             ("audio_patch_proj", audioInput),
@@ -1144,14 +1158,26 @@ public final class MiniMaxH3Transformer: Module {
         ] {
             guard let resident = miniMaxH3ResidentBF16Linear(linear) else { continue }
             rootReplacements.append((path, resident.linear))
-            rootBytes += resident.byteCount
         }
         if !rootReplacements.isEmpty {
             update(modules: ModuleChildren.unflattened(rootReplacements))
-            include(.init(linearCount: rootReplacements.count, byteCount: rootBytes))
         }
-        usesResidentBF16 = total.linearCount > 0
-        return total
+
+        // Sharded BF16 checkpoints already contain dense Linear modules, so
+        // conversion alone is a no-op. Evaluating the complete parameter tree
+        // here makes the requested residency real instead of charging each
+        // transformer block to the first denoise pass.
+        miniMaxH3EvaluateParameters(in: self)
+        MLX.Memory.clearCache()
+
+        let linears = leafModules().flattened().compactMap { $0.1 as? Linear }
+        usesResidentBF16 = !linears.isEmpty && !linears.contains { $0 is QuantizedLinear }
+        return .init(
+            linearCount: linears.count,
+            byteCount: linears.reduce(into: UInt64(0)) { total, linear in
+                total += miniMaxH3ResidentBF16ByteCount(linear)
+            }
+        )
     }
 
     public func callAsFunction(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
@@ -241,6 +241,7 @@ public final class MiniMaxH3VideoVAE: Module {
     static let minimumSpatialTileOverlap = 64
 
     var spatialTileSize = defaultSpatialTileSize
+    var usesCompiledTileDecoder = true
 
     @ModuleInfo(key: "encoder") public var encoder: MiniMaxH3VideoEncoder
     @ModuleInfo(key: "quant_conv") var quantConvolution: Conv3d
@@ -430,10 +431,13 @@ public final class MiniMaxH3VideoVAE: Module {
         let chunkCount = (originalTokenCount + tokenDrop + resolvedPadTokens) / tokensPerChunk - 1
         var decodedChunks: [MLXArray] = []
         var overlap: MLXArray?
-        let tileDecoder = MLX.compile { (channelLast: MLXArray) -> MLXArray in
+        let decodeTile: (MLXArray) -> MLXArray = { (channelLast: MLXArray) -> MLXArray in
             let projected = self.postQuantConvolution(channelLast).transposed(0, 4, 1, 2, 3)
             return self.decoder(projected)
         }
+        let tileDecoder: (MLXArray) -> MLXArray = usesCompiledTileDecoder
+            ? MLX.compile(decodeTile)
+            : decodeTile
         for index in 0..<chunkCount {
             let start = index * tokensPerChunk
             let clip = decodeClip(
@@ -472,7 +476,7 @@ public final class MiniMaxH3VideoVAE: Module {
 
     private func decodeClip(
         _ latent: MLXArray,
-        tileDecoder: @Sendable (MLXArray) -> MLXArray
+        tileDecoder: (MLXArray) -> MLXArray
     ) -> MLXArray {
         let pixelHeight = latent.dim(3) * 16
         let pixelWidth = latent.dim(4) * 16

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
@@ -242,6 +242,7 @@ public final class MiniMaxH3VideoVAE: Module {
 
     var spatialTileSize = defaultSpatialTileSize
     var usesCompiledTileDecoder = true
+    var evaluatesTemporalChunksIndividually = true
 
     @ModuleInfo(key: "encoder") public var encoder: MiniMaxH3VideoEncoder
     @ModuleInfo(key: "quant_conv") var quantConvolution: Conv3d
@@ -444,7 +445,9 @@ public final class MiniMaxH3VideoVAE: Module {
                 denormalized[0..., 0..., start..<(start + tokensPerChunk + tokenOverlap), 0..., 0...],
                 tileDecoder: tileDecoder
             )
-            MLX.eval(clip)
+            if evaluatesTemporalChunksIndividually {
+                MLX.eval(clip)
+            }
             for part in 0..<2 {
                 let frameStart = part * pixelFramesPerChunk
                 let frameEnd = min(frameStart + pixelFramesPerChunk, clip.dim(2))

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3VideoVAE.swift
@@ -237,7 +237,7 @@ public final class MiniMaxH3VideoDecoder: Module {
 }
 
 public final class MiniMaxH3VideoVAE: Module {
-    static let defaultSpatialTileSize = 320
+    static let defaultSpatialTileSize = 256
     static let minimumSpatialTileOverlap = 64
 
     var spatialTileSize = defaultSpatialTileSize

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -294,6 +294,18 @@ final class MachineInferenceAdmissionTests: XCTestCase {
         )
         XCTAssertEqual(
             CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "geo", "fire", "input.safetensors"]
+            ),
+            MachineInferenceRequest(label: "geo fire", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "geo", "olmoearth", "input.safetensors"]
+            ),
+            MachineInferenceRequest(label: "geo olmoearth", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
                 arguments: ["mere.run", "text", "chat", "--model", "text-chat-deepseek-v4-flash"]
             ),
             MachineInferenceRequest(label: "text chat", resourceClass: .large)

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -207,6 +207,51 @@ final class MachineInferenceAdmissionTests: XCTestCase {
         XCTAssertEqual(try coordinator.snapshot().queued.count, 0)
     }
 
+    func testDiskCapacityFallsBackWhenImportantUsageProbeReturnsFalseZero() {
+        let available = 188 * gibibyte
+
+        XCTAssertEqual(
+            MachineInferenceCoordinator.reconciledAvailableDiskBytes(
+                importantUsageCapacity: 0,
+                fileSystemFreeBytes: available
+            ),
+            available
+        )
+    }
+
+    func testDiskCapacityUsesConservativePositiveProbe() {
+        XCTAssertEqual(
+            MachineInferenceCoordinator.reconciledAvailableDiskBytes(
+                importantUsageCapacity: Int64(80 * gibibyte),
+                fileSystemFreeBytes: 100 * gibibyte
+            ),
+            80 * gibibyte
+        )
+        XCTAssertEqual(
+            MachineInferenceCoordinator.reconciledAvailableDiskBytes(
+                importantUsageCapacity: Int64(120 * gibibyte),
+                fileSystemFreeBytes: 100 * gibibyte
+            ),
+            100 * gibibyte
+        )
+    }
+
+    func testDiskCapacityPreservesRealZeroWhenNoPositiveProbeExists() {
+        XCTAssertEqual(
+            MachineInferenceCoordinator.reconciledAvailableDiskBytes(
+                importantUsageCapacity: 0,
+                fileSystemFreeBytes: 0
+            ),
+            0
+        )
+        XCTAssertNil(
+            MachineInferenceCoordinator.reconciledAvailableDiskBytes(
+                importantUsageCapacity: nil,
+                fileSystemFreeBytes: nil
+            )
+        )
+    }
+
     func testLowMemoryRejectsWhenNoActiveWorkCanReleaseHeadroom() async throws {
         let directory = try temporaryDirectory()
         let coordinator = makeCoordinator(

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -680,7 +680,10 @@ final class DiTShapeBenchTests: XCTestCase {
     func testMiniMaxH3PracticalTierSDPA() throws {
         try benchGate()
         Stream.withNewDefaultStream {
-            let rows = 12_925
+            let rows = max(
+                1,
+                Int(ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 12_930
+            )
             let heads = 56
             let headDimension = 128
             let query = MLXRandom.normal([1, heads, rows, headDimension]).asType(.bfloat16)
@@ -1261,7 +1264,10 @@ final class DiTShapeBenchTests: XCTestCase {
     /// schedules so thermal drift hits both arms symmetrically.
     func testMiniMaxH3BlockGEMMSchedules() throws {
         try benchGate()
-        let rows = 37_966
+        let rows = max(
+            1,
+            Int(ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_966
+        )
         let benchmark = MiniMaxH3BlockScheduleBenchmark(
             rowCount: rows,
             maximumQueryTokens: 1_024,
@@ -1289,7 +1295,8 @@ final class DiTShapeBenchTests: XCTestCase {
         }
 
         func selectHybrid() {
-            setenv("MLX_GEMM_H3_TUNED", "1", 1)
+            selectDefault()
+            unsetenv("MLX_GEMM_H3_TUNED")
         }
 
         defer { selectDefault() }
@@ -2119,9 +2126,17 @@ final class DiTShapeBenchTests: XCTestCase {
             return
         }
         let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: frameCount)
+        let usesCompiledDecoder = environment["MERERUN_H3_VAE_COMPILED"] != "0"
+        let materializesWeights = environment["MERERUN_H3_VAE_MATERIALIZE"] == "1"
+        let totalStarted = CFAbsoluteTimeGetCurrent()
         let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: root, isDirectory: true))
         let model = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
         model.spatialTileSize = tileSize
+        model.usesCompiledTileDecoder = usesCompiledDecoder
+        if materializesWeights {
+            MLX.eval(model.parameters())
+        }
+        let loadSeconds = CFAbsoluteTimeGetCurrent() - totalStarted
         let latents = MLXRandom.normal([
             1,
             24,
@@ -2134,13 +2149,19 @@ final class DiTShapeBenchTests: XCTestCase {
         let started = CFAbsoluteTimeGetCurrent()
         let decoded = model.decode(latents)
         MLX.eval(decoded)
+        let decodeSeconds = CFAbsoluteTimeGetCurrent() - started
         print(String(
-            format: "[dit-bench] H3 video VAE tile=%d size=%dx%d frames=%d %.3fs peak=%.2fGiB",
+            format: "[dit-bench] H3 video VAE tile=%d compiled=%@ materialized=%@ "
+                + "size=%dx%d frames=%d load=%.3fs decode=%.3fs total=%.3fs peak=%.2fGiB",
             tileSize,
+            usesCompiledDecoder ? "true" : "false",
+            materializesWeights ? "true" : "false",
             width,
             height,
             decoded.dim(1),
-            CFAbsoluteTimeGetCurrent() - started,
+            loadSeconds,
+            decodeSeconds,
+            loadSeconds + decodeSeconds,
             Double(Memory.snapshot().peakMemory) / 1_073_741_824
         ))
         XCTAssertEqual(decoded.shape, [1, frameCount, height, width, 3])

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -2128,11 +2128,13 @@ final class DiTShapeBenchTests: XCTestCase {
         let latentFrames = try MiniMaxH3Geometry.videoLatentFrameCount(for: frameCount)
         let usesCompiledDecoder = environment["MERERUN_H3_VAE_COMPILED"] != "0"
         let materializesWeights = environment["MERERUN_H3_VAE_MATERIALIZE"] == "1"
+        let evaluatesChunksIndividually = environment["MERERUN_H3_VAE_CHUNK_EVAL"] != "0"
         let totalStarted = CFAbsoluteTimeGetCurrent()
         let resources = MiniMaxH3Resources(rootURL: URL(fileURLWithPath: root, isDirectory: true))
         let model = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
         model.spatialTileSize = tileSize
         model.usesCompiledTileDecoder = usesCompiledDecoder
+        model.evaluatesTemporalChunksIndividually = evaluatesChunksIndividually
         if materializesWeights {
             MLX.eval(model.parameters())
         }
@@ -2151,11 +2153,12 @@ final class DiTShapeBenchTests: XCTestCase {
         MLX.eval(decoded)
         let decodeSeconds = CFAbsoluteTimeGetCurrent() - started
         print(String(
-            format: "[dit-bench] H3 video VAE tile=%d compiled=%@ materialized=%@ "
+            format: "[dit-bench] H3 video VAE tile=%d compiled=%@ materialized=%@ chunk_eval=%@ "
                 + "size=%dx%d frames=%d load=%.3fs decode=%.3fs total=%.3fs peak=%.2fGiB",
             tileSize,
             usesCompiledDecoder ? "true" : "false",
             materializesWeights ? "true" : "false",
+            evaluatesChunksIndividually ? "true" : "false",
             width,
             height,
             decoded.dim(1),

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -592,7 +592,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: false,
-                sequenceLength: 12_925,
+                sequenceLength: 11_925,
                 usesBlockProfiling: false
             ),
             .compiledStep
@@ -601,7 +601,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: false,
-                sequenceLength: 12_925,
+                sequenceLength: 11_925,
                 usesBlockProfiling: true
             ),
             .eagerStep
@@ -610,7 +610,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: true,
-                sequenceLength: 12_925,
+                sequenceLength: 11_925,
                 usesBlockProfiling: false,
                 denoiseStepCount: 1
             ),
@@ -619,7 +619,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: true,
-                sequenceLength: 12_925,
+                sequenceLength: 11_925,
                 usesBlockProfiling: false,
                 denoiseStepCount: 2
             ),
@@ -628,7 +628,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: true,
-                sequenceLength: 12_925,
+                sequenceLength: 11_925,
                 usesBlockProfiling: false,
                 profilingOverride: "compiled"
             ),
@@ -637,7 +637,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: false,
-                sequenceLength: 12_925,
+                sequenceLength: 11_925,
                 usesBlockProfiling: true,
                 profilingOverride: "compiled"
             ),
@@ -656,6 +656,20 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
 
     func testDenoiseExecutionPolicyUsesMeasuredBlockwiseKernelSchedule() {
         XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 12_930)
+                .maximumQueryTokens,
+            640
+        )
+        XCTAssertEqual(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 12_930)
+                .maximumKernelsPerEvaluation,
+            1
+        )
+        XCTAssertNil(
+            MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 12_930)
+                .maximumHeadsPerKernel
+        )
+        XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 14_958)
                 .maximumQueryTokens,
             1_024
@@ -663,7 +677,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 14_958)
                 .maximumKernelsPerEvaluation,
-            4
+            1
         )
         XCTAssertNil(
             MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(sequenceLength: 14_958)
@@ -922,6 +936,40 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             ).max().item(Float.self),
             0.05
         )
+    }
+
+    func testTinyDenseBF16TransformerIsActuallyMaterialized() {
+        let configuration = MiniMaxH3TransformerConfiguration(
+            hiddenSize: 32,
+            layerCount: 2,
+            refinerLayerCount: 1,
+            attentionHeadCount: 4,
+            attentionHeadDimension: 8,
+            feedForwardSize: 64,
+            videoLatentChannels: 8,
+            audioLatentChannels: 32,
+            patchSize: [1, 2, 2],
+            textDimension: 32,
+            timeFrequencyDimension: 32,
+            timeEmbeddingHiddenSize: 32,
+            timeEmbeddingDimension: 32,
+            ropeFrequencyCount: 1
+        )
+        let model = MiniMaxH3Transformer(configuration: configuration)
+        model.update(parameters: model.parameters().mapValues { $0.asType(.bfloat16) })
+        let linearCount = model.leafModules().flattened().count { $0.1 is Linear }
+        let estimatedBytes = model.estimatedResidentBF16ByteCount
+
+        XCTAssertGreaterThan(linearCount, 0)
+        XCTAssertGreaterThan(estimatedBytes, 0)
+        XCTAssertFalse(model.usesResidentBF16)
+
+        let materialized = model.materializeResidentBF16()
+
+        XCTAssertTrue(model.usesResidentBF16)
+        XCTAssertEqual(materialized.linearCount, linearCount)
+        XCTAssertEqual(materialized.byteCount, estimatedBytes)
+        XCTAssertFalse(model.leafModules().flattened().contains { $0.1 is QuantizedLinear })
     }
 
     func testTinyTransformerPreservesTargetShapes() throws {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -400,7 +400,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
 
     func testVideoVAETilePlansPreserveCanvasAndMinimumOverlap() {
         XCTAssertEqual(MiniMaxH3VideoVAE.defaultSpatialTileSize, 320)
-        for tileSize in [256, 320] {
+        for tileSize in [256, 304, 320] {
             for length in [480, 832, 1_344] {
                 let plan = MiniMaxH3VideoVAE.tilePlan(length: length, tileSize: tileSize)
                 XCTAssertEqual(plan.starts.first, 0)

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -399,7 +399,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
     }
 
     func testVideoVAETilePlansPreserveCanvasAndMinimumOverlap() {
-        XCTAssertEqual(MiniMaxH3VideoVAE.defaultSpatialTileSize, 320)
+        XCTAssertEqual(MiniMaxH3VideoVAE.defaultSpatialTileSize, 256)
         for tileSize in [256, 304, 320] {
             for length in [480, 832, 1_344] {
                 let plan = MiniMaxH3VideoVAE.tilePlan(length: length, tileSize: tileSize)

--- a/scripts/h3-end-to-end-benchmark.sh
+++ b/scripts/h3-end-to-end-benchmark.sh
@@ -80,9 +80,10 @@ steps="${MERERUN_H3_BENCH_STEPS:-$steps}"
 if [[ ! -x "$binary" || "${MERERUN_H3_BENCH_REBUILD:-0}" == "1" ]]; then
   swift build -c release --product mere.run
 fi
-if pgrep -f '/mere\.run ' >/dev/null; then
-  print -u2 "another mere.run workload is active; refusing a contaminated H3 benchmark"
-  pgrep -fl '/mere\.run ' >&2
+contaminant_pattern='/mere\.run |mlxfast|mlx-fast|MereRunPackageTests\.xctest|python.*(mlx|train|eval)'
+if pgrep -if "$contaminant_pattern" >/dev/null; then
+  print -u2 "another ML workload is active; refusing a contaminated H3 benchmark"
+  pgrep -ifl "$contaminant_pattern" >&2
   exit 75
 fi
 

--- a/scripts/h3-end-to-end-benchmark.sh
+++ b/scripts/h3-end-to-end-benchmark.sh
@@ -80,8 +80,9 @@ steps="${MERERUN_H3_BENCH_STEPS:-$steps}"
 if [[ ! -x "$binary" || "${MERERUN_H3_BENCH_REBUILD:-0}" == "1" ]]; then
   swift build -c release --product mere.run
 fi
-if pgrep -f "$binary video generate" >/dev/null; then
-  print -u2 "another mere.run video generation is active; refusing a contaminated benchmark"
+if pgrep -f '/mere\.run ' >/dev/null; then
+  print -u2 "another mere.run workload is active; refusing a contaminated H3 benchmark"
+  pgrep -fl '/mere\.run ' >&2
   exit 75
 fi
 

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -11,11 +11,18 @@ export MERERUN_DIT_BENCH=1
 export CFFIXED_USER_HOME="${MERERUN_H3_LAB_HOME:-${TMPDIR:-/tmp}/mere-run-h3-kernel-home}"
 mkdir -p "$CFFIXED_USER_HOME"
 
+if pgrep -f '/mere\.run ' >/dev/null; then
+  print -u2 "another mere.run workload is active; refusing a contaminated H3 kernel benchmark"
+  pgrep -fl '/mere\.run ' >&2
+  exit 75
+fi
+
 run_release_test() {
   local filter="$1"
   local release_root="$repo_root/.build/arm64-apple-macosx/release"
   local test_binary_root="$release_root/MereRunPackageTests.xctest/Contents/MacOS"
   local test_binary="$test_binary_root/MereRunPackageTests"
+  local default_metallib="$release_root/Resources/default.metallib"
   local stale_source=""
 
   if [[ -f "$test_binary" ]]; then
@@ -25,8 +32,11 @@ run_release_test() {
     swift build --build-tests -c release -Xswiftc -enable-testing -Xswiftc -DDEBUG
   fi
   if [[ ! -f "$test_binary_root/mlx.metallib" ]]; then
+    if [[ ! -f "$default_metallib" ]]; then
+      default_metallib="$release_root/magentart.framework/Resources/default.metallib"
+    fi
     mkdir -p "$test_binary_root"
-    cp "$release_root/Resources/default.metallib" "$test_binary_root/mlx.metallib"
+    cp "$default_metallib" "$test_binary_root/mlx.metallib"
   fi
   xcrun xctest -XCTest "$filter" "$release_root/MereRunPackageTests.xctest"
 }

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -11,9 +11,10 @@ export MERERUN_DIT_BENCH=1
 export CFFIXED_USER_HOME="${MERERUN_H3_LAB_HOME:-${TMPDIR:-/tmp}/mere-run-h3-kernel-home}"
 mkdir -p "$CFFIXED_USER_HOME"
 
-if pgrep -f '/mere\.run ' >/dev/null; then
-  print -u2 "another mere.run workload is active; refusing a contaminated H3 kernel benchmark"
-  pgrep -fl '/mere\.run ' >&2
+contaminant_pattern='/mere\.run |mlxfast|mlx-fast|MereRunPackageTests\.xctest|python.*(mlx|train|eval)'
+if pgrep -if "$contaminant_pattern" >/dev/null; then
+  print -u2 "another ML workload is active; refusing a contaminated H3 kernel benchmark"
+  pgrep -ifl "$contaminant_pattern" >&2
   exit 75
 fi
 


### PR DESCRIPTION
## What changed

- make macOS disk admission reconcile important-usage capacity with filesystem free space, fixing false `0 KB` rejections
- classify `geo` inference as a large machine-admitted workload so TESSERA, OlmoEarth, and other graph jobs cannot silently overlap H3
- make resident BF16 transformer residency truthful and materialized before denoise
- use contiguous head-major Q/K/V views and a measured practical-shape attention schedule (`640` query rows, all `56` heads, one kernel evaluation at a time)
- keep practical H3 denoise blockwise compiled to bound graph size and buffer pressure
- reduce the H3 video VAE spatial tile default from `320` to `256`
- strengthen H3 benchmark preflight so Mere, mlx-fast, xctest, and Python MLX workloads cause an explicit refusal instead of a contaminated timing

## Why

MiniMax-H3 at the released 768x448/124-frame shape was losing time to execution boundaries and layouts that benchmark well at smaller shapes but degrade on a sustained M4 Max laptop run. Separately, macOS could report zero important-usage capacity even when the filesystem had substantial free space, and newly added geo graph commands were not protected by the shared inference admission coordinator.

The accepted changes are the candidates that survived repeated clean, same-machine measurements. Eager VAE execution, up-front VAE materialization, removing per-temporal-chunk evaluation, broadcast rotary tensors, rsqrt head normalization, and a custom matmul candidate were all measured and rejected.

## Measured impact

All measurements used the released BF16 H3 model at 768x448, 124 frames, with no competing Mere, mlx-fast, xctest, graph, or Python MLX process.

- practical-shape denoise forward: `113.422s` baseline to a repeated `104.065s` mean with the accepted q640 schedule, about `8.25%` faster
- video VAE: tile 320 repeated mean `75.690s`; tile 256 repeated mean `59.188s`, about `21.8%` less decode time and lower peak memory (`8.81 GiB` to `8.32 GiB`)
- final quality render: 8 full forwards, `12930` rows, resident BF16, fixed seed
  - denoise: `1153.200s` total, `144.150s/forward` sustained
  - video decode: `86.516s`
  - audio decode: `1.081s`
  - generation total: `1256.417s` (`20:56.4`)
  - verified H.264 768x448/24 fps plus stereo AAC, 124 frames, full ffmpeg decode clean

The final laptop render is an honest heat-soaked receipt. Hardware cooling materially affected sustained throughput; this PR claims only the repeatable code-path wins above.

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 0 violations across 1158 files
  - build and CLI/hygiene gates passed
  - 2555 tests passed with 0 failures and 167 asset-gated skips
- targeted macOS disk-admission, geo-classifier, H3 layout/residency, and VAE tile tests passed
- final eight-forward MP4 stream probe, checksum, full decode, and visual contact-sheet inspection passed
