### PR TITLE
Add LightX2V MiniMax-H3 adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Video
+
+- added `minimax-h3-lightx2v-4step` as a second immutable, checksum-pinned
+  MiniMax-H3 managed adapter. The native runtime reads LightX2V's published
+  312-pair PEFT checkpoint directly, preserves its separate Q/K/V projections
+  without an expanded converted copy, applies its published alpha/rank scale,
+  fuses the deltas into BF16 weights once before denoising, and uses the
+  existing exact four-evaluation FL2VA path without per-block LoRA matmuls.
+
 ### Geospatial inference
 
 - added native TerraMind ImpactMesh Fire segmentation, with an immutable

--- a/README.md
+++ b/README.md
@@ -776,6 +776,15 @@ swift run mere.run video generate \
   --width 1280 --height 768 --duration 10 --steps 20 \
   --output ./bus-stop-bf16.mp4
 
+# Two checksum-pinned four-evaluation adapters for the BF16 H3 model
+swift run mere.run adapter pull minimax-h3-turbo-4step
+swift run mere.run adapter pull minimax-h3-lightx2v-4step
+swift run mere.run video generate \
+  "two actors cross a rain-soaked street while trading a whispered line" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --h3-adapter minimax-h3-lightx2v-4step \
+  --output ./street-dialogue-h3.mp4
+
 # A locally converted Ref2VA root preserves reference order semantically
 swift run mere.run video generate \
   "keep the subject, borrow the camera move, and follow the vocal rhythm" \

--- a/Sources/MereRunCore/ManagedAdapterCatalog.swift
+++ b/Sources/MereRunCore/ManagedAdapterCatalog.swift
@@ -81,6 +81,8 @@ public enum ManagedAdapterCatalog {
     public static let scail2LightX2VFourStepRevision = "27ae38da91014b947dd39cc3fa78b97cd7b386dd"
     public static let miniMaxH3TurboFourStepID = "minimax-h3-turbo-4step"
     public static let miniMaxH3TurboFourStepRevision = "b604dd5fe25c4c747699f698a1e63f6c46d4a066"
+    public static let miniMaxH3LightX2VFourStepID = "minimax-h3-lightx2v-4step"
+    public static let miniMaxH3LightX2VFourStepRevision = "b65e359c0d128b3c5e08e0f5bf2791b794378588"
 
     public static let allSpecs: [ManagedAdapterSpec] = [
         ManagedAdapterSpec(
@@ -126,7 +128,7 @@ public enum ManagedAdapterCatalog {
         ),
         ManagedAdapterSpec(
             id: miniMaxH3TurboFourStepID,
-            title: "MiniMax-H3 Turbo 4-step",
+            title: "MiniMax-H3 Turbo 4-step (EMA-850)",
             version: String(miniMaxH3TurboFourStepRevision.prefix(12)),
             summary: "Four-evaluation runtime LoRA for the native MiniMax-H3 BF16 FL2VA model.",
             baseModelID: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
@@ -143,6 +145,27 @@ public enum ManagedAdapterCatalog {
                 filename: "minimax_h3_turbo_4step_ema_ckpt850.safetensors",
                 byteCount: 779_849_816,
                 sha256: "5a6eeba171cf183020a4ad48774bb2968f29f8168afd6ec17a04987f3528b4ea"
+            )
+        ),
+        ManagedAdapterSpec(
+            id: miniMaxH3LightX2VFourStepID,
+            title: "MiniMax-H3 Turbo 4-step (LightX2V)",
+            version: String(miniMaxH3LightX2VFourStepRevision.prefix(12)),
+            summary: "LightX2V four-evaluation PEFT LoRA for the native MiniMax-H3 BF16 FL2VA model.",
+            baseModelID: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            format: MiniMaxH3TurboAdapter.lightX2VFormat,
+            license: "Apache-2.0 (adapter); MiniMax-H3 Community License (base model)",
+            upstreamRevision: miniMaxH3LightX2VFourStepRevision,
+            releaseManifestURL: URL(
+                string: "https://huggingface.co/lightx2v/Minimax-h3-Turbo/commit/\(miniMaxH3LightX2VFourStepRevision)"
+            )!,
+            downloadURL: URL(
+                string: "https://huggingface.co/lightx2v/Minimax-h3-Turbo/resolve/\(miniMaxH3LightX2VFourStepRevision)/minimax_h3_fl2v_turbo_4step_v0.1.safetensors?download=true"
+            )!,
+            artifact: ModelArtifactPin(
+                filename: "minimax_h3_fl2v_turbo_4step_v0.1.safetensors",
+                byteCount: 1_383_677_888,
+                sha256: "5ff4a12c8b4599fec716e1b15a45e504e0d1129111896bdcde5ac4a15e395b29"
             )
         ),
     ]

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
@@ -4,30 +4,86 @@ import MLXNN
 
 public enum MiniMaxH3TurboAdapter {
     public static let format = "minimax-h3-runtime-lora-v1"
+    public static let lightX2VFormat = "minimax-h3-peft-fused-lora-v1"
     public static let expectedPairCount = 259
+    public static let lightX2VExpectedPairCount = 312
     public static let recommendedSchedulePointCount = 5
 
-    enum AdapterError: LocalizedError {
+    private static let lightX2VAlpha: Float = 8
+
+    private enum SourceFormat: Equatable {
+        case runtime
+        case lightX2V
+
+        var pairSuffixes: (String, String) {
+            switch self {
+            case .runtime:
+                return (".lora_A.weight", ".lora_B.weight")
+            case .lightX2V:
+                return (".lora_A.default.weight", ".lora_B.default.weight")
+            }
+        }
+
+        var expectedPairCount: Int {
+            switch self {
+            case .runtime:
+                return MiniMaxH3TurboAdapter.expectedPairCount
+            case .lightX2V:
+                return MiniMaxH3TurboAdapter.lightX2VExpectedPairCount
+            }
+        }
+    }
+
+    private enum QKVBranch: String, CaseIterable {
+        case query
+        case key
+        case value
+    }
+
+    private struct LoRAPair {
+        let down: MLXArray
+        let up: MLXArray
+    }
+
+    private struct LightX2VTarget {
+        let modulePath: String
+        let qkvBranch: QKVBranch?
+    }
+
+    private enum AdapterError: LocalizedError {
+        case unrecognizedFormat(URL)
         case noPairs(URL)
         case unexpectedPairCount(expected: Int, actual: Int)
+        case unsupportedSourceModule(String)
         case missingTargetModule(String)
         case targetIsNotDenseLinear(String)
         case duplicateTarget(String)
+        case duplicateQKVBranch(String, QKVBranch)
+        case incompleteQKVTarget(String, missing: [QKVBranch])
         case invalidPairShape(String, a: [Int], b: [Int])
         case targetShapeMismatch(String, expected: [Int], actual: [Int])
 
         var errorDescription: String? {
             switch self {
+            case .unrecognizedFormat(let url):
+                return "Unsupported MiniMax-H3 LoRA tensor format in \(url.path)."
             case .noPairs(let url):
                 return "No MiniMax-H3 LoRA tensor pairs were found in \(url.path)."
             case .unexpectedPairCount(let expected, let actual):
                 return "MiniMax-H3 LoRA tensor-pair count mismatch: expected \(expected), found \(actual)."
+            case .unsupportedSourceModule(let path):
+                return "Unsupported MiniMax-H3 LoRA source module: \(path)"
             case .missingTargetModule(let path):
                 return "MiniMax-H3 LoRA target module is missing: \(path)"
             case .targetIsNotDenseLinear(let path):
                 return "MiniMax-H3 Turbo currently requires the BF16 transformer; target \(path) is not a dense Linear layer."
             case .duplicateTarget(let path):
                 return "MiniMax-H3 LoRA contains a duplicate target: \(path)"
+            case .duplicateQKVBranch(let path, let branch):
+                return "MiniMax-H3 LoRA contains a duplicate \(branch.rawValue) branch for \(path)."
+            case .incompleteQKVTarget(let path, let missing):
+                let names = missing.map(\.rawValue).joined(separator: ", ")
+                return "MiniMax-H3 LoRA target \(path) is missing QKV branches: \(names)."
             case .invalidPairShape(let path, let a, let b):
                 return "Invalid MiniMax-H3 LoRA pair for \(path): A=\(a), B=\(b)."
             case .targetShapeMismatch(let path, let expected, let actual):
@@ -41,70 +97,285 @@ public enum MiniMaxH3TurboAdapter {
         url: URL,
         into transformer: MiniMaxH3Transformer,
         strength: Float,
-        expectedPairCount: Int? = expectedPairCount
+        expectedPairCount: Int? = nil
     ) throws -> Int {
+        let sourceFormat = try sourceFormat(at: url)
+        let suffixes = sourceFormat.pairSuffixes
         let leafModules = transformer.leafModules().flattened()
         let modulesByPath = Dictionary(uniqueKeysWithValues: leafModules)
         var replacements: [String: Module] = [:]
+        var qkvPairs: [String: [QKVBranch: LoRAPair]] = [:]
+        var fusedTargets: Set<String> = []
 
         let pairCount = try SafetensorsStreamingLoader.forEachTensorPair(
             url: url,
-            firstSuffix: ".lora_A.weight",
-            secondSuffix: ".lora_B.weight"
-        ) { modulePath, rawDown, rawUp in
-            guard replacements[modulePath] == nil else {
-                throw AdapterError.duplicateTarget(modulePath)
-            }
-            guard let module = modulesByPath[modulePath] else {
-                throw AdapterError.missingTargetModule(modulePath)
-            }
-            guard let linear = module as? Linear,
-                  !(linear is QuantizedLinear) else {
-                throw AdapterError.targetIsNotDenseLinear(modulePath)
-            }
+            firstSuffix: suffixes.0,
+            secondSuffix: suffixes.1
+        ) { sourcePath, rawDown, rawUp in
+            let target = try target(for: sourcePath, sourceFormat: sourceFormat)
             guard rawDown.ndim == 2,
                   rawUp.ndim == 2,
                   rawUp.dim(1) == rawDown.dim(0) else {
                 throw AdapterError.invalidPairShape(
-                    modulePath,
+                    sourcePath,
                     a: rawDown.shape,
                     b: rawUp.shape
                 )
             }
 
-            let up = modulePath.hasSuffix(".attn.qkv_proj")
+            let up = scaledUp(rawUp, down: rawDown, sourceFormat: sourceFormat)
+            if let branch = target.qkvBranch {
+                guard !fusedTargets.contains(target.modulePath) else {
+                    throw AdapterError.duplicateTarget(target.modulePath)
+                }
+                var branches = qkvPairs[target.modulePath] ?? [:]
+                guard branches[branch] == nil else {
+                    throw AdapterError.duplicateQKVBranch(target.modulePath, branch)
+                }
+                branches[branch] = LoRAPair(
+                    down: rawDown,
+                    up: up
+                )
+                if branches.count == QKVBranch.allCases.count {
+                    guard replacements[target.modulePath] == nil else {
+                        throw AdapterError.duplicateTarget(target.modulePath)
+                    }
+                    let linear = try denseLinear(at: target.modulePath, in: modulesByPath)
+                    let query = branches[.query]!
+                    let key = branches[.key]!
+                    let value = branches[.value]!
+                    try validateQKV(
+                        target.modulePath,
+                        query: query,
+                        key: key,
+                        value: value,
+                        base: linear
+                    )
+                    fuseQKVLinear(
+                        base: linear,
+                        query: query,
+                        key: key,
+                        value: value,
+                        strength: strength
+                    )
+                    fusedTargets.insert(target.modulePath)
+                    qkvPairs.removeValue(forKey: target.modulePath)
+                } else {
+                    qkvPairs[target.modulePath] = branches
+                }
+                return
+            }
+
+            guard replacements[target.modulePath] == nil,
+                  !fusedTargets.contains(target.modulePath) else {
+                throw AdapterError.duplicateTarget(target.modulePath)
+            }
+            let linear = try denseLinear(at: target.modulePath, in: modulesByPath)
+            let mappedUp = target.modulePath.hasSuffix(".attn.qkv_proj")
                 ? MiniMaxH3ModelLoader.deinterleavedQKVOutputRows(
-                    rawUp,
+                    up,
                     headCount: transformer.configuration.attentionHeadCount,
                     headDimension: transformer.configuration.attentionHeadDimension
                 )
-                : rawUp
-            guard rawDown.dim(1) == linear.shape.1,
-                  up.dim(0) == linear.shape.0 else {
-                throw AdapterError.targetShapeMismatch(
-                    modulePath,
-                    expected: [linear.shape.0, linear.shape.1],
-                    actual: [up.dim(0), rawDown.dim(1)]
-                )
-            }
-
-            let layer = MiniMaxH3RuntimeLoRALinear(
-                base: linear,
-                loraDown: rawDown,
-                loraUp: up,
-                strength: strength
+                : up
+            try validate(
+                target.modulePath,
+                down: rawDown,
+                up: mappedUp,
+                base: linear
             )
-            MLX.eval(layer.loraDown, layer.loraUp)
-            replacements[modulePath] = layer
+            switch sourceFormat {
+            case .runtime:
+                let runtimeLayer = MiniMaxH3RuntimeLoRALinear(
+                    base: linear,
+                    loraDown: rawDown,
+                    loraUp: mappedUp,
+                    strength: strength
+                )
+                MLX.eval(runtimeLayer.loraDown, runtimeLayer.loraUp)
+                replacements[target.modulePath] = runtimeLayer
+            case .lightX2V:
+                fuseLinear(
+                    base: linear,
+                    down: rawDown,
+                    up: mappedUp,
+                    strength: strength
+                )
+                fusedTargets.insert(target.modulePath)
+            }
         }
 
         guard pairCount > 0 else { throw AdapterError.noPairs(url) }
-        if let expectedPairCount, pairCount != expectedPairCount {
-            throw AdapterError.unexpectedPairCount(expected: expectedPairCount, actual: pairCount)
+        let requiredPairCount = expectedPairCount ?? sourceFormat.expectedPairCount
+        guard pairCount == requiredPairCount else {
+            throw AdapterError.unexpectedPairCount(expected: requiredPairCount, actual: pairCount)
         }
+
+        for (modulePath, branches) in qkvPairs {
+            let missing = QKVBranch.allCases.filter { branches[$0] == nil }
+            throw AdapterError.incompleteQKVTarget(modulePath, missing: missing)
+        }
+
         applyModuleReplacements(replacements, leafModules: leafModules, to: transformer)
         Memory.clearCache()
         return pairCount
+    }
+
+    private static func sourceFormat(at url: URL) throws -> SourceFormat {
+        let keys = try SafetensorsStreamingLoader.metadata(url: url).keys
+        if keys.contains(where: { $0.hasSuffix(".lora_A.default.weight") }) {
+            return .lightX2V
+        }
+        if keys.contains(where: { $0.hasSuffix(".lora_A.weight") }) {
+            return .runtime
+        }
+        throw AdapterError.unrecognizedFormat(url)
+    }
+
+    private static func target(
+        for sourcePath: String,
+        sourceFormat: SourceFormat
+    ) throws -> LightX2VTarget {
+        guard sourceFormat == .lightX2V else {
+            return LightX2VTarget(modulePath: sourcePath, qkvBranch: nil)
+        }
+
+        let runtimePrefix: String
+        let remainder: Substring
+        if sourcePath.hasPrefix("transformer_blocks.") {
+            runtimePrefix = "blocks."
+            remainder = sourcePath.dropFirst("transformer_blocks.".count)
+        } else if sourcePath.hasPrefix("token_refiner.refiner_blocks.") {
+            runtimePrefix = "token_refiner.blocks."
+            remainder = sourcePath.dropFirst("token_refiner.refiner_blocks.".count)
+        } else {
+            throw AdapterError.unsupportedSourceModule(sourcePath)
+        }
+        let normalized = runtimePrefix + remainder
+
+        for (suffix, branch) in [
+            (".attn.to_q", QKVBranch.query),
+            (".attn.to_k", QKVBranch.key),
+            (".attn.to_v", QKVBranch.value),
+        ] where normalized.hasSuffix(suffix) {
+            return LightX2VTarget(
+                modulePath: String(normalized.dropLast(suffix.count)) + ".attn.qkv_proj",
+                qkvBranch: branch
+            )
+        }
+
+        for (suffix, replacement) in [
+            (".attn.to_out.0", ".attn.out_proj"),
+            (".ff.net.0.proj", ".mlp.fc1"),
+            (".ff.net.2", ".mlp.fc2"),
+        ] where normalized.hasSuffix(suffix) {
+            return LightX2VTarget(
+                modulePath: String(normalized.dropLast(suffix.count)) + replacement,
+                qkvBranch: nil
+            )
+        }
+        throw AdapterError.unsupportedSourceModule(sourcePath)
+    }
+
+    private static func scaledUp(
+        _ up: MLXArray,
+        down: MLXArray,
+        sourceFormat: SourceFormat
+    ) -> MLXArray {
+        guard sourceFormat == .lightX2V else { return up }
+        let scale = MLXArray(lightX2VAlpha / Float(down.dim(0))).asType(up.dtype)
+        return up * scale
+    }
+
+    private static func denseLinear(
+        at path: String,
+        in modulesByPath: [String: Module]
+    ) throws -> Linear {
+        guard let module = modulesByPath[path] else {
+            throw AdapterError.missingTargetModule(path)
+        }
+        guard let linear = module as? Linear,
+              !(linear is QuantizedLinear) else {
+            throw AdapterError.targetIsNotDenseLinear(path)
+        }
+        return linear
+    }
+
+    private static func validate(
+        _ path: String,
+        down: MLXArray,
+        up: MLXArray,
+        base: Linear
+    ) throws {
+        guard down.dim(1) == base.shape.1,
+              up.dim(0) == base.shape.0 else {
+            throw AdapterError.targetShapeMismatch(
+                path,
+                expected: [base.shape.0, base.shape.1],
+                actual: [up.dim(0), down.dim(1)]
+            )
+        }
+    }
+
+    private static func validateQKV(
+        _ path: String,
+        query: LoRAPair,
+        key: LoRAPair,
+        value: LoRAPair,
+        base: Linear
+    ) throws {
+        guard base.shape.0.isMultiple(of: 3) else {
+            throw AdapterError.targetShapeMismatch(
+                path,
+                expected: [base.shape.0, base.shape.1],
+                actual: [base.shape.0, base.shape.1]
+            )
+        }
+        let branchOutputSize = base.shape.0 / 3
+        for pair in [query, key, value] {
+            guard pair.down.dim(1) == base.shape.1,
+                  pair.up.dim(0) == branchOutputSize else {
+                throw AdapterError.targetShapeMismatch(
+                    path,
+                    expected: [base.shape.0, base.shape.1],
+                    actual: [3 * pair.up.dim(0), pair.down.dim(1)]
+                )
+            }
+        }
+    }
+
+    private static func fuseLinear(
+        base: Linear,
+        down: MLXArray,
+        up: MLXArray,
+        strength: Float
+    ) {
+        let dtype = base.weight.dtype
+        let delta = MLX.matmul(up.asType(dtype), down.asType(dtype))
+            * MLXArray(strength).asType(dtype)
+        let fusedWeight = base.weight + delta
+        MLX.eval(fusedWeight)
+        base.update(parameters: ModuleParameters.unflattened([("weight", fusedWeight)]))
+        Memory.clearCache()
+    }
+
+    private static func fuseQKVLinear(
+        base: Linear,
+        query: LoRAPair,
+        key: LoRAPair,
+        value: LoRAPair,
+        strength: Float
+    ) {
+        let dtype = base.weight.dtype
+        let deltas = [query, key, value].map { pair in
+            MLX.matmul(pair.up.asType(dtype), pair.down.asType(dtype))
+        }
+        let delta = MLX.concatenated(deltas, axis: 0)
+            * MLXArray(strength).asType(dtype)
+        let fusedWeight = base.weight + delta
+        MLX.eval(fusedWeight)
+        base.update(parameters: ModuleParameters.unflattened([("weight", fusedWeight)]))
+        Memory.clearCache()
     }
 
     private static func applyModuleReplacements(

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -30,13 +30,16 @@ the CLI can force either mode. H3 inference also raises MLX wired residency
 through the shared ticket coordinator so weights and activation workspaces do
 not silently fall out of the GPU residency set.
 
-The optional checksum-pinned `minimax-h3-turbo-4step` LoRA runs only with the
-BF16 FL2VA transformer. Its 259 mixed-rank pairs are applied as
-activation-space deltas rather than merged into the base, and its fused QKV
-rows are deinterleaved to match the runtime's global slabs. AdaLN adapter
-deltas are included while the exact four-evaluation schedule cache is built,
-before the large schedule-only weights are discarded. Turbo cannot be
-combined with Ref2VA or tail-residual reuse.
+The checksum-pinned `minimax-h3-turbo-4step` and
+`minimax-h3-lightx2v-4step` LoRAs run only with the BF16 FL2VA transformer.
+The EMA-850 adapter's 259 mixed-rank pairs are applied as activation-space
+deltas, its fused QKV rows are deinterleaved to match the runtime's global
+slabs, and its AdaLN deltas are included while the exact four-evaluation
+schedule cache is built. The LightX2V adapter's 312 native PEFT pairs retain
+their separate Q/K/V projections and published alpha/rank scale while their
+deltas are fused into the BF16 transformer once before denoising. This avoids
+both an expanded converted checkpoint and per-block LoRA matmuls. Neither
+adapter can be combined with Ref2VA or tail-residual reuse.
 
 `--h3-acceleration quality` executes every transformer block and preserves the
 native same-seed trajectory. The explicit `balanced` and `maximum` modes trade

--- a/Tests/MereRunCLITests/AdapterCommandTests.swift
+++ b/Tests/MereRunCLITests/AdapterCommandTests.swift
@@ -34,6 +34,14 @@ struct AdapterCommandTests {
         #expect(command.target == ManagedAdapterCatalog.miniMaxH3TurboFourStepID)
     }
 
+    @Test("MiniMax-H3 LightX2V adapter pull parses its canonical id")
+    func parsesMiniMaxH3LightX2VPull() throws {
+        let command = try AdapterPull.parse([
+            ManagedAdapterCatalog.miniMaxH3LightX2VFourStepID,
+        ])
+        #expect(command.target == ManagedAdapterCatalog.miniMaxH3LightX2VFourStepID)
+    }
+
     @Test("Local LoRA paths remain supported")
     func resolvesLocalPath() throws {
         let relative = "fixtures/local-adapter.safetensors"

--- a/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
@@ -53,6 +53,22 @@ struct ManagedAdapterCatalogTests {
         #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
     }
 
+    @Test("MiniMax-H3 LightX2V release is an immutable BF16 runtime pin")
+    func miniMaxH3LightX2VReleaseIsPinned() throws {
+        let spec = try #require(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.miniMaxH3LightX2VFourStepID)
+        )
+        #expect(spec.version == "b65e359c0d12")
+        #expect(spec.baseModelID == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue)
+        #expect(spec.format == MiniMaxH3TurboAdapter.lightX2VFormat)
+        #expect(spec.upstreamRevision == "b65e359c0d128b3c5e08e0f5bf2791b794378588")
+        #expect(spec.artifact.filename == "minimax_h3_fl2v_turbo_4step_v0.1.safetensors")
+        #expect(spec.artifact.byteCount == 1_383_677_888)
+        #expect(spec.artifact.sha256 == "5ff4a12c8b4599fec716e1b15a45e504e0d1129111896bdcde5ac4a15e395b29")
+        #expect(spec.downloadURL.host == "huggingface.co")
+        #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
+    }
+
     @Test("Catalog ids resolve case-insensitively")
     func normalizedLookup() {
         #expect(ManagedAdapterCatalog.spec(for: " MERE-PLATFORM-ASSISTANT ")?.version == "22")

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -20,6 +20,87 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(output.asArray(Float.self), [8, 11])
     }
 
+    func testLightX2VPEFTAdapterFusesOnceIntoNativeRuntime() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let adapterURL = temp.appendingPathComponent("lightx2v-h3.safetensors")
+        let rankOneInput = MLXArray.ones([1, 2], dtype: .float32)
+        let rankOneAttentionOutput = MLXArray.ones([2, 1], dtype: .float32)
+        try MLX.save(
+            arrays: [
+                "transformer_blocks.0.attn.to_q.lora_A.default.weight": rankOneInput,
+                "transformer_blocks.0.attn.to_q.lora_B.default.weight": rankOneAttentionOutput,
+                "transformer_blocks.0.attn.to_k.lora_A.default.weight": rankOneInput,
+                "transformer_blocks.0.attn.to_k.lora_B.default.weight": rankOneAttentionOutput,
+                "transformer_blocks.0.attn.to_v.lora_A.default.weight": rankOneInput,
+                "transformer_blocks.0.attn.to_v.lora_B.default.weight": rankOneAttentionOutput,
+                "transformer_blocks.0.attn.to_out.0.lora_A.default.weight": rankOneInput,
+                "transformer_blocks.0.attn.to_out.0.lora_B.default.weight": rankOneAttentionOutput,
+                "transformer_blocks.0.ff.net.0.proj.lora_A.default.weight": rankOneInput,
+                "transformer_blocks.0.ff.net.0.proj.lora_B.default.weight": MLXArray.ones(
+                    [6, 1],
+                    dtype: .float32
+                ),
+                "transformer_blocks.0.ff.net.2.lora_A.default.weight": MLXArray.ones(
+                    [1, 3],
+                    dtype: .float32
+                ),
+                "transformer_blocks.0.ff.net.2.lora_B.default.weight": rankOneAttentionOutput,
+            ],
+            url: adapterURL
+        )
+
+        let transformer = MiniMaxH3Transformer(
+            configuration: MiniMaxH3TransformerConfiguration(
+                hiddenSize: 2,
+                layerCount: 1,
+                refinerLayerCount: 0,
+                attentionHeadCount: 1,
+                attentionHeadDimension: 2,
+                feedForwardSize: 3,
+                videoLatentChannels: 1,
+                audioLatentChannels: 1,
+                patchSize: [1, 1, 1],
+                textDimension: 2,
+                timeFrequencyDimension: 2,
+                timeEmbeddingHiddenSize: 2,
+                timeEmbeddingDimension: 2,
+                ropeFrequencyCount: 1
+            ),
+            includeAdaLN: false
+        )
+        let originalLeaves = Dictionary(
+            uniqueKeysWithValues: transformer.leafModules().flattened()
+        )
+        let originalQKV = try XCTUnwrap(
+            originalLeaves["blocks.0.attn.qkv_proj"] as? Linear
+        ).weight
+        MLX.eval(originalQKV)
+        let originalQKVValues = originalQKV.asArray(Float.self)
+        let count = try MiniMaxH3TurboAdapter.install(
+            url: adapterURL,
+            into: transformer,
+            strength: 1,
+            expectedPairCount: 6
+        )
+        let leaves = Dictionary(uniqueKeysWithValues: transformer.leafModules().flattened())
+        let qkv = try XCTUnwrap(leaves["blocks.0.attn.qkv_proj"] as? Linear)
+        MLX.eval(qkv.weight)
+        let qkvDelta = zip(qkv.weight.asArray(Float.self), originalQKVValues).map {
+            $0.0 - $0.1
+        }
+
+        XCTAssertEqual(count, 6)
+        XCTAssertEqual(qkvDelta.count, 12)
+        for value in qkvDelta {
+            XCTAssertEqual(value, 8, accuracy: 1e-5)
+        }
+        XCTAssertFalse(qkv is MiniMaxH3RuntimeLoRALinear)
+        XCTAssertFalse(leaves["blocks.0.attn.out_proj"] is MiniMaxH3RuntimeLoRALinear)
+        XCTAssertFalse(leaves["blocks.0.mlp.fc1"] is MiniMaxH3RuntimeLoRALinear)
+        XCTAssertFalse(leaves["blocks.0.mlp.fc2"] is MiniMaxH3RuntimeLoRALinear)
+    }
+
     func testTurboAdapterUsesFourDenoiseEvaluationsByDefault() throws {
         let options = try MiniMaxH3GenerationOptions(
             prompt: "a cinematic local video",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1897,13 +1897,16 @@ and keep the schedule boundaries native. They remain approximate: the same
 prompt and seed may follow a different motion or composition trajectory. Use
 `quality` when exact-seed fidelity matters.
 
-`--h3-adapter minimax-h3-turbo-4step` selects the separately pulled Turbo
-LoRA for `video-minimax-h3-fl2va-bf16-mlx`. When `--steps` is omitted it uses
-five schedule points (four transformer evaluations). It runs the LoRA in
-activation space and requires `--h3-acceleration quality`; Ref2VA and the
-compact quantized H3 package are rejected. The preflight report resolves the
-managed adapter path, verifies its presence, and preserves the adapter id,
-strength, and resolved schedule in the declarative action.
+`--h3-adapter minimax-h3-turbo-4step` selects the separately pulled EMA-850
+LoRA, while `--h3-adapter minimax-h3-lightx2v-4step` selects the LightX2V
+PEFT LoRA. Both target `video-minimax-h3-fl2va-bf16-mlx`. When `--steps` is
+omitted they use five schedule points (four transformer evaluations). EMA-850
+runs in activation space; LightX2V is fused once into the BF16 transformer
+before denoising and adds no LoRA matmuls to the generation loop. Both require
+`--h3-acceleration quality`; Ref2VA and the compact quantized H3 package are
+rejected. The preflight report resolves the managed adapter path, verifies its
+presence, and preserves the adapter id, strength, and resolved schedule in the
+declarative action.
 
 Preflight mode:
 
@@ -2202,6 +2205,7 @@ mere.run adapter list --json
 mere.run adapter pull mere-platform-assistant
 mere.run adapter pull scail2-lightx2v-4step
 mere.run adapter pull minimax-h3-turbo-4step
+mere.run adapter pull minimax-h3-lightx2v-4step
 ```
 
 The pull verifies the cataloged byte count and SHA-256 before atomically
@@ -2210,8 +2214,9 @@ verification diagnostics go to stderr. Use the adapter id directly with
 `text chat --lora`, `api serve --lora`, or the matching SCAIL
 `video animate --distilled-adapter` option. `video animate --profile fast`
 selects `scail2-lightx2v-4step` and its fixed four-step schedule.
-Use `minimax-h3-turbo-4step` with `video generate --h3-adapter`; its BF16
-FL2VA base remains subject to the MiniMax-H3 Community License acceptance.
+Use either `minimax-h3-turbo-4step` or `minimax-h3-lightx2v-4step` with
+`video generate --h3-adapter`; their BF16 FL2VA base remains subject to the
+MiniMax-H3 Community License acceptance.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 sections below are the command reference for each benchmark lane.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -868,6 +868,21 @@ The runtime remaps the adapter's fused QKV output rows into the same global
 Q/K/V slab order as the converted base and applies all 259 LoRA pairs as live
 activation deltas, including the schedule-only AdaLN projections.
 
+The second managed H3 adapter, `minimax-h3-lightx2v-4step`, pins
+`minimax_h3_fl2v_turbo_4step_v0.1.safetensors` from
+`lightx2v/Minimax-h3-Turbo` at immutable commit
+`b65e359c0d128b3c5e08e0f5bf2791b794378588`. The catalog verifies its exact
+1,383,677,888-byte length and SHA-256
+`5ff4a12c8b4599fec716e1b15a45e504e0d1129111896bdcde5ac4a15e395b29`.
+The runtime consumes its 312 published PEFT pairs directly, applies the
+published alpha/rank scale, and projects its separate Q, K, and V deltas into
+the base transformer's global slabs without producing an expanded converted
+checkpoint. It fuses each scaled delta into the BF16 transformer once during
+model loading and releases the LoRA tensors before denoising, leaving no
+per-block adapter matmuls in the generation loop. Its Apache-2.0 adapter
+license likewise does not replace the base model's MiniMax-H3 Community
+License.
+
 ### `video-wan22-ti2v-5b-mlx`
 
 The native Wan2.2 TI2V-5B model root is:

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -106,12 +106,12 @@ mere.run video generate "a cinematic rain-soaked bus stop at night" \
   --width 1280 --height 768 --duration 10 --steps 20 \
   --output ./bus-stop-bf16.mp4
 
-# Optional four-evaluation Turbo lane for the BF16 FL2VA model
+# Two four-evaluation adapter lanes for the BF16 FL2VA model
 mere.run adapter pull minimax-h3-turbo-4step
+mere.run adapter pull minimax-h3-lightx2v-4step
 mere.run video generate "a superhero waits beneath an umbrella at a bus stop" \
   --model video-minimax-h3-fl2va-bf16-mlx \
-  --h3-adapter minimax-h3-turbo-4step \
-  --h3-adapter-strength 0.9 \
+  --h3-adapter minimax-h3-lightx2v-4step \
   --output ./bus-stop-turbo.mp4
 
 mere.run video generate "preserve the person and use the reference motion" \
@@ -129,15 +129,18 @@ converting, using, or redistributing any artifact. Passing
 `--accept-model-license` and continuing with the download confirms that you
 accept those terms and agree to comply with them.
 
-The optional `minimax-h3-turbo-4step` adapter is checksum-pinned separately
-and applied in activation space so its small BF16 deltas are not rounded into
-the base transformer. It defaults to five schedule points, which are four
-model evaluations. The current adapter was trained for FL2VA, requires the
-BF16 base model, and cannot be combined with Ref2VA references or H3
-tail-residual reuse. Omit `--steps` (or set it to `5`) and keep
-`--h3-acceleration quality`. Strengths around `0.8` to `0.95` can soften the
-preview adapter's oversharp or plastic artifacts; `1.0` applies the released
-weights exactly.
+The `minimax-h3-turbo-4step` EMA-850 adapter and
+`minimax-h3-lightx2v-4step` LightX2V adapter are checksum-pinned separately.
+EMA-850 remains an activation-space adapter because its AdaLN deltas
+participate in schedule-cache construction. LightX2V has no AdaLN targets, so
+the runtime applies its published alpha/rank scale and fuses its deltas into
+the BF16 transformer once before denoising; the PEFT tensors are then released
+and add no per-block LoRA matmuls. Both default to five schedule points, which
+are four model evaluations. They were trained for FL2VA, require the BF16 base
+model, and cannot be combined with Ref2VA references or H3 tail-residual reuse.
+Omit `--steps` (or set it to `5`) and keep `--h3-acceleration quality`.
+Strength `1.0` applies either adapter's released weights exactly; the strength
+control remains available for prompt-specific tuning.
 
 The managed package already includes the inference-only AdaLN cache computed
 from the official BF16/F32 projections; no post-pull optimization step is


### PR DESCRIPTION
## What changed

- add `minimax-h3-lightx2v-4step` beside the existing `minimax-h3-turbo-4step` managed H3 adapter
- pin LightX2V v0.1 to immutable revision `b65e359c0d128b3c5e08e0f5bf2791b794378588`, exact byte count, and SHA-256
- map the published 312-pair PEFT layout directly into the native MiniMax-H3 transformer
- apply the published `alpha / rank` scale and stream-fuse one target at a time into BF16 weights before denoising
- preserve separate Q, K, and V projections without generating an expanded converted checkpoint
- document both pull IDs, provenance, license boundary, and runtime behavior

## Why

LightX2V publishes a distinct four-evaluation H3 adapter with separate Q/K/V PEFT targets. Supporting the checkpoint directly avoids a local conversion copy, while one-time fusion removes LoRA matmuls from every denoise block.

## User impact

```bash
mere.run adapter pull minimax-h3-turbo-4step
mere.run adapter pull minimax-h3-lightx2v-4step

mere.run video generate "..." \
  --model video-minimax-h3-fl2va-bf16-mlx \
  --h3-adapter minimax-h3-lightx2v-4step
```

The existing EMA-850 adapter remains unchanged and backward compatible. Both adapters use the same BF16 FL2VA, exact four-evaluation quality lane and remain subject to the base MiniMax-H3 Community License.

## Validation

- `./scripts/check.sh` — passed; 2,562 tests, 167 fixture-dependent skips, 0 failures
- real `mere.run adapter pull minimax-h3-lightx2v-4step` — exact SHA-256 verified
- real installed 100 GB BF16 H3 load with the managed adapter — completed all 4 denoise evaluations
- generated a 256x160, 22-frame smoke MP4 with H.264 video and AAC audio
