### PR TITLE
Fix quiet streaming text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Text
+
+- fixed `text chat --stream --quiet` so `--quiet` suppresses stderr diagnostics
+  without disconnecting incremental generated text from stdout.
+
 ### Video
 
 - added `minimax-h3-lightx2v-4step` as a second immutable, checksum-pinned

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -297,17 +297,10 @@ struct TextChat: AsyncParsableCommand {
         )
 
         let streamingOutput = StreamingChatOutput(enabled: stream)
-        let progressHandler: (@Sendable (ChatProgress) -> Void)?
-        if quiet {
-            progressHandler = nil
-        } else {
-            progressHandler = { progress in
-                if streamingOutput.write(progress: progress) {
-                    return
-                }
-                CLIStderr.write("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
-            }
-        }
+        let progressHandler = TextChatProgressHandler.make(
+            quiet: quiet,
+            streamingOutput: streamingOutput
+        )
 
         let startTime = Date()
         if !quiet {
@@ -724,14 +717,41 @@ private struct TextChatPreflightReport: Codable, Equatable {
     }
 }
 
-private final class StreamingChatOutput: @unchecked Sendable {
+enum TextChatProgressHandler {
+    static func make(
+        quiet: Bool,
+        streamingOutput: StreamingChatOutput,
+        diagnosticWriter: @escaping @Sendable (String) -> Void = CLIStderr.write
+    ) -> (@Sendable (ChatProgress) -> Void)? {
+        guard !quiet || streamingOutput.enabled else {
+            return nil
+        }
+
+        return { progress in
+            if streamingOutput.write(progress: progress) {
+                return
+            }
+            guard !quiet else {
+                return
+            }
+            diagnosticWriter("[\(progress.stage.rawValue)] \(progress.message ?? "")\n")
+        }
+    }
+}
+
+final class StreamingChatOutput: @unchecked Sendable {
     let enabled: Bool
 
     private let lock = NSLock()
     private var wroteOutput = false
+    private let writer: @Sendable (String) -> Void
 
-    init(enabled: Bool) {
+    init(
+        enabled: Bool,
+        writer: @escaping @Sendable (String) -> Void = CLIStdout.write
+    ) {
         self.enabled = enabled
+        self.writer = writer
     }
 
     var hasWritten: Bool {
@@ -752,7 +772,7 @@ private final class StreamingChatOutput: @unchecked Sendable {
 
         lock.lock()
         defer { lock.unlock() }
-        CLIStdout.write(text)
+        writer(text)
         wroteOutput = true
         return true
     }
@@ -760,6 +780,6 @@ private final class StreamingChatOutput: @unchecked Sendable {
     func finishLine() {
         lock.lock()
         defer { lock.unlock() }
-        CLIStdout.write("\n")
+        writer("\n")
     }
 }

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -45,6 +45,37 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.stream)
     }
 
+    func testQuietStreamingKeepsGeneratingCallbackAndSuppressesDiagnostics() throws {
+        let stdout = TextOutputRecorder()
+        let stderr = TextOutputRecorder()
+        let streamingOutput = StreamingChatOutput(enabled: true, writer: stdout.write)
+        let progressHandler = try XCTUnwrap(
+            TextChatProgressHandler.make(
+                quiet: true,
+                streamingOutput: streamingOutput,
+                diagnosticWriter: stderr.write
+            )
+        )
+
+        progressHandler(ChatProgress(stage: .loadingModel, message: "Loading model"))
+        progressHandler(ChatProgress(stage: .generating, message: "live token"))
+
+        XCTAssertEqual(stdout.value, "live token")
+        XCTAssertEqual(stderr.value, "")
+        XCTAssertTrue(streamingOutput.hasWritten)
+    }
+
+    func testQuietNonStreamingDisablesProgressCallback() {
+        let streamingOutput = StreamingChatOutput(enabled: false)
+
+        XCTAssertNil(
+            TextChatProgressHandler.make(
+                quiet: true,
+                streamingOutput: streamingOutput
+            )
+        )
+    }
+
     func testTextChatParsesJSONObjectResponseFormatForQ36() throws {
         let cmd = try TextChat.parse([
             "--model", Q35Resources.q36NanoModelId,
@@ -318,5 +349,22 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertThrowsError(try cmd.resolveQ35KVCacheMode(for: cmd.model)) { error in
             XCTAssertTrue(String(describing: error).contains("must be 4 or 8"))
         }
+    }
+}
+
+private final class TextOutputRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var text = ""
+
+    var value: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return text
+    }
+
+    func write(_ value: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        text += value
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -822,7 +822,9 @@ Key options:
 
 Unless `--quiet` is set, diagnostics on stderr include the selected text
 backend, for example native MLX/Metal for MLX models or llama.cpp/GGUF for GGUF
-models.
+models. `--quiet` does not change the requested output mode: with `--stream`,
+generated text still arrives incrementally on stdout while diagnostics remain
+suppressed.
 
 `--lora` accepts a compatible local adapter file or cataloged adapter id.
 Native Gemma 4, Laguna XS 2.1, and Inkling-Small adapters produced by


### PR DESCRIPTION
## Summary

- keep the chat progress callback connected when `--stream --quiet` is requested
- send generating-stage deltas to stdout while suppressing non-generating diagnostics
- retain the existing quiet non-streaming behavior
- document the stdout/stderr contract and add focused regressions

## Root cause

`--quiet` previously set the entire progress handler to `nil`. That handler carries both diagnostics and incremental generated text, so quiet mode accidentally disconnected the live token stream and left only the final buffered response.

## Verification

- rebased onto current `main` at `a6abe69229d31c5dd780675e2e41baade18b8656`
- `git range-diff` confirmed the rebased patch is equivalent to the previously reviewed commit
- `./scripts/check.sh` on head `40b5330c5e93f09c2a2399e93ecbf3fb5ecdef91` — strict lint, build, 2,565 XCTest tests with 0 failures (168 asset-dependent skips), Swift Testing suites, CLI help sweep, and hygiene scans all passed
- real installed `text-chat-lfm25-2.6b-4bit` run on the same head with `--require-installed --stream --quiet` exited 0, emitted 53 stdout bytes, and emitted 0 stderr bytes

Fixes #266
