### PR TITLE
Rank ACE-Step candidates by arrangement variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Music
+
+- replaced ACE-Step candidate ranking's positive short-window periodicity
+  reward with a four-second arrangement-repetition metric, so repeated sections
+  no longer outrank developing candidates while silence, clipping, non-finite,
+  and broken-tail rejection remains intact.
+
 ### Video
 
 - added `minimax-h3-lightx2v-4step` as a second immutable, checksum-pinned

--- a/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
@@ -43,7 +43,7 @@ struct ACEStepRecipeLMSampling: Codable, Equatable {
 }
 
 struct ACEStepGenerationRecipe: Codable {
-    static let currentSchemaVersion = 4
+    static let currentSchemaVersion = 5
 
     var schemaVersion: Int
     var createdAt: Date

--- a/Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift
@@ -67,6 +67,7 @@ public struct ACEStepCandidateMetrics: Codable, Hashable, Sendable {
     public var spectralFlatness: Float?
     public var frameEnergyVariation: Float?
     public var periodicity: Float?
+    public var arrangementRepetition: Float?
     public var temporalSpectralVariation: Float?
     public var tailEnergyRatio: Float?
 
@@ -81,6 +82,7 @@ public struct ACEStepCandidateMetrics: Codable, Hashable, Sendable {
         spectralFlatness: Float? = nil,
         frameEnergyVariation: Float? = nil,
         periodicity: Float? = nil,
+        arrangementRepetition: Float? = nil,
         temporalSpectralVariation: Float? = nil,
         tailEnergyRatio: Float? = nil
     ) {
@@ -94,6 +96,7 @@ public struct ACEStepCandidateMetrics: Codable, Hashable, Sendable {
         self.spectralFlatness = spectralFlatness
         self.frameEnergyVariation = frameEnergyVariation
         self.periodicity = periodicity
+        self.arrangementRepetition = arrangementRepetition
         self.temporalSpectralVariation = temporalSpectralVariation
         self.tailEnergyRatio = tailEnergyRatio
     }
@@ -360,6 +363,7 @@ public enum ACEStepCandidateScorer {
                 spectralFlatness: 1,
                 frameEnergyVariation: 0,
                 periodicity: 0,
+                arrangementRepetition: nil,
                 temporalSpectralVariation: 0,
                 tailEnergyRatio: 0
             )
@@ -396,6 +400,7 @@ public enum ACEStepCandidateScorer {
         let spectralFlatness = estimateSpectralFlatness(mono)
         let frameEnergyVariation = estimateFrameEnergyVariation(mono)
         let periodicity = estimatePeriodicity(mono)
+        let arrangementRepetition = estimateArrangementRepetition(mono)
         let temporalSpectralVariation = estimateTemporalSpectralVariation(mono)
         let tailEnergyRatio = estimateTailEnergyRatio(mono)
         let metrics = ACEStepCandidateMetrics(
@@ -409,6 +414,7 @@ public enum ACEStepCandidateScorer {
             spectralFlatness: spectralFlatness,
             frameEnergyVariation: frameEnergyVariation,
             periodicity: periodicity,
+            arrangementRepetition: arrangementRepetition,
             temporalSpectralVariation: temporalSpectralVariation,
             tailEnergyRatio: tailEnergyRatio
         )
@@ -422,7 +428,9 @@ public enum ACEStepCandidateScorer {
         let dcScore = max(0, 1 - metrics.dcOffset * 20)
         let flatnessScore = 1 - min(max((spectralFlatness - 0.15) / 0.7, 0), 1)
         let variationScore = min(max(frameEnergyVariation / 0.35, 0), 1)
-        let periodicityScore = min(max((periodicity - 0.05) / 0.35, 0), 1)
+        let arrangementVariationScore = arrangementRepetition.map {
+            1 - min(max($0, 0), 1)
+        } ?? 0.5
         let temporalStructureScore = min(
             max((temporalSpectralVariation - 0.65) / 0.9, 0),
             1
@@ -434,8 +442,8 @@ public enum ACEStepCandidateScorer {
         let structureScore =
             0.15 * flatnessScore
             + 0.10 * variationScore
-            + 0.10 * periodicityScore
-            + 0.45 * temporalStructureScore
+            + 0.20 * arrangementVariationScore
+            + 0.35 * temporalStructureScore
             + 0.20 * tailContinuityScore
         let score = 100 * (
             0.20 * finiteScore
@@ -561,6 +569,106 @@ public enum ACEStepCandidateScorer {
             periodicitySum += best
         }
         return Float(periodicitySum / Double(starts.count))
+    }
+
+    private static func estimateArrangementRepetition(
+        _ samples: [Float]
+    ) -> Float? {
+        let blockSize = 4 * 48_000
+        guard samples.count >= 3 * blockSize else {
+            return nil
+        }
+        let blockCount = min(16, samples.count / blockSize)
+        let starts = analysisWindowStarts(
+            sampleCount: samples.count,
+            windowSize: blockSize,
+            maximumCount: blockCount
+        )
+        let frameSize = 1_024
+        let frameCount = 16
+        let lastFrameOffset = blockSize - frameSize
+        let frameOffsets = (0..<frameCount).map { index in
+            Int(
+                (Double(lastFrameOffset) * Double(index)
+                    / Double(frameCount - 1)).rounded()
+            )
+        }
+        let minimumBin = 4
+        let maximumBin = 384
+        var spectralBins: [Int] = []
+        spectralBins.reserveCapacity(24)
+        for index in 0..<24 {
+            let ratio = Double(index) / 23
+            let bin = Int(
+                (Double(minimumBin)
+                    * pow(Double(maximumBin) / Double(minimumBin), ratio))
+                    .rounded()
+            )
+            if bin > (spectralBins.last ?? 0) {
+                spectralBins.append(bin)
+            }
+        }
+
+        let signatures = starts.map { blockStart in
+            let spectrum = spectralBins.map { bin in
+                let meanPower = frameOffsets.reduce(0.0) { partial, offset in
+                    partial + goertzelPower(
+                        samples,
+                        start: blockStart + offset,
+                        windowSize: frameSize,
+                        bin: bin
+                    )
+                } / Double(frameOffsets.count)
+                return log(max(meanPower, 1e-20))
+            }
+            let envelope = (0..<16).map { index in
+                let start = blockStart + index * blockSize / 16
+                let end = blockStart + (index + 1) * blockSize / 16
+                return rootMeanSquare(samples[start..<end])
+            }
+            return standardized(spectrum) + standardized(envelope)
+        }
+
+        var similarities: [Double] = []
+        for left in 0..<(signatures.count - 2) {
+            for right in (left + 2)..<signatures.count {
+                let lhs = signatures[left]
+                let rhs = signatures[right]
+                let dot = zip(lhs, rhs).reduce(0.0) { $0 + $1.0 * $1.1 }
+                let lhsMagnitude = sqrt(lhs.reduce(0.0) { $0 + $1 * $1 })
+                let rhsMagnitude = sqrt(rhs.reduce(0.0) { $0 + $1 * $1 })
+                similarities.append(
+                    dot / max(
+                        lhsMagnitude * rhsMagnitude,
+                        Double.leastNonzeroMagnitude
+                    )
+                )
+            }
+        }
+        guard !similarities.isEmpty else {
+            return nil
+        }
+        similarities.sort()
+        let percentileIndex = Int(
+            (Double(similarities.count - 1) * 0.9).rounded(.up)
+        )
+        return Float(min(max(similarities[percentileIndex], 0), 1))
+    }
+
+    private static func standardized(_ values: [Double]) -> [Double] {
+        guard !values.isEmpty else {
+            return []
+        }
+        let mean = values.reduce(0, +) / Double(values.count)
+        let variance = values.reduce(0.0) { partial, value in
+            let difference = value - mean
+            return partial + difference * difference
+        } / Double(values.count)
+        let scale = sqrt(variance)
+        guard scale > 1e-9 else {
+            return [Double](repeating: 0, count: values.count)
+        }
+        return values.map { ($0 - mean) / scale }
     }
 
     private static func estimateTailEnergyRatio(_ samples: [Float]) -> Float {

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -109,7 +109,7 @@ final class MusicServeAndExportTests: XCTestCase {
             JSONSerialization.jsonObject(with: encoded) as? [String: String]
         )
 
-        XCTAssertEqual(ACEStepGenerationRecipe.currentSchemaVersion, 4)
+        XCTAssertEqual(ACEStepGenerationRecipe.currentSchemaVersion, 5)
         XCTAssertEqual(object["bpm"], "118")
         XCTAssertEqual(object["duration"], "12")
         XCTAssertEqual(object["keyscale"], "D major")

--- a/Tests/MereRunCoreTests/ACEStepTaskAndRepaintTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepTaskAndRepaintTests.swift
@@ -87,6 +87,40 @@ final class ACEStepTaskAndRepaintTests: MereRunCoreTestCase {
         )
     }
 
+    func testCandidateScoringPenalizesRepeatedArrangementBlocks() throws {
+        let fixtureURL = try XCTUnwrap(Bundle.module.resourceURL)
+            .appendingPathComponent(
+                "Fixtures/ACEStep/arrangement-repetition.json"
+            )
+        let fixture = try JSONDecoder().decode(
+            ArrangementRepetitionFixture.self,
+            from: Data(contentsOf: fixtureURL)
+        )
+        let repeated = arrangementSamples(
+            fixture.repeatedSections,
+            sampleRate: fixture.sampleRate,
+            sectionSeconds: fixture.sectionSeconds
+        )
+        let evolving = arrangementSamples(
+            fixture.evolvingSections,
+            sampleRate: fixture.sampleRate,
+            sectionSeconds: fixture.sectionSeconds
+        )
+
+        let repeatedResult = ACEStepCandidateScorer.evaluate(MLXArray(repeated))
+        let evolvingResult = ACEStepCandidateScorer.evaluate(MLXArray(evolving))
+        let repeatedMetric = try XCTUnwrap(
+            repeatedResult.metrics.arrangementRepetition
+        )
+        let evolvingMetric = try XCTUnwrap(
+            evolvingResult.metrics.arrangementRepetition
+        )
+
+        XCTAssertGreaterThan(repeatedMetric, 0.9)
+        XCTAssertLessThan(evolvingMetric, repeatedMetric - 0.15)
+        XCTAssertGreaterThan(evolvingResult.score, repeatedResult.score)
+    }
+
     func testCandidateRankingIsScoreDescendingAndStableByIndex() {
         let audio = MLXArray([Float](repeating: 0, count: 2))
         let metrics = ACEStepCandidateScorer.evaluate(audio).metrics
@@ -599,5 +633,59 @@ final class ACEStepTaskAndRepaintTests: MereRunCoreTestCase {
             spliced.asArray(Float.self),
             [0, 5, 10, 10, 10, 10, 5, 0, 0, 0]
         )
+    }
+}
+
+private struct ArrangementRepetitionFixture: Decodable {
+    struct Section: Decodable {
+        var frequencies: [Double]
+        var pulseHz: Double
+        var noiseMix: Double
+
+        enum CodingKeys: String, CodingKey {
+            case frequencies
+            case pulseHz = "pulse_hz"
+            case noiseMix = "noise_mix"
+        }
+    }
+
+    var sampleRate: Int
+    var sectionSeconds: Int
+    var repeatedSections: [Section]
+    var evolvingSections: [Section]
+
+    enum CodingKeys: String, CodingKey {
+        case sampleRate = "sample_rate"
+        case sectionSeconds = "section_seconds"
+        case repeatedSections = "repeated_sections"
+        case evolvingSections = "evolving_sections"
+    }
+}
+
+private func arrangementSamples(
+    _ sections: [ArrangementRepetitionFixture.Section],
+    sampleRate: Int,
+    sectionSeconds: Int
+) -> [Float] {
+    sections.flatMap { section in
+        (0..<(sampleRate * sectionSeconds)).map { index in
+            let time = Double(index) / Double(sampleRate)
+            let pulse = 0.55 + 0.45 * max(
+                0,
+                sin(2 * Double.pi * section.pulseHz * time)
+            )
+            let tone = section.frequencies.enumerated().reduce(0.0) {
+                partial, element in
+                let amplitude = 0.16 / Double(element.offset + 1)
+                return partial + amplitude * sin(
+                    2 * Double.pi * element.element * time
+                )
+            }
+            let hashed = sin(Double(index) * 12.9898) * 43_758.5453
+            let noise = 0.16 * (2 * (hashed - floor(hashed)) - 1)
+            let mixed = (1 - section.noiseMix) * tone
+                + section.noiseMix * noise
+            return Float(pulse * mixed)
+        }
     }
 }

--- a/Tests/MereRunCoreTests/Fixtures/ACEStep/arrangement-repetition.json
+++ b/Tests/MereRunCoreTests/Fixtures/ACEStep/arrangement-repetition.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "sample_rate": 48000,
+  "section_seconds": 4,
+  "repeated_sections": [
+    { "frequencies": [220, 440], "pulse_hz": 4, "noise_mix": 0 },
+    { "frequencies": [220, 440], "pulse_hz": 4, "noise_mix": 0 },
+    { "frequencies": [220, 440], "pulse_hz": 4, "noise_mix": 0 },
+    { "frequencies": [220, 440], "pulse_hz": 4, "noise_mix": 0 }
+  ],
+  "evolving_sections": [
+    { "frequencies": [110, 165], "pulse_hz": 2, "noise_mix": 0 },
+    { "frequencies": [880, 1320, 1760], "pulse_hz": 8, "noise_mix": 0 },
+    { "frequencies": [], "pulse_hz": 6, "noise_mix": 1 },
+    { "frequencies": [220, 330, 550, 880], "pulse_hz": 3, "noise_mix": 0.25 }
+  ]
+}

--- a/docs/runtime/acestep-validation.md
+++ b/docs/runtime/acestep-validation.md
@@ -21,8 +21,9 @@ Hugging Face revisions:
 
 Generation recipes repeat the effective repository/revision set, adapter
 SHA-256 and scale, final effective conditioning metadata, complete inference
-configuration, candidate ranking, and input/output hashes. Recipe schema 4
-adds planner temperature, top-k/top-p, and repetition penalty to schema 3's
+configuration, candidate ranking, and input/output hashes. Recipe schema 5
+adds arrangement-scale repetition to each candidate's technical metrics;
+schema 4 added planner temperature, top-k/top-p, and repetition penalty to schema 3's
 resolved planner source, root, and immutable repository/revision provenance
 and schema 2's post-planning BPM, duration, key/scale, vocal language, and time
 signature. This protects old installs whose original
@@ -150,6 +151,25 @@ for 12 seconds and passed `temporalSpectralVariation >= 0.85` plus
 Repeating the transient case with the same seed reproduced its planner
 metadata, candidate scores/code counts, and WAV byte-for-byte at SHA-256
 `1a5c7c56e5373d69400f553256637199bb2b1e04877435abf8f2e2ebe6e555dc`.
+
+### Arrangement-ranker investigation
+
+Issue #254 was reproduced with a fixed 60-second, 96 BPM, D minor, 4/4
+progressive-electronic prompt; seeds `25400...25403`; four candidates; and the
+same explicit 1.7B planner for Turbo and XL-SFT. Unnormalized float32 exports
+were analyzed under anonymous labels using four-second spectral/envelope
+signatures. The previous ranker selected the XL-SFT candidate with 0.993
+90th-percentile non-adjacent block similarity and only 0.043 mean adjacent
+block change; an unselected candidate measured 0.789 and 0.514 respectively.
+Across both checkpoint lanes, five of the six alternatives had lower
+arrangement repetition than the selected output.
+
+The positive short-window waveform-periodicity contribution did not measure
+this behavior and has been replaced by arrangement variation. The original
+periodicity value remains in recipes as a diagnostic, while finite audio,
+activity, clipping, DC, and the other safety-quality contributions retain
+their prior weights. A deterministic repeated-block versus evolving-section
+fixture protects the new ranking behavior without committing generated audio.
 
 The review CSV remains deliberately unscored until a person listens. The
 technical rank is evidence against the exact stationary-noise regression, but


### PR DESCRIPTION
## Summary

- replace ACE-Step candidate ranking's positive short-window periodicity reward with long-range arrangement variation
- measure 90th-percentile similarity across non-adjacent four-second spectral/envelope blocks
- keep the old periodicity metric as diagnostic recipe data and add `arrangementRepetition` in recipe schema 5
- add a deterministic repeated-block/evolving-section fixture, docs, and changelog coverage

## Investigation evidence

I repeated the same fixed 60-second progressive-electronic prompt in Turbo and XL-SFT with:

- the same explicit 1.7B planner
- 96 BPM, D minor, 4/4
- four candidates per lane
- seed family `25400...25403`
- unnormalized float32 output

Candidates were assigned anonymous labels A-H before arrangement analysis. The old ranker selected the XL-SFT candidate with 0.993 p90 non-adjacent block similarity and only 0.043 mean adjacent block change. An unselected SFT candidate measured 0.789 and 0.514 respectively. Across both checkpoint lanes, five of the six alternatives had lower arrangement repetition than the selected candidate.

The prior short-window periodicity values did not explain those selections. Recipe evidence hashes:

- Turbo: `050528f8ecc2fbd73140d1b564fbe229babff4d5b6d8e66ec83fb8ad569556f7`
- XL-SFT: `5d584a604612309d8bd3cb416fc33cdf4698c9c0f6f389f04fd6c04179bbdfed`

## Safety and verification

Finite audio, activity, clipping, DC, and the other safety-quality contributions remain unchanged.

- focused arrangement regression — passed
- `./scripts/check.sh` — strict lint, build, 2,563 XCTest tests with 0 failures (167 asset-dependent skips), Swift Testing suites, CLI help sweep, and hygiene scans all passed
- branch is one commit ahead of `main` at `cebf598fb30045a8def341a4358e23e90813d497`

Fixes #254
