### PR TITLE
Optimize Laguna routing with exact Active64 tournament

### DIFF
--- a/Sources/MereRunCore/Laguna/LagunaActive64Router.swift
+++ b/Sources/MereRunCore/Laguna/LagunaActive64Router.swift
@@ -1,0 +1,238 @@
+import MLX
+import MLXFast
+
+/// Exact Laguna XS 256-expert Top-8 routing on Metal.
+///
+/// Each SIMD group sorts its 32 experts and contributes its local Top-8. The
+/// final 64 candidates are sorted by only the first two SIMD groups instead of
+/// redundantly running four copies of the same second-stage network. The
+/// ordinal mapping gives every Float32 key (including NaNs, infinities, and
+/// signed zero) a total order, with the original expert index as the stable
+/// tie-breaker. The implementation is the mechanism officially promoted by
+/// MLX Fast submission `cc6ddc12` after exact 1,344-step M5 Max validation.
+enum LagunaActive64Router {
+    private static let ordinalHeader = """
+    METAL_FUNC uint mererun_laguna_router_key_ordinal(float key) {
+        uint bits = as_type<uint>(key);
+        uint magnitude = bits & 0x7FFFFFFFu;
+        if (magnitude > 0x7F800000u) {
+            return 0xFFFFFFFFu;
+        }
+        if (magnitude == 0u) {
+            return 0x80000000u;
+        }
+        return (bits & 0x80000000u) != 0u ? ~bits : (bits ^ 0x80000000u);
+    }
+
+    METAL_FUNC bool mererun_laguna_router_ordinal_before(
+        uint a, uint a_index, uint b, uint b_index) {
+        if (a < b) {
+            return true;
+        }
+        if (b < a) {
+            return false;
+        }
+        return a_index < b_index;
+    }
+    """
+
+    private static func source(normalizing: Bool) -> String {
+        let epilogue = normalizing
+            ? """
+            float my_score2 = lane < 8 ? original_scores[my_index2] : 0.0f;
+            float total = 0.0f;
+            for (uint i = 0; i < 8; ++i) {
+                total = simd_shuffle(my_score2, ushort(i)) + total;
+            }
+            if (lane < 8) {
+                router_indices[row * 8 + lane] = my_index2;
+                router_scores[row * 8 + lane] = my_score2 / total;
+            }
+            """
+            : """
+            if (lane < 8) {
+                router_indices[row * 8 + lane] = my_index2;
+                router_scores[row * 8 + lane] = original_scores[my_index2];
+            }
+            """
+
+        return """
+        uint lane = thread_position_in_threadgroup.x;
+        uint row = threadgroup_position_in_grid.y;
+
+        threadgroup uint xchg_ordinals[64];
+        threadgroup uint xchg_indices[64];
+        threadgroup uint candidate_ordinals[64];
+        threadgroup uint candidate_indices[64];
+        threadgroup float original_scores[256];
+
+        float x = float(logits[row * 256 + lane]);
+        float y = 1.0f / (1.0f + metal::exp(metal::abs(x)));
+        float score = x < 0.0f ? y : 1.0f - y;
+        original_scores[lane] = score;
+        float key = -(score + float(correction_bias[lane]));
+        uint my_ordinal = mererun_laguna_router_key_ordinal(key);
+        uint my_index = lane;
+
+        for (uint sequence = 2; sequence <= 32; sequence <<= 1) {
+            for (uint stride = sequence >> 1; stride > 0; stride >>= 1) {
+                uint other_ordinal = simd_shuffle_xor(my_ordinal, ushort(stride));
+                uint other_index = simd_shuffle_xor(my_index, ushort(stride));
+
+                bool is_lower = (lane & stride) == 0;
+                bool lower_wants_better = (lane & sequence) == 0;
+                bool want_better = lower_wants_better == is_lower;
+                bool other_before_my = mererun_laguna_router_ordinal_before(
+                    other_ordinal, other_index, my_ordinal, my_index);
+                bool take_other = want_better ? other_before_my : !other_before_my;
+                if (take_other) {
+                    my_ordinal = other_ordinal;
+                    my_index = other_index;
+                }
+            }
+        }
+
+        uint block = lane >> 5;
+        uint within_block = lane & 31;
+        bool block_ascending = (block & 1) == 0;
+        uint rank_in_block = block_ascending ? within_block : (31 - within_block);
+        bool is_local_top8 = block_ascending ? (within_block < 8) : (within_block >= 24);
+        if (is_local_top8) {
+            candidate_ordinals[block * 8 + rank_in_block] = my_ordinal;
+            candidate_indices[block * 8 + rank_in_block] = my_index;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        uint my_ordinal2 = 0u;
+        uint my_index2 = 0u;
+        if (lane < 64) {
+            my_ordinal2 = candidate_ordinals[lane];
+            my_index2 = candidate_indices[lane];
+        }
+
+        if (lane < 64) {
+            for (uint sequence = 2; sequence <= 32; sequence <<= 1) {
+                for (uint stride = sequence >> 1; stride > 0; stride >>= 1) {
+                    uint other_ordinal = simd_shuffle_xor(my_ordinal2, ushort(stride));
+                    uint other_index = simd_shuffle_xor(my_index2, ushort(stride));
+
+                    bool is_lower = (lane & stride) == 0;
+                    bool lower_wants_better = (lane & sequence) == 0;
+                    bool want_better = lower_wants_better == is_lower;
+                    bool other_before_my = mererun_laguna_router_ordinal_before(
+                        other_ordinal, other_index, my_ordinal2, my_index2);
+                    bool take_other = want_better ? other_before_my : !other_before_my;
+                    if (take_other) {
+                        my_ordinal2 = other_ordinal;
+                        my_index2 = other_index;
+                    }
+                }
+            }
+        }
+
+        if (lane < 64) {
+            xchg_ordinals[lane] = my_ordinal2;
+            xchg_indices[lane] = my_index2;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (lane < 64) {
+            uint partner = lane ^ 32u;
+            uint other_ordinal = xchg_ordinals[partner];
+            uint other_index = xchg_indices[partner];
+            bool is_lower = (lane & 32u) == 0;
+            bool other_before_my = mererun_laguna_router_ordinal_before(
+                other_ordinal, other_index, my_ordinal2, my_index2);
+            bool take_other = is_lower ? other_before_my : !other_before_my;
+            if (take_other) {
+                my_ordinal2 = other_ordinal;
+                my_index2 = other_index;
+            }
+
+            for (uint stride = 16; stride > 0; stride >>= 1) {
+                other_ordinal = simd_shuffle_xor(my_ordinal2, ushort(stride));
+                other_index = simd_shuffle_xor(my_index2, ushort(stride));
+                is_lower = (lane & stride) == 0;
+                other_before_my = mererun_laguna_router_ordinal_before(
+                    other_ordinal, other_index, my_ordinal2, my_index2);
+                take_other = is_lower ? other_before_my : !other_before_my;
+                if (take_other) {
+                    my_ordinal2 = other_ordinal;
+                    my_index2 = other_index;
+                }
+            }
+        }
+
+        \(epilogue)
+        """
+    }
+
+    private static let kernel = MLXFast.metalKernel(
+        name: "mererun_laguna_router_tournament_ordinal_active64_v1",
+        inputNames: ["logits", "correction_bias"],
+        outputNames: ["router_indices", "router_scores"],
+        source: source(normalizing: false),
+        header: ordinalHeader,
+        ensureRowContiguous: true
+    )
+
+    private static let normalizingKernel = MLXFast.metalKernel(
+        name: "mererun_laguna_router_tournament_ordinal_norm_active64_v1",
+        inputNames: ["logits", "correction_bias"],
+        outputNames: ["router_indices", "router_scores"],
+        source: source(normalizing: true),
+        header: ordinalHeader,
+        ensureRowContiguous: true
+    )
+
+    static func routeIfEnabled(
+        logits: MLXArray,
+        correctionBias: MLXArray,
+        expertCount: Int,
+        topK: Int,
+        normalizing: Bool,
+        useCustomKernels: Bool
+    ) -> (indices: MLXArray, weights: MLXArray)? {
+        guard useCustomKernels,
+              LagunaMoEAccelerationPolicy.active64RouterTournamentEnabled,
+              Device.defaultDevice().deviceType == .gpu,
+              expertCount == 256,
+              topK == 8,
+              logits.ndim >= 2,
+              logits.dim(-1) == expertCount,
+              logits.dtype == .float32,
+              correctionBias.dtype == .float32,
+              correctionBias.size == expertCount else {
+            return nil
+        }
+        return routeForTesting(
+            logits: logits,
+            correctionBias: correctionBias,
+            normalizing: normalizing
+        )
+    }
+
+    static func routeForTesting(
+        logits: MLXArray,
+        correctionBias: MLXArray,
+        normalizing: Bool
+    ) -> (indices: MLXArray, weights: MLXArray) {
+        precondition(logits.ndim >= 2)
+        precondition(logits.dim(-1) == 256)
+        precondition(logits.dtype == .bfloat16 || logits.dtype == .float32)
+        precondition(correctionBias.dtype == .float32)
+        precondition(correctionBias.size == 256)
+
+        let rows = logits.size / 256
+        precondition(rows > 0)
+        let outputShape = Array(logits.shape.dropLast()) + [8]
+        let selectedKernel = normalizing ? normalizingKernel : kernel
+        let outputs = selectedKernel(
+            [logits, correctionBias],
+            grid: (256, rows, 1),
+            threadGroup: (256, 1, 1),
+            outputShapes: [outputShape, outputShape],
+            outputDTypes: [.uint32, .float32]
+        )
+        return (stopGradient(outputs[0]), outputs[1])
+    }
+}

--- a/Sources/MereRunCore/Laguna/LagunaModel.swift
+++ b/Sources/MereRunCore/Laguna/LagunaModel.swift
@@ -58,6 +58,10 @@ enum LagunaMoEAccelerationPolicy {
         "MERERUN_LAGUNA_PREFILL_EXPERT_PAIRWISE_SCALES",
         default: m5MaxDefaultsEnabled
     )
+    static let active64RouterTournamentEnabled = booleanEnvironment(
+        "MERERUN_LAGUNA_ACTIVE64_ROUTER",
+        default: m5MaxDefaultsEnabled
+    )
     static let decodeNVFP4RowsPerSIMDGroup = decodeRowsPerSIMDGroup(
         ProcessInfo.processInfo.environment[
             "MERERUN_LAGUNA_DECODE_NVFP4_ROWS_PER_SIMDGROUP"
@@ -1310,11 +1314,13 @@ final class LagunaRouter: Module {
     @ParameterInfo(key: "e_score_correction_bias") var correctionBias: MLXArray
 
     private let topK: Int
+    private let expertCount: Int
     private let normalize: Bool
     private let softcap: Float
 
     init(config: LagunaConfig) {
         self.topK = config.numExpertsPerToken
+        self.expertCount = config.numExperts
         self.normalize = config.normTopKProbability
         self.softcap = config.moeRouterLogitSoftcapping
         self._weight.wrappedValue = MLXArray.zeros([config.numExperts, config.hiddenSize])
@@ -1322,10 +1328,23 @@ final class LagunaRouter: Module {
         super.init()
     }
 
-    func callAsFunction(_ x: MLXArray) -> (indices: MLXArray, weights: MLXArray) {
+    func callAsFunction(
+        _ x: MLXArray,
+        useCustomKernels: Bool = true
+    ) -> (indices: MLXArray, weights: MLXArray) {
         var logits = x.matmul(weight.T).asType(.float32)
         if softcap > 0 {
             logits = tanh(logits / softcap) * softcap
+        }
+        if let routed = LagunaActive64Router.routeIfEnabled(
+            logits: logits,
+            correctionBias: correctionBias,
+            expertCount: expertCount,
+            topK: topK,
+            normalizing: normalize,
+            useCustomKernels: useCustomKernels
+        ) {
+            return (routed.indices, routed.weights.asType(x.dtype))
         }
         let scores = sigmoid(logits)
         let selectionScores = scores + correctionBias.asType(scores.dtype)
@@ -1374,7 +1393,7 @@ final class LagunaSparseMoE: LagunaFeedForward {
         residual: MLXArray?,
         useCustomKernels: Bool = true
     ) -> MLXArray {
-        let routed = gate(x)
+        let routed = gate(x, useCustomKernels: useCustomKernels)
         if useCustomKernels,
            LagunaMoEAccelerationPolicy.fusedRoutedSharedDownResidualEnabled,
            let residual,

--- a/Tests/MereRunCoreTests/LagunaModelTests.swift
+++ b/Tests/MereRunCoreTests/LagunaModelTests.swift
@@ -698,6 +698,92 @@ final class LagunaModelTests: MereRunCoreTestCase {
         )
     }
 
+    func testActive64RouterMatchesStockTop8AcrossFamilies() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The Laguna Active64 router requires a Metal GPU.")
+        }
+
+        func verify(
+            _ values: [Float],
+            rows: Int,
+            bias: [Float],
+            normalizing: Bool,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let logits = MLXArray(values).reshaped([1, rows, 256])
+            let correctionBias = MLXArray(bias)
+            let scores = sigmoid(logits)
+            let selectionScores = scores + correctionBias
+            let stockIndices = stopGradient(
+                argPartition(-selectionScores, kth: 7, axis: -1)[
+                    .ellipsis,
+                    ..<8
+                ]
+            )
+            var stockWeights = takeAlong(scores, stockIndices, axis: -1)
+            if normalizing {
+                stockWeights = stockWeights / stockWeights.sum(axis: -1, keepDims: true)
+            }
+
+            let active = LagunaActive64Router.routeForTesting(
+                logits: logits,
+                correctionBias: correctionBias,
+                normalizing: normalizing
+            )
+            MLX.eval(stockIndices, stockWeights, active.indices, active.weights)
+
+            XCTAssertEqual(
+                active.indices.asType(.uint32).asArray(UInt32.self),
+                stockIndices.asType(.uint32).asArray(UInt32.self),
+                file: file,
+                line: line
+            )
+            XCTAssertEqual(
+                active.weights.asArray(Float.self),
+                stockWeights.asArray(Float.self),
+                file: file,
+                line: line
+            )
+        }
+
+        var smooth: [Float] = []
+        smooth.reserveCapacity(256)
+        for index in 0..<256 {
+            let position = Float(index)
+            let first = sin(position * Float(0.173)) * Float(5)
+            let second = cos(position * Float(0.071)) * Float(2)
+            smooth.append(first + second)
+        }
+        let smoothBias = (0..<256).map { index in
+            Float((index % 13) - 6) * 0.003
+        }
+        verify(smooth, rows: 1, bias: smoothBias, normalizing: false)
+        verify(smooth, rows: 1, bias: smoothBias, normalizing: true)
+
+        let ties = (0..<(2 * 256)).map { offset -> Float in
+            let column = offset % 256
+            return column.isMultiple(of: 2) ? -0.0 : 0.0
+        }
+        let zeroBias = Array(repeating: Float(0), count: 256)
+        verify(ties, rows: 2, bias: zeroBias, normalizing: false)
+        verify(ties, rows: 2, bias: zeroBias, normalizing: true)
+
+        let extremes = (0..<(3 * 256)).map { offset -> Float in
+            let row = offset / 256
+            let column = offset % 256
+            if column.isMultiple(of: 31) {
+                return row.isMultiple(of: 2) ? 80 : -80
+            }
+            return Float((column % 17) - 8) * Float(row + 1)
+        }
+        let extremeBias = (0..<256).map { index in
+            Float((index % 9) - 4) * 0.0005
+        }
+        verify(extremes, rows: 3, bias: extremeBias, normalizing: false)
+        verify(extremes, rows: 3, bias: extremeBias, normalizing: true)
+    }
+
     func testFusedPrefillResidualRMSNormMatchesStockOperations() throws {
         guard Device.defaultDevice().deviceType == .gpu else {
             throw XCTSkip("The fused Laguna prefill kernel requires a Metal GPU.")


### PR DESCRIPTION
## Summary

- port the MLX Fast Laguna XS 2.1 Active64 router tournament into the production Laguna runtime
- preserve the exact global top-8 result by selecting per-block candidates, then running the stock comparator over the 64 survivors
- retain a production kill switch: `MERERUN_LAGUNA_ACTIVE64_ROUTER=0`

## Why

Laguna routes each token across 256 experts. The stock path globally sorts all 256 logits. Active64 divides them into eight blocks, retains the top eight candidates from each block, then performs the same total-order tournament over 64 candidates. Any global top-8 expert must be in its block's local top eight, so the reduced tournament is exact while doing less ranking work.

This exact mechanism won the MLX Fast Laguna XS 2.1 crown on the official M5 Max runner:

- submission `cc6ddc1`
- challenge commit `c5b0a13c`
- score `2.61650354381456`
- decode `0.004930056640625` s/token
- prefill `0.000188158853515625` s/token
- correctness `1344/1344`, max absolute difference `0`

## Validation

Current rebased commit `9fd99c2a`:

- `git range-diff` confirms the port is byte-equivalent to the previously validated production commit
- `swift test --filter LagunaModelTests`: 54 tests, 0 failures
- `MERERUN_TEST_MLX_DEVICE=gpu swift test --filter LagunaModelTests/testActive64RouterMatchesStockTop8AcrossFamilies`: passed on real Metal
- `./scripts/check.sh`: passed; 2,563 XCTest tests and 25 Swift Testing tests, 0 failures
- `swift build -c release`: passed
- prior installed Laguna XS 2.1 forced-on/off smoke: exact response prefix and no retained-memory growth

A fresh installed-checkpoint smoke was not repeated on the rebased commit because an unrelated 55 GB H3 render is actively using Metal. The byte-equivalent patch already has installed-checkpoint proof, while this exact rebased commit has fresh real-Metal differential coverage, the mandatory full-repository gate, and a release build.
