### PR TITLE
Port Laguna XS 2.1 crown optimization stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
-        "revision" : "79bc410c85df66c3f4246084057bdfd971932ac7"
+        "revision" : "22c76cc40edbae2c2af72532678d8e5c06cbfa46"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -506,7 +506,7 @@ if !isLinuxPackage {
 var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(
     url: "https://github.com/sawfwair/mlx-swift",
-    revision: "79bc410c85df66c3f4246084057bdfd971932ac7"
+    revision: "22c76cc40edbae2c2af72532678d8e5c06cbfa46"
   )
 ]) + [
   .package(

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -27,8 +27,8 @@ enum MLXBundleSupport {
 
     static let expectedProvenance = MetallibProvenance(
       coreVersion: "0.32.1",
-      swiftRevision: "79bc410c85df66c3f4246084057bdfd971932ac7",
-      kernelSourcesSHA256: "a4a91e902e4a3c196ba45f3c6ee65c769c26b5825ae3b72d8b93ca233db2d93f"
+      swiftRevision: "22c76cc40edbae2c2af72532678d8e5c06cbfa46",
+      kernelSourcesSHA256: "961bc42bb4161801fb8b0f7fd9d4570e7e86318f1644520bb39eae04eed9820c"
     )
 
     /// Relationship between a bundle's metallib version stamp

--- a/Sources/MereRunCore/Laguna/LagunaGatedAffineOProj.swift
+++ b/Sources/MereRunCore/Laguna/LagunaGatedAffineOProj.swift
@@ -1,0 +1,152 @@
+import MLX
+import MLXFast
+
+/// Decode-only Laguna XS attention tail. The kernel consumes the raw BF16
+/// per-head gate logits and the ungated attention row, reproduces MLX's stable
+/// FP32 softplus and BF16 rounding boundary, then performs the accepted
+/// group-32 affine INT8 output projection in the same dispatch.
+enum LagunaGatedAffineOProj {
+    private static let hiddenSize = 2_048
+    private static let headDimension = 128
+
+    static func call(
+        attentionOutput: MLXArray,
+        gateLogits: MLXArray,
+        codes: MLXArray,
+        scales: MLXArray,
+        biases: MLXArray,
+        heads: Int
+    ) -> MLXArray? {
+        let inputWidth = heads * headDimension
+        guard let kernel = kernels[heads],
+              attentionOutput.dtype == .bfloat16,
+              attentionOutput.shape == [1, 1, inputWidth],
+              gateLogits.dtype == .bfloat16,
+              gateLogits.shape == [1, 1, heads],
+              codes.dtype == .uint32,
+              codes.shape == [hiddenSize, inputWidth / 4],
+              scales.dtype == .bfloat16,
+              scales.shape == [hiddenSize, inputWidth / 32],
+              biases.dtype == .bfloat16,
+              biases.shape == [hiddenSize, inputWidth / 32] else {
+            return nil
+        }
+
+        return kernel(
+            [attentionOutput, gateLogits, codes, scales, biases],
+            grid: ((hiddenSize / 8) * 64, 1, 1),
+            threadGroup: (64, 1, 1),
+            outputShapes: [[1, 1, hiddenSize]],
+            outputDTypes: [.bfloat16]
+        )[0]
+    }
+
+    #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    private static let kernels: [Int: MLXFast.MLXFastKernel] = {
+        var result: [Int: MLXFast.MLXFastKernel] = [:]
+        for heads in [48, 64] {
+            result[heads] = MLXFast.metalKernel(
+                name: "mere_laguna_gated_affine_oproj_i8g32_h\(heads)_v1",
+                inputNames: [
+                    "attention_output", "gate_logits", "weight_codes",
+                    "weight_scales", "weight_biases",
+                ],
+                outputNames: ["projected"],
+                source: source(heads: heads),
+                ensureRowContiguous: true
+            )
+        }
+        return result
+    }()
+    #else
+    private static let kernels: [Int: MLXFast.MLXFastKernel] = [:]
+    #endif
+
+    private static func source(heads: Int) -> String {
+        """
+        constexpr uint in_vec_size = \(heads * headDimension);
+        constexpr uint out_vec_size = \(hiddenSize);
+        constexpr uint gate_heads = \(heads);
+        constexpr uint head_shift = 7;
+        constexpr uint values_per_thread = 8;
+        constexpr uint block_size = 256;
+        constexpr uint results_per_simdgroup = 4;
+        constexpr uint num_simdgroups = 2;
+        constexpr uint group_size = 32;
+        constexpr uint scale_step_per_thread = group_size / values_per_thread;
+        constexpr uint in_vec_size_g = in_vec_size / group_size;
+
+        uint tile = threadgroup_position_in_grid.x;
+        uint lid = thread_position_in_threadgroup.x;
+        uint simd_gid = simdgroup_index_in_threadgroup;
+        uint simd_lid = thread_index_in_simdgroup;
+
+        threadgroup float gate_table[gate_heads];
+        if (lid < gate_heads) {
+            float logit = float(gate_logits[lid]);
+            float gate;
+            if (metal::isnan(logit)) {
+                gate = NAN;
+            } else {
+                float maxval = metal::max(logit, 0.0f);
+                float minval = metal::min(logit, 0.0f);
+                gate = (metal::isinf(minval) || metal::isinf(maxval))
+                    ? maxval
+                    : maxval + log1p(metal::exp(minval - maxval));
+            }
+            gate_table[lid] = float(bfloat(gate));
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        uint out_row = tile * (num_simdgroups * results_per_simdgroup) +
+            simd_gid * results_per_simdgroup;
+        const device uint8_t* ws = (const device uint8_t*)weight_codes +
+            out_row * in_vec_size + simd_lid * values_per_thread;
+        const device bfloat* sc = weight_scales + out_row * in_vec_size_g +
+            simd_lid / scale_step_per_thread;
+        const device bfloat* bs = weight_biases + out_row * in_vec_size_g +
+            simd_lid / scale_step_per_thread;
+        const device bfloat* xp = attention_output + simd_lid * values_per_thread;
+
+        thread float x_thread[values_per_thread];
+        thread float result[results_per_simdgroup] = {
+            0.0f, 0.0f, 0.0f, 0.0f
+        };
+
+        uint column = simd_lid * values_per_thread;
+        for (uint k = 0; k < in_vec_size; k += block_size) {
+            float gate = gate_table[column >> head_shift];
+            float sum = 0.0f;
+            for (uint i = 0; i < values_per_thread; ++i) {
+                float value = float(bfloat(float(xp[i]) * gate));
+                sum += value;
+                x_thread[i] = value;
+            }
+
+            for (uint row = 0; row < results_per_simdgroup; ++row) {
+                const device uint8_t* wl = ws + row * in_vec_size;
+                float scale = float(sc[row * in_vec_size_g]);
+                float bias = float(bs[row * in_vec_size_g]);
+                float accum = 0.0f;
+                for (uint i = 0; i < values_per_thread; ++i) {
+                    accum += x_thread[i] * wl[i];
+                }
+                result[row] += scale * accum + sum * bias;
+            }
+
+            ws += block_size;
+            sc += block_size / group_size;
+            bs += block_size / group_size;
+            xp += block_size;
+            column += block_size;
+        }
+
+        for (uint row = 0; row < results_per_simdgroup; ++row) {
+            result[row] = simd_sum(result[row]);
+            if (simd_lid == 0) {
+                projected[out_row + row] = bfloat(result[row]);
+            }
+        }
+        """
+    }
+}

--- a/Sources/MereRunCore/Laguna/LagunaModel.swift
+++ b/Sources/MereRunCore/Laguna/LagunaModel.swift
@@ -5,10 +5,23 @@ import MLXNN
 import MLXRandom
 
 enum LagunaMoEAccelerationPolicy {
+    static func supportsActive64ByDefault(architecture: String?) -> Bool {
+        architecture == "applegpu_g16s" || architecture == "applegpu_g17s"
+    }
+
     private static let m5MaxDefaultsEnabled: Bool = {
         #if os(macOS)
         Device.defaultDevice().deviceType == .gpu
             && GPU.deviceInfo().architecture == "applegpu_g17s"
+        #else
+        false
+        #endif
+    }()
+
+    private static let active64DefaultsEnabled: Bool = {
+        #if os(macOS)
+        Device.defaultDevice().deviceType == .gpu
+            && supportsActive64ByDefault(architecture: GPU.deviceInfo().architecture)
         #else
         false
         #endif
@@ -60,7 +73,7 @@ enum LagunaMoEAccelerationPolicy {
     )
     static let active64RouterTournamentEnabled = booleanEnvironment(
         "MERERUN_LAGUNA_ACTIVE64_ROUTER",
-        default: m5MaxDefaultsEnabled
+        default: active64DefaultsEnabled
     )
     static let decodeNVFP4RowsPerSIMDGroup = decodeRowsPerSIMDGroup(
         ProcessInfo.processInfo.environment[
@@ -153,10 +166,23 @@ func lagunaNVFP4AdjacentScalePairsCertified(
 }
 
 enum LagunaGraphAccelerationPolicy {
+    static func supportsNativeAffineByDefault(architecture: String?) -> Bool {
+        architecture == "applegpu_g16s" || architecture == "applegpu_g17s"
+    }
+
     private static let m5MaxDefaultsEnabled: Bool = {
         #if os(macOS)
         Device.defaultDevice().deviceType == .gpu
             && GPU.deviceInfo().architecture == "applegpu_g17s"
+        #else
+        false
+        #endif
+    }()
+
+    private static let nativeAffineQKVDefaultsEnabled: Bool = {
+        #if os(macOS)
+        Device.defaultDevice().deviceType == .gpu
+            && supportsNativeAffineByDefault(architecture: GPU.deviceInfo().architecture)
         #else
         false
         #endif
@@ -190,14 +216,51 @@ enum LagunaGraphAccelerationPolicy {
     )
     static let nativeAffineQKVEnabled = parseBoolean(
         ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_QKV"],
-        default: m5MaxDefaultsEnabled
+        default: nativeAffineQKVDefaultsEnabled
     )
     static let nativeAffineQKVLayerCount = nativeAffineQKVEnabled
         ? parseLayerCount(
             ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_QKV_LAYERS"],
-            default: 28
+            default: 40
         )
         : 0
+    static let nativeAffineOProjEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_OPROJ"],
+        default: nativeAffineQKVDefaultsEnabled
+    )
+    static let nativeAffineOProjLayerCount = nativeAffineOProjEnabled
+        ? parseLayerCount(
+            ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_OPROJ_LAYERS"],
+            default: 40
+        )
+        : 0
+    static let nativeAffineGProjEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_GPROJ"],
+        default: nativeAffineQKVDefaultsEnabled
+    )
+    static let nativeAffineGProjLayerCount = nativeAffineGProjEnabled
+        ? parseLayerCount(
+            ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_GPROJ_LAYERS"],
+            default: 40
+        )
+        : 0
+    static let nativeAffineGProjFoldEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NATIVE_AFFINE_GPROJ_FOLD"],
+        default: m5MaxDefaultsEnabled
+    )
+    static let fusedNormAffineQKVEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_FUSED_NORM_AFFINE_QKV"],
+        default: m5MaxDefaultsEnabled
+    )
+    static let fusedGatedAffineOProjEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_FUSED_GATED_AFFINE_OPROJ"],
+        default: true
+    )
+    static let decodeAsyncStageEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_DECODE_ASYNC_STAGE"],
+        default: nativeAffineQKVDefaultsEnabled
+    )
+    static let decodeAsyncLayerIndices: Set<Int> = [0, 1, 7, 15, 23, 31, 39]
 
     static func parseBoolean(_ raw: String?, default defaultValue: Bool) -> Bool {
         LagunaMoEAccelerationPolicy.parseBoolean(raw, default: defaultValue)
@@ -225,6 +288,14 @@ enum LagunaGraphAccelerationPolicy {
 
     static func usesNativeAffineQKV(layerIndex: Int) -> Bool {
         layerIndex >= 0 && layerIndex < nativeAffineQKVLayerCount
+    }
+
+    static func usesNativeAffineOProj(layerIndex: Int) -> Bool {
+        layerIndex >= 0 && layerIndex < nativeAffineOProjLayerCount
+    }
+
+    static func usesNativeAffineGProj(layerIndex: Int) -> Bool {
+        layerIndex >= 0 && layerIndex < nativeAffineGProjLayerCount
     }
 }
 
@@ -1460,6 +1531,9 @@ final class LagunaAttention: Module {
     private let layerIndex: Int
     private let isTerminalLayer: Bool
     private var _nativeAffineQKV: LagunaNativeAffineWeight?
+    private var _nativeAffineOProj: LagunaNativeAffineWeight?
+    private var _nativeAffineGProj: LagunaNativeAffineWeight?
+    private var _nativeAffineQKVGateRows = 0
     private var _terminalPrefillQGateWeight: MLXArray?
     private var _terminalPrefillKVWeight: MLXArray?
 
@@ -1506,9 +1580,13 @@ final class LagunaAttention: Module {
         super.init()
     }
 
-    func prepareNativeAffineQKV() -> [MLXArray] {
+    func prepareNativeAffineQKV(
+        enabled: Bool? = nil,
+        includeGate: Bool? = nil
+    ) -> [MLXArray] {
         guard _nativeAffineQKV == nil,
-              LagunaGraphAccelerationPolicy.usesNativeAffineQKV(layerIndex: layerIndex),
+              enabled
+                ?? LagunaGraphAccelerationPolicy.usesNativeAffineQKV(layerIndex: layerIndex),
               headDim == 128,
               keyValueHeadCount == 8,
               headCount == 48 || headCount == 64,
@@ -1526,20 +1604,122 @@ final class LagunaAttention: Module {
               let value = lagunaNativeAffineWeight(vProj.weight) else {
             return []
         }
+        let gate: LagunaNativeAffineWeight?
+        let gateEnabled = includeGate
+            ?? (
+                LagunaGraphAccelerationPolicy.nativeAffineGProjFoldEnabled
+                    && LagunaGraphAccelerationPolicy.usesNativeAffineGProj(
+                        layerIndex: layerIndex
+                    )
+            )
+        if gateEnabled,
+           gatePerHead,
+           let gProj,
+           type(of: gProj) == Linear.self,
+           gProj.bias == nil,
+           gProj.weight.shape == [headCount, 2_048] {
+            gate = lagunaNativeAffineWeight(gProj.weight)
+        } else {
+            gate = nil
+        }
+        var packedBlocks = [query.packedCodes, key.packedCodes, value.packedCodes]
+        var scaleBlocks = [query.scales, key.scales, value.scales]
+        var biasBlocks = [query.biases, key.biases, value.biases]
+        if let gate {
+            packedBlocks.append(gate.packedCodes)
+            scaleBlocks.append(gate.scales)
+            biasBlocks.append(gate.biases)
+            _nativeAffineQKVGateRows = headCount
+        }
         let fused = LagunaNativeAffineWeight(
-            packedCodes: concatenated(
-                [query.packedCodes, key.packedCodes, value.packedCodes],
-                axis: 0
-            ),
-            scales: concatenated([query.scales, key.scales, value.scales], axis: 0),
-            biases: concatenated([query.biases, key.biases, value.biases], axis: 0),
+            packedCodes: concatenated(packedBlocks, axis: 0),
+            scales: concatenated(scaleBlocks, axis: 0),
+            biases: concatenated(biasBlocks, axis: 0),
             originalShape: [
-                qProj.weight.dim(0) + kProj.weight.dim(0) + vProj.weight.dim(0),
+                qProj.weight.dim(0) + kProj.weight.dim(0) + vProj.weight.dim(0)
+                    + _nativeAffineQKVGateRows,
                 qProj.weight.dim(1),
             ]
         )
         _nativeAffineQKV = fused
         return fused.arrays
+    }
+
+    func prepareNativeAffineOProj(enabled: Bool? = nil) -> [MLXArray] {
+        let enabled = enabled
+            ?? LagunaGraphAccelerationPolicy.usesNativeAffineOProj(layerIndex: layerIndex)
+        guard enabled,
+              _nativeAffineOProj == nil,
+              type(of: oProj) == Linear.self,
+              oProj.bias == nil,
+              oProj.weight.shape == [2_048, headCount * headDim],
+              let affine = lagunaNativeAffineWeight(oProj.weight) else {
+            return []
+        }
+        _nativeAffineOProj = affine
+        return affine.arrays
+    }
+
+    func prepareNativeAffineGProj(enabled: Bool? = nil) -> [MLXArray] {
+        let enabled = enabled
+            ?? LagunaGraphAccelerationPolicy.usesNativeAffineGProj(layerIndex: layerIndex)
+        guard enabled,
+              _nativeAffineQKVGateRows == 0,
+              _nativeAffineGProj == nil,
+              gatePerHead,
+              let gProj,
+              type(of: gProj) == Linear.self,
+              gProj.bias == nil,
+              gProj.weight.shape == [headCount, 2_048],
+              let affine = lagunaNativeAffineWeight(gProj.weight) else {
+            return []
+        }
+        _nativeAffineGProj = affine
+        return affine.arrays
+    }
+
+    /// Compile and execute the fused decode tail while model loading is still
+    /// untimed. The custom Metal pipeline is keyed only by the Laguna head
+    /// count, so one warm-up per 48/64-head family avoids charging the first
+    /// user request for PSO construction without caching request data.
+    func prepareFusedGatedAffineOProjWarmUp() -> MLXArray? {
+        guard LagunaGraphAccelerationPolicy.fusedGatedAffineOProjEnabled,
+              gatePerHead,
+              headCount == 48 || headCount == 64,
+              let affine = _nativeAffineOProj else {
+            return nil
+        }
+        return LagunaGatedAffineOProj.call(
+            attentionOutput: MLXArray.zeros([1, 1, headCount * headDim], dtype: .bfloat16),
+            gateLogits: MLXArray.zeros([1, 1, headCount], dtype: .bfloat16),
+            codes: affine.packedCodes,
+            scales: affine.scales,
+            biases: affine.biases,
+            heads: headCount
+        )
+    }
+
+    func prepareFusedNormAffineQKVWarmUp(
+        normWeight: MLXArray
+    ) -> (rows: Int, output: MLXArray)? {
+        guard LagunaGraphAccelerationPolicy.fusedNormAffineQKVEnabled,
+              let affine = _nativeAffineQKV else {
+            return nil
+        }
+        let rows = (headCount + 2 * keyValueHeadCount) * headDim
+            + _nativeAffineQKVGateRows
+        guard let output = LagunaNormAffineQKV.call(
+            residual: MLXArray.zeros([1, 1, 2_048], dtype: .bfloat16),
+            normWeight: normWeight,
+            codes: affine.packedCodes,
+            scales: affine.scales,
+            biases: affine.biases,
+            heads: headCount,
+            gateRows: _nativeAffineQKVGateRows
+        ) else {
+            return nil
+        }
+        return (rows, output)
     }
 
     /// Retain two bias-free BF16 side banks for the terminal XS prefill layer.
@@ -1592,8 +1772,31 @@ final class LagunaAttention: Module {
     /// Discard retained base-weight layouts that would otherwise bypass them.
     func invalidateTextLoRAUnsafeAcceleration() {
         _nativeAffineQKV = nil
+        _nativeAffineOProj = nil
+        _nativeAffineGProj = nil
+        _nativeAffineQKVGateRows = 0
         _terminalPrefillQGateWeight = nil
         _terminalPrefillKVWeight = nil
+    }
+
+    private func projectOutput(_ input: MLXArray, useCustomKernels: Bool) -> MLXArray {
+        if useCustomKernels,
+           input.shape == [1, 1, headCount * headDim],
+           input.dtype == .bfloat16,
+           let affine = _nativeAffineOProj,
+           affine.originalShape == [2_048, headCount * headDim] {
+            return MLX.quantizedMM(
+                input,
+                affine.packedCodes,
+                scales: affine.scales,
+                biases: affine.biases,
+                transpose: true,
+                groupSize: 32,
+                bits: 8,
+                mode: .affine
+            )
+        }
+        return oProj(input)
     }
 
     func callAsFunction(
@@ -1601,6 +1804,8 @@ final class LagunaAttention: Module {
         cache: Gemma4AttentionCache?,
         precomputedMask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
         precomputedRoPEAtlas: MLXArray? = nil,
+        residualForFusedQKV: MLXArray? = nil,
+        rmsNormWeight: MLXArray? = nil,
         useCustomKernels: Bool = true
     ) -> MLXArray {
         let batch = x.dim(0)
@@ -1612,16 +1817,38 @@ final class LagunaAttention: Module {
         let rawQueries: MLXArray
         let rawKeys: MLXArray
         var values: MLXArray
+        let bankedGate: MLXArray?
         let queryDimensions = headCount * headDim
         let keyValueDimensions = keyValueHeadCount * headDim
-        if useCustomKernels,
-           batch == 1,
-           sequenceLength == 1,
-           x.dtype == .bfloat16,
-           x.shape == [1, 1, 2_048],
-           let affine = _nativeAffineQKV,
-           affine.originalShape == [queryDimensions + 2 * keyValueDimensions, 2_048] {
-            let qkv = MLX.quantizedMM(
+        let bankedQKV: MLXArray? = {
+            guard useCustomKernels,
+                  batch == 1,
+                  sequenceLength == 1,
+                  x.dtype == .bfloat16,
+                  x.shape == [1, 1, 2_048],
+                  let affine = _nativeAffineQKV,
+                  affine.originalShape == [
+                      queryDimensions + 2 * keyValueDimensions
+                          + _nativeAffineQKVGateRows,
+                      2_048,
+                  ] else {
+                return nil
+            }
+            if LagunaGraphAccelerationPolicy.fusedNormAffineQKVEnabled,
+               let residualForFusedQKV,
+               let rmsNormWeight,
+               let fused = LagunaNormAffineQKV.call(
+                   residual: residualForFusedQKV,
+                   normWeight: rmsNormWeight,
+                   codes: affine.packedCodes,
+                   scales: affine.scales,
+                   biases: affine.biases,
+                   heads: headCount,
+                   gateRows: _nativeAffineQKVGateRows
+               ) {
+                return fused
+            }
+            return MLX.quantizedMM(
                 x,
                 affine.packedCodes,
                 scales: affine.scales,
@@ -1631,6 +1858,8 @@ final class LagunaAttention: Module {
                 bits: 8,
                 mode: .affine
             )
+        }()
+        if let qkv = bankedQKV {
             rawQueries = qkv[.ellipsis, 0..<queryDimensions]
             rawKeys = qkv[
                 .ellipsis,
@@ -1638,8 +1867,14 @@ final class LagunaAttention: Module {
             ]
             values = qkv[
                 .ellipsis,
-                (queryDimensions + keyValueDimensions)...
+                (queryDimensions + keyValueDimensions)..<(queryDimensions + 2 * keyValueDimensions)
             ].reshaped(batch, sequenceLength, keyValueHeadCount, headDim)
+            if _nativeAffineQKVGateRows == headCount {
+                let gateStart = queryDimensions + 2 * keyValueDimensions
+                bankedGate = qkv[.ellipsis, gateStart..<(gateStart + headCount)]
+            } else {
+                bankedGate = nil
+            }
         } else {
             rawQueries = qProj(x)
             rawKeys = kProj(x)
@@ -1649,6 +1884,7 @@ final class LagunaAttention: Module {
                 keyValueHeadCount,
                 headDim
             )
+            bankedGate = nil
         }
         var queries: MLXArray
         var keys: MLXArray
@@ -1709,15 +1945,54 @@ final class LagunaAttention: Module {
         ).transposed(0, 2, 1, 3)
 
         if let gProj {
-            let gate = MLXNN.softplus(gProj(x).asType(.float32)).asType(output.dtype)
+            let projectedGate: MLXArray
+            if let bankedGate {
+                projectedGate = bankedGate
+            } else if useCustomKernels,
+                      x.shape == [1, 1, 2_048],
+                      x.dtype == .bfloat16,
+                      let affine = _nativeAffineGProj,
+                      affine.originalShape == [headCount, 2_048] {
+                projectedGate = MLX.quantizedMM(
+                    x,
+                    affine.packedCodes,
+                    scales: affine.scales,
+                    biases: affine.biases,
+                    transpose: true,
+                    groupSize: 32,
+                    bits: 8,
+                    mode: .affine
+                )
+            } else {
+                projectedGate = gProj(x)
+            }
+            let flattenedOutput = output.reshaped(batch, sequenceLength, -1)
+            if useCustomKernels,
+               LagunaGraphAccelerationPolicy.fusedGatedAffineOProjEnabled,
+               gatePerHead,
+               let affine = _nativeAffineOProj,
+               let projected = LagunaGatedAffineOProj.call(
+                   attentionOutput: flattenedOutput,
+                   gateLogits: projectedGate,
+                   codes: affine.packedCodes,
+                   scales: affine.scales,
+                   biases: affine.biases,
+                   heads: headCount
+               ) {
+                return projected
+            }
+            let gate = MLXNN.softplus(projectedGate.asType(.float32)).asType(output.dtype)
             if gatePerHead {
                 output = output * MLX.expandedDimensions(gate, axis: gate.ndim)
             } else {
-                output = output.reshaped(batch, sequenceLength, -1) * gate
-                return oProj(output)
+                output = flattenedOutput * gate
+                return projectOutput(output, useCustomKernels: useCustomKernels)
             }
         }
-        return oProj(output.reshaped(batch, sequenceLength, -1))
+        return projectOutput(
+            output.reshaped(batch, sequenceLength, -1),
+            useCustomKernels: useCustomKernels
+        )
     }
 
     /// Final-layer multi-token specialization for callers that consume only
@@ -1946,6 +2221,8 @@ final class LagunaDecoderLayer: Module {
             cache: cache,
             precomputedMask: precomputedMask,
             precomputedRoPEAtlas: precomputedRoPEAtlas,
+            residualForFusedQKV: x,
+            rmsNormWeight: inputLayerNorm.weight,
             useCustomKernels: useCustomKernels
         )
         let attended: MLXArray
@@ -1980,6 +2257,12 @@ final class LagunaDecoderLayer: Module {
             )
         }
         return attended + mlp(normalized)
+    }
+
+    func prepareFusedNormAffineQKVWarmUp() -> (rows: Int, output: MLXArray)? {
+        selfAttention.prepareFusedNormAffineQKVWarmUp(
+            normWeight: inputLayerNorm.weight
+        )
     }
 
     /// Preserve every terminal-layer K/V row while carrying only the consumed
@@ -2119,6 +2402,13 @@ final class LagunaLanguageModel: Module {
                (index + 1).isMultiple(of: ladderStride) {
                 asyncEval(hidden)
             }
+            if useCustomKernels,
+               LagunaGraphAccelerationPolicy.decodeAsyncStageEnabled,
+               hidden.dim(0) == 1,
+               sequenceLength == 1,
+               LagunaGraphAccelerationPolicy.decodeAsyncLayerIndices.contains(index) {
+                asyncEval(hidden)
+            }
         }
         if lastPositionOnly, hidden.dim(1) > 1 {
             hidden = hidden[0..., (hidden.dim(1) - 1)..., 0...]
@@ -2173,9 +2463,28 @@ final class LagunaLanguageModel: Module {
         var arrays = preparePrefillAcceleration()
         for layer in layers {
             arrays.append(contentsOf: layer.selfAttention.prepareNativeAffineQKV())
+            arrays.append(contentsOf: layer.selfAttention.prepareNativeAffineGProj())
+            arrays.append(contentsOf: layer.selfAttention.prepareNativeAffineOProj())
             arrays.append(
                 contentsOf: layer.selfAttention.prepareTerminalPrefillProjectionWeights()
             )
+        }
+        var warmedHeadCounts: Set<Int> = []
+        for (layerIndex, layer) in layers.enumerated() {
+            let headCount = config.attentionHeads(layerIndex: layerIndex)
+            guard warmedHeadCounts.insert(headCount).inserted,
+                  let warmUp = layer.selfAttention.prepareFusedGatedAffineOProjWarmUp() else {
+                continue
+            }
+            arrays.append(warmUp)
+        }
+        var warmedQKVRows: Set<Int> = []
+        for layer in layers {
+            guard let warmUp = layer.prepareFusedNormAffineQKVWarmUp(),
+                  warmedQKVRows.insert(warmUp.rows).inserted else {
+                continue
+            }
+            arrays.append(warmUp.output)
         }
         return arrays
     }

--- a/Sources/MereRunCore/Laguna/LagunaNormAffineQKV.swift
+++ b/Sources/MereRunCore/Laguna/LagunaNormAffineQKV.swift
@@ -1,0 +1,215 @@
+import MLX
+import MLXFast
+
+/// Single-token Laguna XS input RMSNorm plus group-32 affine Q/K/V(/gate)
+/// projection. The kernel reproduces MLX's precise RMSNorm reduction and BF16
+/// rounding boundary, then keeps each projection row's affine-QMV arithmetic
+/// and reduction order unchanged. Prefetching immutable weight bytes above the
+/// RMS prologue overlaps memory latency without changing consumption order.
+enum LagunaNormAffineQKV {
+    private static let hiddenSize = 2_048
+    private static let headDimension = 128
+    private static let keyValueHeads = 8
+    private static let prefetchDepth = 4
+
+    static func call(
+        residual: MLXArray,
+        normWeight: MLXArray,
+        codes: MLXArray,
+        scales: MLXArray,
+        biases: MLXArray,
+        heads: Int,
+        gateRows: Int
+    ) -> MLXArray? {
+        let rows = (heads + 2 * keyValueHeads) * headDimension + gateRows
+        guard let kernel = kernels[rows],
+              residual.dtype == .bfloat16,
+              residual.shape == [1, 1, hiddenSize],
+              normWeight.dtype == .bfloat16,
+              normWeight.shape == [hiddenSize],
+              codes.dtype == .uint32,
+              codes.shape == [rows, hiddenSize / 4],
+              scales.dtype == .bfloat16,
+              scales.shape == [rows, hiddenSize / 32],
+              biases.dtype == .bfloat16,
+              biases.shape == [rows, hiddenSize / 32] else {
+            return nil
+        }
+
+        return kernel(
+            [residual, normWeight, codes, scales, biases],
+            grid: ((rows / 8) * 64, 1, 1),
+            threadGroup: (64, 1, 1),
+            outputShapes: [[1, 1, rows]],
+            outputDTypes: [.bfloat16]
+        )[0]
+    }
+
+    #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    private static let kernels: [Int: MLXFast.MLXFastKernel] = {
+        var result: [Int: MLXFast.MLXFastKernel] = [:]
+        for heads in [48, 64] {
+            for gateRows in [0, heads] {
+                let rows = (heads + 2 * keyValueHeads) * headDimension + gateRows
+                result[rows] = MLXFast.metalKernel(
+                    name: "mere_laguna_norm_affine_qkv_i8g32_r\(rows)_pf4_v1",
+                    inputNames: [
+                        "residual", "norm_weight", "weight_codes",
+                        "weight_scales", "weight_biases",
+                    ],
+                    outputNames: ["projected"],
+                    source: source(rows: rows),
+                    ensureRowContiguous: true
+                )
+            }
+        }
+        return result
+    }()
+    #else
+    private static let kernels: [Int: MLXFast.MLXFastKernel] = [:]
+    #endif
+
+    private static func source(rows: Int) -> String {
+        """
+        constexpr uint axis_size = \(hiddenSize);
+        constexpr uint out_vec_size = \(rows);
+        constexpr uint n_reads = 4;
+        constexpr uint norm_threads = axis_size / n_reads;
+        constexpr uint real_threads = 64;
+        constexpr uint virtual_per_thread = norm_threads / real_threads;
+        constexpr uint simd_size = 32;
+        constexpr float norm_eps = 1.0e-6f;
+        constexpr uint values_per_thread = 8;
+        constexpr uint block_size = 256;
+        constexpr uint results_per_simdgroup = 4;
+        constexpr uint num_simdgroups = 2;
+        constexpr uint group_size = 32;
+        constexpr uint scale_step_per_thread = group_size / values_per_thread;
+        constexpr uint in_vec_size_g = axis_size / group_size;
+        constexpr uint pf_depth = \(prefetchDepth);
+
+        uint tile = threadgroup_position_in_grid.x;
+        uint lid = thread_position_in_threadgroup.x;
+        uint simd_gid = simdgroup_index_in_threadgroup;
+        uint simd_lid = thread_index_in_simdgroup;
+
+        threadgroup float local_inv_mean[1];
+        threadgroup float local_sums[simd_size];
+
+        uint out_row = tile * (num_simdgroups * results_per_simdgroup) +
+            simd_gid * results_per_simdgroup;
+        const device uint8_t* ws = (const device uint8_t*)weight_codes +
+            out_row * axis_size + simd_lid * values_per_thread;
+        const device bfloat* sc = weight_scales + out_row * in_vec_size_g +
+            simd_lid / scale_step_per_thread;
+        const device bfloat* bs = weight_biases + out_row * in_vec_size_g +
+            simd_lid / scale_step_per_thread;
+
+        uint8_t pf_w[pf_depth][results_per_simdgroup][values_per_thread];
+        float pf_s[pf_depth][results_per_simdgroup];
+        float pf_b[pf_depth][results_per_simdgroup];
+        for (uint d = 0; d < pf_depth; ++d) {
+            for (uint row = 0; row < results_per_simdgroup; ++row) {
+                const device uint8_t* wl =
+                    ws + d * block_size + row * axis_size;
+                for (uint i = 0; i < values_per_thread; ++i) {
+                    pf_w[d][row][i] = wl[i];
+                }
+                pf_s[d][row] = float(sc[
+                    d * (block_size / group_size) + row * in_vec_size_g]);
+                pf_b[d][row] = float(bs[
+                    d * (block_size / group_size) + row * in_vec_size_g]);
+            }
+        }
+
+        if (lid < simd_size) {
+            local_sums[lid] = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint j = 0; j < virtual_per_thread; ++j) {
+            uint base = (lid + j * real_threads) * n_reads;
+            float accum = 0.0f;
+            for (uint i = 0; i < n_reads; ++i) {
+                float value = float(residual[base + i]);
+                accum += value * value;
+            }
+            accum = simd_sum(accum);
+            if (simd_lid == 0) {
+                local_sums[simd_gid + num_simdgroups * j] = accum;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (simd_gid == 0) {
+            float total = simd_sum(local_sums[simd_lid]);
+            if (simd_lid == 0) {
+                local_inv_mean[0] =
+                    metal::precise::rsqrt(total / float(axis_size) + norm_eps);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        float inv_mean = local_inv_mean[0];
+        thread float x_thread[values_per_thread];
+        thread float result[results_per_simdgroup] = {
+            0.0f, 0.0f, 0.0f, 0.0f
+        };
+
+        uint column = simd_lid * values_per_thread;
+        for (uint d = 0; d < pf_depth; ++d) {
+            float sum = 0.0f;
+            for (uint i = 0; i < values_per_thread; ++i) {
+                float value = float(bfloat(
+                    norm_weight[column + i] *
+                    bfloat(float(residual[column + i]) * inv_mean)));
+                sum += value;
+                x_thread[i] = value;
+            }
+            for (uint row = 0; row < results_per_simdgroup; ++row) {
+                float accum = 0.0f;
+                for (uint i = 0; i < values_per_thread; ++i) {
+                    accum += x_thread[i] * pf_w[d][row][i];
+                }
+                result[row] += pf_s[d][row] * accum + sum * pf_b[d][row];
+            }
+            ws += block_size;
+            sc += block_size / group_size;
+            bs += block_size / group_size;
+            column += block_size;
+        }
+
+        for (uint k = pf_depth * block_size; k < axis_size; k += block_size) {
+            float sum = 0.0f;
+            for (uint i = 0; i < values_per_thread; ++i) {
+                float value = float(bfloat(
+                    norm_weight[column + i] *
+                    bfloat(float(residual[column + i]) * inv_mean)));
+                sum += value;
+                x_thread[i] = value;
+            }
+            for (uint row = 0; row < results_per_simdgroup; ++row) {
+                const device uint8_t* wl = ws + row * axis_size;
+                float scale = float(sc[row * in_vec_size_g]);
+                float bias = float(bs[row * in_vec_size_g]);
+                float accum = 0.0f;
+                for (uint i = 0; i < values_per_thread; ++i) {
+                    accum += x_thread[i] * wl[i];
+                }
+                result[row] += scale * accum + sum * bias;
+            }
+            ws += block_size;
+            sc += block_size / group_size;
+            bs += block_size / group_size;
+            column += block_size;
+        }
+
+        for (uint row = 0; row < results_per_simdgroup; ++row) {
+            result[row] = simd_sum(result[row]);
+            if (simd_lid == 0) {
+                projected[out_row + row] = bfloat(result[row]);
+            }
+        }
+        """
+    }
+}

--- a/Sources/MereRunCore/Laguna/README.md
+++ b/Sources/MereRunCore/Laguna/README.md
@@ -209,16 +209,38 @@ native projection/reduction chain; set it to `1` to opt in on a supported M4
 Max. Any non-XS shape, dtype, quantization layout, or unquantized shared expert
 falls back automatically.
 
-The same M5-ranked runtime uses a retained group-32 affine INT8 side layout for
-Q/K/V on the first 28 layers of one-token decode. Prefill, batched decode, and
-the original BF16 checkpoint parameters are unchanged. Disable it with
+The measured M4 Max and M5 Max runtimes use retained group-32 affine INT8 side
+layouts for Q/K/V, the attention output, and the per-head gate projections on
+all 40 layers of one-token decode. M5 Max folds the gate rows into the Q/K/V
+bank and fuses the input RMSNorm with that projection. The custom kernel keeps
+the reference BF16 normalization boundary before the affine dot products. M4
+Max keeps a separate gate bank because the corrected folded geometry measured
+neutral there. A fused Metal tail consumes the raw gate logits, reproduces the
+stable FP32 softplus and BF16 rounding boundary, and performs the affine output
+projection in the same dispatch. All custom pipelines are warmed during model
+preparation, outside the first request. Prefill, batched decode, DFlash
+verification, and the original BF16 checkpoint parameters are unchanged.
+Disable Q/K/V with
 `MERERUN_LAGUNA_NATIVE_AFFINE_QKV=0`, opt in on other hardware with `=1`, or
 set `MERERUN_LAGUNA_NATIVE_AFFINE_QKV_LAYERS=0...40` for a bounded rollout.
-The official XS head pattern makes the default 28-layer side layout 598.5 MiB;
-preparation is idempotent and decode retains no additional buffer per token.
-The default remains 28 because that exact slice passed the public, hidden,
-semantic, and paired-timing M5 gates; the prepared 40-layer continuation is
-not a production default until it receives the same validation.
+The matching controls are `MERERUN_LAGUNA_NATIVE_AFFINE_OPROJ`,
+`MERERUN_LAGUNA_NATIVE_AFFINE_OPROJ_LAYERS`,
+`MERERUN_LAGUNA_NATIVE_AFFINE_GPROJ`, and
+`MERERUN_LAGUNA_NATIVE_AFFINE_GPROJ_LAYERS`.
+`MERERUN_LAGUNA_FUSED_GATED_AFFINE_OPROJ=0` restores the two-dispatch gate and
+output-projection chain; `MERERUN_LAGUNA_NATIVE_AFFINE_GPROJ_FOLD=0` restores
+the separate gate bank on M5, while `=1` opts into the same folded geometry on
+M4. `MERERUN_LAGUNA_FUSED_NORM_AFFINE_QKV=0` restores the standalone input
+RMSNorm plus affine Q/K/V projection on M5. Unsupported shapes and every
+multi-token forward fall back to the ordinary production modules.
+`MERERUN_LAGUNA_NVFP4_QDOT_FAST=0` restores the reference Laguna routed-QMV
+decode and disables its exact split-nibble, power-of-two scale-fold, and
+dead-zero seed elisions. `MERERUN_LAGUNA_DECODE_ASYNC_STAGE=0` disables the
+exact seven-stage decode enqueue ladder. It is enabled by default on M4 Max and
+M5 Max after repeatable production A/B gains and multiple exact official M5
+receipts. The complete Q/K/V, output, and gate side layouts retain about
+1.50 GiB for the official XS head pattern; preparation is idempotent and
+decode retains no additional buffer per token.
 
 Example:
 

--- a/Sources/MereRunCore/Quantization/RoutedMoERouting.swift
+++ b/Sources/MereRunCore/Quantization/RoutedMoERouting.swift
@@ -32,6 +32,11 @@ enum RoutedMoERouting {
         #endif
     }
 
+    private static let lagunaNVFP4QDotFastEnabled = parseBoolean(
+        ProcessInfo.processInfo.environment["MERERUN_LAGUNA_NVFP4_QDOT_FAST"],
+        default: true
+    )
+
     /// Computes an unsorted NVFP4 gate/up gather-GEMV and SwiGLU activation.
     ///
     /// One threadgroup runs the gate and up projections concurrently for one
@@ -1094,12 +1099,18 @@ enum RoutedMoERouting {
         ensureRowContiguous: true
     )
 
-    private static let lagunaXSDownHeader = """
+    private static let lagunaXSDownHeader = lagunaNVFP4QDotFastEnabled
+        ? lagunaXSFastQDotHeader
+        : lagunaXSReferenceQDotHeader
+
+    private static let lagunaXSReferenceQDotHeader = """
         static inline float mere_laguna_nvfp4_scale(uint8_t bits) {
-            ushort raw = ushort(bits & 127) << 7;
-            half converted = as_type<half>(raw);
-            half signed_value = (bits & 128) ? -converted : converted;
-            return float(signed_value) * 4194304.0f;
+            // E4M3 and IEEE half are both sign-magnitude here. Adding the
+            // source sign bit before the shift carries it directly into the
+            // half sign position, including negative zero, and removes the
+            // post-conversion conditional negate without changing any bits.
+            ushort raw = ushort((uint(bits) + (bits & 128u)) << 7);
+            return float(as_type<half>(raw)) * 4194304.0f;
         }
 
         static inline float mere_laguna_nvfp4_qdot_codes_16(
@@ -1146,8 +1157,96 @@ enum RoutedMoERouting {
         }
         """
 
+    /// Laguna-only NVFP4 group-16 qdot specialization. It constructs the same
+    /// half bit patterns with a split-nibble integer sequence, moves the exact
+    /// 2^14 renormalization into the group scale, and seeds the accumulator
+    /// from the first four-term product group. The only exceptional case is
+    /// the sign of an all-negative-zero partial, which every caller absorbs in
+    /// its existing +0.0 row accumulator before the BF16 output boundary.
+    private static let lagunaXSFastQDotHeader = """
+        static inline float mere_laguna_nvfp4_scale(uint8_t bits) {
+            if (bits < 16u) {
+                return float(uint(bits) << 5);
+            }
+            ushort raw = ushort(bits & 127) << 7;
+            half converted = as_type<half>(raw);
+            half signed_value = (bits & 128) ? -converted : converted;
+            return float(signed_value) * 4194304.0f;
+        }
+
+        static inline float mere_laguna_nvfp4_qdot_codes_16(
+            uint2 codes,
+            const thread float* input,
+            float scale
+        ) {
+            float accum;
+            {
+                const uint c = codes.x;
+                const uint xe = c & 0x0F0F0F0Fu;
+                const uint ge = xe | (xe << 3);
+                const uint yo = c & 0xF0F0F0F0u;
+                const uint go = yo | (yo >> 3);
+                const uint p0 = (ge << 9) & 0x8E008E00u;
+                const uint p1 = (go << 8) & 0x8E008E00u;
+                const uint p2 = (ge << 1) & 0x8E008E00u;
+                const uint p3 = go & 0x8E008E00u;
+                const float2 v04 = float2(as_type<half2>(p0));
+                const float2 v15 = float2(as_type<half2>(p1));
+                const float2 v26 = float2(as_type<half2>(p2));
+                const float2 v37 = float2(as_type<half2>(p3));
+                accum =
+                    (input[0] * v04.x
+                     + input[1] * v15.x
+                     + input[2] * v26.x
+                     + input[3] * v37.x);
+                accum +=
+                    (input[4] * v04.y
+                     + input[5] * v15.y
+                     + input[6] * v26.y
+                     + input[7] * v37.y);
+            }
+            {
+                const uint c = codes.y;
+                const uint xe = c & 0x0F0F0F0Fu;
+                const uint ge = xe | (xe << 3);
+                const uint yo = c & 0xF0F0F0F0u;
+                const uint go = yo | (yo >> 3);
+                const uint p0 = (ge << 9) & 0x8E008E00u;
+                const uint p1 = (go << 8) & 0x8E008E00u;
+                const uint p2 = (ge << 1) & 0x8E008E00u;
+                const uint p3 = go & 0x8E008E00u;
+                const float2 v04 = float2(as_type<half2>(p0));
+                const float2 v15 = float2(as_type<half2>(p1));
+                const float2 v26 = float2(as_type<half2>(p2));
+                const float2 v37 = float2(as_type<half2>(p3));
+                accum +=
+                    (input[8] * v04.x
+                     + input[9] * v15.x
+                     + input[10] * v26.x
+                     + input[11] * v37.x);
+                accum +=
+                    (input[12] * v04.y
+                     + input[13] * v15.y
+                     + input[14] * v26.y
+                     + input[15] * v37.y);
+            }
+            return scale * accum;
+        }
+
+        static inline float mere_laguna_nvfp4_qdot_16(
+            const device uint8_t* weight,
+            const thread float* input,
+            float scale
+        ) {
+            const device uint2* packed = (const device uint2*)weight;
+            return mere_laguna_nvfp4_qdot_codes_16(packed[0], input, scale);
+        }
+        """
+
     private static let lagunaXSRoutedSharedDownResidualKernel = MLXFast.metalKernel(
-        name: "mere_laguna_xs_routed_shared_nvfp4_down_residual_bf16_r1_v1",
+        name: lagunaNVFP4QDotFastEnabled
+            ? "mere_laguna_xs_routed_shared_nvfp4_down_residual_bf16_r1_qf_v1"
+            : "mere_laguna_xs_routed_shared_nvfp4_down_residual_bf16_r1_v1",
         inputNames: [
             "routed_activated",
             "routed_down_weight",
@@ -1254,7 +1353,9 @@ enum RoutedMoERouting {
     )
 
     private static let fusedGatherNVFP4SwiGLUKernel = MLXFast.metalKernel(
-        name: "mere_routed_moe_gather_nvfp4_swiglu",
+        name: lagunaNVFP4QDotFastEnabled
+            ? "mere_routed_moe_gather_nvfp4_swiglu_qf_v1"
+            : "mere_routed_moe_gather_nvfp4_swiglu",
         inputNames: [
             "x",
             "gate_weight",
@@ -1334,12 +1435,10 @@ enum RoutedMoERouting {
                         selected_weight + size_t(row) * packed_input;
                     const device uint8_t* row_scales =
                         selected_scales + size_t(row) * scale_input;
-                    const float scale =
-                        dequantize_scale<float, GROUP_SIZE>(row_scales[0]);
-                    results[row] += qdot<
-                        float,
-                        values_per_thread,
-                        BITS>(row_weight, input_values, scale);
+                    results[row] += mere_laguna_nvfp4_qdot_16(
+                        row_weight,
+                        input_values,
+                        mere_laguna_nvfp4_scale(row_scales[0]));
                 }
 
                 selected_weight +=
@@ -1386,7 +1485,7 @@ enum RoutedMoERouting {
                 ] = DataT(DataT(gate_value * sigmoid_value) * up_value);
             }
         """,
-        header: "// MLX_INCLUDE_FP_QUANTIZED_HEADERS\n",
+        header: "// MLX_INCLUDE_FP_QUANTIZED_HEADERS\n" + lagunaXSDownHeader,
         ensureRowContiguous: true
     )
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -642,10 +642,10 @@ SOFTWARE.
 - source project: [`sawfwair/mlx-swift`](https://github.com/sawfwair/mlx-swift),
   based on upstream [`ml-explore/mlx-swift`](https://github.com/ml-explore/mlx-swift)
   0.32.1
-- pinned package revision: `79bc410c85df66c3f4246084057bdfd971932ac7`
+- pinned package revision: `22c76cc40edbae2c2af72532678d8e5c06cbfa46`
 - embedded MLX revision: `2a977448c20451eb4f100691bd2f6513e610f150`
 - generated-kernel source SHA-256:
-  `a4a91e902e4a3c196ba45f3c6ee65c769c26b5825ae3b72d8b93ca233db2d93f`
+  `961bc42bb4161801fb8b0f7fd9d4570e7e86318f1644520bb39eae04eed9820c`
 - license: MIT
 
 ```

--- a/Tests/MereRunCoreTests/LagunaModelTests.swift
+++ b/Tests/MereRunCoreTests/LagunaModelTests.swift
@@ -1039,6 +1039,36 @@ final class LagunaModelTests: MereRunCoreTestCase {
     }
 
     func testDecodeNVFP4RowsPerSIMDGroupParsing() {
+        XCTAssertTrue(
+            LagunaMoEAccelerationPolicy.supportsActive64ByDefault(
+                architecture: "applegpu_g16s"
+            )
+        )
+        XCTAssertTrue(
+            LagunaMoEAccelerationPolicy.supportsActive64ByDefault(
+                architecture: "applegpu_g17s"
+            )
+        )
+        XCTAssertFalse(
+            LagunaMoEAccelerationPolicy.supportsActive64ByDefault(
+                architecture: "applegpu_g15s"
+            )
+        )
+        XCTAssertTrue(
+            LagunaGraphAccelerationPolicy.supportsNativeAffineByDefault(
+                architecture: "applegpu_g16s"
+            )
+        )
+        XCTAssertTrue(
+            LagunaGraphAccelerationPolicy.supportsNativeAffineByDefault(
+                architecture: "applegpu_g17s"
+            )
+        )
+        XCTAssertFalse(
+            LagunaGraphAccelerationPolicy.supportsNativeAffineByDefault(
+                architecture: nil
+            )
+        )
         XCTAssertEqual(
             LagunaMoEAccelerationPolicy.defaultDecodeRowsPerSIMDGroup(
                 architecture: "applegpu_g17s"
@@ -1087,26 +1117,26 @@ final class LagunaModelTests: MereRunCoreTestCase {
         )
     }
 
-    func testNativeAffineQKVLayerCountParsing() {
+    func testNativeAffineLayerCountParsing() {
         XCTAssertEqual(
-            LagunaGraphAccelerationPolicy.parseLayerCount(nil, default: 28),
-            28
-        )
-        XCTAssertEqual(
-            LagunaGraphAccelerationPolicy.parseLayerCount("16", default: 28),
-            16
-        )
-        XCTAssertEqual(
-            LagunaGraphAccelerationPolicy.parseLayerCount("-1", default: 28),
-            0
-        )
-        XCTAssertEqual(
-            LagunaGraphAccelerationPolicy.parseLayerCount("41", default: 28),
+            LagunaGraphAccelerationPolicy.parseLayerCount(nil, default: 40),
             40
         )
         XCTAssertEqual(
-            LagunaGraphAccelerationPolicy.parseLayerCount("bad", default: 28),
-            28
+            LagunaGraphAccelerationPolicy.parseLayerCount("16", default: 40),
+            16
+        )
+        XCTAssertEqual(
+            LagunaGraphAccelerationPolicy.parseLayerCount("-1", default: 40),
+            0
+        )
+        XCTAssertEqual(
+            LagunaGraphAccelerationPolicy.parseLayerCount("41", default: 40),
+            40
+        )
+        XCTAssertEqual(
+            LagunaGraphAccelerationPolicy.parseLayerCount("bad", default: 40),
+            40
         )
     }
 
@@ -1129,6 +1159,93 @@ final class LagunaModelTests: MereRunCoreTestCase {
         XCTAssertEqual(affine.biases.dtype, .bfloat16)
     }
 
+    func testNativeAffineAttentionOutputAndGateSideLayouts() throws {
+        MLXRandom.seed(63)
+        let attention = LagunaAttention(config: try makeXSAttentionConfig(), layerIndex: 0)
+        attention.update(parameters: attention.parameters().mapValues {
+            $0.asType(.bfloat16)
+        })
+
+        let gate = attention.prepareNativeAffineGProj(enabled: true)
+        let output = attention.prepareNativeAffineOProj(enabled: true)
+        MLX.eval(gate + output)
+
+        XCTAssertEqual(gate.count, 3)
+        XCTAssertEqual(gate[0].shape, [64, 512])
+        XCTAssertEqual(gate[1].shape, [64, 64])
+        XCTAssertEqual(gate[2].shape, [64, 64])
+        XCTAssertEqual(output.count, 3)
+        XCTAssertEqual(output[0].shape, [2_048, 2_048])
+        XCTAssertEqual(output[1].shape, [2_048, 256])
+        XCTAssertEqual(output[2].shape, [2_048, 256])
+
+        XCTAssertTrue(attention.prepareNativeAffineGProj(enabled: true).isEmpty)
+        XCTAssertTrue(attention.prepareNativeAffineOProj(enabled: true).isEmpty)
+    }
+
+    func testFusedGatedAffineOProjMatchesQuantizedReference() throws {
+        #if os(macOS)
+        let architecture = GPU.deviceInfo().architecture
+        guard architecture == "applegpu_g16s" || architecture == "applegpu_g17s" else {
+            throw XCTSkip("The fused Laguna output projection requires M4 Max or M5 Max.")
+        }
+
+        try Device.withDefaultDevice(.gpu) {
+            MLXRandom.seed(65)
+            let heads = 48
+            let inputWidth = heads * 128
+            let attentionOutput = MLXRandom.uniform(
+                low: -0.5,
+                high: 0.5,
+                [1, 1, inputWidth]
+            ).asType(.bfloat16)
+            let gateLogits = MLXRandom.uniform(
+                low: -3,
+                high: 3,
+                [1, 1, heads]
+            ).asType(.bfloat16)
+            let weight = MLXRandom.uniform(
+                low: -0.2,
+                high: 0.2,
+                [2_048, inputWidth]
+            ).asType(.bfloat16)
+            let affine = try XCTUnwrap(lagunaNativeAffineWeight(weight))
+            let gate = MLXNN.softplus(gateLogits.asType(.float32)).asType(.bfloat16)
+            let gated = attentionOutput.reshaped(1, 1, heads, 128)
+                * MLX.expandedDimensions(gate, axis: gate.ndim)
+            let reference = MLX.quantizedMM(
+                gated.reshaped(1, 1, inputWidth),
+                affine.packedCodes,
+                scales: affine.scales,
+                biases: affine.biases,
+                transpose: true,
+                groupSize: 32,
+                bits: 8,
+                mode: .affine
+            )
+            let actual = try XCTUnwrap(
+                LagunaGatedAffineOProj.call(
+                    attentionOutput: attentionOutput,
+                    gateLogits: gateLogits,
+                    codes: affine.packedCodes,
+                    scales: affine.scales,
+                    biases: affine.biases,
+                    heads: heads
+                )
+            )
+            MLX.eval(reference, actual)
+            XCTAssertEqual(actual.shape, reference.shape)
+            XCTAssertEqual(
+                MLX.max(MLX.abs(actual.asType(.float32) - reference.asType(.float32)))
+                    .item(Float.self),
+                0
+            )
+        }
+        #else
+        throw XCTSkip("Metal-only Laguna kernel")
+        #endif
+    }
+
     func testNativeAffineQKVPreparesAndRunsXSDecodeShape() throws {
         guard LagunaGraphAccelerationPolicy.nativeAffineQKVEnabled else {
             throw XCTSkip("Set MERERUN_LAGUNA_NATIVE_AFFINE_QKV=1 to exercise the side layout.")
@@ -1138,7 +1255,7 @@ final class LagunaModelTests: MereRunCoreTestCase {
         attention.update(parameters: attention.parameters().mapValues {
             $0.asType(.bfloat16)
         })
-        let prepared = attention.prepareNativeAffineQKV()
+        let prepared = attention.prepareNativeAffineQKV(includeGate: false)
         guard prepared.count == 3 else {
             XCTFail("Expected one packed QKV side layout.")
             return
@@ -1150,7 +1267,7 @@ final class LagunaModelTests: MereRunCoreTestCase {
         XCTAssertEqual(prepared[2].shape, [10_240, 64])
 
         XCTAssertTrue(
-            attention.prepareNativeAffineQKV().isEmpty,
+            attention.prepareNativeAffineQKV(includeGate: false).isEmpty,
             "Preparation must retain exactly one side layout per attention layer."
         )
 
@@ -1182,6 +1299,90 @@ final class LagunaModelTests: MereRunCoreTestCase {
             activeBefore + 1_048_576,
             "Repeated affine-QKV decode must not retain per-token MLX buffers."
         )
+    }
+
+    func testNativeAffineQKVCanFoldPerHeadGateRows() throws {
+        MLXRandom.seed(66)
+        let attention = LagunaAttention(config: try makeXSAttentionConfig(), layerIndex: 0)
+        attention.update(parameters: attention.parameters().mapValues {
+            $0.asType(.bfloat16)
+        })
+        let prepared = attention.prepareNativeAffineQKV(
+            enabled: true,
+            includeGate: true
+        )
+        MLX.eval(prepared)
+
+        XCTAssertEqual(prepared.count, 3)
+        XCTAssertEqual(prepared[0].shape, [10_304, 512])
+        XCTAssertEqual(prepared[1].shape, [10_304, 64])
+        XCTAssertEqual(prepared[2].shape, [10_304, 64])
+    }
+
+    func testFusedNormAffineQKVMatchesSeparateReference() throws {
+        #if os(macOS)
+        let architecture = GPU.deviceInfo().architecture
+        guard architecture == "applegpu_g16s" || architecture == "applegpu_g17s" else {
+            throw XCTSkip("The fused Laguna QKV projection requires M4 Max or M5 Max.")
+        }
+
+        try Device.withDefaultDevice(.gpu) {
+            MLXRandom.seed(67)
+            let heads = 48
+            let rows = (heads + 16) * 128
+            let residual = MLXRandom.uniform(
+                low: -0.5,
+                high: 0.5,
+                [1, 1, 2_048]
+            ).asType(.bfloat16)
+            let normWeight = MLXRandom.uniform(
+                low: 0.5,
+                high: 1.5,
+                [2_048]
+            ).asType(.bfloat16)
+            let weight = MLXRandom.uniform(
+                low: -0.2,
+                high: 0.2,
+                [rows, 2_048]
+            ).asType(.bfloat16)
+            let affine = try XCTUnwrap(lagunaNativeAffineWeight(weight))
+            let norm = RMSNorm(dimensions: 2_048, eps: 1e-6)
+            try norm.update(
+                parameters: ModuleParameters.unflattened([("weight", normWeight)]),
+                verify: .none
+            )
+            let reference = MLX.quantizedMM(
+                norm(residual),
+                affine.packedCodes,
+                scales: affine.scales,
+                biases: affine.biases,
+                transpose: true,
+                groupSize: 32,
+                bits: 8,
+                mode: .affine
+            )
+            let actual = try XCTUnwrap(
+                LagunaNormAffineQKV.call(
+                    residual: residual,
+                    normWeight: normWeight,
+                    codes: affine.packedCodes,
+                    scales: affine.scales,
+                    biases: affine.biases,
+                    heads: heads,
+                    gateRows: 0
+                )
+            )
+            MLX.eval(reference, actual)
+            XCTAssertEqual(actual.shape, reference.shape)
+            XCTAssertEqual(
+                MLX.max(MLX.abs(actual.asType(.float32) - reference.asType(.float32)))
+                    .item(Float.self),
+                0
+            )
+        }
+        #else
+        throw XCTSkip("Metal-only Laguna kernel")
+        #endif
     }
 
     func testTerminalPrefillProjectionBanksPreserveLastAttentionRow() throws {

--- a/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
+++ b/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
@@ -1,6 +1,6 @@
 mlx-core-version: 0.32.1
 mlx-swift-version: unknown
-mlx-swift-revision: 79bc410c85df66c3f4246084057bdfd971932ac7
-kernel-sources-sha256: a4a91e902e4a3c196ba45f3c6ee65c769c26b5825ae3b72d8b93ca233db2d93f
-built-at: 2026-08-05T21:40:04Z
+mlx-swift-revision: 22c76cc40edbae2c2af72532678d8e5c06cbfa46
+kernel-sources-sha256: 961bc42bb4161801fb8b0f7fd9d4570e7e86318f1644520bb39eae04eed9820c
+built-at: 2026-08-08T20:47:45Z
 metal-compiler: Apple metal version 32023.883 (metalfe-32023.883)


### PR DESCRIPTION
## Summary

- enable exact Active64 and native attention affine side layouts by default on M4 Max and M5 Max
- add single-token fused RMSNorm plus affine QKV, gate-aware affine output projection, decode async staging, and exact Laguna NVFP4 qdot specialization
- pin the MLX fork revision carrying paired JIT/AOT Steel causal-bound elision and NAX expert-gather activation hoisting, with rebuilt provenance-stamped metallib
- preserve production full-logit sampling and training behavior; benchmark-only greedy pruning and negative experiments are intentionally excluded

## Production evidence

- controlled M4 Max A/B, same installed Laguna XS 2.1 checkpoint and deterministic 61-token request:
  - stack disabled: 0.910104 s decode, about 67.0 tok/s; 0.618487 s prefill
  - M4 defaults: 0.592858 s and 0.591912 s decode, about 102.9-103.1 tok/s; 0.520575 s and 0.511391 s prefill
  - net: about 54 percent faster decode and 16-19 percent faster prefill
- installed-checkpoint behavior smoke: 7 of 7 checks passed
- Laguna suite: 58 tests passed, 16 hardware or external-checkpoint cases skipped, 0 failures after rebase
- GPU-focused Laguna suite before rebase: 58 tests, 4 expected external-checkpoint skips, 0 failures
- repository gate: SwiftLint clean; 2,567 tests passed, 168 skips, 0 failures
- MLX provenance suite: 6 of 6 passed
- release worker build passed
- git diff check clean

## Rollback controls

Every new runtime path has a scoped MERERUN_LAGUNA environment kill switch. M4 defaults retain the measured wins while M5-only gate folding and fused norm-QKV stay architecture-gated pending production M5 evidence.